### PR TITLE
Bun.Image: bound ancillary metadata, tolerate bogus ICC markers, align GIF probe with the decoder

### DIFF
--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -394,8 +394,7 @@ fn source_from_js(
             out.truncate(r.written);
             return Ok(Source::Owned(out));
         }
-        // Same check as `Bun.file()`: the worker opens this as a C string, so
-        // an interior NUL would open the prefix.
+        // Same check as `Bun.file()`; the worker opens this as a C string.
         crate::node::types::Valid::path_null_bytes(s, global)?;
         return Ok(Source::Path(ZBox::from_bytes(s)));
     }

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -394,9 +394,8 @@ fn source_from_js(
             out.truncate(r.written);
             return Ok(Source::Owned(out));
         }
-        // Same check as `Bun.file()` / node:fs. The worker opens this path
-        // through a C string, which would stop at an interior NUL and open
-        // the prefix instead of the string the caller validated.
+        // Same check as `Bun.file()`: the worker opens this as a C string, so
+        // an interior NUL would open the prefix.
         crate::node::types::Valid::path_null_bytes(s, global)?;
         return Ok(Source::Path(ZBox::from_bytes(s)));
     }

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -394,6 +394,10 @@ fn source_from_js(
             out.truncate(r.written);
             return Ok(Source::Owned(out));
         }
