### PR TITLE
test(bake): run the bundle dev tests concurrently

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1926,6 +1926,26 @@ class OutputLineStream extends EventEmitter {
   }
 }
 
+/** After `ms`, every `race()` rejects with `message`. Disposing it disarms the timer. */
+class Deadline {
+  #passed = Promise.withResolvers<never>();
+  #timer: ReturnType<typeof setTimeout>;
+
+  constructor(ms: number, message: string) {
+    // The rejection is only observed through `race()`.
+    this.#passed.promise.catch(() => {});
+    this.#timer = setTimeout(() => this.#passed.reject(new Error(message)), Math.max(0, ms));
+  }
+
+  race<T>(promise: Promise<T>): Promise<T> {
+    return Promise.race([promise, this.#passed.promise]);
+  }
+
+  [Symbol.dispose]() {
+    clearTimeout(this.#timer);
+  }
+}
+
 export function indexHtmlScript(htmlFiles: string[]) {
   return [
     ...htmlFiles.map((file, i) => `import html${i} from ${JSON.stringify("./" + file.replaceAll(path.sep, "/"))};`),
@@ -1978,7 +1998,16 @@ function testImpl<T extends DevServerTest>(
 
   const isStressTest = stressTestSelect === "ALL" || (stressTestSelect && name.includes(stressTestSelect));
 
+  // A function: `interactive` is only known once the test runs.
+  const testTimeout = () =>
+    isStressTest
+      ? 11 * 60 * 1000
+      : interactive
+        ? interactive_timeout
+        : (options.timeoutMultiplier ?? 1) * (isWindows ? 45_000 : 30_000) * WAIT_MULTIPLIER;
+
   async function run() {
+    const started = performance.now();
     const root = path.join(tempDir, basename + count);
 
     // Clean the test directory if it exists
@@ -2141,8 +2170,17 @@ function testImpl<T extends DevServerTest>(
         }
       },
     };
+    // When a test times out, the runner kills its processes only if the test
+    // is not concurrent. So the harness gives up before the runner's timeout:
+    // a rejection here returns through the disposers above, which kill this
+    // test's dev server and clients.
+    const timeout = testTimeout();
+    using deadline = new Deadline(
+      timeout - Math.min(5_000, timeout / 10) - (performance.now() - started),
+      `The test did not finish before the harness deadline (runner timeout: ${timeout}ms). Its dev server and clients are killed.`,
+    );
     if (dev.nodeEnv === "development") {
-      await dev.connectSocket();
+      await deadline.race(dev.connectSocket());
     }
     if (isStressTest) {
       dev.stressTestEndurance = true;
@@ -2151,7 +2189,7 @@ function testImpl<T extends DevServerTest>(
     await maybeWaitInteractive("start");
 
     try {
-      await options.test(dev);
+      await deadline.race(options.test(dev));
     } catch (err: any) {
       while (err instanceof SuppressedError) {
         logErr(err.suppressed);
@@ -2174,7 +2212,7 @@ function testImpl<T extends DevServerTest>(
       process.exit(0);
     }
 
-    await dev.gracefulExit();
+    await deadline.race(dev.gracefulExit());
   }
 
   try {
@@ -2184,15 +2222,7 @@ function testImpl<T extends DevServerTest>(
     }
 
     const test = options.only ? jest.test.only : jest.test;
-    (options.concurrent ? test.concurrent : test)(
-      name,
-      run,
-      isStressTest
-        ? 11 * 60 * 1000
-        : interactive
-          ? interactive_timeout
-          : (options.timeoutMultiplier ?? 1) * (isWindows ? 45_000 : 30_000) * WAIT_MULTIPLIER,
-    );
+    (options.concurrent ? test.concurrent : test)(name, run, testTimeout());
     return options;
   } catch {
     // not in bun test. allow interactive use
@@ -2282,11 +2312,18 @@ class TrailingLog {
   }
 }
 
-process.on("exit", () => {
+function killDanglingProcesses() {
   for (const proc of danglingProcesses) {
     proc.kill("SIGKILL");
   }
-});
+}
+process.on("exit", killDanglingProcesses);
+// `bun test` does not run exit listeners. Reap what a test left behind when its file ends.
+try {
+  (Bun as any).jest(import.meta.path).afterAll(killDanglingProcesses);
+} catch {
+  // Not in bun test (interactive use).
+}
 
 export function devTest<T extends DevServerTest>(description: string, options: T): T {
   // Capture the caller name as part of the test tempdir

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1553,8 +1553,10 @@ function stackTraceFileName(line: string): string {
   // Handle drive letters (e.g. C:) and line numbers
   let colon = result.indexOf(":");
 
-  // Check for drive letter (e.g. C:) by looking for single letter before colon
-  if (colon > 0 && /[a-zA-Z]/.test(result[colon - 1])) {
+  // Check for drive letter (e.g. C:): a single letter before the first colon.
+  // On posix the first colon ends the path (`.../x.test.ts:9:1`), so the
+  // letter before it is no drive letter.
+  if (colon === 1 && /[a-zA-Z]/.test(result[colon - 1])) {
     // On Windows, skip past drive letter colon to find line number colon
     colon = result.indexOf(":", colon + 1);
   }
@@ -1973,6 +1975,9 @@ export function indexHtmlScript(htmlFiles: string[]) {
 
 const skipTargets = [process.platform, isCI ? "ci" : null].filter(Boolean);
 
+/** Test files that have an `afterAll` hook to kill what their tests left behind. */
+const filesWithReaper = new Set<string>();
+
 function testImpl<T extends DevServerTest>(
   description: string,
   options: T,
@@ -2216,6 +2221,13 @@ function testImpl<T extends DevServerTest>(
   }
 
   try {
+    // `bun test` does not run exit listeners, and this module is evaluated once
+    // for every file in the run. So each file gets its own hook.
+    if (!filesWithReaper.has(caller)) {
+      jest.afterAll(killDanglingProcesses);
+      filesWithReaper.add(caller);
+    }
+
     if (options.skip && options.skip.some(x => skipTargets.includes(x))) {
       jest.test.todo(name, run);
       return options;
@@ -2312,18 +2324,14 @@ class TrailingLog {
   }
 }
 
+/** Kills every process the tests in this process spawned and did not see exit. */
 function killDanglingProcesses() {
   for (const proc of danglingProcesses) {
     proc.kill("SIGKILL");
   }
 }
+// For interactive use. `bun test` skips exit listeners: see the `afterAll` in `testImpl`.
 process.on("exit", killDanglingProcesses);
-// `bun test` does not run exit listeners. Reap what a test left behind when its file ends.
-try {
-  (Bun as any).jest(import.meta.path).afterAll(killDanglingProcesses);
-} catch {
-  // Not in bun test (interactive use).
-}
 
 export function devTest<T extends DevServerTest>(description: string, options: T): T {
   // Capture the caller name as part of the test tempdir

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -134,6 +134,12 @@ export interface DevServerTest {
    */
   only?: boolean;
   /**
+   * Register with `test.concurrent`, so this test overlaps with the other
+   * concurrent tests in its file. Every test has its own directory, dev server
+   * (`port: 0`) and clients, so a test that shares nothing else can opt in.
+   */
+  concurrent?: boolean;
+  /**
    * Extra environment variables for the spawned dev-server process.
    */
   env?: Record<string, string>;
@@ -203,6 +209,12 @@ export class Dev extends EventEmitter {
   nodeEnv: "development" | "production";
   batchingChanges: { write?: () => void } | null = null;
   stressTestEndurance = false;
+  /**
+   * The dev server and every client this test spawned. The test kills the ones
+   * that still run when it ends. Tests in one file can run concurrently, so
+   * this is per test, not module-global.
+   */
+  processes: Set<Subprocess> = new Set();
 
   socket?: WebSocket;
 
@@ -223,6 +235,7 @@ export class Dev extends EventEmitter {
     this.port = port;
     this.baseUrl = `http://localhost:${port}`;
     this.devProcess = process;
+    this.processes.add(process);
     this.output = stream;
     this.options = options as any;
     this.output.on("panic", () => {
@@ -543,7 +556,9 @@ export class Dev extends EventEmitter {
         hmr: this.nodeEnv === "development",
         expectErrors: !!options.errors,
         allowUnlimitedReloads: options.allowUnlimitedReloads,
+        logName: `web ${path.basename(this.rootDir)}`,
       });
+      this.processes.add(client.process);
       const onPanic = () => client.output.emit("panic");
       this.output.on("panic", onPanic);
       if (this.nodeEnv === "development") {
@@ -845,7 +860,14 @@ export class Client extends EventEmitter {
 
   constructor(
     url: string,
-    options: { storeHotChunks?: boolean; hmr: boolean; expectErrors?: boolean; allowUnlimitedReloads?: boolean },
+    options: {
+      storeHotChunks?: boolean;
+      hmr: boolean;
+      expectErrors?: boolean;
+      allowUnlimitedReloads?: boolean;
+      /** Prefix of this client's output lines in the test log. */
+      logName?: string;
+    },
   ) {
     super();
     activeClient = this;
@@ -893,8 +915,13 @@ export class Client extends EventEmitter {
     });
     this.#proc = proc;
     this.hmr = options.hmr;
-    this.output = new OutputLineStream("web", proc.stdout, proc.stderr);
+    this.output = new OutputLineStream(options.logName ?? "web", proc.stdout, proc.stderr);
     proc.exited.then(exitCode => (this.output.exitCode = exitCode));
+  }
+
+  /** The node subprocess that runs the page. */
+  get process(): Subprocess {
+    return this.#proc;
   }
 
   hardReload(options: { errors?: ErrorSpec[] } = {}) {
@@ -2071,14 +2098,6 @@ function testImpl<T extends DevServerTest>(
       `,
     );
 
-    using _ = {
-      [Symbol.dispose]: () => {
-        for (const proc of danglingProcesses) {
-          proc.kill("SIGKILL");
-        }
-      },
-    };
-
     await using devProcess = Bun.spawn({
       cwd: root,
       cmd: [process.execPath, "./harness_start.ts"],
@@ -2108,10 +2127,20 @@ function testImpl<T extends DevServerTest>(
     if (interactive) {
       console.log("\x1b[35mDev Server PID: " + devProcess.pid + "\x1b[0m");
     }
-    using stream = new OutputLineStream("dev", devProcess.stdout, devProcess.stderr);
+    // The test's directory name tags its lines, so concurrent tests stay apart in the log.
+    using stream = new OutputLineStream(`dev ${basename}${count}`, devProcess.stdout, devProcess.stderr);
     devProcess.exited.then(exitCode => (stream.exitCode = exitCode));
     const port = parseInt((await stream.waitForLine(/localhost:(\d+)/))[1], 10);
     const dev = new Dev(root, port, devProcess, stream, NODE_ENV, options);
+    using _ = {
+      [Symbol.dispose]: () => {
+        // Only this test's processes. Another test in the file may still be
+        // running its own dev server and clients.
+        for (const proc of dev.processes) {
+          proc.kill("SIGKILL");
+        }
+      },
+    };
     if (dev.nodeEnv === "development") {
       await dev.connectSocket();
     }
@@ -2154,7 +2183,8 @@ function testImpl<T extends DevServerTest>(
       return options;
     }
 
-    (options.only ? jest.test.only : jest.test)(
+    const test = options.only ? jest.test.only : jest.test;
+    (options.concurrent ? test.concurrent : test)(
       name,
       run,
       isStressTest

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -493,6 +493,7 @@ devTest("import.meta.main", {
 });
 devTest("commonjs forms", {
   concurrent: true,
+  timeoutMultiplier: 2,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -509,22 +510,34 @@ devTest("commonjs forms", {
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage({ field: {} });
-    // A CommonJS module does not accept hot updates, so each form reloads the page.
-    const forms: [source: string, field: string][] = [
-      [`exports.field = "1";`, "1"],
-      [`let theExports = exports; theExports.field = "2";`, "2"],
-      [`let theModule = module; theModule.exports.field = "3";`, "3"],
-      [`let { exports } = module; exports.field = "4";`, "4"],
-      [`var { exports } = module; exports.field = "4.5";`, "4.5"],
-      [`let theExports = module.exports; theExports.field = "5";`, "5"],
-      [`require; eval("module.exports.field = '6'");`, "6"],
-    ];
-    for (const [source, field] of forms) {
-      await c.expectReload(async () => {
-        await dev.write("cjs.js", source);
-      });
-      await c.expectMessage({ field });
-    }
+    await c.expectReload(async () => {
+      await dev.write("cjs.js", `exports.field = "1";`);
+    });
+    await c.expectMessage({ field: "1" });
+    await c.expectReload(async () => {
+      await dev.write("cjs.js", `let theExports = exports; theExports.field = "2";`);
+    });
+    await c.expectMessage({ field: "2" });
+    await c.expectReload(async () => {
+      await dev.write("cjs.js", `let theModule = module; theModule.exports.field = "3";`);
+    });
+    await c.expectMessage({ field: "3" });
+    await c.expectReload(async () => {
+      await dev.write("cjs.js", `let { exports } = module; exports.field = "4";`);
+    });
+    await c.expectMessage({ field: "4" });
+    await c.expectReload(async () => {
+      await dev.write("cjs.js", `var { exports } = module; exports.field = "4.5";`);
+    });
+    await c.expectMessage({ field: "4.5" });
+    await c.expectReload(async () => {
+      await dev.write("cjs.js", `let theExports = module.exports; theExports.field = "5";`);
+    });
+    await c.expectMessage({ field: "5" });
+    await c.expectReload(async () => {
+      await dev.write("cjs.js", `require; eval("module.exports.field = '6'");`);
+    });
+    await c.expectMessage({ field: "6" });
   },
 });
 

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -3,6 +3,7 @@ import { expect } from "bun:test";
 import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
+  concurrent: true,
   framework: minimalFramework,
   files: {
     "db.ts": `export const abc = "123";`,
@@ -29,6 +30,7 @@ devTest("import identifier doesnt get renamed", {
   },
 });
 devTest("symbol collision with import identifier", {
+  concurrent: true,
   framework: minimalFramework,
   files: {
     "db.ts": `export const abc = "123";`,
@@ -51,6 +53,7 @@ devTest("symbol collision with import identifier", {
   },
 });
 devTest('uses "development" condition', {
+  concurrent: true,
   framework: minimalFramework,
   files: {
     "node_modules/example/package.json": JSON.stringify({
@@ -77,6 +80,7 @@ devTest('uses "development" condition', {
   },
 });
 devTest("importing a file before it is created", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -100,6 +104,7 @@ devTest("importing a file before it is created", {
   },
 });
 devTest("default export same-scope handling", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -168,7 +173,7 @@ devTest("default export same-scope handling", {
   },
   async test(dev) {
     await using c = await dev.client("/", { storeHotChunks: true });
-    c.expectMessage(
+    await c.expectMessage(
       //
       "ONE",
       "TWO",
@@ -198,10 +203,11 @@ devTest("default export same-scope handling", {
 
     // Since fixture7.ts is not marked as accepting, it will bubble the update
     // to `index.ts`, re-evaluate it and some of the dependencies.
-    c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
+    await c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
   },
 });
 devTest("directory cache bust case #17576", {
+  concurrent: true,
   files: {
     "web/index.html": emptyHtmlFile({
       styles: [],
@@ -235,6 +241,7 @@ devTest("directory cache bust case #17576", {
   },
 });
 devTest("deleting imported file shows error then recovers", {
+  concurrent: true,
   skip: [
     "win32", // unlinkSync is having weird behavior
   ],
@@ -281,6 +288,7 @@ devTest("deleting imported file shows error then recovers", {
 // Dep was left pointing at freed memory, and the next directory-watch event
 // that re-resolved that Dep read it (use-after-free, caught by ASAN).
 devTest("removing 'use client' from a component with a pending resolution failure", {
+  concurrent: true,
   // separateSSRGraph is required so the "use client" file is parsed with the
   // browser target; otherwise the resolution failure is attributed to the
   // server graph and the client-graph key is never borrowed.
@@ -353,12 +361,14 @@ devTest("removing 'use client' from a component with a pending resolution failur
     // a heap-use-after-free here and the dev server aborts.
     await dev.write("components/missing.ts", `export const value = "ok";`, { errors: null });
 
-    // The server must still be alive and responding.
+    // The server must still be alive and responding. The route stays failed:
+    // Sibling.ts still imports the missing './sibling-missing'.
     const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(500);
   },
 });
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     // Import-record order is source order, so trackResolutionFailure is
@@ -388,9 +398,11 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
       await dev.write("sub/a.ts", `export {};`);
     }
 
-    // The server should still respond.
+    // The server should still respond, and the route builds now that index.ts
+    // has no failing import.
     const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("/_bun/client/");
 
     // Test teardown sends graceful-exit, which calls DevServer.deinit.
     // Before the fix, deinit iterated every dependencies.items slot and
@@ -399,6 +411,7 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
   },
 });
 devTest("importing html file", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -416,6 +429,7 @@ devTest("importing html file", {
   },
 });
 devTest("importing html file with text loader (#18154)", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -434,6 +448,7 @@ devTest("importing html file with text loader (#18154)", {
   },
 });
 devTest("importing bun on the client", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -451,6 +466,7 @@ devTest("importing bun on the client", {
   },
 });
 devTest("import.meta.main", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -476,7 +492,7 @@ devTest("import.meta.main", {
   },
 });
 devTest("commonjs forms", {
-  timeoutMultiplier: 2,
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -491,60 +507,31 @@ devTest("commonjs forms", {
     `,
   },
   async test(dev) {
-    console.log("Initial");
     await using c = await dev.client("/");
-    console.log("  expecting message");
     await c.expectMessage({ field: {} });
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `exports.field = "1";`);
-      console.log("  now reloading");
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "1" });
-    console.log("Second");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theExports = exports; theExports.field = "2";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "2" });
-    console.log("Third");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theModule = module; theModule.exports.field = "3";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "3" });
-    console.log("Fourth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let { exports } = module; exports.field = "4";`);
-    });
-    await c.expectMessage({ field: "4" });
-    console.log("Fifth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `var { exports } = module; exports.field = "4.5";`);
-    });
-    await c.expectMessage({ field: "4.5" });
-    console.log("Sixth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let theExports = module.exports; theExports.field = "5";`);
-    });
-    await c.expectMessage({ field: "5" });
-    console.log("Seventh");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `require; eval("module.exports.field = '6'");`);
-    });
-    await c.expectMessage({ field: "6" });
+    // A CommonJS module does not accept hot updates, so each form reloads the page.
+    const forms: [source: string, field: string][] = [
+      [`exports.field = "1";`, "1"],
+      [`let theExports = exports; theExports.field = "2";`, "2"],
+      [`let theModule = module; theModule.exports.field = "3";`, "3"],
+      [`let { exports } = module; exports.field = "4";`, "4"],
+      [`var { exports } = module; exports.field = "4.5";`, "4.5"],
+      [`let theExports = module.exports; theExports.field = "5";`, "5"],
+      [`require; eval("module.exports.field = '6'");`, "6"],
+    ];
+    for (const [source, field] of forms) {
+      await c.expectReload(async () => {
+        await dev.write("cjs.js", source);
+      });
+      await c.expectMessage({ field });
+    }
   },
 });
 
 // --- Barrel optimization tests ---
 
 devTest("barrel optimization skips unused submodules", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     "index.ts": `
@@ -575,6 +562,7 @@ devTest("barrel optimization skips unused submodules", {
 });
 
 devTest("barrel optimization: adding a new import triggers reload", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     "index.ts": `
@@ -629,6 +617,7 @@ devTest("barrel optimization: adding a new import triggers reload", {
 });
 
 devTest("barrel optimization: multi-file imports preserved across rebuilds", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     "index.ts": `
@@ -675,6 +664,7 @@ devTest("barrel optimization: multi-file imports preserved across rebuilds", {
 });
 
 devTest("barrel optimization: export star target not deferred (#27521)", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     // The user imports from consumer-lib, which is a non-barrel package
@@ -738,6 +728,7 @@ devTest("barrel optimization: export star target not deferred (#27521)", {
 });
 
 devTest("barrel optimization: two export-from blocks pointing to the same source", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     "index.ts": `
@@ -785,6 +776,7 @@ devTest("barrel optimization: two export-from blocks pointing to the same source
 // record and marks its target submodule as unused → submodule stays `{}` →
 // the export is `undefined` at runtime.
 devTest("barrel optimization: two import statements from the same barrel (#28886)", {
+  concurrent: true,
   // Flakes on darwin in CI (timing); fix is platform-agnostic, coverage via linux/windows/alpine.
   skip: ["darwin"],
   files: {
@@ -816,6 +808,7 @@ devTest("barrel optimization: two import statements from the same barrel (#28886
 });
 
 devTest("barrel optimization: namespace re-export cycle through a star-exported module", {
+  concurrent: true,
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     "index.ts": `


### PR DESCRIPTION
### Problem
- `test/bake/dev/bundle.test.ts` takes 15 to 19s per CI lane (build #106056), 10.7s locally on release, 47.8s on debug+ASAN. Its 21 cases run in sequence, each with its own dev server and usually a happy-dom client. That fixed cost is the time.
- The cases cannot overlap today. `run()` in `test/bake/bake-harness.ts` SIGKILLs the module-global `danglingProcesses` set when any case ends. Under `test.concurrent`, the first case to finish kills every other case's server and clients.

### Fix
- The harness tracks processes per test (`Dev.processes`) and kills only those at teardown. A new opt-in `concurrent` option on `devTest` registers the case with `test.concurrent`.
- The runner kills a timed-out test's processes only when the test is not concurrent, and `bun test` skips `process.on("exit")` listeners. So `run()` gives up 5s (or 10%) before the runner's timeout, and its disposers kill that test's processes. An `afterAll`, registered once per test file, reaps what is left at file end.
- `bundle.test.ts` opts all 21 cases in. Two `expectMessage` calls are now awaited, the two `toBeInstanceOf(Response)` checks assert the status, and "commonjs forms" loses its debug logs. No case is merged, skipped, or changed in what it tests.
- Verified: `bun bd test test/bake/dev/bundle.test.ts` 47.8s before, 13.3 to 13.6s after (ASAN caps concurrency at 5). Release 10.7s before, 1.2 to 1.4s after. All 155 bake dev tests pass. A hung concurrent case leaves no process behind.

### Background
- `devTest` gives each case its own temp directory and a dev server on port 0. `dev.client()` is a node process that loads the page in happy-dom and acks each build over IPC.
- `test.concurrent` lets async tests in one file overlap, up to `--max-concurrency` (20, or 5 in an ASAN build). In CI this file runs alone in the runner's serial phase.

<details><summary>Notes</summary>

**Per-phase timing of one case (local, release, before)**

| phase | ms |
|---|---|
| dev server spawn to port line | 58 (50 of it is the `setTimeout(50)` in `waitForLine`) |
| `dev.client()` page load and overlay check | 275 to 335 |
| one `dev.write()` rebuild and client ack | 67 to 76 (50 of it is the coalescing `Bun.sleep(50)` in `batchChanges`) |
| `gracefulExit` | 20 to 25 |

Debug+ASAN: 330ms to the port line, 460ms page load, 110 to 190ms per write, 800 to 1100ms `gracefulExit`.

The two fixed waits in the harness (50ms after a matched line, 50ms to let watcher events coalesce) are left alone. They exist for every bake dev file, the coalescing one has a stated reason (several watcher events per write on Windows), and under concurrency they overlap with other cases anyway.

**Why the harness and not the file**

Two earlier PRs (#40082, #40315) merged cases onto shared dev servers and were closed: #39488 carries the same restructure of this file, and #40315's own review found that the serial harness was the real cost. This PR keeps the 21 cases as they are, so it stays small against #39488, and makes the harness able to run them concurrently. The `bundle.test.ts` edits are one `concurrent: true` line per case plus the assertion fixes #39488 also has (the awaited `expectMessage` calls matter under concurrency: an unawaited rejection lands on whichever test is current). `concurrent` is opt-in so the other 18 dev files keep their sequential behavior until each one is checked.

**The deadline**

`src/runtime/test_runner/Execution.rs` (`kill_dangling_processes_on_timeout`) kills a timed-out test's spawned processes only when the concurrent group has one sequence. `src/runtime/cli/test_command.rs` (`skip_exit_listeners`) skips a test file's `process.on("exit")` listeners, so the harness's exit hook never ran under `bun test`, on main too. Before this PR the kill-all at the end of every case reaped a hung case's processes when the next case finished. The deadline replaces that: a case that hangs fails with "The test did not finish before the harness deadline" 5s (or 10% for short timeouts) before the runner's timeout, and its disposers SIGKILL its server and clients. `Promise.race` keeps observing the abandoned body, so its later rejection is not unhandled.

Probe (not committed): a `concurrent: true` case with `timeoutMultiplier: 0.1` that awaits a promise that never settles, next to two live siblings and a final check with `process.kill(pid, 0)`. Release: the case fails at 2.7s of its 3s timeout, both siblings pass, server and client are dead. Debug+ASAN: fails at 24.4s of 27s, same result. The `afterAll` reaper fires at file end (checked with a temporary log, 0 processes left).

**Concurrency limits and memory**

`bun test` runs at most `--max-concurrency` tests at once: 20 by default, 5 when the build has ASAN (`src/options_types/context.rs`). Peak RSS per case: about 40 MB for the dev server and 110 MB for the client on release, 400 MB and 120 MB on debug+ASAN. So 20 release cases need about 3 GB, 5 ASAN cases about 2.6 GB. The file is in `excludeFiles` of `test/parallel-allowlist.json`, so the CI runner runs it alone in its serial phase.

Release, pinned to 4 cores (`taskset`), 10 runs: 2.2 to 3.9s, all pass. Pinned to 2 cores, 5 runs: 4.0 to 4.2s, all pass. Debug+ASAN pinned to 8 cores, 4 runs: 13.4 to 13.5s, all pass.

**Other harness users**

`bun bd test test/bake/dev/ test/bake/dev-and-prod.test.ts`: 155 pass, 0 fail (22 files, 425s debug+ASAN), run after every harness change. The interactive mode (`bun test/bake/dev/bundle.test.ts "<filter>"`) still starts: `test.concurrent` and `afterAll` throw outside the test runner the same way `test` does, and the harness catches them.

The harness module is evaluated once per `bun test` process, so an `afterAll` at module scope reached only the first file of a multi-file run. `testImpl` registers it the first time a file adds a test. `stackTraceFileName` used to keep the line number in the caller path on posix (it took the `s` of `.ts` before the first colon for a drive letter), so the per-file key needed that fixed too. Test names and temp directories are unchanged.

**Assertions**

`expect()` calls: 44 before, 45 after. The final fetch in "removing 'use client' from a component with a pending resolution failure" returns 500 today through a runtime error page (#40113, fix in #40115) and a "Build Failed" page once that lands. The route has an unresolved import either way, so the status is the stable assertion.
</details>
