### PR TITLE
Bun.Image: throw ERR_OUT_OF_RANGE for out-of-range encoder options

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -104,12 +104,14 @@ Calling a format method sets the encode target; without one, Bun reuses the sour
 ```ts
 img.jpeg({ quality: 85 }); // 1–100, default 80
 img.png({ compressionLevel: 6 }); // zlib level 0–9
-img.png({ palette: true, colors: 64, dither: true }); // indexed PNG
+img.png({ palette: true, colors: 64, dither: true }); // indexed PNG, 2–256 colors
 img.webp({ quality: 80 });
 img.webp({ lossless: true });
 img.heic({ quality: 80 }); // macOS / Windows only
 img.avif({ quality: 60 }); // macOS / Windows only
 ```
+
+`quality`, `compressionLevel`, and `colors` must be integers in the documented range. A value of the wrong type throws a `TypeError` (`ERR_INVALID_ARG_TYPE`), and a value outside the range throws a `RangeError` (`ERR_OUT_OF_RANGE`). Format methods run synchronously, so the error surfaces at the call, not at the terminal.
 
 `palette: true` quantizes to a ≤256-color palette and emits an indexed (color-type 3) PNG, optionally with Floyd–Steinberg `dither`. The indexed PNG is typically 3–5× smaller than truecolor for screenshots and UI assets.
 

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -365,6 +365,36 @@ fn get_number_option(
     }
 }
 
