### PR TITLE
test(bundler): update the BuildArtifact hash snapshots for the chunk hash change in #40518

### DIFF
--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -66,11 +66,11 @@ NS.then(({ fn: fn2 }) => {
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"g9c33042"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"7gfnt0h6"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"2ksyc1td"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"g9c33042"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 


### PR DESCRIPTION
### Problem
- Three tests in `test/bundler/bun-build-api.test.ts` fail on main: `BuildArtifact properties`, `BuildArtifact properties + entry.naming` and `BuildArtifact properties sourcemap`. Their `toMatchSnapshot("hash")` expects `est79qzq` and `7gfnt0h6` and gets `g9c33042` and `2ksyc1td`.
- #40518 (731aa92dad) replaced `append_isolated_hashes_for_imported_chunks` with `final_chunk_hashes` (`src/bundler/LinkerContext.rs:2454`). It digests each chunk's `isolated_hash` into a per-chunk value and digests that again with the chunk's closure, so every hash changed (a lone chunk now gets `digest(digest(isolated_hash))`).
- CI stayed green because the runner misreads the bucket's junit report. #37483 fixes that (see Notes).

### Fix
- Update the three hash entries in `test/bundler/__snapshots__/bun-build-api.test.ts.snap` to the current values.
- The hash is not a cross-version contract: it changes whenever the printed output changes, and #40518 accepted the same change in the two other test files it touched.
- The exact pin stays, rather than a shape check like `toMatch(/^[0-9a-z]{8}$/)`. It is the one assertion here that fires on a hash-function-only change, which is what #40518 was. The file's text snapshots embed the same cwd-relative path, so a shape check would not remove the cwd dependency.
- Verified: `bun bd test test/bundler/bun-build-api.test.ts -t "BuildArtifact properties"`: 3 fail on main, 3 pass here. The other tests pass, except two `bytecode:` tests that time out under the debug build.

### Background
- `blob.hash` on a `BuildArtifact` is the chunk's final hash in base 36, the same value the `[hash]` naming token uses.
- `isolated_hash` is the hash of one chunk's own printed bytes. The final hash also covers every chunk reachable through cross-chunk imports.

<details><summary>Notes</summary>

- The test depends on cwd: the output contains `// test/bundler/fixtures/trivial/index.js`, a path relative to cwd, and `generate_isolated_hash` hashes that path. Both the old and the new values are for a run from the repo root, which is what CI does. The text snapshots in the same file have the same dependency.
- Binaries built before #40518 (bun 1.4.0, canary 1.4.1 at adc354d99) still produce `est79qzq` from the repo root, so the change is from 731aa92dad. #40518 updated the hash expectations in `test/bundler/html-import-manifest.test.ts` and `test/js/bun/http/bun-serve-html.test.ts` but not this snapshot file.
- These three lines have been re-pinned seven times before (3ee09bfe79, b7a32b87ab, 688ddbda74, 891b1907ae, e2c3749965, 183a8f61d8, 77ca318336). Only 891b1907ae changed the hash algorithm itself. The semantic hash properties (distinct per output, sensitive to a shared-chunk edit, present in the path) are covered by `hash considers cross chunk imports` at line 916, which still passes. The exact pin adds the one thing that test cannot catch: a hash-function change on identical output.
- Why CI did not catch it: `scripts/runner.node.mjs` runs the bucket as `bun test --parallel --reporter=junit` and keys the report's `<testsuite>` elements by their `file` attribute. Nested describe blocks are `<testsuite>` elements with the same `file`, so the last describe block of a file overwrites the file suite. For this file that block has `failures="0"`, so the file is printed as passed (`[33/300] test/bundler/bun-build-api.test.ts (0.01s)`) and the bucket's non-zero exit is swallowed. Buildkite build 106211, jobs 01a03dba-6487-482e-af2f-68e7c16af24a (aarch64) and 01a03dba-648c-43a6-bcf0-67de01ba69f5 (x64) both show `3 fail` in the batch summary and no re-run. The same bug hid one other batch failure in that build and in 106228 (`test/js/bun/websocket/websocket-server.test.ts:963`, a heap-stats assertion). #37483 fixes the parser and adds tests. It is green and waiting on review. This PR should land before it, or the un-masked file turns main red.
- The two `bytecode:` tests that time out locally under the debug build are slow in other sessions' runs too and have their own handoff about file runtime. They are not affected by this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->