### PR TITLE
test(sql): prestart the containers for the statement-cache hash-collision file, store the colliding queries, assert rows and prepare counts

### DIFF
--- a/test/docker/prestart-map.mjs
+++ b/test/docker/prestart-map.mjs
@@ -21,6 +21,7 @@ export const prestartMap = {
   "js/sql/postgres-simple-query-pipeline": ["postgres_plain"],
   "js/sql/sql-onconnect-onclose-throw": ["postgres_plain", "mysql_plain"],
   "js/sql/sql-prepare-false": ["postgres_plain"],
+  "js/sql/sql-statement-cache-hash-collision": ["mysql_plain", "postgres_plain"],
   "js/valkey/": ["redis_unified"],
   "js/bun/s3/": ["minio"],
   "js/web/websocket/autobahn": ["autobahn"],

--- a/test/js/sql/sql-statement-cache-hash-collision.test.ts
+++ b/test/js/sql/sql-statement-cache-hash-collision.test.ts
@@ -8,122 +8,191 @@
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
-import { constructStdCollision } from "../../cli/install/wyhash-std-collision";
 
-// signature.name = SQL text + ".null" for one null-bound param. The free
-// 8-byte word sits inside a string literal, so the two queries return
-// different `v` values while their names collide under std.Wyhash(0).
-function collidingQueryPair(placeholder: string, freeB = "BBBBBBBB") {
-  // Every printable ASCII char that is valid inside a single-quoted SQL
-  // string literal. A wide charset lets the collision search land an in-set
-  // kill word in far fewer iterations, which matters under debug JSC.
-  let charset = "";
-  for (let c = 0x20; c < 0x7f; c++) if (c !== 0x27 && c !== 0x5c) charset += String.fromCharCode(c);
-  const paramSuffix = ".null";
-  const r = constructStdCollision({
-    seed: 0n,
-    prefixStr: "SELECT '",
-    suffixStr: `' AS v, ${placeholder} AS p${paramSuffix}`,
-    charset,
-    freeA: "AAAAAAAA",
-    freeB,
-    padFillCh: "x",
-  });
-  const sqlA = r.str1.slice(0, -paramSuffix.length);
-  const sqlB = r.str2.slice(0, -paramSuffix.length);
-  const enc = (s: string) => new TextEncoder().encode(s);
-  // Self-verify the pair collides under `Bun.hash.wyhash` (seed 0), the hash
-  // that keyed the cache before the fix; that collision is what makes this
-  // pair the regression input.
-  if (Bun.hash.wyhash(enc(r.str1), 0n) !== Bun.hash.wyhash(enc(r.str2), 0n)) {
-    throw new Error("constructed pair does not collide under wyhash");
-  }
-  return { sqlA, sqlB };
+// The old key was std.hash.Wyhash with seed 0, which is `Bun.hash.wyhash(bytes, 0n)`.
+// It consumes its input in 48-byte rounds of three 16-byte lanes; each lane
+// becomes mix(word0 ^ secret, word1 ^ lane). The two names below are:
+//
+//   round 1  "SELECT '" + PAD                   shared
+//   round 2  STEER + FILL                       shared, leaves lane 0 == KILL
+//   round 3  FREE + KILL + FILL                 FREE differs
+//   tail     "' AS v, <placeholder> AS p.null"  shared
+//
+// In round 3 lane 0 is mix(FREE ^ secret, KILL ^ KILL) = mix(FREE ^ secret, 0),
+// which is 0 for every FREE, so the hashes match for any FREE and any tail.
+// STEER and KILL came from the brute-force search in
+// test/cli/install/wyhash-std-collision.ts (prefix "SELECT '", alphanumeric
+// charset). They stay valid until the hash itself changes; the first test
+// below checks them on every platform.
+const PAD = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+const STEER = "qnbaaaaakryFMT07";
+const KILL = "sLwJ3mc5";
+const FILL = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+
+// FREE sits inside a string literal, so query A selects a value that contains
+// "AAAAAAAA" and query B one that contains "BBBBBBBB". BAD_FREE closes the
+// literal early and follows it with "}", which neither server can parse.
+const FREE_A = "AAAAAAAA";
+const FREE_B = "BBBBBBBB";
+const BAD_FREE = "'}}}}}}}";
+
+function collidingQueries(placeholder: string, freeB: string) {
+  const literal = (free: string) => PAD + STEER + FILL + free + KILL + FILL;
+  const query = (free: string) => `SELECT '${literal(free)}' AS v, ${placeholder} AS p`;
+  return {
+    queryA: query(FREE_A),
+    rowA: { v: literal(FREE_A), p: null },
+    queryB: query(freeB),
+    rowB: { v: literal(freeB), p: null },
+  };
 }
 
-async function assertDistinctStatements(sql: SQL, label: string, placeholder: string) {
-  const { sqlA, sqlB } = collidingQueryPair(placeholder);
-  expect(sqlA).not.toBe(sqlB);
-  expect(sqlA).toContain("AAAAAAAA");
-  expect(sqlB).toContain("BBBBBBBB");
+// signature.name of a query with one null-bound parameter.
+const signatureName = (query: string) => new TextEncoder().encode(query + ".null");
 
-  // Query A populates the statement cache; query B, byte-distinct but
-  // wyhash-colliding, must prepare its own statement and return its own value.
-  const [[rA], [rB], [rC]] = await Promise.all([
-    sql.unsafe(sqlA, [null]),
-    sql.unsafe(sqlB, [null]),
-    sql.unsafe(`SELECT 'CONTROL' AS v, ${placeholder} AS p`, [null]),
-  ]);
-  expect({ a: rA.v.includes("AAAAAAAA"), b: rB.v.includes("BBBBBBBB"), c: rC.v }).toEqual({
-    a: true,
-    b: true,
-    c: "CONTROL",
-  });
-  // Before the fix, rB.v contained "AAAAAAAA" (A's statement was reused).
-  expect(rB.v).not.toContain("AAAAAAAA");
+test.each([
+  ["?", FREE_B],
+  ["?", BAD_FREE],
+  ["$1", FREE_B],
+  ["$1", BAD_FREE],
+])("the stored queries collide under Bun.hash.wyhash (placeholder %s, free word %p)", (placeholder, freeB) => {
+  const { queryA, queryB } = collidingQueries(placeholder, freeB);
+  expect(queryA).not.toBe(queryB);
+  expect(Bun.hash.wyhash(signatureName(queryA), 0n)).toBe(Bun.hash.wyhash(signatureName(queryB), 0n));
+});
 
-  // Re-running A still hits its cached statement (nothing was evicted) and
-  // still returns A's own value.
-  const [rA2] = await sql.unsafe(sqlA, [null]);
-  expect(rA2.v).toBe(rA.v);
+type Backend = {
+  placeholder: string;
+  // Number of statements this session has prepared on the server so far.
+  prepares: (sql: SQL) => Promise<number>;
+  describeError: (err: unknown) => Record<string, unknown>;
+  syntaxError: Record<string, unknown>;
+};
 
-  // Re-running B hits B's own cached statement and still returns B's value.
-  const [rB2] = await sql.unsafe(sqlB, [null]);
-  expect(rB2.v).toBe(rB.v);
+const controlRow = { v: "CONTROL", p: null };
+const rejection = (promise: Promise<unknown>) =>
+  promise.then(
+    () => null,
+    (err: unknown) => err,
+  );
 
-  console.log(`${label}: A="${rA.v.includes("AAAAAAAA") ? "A" : "?"}", B="${rB.v.includes("BBBBBBBB") ? "B" : "?"}"`);
+// Query A populates the statement cache. Query B is byte-distinct but
+// hash-colliding, so it must prepare its own statement and return its own
+// row; before the fix it reused A's statement and returned rowA. The re-runs,
+// in the other order, must hit the cached statements without a new prepare.
+async function expectDistinctStatements(sql: SQL, { placeholder, prepares }: Backend) {
+  const { queryA, rowA, queryB, rowB } = collidingQueries(placeholder, FREE_B);
+  const control = `SELECT 'CONTROL' AS v, ${placeholder} AS p`;
+  const run = (query: string) => sql.unsafe(query, [null]);
+
+  const prepared = await prepares(sql);
+  expect(await Promise.all([run(queryA), run(queryB), run(control)])).toEqual([[rowA], [rowB], [controlRow]]);
+  expect(await prepares(sql)).toBe(prepared + 3);
+  expect(await Promise.all([run(queryB), run(queryA)])).toEqual([[rowB], [rowA]]);
+  expect(await prepares(sql)).toBe(prepared + 3);
 }
 
-describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-  test("MySQL: hash-colliding prepared statements are not confused", async () => {
-    await container.ready;
-    await using sql = new SQL({
+// The bad query's free word closes the string literal early, so the server
+// rejects it at prepare time. Its name collides with the good query's, which
+// is the input that made the old cache hand the good statement to the bad
+// query. The good statement must stay cached and usable, the failure is cached
+// under the bad query's own key, and the connection stays usable.
+async function expectFailedPrepareKeepsCachedStatement(
+  sql: SQL,
+  { placeholder, prepares, describeError, syntaxError }: Backend,
+) {
+  const { queryA: good, rowA: goodRow, queryB: bad } = collidingQueries(placeholder, BAD_FREE);
+  const control = `SELECT 'CONTROL' AS v, ${placeholder} AS p`;
+  const run = (query: string) => sql.unsafe(query, [null]);
+
+  expect(await run(good)).toEqual([goodRow]);
+  // Before the fix this resolved with goodRow instead of rejecting.
+  const err = await rejection(run(bad));
+  expect(err).toBeInstanceOf(SQL.SQLError);
+  expect(describeError(err)).toEqual(syntaxError);
+  const prepared = await prepares(sql);
+
+  Bun.gc(true);
+
+  expect(await run(good)).toEqual([goodRow]);
+  expect(describeError(await rejection(run(bad)))).toEqual(syntaxError);
+  expect(await prepares(sql)).toBe(prepared);
+  expect(await run(control)).toEqual([controlRow]);
+  expect(await prepares(sql)).toBe(prepared + 1);
+}
+
+const mysql: Backend = {
+  placeholder: "?",
+  // Counts every COM_STMT_PREPARE of this session, including rejected ones.
+  // `.simple()` runs the status query over the text protocol, so it does not
+  // count itself.
+  prepares: async sql => Number((await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple())[0].Value),
+  describeError: (err: any) => ({ code: err.code, errno: err.errno, sqlState: err.sqlState, message: err.message }),
+  syntaxError: {
+    code: "ERR_MYSQL_SYNTAX_ERROR",
+    errno: 1064,
+    sqlState: "42000",
+    // MySQL and MariaDB name themselves in the middle of this message.
+    message: expect.stringMatching(/^You have an error in your SQL syntax; .* near '}/),
+  },
+};
+
+const postgres: Backend = {
+  placeholder: "$1",
+  // Statements that exist in this session. A rejected Parse creates none.
+  prepares: async sql =>
+    Number((await sql.unsafe("SELECT count(*)::int AS n FROM pg_prepared_statements").simple())[0].n),
+  describeError: (err: any) => ({ name: err.name, code: err.code, errno: err.errno, message: err.message }),
+  syntaxError: {
+    name: "PostgresError",
+    code: "ERR_POSTGRES_SYNTAX_ERROR",
+    errno: "42601",
+    message: 'syntax error at or near "}"',
+  },
+};
+
+describeWithContainer("mysql", { image: "mysql_plain", concurrent: true }, container => {
+  const connect = () =>
+    new SQL({
       url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
       max: 1,
     });
-    await assertDistinctStatements(sql, "mysql", "?");
+
+  test("MySQL: hash-colliding prepared statements are not confused", async () => {
+    await container.ready;
+    await using sql = connect();
+    await expectDistinctStatements(sql, mysql);
+  });
+
+  test("MySQL: a hash-colliding query that fails to prepare does not evict or free the cached statement", async () => {
+    await container.ready;
+    await using sql = connect();
+    await expectFailedPrepareKeepsCachedStatement(sql, mysql);
   });
 });
 
-describeWithContainer("postgres", { image: "postgres_plain" }, container => {
-  test("Postgres: hash-colliding prepared statements are not confused", async () => {
-    await container.ready;
-    await using sql = new SQL({
+describeWithContainer("postgres", { image: "postgres_plain", concurrent: true }, container => {
+  const connect = () =>
+    new SQL({
       url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
       max: 1,
     });
-    await assertDistinctStatements(sql, "postgres", "$1");
+
+  test("Postgres: hash-colliding prepared statements are not confused", async () => {
+    await container.ready;
+    await using sql = connect();
+    await expectDistinctStatements(sql, postgres);
   });
 
   test("Postgres: a hash-colliding query that fails to parse does not evict or free the cached statement", async () => {
     await container.ready;
-    await using sql = new SQL({
-      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
-      max: 1,
-    });
-    // The bad query's 8-byte free word breaks out of the string literal, so
-    // Postgres rejects it at Parse; its name wyhash-collides with the good
-    // query's, which is the input that confused the old hash-keyed cache.
-    const { sqlA: good, sqlB: bad } = collidingQueryPair("$1", "'||qq9z(");
-    const [rGood] = await sql.unsafe(good, [null]);
-    expect(rGood.v).toContain("AAAAAAAA");
+    await using sql = connect();
+    await expectFailedPrepareKeepsCachedStatement(sql, postgres);
 
-    // Before the collision fix this resolved with the good query's row
-    // instead of erroring, because it reused the cached Prepared statement.
-    const err = await sql.unsafe(bad, [null]).then(
-      () => null,
-      (e: unknown) => e,
-    );
-    expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toMatch(/syntax error|unterminated|multiple commands/i);
-
-    Bun.gc(true);
-
-    // The connection must survive the parse failure: the good query still
-    // hits its cached statement and returns its own row, and a fresh query
-    // still works.
-    const [rGood2] = await sql.unsafe(good, [null]);
-    const [rCtl] = await sql.unsafe(`SELECT 'CONTROL' AS v, $1 AS p`, [null]);
-    expect({ good: rGood2.v.includes("AAAAAAAA"), control: rCtl.v }).toEqual({ good: true, control: "CONTROL" });
+    // The server holds exactly one statement with the good query's text (it was
+    // not re-prepared) and none with the bad query's text.
+    const { queryA: good, queryB: bad } = collidingQueries(postgres.placeholder, BAD_FREE);
+    const statements = await sql.unsafe("SELECT statement FROM pg_prepared_statements").simple();
+    expect(statements.map(row => row.statement).filter(text => text === good || text === bad)).toEqual([good]);
   });
 });

--- a/test/js/sql/sql-statement-cache-hash-collision.test.ts
+++ b/test/js/sql/sql-statement-cache-hash-collision.test.ts
@@ -65,6 +65,7 @@ type Backend = {
   placeholder: string;
   // Number of statements this session has prepared on the server so far.
   prepares: (sql: SQL) => Promise<number>;
+  // The fields of a prepare-time syntax error, compared with `syntaxError`.
   describeError: (err: unknown) => Record<string, unknown>;
   syntaxError: Record<string, unknown>;
 };
@@ -95,30 +96,38 @@ async function expectDistinctStatements(sql: SQL, { placeholder, prepares }: Bac
 // The bad query's free word closes the string literal early, so the server
 // rejects it at prepare time. Its name collides with the good query's, which
 // is the input that made the old cache hand the good statement to the bad
-// query. The good statement must stay cached and usable, the failure is cached
-// under the bad query's own key, and the connection stays usable.
+// query. The drivers treat the failed entry differently: MySQL keeps it and
+// replays the stored error, Postgres drops it and parses again on the next
+// run. Under either policy the bad query must fail the same way every time,
+// the good statement must stay cached, and the connection must stay usable.
+// Returns the rejection of the second bad run for the caller's class check.
 async function expectFailedPrepareKeepsCachedStatement(
   sql: SQL,
   { placeholder, prepares, describeError, syntaxError }: Backend,
-) {
+): Promise<unknown> {
   const { queryA: good, rowA: goodRow, queryB: bad } = collidingQueries(placeholder, BAD_FREE);
   const control = `SELECT 'CONTROL' AS v, ${placeholder} AS p`;
   const run = (query: string) => sql.unsafe(query, [null]);
 
   expect(await run(good)).toEqual([goodRow]);
   // Before the fix this resolved with goodRow instead of rejecting.
-  const err = await rejection(run(bad));
-  expect(err).toBeInstanceOf(SQL.SQLError);
-  expect(describeError(err)).toEqual(syntaxError);
+  const first = await rejection(run(bad));
+  expect(first).toBeInstanceOf(SQL.SQLError);
+  expect(describeError(first)).toEqual(syntaxError);
+  const second = await rejection(run(bad));
+  expect(describeError(second)).toEqual(syntaxError);
+
+  // Taken after both bad runs, so the count does not depend on whether the
+  // driver prepared the bad query once or twice.
   const prepared = await prepares(sql);
 
   Bun.gc(true);
 
   expect(await run(good)).toEqual([goodRow]);
-  expect(describeError(await rejection(run(bad)))).toEqual(syntaxError);
   expect(await prepares(sql)).toBe(prepared);
   expect(await run(control)).toEqual([controlRow]);
   expect(await prepares(sql)).toBe(prepared + 1);
+  return second;
 }
 
 const mysql: Backend = {
@@ -127,6 +136,8 @@ const mysql: Backend = {
   // `.simple()` runs the status query over the text protocol, so it does not
   // count itself.
   prepares: async sql => Number((await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple())[0].Value),
+  // No `name`: the replayed error is a plain object, not a MySQLError. See the
+  // todo in the mysql block below.
   describeError: (err: any) => ({ code: err.code, errno: err.errno, sqlState: err.sqlState, message: err.message }),
   syntaxError: {
     code: "ERR_MYSQL_SYNTAX_ERROR",
@@ -169,6 +180,17 @@ describeWithContainer("mysql", { image: "mysql_plain", concurrent: true }, conta
     await using sql = connect();
     await expectFailedPrepareKeepsCachedStatement(sql, mysql);
   });
+
+  // The replayed error is thrown synchronously from the native run() and reaches
+  // query.reject() without wrapError (src/js/bun/sql.ts), so it is the raw
+  // options object. #33189 drops the replay and re-prepares instead.
+  test.todo("MySQL: a replayed prepare failure rejects with a MySQLError", async () => {
+    await container.ready;
+    await using sql = connect();
+    const { queryB: bad } = collidingQueries(mysql.placeholder, BAD_FREE);
+    expect(await rejection(sql.unsafe(bad, [null]))).toBeInstanceOf(SQL.MySQLError);
+    expect(await rejection(sql.unsafe(bad, [null]))).toBeInstanceOf(SQL.MySQLError);
+  });
 });
 
 describeWithContainer("postgres", { image: "postgres_plain", concurrent: true }, container => {
@@ -187,7 +209,9 @@ describeWithContainer("postgres", { image: "postgres_plain", concurrent: true },
   test("Postgres: a hash-colliding query that fails to parse does not evict or free the cached statement", async () => {
     await container.ready;
     await using sql = connect();
-    await expectFailedPrepareKeepsCachedStatement(sql, postgres);
+    // Postgres dropped the failed entry, so the second bad run was parsed again
+    // and rejected through the same path as the first.
+    expect(await expectFailedPrepareKeepsCachedStatement(sql, postgres)).toBeInstanceOf(SQL.PostgresError);
 
     // The server holds exactly one statement with the good query's text (it was
     // not re-prepared) and none with the bad query's text.


### PR DESCRIPTION
### Problem
- `test/js/sql/sql-statement-cache-hash-collision.test.ts` reports 24 to 28 s on every Linux CI lane (build 106056: 28.30 s on alpine 3.23 aarch64). Its 3 tests finish within 90 ms of `coordinator: mysql_plain ready`. The rest is the `mysql_plain` cold start, paid in the docker block's `beforeAll` because the file is not in `test/docker/prestart-map.mjs`.
- Under a local debug build the file takes 8.1 s. It ran the wyhash collision search three times, 1.4 to 1.7 s each under debug JSC, although the result does not depend on the placeholder or the free word.
- The assertions checked substrings (`rB.v.includes("BBBBBBBB")`) and a message regex. Nothing observed whether a re-run hit the cache or prepared again.

### Fix
- Add the file to `test/docker/prestart-map.mjs`: the coordinator starts `mysql_plain` and `postgres_plain` at shard launch and the runner orders the file after the non-docker tests. This is a one-file entry in a hand-maintained map. Five other `describeWithContainer` files are still unmapped (list in Notes) and are a follow-up.
- Store the two 8-byte words the search produced (`STEER`, `KILL`) as constants, with the construction explained in a comment. A `test.each` over the four query pairs checks they still collide under `Bun.hash.wyhash(name, 0n)`. It runs on every lane, including those without docker.
- Assert full rows with `toEqual`, the exact error (`ERR_POSTGRES_SYNTAX_ERROR` / `42601` / `syntax error at or near "}"`, `ERR_MYSQL_SYNTAX_ERROR` / `1064` / `42000`), and the server-side prepare count: `Com_stmt_prepare` on MySQL, `pg_prepared_statements` on Postgres. The failed-prepare case runs the bad query twice, then takes the count, so it holds under both eviction policies (Background): the good statement adds no prepare on re-run, the control query adds exactly one. Postgres also checks the server holds one statement with the good text and none with the bad text. The failed-prepare case now runs on MySQL too. Both docker blocks run `concurrent: true`.
- Verified: `bun bd test test/js/sql/sql-statement-cache-hash-collision.test.ts`, 8 pass, 1 todo. Debug build 8.1 s before, 3.1 s after (2.3 s of that is the file's load floor). Release: 0.17 to 0.27 s before, 0.10 s after.

### Background
- `describeWithContainer` (`test/harness.ts`) awaits a docker-compose service in `beforeAll`. The coordinator (`test/docker/coordinator.ts`) starts at shard launch only the services that `prestart-map.mjs` lists for the shard's files. A file that is missing from the map starts its service on first request and is charged the wait.
- The prepared-statement cache key is `signature.name`: the query text plus one suffix per bound parameter (`.null` here). It used to be `wyhash(signature.name)` with identity equality (#32741). The stored pair collides under that hash, so it is the regression input.
- Wyhash consumes 48-byte rounds of three lanes, `lane = mix(word0 ^ secret, word1 ^ lane)`. `STEER` drives lane 0 to `KILL`. The next round starts with the differing word followed by `KILL`, so `word1 ^ lane` is 0 and the lane is 0 for either word. The remaining bytes are shared.
- A failed prepare is handled differently per driver. Postgres removes the entry from the cache (`PostgresSQLConnection.rs`, the `ErrorResponse` arm) and parses again on the next run. MySQL keeps the entry with the error and replays it with no new `COM_STMT_PREPARE` (`MySQLQuery.rs`). #33189 moves MySQL to the Postgres behaviour.
- `Com_stmt_prepare` is a MySQL session counter of `COM_STMT_PREPARE` commands, failed ones included. `pg_prepared_statements` lists the statements alive in the Postgres session, so a rejected Parse adds none. Both are read with `.simple()` (text protocol), which prepares nothing itself.

<details><summary>Notes</summary>

CI attribution, build 106056, relative to the file's `[N/299]` header:

| lane | `coordinator: mysql_plain ready` | `Ran 3 tests` |
|---|---|---|
| alpine 3.23 aarch64 | +28.17 s | +28.30 s |
| alpine 3.23 x64 | +27.48 s | +27.58 s |
| debian 13 aarch64 | +24.29 s | +24.38 s |
| debian 13 x64 | +24.25 s | +24.35 s |
| ubuntu 25.04 aarch64 | +23.49 s | +23.58 s |
| ubuntu 25.04 x64 | +26.57 s | +26.65 s |
| debian 13 x64-asan | ready (cached) at +0.2 s | 1.09 s |

`postgres_plain` was `ready (cached)` on every lane. The x64-asan lane had `mysql_plain` cached too and is the one lane that shows the file's own cost. #39431 changes how the slow-test scripts account for this wait.

Prestart map: #40193 adds `postgres-listen-notify` and #35912 adds `postgres-prepared-pipeline-reorder`, each as a one-line entry like this one. After those three, `describeWithContainer` files with no prefix in the map: `js/sql/postgres-datestyle.test.ts` (postgres_plain, `test/expected-durations.json` records 15 s on the default lane against 82 ms on Windows, the same wait), `js/sql/sql-empty-column-name.test.ts` (mariadb_plain), `js/sql/sql-reserve-abort.test.ts` (postgres_plain). A completeness check or a derivation of the map from the test sources would stop the drift. That belongs in its own PR.

Local timings (12 CPUs, local MariaDB 11.8 and Postgres 17 through `BUN_TEST_SERVICE_*`; MariaDB needed `root@localhost` to accept an empty password over TCP, as the `mysql_plain` image does):

| | before | after |
|---|---|---|
| `bun bd test` (debug, ASAN), 3 runs | 7.94 / 7.95 / 8.30 s | 3.07 / 3.12 / 3.13 s |
| `USE_SYSTEM_BUN=1 bun test` (release) | 0.17 to 0.27 s | 0.10 to 0.12 s |
| trivial file with one `describeWithContainer` block, debug | | 2.34 s |

Collision search cost alone, per call: debug build 1662 / 1458 / 1389 ms, release 18 / 11 / 10 ms. All three calls produced the same `STEER` and `KILL` words because the search depends only on the prefix `SELECT '`, the pad character and the charset. The stored words were generated with `constructStdCollision` from `test/cli/install/wyhash-std-collision.ts` using an alphanumeric charset, so they contain no spaces or punctuation. `FILL` replaces the helper's filler bytes; any shared bytes work there. A probe with `STEER` changed in its last character does not collide.

The bad free word changed from `'||qq9z(` to `'}}}}}}}`. With the alphanumeric `KILL`, the old word read as an identifier up to the closing quote and Postgres reported `unterminated quoted string` instead of a fixed syntax error. `}` is not a valid token on either server, so the message is stable: Postgres `syntax error at or near "}"` at position 98, MySQL 1064 `... near '}}}}}}}sLwJ3mc5yyy...`. MariaDB says "MariaDB server version" where MySQL says "MySQL server version", hence `expect.stringMatching`.

Without `BUN_TEST_SERVICE_*` and without docker, the file runs the 4 collision tests and marks both docker blocks todo.

Revision 2 (after review): the first version of the failed-prepare helper took the prepare count before the second bad run and asserted it flat across that run. That is the MySQL replay behaviour; Postgres passed only because its re-Parse fails and `pg_prepared_statements` does not count failed attempts. The count is now taken after both bad runs. The second rejection's class is asserted on Postgres (`PostgresError`, both rejections go through the async reject path). On MySQL the replayed error is the raw options object (`{code, errno, sqlState, message}`, `constructor.name === "Object"`): the cached `Failed` entry is thrown synchronously from the native `run()` and `src/js/bun/sql.ts` passes it to `query.reject()` without `wrapError`. That is recorded as `test.todo("MySQL: a replayed prepare failure rejects with a MySQLError")`, which fails as expected under `bun test --todo` today. #33189 fixes it by removing the replay.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/sql-statement-cache-hash-collision.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/sql-statement-cache-hash-collision.test.ts
bun test v1.4.1 (adc354d99)

test/js/sql/sql-statement-cache-hash-collision.test.ts:
(pass) the stored queries collide under Bun.hash.wyhash (placeholder ?, free word "BBBBBBBB") [31.45ms]
(pass) the stored queries collide under Bun.hash.wyhash (placeholder ?, free word "'}}}}}}}") [1.61ms]
(pass) the stored queries collide under Bun.hash.wyhash (placeholder $1, free word "BBBBBBBB") [1.28ms]
(pass) the stored queries collide under Bun.hash.wyhash (placeholder $1, free word "'}}}}}}}") [1.30ms]
Container ready via docker-compose: mysql_plain at 127.0.0.1:3306
(todo) mysql > MySQL: a replayed prepare failure rejects with a MySQLError
(pass) mysql > MySQL: a hash-colliding query that fails to prepare does not evict or free the cached statement [237.91ms]
(pass) mysql > MySQL: hash-colliding prepared statements are not confused [404.11ms]
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > Postgres: hash-colliding prepared statements are not confused [177.41ms]
(pass) postgres > Postgres: a hash-colliding query that fails to parse does not evict or free the cached statement [158.45ms]

 8 pass
 1 todo
 0 fail
 34 expect() calls
Ran 9 tests across 1 file. [3.15s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/docker/prestart-map.mjs                       |   1 +
 .../sql/sql-statement-cache-hash-collision.test.ts | 287 ++++++++++++++-------
 2 files changed, 191 insertions(+), 97 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
test/docker/prestart-map.mjs                                1      1      0
test/js/sql/sql-statement-cache-hash-collision.test.ts      5      8      0
```

</details>

<!-- robobun:evidence:end -->