### PR TITLE
module_info: fixed-width tagged wire format with one string table per executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,6 @@ dependencies = [
  "bun_jsc",
  "bun_opaque",
  "bun_options_types",
- "scopeguard",
 ]
 
 [[package]]

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -146,13 +146,11 @@ pub enum ModuleInfoError {
 pub struct ModuleInfoDeserialized {
     body: Body<'static>,
     table: ModuleInfoStringTable<'static>,
-    /// The ids index the executable's shared string table, so identifiers
-    /// come from the VM-wide slots (`Bun__VM__sharedModuleInfoIdentifiers`)
-    /// rather than a per-record array.
-    shared: bool,
     pub flags: Flags,
-    /// Backing storage for `body`/`table` when they were not `'static`.
-    #[allow(dead_code)]
+    /// Backing storage for `body`/`table`: `None` when they live in the
+    /// executable's mapped section — the ids then index the shared string
+    /// table and identifiers come from the VM-wide slots
+    /// (`Bun__VM__sharedModuleInfoIdentifiers`) rather than a per-record array.
     owned: Option<Box<[u8]>>,
 }
 
@@ -255,10 +253,11 @@ impl ModuleInfoDeserialized {
             count: self.table.count,
         }
     }
-    /// Whether identifiers come from the VM-wide shared slots.
+    /// Whether the ids index the executable's shared string table (and so
+    /// the VM-wide identifier slots).
     #[inline]
     pub fn shared(&self) -> bool {
-        self.shared
+        self.owned.is_none()
     }
     /// Ids below this are strings; the rest are sentinels.
     #[inline]
@@ -294,7 +293,6 @@ impl ModuleInfoDeserialized {
         Ok(Box::new(ModuleInfoDeserialized {
             body,
             table,
-            shared: false,
             flags,
             owned: Some(owned),
         }))
@@ -317,7 +315,6 @@ impl ModuleInfoDeserialized {
         Some(Box::new(ModuleInfoDeserialized {
             body,
             table: *table,
-            shared: true,
             flags,
             owned: None,
         }))

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -70,26 +70,6 @@ impl RecordKind {
     pub const ExportInfoLocal: Self = Self::EXPORT_INFO_LOCAL;
     pub const ExportInfoNamespace: Self = Self::EXPORT_INFO_NAMESPACE;
     pub const ExportInfoStar: Self = Self::EXPORT_INFO_STAR;
-
-    pub fn len(self) -> crate::Result<usize> {
-        match self {
-            Self::IMPORT_INFO_SINGLE => Ok(4),
-            Self::IMPORT_INFO_SINGLE_TYPE_SCRIPT => Ok(4),
-            Self::IMPORT_INFO_NAMESPACE => Ok(4),
-            Self::IMPORT_INFO_NAMESPACE_DEFER => Ok(4),
-            Self::EXPORT_INFO_INDIRECT => Ok(4),
-            Self::EXPORT_INFO_LOCAL => Ok(4),
-            Self::EXPORT_INFO_NAMESPACE => Ok(3),
-            Self::EXPORT_INFO_STAR => Ok(2),
-            _ => Err(crate::Error::InvalidRecordKind),
-        }
-    }
-
-    /// Number of trailing slots holding a bitcast `FetchParameters` rather
-    /// than a `StringID`. Every record kind has exactly one trailing FP slot.
-    pub fn trailing_fetch_parameters_slots(self) -> usize {
-        1
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -135,316 +135,192 @@ pub enum ModuleInfoError {
     BadModuleInfo,
 }
 
-/// All slice fields are **self-referential** views into `owner`
-/// (`Owner::Decoded`'s boxed slices) or into the parent `ModuleInfo`'s `Vec`
-/// storage (`Owner::ModuleInfo`). They are stored as [`bun_ptr::RawSlice`] (raw fat
-/// pointers) because Rust references cannot express the self-borrow.
+/// A validated view over a serialized module record: the body bytes written
+/// by `bun_js_printer::analyze_transpiled_module::ModuleInfoDeserialized::serialize_body`
+/// plus the string table its ids index. `to_js_module_record` walks the body
+/// in place; nothing is widened or copied.
 ///
+/// `body` / `table` are lifetime-erased: they point either into the
+/// executable's mapped section (`'static`) or into `owned`, which lives as long
+/// as `self`.
 pub struct ModuleInfoDeserialized {
-    /// When the ids index the executable's shared module-info string table:
-    /// that table. Identifiers then come from the VM-wide slots
-    /// (`Bun__VM__moduleInfoIdentifiers`), filled on first use, and
-    /// `strings_buf` / `string_ranges` are empty.
-    pub(crate) shared_table: Option<ModuleInfoStringTable<'static>>,
-    /// Base the `string_ranges` offsets index: the decoded copy of a module's
-    /// own table, or the live `ModuleInfo`'s string buffer.
-    pub(crate) strings_buf: bun_ptr::RawSlice<u8>,
-    /// `(offset, len)` into `strings_buf` per local string id.
-    pub(crate) string_ranges: bun_ptr::RawSlice<[u32; 2]>,
-    pub(crate) requested_modules_keys: bun_ptr::RawSlice<StringID>,
-    pub(crate) requested_modules_values: bun_ptr::RawSlice<FetchParameters>,
-    pub(crate) requested_modules_phases: bun_ptr::RawSlice<u8>,
-    pub(crate) buffer: bun_ptr::RawSlice<StringID>,
-    pub(crate) record_kinds: bun_ptr::RawSlice<RecordKind>,
+    body: Body<'static>,
+    table: ModuleInfoStringTable<'static>,
+    /// The ids index the executable's shared string table, so identifiers
+    /// come from the VM-wide slots (`Bun__VM__sharedModuleInfoIdentifiers`)
+    /// rather than a per-record array.
+    shared: bool,
     pub flags: Flags,
-    pub(crate) owner: Owner,
+    /// Backing storage for `body`/`table` when they were not `'static`.
+    #[allow(dead_code)]
+    owned: Option<Box<[u8]>>,
 }
 
-pub enum Owner {
-    /// `Box<ModuleInfo>` whose internal vectors back the raw slice fields,
-    /// plus the `string_ranges` derived from its length list.
-    ModuleInfo(*mut ModuleInfo, Box<[[u32; 2]]>),
-    /// Decoded from the wire format by [`ModuleInfoDeserialized::create`].
-    Decoded(Box<Decoded>),
+/// The body split into its regions; every count has been bounds-checked
+/// against the byte length, but ids are validated as they are read.
+#[derive(Clone, Copy)]
+pub struct Body<'a> {
+    pub id_width: u8,
+    /// `kind | fetch-kind << 3 | same-name << 6` per record.
+    pub record_tags: &'a [u8],
+    /// `phase | fetch-kind << 1` per requested module.
+    pub requested_tags: &'a [u8],
+    /// Requested-module ids, then record ids, at `id_width` bytes each.
+    pub ids: &'a [u8],
 }
 
-/// The fixed-width in-memory layout the wire format decodes into: one `u32`
-/// arena (`[string ranges | requested keys | requested values | buffer]`) and
-/// one byte arena (`[record_kinds | requested phases | strings?]` — the string
-/// bytes only when the table they came from does not outlive the record).
-pub struct Decoded {
-    words: Box<[u32]>,
-    bytes: Box<[u8]>,
-}
-
-impl Drop for ModuleInfoDeserialized {
-    fn drop(&mut self) {
-        if let Owner::ModuleInfo(mi, _) = self.owner {
-            // SAFETY: `owner` is the unique owner of the leaked `Box<ModuleInfo>`.
-            drop(unsafe { bun_core::heap::take(mi) });
+impl<'a> Body<'a> {
+    fn parse(body: &'a [u8]) -> Result<(Flags, Self), ModuleInfoError> {
+        let mut r = Reader { rem: body };
+        let &[flags, id_width, 0, 0] = r.bytes(4)? else {
+            return Err(ModuleInfoError::BadModuleInfo);
+        };
+        width(id_width)?;
+        let requested_count = r.u32()? as usize;
+        let record_count = r.u32()? as usize;
+        if requested_count.saturating_add(record_count) > r.rem.len() {
+            return Err(ModuleInfoError::BadModuleInfo);
         }
+        let record_tags = r.bytes(record_count)?;
+        let requested_tags = r.bytes(requested_count)?;
+        Ok((
+            Flags::from_bits_retain(flags),
+            Body {
+                id_width,
+                record_tags,
+                requested_tags,
+                ids: r.rem,
+            },
+        ))
+    }
+}
+
+/// Reads ids off a [`Body`] in order, mapping the two sentinels back to
+/// `STAR_NAMESPACE` / `STAR_DEFAULT` and rejecting anything else out of range.
+pub struct IdCursor<'a> {
+    rem: &'a [u8],
+    width: usize,
+    count: u32,
+}
+impl IdCursor<'_> {
+    #[inline]
+    pub fn next_id(&mut self) -> Result<StringID, ModuleInfoError> {
+        if self.rem.len() < self.width {
+            return Err(ModuleInfoError::BadModuleInfo);
+        }
+        let v = read_uint(self.rem, self.width);
+        self.rem = &self.rem[self.width..];
+        match v.checked_sub(self.count) {
+            None => Ok(StringID(v)),
+            Some(0) => Ok(StringID::STAR_NAMESPACE),
+            Some(1) => Ok(StringID::STAR_DEFAULT),
+            Some(_) => Err(ModuleInfoError::BadModuleInfo),
+        }
+    }
+    /// A fetch-parameter slot: kinds 0..=3 are constants, 4 reads a string id.
+    #[inline]
+    pub fn next_fetch(&mut self, kind: u8) -> Result<FetchParameters, ModuleInfoError> {
+        Ok(match kind {
+            0 => FetchParameters::None,
+            1 => FetchParameters::Javascript,
+            2 => FetchParameters::Webassembly,
+            3 => FetchParameters::Json,
+            4 => match self.next_id()? {
+                id if id.0 < self.count => FetchParameters(id.0),
+                _ => return Err(ModuleInfoError::BadModuleInfo),
+            },
+            _ => return Err(ModuleInfoError::BadModuleInfo),
+        })
+    }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.rem.is_empty()
     }
 }
 
 impl ModuleInfoDeserialized {
-    // ── safe accessors ───────────────────────────────────────────────────
-    // All slice fields are non-null self-referential views into `self.owner`
-    // (see struct docs). They are initialized in every constructor (`create` /
-    // `into_deserialized`), the backing allocation is immutable and outlives
-    // `&self`, and no `&mut` alias to that storage is ever handed out — so
-    // materialising `&[T]` for `'_ self` (via `RawSlice::slice`) is sound.
-    //
-    // Both constructors borrow from typed `Vec<T>` / `Box<[T]>` storage,
-    // which is naturally aligned.
-
+    #[inline]
+    pub fn body(&self) -> &Body<'_> {
+        &self.body
+    }
+    #[inline]
+    pub fn table(&self) -> &ModuleInfoStringTable<'_> {
+        &self.table
+    }
+    #[inline]
+    pub fn ids(&self) -> IdCursor<'_> {
+        IdCursor {
+            rem: self.body.ids,
+            width: self.body.id_width as usize,
+            count: self.table.count,
+        }
+    }
+    /// Whether identifiers come from the VM-wide shared slots.
+    #[inline]
+    pub fn shared(&self) -> bool {
+        self.shared
+    }
     /// Ids below this are strings; the rest are sentinels.
     #[inline]
     pub fn strings_count(&self) -> usize {
-        match &self.shared_table {
-            Some(table) => table.count as usize,
-            None => self.string_ranges.len(),
-        }
-    }
-    #[inline]
-    pub fn shared_table(&self) -> Option<&ModuleInfoStringTable<'static>> {
-        self.shared_table.as_ref()
+        self.table.count as usize
     }
     /// The WTF-8 bytes of string `id`, or `None` if out of bounds (corrupt input).
     #[inline]
-    pub fn string(&self, id: usize) -> Option<&[u8]> {
-        if let Some(table) = &self.shared_table {
-            return table.get(u32::try_from(id).ok()?);
-        }
-        let [offset, len] = *self.string_ranges.slice().get(id)?;
-        self.strings_buf
-            .slice()
-            .get(offset as usize..offset as usize + len as usize)
-    }
-    #[inline]
-    pub fn requested_modules_keys(&self) -> &[StringID] {
-        self.requested_modules_keys.slice()
-    }
-    #[inline]
-    pub fn requested_modules_values(&self) -> &[FetchParameters] {
-        self.requested_modules_values.slice()
-    }
-    #[inline]
-    pub fn requested_modules_phases(&self) -> &[u8] {
-        self.requested_modules_phases.slice()
-    }
-    #[inline]
-    pub fn buffer(&self) -> &[StringID] {
-        self.buffer.slice()
-    }
-    #[inline]
-    pub fn record_kinds(&self) -> &[RecordKind] {
-        self.record_kinds.slice()
+    pub fn string(&self, id: u32) -> Option<&[u8]> {
+        self.table.get(id)
     }
 
     /// Consumes the heap allocation containing `self`.
     ///
     /// # Safety
-    /// `this` must have been produced by [`Self::create`] (heap box) or by
-    /// [`ModuleInfoExt::into_deserialized`].
+    /// `this` must have been produced by one of the constructors below.
     pub(crate) unsafe fn deinit(this: *mut ModuleInfoDeserialized) {
         // SAFETY: caller contract — see fn doc above.
         drop(unsafe { bun_core::heap::take(this) });
     }
 
-    /// Decodes the self-contained form (a module's own string table followed
-    /// by its body, as the runtime transpiler cache stores it).
+    /// The self-contained form (a module's own string table followed by its
+    /// body, as the runtime transpiler cache stores it). The bytes are copied
+    /// once; the record views the copy.
     pub(crate) fn create(source: &[u8]) -> Result<Box<ModuleInfoDeserialized>, ModuleInfoError> {
-        let table = ModuleInfoStringTable::parse(source)?;
-        let body = &source[table.byte_len..];
-        Self::decode(&table, None, body)
-    }
-
-    /// Decodes a body whose ids index `table`, the string table an executable
-    /// shares between all its modules (`StandaloneModuleGraph`). The record
-    /// keeps the table's ids and references its bytes in place.
-    pub fn create_with_table(
-        table: &ModuleInfoStringTable<'static>,
-        body: &[u8],
-    ) -> Option<Box<ModuleInfoDeserialized>> {
-        Self::decode(table, Some(*table), body).ok()
-    }
-
-    /// Widens the body wire format written by
-    /// `bun_js_printer::analyze_transpiled_module::ModuleInfoDeserialized::serialize_body`
-    /// (layout documented there) into the fixed `u32` layout
-    /// `to_js_module_record` reads: one `u32` arena
-    /// `[string ranges? | requested keys | requested values | buffer]` and one
-    /// byte arena `[record_kinds | requested phases | strings?]` — the string
-    /// ranges and bytes only when the table is the module's own (it does not
-    /// outlive `body`); with a `shared_table` the ids are left as they are.
-    fn decode(
-        table: &ModuleInfoStringTable<'_>,
-        shared_table: Option<ModuleInfoStringTable<'static>>,
-        body: &[u8],
-    ) -> Result<Box<ModuleInfoDeserialized>, ModuleInfoError> {
-        use ModuleInfoError::BadModuleInfo;
-        let mut r = Reader { rem: body };
-        let &[flags, id_width, 0, 0] = r.bytes(4)? else {
-            return Err(BadModuleInfo);
-        };
-        let flags = Flags::from_bits_retain(flags);
-        let id_width = width(id_width)?;
-        let requested_count = r.u32()? as usize;
-        let record_count = r.u32()? as usize;
-        // Every counted item takes at least one byte below; reject headers
-        // that would over-allocate before reading anything.
-        if requested_count + record_count > r.rem.len() {
-            return Err(BadModuleInfo);
-        }
-        let record_tags = r.bytes(record_count)?;
-        let requested_tags = r.bytes(requested_count)?;
-        let mut buffer_len = 0usize;
-        for &tag in record_tags {
-            buffer_len += RecordKind(tag & 0b111).len().map_err(|_| BadModuleInfo)?;
-        }
-
-        struct Ids {
-            table_count: u32,
-            id_width: usize,
-        }
-        impl Ids {
-            fn id(&mut self, r: &mut Reader<'_>) -> Result<u32, ModuleInfoError> {
-                let v = r.uint(self.id_width)?;
-                Ok(match v.checked_sub(self.table_count) {
-                    None => v,
-                    Some(0) => StringID::STAR_NAMESPACE.0,
-                    Some(1) => StringID::STAR_DEFAULT.0,
-                    Some(_) => return Err(ModuleInfoError::BadModuleInfo),
-                })
-            }
-            fn fetch(&mut self, r: &mut Reader<'_>, kind: u8) -> Result<u32, ModuleInfoError> {
-                Ok(match kind {
-                    0 => FetchParameters::None.0,
-                    1 => FetchParameters::Javascript.0,
-                    2 => FetchParameters::Webassembly.0,
-                    3 => FetchParameters::Json.0,
-                    4 => self.id(r)?,
-                    _ => return Err(ModuleInfoError::BadModuleInfo),
-                })
-            }
-        }
-        let table_count = table.count;
-        let mut ids = Ids {
-            table_count,
-            id_width,
-        };
-        let mut words: Vec<u32> = Vec::with_capacity(2 * requested_count + buffer_len);
-        // requested keys, then values
-        words.resize(2 * requested_count, 0);
-        for (n, &tag) in requested_tags.iter().enumerate() {
-            if tag >> 1 > 4 {
-                return Err(BadModuleInfo);
-            }
-            words[n] = ids.id(&mut r)?;
-            words[requested_count + n] = ids.fetch(&mut r, tag >> 1)?;
-        }
-        for &tag in record_tags {
-            let kind = RecordKind(tag & 0b111);
-            let same_name = tag & (1 << 6) != 0;
-            match kind {
-                RecordKind::IMPORT_INFO_SINGLE | RecordKind::IMPORT_INFO_SINGLE_TYPE_SCRIPT => {
-                    let module_name = ids.id(&mut r)?;
-                    let import_name = ids.id(&mut r)?;
-                    let local_name = if same_name {
-                        import_name
-                    } else {
-                        ids.id(&mut r)?
-                    };
-                    words.extend([module_name, import_name, local_name]);
-                }
-                RecordKind::IMPORT_INFO_NAMESPACE | RecordKind::IMPORT_INFO_NAMESPACE_DEFER => {
-                    let module_name = ids.id(&mut r)?;
-                    words.extend([module_name, StringID::STAR_NAMESPACE.0, ids.id(&mut r)?]);
-                }
-                RecordKind::EXPORT_INFO_INDIRECT => {
-                    let export_name = ids.id(&mut r)?;
-                    let import_name = ids.id(&mut r)?;
-                    words.extend([export_name, import_name, ids.id(&mut r)?]);
-                }
-                RecordKind::EXPORT_INFO_LOCAL => {
-                    let export_name = ids.id(&mut r)?;
-                    words.extend([export_name, ids.id(&mut r)?, u32::MAX]);
-                }
-                RecordKind::EXPORT_INFO_NAMESPACE => {
-                    let export_name = ids.id(&mut r)?;
-                    words.extend([export_name, ids.id(&mut r)?]);
-                }
-                RecordKind::EXPORT_INFO_STAR => words.push(ids.id(&mut r)?),
-                _ => return Err(BadModuleInfo),
-            }
-            words.push(ids.fetch(&mut r, (tag >> 3) & 0b111)?);
-        }
-        if !r.rem.is_empty() {
-            return Err(BadModuleInfo);
-        }
-        debug_assert_eq!(words.len(), 2 * requested_count + buffer_len);
-
-        // A module's own table does not outlive `body`: copy its bytes and
-        // build `(offset, len)` ranges. A shared table is referenced as is.
-        let strings_count = if shared_table.is_some() {
-            0
-        } else {
-            table_count as usize
-        };
-        let mut all_words: Vec<u32> = Vec::with_capacity(2 * strings_count + words.len());
-        for id in 0..strings_count as u32 {
-            let [offset, len] = table.range(id).ok_or(BadModuleInfo)?;
-            all_words.extend([offset, len]);
-        }
-        all_words.extend_from_slice(&words);
-        drop(words);
-        let strings_bytes: &[u8] = if shared_table.is_some() {
-            &[]
-        } else {
-            table.buf
-        };
-        let mut bytes: Vec<u8> =
-            Vec::with_capacity(record_count + requested_count + strings_bytes.len());
-        bytes.extend(record_tags.iter().map(|&tag| tag & 0b111));
-        bytes.extend(requested_tags.iter().map(|&tag| tag & 1));
-        bytes.extend_from_slice(strings_bytes);
-
-        let decoded = Box::new(Decoded {
-            words: all_words.into(),
-            bytes: bytes.into(),
-        });
-        let (string_ranges, rest) = decoded.words.split_at(2 * strings_count);
-        let (requested_keys, rest) = rest.split_at(requested_count);
-        let (requested_values, buffer) = rest.split_at(requested_count);
-        let (record_kinds, rest) = decoded.bytes.split_at(record_count);
-        let (requested_phases, strings_buf) = rest.split_at(requested_count);
-        // All views borrow the boxed `Decoded` moved into `owner` below; its two
-        // heap slices stay at a stable address for the struct's lifetime.
-        // `StringID` / `FetchParameters` / `RecordKind` / `[u32; 2]` are
-        // plain-old-data over `u32` / `u8`, so `cast_slice` is a safe reinterpret.
+        let owned: Box<[u8]> = source.into();
+        // SAFETY: `owned` is moved into the returned struct and never
+        // reallocated, so views into its heap buffer stay valid for `self`'s
+        // lifetime; the `'static` is an erased self-borrow, not exposed.
+        let bytes: &'static [u8] = unsafe { &*core::ptr::from_ref::<[u8]>(&owned) };
+        let table = ModuleInfoStringTable::parse(bytes)?;
+        let (flags, body) = Body::parse(&bytes[table.byte_len..])?;
         Ok(Box::new(ModuleInfoDeserialized {
-            shared_table,
-            strings_buf: bun_ptr::RawSlice::new(strings_buf),
-            string_ranges: bun_ptr::RawSlice::new(bytemuck::cast_slice(string_ranges)),
-            requested_modules_keys: bun_ptr::RawSlice::new(bytemuck::cast_slice(requested_keys)),
-            requested_modules_values: bun_ptr::RawSlice::new(bytemuck::cast_slice(
-                requested_values,
-            )),
-            requested_modules_phases: bun_ptr::RawSlice::new(requested_phases),
-            buffer: bun_ptr::RawSlice::new(bytemuck::cast_slice(buffer)),
-            record_kinds: bun_ptr::RawSlice::new(bytemuck::cast_slice(record_kinds)),
+            body,
+            table,
+            shared: false,
             flags,
-            owner: Owner::Decoded(decoded),
+            owned: Some(owned),
         }))
     }
 
-    /// Wrapper around `create` for use when loading from a cache (transpiler
-    /// cache or standalone module graph). Returns `None` instead of panicking on
-    /// corrupt/truncated data.
+    /// Wrapper around `create` for use when loading from a cache. Returns
+    /// `None` on corrupt/truncated data.
     pub fn create_from_cached_record(source: &[u8]) -> Option<Box<ModuleInfoDeserialized>> {
-        // Allocation failure aborts via the global arena, so only
-        // BadModuleInfo remains.
         Self::create(source).ok()
+    }
+
+    /// A body inside the executable whose ids index the string table the
+    /// executable shares between all its modules (`StandaloneModuleGraph`).
+    /// Nothing is copied.
+    pub fn create_with_table(
+        table: &ModuleInfoStringTable<'static>,
+        body: &'static [u8],
+    ) -> Option<Box<ModuleInfoDeserialized>> {
+        let (flags, body) = Body::parse(body).ok()?;
+        Some(Box::new(ModuleInfoDeserialized {
+            body,
+            table: *table,
+            shared: true,
+            flags,
+            owned: None,
+        }))
     }
 }
 
@@ -462,9 +338,6 @@ impl<'a> Reader<'a> {
     }
     fn u32(&mut self) -> Result<u32, ModuleInfoError> {
         Ok(u32::from_le_bytes(self.bytes(4)?.try_into().unwrap()))
-    }
-    fn uint(&mut self, width: usize) -> Result<u32, ModuleInfoError> {
-        Ok(read_uint(self.bytes(width)?, width))
     }
 }
 #[inline]
