### PR TITLE
bun_ptr: test that RefPtr clones cross threads and the last drop destroys

### DIFF
--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -16,6 +16,10 @@
 //! types (`Box`, `Rc`, `Arc`, `Cow`) and `bun_collections` (`TaggedPtr`,
 //! `TaggedPtrUnion`). This crate hosts the intrusive/FFI-crossing variants.
 
+// Allow the `::bun_ptr::…` paths emitted by the ref-count derives to resolve
+// when used inside this crate (the test hosts in `ref_count.rs`).
+extern crate self as bun_ptr;
+
 // `bun.ptr.CowSlice(T)` / `CowSliceZ` — the lifetime-free struct port (owns or
 // borrows a raw slice with `init_owned`/`borrow_subslice`/`length`). Callers
 // that need the struct-shaped API (e.g. `pack_command::Pattern`) reach for

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -16,8 +16,7 @@
 //! types (`Box`, `Rc`, `Arc`, `Cow`) and `bun_collections` (`TaggedPtr`,
 //! `TaggedPtrUnion`). This crate hosts the intrusive/FFI-crossing variants.
 
-// Allow the `::bun_ptr::…` paths emitted by the ref-count derives to resolve
-// when used inside this crate (the test hosts in `ref_count.rs`).
+// Lets the `::bun_ptr::` paths the ref-count derives emit resolve in-crate.
 extern crate self as bun_ptr;
 
 // `bun.ptr.CowSlice(T)` / `CowSliceZ` — the lifetime-free struct port (owns or

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -976,6 +976,63 @@ mod tests {
         assert_eq!(drops(), before + 1);
     }
 