+/// Integer option with a documented range, e.g. `quality` (1-100). Missing
+/// or `undefined` → `None` (use the default). A non-number throws
+/// `ERR_INVALID_ARG_TYPE`; NaN or a fraction throws the same with "integer";
+/// a value outside `min..=max` throws `ERR_OUT_OF_RANGE`.
+fn get_int_option<T: bun_core::Integer>(
+    opt: JSValue,
+    global: &JSGlobalObject,
+    name: &'static str,
+    min: i128,
+    max: i128,
+) -> JsResult<Option<T>> {
+    let Some(v) = opt.get(global, name)? else {
+        return Ok(None);
+    };
+    // `validate_integer_range` maps NaN to the default; reject it instead.
+    if v.is_number() && v.as_number().is_nan() {
+        return Err(global.throw_invalid_property_type_value(name.as_bytes(), b"integer", v));
+    }
+    Ok(Some(global.validate_integer_range::<T>(
+        v,
+        T::ZERO,
+        jsc::IntegerRange {
+            min,
+            max,
+            field_name: name.as_bytes(),
+            always_allow_zero: false,
+        },
+    )?))
+}
+
 fn apply_options(img: &mut Image, global: &JSGlobalObject, opt: JSValue) -> JsResult<()> {
     if !opt.is_object() {
         return Ok(());
@@ -597,20 +627,20 @@ impl Image {
         let args = callframe.arguments();
         if args.len() > 0 && args[0].is_object() {
             let opt = args[0];
-            if let Some(q) = get_number_option(opt, global, "quality")? {
-                enc.quality = coerce_int!(u8, q, 1.0, 100.0);
+            if let Some(q) = get_int_option::<u8>(opt, global, "quality", 1, 100)? {
+                enc.quality = q;
             }
             if let Some(l) = opt.get(global, "lossless")? {
                 enc.lossless = l.to_boolean();
             }
-            if let Some(c) = get_number_option(opt, global, "compressionLevel")? {
-                enc.compression_level = coerce_int!(i8, c, 0.0, 9.0);
+            if let Some(c) = get_int_option::<i8>(opt, global, "compressionLevel", 0, 9)? {
+                enc.compression_level = c;
             }
             if let Some(p) = opt.get(global, "palette")? {
                 enc.palette = p.to_boolean();
             }
-            if let Some(c) = get_number_option(opt, global, "colors")? {
-                enc.colors = coerce_int!(u16, c, 2.0, 256.0);
+            if let Some(c) = get_int_option::<u16>(opt, global, "colors", 2, 256)? {
+                enc.colors = c;
             }
             if let Some(d) = opt.get(global, "dither")? {
                 enc.dither = d.to_boolean();

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -896,8 +896,8 @@ describe("Bun.Image", () => {
     for (const v of [Infinity, -Infinity, NaN, 1e300, -1e300]) {
       expect(() => new Bun.Image(cornersPng).rotate(v)).toThrow(/only multiples of 90/);
     }
-    // resize/quality/maxPixels clamp; NaN→lo bound, ±Inf→matching bound.
-    const out = await new Bun.Image(cornersPng).resize(NaN, NaN).jpeg({ quality: NaN }).bytes();
+    // resize/maxPixels clamp; NaN→lo bound, ±Inf→matching bound.
+    const out = await new Bun.Image(cornersPng).resize(NaN, NaN).jpeg().bytes();
     expect(out[0]).toBe(0xff);
     expect((await new Bun.Image(gradientPng, { maxPixels: Infinity }).metadata()).width).toBe(16);
     // Infinity width clamps to the per-side cap; output then exceeds maxPixels
@@ -940,6 +940,42 @@ describe("Bun.Image", () => {
     const out = await img().jpeg({ quality: undefined }).bytes();
     const defaultOut = await img().jpeg().bytes();
     expect(out).toEqual(defaultOut);
+  });
+
+  // #40490: an out-of-range encoder option used to clamp in silence, so
+  // `.jpeg({ quality: 999 })` encoded at quality 100 and `{ quality: -5 }`
+  // at quality 1. The documented ranges are now enforced.
+  test("out-of-range encoder options throw ERR_OUT_OF_RANGE", async () => {
+    const img = () => new Bun.Image(cornersPng);
+    let caught: any;
+    try {
+      img().jpeg({ quality: 999 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toMatchObject({
+      name: "RangeError",
+      code: "ERR_OUT_OF_RANGE",
+      message: 'The value of "quality" is out of range. It must be >= 1 and <= 100. Received 999',
+    });
+    for (const bad of [0, -5, 101, Infinity, -Infinity]) {
+      expect(() => img().jpeg({ quality: bad })).toThrow(RangeError);
+      expect(() => img().webp({ quality: bad })).toThrow(RangeError);
+    }
+    for (const bad of [-1, 10, 1e300]) {
+      expect(() => img().png({ compressionLevel: bad })).toThrow(/"compressionLevel".*>= 0 and <= 9/);
+    }
+    for (const bad of [1, 257, 1000]) {
+      expect(() => img().png({ palette: true, colors: bad })).toThrow(/"colors".*>= 2 and <= 256/);
+    }
+    // NaN and fractions are not valid integers either.
+    for (const bad of [NaN, 80.5]) {
+      expect(() => img().jpeg({ quality: bad })).toThrow(/"quality" property must be of type integer/);
+    }
+    // The bounds themselves are accepted.
+    img().jpeg({ quality: 1 }).jpeg({ quality: 100 });
+    img().png({ compressionLevel: 0 }).png({ compressionLevel: 9 });
+    img().png({ colors: 2 }).png({ colors: 256 });
   });
 
   test("constructor cleans up on throwing options getter", () => {


### PR DESCRIPTION
Stacked on #40491. That PR makes a wrong-type option value throw. This one makes an out-of-range value throw too. The diff shown here is only the range check.

### Problem
- An out-of-range `Bun.Image` encoder option clamps in silence. `.jpeg({ quality: 999 })` encodes at quality 100, `{ quality: -5 }` and `{ quality: NaN }` encode at quality 1. Nothing throws or warns (#40490).
- The cause: `set_format` in `src/runtime/image/Image.rs` reads `quality`, `compressionLevel` and `colors` through `coerce_int!`, which exists to keep NaN and out-of-range floats out of an integer cast. It clamps instead of reporting.

### Fix
- Add `get_int_option`. It reads the property and runs it through `JSGlobalObject::validate_integer_range` with the documented range: `quality` 1-100, `compressionLevel` 0-9, `colors` 2-256. A value outside the range throws a `RangeError` with `code: "ERR_OUT_OF_RANGE"`, for example `The value of "quality" is out of range. It must be >= 1 and <= 100. Received 999`. NaN and fractions throw `ERR_INVALID_ARG_TYPE` with type `integer`.
- This matches how the other Bun APIs treat a documented integer range: `Bun.Archive` `level` (1-12), `Bun.password` bcrypt `cost` (4-31) and `Response` `compress.level` all throw on an out-of-range value. None of them clamp.
- `resize`, `rotate`, `maxPixels` and `modulate` keep their existing clamps. Those values are sizes and multipliers without a documented range, and the clamp there is a guard, not an option parse.
- Verified: `test/js/bun/image/image.test.ts` (new test, fails on released bun, passes with this change). The full file passes: 97 pass, 2 skip.

### Background
- `Bun.Image` records encode options synchronously in `.jpeg()` / `.png()` / `.webp()` and does the work later in a terminal such as `.bytes()`. So the error surfaces at the format call, before any decode.
- `validate_integer_range` is the Rust port of Node's `validateInteger`. It throws `ERR_INVALID_ARG_TYPE` for a non-number or a fraction and `ERR_OUT_OF_RANGE` for a value outside `min..=max`. It maps NaN to the default, so `get_int_option` rejects NaN first, the same way `Bun.build` does for `bytecodeDepth`.
- Unknown keys (the `qualiy` typo in the report) stay ignored. No Bun API rejects unknown option keys, and the TypeScript types catch the typo at compile time.

<details><summary>Notes</summary>

Measured on released bun 1.4.1 with a 256x256 noise PNG, `.jpeg(o).bytes().byteLength`: `{}` 40743, `{ quality: 100 }` 123985, `{ quality: 999 }` 123985 (clamped to 100), `{ quality: -5 }` 3343, `{ quality: 0 }` 3343, `{ quality: NaN }` 3343 (all clamped to 1), `{ quality: 80.5 }` 40743, `{ quality: "84" }` 40743 (ignored). `.png({ compressionLevel: 10 })` and `.png({ palette: true, colors: 1000 })` and `colors: 1` were accepted.

With this change each of those throws: `quality: 999`, `-5`, `0`, `compressionLevel: 10`, `colors: 1000`, `colors: 1` throw `ERR_OUT_OF_RANGE`. `quality: NaN` and `80.5` throw `ERR_INVALID_ARG_TYPE` (`must be of type integer`). `quality: "84"` throws `ERR_INVALID_ARG_TYPE` (`must be of type number`, from #40491).

The existing test `non-finite / huge numeric inputs are clamped by coerceInt` asserted that `.jpeg({ quality: NaN })` does not throw. That assertion is removed. The `resize(NaN, NaN)` and `maxPixels: Infinity` assertions in that test are unchanged.

The docs (`docs/runtime/image.mdx`) now state the ranges and the two error codes. The type declarations already document the ranges.

Suites run: `bun bd test test/js/bun/image/image.test.ts` (97 pass, 2 skip, 0 fail). `cargo fmt --check`, `cargo clippy -p bun_runtime` (no new warnings), prettier check on the test and docs.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/image/image.test.ts

<!-- robobun:evidence:end -->