### PR TITLE
build: link libutil statically on FreeBSD

### DIFF
--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -95,8 +95,11 @@ function systemLibs(cfg: Config): string[] {
   if (cfg.freebsd) {
     // pthread/m: explicit on FreeBSD (not folded into libc).
     // execinfo: backtrace() — separate library on FreeBSD.
-    // kvm/procstat/elf/util: process introspection for node:os and crash handler.
-    libs.push("-lc", "-lpthread", "-lm", "-lexecinfo", "-lkvm", "-lprocstat", "-lelf", "-lutil");
+    // kvm/procstat/elf: process introspection for node:os and crash handler.
+    // libutil (openpty) is linked statically: its soname bumped .so.9 → .so.10
+    // between 14.x and 15.0, so a dynamic NEEDED entry from the 14.3 sysroot
+    // fails to load on 15.x (#40530). Every other lib here kept its soname.
+    libs.push("-lc", "-lpthread", "-lm", "-lexecinfo", "-lkvm", "-lprocstat", "-lelf", "-l:libutil.a");
   }
 
   if (cfg.windows) {


### PR DESCRIPTION
### Problem
- The bun-freebsd-x64 release binary fails to load on FreeBSD 15: `ld-elf.so.1: Shared object "libutil.so.9" not found, required by "bun"` (#40530). `readelf -d` on the 1.4.0 release binary shows a NEEDED entry for `libutil.so.9`.
- FreeBSD builds target the 14.3 sysroot (`FREEBSD_VERSION_DEFAULT` in `scripts/build/config.ts`) and link `-lutil` (`scripts/build/bun.ts:99`). FreeBSD 15.0 bumped libutil's soname to `libutil.so.10` and `ObsoleteFiles.inc` removed `libutil.so.9` from base, so a fresh 15.x install cannot satisfy the dependency.

### Fix
- Replace `-lutil` with `-l:libutil.a` on the FreeBSD link line. The static archive ships in base.txz (`/usr/lib/libutil.a`), so the sysroot already has it.
- The only symbol bun imports from libutil is `openpty` (used by `src/runtime/api/bun/Terminal.rs`). With the static link it resolves at link time and the NEEDED entry disappears, so one binary runs on 14.x and 15.x.
- Every other library on the FreeBSD link line (libc.so.7, libthr.so.3, libm.so.5, libkvm.so.7, libprocstat.so.1, libelf.so.2, libexecinfo.so.1, libcxxrt.so.1, libc++.so.1) kept its soname across the 15.0 bump, so libutil is the single blocker.
- Verified: the generated FreeBSD `build.ninja` link edge now carries `-l:libutil.a` and no `-lutil`, and a FreeBSD-target link probe with lld shows the dynamic link produces `NEEDED libutil.so.9` + undefined `openpty` while the static link produces no libutil NEEDED entry and a defined `openpty`.

### Background
- `-l:name` tells the linker to search for that exact file name, which forces the static archive even when `libutil.so` exists next to it. The build already uses this idiom for libatomic on Linux.
- No runtime test can exercise this: it is a cross-link configuration for the FreeBSD target, and CI runners cannot execute FreeBSD binaries. Verification is at the ELF level (above).

<details><summary>Notes</summary>

Evidence for the soname bump, from freebsd-src:

- `releng/14.3 lib/libutil/Makefile`: `SHLIB_MAJOR= 9`
- `releng/15.1 lib/libutil/Makefile`: `SHLIB_MAJOR= 10`
- `releng/15.1 ObsoleteFiles.inc` lists `OLD_LIBS+=lib/libutil.so.9`

Release binary check (bun-v1.4.0 `bun-freebsd-x64.zip`):

```
$ readelf -d bun | grep NEEDED
 libc.so.7 libthr.so.3 libm.so.5 libutil.so.9 libc++.so.1 libcxxrt.so.1
```

Only `openpty` in the dynamic symbol table matches libutil's API set, so static linking pulls in one small object.

Link probe (lld, `--target=x86_64-unknown-freebsd14.3`): an executable that references `openpty` linked with `-lutil` gets `NEEDED libutil.so.9` and `UND openpty`; linked with `-l:libutil.a` it gets no libutil NEEDED entry and a defined `openpty` symbol.

Also checked: `scripts/build` typecheck failures (`bunx tsc -p scripts/build/tsconfig.json`) are identical with and without this change (14 pre-existing errors in ci.ts, jsonByteClass.ts, rust-lto-fix-cli.ts, xmlByteClass.ts). The native-FreeBSD build path is unaffected: `/usr/lib/libutil.a` is part of base there too.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->