### PR TITLE
Bun.build: reject a publicPath that contains a NUL byte

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1023,6 +1023,19 @@ pub mod js_bundler {
             }
 
             if let Some(slice) = config.get_optional_slice(global_this, b"publicPath")? {
+                // Prefixes every emitted chunk and asset URL verbatim; a NUL
+                // would land in the artifacts as a raw byte.
+                if bun_core::strings::index_of_char(slice.slice(), 0).is_some() {
+                    return Err(global_this
+                        .err(
+                            jsc::ErrorCode::INVALID_ARG_VALUE,
+                            format_args!(
+                                "The property 'publicPath' must be a string without null bytes. Received {}",
+                                bun_core::fmt::quote(slice.slice())
+                            ),
+                        )
+                        .throw());
+                }
                 this.public_path.append_slice_exact(slice.slice())?;
                 drop(slice);
             }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "fs";
 import {
   bunEnv,
   bunExe,
@@ -367,6 +367,40 @@ describe("Bun.build", () => {
         sourcemap: "invalid",
       } as any),
     ).toThrow();
+  });
+
+  test.concurrent("publicPath with an interior NUL byte is rejected before anything is written", async () => {
+    using dir = tempDir("bun-build-api-public-path-nul", {
+      "index.js": `import a from "./asset.png"; console.log(a);`,
+      "asset.png": "PNG",
+    });
+    const outdir = join(String(dir), "out");
+    let thrown: any;
+    try {
+      Bun.build({
+        entrypoints: [join(String(dir), "index.js")],
+        outdir,
+        publicPath: "/p\0q/",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(TypeError);
+    expect({ code: thrown.code, message: thrown.message }).toEqual({
+      code: "ERR_INVALID_ARG_VALUE",
+      message: `The property 'publicPath' must be a string without null bytes. Received "/p\\u0000q/"`,
+    });
+    expect(existsSync(outdir)).toBe(false);
+
+    // The same prefix without the NUL is accepted and lands in the artifact.
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "index.js")],
+      outdir,
+      publicPath: "/pq/",
+    });
+    expect(result.success).toBe(true);
+    const js = result.outputs.find(o => o.path.endsWith(".js"))!;
+    expect(await js.text()).toContain(`"/pq/asset-`);
   });
 
   test("returns errors properly", async () => {


### PR DESCRIPTION
### Problem
- `Bun.build({ publicPath: "/p\0q/" })` succeeds and writes the NUL into the artifacts as a raw 0x00 byte: `var asset_default = "/p\0q/asset-by76q83z.png";` in the JS chunk, `href="/p\0q/chunk-cddttw4j.css"` in the HTML entry. Same on 1.3.14, 1.4.1 and main.
- `publicPath` is read at `src/runtime/api/JSBundler.rs:1025` with no check. The bundler splices it verbatim in front of every chunk and asset URL. It never becomes a C string, so the `ZStr::as_cstr` debug assertion does not catch it.

### Fix
- The config parser throws `TypeError [ERR_INVALID_ARG_VALUE]: The property 'publicPath' must be a string without null bytes. Received "/p\^@q/"`, the shape `Bun.spawn` and `node:fs` use. Nothing is written to `outdir`.
- A NUL has no meaning in a URL prefix, and a consumer that reads the artifact as a C string would cut it there. One check at intake covers the JS, HTML and source map URLs.
- Verified: `test/bundler/bun-build-api.test.ts` ("publicPath with an interior NUL byte is rejected before anything is written") fails on the release build (no throw) and passes with the fix. The rest of the file passes with the debug build (see Notes).

### Background
- `publicPath` is the URL prefix in front of chunk and asset paths in the output: `import x from "./a.png"` becomes `var x = "<publicPath>a-<hash>.png"`.
- Those paths are unknown while a chunk is printed. The printer emits placeholders, and `code_with_source_map_shifts` (`src/bundler/Chunk.rs`) later replaces each with `publicPath + final path`, byte for byte.
- Related open PRs: #37007 rejects NUL in the path options of `Bun.build`. #38666 escapes spliced JS paths (a NUL would print as `\0` in JS, but HTML and source map URLs would keep the raw byte). This change is independent of both.

<details><summary>Notes</summary>

Repro used (release 1.4.1):

```js
import fs from "fs";
fs.mkdirSync("r", { recursive: true });
fs.writeFileSync("r/e.js", `import a from "./asset.png"; console.log(a);`);
fs.writeFileSync("r/asset.png", "PNG");
const r = await Bun.build({ entrypoints: ["./r/e.js"], outdir: "./out", publicPath: "/p\0q/" });
const js = await r.outputs.find(o => o.path.endsWith(".js")).text();
console.log(r.success, js.includes("\0"), JSON.stringify(js.match(/asset_default = "[^"]*"/)[0]));
// true true "asset_default = \"/p\^@q/asset-by76q83z.png\""
```

With an HTML entry point (`<link href="./s.css">`, `<script src="./e.js">`) and `sourcemap: "linked"`, the raw byte also appears in `index.html` (`href="/p\0q/chunk-….css"`). The small PNG was inlined as a data URL in CSS, so the CSS chunk did not show it in that run.

Other intake points checked: the CLI `--public-path` cannot carry a NUL (argv is a C string). `bunfig.toml` `serve.publicPath` is config-file sourced and out of scope here.

`bun bd test test/bundler/bun-build-api.test.ts`: 60 pass, 1 skip, 1 todo, 2 fail. The two failures are `bytecode: function record on an encoder page boundary` and `bytecode: repeated builds don't retain the generated code`, both at the 5000 ms timeout. They spawn more than a hundred builds each and do not use `publicPath`; they time out in this container with or without the change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->