### PR TITLE
image: resample through premultiplied alpha in resize

### DIFF
--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -665,11 +665,11 @@ fn mul_div_255(c: u32, a: u32) -> u8 {
 /// Premultiplied copy of `src`, or `None` when every pixel is opaque (the
 /// round trip would be an identity, so skip the copy).
 fn premultiplied(src: &[u8]) -> Option<Vec<u8>> {
-    if !src.chunks_exact(4).any(|p| p[3] != 255) {
+    if !src.as_chunks::<4>().0.iter().any(|p| p[3] != 255) {
         return None;
     }
     let mut out = src.to_vec();
-    for p in out.chunks_exact_mut(4) {
+    for p in out.as_chunks_mut::<4>().0 {
         let a = u32::from(p[3]);
         if a == 255 {
             continue;
@@ -682,7 +682,7 @@ fn premultiplied(src: &[u8]) -> Option<Vec<u8>> {
 }
 
 fn unpremultiply(rgba: &mut [u8]) {
-    for p in rgba.chunks_exact_mut(4) {
+    for p in rgba.as_chunks_mut::<4>().0 {
         let a = u32::from(p[3]);
         if a == 255 {
             continue;

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -700,8 +700,7 @@ fn unpremultiply(rgba: &mut [u8]) {
 }
 
 /// Resample through premultiplied alpha so transparent pixels don't bleed
-/// RGB into neighbours. `nearest` copies single source samples (no mixing),
-/// so it skips the lossy u8 round trip and stays bit-exact.
+/// RGB into neighbours.
 pub(crate) fn resize(
     src: &[u8],
     sw: u32,
@@ -710,6 +709,7 @@ pub(crate) fn resize(
     dh: u32,
     f: Filter,
 ) -> Result<Vec<u8>, Error> {
+    // `nearest` copies single samples; skip the lossy u8 round trip.
     let premul = if f == Filter::Nearest {
         None
     } else {

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -655,7 +655,76 @@ pub(crate) fn modulate(rgba: &mut [u8], brightness: f32, saturation: f32) {
     unsafe { bun_image_modulate_rgba8(rgba.as_mut_ptr(), rgba.len(), brightness, saturation) }
 }
 
+/// `round(c * a / 255)` without a divide.
+#[inline]
+fn mul_div_255(c: u32, a: u32) -> u8 {
+    let x = c * a + 128;
+    ((x + (x >> 8)) >> 8) as u8
+}
+
+/// Premultiplied copy of `src`, or `None` when every pixel is opaque (the
+/// round trip would be an identity, so skip the copy).
+fn premultiplied(src: &[u8]) -> Option<Vec<u8>> {
+    if !src.chunks_exact(4).any(|p| p[3] != 255) {
+        return None;
+    }
+    let mut out = src.to_vec();
+    for p in out.chunks_exact_mut(4) {
+        let a = u32::from(p[3]);
+        if a == 255 {
+            continue;
+        }
+        p[0] = mul_div_255(u32::from(p[0]), a);
+        p[1] = mul_div_255(u32::from(p[1]), a);
+        p[2] = mul_div_255(u32::from(p[2]), a);
+    }
+    Some(out)
+}
+
+fn unpremultiply(rgba: &mut [u8]) {
+    for p in rgba.chunks_exact_mut(4) {
+        let a = u32::from(p[3]);
+        if a == 255 {
+            continue;
+        }
+        if a == 0 {
+            p[0] = 0;
+            p[1] = 0;
+            p[2] = 0;
+            continue;
+        }
+        for c in &mut p[..3] {
+            // Ringing filters can push premultiplied RGB past alpha; clamp.
+            *c = ((u32::from(*c) * 255 + a / 2) / a).min(255) as u8;
+        }
+    }
+}
+
+/// Resample through premultiplied alpha so transparent pixels don't bleed
+/// their RGB into neighbours. `nearest` copies single source samples (no
+/// mixing), so it skips the lossy u8 premultiply round trip and stays exact.
 pub(crate) fn resize(
+    src: &[u8],
+    sw: u32,
+    sh: u32,
+    dw: u32,
+    dh: u32,
+    f: Filter,
+) -> Result<Vec<u8>, Error> {
+    let premul = if f == Filter::Nearest {
+        None
+    } else {
+        premultiplied(src)
+    };
+    let Some(premul) = premul else {
+        return resize_straight(src, sw, sh, dw, dh, f);
+    };
+    let mut out = resize_straight(&premul, sw, sh, dw, dh, f)?;
+    unpremultiply(&mut out);
+    Ok(out)
+}
+
+fn resize_straight(
     src: &[u8],
     sw: u32,
     sh: u32,

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -662,8 +662,7 @@ fn mul_div_255(c: u32, a: u32) -> u8 {
     ((x + (x >> 8)) >> 8) as u8
 }
 
-/// Premultiplied copy of `src`, or `None` when every pixel is opaque (the
-/// round trip would be an identity, so skip the copy).
+/// Premultiplied copy of `src`, or `None` when every pixel is opaque.
 fn premultiplied(src: &[u8]) -> Option<Vec<u8>> {
     if !src.as_chunks::<4>().0.iter().any(|p| p[3] != 255) {
         return None;
@@ -701,8 +700,8 @@ fn unpremultiply(rgba: &mut [u8]) {
 }
 
 /// Resample through premultiplied alpha so transparent pixels don't bleed
-/// their RGB into neighbours. `nearest` copies single source samples (no
-/// mixing), so it skips the lossy u8 premultiply round trip and stays exact.
+/// RGB into neighbours. `nearest` copies single source samples (no mixing),
+/// so it skips the lossy u8 round trip and stays bit-exact.
 pub(crate) fn resize(
     src: &[u8],
     sw: u32,

--- a/test/js/bun/image/image-kernels.test.ts
+++ b/test/js/bun/image/image-kernels.test.ts
@@ -102,7 +102,7 @@ async function resizePixels(
   src: Uint8Array,
   w: number,
   h: number,
-  filter: "box" | "bilinear" | "lanczos3" | "mitchell",
+  filter: "box" | "bilinear" | "lanczos3" | "mitchell" | "nearest",
 ): Promise<Uint8Array> {
   return decodePng(await new Bun.Image(src).resize(w, h, { filter }).png().bytes()).data;
 }
@@ -227,6 +227,68 @@ describe("resize filter properties", () => {
     const flat = makePng(16, 5, x => [(x * 16) & 255, 0, 0, 255]);
     const out = await resizePixels(flat, 8, 5, filter);
     for (let x = 0; x < 8; x++) for (let y = 1; y < 5; y++) expect(out[(y * 8 + x) * 4]).toBe(out[x * 4]);
+  });
+});
+
+// ─── premultiplied-alpha resampling ─────────────────────────────────────────
+// Resize must filter premultiplied RGBA: a fully transparent pixel's RGB
+// carries no weight, so it can't bleed into neighbours (issue #40514).
+
+describe("premultiplied alpha resampling", () => {
+  // box 2×1 → 1×1 is an exact average, so the expected pixel is exact.
+  // premul(transparent white) = (0,0,0,0); average with opaque black =
+  // (0,0,0,128); unpremultiply leaves RGB at 0. Straight-alpha resampling
+  // produced rgba(128,128,128,128) here.
+  test("transparent white does not bleed into opaque black (box)", async () => {
+    const src = makePng(2, 1, x => (x === 0 ? [0, 0, 0, 255] : [255, 255, 255, 0]));
+    const out = await resizePixels(src, 1, 1, "box");
+    expect(Array.from(out)).toEqual([0, 0, 0, 128]);
+  });
+
+  // The transparent pixels' green is premultiplied to 0, so no filter tap can
+  // introduce it — the green channel must be exactly 0 everywhere.
+  test("transparent green does not tint an opaque red checker (lanczos3)", async () => {
+    const src = makePng(16, 16, (x, y) => ((x + y) & 1 ? [255, 0, 0, 255] : [0, 255, 0, 0]));
+    const out = await resizePixels(src, 8, 8, "lanczos3");
+    for (let i = 0; i < out.length; i += 4) expect(out[i + 1]).toBe(0);
+  });
+
+  test("fully transparent output pixels have zero RGB", async () => {
+    const src = makePng(4, 4, () => [255, 255, 255, 0]);
+    const out = await resizePixels(src, 2, 2, "box");
+    for (let i = 0; i < out.length; i += 4) {
+      expect([out[i], out[i + 1], out[i + 2], out[i + 3]]).toEqual([0, 0, 0, 0]);
+    }
+  });
+
+  // The u8 premultiply round trip loses at most ~255/alpha per channel; at
+  // alpha 128 a flat field must come back within 1.
+  test("translucent flat field survives resize within rounding", async () => {
+    const src = makePng(9, 7, () => [200, 100, 50, 128]);
+    const out = await resizePixels(src, 3, 3, "mitchell");
+    for (let i = 0; i < out.length; i += 4) {
+      expect(Math.abs(out[i] - 200)).toBeLessThanOrEqual(1);
+      expect(Math.abs(out[i + 1] - 100)).toBeLessThanOrEqual(1);
+      expect(Math.abs(out[i + 2] - 50)).toBeLessThanOrEqual(1);
+      expect(out[i + 3]).toBe(128);
+    }
+  });
+
+  // nearest copies single source samples, so it must stay bit-exact for
+  // translucent pixels (no premultiply round trip).
+  test("nearest keeps translucent pixels bit-exact", async () => {
+    const colors: [number, number, number, number][] = [
+      [200, 100, 50, 128],
+      [7, 250, 13, 3],
+      [255, 0, 255, 0],
+      [1, 2, 3, 254],
+    ];
+    const src = makePng(2, 2, (x, y) => colors[y * 2 + x]);
+    const out = await resizePixels(src, 4, 4, "nearest");
+    for (let i = 0; i < out.length; i += 4) {
+      const px = [out[i], out[i + 1], out[i + 2], out[i + 3]];
+      expect(colors.some(c => c[0] === px[0] && c[1] === px[1] && c[2] === px[2] && c[3] === px[3])).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.Image.resize()` resamples straight (non-premultiplied) RGBA. A fully transparent pixel still contributes its RGB to neighboring output pixels. A 2x1 image of opaque black next to transparent white, resized to 1x1 with the box filter, produces rgba(128,128,128,128) instead of rgba(0,0,0,128). Composited, that is a light fringe. Fixes #40514.
- The cause is `resize()` in `src/runtime/image/codecs.rs:658`. It feeds the straight RGBA buffer to the resample kernel. The macOS vImage path (`backend_coregraphics.rs` `scale()`) has the same behavior.

### Fix
- `codecs::resize()` now premultiplies RGB by alpha before the resample and unpremultiplies after, with a zero-alpha guard (RGB stays 0). The wrapper sits around both backends, so the highway kernel and the vImage path behave the same.
- A fully opaque image skips the round trip (one scan of the alpha bytes). The `nearest` filter also skips it: it copies single source samples with no mixing, so it stays bit-exact for translucent pixels.
- This matches Sharp, which premultiplies by default before resampling.
- Verified: `test/js/bun/image/image-kernels.test.ts` (new `premultiplied alpha resampling` block, 3 of 5 tests fail on stock bun). Also the full `test/js/bun/image/` suite (227 pass), including the Sharp parity tests.

### Background
- Premultiplied alpha stores each channel as RGB times alpha. A linear filter over premultiplied pixels weights each tap by its coverage, so an invisible pixel (alpha 0) contributes nothing. Filtering straight RGBA weights all taps equally and lets hidden RGB leak in.
- The premultiply runs at u8 precision, like pixman and Skia. The round trip loses at most about 255/alpha per channel. A flat rgba(200,100,50,128) field comes back within 1 (asserted in the tests). Sharp premultiplies in float, so low-alpha pixels can differ from Sharp by a few ULPs of u8.

<details><summary>Notes</summary>

- Repro: hand-built 2x1 RGBA PNG, pixel 0 opaque black, pixel 1 transparent white, `resize(1, 1, { fit: "fill", filter: "box" })`. Expected rgba(0,0,0,128) (exact for the box average), got rgba(128,128,128,128) before the fix.
- The placeholder/thumbhash downscale (`Image.rs:2008`) calls the same `codecs::resize`, so it is covered too.
- The unpremultiply clamps to 255: ringing filters (lanczos) can push premultiplied RGB past alpha.
- PR #40512 (opt-in linear-light resize) is open, not merged. If it lands, its linear path goes through the same `codecs::resize` wrapper, but premultiplying inside linear light would be the cleaner operation there.
- Suites run: `test/js/bun/image/` (image.test.ts, image-kernels.test.ts, image-adversarial.test.ts, image-vs-sharp.test.ts): 227 pass, 2 skip (macOS-only), 0 fail.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/image/image-kernels.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/image/image-kernels.test.ts:
(pass) resize filter properties > nearest preserves a flat field exactly (sum-to-one + edge renormalisation) [227.60ms]
(pass) resize filter properties > box preserves a flat field exactly (sum-to-one + edge renormalisation) [98.66ms]
(pass) resize filter properties > bilinear preserves a flat field exactly (sum-to-one + edge renormalisation) [91.10ms]
(pass) resize filter properties > cubic preserves a flat field exactly (sum-to-one + edge renormalisation) [89.96ms]
(pass) resize filter properties > mitchell preserves a flat field exactly (sum-to-one + edge renormalisation) [86.45ms]
(pass) resize filter properties > lanczos2 preserves a flat field exactly (sum-to-one + edge renormalisation) [85.35ms]
(pass) resize filter properties > lanczos3 preserves a flat field exactly (sum-to-one + edge renormalisation) [83.92ms]
(pass) resize filter properties > mks2013 preserves a flat field exactly (sum-to-one + edge renormalisation) 
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (cb4b8476a)

test/js/bun/image/image-kernels.test.ts:
(pass) resize filter properties > nearest preserves a flat field exactly (sum-to-one + edge renormalisation) [3.06ms]
(pass) resize filter properties > box preserves a flat field exactly (sum-to-one + edge renormalisation) [0.77ms]
(pass) resize filter properties > bilinear preserves a flat field exactly (sum-to-one + edge renormalisation) [0.59ms]
(pass) resize filter properties > cubic preserves a flat field exactly (sum-to-one + edge renormalisation) [0.46ms]
(pass) resize filter properties > mitchell preserves a flat field exactly (sum-to-one + edge renormalisation) [0.52ms]
(pass) resize filter properties > lanczos2 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.52ms]
(pass) resize filter properties > lanczos3 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.42ms]
(pass) resize filter properties > mks2013 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.38ms]
(pass) resize filter properties > mks2021 preserves a flat field exactly (sum-to-one + edge renormalisation) [0.62ms]
(pass) resize filter properties > nearest 1×
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/image/image-kernels.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/image/image-kernels.test.ts:
(pass) resize filter properties > nearest preserves a flat field exactly (sum-to-one + edge renormalisation) [228.10ms]
(pass) resize filter properties > box preserves a flat field exactly (sum-to-one + edge renormalisation) [98.84ms]
(pass) resize filter properties > bilinear preserves a flat field exactly (sum-to-one + edge renormalisation) [90.47ms]
(pass) resize filter properties > cubic preserves a flat field exactly (sum-to-one + edge renormalisation) [87.57ms]
(pass) resize filter properties > mitchell preserves a flat field exactly (sum-to-one + edge renormalisation) [85.79ms]
(pass) resize filter properties > lanczos2 preserves a flat field exactly (sum-to-one + edge renormalisation) [83.66ms]
(pass) resize filter properties > lanczos3 preserves a flat field exactly (sum-to-one + edge renormalisation) [83.39ms]
(pass) resize filter properties > mks2013 preserves a flat field exactly (sum-to-one + edge renormalisation) 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 667ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 242 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_pic
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/image/codecs.rs             | 68 +++++++++++++++++++++++++++++++++
 test/js/bun/image/image-kernels.test.ts | 64 ++++++++++++++++++++++++++++++-
 2 files changed, 131 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/image/codecs.rs                  3      6      0
test/js/bun/image/image-kernels.test.ts      1      3      0
```

</details>

**root cause** · written by the author bot

Bun.Image.resize() resampled straight RGBA, so fully transparent pixels still contributed their RGB values to neighboring output pixels, producing color fringes along transparent edges in every resize path. The fix premultiplies each pixel's RGB by its alpha before resampling and unpremultiplies afterward, so transparent pixels carry zero color weight and cannot bleed into their neighbors. The unpremultiply step zeroes RGB when alpha is zero and clamps values that ringing filters push past alpha, while nearest-neighbor resampling skips the round trip since it copies single samples and stays…

<!-- robobun:evidence:end -->