### PR TITLE
node:crypto: copy password and salt for async pbkdf2 and scrypt

### DIFF
--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -229,8 +229,8 @@ impl PBKDF2 {
                 }
             }
             Flavor::Async => {
-                out.salt.make_thread_isolated_copy(global_this);
-                out.password.make_thread_isolated_copy(global_this);
+                out.salt.make_thread_isolated_copy(global_this)?;
+                out.password.make_thread_isolated_copy(global_this)?;
             }
         }
 

--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -5,7 +5,7 @@ use bun_jsc::{
     ArrayBuffer, CallFrame, JSGlobalObject, JSValue, Job, JobContext, JsResult, JsThread, Strong,
 };
 
-use crate::node::{Flavor, StringObjects, StringOrBuffer, ThreadIsolated, ThreadIsolatedArg};
+use crate::node::{Flavor, StringOrBuffer, ThreadIsolated, ThreadIsolatedArg};
 
 use crate::crypto::evp::{self, Algorithm};
 
@@ -177,12 +177,7 @@ impl PBKDF2 {
             length: keylen,
             algorithm,
         };
-        out.salt = match StringOrBuffer::from_js_maybe_async(
-            global_this,
-            arg1,
-            flavor,
-            StringObjects::Allow,
-        )? {
+        out.salt = match StringOrBuffer::from_js(global_this, arg1)? {
             Some(v) => v,
             None => {
                 return Err(global_this.throw_invalid_argument_type_value(
@@ -197,12 +192,7 @@ impl PBKDF2 {
             return Err(global_this.throw_invalid_arguments(format_args!("salt is too long")));
         }
 
-        out.password = match StringOrBuffer::from_js_maybe_async(
-            global_this,
-            arg0,
-            flavor,
-            StringObjects::Allow,
-        )? {
+        out.password = match StringOrBuffer::from_js(global_this, arg0)? {
             Some(v) => v,
             None => {
                 return Err(global_this.throw_invalid_argument_type_value(
@@ -215,12 +205,6 @@ impl PBKDF2 {
 
         if out.password.slice().len() > i32::MAX as usize {
             return Err(global_this.throw_invalid_arguments(format_args!("password is too long")));
-        }
-
-        if flavor == Flavor::Sync {
-            if let StringOrBuffer::Buffer(buffer) = &mut out.salt {
-                buffer.buffer = ArrayBuffer::from_typed_array(global_this, buffer.buffer.value);
-            }
         }
 
         let callback = match flavor {
@@ -237,6 +221,19 @@ impl PBKDF2 {
             Flavor::Sync => JSValue::UNDEFINED,
         };
 
+        // A String-object password's `toString` may have changed the salt buffer.
+        match flavor {
+            Flavor::Sync => {
+                if let StringOrBuffer::Buffer(buffer) = &mut out.salt {
+                    buffer.buffer = ArrayBuffer::from_typed_array(global_this, buffer.buffer.value);
+                }
+            }
+            Flavor::Async => {
+                out.salt.make_thread_isolated_copy(global_this);
+                out.password.make_thread_isolated_copy(global_this);
+            }
+        }
+
         Ok((out, callback))
     }
 
@@ -246,7 +243,7 @@ impl PBKDF2 {
         call_frame: &CallFrame,
     ) -> JsResult<(ThreadIsolated<PBKDF2>, JSValue)> {
         let (data, callback) = Self::from_js(global_this, call_frame, Flavor::Async)?;
-        // SAFETY: parsed with `Flavor::Async`.
+        // SAFETY: `Flavor::Async` copied the buffers and thread-isolated the strings.
         Ok((unsafe { ThreadIsolated::new(data) }, callback))
     }
 }

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -968,7 +968,7 @@ mod _impl {
             // An option getter may have changed the buffers.
             for input in [&mut ctx.password, &mut ctx.salt] {
                 if IS_ASYNC {
-                    input.make_thread_isolated_copy(global);
+                    input.make_thread_isolated_copy(global)?;
                 } else if let StringOrBuffer::Buffer(buffer) = input {
                     buffer.buffer = ArrayBuffer::from_typed_array(global, buffer.buffer.value);
                 }

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -13,7 +13,7 @@ use bun_jsc::{
     JsThread, Protected, Strong,
 };
 
-use crate::node::{Flavor, StringObjects, StringOrBuffer, ThreadIsolated, ThreadIsolatedArg};
+use crate::node::{Flavor, StringOrBuffer, ThreadIsolated, ThreadIsolatedArg};
 
 // `&JSGlobalObject` is ABI-identical to a non-null pointer; remaining params
 // are by-value `JSValue`, so no caller-side preconditions remain.
@@ -811,11 +811,6 @@ mod _impl {
             ] = call_frame.arguments_as_array::<5>();
             let mut maybe_options_value: Option<JSValue> = Some(options_arg);
             let mut callback = callback_arg;
-            let flavor = if IS_ASYNC {
-                Flavor::Async
-            } else {
-                Flavor::Sync
-            };
 
             if IS_ASYNC {
                 if callback.is_undefined() {
@@ -824,13 +819,7 @@ mod _impl {
                 }
             }
 
-            let Some(password) = StringOrBuffer::from_js_maybe_async(
-                global,
-                password_value,
-                flavor,
-                StringObjects::Allow,
-            )?
-            else {
+            let Some(password) = StringOrBuffer::from_js(global, password_value)? else {
                 return Err(global.throw_invalid_argument_type_value(
                     b"password",
                     b"string, ArrayBuffer, Buffer, TypedArray, or DataView",
@@ -838,13 +827,7 @@ mod _impl {
                 ));
             };
 
-            let Some(salt) = StringOrBuffer::from_js_maybe_async(
-                global,
-                salt_value,
-                flavor,
-                StringObjects::Allow,
-            )?
-            else {
+            let Some(salt) = StringOrBuffer::from_js(global, salt_value)? else {
                 return Err(global.throw_invalid_argument_type_value(
                     b"salt",
                     b"string, ArrayBuffer, Buffer, TypedArray, or DataView",
@@ -982,16 +965,18 @@ mod _impl {
 
             ctx.check_scrypt_params(global)?;
 
-            if IS_ASYNC {
-                return Ok((ctx, callback));
-            }
-
+            // An option getter may have changed the buffers.
             for input in [&mut ctx.password, &mut ctx.salt] {
-                if let StringOrBuffer::Buffer(buffer) = input {
+                if IS_ASYNC {
+                    input.make_thread_isolated_copy(global);
+                } else if let StringOrBuffer::Buffer(buffer) = input {
                     buffer.buffer = ArrayBuffer::from_typed_array(global, buffer.buffer.value);
                 }
             }
 
+            if IS_ASYNC {
+                return Ok((ctx, callback));
+            }
             Ok((ctx, JSValue::UNDEFINED))
         }
 
@@ -1001,7 +986,7 @@ mod _impl {
             call_frame: &CallFrame,
         ) -> JsResult<(ThreadIsolated<Self>, JSValue)> {
             let (ctx, callback) = Self::from_js::<true>(global, call_frame)?;
-            // SAFETY: parsed with the async flavor (`from_js::<true>`).
+            // SAFETY: `from_js::<true>` copied the buffers and thread-isolated the strings.
             Ok((unsafe { ThreadIsolated::new(ctx) }, callback))
         }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -341,9 +341,7 @@ impl StringOrBuffer<'static> {
         unsafe { ThreadIsolated::new(Self::owned(bytes)) }
     }
 
-    /// Makes a value parsed with `Flavor::Sync` own its bytes for a work-pool job:
-    /// copies a buffer's current bytes, isolates a string. A `Flavor::Async` parse
-    /// is the pinned borrow this replaces, so a `PinnedBuffer` never reaches it.
+    /// Copies a `Sync`-parsed buffer's current bytes (or isolates a string) for a work-pool job.
     pub(crate) fn make_thread_isolated_copy(&mut self, global: &JSGlobalObject) -> JsResult<()> {
         match self {
             Self::Buffer(buffer) => {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -341,7 +341,9 @@ impl StringOrBuffer<'static> {
         unsafe { ThreadIsolated::new(Self::owned(bytes)) }
     }
 
-    /// For a work-pool job without a pin: copies a buffer's current bytes, isolates a string.
+    /// Makes a value parsed with `Flavor::Sync` own its bytes for a work-pool job:
+    /// copies a buffer's current bytes, isolates a string. A `Flavor::Async` parse
+    /// is the pinned borrow this replaces, so a `PinnedBuffer` never reaches it.
     pub(crate) fn make_thread_isolated_copy(&mut self, global: &JSGlobalObject) -> JsResult<()> {
         match self {
             Self::Buffer(buffer) => {
@@ -360,7 +362,10 @@ impl StringOrBuffer<'static> {
                 str.make_thread_isolated();
                 *self = Self::ThreadIsolatedString(core::mem::take(str));
             }
-            Self::ThreadIsolatedString(_) | Self::Utf8(_) | Self::PinnedBuffer(_) => {}
+            Self::ThreadIsolatedString(_) | Self::Utf8(_) => {}
+            Self::PinnedBuffer(_) => {
+                unreachable!("make_thread_isolated_copy on a value parsed with Flavor::Async")
+            }
         }
         Ok(())
     }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -342,13 +342,17 @@ impl StringOrBuffer<'static> {
     }
 
     /// For a work-pool job without a pin: copies a buffer's current bytes, isolates a string.
-    pub(crate) fn make_thread_isolated_copy(&mut self, global: &JSGlobalObject) {
+    pub(crate) fn make_thread_isolated_copy(&mut self, global: &JSGlobalObject) -> JsResult<()> {
         match self {
             Self::Buffer(buffer) => {
                 if let Some(current) = buffer.buffer.value.as_array_buffer(global) {
                     buffer.buffer = current;
                 }
-                let bytes = buffer.slice().to_vec();
+                let mut bytes = Vec::new();
+                if bytes.try_reserve_exact(buffer.slice().len()).is_err() {
+                    return Err(global.throw_out_of_memory());
+                }
+                bytes.extend_from_slice(buffer.slice());
                 global.vm().report_extra_memory(bytes.len());
                 *self = Self::owned(bytes);
             }
@@ -358,6 +362,7 @@ impl StringOrBuffer<'static> {
             }
             Self::ThreadIsolatedString(_) | Self::Utf8(_) | Self::PinnedBuffer(_) => {}
         }
+        Ok(())
     }
 
     /// `value` is ArrayBuffer-like (the caller checked): borrowed for `Sync`,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -341,6 +341,25 @@ impl StringOrBuffer<'static> {
         unsafe { ThreadIsolated::new(Self::owned(bytes)) }
     }
 
+    /// For a work-pool job without a pin: copies a buffer's current bytes, isolates a string.
+    pub(crate) fn make_thread_isolated_copy(&mut self, global: &JSGlobalObject) {
+        match self {
+            Self::Buffer(buffer) => {
+                if let Some(current) = buffer.buffer.value.as_array_buffer(global) {
+                    buffer.buffer = current;
+                }
+                let bytes = buffer.slice().to_vec();
+                global.vm().report_extra_memory(bytes.len());
+                *self = Self::owned(bytes);
+            }
+            Self::String(str) => {
+                str.make_thread_isolated();
+                *self = Self::ThreadIsolatedString(core::mem::take(str));
+            }
+            Self::ThreadIsolatedString(_) | Self::Utf8(_) | Self::PinnedBuffer(_) => {}
+        }
+    }
+
     /// `value` is ArrayBuffer-like (the caller checked): borrowed for `Sync`,
     /// pinned and GC-rooted for `Async`.
     pub(crate) fn buffer_from_js(

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -267,6 +267,66 @@ test("pbkdf2 keeps the callback alive across GC until the job completes", async 
   expect(results.filter(r => r === "PBKDF2 derivation failed")).toHaveLength(count);
 });
 
+test("pbkdf2 copies password and salt at call time, so the caller can zero them right after the call", async () => {
+  const password = Buffer.alloc(4096, "p");
+  const salt = Buffer.alloc(16, "s");
+  const expected = crypto.pbkdf2Sync(password, salt, 1, 32, "sha256").toString("hex");
+  const results: string[] = [];
+  for (let i = 0; i < 20; i++) {
+    password.fill("p");
+    salt.fill("s");
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    crypto.pbkdf2(password, salt, 1, 32, "sha256", (err, key) => (err ? reject(err) : resolve(key.toString("hex"))));
+    password.fill(0);
+    salt.fill(0);
+    results.push(await promise);
+  }
+  expect(results).toEqual(Array(20).fill(expected));
+});
+
+test("pbkdf2 copies the salt buffer only after every argument has been coerced", async () => {
+  const salt = new Uint8Array(64).fill(3);
+  const password = new String("password");
+  password.toString = () => {
+    structuredClone(salt.buffer, { transfer: [salt.buffer] });
+    Bun.gc(true);
+    return "password";
+  };
+  const key = await promisify(crypto.pbkdf2)(password, salt, 1, 32, "sha256");
+  expect(salt.byteLength).toBe(0);
+  expect(key).toStrictEqual(crypto.pbkdf2Sync("password", new Uint8Array(0), 1, 32, "sha256"));
+});
+
+test("pbkdf2 does not read a resizable ArrayBuffer that shrinks after the call", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const crypto = require("crypto");
+        const expected = crypto.pbkdf2Sync(Buffer.alloc(65536, 0x41), "salt", 1, 32, "sha256").toString("hex");
+        let wrong = 0;
+        for (let i = 0; i < 20; i++) {
+          const ab = new ArrayBuffer(65536, { maxByteLength: 1 << 20 });
+          new Uint8Array(ab).fill(0x41);
+          const { promise, resolve, reject } = Promise.withResolvers();
+          crypto.pbkdf2(new Uint8Array(ab), "salt", 1, 32, "sha256", (err, key) => (err ? reject(err) : resolve(key.toString("hex"))));
+          ab.resize(0);
+          if ((await promise) !== expected) wrong++;
+        }
+        console.log("wrong:", wrong);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("wrong: 0\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 test("pbkdf2 works with util.promisify", async () => {
   const key = await promisify(crypto.pbkdf2)("pw", "salt", 1, 8, "sha256");
   expect(Buffer.isBuffer(key)).toBe(true);

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -327,6 +327,36 @@ test("pbkdf2 does not read a resizable ArrayBuffer that shrinks after the call",
   expect(exitCode).toBe(0);
 });
 
+test("pbkdf2 copies the salt buffer after a later argument's toString resized it to 0", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const crypto = require("crypto");
+        const expected = crypto.pbkdf2Sync("password", new Uint8Array(0), 1, 32, "sha256").toString("hex");
+        const salt = new Uint8Array(new ArrayBuffer(65536, { maxByteLength: 65536 })).fill(0x41);
+        const password = new String("password");
+        password.toString = () => {
+          salt.buffer.resize(0);
+          return "password";
+        };
+        crypto.pbkdf2(password, salt, 1, 32, "sha256", (err, key) => {
+          if (err) throw err;
+          console.log(key.toString("hex") === expected ? "ok" : "wrong");
+        });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 test("pbkdf2 works with util.promisify", async () => {
   const key = await promisify(crypto.pbkdf2)("pw", "salt", 1, 8, "sha256");
   expect(Buffer.isBuffer(key)).toBe(true);

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -145,6 +145,39 @@ test("scrypt does not read a resizable ArrayBuffer that shrinks after the call",
   expect(exitCode).toBe(0);
 });
 
+test("scrypt copies its buffers after an option getter resized them to 0", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const crypto = require("crypto");
+        const expected = crypto.scryptSync("", "", 16, { N: 1024 }).toString("hex");
+        const password = new Uint8Array(new ArrayBuffer(65536, { maxByteLength: 65536 })).fill(0x41);
+        const salt = new Uint8Array(new ArrayBuffer(65536, { maxByteLength: 65536 })).fill(0x42);
+        const options = {
+          get N() {
+            password.buffer.resize(0);
+            salt.buffer.resize(0);
+            return 1024;
+          },
+        };
+        crypto.scrypt(password, salt, 16, options, (err, key) => {
+          if (err) throw err;
+          console.log(key.toString("hex") === expected ? "ok" : "wrong");
+        });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 test("scryptSync reads its buffers only after every argument has been coerced", () => {
   const passwordBytes = new Uint8Array(64).fill(97);
   const key = scryptSync(passwordBytes, "salt", 16, {

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { scryptSync } from "node:crypto";
+import { scrypt, scryptSync } from "node:crypto";
 
 // When `crypto.scrypt` fails to allocate the output buffer (OOM for a huge
-// `keylen`), `CryptoJob.init` takes the error path. Previously the `errdefer`
-// only freed the job allocation and leaked the callback `Strong` plus the
-// protected password/salt buffers.
+// `keylen`), the call takes the error path. It once leaked the callback
+// `Strong` there, and the password/salt buffers that the job `protect()`ed at
+// the time. The job copies its inputs now, so a buffer can no longer be
+// protected; the Uint8Array count guards that this stays so.
 //
 // `heapStats().protectedObjectTypeCounts` counts both `protect()`ed values and
-// `HandleSet` strong handles, so it catches both the protected input buffers
-// and the callback Strong.
+// `HandleSet` strong handles.
 //
 // Run in a subprocess so that on builds without the synthetic-limit check
 // (where the 2 GiB allocation succeeds and scrypt jobs start running) we can
@@ -65,8 +65,8 @@ test("scrypt async does not leak callback/buffers when output allocation fails",
   // this test isn't measuring anything meaningful.
   expect(thrown).toBe(50);
 
-  // Each failed call previously leaked 1 Function (callback Strong) and
-  // 2 Uint8Array (password + salt). With the fix, counts return to baseline.
+  // Each failed call once leaked 1 Function (callback Strong) and 2 Uint8Array
+  // (password + salt). Counts must stay at baseline.
   expect({
     Function: after.Function - before.Function,
     Uint8Array: after.Uint8Array - before.Uint8Array,
@@ -75,6 +75,73 @@ test("scrypt async does not leak callback/buffers when output allocation fails",
     Uint8Array: 0,
   });
 
+  expect(exitCode).toBe(0);
+});
+
+test("scrypt copies password and salt at call time, so the caller can zero them right after the call", async () => {
+  const password = Buffer.alloc(4096, "p");
+  const salt = Buffer.alloc(16, "s");
+  const expected = scryptSync(password, salt, 32, { N: 1024 }).toString("hex");
+  const results: string[] = [];
+  for (let i = 0; i < 20; i++) {
+    password.fill("p");
+    salt.fill("s");
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    scrypt(password, salt, 32, { N: 1024 }, (err, key) => (err ? reject(err) : resolve(key.toString("hex"))));
+    password.fill(0);
+    salt.fill(0);
+    results.push(await promise);
+  }
+  expect(results).toEqual(Array(20).fill(expected));
+});
+
+test("scrypt copies its buffers only after every argument has been coerced", async () => {
+  const passwordBytes = new Uint8Array(64).fill(97);
+  const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
+  scrypt(
+    passwordBytes,
+    "salt",
+    16,
+    {
+      get N() {
+        structuredClone(passwordBytes.buffer, { transfer: [passwordBytes.buffer] });
+        Bun.gc(true);
+        return 1024;
+      },
+    },
+    (err, key) => (err ? reject(err) : resolve(key)),
+  );
+  expect(passwordBytes.byteLength).toBe(0);
+  expect(await promise).toStrictEqual(scryptSync("", "salt", 16, { N: 1024 }));
+});
+
+test("scrypt does not read a resizable ArrayBuffer that shrinks after the call", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const crypto = require("crypto");
+        const expected = crypto.scryptSync(Buffer.alloc(65536, 0x41), "salt", 32, { N: 1024 }).toString("hex");
+        let wrong = 0;
+        for (let i = 0; i < 20; i++) {
+          const ab = new ArrayBuffer(65536, { maxByteLength: 1 << 20 });
+          new Uint8Array(ab).fill(0x41);
+          const { promise, resolve, reject } = Promise.withResolvers();
+          crypto.scrypt(new Uint8Array(ab), "salt", 32, { N: 1024 }, (err, key) => (err ? reject(err) : resolve(key.toString("hex"))));
+          ab.resize(0);
+          if ((await promise) !== expected) wrong++;
+        }
+        console.log("wrong:", wrong);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("wrong: 0\n");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- Async `crypto.pbkdf2` and `crypto.scrypt` hand the pool thread a borrow of the caller's buffers. A caller that zeroizes the secret right after the call gets a key from wiped bytes. Node copies.
- The same borrow crashes the pool thread (`Segmentation fault`) when a resizable `ArrayBuffer` input calls `resize(0)` after the call.
- Cause: `StringOrBuffer::from_js_maybe_async` with `Flavor::Async` (`src/runtime/node/types.rs`) pins and GC-roots the buffer but keeps a pointer into it. `PBKDF2::run` and `Scrypt::run_task_impl` read that pointer on the pool thread.

### Fix
- Add `StringOrBuffer::make_thread_isolated_copy`. It copies a buffer's current bytes into an owned `Vec` (no pin, no root) and thread-isolates a string.
- `PBKDF2::from_js` and `Scrypt::from_js` copy `password` and `salt` after the option getters and the callback check ran, where the sync flavor already re-reads them. `pbkdf2Sync` and `scryptSync` are unchanged.
- Correct because the job owns every byte it reads. Node's async KDF jobs and bun's `hkdf` and `argon2` already do this.
- Verified: `test/js/node/crypto/pbkdf2.test.ts` and `test/js/node/crypto/scrypt.test.ts`, four new tests each. All eight fail on the unfixed build. Other suites: see Notes.

### Background
- A `StringOrBuffer` is a parsed string-or-buffer JS argument. Its `Buffer` arm is a pointer into the JS `ArrayBuffer`, not a copy. `Flavor::Async` marks a value that outlives the call.
- A pin stops a detach (a `transfer()` copies instead). A GC root stops collection. Neither stops JS from writing to, or resizing, the buffer while the pool thread reads it.
- `ThreadIsolated<T>` (#40511) is the `Send` wrapper that carries parsed arguments to the pool. Its `unsafe` constructor asks why the value is sendable.

<details><summary>Notes</summary>

Repro (from the report):

```js
import crypto from "node:crypto";
const pw = Buffer.alloc(4096, "p"), salt = Buffer.alloc(16, "s");
const want  = crypto.pbkdf2Sync(pw, salt, 1, 32, "sha256").toString("hex");
const wantS = crypto.scryptSync(pw, salt, 32, { N: 1024 }).toString("hex");
let r = { pbkdf2: { ok: 0, wrong: 0 }, scrypt: { ok: 0, wrong: 0 } };
for (let i = 0; i < 50; i++) {
  pw.fill("p"); salt.fill("s");
  const a = new Promise(res => crypto.pbkdf2(pw, salt, 1, 32, "sha256", (e, d) => res(d.toString("hex"))));
  const b = new Promise(res => crypto.scrypt(pw, salt, 32, { N: 1024 }, (e, d) => res(d.toString("hex"))));
  pw.fill(0); salt.fill(0);
  const [da, db] = await Promise.all([a, b]);
  r.pbkdf2[da === want ? "ok" : "wrong"]++; r.scrypt[db === wantS ? "ok" : "wrong"]++;
}
console.log(JSON.stringify(r));
```

- On bun 1.4.1 the repro above gives pbkdf2 2 ok / 48 wrong and scrypt 0 ok / 50 wrong. Node: 50 / 50 ok.
- The four new tests per file: zeroize after the call, copy only after every argument was coerced, `resize(0)` after the call, `resize(0)` from a later argument's getter or `toString`. The last one is the case #35821 raised for the sync path, here for the async path.
- Other suites run: `node-crypto.test.js`, `crypto.test.ts`, `crypto-extra-memory.test.ts`, Node's `test-crypto-pbkdf2.js` and `test-crypto-scrypt.js`, and the `fs.test.ts` Buffer-path test from #40511.
- The `SAFETY` notes on `ThreadIsolated::new` in both `from_js_async` constructors now name the copy as the reason the value is sendable.
- With the wipe placed right after each call (the shape the tests use), every round is wrong on the unfixed release build for password sizes from 16 bytes to 1 MiB, and on the unfixed debug ASAN build in 3 of 3 runs.
- A partial overwrite gives a key that matches neither the old nor the new input: the pool thread hashes the buffer while the JS thread writes it.
- The other async crypto jobs (`hkdf`, `sign`/`verify`, `checkPrime`, `subtle.*`, `Bun.password`, `argon2`) already copy at call time.
- Why the copy is taken at the end of parsing and not at parse time: Node reads the buffers in `check()` (`lib/internal/crypto/scrypt.js`), runs the option getters there, and copies in the `ScryptJob` constructor afterwards. `scryptSync` in bun already re-reads its buffers after option coercion (`scryptSync reads its buffers only after every argument has been coerced`). A first version of this PR copied at parse time, so an option getter that wrote to the password was invisible to the job. The review caught it.
- The copy is reported to the GC with `report_extra_memory`, like `from_js_to_owned_slice` and the transcoded-string path in the same file.
- Rebased onto #40511, which replaced the `protect()`/`Unprotect` bookkeeping with `PinnedArrayBuffer` and the `unsafe` `ThreadIsolated::new`. That PR fixed the leak of the root; this one removes the borrow. The earlier commits of this PR (the removed unprotect scope guards) are folded into one commit because #40511 removed the same guards.
- #34751 and #35821 took a narrower cut at the same borrow (copy only resizable `ArrayBuffer` inputs) on the plumbing that #40511 replaced. Both are closed in favor of this PR for the KDF slice. This PR copies every buffer input of the two KDF jobs, which is what makes wipe-after-use correct. The cases from those PRs that still crash on main are recorded in their closing comments: `Bun.zstdCompress`/`Bun.zstdDecompress` with a resizable input that shrinks after the call (#34751, now fixed by #40641), and `Bun.markdown.html` with an option getter that shrinks the input (#35821, proposed in #31730). Neither is in this PR's scope.
- The `scrypt async does not leak callback/buffers when output allocation fails` test still passes: it measures the delta of protected `Uint8Array` counts, and that delta stays 0. Its comments are updated: the inputs are no longer rooted, so that half of the assertion now guards that no root comes back.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/crypto/pbkdf2.test.ts" test/js/node/crypto/scrypt.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/165] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/165] gen cpp.rs (cppbind)
[3/165] gen JS modules (bundle-modules)
Preprocess modules (7337ms)
Bundle modules (31ms)
Postprocesss modules (30ms)
Bundle Functions (385ms)
Generate Code (34ms)

[7.82s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/165] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[4/165] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_D
... (truncated)

release without fix: 8 FAILED
bun test v1.4.1-canary.1 (731aa92da)

test/js/node/crypto/pbkdf2.test.ts:
(pass) 120fb6cffcf8b32c43e7225256c4f837a86548c9 [0.32ms]
(pass) ae4d0c95af6b46d32d0adff928f06dd02a303f8e [0.04ms]
(pass) c5e478d59288c841aa530db6845c4c8d962893a0 [1.36ms]
(pass) 348c89dbcbd32b2f32d814b8116e84cf2b17347ebc1800181c [1.53ms]
(pass) 89b69d0516f829893c696226650a8687 [1.56ms]
(pass) 64c486c55d30d4c5a079b8823b7d7cb37ff0556f537da8410233bcec330ed956 [0.08ms]
(pass) f7ce0b653d2d72a4108cf5abe912ffdd777616dbbb27a70e8204f3ae2d0f6fad [0.02ms]
(pass) keylen is the length of the derived key > keylen=1 [0.22ms]
(pass) keylen is the length of the derived key > keylen=31 [0.04ms]
(pass) keylen is the length of the derived key > keylen=32 [0.03ms]
(pass) keylen is the length of the derived key > keylen=33 [0.03ms]
(pass) keylen is the length of the derived key > keylen=63 [0.04ms]
(pass) keylen is the length of the derived key > keylen=64 [0.02ms]
(pass) invalid inputs > test is invalid [0.17ms]
(pass) invalid inputs >  is invalid [0.01ms]
(pass) invalid inputs > true is invalid [0.33ms]
(pass) invalid inputs > undefined is invalid
(pass) invalid inputs > null is invalid
(pass) invalid inputs > {}
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/crypto/pbkdf2.test.ts" test/js/node/crypto/scrypt.test.ts
bun test v1.4.1 (731aa92da)

test/js/node/crypto/pbkdf2.test.ts:
(pass) 120fb6cffcf8b32c43e7225256c4f837a86548c9 [44.98ms]
(pass) ae4d0c95af6b46d32d0adff928f06dd02a303f8e [2.84ms]
(pass) c5e478d59288c841aa530db6845c4c8d962893a0 [9.78ms]
(pass) 348c89dbcbd32b2f32d814b8116e84cf2b17347ebc1800181c [11.72ms]
(pass) 89b69d0516f829893c696226650a8687 [8.86ms]
(pass) 64c486c55d30d4c5a079b8823b7d7cb37ff0556f537da8410233bcec330ed956 [1.21ms]
(pass) f7ce0b653d2d72a4108cf5abe912ffdd777616dbbb27a70e8204f3ae2d0f6fad [1.29ms]
(pass) keylen is the length of the derived key > keylen=1 [12.00ms]
(pass) keylen is the length of the derived key > keylen=31 [2.80ms]
(pass) keylen is the length of the derived key > keylen=32 [1.57ms]
(pass) keylen is the length of the derived key > keylen=33 [1.60ms]
(pass) keylen is the length of the derived key > keylen=63 [1.55ms]
(pass) keylen is the length of the derived key > keylen=64 [1.43ms]
(pass) invalid inputs > test is invalid [9.65ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 629ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (7318ms)
Bundle modules (35ms)
Postprocesss modules (25ms)
Bundle Functions (470ms)
Generate Code (30ms)

[7.89s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_analytics v0.0.0 (/workspace/bun/src/analytics)
[1m[92m   Compiling[0m bun_exe_format v0.0.0 (/workspace/bun/src/exe_format)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/crypto/PBKDF2.rs            |  37 +++++-----
 src/runtime/node/node_crypto_binding.rs |  37 +++-------
 src/runtime/node/types.rs               |  27 ++++++++
 test/js/node/crypto/pbkdf2.test.ts      |  90 +++++++++++++++++++++++++
 test/js/node/crypto/scrypt.test.ts      | 116 +++++++++++++++++++++++++++++---
 5 files changed, 253 insertions(+), 54 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/crypto/PBKDF2.rs                10     16      0
src/runtime/node/node_crypto_binding.rs     13     19      0
src/runtime/node/types.rs                   10     12      0
test/js/node/crypto/pbkdf2.test.ts           1      2      0
test/js/node/crypto/scrypt.test.ts           2      5      0
```

</details>

<!-- robobun:evidence:end -->

