### PR TITLE
child_process: match Node's spawnSync result when the process fails to spawn

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -465,6 +465,18 @@ Object.defineProperty(execFile, kCustomPromisifySymbol, {
 
 execFile[kCustomPromisifySymbol][kCustomPromisifySymbol] = execFile[kCustomPromisifySymbol];
 
+function spawnSyncFailureResult(error) {
+  return {
+    signal: null,
+    status: null,
+    output: null,
+    pid: 0,
+    stdout: undefined,
+    stderr: undefined,
+    error,
+  };
+}
+
 /**
  * Spawns a new process synchronously using the given `file`.
  * @param {string} file
@@ -511,15 +523,7 @@ function spawnSync(file, args, options) {
       "EINVAL",
     );
     error.spawnargs = ArrayPrototypeSlice.$call(options.args, 1);
-    return {
-      signal: null,
-      status: null,
-      output: [null, null, null],
-      pid: 0,
-      stdout: null,
-      stderr: null,
-      error,
-    };
+    return spawnSyncFailureResult(error);
   }
 
   const maxBuffer = options.maxBuffer;
@@ -550,8 +554,6 @@ function spawnSync(file, args, options) {
     }
   }
 
-  var error;
-  var failedToSpawn = false;
   try {
     var {
       stdout = null,
@@ -584,56 +586,36 @@ function spawnSync(file, args, options) {
       maxBuffer: options.maxBuffer,
     });
   } catch (err) {
-    error = err;
-    failedToSpawn = true;
+    err.syscall = "spawnSync " + options.file;
+    err.spawnargs = ArrayPrototypeSlice.$call(options.args, 1);
+    return spawnSyncFailureResult(err);
   }
 
-  let result;
-  if (failedToSpawn) {
-    // Node's SyncProcessRunner::BuildResultObject (src/spawn_sync.cc) sets `status`
-    // and `output` to null when the process was never started, and always sets
-    // `pid` (uv_process_t is zero-initialized on a failed spawn). `stdout` and
-    // `stderr` stay undefined (`result.stdout = result.output?.[1]` in
-    // lib/internal/child_process.js).
-    result = {
-      signal: null,
-      status: null,
-      output: null,
-      pid: 0,
-      stdout: undefined,
-      stderr: undefined,
-    };
-  } else {
-    // When stdio is redirected to a file descriptor, Bun.spawnSync returns the fd number
-    // instead of the actual output. We should treat this as no output available.
-    const outputStdout = typeof stdout === "number" ? null : stdout;
-    const outputStderr = typeof stderr === "number" ? null : stderr;
+  // When stdio is redirected to a file descriptor, Bun.spawnSync returns the fd number
+  // instead of the actual output. We should treat this as no output available.
+  const outputStdout = typeof stdout === "number" ? null : stdout;
+  const outputStderr = typeof stderr === "number" ? null : stderr;
 
-    result = {
-      signal: signalCode ?? null,
-      status: exitCode,
-      // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
-      output: [null, outputStdout, outputStderr],
-      pid,
-    };
+  const result = {
+    signal: signalCode ?? null,
+    status: exitCode,
+    // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
+    output: [null, outputStdout, outputStderr],
+    pid,
+  };
 
-    if (outputStdout && encoding && encoding !== "buffer") {
-      result.output[1] = result.output[1]?.toString(encoding);
-    }
-
-    if (outputStderr && encoding && encoding !== "buffer") {
-      result.output[2] = result.output[2]?.toString(encoding);
-    }
-
-    result.stdout = result.output[1];
-    result.stderr = result.output[2];
+  if (outputStdout && encoding && encoding !== "buffer") {
+    result.output[1] = result.output[1]?.toString(encoding);
   }
 
-  if (error) {
-    result.error = error;
+  if (outputStderr && encoding && encoding !== "buffer") {
+    result.output[2] = result.output[2]?.toString(encoding);
   }
 
-  if (exitedDueToTimeout && error == null) {
+  result.stdout = result.output[1];
+  result.stderr = result.output[2];
+
+  if (exitedDueToTimeout) {
     result.error = new SystemError(
       "spawnSync " + options.file + " ETIMEDOUT",
       options.file,
@@ -642,7 +624,7 @@ function spawnSync(file, args, options) {
       "ETIMEDOUT",
     );
   }
-  if (exitedDueToMaxBuffer && error == null) {
+  if (exitedDueToMaxBuffer) {
     result.error = new SystemError(
       "spawnSync " + options.file + " ENOBUFS (stdout or stderr buffer reached maxBuffer size limit)",
       options.file,

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -551,6 +551,7 @@ function spawnSync(file, args, options) {
   }
 
   var error;
+  var failedToSpawn = false;
   try {
     var {
       stdout = null,
@@ -584,37 +585,53 @@ function spawnSync(file, args, options) {
     });
   } catch (err) {
     error = err;
-    stdout = null;
-    stderr = null;
+    failedToSpawn = true;
   }
 
-  // When stdio is redirected to a file descriptor, Bun.spawnSync returns the fd number
-  // instead of the actual output. We should treat this as no output available.
-  const outputStdout = typeof stdout === "number" ? null : stdout;
-  const outputStderr = typeof stderr === "number" ? null : stderr;
+  let result;
+  if (failedToSpawn) {
+    // Node's SyncProcessRunner::BuildResultObject (src/spawn_sync.cc) sets `status`
+    // and `output` to null when the process was never started, and always sets
+    // `pid` (uv_process_t is zero-initialized on a failed spawn). `stdout` and
+    // `stderr` stay undefined (`result.stdout = result.output?.[1]` in
+    // lib/internal/child_process.js).
+    result = {
+      signal: null,
+      status: null,
+      output: null,
+      pid: 0,
+      stdout: undefined,
+      stderr: undefined,
+    };
+  } else {
+    // When stdio is redirected to a file descriptor, Bun.spawnSync returns the fd number
+    // instead of the actual output. We should treat this as no output available.
+    const outputStdout = typeof stdout === "number" ? null : stdout;
+    const outputStderr = typeof stderr === "number" ? null : stderr;
 
-  const result = {
-    signal: signalCode ?? null,
-    status: exitCode,
-    // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
-    output: [null, outputStdout, outputStderr],
-    pid,
-  };
+    result = {
+      signal: signalCode ?? null,
+      status: exitCode,
+      // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
+      output: [null, outputStdout, outputStderr],
+      pid,
+    };
+
+    if (outputStdout && encoding && encoding !== "buffer") {
+      result.output[1] = result.output[1]?.toString(encoding);
+    }
+
+    if (outputStderr && encoding && encoding !== "buffer") {
+      result.output[2] = result.output[2]?.toString(encoding);
+    }
+
+    result.stdout = result.output[1];
+    result.stderr = result.output[2];
+  }
 
   if (error) {
     result.error = error;
   }
-
-  if (outputStdout && encoding && encoding !== "buffer") {
-    result.output[1] = result.output[1]?.toString(encoding);
-  }
-
-  if (outputStderr && encoding && encoding !== "buffer") {
-    result.output[2] = result.output[2]?.toString(encoding);
-  }
-
-  result.stdout = result.output[1];
-  result.stderr = result.output[2];
 
   if (exitedDueToTimeout && error == null) {
     result.error = new SystemError(

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -826,9 +826,24 @@ it("spawnSync(does-not-exist)", () => {
   expect(x.error?.code).toEqual("ENOENT");
   expect(x.error.path).toEqual("does-not-exist");
   expect(x.signal).toEqual(null);
-  expect(x.output).toEqual([null, null, null]);
-  expect(x.stdout).toEqual(null);
-  expect(x.stderr).toEqual(null);
+  expect(x.output).toEqual(null);
+  // Node leaves `stdout`/`stderr` as `undefined` on spawn failure
+  // (`result.stdout = result.output?.[1]`, and `output` is null).
+  expect(x.stdout).toBeUndefined();
+  expect(x.stderr).toBeUndefined();
+});
+
+// Node's SyncProcessRunner::BuildResultObject (src/spawn_sync.cc) sets `status`
+// to null when the process was never started, and always reports a `pid`
+// (libuv's uv_process_t is zero-initialized, so it reads as 0).
+it("spawnSync(does-not-exist) reports status: null and pid: 0 like Node", () => {
+  const x = spawnSync("does-not-exist");
+  expect(x.status).toEqual(null);
+  expect(x.pid).toEqual(0);
+
+  const y = spawnSync("does-not-exist", { encoding: "buffer" });
+  expect(y.status).toEqual(null);
+  expect(y.output).toEqual(null);
 });
 
 // https://github.com/oven-sh/bun/issues/32067

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -846,6 +846,17 @@ it("spawnSync(does-not-exist) reports status: null and pid: 0 like Node", () => 
   expect(y.output).toEqual(null);
 });
 
+it.if(isWindows)("spawnSync(batch-file) reports the never-started result shape", () => {
+  const x = spawnSync("does-not-exist.cmd");
+  expect(x.error?.code).toBe("EINVAL");
+  expect(x.status).toBeNull();
+  expect(x.signal).toBeNull();
+  expect(x.output).toBeNull();
+  expect(x.pid).toBe(0);
+  expect(x.stdout).toBeUndefined();
+  expect(x.stderr).toBeUndefined();
+});
+
 // https://github.com/oven-sh/bun/issues/32067
 // Darwin's posix_spawn file actions reject any fd number >= OPEN_MAX (10240)
 // with EBADF at registration time, before checking whether the fd is open.


### PR DESCRIPTION
### What does this PR do?

When `child_process.spawnSync()` fails to spawn the child (ENOENT, EACCES, …), Bun returned a result whose shape diverged from Node's:

| field  | Node v24.15.0 | Bun (before)    |
|--------|---------------|-----------------|
| status | `null`        | `undefined`     |
| pid    | `0`           | `undefined`     |
| output | `null`        | `[null, null, null]` |
| stdout / stderr | `undefined` | `null`   |

Node's contract is pinned by its source: `SyncProcessRunner::BuildResultObject` (`src/spawn_sync.cc`) sets `status` and `output` to `null` when `exit_status_ < 0` — "the process was never started because of some error" — and always sets `pid` (libuv's `uv_process_t` is zero-initialized when spawn failed). The JS layer then does `result.stdout = result.output?.[1]`, leaving `stdout`/`stderr` as own-properties with value `undefined`. Node's docs also declare `status: <number> | <null>`, null if the child failed to spawn; Bun's own JSDoc on `spawnSync` already says `status: number | null`, and `@types/node` declares `status: number | null`.

Supervision/runner code reads these fields directly (`res.status === null`, `child.pid`, JSON-serialized results), so the undefined/null and array/null mismatches are observable.

Repro (Windows, any platform gives the same shape):

```js
const { spawnSync } = require("node:child_process");
console.log(JSON.stringify(spawnSync("does-not-exist")));
// node v24.15.0: {"status":null,"output":null,"pid":0,"signal":null,...}
// bun 1.4.0:     {"signal":null,"output":[null,null,null]}  (status/pid omitted = undefined)
```

**Fix** — in `spawnSync()`'s wrapper (`src/js/node/child_process.ts`), both pre-spawn failure paths now use one helper that builds Node's exact result: `status: null`, `signal: null`, `output: null`, `pid: 0`, with `stdout`/`stderr` present but `undefined`. This covers errors thrown by `Bun.spawnSync()` (ENOENT, EACCES, missing `cwd`, …) and the Windows `.bat`/`.cmd` EINVAL validation path, which also returns before `uv_spawn` runs. Everything else is untouched:

- A successful spawn keeps the previous construction path (fd-redirect handling, encoding conversion, stdout/stderr derivation).
- The timeout (`ETIMEDOUT`) and maxBuffer (`ENOBUFS`) paths only run after `Bun.spawnSync()` returns, i.e. the process actually ran; their results keep `status` as a number and an array `output`. Unchanged.
- `checkExecSyncError` (execSync/execFileSync) branches on `ret.error` first, so those paths behave identically.

The async side of spawn-failure (`close` args / `exitCode` after a deferred spawn error) is intentionally **not** part of this PR — it's already covered by #33304.

### How did you verify your code works?

Fail-before (released bun):

```
USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t does-not-exist
(fail) spawnSync(does-not-exist)
  Expected: null   Received: [null, null, null]          (output)
(fail) spawnSync(does-not-exist) reports status: null and pid: 0 like Node
  Expected: null   Received: undefined                   (status)

USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t batch-file
(fail) spawnSync(batch-file) reports the never-started result shape
  Expected: null   Received: [null, null, null]          (output)
```

Pass-after (`bun bd test test/js/node/child_process/child_process.test.ts -t does-not-exist` and `-t batch-file`, debug build of this branch):

```
 2 pass / 0 fail  (does-not-exist)
 1 pass / 0 fail  (batch-file)
```

Full suites on this branch, debug build, Windows x64:

```
bun bd test test/js/node/child_process/child_process.test.ts
  54 pass, 18 skip, 0 fail

bun bd test test/js/node/child_process/child_process-node.test.js
  0 fail (34 tests)

bun bd test test/js/bun/spawn/spawnSync.test.ts
  6 pass, 12 skip, 0 fail
```

Differential vs real Node v24.15.0 with the same script — ENOENT, the Windows batch-file EINVAL path, an unaffected success run, `execFileSync`, and `execSync` behavior are identical between `node` and `bun bd`:

```js
const r = spawnSync("does-not-exist-xyz");
// both: {"status":null,"pid":0,"output":null,"stdout":"<undefined>","stderr":"<undefined>","signal":null,"errcode":"ENOENT"}
const batch = spawnSync("does-not-exist.cmd");
// both: {"status":null,"pid":0,"output":null,"stdout":"<undefined>","stderr":"<undefined>","signal":null,"errcode":"EINVAL"}
const ok = spawnSync(<self>, ["-e", "console.log('x')"]);
// both: status 0, stdout "x"
```

Not run locally: Linux/macOS CI lanes (this machine is Windows-only). The `Bun.spawnSync()` catch/helper path is platform-independent; the batch-file EINVAL regression is intentionally Windows-only because `process.platform === "win32"` is inlined and dead-code eliminated elsewhere.