@@ -565,8 +438,8 @@ impl StringIDExt for StringID {
     }
 }
 
-/// Bridges the printer-crate `ModuleInfo` to the raw-pointer FFI
-/// `ModuleInfoDeserialized` view kept in this crate.
+/// Bridges the printer-crate `ModuleInfo` builder to the serialized view
+/// JSC consumes.
 pub trait ModuleInfoExt {
     /// Finalize and box the raw-pointer `ModuleInfoDeserialized` view, taking
     /// ownership of `self`.
@@ -575,62 +448,9 @@ pub trait ModuleInfoExt {
 
 impl ModuleInfoExt for ModuleInfo {
     fn into_deserialized(mut self: Box<Self>) -> Box<ModuleInfoDeserialized> {
-        // The printer-crate `ModuleInfo`
-        // exposes a borrowed `as_deserialized()`; here we materialise the
-        // raw-pointer FFI shape and tie its lifetime to the leaked `Box<ModuleInfo>`.
-        if !self.finalized {
-            let _ = self.finalize();
-        }
-        // Reshaped for borrowck — capture lifetime-erased `RawSlice`
-        // views before `heap::into_raw(self)` consumes the box.
-        let (strings_buf, ranges, rm_keys, rm_values, rm_phases, buffer, record_kinds, flags);
-        {
-            let view = self.as_deserialized();
-            strings_buf = bun_ptr::RawSlice::new(view.strings_buf);
-            let mut offset = 0u32;
-            ranges = view
-                .strings_lens
-                .iter()
-                .map(|&len| {
-                    let range = [offset, len];
-                    offset += len;
-                    range
-                })
-                .collect::<Box<[[u32; 2]]>>();
-            rm_keys = bun_ptr::RawSlice::new(view.requested_modules_keys);
-            rm_values = bun_ptr::RawSlice::new(view.requested_modules_values);
-            // Printer's `ModulePhase` is `#[repr(u8)] NoUninit` — safe to view as `&[u8]`.
-            rm_phases = bun_ptr::RawSlice::new(bytemuck::cast_slice::<_, u8>(
-                view.requested_modules_phases,
-            ));
-            buffer = bun_ptr::RawSlice::new(view.buffer);
-            // Printer's `RecordKind` is `#[repr(u8)] NoUninit` with the same
-            // discriminant layout as this crate's `#[repr(transparent)] u8`
-            // `RecordKind` (Pod) — `bytemuck::cast_slice` is the safe reinterpret.
-            record_kinds =
-                bun_ptr::RawSlice::new(bytemuck::cast_slice::<_, RecordKind>(view.record_kinds));
-            let mut f = Flags::empty();
-            f.set(Flags::CONTAINS_IMPORT_META, view.flags.contains_import_meta);
-            f.set(Flags::IS_TYPESCRIPT, view.flags.is_typescript);
-            f.set(Flags::HAS_TLA, view.flags.has_tla);
-            flags = f;
-        }
-        // The views point into the `Box<ModuleInfo>`'s vectors (and `ranges`), moved into
-        // `owner` below; they stay valid and stable for the lifetime of every
-        // `RawSlice` copied from this struct.
-        Box::new(ModuleInfoDeserialized {
-            shared_table: None,
-            strings_buf,
-            // Boxed slice: its heap address is stable across the move into `owner`.
-            string_ranges: bun_ptr::RawSlice::new(&ranges),
-            requested_modules_keys: rm_keys,
-            requested_modules_values: rm_values,
-            requested_modules_phases: rm_phases,
-            buffer,
-            record_kinds,
-            flags,
-            owner: Owner::ModuleInfo(bun_core::heap::into_raw(self), ranges),
-        })
+        let bytes = bun_js_printer::serialize_module_info(Some(&mut self))
+            .expect("finalize cannot fail after printing");
+        ModuleInfoDeserialized::create(&bytes).expect("just serialized")
     }
 }
 

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -1,4 +1,3 @@
-use core::mem::size_of;
 use core::ptr::NonNull;
 
 use bun_core;
@@ -137,14 +136,10 @@ pub enum ModuleInfoError {
 }
 
 /// All slice fields are **self-referential** views into `owner`
-/// (`Owner::AllocatedSlice`) or into the parent `ModuleInfo`'s `Vec` storage
-/// (`Owner::ModuleInfo`). They are stored as [`bun_ptr::RawSlice`] (raw fat
+/// (`Owner::Decoded`'s boxed slices) or into the parent `ModuleInfo`'s `Vec`
+/// storage (`Owner::ModuleInfo`). They are stored as [`bun_ptr::RawSlice`] (raw fat
 /// pointers) because Rust references cannot express the self-borrow.
 ///
-/// Alignment: the on-disk format pads every multi-byte field to a 4-byte
-/// offset, and [`Self::create`] allocates the backing buffer with 4-byte
-/// alignment ([`MODULE_INFO_ALIGN`]), so every `RawSlice<T>` here is properly
-/// aligned for `T` and `.slice()` is sound.
 pub struct ModuleInfoDeserialized {
     pub(crate) strings_buf: bun_ptr::RawSlice<u8>,
     pub(crate) strings_lens: bun_ptr::RawSlice<u32>,
@@ -160,21 +155,23 @@ pub struct ModuleInfoDeserialized {
 pub enum Owner {
     /// `Box<ModuleInfo>` whose internal vectors back the raw slice fields.
     ModuleInfo(*mut ModuleInfo),
-    AllocatedSlice {
-        /// [`MODULE_INFO_ALIGN`]-aligned heap slice from [`dupe_aligned`];
-        /// freed via [`free_aligned_dup`].
-        slice: *mut [u8],
-    },
+    /// Decoded from the wire format by [`ModuleInfoDeserialized::create`].
+    Decoded(Box<Decoded>),
+}
+
+/// The fixed-width in-memory layout the wire format decodes into: one `u32`
+/// arena (`[strings_lens | requested keys | requested values | buffer]`) and
+/// one byte arena (`[record_kinds | requested phases | strings_buf]`).
+pub struct Decoded {
+    words: Box<[u32]>,
+    bytes: Box<[u8]>,
 }
 
 impl Drop for ModuleInfoDeserialized {
     fn drop(&mut self) {
-        // SAFETY: `owner` is the unique owner of its allocation (see `Owner`).
-        unsafe {
-            match self.owner {
-                Owner::ModuleInfo(mi) => drop(bun_core::heap::take(mi)),
-                Owner::AllocatedSlice { slice } => free_aligned_dup(slice),
-            }
+        if let Owner::ModuleInfo(mi) = self.owner {
+            // SAFETY: `owner` is the unique owner of the leaked `Box<ModuleInfo>`.
+            drop(unsafe { bun_core::heap::take(mi) });
         }
     }
 }
@@ -187,10 +184,8 @@ impl ModuleInfoDeserialized {
     // `&self`, and no `&mut` alias to that storage is ever handed out — so
     // materialising `&[T]` for `'_ self` (via `RawSlice::slice`) is sound.
     //
-    // Alignment: every constructor guarantees each view is aligned for its
-    // element type — `create` allocates a `MODULE_INFO_ALIGN`-aligned buffer
-    // and `bytes_as_slice` rejects misaligned sub-slices; `into_deserialized`
-    // borrows from typed `Vec<T>` storage which is naturally aligned.
+    // Both constructors borrow from typed `Vec<T>` / `Box<[T]>` storage,
+    // which is naturally aligned.
 
     #[inline]
     pub fn strings_buf(&self) -> &[u8] {
@@ -231,94 +226,209 @@ impl ModuleInfoDeserialized {
         drop(unsafe { bun_core::heap::take(this) });
     }
 
-    #[inline]
-    fn eat<'a>(rem: &mut &'a [u8], len: usize) -> Result<&'a [u8], ModuleInfoError> {
-        if rem.len() < len {
-            return Err(ModuleInfoError::BadModuleInfo);
-        }
-        let res = &rem[..len];
-        *rem = &rem[len..];
-        Ok(res)
-    }
-
-    #[inline]
-    fn eat_c<'a, const N: usize>(rem: &mut &'a [u8]) -> Result<&'a [u8; N], ModuleInfoError> {
-        let (head, tail) = rem
-            .split_first_chunk::<N>()
-            .ok_or(ModuleInfoError::BadModuleInfo)?;
-        *rem = tail;
-        Ok(head)
-    }
-
+    /// Decodes the self-contained form (a module's own string table followed
+    /// by its body, as the runtime transpiler cache stores it).
     pub(crate) fn create(source: &[u8]) -> Result<Box<ModuleInfoDeserialized>, ModuleInfoError> {
-        // Copy into a `MODULE_INFO_ALIGN`-aligned buffer so the typed
-        // sub-slices below (whose offsets the format pads to 4 bytes) are
-        // properly aligned for `&[T]` materialisation.
-        let duped_raw: *mut [u8] = dupe_aligned(source);
-        // On error, reclaim the allocation.
-        let guard = scopeguard::guard(duped_raw, |p| {
-            // SAFETY: `p` is the `dupe_aligned` result captured above and has
-            // not been freed — this guard only fires on the error path, before
-            // `ScopeGuard::into_inner` transfers ownership into `owner`.
-            unsafe { free_aligned_dup(p) }
+        let table = ModuleInfoStringTable::parse(source)?;
+        let body = &source[table.byte_len..];
+        Self::decode(&table, body, false)
+    }
+
+    /// Decodes a body whose ids index `table`, a string table shared by many
+    /// modules (`StandaloneModuleGraph`); only the strings this body uses are
+    /// copied out.
+    pub fn create_with_table(
+        table: &ModuleInfoStringTable<'_>,
+        body: &[u8],
+    ) -> Option<Box<ModuleInfoDeserialized>> {
+        Self::decode(table, body, true).ok()
+    }
+
+    /// Widens the body wire format written by
+    /// `bun_js_printer::analyze_transpiled_module::ModuleInfoDeserialized::serialize_body`
+    /// (layout documented there) into the fixed `u32` layout
+    /// `to_js_module_record` reads: one `u32` arena
+    /// `[strings_lens | requested keys | requested values | buffer]` and one
+    /// byte arena `[record_kinds | requested phases | strings_buf]`. With
+    /// `remap`, table ids are renumbered densely in first-use order so the
+    /// module's identifier array holds only its own strings.
+    fn decode(
+        table: &ModuleInfoStringTable<'_>,
+        body: &[u8],
+        remap: bool,
+    ) -> Result<Box<ModuleInfoDeserialized>, ModuleInfoError> {
+        use ModuleInfoError::BadModuleInfo;
+        let mut r = Reader { rem: body };
+        let &[flags, id_width, 0, 0] = r.bytes(4)? else {
+            return Err(BadModuleInfo);
+        };
+        let flags = Flags::from_bits_retain(flags);
+        let id_width = width(id_width)?;
+        let requested_count = r.u32()? as usize;
+        let record_count = r.u32()? as usize;
+        // Every counted item takes at least one byte below; reject headers
+        // that would over-allocate before reading anything.
+        if requested_count + record_count > r.rem.len() {
+            return Err(BadModuleInfo);
+        }
+        let record_tags = r.bytes(record_count)?;
+        let requested_tags = r.bytes(requested_count)?;
+        let mut buffer_len = 0usize;
+        for &tag in record_tags {
+            buffer_len += RecordKind(tag & 0b111).len().map_err(|_| BadModuleInfo)?;
+        }
+
+        // Table id -> local id. Without `remap` the table is this module's own
+        // and ids pass through.
+        struct Ids {
+            table_count: u32,
+            id_width: usize,
+            remap: bool,
+            local_of: bun_collections::HashMap<u32, u32>,
+            used: Vec<u32>,
+        }
+        impl Ids {
+            fn id(&mut self, r: &mut Reader<'_>) -> Result<u32, ModuleInfoError> {
+                let v = r.uint(self.id_width)?;
+                Ok(match v.checked_sub(self.table_count) {
+                    Some(0) => StringID::STAR_NAMESPACE.0,
+                    Some(1) => StringID::STAR_DEFAULT.0,
+                    Some(_) => return Err(ModuleInfoError::BadModuleInfo),
+                    None if !self.remap => v,
+                    None => {
+                        let used = &mut self.used;
+                        *self.local_of.entry(v).or_insert_with(|| {
+                            used.push(v);
+                            (used.len() - 1) as u32
+                        })
+                    }
+                })
+            }
+            fn fetch(&mut self, r: &mut Reader<'_>, kind: u8) -> Result<u32, ModuleInfoError> {
+                Ok(match kind {
+                    0 => FetchParameters::None.0,
+                    1 => FetchParameters::Javascript.0,
+                    2 => FetchParameters::Webassembly.0,
+                    3 => FetchParameters::Json.0,
+                    4 => self.id(r)?,
+                    _ => return Err(ModuleInfoError::BadModuleInfo),
+                })
+            }
+        }
+        let table_count = table.count;
+        let mut ids = Ids {
+            table_count,
+            id_width,
+            remap,
+            local_of: Default::default(),
+            used: Vec::new(),
+        };
+        let mut words: Vec<u32> = Vec::with_capacity(2 * requested_count + buffer_len);
+        // requested keys, then values
+        words.resize(2 * requested_count, 0);
+        for (n, &tag) in requested_tags.iter().enumerate() {
+            if tag >> 1 > 4 {
+                return Err(BadModuleInfo);
+            }
+            words[n] = ids.id(&mut r)?;
+            words[requested_count + n] = ids.fetch(&mut r, tag >> 1)?;
+        }
+        for &tag in record_tags {
+            let kind = RecordKind(tag & 0b111);
+            let same_name = tag & (1 << 6) != 0;
+            match kind {
+                RecordKind::IMPORT_INFO_SINGLE | RecordKind::IMPORT_INFO_SINGLE_TYPE_SCRIPT => {
+                    let module_name = ids.id(&mut r)?;
+                    let import_name = ids.id(&mut r)?;
+                    let local_name = if same_name {
+                        import_name
+                    } else {
+                        ids.id(&mut r)?
+                    };
+                    words.extend([module_name, import_name, local_name]);
+                }
+                RecordKind::IMPORT_INFO_NAMESPACE | RecordKind::IMPORT_INFO_NAMESPACE_DEFER => {
+                    let module_name = ids.id(&mut r)?;
+                    words.extend([module_name, StringID::STAR_NAMESPACE.0, ids.id(&mut r)?]);
+                }
+                RecordKind::EXPORT_INFO_INDIRECT => {
+                    let export_name = ids.id(&mut r)?;
+                    let import_name = ids.id(&mut r)?;
+                    words.extend([export_name, import_name, ids.id(&mut r)?]);
+                }
+                RecordKind::EXPORT_INFO_LOCAL => {
+                    let export_name = ids.id(&mut r)?;
+                    words.extend([export_name, ids.id(&mut r)?, u32::MAX]);
+                }
+                RecordKind::EXPORT_INFO_NAMESPACE => {
+                    let export_name = ids.id(&mut r)?;
+                    words.extend([export_name, ids.id(&mut r)?]);
+                }
+                RecordKind::EXPORT_INFO_STAR => words.push(ids.id(&mut r)?),
+                _ => return Err(BadModuleInfo),
+            }
+            words.push(ids.fetch(&mut r, (tag >> 3) & 0b111)?);
+        }
+        let used = ids.used;
+        if !r.rem.is_empty() {
+            return Err(BadModuleInfo);
+        }
+        debug_assert_eq!(words.len(), 2 * requested_count + buffer_len);
+
+        // Local string table: lengths up front in `words`, bytes at the end of `bytes`.
+        let strings_count = if remap {
+            used.len()
+        } else {
+            table_count as usize
+        };
+        let string = |local: usize| {
+            if remap {
+                table.get(used[local])
+            } else {
+                table.get(local as u32)
+            }
+        };
+        let mut strings_total = 0usize;
+        let mut all_words: Vec<u32> = Vec::with_capacity(strings_count + words.len());
+        for local in 0..strings_count {
+            let s = string(local).ok_or(BadModuleInfo)?;
+            strings_total += s.len();
+            all_words.push(s.len() as u32);
+        }
+        all_words.extend_from_slice(&words);
+        drop(words);
+        let mut bytes: Vec<u8> = Vec::with_capacity(record_count + requested_count + strings_total);
+        bytes.extend(record_tags.iter().map(|&tag| tag & 0b111));
+        bytes.extend(requested_tags.iter().map(|&tag| tag & 1));
+        for local in 0..strings_count {
+            bytes.extend_from_slice(string(local).ok_or(BadModuleInfo)?);
+        }
+
+        let decoded = Box::new(Decoded {
+            words: all_words.into(),
+            bytes: bytes.into(),
         });
-
-        // SAFETY: `duped_raw` is a valid, exclusively-owned allocation.
-        let mut rem: &[u8] = unsafe { &*duped_raw };
-
-        let record_kinds_len = u32::from_le_bytes(*Self::eat_c::<4>(&mut rem)?);
-        let record_kinds = bytes_as_slice::<RecordKind>(Self::eat(
-            &mut rem,
-            record_kinds_len as usize * size_of::<RecordKind>(),
-        )?)?;
-        let _ = Self::eat(&mut rem, ((4 - (record_kinds_len % 4)) % 4) as usize)?; // alignment padding
-
-        let buffer_len = u32::from_le_bytes(*Self::eat_c::<4>(&mut rem)?);
-        let buffer = bytes_as_slice::<StringID>(Self::eat(
-            &mut rem,
-            buffer_len as usize * size_of::<StringID>(),
-        )?)?;
-
-        let requested_modules_len = u32::from_le_bytes(*Self::eat_c::<4>(&mut rem)?);
-        let requested_modules_keys = bytes_as_slice::<StringID>(Self::eat(
-            &mut rem,
-            requested_modules_len as usize * size_of::<StringID>(),
-        )?)?;
-        let requested_modules_values = bytes_as_slice::<FetchParameters>(Self::eat(
-            &mut rem,
-            requested_modules_len as usize * size_of::<FetchParameters>(),
-        )?)?;
-        let requested_modules_phases = Self::eat(&mut rem, requested_modules_len as usize)?;
-        let _ = Self::eat(&mut rem, ((4 - (requested_modules_len % 4)) % 4) as usize)?; // alignment padding
-
-        let flags = Flags::from_bits_retain(Self::eat_c::<1>(&mut rem)?[0]);
-        let _ = Self::eat(&mut rem, 3)?; // alignment padding
-
-        let strings_len = u32::from_le_bytes(*Self::eat_c::<4>(&mut rem)?);
-        let strings_lens = bytes_as_slice::<u32>(Self::eat(
-            &mut rem,
-            strings_len as usize * size_of::<u32>(),
-        )?)?;
-        let strings_buf: &[u8] = rem;
-
-        // Disarm the errdefer: ownership moves into the result.
-        let duped_raw = scopeguard::ScopeGuard::into_inner(guard);
-
-        // All seven views borrow `duped_raw` (the boxed allocation moved into
-        // `owner` below); they stay valid and at a stable address for the
-        // lifetime of every `RawSlice` copied from this struct. `RawSlice::new`
-        // erases the borrow lifetime — the structural invariant is upheld by
-        // `owner` outliving the views.
+        let (strings_lens, rest) = decoded.words.split_at(strings_count);
+        let (requested_keys, rest) = rest.split_at(requested_count);
+        let (requested_values, buffer) = rest.split_at(requested_count);
+        let (record_kinds, rest) = decoded.bytes.split_at(record_count);
+        let (requested_phases, strings_buf) = rest.split_at(requested_count);
+        // All seven views borrow the boxed `Decoded` moved into `owner` below;
+        // its two heap slices stay at a stable address for the struct's lifetime.
+        // `StringID` / `FetchParameters` / `RecordKind` are `#[repr(transparent)]`
+        // over `u32` / `u32` / `u8` (Pod), so `cast_slice` is a safe reinterpret.
         Ok(Box::new(ModuleInfoDeserialized {
             strings_buf: bun_ptr::RawSlice::new(strings_buf),
             strings_lens: bun_ptr::RawSlice::new(strings_lens),
-            requested_modules_keys: bun_ptr::RawSlice::new(requested_modules_keys),
-            requested_modules_values: bun_ptr::RawSlice::new(requested_modules_values),
-            requested_modules_phases: bun_ptr::RawSlice::new(requested_modules_phases),
-            buffer: bun_ptr::RawSlice::new(buffer),
-            record_kinds: bun_ptr::RawSlice::new(record_kinds),
+            requested_modules_keys: bun_ptr::RawSlice::new(bytemuck::cast_slice(requested_keys)),
+            requested_modules_values: bun_ptr::RawSlice::new(bytemuck::cast_slice(
+                requested_values,
+            )),
+            requested_modules_phases: bun_ptr::RawSlice::new(requested_phases),
+            buffer: bun_ptr::RawSlice::new(bytemuck::cast_slice(buffer)),
+            record_kinds: bun_ptr::RawSlice::new(bytemuck::cast_slice(record_kinds)),
             flags,
-            owner: Owner::AllocatedSlice { slice: duped_raw },
+            owner: Owner::Decoded(decoded),
         }))
     }
 
@@ -332,67 +442,94 @@ impl ModuleInfoDeserialized {
     }
 }
 
-/// Maximum element alignment appearing in the serialized format
-/// (`u32` / `StringID` / `FetchParameters`). The writer pads every multi-byte
-/// field to this boundary, and [`dupe_aligned`] allocates the backing buffer
-/// at this alignment, so every typed sub-slice is properly aligned.
-const MODULE_INFO_ALIGN: usize = core::mem::align_of::<u32>();
-
-// Compile-time guard: if a wider element type is ever added to the format,
-// bump `MODULE_INFO_ALIGN` accordingly.
-const _: () = {
-    assert!(core::mem::align_of::<StringID>() <= MODULE_INFO_ALIGN);
-    assert!(core::mem::align_of::<FetchParameters>() <= MODULE_INFO_ALIGN);
-    assert!(core::mem::align_of::<RecordKind>() <= MODULE_INFO_ALIGN);
-};
-
-/// Allocate a [`MODULE_INFO_ALIGN`]-aligned copy of `source`.
-/// Paired with [`free_aligned_dup`].
-fn dupe_aligned(source: &[u8]) -> *mut [u8] {
-    if source.is_empty() {
-        // Non-null, well-aligned, len-0 — valid input for `&*` and for
-        // `free_aligned_dup` (which no-ops on len 0).
-        return core::ptr::slice_from_raw_parts_mut(MODULE_INFO_ALIGN as *mut u8, 0);
-    }
-    let layout = std::alloc::Layout::from_size_align(source.len(), MODULE_INFO_ALIGN)
-        .expect("module-info buffer too large");
-    // SAFETY: layout has non-zero size (checked above).
-    let ptr = unsafe { std::alloc::alloc(layout) };
-    if ptr.is_null() {
-        std::alloc::handle_alloc_error(layout);
-    }
-    // SAFETY: `ptr` is a fresh `source.len()`-byte allocation; `source` is a
-    // valid readable slice; the regions cannot overlap.
-    unsafe { core::ptr::copy_nonoverlapping(source.as_ptr(), ptr, source.len()) };
-    core::ptr::slice_from_raw_parts_mut(ptr, source.len())
+struct Reader<'a> {
+    rem: &'a [u8],
 }
-
-/// # Safety
-/// `slice` must have been returned by [`dupe_aligned`] and not yet freed.
-unsafe fn free_aligned_dup(slice: *mut [u8]) {
-    let len = slice.len();
-    if len == 0 {
-        return;
+impl<'a> Reader<'a> {
+    fn bytes(&mut self, len: usize) -> Result<&'a [u8], ModuleInfoError> {
+        if self.rem.len() < len {
+            return Err(ModuleInfoError::BadModuleInfo);
+        }
+        let (head, rest) = self.rem.split_at(len);
+        self.rem = rest;
+        Ok(head)
     }
-    // SAFETY: caller contract — `slice` came from `dupe_aligned`, which
-    // allocated with this exact layout.
-    unsafe {
-        std::alloc::dealloc(
-            slice.cast::<u8>(),
-            std::alloc::Layout::from_size_align_unchecked(len, MODULE_INFO_ALIGN),
-        );
+    fn u32(&mut self) -> Result<u32, ModuleInfoError> {
+        Ok(u32::from_le_bytes(self.bytes(4)?.try_into().unwrap()))
+    }
+    fn uint(&mut self, width: usize) -> Result<u32, ModuleInfoError> {
+        Ok(read_uint(self.bytes(width)?, width))
     }
 }
-
-/// Reinterpret a byte sub-slice of the [`MODULE_INFO_ALIGN`]-aligned backing
-/// buffer as `&[T]`. Returns `BadModuleInfo` if `bytes` is not aligned for `T`
-/// or its length is not a multiple of `size_of::<T>()` (i.e. the format's
-/// internal padding was violated).
-///
-/// (`bytemuck::try_cast_slice` checks both alignment and size.)
 #[inline]
-fn bytes_as_slice<T: bytemuck::AnyBitPattern>(bytes: &[u8]) -> Result<&[T], ModuleInfoError> {
-    bytemuck::try_cast_slice(bytes).map_err(|_| ModuleInfoError::BadModuleInfo)
+fn read_uint(b: &[u8], width: usize) -> u32 {
+    match width {
+        1 => b[0] as u32,
+        2 => u16::from_le_bytes([b[0], b[1]]) as u32,
+        _ => u32::from_le_bytes([b[0], b[1], b[2], b[3]]),
+    }
+}
+fn width(b: u8) -> Result<usize, ModuleInfoError> {
+    match b {
+        1 | 2 | 4 => Ok(b as usize),
+        _ => Err(ModuleInfoError::BadModuleInfo),
+    }
+}
+
+/// Borrowed view over a serialized
+/// `bun_js_printer::analyze_transpiled_module::ModuleInfoStringTable`
+/// (layout documented there).
+pub struct ModuleInfoStringTable<'a> {
+    count: u32,
+    offset_width: usize,
+    /// `count + 1` offsets at `offset_width` bytes each.
+    offsets: &'a [u8],
+    buf: &'a [u8],
+    /// Bytes the table occupies at the front of the slice it was parsed from.
+    byte_len: usize,
+}
+impl<'a> ModuleInfoStringTable<'a> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, ModuleInfoError> {
+        if bytes.is_empty() {
+            return Ok(Self {
+                count: 0,
+                offset_width: 1,
+                offsets: &[0],
+                buf: &[],
+                byte_len: 0,
+            });
+        }
+        let mut r = Reader { rem: bytes };
+        let &[offset_width, 0, 0, 0] = r.bytes(4)? else {
+            return Err(ModuleInfoError::BadModuleInfo);
+        };
+        let offset_width = width(offset_width)?;
+        let count = r.u32()?;
+        let offsets_len = (count as usize)
+            .checked_add(1)
+            .and_then(|n| n.checked_mul(offset_width))
+            .ok_or(ModuleInfoError::BadModuleInfo)?;
+        let offsets = r.bytes(offsets_len)?;
+        let total = read_uint(&offsets[offsets_len - offset_width..], offset_width) as usize;
+        let buf = r.bytes(total)?;
+        Ok(Self {
+            count,
+            offset_width,
+            offsets,
+            buf,
+            byte_len: bytes.len() - r.rem.len(),
+        })
+    }
+    #[inline]
+    fn get(&self, id: u32) -> Option<&'a [u8]> {
+        if id >= self.count {
+            return None;
+        }
+        let at = id as usize * self.offset_width;
+        let start = read_uint(&self.offsets[at..], self.offset_width) as usize;
+        let end = read_uint(&self.offsets[at + self.offset_width..], self.offset_width) as usize;
+        self.buf.get(start..end)
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -141,8 +141,16 @@ pub enum ModuleInfoError {
 /// pointers) because Rust references cannot express the self-borrow.
 ///
 pub struct ModuleInfoDeserialized {
+    /// When the ids index the executable's shared module-info string table:
+    /// that table. Identifiers then come from the VM-wide slots
+    /// (`Bun__VM__moduleInfoIdentifiers`), filled on first use, and
+    /// `strings_buf` / `string_ranges` are empty.
+    pub(crate) shared_table: Option<ModuleInfoStringTable<'static>>,
+    /// Base the `string_ranges` offsets index: the decoded copy of a module's
+    /// own table, or the live `ModuleInfo`'s string buffer.
     pub(crate) strings_buf: bun_ptr::RawSlice<u8>,
-    pub(crate) strings_lens: bun_ptr::RawSlice<u32>,
+    /// `(offset, len)` into `strings_buf` per local string id.
+    pub(crate) string_ranges: bun_ptr::RawSlice<[u32; 2]>,
     pub(crate) requested_modules_keys: bun_ptr::RawSlice<StringID>,
     pub(crate) requested_modules_values: bun_ptr::RawSlice<FetchParameters>,
     pub(crate) requested_modules_phases: bun_ptr::RawSlice<u8>,
@@ -153,15 +161,17 @@ pub struct ModuleInfoDeserialized {
 }
 
 pub enum Owner {
-    /// `Box<ModuleInfo>` whose internal vectors back the raw slice fields.
-    ModuleInfo(*mut ModuleInfo),
+    /// `Box<ModuleInfo>` whose internal vectors back the raw slice fields,
+    /// plus the `string_ranges` derived from its length list.
+    ModuleInfo(*mut ModuleInfo, Box<[[u32; 2]]>),
     /// Decoded from the wire format by [`ModuleInfoDeserialized::create`].
     Decoded(Box<Decoded>),
 }
 
 /// The fixed-width in-memory layout the wire format decodes into: one `u32`
-/// arena (`[strings_lens | requested keys | requested values | buffer]`) and
-/// one byte arena (`[record_kinds | requested phases | strings_buf]`).
+/// arena (`[string ranges | requested keys | requested values | buffer]`) and
+/// one byte arena (`[record_kinds | requested phases | strings?]` — the string
+/// bytes only when the table they came from does not outlive the record).
 pub struct Decoded {
     words: Box<[u32]>,
     bytes: Box<[u8]>,
@@ -169,7 +179,7 @@ pub struct Decoded {
 
 impl Drop for ModuleInfoDeserialized {
     fn drop(&mut self) {
-        if let Owner::ModuleInfo(mi) = self.owner {
+        if let Owner::ModuleInfo(mi, _) = self.owner {
             // SAFETY: `owner` is the unique owner of the leaked `Box<ModuleInfo>`.
             drop(unsafe { bun_core::heap::take(mi) });
         }
@@ -187,13 +197,28 @@ impl ModuleInfoDeserialized {
     // Both constructors borrow from typed `Vec<T>` / `Box<[T]>` storage,
     // which is naturally aligned.
 
+    /// Ids below this are strings; the rest are sentinels.
     #[inline]
-    pub fn strings_buf(&self) -> &[u8] {
-        self.strings_buf.slice()
+    pub fn strings_count(&self) -> usize {
+        match &self.shared_table {
+            Some(table) => table.count as usize,
+            None => self.string_ranges.len(),
+        }
     }
     #[inline]
-    pub fn strings_lens(&self) -> &[u32] {
-        self.strings_lens.slice()
+    pub fn shared_table(&self) -> Option<&ModuleInfoStringTable<'static>> {
+        self.shared_table.as_ref()
+    }
+    /// The WTF-8 bytes of string `id`, or `None` if out of bounds (corrupt input).
+    #[inline]
+    pub fn string(&self, id: usize) -> Option<&[u8]> {
+        if let Some(table) = &self.shared_table {
+            return table.get(u32::try_from(id).ok()?);
+        }
+        let [offset, len] = *self.string_ranges.slice().get(id)?;
+        self.strings_buf
+            .slice()
+            .get(offset as usize..offset as usize + len as usize)
     }
     #[inline]
     pub fn requested_modules_keys(&self) -> &[StringID] {
@@ -231,31 +256,31 @@ impl ModuleInfoDeserialized {
     pub(crate) fn create(source: &[u8]) -> Result<Box<ModuleInfoDeserialized>, ModuleInfoError> {
         let table = ModuleInfoStringTable::parse(source)?;
         let body = &source[table.byte_len..];
-        Self::decode(&table, body, false)
+        Self::decode(&table, None, body)
     }
 
-    /// Decodes a body whose ids index `table`, a string table shared by many
-    /// modules (`StandaloneModuleGraph`); only the strings this body uses are
-    /// copied out.
+    /// Decodes a body whose ids index `table`, the string table an executable
+    /// shares between all its modules (`StandaloneModuleGraph`). The record
+    /// keeps the table's ids and references its bytes in place.
     pub fn create_with_table(
-        table: &ModuleInfoStringTable<'_>,
+        table: &ModuleInfoStringTable<'static>,
         body: &[u8],
     ) -> Option<Box<ModuleInfoDeserialized>> {
-        Self::decode(table, body, true).ok()
+        Self::decode(table, Some(*table), body).ok()
     }
 
     /// Widens the body wire format written by
     /// `bun_js_printer::analyze_transpiled_module::ModuleInfoDeserialized::serialize_body`
     /// (layout documented there) into the fixed `u32` layout
     /// `to_js_module_record` reads: one `u32` arena
-    /// `[strings_lens | requested keys | requested values | buffer]` and one
-    /// byte arena `[record_kinds | requested phases | strings_buf]`. With
-    /// `remap`, table ids are renumbered densely in first-use order so the
-    /// module's identifier array holds only its own strings.
+    /// `[string ranges? | requested keys | requested values | buffer]` and one
+    /// byte arena `[record_kinds | requested phases | strings?]` — the string
+    /// ranges and bytes only when the table is the module's own (it does not
+    /// outlive `body`); with a `shared_table` the ids are left as they are.
     fn decode(
         table: &ModuleInfoStringTable<'_>,
+        shared_table: Option<ModuleInfoStringTable<'static>>,
         body: &[u8],
-        remap: bool,
     ) -> Result<Box<ModuleInfoDeserialized>, ModuleInfoError> {
         use ModuleInfoError::BadModuleInfo;
         let mut r = Reader { rem: body };
@@ -278,30 +303,18 @@ impl ModuleInfoDeserialized {
             buffer_len += RecordKind(tag & 0b111).len().map_err(|_| BadModuleInfo)?;
         }
 
-        // Table id -> local id. Without `remap` the table is this module's own
-        // and ids pass through.
         struct Ids {
             table_count: u32,
             id_width: usize,
-            remap: bool,
-            local_of: bun_collections::HashMap<u32, u32>,
-            used: Vec<u32>,
         }
         impl Ids {
             fn id(&mut self, r: &mut Reader<'_>) -> Result<u32, ModuleInfoError> {
                 let v = r.uint(self.id_width)?;
                 Ok(match v.checked_sub(self.table_count) {
+                    None => v,
                     Some(0) => StringID::STAR_NAMESPACE.0,
                     Some(1) => StringID::STAR_DEFAULT.0,
                     Some(_) => return Err(ModuleInfoError::BadModuleInfo),
-                    None if !self.remap => v,
-                    None => {
-                        let used = &mut self.used;
-                        *self.local_of.entry(v).or_insert_with(|| {
-                            used.push(v);
-                            (used.len() - 1) as u32
-                        })
-                    }
                 })
             }
             fn fetch(&mut self, r: &mut Reader<'_>, kind: u8) -> Result<u32, ModuleInfoError> {
@@ -319,9 +332,6 @@ impl ModuleInfoDeserialized {
         let mut ids = Ids {
             table_count,
             id_width,
-            remap,
-            local_of: Default::default(),
-            used: Vec::new(),
         };
         let mut words: Vec<u32> = Vec::with_capacity(2 * requested_count + buffer_len);
         // requested keys, then values
@@ -369,57 +379,53 @@ impl ModuleInfoDeserialized {
             }
             words.push(ids.fetch(&mut r, (tag >> 3) & 0b111)?);
         }
-        let used = ids.used;
         if !r.rem.is_empty() {
             return Err(BadModuleInfo);
         }
         debug_assert_eq!(words.len(), 2 * requested_count + buffer_len);
 
-        // Local string table: lengths up front in `words`, bytes at the end of `bytes`.
-        let strings_count = if remap {
-            used.len()
+        // A module's own table does not outlive `body`: copy its bytes and
+        // build `(offset, len)` ranges. A shared table is referenced as is.
+        let strings_count = if shared_table.is_some() {
+            0
         } else {
             table_count as usize
         };
-        let string = |local: usize| {
-            if remap {
-                table.get(used[local])
-            } else {
-                table.get(local as u32)
-            }
-        };
-        let mut strings_total = 0usize;
-        let mut all_words: Vec<u32> = Vec::with_capacity(strings_count + words.len());
-        for local in 0..strings_count {
-            let s = string(local).ok_or(BadModuleInfo)?;
-            strings_total += s.len();
-            all_words.push(s.len() as u32);
+        let mut all_words: Vec<u32> = Vec::with_capacity(2 * strings_count + words.len());
+        for id in 0..strings_count as u32 {
+            let [offset, len] = table.range(id).ok_or(BadModuleInfo)?;
+            all_words.extend([offset, len]);
         }
         all_words.extend_from_slice(&words);
         drop(words);
-        let mut bytes: Vec<u8> = Vec::with_capacity(record_count + requested_count + strings_total);
+        let strings_bytes: &[u8] = if shared_table.is_some() {
+            &[]
+        } else {
+            table.buf
+        };
+        let mut bytes: Vec<u8> =
+            Vec::with_capacity(record_count + requested_count + strings_bytes.len());
         bytes.extend(record_tags.iter().map(|&tag| tag & 0b111));
         bytes.extend(requested_tags.iter().map(|&tag| tag & 1));
-        for local in 0..strings_count {
-            bytes.extend_from_slice(string(local).ok_or(BadModuleInfo)?);
-        }
+        bytes.extend_from_slice(strings_bytes);
 
         let decoded = Box::new(Decoded {
             words: all_words.into(),
             bytes: bytes.into(),
         });
-        let (strings_lens, rest) = decoded.words.split_at(strings_count);
+        let (string_ranges, rest) = decoded.words.split_at(2 * strings_count);
         let (requested_keys, rest) = rest.split_at(requested_count);
         let (requested_values, buffer) = rest.split_at(requested_count);
         let (record_kinds, rest) = decoded.bytes.split_at(record_count);
         let (requested_phases, strings_buf) = rest.split_at(requested_count);
-        // All seven views borrow the boxed `Decoded` moved into `owner` below;
-        // its two heap slices stay at a stable address for the struct's lifetime.
-        // `StringID` / `FetchParameters` / `RecordKind` are `#[repr(transparent)]`
-        // over `u32` / `u32` / `u8` (Pod), so `cast_slice` is a safe reinterpret.
+        // All views borrow the boxed `Decoded` moved into `owner` below; its two
+        // heap slices stay at a stable address for the struct's lifetime.
+        // `StringID` / `FetchParameters` / `RecordKind` / `[u32; 2]` are
+        // plain-old-data over `u32` / `u8`, so `cast_slice` is a safe reinterpret.
         Ok(Box::new(ModuleInfoDeserialized {
+            shared_table,
             strings_buf: bun_ptr::RawSlice::new(strings_buf),
-            strings_lens: bun_ptr::RawSlice::new(strings_lens),
+            string_ranges: bun_ptr::RawSlice::new(bytemuck::cast_slice(string_ranges)),
             requested_modules_keys: bun_ptr::RawSlice::new(bytemuck::cast_slice(requested_keys)),
             requested_modules_values: bun_ptr::RawSlice::new(bytemuck::cast_slice(
                 requested_values,
@@ -479,6 +485,7 @@ fn width(b: u8) -> Result<usize, ModuleInfoError> {
 /// Borrowed view over a serialized
 /// `bun_js_printer::analyze_transpiled_module::ModuleInfoStringTable`
 /// (layout documented there).
+#[derive(Clone, Copy)]
 pub struct ModuleInfoStringTable<'a> {
     count: u32,
     offset_width: usize,
@@ -520,15 +527,24 @@ impl<'a> ModuleInfoStringTable<'a> {
             byte_len: bytes.len() - r.rem.len(),
         })
     }
+    /// `[offset, len]` of string `id` within `buf`, bounds-checked.
     #[inline]
-    fn get(&self, id: u32) -> Option<&'a [u8]> {
+    fn range(&self, id: u32) -> Option<[u32; 2]> {
         if id >= self.count {
             return None;
         }
         let at = id as usize * self.offset_width;
-        let start = read_uint(&self.offsets[at..], self.offset_width) as usize;
-        let end = read_uint(&self.offsets[at + self.offset_width..], self.offset_width) as usize;
-        self.buf.get(start..end)
+        let start = read_uint(&self.offsets[at..], self.offset_width);
+        let end = read_uint(&self.offsets[at + self.offset_width..], self.offset_width);
+        if start > end || end as usize > self.buf.len() {
+            return None;
+        }
+        Some([start, end - start])
+    }
+    #[inline]
+    pub fn get(&self, id: u32) -> Option<&'a [u8]> {
+        let [offset, len] = self.range(id)?;
+        Some(&self.buf[offset as usize..(offset + len) as usize])
     }
 }
 
@@ -567,11 +583,20 @@ impl ModuleInfoExt for ModuleInfo {
         }
         // Reshaped for borrowck — capture lifetime-erased `RawSlice`
         // views before `heap::into_raw(self)` consumes the box.
-        let (strings_buf, strings_lens, rm_keys, rm_values, rm_phases, buffer, record_kinds, flags);
+        let (strings_buf, ranges, rm_keys, rm_values, rm_phases, buffer, record_kinds, flags);
         {
             let view = self.as_deserialized();
             strings_buf = bun_ptr::RawSlice::new(view.strings_buf);
-            strings_lens = bun_ptr::RawSlice::new(view.strings_lens);
+            let mut offset = 0u32;
+            ranges = view
+                .strings_lens
+                .iter()
+                .map(|&len| {
+                    let range = [offset, len];
+                    offset += len;
+                    range
+                })
+                .collect::<Box<[[u32; 2]]>>();
             rm_keys = bun_ptr::RawSlice::new(view.requested_modules_keys);
             rm_values = bun_ptr::RawSlice::new(view.requested_modules_values);
             // Printer's `ModulePhase` is `#[repr(u8)] NoUninit` — safe to view as `&[u8]`.
@@ -590,19 +615,21 @@ impl ModuleInfoExt for ModuleInfo {
             f.set(Flags::HAS_TLA, view.flags.has_tla);
             flags = f;
         }
-        // All seven views point into the `Box<ModuleInfo>`'s vectors, moved into
+        // The views point into the `Box<ModuleInfo>`'s vectors (and `ranges`), moved into
         // `owner` below; they stay valid and stable for the lifetime of every
         // `RawSlice` copied from this struct.
         Box::new(ModuleInfoDeserialized {
+            shared_table: None,
             strings_buf,
-            strings_lens,
+            // Boxed slice: its heap address is stable across the move into `owner`.
+            string_ranges: bun_ptr::RawSlice::new(&ranges),
             requested_modules_keys: rm_keys,
             requested_modules_values: rm_values,
             requested_modules_phases: rm_phases,
             buffer,
             record_kinds,
             flags,
-            owner: Owner::ModuleInfo(bun_core::heap::into_raw(self)),
+            owner: Owner::ModuleInfo(bun_core::heap::into_raw(self), ranges),
         })
     }
 }

--- a/src/bundler/error.rs
+++ b/src/bundler/error.rs
@@ -1,7 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("InvalidRecordKind")]
-    InvalidRecordKind,
     #[error("ModuleNotFound")]
     ModuleNotFound,
     #[error("BuildFailed")]
@@ -104,7 +102,6 @@ impl Error {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {
-            Self::InvalidRecordKind => "InvalidRecordKind",
             Self::ModuleNotFound => "ModuleNotFound",
             Self::BuildFailed => "BuildFailed",
             Self::CompilationFailed => "CompilationFailed",

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -277,6 +277,9 @@ pub mod options {
         /// The one shared string table every chunk's bytecode references by ordinal (`EncoderStringTable::serialize`).
         #[strum(serialize = "bytecode-string-table")]
         BytecodeStringTable,
+        /// The string table every chunk's `ModuleInfo` body indexes (`ModuleInfoStringTable::serialize`).
+        #[strum(serialize = "module-info-string-table")]
+        ModuleInfoStringTable,
         #[strum(serialize = "metafile-json")]
         MetafileJson,
         #[strum(serialize = "metafile-markdown")]
@@ -292,6 +295,7 @@ pub mod options {
                     | OutputKind::ModuleInfo
                     | OutputKind::BuiltinBytecode
                     | OutputKind::BytecodeStringTable
+                    | OutputKind::ModuleInfoStringTable
                     | OutputKind::MetafileJson
                     | OutputKind::MetafileMarkdown
             )

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -502,6 +502,8 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     // cross-chunk import specifiers. During printing, cross-chunk imports use
     // unique_key placeholders as paths. Now that final paths are known, replace
     // those placeholders with the resolved paths and serialize.
+    let mut module_info_strings =
+        bun_js_printer::analyze_transpiled_module::ModuleInfoStringTable::default();
     if c.options.generates_module_info() {
         // Build map from unique_key -> final resolved path
         // SAFETY: c points to LinkerContext which is the `linker` field of BundleV2.
@@ -531,7 +533,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             }
         }
 
-        // Fix up each chunk's module_info
+        // Fix up each chunk's module_info; every chunk's strings go into one
+        // table (`OutputKind::ModuleInfoStringTable`) their bodies index into.
+        let mut table_ids: Vec<Vec<u32>> = Vec::new();
         for chunk in chunks.iter_mut() {
             let crate::chunk::Content::Javascript(js) = &mut chunk.content else {
                 continue;
@@ -570,14 +574,25 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 mi.replace_string_id(rep.old_id, new_id);
             }
 
-            // Serialize the fixed-up module_info
-            js.module_info_bytes = bun_js_printer::serialize_module_info(Some(mi));
-
-            // Free the ModuleInfo now that it's been serialized to bytes.
-            // It was allocated with bun.default_allocator (not the arena),
-            // so it must be explicitly destroyed.
-            // In Rust, dropping the Option<Box<ModuleInfo>> frees it.
-            js.module_info = None;
+            if mi.finalize().is_err() {
+                js.module_info = None;
+                continue;
+            }
+            table_ids.push(module_info_strings.intern_all(mi));
+        }
+        let mut table_ids = table_ids.iter();
+        for chunk in chunks.iter_mut() {
+            let crate::chunk::Content::Javascript(js) = &mut chunk.content else {
+                continue;
+            };
+            let Some(mi) = js.module_info.take() else {
+                continue;
+            };
+            js.module_info_bytes = Some(bun_js_printer::serialize_module_info_body(
+                &mi,
+                module_info_strings.count(),
+                table_ids.next().expect("one per chunk with module_info"),
+            ));
         }
     }
 
@@ -1337,6 +1352,34 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             &mut result,
             external_string_table.as_ref().and_then(|t| t.get()),
         );
+    }
+    if c.options.generates_module_info() {
+        let mut bytes = Vec::new();
+        module_info_strings
+            .serialize(&mut bytes)
+            .expect("Vec<u8> write");
+        debug!(
+            "module_info string table: {} strings, {} bytes",
+            module_info_strings.count(),
+            bytes.len()
+        );
+        result.push(options::OutputFile::init(options::OutputFileInit {
+            output_path: b".module-info-strings".to_vec().into_boxed_slice(),
+            input_path: Box::default(),
+            input_loader: Loader::File,
+            hash: None,
+            output_kind: options::OutputKind::ModuleInfoStringTable,
+            loader: Loader::File,
+            size: Some(bytes.len()),
+            display_size: bytes.len() as u32,
+            data: options::OutputFileData::Buffer {
+                data: bytes.into_boxed_slice(),
+            },
+            side: None,
+            entry_point_index: None,
+            is_executable: false,
+            ..Default::default()
+        }));
     }
     if let Some(table) = external_string_table {
         let bytes = table.take();

--- a/src/bundler_jsc/Cargo.toml
+++ b/src/bundler_jsc/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 bun_opaque.workspace = true
 bstr.workspace = true
-scopeguard.workspace = true
 bun_core.workspace = true
 bun_bundler.workspace = true
 bun_ast.workspace = true

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -519,7 +519,7 @@ trait JSModuleRecordExt {
 }
 impl JSModuleRecordExt for *mut JSModuleRecord {
     // SAFETY (all below): `self` is the non-null pointer returned by JSC_JSModuleRecord__create;
-    // `ia` is one of the VM-owned identifier arrays, which outlive the caller.
+    // `ia` is either the VM's shared identifier slots or the caller's `OwnedIdentifierArray`; both outlive every call below.
     #[inline]
     fn add_indirect_export(
         self,
@@ -529,7 +529,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addIndirectExport(
                 self,
@@ -548,7 +548,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         export_name: StringID,
         local_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe { JSC_JSModuleRecord__addLocalExport(self, ia, export_name, local_name) }
     }
     #[inline]
@@ -559,7 +559,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addNamespaceExport(
                 self,
@@ -577,7 +577,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe { JSC_JSModuleRecord__addStarExport(self, ia, module_name, module_request_type) }
     }
     #[inline]
@@ -587,7 +587,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleNullAttributesPtr(
                 self,
@@ -604,7 +604,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleJavaScript(self, ia, module_name, phase_defer)
         }
@@ -616,7 +616,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleWebAssembly(self, ia, module_name, phase_defer)
         }
@@ -628,7 +628,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe { JSC_JSModuleRecord__addRequestedModuleJSON(self, ia, module_name, phase_defer) }
     }
     #[inline]
@@ -639,7 +639,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         host_defined_import_type: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleHostDefined(
                 self,
@@ -659,7 +659,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntrySingle(
                 self,
@@ -680,7 +680,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntrySingleTypeScript(
                 self,
@@ -701,7 +701,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntryNamespace(
                 self,
@@ -722,7 +722,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` (the VM's shared slots or the caller's `OwnedIdentifierArray`) outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntryNamespaceDefer(
                 self,

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -29,15 +29,13 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     // `ModuleInfoDeserialized` accessors. If a strict-alignment target is ever
     // added, switch element reads to `read_unaligned` per the upstream note in
     // `analyze_transpiled_module.rs`.
-    let strings_buf: &[u8] = res.strings_buf();
-    let strings_lens: &[u32] = res.strings_lens();
     let requested_modules_keys: &[StringID] = res.requested_modules_keys();
     let requested_modules_values: &[RequestedModuleValue] = res.requested_modules_values();
     let requested_modules_phases: &[u8] = res.requested_modules_phases();
     let buffer: &[StringID] = res.buffer();
     let record_kinds: &[RecordKind] = res.record_kinds();
 
-    let identifier_count = strings_lens.len();
+    let identifier_count = res.strings_count();
     let is_valid_string_id =
         |id: StringID| (id.0 as usize) < identifier_count || id.0 >= StringID::STAR_NAMESPACE.0;
     let is_valid_fetch_parameters =
@@ -53,25 +51,42 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
         return core::ptr::null_mut();
     }
 
-    let identifiers = IdentifierArray::create(strings_lens.len());
-    // SAFETY: `identifiers` is non-null (returned by `create`); the scopeguard destroys it
-    // exactly once at scope exit (on both success and early-return paths).
-    let _identifiers_guard = scopeguard::guard(identifiers, |p| unsafe {
-        IdentifierArray::destroy(p);
-    });
-    let identifiers: *mut IdentifierArray = *_identifiers_guard;
-
-    let mut offset: usize = 0;
-    for (index, &len) in strings_lens.iter().enumerate() {
-        let len = len as usize;
-        if strings_buf.len() < offset + len {
-            return core::ptr::null_mut(); // error!
+    // Both arrays live on the VM's client data and outlive this call.
+    let identifiers: *mut IdentifierArray = if res.shared_table().is_some() {
+        // Ids index the executable's shared table: fill only the slots this
+        // record touches that no earlier module filled.
+        let identifiers = IdentifierArray::shared(vm, identifier_count);
+        for id in requested_modules_keys
+            .iter()
+            .map(|k| k.0)
+            .chain(requested_modules_values.iter().map(|v| v.0))
+            .chain(buffer.iter().map(|s| s.0))
+        {
+            // Sentinels and non-host-defined fetch parameters sit above the count.
+            if (id as usize) >= identifier_count {
+                continue;
+            }
+            // SAFETY: `identifiers` has at least `identifier_count` slots.
+            if unsafe { IdentifierArray::is_null(identifiers, id as usize) } {
+                let Some(sub) = res.string(id as usize) else {
+                    return core::ptr::null_mut();
+                };
+                // SAFETY: as above.
+                unsafe { IdentifierArray::set_from_utf8(identifiers, id as usize, vm, sub) };
+            }
         }
-        let sub = &strings_buf[offset..offset + len];
-        // SAFETY: `identifiers` is live for the scope of this fn (guard above).
-        unsafe { IdentifierArray::set_from_utf8(identifiers, index, vm, sub) };
-        offset += len;
-    }
+        identifiers
+    } else {
+        let identifiers = IdentifierArray::scratch(vm, identifier_count);
+        for index in 0..identifier_count {
+            let Some(sub) = res.string(index) else {
+                return core::ptr::null_mut();
+            };
+            // SAFETY: `identifiers` has at least `identifier_count` slots.
+            unsafe { IdentifierArray::set_from_utf8(identifiers, index, vm, sub) };
+        }
+        identifiers
+    };
 
     {
         let mut i: usize = 0;
@@ -234,8 +249,9 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
 
 bun_opaque::opaque_ffi! { pub struct IdentifierArray; }
 unsafe extern "C" {
-    fn JSC__IdentifierArray__create(len: usize) -> *mut IdentifierArray;
-    fn JSC__IdentifierArray__destroy(identifier_array: *mut IdentifierArray);
+    fn Bun__VM__sharedModuleInfoIdentifiers(vm: *const VM, count: usize) -> *mut IdentifierArray;
+    fn Bun__VM__scratchModuleInfoIdentifiers(vm: *const VM, count: usize) -> *mut IdentifierArray;
+    fn JSC__IdentifierArray__isNull(identifier_array: *mut IdentifierArray, n: usize) -> bool;
     fn JSC__IdentifierArray__setFromUtf8(
         identifier_array: *mut IdentifierArray,
         n: usize,
@@ -245,17 +261,26 @@ unsafe extern "C" {
     );
 }
 impl IdentifierArray {
+    /// The VM's slots for the executable's shared module-info string table,
+    /// grown to at least `count`; null until filled.
     #[inline]
-    pub(crate) fn create(len: usize) -> *mut IdentifierArray {
-        // SAFETY: FFI call; C++ side allocates.
-        unsafe { JSC__IdentifierArray__create(len) }
+    pub(crate) fn shared(vm: &VM, count: usize) -> *mut IdentifierArray {
+        // SAFETY: FFI call; the vector lives on the VM's client data.
+        unsafe { Bun__VM__sharedModuleInfoIdentifiers(vm, count) }
+    }
+    /// The VM's reusable scratch slots, grown to at least `count`; every
+    /// slot must be written before it is read.
+    #[inline]
+    pub(crate) fn scratch(vm: &VM, count: usize) -> *mut IdentifierArray {
+        // SAFETY: FFI call; the vector lives on the VM's client data.
+        unsafe { Bun__VM__scratchModuleInfoIdentifiers(vm, count) }
     }
     /// # Safety
-    /// `identifier_array` must be a pointer previously returned by `create` and not yet destroyed.
+    /// `this` must be live; `n` must be in-bounds for the array's length.
     #[inline]
-    pub(crate) unsafe fn destroy(identifier_array: *mut IdentifierArray) {
-        // SAFETY: caller contract — `identifier_array` came from `create` and has not been destroyed.
-        unsafe { JSC__IdentifierArray__destroy(identifier_array) }
+    pub(crate) unsafe fn is_null(this: *mut IdentifierArray, n: usize) -> bool {
+        // SAFETY: caller contract.
+        unsafe { JSC__IdentifierArray__isNull(this, n) }
     }
     /// # Safety
     /// `this` must be live; `n` must be in-bounds for the array's length.
@@ -496,7 +521,7 @@ trait JSModuleRecordExt {
 }
 impl JSModuleRecordExt for *mut JSModuleRecord {
     // SAFETY (all below): `self` is the non-null pointer returned by JSC_JSModuleRecord__create;
-    // `ia` is the live IdentifierArray guarded by scopeguard for the duration of the caller.
+    // `ia` is one of the VM-owned identifier arrays, which outlive the caller.
     #[inline]
     fn add_indirect_export(
         self,
@@ -506,7 +531,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addIndirectExport(
                 self,
@@ -525,7 +550,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         export_name: StringID,
         local_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe { JSC_JSModuleRecord__addLocalExport(self, ia, export_name, local_name) }
     }
     #[inline]
@@ -536,7 +561,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addNamespaceExport(
                 self,
@@ -554,7 +579,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe { JSC_JSModuleRecord__addStarExport(self, ia, module_name, module_request_type) }
     }
     #[inline]
@@ -564,7 +589,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleNullAttributesPtr(
                 self,
@@ -581,7 +606,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleJavaScript(self, ia, module_name, phase_defer)
         }
@@ -593,7 +618,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleWebAssembly(self, ia, module_name, phase_defer)
         }
@@ -605,7 +630,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe { JSC_JSModuleRecord__addRequestedModuleJSON(self, ia, module_name, phase_defer) }
     }
     #[inline]
@@ -616,7 +641,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         host_defined_import_type: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleHostDefined(
                 self,
@@ -636,7 +661,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntrySingle(
                 self,
@@ -657,7 +682,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntrySingleTypeScript(
                 self,
@@ -678,7 +703,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntryNamespace(
                 self,
@@ -699,7 +724,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         module_name: StringID,
         module_request_type: u8,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is VM-owned and outlives the call.
         unsafe {
             JSC_JSModuleRecord__addImportEntryNamespaceDefer(
                 self,

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -51,7 +51,7 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
         return core::ptr::null_mut();
     }
 
-    // Both arrays live on the VM's client data and outlive this call.
+    let mut owned_identifiers: Option<OwnedIdentifierArray> = None;
     let identifiers: *mut IdentifierArray = if res.shared_table().is_some() {
         // Ids index the executable's shared table: fill only the slots this
         // record touches that no earlier module filled.
@@ -77,12 +77,16 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
         }
         identifiers
     } else {
-        let identifiers = IdentifierArray::scratch(vm, identifier_count);
+        // The record carries its own strings: a throwaway array, freed when
+        // `owned_identifiers` drops at the end of this function.
+        let identifiers = owned_identifiers
+            .insert(OwnedIdentifierArray::new(identifier_count))
+            .ptr;
         for index in 0..identifier_count {
             let Some(sub) = res.string(index) else {
                 return core::ptr::null_mut();
             };
-            // SAFETY: `identifiers` has at least `identifier_count` slots.
+            // SAFETY: `identifiers` has `identifier_count` slots.
             unsafe { IdentifierArray::set_from_utf8(identifiers, index, vm, sub) };
         }
         identifiers
@@ -250,7 +254,8 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
 bun_opaque::opaque_ffi! { pub struct IdentifierArray; }
 unsafe extern "C" {
     fn Bun__VM__sharedModuleInfoIdentifiers(vm: *const VM, count: usize) -> *mut IdentifierArray;
-    fn Bun__VM__scratchModuleInfoIdentifiers(vm: *const VM, count: usize) -> *mut IdentifierArray;
+    fn JSC__IdentifierArray__create(count: usize) -> *mut IdentifierArray;
+    fn JSC__IdentifierArray__destroy(identifiers: *mut IdentifierArray, count: usize);
     fn JSC__IdentifierArray__isNull(identifier_array: *mut IdentifierArray, n: usize) -> bool;
     fn JSC__IdentifierArray__setFromUtf8(
         identifier_array: *mut IdentifierArray,
@@ -268,13 +273,28 @@ impl IdentifierArray {
         // SAFETY: FFI call; the vector lives on the VM's client data.
         unsafe { Bun__VM__sharedModuleInfoIdentifiers(vm, count) }
     }
-    /// The VM's reusable scratch slots, grown to at least `count`; every
-    /// slot must be written before it is read.
-    #[inline]
-    pub(crate) fn scratch(vm: &VM, count: usize) -> *mut IdentifierArray {
-        // SAFETY: FFI call; the vector lives on the VM's client data.
-        unsafe { Bun__VM__scratchModuleInfoIdentifiers(vm, count) }
+}
+/// `count` identifier slots owned by this value (fastMalloc'd on the C++ side).
+struct OwnedIdentifierArray {
+    ptr: *mut IdentifierArray,
+    count: usize,
+}
+impl OwnedIdentifierArray {
+    fn new(count: usize) -> Self {
+        Self {
+            // SAFETY: FFI call; returns `count` null slots.
+            ptr: unsafe { JSC__IdentifierArray__create(count) },
+            count,
+        }
     }
+}
+impl Drop for OwnedIdentifierArray {
+    fn drop(&mut self) {
+        // SAFETY: `ptr`/`count` are exactly what `create` returned / was given.
+        unsafe { JSC__IdentifierArray__destroy(self.ptr, self.count) }
+    }
+}
+impl IdentifierArray {
     /// # Safety
     /// `this` must be live; `n` must be in-bounds for the array's length.
     #[inline]

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -24,97 +24,59 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     // The caller (BunAnalyzeTranspiledModule.cpp) decides whether to free
     // immediately or keep it alive on the SourceProvider for the isolation
     // SourceProvider cache.
+    to_js_module_record(global_object, vm, module_key, source_code, res)
+        .unwrap_or(core::ptr::null_mut())
+}
 
-    // Slice-field validity / alignment caveats are documented on the
-    // `ModuleInfoDeserialized` accessors. If a strict-alignment target is ever
-    // added, switch element reads to `read_unaligned` per the upstream note in
-    // `analyze_transpiled_module.rs`.
-    let requested_modules_keys: &[StringID] = res.requested_modules_keys();
-    let requested_modules_values: &[RequestedModuleValue] = res.requested_modules_values();
-    let requested_modules_phases: &[u8] = res.requested_modules_phases();
-    let buffer: &[StringID] = res.buffer();
-    let record_kinds: &[RecordKind] = res.record_kinds();
-
+/// Walks the serialized body in place (layout documented on the printer's
+/// `ModuleInfoDeserialized::serialize_body`) and feeds JSC's module record.
+/// Any out-of-range id or truncated region yields `Err` → null → a clean
+/// "parseFromSourceCode failed" rejection in the caller.
+fn to_js_module_record(
+    global_object: &JSGlobalObject,
+    vm: &VM,
+    module_key: &IdentifierArray,
+    source_code: &SourceCode,
+    res: &ModuleInfoDeserialized,
+) -> Result<*mut JSModuleRecord, analyze::ModuleInfoError> {
+    let body = *res.body();
     let identifier_count = res.strings_count();
-    let is_valid_string_id =
-        |id: StringID| (id.0 as usize) < identifier_count || id.0 >= StringID::STAR_NAMESPACE.0;
-    let is_valid_fetch_parameters =
-        |v: u32| (v as usize) < identifier_count || v >= RequestedModuleValue::Json.0;
-    if !requested_modules_keys
-        .iter()
-        .copied()
-        .all(is_valid_string_id)
-        || !requested_modules_values
-            .iter()
-            .all(|&v| is_valid_fetch_parameters(v.0))
-    {
-        return core::ptr::null_mut();
-    }
 
+    // Identifier slots the ids index. Shared: the VM-wide slots for the
+    // executable's string table, filled on first use below. Otherwise a
+    // throwaway array covering this record's own table, filled up front.
     let mut owned_identifiers: Option<OwnedIdentifierArray> = None;
-    let identifiers: *mut IdentifierArray = if res.shared_table().is_some() {
-        // Ids index the executable's shared table: fill only the slots this
-        // record touches that no earlier module filled.
-        let identifiers = IdentifierArray::shared(vm, identifier_count);
-        for id in requested_modules_keys
-            .iter()
-            .map(|k| k.0)
-            .chain(requested_modules_values.iter().map(|v| v.0))
-            .chain(buffer.iter().map(|s| s.0))
-        {
-            // Sentinels and non-host-defined fetch parameters sit above the count.
-            if (id as usize) >= identifier_count {
-                continue;
-            }
-            // SAFETY: `identifiers` has at least `identifier_count` slots.
-            if unsafe { IdentifierArray::is_null(identifiers, id as usize) } {
-                let Some(sub) = res.string(id as usize) else {
-                    return core::ptr::null_mut();
-                };
-                // SAFETY: as above.
-                unsafe { IdentifierArray::set_from_utf8(identifiers, id as usize, vm, sub) };
-            }
-        }
-        identifiers
+    let identifiers: *mut IdentifierArray = if res.shared() {
+        IdentifierArray::shared(vm, identifier_count)
     } else {
-        // The record carries its own strings: a throwaway array, freed when
-        // `owned_identifiers` drops at the end of this function.
         let identifiers = owned_identifiers
             .insert(OwnedIdentifierArray::new(identifier_count))
             .ptr;
         for index in 0..identifier_count {
-            let Some(sub) = res.string(index) else {
-                return core::ptr::null_mut();
-            };
+            let sub = res
+                .string(index as u32)
+                .ok_or(analyze::ModuleInfoError::BadModuleInfo)?;
             // SAFETY: `identifiers` has `identifier_count` slots.
             unsafe { IdentifierArray::set_from_utf8(identifiers, index, vm, sub) };
         }
         identifiers
     };
-
-    {
-        let mut i: usize = 0;
-        for &k in record_kinds.iter() {
-            let Ok(len) = k.len() else {
-                return core::ptr::null_mut();
-            };
-            if i + len > buffer.len() {
-                return core::ptr::null_mut();
+    // Every id handed to JSC goes through here: in range (or a sentinel, which
+    // `IdCursor` already vetted) and, for the shared slots, materialized.
+    let shared = res.shared();
+    let ready = |id: StringID| -> Result<StringID, analyze::ModuleInfoError> {
+        if shared && (id.0 as usize) < identifier_count {
+            // SAFETY: `identifiers` has at least `identifier_count` slots.
+            if unsafe { IdentifierArray::is_null(identifiers, id.0 as usize) } {
+                let sub = res
+                    .string(id.0)
+                    .ok_or(analyze::ModuleInfoError::BadModuleInfo)?;
+                // SAFETY: as above.
+                unsafe { IdentifierArray::set_from_utf8(identifiers, id.0 as usize, vm, sub) };
             }
-            let fp_slots = k.trailing_fetch_parameters_slots();
-            if !buffer[i..i + len - fp_slots]
-                .iter()
-                .copied()
-                .all(is_valid_string_id)
-                || !buffer[i + len - fp_slots..i + len]
-                    .iter()
-                    .all(|s| is_valid_fetch_parameters(s.0))
-            {
-                return core::ptr::null_mut();
-            }
-            i += len;
         }
-    }
+        Ok(id)
+    };
 
     let module_record = JSModuleRecord::create(
         global_object,
@@ -126,127 +88,143 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
         res.flags.has_tla(),
     );
 
-    if requested_modules_keys.len() != requested_modules_values.len()
-        || requested_modules_keys.len() != requested_modules_phases.len()
-    {
-        return core::ptr::null_mut();
-    }
-    for ((&reqk, &reqv), &reqp) in requested_modules_keys
-        .iter()
-        .zip(requested_modules_values.iter())
-        .zip(requested_modules_phases.iter())
-    {
-        // 0 = ModulePhase::Evaluation, 1 = ModulePhase::Defer. Reject anything
-        // else — the buffer may have come from an on-disk cache.
-        let phase_defer = match reqp {
-            0 => false,
-            1 => true,
-            _ => return core::ptr::null_mut(),
-        };
-        match reqv {
+    let mut ids = res.ids();
+    for &tag in body.requested_tags {
+        // bit 0: ModulePhase::Defer; bits 1..: fetch-parameter kind.
+        let phase_defer = tag & 1 != 0;
+        let key = ready(ids.next_id()?)?;
+        match ids.next_fetch(tag >> 1)? {
             RequestedModuleValue::None => module_record.add_requested_module_null_attributes_ptr(
                 identifiers,
-                reqk,
+                key,
                 phase_defer,
             ),
             RequestedModuleValue::Javascript => {
-                module_record.add_requested_module_java_script(identifiers, reqk, phase_defer)
+                module_record.add_requested_module_java_script(identifiers, key, phase_defer)
             }
             RequestedModuleValue::Webassembly => {
-                module_record.add_requested_module_web_assembly(identifiers, reqk, phase_defer)
+                module_record.add_requested_module_web_assembly(identifiers, key, phase_defer)
             }
             RequestedModuleValue::Json => {
-                module_record.add_requested_module_json(identifiers, reqk, phase_defer)
+                module_record.add_requested_module_json(identifiers, key, phase_defer)
             }
-            // FetchParameters and StringID are both `#[repr(transparent)] u32`, so this
-            // is a bitcast of the raw discriminant back into the interned-string index.
-            uv => module_record.add_requested_module_host_defined(
+            host => module_record.add_requested_module_host_defined(
                 identifiers,
-                reqk,
-                StringID(uv.0),
+                key,
+                ready(StringID(host.0))?,
                 phase_defer,
             ),
         }
     }
 
-    {
-        let mut i: usize = 0;
-        for &k in record_kinds.iter() {
-            if i + k.len().expect("unreachable") > buffer.len() {
-                unreachable!(); // handled above
-            }
-            match k {
-                RecordKind::ImportInfoSingle => module_record.add_import_entry_single(
-                    identifiers,
-                    buffer[i + 1],
-                    buffer[i + 2],
-                    buffer[i],
-                    analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
-                ),
-                RecordKind::ImportInfoSingleTypeScript => module_record
-                    .add_import_entry_single_type_script(
+    for &tag in body.record_tags {
+        let kind = RecordKind(tag & 0b111);
+        let fetch_kind = (tag >> 3) & 0b111;
+        let same_name = tag & (1 << 6) != 0;
+        // Slot order on the wire matches the printer's in-memory record; the
+        // fetch parameter (when present) comes last.
+        match kind {
+            RecordKind::ImportInfoSingle | RecordKind::ImportInfoSingleTypeScript => {
+                let module_name = ready(ids.next_id()?)?;
+                let import_name = ready(ids.next_id()?)?;
+                let local_name = if same_name {
+                    import_name
+                } else {
+                    ready(ids.next_id()?)?
+                };
+                let ty = ids
+                    .next_fetch(fetch_kind)?
+                    .to_script_fetch_parameters_type();
+                if kind == RecordKind::ImportInfoSingle {
+                    module_record.add_import_entry_single(
                         identifiers,
-                        buffer[i + 1],
-                        buffer[i + 2],
-                        buffer[i],
-                        analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
-                    ),
-                RecordKind::ImportInfoNamespace => module_record.add_import_entry_namespace(
-                    identifiers,
-                    buffer[i + 1],
-                    buffer[i + 2],
-                    buffer[i],
-                    analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
-                ),
-                RecordKind::ImportInfoNamespaceDefer => module_record
-                    .add_import_entry_namespace_defer(
+                        import_name,
+                        local_name,
+                        module_name,
+                        ty,
+                    )
+                } else {
+                    module_record.add_import_entry_single_type_script(
                         identifiers,
-                        buffer[i + 1],
-                        buffer[i + 2],
-                        buffer[i],
-                        analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
-                    ),
-                RecordKind::ExportInfoIndirect => {
-                    let ty =
-                        analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type();
-                    if buffer[i + 1] == StringID::STAR_NAMESPACE {
-                        module_record.add_namespace_export(
-                            identifiers,
-                            buffer[i],
-                            buffer[i + 2],
-                            ty,
-                        )
-                    } else {
-                        module_record.add_indirect_export(
-                            identifiers,
-                            buffer[i],
-                            buffer[i + 1],
-                            buffer[i + 2],
-                            ty,
-                        )
-                    }
+                        import_name,
+                        local_name,
+                        module_name,
+                        ty,
+                    )
                 }
-                RecordKind::ExportInfoLocal => {
-                    module_record.add_local_export(identifiers, buffer[i], buffer[i + 1])
-                }
-                RecordKind::ExportInfoNamespace => module_record.add_namespace_export(
-                    identifiers,
-                    buffer[i],
-                    buffer[i + 1],
-                    analyze::FetchParameters(buffer[i + 2].0).to_script_fetch_parameters_type(),
-                ),
-                RecordKind::ExportInfoStar => module_record.add_star_export(
-                    identifiers,
-                    buffer[i],
-                    analyze::FetchParameters(buffer[i + 1].0).to_script_fetch_parameters_type(),
-                ),
-                _ => unreachable!(), // handled above
             }
-            i += k.len().expect("unreachable"); // handled above
+            RecordKind::ImportInfoNamespace | RecordKind::ImportInfoNamespaceDefer => {
+                let module_name = ready(ids.next_id()?)?;
+                let local_name = ready(ids.next_id()?)?;
+                let ty = ids
+                    .next_fetch(fetch_kind)?
+                    .to_script_fetch_parameters_type();
+                if kind == RecordKind::ImportInfoNamespace {
+                    module_record.add_import_entry_namespace(
+                        identifiers,
+                        StringID::STAR_NAMESPACE,
+                        local_name,
+                        module_name,
+                        ty,
+                    )
+                } else {
+                    module_record.add_import_entry_namespace_defer(
+                        identifiers,
+                        StringID::STAR_NAMESPACE,
+                        local_name,
+                        module_name,
+                        ty,
+                    )
+                }
+            }
+            RecordKind::ExportInfoIndirect => {
+                let export_name = ready(ids.next_id()?)?;
+                let import_name = ready(ids.next_id()?)?;
+                let module_name = ready(ids.next_id()?)?;
+                let ty = ids
+                    .next_fetch(fetch_kind)?
+                    .to_script_fetch_parameters_type();
+                if import_name == StringID::STAR_NAMESPACE {
+                    module_record.add_namespace_export(identifiers, export_name, module_name, ty)
+                } else {
+                    module_record.add_indirect_export(
+                        identifiers,
+                        export_name,
+                        import_name,
+                        module_name,
+                        ty,
+                    )
+                }
+            }
+            RecordKind::ExportInfoLocal => {
+                let export_name = ready(ids.next_id()?)?;
+                let local_name = ready(ids.next_id()?)?;
+                ids.next_fetch(fetch_kind)?;
+                module_record.add_local_export(identifiers, export_name, local_name)
+            }
+            RecordKind::ExportInfoNamespace => {
+                let export_name = ready(ids.next_id()?)?;
+                let module_name = ready(ids.next_id()?)?;
+                let ty = ids
+                    .next_fetch(fetch_kind)?
+                    .to_script_fetch_parameters_type();
+                module_record.add_namespace_export(identifiers, export_name, module_name, ty)
+            }
+            RecordKind::ExportInfoStar => {
+                let module_name = ready(ids.next_id()?)?;
+                let ty = ids
+                    .next_fetch(fetch_kind)?
+                    .to_script_fetch_parameters_type();
+                module_record.add_star_export(identifiers, module_name, ty)
+            }
+            _ => return Err(analyze::ModuleInfoError::BadModuleInfo),
         }
     }
+    if !ids.is_empty() {
+        return Err(analyze::ModuleInfoError::BadModuleInfo);
+    }
 
-    module_record
+    Ok(module_record)
 }
 
 // ─── opaque FFI types ─────────────────────────────────────────────────────────

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -325,8 +325,8 @@ pub mod analyze_transpiled_module {
         /// (`*` for a namespace import, `ExportInfoLocal`'s padding, the fetch
         /// parameter itself) are not written; `same-name` elides an import's
         /// local name when it equals the import name.
-        /// `bun_bundler::analyze_transpiled_module` widens this back into the
-        /// fixed u32 in-memory layout.
+        /// `bun_bundler::analyze_transpiled_module` (`Body` / `IdCursor`) reads
+        /// this in place when building the `JSModuleRecord`.
         pub fn serialize_body<W: std::io::Write>(
             &self,
             w: &mut W,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -71,7 +71,6 @@ pub type MangledProps = bun_collections::ArrayHashMap<Ref, Box<[u8]>>;
 /// only consume the serialized form.
 pub mod analyze_transpiled_module {
     use bun_collections::HashMap;
-    use bun_core::slice_as_bytes;
 
     /// Every record kind carries one trailing bitcast-`FetchParameters` slot
     /// after its `StringID` payload.
@@ -143,7 +142,7 @@ pub mod analyze_transpiled_module {
     // SAFETY: `#[repr(transparent)]` over `u32` (Pod).
     unsafe impl bytemuck::Pod for StringID {}
     impl StringID {
-        pub(crate) const STAR_DEFAULT: Self = Self(u32::MAX);
+        pub const STAR_DEFAULT: Self = Self(u32::MAX);
         pub const STAR_NAMESPACE: Self = Self(u32::MAX - 1);
     }
 
@@ -207,42 +206,228 @@ pub mod analyze_transpiled_module {
         pub record_kinds: &'a [RecordKind],
         pub flags: Flags,
     }
+    /// Width in bytes of a run of integers: the smallest of 1, 2, 4 that holds
+    /// the largest value.
+    #[inline]
+    pub fn int_width(max_value: u32) -> u8 {
+        if max_value <= u8::MAX as u32 {
+            1
+        } else if max_value <= u16::MAX as u32 {
+            2
+        } else {
+            4
+        }
+    }
+    #[inline]
+    fn put<W: std::io::Write>(w: &mut W, width: u8, v: u32) -> std::io::Result<()> {
+        match width {
+            1 => w.write_all(&[v as u8]),
+            2 => w.write_all(&(v as u16).to_le_bytes()),
+            _ => w.write_all(&v.to_le_bytes()),
+        }
+    }
+
+    /// Strings referenced by one or more serialized `ModuleInfo` bodies. A
+    /// `--compile` build shares one across every chunk (chunk specifiers and
+    /// export names repeat in most of them); the runtime transpiler cache
+    /// writes a module's own strings followed by its body.
+    ///
+    /// ```text
+    /// u8   offset width O ∈ {1,2,4}, sized for the total byte length
+    /// u8   0, 0, 0
+    /// u32  count
+    /// uO   × (count + 1): byte offset of each string, then the total
+    /// u8…  concatenated WTF-8
+    /// ```
+    #[derive(Default)]
+    pub struct ModuleInfoStringTable {
+        map: HashMap<Box<[u8]>, u32>,
+        offsets: Vec<u32>,
+        buf: Vec<u8>,
+    }
+    impl ModuleInfoStringTable {
+        pub fn intern(&mut self, s: &[u8]) -> u32 {
+            if let Some(&id) = self.map.get(s) {
+                return id;
+            }
+            let id = u32::try_from(self.offsets.len()).unwrap();
+            self.offsets.push(u32::try_from(self.buf.len()).unwrap());
+            self.buf.extend_from_slice(s);
+            self.map.insert(s.into(), id);
+            id
+        }
+        /// Interns every string of `mi`; the result maps its local ids to table ids.
+        pub fn intern_all(&mut self, mi: &ModuleInfo) -> Vec<u32> {
+            let mut ids = Vec::with_capacity(mi.strings_lens.len());
+            let mut offset = 0usize;
+            for &len in &mi.strings_lens {
+                ids.push(self.intern(&mi.strings_buf[offset..offset + len as usize]));
+                offset += len as usize;
+            }
+            ids
+        }
+        pub fn count(&self) -> u32 {
+            self.offsets.len() as u32
+        }
+        pub fn serialize<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+            Self::serialize_parts(w, self.offsets.iter().copied(), &self.buf)
+        }
+        fn serialize_parts<W: std::io::Write>(
+            w: &mut W,
+            offsets: impl ExactSizeIterator<Item = u32>,
+            buf: &[u8],
+        ) -> std::io::Result<()> {
+            let total = u32::try_from(buf.len()).unwrap();
+            let width = int_width(total);
+            w.write_all(&[width, 0, 0, 0])?;
+            w.write_all(&u32::try_from(offsets.len()).unwrap().to_le_bytes())?;
+            for offset in offsets {
+                put(w, width, offset)?;
+            }
+            put(w, width, total)?;
+            w.write_all(buf)
+        }
+    }
+
     impl<'a> ModuleInfoDeserialized<'a> {
+        /// Self-contained form: this module's own string table, then its body.
         pub(crate) fn serialize<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
-            w.write_all(
-                &u32::try_from(self.record_kinds.len())
-                    .unwrap()
-                    .to_le_bytes(),
+            let mut offset = 0u32;
+            ModuleInfoStringTable::serialize_parts(
+                w,
+                self.strings_lens.iter().map(|&len| {
+                    let at = offset;
+                    offset += len;
+                    at
+                }),
+                self.strings_buf,
             )?;
-            // `RecordKind: NoUninit` (#[repr(u8)]) → safe byte view.
-            w.write_all(slice_as_bytes(self.record_kinds))?;
-            let pad = (4 - (self.record_kinds.len() % 4)) % 4;
-            w.write_all(&[0u8; 4][..pad])?; // alignment padding
+            self.serialize_body(w, self.strings_lens.len() as u32, |id| id)
+        }
 
-            w.write_all(&u32::try_from(self.buffer.len()).unwrap().to_le_bytes())?;
-            w.write_all(slice_as_bytes(self.buffer))?;
+        /// Body wire format (little-endian), ids index a `ModuleInfoStringTable`
+        /// of `table_count` strings through `table_id`:
+        ///
+        /// ```text
+        /// u8   flags
+        /// u8   id width W ∈ {1,2,4}, sized for table_count + 2 sentinels
+        /// u8   0, 0
+        /// u32  requested-module count, u32 record count
+        /// u8   × records:    kind | fetch-kind << 3 | same-name << 6
+        /// u8   × requested:  phase | fetch-kind << 1
+        /// uW…  per requested module: specifier [, host-defined type]
+        /// uW…  per record: its string ids [, host-defined type]
+        /// ```
+        ///
+        /// fetch-kind 0..=3 is None / JavaScript / WebAssembly / JSON and 4 means
+        /// a host-defined type id follows. `STAR_NAMESPACE` / `STAR_DEFAULT` are
+        /// written as `table_count` / `table_count + 1`. Slots the kind implies
+        /// (`*` for a namespace import, `ExportInfoLocal`'s padding, the fetch
+        /// parameter itself) are not written; `same-name` elides an import's
+        /// local name when it equals the import name.
+        /// `bun_bundler::analyze_transpiled_module` widens this back into the
+        /// fixed u32 in-memory layout.
+        pub fn serialize_body<W: std::io::Write>(
+            &self,
+            w: &mut W,
+            table_count: u32,
+            table_id: impl Fn(u32) -> u32,
+        ) -> std::io::Result<()> {
+            let id_width = int_width(table_count + 1);
+            let id = |w: &mut W, s: StringID| {
+                put(
+                    w,
+                    id_width,
+                    match s {
+                        StringID::STAR_NAMESPACE => table_count,
+                        StringID::STAR_DEFAULT => table_count + 1,
+                        s => table_id(s.0),
+                    },
+                )
+            };
+            let fetch_kind = |fp: FetchParameters| match fp {
+                FetchParameters::None => 0u8,
+                FetchParameters::Javascript => 1,
+                FetchParameters::Webassembly => 2,
+                FetchParameters::Json => 3,
+                _ => 4,
+            };
+            // (ids written, fetch parameters, elide slot 1, elide slot 2)
+            let shape = |kind: RecordKind, data: &'a [StringID]| match kind {
+                RecordKind::ImportInfoSingle | RecordKind::ImportInfoSingleTypeScript => (
+                    &data[..3],
+                    FetchParameters(data[3].0),
+                    false,
+                    data[1] == data[2],
+                ),
+                RecordKind::ImportInfoNamespace | RecordKind::ImportInfoNamespaceDefer => {
+                    debug_assert!(data[1] == StringID::STAR_NAMESPACE);
+                    (&data[..3], FetchParameters(data[3].0), true, false)
+                }
+                RecordKind::ExportInfoIndirect => {
+                    (&data[..3], FetchParameters(data[3].0), false, false)
+                }
+                RecordKind::ExportInfoLocal => (&data[..2], FetchParameters::None, false, false),
+                RecordKind::ExportInfoNamespace => {
+                    (&data[..2], FetchParameters(data[2].0), false, false)
+                }
+                RecordKind::ExportInfoStar => {
+                    (&data[..1], FetchParameters(data[1].0), false, false)
+                }
+            };
+            let records = || {
+                let mut i = 0usize;
+                self.record_kinds.iter().map(move |&kind| {
+                    let data = &self.buffer[i..i + kind.len()];
+                    i += kind.len();
+                    (kind, data)
+                })
+            };
 
+            w.write_all(&[self.flags.to_byte(), id_width, 0, 0])?;
             w.write_all(
                 &u32::try_from(self.requested_modules_keys.len())
                     .unwrap()
                     .to_le_bytes(),
             )?;
-            w.write_all(slice_as_bytes(self.requested_modules_keys))?;
-            w.write_all(slice_as_bytes(self.requested_modules_values))?;
-            w.write_all(slice_as_bytes(self.requested_modules_phases))?;
-            let pad = (4 - (self.requested_modules_phases.len() % 4)) % 4;
-            w.write_all(&[0u8; 4][..pad])?; // alignment padding
-
-            w.write_all(&[self.flags.to_byte()])?;
-            w.write_all(&[0u8; 3])?; // alignment padding
-
             w.write_all(
-                &u32::try_from(self.strings_lens.len())
+                &u32::try_from(self.record_kinds.len())
                     .unwrap()
                     .to_le_bytes(),
             )?;
-            w.write_all(slice_as_bytes(self.strings_lens))?;
-            w.write_all(self.strings_buf)?;
+            for (kind, data) in records() {
+                let (_, fetch, _, same_name) = shape(kind, data);
+                w.write_all(&[(kind as u8) | (fetch_kind(fetch) << 3) | ((same_name as u8) << 6)])?;
+            }
+            for (&value, &phase) in self
+                .requested_modules_values
+                .iter()
+                .zip(self.requested_modules_phases)
+            {
+                w.write_all(&[(phase as u8) | (fetch_kind(value) << 1)])?;
+            }
+            for (&key, &value) in self
+                .requested_modules_keys
+                .iter()
+                .zip(self.requested_modules_values)
+            {
+                id(w, key)?;
+                if fetch_kind(value) == 4 {
+                    id(w, StringID(value.0))?;
+                }
+            }
+            for (kind, data) in records() {
+                let (ids, fetch, skip1, skip2) = shape(kind, data);
+                for (slot, &s) in ids.iter().enumerate() {
+                    if (skip1 && slot == 1) || (skip2 && slot == 2) {
+                        continue;
+                    }
+                    id(w, s)?;
+                }
+                if fetch_kind(fetch) == 4 {
+                    id(w, StringID(fetch.0))?;
+                }
+            }
             Ok(())
         }
     }
@@ -7795,8 +7980,8 @@ pub(crate) fn print_with_writer_and_platform<
     })
 }
 
-/// Serializes ModuleInfo to an owned byte slice. Returns null on failure.
-/// The caller is responsible for freeing the returned slice.
+/// Serializes ModuleInfo (its own string table, then its body) to an owned
+/// byte slice. Returns `None` on failure.
 pub fn serialize_module_info(
     module_info: Option<&mut analyze_transpiled_module::ModuleInfo>,
 ) -> Option<Box<[u8]>> {
@@ -7812,4 +7997,20 @@ pub fn serialize_module_info(
         return None;
     }
     Some(buf.into_boxed_slice())
+}
+
+/// Serializes only ModuleInfo's body, with its strings referenced through
+/// `table_ids` (from `ModuleInfoStringTable::intern_all`) into a table of
+/// `table_count` strings that is stored once for many modules.
+pub fn serialize_module_info_body(
+    mi: &analyze_transpiled_module::ModuleInfo,
+    table_count: u32,
+    table_ids: &[u32],
+) -> Box<[u8]> {
+    debug_assert!(mi.finalized);
+    let mut buf: Vec<u8> = Vec::new();
+    mi.as_deserialized()
+        .serialize_body(&mut buf, table_count, |id| table_ids[id as usize])
+        .expect("Vec<u8> write");
+    buf.into_boxed_slice()
 }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,8 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: ModuleInfo wire format is LEB128-encoded (varint string
-/// lengths and ids, implied slots dropped) instead of fixed u32 arrays.
+/// Version 26: ModuleInfo wire format is a string table (u8/u16/u32
+/// offsets picked by a header byte) plus a body of tagged records with
+/// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: ModuleInfo wire format is LEB128-encoded (varint string
+/// lengths and ids, implied slots dropped) instead of fixed u32 arrays.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -8,6 +8,7 @@
 #include "JavaScriptCore/ParserError.h"
 #include "JavaScriptCore/SyntheticModuleRecord.h"
 #include <wtf/text/MakeString.h>
+#include "BunClientData.h"
 #include "JavaScriptCore/JSGlobalObject.h"
 #include "JavaScriptCore/ExceptionScope.h"
 #include "ZigSourceProvider.h"
@@ -42,17 +43,31 @@ Identifier getFromIdentifierArray(VM& vm, Identifier* identifierArray, uint32_t 
 extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject* globalObject, VM& vm, const Identifier& module_key, const SourceCode& source_code, bun_ModuleInfoDeserialized* module_info);
 extern "C" void zig__renderDiff(const char* expected_ptr, size_t expected_len, const char* received_ptr, size_t received_len, JSGlobalObject* globalObject);
 
-extern "C" Identifier* JSC__IdentifierArray__create(size_t len)
-{
-    return new Identifier[len];
-}
-extern "C" void JSC__IdentifierArray__destroy(Identifier* identifier)
-{
-    delete[] identifier;
-}
 extern "C" void JSC__IdentifierArray__setFromUtf8(Identifier* identifierArray, size_t n, VM& vm, char* str, size_t len)
 {
     identifierArray[n] = Identifier::fromString(vm, AtomString::fromUTF8(std::span<const char>(str, len)));
+}
+extern "C" bool JSC__IdentifierArray__isNull(Identifier* identifierArray, size_t n)
+{
+    return identifierArray[n].isNull();
+}
+// Slots for the executable's shared module-info string table (`count`
+// strings): null until first use, then kept for every later module.
+extern "C" Identifier* Bun__VM__sharedModuleInfoIdentifiers(VM& vm, size_t count)
+{
+    auto& identifiers = WebCore::clientData(vm)->moduleInfoIdentifiers.shared;
+    if (identifiers.size() < count)
+        identifiers.grow(count);
+    return identifiers.mutableSpan().data();
+}
+// `count` slots for a record that carries its own strings; the caller
+// overwrites every slot before reading it.
+extern "C" Identifier* Bun__VM__scratchModuleInfoIdentifiers(VM& vm, size_t count)
+{
+    auto& identifiers = WebCore::clientData(vm)->moduleInfoIdentifiers.scratch;
+    if (identifiers.size() < count)
+        identifiers.grow(count);
+    return identifiers.mutableSpan().data();
 }
 
 extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObject, VM& vm, const Identifier* moduleKey, const SourceCode& sourceCode, bool hasImportMeta, bool isTypescript, bool hasTLA)

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -55,19 +55,23 @@ extern "C" bool JSC__IdentifierArray__isNull(Identifier* identifierArray, size_t
 // strings): null until first use, then kept for every later module.
 extern "C" Identifier* Bun__VM__sharedModuleInfoIdentifiers(VM& vm, size_t count)
 {
-    auto& identifiers = WebCore::clientData(vm)->moduleInfoIdentifiers.shared;
+    auto& identifiers = WebCore::clientData(vm)->sharedModuleInfoIdentifiers;
     if (identifiers.size() < count)
         identifiers.grow(count);
     return identifiers.mutableSpan().data();
 }
-// `count` slots for a record that carries its own strings; the caller
-// overwrites every slot before reading it.
-extern "C" Identifier* Bun__VM__scratchModuleInfoIdentifiers(VM& vm, size_t count)
+// `count` null slots for a record that carries its own strings, freed by
+// JSC__IdentifierArray__destroy once the JSModuleRecord is built.
+extern "C" Identifier* JSC__IdentifierArray__create(size_t count)
 {
-    auto& identifiers = WebCore::clientData(vm)->moduleInfoIdentifiers.scratch;
-    if (identifiers.size() < count)
-        identifiers.grow(count);
-    return identifiers.mutableSpan().data();
+    static_assert(VectorTraits<Identifier>::canInitializeWithMemset);
+    return static_cast<Identifier*>(WTF::fastZeroedMalloc(count * sizeof(Identifier)));
+}
+extern "C" void JSC__IdentifierArray__destroy(Identifier* identifiers, size_t count)
+{
+    for (size_t i = 0; i < count; ++i)
+        identifiers[i].~Identifier();
+    WTF::fastFree(identifiers);
 }
 
 extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObject, VM& vm, const Identifier* moduleKey, const SourceCode& sourceCode, bool hasImportMeta, bool isTypescript, bool hasTLA)

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -253,6 +253,16 @@ public:
     ALWAYS_INLINE bool isStoppingOrStopped(const JSC::VM& vm) const { return !scriptAllowed() || vm.executionForbidden(); }
     Bun::JSCTaskScheduler deferredWorkTimer;
 
+    // Identifiers for building JSModuleRecords from serialized module info
+    // (BunAnalyzeTranspiledModule.cpp). `shared`: one slot per string of the
+    // executable's module-info string table, filled on first use so each name
+    // is atomized once however many chunks import or export it. `scratch`:
+    // reused for records that carry their own strings (transpiler cache).
+    struct ModuleInfoIdentifiers {
+        Vector<JSC::Identifier> shared;
+        Vector<JSC::Identifier> scratch;
+    } moduleInfoIdentifiers;
+
     // Linked list of StrongRootBlock cells backing bun_jsc::Strong handles
     // (see StrongRootBlock.h). Raw pointers into the GC heap: they are rooted
     // by a SimpleMarkingConstraint registered in JSVMClientData::create(), so

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -253,15 +253,10 @@ public:
     ALWAYS_INLINE bool isStoppingOrStopped(const JSC::VM& vm) const { return !scriptAllowed() || vm.executionForbidden(); }
     Bun::JSCTaskScheduler deferredWorkTimer;
 
-    // Identifiers for building JSModuleRecords from serialized module info
-    // (BunAnalyzeTranspiledModule.cpp). `shared`: one slot per string of the
-    // executable's module-info string table, filled on first use so each name
-    // is atomized once however many chunks import or export it. `scratch`:
-    // reused for records that carry their own strings (transpiler cache).
-    struct ModuleInfoIdentifiers {
-        Vector<JSC::Identifier> shared;
-        Vector<JSC::Identifier> scratch;
-    } moduleInfoIdentifiers;
+    // One slot per string of the executable's module-info string table,
+    // filled on first use so each name is atomized once however many chunks
+    // import or export it (BunAnalyzeTranspiledModule.cpp).
+    Vector<JSC::Identifier> sharedModuleInfoIdentifiers;
 
     // Linked list of StrongRootBlock cells backing bun_jsc::Strong handles
     // (see StrongRootBlock.h). Raw pointers into the GC heap: they are rooted

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -771,7 +771,8 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                         OutputKind::Sourcemap => {}
                         OutputKind::ModuleInfo
                         | OutputKind::BuiltinBytecode
-                        | OutputKind::BytecodeStringTable => {}
+                        | OutputKind::BytecodeStringTable
+                        | OutputKind::ModuleInfoStringTable => {}
                         OutputKind::MetafileJson | OutputKind::MetafileMarkdown => {}
                     }
                 }

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1096,7 +1096,8 @@ impl BuildCommand {
                         options::OutputKind::Bytecode => "<d>",
                         options::OutputKind::ModuleInfo
                         | options::OutputKind::BuiltinBytecode
-                        | options::OutputKind::BytecodeStringTable => "<d>",
+                        | options::OutputKind::BytecodeStringTable
+                        | options::OutputKind::ModuleInfoStringTable => "<d>",
                         options::OutputKind::MetafileJson
                         | options::OutputKind::MetafileMarkdown => "<green>",
                     }))?;
@@ -1144,6 +1145,7 @@ impl BuildCommand {
                         options::OutputKind::ModuleInfo => "module info",
                         options::OutputKind::BuiltinBytecode => "builtin bytecode",
                         options::OutputKind::BytecodeStringTable => "bytecode strings",
+                        options::OutputKind::ModuleInfoStringTable => "module info strings",
                         options::OutputKind::MetafileJson => "metafile json",
                         options::OutputKind::MetafileMarkdown => "metafile markdown",
                     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3791,9 +3791,11 @@ export default db;
         }
 
         // SAFETY: `file.module_info`/`file.bytecode` are live subranges of
-        // the embedded section (set in `Graph::from_bytes`);
-        // `create_from_cached_record` copies out of it before returning.
+        // the embedded section (set in `Graph::from_bytes`).
         let (module_info, bytecode) = unsafe { (&*file.module_info, &*file.bytecode) };
+        // SAFETY: `graph` is the process-global standalone graph; the table
+        // is a read-only subrange of the embedded section.
+        let module_info_strings = unsafe { (*graph).module_info_string_table };
         return Some(ResolvedSource {
             source_code: file.to_wtf_string(),
             source_url: specifier.clone(),
@@ -3801,8 +3803,17 @@ export default db;
             bytecode_cache: Bytecode::persistent(bytecode),
             source_code_hash: file.source_hash,
             module_info: if !module_info.is_empty() {
-                bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized
-                    ::create_from_cached_record(module_info)
+                let decoded =
+                    bun_bundler::analyze_transpiled_module::ModuleInfoStringTable::parse(
+                        module_info_strings,
+                    )
+                    .ok()
+                    .and_then(|table| {
+                        bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized
+                            ::create_with_table(&table, module_info)
+                    });
+                debug_assert!(decoded.is_some(), "embedded module_info does not decode");
+                decoded
             } else {
                 None
             },

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3793,9 +3793,8 @@ export default db;
         // SAFETY: `file.module_info`/`file.bytecode` are live subranges of
         // the embedded section (set in `Graph::from_bytes`).
         let (module_info, bytecode) = unsafe { (&*file.module_info, &*file.bytecode) };
-        // SAFETY: `graph` is the process-global standalone graph; the table
-        // is a read-only subrange of the embedded section.
-        let module_info_strings = unsafe { (*graph).module_info_string_table };
+        let module_info_strings: &'static [u8] = bun_standalone_graph::Graph::get_ref()
+            .map_or(&[], |graph| graph.module_info_string_table);
         return Some(ResolvedSource {
             source_code: file.to_wtf_string(),
             source_url: specifier.clone(),
@@ -3803,15 +3802,14 @@ export default db;
             bytecode_cache: Bytecode::persistent(bytecode),
             source_code_hash: file.source_hash,
             module_info: if !module_info.is_empty() {
-                let decoded =
-                    bun_bundler::analyze_transpiled_module::ModuleInfoStringTable::parse(
-                        module_info_strings,
-                    )
-                    .ok()
-                    .and_then(|table| {
-                        bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized
+                let decoded = bun_bundler::analyze_transpiled_module::ModuleInfoStringTable::parse(
+                    module_info_strings,
+                )
+                .ok()
+                .and_then(|table| {
+                    bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized
                             ::create_with_table(&table, module_info)
-                    });
+                });
                 debug_assert!(decoded.is_some(), "embedded module_info does not decode");
                 decoded
             } else {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -49,6 +49,8 @@ pub struct StandaloneModuleGraph {
     pub builtin_bytecode: Vec<(u32, *mut [u8])>,
     /// The one shared bytecode string table (`JSC::EncoderStringTable::serialize`) every chunk's payload references by ordinal; installed on the VM's `DecoderStringTable` at startup.
     pub bytecode_string_table: &'static [u8],
+    /// The string table every module's `module_info` body indexes (`ModuleInfoStringTable`); empty when there is none.
+    pub module_info_string_table: &'static [u8],
     /// The first `startup_module_count` of `files` (table order = load order) are the entry
     /// point's static import closure, i.e. what loads before the first `import()`.
     pub startup_module_count: u32,
@@ -769,6 +771,9 @@ bitflags::bitflags! {
         /// After the string-table pointer: `u32` count of leading modules (in table order) that make up the
         /// entry point's static import closure, i.e. load before the first `import()`; `prefetch_startup_pages` reads ahead what they need.
         const HAS_STARTUP_MODULE_COUNT      = 1 << 8;
+        /// After the startup module count: one `StringPointer` to the string table every module's `module_info`
+        /// body indexes.
+        const HAS_MODULE_INFO_STRING_TABLE  = 1 << 9;
         // _padding: u23
     }
 }
@@ -800,6 +805,7 @@ impl StandaloneModuleGraph {
                 flags: Flags::default(),
                 builtin_bytecode: Vec::new(),
                 bytecode_string_table: &[],
+                module_info_string_table: &[],
                 startup_module_count: 0,
             });
         }
@@ -891,10 +897,25 @@ impl StandaloneModuleGraph {
         let startup_module_count = if offsets.flags.contains(Flags::HAS_STARTUP_MODULE_COUNT)
             && record_at + size_of::<u32>() <= raw_len
         {
-            read_u32(record_at)
+            let count = read_u32(record_at);
+            record_at += size_of::<u32>();
+            count
         } else {
             0
         };
+        let module_info_string_table: &'static [u8] =
+            if offsets.flags.contains(Flags::HAS_MODULE_INFO_STRING_TABLE)
+                && record_at + 2 * size_of::<u32>() <= raw_len
+            {
+                let ptr = StringPointer {
+                    offset: read_u32(record_at),
+                    length: read_u32(record_at + 4),
+                };
+                // SAFETY: read-only subrange placed by `to_bytes`, disjoint from the writable regions.
+                unsafe { slice_to(raw_const, raw_len, ptr) }
+            } else {
+                &[]
+            };
 
         let mut modules = StringArrayHashMap::<File>::new();
         modules.reserve(modules_list_count);
@@ -999,6 +1020,7 @@ impl StandaloneModuleGraph {
             flags: offsets.flags,
             builtin_bytecode,
             bytecode_string_table,
+            module_info_string_table,
             startup_module_count: startup_module_count.min(module_count as u32),
         })
     }
@@ -1158,6 +1180,8 @@ pub(crate) fn to_bytes(
                 string_builder.cap += bytes.len().div_ceil(256) * 256 + 256 + 16;
             } else if output_file.output_kind == options::OutputKind::ModuleInfo {
                 string_builder.cap += bytes.len();
+            } else if output_file.output_kind == options::OutputKind::ModuleInfoStringTable {
+                string_builder.cap += bytes.len() + 2 * size_of::<u32>();
             } else {
                 has_entry_point |= is_entry_point(output_file);
 
@@ -1229,7 +1253,7 @@ pub(crate) fn to_bytes(
         .iter()
         .take_while(|f| f.loads_at_startup)
         .count();
-    let mut shared_bytecode: Option<(Vec<u8>, StringPointer)> = None;
+    let mut shared_bytecode: Option<(Vec<u8>, StringPointer, StringPointer)> = None;
 
     let mut modules: Vec<CompiledModuleGraphFile> = Vec::with_capacity(module_files.len());
     for (i, &output_file) in module_files.iter().enumerate() {
@@ -1271,6 +1295,14 @@ pub(crate) fn to_bytes(
                 let mi_bytes = output_files[output_file.module_info_index as usize]
                     .value
                     .as_slice();
+                bun_core::scoped_log!(
+                    StandaloneModuleGraph,
+                    "module_info {}: {} bytes (js {} bytes, bytecode {} bytes)",
+                    bstr::BStr::new(&output_file.dest_path),
+                    mi_bytes.len(),
+                    output_file.value.as_slice().len(),
+                    bytecode.length
+                );
                 let offset = string_builder.len;
                 let writable = string_builder.writable();
                 writable[0..mi_bytes.len()].copy_from_slice(&mi_bytes[0..mi_bytes.len()]);
@@ -1362,8 +1394,9 @@ pub(crate) fn to_bytes(
         });
     }
 
-    let (builtin_bytecode_table, bytecode_string_table_ptr) = shared_bytecode
-        .unwrap_or_else(|| append_shared_bytecode(&mut string_builder, output_files));
+    let (builtin_bytecode_table, bytecode_string_table_ptr, module_info_string_table_ptr) =
+        shared_bytecode
+            .unwrap_or_else(|| append_shared_bytecode(&mut string_builder, output_files));
 
     // Region layout after the bytecode/module_info run above: source maps
     // (unread until an error prints), then every file's source text as one run
@@ -1453,6 +1486,13 @@ pub(crate) fn to_bytes(
     }
     let _ = string_builder.append_count(&(startup_module_count as u32).to_le_bytes());
     flags |= Flags::HAS_STARTUP_MODULE_COUNT;
+    if module_info_string_table_ptr.length != 0 {
+        let mut record = [0u8; 8];
+        record[0..4].copy_from_slice(&module_info_string_table_ptr.offset.to_le_bytes());
+        record[4..8].copy_from_slice(&module_info_string_table_ptr.length.to_le_bytes());
+        let _ = string_builder.append_count(&record);
+        flags |= Flags::HAS_MODULE_INFO_STRING_TABLE;
+    }
     let compile_exec_argv_ptr = string_builder.append_count_z(compile_exec_argv);
 
     let offsets = Offsets {
@@ -2710,13 +2750,14 @@ fn address_span(regions: impl Iterator<Item = (*const u8, usize)>) -> Option<(us
     (lo < hi).then_some((lo, hi))
 }
 
-/// Writes the ahead-of-time bytecode of the internal modules and the shared
-/// bytecode string table. Returns the builtin table (`u32 count`, then `count`
-/// × `{ u32 id, StringPointer bytes }`) and the string table's pointer.
+/// Writes the ahead-of-time bytecode of the internal modules, the shared
+/// bytecode string table and the module-info string table. Returns the builtin
+/// table (`u32 count`, then `count` × `{ u32 id, StringPointer bytes }`) and
+/// the two string tables' pointers.
 fn append_shared_bytecode(
     string_builder: &mut bun_core::StringBuilder,
     output_files: &[OutputFile],
-) -> (Vec<u8>, StringPointer) {
+) -> (Vec<u8>, StringPointer, StringPointer) {
     let mut builtin_bytecode_table: Vec<u8> = Vec::new();
     let mut count: u32 = 0;
     builtin_bytecode_table.extend_from_slice(&0u32.to_le_bytes());
@@ -2751,7 +2792,18 @@ fn append_shared_bytecode(
         };
         bytecode_string_table_ptr = append_bytecode_aligned(string_builder, bytes);
     }
-    (builtin_bytecode_table, bytecode_string_table_ptr)
+    let mut module_info_string_table_ptr = StringPointer::default();
+    if let Some(table) = output_files
+        .iter()
+        .find(|f| f.output_kind == options::OutputKind::ModuleInfoStringTable)
+    {
+        module_info_string_table_ptr = string_builder.append_count(table.value.as_slice());
+    }
+    (
+        builtin_bytecode_table,
+        bytecode_string_table_ptr,
+        module_info_string_table_ptr,
+    )
 }
 
 /// JSC reads cached bytecode in place and expects its start 128-byte aligned once mapped. The section data begins

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -911,8 +911,13 @@ impl StandaloneModuleGraph {
                     offset: read_u32(record_at),
                     length: read_u32(record_at + 4),
                 };
-                // SAFETY: read-only subrange placed by `to_bytes`, disjoint from the writable regions.
-                unsafe { slice_to(raw_const, raw_len, ptr) }
+                if (ptr.offset as usize).saturating_add(ptr.length as usize) > raw_len {
+                    &[]
+                } else {
+                    // SAFETY: bounds checked above; read-only subrange placed by `to_bytes`, disjoint from
+                    // the writable regions.
+                    unsafe { slice_to(raw_const, raw_len, ptr) }
+                }
             } else {
                 &[]
             };

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -774,7 +774,7 @@ bitflags::bitflags! {
         /// After the startup module count: one `StringPointer` to the string table every module's `module_info`
         /// body indexes.
         const HAS_MODULE_INFO_STRING_TABLE  = 1 << 9;
-        // _padding: u23
+        // _padding: u22
     }
 }
 

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -306,10 +306,11 @@ test("rejects cached module records containing out-of-range string indices", () 
   //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8,
   //   then twelve u64 fields; esm_record_byte_offset @ 78,
   //   esm_record_byte_length @ 86, esm_record_hash @ 94. Payload follows @ 102.
-  // Serialized module record layout (src/bundler/analyze_transpiled_module.rs,
-  // serialize()):
-  //   [record_kinds_len u32][record_kinds, 1 byte each][pad to 4]
-  //   [buffer_len u32][buffer: u32 string index x buffer_len] ...
+  // Serialized module record layout (ModuleInfoStringTable + body, see
+  // `ModuleInfoDeserialized::serialize` in src/js_printer/lib.rs):
+  //   table: [offset_width u8][0;3][count u32][(count+1) offsets][bytes]
+  //   body:  [flags u8][id_width u8][0;2][n_requested u32][n_records u32]
+  //          [n_records tag bytes][n_requested tag bytes][string ids @ id_width ...]
   const ESM_RECORD_BYTE_OFFSET_AT = 78;
   const ESM_RECORD_BYTE_LENGTH_AT = 86;
   const ESM_RECORD_HASH_AT = 94;
@@ -322,18 +323,22 @@ test("rejects cached module records containing out-of-range string indices", () 
     const esmLen = Number(data.readBigUInt64LE(ESM_RECORD_BYTE_LENGTH_AT));
     if (esmLen === 0 || esmOff + esmLen > data.length) return false;
 
-    const recordKindsLen = data.readUInt32LE(esmOff);
-    const pad = (4 - (recordKindsLen % 4)) % 4;
-    let off = esmOff + 4 + recordKindsLen + pad;
-    const bufferLen = data.readUInt32LE(off);
-    off += 4;
-    if (bufferLen === 0) return false;
+    const readUint = (at: number, width: number) =>
+      width === 1 ? data.readUInt8(at) : width === 2 ? data.readUInt16LE(at) : data.readUInt32LE(at);
+    const offsetWidth = data.readUInt8(esmOff);
+    const count = data.readUInt32LE(esmOff + 4);
+    const offsetsAt = esmOff + 8;
+    const total = readUint(offsetsAt + count * offsetWidth, offsetWidth);
+    const bodyAt = offsetsAt + (count + 1) * offsetWidth + total;
+    const nRequested = data.readUInt32LE(bodyAt + 4);
+    const nRecords = data.readUInt32LE(bodyAt + 8);
+    const idsAt = bodyAt + 12 + nRecords + nRequested;
+    const end = esmOff + esmLen;
+    if (nRecords === 0 || idsAt >= end) return false;
 
-    // Point every string index in the record buffer far beyond the identifier
-    // table (but below the reserved sentinel range near u32::MAX).
-    for (let i = 0; i < bufferLen; i++) {
-      data.writeUInt32LE(0x7fffffff, off + i * 4);
-    }
+    // Point every string id in the body past the table (and past the two
+    // sentinels count / count+1): all-ones at whatever width the ids use.
+    data.fill(0xff, idsAt, end);
     // The cache loader skips esm-record content verification when the stored
     // hash field is zero, so whoever writes the cache file controls exactly
     // what reaches the module record deserializer.
@@ -397,10 +402,12 @@ test("cached module still works", () => {
   }
   expect(corrupted).toBeGreaterThanOrEqual(1);
 
-  // Third run: the corrupted record must be rejected with a clean module load
-  // error and a normal (non-signal) process exit.
+  // Third run: the corrupted record must be rejected while decoding (the ids
+  // are range-checked against the string table there), so the module is
+  // analyzed from source instead and still works; no out-of-bounds read, no
+  // signal.
   const third = run();
-  expect(third.stderr.toString() + third.stdout.toString()).toContain("parseFromSourceCode failed");
+  expect(third.stderr.toString() + third.stdout.toString()).toContain("1 pass");
   expect(third.signalCode).toBeUndefined();
-  expect(third.exitCode).toBe(1);
+  expect(third.exitCode).toBe(0);
 });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -402,12 +402,10 @@ test("cached module still works", () => {
   }
   expect(corrupted).toBeGreaterThanOrEqual(1);
 
-  // Third run: the corrupted record must be rejected while decoding (the ids
-  // are range-checked against the string table there), so the module is
-  // analyzed from source instead and still works; no out-of-bounds read, no
-  // signal.
+  // Third run: the corrupted record must be rejected with a clean module load
+  // error and a normal (non-signal) process exit.
   const third = run();
-  expect(third.stderr.toString() + third.stdout.toString()).toContain("1 pass");
+  expect(third.stderr.toString() + third.stdout.toString()).toContain("parseFromSourceCode failed");
   expect(third.signalCode).toBeUndefined();
-  expect(third.exitCode).toBe(0);
+  expect(third.exitCode).toBe(1);
 });

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -787,20 +787,22 @@ test.concurrent("--isolate: cached SourceProvider's module_info rebuilds correct
   // export entries. Under --isolate, file b hits the SourceProvider cache and
   // rebuilds JSModuleRecord from the cached module_info (Bun__analyzeTranspiledModule)
   // instead of re-parsing. If the record is wrong, named imports would be
-  // undefined or the count would mismatch.
+  // undefined or the count would mismatch. The names are long enough that the
+  // record's string table passes 64 KB and stores its offsets as u32.
   const N = 2000;
+  const P = Buffer.alloc(40, "p").toString();
   let big = "";
-  for (let i = 0; i < N; i++) big += `export function f${i}(x){return x+${i};}\n`;
+  for (let i = 0; i < N; i++) big += `export function f${i}${P}(x){return x+${i};}\n`;
   big += `export const COUNT = ${N};\n`;
 
   const tBody = (name: string) => `
     import { test, expect } from "bun:test";
-    import { f0, f1, f${N - 1}, COUNT } from "./big";
+    import { f0${P}, f1${P}, f${N - 1}${P}, COUNT } from "./big";
     import * as all from "./big";
     test("${name}", () => {
-      expect(f0(1)).toBe(1);
-      expect(f1(1)).toBe(2);
-      expect(f${N - 1}(1)).toBe(${N});
+      expect(f0${P}(1)).toBe(1);
+      expect(f1${P}(1)).toBe(2);
+      expect(f${N - 1}${P}(1)).toBe(${N});
       expect(COUNT).toBe(${N});
       expect(Object.keys(all).length).toBe(${N + 1});
     });


### PR DESCRIPTION
### What does this PR do?

Follow-up to #40506. Shrinks the serialized `ModuleInfo` (the ES module record — imports, exports, requested modules — that `--compile --bytecode --splitting` embeds per chunk and that the runtime transpiler cache / `--isolate` source-provider cache store per file), and removes the decode step: JSC now reads the wire bytes in place.

**Before:** every import/export record was 1 kind byte + 4 × u32 slots, every string had a u32 length prefix, requested modules were three parallel u32/u32/u8 arrays, every chunk carried its own copy of the same chunk specifiers and export names, and loading a record memcpy'd the whole blob into an aligned buffer and built a fresh `new Identifier[]` for all of its strings.

**After:**

- A record is a **string table** + a **body**. Header bytes pick the integer width — u8, u16 or u32 — for string ids (from the table's count) and for string offsets (from the total string bytes). No varints.
- One tag byte per record: `kind | fetch-kind << 3 | same-name << 6`. Slots the kind implies (`*` for a namespace import, `ExportInfoLocal`'s padding, a `None`/JS/Wasm/JSON fetch parameter) are not written; `same-name` drops an import's local name when it equals the imported name. `STAR_NAMESPACE`/`STAR_DEFAULT` are `count`/`count+1`.
- `--compile`: **one string table for the whole executable** (`HAS_MODULE_INFO_STRING_TABLE` region in the `StandaloneModuleGraph`, in the startup run next to the bytecode string table); each chunk's body indexes it directly.
- **No decoded copy.** `ModuleInfoDeserialized` is a validated view over the body bytes and the table; for a compiled chunk both live in the mapped section, so building the `JSModuleRecord` allocates nothing on the Rust side. `toJSModuleRecord` walks tag bytes + fixed-width ids and range-checks as it goes.
- **Per-VM identifier slots.** Ids of a compiled chunk index one `Vector<Identifier>` on `JSVMClientData`, filled on first use, so each name is UTF-8-decoded and atomized once per VM instead of once per chunk that mentions it. Self-contained records (transpiler cache) use a throwaway fastMalloc'd array (was `new Identifier[]`).
- Runtime transpiler cache / isolated module cache: one blob = the module's own table + body, same reader. Cache version → 26.

### Numbers

`bun build --compile --splitting --bytecode --format=esm` (this branch also has #40506's chunk folding, hence fewer chunks). Every configuration produces the same program output as the unbundled source; debug builds assert every embedded record decodes and diff it against JSC's own `ModuleAnalyzer` result.

| fixture | | chunks | module_info | JS | bytecode |
|---|---|---:|---:|---:|---:|
| 1 entry + 40 `import()` routes, 300 shared modules | main | 218 | 212,887 B | 150,177 | 205,424 |
| | **this PR** | 150 | **19,491 B** (10,896 bodies + 8,595 table) | 86,877 | 162,576 |
| | main `--minify` | 218 | 217,303 B | 131,654 | 202,192 |
| | **this PR `--minify`** | 150 | **20,908 B** | 71,658 | 160,128 |
| 1 entry + 100 routes × 40 imports, 600 shared modules (17.7k import/export names) | main | 515 | 1,603,741 B | 1,032,270 | 1,252,992 |
| | **this PR** | 358 | **129,266 B** (101,627 + 27,639) | 576,121 | 1,111,664 |
| | main `--minify` | 515 | 1,662,600 B | 919,031 | 1,242,784 |
| | **this PR `--minify`** | 358 | **154,078 B** | 483,028 | 1,103,488 |

−90…91%; ~91 → ~8.7 bytes per import/export name on the larger fixture. Format-only on an identical chunk layout (before rebasing over #40506) was 219,522 → 30,393 B (−86%): after fixed-width packing, 88% of what remained was string bytes repeated across chunks, which the shared table removes.

### How did you verify your code works?

- `test/cli/test/isolation.test.ts` (the wide-module test now uses long names so the table's offsets take the u32 path), `test/regression/issue/30887.test.ts` (transpiler-cache round-trip with TLA), `test/cli/run/transpiler-cache.test.ts` (corrupt-record test rewritten for the new layout; out-of-range ids are still rejected with `parseFromSourceCode failed`), `bundler_compile_splitting`, `bundler_compile`, `type-export`, `debugger-buntranspiledmodule`, `bundler_barrel` — green with `bun bd test`.
- Compiled both fixtures (plain and `--minify`) plus a zero-import single-file entry with the debug build and ran them, including a driver that loads every lazy route; a 70k-export module round-trips through `--isolate` (u32 ids) locally.

### Decode cost (added after merge, corrected)

CI release binaries, main at `a3745c2` (already includes #40506, so the chunk layout is identical: 359 files) vs this PR, 1 entry + 100 lazy routes + 600 shared modules, `--compile --splitting --bytecode --minify`:

| | main | this PR |
|---|---:|---:|
| startup (entry + its one shared chunk, 2 module records), wall | 6.3 ms ± 0.9 | 7.0 ms ± 0.6 (noise) |
| startup, userspace instructions | 10.62 M | 10.71 M (flat) |
| load every chunk (358 module records), wall | 71.1 ms ± 4.3 | **65.8 ms ± 3.4** (1.08×) |
| load every chunk, userspace instructions | 261.1 M | **236.6 M** (−9.4%) |
| executable size | 83.5 MB | 82.8 MB |

An earlier version of this note compared against a canary that predated #40506 and so overstated the startup win; those numbers were #40506's, not this PR's. With only two module records on the startup path there is nothing to see there; the gain shows when many chunks load.
