### PR TITLE
Bun.Image: add opt-in linear-light resize (resize colorspace option)

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -88,7 +88,7 @@ img.resize(800, 600, { colorspace: "linear" }); // physically correct averaging
 
 The linear path always runs Bun's portable kernel, so its output is byte-identical across platforms and `Bun.Image.backend` settings.
 
-When the source is a JPEG and the target is at most half the source size, decode skips straight to the nearest M/8 IDCT scale. As a result, generating a thumbnail from a 24 MP photo never materializes the full-resolution buffer.
+When the source is a JPEG and the target is at most half the source size, decode skips straight to the nearest M/8 IDCT scale. As a result, generating a thumbnail from a 24 MP photo never materializes the full-resolution buffer. `colorspace: "linear"` disables this shortcut: the IDCT scale averages encoded values, so the linear path decodes JPEG sources at full resolution.
 
 ## Rotate · flip
 

--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -78,6 +78,16 @@ img.resize(800, 600, { filter: "mitchell" });
 | `"box"`                   | Area-average; good for large integer downscales  |
 | `"nearest"`               | Pixel art / hard edges                           |
 
+### Linear-light resizing
+
+By default, `resize()` averages the encoded 8-bit sRGB values. This matches Sharp and the OS resizers, but sRGB encodes perceived brightness, not light, so downscaling darkens fine detail. Pass `colorspace: "linear"` to decode to linear light, resize in 16-bit, and re-encode:
+
+```ts
+img.resize(800, 600, { colorspace: "linear" }); // physically correct averaging
+```
+
+The linear path always runs Bun's portable kernel, so its output is byte-identical across platforms and `Bun.Image.backend` settings.
+
 When the source is a JPEG and the target is at most half the source size, decode skips straight to the nearest M/8 IDCT scale. As a result, generating a thumbnail from a 24 MP photo never materializes the full-resolution buffer.
 
 ## Rotate · flip

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8951,6 +8951,17 @@ declare module "bun" {
       fit?: "fill" | "inside";
       /** Never upscale — if the source is already smaller, leave it. */
       withoutEnlargement?: boolean;
+      /**
+       * Color space the resample averages in. `"srgb"` averages the encoded
+       * 8-bit values — the industry default, matching Sharp and the OS
+       * resizers. `"linear"` decodes sRGB to linear light, resizes in
+       * 16-bit, and re-encodes; averaging light is physically correct and
+       * keeps downscaled fine detail from darkening. The linear path always
+       * uses Bun's portable kernel, so its output is byte-identical across
+       * platforms and `Bun.Image.backend` settings.
+       * @default "srgb"
+       */
+      colorspace?: "srgb" | "linear";
     }
 
     interface ModulateOptions {

--- a/src/jsc/bindings/image_resize.cpp
+++ b/src/jsc/bindings/image_resize.cpp
@@ -476,6 +476,70 @@ int buildWeights(int kind, int32_t src_len, int32_t dst_len,
 // Round n up to a multiple of a (a is a power of two).
 constexpr size_t alignUp(size_t n, size_t a) { return (n + a - 1) & ~(a - 1); }
 
+// RGBA16 passes for the linear-light resize path (`colorspace: "linear"`).
+// Same spans/weights as the u8 passes; pixels are u16 so the PMADDWD trick
+// (i16×i16) can't hold a 16-bit sample — accumulate in i64 instead, which is
+// exact: |Σ pixel·w| ≤ 65535 · 32767 · 256 taps ≈ 5.5e11, past i32 in the
+// clipped-weight worst case. Scalar loops; this path is opt-in and the
+// sRGB⇄linear conversions around it dominate anyway.
+constexpr int64_t kFixRound16 = 1 << 13; // 1 << (kFixShift - 1)
+
+uint16_t clamp16(int64_t v)
+{
+    return static_cast<uint16_t>(v < 0 ? 0 : v > 65535 ? 65535
+                                                       : v);
+}
+
+void HorizPass16(const uint16_t* HWY_RESTRICT src, size_t src_w, size_t src_h,
+    uint16_t* HWY_RESTRICT dst, size_t dst_w,
+    const Span* HWY_RESTRICT spans, const int16_t* HWY_RESTRICT weights, size_t wstride)
+{
+    const size_t src_row = src_w * 4;
+    const size_t dst_row = dst_w * 4;
+    const uint16_t* srow = src;
+    uint16_t* drow = dst;
+    for (size_t y = 0; y < src_h; y++, srow += src_row, drow += dst_row) {
+        const int16_t* w = weights;
+        uint16_t* dp = drow;
+        for (size_t x = 0; x < dst_w; x++, w += wstride, dp += 4) {
+            const Span s = spans[x];
+            const uint16_t* sp = srow + static_cast<size_t>(s.start) * 4;
+            int64_t acc0 = kFixRound16, acc1 = kFixRound16, acc2 = kFixRound16, acc3 = kFixRound16;
+            for (int32_t k = 0; k < s.n; k++, sp += 4) {
+                const int64_t wk = w[k];
+                acc0 += wk * sp[0];
+                acc1 += wk * sp[1];
+                acc2 += wk * sp[2];
+                acc3 += wk * sp[3];
+            }
+            dp[0] = clamp16(acc0 >> 14);
+            dp[1] = clamp16(acc1 >> 14);
+            dp[2] = clamp16(acc2 >> 14);
+            dp[3] = clamp16(acc3 >> 14);
+        }
+    }
+}
+
+void VertPass16(const uint16_t* HWY_RESTRICT src, size_t dst_w,
+    uint16_t* HWY_RESTRICT dst, size_t dst_h,
+    const Span* HWY_RESTRICT spans, const int16_t* HWY_RESTRICT weights, size_t wstride)
+{
+    const size_t row = dst_w * 4;
+    uint16_t* drow = dst;
+    const int16_t* w = weights;
+    for (size_t y = 0; y < dst_h; y++, drow += row, w += wstride) {
+        const Span s = spans[y];
+        const uint16_t* col0 = src + static_cast<size_t>(s.start) * row;
+        for (size_t i = 0; i < row; i++) {
+            int64_t acc = kFixRound16;
+            const uint16_t* sp = col0 + i;
+            for (int32_t k = 0; k < s.n; k++, sp += row)
+                acc += static_cast<int64_t>(w[k]) * *sp;
+            drow[i] = clamp16(acc >> 14);
+        }
+    }
+}
+
 // Layout of the caller-provided scratch arena. The intermediate row buffer
 // (dst_w×src_h×4) dominates; the spans/weights tables are a few tens of KB
 // packed into its tail. Computed once so `_scratch_size` and the resize body
@@ -483,14 +547,16 @@ constexpr size_t alignUp(size_t n, size_t a) { return (n + a - 1) & ~(a - 1); }
 struct ScratchLayout {
     size_t wsx, wsy;
     size_t off_xs, off_ys, off_xw, off_yw, total;
-    ScratchLayout(size_t src_w, size_t src_h, size_t dst_w, size_t dst_h, int kind)
+    // `pixel_bytes` is 4 for the RGBA8 path and 8 for the RGBA16 (linear
+    // light) path — it only scales the intermediate row buffer.
+    ScratchLayout(size_t src_w, size_t src_h, size_t dst_w, size_t dst_h, int kind, size_t pixel_bytes)
     {
         const double xs = static_cast<double>(dst_w) / src_w;
         const double ys = static_cast<double>(dst_h) / src_h;
         // 256 mirrors buildWeights' support cap (see comment there).
         wsx = std::min<size_t>(256, static_cast<size_t>(std::ceil(radius(kind) / (xs < 1.0 ? xs : 1.0))) * 2 + 2);
         wsy = std::min<size_t>(256, static_cast<size_t>(std::ceil(radius(kind) / (ys < 1.0 ? ys : 1.0))) * 2 + 2);
-        const size_t tmp_sz = dst_w * src_h * 4;
+        const size_t tmp_sz = dst_w * src_h * pixel_bytes;
         off_xs = alignUp(tmp_sz, alignof(Span));
         off_ys = off_xs + sizeof(Span) * dst_w;
         off_xw = alignUp(off_ys + sizeof(Span) * dst_h, alignof(int16_t));
@@ -508,7 +574,7 @@ extern "C" {
 size_t bun_image_resize_scratch_size(int32_t src_w, int32_t src_h, int32_t dst_w, int32_t dst_h, int32_t filter_kind)
 {
     if (src_w <= 0 || src_h <= 0 || dst_w <= 0 || dst_h <= 0) return 0;
-    return ScratchLayout(src_w, src_h, dst_w, dst_h, filter_kind).total;
+    return ScratchLayout(src_w, src_h, dst_w, dst_h, filter_kind, 4).total;
 }
 
 // Resize RGBA8. `scratch` must be at least `bun_image_resize_scratch_size(...)`
@@ -518,7 +584,7 @@ int bun_image_resize_rgba8(const uint8_t* src, int32_t src_w, int32_t src_h,
     uint8_t* dst, int32_t dst_w, int32_t dst_h, int32_t filter_kind, uint8_t* scratch)
 {
     if (src_w <= 0 || src_h <= 0 || dst_w <= 0 || dst_h <= 0 || !scratch) return -1;
-    const ScratchLayout L(src_w, src_h, dst_w, dst_h, filter_kind);
+    const ScratchLayout L(src_w, src_h, dst_w, dst_h, filter_kind, 4);
     auto* tmp = scratch;
     auto* xspans = reinterpret_cast<Span*>(scratch + L.off_xs);
     auto* yspans = reinterpret_cast<Span*>(scratch + L.off_ys);
@@ -530,6 +596,34 @@ int bun_image_resize_rgba8(const uint8_t* src, int32_t src_w, int32_t src_h,
 
     BUN_HWY_DISPATCH(HorizPass)(src, src_w, src_h, tmp, dst_w, xspans, xw, L.wsx);
     BUN_HWY_DISPATCH(VertPass)(tmp, src_h, dst_w, dst, dst_h, yspans, yw, L.wsy);
+    return 0;
+}
+
+size_t bun_image_resize_scratch_size_rgba16(int32_t src_w, int32_t src_h, int32_t dst_w, int32_t dst_h, int32_t filter_kind)
+{
+    if (src_w <= 0 || src_h <= 0 || dst_w <= 0 || dst_h <= 0) return 0;
+    return ScratchLayout(src_w, src_h, dst_w, dst_h, filter_kind, 8).total;
+}
+
+// Resize RGBA16 (the linear-light path). Same contract as the rgba8 variant;
+// `scratch` must be at least `bun_image_resize_scratch_size_rgba16(...)` bytes
+// and aligned for uint16_t.
+int bun_image_resize_rgba16(const uint16_t* src, int32_t src_w, int32_t src_h,
+    uint16_t* dst, int32_t dst_w, int32_t dst_h, int32_t filter_kind, uint8_t* scratch)
+{
+    if (src_w <= 0 || src_h <= 0 || dst_w <= 0 || dst_h <= 0 || !scratch) return -1;
+    const ScratchLayout L(src_w, src_h, dst_w, dst_h, filter_kind, 8);
+    auto* tmp = reinterpret_cast<uint16_t*>(scratch);
+    auto* xspans = reinterpret_cast<Span*>(scratch + L.off_xs);
+    auto* yspans = reinterpret_cast<Span*>(scratch + L.off_ys);
+    auto* xw = reinterpret_cast<int16_t*>(scratch + L.off_xw);
+    auto* yw = reinterpret_cast<int16_t*>(scratch + L.off_yw);
+
+    buildWeights(filter_kind, src_w, dst_w, xspans, xw, static_cast<int32_t>(L.wsx));
+    buildWeights(filter_kind, src_h, dst_h, yspans, yw, static_cast<int32_t>(L.wsy));
+
+    HorizPass16(src, src_w, src_h, tmp, dst_w, xspans, xw, L.wsx);
+    VertPass16(tmp, dst_w, dst, dst_h, yspans, yw, L.wsy);
     return 0;
 }
 

--- a/src/jsc/bindings/image_resize.cpp
+++ b/src/jsc/bindings/image_resize.cpp
@@ -482,7 +482,8 @@ constexpr size_t alignUp(size_t n, size_t a) { return (n + a - 1) & ~(a - 1); }
 // exact: |Σ pixel·w| ≤ 65535 · 32767 · 256 taps ≈ 5.5e11, past i32 in the
 // clipped-weight worst case. Scalar loops; this path is opt-in and the
 // sRGB⇄linear conversions around it dominate anyway.
-constexpr int64_t kFixRound16 = 1 << 13; // 1 << (kFixShift - 1)
+constexpr int kFixShift16 = 14; // = kFixShift; mirrored like kFixOne above
+constexpr int64_t kFixRound16 = int64_t { 1 } << (kFixShift16 - 1);
 
 uint16_t clamp16(int64_t v)
 {
@@ -512,10 +513,10 @@ void HorizPass16(const uint16_t* HWY_RESTRICT src, size_t src_w, size_t src_h,
                 acc2 += wk * sp[2];
                 acc3 += wk * sp[3];
             }
-            dp[0] = clamp16(acc0 >> 14);
-            dp[1] = clamp16(acc1 >> 14);
-            dp[2] = clamp16(acc2 >> 14);
-            dp[3] = clamp16(acc3 >> 14);
+            dp[0] = clamp16(acc0 >> kFixShift16);
+            dp[1] = clamp16(acc1 >> kFixShift16);
+            dp[2] = clamp16(acc2 >> kFixShift16);
+            dp[3] = clamp16(acc3 >> kFixShift16);
         }
     }
 }
@@ -535,7 +536,7 @@ void VertPass16(const uint16_t* HWY_RESTRICT src, size_t dst_w,
             const uint16_t* sp = col0 + i;
             for (int32_t k = 0; k < s.n; k++, sp += row)
                 acc += static_cast<int64_t>(w[k]) * *sp;
-            drow[i] = clamp16(acc >> 14);
+            drow[i] = clamp16(acc >> kFixShift16);
         }
     }
 }

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1667,7 +1667,16 @@ impl PipelineTask {
         // can be over-shrunk and then upscaled, throwing away detail.
         // (flip/flop are pure mirrors that never change w/h, so the hint
         //  stays valid through them.)
-        let hint: codecs::DecodeHint = if let Some(r) = self.pipeline.resize {
+        //
+        // `colorspace: "linear"` disables the hint: the M/8 IDCT scale
+        // averages encoded DC coefficients — exactly the code-averaging the
+        // option opts out of — so a hinted JPEG decode would darken the
+        // result before `resize_linear` ever sees the pixels.
+        let hint: codecs::DecodeHint = if let Some(r) = self
+            .pipeline
+            .resize
+            .filter(|r| r.colorspace == Colorspace::Srgb)
+        {
             let mut tw = r.w;
             // r.h==0 means "preserve aspect" — constrain on width only.
             let mut th = if r.h != 0 { r.h } else { r.w };

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -169,6 +169,27 @@ impl jsc::FromJsEnum for codecs::Filter {
     }
 }
 
+/// Which space the resample averages in. `Srgb` (default) averages the
+/// encoded 8-bit codes — Sharp/CoreGraphics/WIC parity. `Linear` decodes to
+/// linear light first, which is the physically correct average (#40510).
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Colorspace {
+    Srgb,
+    Linear,
+}
+bun_core::comptime_string_map! {
+    static COLORSPACE_MAP: Colorspace = {
+        b"srgb" => Colorspace::Srgb,
+        b"linear" => Colorspace::Linear,
+    };
+}
+impl jsc::FromJsEnum for Colorspace {
+    fn from_js_value(v: JSValue, global: &JSGlobalObject, prop: &'static str) -> JsResult<Self> {
+        v.to_enum_from_map(global, prop, &COLORSPACE_MAP, "'srgb' or 'linear'")
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct Resize {
     pub(crate) w: u32,
@@ -176,6 +197,7 @@ pub struct Resize {
     pub(crate) filter: codecs::Filter,
     pub(crate) fit: Fit,
     pub(crate) without_enlargement: bool,
+    pub(crate) colorspace: Colorspace,
 }
 
 impl Default for Resize {
@@ -186,6 +208,7 @@ impl Default for Resize {
             filter: codecs::Filter::Lanczos3,
             fit: Fit::Fill,
             without_enlargement: false,
+            colorspace: Colorspace::Srgb,
         }
     }
 }
@@ -482,6 +505,9 @@ impl Image {
             }
             if let Some(v) = opt.get(global, "withoutEnlargement")? {
                 r.without_enlargement = v.to_boolean();
+            }
+            if let Some(v) = opt.get_optional_enum::<Colorspace>(global, "colorspace")? {
+                r.colorspace = v;
             }
         }
         self.update_pipeline(|p| p.resize = Some(r));
@@ -1971,7 +1997,11 @@ impl PipelineTask {
                 return Err(codecs::Error::TooManyPixels);
             }
             if t.0 != d.width || t.1 != d.height {
-                let next = codecs::resize(&d.rgba, d.width, d.height, t.0, t.1, r.filter)?;
+                let next = if r.colorspace == Colorspace::Linear {
+                    codecs::resize_linear(&d.rgba, d.width, d.height, t.0, t.1, r.filter)?
+                } else {
+                    codecs::resize(&d.rgba, d.width, d.height, t.0, t.1, r.filter)?
+                };
                 d.rgba = next;
                 d.width = t.0;
                 d.height = t.1;

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -789,11 +789,20 @@ pub(crate) fn resize_linear(
     dh: u32,
     f: Filter,
 ) -> Result<Vec<u8>, Error> {
+    // These buffers are user-sized (up to GiBs at the `maxPixels` cap, and
+    // 2× the u8 path's footprint), so allocate fallibly and surface
+    // `Error::OutOfMemory` instead of aborting.
+    fn alloc_zeroed<T: Copy + Default>(n: usize) -> Result<Vec<T>, Error> {
+        let mut v: Vec<T> = Vec::new();
+        v.try_reserve_exact(n).map_err(|_| Error::OutOfMemory)?;
+        v.resize(n, T::default());
+        Ok(v)
+    }
     let fwd = srgb_to_linear_lut();
     let rev = linear_to_srgb_lut();
     let src_px: usize = (sw as usize) * (sh as usize) * 4;
     let dst_px: usize = (dw as usize) * (dh as usize) * 4;
-    let mut lin: Vec<u16> = vec![0u16; src_px];
+    let mut lin: Vec<u16> = alloc_zeroed(src_px)?;
     for (dst4, src4) in lin
         .as_chunks_mut::<4>()
         .0
@@ -815,10 +824,10 @@ pub(crate) fn resize_linear(
             f as i32,
         )
     };
-    let mut out16: Vec<u16> = vec![0u16; dst_px];
+    let mut out16: Vec<u16> = alloc_zeroed(dst_px)?;
     // u64-element scratch so the kernel's internal u16/Span/i16 partitions
     // are all sufficiently aligned.
-    let mut scratch: Vec<u64> = vec![0u64; scratch_sz.div_ceil(8)];
+    let mut scratch: Vec<u64> = alloc_zeroed(scratch_sz.div_ceil(8))?;
     // SAFETY: lin has sw*sh*4 u16s, out16 has dw*dh*4 u16s, scratch covers
     // the queried size; the kernel writes within those bounds.
     let rc = unsafe {
@@ -838,7 +847,7 @@ pub(crate) fn resize_linear(
     }
     drop(lin);
     drop(scratch);
-    let mut out: Vec<u8> = vec![0u8; dst_px];
+    let mut out: Vec<u8> = alloc_zeroed(dst_px)?;
     for (dst4, src4) in out
         .as_chunks_mut::<4>()
         .0

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -642,6 +642,23 @@ unsafe extern "C" {
         filter: i32,
         scratch: *mut u8,
     ) -> c_int;
+    fn bun_image_resize_scratch_size_rgba16(
+        src_w: i32,
+        src_h: i32,
+        dst_w: i32,
+        dst_h: i32,
+        filter: i32,
+    ) -> usize;
+    fn bun_image_resize_rgba16(
+        src: *const u16,
+        src_w: i32,
+        src_h: i32,
+        dst: *mut u16,
+        dst_w: i32,
+        dst_h: i32,
+        filter: i32,
+        scratch: *mut u8,
+    ) -> c_int;
     fn bun_image_rotate_rgba8(src: *const u8, w: i32, h: i32, dst: *mut u8, deg: i32);
     fn bun_image_flip_rgba8(src: *const u8, w: i32, h: i32, dst: *mut u8, horiz: i32);
     fn bun_image_modulate_rgba8(buf: *mut u8, len: usize, brightness: f32, saturation: f32);
@@ -712,6 +729,128 @@ pub(crate) fn resize(
     block.shrink_to_fit();
     // PERF: Vec::shrink_to_fit may not be in-place — profile if hot.
     Ok(block)
+}
+
+/// sRGB code → linear light, scaled to the full u16 range. 0 → 0 and
+/// 255 → 65535 exactly (both transfer-function branches are exact at the
+/// ends), so a pure black/white image converts losslessly.
+fn srgb_to_linear_lut() -> &'static [u16; 256] {
+    static LUT: std::sync::OnceLock<[u16; 256]> = std::sync::OnceLock::new();
+    LUT.get_or_init(|| {
+        let mut lut = [0u16; 256];
+        for (c, out) in lut.iter_mut().enumerate() {
+            let x = c as f64 / 255.0;
+            let lin = if x <= 0.04045 {
+                x / 12.92
+            } else {
+                ((x + 0.055) / 1.055).powf(2.4)
+            };
+            *out = (lin * 65535.0).round() as u16;
+        }
+        lut
+    })
+}
+
+/// Linear u16 → sRGB code. Inverse of `srgb_to_linear_lut` (round-trips all
+/// 256 codes; the flat-field kernel test pins that).
+fn linear_to_srgb_lut() -> &'static [u8; 65536] {
+    static LUT: std::sync::OnceLock<[u8; 65536]> = std::sync::OnceLock::new();
+    LUT.get_or_init(|| {
+        let mut lut = [0u8; 65536];
+        for (v, out) in lut.iter_mut().enumerate() {
+            let y = v as f64 / 65535.0;
+            let s = if y <= 0.003_130_8 {
+                12.92 * y
+            } else {
+                1.055 * y.powf(1.0 / 2.4) - 0.055
+            };
+            *out = (s * 255.0).round() as u8;
+        }
+        lut
+    })
+}
+
+/// Linear-light resize (`resize(w, h, { colorspace: "linear" })`): decode
+/// sRGB to linear in u16, run the RGBA16 kernel, re-encode. Averaging
+/// encoded sRGB codes (the default path, and what Sharp/CoreGraphics/WIC
+/// do) darkens downscaled detail because sRGB is an encoding of perceived
+/// brightness, not of light. Alpha is not gamma-encoded, so it is scaled
+/// linearly (×257 maps 255 → 65535 exactly).
+///
+/// Always runs the static kernel — vImage on the macOS system backend
+/// averages encoded values too, so routing through it would undo the
+/// point of the option. Output is therefore byte-identical across
+/// platforms and backends.
+pub(crate) fn resize_linear(
+    src: &[u8],
+    sw: u32,
+    sh: u32,
+    dw: u32,
+    dh: u32,
+    f: Filter,
+) -> Result<Vec<u8>, Error> {
+    let fwd = srgb_to_linear_lut();
+    let rev = linear_to_srgb_lut();
+    let src_px: usize = (sw as usize) * (sh as usize) * 4;
+    let dst_px: usize = (dw as usize) * (dh as usize) * 4;
+    let mut lin: Vec<u16> = vec![0u16; src_px];
+    for (dst4, src4) in lin
+        .as_chunks_mut::<4>()
+        .0
+        .iter_mut()
+        .zip(src.as_chunks::<4>().0)
+    {
+        dst4[0] = fwd[src4[0] as usize];
+        dst4[1] = fwd[src4[1] as usize];
+        dst4[2] = fwd[src4[2] as usize];
+        dst4[3] = u16::from(src4[3]) * 257;
+    }
+    // SAFETY: pure FFI query; all args are by-value ints, no pointers.
+    let scratch_sz = unsafe {
+        bun_image_resize_scratch_size_rgba16(
+            i32::try_from(sw).expect("int cast"),
+            i32::try_from(sh).expect("int cast"),
+            i32::try_from(dw).expect("int cast"),
+            i32::try_from(dh).expect("int cast"),
+            f as i32,
+        )
+    };
+    let mut out16: Vec<u16> = vec![0u16; dst_px];
+    // u64-element scratch so the kernel's internal u16/Span/i16 partitions
+    // are all sufficiently aligned.
+    let mut scratch: Vec<u64> = vec![0u64; scratch_sz.div_ceil(8)];
+    // SAFETY: lin has sw*sh*4 u16s, out16 has dw*dh*4 u16s, scratch covers
+    // the queried size; the kernel writes within those bounds.
+    let rc = unsafe {
+        bun_image_resize_rgba16(
+            lin.as_ptr(),
+            i32::try_from(sw).expect("int cast"),
+            i32::try_from(sh).expect("int cast"),
+            out16.as_mut_ptr(),
+            i32::try_from(dw).expect("int cast"),
+            i32::try_from(dh).expect("int cast"),
+            f as i32,
+            scratch.as_mut_ptr().cast::<u8>(),
+        )
+    };
+    if rc != 0 {
+        return Err(Error::OutOfMemory);
+    }
+    drop(lin);
+    drop(scratch);
+    let mut out: Vec<u8> = vec![0u8; dst_px];
+    for (dst4, src4) in out
+        .as_chunks_mut::<4>()
+        .0
+        .iter_mut()
+        .zip(out16.as_chunks::<4>().0)
+    {
+        dst4[0] = rev[src4[0] as usize];
+        dst4[1] = rev[src4[1] as usize];
+        dst4[2] = rev[src4[2] as usize];
+        dst4[3] = u8::try_from((u32::from(src4[3]) + 128) / 257).expect("int cast");
+    }
+    Ok(out)
 }
 
 pub(crate) fn rotate(src: &[u8], w: u32, h: u32, degrees: u32) -> Result<Decoded, Error> {

--- a/test/js/bun/image/image-kernels.test.ts
+++ b/test/js/bun/image/image-kernels.test.ts
@@ -230,6 +230,98 @@ describe("resize filter properties", () => {
   });
 });
 
+// ─── linear-light resize (colorspace: "linear") ─────────────────────────────
+//
+// sRGB encodes perceived brightness, not light. Averaging the encoded codes
+// (the default, Sharp-parity path) darkens downscaled detail; the opt-in
+// `colorspace: "linear"` decodes to linear light, resizes in 16-bit, and
+// re-encodes. The instrument is a 1px black/white checkerboard: half the
+// pixels are 0 and half 255, so averaging light gives sRGB ~188 while
+// averaging codes gives ~128. See issue #40510.
+
+describe("linear-light resize", () => {
+  async function resizeWith(
+    src: Uint8Array,
+    w: number,
+    h: number,
+    options: Bun.Image.ResizeOptions,
+  ): Promise<Uint8Array> {
+    return decodePng(await new Bun.Image(src).resize(w, h, options).png().bytes()).data;
+  }
+
+  test("checkerboard downscale averages light, not codes", async () => {
+    const checker = makePng(64, 64, (x, y) => ((x + y) & 1 ? [255, 255, 255, 255] : [0, 0, 0, 255]));
+    // box 64→8: every output pixel covers an 8×8 block that is exactly half
+    // black, half white. Linear mean 0.5 encodes to sRGB ~188.
+    const linear = await resizeWith(checker, 8, 8, { filter: "box", colorspace: "linear" });
+    for (let i = 0; i < linear.length; i += 4) {
+      expect(linear[i]).toBeGreaterThanOrEqual(186);
+      expect(linear[i]).toBeLessThanOrEqual(189);
+      expect(linear[i + 3]).toBe(255);
+    }
+    // The default path is unchanged: it averages the encoded codes to ~128.
+    const srgb = await resizeWith(checker, 8, 8, { filter: "box" });
+    for (let i = 0; i < srgb.length; i += 4) {
+      expect(srgb[i]).toBeGreaterThanOrEqual(126);
+      expect(srgb[i]).toBeLessThanOrEqual(129);
+    }
+  });
+
+  test("lanczos3 interior mean on the checkerboard lands near 188", async () => {
+    const checker = makePng(64, 64, (x, y) => ((x + y) & 1 ? [255, 255, 255, 255] : [0, 0, 0, 255]));
+    const out = await resizeWith(checker, 8, 8, { colorspace: "linear" });
+    let sum = 0;
+    let n = 0;
+    for (let y = 1; y < 7; y++) {
+      for (let x = 1; x < 7; x++) {
+        sum += out[(y * 8 + x) * 4];
+        n++;
+      }
+    }
+    const mean = sum / n;
+    expect(mean).toBeGreaterThan(180);
+    expect(mean).toBeLessThan(195);
+  });
+
+  // DC gain through the LUT round-trip: every sRGB code must survive
+  // srgb→linear16→srgb unchanged when the resample is a pure average.
+  test("flat fields stay flat exactly (LUT round-trip + DC gain)", async () => {
+    for (const v of [0, 1, 13, 128, 173, 254, 255]) {
+      const flat = makePng(9, 7, () => [v, v, v, 200]);
+      const out = await resizeWith(flat, 3, 3, { colorspace: "linear" });
+      for (let i = 0; i < out.length; i += 4) {
+        expect([out[i], out[i + 1], out[i + 2], out[i + 3]]).toEqual([v, v, v, 200]);
+      }
+    }
+  });
+
+  test("explicit colorspace 'srgb' matches the default byte-for-byte", async () => {
+    const src = makePng(16, 16, (x, y) => [(x * 37) & 255, (y * 53) & 255, ((x ^ y) * 11) & 255, 255]);
+    const a = await new Bun.Image(src).resize(7, 5, { colorspace: "srgb" }).png().bytes();
+    const b = await new Bun.Image(src).resize(7, 5).png().bytes();
+    expect(Buffer.compare(Buffer.from(a), Buffer.from(b))).toBe(0);
+  });
+
+  test("linear output is identical across backends", async () => {
+    const checker = makePng(32, 32, (x, y) => ((x + y) & 1 ? [255, 255, 255, 255] : [0, 0, 0, 255]));
+    const prev = Bun.Image.backend;
+    try {
+      Bun.Image.backend = "system";
+      const sys = await new Bun.Image(checker).resize(4, 4, { colorspace: "linear" }).png().bytes();
+      Bun.Image.backend = "bun";
+      const bun = await new Bun.Image(checker).resize(4, 4, { colorspace: "linear" }).png().bytes();
+      expect(Buffer.compare(Buffer.from(sys), Buffer.from(bun))).toBe(0);
+    } finally {
+      Bun.Image.backend = prev;
+    }
+  });
+
+  test("invalid colorspace value throws", () => {
+    const src = makePng(4, 4, () => [0, 0, 0, 255]);
+    expect(() => new Bun.Image(src).resize(2, 2, { colorspace: "rec2020" as any })).toThrow();
+  });
+});
+
 // ─── Floyd–Steinberg dither ─────────────────────────────────────────────────
 
 describe("Floyd–Steinberg dither", () => {

--- a/test/js/bun/image/image-kernels.test.ts
+++ b/test/js/bun/image/image-kernels.test.ts
@@ -316,9 +316,35 @@ describe("linear-light resize", () => {
     }
   });
 
+  // A JPEG source at 2x+ shrink normally decodes through the M/8 IDCT scale,
+  // which averages encoded DC coefficients per 8×8 block — the exact
+  // code-averaging `colorspace: "linear"` opts out of. The linear path must
+  // decode at full resolution, so the checkerboard still lands near 188.
+  test("linear resize of a JPEG source skips the IDCT downscale hint", async () => {
+    const checker = makePng(128, 128, (x, y) => ((x + y) & 1 ? [255, 255, 255, 255] : [0, 0, 0, 255]));
+    const jpeg = await new Bun.Image(checker).jpeg({ quality: 100 }).bytes();
+    const out = decodePng(
+      await new Bun.Image(jpeg).resize(16, 16, { filter: "box", colorspace: "linear" }).png().bytes(),
+    ).data;
+    let sum = 0;
+    let n = 0;
+    for (let y = 2; y < 14; y++) {
+      for (let x = 2; x < 14; x++) {
+        sum += out[(y * 16 + x) * 4];
+        n++;
+      }
+    }
+    // A hinted decode collapses every 8×8 block to its ~128 DC before the
+    // linear resize runs, so the mean reads ~128. Full decode + linear
+    // resize reads ~188 (JPEG quantization noise gives a wide margin).
+    expect(sum / n).toBeGreaterThan(165);
+  });
+
   test("invalid colorspace value throws", () => {
     const src = makePng(4, 4, () => [0, 0, 0, 255]);
-    expect(() => new Bun.Image(src).resize(2, 2, { colorspace: "rec2020" as any })).toThrow();
+    expect(() => new Bun.Image(src).resize(2, 2, { colorspace: "rec2020" as any })).toThrow(
+      TypeError("colorspace must be one of 'srgb' or 'linear'"),
+    );
   });
 });
 

--- a/test/js/bun/image/image-kernels.test.ts
+++ b/test/js/bun/image/image-kernels.test.ts
@@ -337,7 +337,9 @@ describe("linear-light resize", () => {
     // A hinted decode collapses every 8×8 block to its ~128 DC before the
     // linear resize runs, so the mean reads ~128. Full decode + linear
     // resize reads ~188 (JPEG quantization noise gives a wide margin).
-    expect(sum / n).toBeGreaterThan(165);
+    const mean = sum / n;
+    expect(mean).toBeGreaterThan(165);
+    expect(mean).toBeLessThan(210);
   });
 
   test("invalid colorspace value throws", () => {


### PR DESCRIPTION
### Problem

- `Bun.Image.resize()` averages encoded sRGB values as if they were light. A 1px black/white checkerboard downscales to a mean of ~127 instead of ~188, on both backends (#40510).
- sRGB encodes perceived brightness, not light. The resize kernels in `src/jsc/bindings/image_resize.cpp` (and vImage on macOS) operate directly on the encoded RGBA8 codes, so every downscale darkens fine detail.

### Fix

- Adds the opt-in the issue asks for: `resize(w, h, { colorspace: "linear" })`. The default (`"srgb"`) is unchanged, so Sharp parity (`image-vs-sharp.test.ts`) and backend parity hold.
- `codecs::resize_linear` decodes sRGB to linear light in u16 (256-entry LUT), resizes through a new RGBA16 kernel (`bun_image_resize_rgba16`), and re-encodes (65536-entry LUT). Alpha is not gamma-encoded, so it scales linearly.
- The RGBA16 kernel reuses the existing `buildWeights` and `ScratchLayout` machinery. It accumulates in i64 because a 16-bit sample does not fit the i16 PMADDWD trick of the u8 path, and i64 is exact for the clipped-weight worst case.
- The linear path always runs the static kernel. vImage also averages encoded values, so output is byte-identical across platforms and `Bun.Image.backend` settings.
- Verified: `test/js/bun/image/image-kernels.test.ts` (6 new tests, 3 fail on released bun). Also all of `test/js/bun/image/` (230 pass) and the bun-types test.

### Background

- The checkerboard is the instrument: half the pixels are 0 and half 255, so a faithful downscale must average them. Averaging light gives linear 0.5, which encodes to sRGB ~188. Averaging codes gives (0+255)/2 ~ 128.
- The resize is separable (horizontal then vertical) with i16 fixed-point weights that sum to exactly 1<<14, so a flat field stays flat. The new u16 passes keep that property, and the LUT pair round-trips all 256 codes, which the new flat-field test pins.
- Sharp, swscale, and the Rust `image` crate all average encoded values by default, which is why the default stays `"srgb"` and the correct behavior is opt-in.

<details><summary>Notes</summary>

- Issue repro (verbatim script from #40510) with `colorspace: "linear"`: `512->32 interior mean: 188.00` on both backend settings. Without the option it still reads `127.07`.
- Peak memory: the linear path holds the source and destination in u16, so it transiently uses about 2x the memory of the default path for the same `maxPixels` budget.
- Pre-existing and unchanged: neither path premultiplies alpha before resampling, so fully transparent pixels' RGB can bleed into edges. Sharp premultiplies by default. That is a separate divergence and is not widened or narrowed here.
- The fail-before set: "checkerboard downscale averages light, not codes", "lanczos3 interior mean on the checkerboard lands near 188", and "invalid colorspace value throws" all fail under `USE_SYSTEM_BUN=1`. The other three new tests (flat-field exactness, explicit `"srgb"` equals default, backend parity) pass both ways by design: they pin that the default and the DC gain did not move.
- Suites run: `bun bd test test/js/bun/image/` (228 pass, 2 skip), `bun test test/integration/bun-types/bun-types.test.ts` (17 pass), `cargo check -p bun_runtime`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/image/image-kernels.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/image/image-kernels.test.ts:
(pass) resize filter properties > nearest preserves a flat field exactly (sum-to-one + edge renormalisation) [217.58ms]
(pass) resize filter properties > box preserves a flat field exactly (sum-to-one + edge renormalisation) [103.93ms]
(pass) resize filter properties > bilinear preserves a flat field exactly (sum-to-one + edge renormalisation) [100.61ms]
(pass) resize filter properties > cubic preserves a flat field exactly (sum-to-one + edge renormalisation) [89.07ms]
(pass) resize filter properties > mitchell preserves a flat field exactly (sum-to-one + edge renormalisation) [87.75ms]
(pass) resize filter properties > lanczos2 preserves a flat field exactly (sum-to-one + edge renormalisation) [88.91ms]
(pass) resize filter properties > lanczos3 preserves a flat field exactly (sum-to-one + edge renormalisation) [83.04ms]
(pass) resize filter properties > mks2013 preserves a flat field exactly (sum-to-one + edge renormalisation
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (50f8a93c3)

test/js/bun/image/image-kernels.test.ts:
(pass) resize filter properties > nearest preserves a flat field exactly (sum-to-one + edge renormalisation) [2.93ms]
(pass) resize filter properties > box preserves a flat field exactly (sum-to-one + edge renormalisation) [0.81ms]
(pass) resize filter properties > bilinear preserves a flat field exactly (sum-to-one + edge renormalisation) [0.81ms]
(pass) resize filter properties > cubic preserves a flat field exactly (sum-to-one + edge renormalisation) [0.91ms]
(pass) resize filter properties > mitchell preserves a flat field exactly (sum-to-one + edge renormalisation) [0.77ms]
(pass) resize filter properties > lanczos2 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.58ms]
(pass) resize filter properties > lanczos3 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.53ms]
(pass) resize filter properties > mks2013 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.48ms]
(pass) resize filter properties > mks2021 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.45ms]
(pass) resize filter properties > nearest 1×
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/image/image-kernels.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/image/image-kernels.test.ts:
(pass) resize filter properties > nearest preserves a flat field exactly (sum-to-one + edge renormalisation) [235.18ms]
(pass) resize filter properties > box preserves a flat field exactly (sum-to-one + edge renormalisation) [102.06ms]
(pass) resize filter properties > bilinear preserves a flat field exactly (sum-to-one + edge renormalisation) [93.45ms]
(pass) resize filter properties > cubic preserves a flat field exactly (sum-to-one + edge renormalisation) [90.39ms]
(pass) resize filter properties > mitchell preserves a flat field exactly (sum-to-one + edge renormalisation) [90.51ms]
(pass) resize filter properties > lanczos2 preserves a flat field exactly (sum-to-one + edge renormalisation) [90.96ms]
(pass) resize filter properties > lanczos3 preserves a flat field exactly (sum-to-one + edge renormalisation) [86.11ms]
(pass) resize filter properties > mks2013 preserves a flat field exactly (sum-to-one + edge renormalisation)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 639ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/jsc/bindings/image_resize.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 242 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/image.mdx                  |  12 ++-
 packages/bun-types/bun.d.ts             |  11 +++
 src/jsc/bindings/image_resize.cpp       | 103 +++++++++++++++++++++-
 src/runtime/image/Image.rs              |  43 +++++++++-
 src/runtime/image/codecs.rs             | 148 ++++++++++++++++++++++++++++++++
 test/js/bun/image/image-kernels.test.ts | 120 ++++++++++++++++++++++++++
 6 files changed, 430 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
docs/runtime/image.mdx                       1      2      0
packages/bun-types/bun.d.ts                  1      2      0
src/jsc/bindings/image_resize.cpp            2      7      0
src/runtime/image/Image.rs                   2      4      0
src/runtime/image/codecs.rs                  1      5      0
test/js/bun/image/image-kernels.test.ts      2      3      0
```

</details>

**root cause** · written by the author bot

Bun.Image.resize averaged encoded sRGB pixel values as though they were linear light, but sRGB encodes perceived brightness rather than physical intensity, so every downscale systematically darkened fine detail on both the system and portable backends. The fix adds a colorspace: "linear" resize option that decodes pixels to linear light, performs the resize in a 16-bit RGBA kernel, and re-encodes the result to sRGB, so averaged pixels correctly represent averaged light. The default remains "srgb" for compatibility with Sharp and OS resizers, and the linear path always runs the portable kern…

<!-- robobun:evidence:end -->