### PR TITLE
windows: hold WTF's thread-suspend lock across ExitProcess

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -729,13 +729,9 @@ pub fn exit(code: u32) -> ! {
     }
     #[cfg(windows)]
     {
-        // Defined in src/jsc/bindings/c-bindings.cpp. Holds WTF's thread-suspension
-        // lock so no other thread (a Wasm compiler thread's instruction-cache
-        // barrier, the GC stack scan, the libpas scavenger) has this one suspended
-        // when ExitProcess kills them: a thread killed between its SuspendThread and
-        // ResumeThread would leave us suspended inside NtTerminateProcess and the
-        // process would never finish exiting. Takes no args and has no
-        // preconditions, so `safe fn`.
+        // src/jsc/bindings/c-bindings.cpp. Keeps WTF from suspending this thread
+        // while ExitProcess kills the threads that would resume it. No args, no
+        // preconditions: `safe fn`.
         unsafe extern "C" {
             safe fn Bun__lockThreadSuspensionForExit();
         }

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -729,7 +729,18 @@ pub fn exit(code: u32) -> ! {
     }
     #[cfg(windows)]
     {
+        // Defined in src/jsc/bindings/c-bindings.cpp. Holds WTF's thread-suspension
+        // lock so no other thread (a Wasm compiler thread's instruction-cache
+        // barrier, the GC stack scan, the libpas scavenger) has this one suspended
+        // when ExitProcess kills them: a thread killed between its SuspendThread and
+        // ResumeThread would leave us suspended inside NtTerminateProcess and the
+        // process would never finish exiting. Takes no args and has no
+        // preconditions, so `safe fn`.
+        unsafe extern "C" {
+            safe fn Bun__lockThreadSuspensionForExit();
+        }
         Bun__onExit();
+        Bun__lockThreadSuspensionForExit();
         // `ExitProcess` is `safe fn` (no preconditions; never returns).
         crate::windows_sys::kernel32::ExitProcess(code)
     }

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -729,9 +729,8 @@ pub fn exit(code: u32) -> ! {
     }
     #[cfg(windows)]
     {
-        // src/jsc/bindings/c-bindings.cpp. Keeps WTF from suspending this thread
-        // while ExitProcess kills the threads that would resume it. No args, no
-        // preconditions: `safe fn`.
+        // c-bindings.cpp: no WTF thread may hold this one suspended when ExitProcess
+        // kills it. No args, no preconditions: `safe fn`.
         unsafe extern "C" {
             safe fn Bun__lockThreadSuspensionForExit();
         }

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -20,6 +20,9 @@
 #include <uv.h>
 #include <windows.h>
 #include <corecrt_io.h>
+#include <atomic>
+#include <new>
+#include <wtf/Threading.h>
 #endif // !OS(WINDOWS)
 #include <lshpack.h>
 
@@ -605,6 +608,37 @@ BOOL WINAPI Ctrlhandler(DWORD signal)
 extern "C" void Bun__setCTRLHandler(BOOL add)
 {
     SetConsoleCtrlHandler(Ctrlhandler, add);
+}
+
+// Called right before ExitProcess(). ExitProcess terminates every other thread
+// and waits for them to finish. WTF suspends threads with SuspendThread() from
+// other threads: a Wasm compiler thread runs Thread::barrierInstructionCache()
+// on every thread that executes Wasm when it installs compiled code (ARM64
+// only; x64 needs no barrier), the GC scans machine stacks, the libpas
+// scavenger force-stops an idle thread's allocators. If such a thread has
+// suspended the exiting thread and is killed before its ResumeThread(), the
+// exiting thread stays suspended inside NtTerminateProcess forever and the
+// process never finishes exiting. Every suspender holds the ThreadSuspendLocker
+// across its suspend/resume pair, so taking it here waits for an in-flight
+// suspension to end and keeps a new one from starting. It is never released:
+// the process is going away.
+extern "C" void Bun__lockThreadSuspensionForExit()
+{
+    static std::atomic<DWORD> owner { 0 };
+    DWORD self = GetCurrentThreadId();
+    DWORD expected = 0;
+    if (!owner.compare_exchange_strong(expected, self, std::memory_order_acq_rel)) {
+        // Re-entered on the exiting thread (something in ExitProcess exits
+        // again): the lock is already ours.
+        if (expected == self)
+            return;
+        // Another thread is exiting and owns the lock. Its ExitProcess
+        // terminates this thread; wait for that instead of racing it.
+        for (;;)
+            SleepEx(INFINITE, FALSE);
+    }
+    alignas(WTF::ThreadSuspendLocker) static unsigned char storage[sizeof(WTF::ThreadSuspendLocker)];
+    new (storage) WTF::ThreadSuspendLocker();
 }
 #endif
 

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -610,10 +610,8 @@ extern "C" void Bun__setCTRLHandler(BOOL add)
     SetConsoleCtrlHandler(Ctrlhandler, add);
 }
 
-// ExitProcess kills every other thread. A WTF suspender (Wasm i-cache barrier, GC
-// stack scan, libpas scavenger) killed between SuspendThread and ResumeThread of
-// this thread would leave it suspended inside NtTerminateProcess forever. All of
-// them hold ThreadSuspendLocker across that pair: hold it here, never release it.
+// Held, never released, across ExitProcess: a WTF suspender it kills between
+// SuspendThread and ResumeThread of this thread would leave it suspended forever.
 extern "C" void Bun__lockThreadSuspensionForExit()
 {
     static std::atomic<DWORD> owner { 0 };

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -610,30 +610,20 @@ extern "C" void Bun__setCTRLHandler(BOOL add)
     SetConsoleCtrlHandler(Ctrlhandler, add);
 }
 
-// Called right before ExitProcess(). ExitProcess terminates every other thread
-// and waits for them to finish. WTF suspends threads with SuspendThread() from
-// other threads: a Wasm compiler thread runs Thread::barrierInstructionCache()
-// on every thread that executes Wasm when it installs compiled code (ARM64
-// only; x64 needs no barrier), the GC scans machine stacks, the libpas
-// scavenger force-stops an idle thread's allocators. If such a thread has
-// suspended the exiting thread and is killed before its ResumeThread(), the
-// exiting thread stays suspended inside NtTerminateProcess forever and the
-// process never finishes exiting. Every suspender holds the ThreadSuspendLocker
-// across its suspend/resume pair, so taking it here waits for an in-flight
-// suspension to end and keeps a new one from starting. It is never released:
-// the process is going away.
+// ExitProcess kills every other thread. A WTF suspender (Wasm i-cache barrier, GC
+// stack scan, libpas scavenger) killed between SuspendThread and ResumeThread of
+// this thread would leave it suspended inside NtTerminateProcess forever. All of
+// them hold ThreadSuspendLocker across that pair: hold it here, never release it.
 extern "C" void Bun__lockThreadSuspensionForExit()
 {
     static std::atomic<DWORD> owner { 0 };
     DWORD self = GetCurrentThreadId();
     DWORD expected = 0;
     if (!owner.compare_exchange_strong(expected, self, std::memory_order_acq_rel)) {
-        // Re-entered on the exiting thread (something in ExitProcess exits
-        // again): the lock is already ours.
+        // Re-entered on the thread that already holds the lock.
         if (expected == self)
             return;
-        // Another thread is exiting and owns the lock. Its ExitProcess
-        // terminates this thread; wait for that instead of racing it.
+        // Another thread's exit holds it and is about to terminate this thread.
         for (;;)
             SleepEx(INFINITE, FALSE);
     }

--- a/test/js/node/process/process-exit-during-wasm-tier-up.test.ts
+++ b/test/js/node/process/process-exit-during-wasm-tier-up.test.ts
@@ -1,0 +1,129 @@
+// On Windows, ExitProcess terminates every other thread and waits for them to
+// finish. JSC's Wasm compiler threads run Thread::barrierInstructionCache() on
+// every thread that executes Wasm when they install compiled code. On arm64 that
+// is SuspendThread() + ResumeThread() of the target (x64 needs no barrier). A
+// compiler thread killed by ExitProcess between those two calls left the exiting
+// thread suspended inside NtTerminateProcess forever: the process printed its
+// output and never exited.
+//
+// The fixture queues thousands of background Wasm compiles and exits while they
+// are still running. Without the fix about half of these processes never exit on
+// Windows arm64. The test cannot fail elsewhere; it runs on every Windows lane so
+// the exit path is still exercised there.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+const functionCount = 4000;
+const passes = 20;
+// Function i returns its argument plus i; the fixture sums every call.
+const expectedSum =
+  passes * ((functionCount * (functionCount - 1)) / 2) + functionCount * ((passes * (passes - 1)) / 2);
+
+// A file, not `-e`: one-shot invocations compile Wasm synchronously, and the
+// race needs the compiles to finish on the compiler threads.
+const fixture = `
+  // A module with many tiny functions: (func (param i32) (result i32) local.get 0 i32.const k i32.add).
+  function uleb(v, out) {
+    do {
+      let b = v & 0x7f;
+      v >>>= 7;
+      if (v) b |= 0x80;
+      out.push(b);
+    } while (v);
+  }
+  function sleb(v, out) {
+    for (;;) {
+      const b = v & 0x7f;
+      v >>= 7;
+      if ((v === 0 && (b & 0x40) === 0) || (v === -1 && (b & 0x40) !== 0)) {
+        out.push(b);
+        return;
+      }
+      out.push(b | 0x80);
+    }
+  }
+  function section(id, content, out) {
+    out.push(id);
+    uleb(content.length, out);
+    for (const b of content) out.push(b);
+  }
+  const n = ${functionCount};
+  const out = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+  section(1, [0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f], out);
+  const funcs = [];
+  uleb(n, funcs);
+  for (let i = 0; i < n; i++) funcs.push(0x00);
+  section(3, funcs, out);
+  const exports = [];
+  uleb(n, exports);
+  for (let i = 0; i < n; i++) {
+    const name = Array.from(new TextEncoder().encode("f" + i));
+    uleb(name.length, exports);
+    exports.push(...name, 0x00);
+    uleb(i, exports);
+  }
+  section(7, exports, out);
+  const code = [];
+  uleb(n, code);
+  for (let i = 0; i < n; i++) {
+    const body = [0x00, 0x20, 0x00, 0x41];
+    sleb(i, body);
+    body.push(0x6a, 0x0b);
+    uleb(body.length, code);
+    code.push(...body);
+  }
+  section(10, code, out);
+
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array(out)));
+  const fns = Object.values(instance.exports);
+  // Call every function past the BBQ tier-up threshold. Each compile finishes on
+  // a compiler thread, which then suspends and resumes this thread. Exit while
+  // the queue is still full.
+  let acc = 0;
+  for (let pass = 0; pass < ${passes}; pass++) {
+    for (let i = 0; i < fns.length; i++) acc += fns[i](pass);
+  }
+  console.log(acc);
+  process.exit(0);
+`;
+
+test.skipIf(!isWindows)(
+  "process exits while Wasm compiler threads are installing code",
+  async () => {
+    using dir = tempDir("exit-during-wasm-tier-up", { "fixture.mjs": fixture });
+    const procs = Array.from({ length: 8 }, () =>
+      Bun.spawn({
+        cmd: [bunExe(), "fixture.mjs"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      }),
+    );
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<"timeout">(resolve => {
+      timer = setTimeout(() => resolve("timeout"), 20_000);
+    });
+    try {
+      const results = await Promise.all(
+        procs.map(async proc => {
+          const exited = await Promise.race([proc.exited, timeout]);
+          if (exited === "timeout") {
+            // A process stuck in termination cannot be killed. Do not wait for it.
+            try {
+              proc.kill();
+            } catch {}
+            return "did not exit";
+          }
+          const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+          return { exitCode: exited, stdout, stderr };
+        }),
+      );
+      expect(results).toEqual(procs.map(() => ({ exitCode: 0, stdout: `${expectedSum}\n`, stderr: "" })));
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+  30_000,
+);

--- a/test/js/node/process/process-exit-during-wasm-tier-up.test.ts
+++ b/test/js/node/process/process-exit-during-wasm-tier-up.test.ts
@@ -87,43 +87,43 @@ const fixture = `
   process.exit(0);
 `;
 
-test.skipIf(!isWindows)(
-  "process exits while Wasm compiler threads are installing code",
-  async () => {
-    using dir = tempDir("exit-during-wasm-tier-up", { "fixture.mjs": fixture });
-    const procs = Array.from({ length: 8 }, () =>
-      Bun.spawn({
-        cmd: [bunExe(), "fixture.mjs"],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
+test.skipIf(!isWindows)("process exits while Wasm compiler threads are installing code", async () => {
+  using dir = tempDir("exit-during-wasm-tier-up", { "fixture.mjs": fixture });
+  const procs = Array.from({ length: 8 }, () =>
+    Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    }),
+  );
+
+  // The failure this test detects is a process that never exits, so the wait
+  // for `exited` needs a bound. A process stuck in termination cannot be killed
+  // and its pipes never close: on timeout, report it and leave it alone.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<"timeout">(resolve => {
+    timer = setTimeout(() => resolve("timeout"), 20_000);
+  });
+  try {
+    const results = await Promise.all(
+      procs.map(async proc => {
+        // Drain both pipes while the child runs so a large stderr cannot block it.
+        const stdout = proc.stdout.text();
+        const stderr = proc.stderr.text();
+        const exited = await Promise.race([proc.exited, timeout]);
+        if (exited === "timeout") {
+          try {
+            proc.kill();
+          } catch {}
+          return "did not exit";
+        }
+        return { exitCode: exited, stdout: await stdout, stderr: await stderr };
       }),
     );
-
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<"timeout">(resolve => {
-      timer = setTimeout(() => resolve("timeout"), 20_000);
-    });
-    try {
-      const results = await Promise.all(
-        procs.map(async proc => {
-          const exited = await Promise.race([proc.exited, timeout]);
-          if (exited === "timeout") {
-            // A process stuck in termination cannot be killed. Do not wait for it.
-            try {
-              proc.kill();
-            } catch {}
-            return "did not exit";
-          }
-          const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
-          return { exitCode: exited, stdout, stderr };
-        }),
-      );
-      expect(results).toEqual(procs.map(() => ({ exitCode: 0, stdout: `${expectedSum}\n`, stderr: "" })));
-    } finally {
-      clearTimeout(timer);
-    }
-  },
-  30_000,
-);
+    expect(results).toEqual(procs.map(() => ({ exitCode: 0, stdout: `${expectedSum}\n`, stderr: "" })));
+  } finally {
+    clearTimeout(timer);
+  }
+});


### PR DESCRIPTION
### Problem
- On Windows 11 arm64, `bun test test/js/third_party/solc/solc.test.ts` prints `1 pass, 0 fail` and the process never exits. The CI runner reports `solc.test.ts - timeout` (38 of the last 400 builds, this lane only). A release build from this commit, pinned to 4 cores like the CI VM, hangs in 25 of 300 runs.
- The stuck process has one thread left: the main thread, inside `NtTerminateProcess(NULL)` (the first call `ExitProcess` makes, which kills the other threads and waits for them), with `suspendCount=1`. A Wasm compiler thread suspended it from `JSC::Wasm::barrierInstructionCacheOnAllThreads` → `WTF::Thread::barrierInstructionCache` (`SuspendThread` + `ResumeThread`) and was killed by that same `ExitProcess` before its `ResumeThread`. Nothing can resume the main thread, so the exit never completes.
- Only arm64 sees it: `Thread::barrierInstructionCache` is a no-op on x64.

### Fix
- `bun_core::Global::exit` on Windows calls `Bun__lockThreadSuspensionForExit()` (new, `src/jsc/bindings/c-bindings.cpp`) after `Bun__onExit()` and right before `ExitProcess`. It takes `WTF::ThreadSuspendLocker` and never releases it.
- Correct because every WTF suspender (the Wasm compiler barrier, the GC stack scan, the libpas scavenger) holds `ThreadSuspendLocker` across its suspend/resume pair. Taking it waits for an in-flight suspension to end and blocks a new one from starting, so the kernel kills no thread that holds a suspension. A second exit on another thread sleeps until the first exit kills it. A re-entrant call on the exiting thread returns at once.
- The hold is safe across `ExitProcess`: WTF's and libpas's thread teardown on the exiting thread return early when `RtlDllShutdownInProgress()` is set, so they take no lock a killed thread held.
- Verified on Windows 11 arm64 (16 vCPU, and pinned to 4): release builds from this commit, unfixed vs fixed. `solc.test.ts` loop: 25/300 hangs → 0/300. New test: 5/5 fail → 10/10 pass. `process.test.js`, `process-on.test.ts`, `worker.test.ts`, `wasi.test.js` pass.

### Background
- `ExitProcess` (`RtlExitUserProcess`) calls `NtTerminateProcess(NULL)`, which terminates every other thread and returns only after they are gone. Then it runs DLL detach and terminates the process.
- `SuspendThread` queues a kernel APC on the target. A thread waiting inside a system call gets suspended there and resumes only when someone calls `ResumeThread`. The exiting thread is excluded from its own kill list, so a leaked suspension on it is permanent.
- `Thread::barrierInstructionCache` (WTF, Windows) publishes freshly written JIT code to another thread by suspending and resuming it: the resume runs a context-synchronizing return on the target. JSC does this for every Wasm thread each time a BBQ or OMG compile installs its code, so a module with thousands of functions produces bursts of suspensions while its tier-up compiles drain.
- `WTF::ThreadSuspendLocker` is the process-wide lock that serializes thread suspension in WebKit. On Windows it is libpas's `pas_thread_suspend_lock`, which the libpas scavenger also uses.

<details><summary>Notes</summary>

How it was found. The hung process was inspected with `NtQueryInformationThread`: `ThreadLastSystemCall` = `NtTerminateProcess` with a NULL handle (return address `RtlExitUserProcess+0x4c`, the first of its two `ZwTerminateProcess` calls), `ThreadSuspendCount` = 1, `SystemProcessInformation` wait reason `Suspended`, all 14 other threads terminated. Sampling the other threads while the main thread was suspended during a run, and symbolizing with the PDB, gave `WTF::Thread::suspend` ← `Thread::barrierInstructionCache` ← `Wasm::barrierInstructionCacheOnAllThreads` ← `Wasm::CalleeGroup::installOptimizedCallee` ← `Wasm::BBQPlan::work` on the compiler threads.

Why this test shape. The race needs background Wasm compiles to be finishing as the process exits. `bun -e` is a one-shot invocation with `useConcurrentJIT=false`, where tier-up compiles complete synchronously, so the fixture runs from a file. A module with 4000 tiny functions, each called 20 times, queues thousands of BBQ compiles; unfixed, 40 to 60% of such processes hang on arm64 (N=4000, passes 10 to 45 all reproduce; passes ≥ 50 do not, the compiles then finish before exit). The test spawns 8 and takes about 0.2 s with a release build, 2.8 s with a debug build. A debug build does not reproduce the hang (0/60 on `solc.test.ts`, 3/3 pass unfixed on the new test), so only release lanes can fail it. The test is skipped off Windows and cannot fail on Windows x64. The gate's fail-before run is on Linux, where the changed code is not compiled.

`BUN_JSC_useConcurrentGC=false` did not change the hang rate, which ruled out the GC's conservative scan as the required suspender. `TerminateProcess(self)` instead of `ExitProcess` was considered and rejected: its self-termination path has the same window, only shorter, and it skips DLL detach.

Other `ExitProcess` callers (`src/io/lib.rs`, the crash handler) run on threads without a `WTF::Thread` or on the crash path and are left alone.
</details>