+        // Same check as `Bun.file()` / node:fs. The worker opens this path
+        // through a C string, which would stop at an interior NUL and open
+        // the prefix instead of the string the caller validated.
+        crate::node::types::Valid::path_null_bytes(s, global)?;
         return Ok(Source::Path(ZBox::from_bytes(s)));
     }
     if let Some(ab) = value.as_array_buffer(global) {

--- a/src/runtime/image/README.md
+++ b/src/runtime/image/README.md
@@ -55,6 +55,15 @@ The codecs themselves are vendored via `scripts/build/deps/{libjpeg-turbo,libspn
   codecs return `Encoded` with the right `free`, not a default_allocator slice.
 - The `max_pixels` guard fires **after the header read, before the RGBA alloc**
   in every codec. New codecs must do the same.
+- `probe()` reports the dimensions the decoder will produce, so `metadata()`
+  and the terminals agree on what `max_pixels` rejects. For GIF that is the
+  first Image Descriptor, not the Logical Screen Descriptor.
+- Metadata is bounded independently of `max_pixels`. An ICC profile over
+  `MAX_ICC_PROFILE_BYTES` is dropped at decode before it is copied out of the
+  codec (JPEG cannot carry more than 255 × 65519 bytes anyway), and libspng
+  runs with chunk limits so an iCCP/zTXt/iTXt that inflates past the cap
+  fails the decode instead of filling memory. New codecs must cap whatever
+  they inflate or copy out of the container the same way.
 - `image_resize.cpp` must stay in `noUnify` (see `scripts/build/unified.ts`) —
   highway's `foreach_target.h` has a TU-wide include guard that breaks with
   two highway TUs in one bundle.

--- a/src/runtime/image/codec_gif.rs
+++ b/src/runtime/image/codec_gif.rs
@@ -129,9 +129,8 @@ impl Dict {
     }
 }
 
-/// Everything in front of the first frame's LZW data. `width`/`height` come
-/// from the Image Descriptor, not the Logical Screen Descriptor: that is the
-/// size the decoder produces, and `codecs::probe` must report the same.
+/// Everything in front of the first frame's LZW data. `width`/`height` are the
+/// Image Descriptor's (the decoded size), not the Logical Screen Descriptor's.
 pub(crate) struct Header {
     pub(crate) width: u32,
     pub(crate) height: u32,
@@ -145,8 +144,7 @@ pub(crate) struct Header {
     lzw_off: usize,
 }
 
-/// Walk to the first Image Descriptor, skipping extensions by sub-block
-/// length. No LZW is read.
+/// Walk to the first Image Descriptor, skipping extensions. No LZW is read.
 pub(crate) fn parse_header(bytes: &[u8]) -> Result<Header, codecs::Error> {
     // ── header + LSD ───────────────────────────────────────────────────────
     if bytes.len() < 13 || !(&bytes[0..6] == b"GIF89a" || &bytes[0..6] == b"GIF87a") {

--- a/src/runtime/image/codec_gif.rs
+++ b/src/runtime/image/codec_gif.rs
@@ -129,17 +129,14 @@ impl Dict {
     }
 }
 
-/// Everything in front of the first frame's LZW data. `width`/`height` are
-/// the frame's, from its Image Descriptor: that is the size the decoder
-/// produces, so `codecs::probe` reports the same numbers (the Logical Screen
-/// Descriptor can say anything). Byte ranges instead of slices so the struct
-/// carries no borrow.
+/// Everything in front of the first frame's LZW data. `width`/`height` come
+/// from the Image Descriptor, not the Logical Screen Descriptor: that is the
+/// size the decoder produces, and `codecs::probe` must report the same.
 pub(crate) struct Header {
     pub(crate) width: u32,
     pub(crate) height: u32,
     interlace: bool,
-    /// Active colour table (local if the frame has one, else global) as a
-    /// byte range into the input.
+    /// Local colour table if the frame has one, else the global one.
     color_table: core::ops::Range<usize>,
     min_code: u8,
     /// Transparency index from the most recent Graphics Control Extension.
@@ -148,9 +145,8 @@ pub(crate) struct Header {
     lzw_off: usize,
 }
 
-/// Walk header, Logical Screen Descriptor and the block stream up to the
-/// first Image Descriptor. Extensions are skipped by sub-block length; no LZW
-/// is read.
+/// Walk to the first Image Descriptor, skipping extensions by sub-block
+/// length. No LZW is read.
 pub(crate) fn parse_header(bytes: &[u8]) -> Result<Header, codecs::Error> {
     // ── header + LSD ───────────────────────────────────────────────────────
     if bytes.len() < 13 || !(&bytes[0..6] == b"GIF89a" || &bytes[0..6] == b"GIF87a") {

--- a/src/runtime/image/codec_gif.rs
+++ b/src/runtime/image/codec_gif.rs
@@ -129,7 +129,29 @@ impl Dict {
     }
 }
 
-pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::Error> {
+/// Everything in front of the first frame's LZW data. `width`/`height` are
+/// the frame's, from its Image Descriptor: that is the size the decoder
+/// produces, so `codecs::probe` reports the same numbers (the Logical Screen
+/// Descriptor can say anything). Byte ranges instead of slices so the struct
+/// carries no borrow.
+pub(crate) struct Header {
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    interlace: bool,
+    /// Active colour table (local if the frame has one, else global) as a
+    /// byte range into the input.
+    color_table: core::ops::Range<usize>,
+    min_code: u8,
+    /// Transparency index from the most recent Graphics Control Extension.
+    transparent: Option<u8>,
+    /// Offset of the first LZW sub-block.
+    lzw_off: usize,
+}
+
+/// Walk header, Logical Screen Descriptor and the block stream up to the
+/// first Image Descriptor. Extensions are skipped by sub-block length; no LZW
+/// is read.
+pub(crate) fn parse_header(bytes: &[u8]) -> Result<Header, codecs::Error> {
     // ── header + LSD ───────────────────────────────────────────────────────
     if bytes.len() < 13 || !(&bytes[0..6] == b"GIF89a" || &bytes[0..6] == b"GIF87a") {
         return Err(codecs::Error::DecodeFailed);
@@ -146,11 +168,7 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
     if i > bytes.len() {
         return Err(codecs::Error::DecodeFailed);
     }
-    let gct: &[u8] = if has_gct {
-        &bytes[13..][..(gct_size as usize) * 3]
-    } else {
-        &[]
-    };
+    let gct: core::ops::Range<usize> = if has_gct { 13..i } else { 0..0 };
 
     let mut trns: Option<u8> = None; // transparency index from the most recent GCE
 
@@ -203,18 +221,17 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
                 if w == 0 || h == 0 {
                     return Err(codecs::Error::DecodeFailed);
                 }
-                codecs::guard(w, h, max_pixels)?;
-                let ct: &[u8] = if has_lct {
+                let color_table: core::ops::Range<usize> = if has_lct {
                     if i + lct_size * 3 > bytes.len() {
                         return Err(codecs::Error::DecodeFailed);
                     }
-                    let s = &bytes[i..][..lct_size * 3];
+                    let r = i..i + lct_size * 3;
                     i += lct_size * 3;
-                    s
+                    r
                 } else {
                     gct
                 };
-                if ct.is_empty() {
+                if color_table.is_empty() {
                     return Err(codecs::Error::DecodeFailed); // no palette at all
                 }
 
@@ -223,12 +240,35 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
                 }
                 let min_code: u8 = bytes[i].clamp(2, 11);
                 i += 1;
-                return decode_frame(bytes, i, w, h, interlace, ct, min_code, trns);
+                return Ok(Header {
+                    width: w,
+                    height: h,
+                    interlace,
+                    color_table,
+                    min_code,
+                    transparent: trns,
+                    lzw_off: i,
+                });
             }
             _ => return Err(codecs::Error::DecodeFailed),
         }
     }
     Err(codecs::Error::DecodeFailed)
+}
+
+pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::Error> {
+    let hdr = parse_header(bytes)?;
+    codecs::guard(hdr.width, hdr.height, max_pixels)?;
+    decode_frame(
+        bytes,
+        hdr.lzw_off,
+        hdr.width,
+        hdr.height,
+        hdr.interlace,
+        &bytes[hdr.color_table],
+        hdr.min_code,
+        hdr.transparent,
+    )
 }
 
 fn decode_frame(

--- a/src/runtime/image/codec_jpeg.rs
+++ b/src/runtime/image/codec_jpeg.rs
@@ -116,16 +116,12 @@ const TJPARAM_MAXPIXELS: c_int = 24;
 const TJPARAM_SAVEMARKERS: c_int = 25;
 const TJPF_RGBA: c_int = 7;
 const TJSAMP_420: c_int = 2;
-/// `tj3GetErrorCode` value for a -1 return where libjpeg only warned and
-/// kept going (`TJERR_FATAL` = 1 means it bailed out).
+/// `tj3GetErrorCode` after a -1 return: libjpeg warned but kept going.
 const TJERR_WARNING: c_int = 0;
 
 /// Parse the header (SOF dims, saved markers) without touching scan data.
-///
-/// A warning still yields valid SOF fields, so only a fatal error rejects.
-/// The case that matters is `JWRN_BOGUS_ICC`: an ICC marker sequence that
-/// does not reassemble leaves the pixels intact and the profile absent.
-/// `tj3Decompress8` re-parses the header and stays strict about warnings.
+/// A warning (`JWRN_BOGUS_ICC`: ICC markers that do not reassemble) leaves
+/// the SOF fields valid and the profile absent, so only a fatal error rejects.
 pub(crate) fn read_header(h: tjhandle, bytes: &[u8]) -> Result<(u32, u32), codecs::Error> {
     // SAFETY: `h` is a live tjhandle; ptr/len come from a valid `&[u8]`
     // borrowed for the call.
@@ -138,8 +134,7 @@ pub(crate) fn read_header(h: tjhandle, bytes: &[u8]) -> Result<(u32, u32), codec
     let rw = unsafe { tj3Get(h, TJPARAM_JPEGWIDTH) };
     // SAFETY: `h` is live; tj3Get only reads handle state.
     let rh = unsafe { tj3Get(h, TJPARAM_JPEGHEIGHT) };
-    // -1 on error, 0 when the header never reached SOF; either way reject
-    // instead of letting the cast trap on hostile input.
+    // -1 on error, 0 if SOF was never reached: reject before the cast.
     if rw <= 0 || rh <= 0 {
         return Err(codecs::Error::DecodeFailed);
     }

--- a/src/runtime/image/codec_jpeg.rs
+++ b/src/runtime/image/codec_jpeg.rs
@@ -38,6 +38,7 @@ unsafe extern "C" {
     fn tj3SetScalingFactor(h: tjhandle, sf: ScalingFactor) -> c_int;
     fn tj3SetCroppingRegion(h: tjhandle, r: CropRegion) -> c_int;
     fn tj3GetScalingFactors(n: *mut c_int) -> *const ScalingFactor;
+    fn tj3GetErrorCode(h: tjhandle) -> c_int;
     pub(crate) fn tj3Free(ptr: *mut c_void);
     // ICC profile transport: the APP2 ICC_PROFILE marker carries the source's
     // colour space (sRGB implicit when absent; Display-P3 / Adobe RGB / Jpegli
@@ -115,6 +116,44 @@ const TJPARAM_MAXPIXELS: c_int = 24;
 const TJPARAM_SAVEMARKERS: c_int = 25;
 const TJPF_RGBA: c_int = 7;
 const TJSAMP_420: c_int = 2;
+/// `tj3GetErrorCode` after a failed call: `TJERR_WARNING` means libjpeg
+/// emitted a warning and carried on, `TJERR_FATAL` (1) means it bailed out.
+const TJERR_WARNING: c_int = 0;
+
+/// Parse the header (SOF dims, saved markers) without touching scan data.
+///
+/// libjpeg reports a malformed ancillary marker as a *warning* and keeps
+/// going: an `ICC_PROFILE` APP2 sequence that does not reassemble (sequence
+/// number above the count, a duplicate, more than 255 segments) is
+/// `JWRN_BOGUS_ICC`, and `tj3DecompressHeader` still returns -1 for it. The
+/// SOF fields are valid in that case and the pixels are untouched, so a
+/// warning is accepted here and the profile is simply absent; only a fatal
+/// error rejects the file. Browsers and libvips decode such files the same
+/// way. The full decode stays strict: `tj3Decompress8` re-parses the header
+/// and any warning there (truncated scan data, extraneous bytes) still fails.
+pub(crate) fn read_header(h: tjhandle, bytes: &[u8]) -> Result<(u32, u32), codecs::Error> {
+    // SAFETY: `h` is a live tjhandle; ptr/len come from a valid `&[u8]`
+    // borrowed for the call.
+    let rc = unsafe { tj3DecompressHeader(h, bytes.as_ptr(), bytes.len()) };
+    // SAFETY: `h` is live; tj3GetErrorCode only reads handle state.
+    if rc != 0 && unsafe { tj3GetErrorCode(h) } != TJERR_WARNING {
+        return Err(codecs::Error::DecodeFailed);
+    }
+    // SAFETY: `h` is live; tj3Get only reads handle state.
+    let rw = unsafe { tj3Get(h, TJPARAM_JPEGWIDTH) };
+    // SAFETY: `h` is live; tj3Get only reads handle state.
+    let rh = unsafe { tj3Get(h, TJPARAM_JPEGHEIGHT) };
+    // tj3Get returns -1 on error (and 0 when the header never reached SOF);
+    // treat any non-positive dim as a decode failure rather than letting
+    // the cast trap on hostile input.
+    if rw <= 0 || rh <= 0 {
+        return Err(codecs::Error::DecodeFailed);
+    }
+    Ok((
+        u32::try_from(rw).expect("int cast"),
+        u32::try_from(rh).expect("int cast"),
+    ))
+}
 
 pub(crate) fn decode(
     bytes: &[u8],
@@ -134,21 +173,9 @@ pub(crate) fn decode(
     // marker buffer is discarded if we set this after.
     // SAFETY: `h` is a live tjhandle for the duration of `_h_guard`.
     unsafe { tj3Set(h, TJPARAM_SAVEMARKERS, 2) };
-    // SAFETY: `h` is live; ptr/len come from a valid `&[u8]` borrowed for the call.
-    if unsafe { tj3DecompressHeader(h, bytes.as_ptr(), bytes.len()) } != 0 {
-        return Err(codecs::Error::DecodeFailed);
-    }
-    // SAFETY: `h` is live; tj3Get only reads handle state.
-    let rw = unsafe { tj3Get(h, TJPARAM_JPEGWIDTH) };
-    // SAFETY: `h` is live; tj3Get only reads handle state.
-    let rh = unsafe { tj3Get(h, TJPARAM_JPEGHEIGHT) };
-    // tj3Get returns -1 on error; treat any non-positive dim as a decode
-    // failure rather than letting the cast trap on hostile input.
-    if rw <= 0 || rh <= 0 {
-        return Err(codecs::Error::DecodeFailed);
-    }
-    let src_w: u32 = u32::try_from(rw).expect("int cast");
-    let src_h: u32 = u32::try_from(rh).expect("int cast");
+    let (src_w, src_h) = read_header(h, bytes)?;
+    let rw = c_int::try_from(src_w).expect("int cast");
+    let rh = c_int::try_from(src_h).expect("int cast");
     codecs::guard(src_w, src_h, max_pixels)?;
 
     let mut w = src_w;
@@ -279,7 +306,7 @@ pub(crate) fn decode(
                 unsafe { tj3Free(p.cast()) };
             }
         });
-        if icc_ptr.is_null() {
+        if icc_ptr.is_null() || icc_size > codecs::MAX_ICC_PROFILE_BYTES {
             break 'blk None;
         }
         // SAFETY: tj3GetICCProfile wrote `icc_size` bytes at `icc_ptr`.

--- a/src/runtime/image/codec_jpeg.rs
+++ b/src/runtime/image/codec_jpeg.rs
@@ -116,21 +116,16 @@ const TJPARAM_MAXPIXELS: c_int = 24;
 const TJPARAM_SAVEMARKERS: c_int = 25;
 const TJPF_RGBA: c_int = 7;
 const TJSAMP_420: c_int = 2;
-/// `tj3GetErrorCode` after a failed call: `TJERR_WARNING` means libjpeg
-/// emitted a warning and carried on, `TJERR_FATAL` (1) means it bailed out.
+/// `tj3GetErrorCode` value for a -1 return where libjpeg only warned and
+/// kept going (`TJERR_FATAL` = 1 means it bailed out).
 const TJERR_WARNING: c_int = 0;
 
 /// Parse the header (SOF dims, saved markers) without touching scan data.
 ///
-/// libjpeg reports a malformed ancillary marker as a *warning* and keeps
-/// going: an `ICC_PROFILE` APP2 sequence that does not reassemble (sequence
-/// number above the count, a duplicate, more than 255 segments) is
-/// `JWRN_BOGUS_ICC`, and `tj3DecompressHeader` still returns -1 for it. The
-/// SOF fields are valid in that case and the pixels are untouched, so a
-/// warning is accepted here and the profile is simply absent; only a fatal
-/// error rejects the file. Browsers and libvips decode such files the same
-/// way. The full decode stays strict: `tj3Decompress8` re-parses the header
-/// and any warning there (truncated scan data, extraneous bytes) still fails.
+/// A warning still yields valid SOF fields, so only a fatal error rejects.
+/// The case that matters is `JWRN_BOGUS_ICC`: an ICC marker sequence that
+/// does not reassemble leaves the pixels intact and the profile absent.
+/// `tj3Decompress8` re-parses the header and stays strict about warnings.
 pub(crate) fn read_header(h: tjhandle, bytes: &[u8]) -> Result<(u32, u32), codecs::Error> {
     // SAFETY: `h` is a live tjhandle; ptr/len come from a valid `&[u8]`
     // borrowed for the call.
@@ -143,9 +138,8 @@ pub(crate) fn read_header(h: tjhandle, bytes: &[u8]) -> Result<(u32, u32), codec
     let rw = unsafe { tj3Get(h, TJPARAM_JPEGWIDTH) };
     // SAFETY: `h` is live; tj3Get only reads handle state.
     let rh = unsafe { tj3Get(h, TJPARAM_JPEGHEIGHT) };
-    // tj3Get returns -1 on error (and 0 when the header never reached SOF);
-    // treat any non-positive dim as a decode failure rather than letting
-    // the cast trap on hostile input.
+    // -1 on error, 0 when the header never reached SOF; either way reject
+    // instead of letting the cast trap on hostile input.
     if rw <= 0 || rh <= 0 {
         return Err(codecs::Error::DecodeFailed);
     }

--- a/src/runtime/image/codec_jpeg.rs
+++ b/src/runtime/image/codec_jpeg.rs
@@ -12,11 +12,11 @@ type tjhandle = *mut c_void;
 
 // TJINIT_COMPRESS=0, TJINIT_DECOMPRESS=1.
 unsafe extern "C" {
-    pub(crate) fn tj3Init(init_type: c_int) -> tjhandle;
-    pub(crate) fn tj3Destroy(h: tjhandle);
+    fn tj3Init(init_type: c_int) -> tjhandle;
+    fn tj3Destroy(h: tjhandle);
     fn tj3Set(h: tjhandle, param: c_int, value: c_int) -> c_int;
-    pub(crate) fn tj3Get(h: tjhandle, param: c_int) -> c_int;
-    pub(crate) fn tj3DecompressHeader(h: tjhandle, buf: *const u8, len: usize) -> c_int;
+    fn tj3Get(h: tjhandle, param: c_int) -> c_int;
+    fn tj3DecompressHeader(h: tjhandle, buf: *const u8, len: usize) -> c_int;
     fn tj3Decompress8(
         h: tjhandle,
         buf: *const u8,
@@ -106,8 +106,8 @@ fn scaled(dim: u32, sf: ScalingFactor) -> u32 {
 // tjparam / tjpf enum values from turbojpeg.h.
 const TJPARAM_QUALITY: c_int = 3;
 const TJPARAM_SUBSAMP: c_int = 4;
-pub(crate) const TJPARAM_JPEGWIDTH: c_int = 5;
-pub(crate) const TJPARAM_JPEGHEIGHT: c_int = 6;
+const TJPARAM_JPEGWIDTH: c_int = 5;
+const TJPARAM_JPEGHEIGHT: c_int = 6;
 const TJPARAM_PROGRESSIVE: c_int = 12;
 const TJPARAM_MAXPIXELS: c_int = 24;
 /// `2` = save only APP2/ICC_PROFILE markers (enough for colour management,

--- a/src/runtime/image/codec_png.rs
+++ b/src/runtime/image/codec_png.rs
@@ -47,14 +47,11 @@ unsafe extern "C" {
     fn spng_set_chunk_limits(ctx: *mut spng_ctx, chunk_size: usize, cache_limit: usize) -> c_int;
 }
 
-/// Caps on what libspng inflates and keeps for ancillary chunks (iCCP,
-/// zTXt, iTXt, eXIf, sPLT): `MAX_CHUNK_BYTES` is the decompressed size of
-/// one chunk, `MAX_CHUNK_CACHE_BYTES` the total across the file. libspng
-/// reads these chunks before the first IDAT, so without the caps a 1 MB PNG
-/// whose iCCP inflates to 1 GiB costs that much memory and seconds of CPU
-/// no matter what `maxPixels` says. A chunk over either cap fails the
-/// decode (`SPNG_ECHUNK_LIMITS`). The per-chunk cap equals the pipeline's
-/// ICC cap so any profile that decodes is one the encoders will carry.
+/// libspng inflates ancillary chunks (iCCP, zTXt, iTXt) before the first
+/// IDAT, outside the reach of `max_pixels`. Cap one chunk's inflated size
+/// and the total it keeps; over either, the decode fails with
+/// `SPNG_ECHUNK_LIMITS`. The per-chunk cap is the ICC cap so any profile
+/// that decodes is one the encoders carry.
 const MAX_CHUNK_BYTES: usize = codecs::MAX_ICC_PROFILE_BYTES;
 const MAX_CHUNK_CACHE_BYTES: usize = 4 * MAX_CHUNK_BYTES;
 

--- a/src/runtime/image/codec_png.rs
+++ b/src/runtime/image/codec_png.rs
@@ -47,11 +47,8 @@ unsafe extern "C" {
     fn spng_set_chunk_limits(ctx: *mut spng_ctx, chunk_size: usize, cache_limit: usize) -> c_int;
 }
 
-/// libspng inflates ancillary chunks (iCCP, zTXt, iTXt) before the first
-/// IDAT, outside the reach of `max_pixels`. Cap one chunk's inflated size
-/// and the total it keeps; over either, the decode fails with
-/// `SPNG_ECHUNK_LIMITS`. The per-chunk cap is the ICC cap so any profile
-/// that decodes is one the encoders carry.
+/// libspng inflates iCCP/zTXt/iTXt before the first IDAT, where `max_pixels`
+/// cannot see it. Over either cap the decode fails with `SPNG_ECHUNK_LIMITS`.
 const MAX_CHUNK_BYTES: usize = codecs::MAX_ICC_PROFILE_BYTES;
 const MAX_CHUNK_CACHE_BYTES: usize = 4 * MAX_CHUNK_BYTES;
 

--- a/src/runtime/image/codec_png.rs
+++ b/src/runtime/image/codec_png.rs
@@ -44,7 +44,19 @@ unsafe extern "C" {
     /// the context and freed with `spng_ctx_free`; dupe out before then.
     fn spng_get_iccp(ctx: *mut spng_ctx, iccp: *mut Iccp) -> c_int;
     fn spng_set_iccp(ctx: *mut spng_ctx, iccp: *const Iccp) -> c_int;
+    fn spng_set_chunk_limits(ctx: *mut spng_ctx, chunk_size: usize, cache_limit: usize) -> c_int;
 }
+
+/// Caps on what libspng inflates and keeps for ancillary chunks (iCCP,
+/// zTXt, iTXt, eXIf, sPLT): `MAX_CHUNK_BYTES` is the decompressed size of
+/// one chunk, `MAX_CHUNK_CACHE_BYTES` the total across the file. libspng
+/// reads these chunks before the first IDAT, so without the caps a 1 MB PNG
+/// whose iCCP inflates to 1 GiB costs that much memory and seconds of CPU
+/// no matter what `maxPixels` says. A chunk over either cap fails the
+/// decode (`SPNG_ECHUNK_LIMITS`). The per-chunk cap equals the pipeline's
+/// ICC cap so any profile that decodes is one the encoders will carry.
+const MAX_CHUNK_BYTES: usize = codecs::MAX_ICC_PROFILE_BYTES;
+const MAX_CHUNK_CACHE_BYTES: usize = 4 * MAX_CHUNK_BYTES;
 
 #[repr(C)]
 struct Iccp {
@@ -108,6 +120,10 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
         unsafe { spng_ctx_free(c) }
     });
 
+    // SAFETY: ctx is valid; both limits are plain sizes.
+    if unsafe { spng_set_chunk_limits(ctx, MAX_CHUNK_BYTES, MAX_CHUNK_CACHE_BYTES) } != 0 {
+        return Err(codecs::Error::DecodeFailed);
+    }
     // SAFETY: ctx is valid; bytes outlives the ctx (freed at end of scope).
     if unsafe { spng_set_png_buffer(ctx, bytes.as_ptr(), bytes.len()) } != 0 {
         return Err(codecs::Error::DecodeFailed);
@@ -153,6 +169,7 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
     // SAFETY: ctx is valid; iccp is a valid out-ptr.
     let icc: Option<Vec<u8>> = if unsafe { spng_get_iccp(ctx, &raw mut iccp) } == 0
         && iccp.profile_len > 0
+        && iccp.profile_len <= codecs::MAX_ICC_PROFILE_BYTES
         && !iccp.profile.is_null()
     {
         // SAFETY: libspng guarantees profile points to profile_len bytes owned by ctx.

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -207,7 +207,9 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
         if iter.chunk.bytes.is_null() {
             break 'blk None;
         }
-        if iter.chunk.size == 0 {
+        // RIFF chunks are stored raw, so an ICCP chunk can be as large as the
+        // file itself; the cap keeps that out of the encoders.
+        if iter.chunk.size == 0 || iter.chunk.size > codecs::MAX_ICC_PROFILE_BYTES {
             break 'blk None;
         }
         // SAFETY: chunk.bytes points into `bytes` for chunk.size bytes per libwebp contract.

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -207,8 +207,7 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
         if iter.chunk.bytes.is_null() {
             break 'blk None;
         }
-        // RIFF chunks are stored raw, so an ICCP chunk can be as large as the
-        // file itself; the cap keeps that out of the encoders.
+        // RIFF stores chunks raw: an ICCP chunk can be as large as the file.
         if iter.chunk.size == 0 || iter.chunk.size > codecs::MAX_ICC_PROFILE_BYTES {
             break 'blk None;
         }

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -253,6 +253,16 @@ bun_core::oom_from_alloc!(Error);
 /// cap is ~1 GiB, which is already past where you'd want to be.
 pub(crate) const DEFAULT_MAX_PIXELS: u64 = 0x3FFF * 0x3FFF;
 
+/// Largest ICC profile the pipeline carries from decode to encode; anything
+/// bigger is treated as "no profile". Real profiles are well under 4 MB
+/// (libpng's user-chunk default is 8 MB). The container bound is JPEG: the
+/// `ICC_PROFILE` APP2 sequence counter is one byte, so a profile over
+/// 255 × 65519 bytes gets marker numbers that wrap and libjpeg-turbo itself
+/// then refuses to read the file it wrote. Decoders check this before
+/// copying the profile out of the codec, so an oversized profile costs
+/// nothing.
+pub(crate) const MAX_ICC_PROFILE_BYTES: usize = 8 << 20;
+
 /// Hint from the pipeline about the eventual output size. JPEG can do M/8
 /// IDCT scaling for free, so when we know the resize target up front we
 /// decode at the smallest factor that still ≥ the target — skipping most of
@@ -357,21 +367,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
         Format::Jpeg => {
             // turbojpeg's header decode is already cheap (no scan data read).
             let handle = jpeg::Handle::init(1).ok_or(Error::OutOfMemory)?;
-            // SAFETY: handle is live; (ptr,len) come from a valid live slice.
-            if unsafe { jpeg::tj3DecompressHeader(handle.as_ptr(), bytes.as_ptr(), bytes.len()) }
-                != 0
-            {
-                return Err(Error::DecodeFailed);
-            }
-            // SAFETY: handle is live and has had a header decoded into it above.
-            let rw = unsafe { jpeg::tj3Get(handle.as_ptr(), jpeg::TJPARAM_JPEGWIDTH) };
-            // SAFETY: same handle invariant as above.
-            let rh = unsafe { jpeg::tj3Get(handle.as_ptr(), jpeg::TJPARAM_JPEGHEIGHT) };
-            if rw <= 0 || rh <= 0 {
-                return Err(Error::DecodeFailed);
-            }
-            w = u32::try_from(rw).expect("int cast");
-            h = u32::try_from(rh).expect("int cast");
+            (w, h) = jpeg::read_header(handle.as_ptr(), bytes)?;
         }
         Format::Webp => {
             let mut cw: c_int = 0;
@@ -393,14 +389,14 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             h = ih.height;
         }
         Format::Gif => {
-            // sig(6) · LSD: w(u16le) h(u16le) …
-            if bytes.len() < 10 {
-                return Err(Error::DecodeFailed);
-            }
-            w = u16::from_le_bytes(bytes[6..8].try_into().expect("infallible: size matches"))
-                as u32;
-            h = u16::from_le_bytes(bytes[8..10].try_into().expect("infallible: size matches"))
-                as u32;
+            // The decoder sizes its output from the first Image Descriptor,
+            // not the Logical Screen Descriptor, so report and guard those
+            // dims: a 1×1 screen wrapping a 16383×16383 frame must not read
+            // as 1×1 here and then decode to a 1 GiB frame. The walk skips
+            // extension sub-blocks and stops at the first image; no LZW.
+            let hdr = gif::parse_header(bytes)?;
+            w = hdr.width;
+            h = hdr.height;
         }
         Format::Tiff => {
             // IFD walk would be a full TIFF parser; defer to whoever
@@ -541,7 +537,10 @@ pub(crate) fn encode(
 ) -> Result<Encoded, Error> {
     // SAFETY: `EncodeOptions.icc_profile` is borrowed from the caller for the
     // duration of this call (raw-ptr stand-in for a lifetime param).
-    let icc: Option<&[u8]> = opts.icc_profile.map(|p| unsafe { p.as_ref() });
+    let icc: Option<&[u8]> = opts
+        .icc_profile
+        .map(|p| unsafe { p.as_ref() })
+        .filter(|p| p.len() <= MAX_ICC_PROFILE_BYTES);
     match opts.format {
         Format::Jpeg => jpeg::encode(rgba, width, height, opts.quality, opts.progressive, icc),
         // PNG carries iCCP on both truecolour and indexed images — quantise

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -253,14 +253,10 @@ bun_core::oom_from_alloc!(Error);
 /// cap is ~1 GiB, which is already past where you'd want to be.
 pub(crate) const DEFAULT_MAX_PIXELS: u64 = 0x3FFF * 0x3FFF;
 
-/// Largest ICC profile the pipeline carries from decode to encode; anything
-/// bigger is treated as "no profile". Real profiles are well under 4 MB
-/// (libpng's user-chunk default is 8 MB). The container bound is JPEG: the
-/// `ICC_PROFILE` APP2 sequence counter is one byte, so a profile over
-/// 255 × 65519 bytes gets marker numbers that wrap and libjpeg-turbo itself
-/// then refuses to read the file it wrote. Decoders check this before
-/// copying the profile out of the codec, so an oversized profile costs
-/// nothing.
+/// Largest ICC profile carried from decode to encode; bigger is "no
+/// profile", decided before the bytes leave the codec. Real profiles are
+/// under 4 MB. JPEG caps at 255 × 65519 bytes (one-byte APP2 sequence
+/// counter) and libjpeg-turbo cannot read back what it writes past that.
 pub(crate) const MAX_ICC_PROFILE_BYTES: usize = 8 << 20;
 
 /// Hint from the pipeline about the eventual output size. JPEG can do M/8
@@ -390,10 +386,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
         }
         Format::Gif => {
             // The decoder sizes its output from the first Image Descriptor,
-            // not the Logical Screen Descriptor, so report and guard those
-            // dims: a 1×1 screen wrapping a 16383×16383 frame must not read
-            // as 1×1 here and then decode to a 1 GiB frame. The walk skips
-            // extension sub-blocks and stops at the first image; no LZW.
+            // not the Logical Screen Descriptor; guard the same dims.
             let hdr = gif::parse_header(bytes)?;
             w = hdr.width;
             h = hdr.height;

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -253,10 +253,8 @@ bun_core::oom_from_alloc!(Error);
 /// cap is ~1 GiB, which is already past where you'd want to be.
 pub(crate) const DEFAULT_MAX_PIXELS: u64 = 0x3FFF * 0x3FFF;
 
-/// Largest ICC profile carried from decode to encode; bigger is "no
-/// profile", decided before the bytes leave the codec. Real profiles are
-/// under 4 MB. JPEG caps at 255 × 65519 bytes (one-byte APP2 sequence
-/// counter) and libjpeg-turbo cannot read back what it writes past that.
+/// Largest ICC profile carried from decode to encode; bigger is "no profile".
+/// Real profiles are under 4 MB, and JPEG cannot hold more than 255 × 65519.
 pub(crate) const MAX_ICC_PROFILE_BYTES: usize = 8 << 20;
 
 /// Hint from the pipeline about the eventual output size. JPEG can do M/8
@@ -385,8 +383,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             h = ih.height;
         }
         Format::Gif => {
-            // The decoder sizes its output from the first Image Descriptor,
-            // not the Logical Screen Descriptor; guard the same dims.
+            // The dims the decoder produces, not the Logical Screen Descriptor's.
             let hdr = gif::parse_header(bytes)?;
             w = hdr.width;
             h = hdr.height;

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -778,3 +778,212 @@ describe("random-byte fuzz", () => {
     });
   }
 });
+
+// ─── 11. path strings ────────────────────────────────────────────────────────
+
+describe("path source", () => {
+  test("interior NUL is rejected at construction with ERR_INVALID_ARG_VALUE, like Bun.file()", async () => {
+    // The worker opens the path as a C string, so "secret-no-ext\0.png" would
+    // open "secret-no-ext" while `.endsWith(".png")` on the JS string says
+    // yes. The constructor must refuse it the way Bun.file() and node:fs do.
+    using dir = tempDir("image-nul-path", { "secret-no-ext": tinyPng });
+    const p = join(String(dir), "secret-no-ext\0.png");
+    expect(p.endsWith(".png")).toBe(true);
+    const codeOf = (f: () => unknown) => {
+      try {
+        f();
+      } catch (e: any) {
+        return e.code;
+      }
+      return "no throw";
+    };
+    expect(codeOf(() => new Bun.Image(p))).toBe("ERR_INVALID_ARG_VALUE");
+    expect(codeOf(() => Bun.file(p))).toBe("ERR_INVALID_ARG_VALUE");
+    // Sanity: the same path without the NUL decodes.
+    expect(await new Bun.Image(join(String(dir), "secret-no-ext")).metadata()).toEqual({
+      width: 2,
+      height: 2,
+      format: "png",
+    });
+  });
+});
+
+// ─── 12. ancillary-chunk bombs and ICC profile transport ─────────────────────
+
+describe("PNG ancillary chunk limits", () => {
+  // A 4×4 PNG whose `kind` chunk inflates to `inflatedBytes` of zeros. The
+  // file itself stays tiny (deflate of zeros is ~1000:1), so `maxPixels`
+  // never sees anything wrong: the bomb is in metadata libspng inflates
+  // before the first IDAT.
+  function pngWithInflatingChunk(kind: "iCCP" | "zTXt" | "iTXt", inflatedBytes: number): Uint8Array {
+    const ihdr = new Uint8Array(13);
+    const iv = new DataView(ihdr.buffer);
+    iv.setUint32(0, 4);
+    iv.setUint32(4, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 6;
+    const deflated = zlib.deflateSync(Buffer.alloc(inflatedBytes));
+    // iCCP: keyword \0 method deflate · zTXt: keyword \0 method deflate ·
+    // iTXt: keyword \0 compressed=1 method=0 lang \0 translated \0 deflate
+    const head =
+      kind === "iTXt" ? Buffer.from("k\0\x01\0\0\0", "latin1") : Buffer.from(kind === "iCCP" ? "icc\0\0" : "k\0\0");
+    return Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      pngChunk("IHDR", ihdr),
+      pngChunk(kind, Buffer.concat([head, deflated])),
+      pngChunk("IDAT", zlib.deflateSync(Buffer.alloc(4 * (1 + 4 * 4)))),
+      pngChunk("IEND", new Uint8Array(0)),
+    ]);
+  }
+
+  test.each(["iCCP", "zTXt", "iTXt"] as const)("%s inflating to 32 MiB rejects instead of inflating", async kind => {
+    const png = pngWithInflatingChunk(kind, 32 << 20);
+    expect(png.length).toBeLessThan(100_000);
+    // metadata() reads only the IHDR, so it is unaffected.
+    expect(await new Bun.Image(png).metadata()).toEqual({ width: 4, height: 4, format: "png" });
+    // libspng stops inflating at the 8 MiB per-chunk cap and fails the
+    // decode; the 32 MiB never materialises and `maxPixels` is irrelevant.
+    await expect(new Bun.Image(png, { maxPixels: 64 }).png().bytes()).rejects.toThrow(/decode failed/);
+  });
+
+  test("an oversized iCCP does not ride into the output", async () => {
+    // Pre-fix a 1 MB PNG became a 1 GiB WebP (the inflated profile was
+    // copied into an ICCP chunk verbatim). Anything over the cap fails the
+    // decode, so no terminal can emit it.
+    const png = pngWithInflatingChunk("iCCP", 9 << 20);
+    await expect(new Bun.Image(png).webp().bytes()).rejects.toThrow(/decode failed/);
+    await expect(new Bun.Image(png).jpeg().bytes()).rejects.toThrow(/decode failed/);
+  });
+
+  test("a 1 MiB iCCP is under the cap and still round-trips", async () => {
+    // Real profiles are far smaller than this (sRGB ~3 KB, the largest
+    // CMYK press profiles ~3 MB), so the cap must not touch them.
+    const profile = new Uint8Array(1 << 20);
+    for (let i = 0; i < profile.length; i++) profile[i] = (i * 131 + 7) & 0xff;
+    const body = Buffer.concat([Buffer.from("ICC Profile\0\0", "latin1"), zlib.deflateSync(profile)]);
+    const png = Buffer.concat([tinyPng.subarray(0, 33), pngChunk("iCCP", body), tinyPng.subarray(33)]);
+    const out = await new Bun.Image(png).png().bytes();
+    const dv = new DataView(out.buffer, out.byteOffset, out.byteLength);
+    let off = 8;
+    let got: Uint8Array | null = null;
+    while (off + 8 <= out.length) {
+      const len = dv.getUint32(off);
+      const type = String.fromCharCode(out[off + 4], out[off + 5], out[off + 6], out[off + 7]);
+      if (type === "iCCP") {
+        const chunk = out.subarray(off + 8, off + 8 + len);
+        let nul = 0;
+        while (chunk[nul] !== 0) nul++;
+        got = zlib.inflateSync(chunk.subarray(nul + 2));
+        break;
+      }
+      off += 12 + len;
+    }
+    expect(got).not.toBeNull();
+    expect(Buffer.compare(got!, profile)).toBe(0);
+  });
+});
+
+describe("JPEG ICC markers", () => {
+  // One APP2 `ICC_PROFILE` segment with the given sequence number / count
+  // and a 16-byte payload.
+  function app2(seq: number, count: number): Buffer {
+    const body = Buffer.concat([
+      Buffer.from("ICC_PROFILE\0", "latin1"),
+      Buffer.from([seq, count]),
+      Buffer.alloc(16, 0xaa),
+    ]);
+    const seg = Buffer.alloc(4 + body.length);
+    seg[0] = 0xff;
+    seg[1] = 0xe2;
+    seg.writeUInt16BE(body.length + 2, 2);
+    body.copy(seg, 4);
+    return seg;
+  }
+  // Splice segments right after SOI of a known-good JPEG.
+  const withApp2 = (...segs: Buffer[]) => Buffer.concat([tinyJpeg.subarray(0, 2), ...segs, tinyJpeg.subarray(2)]);
+  const hasIccMarker = (jpg: Uint8Array) =>
+    Buffer.from(jpg.buffer, jpg.byteOffset, jpg.byteLength).includes(Buffer.from("ICC_PROFILE\0", "latin1"));
+
+  test.each([
+    ["sequence number above the count", withApp2(app2(2, 1))],
+    ["duplicate sequence number", withApp2(app2(1, 2), app2(1, 2))],
+    ["inconsistent counts", withApp2(app2(1, 2), app2(2, 3))],
+    ["missing sequence number", withApp2(app2(1, 3), app2(3, 3))],
+  ])("%s: pixels decode, the profile is dropped", async (_name, jpg) => {
+    // libjpeg reports an ICC sequence it cannot reassemble as a warning
+    // (JWRN_BOGUS_ICC). The scan data is intact, so the image must decode
+    // without a profile (what browsers and libvips do), not fail outright.
+    expect(await new Bun.Image(jpg).metadata()).toEqual({ width: 2, height: 2, format: "jpeg" });
+    const out = await new Bun.Image(jpg).jpeg().bytes();
+    expect(hasIccMarker(out)).toBe(false);
+    expect(Buffer.compare(await rgbaOf(jpg), await rgbaOf(tinyJpeg))).toBe(0);
+  });
+
+  test("a profile too large for JPEG's 255-marker ceiling is dropped, so .jpeg() output re-decodes", async () => {
+    // The APP2 sequence counter is one byte: a profile over 255 × 65519 B
+    // gets wrapped marker numbers and libjpeg-turbo itself then rejects the
+    // file it wrote. RIFF stores chunks raw, so a WebP can carry such a
+    // profile; wrap tinyWebp's VP8 bitstream in VP8X + a 17 MiB ICCP chunk.
+    const profile = Buffer.alloc(17 << 20, 0x5a);
+    const vp8x = Buffer.from([0x20, 0, 0, 0, 1, 0, 0, 1, 0, 0]); // ICC flag · canvas 2×2 (minus one, 24-bit LE)
+    const riffChunk = (fourcc: string, payload: Uint8Array) => {
+      const size = Buffer.alloc(4);
+      size.writeUInt32LE(payload.length);
+      return Buffer.concat([
+        Buffer.from(fourcc),
+        size,
+        payload,
+        payload.length & 1 ? Buffer.alloc(1) : Buffer.alloc(0),
+      ]);
+    };
+    const body = Buffer.concat([
+      Buffer.from("WEBP"),
+      riffChunk("VP8X", vp8x),
+      riffChunk("ICCP", profile),
+      tinyWebp.subarray(12),
+    ]);
+    const riffSize = Buffer.alloc(4);
+    riffSize.writeUInt32LE(body.length);
+    const webp = Buffer.concat([Buffer.from("RIFF"), riffSize, body]);
+    expect(await new Bun.Image(webp).metadata()).toEqual({ width: 2, height: 2, format: "webp" });
+
+    const jpg = await new Bun.Image(webp).jpeg().bytes();
+    expect(hasIccMarker(jpg)).toBe(false);
+    expect(jpg.length).toBeLessThan(1 << 20);
+    expect(await new Bun.Image(jpg).metadata()).toEqual({ width: 2, height: 2, format: "jpeg" });
+    // Same cap on the WebP → WebP and WebP → PNG paths.
+    const rewebp = await new Bun.Image(webp).webp().bytes();
+    expect(rewebp.length).toBeLessThan(1 << 20);
+    expect((await new Bun.Image(webp).png().bytes()).length).toBeLessThan(1 << 20);
+  });
+});
+
+// ─── 13. GIF: metadata() and decode must size the same frame ─────────────────
+
+describe("GIF probe", () => {
+  // Logical screen 1×1, first Image Descriptor 16383×16383, LZW = clear+EOI.
+  // The static decoder sizes its output (and runs the maxPixels guard) from
+  // the Image Descriptor, so metadata() has to report the same dims or a
+  // "check metadata() first" gate lets a 1 GiB canvas through.
+  const g = Buffer.from("47494638396101000100800000000000255b0d2c00000000ff3fff3f0002022c003b", "hex");
+  // Reverse: screen 65535×65535 wrapping a 4×4 frame.
+  const r = Buffer.from(g);
+  r.writeUInt16LE(65535, 6);
+  r.writeUInt16LE(65535, 8);
+  r.writeUInt16LE(4, 24);
+  r.writeUInt16LE(4, 26);
+
+  test("metadata() reports the first frame's dimensions, not the logical screen", async () => {
+    expect(await new Bun.Image(g).metadata()).toEqual({ width: 16383, height: 16383, format: "gif" });
+    expect(await new Bun.Image(r).metadata()).toEqual({ width: 4, height: 4, format: "gif" });
+  });
+
+  test("metadata() and decode agree on maxPixels", async () => {
+    Bun.Image.backend = "bun";
+    await expect(new Bun.Image(g, { maxPixels: 64 }).metadata()).rejects.toThrow(/maxPixels/);
+    await expect(new Bun.Image(g, { maxPixels: 64 }).png().bytes()).rejects.toThrow(/maxPixels/);
+    expect(await new Bun.Image(r, { maxPixels: 64 }).metadata()).toEqual({ width: 4, height: 4, format: "gif" });
+    const px = await rgbaOf(r);
+    expect(px.length).toBe(4 * 4 * 4);
+  });
+});


### PR DESCRIPTION
### Problem
- `new Bun.Image("secret-no-ext\0.png")` opened `secret-no-ext`. The worker passes the path to `openat` as a C string (`Image.rs:1566`), so a JS-side extension check on the string is bypassed. `Bun.file()` and `node:fs` reject the same string with `ERR_INVALID_ARG_VALUE`. Under debug asserts this is `panic: ZStr::as_cstr: interior NUL would truncate the C view`.
- A 1 MB PNG with an iCCP (or zTXt/iTXt) that inflates to 1 GiB cost 2 GB of RSS and seconds of CPU per decode, even with `maxPixels: 64`. `codec_png.rs` never set `spng_set_chunk_limits`, and the inflated profile was copied into every output (`.webp()` emitted a 1 GiB file). A profile over 255 x 65519 bytes made `.jpeg()` write a file Bun could not read back, and any JPEG whose `ICC_PROFILE` markers did not reassemble failed every terminal, including `metadata()`.
- For GIF, `metadata()` read the Logical Screen Descriptor while the decoder sized its output and ran the `maxPixels` guard from the first Image Descriptor. A 1x1 screen wrapping a 16383x16383 frame reported 1x1 and decoded to 1 GiB.

### Fix
- The constructor's path branch calls `Valid::path_null_bytes`, the check `Bun.file()` uses, and throws `ERR_INVALID_ARG_VALUE`.
- `codec_png.rs` sets libspng chunk limits (8 MiB per inflated chunk, 32 MiB total); a chunk over the cap fails the decode. `codecs::MAX_ICC_PROFILE_BYTES` (8 MiB) is checked in all three decoders before the profile is copied out, and once more in `codecs::encode`. 8 MiB is libpng's user-chunk default and fits under the JPEG ceiling.
- `codec_jpeg::read_header` accepts a header that returned -1 with `tj3GetErrorCode == TJERR_WARNING`: the SOF fields are valid, the profile is absent. The full decode is unchanged and still fails on any warning from `tj3Decompress8`.
- `codec_gif::parse_header` is split out of `decode` and the probe uses it, so both report the frame's dimensions.
- Verified: `test/js/bun/image/image-adversarial.test.ts` (12 new tests fail on stock 1.4.1, pass with the fix). Also all of `test/js/bun/image/`.

### Background
- `Bun.Image` decodes into RGBA8 and re-encodes. The ICC profile (JPEG APP2, PNG iCCP, WebP ICCP) travels with the pixels untouched because the pipeline does no colour conversion (#30197).
- libspng inflates ancillary chunks before the first IDAT. `maxPixels` guards the RGBA buffer only, so it never sees that memory.
- libjpeg distinguishes warnings (decoder continues) from fatal errors (longjmp out). TurboJPEG returns -1 for both; `tj3GetErrorCode` tells them apart.
- The static GIF decoder decodes the first frame at its own size. The Logical Screen Descriptor is not used for output.

<details><summary>Notes</summary>

Ledger items from the fuzz census: #18181 (NUL path), #18182 (iCCP bomb), #18183 (ICC marker overflow), #18184 (GIF probe vs decode).

Design notes:

- libspng treats `SPNG_ECHUNK_LIMITS` as fatal even on ancillary chunks (`read_chunks` only recovers from the listed per-chunk errors), so an over-cap iCCP fails the decode rather than being dropped the way libpng does. Patching libspng to discard the chunk instead is possible but not done here. In practice the band between "real profile" (under 4 MB) and the 8 MiB cap is empty.
- The JPEG decode path re-runs `jpeg_read_header` inside `tj3Decompress8`, which does not call `jpeg_read_icc_profile`, so `JWRN_BOGUS_ICC` does not fire there and the decode succeeds. Other header warnings (extraneous bytes, JFIF major version) do fire again there and still reject, as before. The only observable change for decode is the ICC case; `metadata()` is now tolerant of all header warnings.
- GIF semantics: this keeps the decoder's existing "first frame at frame size" output and makes the probe match it. Canvas semantics (logical screen with the frame composited and clipped, what libvips/nsgif do) would be a behaviour change for frame-smaller-than-screen GIFs and is left as is. The static decoder still pads a truncated LZW stream with the transparent index; the 34-byte GIF from the census now reports 16383x16383 from `metadata()` and is rejected by any `maxPixels` below that, consistently with the terminals.
- With the 8 MiB cap, a 15 or 16 MiB iCCP from a PNG now fails the decode (previously the 15 MiB one round-tripped through JPEG with 241 markers). A 17 MiB ICCP in a WebP decodes with the profile dropped; the test covers that path.

Stock 1.4.1 before / debug build after, on the census repros:

```
18181: path with NUL -> { width: 1, height: 1, format: "png" }   ->  threw ERR_INVALID_ARG_VALUE
18182: iCCP bomb in 65324 B -> webp out 67108952 B              ->  threw ERR_IMAGE_DECODE_FAILED (62 ms)
18182: zTXt bomb -> png out, rss 375 MB                         ->  threw ERR_IMAGE_DECODE_FAILED (32 ms)
18183: 16 MiB profile -> jpeg 16782473 B, ERR_IMAGE_DECODE_FAILED on re-read -> threw ERR_IMAGE_DECODE_FAILED at decode
18183: JPEG w/ ICC seq>num -> ERR_IMAGE_DECODE_FAILED           ->  {"width":1,"height":1,"format":"jpeg"}, decoded
18184: metadata(screen 1x1, frame 16383^2) -> 1x1              ->  16383x16383 (maxPixels 64: ERR_IMAGE_TOO_MANY_PIXELS)
18184: metadata(screen 65535^2, frame 4x4) -> ERR_IMAGE_TOO_MANY_PIXELS -> 4x4
```

Suites run: `test/js/bun/image/image-adversarial.test.ts`, `test/js/bun/image/image.test.ts`, `test/js/bun/image/image-kernels.test.ts`, `test/js/bun/image/image-vs-sharp.test.ts` (235 pass, 2 platform skips, 0 fail). `cargo clippy -p bun_runtime` clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/image/image-adversarial.test.ts

<!-- robobun:evidence:end -->