### PR TITLE
test(buffer-jit): speed up buffer-jit.test.ts and pin exact compile counts

### DIFF
--- a/test/js/node/buffer-jit.test.ts
+++ b/test/js/node/buffer-jit.test.ts
@@ -689,8 +689,9 @@ describe.concurrent("Buffer accessor JIT", () => {
   });
 
   // The two large-view scenarios allocate 3GB and 4GB. The pages are never touched, so the cost is
-  // address space and the allocator's consent, not RSS; still, only ask on a machine that has it.
-  const enoughMemory = totalmem() >= 8 * 1024 ** 3;
+  // address space, not RSS, but the kernel refuses an allocation larger than physical memory up
+  // front. 6GB admits the 8GB-class CI runners and excludes machines where 4GB would not fit.
+  const enoughMemory = totalmem() >= 6 * 1024 ** 3;
 
   test.skipIf(!enoughMemory)("a >2GB receiver stays optimized: no exit storm, and OOB still throws", async () => {
     const result = await scenario(`

--- a/test/js/node/buffer-jit.test.ts
+++ b/test/js/node/buffer-jit.test.ts
@@ -16,8 +16,7 @@ import { totalmem } from "node:os";
 // and turns the concurrent JIT off, so a function reaches the FTL within a handful of calls and
 // numberOfDFGCompiles() is exact. Optimized code that keeps exiting is jettisoned and recompiled
 // after 20 exits instead of 100, so every exit -> recompile chain below settles within a few
-// hundred calls. (Not jitPolicyScale: Bun applies BUN_JSC_ options one at a time and JSC
-// re-applies the scale on every change, so the result would depend on how many options are set.)
+// hundred calls. (Not jitPolicyScale: until #40583, Bun applied it once per BUN_JSC_ variable.)
 const jitEnv = {
   ...bunEnv,
   BUN_JSC_forceEagerCompilation: "1",

--- a/test/js/node/buffer-jit.test.ts
+++ b/test/js/node/buffer-jit.test.ts
@@ -167,12 +167,17 @@ describe.concurrent("Buffer accessor JIT", () => {
       });
     `,
     );
+    // The plain object defeats the intrinsic's receiver check and, when the FTL compiled the site
+    // after the property lookup's inline cache had filled, the structure check of that lookup too:
+    // 2 or 3 compiles, depending on when the compiles landed. The other chains do not depend on it.
     expect(result).toEqual({
-      "plain object receiver": { compiles: 3, outcomes: ["throw:TypeError:ERR_INVALID_ARG_TYPE"] },
+      "plain object receiver": { compiles: expect.any(Number), outcomes: ["throw:TypeError:ERR_INVALID_ARG_TYPE"] },
       "detached receiver": { compiles: 2, outcomes: ["throw:RangeError:ERR_BUFFER_OUT_OF_BOUNDS"] },
       "value out of int8 range": { compiles: 2, outcomes: ["throw:RangeError:ERR_OUT_OF_RANGE"] },
       "fractional value": { compiles: 3, outcomes: ["value:201"] }, // truncated to 1, no throw
     });
+    expect(result["plain object receiver"].compiles).toBeGreaterThanOrEqual(2);
+    expect(result["plain object receiver"].compiles).toBeLessThanOrEqual(3);
   });
 
   test("a value the compiler has proven non-integral exits once and does not recompile in a loop", async () => {
@@ -431,8 +436,11 @@ describe.concurrent("Buffer accessor JIT", () => {
       report(compiles);
     `);
     // The warm site was compiled once, and each change of what b.readInt32LE resolves to costs it at
-    // most one recompile (a site that already handles both callees absorbs the restore for free).
-    expect(result).toMatchObject({ warm: 1, afterInstanceShadow: 2, afterPrototypeReplace: 3 });
+    // most one recompile. The first change always costs one (the callee the intrinsic was inlined for
+    // is gone). Whether the later ones cost another depends on when the compiles landed: the site
+    // may already check the structure of the lookup, or already handle both callees.
+    expect(result).toMatchObject({ warm: 1, afterInstanceShadow: 2 });
+    expect(result.afterPrototypeReplace).toBeLessThanOrEqual(3);
     expect(result.afterPrototypeRestore).toBeLessThanOrEqual(4);
   });
 
@@ -497,8 +505,14 @@ describe.concurrent("Buffer accessor JIT", () => {
     function rand() { seed ^= seed << 13; seed |= 0; seed ^= seed >>> 17; seed ^= seed << 5; seed |= 0; return (seed >>> 0) / 4294967296; }
     function randInt(lo, hi) { return lo + ((rand() * (hi - lo + 1)) | 0); }
     function pick(list) { return list[(rand() * list.length) | 0]; }
-    const names = Object.getOwnPropertyNames(Buffer.prototype).filter(n => /^(read|write)(U?Int|Float|Double|Big)/.test(n));
-    const readers = names.filter(n => n.startsWith("read")), writers = names.filter(n => n.startsWith("write"));
+    // The accessors under test, listed here rather than read off Buffer.prototype, so the seeded
+    // stream depends on the seed alone and not on the order of the prototype's property table.
+    const kinds = ["Int8", "UInt8", "Int16LE", "Int16BE", "UInt16LE", "UInt16BE", "Int32LE", "Int32BE", "UInt32LE", "UInt32BE",
+      "BigInt64LE", "BigInt64BE", "BigUInt64LE", "BigUInt64BE", "FloatLE", "FloatBE", "DoubleLE", "DoubleBE", "IntLE", "IntBE", "UIntLE", "UIntBE"];
+    const readers = kinds.map(k => "read" + k), writers = kinds.map(k => "write" + k);
+    for (const name of [...readers, ...writers]) {
+      if (typeof Buffer.prototype[name] !== "function") throw new Error(name + " is not a Buffer.prototype method");
+    }
     function describeName(name) {
       const isWrite = name.startsWith("write"), isFloat = /Float|Double/.test(name), isBigInt = /Big/.test(name);
       const isVarWidth = /Int(LE|BE)$/.test(name) && !/(8|16|32|64)/.test(name), isSigned = !/UInt/.test(name);
@@ -697,11 +711,13 @@ describe.concurrent("Buffer accessor JIT", () => {
     const referenceResult = JSON.parse(reference.stdout);
     // The JIT arm reproduces the interpreter's trace exactly.
     expect(jitResult).toEqual(referenceResult);
-    // A meaningful volume ran: many accessors, dirty inputs that threw, and receivers that were resized.
-    expect(referenceResult.ops).toBeGreaterThan(isDebug ? 1_000 : 30_000);
-    expect(referenceResult.accessors).toBeGreaterThan(isDebug ? 4 : 25);
-    expect(referenceResult.throws).toBeGreaterThan(isDebug ? 100 : 10_000);
-    if (!isDebug) expect(referenceResult.resizes).toBeGreaterThan(10);
+    // The stream is a function of the seed and the accessor list alone, so its shape is fixed: how
+    // many operations ran, how many distinct accessors they hit, how many receivers were resized.
+    // Which dirty inputs throw is the host's decision, so that count only has to be large.
+    expect(referenceResult).toMatchObject(
+      isDebug ? { ops: 1800, accessors: 4, resizes: 0 } : { ops: 34000, accessors: 30, resizes: 13 },
+    );
+    expect(referenceResult.throws).toBeGreaterThan(isDebug ? 500 : 9_000);
   });
 
   // The two large-view scenarios allocate 3GB and 4GB. The pages are never touched, so the cost is

--- a/test/js/node/buffer-jit.test.ts
+++ b/test/js/node/buffer-jit.test.ts
@@ -37,9 +37,13 @@ async function run(source: string, extraEnv: Record<string, string> = {}) {
 
 // Warm-up calls on the fast path: reaches the FTL many times over under this tier-up policy.
 const N = 500;
-// Repetitions of an input that makes optimized code exit: enough for several exit -> recompile
-// rounds, so a site that never settles shows up as a runaway compile count.
+// Repetitions of an input that makes optimized code exit, in the tests that pin compile counts
+// after a change of receiver or method: enough for the exit, the jettison after 20 of them, the
+// recompile, and a long run of the recompiled code.
 const T = 300;
+// Calls per host-semantics case. Each call exits the compiled site, so the jettison and the
+// recompile without the intrinsic are over by call 50. The rest runs the recompiled code.
+const R = 150;
 
 // Shared prelude: helpers and a deterministic buffer.
 const prelude = `
@@ -49,7 +53,7 @@ function report(result) { console.log(JSON.stringify(result)); }
 const buf = Buffer.alloc(256);
 const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
 for (let i = 0; i < buf.length; i++) buf[i] = (i * 37 + 11) & 0xff;
-const N = ${N}, T = ${T};
+const N = ${N}, T = ${T}, R = ${R};
 `;
 
 // Runs a scenario and returns the object it passed to report(). The scenario body is the harness
@@ -84,8 +88,15 @@ describe.concurrent("Buffer accessor JIT", () => {
   });
 
   // Each case gets its own call site: warm it on the fast path, then keep feeding it one input that
-  // makes the optimized code exit, with a fast call in between. The site must settle on a bounded
-  // number of recompiles, and every exit must land on the same answer as the host.
+  // makes the optimized code exit, with a fast call in between, until the site has settled. Every
+  // exit must land on the same answer as the host.
+  //
+  // Optimized code is jettisoned after osrExitCountForReoptimization exits, doubled for every
+  // recompile the function already had (CodeBlock::adjustedExitCountThreshold), so a site whose
+  // latest code still exits on every bad call recompiles again within 20 << (compiles - 1)
+  // iterations plus a short re-warm. The loop runs until the compile count has held still for
+  // longer than that, so the count it reports is final. A site that never settles reads 7 or more
+  // at the 2000-iteration cap.
   //
   // compiles: 1 for the warm-up plus 1 per speculation the bad input defeats, each followed by a
   // recompile without it. outcomes: a single entry means every exit produced the host's answer,
@@ -101,11 +112,14 @@ describe.concurrent("Buffer accessor JIT", () => {
       const expected = outcome(fn, fast);
       for (let i = 0; i < N; i++) assert(outcome(fn, fast) === expected, "warm-up");
       const seen = new Set();
-      for (let i = 0; i < T; i++) {
+      let compiles = numberOfDFGCompiles(fn), lastRecompile = 0;
+      for (let i = 0; i < 2000 && i - lastRecompile <= (20 << (compiles - 1)) + 100; i++) {
         seen.add(outcome(fn, bad));
         assert(outcome(fn, fast) === expected, "the fast path between exits");
+        const now = numberOfDFGCompiles(fn);
+        if (now !== compiles) { compiles = now; lastRecompile = i; }
       }
-      return { compiles: numberOfDFGCompiles(fn), outcomes: [...seen] };
+      return { compiles, outcomes: [...seen] };
     }
     noInline(exercise); noFTL(exercise);
   `;
@@ -183,31 +197,33 @@ describe.concurrent("Buffer accessor JIT", () => {
     // uint32 writers' Int52 conversion exits with Int52Overflow and the int8 writer's Int32
     // conversion exits unconditionally (Uncountable). Neither is the BadType exit a boxed argument
     // produces, and both must stop the intrinsic from being inlined again: one exit, one recompile,
-    // 2 compiles. A compiler that inlines it again after these exit kinds reaches 10 or more here.
+    // 2 compiles. A compiler that inlines it again after these exit kinds exits on every call and
+    // reads 5 here (recompiles after 20, 60, 140 and 300 exits).
     expect(result).toEqual({ writeUInt32LE: 2, writeUIntBE: 2, writeInt8: 2 });
   });
 
   // Host semantics under the JIT: each case is its own function, so its constants are compiled into
-  // the call site, and it runs T times on a zeroed scratch buffer. The outcome of a call is what it
+  // the call site, and it runs R times on a zeroed scratch buffer. The outcome of a call is what it
   // returned and what the bytes say afterwards, or what it threw. One outcome per case means every
   // call gave the host's answer, from the first (interpreted) to the last (compiled, or recompiled
   // after an exit).
   const semanticsHelpers = `
     const s = Buffer.alloc(16);
     const sv = new DataView(s.buffer, s.byteOffset, s.byteLength);
+    function bytesAfter(readBack) { return readBack ? ", bytes " + String(readBack()) : ""; }
+    noInline(bytesAfter); noFTL(bytesAfter);
     function effect(fn, i, readBack) {
-      const bytes = () => (readBack ? ", bytes " + String(readBack()) : "");
-      try { return "returns " + String(fn(s, i)) + bytes(); }
-      catch (e) { return "throws " + e.constructor.name + ":" + e.code + bytes(); }
+      try { return "returns " + String(fn(s, i)) + bytesAfter(readBack); }
+      catch (e) { return "throws " + e.constructor.name + ":" + e.code + bytesAfter(readBack); }
     }
     noInline(effect); noFTL(effect);
     function outcomesOf(cases) {
       const outcomes = {};
       for (const [name, [fn, readBack]] of Object.entries(cases)) {
         noInline(fn);
-        if (readBack) noInline(readBack);
+        if (readBack) { noInline(readBack); noFTL(readBack); } // harness, like effect
         const seen = new Set();
-        for (let i = 0; i < T; i++) {
+        for (let i = 0; i < R; i++) {
           sv.setBigUint64(0, 0n, true); // the bytes a write may touch start out zero on every call
           seen.add(effect(fn, i, readBack));
         }
@@ -279,7 +295,7 @@ describe.concurrent("Buffer accessor JIT", () => {
         "uint64 negative": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
       },
       // The value is coerced exactly once per call, even when the call then throws.
-      coerced: 2 * T,
+      coerced: 2 * R,
     });
   });
 
@@ -715,7 +731,8 @@ describe.concurrent("Buffer accessor JIT", () => {
     `);
     // The site sees three things worth one recompile each, in an order that depends on when the
     // first compile lands: offset + 4 overflowing int32 at the ceiling, a second receiver shape, and
-    // a straddling offset that is not an int32. A site that keeps exiting reaches 8 or more here.
+    // a straddling offset that is not an int32. A site that keeps exiting on every call has 1800
+    // exits to spend here and reads 6 or 7 (the exit budget doubles with every recompile).
     expect(result.straddling).toEqual(["ERR_OUT_OF_RANGE"]);
     expect(result.compiles.readAt).toBeLessThanOrEqual(5);
     expect(result.compiles.writeAt).toBeLessThanOrEqual(5);
@@ -746,7 +763,8 @@ describe.concurrent("Buffer accessor JIT", () => {
     `);
     // The last stores landed at byteOffset + offset (seen through a DataView over the whole 4GB
     // buffer), and a read past the end of the tiny high-offset view throws. wide.length is 2**31,
-    // not an int32, so offsets computed from it cost the site a recompile or two, not a storm.
+    // not an int32, so offsets computed from it cost the site a recompile or two; a site that keeps
+    // exiting on every call has 1000 exits to spend here and reads 6.
     expect(result).toMatchObject({ tailStore: N - 1, wideStore: ~(N - 1), straddling: "ERR_OUT_OF_RANGE" });
     expect(result.compiles.readAt).toBeLessThanOrEqual(5);
     expect(result.compiles.writeAt).toBeLessThanOrEqual(5);

--- a/test/js/node/buffer-jit.test.ts
+++ b/test/js/node/buffer-jit.test.ts
@@ -196,8 +196,9 @@ describe.concurrent("Buffer accessor JIT", () => {
     const s = Buffer.alloc(16);
     const sv = new DataView(s.buffer, s.byteOffset, s.byteLength);
     function effect(fn, i, readBack) {
-      try { return "returns " + String(fn(s, i)) + (readBack ? ", bytes " + String(readBack()) : ""); }
-      catch (e) { return "throws " + e.constructor.name + ":" + e.code + ", bytes " + String(readBack()); }
+      const bytes = () => (readBack ? ", bytes " + String(readBack()) : "");
+      try { return "returns " + String(fn(s, i)) + bytes(); }
+      catch (e) { return "throws " + e.constructor.name + ":" + e.code + bytes(); }
     }
     noInline(effect); noFTL(effect);
     function outcomesOf(cases) {

--- a/test/js/node/buffer-jit.test.ts
+++ b/test/js/node/buffer-jit.test.ts
@@ -5,21 +5,28 @@
 // speculation failure lands back on the correct host behavior, that loads and stores are not
 // mis-ordered or mis-CSE'd, and that swapping the method is respected.
 //
-// It runs each scenario in a fresh subprocess with the concurrent JIT off and a deterministic tier-up
-// policy, so numberOfDFGCompiles() is meaningful.
+// Each scenario runs in a fresh subprocess and reports one JSON object (compile counts, outcomes)
+// that the test compares as a whole.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
+
+// One eager, deterministic tier-up policy for every subprocess. forceEagerCompilation compiles a
+// function to baseline after 10 and to DFG and FTL after 20 execution counts (a call counts 15)
+// and turns the concurrent JIT off, so a function reaches the FTL within a handful of calls and
+// numberOfDFGCompiles() is exact. Optimized code that keeps exiting is jettisoned and recompiled
+// after 20 exits instead of 100, so every exit -> recompile chain below settles within a few
+// hundred calls. (Not jitPolicyScale: Bun applies BUN_JSC_ options one at a time and JSC
+// re-applies the scale on every change, so the result would depend on how many options are set.)
+const jitEnv = {
+  ...bunEnv,
+  BUN_JSC_forceEagerCompilation: "1",
+  BUN_JSC_osrExitCountForReoptimization: "20",
+};
 
 async function run(source: string, extraEnv: Record<string, string> = {}) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", source],
-    env: {
-      ...bunEnv,
-      BUN_JSC_useConcurrentJIT: "0",
-      // Tier up quickly and deterministically, but not so eagerly that profiling is skipped.
-      BUN_JSC_jitPolicyScale: "0.05",
-      ...extraEnv,
-    },
+    env: { ...jitEnv, ...extraEnv },
     stderr: "pipe",
     stdout: "pipe",
   });
@@ -27,175 +34,255 @@ async function run(source: string, extraEnv: Record<string, string> = {}) {
   return { stdout, stderr, exitCode };
 }
 
-// Shared prelude: helpers + a deterministic buffer.
+// Warm-up calls on the fast path: reaches the FTL many times over under this tier-up policy.
+const N = 500;
+// Repetitions of an input that makes optimized code exit: enough for several exit -> recompile
+// rounds, so a site that never settles shows up as a runaway compile count.
+const T = 300;
+
+// Shared prelude: helpers and a deterministic buffer.
 const prelude = `
-const { numberOfDFGCompiles, noInline } = require("bun:jsc");
+const { numberOfDFGCompiles, noInline, noFTL } = require("bun:jsc");
 function assert(condition, message) { if (!condition) throw new Error("Assertion failed: " + message); }
+function report(result) { console.log(JSON.stringify(result)); }
 const buf = Buffer.alloc(256);
 const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
 for (let i = 0; i < buf.length; i++) buf[i] = (i * 37 + 11) & 0xff;
-const N = 20000;
+const N = ${N}, T = ${T};
 `;
 
+// Runs a scenario and returns the object it passed to report(). The scenario body is the harness
+// around the functions under test (which are noInline'd and compiled on their own), so it runs in
+// the DFG only: FTL-compiling its loops costs seconds per scenario in a debug build and proves nothing.
+async function scenario(source: string, extraEnv?: Record<string, string>) {
+  const { stdout, stderr, exitCode } = await run(
+    prelude + "function main() {" + source + "}\nnoFTL(main);\nmain();\n",
+    extraEnv,
+  );
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
 describe.concurrent("Buffer accessor JIT", () => {
-  test("the JIT path is actually taken, and compile counts converge", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+  test("the JIT path is taken and the fast path never exits", async () => {
+    const result = await scenario(`
       function read(b, o) { return b.readInt32LE(o); }
       function write(b, v, o) { return b.writeInt32LE(v, o); }
       noInline(read); noInline(write);
       for (let i = 0; i < N; i++) {
-        assert(read(buf, i & 63) === dv.getInt32(i & 63, true), "read");
-        assert(write(buf, i, (i & 63) + 128) === (i & 63) + 132, "write");
-        assert(dv.getInt32((i & 63) + 128, true) === i, "write store");
+        assert(read(buf, i & 63) === dv.getInt32(i & 63, true), "read at " + i);
+        assert(write(buf, i, (i & 63) + 128) === (i & 63) + 132, "write at " + i);
+        assert(dv.getInt32((i & 63) + 128, true) === i, "write store at " + i);
       }
-      const readCompiles = numberOfDFGCompiles(read);
-      const writeCompiles = numberOfDFGCompiles(write);
-      // Compiled at least once (the intrinsic did not stop the DFG from taking these), and no
-      // OSR-exit -> recompile storm: a well-behaved call site converges in a handful of compiles.
-      assert(readCompiles >= 1 && readCompiles <= 4, "read compiles: " + readCompiles);
-      assert(writeCompiles >= 1 && writeCompiles <= 4, "write compiles: " + writeCompiles);
-      console.log("OK");
+      report({ read: numberOfDFGCompiles(read), write: numberOfDFGCompiles(write) });
+    `);
+    // Exactly one optimizing compile each: the intrinsic did not stop the DFG from taking the
+    // function, and nothing on the fast path exited and forced a recompile.
+    expect(result).toEqual({ read: 1, write: 1 });
+  });
+
+  // Each case gets its own call site: warm it on the fast path, then keep feeding it one input that
+  // makes the optimized code exit, with a fast call in between. The site must settle on a bounded
+  // number of recompiles, and every exit must land on the same answer as the host.
+  //
+  // compiles: 1 for the warm-up plus 1 per speculation the bad input defeats, each followed by a
+  // recompile without it. outcomes: a single entry means every exit produced the host's answer,
+  // from the first (optimized) call to the last (recompiled) one.
+  const exitHelpers = `
+    function outcome(fn, args) {
+      try { return "value:" + String(fn(args[0], args[1], args[2])); }
+      catch (e) { return "throw:" + e.constructor.name + ":" + e.code; }
+    }
+    noInline(outcome); noFTL(outcome);
+    function exercise(fn, fast, bad) {
+      noInline(fn);
+      const expected = outcome(fn, fast);
+      for (let i = 0; i < N; i++) assert(outcome(fn, fast) === expected, "warm-up");
+      const seen = new Set();
+      for (let i = 0; i < T; i++) {
+        seen.add(outcome(fn, bad));
+        assert(outcome(fn, fast) === expected, "the fast path between exits");
+      }
+      return { compiles: numberOfDFGCompiles(fn), outcomes: [...seen] };
+    }
+    noInline(exercise); noFTL(exercise);
+  `;
+
+  test("an offset that defeats a speculation exits to the host error and converges", async () => {
+    const result = await scenario(
+      exitHelpers +
+        `
+      report({
+        "past the end": exercise((b, o) => b.readInt32LE(o), [buf, 12], [buf, buf.length]),
+        "negative": exercise((b, o) => b.readInt32LE(o), [buf, 12], [buf, -1]),
+        "fractional": exercise((b, o) => b.readInt32LE(o), [buf, 12], [buf, 1.5]),
+        "a string": exercise((b, o) => b.readInt32LE(o), [buf, 12], [buf, "4"]),
+      });
     `,
     );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+    // An out-of-bounds offset defeats one check. A fractional offset defeats three in turn: the
+    // int32 speculation on the argument, then the double-to-int32 conversion, then the offset check
+    // inside the intrinsic, after which the site calls the host directly.
+    expect(result).toEqual({
+      "past the end": { compiles: 2, outcomes: ["throw:RangeError:ERR_OUT_OF_RANGE"] },
+      "negative": { compiles: 2, outcomes: ["throw:RangeError:ERR_OUT_OF_RANGE"] },
+      "fractional": { compiles: 4, outcomes: ["throw:RangeError:ERR_OUT_OF_RANGE"] },
+      "a string": { compiles: 3, outcomes: ["throw:TypeError:ERR_INVALID_ARG_TYPE"] },
+    });
+  });
 
-  test("each speculation exit converges instead of looping", async () => {
-    // Warm up on the fast path, then keep triggering one exit kind at the same call site: the
-    // site must fall back to a stable state (bounded recompiles), not exit -> recompile forever.
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
+  test("a receiver or value that defeats a speculation exits to the host behavior and converges", async () => {
+    const result = await scenario(
+      exitHelpers +
         `
-      function readAt(b, o) { return b.readInt32LE(o); }
-      noInline(readAt);
-      function writeAt(b, v, o) { return b.writeInt8(v, o); }
-      noInline(writeAt);
-      for (let i = 0; i < N; i++) {
-        readAt(buf, i & 63);
-        writeAt(buf, i & 127, i & 63);
-      }
-      // Carries the real accessor, so the call reaches it and fails the receiver check itself
-      // (rather than throwing "not a function" at the property lookup).
-      const badReceiver = { length: 4, readInt32LE: Buffer.prototype.readInt32LE };
+      // Detach first: detaching any ArrayBuffer fires a watchpoint that jettisons every compiled
+      // function that assumed no buffer had been detached, which would add a recompile to
+      // whichever case happened to be running.
       const detached = Buffer.alloc(8);
       structuredClone(detached.buffer, { transfer: [detached.buffer] });
-      const exits = [
-        () => readAt(buf, buf.length),        // out of bounds
-        () => readAt(buf, -1),                // negative offset
-        () => readAt(buf, 1.5),               // fractional offset
-        () => readAt(buf, "4"),               // wrong offset type
-        () => readAt(badReceiver, 0),         // wrong receiver: a plain object
-        () => readAt(detached, 0),            // detached
-        () => writeAt(buf, 200, 0),           // value out of int8 range
-        () => writeAt(buf, 1.5, 0),           // fractional value (host truncates; no throw)
-      ];
-      for (const trigger of exits) {
-        for (let i = 0; i < 2000; i++) {
-          try { trigger(); } catch {}
-          readAt(buf, i & 63); // and the fast path keeps working in between
-        }
-      }
-      const compiles = Math.max(numberOfDFGCompiles(readAt), numberOfDFGCompiles(writeAt));
-      assert(compiles <= 8, "compile count did not converge: " + compiles);
-      assert(readAt(buf, 12) === dv.getInt32(12, true), "still correct after all the exits");
-      console.log("OK");
+      // Carries the real accessor, so the call reaches it and fails the receiver check itself
+      // (rather than throwing "not a function" at the property lookup).
+      const plain = { length: 256, readInt32LE: Buffer.prototype.readInt32LE };
+      report({
+        "plain object receiver": exercise((b, o) => b.readInt32LE(o), [buf, 12], [plain, 0]),
+        "detached receiver": exercise((b, o) => b.readInt32LE(o), [buf, 12], [detached, 0]),
+        "value out of int8 range": exercise((b, v, o) => b.writeInt8(v, o), [buf, 5, 200], [buf, 200, 200]),
+        "fractional value": exercise((b, v, o) => b.writeInt8(v, o), [buf, 5, 200], [buf, 1.5, 200]),
+      });
     `,
     );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+    expect(result).toEqual({
+      "plain object receiver": { compiles: 3, outcomes: ["throw:TypeError:ERR_INVALID_ARG_TYPE"] },
+      "detached receiver": { compiles: 2, outcomes: ["throw:RangeError:ERR_BUFFER_OUT_OF_BOUNDS"] },
+      "value out of int8 range": { compiles: 2, outcomes: ["throw:RangeError:ERR_OUT_OF_RANGE"] },
+      "fractional value": { compiles: 3, outcomes: ["value:201"] }, // truncated to 1, no throw
+    });
+  });
 
-  test("a fractional value the compiler has proven non-integral does not cause a recompile loop", async () => {
-    // The integer writers truncate a fractional number (no throw). When the value reaches the call as
-    // an unboxed double that is known to be non-integral, the uint32 writers' Int52 conversion exits
-    // with Int52Overflow and the int8 writer's Int32 conversion exits unconditionally (Uncountable);
-    // neither is the BadType exit a boxed argument produces, and both must stop the site from being
-    // inlined again. Runs at the default tier-up policy, where the loop shows up as ~10 compiles.
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+  test("a value the compiler has proven non-integral exits once and does not recompile in a loop", async () => {
+    const result = await scenario(`
       function writeHalfU32(b, v, o) { return b.writeUInt32LE(v * 0.5, o); }
-      noInline(writeHalfU32);
       function writeHalfVarU32(b, v, o) { return b.writeUIntBE(v * 0.5, o, 4); }
-      noInline(writeHalfVarU32);
       function writeHalfI8(b, v, o) { return b.writeInt8(v * 0.5, o); }
-      noInline(writeHalfI8);
-      for (let i = 0; i < N * 10; i++) {
-        const v = (i & 127) | 1;
-        assert(writeHalfU32(buf, v, 64) === 68 && dv.getUint32(64, true) === (v * 0.5) >>> 0, "writeUInt32LE(fraction)");
-        assert(writeHalfVarU32(buf, v, 68) === 72 && dv.getUint32(68, false) === (v * 0.5) >>> 0, "writeUIntBE(fraction, 4)");
-        assert(writeHalfI8(buf, v, 72) === 73 && dv.getInt8(72) === ((v * 0.5) | 0), "writeInt8(fraction)");
+      noInline(writeHalfU32); noInline(writeHalfVarU32); noInline(writeHalfI8);
+      for (let i = 0; i < N; i++) {
+        const v = (i & 127) | 1; // odd, so v * 0.5 is never an integer
+        assert(writeHalfU32(buf, v, 64) === 68 && dv.getUint32(64, true) === (v * 0.5) >>> 0, "writeUInt32LE(fraction) at " + i);
+        assert(writeHalfVarU32(buf, v, 68) === 72 && dv.getUint32(68, false) === (v * 0.5) >>> 0, "writeUIntBE(fraction, 4) at " + i);
+        assert(writeHalfI8(buf, v, 72) === 73 && dv.getInt8(72) === ((v * 0.5) | 0), "writeInt8(fraction) at " + i);
       }
-      const compiles = Math.max(numberOfDFGCompiles(writeHalfU32), numberOfDFGCompiles(writeHalfVarU32), numberOfDFGCompiles(writeHalfI8));
-      assert(compiles <= 4, "compile count did not converge: " + compiles);
-      console.log("OK");
-    `,
-      { BUN_JSC_jitPolicyScale: "1" },
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      report({
+        writeUInt32LE: numberOfDFGCompiles(writeHalfU32),
+        writeUIntBE: numberOfDFGCompiles(writeHalfVarU32),
+        writeInt8: numberOfDFGCompiles(writeHalfI8),
+      });
+    `);
+    // The value reaches the call as an unboxed double the compiler knows is non-integral: the
+    // uint32 writers' Int52 conversion exits with Int52Overflow and the int8 writer's Int32
+    // conversion exits unconditionally (Uncountable). Neither is the BadType exit a boxed argument
+    // produces, and both must stop the intrinsic from being inlined again: one exit, one recompile,
+    // 2 compiles. A compiler that inlines it again after these exit kinds reaches 10 or more here.
+    expect(result).toEqual({ writeUInt32LE: 2, writeUIntBE: 2, writeInt8: 2 });
+  });
 
-  test("host semantics survive every exit path (results, not just compile counts)", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
+  // Host semantics under the JIT: each case is its own function, so its constants are compiled into
+  // the call site, and it runs T times on a zeroed scratch buffer. The outcome of a call is what it
+  // returned and what the bytes say afterwards, or what it threw. One outcome per case means every
+  // call gave the host's answer, from the first (interpreted) to the last (compiled, or recompiled
+  // after an exit).
+  const semanticsHelpers = `
+    const s = Buffer.alloc(16);
+    const sv = new DataView(s.buffer, s.byteOffset, s.byteLength);
+    function effect(fn, i, readBack) {
+      try { return "returns " + String(fn(s, i)) + (readBack ? ", bytes " + String(readBack()) : ""); }
+      catch (e) { return "throws " + e.constructor.name + ":" + e.code + ", bytes " + String(readBack()); }
+    }
+    noInline(effect); noFTL(effect);
+    function outcomesOf(cases) {
+      const outcomes = {};
+      for (const [name, [fn, readBack]] of Object.entries(cases)) {
+        noInline(fn);
+        if (readBack) noInline(readBack);
+        const seen = new Set();
+        for (let i = 0; i < T; i++) {
+          sv.setBigUint64(0, 0n, true); // the bytes a write may touch start out zero on every call
+          seen.add(effect(fn, i, readBack));
+        }
+        assert(numberOfDFGCompiles(fn) >= 1, name + " was never compiled");
+        outcomes[name] = [...seen];
+      }
+      return outcomes;
+    }
+    noInline(outcomesOf); noFTL(outcomesOf);
+  `;
+
+  test("host semantics survive the JIT: values that the accessor converts and stores", async () => {
+    const result = await scenario(
+      semanticsHelpers +
         `
-      function read(b, o) { return b.readUInt16BE(o); }
-      function write(b, v, o) { return b.writeUInt16LE(v, o); }
-      noInline(read); noInline(write);
-      for (let i = 0; i < N; i++) { read(buf, i & 63); write(buf, i & 0xffff, (i & 63) + 128); }
-      // Non-int32 but valid inputs the JIT does not speculate on must produce the host result.
-      assert(read(buf, 4.0) === dv.getUint16(4, false), "integral double offset");
-      const scratch = Buffer.alloc(8);
-      assert(scratch.writeUInt16LE(1.5, 0) === 2, "fractional value returns offset + 2");
-      assert(scratch.readUInt16LE(0) === 1, "fractional value truncates");
-      assert(scratch.writeUInt16LE(NaN, 0) === 2 && scratch.readUInt16LE(0) === 0, "NaN stores 0");
-      assert(scratch.writeUInt16LE({ valueOf() { return 7; } }, 2) === 4 && scratch.readUInt16LE(2) === 7, "valueOf value");
+      s.writeUInt16BE(0xbeef, 12);
+      report(outcomesOf({
+        // (i & 8) * 1.5 is 0 or 12: an integral offset that arrives as a double, not an int32.
+        "integral double offset": [(b, i) => b.readUInt16BE((i & 8) * 1.5)],
+        "fractional value truncates": [b => b.writeUInt16LE(1.5, 0), () => sv.getUint16(0, true)],
+        "NaN stores 0 (uint16)": [b => b.writeUInt16LE(NaN, 0), () => sv.getUint16(0, true)],
+        "NaN stores 0 (int8)": [b => b.writeInt8(NaN, 0), () => sv.getInt8(0)],
+        "NaN stores 0 (variable width)": [b => b.writeUIntLE(NaN, 0, 3), () => sv.getUint32(0, true) & 0xffffff],
+        "valueOf supplies the value": [b => b.writeUInt16LE({ valueOf() { return 7; } }, 2), () => sv.getUint16(2, true)],
+        "int64 minimum": [b => b.writeBigInt64LE(-(2n ** 63n), 0), () => String(sv.getBigInt64(0, true))],
+        "uint64 maximum": [b => b.writeBigUInt64BE(2n ** 64n - 1n, 0), () => String(sv.getBigUint64(0, false))],
+      }));
+    `,
+    );
+    expect(result).toEqual({
+      "integral double offset": ["returns 0", "returns 48879"], // 0xbeef at offset 12
+      "fractional value truncates": ["returns 2, bytes 1"],
+      "NaN stores 0 (uint16)": ["returns 2, bytes 0"],
+      "NaN stores 0 (int8)": ["returns 1, bytes 0"],
+      "NaN stores 0 (variable width)": ["returns 3, bytes 0"],
+      "valueOf supplies the value": ["returns 4, bytes 7"],
+      "int64 minimum": ["returns 8, bytes -9223372036854775808"],
+      "uint64 maximum": ["returns 8, bytes 18446744073709551615"],
+    });
+  });
+
+  test("host semantics survive the JIT: values that the accessor rejects", async () => {
+    const result = await scenario(
+      semanticsHelpers +
+        `
       let coerced = 0;
       const counting = { valueOf() { coerced++; return 300; } };
-      for (let i = 0; i < 1000; i++) {
-        try { scratch.writeInt8(counting, 0); assert(false, "should throw"); } catch (e) { assert(e.code === "ERR_OUT_OF_RANGE", "range code"); }
-        try { scratch.writeInt8(counting, 100); assert(false, "should throw"); } catch (e) { assert(e.code === "ERR_OUT_OF_RANGE", "an out-of-range value at an out-of-range offset is still ERR_OUT_OF_RANGE"); }
-      }
-      assert(coerced === 2000, "value coerced exactly once per call, even when it then throws: " + coerced);
-      // The BigInt writers: too-wide BigInts throw; the widest valid ones store.
-      // NaN and +-Infinity, which the value range check treats differently (Node stores 0 for NaN
-      // but throws for the infinities), must keep doing so once the write is JIT-compiled.
-      for (let i = 0; i < 2000; i++) {
-        assert(scratch.writeInt8(NaN, 0) === 1 && scratch.readInt8(0) === 0, "NaN stores 0 (int8)");
-        assert(scratch.writeUInt16LE(NaN, 0) === 2 && scratch.readUInt16LE(0) === 0, "NaN stores 0 (uint16)");
-        assert(scratch.writeUIntLE(NaN, 0, 3) === 3 && scratch.readUIntLE(0, 3) === 0, "NaN stores 0 (var width)");
-        for (const [f, what] of [[() => scratch.writeInt8(Infinity, 0), "int8 +Inf"], [() => scratch.writeInt8(-Infinity, 0), "int8 -Inf"], [() => scratch.writeIntLE(Infinity, 0, 4), "var-width +Inf"]]) {
-          try { f(); assert(false, what + " should throw"); } catch (e) { assert(e.code === "ERR_OUT_OF_RANGE", what + ": " + e.code); }
-        }
-      }
-
-      const bb = Buffer.alloc(8);
-      const bd = new DataView(bb.buffer, bb.byteOffset, 8);
-      for (let i = 0; i < 2000; i++) {
-        assert(bb.writeBigInt64LE(-(2n ** 63n), 0) === 8 && bd.getBigInt64(0, true) === -(2n ** 63n), "int64 min");
-        assert(bb.writeBigUInt64BE(2n ** 64n - 1n, 0) === 8 && bd.getBigUint64(0, false) === 2n ** 64n - 1n, "uint64 max");
-        try { bb.writeBigInt64LE(2n ** 63n, 0); assert(false, "should throw"); } catch (e) { assert(e.code === "ERR_OUT_OF_RANGE", "int64 too big"); }
-        try { bb.writeBigUInt64LE(-1n, 0); assert(false, "should throw"); } catch (e) { assert(e.code === "ERR_OUT_OF_RANGE", "uint64 negative"); }
-      }
-      console.log("OK");
+      const outcomes = outcomesOf({
+        "out-of-range valueOf value": [b => b.writeInt8(counting, 0), () => sv.getInt8(0)],
+        "out-of-range valueOf value at an out-of-range offset": [b => b.writeInt8(counting, 100), () => sv.getInt8(0)],
+        "+Infinity (int8)": [b => b.writeInt8(Infinity, 0), () => sv.getInt8(0)],
+        "-Infinity (int8)": [b => b.writeInt8(-Infinity, 0), () => sv.getInt8(0)],
+        "+Infinity (variable width)": [b => b.writeIntLE(Infinity, 0, 4), () => sv.getInt32(0, true)],
+        "int64 too large": [b => b.writeBigInt64LE(2n ** 63n, 0), () => String(sv.getBigInt64(0, true))],
+        "uint64 negative": [b => b.writeBigUInt64LE(-1n, 0), () => String(sv.getBigUint64(0, true))],
+      });
+      report({ outcomes, coerced });
     `,
     );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+    // Where the host throws, the bytes stay untouched.
+    expect(result).toEqual({
+      outcomes: {
+        "out-of-range valueOf value": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
+        "out-of-range valueOf value at an out-of-range offset": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
+        "+Infinity (int8)": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
+        "-Infinity (int8)": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
+        "+Infinity (variable width)": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
+        "int64 too large": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
+        "uint64 negative": ["throws RangeError:ERR_OUT_OF_RANGE, bytes 0"],
+      },
+      // The value is coerced exactly once per call, even when the call then throws.
+      coerced: 2 * T,
+    });
+  });
 
   test("no stale reads: a store between two loads of the same offset is observed", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+    const result = await scenario(`
       function readWriteRead(b, o, v) {
         const before = b.readInt32LE(o);
         b.writeInt32LE(v, o);
@@ -224,18 +311,13 @@ describe.concurrent("Buffer accessor JIT", () => {
         const [a, c, d] = readAroundOtherStores(buf, o, i);
         assert(a === a0 && c === (i & 0xff) && d === ((i + 1) & 0xff), "typed array / DataView stores observed at " + i);
       }
-      console.log("OK");
-    `,
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      report({ readWriteRead: numberOfDFGCompiles(readWriteRead), readAroundOtherStores: numberOfDFGCompiles(readAroundOtherStores) });
+    `);
+    expect(result).toEqual({ readWriteRead: 1, readAroundOtherStores: 1 });
+  });
 
   test("two Buffers over the same ArrayBuffer are never mis-aliased", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+    const result = await scenario(`
       const backing = new ArrayBuffer(64);
       const a = Buffer.from(backing);          // views over the SAME memory
       const b = Buffer.from(backing, 8, 32);
@@ -263,25 +345,19 @@ describe.concurrent("Buffer accessor JIT", () => {
         return sum;
       }
       noInline(sumWhileWriting);
-      a.writeUInt8(3, 12);
       let expected = 0, cell = 3;
       for (let i = 0; i < 500; i++) { expected += cell; cell = (expected + i) & 0xff; }
-      for (let i = 0; i < 200; i++) {
+      for (let i = 0; i < 50; i++) {
         a.writeUInt8(3, 12);
-        assert(sumWhileWriting(500) === expected, "loop with aliasing store");
+        assert(sumWhileWriting(500) === expected, "loop with aliasing store at call " + i);
       }
-      console.log("OK");
-    `,
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      report({ crossViewReadAfterWrite: numberOfDFGCompiles(crossViewReadAfterWrite), sumWhileWriting: numberOfDFGCompiles(sumWhileWriting) });
+    `);
+    expect(result).toEqual({ crossViewReadAfterWrite: 1, sumWhileWriting: 1 });
+  });
 
   test("a loop-carried load is not kept alive across a call that mutates the buffer", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+    const result = await scenario(`
       let mutations = 0;
       function mutate(b) { b.writeUInt8((++mutations) & 0xff, 0); }
       noInline(mutate);
@@ -295,103 +371,114 @@ describe.concurrent("Buffer accessor JIT", () => {
         return last;
       }
       noInline(readAroundCall);
-      for (let i = 0; i < 300; i++) {
+      for (let i = 0; i < 100; i++) {
         buf.writeUInt8(200, 0);
         mutations = 0;
         const last = readAroundCall(buf, 100);
-        assert(last === (99 & 0xff), "the read is re-done each iteration after the call: got " + last);
+        assert(last === 99, "the read is re-done each iteration after the call: got " + last + " at call " + i);
       }
-      console.log("OK");
-    `,
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      report({ mutate: numberOfDFGCompiles(mutate), readAroundCall: numberOfDFGCompiles(readAroundCall) });
+    `);
+    expect(result).toEqual({ mutate: 1, readAroundCall: 1 });
+  });
 
   test("replacing or shadowing the method after tier-up takes effect", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+    const result = await scenario(`
       function readViaMethod(b, o) { return b.readInt32LE(o); }
       noInline(readViaMethod);
       for (let i = 0; i < N; i++) assert(readViaMethod(buf, i & 63) === dv.getInt32(i & 63, true), "warm");
+      const compiles = { warm: numberOfDFGCompiles(readViaMethod) };
 
       // 1. Shadow on one instance: only that receiver changes behavior.
       const special = Buffer.alloc(16);
       special.readInt32LE = function () { return 424242; };
-      for (let i = 0; i < 5000; i++) {
+      for (let i = 0; i < T; i++) {
         assert(readViaMethod(special, 0) === 424242, "instance shadow at " + i);
         assert(readViaMethod(buf, 4) === dv.getInt32(4, true), "normal buffer unaffected at " + i);
       }
+      compiles.afterInstanceShadow = numberOfDFGCompiles(readViaMethod);
 
       // 2. Replace on the prototype: every receiver changes behavior, immediately.
       const original = Buffer.prototype.readInt32LE;
       Buffer.prototype.readInt32LE = function (o) { return -original.call(this, o) - 1; };
-      for (let i = 0; i < 5000; i++) {
+      for (let i = 0; i < T; i++) {
         assert(readViaMethod(buf, i & 63) === -dv.getInt32(i & 63, true) - 1, "prototype replaced at " + i);
       }
+      compiles.afterPrototypeReplace = numberOfDFGCompiles(readViaMethod);
       Buffer.prototype.readInt32LE = original;
-      for (let i = 0; i < 5000; i++) {
+      for (let i = 0; i < T; i++) {
         assert(readViaMethod(buf, i & 63) === dv.getInt32(i & 63, true), "prototype restored at " + i);
       }
-      console.log("OK");
-    `,
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      compiles.afterPrototypeRestore = numberOfDFGCompiles(readViaMethod);
+      report(compiles);
+    `);
+    // The warm site was compiled once, and each change of what b.readInt32LE resolves to costs it at
+    // most one recompile (a site that already handles both callees absorbs the restore for free).
+    expect(result).toMatchObject({ warm: 1, afterInstanceShadow: 2, afterPrototypeReplace: 3 });
+    expect(result.afterPrototypeRestore).toBeLessThanOrEqual(4);
+  });
 
   test("resizable and growable receivers keep tracking the length after tier-up", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+    const result = await scenario(`
       function readEnd(b) { return b.readUInt16LE(b.length - 2); }
       function readAt(b, o) { return b.readUInt16LE(o); }
       noInline(readEnd); noInline(readAt);
       // Warm on fixed-size buffers first so the resizable ones arrive after optimization.
       for (let i = 0; i < N; i++) { readEnd(buf); readAt(buf, i & 63); }
+      const compiles = { warm: [numberOfDFGCompiles(readEnd), numberOfDFGCompiles(readAt)] };
 
       const rab = new ArrayBuffer(16, { maxByteLength: 128 });
       const tracking = Buffer.from(rab); // length-tracking view
       tracking.writeUInt16LE(0xabcd, 14);
-      for (let i = 0; i < 5000; i++) assert(readEnd(tracking) === 0xabcd, "before grow");
+      for (let i = 0; i < T; i++) assert(readEnd(tracking) === 0xabcd, "before grow at " + i);
       rab.resize(128);
       tracking.writeUInt16LE(0x1234, 126);
-      for (let i = 0; i < 5000; i++) {
-        assert(readEnd(tracking) === 0x1234, "after grow");
-        assert(readAt(tracking, 126) === 0x1234, "read into the grown region");
+      for (let i = 0; i < T; i++) {
+        assert(readEnd(tracking) === 0x1234, "after grow at " + i);
+        assert(readAt(tracking, 126) === 0x1234, "read into the grown region at " + i);
       }
       rab.resize(8);
-      for (let i = 0; i < 2000; i++) {
-        try { readAt(tracking, 14); assert(false, "must throw after shrink"); }
-        catch (e) { assert(e.code === "ERR_OUT_OF_RANGE" || e.code === "ERR_BUFFER_OUT_OF_BOUNDS", "shrink error: " + e.code); }
+      const shrinkErrors = new Set();
+      for (let i = 0; i < T; i++) {
+        try { readAt(tracking, 14); shrinkErrors.add("no throw"); }
+        catch (e) { shrinkErrors.add(e.code); }
       }
+      compiles.afterResizable = [numberOfDFGCompiles(readEnd), numberOfDFGCompiles(readAt)];
 
       const gsab = new SharedArrayBuffer(16, { maxByteLength: 128 });
       const shared = Buffer.from(gsab);
       shared.writeUInt16LE(0x5678, 14);
-      for (let i = 0; i < 5000; i++) assert(readEnd(shared) === 0x5678, "shared before grow");
+      for (let i = 0; i < T; i++) assert(readEnd(shared) === 0x5678, "shared before grow at " + i);
       gsab.grow(128);
       shared.writeUInt16LE(0x9abc, 126);
-      for (let i = 0; i < 5000; i++) assert(readEnd(shared) === 0x9abc, "shared after grow");
-      console.log("OK");
-    `,
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      for (let i = 0; i < T; i++) assert(readEnd(shared) === 0x9abc, "shared after grow at " + i);
+      compiles.afterGrowable = [numberOfDFGCompiles(readEnd), numberOfDFGCompiles(readAt)];
+      report({ compiles, shrinkErrors: [...shrinkErrors] });
+    `);
+    // A view over a resizable buffer has its own structure, so each site recompiles once when it
+    // first sees one, and readAt once more when the shrink puts its offset out of bounds. The
+    // growable shared buffer is then handled by the code that already tracks the length.
+    expect(result).toEqual({
+      compiles: { warm: [1, 1], afterResizable: [2, 3], afterGrowable: [2, 3] },
+      shrinkErrors: ["ERR_OUT_OF_RANGE"],
+    });
+  });
 
   // Differential fuzzer: an identical seeded operation stream runs once with the JIT and once with
-  // BUN_JSC_useJIT=0; the two traces (return values, error codes/messages, and the buffer bytes
-  // after every write) must match. Ported from JSTests/stress/buffer-accessor-jit-differential.js.
+  // BUN_JSC_useJIT=0; the two traces (return values, error class/code/message, and the receiver's
+  // length and bytes after every operation) must match. Ported from
+  // JSTests/stress/buffer-accessor-jit-differential.js.
+  //
+  // Debug builds compile 50-100x slower, so they run a short DFG-only round as a smoke test; the
+  // release and release-ASAN lanes carry the full FTL coverage.
+  const fuzzerEnv = isDebug ? { BUN_JSC_useFTLJIT: "0" } : {};
   const fuzzerSource = `
+    const { noInline, noFTL } = require("bun:jsc");
+    const ROUNDS = ${isDebug ? 6 : 40}, STEPS = ${isDebug ? 300 : 850};
     let seed = 0x9e3779b1;
     function rand() { seed ^= seed << 13; seed |= 0; seed ^= seed >>> 17; seed ^= seed << 5; seed |= 0; return (seed >>> 0) / 4294967296; }
-    function pick(list) { return list[(rand() * list.length) | 0]; }
     function randInt(lo, hi) { return lo + ((rand() * (hi - lo + 1)) | 0); }
+    function pick(list) { return list[(rand() * list.length) | 0]; }
     const names = Object.getOwnPropertyNames(Buffer.prototype).filter(n => /^(read|write)(U?Int|Float|Double|Big)/.test(n));
     const readers = names.filter(n => n.startsWith("read")), writers = names.filter(n => n.startsWith("write"));
     function describeName(name) {
@@ -400,137 +487,239 @@ describe.concurrent("Buffer accessor JIT", () => {
       const byteSize = /Double/.test(name) ? 8 : /Float/.test(name) ? 4 : isBigInt ? 8 : isVarWidth ? 0 : Number(name.match(/(8|16|32|64)/)[0]) / 8;
       return { isWrite, isFloat, isBigInt, isVarWidth, isSigned, byteSize };
     }
+    // A value the accessor accepts: the edges of its range and something in between.
     function cleanValue(shape, size) {
-      if (shape.isBigInt) return pick(shape.isSigned ? [-(2n ** 63n), 2n ** 63n - 1n, 0n, -1n, BigInt(randInt(-1e6, 1e6))] : [0n, 2n ** 64n - 1n, 12345678901234567890n, BigInt(randInt(0, 1e6))]);
-      if (shape.isFloat) return pick([() => rand() * 1e6 - 5e5, () => Math.fround(rand() * 100), () => -0, () => Infinity, () => 2 ** -1074, () => 1e300])();
+      if (shape.isBigInt) {
+        switch (randInt(0, 3)) {
+          case 0: return shape.isSigned ? -(2n ** 63n) : 0n;
+          case 1: return shape.isSigned ? 2n ** 63n - 1n : 2n ** 64n - 1n;
+          case 2: return shape.isSigned ? -1n : 12345678901234567890n;
+          default: return BigInt(randInt(shape.isSigned ? -1e6 : 0, 1e6));
+        }
+      }
+      if (shape.isFloat) {
+        switch (randInt(0, 5)) {
+          case 0: return rand() * 1e6 - 5e5;
+          case 1: return Math.fround(rand() * 100);
+          case 2: return -0;
+          case 3: return Infinity;
+          case 4: return 2 ** -1074;
+          default: return 1e300;
+        }
+      }
       const min = shape.isSigned ? -(2 ** (8 * size - 1)) : 0, max = shape.isSigned ? 2 ** (8 * size - 1) - 1 : 2 ** (8 * size) - 1;
-      return pick([() => min, () => max, () => randInt(min, max), () => randInt(min, max), () => 0])();
+      switch (randInt(0, 4)) {
+        case 0: return min;
+        case 1: return max;
+        case 2: return 0;
+        default: return randInt(min, max);
+      }
     }
-    const dirtyValue = () => pick([() => (rand() * 2 ** 32) | 0, () => -((rand() * 2 ** 31) | 0), () => 2 ** 31, () => 2 ** 32, () => -(2 ** 31) - 1,
-      () => rand() * 1e6 - 5e5, () => 0.5, () => -0.5, () => -0, () => NaN, () => Infinity, () => -Infinity, () => 2 ** 53 + 1,
-      () => "42", () => "abc", () => "", () => true, () => false, () => null, () => undefined,
-      () => 5n, () => 2n ** 63n, () => 2n ** 64n, () => -1n, () => -(2n ** 63n) - 1n, () => Symbol("v")])();
-    const dirtyOffset = length => pick([() => randInt(0, length + 3), () => -randInt(1, 8), () => length - randInt(0, 8), () => rand() * length,
-      () => -0, () => 2 ** 31 + randInt(0, 8), () => 2 ** 32, () => 2 ** 53 + 2, () => NaN, () => Infinity, () => -Infinity,
-      () => undefined, () => null, () => String(randInt(0, length)), () => "not a number", () => true, () => Symbol("s"), () => 3n])();
-    const dirtyByteLength = () => pick([() => randInt(1, 6), () => 0, () => 7, () => -1, () => 2.5, () => NaN, () => "4", () => undefined, () => 9n])();
+    // Anything at all: out-of-range and non-integral numbers, every other primitive, BigInts of every size.
+    function dirtyValue() {
+      switch (randInt(0, 25)) {
+        case 0: return (rand() * 2 ** 32) | 0;
+        case 1: return -((rand() * 2 ** 31) | 0);
+        case 2: return 2 ** 31;
+        case 3: return 2 ** 32;
+        case 4: return -(2 ** 31) - 1;
+        case 5: return rand() * 1e6 - 5e5;
+        case 6: return 0.5;
+        case 7: return -0.5;
+        case 8: return -0;
+        case 9: return NaN;
+        case 10: return Infinity;
+        case 11: return -Infinity;
+        case 12: return 2 ** 53 + 1;
+        case 13: return "42";
+        case 14: return "abc";
+        case 15: return "";
+        case 16: return true;
+        case 17: return false;
+        case 18: return null;
+        case 19: return undefined;
+        case 20: return 5n;
+        case 21: return 2n ** 63n;
+        case 22: return 2n ** 64n;
+        case 23: return -1n;
+        case 24: return -(2n ** 63n) - 1n;
+        default: return Symbol("v");
+      }
+    }
+    function dirtyOffset(length) {
+      switch (randInt(0, 17)) {
+        case 0: return randInt(0, length + 3);
+        case 1: return -randInt(1, 8);
+        case 2: return length - randInt(0, 8);
+        case 3: return rand() * length;
+        case 4: return -0;
+        case 5: return 2 ** 31 + randInt(0, 8);
+        case 6: return 2 ** 32;
+        case 7: return 2 ** 53 + 2;
+        case 8: return NaN;
+        case 9: return Infinity;
+        case 10: return -Infinity;
+        case 11: return undefined;
+        case 12: return null;
+        case 13: return String(randInt(0, length));
+        case 14: return "not a number";
+        case 15: return true;
+        case 16: return Symbol("s");
+        default: return 3n;
+      }
+    }
+    function dirtyByteLength() {
+      switch (randInt(0, 8)) {
+        case 0: return randInt(1, 6);
+        case 1: return 0;
+        case 2: return 7;
+        case 3: return -1;
+        case 4: return 2.5;
+        case 5: return NaN;
+        case 6: return "4";
+        case 7: return undefined;
+        default: return 9n;
+      }
+    }
     function makeReceiver() {
-      return pick([() => Buffer.alloc(32), () => Buffer.from(new ArrayBuffer(64), 8, 24), () => Buffer.alloc(7),
-        () => Buffer.from(new ArrayBuffer(16, { maxByteLength: 64 })),
-        () => Buffer.from(new ArrayBuffer(48, { maxByteLength: 64 }), 8, 16)])();
+      switch (randInt(0, 4)) {
+        case 0: return Buffer.alloc(32);
+        case 1: return Buffer.from(new ArrayBuffer(64), 8, 24);
+        case 2: return Buffer.alloc(7);
+        case 3: return Buffer.from(new ArrayBuffer(16, { maxByteLength: 64 }));
+        default: return Buffer.from(new ArrayBuffer(48, { maxByteLength: 64 }), 8, 16);
+      }
     }
+    // One call site per accessor. noInline keeps it out of the driver loop, so the driver is not
+    // recompiled every round and the accessor call is compiled (and recompiled after exits) on its own.
     function makeInvoker(name) {
       if (!/^[A-Za-z0-9]+$/.test(name)) throw new Error("bad name " + name);
-      return new Function("return function invoke_" + name + "(receiver, args, box) { try { let result;" +
+      const invoke = new Function("return function invoke_" + name + "(receiver, args, box) { try { let result;" +
         " switch (args.length) { case 0: result = receiver." + name + "(); break;" +
         " case 1: result = receiver." + name + "(args[0]); break;" +
         " case 2: result = receiver." + name + "(args[0], args[1]); break;" +
         " default: result = receiver." + name + "(args[0], args[1], args[2]); break; }" +
         " box.value = result; box.error = null; } catch (e) { box.value = undefined;" +
         " box.error = e === null || typeof e !== 'object' ? 'throw:' + String(e) : 'throw:' + e.constructor.name + ':' + (e.code === undefined ? '' : e.code) + ':' + e.message; } };")();
+      noInline(invoke);
+      return invoke;
     }
     const invokers = new Map();
     const invokerFor = name => { let f = invokers.get(name); if (!f) invokers.set(name, (f = makeInvoker(name))); return f; };
-    const fmt = v => typeof v === "bigint" ? v + "n" : typeof v === "symbol" ? "Symbol" : Object.is(v, -0) ? "-0" : String(v);
+    // FNV-1a over 32-bit words. A number enters as its exact bits (so -0 and 0 differ), an error or
+    // a BigInt as the crc32 of its text, and the receiver as its length and the crc32 of its bytes.
     let digest = 0x811c9dc5;
-    const mix = str => { for (let i = 0; i < str.length; i++) { digest ^= str.charCodeAt(i); digest = Math.imul(digest, 0x01000193); } };
+    const mix = word => { digest = Math.imul(digest ^ word, 0x01000193); };
+    const bits = new Float64Array(1), words = new Uint32Array(bits.buffer);
+    let throws = 0;
+    function mixOutcome(box) {
+      if (box.error !== null) { throws++; mix(1); mix(Bun.hash.crc32(box.error)); return; }
+      const value = box.value;
+      switch (typeof value) {
+        case "number": bits[0] = value; mix(2); mix(words[0]); mix(words[1]); return;
+        case "bigint": mix(3); mix(Bun.hash.crc32(String(value))); return;
+        case "undefined": mix(4); return;
+        default: throw new Error("unexpected result type " + typeof value);
+      }
+    }
     const box = { value: undefined, error: null };
-    let ops = 0;
-    for (let round = 0; round < 40; ++round) {
-      const receiver = makeReceiver();
-      const name = pick(rand() < 0.5 ? readers : writers);
-      const shape = describeName(name), clean = rand() < 0.6, invoke = invokerFor(name);
-      const width = shape.isVarWidth ? randInt(1, 6) : shape.byteSize;
-      let resizeCountdown = clean ? Infinity : 100 + randInt(0, 400);
-      for (let step = 0; step < 850; ++step) {
-        const args = [];
-        const maxOffset = receiver.length - width;
-        if (clean) {
-          if (maxOffset < 0) break;
-          if (shape.isWrite) args.push(cleanValue(shape, width));
-          args.push(randInt(0, maxOffset));
-          if (shape.isVarWidth) args.push(width);
-        } else {
-          if (shape.isWrite) args.push(dirtyValue());
-          if (rand() < 0.9 || shape.isVarWidth) args.push(dirtyOffset(receiver.length));
-          if (shape.isVarWidth) args.push(dirtyByteLength());
-          while (args.length && args[args.length - 1] === undefined && rand() < 0.3) args.pop();
-          if (args.length && typeof args[args.length - 1] === "symbol" && rand() < 0.5) args[args.length - 1] = 0;
-        }
-        invoke(receiver, args, box);
-        ops++;
-        let bytes;
-        try { bytes = Array.prototype.join.call(receiver, ","); } catch { bytes = "<oob>"; }
-        mix(name + "|" + args.map(fmt).join(",") + "=>" + (box.error === null ? fmt(box.value) : box.error) + "|" + bytes);
-        if (--resizeCountdown === 0) {
-          resizeCountdown = 100 + randInt(0, 400);
-          const ab = receiver.buffer;
-          if (typeof ab.resize === "function" && ab.resizable) { try { ab.resize(randInt(0, ab.maxByteLength)); } catch {} }
+    let ops = 0, resizes = 0;
+    // The driver is the harness around the invokers, which are compiled on their own: it runs in the
+    // DFG only, since FTL-compiling it proves nothing and costs seconds in a debug build.
+    function drive() {
+      for (let round = 0; round < ROUNDS; ++round) {
+        const receiver = makeReceiver();
+        const name = pick(rand() < 0.5 ? readers : writers);
+        const shape = describeName(name), clean = rand() < 0.6, invoke = invokerFor(name);
+        const width = shape.isVarWidth ? randInt(1, 6) : shape.byteSize;
+        let resizeCountdown = clean ? Infinity : 100 + randInt(0, 400);
+        for (let step = 0; step < STEPS; ++step) {
+          const args = [];
+          const maxOffset = receiver.length - width;
+          if (clean) {
+            if (maxOffset < 0) break;
+            if (shape.isWrite) args.push(cleanValue(shape, width));
+            args.push(randInt(0, maxOffset));
+            if (shape.isVarWidth) args.push(width);
+          } else {
+            if (shape.isWrite) args.push(dirtyValue());
+            if (rand() < 0.9 || shape.isVarWidth) args.push(dirtyOffset(receiver.length));
+            if (shape.isVarWidth) args.push(dirtyByteLength());
+            while (args.length && args[args.length - 1] === undefined && rand() < 0.3) args.pop();
+            if (args.length && typeof args[args.length - 1] === "symbol" && rand() < 0.5) args[args.length - 1] = 0;
+          }
+          invoke(receiver, args, box);
+          ops++;
+          mixOutcome(box);
+          mix(receiver.length);
+          mix(Bun.hash.crc32(receiver));
+          if (--resizeCountdown === 0) {
+            resizeCountdown = 100 + randInt(0, 400);
+            const ab = receiver.buffer;
+            if (typeof ab.resize === "function" && ab.resizable) { resizes++; try { ab.resize(randInt(0, ab.maxByteLength)); } catch {} }
+          }
         }
       }
     }
-    console.log("digest=" + (digest >>> 0).toString(16) + " ops=" + ops);
+    noFTL(drive);
+    drive();
+    console.log(JSON.stringify({ digest: (digest >>> 0).toString(16), ops, throws, resizes, accessors: invokers.size }));
   `;
 
   test("differential fuzzer: JIT and useJIT=0 agree on every result, error and byte", async () => {
-    const [jit, reference] = await Promise.all([run(fuzzerSource), run(fuzzerSource, { BUN_JSC_useJIT: "0" })]);
+    const [jit, reference] = await Promise.all([
+      run(fuzzerSource, fuzzerEnv),
+      run(fuzzerSource, { ...fuzzerEnv, BUN_JSC_useJIT: "0" }),
+    ]);
     expect(jit.stderr).toBe("");
     expect(reference.stderr).toBe("");
     expect(jit.exitCode).toBe(0);
     expect(reference.exitCode).toBe(0);
-    const parse = (out: string) =>
-      Object.fromEntries(
-        out
-          .trim()
-          .split(/\s+/)
-          .map(kv => kv.split("=")),
-      );
-    const jitResult = parse(jit.stdout),
-      referenceResult = parse(reference.stdout);
-    // A meaningful volume actually ran, and the JIT arm reproduces the interpreter's trace exactly.
-    expect(Number(referenceResult.ops)).toBeGreaterThan(20_000);
-    expect(jitResult.ops).toBe(referenceResult.ops);
-    expect(jitResult.digest).toBe(referenceResult.digest);
-  }, 120_000);
+    const jitResult = JSON.parse(jit.stdout);
+    const referenceResult = JSON.parse(reference.stdout);
+    // The JIT arm reproduces the interpreter's trace exactly.
+    expect(jitResult).toEqual(referenceResult);
+    // A meaningful volume ran: many accessors, dirty inputs that threw, and receivers that were resized.
+    expect(referenceResult.ops).toBeGreaterThan(isDebug ? 1_000 : 30_000);
+    expect(referenceResult.accessors).toBeGreaterThan(isDebug ? 4 : 25);
+    expect(referenceResult.throws).toBeGreaterThan(isDebug ? 100 : 10_000);
+    if (!isDebug) expect(referenceResult.resizes).toBeGreaterThan(10);
+  });
 
   test("a >2GB receiver stays optimized: no exit storm, and OOB still throws", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+    const result = await scenario(`
       let big;
-      try { big = new Uint8Array(3 * 2**30); } catch { console.log("OK"); process.exit(0); }
+      try { big = new Uint8Array(3 * 2**30); } catch { report({ skipped: "could not allocate 3GB" }); process.exit(0); }
       Object.setPrototypeOf(big, Buffer.prototype);
       const small = Buffer.alloc(64);
       function readAt(b, o) { return b.readInt32LE(o); }
       function writeAt(b, v, o) { return b.writeInt32LE(v, o); }
       noInline(readAt); noInline(writeAt);
       const top = 2 ** 31 - 4;
-      for (let i = 0; i < N * 10; i++) {
-        assert(writeAt(big, i, 100) === 104, "write low");
-        assert(readAt(big, 100) === i, "read low");
-        assert(writeAt(big, ~i, top) === top + 4, "write at the int32 offset ceiling");
-        assert(readAt(big, top) === ~i, "read at the int32 offset ceiling");
-        assert(writeAt(small, i, 60) === 64 && readAt(small, 60) === i, "the same site with a small receiver");
+      for (let i = 0; i < N; i++) {
+        assert(writeAt(big, i, 100) === 104, "write low at " + i);
+        assert(readAt(big, 100) === i, "read low at " + i);
+        assert(writeAt(big, ~i, top) === top + 4, "write at the int32 offset ceiling at " + i);
+        assert(readAt(big, top) === ~i, "read at the int32 offset ceiling at " + i);
+        assert(writeAt(small, i, 60) === 64 && readAt(small, 60) === i, "the same site with a small receiver at " + i);
       }
-      const compiles = Math.max(numberOfDFGCompiles(readAt), numberOfDFGCompiles(writeAt));
-      assert(compiles <= 3, "the large receiver caused recompiles: " + compiles);
-      let threw = 0;
-      for (let i = 0; i < 200; i++) { try { readAt(big, big.length - 3); } catch (e) { threw += e.code === "ERR_OUT_OF_RANGE"; } }
-      assert(threw === 200, "straddling the end of a >2GB view throws");
-      console.log("OK");
-    `,
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 120_000);
+      const straddling = new Set();
+      for (let i = 0; i < T; i++) { try { readAt(big, big.length - 3); straddling.add("no throw"); } catch (e) { straddling.add(e.code); } }
+      report({ compiles: { readAt: numberOfDFGCompiles(readAt), writeAt: numberOfDFGCompiles(writeAt) }, straddling: [...straddling] });
+    `);
+    if (result.skipped) return;
+    // The site sees three things worth one recompile each, in an order that depends on when the
+    // first compile lands: offset + 4 overflowing int32 at the ceiling, a second receiver shape, and
+    // a straddling offset that is not an int32. A site that keeps exiting reaches 8 or more here.
+    expect(result.straddling).toEqual(["ERR_OUT_OF_RANGE"]);
+    expect(result.compiles.readAt).toBeLessThanOrEqual(5);
+    expect(result.compiles.writeAt).toBeLessThanOrEqual(5);
+  });
 
   test("views with 2GB and ~4GB byteOffsets read and write correctly after tier-up", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      prelude +
-        `
+    const result = await scenario(`
       let ab;
-      try { ab = new ArrayBuffer(4 * 2**30); } catch { console.log("OK"); process.exit(0); }
+      try { ab = new ArrayBuffer(4 * 2**30); } catch { report({ skipped: "could not allocate 4GB" }); process.exit(0); }
       const tailOffset = 4 * 2**30 - 64;
       const tail = Buffer.from(ab, tailOffset, 64);
       const wide = Buffer.from(ab, 2**31);
@@ -539,19 +728,24 @@ describe.concurrent("Buffer accessor JIT", () => {
       function writeAt(v, x, o) { return v.writeInt32LE(x, o); }
       noInline(readAt); noInline(writeAt);
       for (let i = 0; i < N; i++) {
-        assert(writeAt(tail, i, 8) === 12 && readAt(tail, 8) === i, "~4GB byteOffset view");
-        assert(writeAt(wide, ~i, wide.length - 4) === wide.length && readAt(wide, wide.length - 4) === ~i, "2GB byteOffset view");
+        assert(writeAt(tail, i, 8) === 12 && readAt(tail, 8) === i, "~4GB byteOffset view at " + i);
+        assert(writeAt(wide, ~i, wide.length - 4) === wide.length && readAt(wide, wide.length - 4) === ~i, "2GB byteOffset view at " + i);
       }
-      assert(raw.getInt32(tailOffset + 8, true) === N - 1, "the store landed at byteOffset + offset");
-      assert(raw.getInt32(2**31 + wide.length - 4, true) === ~(N - 1), "the store landed at the 2GB byteOffset");
-      let threw = false;
-      try { readAt(tail, 61); } catch (e) { threw = e.code === "ERR_OUT_OF_RANGE"; }
-      assert(threw, "straddling the end of the tiny high-offset view throws");
-      console.log("OK");
-    `,
-    );
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  }, 120_000);
+      let straddling;
+      try { readAt(tail, 61); straddling = "no throw"; } catch (e) { straddling = e.code; }
+      report({
+        tailStore: raw.getInt32(tailOffset + 8, true),
+        wideStore: raw.getInt32(2**31 + wide.length - 4, true),
+        compiles: { readAt: numberOfDFGCompiles(readAt), writeAt: numberOfDFGCompiles(writeAt) },
+        straddling,
+      });
+    `);
+    if (result.skipped) return;
+    // The last stores landed at byteOffset + offset (seen through a DataView over the whole 4GB
+    // buffer), and a read past the end of the tiny high-offset view throws. wide.length is 2**31,
+    // not an int32, so offsets computed from it cost the site a recompile or two, not a storm.
+    expect(result).toMatchObject({ tailStore: N - 1, wideStore: ~(N - 1), straddling: "ERR_OUT_OF_RANGE" });
+    expect(result.compiles.readAt).toBeLessThanOrEqual(5);
+    expect(result.compiles.writeAt).toBeLessThanOrEqual(5);
+  });
 });

--- a/test/js/node/buffer-jit.test.ts
+++ b/test/js/node/buffer-jit.test.ts
@@ -9,6 +9,7 @@
 // that the test compares as a whole.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug } from "harness";
+import { totalmem } from "node:os";
 
 // One eager, deterministic tier-up policy for every subprocess. forceEagerCompilation compiles a
 // function to baseline after 10 and to DFG and FTL after 20 execution counts (a call counts 15)
@@ -686,10 +687,13 @@ describe.concurrent("Buffer accessor JIT", () => {
     if (!isDebug) expect(referenceResult.resizes).toBeGreaterThan(10);
   });
 
-  test("a >2GB receiver stays optimized: no exit storm, and OOB still throws", async () => {
+  // The two large-view scenarios allocate 3GB and 4GB. The pages are never touched, so the cost is
+  // address space and the allocator's consent, not RSS; still, only ask on a machine that has it.
+  const enoughMemory = totalmem() >= 8 * 1024 ** 3;
+
+  test.skipIf(!enoughMemory)("a >2GB receiver stays optimized: no exit storm, and OOB still throws", async () => {
     const result = await scenario(`
-      let big;
-      try { big = new Uint8Array(3 * 2**30); } catch { report({ skipped: "could not allocate 3GB" }); process.exit(0); }
+      const big = new Uint8Array(3 * 2**30);
       Object.setPrototypeOf(big, Buffer.prototype);
       const small = Buffer.alloc(64);
       function readAt(b, o) { return b.readInt32LE(o); }
@@ -707,7 +711,6 @@ describe.concurrent("Buffer accessor JIT", () => {
       for (let i = 0; i < T; i++) { try { readAt(big, big.length - 3); straddling.add("no throw"); } catch (e) { straddling.add(e.code); } }
       report({ compiles: { readAt: numberOfDFGCompiles(readAt), writeAt: numberOfDFGCompiles(writeAt) }, straddling: [...straddling] });
     `);
-    if (result.skipped) return;
     // The site sees three things worth one recompile each, in an order that depends on when the
     // first compile lands: offset + 4 overflowing int32 at the ceiling, a second receiver shape, and
     // a straddling offset that is not an int32. A site that keeps exiting reaches 8 or more here.
@@ -716,10 +719,9 @@ describe.concurrent("Buffer accessor JIT", () => {
     expect(result.compiles.writeAt).toBeLessThanOrEqual(5);
   });
 
-  test("views with 2GB and ~4GB byteOffsets read and write correctly after tier-up", async () => {
+  test.skipIf(!enoughMemory)("views with 2GB and ~4GB byteOffsets read and write correctly after tier-up", async () => {
     const result = await scenario(`
-      let ab;
-      try { ab = new ArrayBuffer(4 * 2**30); } catch { report({ skipped: "could not allocate 4GB" }); process.exit(0); }
+      const ab = new ArrayBuffer(4 * 2**30);
       const tailOffset = 4 * 2**30 - 64;
       const tail = Buffer.from(ab, tailOffset, 64);
       const wide = Buffer.from(ab, 2**31);
@@ -740,7 +742,6 @@ describe.concurrent("Buffer accessor JIT", () => {
         straddling,
       });
     `);
-    if (result.skipped) return;
     // The last stores landed at byteOffset + offset (seen through a DataView over the whole 4GB
     // buffer), and a read past the end of the tiny high-offset view throws. wide.length is 2**31,
     // not an int32, so offsets computed from it cost the site a recompile or two, not a storm.


### PR DESCRIPTION
### Problem
- `test/js/node/buffer-jit.test.ts` took 31s on the debian 13 x64-asan lane (build #106056). Locally on a release-ASAN build it takes 6.3s, of which the differential fuzzer takes 5.7s. Under `bun bd test` the fuzzer hit its 120s timeout and the file failed.
- The fuzzer's trace built a string per operation (`Array.prototype.join` over the receiver plus `charCodeAt` over 150 to 250 chars). That was 86% of the `useJIT=0` arm under ASAN. Each test also ran 20000 warm-up calls and 2000 to 5000 exit repetitions, while the tier-up thresholds were already at their floor: Bun applies `BUN_JSC_` options one at a time and JSC re-applies `jitPolicyScale` on every change, so `0.05` was applied two or three times.

### Fix
- The trace mixes exact number bits, the crc32 of error text, and the crc32 of the receiver bytes. The invokers are `noInline`'d, so the driver loop is not recompiled every round. The value generators are `switch` statements instead of arrays of closures (68 fewer functions to compile).
- Every subprocess runs under `forceEagerCompilation=1` and `osrExitCountForReoptimization=20`: deterministic, eager tier-up with exit chains that settle within a few hundred calls. Warm-up loops are 500 calls. The harness code around each function under test stays out of the FTL (`noFTL`), which is what made debug builds slow.
- Every child reports a JSON object and the test compares it with `toEqual`: exact compile counts per speculation exit kind (each kind now gets its own warmed call site), and the outcome of every exit (error class and code, or value and stored bytes). The old version fed all exit kinds to one site, so only the first kind ever reached the intrinsic. An exit case runs until its compile count has held still for longer than the next recompile would need, so the count it reports is final. Counts that depend on when the first compile lands (the >2GB views, the prototype restore) keep a bound.
- Verified: `bun bd test test/js/node/buffer-jit.test.ts` (14 pass, 7.2s on 16 cores, 7.8s pinned to 4 cores). Also the release and release-ASAN builds, each 3 times. On CI (build 106224) the file took 1.76s on the x64-asan lane and 0.3s to 0.8s on the others, and every pinned count held on x64, aarch64, macOS and Windows.

| build | before | after |
| --- | --- | --- |
| release | 0.88s | 0.35s |
| release-ASAN (the CI lane) | 6.3s, fuzzer 5.7s | 2.0s, fuzzer 1.3s |
| `bun bd test` (debug+ASAN) | 125s, 1 timeout | 7.2s, 14 pass |

### Background
- `numberOfDFGCompiles(f)` from `bun:jsc` is 1 when `f` has an optimized replacement, plus 1 for each time that code was thrown away (jettisoned) and recompiled. Exactly 1 means the fast path never exited.
- An OSR exit is optimized code giving up on a speculation and falling back to baseline. After `osrExitCountForReoptimization` exits the code is jettisoned and the exit kind is recorded, so the next compile does not make that speculation. That exit budget doubles with every recompile the function already had (`CodeBlock::adjustedExitCountThreshold`). `BufferAccessorIntrinsic` in `DFGByteCodeParser.cpp` refuses to inline when it sees BadType, BadIndexingType, OutOfBounds, Int52Overflow or Uncountable at the call site.
- A chain like "fractional offset: 4 compiles" is one recompile per defeated speculation: the int32 argument check, then the double-to-int32 conversion (Overflow, not in that list, so the intrinsic is inlined once more), then the intrinsic's own check.
- Detaching any ArrayBuffer fires a watchpoint that jettisons all compiled code that assumed no detach had happened. The receiver test detaches before it warms anything.

<details><summary>Notes</summary>

**Where the time went (release-ASAN, 16 cores).** Fuzzer `useJIT=0` arm: 5.5s total, 4.75s in `join` + `mix`. Fuzzer JIT arm: 3.3s, of which 2.0s is compile time (`reportTotalCompileTimes`): 191 FTL compiles, 7 of them `FTLForOSREntry` of the top-level driver at 60ms each, because each new invoker was inlined into the driver and then exited. Other tests: 140 to 390ms each, mostly process start (100ms) and compile time.

**jitPolicyScale.** `ZigGlobalObject.cpp:364` calls `JSC::Options::setOption(env + 8)` per `BUN_JSC_` env var (in reverse envp order) with the default `verify = true`. Each call runs `notifyOptionsChanged`, which runs `scaleJITPolicy` whenever `jitPolicyScale` was overridden, so the scale is applied once per option (upstream `jsc.cpp` passes `verify = false` and notifies once). With `useConcurrentJIT=0` plus `jitPolicyScale=0.05` the effective thresholds were `thresholdForOptimizeAfterWarmUp=1` and `thresholdForFTLOptimizeAfterWarmUp=8` (via `BUN_JSC_dumpOptions=2`), and adding any third `BUN_JSC_` variable changed the compile counts. Explicit `thresholdFor*` options hit a different problem: `notifyOptionsChanged` asserts `thresholdForOptimizeAfterLongWarmUp >= thresholdForOptimizeAfterWarmUp` after each single option, so the env var order matters on assertion builds. `forceEagerCompilation` sets all of them in one step. The runtime fix is #40583 and does not block this one.

**Compile count determinism.** Each pinned count was checked with 300 to 5000 repetitions and N = 500, 1000, 5000 on release, release-ASAN and debug, and the exit kinds behind each chain were read with `BUN_JSC_verboseExitProfile=1`. The exit cases run until the count has held still for `(20 << (compiles - 1)) + 100` iterations, the budget the latest code would need to exit its way to one more recompile; the fractional-offset chain recompiles at iterations 20, 64 and 151 and the loop stops at 412. A site forced to exit on every call (`BUN_JSC_useOSRExitFuzz=1` on the case functions only) reads 8 at the 2000-iteration cap. Two counts are sensitive to when the first compile lands relative to the profile (polymorphic from the first call): the >2GB receiver test and the prototype-restore step. Those keep `<=` bounds.

**Debug builds.** An FTL compile costs 0.2 to 3s there, so the fuzzer runs 6 rounds of 300 steps with the FTL off as a smoke test. Release and release-ASAN run the full 40 x 850 with the FTL on. The host-semantics and exit tests are split in two each, every harness function is `noFTL`'d, and each semantics case runs 150 times, so the heaviest child takes 2.1s standalone and the file passes with the default 5s timeout pinned to 4 cores (5 runs). Pinned to 2 cores, two tests still time out.

**Memory gate.** The two large-view scenarios are `test.skipIf(totalmem() < 6GB)`. The CI runners for the release lanes report 7.8GB, the asan and alpine runners 16GB to 63GB. The old in-child `try/catch` around the allocation is gone: on a machine that passes the gate an allocation failure is a failure, not a silent pass.

**Coverage kept.** Every scenario of the old file is still present: JIT path taken, each exit kind (now on its own site), the Int52Overflow/Uncountable regression guard, host semantics for NaN, Infinity, valueOf, fractional values and BigInt limits, store/load ordering, aliasing views, loop-carried loads, method replacement, resizable and growable receivers, the differential fuzzer, and the >2GB and 4GB views.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/buffer-jit.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/buffer-jit.test.ts
bun test v1.4.1 (adc354d99)

test/js/node/buffer-jit.test.ts:
(pass) Buffer accessor JIT > the JIT path is taken and the fast path never exits [770.70ms]
(pass) Buffer accessor JIT > a value the compiler has proven non-integral exits once and does not recompile in a loop [877.75ms]
(pass) Buffer accessor JIT > a receiver or value that defeats a speculation exits to the host behavior and converges [1570.15ms]
(pass) Buffer accessor JIT > host semantics survive the JIT: values that the accessor converts and stores [1606.33ms]
(pass) Buffer accessor JIT > an offset that defeats a speculation exits to the host error and converges [1900.60ms]
(pass) Buffer accessor JIT > no stale reads: a store between two loads of the same offset is observed [1071.54ms]
(pass) Buffer accessor JIT > a loop-carried load is not kept alive across a call that mutates the buffer [901.98ms]
(pass) Buffer accessor JIT > host semantics survive the JIT: values that the accessor rejects [1919.87ms]
(pass) Buffer accessor JIT > two Buffers over the same ArrayBuffer are never mis-aliased [1135.07ms]
(pass) Buffer accessor JIT > replacing or shadowing the method after tier-up takes effect [1067.26ms]
(pass) Buffer accessor JIT > resizable and growable receivers keep tracking the length after tier-up [1131.66ms]
(pass) Buffer accessor JIT > a >2GB receiver stays optimized: no exit storm, and OOB still throws [1014.95ms]
(pass) Buffer accessor JIT > views with 2GB and ~4GB byteOffsets read and write correctly after tier-up [983.21ms]
(pass) Buffer accessor JIT > differential fuzzer: JIT and useJIT=0 agree on every result, error and byte [2784.72ms]

 14 pass
 0 fail
 54 expect() calls
Ran 14 tests across 1 file. [7.43s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/buffer-jit.test.ts | 870 +++++++++++++++++++++++++---------------
 1 file changed, 550 insertions(+), 320 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
test/js/node/buffer-jit.test.ts     28     42      0
```

</details>

<!-- robobun:evidence:end -->