### PR TITLE
test: read the embedded module graph from the .bun section in compile splitting tests

### DIFF
--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -401,12 +401,12 @@ describe("bundler", () => {
             },
             onAfterBundle(api) {
               const graph = readModuleGraph(api.outfile);
-              // The dead import is in no printed chunk and, with --bytecode, in
-              // no module record (every record's strings live in one table).
+              // The dead import is in no printed chunk and, with --bytecode, not
+              // in the record of the chunk that holds wrapped.js: that chunk
+              // requests no module at all.
               for (const module of graph.modules) expect(module.source).not.toContain("fs/promises");
               if (bytecode) {
-                expect(graph.moduleInfoStringTable).not.toBeNull();
-                expect(graph.moduleInfoStringTable!.text).not.toContain("fs/promises");
+                expect(moduleContaining(graph, "42;").moduleRecord?.requestedModules).toBe(0);
               }
               for (const module of graph.modules) {
                 expect(module.bytecode.length > 0, `${module.name} bytecode`).toBe(bytecode);

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -1,6 +1,42 @@
 import { describe, expect } from "bun:test";
-import { readFileSync } from "node:fs";
 import { itBundled } from "./expectBundled";
+import { EmbeddedModule, Flags, ModuleGraph, readModuleGraph, Span } from "./standalone-graph";
+
+// Every compile below rewrites a copy of the whole bun executable in memory
+// (hundreds of MB in a debug build, about two seconds each), so the number of
+// compiles is what this file costs on the test side. Cases that share a build
+// configuration share one executable, and the module graph embedded in it is
+// checked next to the run. Compiles stay serial on purpose: several at once
+// exhaust CI memory (see bundler_compile.test.ts).
+
+const entryName = /^(\/\$bunfs|B:\/~BUN)\/root\/out$/;
+const chunkName = /^(\/\$bunfs|B:\/~BUN)\/root\/chunk-[0-9a-z]+\.js$/;
+
+/** The embedded paths a printed chunk loads: static imports, `import()`, and `import.meta.require()`. */
+function importedPaths(source: string): string[] {
+  return [
+    ...source.matchAll(/\b(?:import\.meta\.require|import|from)\s*\(?\s*"((?:\/\$bunfs|B:\/~BUN)\/root\/[^"]+)"/g),
+  ].map(m => m[1]);
+}
+
+function moduleContaining(graph: ModuleGraph, text: string): EmbeddedModule {
+  const found = graph.modules.filter(m => m.source.includes(text));
+  expect(
+    found.map(m => m.name),
+    `exactly one embedded module contains ${JSON.stringify(text)}`,
+  ).toHaveLength(1);
+  return found[0];
+}
+
+/** Every embedded path a chunk loads names a module of the graph. */
+function expectImportsResolve(graph: ModuleGraph) {
+  const names = graph.modules.map(m => m.name);
+  for (const module of graph.modules) {
+    for (const path of importedPaths(module.source)) {
+      expect(names, `${module.name} loads ${path}`).toContain(path);
+    }
+  }
+}
 
 describe("bundler", () => {
   describe("compile with splitting", () => {
@@ -116,19 +152,29 @@ describe("bundler", () => {
       },
     });
 
-    // The embedded module graph is laid out in load order: the entry point's
-    // static imports (dependencies first), then each dynamic import's closure,
-    // breadth-first. Chunk index order would be entry, lazy1, lazy2, shared,
-    // shared2.
-    itBundled("compile/splitting/ModulesLaidOutInLoadOrder", {
+    // One executable pins the layout of the embedded module graph:
+    //
+    // - Modules are laid out in load order: the entry point's static imports
+    //   (dependencies first), then each dynamic import's closure, breadth-first.
+    //   So the table reads shared, entry, shared2, lazy1, lazy2, and every
+    //   per-module region (bytecode, source text) follows the table order.
+    // - The payload records how many leading modules make up the entry point's
+    //   static import closure, and writes the internal-module bytecode (here
+    //   node:fs and what it requires) and the string tables right after them,
+    //   so a cold start prefetches one run. Lazily imported chunks come after
+    //   that run.
+    // - Chunks keep their hashed `chunk-<hash>.js` names inside the executable,
+    //   and the entry point is keyed by the outfile name.
+    itBundled("compile/splitting/ModuleGraphLayout", {
       compile: true,
       splitting: true,
       bytecode: true,
       format: "esm",
       files: {
         "/entry.ts": /* js */ `
+          import { readFileSync } from "node:fs";
           import "./shared";
-          console.log("mark:entry");
+          console.log("mark:entry", typeof readFileSync);
           await import("./lazy1");
         `,
         "/lazy1.ts": /* js */ `
@@ -149,138 +195,60 @@ describe("bundler", () => {
         `,
       },
       run: {
-        stdout: "mark:shared\nmark:entry\nmark:shared2\nmark:lazy1\nmark:lazy2",
+        stdout: "mark:shared\nmark:entry function\nmark:shared2\nmark:lazy1\nmark:lazy2",
       },
       onAfterBundle(api) {
-        const payload = readFileSync(api.outfile).toString("latin1");
-        const order = ["entry", "lazy1", "lazy2", "shared", "shared2"]
-          .map(name => {
-            const offset = payload.lastIndexOf(`mark:${name}"`);
-            expect(offset, `marker mark:${name} not found in the payload`).toBeGreaterThanOrEqual(0);
-            return { name, offset };
-          })
-          .sort((a, b) => a.offset - b.offset)
-          .map(m => m.name);
-        expect(order).toEqual(["shared", "entry", "shared2", "lazy1", "lazy2"]);
-      },
-    });
+        const graph = readModuleGraph(api.outfile);
+        const end = (span: Span) => span.offset + span.length;
 
-    // The payload records how many leading modules make up the entry point's
-    // static import closure, and writes the internal-module bytecode and string
-    // table right after them, so a cold start prefetches one run. Lazily
-    // imported chunks come after that run.
-    itBundled("compile/splitting/StartupModulesPrecedeLazyChunks", {
-      compile: true,
-      splitting: true,
-      bytecode: true,
-      format: "esm",
-      files: {
-        "/entry.ts": /* js */ `
-          import "./shared";
-          console.log("mark:entry");
-          await import("./lazy1");
-        `,
-        "/lazy1.ts": /* js */ `
-          import "./shared";
-          console.log("mark:lazy1");
-        `,
-        "/shared.ts": /* js */ `
-          console.log("mark:shared");
-        `,
-      },
-      run: {
-        stdout: "mark:shared\nmark:entry\nmark:lazy1",
-      },
-      onAfterBundle(api) {
-        const file = readFileSync(api.outfile);
-        const trailer = file.lastIndexOf("\n---- Bun! ----\n", undefined, "latin1");
-        expect(trailer).toBeGreaterThan(0);
-        // `Offsets { byte_count: usize, modules_ptr: StringPointer, entry_point_id: u32, compile_exec_argv_ptr: StringPointer, flags: u32 }`
-        const offsets = trailer - 32;
-        const base = offsets - Number(file.readBigUInt64LE(offsets));
-        const modules = { offset: file.readUInt32LE(offsets + 8), length: file.readUInt32LE(offsets + 12) };
-        const flags = file.readUInt32LE(offsets + 28);
-        const u32 = (at: number) => file.readUInt32LE(base + at);
-        // Three chunks of 52 bytes each; anything else means the layout above is stale.
-        expect(modules.length).toBe(3 * 52);
-
-        // Records chained after the module table, in `Flags` bit order.
-        let at = modules.offset + modules.length;
-        const count = modules.length / 52;
-        if (flags & (1 << 5)) at += count * 4; // source hashes
-        expect(flags & (1 << 6), "Flags::HAS_BUILTIN_BYTECODE").not.toBe(0);
-        const builtinCount = u32(at);
-        at += 4 + builtinCount * 12;
-        expect(flags & (1 << 7), "Flags::HAS_BYTECODE_STRING_TABLE").not.toBe(0);
-        const stringTable = { offset: u32(at), length: u32(at + 4) };
-        at += 8;
-        expect(flags & (1 << 8), "Flags::HAS_STARTUP_MODULE_COUNT").not.toBe(0);
-        const startupCount = u32(at);
-
-        // `CompiledModuleGraphFile`: name, contents, sourcemap, bytecode, module_info, bytecode_origin_path
-        // (StringPointer each), then 4 bytes. Chunk names are hashed, so identify them by their source text.
-        const index: Record<string, number> = {};
-        const bytecodeEnd: number[] = [];
-        for (let i = 0; i < count; i++) {
-          const record = base + modules.offset + i * 52;
-          const contents = { offset: file.readUInt32LE(record + 8), length: file.readUInt32LE(record + 12) };
-          const bytecode = { offset: file.readUInt32LE(record + 24), length: file.readUInt32LE(record + 28) };
-          expect(bytecode.length, `module ${i} has bytecode`).toBeGreaterThan(0);
-          bytecodeEnd.push(bytecode.offset + bytecode.length);
-          const source = file.toString("latin1", base + contents.offset, base + contents.offset + contents.length);
-          for (const name of ["entry", "lazy1", "shared"]) {
-            if (source.includes(`mark:${name}"`)) index[name] = i;
-          }
+        // Load order. Chunk names are hashed, so identify modules by their source text.
+        expect(graph.modules.map(m => /mark:(\w+)"/.exec(m.source)?.[1])).toEqual([
+          "shared",
+          "entry",
+          "shared2",
+          "lazy1",
+          "lazy2",
+        ]);
+        expect(graph.entryPointId).toBe(1);
+        for (const region of ["bytecode", "contents"] as const) {
+          const offsets = graph.modules.map(m => m[region].offset);
+          expect(offsets, `${region} regions follow the table order`).toEqual([...offsets].sort((a, b) => a - b));
         }
-        expect(startupCount).toBe(2);
-        expect([index.shared, index.entry].sort()).toEqual([0, 1]);
-        expect(index.lazy1).toBe(2);
-        // The string table sits between the startup modules' bytecode and the lazy chunk's.
-        expect(stringTable.offset).toBeGreaterThanOrEqual(Math.max(bytecodeEnd[0], bytecodeEnd[1]));
-        expect(stringTable.offset + stringTable.length).toBeLessThanOrEqual(bytecodeEnd[2]);
-      },
-    });
+        for (const module of graph.modules) {
+          expect(module.bytecode.length, `${module.name} has bytecode`).toBeGreaterThan(0);
+          expect(module.moduleInfo.length, `${module.name} has a module record`).toBeGreaterThan(0);
+        }
 
-    itBundled("compile/splitting/ChunkNamesAreHashed", {
-      compile: true,
-      splitting: true,
-      files: {
-        "/entry.ts": /* js */ `
-          import "./shared";
-          console.log("mark:entry");
-          await import("./lazy");
-        `,
-        "/lazy.ts": /* js */ `
-          import "./shared";
-          console.log("mark:lazy");
-        `,
-        "/shared.ts": /* js */ `
-          console.log("mark:shared");
-        `,
-      },
-      run: {
-        stdout: "mark:shared\nmark:entry\nmark:lazy",
-      },
-      onAfterBundle(api) {
-        const file = readFileSync(api.outfile);
-        const trailer = file.lastIndexOf("\n---- Bun! ----\n", undefined, "latin1");
-        expect(trailer).toBeGreaterThan(0);
-        const offsets = trailer - 32;
-        const base = offsets - Number(file.readBigUInt64LE(offsets));
-        const modules = { offset: file.readUInt32LE(offsets + 8), length: file.readUInt32LE(offsets + 12) };
-        const count = modules.length / 52;
-        expect(count).toBe(3);
-        const names: string[] = [];
-        for (let i = 0; i < count; i++) {
-          const record = base + modules.offset + i * 52;
-          const name = { offset: file.readUInt32LE(record), length: file.readUInt32LE(record + 4) };
-          names.push(file.toString("latin1", base + name.offset, base + name.offset + name.length));
+        // Startup run: shared and entry, then the internal-module bytecode, then
+        // the two string tables, then the lazy chunks.
+        const required =
+          Flags.HAS_BUILTIN_BYTECODE |
+          Flags.HAS_BYTECODE_STRING_TABLE |
+          Flags.HAS_STARTUP_MODULE_COUNT |
+          Flags.HAS_MODULE_INFO_STRING_TABLE;
+        expect(graph.flags & required).toBe(required);
+        expect(graph.startupCount).toBe(2);
+        const startup = graph.modules.slice(0, graph.startupCount);
+        const lazy = graph.modules.slice(graph.startupCount);
+        const startupEnd = Math.max(...startup.flatMap(m => [end(m.bytecode), end(m.moduleInfo)]));
+        const lazyStart = Math.min(...lazy.map(m => m.bytecode.offset));
+        expect(graph.builtinBytecode.length, "node:fs ships as internal-module bytecode").toBeGreaterThan(0);
+        for (const region of [...graph.builtinBytecode, graph.bytecodeStringTable!, graph.moduleInfoStringTable!]) {
+          expect(region.length).toBeGreaterThan(0);
+          expect(region.offset).toBeGreaterThanOrEqual(startupEnd);
+          expect(end(region)).toBeLessThanOrEqual(lazyStart);
         }
-        const chunks = names.filter(name => !name.endsWith("/root/out"));
-        expect(chunks).toHaveLength(2);
-        for (const name of chunks) {
-          expect(name).toMatch(/^(\/\$bunfs|B:\/~BUN)\/root\/chunk-[0-9a-z]+\.js$/);
-        }
+        expect(graph.bytecodeStringTable!.offset).toBeGreaterThanOrEqual(Math.max(...graph.builtinBytecode.map(end)));
+        expect(graph.moduleInfoStringTable!.offset).toBeGreaterThanOrEqual(end(graph.bytecodeStringTable!));
+
+        // Names.
+        const entry = graph.modules[graph.entryPointId];
+        expect(entry.name).toMatch(entryName);
+        const chunks = graph.modules.filter(m => m !== entry).map(m => m.name);
+        expect(chunks).toHaveLength(4);
+        for (const name of chunks) expect(name).toMatch(chunkName);
+        expect(new Set(chunks).size).toBe(4);
+        expectImportsResolve(graph);
       },
     });
 
@@ -316,7 +284,37 @@ describe("bundler", () => {
       run: {
         stdout: "app entry\nheader rendering\nmenu showing\nitems: home,about,contact",
       },
+      onAfterBundle(api) {
+        // One chunk per import() target, in load order; each import() names the
+        // embedded chunk, whatever directory the source file lived in.
+        const graph = readModuleGraph(api.outfile);
+        expect(graph.modules).toHaveLength(4);
+        const [entry, header, menu, items] = graph.modules;
+        expect(graph.entryPointId).toBe(0);
+        expect(entry.name).toMatch(entryName);
+        expect(importedPaths(entry.source)).toEqual([header.name]);
+        expect(importedPaths(header.source)).toEqual([menu.name]);
+        expect(importedPaths(menu.source)).toEqual([items.name]);
+        expect(importedPaths(items.source)).toEqual([]);
+        for (const module of graph.modules) expect(module.bytecode.length, `${module.name} has no bytecode`).toBe(0);
+      },
     });
+
+    // A split chunk with --bytecode gets its own bytecode and module record;
+    // `expectSplitChunkRecords` checks that the entry and its one chunk both
+    // have them and that the entry's import() names the embedded chunk.
+    const expectSplitChunkRecords = (graph: ModuleGraph) => {
+      expect(graph.modules).toHaveLength(2);
+      const entry = graph.modules[graph.entryPointId];
+      expect(entry.name).toMatch(entryName);
+      const chunk = graph.modules.find(m => m !== entry)!;
+      expect(chunk.name).toMatch(chunkName);
+      expect(importedPaths(entry.source)).toEqual([chunk.name]);
+      for (const module of graph.modules) {
+        expect(module.bytecode.length, `${module.name} has bytecode`).toBeGreaterThan(0);
+        expect(module.moduleInfo.length, `${module.name} has a module record`).toBeGreaterThan(0);
+      }
+    };
 
     for (const minify of [false, true]) {
       itBundled(`compile/splitting/ImportMetaInSplitChunk${minify ? "+minify" : ""}`, {
@@ -339,6 +337,9 @@ describe("bundler", () => {
         },
         run: {
           stdout: "ok\nok",
+        },
+        onAfterBundle(api) {
+          expectSplitChunkRecords(readModuleGraph(api.outfile));
         },
       });
     }
@@ -397,6 +398,29 @@ describe("bundler", () => {
             run: {
               stdout: "entry: local rm 42\npage: local rm 42",
             },
+            onAfterBundle(api) {
+              const graph = readModuleGraph(api.outfile);
+              // The dead import is in no printed chunk and, with --bytecode, in
+              // no module record (every record's strings live in one table).
+              for (const module of graph.modules) expect(module.source).not.toContain("fs/promises");
+              if (bytecode) {
+                expect(graph.moduleInfoStringTable).not.toBeNull();
+                expect(graph.moduleInfoStringTable!.text).not.toContain("fs/promises");
+              }
+              for (const module of graph.modules) {
+                expect(module.bytecode.length > 0, `${module.name} bytecode`).toBe(bytecode);
+              }
+              if (splitting) {
+                // The entry and the page chunk both import rm from shared.js's chunk.
+                const shared = moduleContaining(graph, '"local rm "');
+                expect(shared.name).toMatch(chunkName);
+                for (const importer of [graph.modules[graph.entryPointId], moduleContaining(graph, '"page:"')]) {
+                  expect(importedPaths(importer.source), `${importer.name} imports rm`).toContain(shared.name);
+                }
+              } else {
+                expect(graph.modules.map(m => m.name)).toEqual([expect.stringMatching(entryName)]);
+              }
+            },
           });
         }
       }
@@ -428,12 +452,20 @@ describe("bundler", () => {
         run: {
           stdout: "function function function",
         },
+        onAfterBundle(api) {
+          expectSplitChunkRecords(readModuleGraph(api.outfile));
+        },
       });
     }
 
     // The executable keys the entry point's module at `/$bunfs/root/<outfile>`,
-    // so nothing may fold into the entry's own chunk; chunks shared between
-    // `import()` targets still fold into the first target's chunk.
+    // so nothing may fold into the entry's own chunk. `shared` is loaded
+    // whenever the entry is, and the same graph without --compile folds it into
+    // the entry (see splitting/FoldsSharedIntoEntry). The entry must not use
+    // top-level await: an awaiting entry guarantees nothing to its `import()`
+    // targets, no fold is possible, and the pin has nothing to block.
+    // `helper` stays in a chunk of its own because a.ts has exports, so its
+    // chunk absorbs nothing either.
     itBundled("compile/splitting/MinChunkSizeKeepsEntryChunkImportable", {
       compile: true,
       splitting: true,
@@ -444,8 +476,7 @@ describe("bundler", () => {
         "/entry.ts": /* js */ `
           import { shared } from "./shared";
           console.log("entry", shared());
-          const a = await import("./a");
-          console.log("a", a.a());
+          import("./a").then(a => console.log("a", a.a()));
         `,
         "/a.ts": /* js */ `
           import { shared } from "./shared";
@@ -463,6 +494,21 @@ describe("bundler", () => {
         "/helper.ts": /* js */ `
           export function helper() { return 1 }
         `,
+      },
+      onAfterBundle(api) {
+        // `shared` stays out of the entry's chunk, in a chunk the entry and a's chunk import.
+        const graph = readModuleGraph(api.outfile);
+        const entry = graph.modules[graph.entryPointId];
+        expect(entry.name).toMatch(entryName);
+        expect(entry.source).not.toContain("function shared");
+        const shared = moduleContaining(graph, "function shared");
+        expect(shared.name).toMatch(chunkName);
+        expect(importedPaths(entry.source)).toContain(shared.name);
+        expect(importedPaths(moduleContaining(graph, "function a()").source)).toContain(shared.name);
+        const helper = moduleContaining(graph, "function helper");
+        expect(helper.name).toMatch(chunkName);
+        expect(importedPaths(moduleContaining(graph, "function b()").source)).toEqual([helper.name]);
+        expectImportsResolve(graph);
       },
       run: {
         stdout: "entry 40\na 41",
@@ -518,8 +564,17 @@ describe("bundler", () => {
             : undefined,
         },
         onAfterBundle(api) {
-          const payload = readFileSync(api.outfile).toString("latin1");
-          expect(payload).toMatch(/import\.meta\.require\("(\/\$bunfs|B:\/~BUN)\/root\/[^"]+\.js"\)/);
+          // The require() calls are printed as import.meta.require() of embedded chunks.
+          const graph = readModuleGraph(api.outfile);
+          const required = graph.modules.flatMap(m =>
+            [...m.source.matchAll(/import\.meta\.require\("([^"]+)"\)/g)].map(match => match[1]),
+          );
+          expect(required.length).toBeGreaterThan(0);
+          for (const path of required) expect(path).toMatch(/^(\/\$bunfs|B:\/~BUN)\/root\/[^/]+\.js$/);
+          expectImportsResolve(graph);
+          for (const module of graph.modules) {
+            expect(module.bytecode.length > 0, `${module.name} bytecode`).toBe(bytecode);
+          }
         },
       });
     }

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { readdirSync } from "node:fs";
 import { itBundled } from "./expectBundled";
 import { EmbeddedModule, Flags, ModuleGraph, readModuleGraph, Span } from "./standalone-graph";
 
@@ -459,45 +460,65 @@ describe("bundler", () => {
     }
 
     // The executable keys the entry point's module at `/$bunfs/root/<outfile>`,
-    // so nothing may fold into the entry's own chunk. `shared` is loaded
+    // so nothing may fold into the entry's own chunk: `shared` is loaded
     // whenever the entry is, and the same graph without --compile folds it into
-    // the entry (see splitting/FoldsSharedIntoEntry). The entry must not use
-    // top-level await: an awaiting entry guarantees nothing to its `import()`
-    // targets, no fold is possible, and the pin has nothing to block.
-    // `helper` stays in a chunk of its own because a.ts has exports, so its
-    // chunk absorbs nothing either.
+    // the entry, which the uncompiled twin pins. An `import()` target's chunk
+    // still absorbs the chunks only it and its own `import()` targets load:
+    // `helper2` lands in c's chunk and d imports it from there, compiled or not.
+    // The entry must not use top-level await: an awaiting entry guarantees
+    // nothing to its `import()` targets, no fold is possible, and the pin has
+    // nothing to block. `helper` stays in a chunk of its own because a.ts has
+    // exports, so its chunk absorbs nothing.
+    const minChunkSizeFiles = {
+      "/entry.ts": /* js */ `
+        import { shared } from "./shared";
+        console.log("entry", shared());
+        import("./a").then(a => {
+          console.log("a", a.a());
+          return import("./c");
+        });
+      `,
+      "/a.ts": /* js */ `
+        import { shared } from "./shared";
+        import { helper } from "./helper";
+        export function a() { return shared() + helper() }
+        export const b = import("./b").then(m => m.b());
+      `,
+      "/b.ts": /* js */ `
+        import { helper } from "./helper";
+        export function b() { return helper() * 2 }
+      `,
+      "/shared.ts": /* js */ `
+        export function shared() { return 40 }
+      `,
+      "/helper.ts": /* js */ `
+        export function helper() { return 1 }
+      `,
+      "/c.ts": /* js */ `
+        import { helper2 } from "./helper2";
+        console.log("c", helper2());
+        import("./d");
+      `,
+      "/d.ts": /* js */ `
+        import { helper2 } from "./helper2";
+        console.log("d", helper2() * 2);
+      `,
+      "/helper2.ts": /* js */ `
+        export function helper2() { return 2 }
+      `,
+    };
+    const minChunkSizeStdout = "entry 40\na 41\nc 2\nd 4";
+
     itBundled("compile/splitting/MinChunkSizeKeepsEntryChunkImportable", {
       compile: true,
       splitting: true,
       bytecode: true,
       format: "esm",
       minChunkSize: 1024 * 1024,
-      files: {
-        "/entry.ts": /* js */ `
-          import { shared } from "./shared";
-          console.log("entry", shared());
-          import("./a").then(a => console.log("a", a.a()));
-        `,
-        "/a.ts": /* js */ `
-          import { shared } from "./shared";
-          import { helper } from "./helper";
-          export function a() { return shared() + helper() }
-          export const b = import("./b").then(m => m.b());
-        `,
-        "/b.ts": /* js */ `
-          import { helper } from "./helper";
-          export function b() { return helper() * 2 }
-        `,
-        "/shared.ts": /* js */ `
-          export function shared() { return 40 }
-        `,
-        "/helper.ts": /* js */ `
-          export function helper() { return 1 }
-        `,
-      },
+      files: minChunkSizeFiles,
       onAfterBundle(api) {
-        // `shared` stays out of the entry's chunk, in a chunk the entry and a's chunk import.
         const graph = readModuleGraph(api.outfile);
+        // `shared` stays out of the entry's chunk, in a chunk the entry and a's chunk import.
         const entry = graph.modules[graph.entryPointId];
         expect(entry.name).toMatch(entryName);
         expect(entry.source).not.toContain("function shared");
@@ -505,13 +526,45 @@ describe("bundler", () => {
         expect(shared.name).toMatch(chunkName);
         expect(importedPaths(entry.source)).toContain(shared.name);
         expect(importedPaths(moduleContaining(graph, "function a()").source)).toContain(shared.name);
-        const helper = moduleContaining(graph, "function helper");
+        const helper = moduleContaining(graph, "function helper()");
         expect(helper.name).toMatch(chunkName);
         expect(importedPaths(moduleContaining(graph, "function b()").source)).toEqual([helper.name]);
+        // `helper2` folds into c's chunk, which d imports.
+        const c = moduleContaining(graph, "function helper2");
+        expect(c.name).toMatch(chunkName);
+        expect(c.source).toContain('console.log("c"');
+        expect(importedPaths(moduleContaining(graph, 'console.log("d"').source)).toEqual([c.name]);
         expectImportsResolve(graph);
       },
       run: {
-        stdout: "entry 40\na 41",
+        stdout: minChunkSizeStdout,
+      },
+    });
+
+    itBundled("splitting/MinChunkSizeFoldsSharedIntoEntryWithoutCompile", {
+      splitting: true,
+      format: "esm",
+      target: "bun",
+      minChunkSize: 1024 * 1024,
+      outdir: "/out",
+      files: minChunkSizeFiles,
+      onAfterBundle(api) {
+        const outputs = readdirSync(api.outdir).filter(file => file.endsWith(".js"));
+        const outputContaining = (text: string) => {
+          const found = outputs.filter(file => api.readFile(`/out/${file}`).includes(text));
+          expect(found, `exactly one output contains ${JSON.stringify(text)}`).toHaveLength(1);
+          return found[0];
+        };
+        // Without the pin, `shared` folds into the entry and a's chunk imports it from there.
+        expect(outputContaining("function shared")).toBe("entry.js");
+        expect(api.readFile(`/out/${outputContaining("function a()")}`)).toContain('from "./entry.js"');
+        expect(outputContaining("function helper()")).not.toBe("entry.js");
+        const c = outputContaining("function helper2");
+        expect(api.readFile(`/out/${c}`)).toContain('console.log("c"');
+        expect(api.readFile(`/out/${outputContaining('console.log("d"')}`)).toContain(`from "./${c}"`);
+      },
+      run: {
+        stdout: minChunkSizeStdout,
       },
     });
 

--- a/test/bundler/standalone-graph.ts
+++ b/test/bundler/standalone-graph.ts
@@ -1,12 +1,14 @@
 /**
- * Reads the module graph that `bun build --compile` embeds in an executable,
- * without reading the whole executable (hundreds of MB in a debug build).
+ * Reads the module graph that `bun build --compile` embeds in an executable.
+ * Only the section that holds it is read (ELF `.bun`, Mach-O `__BUN,__bun`,
+ * PE `.bun`), not the whole executable (hundreds of MB in a debug build).
  *
  * The layout is `to_bytes` in src/standalone_graph/StandaloneModuleGraph.rs.
- * The payload ends with `Offsets { byte_count: usize, modules_ptr:
- * StringPointer, entry_point_id: u32, compile_exec_argv_ptr: StringPointer,
- * flags: u32 }` (32 bytes) and the `---- Bun! ----` trailer. A `StringPointer`
- * is `{ offset: u32, length: u32 }` relative to the payload.
+ * The section starts with a u64 payload length. The payload ends with
+ * `Offsets { byte_count: usize, modules_ptr: StringPointer, entry_point_id:
+ * u32, compile_exec_argv_ptr: StringPointer, flags: u32 }` (32 bytes) and the
+ * `---- Bun! ----` trailer. A `StringPointer` is `{ offset: u32, length: u32 }`
+ * relative to the payload.
  */
 import { expect } from "bun:test";
 import { isWindows } from "harness";
@@ -51,10 +53,13 @@ export const Flags = {
 
 const TRAILER = Buffer.from("\n---- Bun! ----\n", "latin1");
 
-/**
- * On Linux the graph is the ELF `.bun` section, far from the end of the file.
- * Returns null for any other executable format.
- */
+function readAt(fd: number, offset: number, size: number): Buffer {
+  const buf = Buffer.alloc(size);
+  readSync(fd, buf, 0, size, offset);
+  return buf;
+}
+
+/** The ELF `.bun` section, through the section header table. Null for another format. */
 export function readBunSectionELF(fd: number): Buffer | null {
   const ehdr = Buffer.alloc(64);
   readSync(fd, ehdr, 0, 64, 0);
@@ -64,8 +69,8 @@ export function readBunSectionELF(fd: number): Buffer | null {
   const shentsize = ehdr.readUInt16LE(0x3a);
   const shnum = ehdr.readUInt16LE(0x3c);
   const shstrndx = ehdr.readUInt16LE(0x3e);
-  const shdrs = Buffer.alloc(shentsize * shnum);
-  readSync(fd, shdrs, 0, shdrs.length, shoff);
+  const shdrs = readAt(fd, shoff, shentsize * shnum);
+  // Elf64_Shdr: sh_name u32, sh_type u32, sh_flags u64, sh_addr u64, sh_offset u64, sh_size u64, ...
   const header = (i: number) => {
     const sh = shdrs.subarray(i * shentsize, (i + 1) * shentsize);
     return {
@@ -74,29 +79,66 @@ export function readBunSectionELF(fd: number): Buffer | null {
       size: Number(sh.readBigUInt64LE(0x20)),
     };
   };
-  const read = ({ offset, size }: { offset: number; size: number }) => {
-    const buf = Buffer.alloc(size);
-    readSync(fd, buf, 0, size, offset);
-    return buf;
-  };
-  const names = read(header(shstrndx));
+  const strtab = header(shstrndx);
+  const names = readAt(fd, strtab.offset, strtab.size);
   for (let i = 0; i < shnum; i++) {
     const sh = header(i);
-    if (names.toString("latin1", sh.name, names.indexOf(0, sh.name)) === ".bun") return read(sh);
+    if (names.toString("latin1", sh.name, names.indexOf(0, sh.name)) === ".bun") return readAt(fd, sh.offset, sh.size);
+  }
+  return null;
+}
+
+/** The Mach-O `__bun` section of the `__BUN` segment, through the load commands. Null for another format. */
+export function readBunSectionMachO(fd: number): Buffer | null {
+  // mach_header_64: magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags, reserved (32 bytes)
+  const header = readAt(fd, 0, 32);
+  if (header.readUInt32LE(0) !== 0xfeedfacf) return null;
+  const ncmds = header.readUInt32LE(16);
+  const commands = readAt(fd, 32, header.readUInt32LE(20));
+  for (let at = 0, i = 0; i < ncmds; i++, at += commands.readUInt32LE(at + 4)) {
+    // segment_command_64 (72 bytes): cmd, cmdsize, segname[16], vmaddr, vmsize, fileoff, filesize,
+    // maxprot, initprot, nsects, flags. LC_SEGMENT_64 is 0x19.
+    if (commands.readUInt32LE(at) !== 0x19 || commands.toString("latin1", at + 8, at + 14) !== "__BUN\0") continue;
+    const nsects = commands.readUInt32LE(at + 64);
+    for (let section = at + 72, j = 0; j < nsects; j++, section += 80) {
+      // section_64 (80 bytes): sectname[16], segname[16], addr u64, size u64, offset u32, ...
+      if (commands.toString("latin1", section, section + 6) !== "__bun\0") continue;
+      return readAt(fd, commands.readUInt32LE(section + 48), Number(commands.readBigUInt64LE(section + 40)));
+    }
+  }
+  return null;
+}
+
+/** The PE `.bun` section, through the section table. Null for another format. */
+export function readBunSectionPE(fd: number): Buffer | null {
+  const dos = readAt(fd, 0, 64);
+  if (dos.toString("latin1", 0, 2) !== "MZ") return null;
+  const pe = dos.readUInt32LE(0x3c);
+  // "PE\0\0", then the COFF header: Machine u16, NumberOfSections u16, TimeDateStamp u32,
+  // PointerToSymbolTable u32, NumberOfSymbols u32, SizeOfOptionalHeader u16, Characteristics u16.
+  const coff = readAt(fd, pe, 24);
+  if (coff.toString("latin1", 0, 4) !== "PE\0\0") return null;
+  const sectionCount = coff.readUInt16LE(6);
+  const sections = readAt(fd, pe + 24 + coff.readUInt16LE(20), sectionCount * 40);
+  for (let at = 0, i = 0; i < sectionCount; i++, at += 40) {
+    // IMAGE_SECTION_HEADER (40 bytes): Name[8], VirtualSize u32, VirtualAddress u32, SizeOfRawData u32, PointerToRawData u32, ...
+    if (sections.toString("latin1", at, at + 5) !== ".bun\0") continue;
+    return readAt(fd, sections.readUInt32LE(at + 20), sections.readUInt32LE(at + 16));
   }
   return null;
 }
 
 /**
- * Parses the module graph embedded in the executable at `outfile`. On Linux
- * only the `.bun` section is read. Other formats read the whole file.
+ * Parses the module graph embedded in the executable at `outfile`. Only the
+ * section that holds it is read; an executable of a format the readers above
+ * do not know is read whole.
  */
 export function readModuleGraph(outfile: string): ModuleGraph {
   // A Windows target gets `.exe` appended to the outfile it was asked for.
   const fd = openSync(isWindows ? `${outfile}.exe` : outfile, "r");
   let data: Buffer;
   try {
-    data = readBunSectionELF(fd) ?? readFileSync(fd);
+    data = readBunSectionELF(fd) ?? readBunSectionMachO(fd) ?? readBunSectionPE(fd) ?? readFileSync(fd);
   } finally {
     closeSync(fd);
   }
@@ -154,6 +196,17 @@ export function readModuleGraph(outfile: string): ModuleGraph {
   if (flags & Flags.HAS_MODULE_INFO_STRING_TABLE) {
     const strings = span(at);
     moduleInfoStringTable = { ...strings, text: text(strings) };
+  }
+
+  // JSC reads the bytecode in place and expects it 128-byte aligned once
+  // mapped. The section is page aligned and starts with the 8-byte length, so
+  // every bytecode region sits at 120 mod 128 (`append_bytecode_aligned`).
+  // Module records and their string table are not aligned.
+  const aligned: Span[] = [...modules.map(m => m.bytecode), ...builtinBytecode];
+  if (bytecodeStringTable) aligned.push(bytecodeStringTable);
+  for (const region of aligned) {
+    if (region.length > 0)
+      expect(region.offset % 128, `bytecode at payload offset ${region.offset} is aligned`).toBe(120);
   }
 
   return { modules, entryPointId, flags, startupCount, builtinBytecode, bytecodeStringTable, moduleInfoStringTable };

--- a/test/bundler/standalone-graph.ts
+++ b/test/bundler/standalone-graph.ts
@@ -27,6 +27,8 @@ export interface EmbeddedModule {
   contents: Span;
   bytecode: Span;
   moduleInfo: Span;
+  /** Header of the ES module record a `--bytecode` chunk carries (`serialize_body` in src/js_printer/lib.rs). */
+  moduleRecord: { requestedModules: number; records: number } | null;
 }
 
 export interface ModuleGraph {
@@ -39,7 +41,8 @@ export interface ModuleGraph {
   /** Ahead-of-time bytecode of the internal modules the bundle imports, by InternalModuleRegistry id. */
   builtinBytecode: (Span & { id: number })[];
   bytecodeStringTable: Span | null;
-  moduleInfoStringTable: (Span & { text: string }) | null;
+  /** Slots of the bytecode string table that the module records' names resolve through. */
+  moduleInfoStringTable: Span | null;
 }
 
 /** `Flags` in src/standalone_graph/StandaloneModuleGraph.rs */
@@ -162,12 +165,21 @@ export function readModuleGraph(outfile: string): ModuleGraph {
   const modules: EmbeddedModule[] = [];
   for (let record = table.offset; record < table.offset + table.length; record += RECORD) {
     const contents = span(record + 8);
+    const moduleInfo = span(record + 32);
     modules.push({
       name: text(span(record)),
       source: text(contents),
       contents,
       bytecode: span(record + 24),
-      moduleInfo: span(record + 32),
+      moduleInfo,
+      // u8 flags, u8 id width, u8 0, u8 0, u32 requested-module count, u32 record count, ...
+      moduleRecord:
+        moduleInfo.length >= 12
+          ? {
+              requestedModules: payload.readUInt32LE(moduleInfo.offset + 4),
+              records: payload.readUInt32LE(moduleInfo.offset + 8),
+            }
+          : null,
     });
   }
 
@@ -193,10 +205,9 @@ export function readModuleGraph(outfile: string): ModuleGraph {
     startupCount = payload.readUInt32LE(at);
     at += 4;
   }
-  let moduleInfoStringTable: ModuleGraph["moduleInfoStringTable"] = null;
+  let moduleInfoStringTable: Span | null = null;
   if (flags & Flags.HAS_MODULE_INFO_STRING_TABLE) {
-    const strings = span(at);
-    moduleInfoStringTable = { ...strings, text: text(strings) };
+    moduleInfoStringTable = span(at);
   }
 
   // JSC reads the bytecode in place and expects it 128-byte aligned once

--- a/test/bundler/standalone-graph.ts
+++ b/test/bundler/standalone-graph.ts
@@ -12,7 +12,7 @@
  */
 import { expect } from "bun:test";
 import { isWindows } from "harness";
-import { closeSync, openSync, readFileSync, readSync } from "node:fs";
+import { closeSync, openSync, readSync } from "node:fs";
 
 export interface Span {
   offset: number;
@@ -130,18 +130,19 @@ export function readBunSectionPE(fd: number): Buffer | null {
 
 /**
  * Parses the module graph embedded in the executable at `outfile`. Only the
- * section that holds it is read; an executable of a format the readers above
- * do not know is read whole.
+ * section that holds it is read.
  */
 export function readModuleGraph(outfile: string): ModuleGraph {
   // A Windows target gets `.exe` appended to the outfile it was asked for.
-  const fd = openSync(isWindows ? `${outfile}.exe` : outfile, "r");
-  let data: Buffer;
+  const path = isWindows ? `${outfile}.exe` : outfile;
+  const fd = openSync(path, "r");
+  let data: Buffer | null;
   try {
-    data = readBunSectionELF(fd) ?? readBunSectionMachO(fd) ?? readBunSectionPE(fd) ?? readFileSync(fd);
+    data = readBunSectionELF(fd) ?? readBunSectionMachO(fd) ?? readBunSectionPE(fd);
   } finally {
     closeSync(fd);
   }
+  if (!data) throw new Error(`${path} has no module graph section: not an ELF, Mach-O or PE executable`);
   const trailer = data.lastIndexOf(TRAILER);
   expect(trailer).toBeGreaterThan(0);
   const offsets = trailer - 32;

--- a/test/bundler/standalone-graph.ts
+++ b/test/bundler/standalone-graph.ts
@@ -58,7 +58,8 @@ const TRAILER = Buffer.from("\n---- Bun! ----\n", "latin1");
 
 function readAt(fd: number, offset: number, size: number): Buffer {
   const buf = Buffer.alloc(size);
-  readSync(fd, buf, 0, size, offset);
+  const read = readSync(fd, buf, 0, size, offset);
+  if (read !== size) throw new Error(`read ${read} of ${size} bytes at offset ${offset}`);
   return buf;
 }
 

--- a/test/bundler/standalone-graph.ts
+++ b/test/bundler/standalone-graph.ts
@@ -1,0 +1,160 @@
+/**
+ * Reads the module graph that `bun build --compile` embeds in an executable,
+ * without reading the whole executable (hundreds of MB in a debug build).
+ *
+ * The layout is `to_bytes` in src/standalone_graph/StandaloneModuleGraph.rs.
+ * The payload ends with `Offsets { byte_count: usize, modules_ptr:
+ * StringPointer, entry_point_id: u32, compile_exec_argv_ptr: StringPointer,
+ * flags: u32 }` (32 bytes) and the `---- Bun! ----` trailer. A `StringPointer`
+ * is `{ offset: u32, length: u32 }` relative to the payload.
+ */
+import { expect } from "bun:test";
+import { isWindows } from "harness";
+import { closeSync, openSync, readFileSync, readSync } from "node:fs";
+
+export interface Span {
+  offset: number;
+  length: number;
+}
+
+export interface EmbeddedModule {
+  /** `/$bunfs/root/<name>` (`B:/~BUN/root/<name>` on Windows) */
+  name: string;
+  /** The printed chunk. */
+  source: string;
+  contents: Span;
+  bytecode: Span;
+  moduleInfo: Span;
+}
+
+export interface ModuleGraph {
+  /** Table order is load order. */
+  modules: EmbeddedModule[];
+  entryPointId: number;
+  flags: number;
+  /** Leading modules that make up the entry point's static import closure. */
+  startupCount: number;
+  /** Ahead-of-time bytecode of the internal modules the bundle imports, by InternalModuleRegistry id. */
+  builtinBytecode: (Span & { id: number })[];
+  bytecodeStringTable: Span | null;
+  moduleInfoStringTable: (Span & { text: string }) | null;
+}
+
+/** `Flags` in src/standalone_graph/StandaloneModuleGraph.rs */
+export const Flags = {
+  HAS_SOURCE_HASHES: 1 << 5,
+  HAS_BUILTIN_BYTECODE: 1 << 6,
+  HAS_BYTECODE_STRING_TABLE: 1 << 7,
+  HAS_STARTUP_MODULE_COUNT: 1 << 8,
+  HAS_MODULE_INFO_STRING_TABLE: 1 << 9,
+};
+
+const TRAILER = Buffer.from("\n---- Bun! ----\n", "latin1");
+
+/**
+ * On Linux the graph is the ELF `.bun` section, far from the end of the file.
+ * Returns null for any other executable format.
+ */
+export function readBunSectionELF(fd: number): Buffer | null {
+  const ehdr = Buffer.alloc(64);
+  readSync(fd, ehdr, 0, 64, 0);
+  // "\x7fELF", ELFCLASS64, little-endian
+  if (ehdr.toString("latin1", 0, 4) !== "\x7fELF" || ehdr[4] !== 2 || ehdr[5] !== 1) return null;
+  const shoff = Number(ehdr.readBigUInt64LE(0x28));
+  const shentsize = ehdr.readUInt16LE(0x3a);
+  const shnum = ehdr.readUInt16LE(0x3c);
+  const shstrndx = ehdr.readUInt16LE(0x3e);
+  const shdrs = Buffer.alloc(shentsize * shnum);
+  readSync(fd, shdrs, 0, shdrs.length, shoff);
+  const header = (i: number) => {
+    const sh = shdrs.subarray(i * shentsize, (i + 1) * shentsize);
+    return {
+      name: sh.readUInt32LE(0),
+      offset: Number(sh.readBigUInt64LE(0x18)),
+      size: Number(sh.readBigUInt64LE(0x20)),
+    };
+  };
+  const read = ({ offset, size }: { offset: number; size: number }) => {
+    const buf = Buffer.alloc(size);
+    readSync(fd, buf, 0, size, offset);
+    return buf;
+  };
+  const names = read(header(shstrndx));
+  for (let i = 0; i < shnum; i++) {
+    const sh = header(i);
+    if (names.toString("latin1", sh.name, names.indexOf(0, sh.name)) === ".bun") return read(sh);
+  }
+  return null;
+}
+
+/**
+ * Parses the module graph embedded in the executable at `outfile`. On Linux
+ * only the `.bun` section is read. Other formats read the whole file.
+ */
+export function readModuleGraph(outfile: string): ModuleGraph {
+  // A Windows target gets `.exe` appended to the outfile it was asked for.
+  const fd = openSync(isWindows ? `${outfile}.exe` : outfile, "r");
+  let data: Buffer;
+  try {
+    data = readBunSectionELF(fd) ?? readFileSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  const trailer = data.lastIndexOf(TRAILER);
+  expect(trailer).toBeGreaterThan(0);
+  const offsets = trailer - 32;
+  const base = offsets - Number(data.readBigUInt64LE(offsets));
+  const payload = data.subarray(base, trailer);
+
+  const span = (at: number): Span => ({ offset: payload.readUInt32LE(at), length: payload.readUInt32LE(at + 4) });
+  const text = ({ offset, length }: Span) => payload.toString("latin1", offset, offset + length);
+  const table = span(payload.length - 32 + 8);
+  const entryPointId = payload.readUInt32LE(payload.length - 32 + 16);
+  const flags = payload.readUInt32LE(payload.length - 32 + 28);
+
+  // `CompiledModuleGraphFile`: name, contents, sourcemap, bytecode, module_info,
+  // bytecode_origin_path (StringPointer each), then 4 bytes.
+  const RECORD = 52;
+  expect(table.length % RECORD).toBe(0);
+  const modules: EmbeddedModule[] = [];
+  for (let record = table.offset; record < table.offset + table.length; record += RECORD) {
+    const contents = span(record + 8);
+    modules.push({
+      name: text(span(record)),
+      source: text(contents),
+      contents,
+      bytecode: span(record + 24),
+      moduleInfo: span(record + 32),
+    });
+  }
+
+  // Records chained after the module table, in `Flags` bit order.
+  let at = table.offset + table.length;
+  if (flags & Flags.HAS_SOURCE_HASHES) at += modules.length * 4;
+  const builtinBytecode: ModuleGraph["builtinBytecode"] = [];
+  if (flags & Flags.HAS_BUILTIN_BYTECODE) {
+    // `u32 count`, then `count` × `{ u32 id, StringPointer bytes }`
+    const count = payload.readUInt32LE(at);
+    at += 4;
+    for (let i = 0; i < count; i++, at += 12) {
+      builtinBytecode.push({ id: payload.readUInt32LE(at), ...span(at + 4) });
+    }
+  }
+  let bytecodeStringTable: Span | null = null;
+  if (flags & Flags.HAS_BYTECODE_STRING_TABLE) {
+    bytecodeStringTable = span(at);
+    at += 8;
+  }
+  let startupCount = modules.length;
+  if (flags & Flags.HAS_STARTUP_MODULE_COUNT) {
+    startupCount = payload.readUInt32LE(at);
+    at += 4;
+  }
+  let moduleInfoStringTable: ModuleGraph["moduleInfoStringTable"] = null;
+  if (flags & Flags.HAS_MODULE_INFO_STRING_TABLE) {
+    const strings = span(at);
+    moduleInfoStringTable = { ...strings, text: text(strings) };
+  }
+
+  return { modules, entryPointId, flags, startupCount, builtinBytecode, bytecodeStringTable, moduleInfoStringTable };
+}


### PR DESCRIPTION
### Problem
- Five cases of `bundler_compile_splitting.test.ts` inspect the compiled executable by reading the whole file (800 MB in a debug build), one as a `latin1` string searched five times (26 s in a local debug run). They open `out`, but a Windows target writes `out.exe`.
- `MinChunkSizeKeepsEntryChunkImportable` used a top-level `await import()`, which disables every chunk fold by itself, so the `--compile` pin it describes was never exercised. The startup-run case described internal-module bytecode its fixture did not have.

### Fix
- New `test/bundler/standalone-graph.ts` parses the embedded module graph from the section that holds it (ELF `.bun`, Mach-O `__BUN,__bun`, PE `.bun`, a few KB each) and throws for any other file. On Windows it opens `out.exe`. It pins that every bytecode region sits at 120 mod 128 in the payload, the alignment JSC needs.
- Every case checks the embedded layout next to its run: module count and names, each import names an embedded module, bytecode present exactly when `--bytecode` is set, no `fs/promises` in any dead-import chunk, and the chunk that holds the dead import requests no module in its record. 48 `expect()` calls become 377.
- The three layout cases (#40274, #40407, #40498) share one executable and now pin the internal-module bytecode (node:fs) in the startup run. 22 compiles become 20. All other cases keep their names.
- The MinChunkSize fixture uses `import().then()`, and an uncompiled twin (no extra compile) asserts the fold the pin blocks: `shared` lands in `entry.js`. An `import()` target without exports whose chunk absorbs a helper covers the other half of the pin clause.
- Verified: `bun bd test test/bundler/bundler_compile_splitting.test.ts`, 21 pass after the rebase onto #40677. CI asan, file run solo: 43.3 s (build 105983, 16 cases) to 34.9 s and 35.6 s (builds 106601 and 106752, 17 compiles, before #40643 added two cases). Local debug ASAN build: 84.3 s (main at 2c0284ee84, 19 cases) to 52.1 s (18 cases, 17 compiles).

### Background
- `--compile` appends a module graph (`StandaloneModuleGraph.rs`, `to_bytes`) to a copy of the bun binary, rewritten in memory (#33621 is the runtime-side fix for that cost). On Linux the graph is the ELF `.bun` section, 330 MB before the end of the file.
- `mergeSmallChunks.rs` folds a chunk into the entry's chunk when the entry is guaranteed to load first. `--compile` pins the entry chunk. Top-level await in the entry guarantees nothing, so no fold happens either way.
- The API backend of `itBundled` is `it.serial`, and concurrent compiles exhaust CI memory (`bundler_compile.test.ts`). On the test side, the compile count is the lever.

<details><summary>Notes</summary>

- Per-phase cost of one case, local debug ASAN build: `Bun.build` with `compile` 2.2 to 2.5 s, `Bun.gc(true)` 20 ms, running the executable 0.24 s. Inside the compile the bundle itself is 0.3 s. The rest is `inject()` in `StandaloneModuleGraph.rs`: the in-kernel `copy_file` of the executable is about 0.3 s, and reading the copy back into a `Vec`, the ASAN realloc that grows it, and the in-memory ELF rewrite (a 330 MB tail move) are about 1.4 s. #33621 (mmap the source executable, write the image once) removes most of that for every `--compile` test. It is open and needs a rebase.
- Reading an executable: `readFileSync` of the 800 MB output plus `lastIndexOf` is 1.7 s in a local debug build, the `latin1` string conversion plus five `String#lastIndexOf` calls 25 s. Reading the `.bun` section through the ELF section headers takes a few ms.
- Local, main at 2c0284ee84, per test: `ModulesLaidOutInLoadOrder` 25.4 s, `StartupModulesPrecedeLazyChunks` 4.1 s, `ChunkNamesAreHashed` 4.0 s, the two `SplitRequireLoadsChunkSynchronously` cases 4.1 s and 4.8 s (whole-file read each), the other 14 cases 2.3 to 3.4 s. After: 2.4 to 3.4 s each.
- CI, this revision, build 106601, file run solo (the runner runs modified files first and alone): debian 13 x64-asan 34.9 s, debian 13 x64 18.5 s, darwin x64 19.3 s, darwin aarch64 9.4 s. The 16-case file in build 105983 solo: asan 43.3 s, debian x64 8.7 s, darwin x64 18.0 s, darwin aarch64 7.5 s. An earlier revision of this branch with 13 cases (two more folds) ran in 29.1 s on asan (build 106200). On the release lanes the numbers move with machine load more than with this change. This file is the third slowest bundler test file on the ASAN lane, behind `bundler_compile.test.ts` and `bun-build-compile.test.ts`.
- The `import.meta` (#26402) and external re-export (#37677) cases stay separate. An earlier revision merged them to save two compiles. Two regression pins with their own issue numbers are clearer apart.
- The folded layout case uses the five-module graph of `ModulesLaidOutInLoadOrder`. The startup-run check generalizes the old one: the internal-module bytecode (4 blobs, 79 KB in the debug build) and both string tables lie between the end of the startup modules' bytecode and module records and the first lazy module's bytecode, in that order. The old case skipped the builtin table and its fixture imported no builtin. The chunk-name check covers the four chunks of that graph. Chunk naming does not depend on `--bytecode` (the `./_N.js` numbering #40498 reverted applied to every executable), and the no-bytecode splitting path is still compiled and run by `RelativePathsAcrossChunks`, `SplitRequireLoadsChunkSynchronously-source` and four dead-import configurations.
- `MinChunkSizeKeepsEntryChunkImportable`: with the old `await import("./a")` entry, the compiled and the uncompiled build both kept every chunk separate, so the assertions could not tell whether the `compile_mode.is_executable()` clause in `pin_entry_chunk` exists. With `import().then()` the uncompiled build folds `shared` into `entry.js` (a's chunk imports it from `./entry.js`) and the compiled build keeps it in a chunk of its own. `splitting/MinChunkSizeFoldsSharedIntoEntryWithoutCompile` pins the uncompiled half on the same fixture, so a fixture edit that removes the fold fails loudly instead of hollowing the compiled case. `helper` does not fold into a's chunk in either shape because a.ts has exports (`preserveEntrySignatures: "exports-only"`). `c.ts` has none, so `helper2` (shared by c and its `import()` target d) folds into c's chunk in both shapes, which covers the `!is_dynamic_entry` half of the clause. The old comment claimed the fold for `helper`. It now states what the fixture shows.
- Bytecode alignment: `append_bytecode_aligned` in `StandaloneModuleGraph.rs` places module bytecode, internal-module bytecode and the bytecode string table at 120 mod 128 so they are 128-byte aligned after the section's 8-byte length header at a page-aligned address. #26299 fixed a Windows crash from misaligned offsets. No test asserted the offsets. `readModuleGraph` now does for every caller. Module records and their string table are unaligned by design and are excluded.
- Rebased onto #40643 and then #40677, which added `PreRegisteredClosure` (two cases) and `ModuleRecordNamesMatchBytecode` at the top of the describe block. Each conflict was that insertion against the rewritten layout case below it. Resolved by keeping the new cases first, unchanged, then the layout case.
- #40677 turned the module-info string table into slots of the bytecode string table, so the dead-import check that searched it for `fs/promises` checked nothing. The bytecode string table does contain `fs/promises`, but from the internal-module bytecode the tree-shaken import still pulls into the executable (six builtin blobs and a 20 KB table that the same fixture without the import does not have), not from a record. The matrix now reads each record's header and asserts that the chunk holding wrapped.js requests no module. Since #40519 that chunk is wrapped.js alone.
- The `SplitRequireLoadsChunkSynchronously` cases (#40519) keep their assertion (`import.meta.require()` of an embedded chunk) through the parser. The bytecode variant builds through the CLI, whose default chunk names are `[name]-[hash].js`, so that check accepts any embedded `.js` path and `expectImportsResolve` checks the path exists.
- Not done: `test.concurrent`. The API backend is `it.serial` in `expectBundled.ts`, and each compile holds about two copies of the executable in memory.
- `itBundled` cases do not run on Windows today: `expectBundled` checks that `new Error().stack` includes `test/bundler/`, Windows stacks use backslashes, and `itBundled` swallows the throw during its dry run (#34552 and #38655 are open for this). Build 106200 shows `Ran 0 tests across 1 file` for this file on both Windows lanes.
- The Mach-O reader was checked against an arm64 output cross-compiled with `--compile-executable-path` (section 591 bytes, payload equal to the whole-file read). The PE reader was checked on a Windows x64 compile with the canary build (section 3584 bytes, payload equal, bytecode at 120, 632, 1912). An earlier revision fell back to reading the whole file when no reader matched. No supported target reaches that path (`inject` writes ELF, Mach-O or PE), so the fallback could only hide a reader regression as a slow test, and `readModuleGraph` now throws instead. `bun-build-compile.test.ts` has three inline ELF `.bun` section walkers that could import `readBunSectionELF` from the new module. Not changed here.
- With about 29 s on the ASAN lane the file is still above the 15 s `fast_ms` bound of `test/parallel-allowlist.json`. Its entry there (asan 4957 ms) predates most of these cases.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/bundler_compile_splitting.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/bundler_compile_splitting.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/bundler_compile_splitting.test.ts:
(pass) bundler > compile with splitting > compile/splitting/PreRegisteredClosure [4826.53ms]
(pass) bundler > compile with splitting > compile/splitting/PreRegisteredClosure+bytecode [6061.52ms]
(pass) bundler > compile with splitting > compile/splitting/ModuleRecordNamesMatchBytecode [3046.53ms]
(pass) bundler > compile with splitting > compile/splitting/ModuleGraphLayout [3861.10ms]
(pass) bundler > compile with splitting > compile/splitting/RelativePathsAcrossChunks [4085.16ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk [3317.76ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk+minify [3572.05ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule [3907.26ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+minify [3356.25ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode [3899.85ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode+minify [5319.02ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting [3845.79ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+minify [4691.79ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+bytecode [3790.70ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+bytecode+minify [4514.14ms]
(pass) bundler > compile with splitting > compile/splitting/ReExportExternalFromSplitChunk [3563.66ms]
(pass) bundler > compile with splitting > compile/splitting/ReExportExternalFromSplitChunk+minify [4486.09ms]
(pass) bundler > 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/bundler_compile_splitting.test.ts | 430 ++++++++++++++++---------
 test/bundler/standalone-graph.ts               | 226 +++++++++++++
 2 files changed, 495 insertions(+), 161 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
test/bundler/bundler_compile_splitting.test.ts     19     20      0
test/bundler/standalone-graph.ts                    4      7      0
```

</details>

<!-- robobun:evidence:end -->