+    // What `#[derive(ThreadSafeRefCounted)]` emits for a real host. Spelled out
+    // because the derive expands to `::bun_ptr::` paths, which do not resolve
+    // from inside this crate.
+    impl AnyRefCounted for Shared {
+        unsafe fn rc_ref(this: *mut Self) {
+            // SAFETY: caller contract — `this` points to a live `Shared`.
+            unsafe { ThreadSafeRefCount::<Shared>::ref_(this) }
+        }
+        unsafe fn rc_deref(this: *mut Self) {
+            // SAFETY: caller contract — `this` points to a live `Shared`.
+            unsafe { ThreadSafeRefCount::<Shared>::deref(this) }
+        }
+        unsafe fn rc_has_one_ref(this: *const Self) -> bool {
+            // SAFETY: caller contract — `this` points to a live `Shared`.
+            unsafe { (*ThreadSafeRefCounted::get_ref_count(this.cast_mut())).has_one_ref() }
+        }
+        unsafe fn rc_assert_valid(this: *const Self) {
+            // SAFETY: caller contract — `this` points to a live `Shared`.
+            unsafe { (*ThreadSafeRefCounted::get_ref_count(this.cast_mut())).assert_valid() }
+        }
+    }
+
+    // SAFETY: the count is atomic and `payload` is only ever read, so `&Shared`
+    // may be used from any thread and the last thread out may run the
+    // destructor. This is what makes `RefPtr<Shared>: Send + Sync`.
+    unsafe impl Send for Shared {}
+    // SAFETY: as above.
+    unsafe impl Sync for Shared {}
+
+    #[test]
+    fn ref_ptr_clones_cross_threads_and_the_last_one_destroys() {
+        let _serial = serial();
+        let before = drops();
+        let main_ref = RefPtr::new(Shared {
+            ref_count: ThreadSafeRefCount::init(),
+            payload: Box::new(5),
+        });
+
+        // Each thread gets its own clone and releases it by dropping it.
+        // `RefPtr<Shared>: Send` is what lets the clone move into the closure.
+        let workers: Vec<_> = (0..4)
+            .map(|_| {
+                let theirs = main_ref.clone();
+                std::thread::spawn(move || *theirs.payload)
+            })
+            .collect();
+        for worker in workers {
+            assert_eq!(worker.join().unwrap(), 5);
+        }
+        assert_eq!(drops(), before);
+        assert!(main_ref.ref_count.has_one_ref());
+
+        // The destroying release may also happen off the creating thread.
+        std::thread::spawn(move || drop(main_ref)).join().unwrap();
+        assert_eq!(drops(), before + 1);
+    }
+
     #[test]
     fn thread_safe_release_defers_destruction() {
         let _serial = serial();

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -918,6 +918,7 @@ mod tests {
 
     // ── ThreadSafeRefCount (atomic, cross-thread) ─────────────────────────
 
+    #[derive(crate::ThreadSafeRefCounted)]
     struct Shared {
         ref_count: ThreadSafeRefCount<Shared>,
         payload: Box<u32>,
@@ -929,12 +930,12 @@ mod tests {
         }
     }
 
-    impl ThreadSafeRefCounted for Shared {
-        unsafe fn get_ref_count(this: *mut Self) -> *mut ThreadSafeRefCount<Self> {
-            // SAFETY: caller contract — pure field projection, no read.
-            unsafe { &raw mut (*this).ref_count }
-        }
-    }
+    // SAFETY: the count is atomic and `payload` is only ever read, so `&Shared`
+    // may be used from any thread and the last thread out may run the
+    // destructor. This is what makes `RefPtr<Shared>: Send + Sync`.
+    unsafe impl Send for Shared {}
+    // SAFETY: as above.
+    unsafe impl Sync for Shared {}
 
     /// `*mut Shared` is not `Send`; the refcount is what makes sharing it sound.
     #[derive(Clone, Copy)]
@@ -976,35 +977,6 @@ mod tests {
         assert_eq!(drops(), before + 1);
     }
 
-    // What `#[derive(ThreadSafeRefCounted)]` emits for a real host. Spelled out
-    // because the derive expands to `::bun_ptr::` paths, which do not resolve
-    // from inside this crate.
-    impl AnyRefCounted for Shared {
-        unsafe fn rc_ref(this: *mut Self) {
-            // SAFETY: caller contract — `this` points to a live `Shared`.
-            unsafe { ThreadSafeRefCount::<Shared>::ref_(this) }
-        }
-        unsafe fn rc_deref(this: *mut Self) {
-            // SAFETY: caller contract — `this` points to a live `Shared`.
-            unsafe { ThreadSafeRefCount::<Shared>::deref(this) }
-        }
-        unsafe fn rc_has_one_ref(this: *const Self) -> bool {
-            // SAFETY: caller contract — `this` points to a live `Shared`.
-            unsafe { (*ThreadSafeRefCounted::get_ref_count(this.cast_mut())).has_one_ref() }
-        }
-        unsafe fn rc_assert_valid(this: *const Self) {
-            // SAFETY: caller contract — `this` points to a live `Shared`.
-            unsafe { (*ThreadSafeRefCounted::get_ref_count(this.cast_mut())).assert_valid() }
-        }
-    }
-
-    // SAFETY: the count is atomic and `payload` is only ever read, so `&Shared`
-    // may be used from any thread and the last thread out may run the
-    // destructor. This is what makes `RefPtr<Shared>: Send + Sync`.
-    unsafe impl Send for Shared {}
-    // SAFETY: as above.
-    unsafe impl Sync for Shared {}
-
     #[test]
     fn ref_ptr_clones_cross_threads_and_the_last_one_destroys() {
         let _serial = serial();
@@ -1014,22 +986,30 @@ mod tests {
             payload: Box::new(5),
         });
 
-        // Each thread gets its own clone and releases it by dropping it.
-        // `RefPtr<Shared>: Send` is what lets the clone move into the closure.
-        let workers: Vec<_> = (0..4)
-            .map(|_| {
-                let theirs = main_ref.clone();
-                std::thread::spawn(move || *theirs.payload)
-            })
+        // Four threads each take a ref through the shared `&RefPtr`
+        // (`RefPtr<Shared>: Sync`) and hand it back (`RefPtr<Shared>: Send`).
+        let clones: Vec<RefPtr<Shared>> = std::thread::scope(|scope| {
+            let shared = &main_ref;
+            let workers: Vec<_> = (0..4)
+                .map(|_| scope.spawn(move || shared.clone()))
+                .collect();
+            workers.into_iter().map(|w| w.join().unwrap()).collect()
+        });
+        assert_eq!(main_ref.ref_count.get(), 5);
+        assert_eq!(drops(), before);
+
+        // Every ref, the original included, is read and released on its own
+        // thread with no join in between. Only the count's own ordering can put
+        // the destructor after the other threads' reads of `payload`, which is
+        // what Miri's data-race detector checks here.
+        let workers: Vec<_> = clones
+            .into_iter()
+            .chain(core::iter::once(main_ref))
+            .map(|theirs| std::thread::spawn(move || *theirs.payload))
             .collect();
         for worker in workers {
             assert_eq!(worker.join().unwrap(), 5);
         }
-        assert_eq!(drops(), before);
-        assert!(main_ref.ref_count.has_one_ref());
-
-        // The destroying release may also happen off the creating thread.
-        std::thread::spawn(move || drop(main_ref)).join().unwrap();
         assert_eq!(drops(), before + 1);
     }
 

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -997,8 +997,7 @@ mod tests {
         assert_eq!(main_ref.ref_count.get(), 5);
         assert_eq!(drops(), before);
 
-        // No join between the releases: only the count's ordering places the
-        // destructor after the other threads' reads, and Miri checks that.
+        // Release all five refs on concurrent threads: only the count orders the destructor.
         let workers: Vec<_> = clones
             .into_iter()
             .chain(core::iter::once(main_ref))

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -986,8 +986,7 @@ mod tests {
             payload: Box::new(5),
         });
 
-        // Four threads each take a ref through the shared `&RefPtr`
-        // (`RefPtr<Shared>: Sync`) and hand it back (`RefPtr<Shared>: Send`).
+        // Clone through a shared `&RefPtr` on other threads (`Sync`), hand back (`Send`).
         let clones: Vec<RefPtr<Shared>> = std::thread::scope(|scope| {
             let shared = &main_ref;
             let workers: Vec<_> = (0..4)
@@ -998,10 +997,8 @@ mod tests {
         assert_eq!(main_ref.ref_count.get(), 5);
         assert_eq!(drops(), before);
 
-        // Every ref, the original included, is read and released on its own
-        // thread with no join in between. Only the count's own ordering can put
-        // the destructor after the other threads' reads of `payload`, which is
-        // what Miri's data-race detector checks here.
+        // No join between the releases: only the count's ordering places the
+        // destructor after the other threads' reads, and Miri checks that.
         let workers: Vec<_> = clones
             .into_iter()
             .chain(core::iter::once(main_ref))

--- a/test/internal/rust-ref-ptr-miri.test.ts
+++ b/test/internal/rust-ref-ptr-miri.test.ts
@@ -1,0 +1,51 @@
+// `RefPtr<T>` (src/ptr/ref_count.rs) is `Send + Sync` when `T` is. The unit
+// test `ref_ptr_clones_cross_threads_and_the_last_one_destroys` is the coverage
+// for those impls: five threads release their refs concurrently, so only the
+// count's own ordering places the destructor after the other threads' reads,
+// and Miri's data-race detector is what checks that. The bun_ptr test binary
+// does not link natively, so the crate's tests run under Miri only. This runs
+// that test with the same Tree Borrows flags as `bun run rust:miri` and checks
+// that it ran and passed. Skipped where miri is not installed or the cargo
+// workspace is not resolvable (same prerequisite check as linear-fifo.test.ts).
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const cargoBin = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(path.join(repoRoot, "vendor", "rust-argon2", "Cargo.toml")) &&
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+const miriAvailable =
+  !!cargoBin &&
+  workspaceResolvable &&
+  Bun.spawnSync({
+    cmd: [cargoBin, "miri", "--version"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  }).exitCode === 0;
+
+test.skipIf(!miriAvailable)(
+  "RefPtr cross-thread clone and drop is clean under miri's data-race detector",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [cargoBin!, "miri", "test", "--locked", "-p", "bun_ptr", "--", "ref_ptr_clones_cross_threads"],
+      cwd: repoRoot,
+      env: { ...process.env, MIRIFLAGS: "-Zmiri-tree-borrows", CARGO_TERM_COLOR: "never" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      // Surface miri's diagnostic so the gate/CI log shows the actual UB.
+      console.error(stderr || stdout);
+    }
+    expect(stderr).not.toContain("Undefined Behavior");
+    expect(stdout).toContain("test ref_count::tests::ref_ptr_clones_cross_threads_and_the_last_one_destroys ... ok");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);


### PR DESCRIPTION
### Problem
- #40478 made `RefPtr<T>` owning: `Drop` releases, `Clone` takes a ref, and `RefPtr<T>` is `Send + Sync` when `T` is (`src/ptr/ref_count.rs:586-599`). No test moved or shared a `RefPtr` across threads.
- The existing cross-thread test drives `ThreadSafeRefCount::ref_`/`deref` by hand through a `SendPtr` newtype. It never constructs a `RefPtr`.

### Fix
- Add `ref_ptr_clones_cross_threads_and_the_last_one_destroys`. Four scoped threads clone through a shared `&RefPtr<Shared>` (`Sync`) and hand the clone back (`Send`). All five refs are then released on their own threads with no join in between, so only the count's atomics order the destructor after the other threads' reads. A `Relaxed` `fetch_sub` in `ThreadSafeRefCount::deref` makes Miri report a data race. A shape that joins the workers first passes with `Relaxed`.
- Add `extern crate self as bun_ptr;` to `src/ptr/lib.rs`, as `bun_jsc`, `bun_install`, and `bun_css` do. The test host `Shared` now uses `#[derive(ThreadSafeRefCounted)]` instead of a hand-written copy of the derive output.
- Add `test/internal/rust-ref-ptr-miri.test.ts`. It runs that unit test under Miri from `bun test`, with the flags `bun run rust:miri` uses, and checks that it ran and passed. It skips where miri or the cargo workspace is missing, like `linear-fifo.test.ts`.
- Verified: `bun run rust:miri -p bun_ptr` (23 pass). The wrapper test passes, and fails with main's `src/ptr` files. `cargo clippy -p bun_ptr` is clean. No runtime code changes.

### Background
- `RefPtr<T>` is the intrusive `Arc<T>`: the count lives inside `T`.
- The `bun_ptr` unit tests run under Miri only: the native test binary does not link the `OutputSink` symbols. Miri tracks happens-before with vector clocks, so a racing read and free is reported in any schedule.
- `std::thread::spawn` is what this test module already uses. `bun_threading` is not a dependency of `bun_ptr`.

<details><summary>Notes</summary>

- The test is ported from #37665, which proposed the same behavior as a separate `OwnedRef<T>` type before #40478 gave it to `RefPtr` itself. #37665 and #31173 are closed as superseded.
- The other test hosts (`Thing`, `Light`) keep their hand-written trait impls. With the self-alias in place they can move to `#[derive(RefCounted)]` and `#[derive(CellRefCounted)]` in a follow-up, which would also make `RefPtr<Light>` constructible in tests.
- Probe: `sed -i '352s/Ordering::SeqCst/Ordering::Relaxed/' src/ptr/ref_count.rs`, then `cargo miri test -p bun_ptr ref_ptr_clones_cross_threads` fails with `Data race detected between (1) non-atomic read on thread unnamed-6 and (2) non-atomic write on thread unnamed-10`. Reverted before commit.
- Fail-before for the wrapper: `git checkout origin/main -- src/ptr/lib.rs src/ptr/ref_count.rs`, then the wrapper test fails on `expect(stdout).toContain(... ... ok)` with `running 0 tests` in the output.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-ref-ptr-miri.test.ts
bun test v1.4.1 (adc354d99)

test/internal/rust-ref-ptr-miri.test.ts:
42 |     if (exitCode !== 0) {
43 |       // Surface miri's diagnostic so the gate/CI log shows the actual UB.
44 |       console.error(stderr || stdout);
45 |     }
46 |     expect(stderr).not.toContain("Undefined Behavior");
47 |     expect(stdout).toContain("test ref_count::tests::ref_ptr_clones_cross_threads_and_the_last_one_destroys ... ok");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "test ref_count::tests::ref_ptr_clones_cross_threads_and_the_last_one_destroys ... ok"
Received: "\nrunning 0 tests\n\ntest result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.11s\n\n\nrunning 0 tests\n\ntest result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s\n\nall doctests ran in 0.01s; merged doctests compilation took 0.01s\n"

      at <anonymous> (/workspace/bun/test/internal/rust-ref-ptr-miri.test.ts:47:20)
(fail) Ref
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/internal/rust-ref-ptr-miri.test.ts:
42 |     if (exitCode !== 0) {
43 |       // Surface miri's diagnostic so the gate/CI log shows the actual UB.
44 |       console.error(stderr || stdout);
45 |     }
46 |     expect(stderr).not.toContain("Undefined Behavior");
47 |     expect(stdout).toContain("test ref_count::tests::ref_ptr_clones_cross_threads_and_the_last_one_destroys ... ok");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "test ref_count::tests::ref_ptr_clones_cross_threads_and_the_last_one_destroys ... ok"
Received: "\nrunning 0 tests\n\ntest result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.11s\n\n\nrunning 0 tests\n\ntest result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s\n\nall doctests ran in 0.01s; merged doctests compilation took 0.01s\n"

      at <anonymous> (/workspace/bun/test/internal/rust-ref-ptr-miri.test.ts:47:20)
(fail) RefPtr cross-thread clone and drop is clean under miri's data-race detector [1338.39ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [1466.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-ref-ptr-miri.test.ts
bun test v1.4.1 (adc354d99)

test/internal/rust-ref-ptr-miri.test.ts:
(pass) RefPtr cross-thread clone and drop is clean under miri's data-race detector [2055.74ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [4.17s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ecb981f449
  features     baseline

23 deps, 129 codegen, 1172 objects in 632ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (adc354d99)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (adc354d99)

Checked 1 install across 2 packages (no changes) [4.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen .bind.ts → GeneratedBindings.cpp
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (adc354d99)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 9ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ptr/lib.rs                          |  3 ++
 src/ptr/ref_count.rs                    | 45 +++++++++++++++++++++++++----
 test/internal/rust-ref-ptr-miri.test.ts | 51 +++++++++++++++++++++++++++++++++
 3 files changed, 93 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/ptr/lib.rs                               1      3      0
src/ptr/ref_count.rs                         3      7      0
test/internal/rust-ref-ptr-miri.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->