### PR TITLE
docs: clarify node_modules phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ At its core is the _Bun runtime_, a fast JavaScript runtime designed as **a drop
 bun run index.tsx             # TS and JSX supported out-of-the-box
 ```
 
-The `bun` command-line tool also implements a test runner, script runner, and Node.js-compatible package manager. Instead of 1,000 node_modules for development, you only need `bun`. Bun's built-in tools are significantly faster than existing options and usable in existing Node.js projects with little to no changes.
+The `bun` command-line tool also implements a test runner, script runner, and Node.js-compatible package manager. Instead of 1,000 `node_modules` folders for development, you only need `bun`. Bun's built-in tools are significantly faster than existing options and usable in existing Node.js projects with little to no changes.
 
 ```bash
 bun test                      # run tests


### PR DESCRIPTION
Clarify that Bun reduces the need for many \
ode_modules\ folders. Add code formatting and noun.