### PR TITLE
bundler: one bundle-wide name per cross-chunk binding (no more `export {x as y}` / `import {y as z}` between chunks)

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1306,7 +1306,8 @@ pub struct JavaScriptChunk {
     // The map hashes via `Ref`'s `Hash` impl. Values
     // are `&'static`-erased slices into bundler-owned storage (see the
     // lifetime note on `Chunk`).
-    pub(crate) exports_to_other_chunks: ArrayHashMap<Ref, &'static [u8]>,
+    /// Bindings declared in this chunk that another chunk imports; named by `cross_chunk_names`.
+    pub(crate) exports_to_other_chunks: ArrayHashMap<Ref, ()>,
     pub(crate) imports_from_other_chunks: ImportsFromOtherChunks,
     pub(crate) cross_chunk_prefix_stmts: Vec<Stmt>,
     pub(crate) cross_chunk_suffix_stmts: Vec<Stmt>,

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1533,7 +1533,6 @@ pub(crate) type ImportsFromOtherChunks = ArrayHashMap<IndexInt, cross_chunk_impo
 
 #[derive(Default, Clone)]
 pub struct CrossChunkImportItem {
-    pub(crate) export_alias: Box<[u8]>,
     pub(crate) r#ref: Ref,
 }
 pub type CrossChunkImportItemList = Vec<CrossChunkImportItem>;
@@ -1552,6 +1551,7 @@ impl CrossChunkImport {
         list: &mut Vec<CrossChunkImport>,
         chunks: &mut [Chunk],
         imports_from_other_chunks: &mut ImportsFromOtherChunks,
+        stable_source_indices: &[u32],
     ) -> Result<(), crate::Error> {
         list.clear();
         list.reserve(imports_from_other_chunks.count());
@@ -1560,14 +1560,24 @@ impl CrossChunkImport {
             let chunk_index = imports_from_other_chunks.keys()[i];
             let chunk = &mut chunks[chunk_index as usize];
 
-            let exports_to_other_chunks = &chunk.content.javascript().exports_to_other_chunks;
+            debug_assert!({
+                let exports_to_other_chunks = &chunk.content.javascript().exports_to_other_chunks;
+                imports_from_other_chunks.values()[i]
+                    .iter()
+                    .all(|item| exports_to_other_chunks.contains(&item.r#ref))
+            });
+            let _ = chunk;
             let import_items = &mut imports_from_other_chunks.values_mut()[i];
-            for item in import_items.slice_mut() {
-                item.export_alias = (*exports_to_other_chunks.get(&item.r#ref).unwrap()).into();
-                debug_assert!(!item.export_alias.is_empty());
-            }
+            // Deterministic order; the names are only known after renaming.
             index_sort::sort_slice_by(import_items.slice_mut(), |a, b| {
-                strings::order(&a.export_alias, &b.export_alias)
+                (
+                    stable_source_indices[a.r#ref.source_index() as usize],
+                    a.r#ref.inner_index(),
+                )
+                    .cmp(&(
+                        stable_source_indices[b.r#ref.source_index() as usize],
+                        b.r#ref.inner_index(),
+                    ))
             });
 
             list.push(CrossChunkImport {

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1303,9 +1303,6 @@ pub struct JavaScriptChunk {
     pub parts_in_chunk_in_order: Box<[PartRange]>,
 
     // for code splitting
-    // The map hashes via `Ref`'s `Hash` impl. Values
-    // are `&'static`-erased slices into bundler-owned storage (see the
-    // lifetime note on `Chunk`).
     /// Bindings declared in this chunk that another chunk imports; named by `cross_chunk_names`.
     pub(crate) exports_to_other_chunks: ArrayHashMap<Ref, ()>,
     pub(crate) imports_from_other_chunks: ImportsFromOtherChunks,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2492,10 +2492,13 @@ impl<'a> LinkerContext<'a> {
                             }
                         }
                         crate::chunk::QueryKind::Chunk => out.push(piece.query.index()),
-                        crate::chunk::QueryKind::Scb => out.push(
-                            self.graph.files.items_entry_point_chunk_index()
-                                [piece.query.index() as usize],
-                        ),
+                        crate::chunk::QueryKind::Scb => {
+                            let chunk_index = self.graph.files.items_entry_point_chunk_index()
+                                [piece.query.index() as usize];
+                            if chunk_index != u32::MAX {
+                                out.push(chunk_index);
+                            }
+                        }
                         crate::chunk::QueryKind::None | crate::chunk::QueryKind::HtmlImport => {}
                     }
                 }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2448,7 +2448,9 @@ impl<'a> LinkerContext<'a> {
     /// asset paths its output pieces reference) and that of every chunk it
     /// transitively reaches through cross-chunk imports or output pieces, so a
     /// change anywhere below a chunk renames it. Cycles are fine: reachability
-    /// is a fixpoint over bitsets, and each closure is digested in chunk order.
+    /// is a fixpoint over bitsets, and each chunk digests its own hash first,
+    /// then the rest of its closure in chunk order (so two chunks that reach
+    /// each other still differ).
     pub(crate) fn final_chunk_hashes(&self, chunks: &[Chunk]) -> Result<Vec<u64>, AllocError> {
         let n = chunks.len();
         let mut own: Vec<u64> = Vec::with_capacity(n);
@@ -2529,11 +2531,15 @@ impl<'a> LinkerContext<'a> {
 
         Ok(reach
             .iter()
-            .map(|bits| {
+            .enumerate()
+            .map(|(i, bits)| {
                 let mut hash = ContentHasher::default();
+                hash.write(&own[i].to_ne_bytes());
                 let mut iter = bits.iterator::<true, true>();
                 while let Some(j) = iter.next() {
-                    hash.write(&own[j].to_ne_bytes());
+                    if j != i {
+                        hash.write(&own[j].to_ne_bytes());
+                    }
                 }
                 hash.digest()
             })

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2444,114 +2444,100 @@ impl<'a> LinkerContext<'a> {
         }
     }
 
-    pub(crate) fn append_isolated_hashes_for_imported_chunks(
-        &self,
-        hash: &mut ContentHasher,
-        chunks: &mut [Chunk],
-        index: u32,
-        chunk_visit_map: &mut AutoBitSet,
-    ) {
-        // Only visit each chunk at most once. This is important because there may be
-        // cycles in the chunk import graph. If there's a cycle, we want to include
-        // the hash of every chunk involved in the cycle (along with all of their
-        // dependencies). This depth-first traversal will naturally do that.
-        if chunk_visit_map.is_set(index as usize) {
-            return;
-        }
-        chunk_visit_map.set(index as usize);
-
-        // Visit the other chunks that this chunk imports before visiting this chunk
-        // Note: reshaped for borrowck — collect imports first to avoid aliasing &chunks[index] with recursive &mut chunks
-        let cross_chunk_imports: Vec<u32> = chunks[index as usize]
-            .cross_chunk_imports
-            .slice()
-            .iter()
-            .map(|import| import.chunk_index)
-            .collect();
-        for chunk_index in cross_chunk_imports {
-            self.append_isolated_hashes_for_imported_chunks(
-                hash,
-                chunks,
-                chunk_index,
-                chunk_visit_map,
-            );
-        }
-
-        // Mix in hashes for content referenced via output pieces. JS chunks
-        // express cross-chunk dependencies via `cross_chunk_imports` above, but
-        // HTML (and CSS) chunks only reference other chunks through pieces, so
-        // recurse on those too.
-        // Note: reshaped for borrowck — collect piece queries first so the
-        // `&chunks[index]` borrow is dropped before the recursive `&mut chunks`
-        // calls in the Chunk/Scb arms below. `final_rel_path` is re-indexed per
-        // Asset arm (not hoisted) because it is now `Box<[u8]>` (not `Copy`).
-        let piece_queries: Vec<(crate::chunk::QueryKind, u32)> =
-            if let crate::chunk::IntermediateOutput::Pieces(pieces) =
-                &chunks[index as usize].intermediate_output
-            {
-                pieces
-                    .slice()
-                    .iter()
-                    .map(|p| (p.query.kind(), p.query.index()))
-                    .collect()
-            } else {
-                Vec::new()
-            };
-
-        for (kind, piece_index) in piece_queries {
-            match kind {
-                crate::chunk::QueryKind::Asset => {
-                    let mut from_chunk_dir = bun_paths::resolve_path::dirname::<
-                        bun_paths::resolve_path::platform::Posix,
-                    >(
-                        &chunks[index as usize].final_rel_path
-                    );
-                    if from_chunk_dir == b"." {
-                        from_chunk_dir = b"";
-                    }
-
-                    let source_index = piece_index;
-                    let parse_graph = self.parse_graph();
-                    let additional_files: &[AdditionalFile] =
-                        parse_graph.input_files.items_additional_files()[source_index as usize]
-                            .slice();
-                    debug_assert!(!additional_files.is_empty());
-                    match &additional_files[0] {
-                        AdditionalFile::OutputFile(output_file_id) => {
-                            let path = &parse_graph.additional_output_files
-                                [*output_file_id as usize]
-                                .dest_path;
-                            hash.write(bun_paths::resolve_path::relative_platform::<
-                                bun_paths::resolve_path::platform::Posix,
-                                false,
-                            >(from_chunk_dir, path));
+    /// Each chunk's final content hash: its own isolated hash (plus the
+    /// asset paths its output pieces reference) and that of every chunk it
+    /// transitively reaches through cross-chunk imports or output pieces, so a
+    /// change anywhere below a chunk renames it. Cycles are fine: reachability
+    /// is a fixpoint over bitsets, and each closure is digested in chunk order.
+    pub(crate) fn final_chunk_hashes(&self, chunks: &[Chunk]) -> Result<Vec<u64>, AllocError> {
+        let n = chunks.len();
+        let mut own: Vec<u64> = Vec::with_capacity(n);
+        let mut edges: Vec<Vec<u32>> = Vec::with_capacity(n);
+        for chunk in chunks {
+            let mut hash = ContentHasher::default();
+            let mut out: Vec<u32> = chunk
+                .cross_chunk_imports
+                .slice()
+                .iter()
+                .map(|import| import.chunk_index)
+                .collect();
+            if let crate::chunk::IntermediateOutput::Pieces(pieces) = &chunk.intermediate_output {
+                for piece in pieces.slice() {
+                    match piece.query.kind() {
+                        crate::chunk::QueryKind::Asset => {
+                            let mut from_chunk_dir =
+                                bun_paths::resolve_path::dirname::<
+                                    bun_paths::resolve_path::platform::Posix,
+                                >(&chunk.final_rel_path);
+                            if from_chunk_dir == b"." {
+                                from_chunk_dir = b"";
+                            }
+                            let parse_graph = self.parse_graph();
+                            let additional_files: &[AdditionalFile] =
+                                parse_graph.input_files.items_additional_files()
+                                    [piece.query.index() as usize]
+                                    .slice();
+                            debug_assert!(!additional_files.is_empty());
+                            if let AdditionalFile::OutputFile(output_file_id) = &additional_files[0]
+                            {
+                                let path = &parse_graph.additional_output_files
+                                    [*output_file_id as usize]
+                                    .dest_path;
+                                hash.write(bun_paths::resolve_path::relative_platform::<
+                                    bun_paths::resolve_path::platform::Posix,
+                                    false,
+                                >(from_chunk_dir, path));
+                            }
                         }
-                        AdditionalFile::SourceIndex(_) => {}
+                        crate::chunk::QueryKind::Chunk => out.push(piece.query.index()),
+                        crate::chunk::QueryKind::Scb => out.push(
+                            self.graph.files.items_entry_point_chunk_index()
+                                [piece.query.index() as usize],
+                        ),
+                        crate::chunk::QueryKind::None | crate::chunk::QueryKind::HtmlImport => {}
                     }
                 }
-                crate::chunk::QueryKind::Chunk => {
-                    self.append_isolated_hashes_for_imported_chunks(
-                        hash,
-                        chunks,
-                        piece_index,
-                        chunk_visit_map,
-                    );
+            }
+            hash.write(&chunk.isolated_hash.to_ne_bytes());
+            own.push(hash.digest());
+            edges.push(out);
+        }
+
+        let mut reach: Vec<AutoBitSet> = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut bits = AutoBitSet::init_empty(n)?;
+            bits.set(i);
+            reach.push(bits);
+        }
+        loop {
+            let mut changed = false;
+            for i in 0..n {
+                for &j in &edges[i] {
+                    let j = j as usize;
+                    if j == i || reach[j].subset_of(&reach[i]) {
+                        continue;
+                    }
+                    let other = reach[j].clone()?;
+                    reach[i].set_union(&other);
+                    changed = true;
                 }
-                crate::chunk::QueryKind::Scb => {
-                    self.append_isolated_hashes_for_imported_chunks(
-                        hash,
-                        chunks,
-                        self.graph.files.items_entry_point_chunk_index()[piece_index as usize],
-                        chunk_visit_map,
-                    );
-                }
-                crate::chunk::QueryKind::None | crate::chunk::QueryKind::HtmlImport => {}
+            }
+            if !changed {
+                break;
             }
         }
 
-        // Mix in the hash for this chunk
-        let chunk = &chunks[index as usize];
-        hash.write(&chunk.isolated_hash.to_ne_bytes());
+        Ok(reach
+            .iter()
+            .map(|bits| {
+                let mut hash = ContentHasher::default();
+                let mut iter = bits.iterator::<true, true>();
+                while let Some(j) = iter.next() {
+                    hash.write(&own[j].to_ne_bytes());
+                }
+                hash.digest()
+            })
+            .collect())
     }
 
     // Sort cross-chunk exports by chunk name for determinism

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -122,6 +122,11 @@ pub struct LinkerContext<'a> {
     pub(crate) framework: Option<bun_ptr::BackRef<bake::Framework>>,
 
     pub(crate) mangled_props: MangledProps,
+
+    /// One name per binding that crosses a chunk boundary, shared by the
+    /// chunk that exports it and every chunk that imports it
+    /// (`assign_cross_chunk_names`). Values live in the linker arena.
+    pub(crate) cross_chunk_names: bun_collections::HashMap<bun_ast::Ref, &'static [u8]>,
 }
 
 // SAFETY: `LinkerContext` is shared across the worker pool via `each_ptr` /
@@ -155,6 +160,7 @@ impl<'a> Default for LinkerContext<'a> {
             dev_server: None,
             framework: None,
             mangled_props: Default::default(),
+            cross_chunk_names: Default::default(),
         }
     }
 }
@@ -999,6 +1005,20 @@ impl<'a> LinkerContext<'a> {
         let mut worker = scopeguard::guard(worker, |w| w.unget());
         if let crate::chunk::Content::Javascript(_) = chunk.content {
             Self::generate_js_renamer_(*ctx, &mut **worker, chunk, chunk_index);
+        }
+    }
+
+    /// Second half of the minifying renamer under code splitting: names every
+    /// slot `assign_cross_chunk_names` did not pin. Writes `chunk.renamer` only.
+    pub(crate) fn finish_js_renamer(
+        _ctx: &GenerateChunkCtx,
+        chunk: *mut Chunk,
+        _chunk_index: usize,
+    ) {
+        // SAFETY: `each_ptr` hands us a unique `*mut Chunk` per task.
+        let chunk: &mut Chunk = unsafe { &mut *chunk };
+        if let crate::bun_renamer::ChunkRenamer::Minify(r) = &mut chunk.renamer {
+            r.finish().expect("TODO: handle error");
         }
     }
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1018,7 +1018,8 @@ impl<'a> LinkerContext<'a> {
         // SAFETY: `each_ptr` hands us a unique `*mut Chunk` per task.
         let chunk: &mut Chunk = unsafe { &mut *chunk };
         if let crate::bun_renamer::ChunkRenamer::Minify(r) = &mut chunk.renamer {
-            r.finish().expect("TODO: handle error");
+            // Only allocation can fail here.
+            bun_core::handle_oom(r.finish());
         }
     }
 

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -123,6 +123,9 @@ pub mod linker_context {
     #[path = "mergeSmallChunks.rs"]
     pub mod merge_small_chunks;
 
+    #[path = "crossChunkNames.rs"]
+    pub mod cross_chunk_names;
+
     #[path = "computeCrossChunkDependencies.rs"]
     pub mod compute_cross_chunk_dependencies;
 

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -573,7 +573,7 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                             alias_loc: bun_ast::Loc::EMPTY,
                             original_name: bun_ast::StoreStr::EMPTY,
                         });
-                        let _ = repr.exports_to_other_chunks.put(ref_, b""); // OOM-only Result
+                        let _ = repr.exports_to_other_chunks.put(ref_, ()); // OOM-only Result
                     }
 
                     if clause_items.len() > 0 {

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -532,9 +532,9 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
         }
     }
 
-    // Generate cross-chunk exports. These must be computed before cross-chunk
-    // imports because of export alias renaming, which must consider all export
-    // aliases simultaneously to avoid collisions.
+    // Generate cross-chunk export clauses. Aliases are left empty here and in
+    // the import clauses below; `cross_chunk_names` fills both in once every
+    // chunk's renamer has run.
     {
         debug_assert!(chunk_metas.len() == chunks.len());
         debug!("Generating cross-chunk exports");
@@ -598,9 +598,8 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
         }
     }
 
-    // Generate cross-chunk imports. These must be computed after cross-chunk
-    // exports because the export aliases must already be finalized so they can
-    // be embedded in the generated import statements.
+    // Generate cross-chunk import clauses (needs `exports_to_other_chunks`
+    // from the loop above to know which chunk declares each binding).
     {
         debug!("Generating cross-chunk imports");
         let mut list: Vec<CrossChunkImport> = Vec::new();

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -1,4 +1,3 @@
-use crate::bun_renamer as renamer;
 use crate::mal_prelude::*;
 use bun_alloc::ArenaVecExt as _;
 use bun_collections::{ArrayHashMap, VecExt, index_sort};
@@ -453,10 +452,9 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                             other_chunk_index,
                             CrossChunkImportItemList::default(),
                         )?;
-                        entry.value_ptr.push(CrossChunkImportItem {
-                            r#ref: import_ref,
-                            ..Default::default()
-                        });
+                        entry
+                            .value_ptr
+                            .push(CrossChunkImportItem { r#ref: import_ref });
                     }
                     let _ = chunk_metas[other_chunk_index as usize]
                         .exports
@@ -539,7 +537,6 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
     // aliases simultaneously to avoid collisions.
     {
         debug_assert!(chunk_metas.len() == chunks.len());
-        let mut r = renamer::ExportRenamer::init();
         debug!("Generating cross-chunk exports");
 
         let mut stable_ref_list: Vec<StableRef> = Vec::new();
@@ -550,7 +547,6 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                 continue;
             }
 
-            let entry_point = chunk.entry_point;
             let repr = chunk.content.javascript_mut();
 
             match c.options.output_format {
@@ -562,66 +558,22 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                             c.arena(),
                         );
                     repr.exports_to_other_chunks.reserve(stable_ref_list.len());
-                    r.clear_retaining_capacity();
 
-                    // An entry point chunk already exports its own names
-                    // (`generate_entry_point_tail_js`); a cross-chunk export
-                    // reusing one would be a duplicate export.
-                    if entry_point.is_entry_point() && !stable_ref_list.is_empty() {
-                        let entry_source = entry_point.source_index() as usize;
-                        let flags = &c.graph.meta.items_flags()[entry_source];
-                        if flags.wrap == WrapKind::Cjs || flags.needs_synthetic_default_export {
-                            r.reserve_name(b"default");
-                        }
-                        if flags.wrap != WrapKind::Cjs {
-                            for alias in c.graph.meta.items_sorted_and_filtered_export_aliases()
-                                [entry_source]
-                                .iter()
-                            {
-                                r.reserve_name(alias);
-                            }
-                        }
-                    }
-
+                    // The alias is the bundle-wide name `assign_cross_chunk_names`
+                    // gives the binding once every chunk's renamer has counted
+                    // its uses; until then the clause item carries an empty one.
                     for stable_ref in stable_ref_list.iter() {
                         let ref_ = stable_ref.r#ref;
-                        let original_name = c
-                            .graph
-                            .symbols
-                            .get_const(ref_)
-                            .unwrap()
-                            .original_name
-                            .slice();
-                        // The alias is stored on the chunk (`exports_to_other_chunks`,
-                        // `cross_chunk_suffix_stmts`) and read later in postProcessJSChunk,
-                        // so it must live in the linker arena — `r`'s internal arena is
-                        // reset per chunk and dropped at the end of this block.
-                        let alias: bun_ast::StoreStr = if c.options.minify_identifiers {
-                            bun_ast::StoreStr::new(
-                                c.arena()
-                                    .alloc_slice_copy(&r.next_minified_name().expect("OOM")),
-                            )
-                        } else {
-                            bun_ast::StoreStr::new(
-                                c.arena()
-                                    .alloc_slice_copy(r.next_renamed_name(original_name)),
-                            )
-                        };
-
                         clause_items.push(bun_ast::ClauseItem {
                             name: bun_ast::LocRef {
                                 ref_,
                                 loc: bun_ast::Loc::EMPTY,
                             },
-                            alias,
+                            alias: bun_ast::StoreStr::EMPTY,
                             alias_loc: bun_ast::Loc::EMPTY,
-                            original_name: bun_ast::StoreStr::new(b"" as &[u8]),
+                            original_name: bun_ast::StoreStr::EMPTY,
                         });
-
-                        // `alias` points into the link-pass arena (see note above),
-                        // which outlives `exports_to_other_chunks`; `.slice()` re-borrows
-                        // under the StoreStr arena contract.
-                        let _ = repr.exports_to_other_chunks.put(ref_, alias.slice()); // OOM-only Result
+                        let _ = repr.exports_to_other_chunks.put(ref_, b""); // OOM-only Result
                     }
 
                     if clause_items.len() > 0 {
@@ -677,6 +629,7 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                 &mut list,
                 chunks,
                 &mut imports_from_other_chunks,
+                c.graph.stable_source_indices.slice(),
             )
             .expect("unreachable");
             let cross_chunk_imports_input: &[CrossChunkImport] = list.as_slice();
@@ -697,7 +650,7 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                                     ref_: item.r#ref,
                                     loc: bun_ast::Loc::EMPTY,
                                 },
-                                alias: bun_ast::StoreStr::new(item.export_alias.as_ref()),
+                                alias: bun_ast::StoreStr::EMPTY,
                                 alias_loc: bun_ast::Loc::EMPTY,
                                 original_name: bun_ast::StoreStr::new(b"" as &[u8]),
                             });

--- a/src/bundler/linker_context/crossChunkNames.rs
+++ b/src/bundler/linker_context/crossChunkNames.rs
@@ -1,0 +1,216 @@
+//! One bundle-wide name for every binding that crosses a chunk boundary.
+//!
+//! Left to themselves, the chunk that declares a binding and each chunk that
+//! imports it rename it independently, and the printer bridges the two with
+//! `export { x as Qc }` / `import { Qc as ur }`. Instead, once every chunk's
+//! renamer has counted symbol uses, each such binding gets a single name —
+//! the shortest free names going to the most used bindings when minifying,
+//! otherwise its own name made unique among them — and every chunk's renamer
+//! pins that name before naming anything else. Exporter, alias and importer
+//! then agree, so both clauses print bare names.
+
+use crate::mal_prelude::*;
+use bun_ast::Ref;
+use bun_collections::StringHashMap;
+
+use crate::bun_renamer as renamer;
+use crate::bun_renamer::ChunkRenamer;
+use crate::chunk::Content;
+use crate::{Chunk, LinkerContext};
+use std::io::Write as _;
+
+/// The bindings in a deterministic order: chunk by chunk, each chunk's
+/// cross-chunk exports in their (stable-ref sorted) clause order.
+fn cross_chunk_refs(chunks: &[Chunk]) -> Vec<Ref> {
+    let mut refs = Vec::new();
+    for chunk in chunks {
+        if let Content::Javascript(js) = &chunk.content {
+            refs.extend_from_slice(js.exports_to_other_chunks.keys());
+        }
+    }
+    refs
+}
+
+/// Names no chunk may use for a top-level binding: keywords and the like,
+/// plus every unbound or must-not-be-renamed name in any module scope of the
+/// bundle. A per-chunk renamer only avoids its own chunk's; a bundle-wide
+/// name has to avoid all of them.
+fn reserved_names(
+    c: &LinkerContext,
+    chunks: &[Chunk],
+) -> Result<StringHashMap<u32>, bun_alloc::AllocError> {
+    let mut reserved = renamer::compute_initial_reserved_names(c.options.output_format)?;
+    let scopes = c.graph.ast.items_module_scope();
+    for chunk in chunks {
+        if let Content::Javascript(js) = &chunk.content {
+            for &source_index in js.files_in_chunk_order.iter() {
+                renamer::compute_reserved_names_for_scope(
+                    &scopes[source_index as usize],
+                    &c.graph.symbols,
+                    &mut reserved,
+                );
+            }
+        }
+    }
+    Ok(reserved)
+}
+
+fn intern(c: &LinkerContext, name: &[u8]) -> &'static [u8] {
+    // SAFETY: the linker arena outlives every chunk, renamer and clause item
+    // that holds one of these names (all dropped with the link pass).
+    unsafe { bun_ptr::detach_lifetime_ref::<[u8]>(c.arena().alloc_slice_copy(name)) }
+}
+
+/// Without `--minify-identifiers`: each binding keeps its own name, numbered
+/// only against reserved names and the other cross-chunk bindings. Runs
+/// before the chunk renamers, which pin these and number the rest around them.
+pub(crate) fn assign_unminified(
+    c: &mut LinkerContext,
+    chunks: &[Chunk],
+) -> Result<(), crate::Error> {
+    let refs = cross_chunk_refs(chunks);
+    if refs.is_empty() {
+        return Ok(());
+    }
+    let mut used = reserved_names(c, chunks)?;
+    let mut buf: Vec<u8> = Vec::new();
+    c.cross_chunk_names.reserve(refs.len());
+    for ref_ in refs {
+        let original = c
+            .graph
+            .symbols
+            .get_const(ref_)
+            .unwrap()
+            .original_name
+            .slice();
+        let base = bun_core::MutableString::ensure_valid_identifier(original)?;
+        let mut name: &[u8] = &base;
+        let mut tries = 1u32;
+        while used.contains_key(name) {
+            tries += 1;
+            buf.clear();
+            buf.extend_from_slice(&base);
+            write!(&mut buf, "{tries}").expect("Vec<u8> write");
+            name = &buf;
+        }
+        used.put(name, 1)?;
+        let name = intern(c, name);
+        c.cross_chunk_names.insert(ref_, name);
+    }
+    Ok(())
+}
+
+/// With `--minify-identifiers`: runs between the chunk renamers' accumulate
+/// and finish steps. Sums each binding's use count over every chunk that sees
+/// it, hands out the shortest names in that order, and pins them in every
+/// chunk's renamer so `finish` names the rest around them.
+pub(crate) fn assign_minified(
+    c: &mut LinkerContext,
+    chunks: &mut [Chunk],
+) -> Result<(), crate::Error> {
+    let refs = cross_chunk_refs(chunks);
+    if refs.is_empty() {
+        return Ok(());
+    }
+    let reserved = reserved_names(c, chunks)?;
+
+    // (total count, first-seen order) per binding; most used first.
+    let mut order: Vec<(u32, u32, Ref, bool)> = Vec::with_capacity(refs.len());
+    for (i, &ref_) in refs.iter().enumerate() {
+        let mut count = 0u32;
+        for chunk in chunks.iter() {
+            if let ChunkRenamer::Minify(r) = &chunk.renamer {
+                count = count.saturating_add(r.top_level_count(ref_).unwrap_or(0));
+            }
+        }
+        let capital = c
+            .graph
+            .symbols
+            .get_const(ref_)
+            .unwrap()
+            .must_start_with_capital_letter_for_jsx();
+        order.push((count, i as u32, ref_, capital));
+    }
+    order.sort_unstable_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
+
+    // One name sequence for the bundle, tuned to its overall character mix.
+    let mut freq = bun_ast::CharFreq { freqs: [0i32; 64] };
+    let (flags, char_freqs) = (c.graph.ast.items_flags(), c.graph.ast.items_char_freq());
+    for chunk in chunks.iter() {
+        if let Content::Javascript(js) = &chunk.content {
+            for &source_index in js.files_in_chunk_order.iter() {
+                if flags[source_index as usize].contains(crate::bundled_ast::Flags::HAS_CHAR_FREQ) {
+                    freq.include(&char_freqs[source_index as usize]);
+                }
+            }
+        }
+    }
+    let minifier = freq.compile();
+
+    let mut name: Vec<u8> = Vec::with_capacity(16);
+    let mut next: isize = 0;
+    c.cross_chunk_names.reserve(refs.len());
+    for &(_, _, ref_, capital) in &order {
+        loop {
+            minifier.number_to_minified_name(&mut name, next)?;
+            next += 1;
+            if reserved.contains_key(name.as_slice()) || (capital && name[0].is_ascii_lowercase()) {
+                continue;
+            }
+            break;
+        }
+        let interned = intern(c, &name);
+        c.cross_chunk_names.insert(ref_, interned);
+    }
+
+    // Pin in every chunk that declares or imports the binding.
+    for chunk in chunks.iter_mut() {
+        let Content::Javascript(js) = &chunk.content else {
+            continue;
+        };
+        let ChunkRenamer::Minify(r) = &mut chunk.renamer else {
+            continue;
+        };
+        for &ref_ in js.exports_to_other_chunks.keys() {
+            r.pin(ref_, *c.cross_chunk_names.get(&ref_).unwrap())?;
+        }
+        for items in js.imports_from_other_chunks.values() {
+            for item in items.iter() {
+                r.pin(item.r#ref, *c.cross_chunk_names.get(&item.r#ref).unwrap())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Writes the names into the cross-chunk `export {}` / `import {}` clause
+/// items and `exports_to_other_chunks`.
+pub(crate) fn apply_to_clauses(c: &LinkerContext, chunks: &mut [Chunk]) {
+    if c.cross_chunk_names.is_empty() {
+        return;
+    }
+    for chunk in chunks.iter_mut() {
+        let Content::Javascript(js) = &mut chunk.content else {
+            continue;
+        };
+        for i in 0..js.exports_to_other_chunks.count() {
+            let ref_ = js.exports_to_other_chunks.keys()[i];
+            js.exports_to_other_chunks.values_mut()[i] = *c.cross_chunk_names.get(&ref_).unwrap();
+        }
+        for stmt in js
+            .cross_chunk_suffix_stmts
+            .iter_mut()
+            .chain(js.cross_chunk_prefix_stmts.iter_mut())
+        {
+            let items = match &mut stmt.data {
+                bun_ast::StmtData::SExportClause(clause) => clause.items.slice_mut(),
+                bun_ast::StmtData::SImport(import) => import.items.slice_mut(),
+                _ => continue,
+            };
+            for item in items {
+                item.alias =
+                    bun_ast::StoreStr::new(*c.cross_chunk_names.get(&item.name.ref_).unwrap());
+            }
+        }
+    }
+}

--- a/src/bundler/linker_context/crossChunkNames.rs
+++ b/src/bundler/linker_context/crossChunkNames.rs
@@ -38,7 +38,6 @@ fn cross_chunk_refs(chunks: &[Chunk]) -> Vec<Ref> {
 fn reserved_names(
     c: &LinkerContext,
     chunks: &[Chunk],
-    minify: bool,
 ) -> Result<StringHashMap<u32>, bun_alloc::AllocError> {
     let mut reserved = renamer::compute_initial_reserved_names(c.options.output_format)?;
     let scopes = c.graph.ast.items_module_scope();
@@ -61,11 +60,6 @@ fn reserved_names(
             }
         }
     }
-    // `MinifyRenamer::init` never hands out bare `$` (#14586); an unminified
-    // binding named `$` keeps it.
-    if minify {
-        reserved.put(b"$", 1)?;
-    }
     Ok(reserved)
 }
 
@@ -86,7 +80,7 @@ pub(crate) fn assign_unminified(
     if refs.is_empty() {
         return Ok(());
     }
-    let mut used = reserved_names(c, chunks, false)?;
+    let mut used = reserved_names(c, chunks)?;
     let mut buf: Vec<u8> = Vec::new();
     c.cross_chunk_names.reserve(refs.len());
     for ref_ in refs {
@@ -126,24 +120,53 @@ pub(crate) fn assign_minified(
     if refs.is_empty() {
         return Ok(());
     }
-    let reserved = reserved_names(c, chunks, true)?;
-
-    // (total count, first-seen order) per binding; most used first.
-    let mut order: Vec<(u32, u32, Ref, bool)> = Vec::with_capacity(refs.len());
-    for (i, &ref_) in refs.iter().enumerate() {
-        let mut count = 0u32;
-        for chunk in chunks.iter() {
-            if let ChunkRenamer::Minify(r) = &chunk.renamer {
-                count = count.saturating_add(r.top_level_count(ref_).unwrap_or(0));
+    // Every chunk's renamer already reserved the keywords plus its own module
+    // scopes' unbound / pinned names; a bundle-wide name avoids all of them.
+    let mut reserved = StringHashMap::<u32>::default();
+    let export_aliases = c.graph.meta.items_sorted_and_filtered_export_aliases();
+    for chunk in chunks.iter() {
+        if let ChunkRenamer::Minify(r) = &chunk.renamer {
+            for (name, _) in r.reserved_names().iter() {
+                reserved.put(name, 1)?;
             }
         }
+        if chunk.entry_point.is_entry_point() {
+            for alias in export_aliases[chunk.entry_point.source_index() as usize].iter() {
+                reserved.put(alias, 1)?;
+            }
+        }
+    }
+
+    // (total count, first-seen order) per binding; most used first. Each
+    // chunk contributes the count of the bindings it declares or imports.
+    let mut index_of: bun_collections::HashMap<Ref, u32> = Default::default();
+    let mut order: Vec<(u32, u32, Ref, bool)> = Vec::with_capacity(refs.len());
+    for (i, &ref_) in refs.iter().enumerate() {
         let capital = c
             .graph
             .symbols
             .get_const(ref_)
             .unwrap()
             .must_start_with_capital_letter_for_jsx();
-        order.push((count, i as u32, ref_, capital));
+        index_of.insert(ref_, i as u32);
+        order.push((0, i as u32, ref_, capital));
+    }
+    for chunk in chunks.iter() {
+        let (Content::Javascript(js), ChunkRenamer::Minify(r)) = (&chunk.content, &chunk.renamer)
+        else {
+            continue;
+        };
+        let refs_here = js.exports_to_other_chunks.keys().iter().copied().chain(
+            js.imports_from_other_chunks
+                .values()
+                .iter()
+                .flat_map(|items| items.iter().map(|item| item.r#ref)),
+        );
+        for ref_ in refs_here {
+            if let (Some(&i), Some(count)) = (index_of.get(&ref_), r.top_level_count(ref_)) {
+                order[i as usize].0 = order[i as usize].0.saturating_add(count);
+            }
+        }
     }
     order.sort_unstable_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
 

--- a/src/bundler/linker_context/crossChunkNames.rs
+++ b/src/bundler/linker_context/crossChunkNames.rs
@@ -31,16 +31,19 @@ fn cross_chunk_refs(chunks: &[Chunk]) -> Vec<Ref> {
     refs
 }
 
-/// Names no chunk may use for a top-level binding: keywords and the like,
-/// plus every unbound or must-not-be-renamed name in any module scope of the
-/// bundle. A per-chunk renamer only avoids its own chunk's; a bundle-wide
-/// name has to avoid all of them.
+/// Names no chunk may use for a cross-chunk binding: keywords and the like,
+/// every unbound or must-not-be-renamed name in any module scope of the
+/// bundle, and the entry points' own export names. A per-chunk renamer only
+/// avoids its own chunk's; a bundle-wide name has to avoid all of them.
 fn reserved_names(
     c: &LinkerContext,
     chunks: &[Chunk],
 ) -> Result<StringHashMap<u32>, bun_alloc::AllocError> {
     let mut reserved = renamer::compute_initial_reserved_names(c.options.output_format)?;
+    // `MinifyRenamer::init` keeps bare `$` free as well (#14586).
+    reserved.put(b"$", 1)?;
     let scopes = c.graph.ast.items_module_scope();
+    let export_aliases = c.graph.meta.items_sorted_and_filtered_export_aliases();
     for chunk in chunks {
         if let Content::Javascript(js) = &chunk.content {
             for &source_index in js.files_in_chunk_order.iter() {
@@ -49,6 +52,13 @@ fn reserved_names(
                     &c.graph.symbols,
                     &mut reserved,
                 );
+            }
+        }
+        // An entry point's own `export {}` names share its export namespace
+        // with the cross-chunk exports it may carry.
+        if chunk.entry_point.is_entry_point() {
+            for alias in export_aliases[chunk.entry_point.source_index() as usize].iter() {
+                reserved.put(alias, 1)?;
             }
         }
     }
@@ -183,8 +193,7 @@ pub(crate) fn assign_minified(
     Ok(())
 }
 
-/// Writes the names into the cross-chunk `export {}` / `import {}` clause
-/// items and `exports_to_other_chunks`.
+/// Writes the names into the cross-chunk `export {}` / `import {}` clause items.
 pub(crate) fn apply_to_clauses(c: &LinkerContext, chunks: &mut [Chunk]) {
     if c.cross_chunk_names.is_empty() {
         return;
@@ -193,10 +202,6 @@ pub(crate) fn apply_to_clauses(c: &LinkerContext, chunks: &mut [Chunk]) {
         let Content::Javascript(js) = &mut chunk.content else {
             continue;
         };
-        for i in 0..js.exports_to_other_chunks.count() {
-            let ref_ = js.exports_to_other_chunks.keys()[i];
-            js.exports_to_other_chunks.values_mut()[i] = *c.cross_chunk_names.get(&ref_).unwrap();
-        }
         for stmt in js
             .cross_chunk_suffix_stmts
             .iter_mut()

--- a/src/bundler/linker_context/crossChunkNames.rs
+++ b/src/bundler/linker_context/crossChunkNames.rs
@@ -38,10 +38,9 @@ fn cross_chunk_refs(chunks: &[Chunk]) -> Vec<Ref> {
 fn reserved_names(
     c: &LinkerContext,
     chunks: &[Chunk],
+    minify: bool,
 ) -> Result<StringHashMap<u32>, bun_alloc::AllocError> {
     let mut reserved = renamer::compute_initial_reserved_names(c.options.output_format)?;
-    // `MinifyRenamer::init` keeps bare `$` free as well (#14586).
-    reserved.put(b"$", 1)?;
     let scopes = c.graph.ast.items_module_scope();
     let export_aliases = c.graph.meta.items_sorted_and_filtered_export_aliases();
     for chunk in chunks {
@@ -61,6 +60,11 @@ fn reserved_names(
                 reserved.put(alias, 1)?;
             }
         }
+    }
+    // `MinifyRenamer::init` never hands out bare `$` (#14586); an unminified
+    // binding named `$` keeps it.
+    if minify {
+        reserved.put(b"$", 1)?;
     }
     Ok(reserved)
 }
@@ -82,7 +86,7 @@ pub(crate) fn assign_unminified(
     if refs.is_empty() {
         return Ok(());
     }
-    let mut used = reserved_names(c, chunks)?;
+    let mut used = reserved_names(c, chunks, false)?;
     let mut buf: Vec<u8> = Vec::new();
     c.cross_chunk_names.reserve(refs.len());
     for ref_ in refs {
@@ -122,7 +126,7 @@ pub(crate) fn assign_minified(
     if refs.is_empty() {
         return Ok(());
     }
-    let reserved = reserved_names(c, chunks)?;
+    let reserved = reserved_names(c, chunks, true)?;
 
     // (total count, first-seen order) per binding; most used first.
     let mut order: Vec<(u32, u32, Ref, bool)> = Vec::with_capacity(refs.len());

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -37,16 +37,13 @@ pub(crate) fn find_all_imported_parts_in_js_order(
             }
             // SAFETY: shared for reading; see the note above on the one column written.
             let c: &LinkerContext = unsafe { &*ctx.c.as_mut_ptr() };
-            bun_core::handle_oom(
-                find_imported_parts_in_js_order(
-                    c,
-                    chunk,
-                    &mut Vec::new(),
-                    &mut Vec::new(),
-                    u32::try_from(index).expect("int cast"),
-                )
-                .map_err(|_| bun_alloc::AllocError),
-            );
+            bun_core::handle_oom(find_imported_parts_in_js_order(
+                c,
+                chunk,
+                &mut Vec::new(),
+                &mut Vec::new(),
+                u32::try_from(index).expect("int cast"),
+            ));
         },
         chunks,
     );
@@ -59,7 +56,7 @@ pub(crate) fn find_imported_parts_in_js_order(
     part_ranges_shared: &mut Vec<PartRange>,
     parts_prefix_shared: &mut Vec<PartRange>,
     chunk_index: u32,
-) -> Result<(), crate::Error> {
+) -> Result<(), bun_alloc::AllocError> {
     let mut chunk_order_array: Vec<Order> =
         Vec::with_capacity(chunk.files_with_parts_in_chunk.count());
     {

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -14,32 +14,47 @@ pub(crate) fn find_all_imported_parts_in_js_order(
     chunks: &mut [Chunk],
 ) -> Result<(), crate::Error> {
     let _trace = perf::trace("Bundler.findAllImportedPartsInJSOrder");
-
-    let mut part_ranges_shared: Vec<PartRange> = Vec::new();
-    let mut parts_prefix_shared: Vec<PartRange> = Vec::new();
-    // PERF: these scratch lists could become
-    // `bun_alloc::ArenaVec<'bump, PartRange>` with a threaded `&'bump Bump`
-    // (introduces lifetimes on this fn + visitor). Profile if hot.
-    for (index, chunk) in chunks.iter_mut().enumerate() {
-        match &chunk.content {
-            chunk::Content::Javascript(_) => {
-                find_imported_parts_in_js_order(
-                    this,
-                    chunk,
-                    &mut part_ranges_shared,
-                    &mut parts_prefix_shared,
-                    u32::try_from(index).expect("int cast"),
-                )?;
-            }
-            chunk::Content::Css(_) => {} // handled in `find_imported_css_files_in_js_order`
-            chunk::Content::Html => {}
-        }
+    if chunks.is_empty() {
+        return Ok(());
     }
+
+    // One chunk per task. Each task writes only its own `Chunk` and, for
+    // server-component files, that file's `entry_point_chunk_index` slot (a
+    // file belongs to exactly one chunk), and reads the graph columns.
+    let ctx = crate::linker_context_mod::GenerateChunkCtx {
+        chunk: bun_ptr::BackRef::new_mut(&mut chunks[0]),
+        // SAFETY: `this` is the live `&mut LinkerContext` for the link step.
+        c: unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(this)) },
+        chunks: bun_ptr::BackRef::new(&*chunks),
+    };
+    this.worker_pool().each_ptr(
+        ctx,
+        |ctx: &crate::linker_context_mod::GenerateChunkCtx, chunk: *mut Chunk, index: usize| {
+            // SAFETY: `each_ptr` hands each task a distinct `*mut Chunk`.
+            let chunk = unsafe { &mut *chunk };
+            if !matches!(chunk.content, chunk::Content::Javascript(_)) {
+                return; // CSS: `find_imported_css_files_in_js_order`; HTML: nothing
+            }
+            // SAFETY: shared for reading; see the note above on the one column written.
+            let c: &LinkerContext = unsafe { &*ctx.c.as_mut_ptr() };
+            bun_core::handle_oom(
+                find_imported_parts_in_js_order(
+                    c,
+                    chunk,
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    u32::try_from(index).expect("int cast"),
+                )
+                .map_err(|_| bun_alloc::AllocError),
+            );
+        },
+        chunks,
+    );
     Ok(())
 }
 
 pub(crate) fn find_imported_parts_in_js_order(
-    this: &mut LinkerContext,
+    this: &LinkerContext,
     chunk: &mut Chunk,
     part_ranges_shared: &mut Vec<PartRange>,
     parts_prefix_shared: &mut Vec<PartRange>,
@@ -88,7 +103,7 @@ pub(crate) fn find_imported_parts_in_js_order(
             parts: this.graph.ast.items_parts(),
             import_records: this.graph.ast.items_import_records(),
             entry_bits: chunk.entry_bits(),
-            c: &*this,
+            c: this,
             chunk_index,
             entry_point_chunk_indices,
             stack: Vec::new(),

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -255,7 +255,8 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                             // link step. Chunks run in parallel and, without code
                             // splitting, several may contain this file: highest index wins
                             // (unset is `u32::MAX`), as when this ran chunk by chunk.
-                            unsafe {
+                            // Err = another chunk with a higher index already claimed it.
+                            let _ = unsafe {
                                 core::sync::atomic::AtomicU32::from_ptr(
                                     (*self.entry_point_chunk_indices)
                                         .as_mut_ptr()
@@ -269,8 +270,7 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                                             .then_some(self.chunk_index)
                                     },
                                 )
-                                .ok();
-                            }
+                            };
                         }
 
                         self.files.push(source_index);

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -255,10 +255,24 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                             // for `entry_point_chunk_index` (distinct from every
                             // column read through `self.c` / `self.flags` / `self.parts`),
                             // valid for `graph.files.len()` writes for the duration of the
-                            // link step. No `&` to this column is live here.
+                            // link step. Chunks run in parallel and, without code
+                            // splitting, several may contain this file: highest index wins
+                            // (unset is `u32::MAX`), as when this ran chunk by chunk.
                             unsafe {
-                                (*self.entry_point_chunk_indices)[source_index as usize] =
-                                    self.chunk_index;
+                                core::sync::atomic::AtomicU32::from_ptr(
+                                    (*self.entry_point_chunk_indices)
+                                        .as_mut_ptr()
+                                        .add(source_index as usize),
+                                )
+                                .try_update(
+                                    core::sync::atomic::Ordering::Relaxed,
+                                    core::sync::atomic::Ordering::Relaxed,
+                                    |cur| {
+                                        (cur == u32::MAX || cur < self.chunk_index)
+                                            .then_some(self.chunk_index)
+                                    },
+                                )
+                                .ok();
                             }
                         }
 

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -12,7 +12,6 @@ use bun_threading::thread_pool as ThreadPoolLib;
 
 use crate::BundleV2;
 use crate::Chunk;
-use crate::ContentHasher;
 use crate::Index;
 use crate::analyze_transpiled_module;
 use crate::analyze_transpiled_module::StringIDExt as _;
@@ -376,24 +375,12 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         }
         let mut duplicates_map: StringArrayHashMap<DuplicateEntry> = StringArrayHashMap::default();
 
-        let mut chunk_visit_map = AutoBitSet::init_empty(chunks.len())?;
-
         // Compute the final hashes of each chunk, then use those to create the final
-        // paths of each chunk. This can technically be done in parallel but it
-        // probably doesn't matter so much because we're not hashing that much data.
-        // Reshaped for borrowck — index loop so `chunks` can be passed
-        // whole to `append_isolated_hashes_for_imported_chunks` and then indexed.
+        // paths of each chunk.
+        let hashes = c.final_chunk_hashes(chunks)?;
         for index in 0..chunks.len() {
-            let mut hash = ContentHasher::default();
-            c.append_isolated_hashes_for_imported_chunks(
-                &mut hash,
-                chunks,
-                u32::try_from(index).expect("int cast"),
-                &mut chunk_visit_map,
-            );
-            chunk_visit_map.set_all(false);
             let chunk = &mut chunks[index];
-            chunk.template.placeholder.hash = Some(hash.digest());
+            chunk.template.placeholder.hash = Some(hashes[index]);
 
             let mut rel_path: Vec<u8> = Vec::new();
             // Use the byte-writer (`PathTemplate::print`) directly —

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -60,6 +60,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     {
         // TODO: instead of running a renamer per chunk, run it per file
         debug!(" START {} renamers", chunks.len());
+        if c.graph.code_splitting && !c.options.minify_identifiers {
+            crate::linker_context::cross_chunk_names::assign_unminified(c, chunks)?;
+        }
         let ctx = GenerateChunkCtx {
             chunk: bun_ptr::BackRef::new_mut(&mut chunks[0]),
             // SAFETY: `c` is the live `&mut LinkerContext` for the link step;
@@ -71,6 +74,16 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         // link step); `pool` is the arena-allocated bundler ThreadPool.
         c.worker_pool()
             .each_ptr(ctx, LinkerContext::generate_js_renamer, chunks);
+        if c.graph.code_splitting {
+            if c.options.minify_identifiers {
+                // Counts are in; name the cross-chunk bindings, pin them, then
+                // let every chunk name the rest.
+                crate::linker_context::cross_chunk_names::assign_minified(c, chunks)?;
+                c.worker_pool()
+                    .each_ptr(ctx, LinkerContext::finish_js_renamer, chunks);
+            }
+            crate::linker_context::cross_chunk_names::apply_to_clauses(c, chunks);
+        }
         debug!("  DONE {} renamers", chunks.len());
     }
 

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -265,14 +265,34 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         top_level_symbols_all.extend_from_slice(&top_level_symbols);
         minify_renamer.allocate_top_level_symbol_slots(&top_level_symbols_all)?;
 
-        let minifier = freq.compile();
-        minify_renamer.assign_names_by_frequency(&minifier)?;
+        minify_renamer.name_minifier = Some(freq.compile());
+        // With code splitting, names are assigned (`MinifyRenamer::finish`)
+        // after `assign_cross_chunk_names` has seen every chunk's counts and
+        // pinned the bindings that cross chunks.
+        if !c.graph.code_splitting {
+            minify_renamer.finish()?;
+        }
 
         let _ = capacity;
         return Ok(ChunkRenamer::Minify(minify_renamer));
     }
 
     let mut r = NumberRenamer::init(make_symbols_view(symbols), &reserved_names)?;
+    // Bindings that cross chunks carry one bundle-wide name
+    // (`assign_cross_chunk_names`); everything else is numbered around them.
+    if let Content::Javascript(js) = &chunk.content {
+        for &ref_ in js.exports_to_other_chunks.keys() {
+            if let Some(name) = c.cross_chunk_names.get(&ref_) {
+                r.pin_top_level_symbol(ref_, name);
+            }
+        }
+    }
+    for stable_ref in &sorted_imports_from_other_chunks {
+        let ref_ = { stable_ref.r#ref };
+        if let Some(name) = c.cross_chunk_names.get(&ref_) {
+            r.pin_top_level_symbol(ref_, name);
+        }
+    }
     for stable_ref in &sorted_imports_from_other_chunks {
         // `StableRef` is `repr(packed)`; copy the field to avoid an unaligned ref.
         r.add_top_level_symbol(stable_ref.r#ref);

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -190,7 +190,6 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         let stable_source_indices = c.graph.stable_source_indices.slice();
         let mut freq = bun_ast::CharFreq { freqs: [0i32; 64] };
 
-        let mut capacity = sorted_imports_from_other_chunks.len();
         for &source_index in files_in_order {
             if ast_flags_col[source_index as usize].contains(AstFlags::HAS_CHAR_FREQ) {
                 freq.include(&char_freq_col[source_index as usize]);
@@ -247,7 +246,6 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             }
 
             top_level_symbols.sort_unstable_by(StableSymbolCount::less_than);
-            capacity += top_level_symbols.len();
             top_level_symbols_all.extend_from_slice(&top_level_symbols);
         }
 
@@ -272,8 +270,6 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         if !c.graph.code_splitting {
             minify_renamer.finish()?;
         }
-
-        let _ = capacity;
         return Ok(ChunkRenamer::Minify(minify_renamer));
     }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8028,6 +8028,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // A direct eval at module scope can reach every top-level name. Nested
+        // scopes are pinned in `pop_scope`; the module scope never pops. When
+        // the bundler wraps this file in a CommonJS closure those names stay
+        // private to it, so pin them too. A flat ESM file's top-level names
+        // share the chunk's scope with other files', so they stay renameable
+        // (as in esbuild) and eval may not see them.
+        if bundling
+            && exports_kind == js_ast::ExportsKind::Cjs
+            && self.module_scope().contains_direct_eval
+        {
+            let module_scope = self.module_scope_ref();
+            for member in module_scope.members.values() {
+                self.symbols[member.ref_.inner_index() as usize].set_must_not_be_renamed(true);
+            }
+        }
+
         if wrap_mode == WrapMode::BunCommonjs && !self.options.features.remove_cjs_module_wrapper {
             // This transforms the user's code into.
             //

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8033,14 +8033,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // the bundler wraps this file in a CommonJS closure those names stay
         // private to it, so pin them too. A flat ESM file's top-level names
         // share the chunk's scope with other files', so they stay renameable
-        // (as in esbuild) and eval may not see them.
+        // (as in esbuild) and eval may not see them. Import bindings are left
+        // out: the linker merges them into the exporting file's symbol, which
+        // would pin that name in every chunk that references it.
         if bundling
             && exports_kind == js_ast::ExportsKind::Cjs
             && self.module_scope().contains_direct_eval
         {
             let module_scope = self.module_scope_ref();
             for member in module_scope.members.values() {
-                self.symbols[member.ref_.inner_index() as usize].set_must_not_be_renamed(true);
+                let symbol = &mut self.symbols[member.ref_.inner_index() as usize];
+                if symbol.kind != js_ast::symbol::Kind::Import {
+                    symbol.set_must_not_be_renamed(true);
+                }
             }
         }
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -177,6 +177,8 @@ pub struct SymbolSlot {
     pub(crate) name: TinyString,
     pub(crate) count: u32,
     pub(crate) needs_capital_for_jsx: bool,
+    /// Named ahead of `assign_names_by_frequency` (`MinifyRenamer::pin`).
+    pub(crate) pinned: bool,
 }
 
 impl Default for SymbolSlot {
@@ -185,6 +187,7 @@ impl Default for SymbolSlot {
             name: TinyString::String(name_str_empty()),
             count: 0,
             needs_capital_for_jsx: false,
+            pinned: false,
         }
     }
 }
@@ -258,6 +261,9 @@ pub struct MinifyRenamer {
     pub(crate) owns_symbols: bool,
     /// Backs `TinyString::String` slot-name allocations.
     pub(crate) arena: Bump,
+    /// Set once use counts are in; `finish` names the slots with it. Kept
+    /// here so the bundler can pin cross-chunk names between the two steps.
+    pub name_minifier: Option<js_ast::NameMinifier>,
 }
 
 impl Drop for MinifyRenamer {
@@ -296,6 +302,7 @@ impl MinifyRenamer {
             slots,
             top_level_symbol_to_slot: TopLevelSymbolSlotMap::default(),
             arena: Bump::new(),
+            name_minifier: None,
         }))
     }
 
@@ -406,10 +413,47 @@ impl MinifyRenamer {
                     name: TinyString::String(name_str_empty()),
                     count: stable.count,
                     needs_capital_for_jsx: must_start_with_capital,
+                    pinned: false,
                 });
             }
         }
         Ok(())
+    }
+
+    /// The accumulated use count of a top-level symbol in this chunk, if it has one.
+    pub fn top_level_count(&self, ref_: Ref) -> Option<u32> {
+        let ref_ = self.symbols.follow(ref_);
+        let slot = *self.top_level_symbol_to_slot.get(&ref_)?;
+        let ns = self.symbols.get_const(ref_).unwrap().slot_namespace();
+        Some(self.slots[ns][slot].count)
+    }
+
+    /// Gives top-level symbol `ref_` the name `name` ahead of
+    /// `assign_names_by_frequency`, which then hands `name` to nothing else.
+    /// Used for bindings that cross chunks, so every chunk calls them the same.
+    pub fn pin(&mut self, ref_: Ref, name: &[u8]) -> Result<(), bun_alloc::AllocError> {
+        let ref_ = self.symbols.follow(ref_);
+        let Some(&slot) = self.top_level_symbol_to_slot.get(&ref_) else {
+            return Ok(());
+        };
+        let ns = self.symbols.get_const(ref_).unwrap().slot_namespace();
+        let slot = &mut self.slots[ns][slot];
+        slot.name = TinyString::init(name, &self.arena)?;
+        slot.pinned = true;
+        self.reserved_names.put(name, 1)?;
+        Ok(())
+    }
+
+    /// Names every slot not already pinned, using the `name_minifier` stored
+    /// by the accumulate step.
+    pub fn finish(&mut self) -> Result<(), crate::Error> {
+        let name_minifier = self
+            .name_minifier
+            .take()
+            .expect("name_minifier set before finish");
+        let result = self.assign_names_by_frequency(&name_minifier);
+        self.name_minifier = Some(name_minifier);
+        result
     }
 
     pub fn assign_names_by_frequency(
@@ -423,10 +467,16 @@ impl MinifyRenamer {
         for &ns in SLOT_NAMESPACES.iter() {
             let slots = &mut self.slots[ns];
             sorted.clear();
-            sorted.extend(slots.iter().enumerate().map(|(i, slot)| SlotAndCount {
-                slot: u32::try_from(i).expect("int cast"),
-                count: slot.count,
-            }));
+            sorted.extend(
+                slots
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, slot)| !slot.pinned)
+                    .map(|(i, slot)| SlotAndCount {
+                        slot: u32::try_from(i).expect("int cast"),
+                        count: slot.count,
+                    }),
+            );
             sorted.sort_unstable_by(|a, b| SlotAndCount::less_than(*a, *b));
 
             let mut next_name: isize = 0;
@@ -700,6 +750,25 @@ impl NumberRenamer {
             unsafe { self.number_scope_pool.put(s) };
             s = parent;
         }
+    }
+
+    /// Gives top-level symbol `ref_` the name `name` (taken to be free in the
+    /// root scope) so later symbols are numbered around it. Used for bindings
+    /// that cross chunks, so every chunk calls them the same.
+    pub fn pin_top_level_symbol(&mut self, ref_: Ref, name: &[u8]) {
+        let ref_ = self.symbols.follow(ref_);
+        if self.symbols.get_const(ref_).unwrap().slot_namespace() != SlotNamespace::Default {
+            return;
+        }
+        let duped: &[u8] = self.arena.alloc_slice_copy(name);
+        let name = NameStr::new(duped);
+        self.root.name_counts.insert(NameKey(name), 1);
+        let inner: &mut Vec<NameStr> = &mut self.names[ref_.source_index() as usize];
+        let new_len = inner.len().max(ref_.inner_index() as usize + 1);
+        if inner.len() < new_len {
+            inner.resize(new_len, name_str_empty());
+        }
+        inner[ref_.inner_index() as usize] = name;
     }
 
     pub fn add_top_level_symbol(&mut self, ref_: Ref) {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -420,6 +420,11 @@ impl MinifyRenamer {
         Ok(())
     }
 
+    /// Names this renamer will not hand out (keywords, unbound globals, pinned names).
+    pub fn reserved_names(&self) -> &StringHashMap<u32> {
+        &self.reserved_names
+    }
+
     /// The accumulated use count of a top-level symbol in this chunk, if it has one.
     pub fn top_level_count(&self, ref_: Ref) -> Option<u32> {
         let ref_ = self.symbols.follow(ref_);

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -393,6 +393,11 @@ impl MinifyRenamer {
         &mut self,
         top_level_symbols: &[StableSymbolCount],
     ) -> Result<(), bun_alloc::AllocError> {
+        // Upper bound (a ref can repeat across files); sizes the map and the
+        // default namespace, where nearly all top-level symbols live, once.
+        self.top_level_symbol_to_slot
+            .ensure_total_capacity(top_level_symbols.len())?;
+        self.slots[SlotNamespace::Default].reserve(top_level_symbols.len());
         for stable in top_level_symbols {
             let symbol: &Symbol = self.symbols.get_const(stable.ref_).unwrap();
             // Reshaped for borrowck — capture symbol fields before mut-borrowing slots

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -3,6 +3,22 @@ import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
+  // A direct eval at the top level of a file the bundler wraps in a CommonJS
+  // closure can reach that file's top-level names, so they are not renamed.
+  itBundled("minify/DirectEvalKeepsTopLevelNamesOfWrappedFile", {
+    files: {
+      "/entry.js": /* js */ `
+        var secret = 'top'
+        function helper() { return 'fn' }
+        console.log(eval('secret'), eval('helper()'))
+      `,
+    },
+    minifyIdentifiers: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("secret");
+    },
+    run: { stdout: "top fn" },
+  });
   itBundled("minify/TemplateStringFolding", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -710,6 +710,41 @@ describe("bundler", () => {
       { file: "/out/b.js", stdout: "A B" },
     ],
   });
+  // The eval file's *import* bindings must not be pinned: the linker merges
+  // them into the exporter's symbol, and a third chunk importing that symbol
+  // would then print it under its source name without having reserved it.
+  itBundled("splitting/DirectEvalDoesNotPinSharedExport", {
+    files: {
+      "/e.js": /* js */ `
+        import { a } from './shared.js'
+        var x = 'ex'
+        console.log(a(), eval('x'))
+      `,
+      "/p.js": /* js */ `
+        import { a, b } from './shared.js'
+        ${Array.from({ length: 120 }, (_, i) => `var l${i} = ${i}; l${i}++; l${i}++; l${i}++;`).join("\n")}
+        console.log(a(), b(), ${Array.from({ length: 120 }, (_, i) => `l${i}`).join("+")})
+      `,
+      "/q.js": /* js */ `
+        import { a, b } from './shared.js'
+        console.log(a(), b())
+      `,
+      "/shared.js": /* js */ `
+        export function a() { return 'A' }
+        export function b() { return 'B' }
+      `,
+    },
+    entryPoints: ["/e.js", "/p.js", "/q.js"],
+    splitting: true,
+    minifyIdentifiers: true,
+    outdir: "/out",
+    format: "esm",
+    run: [
+      { file: "/out/e.js", stdout: "A ex" },
+      { file: "/out/p.js", stdout: `A B ${120 * 3 + (119 * 120) / 2}` },
+      { file: "/out/q.js", stdout: "A B" },
+    ],
+  });
   itBundled("splitting/CrossChunkNamesWithDirectEval", {
     files: {
       "/a.js": /* js */ `

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -608,6 +608,106 @@ describe("bundler", () => {
   // An entry point with exports of its own keeps its module namespace as
   // written: shared code is not folded into it (which would add exports),
   // but the chunks that are always loaded with it still fold into one.
+  // A binding shared across chunks carries one bundle-wide name that every
+  // chunk's renamer pins; locals that already have that name (top level or
+  // nested) are renamed around it and the import stays bare.
+  itBundled("splitting/CrossChunkNameCollidesWithLocal", {
+    files: {
+      "/a.js": /* js */ `
+        import { foo } from './shared.js'
+        function foo2() { return 'a-foo2' }
+        var local = (function () { var foo = 'nested'; return foo })()
+        console.log(foo(), foo2(), local)
+      `,
+      "/b.js": /* js */ `
+        import { foo as sharedFoo } from './shared.js'
+        function foo() { return 'b-local-foo' }
+        console.log(sharedFoo(), foo())
+      `,
+      "/shared.js": /* js */ `
+        export function foo() { return 'shared' }
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      api.expectFile("/out/a.js").toMatch(/import\s*\{\s*foo\s*\}\s*from/);
+      api.expectFile("/out/b.js").toMatch(/import\s*\{\s*foo\s*\}\s*from/);
+    },
+    run: [
+      { file: "/out/a.js", stdout: "shared a-foo2 nested" },
+      { file: "/out/b.js", stdout: "shared b-local-foo" },
+    ],
+  });
+
+  // Same under --minify-identifiers: the shared bindings take the shortest
+  // names bundle-wide; a chunk with many hot locals of its own must not hand
+  // one of those names out again, and both clauses stay free of `as`.
+  itBundled("splitting/CrossChunkNameCollidesWithLocalMinified", {
+    files: {
+      "/a.js": /* js */ `
+        import { s0, s1, s2 } from './shared.js'
+        ${Array.from({ length: 80 }, (_, i) => `var l${i} = ${i}; l${i}++; l${i}++; l${i}++; l${i}++;`).join("\n")}
+        console.log(s0() + s1() + s2(), ${Array.from({ length: 80 }, (_, i) => `l${i}`).join("+")})
+      `,
+      "/b.js": /* js */ `
+        import { s0, s1, s2 } from './shared.js'
+        console.log(s0() + s1() + s2())
+      `,
+      "/shared.js": /* js */ `
+        export function s0() { return 1 }
+        export function s1() { return 20 }
+        export function s2() { return 300 }
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    splitting: true,
+    minifyIdentifiers: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      for (const f of jsFilesIn(api)) {
+        const out = api.readFile("/out/" + f);
+        for (const clause of out.match(/(?:import|export)\s*\{[^}]*\}/g) ?? []) expect(clause).not.toContain(" as ");
+      }
+    },
+    run: [
+      { file: "/out/a.js", stdout: `321 ${80 * 4 + (79 * 80) / 2}` },
+      { file: "/out/b.js", stdout: "321" },
+    ],
+  });
+
+  // Direct eval keeps every name in its scope chain as written; the shared
+  // bindings are numbered around those and the program still links.
+  itBundled("splitting/CrossChunkNamesWithDirectEval", {
+    files: {
+      "/a.js": /* js */ `
+        import { a, b } from './shared.js'
+        var x = 'ax'
+        function a2() { return 'local-a2' }
+        console.log(a(), b, eval('x'), eval('a2()'))
+      `,
+      "/b.js": /* js */ `
+        import { a, b } from './shared.js'
+        console.log(a(), b)
+      `,
+      "/shared.js": /* js */ `
+        export function a() { return 'A' }
+        export var b = eval('"B"')
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: [
+      { file: "/out/a.js", stdout: "A B ax local-a2" },
+      { file: "/out/b.js", stdout: "A B" },
+    ],
+  });
+
   itBundled("splitting/EntryWithExportsKeepsSignature", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -772,6 +772,28 @@ describe("bundler", () => {
     ],
   });
 
+  // Two chunks that import() each other reach the same set of chunks; their
+  // content hashes must still differ, or hash-only naming collides.
+  itBundled("splitting/ChunkImportCycleDistinctHashes", {
+    files: {
+      "/a.js": /* js */ `
+        export function a() { return 'a' }
+        import('./b.js').then(m => console.log(a(), m.b()))
+      `,
+      "/b.js": /* js */ `
+        export function b() { return 'b' }
+        export const again = () => import('./a.js')
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    entryNaming: "[hash].[ext]",
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).filter(f => f.endsWith(".js"))).toHaveLength(2);
+    },
+  });
   // An entry point with exports of its own keeps its module namespace as
   // written: shared code is not folded into it (which would add exports),
   // but the chunks that are always loaded with it still fold into one.

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -605,9 +605,6 @@ describe("bundler", () => {
     run: { file: "/out/entry.js", stdout: "shared evaluated\nentry 1\nlazy 2" },
   });
 
-  // An entry point with exports of its own keeps its module namespace as
-  // written: shared code is not folded into it (which would add exports),
-  // but the chunks that are always loaded with it still fold into one.
   // A binding shared across chunks carries one bundle-wide name that every
   // chunk's renamer pins; locals that already have that name (top level or
   // nested) are renamed around it and the import stays bare.
@@ -740,6 +737,9 @@ describe("bundler", () => {
     ],
   });
 
+  // An entry point with exports of its own keeps its module namespace as
+  // written: shared code is not folded into it (which would add exports),
+  // but the chunks that are always loaded with it still fold into one.
   itBundled("splitting/EntryWithExportsKeepsSignature", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -536,7 +536,7 @@ describe("bundler", () => {
       api.expectFile("/out/entry.js").toContain("41");
       api.expectFile("/out/entry.js").not.toMatch(/^\s*import\s*[{"]/m);
       expect(api.readFile("/out/entry.js").match(/^\s*export\b/gm)).toHaveLength(1);
-      expect(jsOutput(api, "lazy")).toMatch(/import\s*\{\s*helper,\s*shared\s*\}\s*from "\.\/entry\.js"/);
+      expect(jsOutput(api, "lazy")).toMatch(/import\s*\{\s*shared,\s*helper\s*\}\s*from "\.\/entry\.js"/);
     },
     run: { file: "/out/entry.js", stdout: "shared\nentry 41 1\nlazy 42" },
   });

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -679,8 +679,40 @@ describe("bundler", () => {
     ],
   });
 
-  // Direct eval keeps every name in its scope chain as written; the shared
-  // bindings are numbered around those and the program still links.
+  // Direct eval keeps every name in its scope chain as written — including a
+  // CommonJS-wrapped file's top level — so the bundle-wide namer must route
+  // around those names, and the shared bindings such a file declares fall
+  // back to `export { name as alias }`.
+  itBundled("splitting/CrossChunkNamesWithDirectEvalMinified", {
+    files: {
+      "/a.js": /* js */ `
+        import { a, b } from './shared.js'
+        var x = 'ax'
+        function a2() { return 'local-a2' }
+        console.log(a(), b, eval('x'), eval('a2()'))
+      `,
+      "/b.js": /* js */ `
+        import { a, b } from './shared.js'
+        console.log(a(), b)
+      `,
+      "/shared.js": /* js */ `
+        export function a() { return 'A' }
+        export var b = eval('"B"')
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    splitting: true,
+    minifyIdentifiers: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      api.expectFile("/out/a.js").toContain('var x = "ax"');
+    },
+    run: [
+      { file: "/out/a.js", stdout: "A B ax local-a2" },
+      { file: "/out/b.js", stdout: "A B" },
+    ],
+  });
   itBundled("splitting/CrossChunkNamesWithDirectEval", {
     files: {
       "/a.js": /* js */ `

--- a/test/bundler/esbuild/splitting.test.ts
+++ b/test/bundler/esbuild/splitting.test.ts
@@ -512,9 +512,10 @@ describe("bundler", () => {
     entryPoints: ["/a.js", "/b.js", "/c.js"],
     splitting: true,
     minifyIdentifiers: true,
+    // `foo` crosses chunks, so it carries one bundle-wide minified name.
     run: [
-      { file: "/out/a.js", stdout: "[Function: f]" },
-      { file: "/out/b.js", stdout: "[Function: f]" },
+      { file: "/out/a.js", stdout: "[Function: o]" },
+      { file: "/out/b.js", stdout: "[Function: o]" },
     ],
   });
   itBundled("splitting/HybridESMAndCJSESBuildIssue617", {

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -107,11 +107,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-sjg7egv9.js",
+                "path": "./client-tevdxjba.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "efKwB-6QGwk",
+                  "etag": "2s77zd0SC2o",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -121,17 +121,17 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "sJJm55rxM4I",
+                  "etag": "BZtLPrvSsFc",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
               {
                 "input": "client.html",
-                "path": "./client-0z58sk45.css",
+                "path": "./client-gsg59jv4.css",
                 "loader": "css",
                 "isEntry": true,
                 "headers": {
-                  "etag": "4B9l6JnTRAU",
+                  "etag": "cJnwBSkS-4Q",
                   "content-type": "text/css;charset=utf-8"
                 }
               },
@@ -291,17 +291,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "xAZoSOIIQJ8",
+                  "etag": "Dl7kT6q7eY4",
                 },
                 "input": "home.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./home-4688280z.js",
+                "path": "./home-ey4favse.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "uIE6dXgvM-4",
+                  "etag": "PxkCWGv-T1w",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -311,12 +311,12 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/css;charset=utf-8",
-                  "etag": "ZTZtbLd3364",
+                  "etag": "hT1GudlsHgI",
                 },
                 "input": "home.html",
                 "isEntry": true,
                 "loader": "css",
-                "path": "./home-5pdcqqze.css",
+                "path": "./home-5x6sscy2.css",
               },
             ],
             "index": "./home.html",
@@ -326,17 +326,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "INLwcb4oxw8",
+                  "etag": "RCRrF1EbBvo",
                 },
                 "input": "about.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./about-0jghy87f.js",
+                "path": "./about-44bqhv6t.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "ZpqlG2wo2xo",
+                  "etag": "RRbSlWvBFIQ",
                 },
                 "input": "about.html",
                 "isEntry": true,
@@ -346,12 +346,12 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/css;charset=utf-8",
-                  "etag": "x6pW8hAzxGI",
+                  "etag": "ti_Q2k-EP3o",
                 },
                 "input": "about.html",
                 "isEntry": true,
                 "loader": "css",
-                "path": "./about-7apjgk42.css",
+                "path": "./about-pfgtf4zt.css",
               },
             ],
             "index": "./about.html",

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -121,7 +121,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "BZtLPrvSsFc",
+                  "etag": "GDn0RdEyL2w",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
@@ -301,7 +301,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "PxkCWGv-T1w",
+                  "etag": "IhvRaM9jGDU",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -336,7 +336,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "RRbSlWvBFIQ",
+                  "etag": "2OGqRD6vx54",
                 },
                 "input": "about.html",
                 "isEntry": true,

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -222,7 +222,7 @@ console.log("How...dashing?");
   "content-length": "316",
   "content-type": "text/javascript;charset=utf-8",
   "date": "<date>",
-  "etag": ""0f2405c506dd6bd3"",
+  "etag": ""f862dbeedf9b72bc"",
   "sourcemap": "/chunk-HASH.js.map",
 }
 `);


### PR DESCRIPTION
### What does this PR do?

Third code-splitting overhead PR after #40506 / #40509: **every binding that crosses a chunk boundary gets one bundle-wide name**, so cross-chunk `export {}` / `import {}` clauses print bare names instead of `export { x as Qc }` … `import { Qc as ur }`.

Today (esbuild's structure) three namers disagree: `computeCrossChunkDependencies` picks an export alias with its own `ExportRenamer` before any chunk is renamed, then the exporting chunk's renamer and each importing chunk's renamer name the same ref independently, and the printer bridges them with `as` on both ends. Under `--minify` that is essentially every item (and the alias counter was never reset per chunk, so aliases were `Qc`/`Th` while the locals were 1 char).

Now:
- `computeCrossChunkDependencies` builds the clauses with empty aliases; import items are ordered by stable ref instead of by alias.
- The per-chunk renamer pass stays parallel but the minifier is split into *accumulate* and *finish*. Between the two, `cross_chunk_names::assign_minified` sums each cross-chunk binding's use count over every chunk that sees it, hands out the shortest names in that order from one bundle-wide `NameMinifier` (skipping every module scope's reserved/unbound names), and **pins** them in each chunk's `MinifyRenamer` (`pin` names the slot and reserves the name; `finish` names everything else around it). Without `--minify-identifiers`, `assign_unminified` runs before the renamers: each binding keeps its own name, numbered only against the other cross-chunk bindings, and `NumberRenamer::pin_top_level_symbol` seeds it.
- Exporter local == alias == importer local by construction, so the printer's existing "elide `as` when equal" path fires everywhere; the only `as` left are an entry point's own public exports (`export { m as default, X as load3 }`).
- Names only need to be unique within a chunk, so a chunk that doesn't see a given shared binding can still use its short name locally — the bundle-wide namespace costs each chunk only the handful of shared refs it actually touches.

### Numbers

1 entry + 100 `import()` routes + 600 shared modules (17.7k import/export items), `bun build --splitting`, main (with #40506/#40509) vs this PR, identical 359-file layout:

| | main | this PR |
|---|---:|---:|
| `--minify` total JS | 421,089 B | **340,416 B (−19.2%)** |
| `--minify` total JS, gzip | 98,382 B | **79,945 B (−18.7%)** |
| `--minify` export items with `as` | 2,286 | 496 (entry points' public names only) |
| `--minify` import items with `as` | 14,096 | **0** |
| no minify, total JS | 517,157 B | 517,157 B (gzip 102,861 → 98,493) |

40-route fixture `--minify`: 59,677 → 54,474 B (−8.7%). All variants (plain / `--minify` / `--compile --bytecode --minify`) produce identical program output, including every lazy route.

### How did you verify your code works?

`bun bd test` on `bundler_splitting`, `esbuild/splitting`, `esbuild/default`, `bundler_minify`, `bundler_edgecase`, `bundler_naming`, `esbuild/importstar`, `bundler_html`, `bundler_compile_splitting` — green; two expectations updated (`splitting/FoldsSharedIntoEntry` import order now follows stable ref order; `splitting/MinifyIdentifiersCrashESBuildIssue437`'s shared `foo` now prints under its bundle-wide minified name). Built and ran both fixtures split / minified / compiled+bytecode with the debug build.

### Also in this PR: direct `eval` at module scope + `--minify`

Writing the collision tests turned up a pre-existing bug (same behaviour in esbuild): `pop_scope` pins the names of every scope that contains a direct eval, but the module scope never pops, so `var x = 1; eval('x')` at the *top level* of a bundled file lost `x` to the minifier — `ReferenceError` at runtime, splitting or not. When the bundler wraps such a file in a CommonJS closure (which a top-level direct eval in a file without ESM exports forces), its top-level names are private to that closure, so they are now pinned as well; a flat ESM file's top-level names still share the chunk scope with other files and stay renameable, as in esbuild. Tests: `minify/DirectEvalKeepsTopLevelNamesOfWrappedFile`, `splitting/CrossChunkNamesWithDirectEval{,Minified}`, `splitting/CrossChunkNameCollidesWithLocal{,Minified}`.