### PR TITLE
bun:test: do not format the expected value after the received value threw in a diff

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use bun_core::Output;
-use bun_jsc::{JSGlobalObject, JSValue};
+use bun_jsc::{JSGlobalObject, JSValue, js_error_to_write_error};
 
 use super::diff::print_diff::{print_diff_main, DiffConfig};
 use super::pretty_format::{FormatOptions, JestPrettyFormat, MessageLevel};
@@ -44,23 +44,25 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(js_error_to_write_error)?;
 
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(js_error_to_write_error)?;
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2872,7 +2872,17 @@ impl ExpectMatcherUtils {
         } else {
             bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", false)
         };
-        let buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n");
+        use fmt::Write as _;
+        let mut buf = String::new();
+        if write!(
+            buf,
+            "{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n"
+        )
+        .is_err()
+            && global_this.has_exception()
+        {
+            return Err(JsError::Thrown);
+        }
         bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }
 }

--- a/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
+++ b/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
@@ -19,3 +19,56 @@ test("expect does not crash when value has Symbol.toPrimitive returning a Symbol
 
   expect(exitCode).toBe(0);
 });
+
+// The diff printed by a failed toEqual/toStrictEqual formats both values. When
+// the first one throws, the second must not be formatted with that exception
+// still pending. The matcher throws its own error with the partial message.
+// matcherHint returns a string to user code, so it surfaces the exception.
+test("expect does not crash when value.toString() returns a Symbol while printing a diff", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { expect } from "bun:test";
+        const re = /u/i;
+        re.toString = Symbol;
+        const results = {};
+        const record = (name, fn) => {
+          try {
+            fn();
+            results[name] = "did not throw";
+          } catch (e) {
+            results[name] = e.constructor.name + ": " + e.message.split("\\n")[0];
+          }
+        };
+        record("toStrictEqual", () => expect(re).toStrictEqual({}));
+        record("toEqual", () => expect(re).toEqual(/x/i));
+        record("toMatchObject", () => expect({ a: re }).toMatchObject({ a: 1 }));
+        expect.extend({
+          _hint(received) {
+            record("matcherHint", () => this.utils.matcherHint("_hint", received, 1));
+            return { pass: true, message: () => "" };
+          },
+        });
+        expect(re)._hint();
+        console.log(JSON.stringify(results));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      toStrictEqual: "Error: expect(received).toStrictEqual(expected)",
+      toEqual: "Error: expect(received).toEqual(expected)",
+      toMatchObject: "Error: expect(received).toMatchObject(expected)",
+      matcherHint: "TypeError: Cannot convert a symbol to a string",
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a debug assertion abort in `bun:test` found by fuzzing. The input is a value whose string conversion throws, compared with a matcher that prints a diff:

```js
const re = /u/i;
re.toString = Symbol; // toString() returns a Symbol, so ToString throws a TypeError
expect(re).toStrictEqual({});
```

Debug builds abort with:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Cannot convert a symbol to a string
ExceptionScope.h(63) : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

### Root cause

`DiffFormatter::fmt` (`src/runtime/test_runner/diff_format.rs`) formats the received value and then the expected value. Both results were dropped with `let _ = ...; // TODO:`. When the first `JestPrettyFormat::format` threw, the `TypeError` stayed pending on the VM. The second `format` call then reached `JSC__JSValue__getOwn`, which asserts that no exception is pending.

Stack at the assertion: `DiffFormatter::fmt` (diff_format.rs:56) -> `JestPrettyFormat::format_adapted` -> `Tag::get` (pretty_format.rs:501) -> `get_own_truthy` -> `JSC__JSValue__getOwn` (bindings.cpp:4602).

### The fix

The fixing lines are the two `.map_err(js_error_to_write_error)?` in `DiffFormatter::fmt`. This is the same pattern the other `Display` adapters in the test runner use (`AllCallsFormatter`, `ZigFormatter`). The first failure now returns `fmt::Error` and the second value is not formatted.

The matchers consume the formatter through `global.throw(format_args!(..))`. `error_message` already handles a `fmt::Error` there: it clears the pending exception and throws the matcher error with the partial message. That is the documented convention ("better to just return the formatting string than an error about an error") and matches what `toBe` and the other single value matchers already do.

`ExpectMatcherUtils.matcherHint` built its string with `format!`, which panics when a `Display` impl returns `Err`. It now writes into a buffer and returns the pending exception to the caller, the same way `stringify`, `printExpected` and `printReceived` surface a throwing inspect.

### Behavior change

In release builds, `toEqual`/`toStrictEqual`/`toMatchObject` on such a value threw the `TypeError` by accident: the pending exception was picked up when the matcher error was thrown. They now throw the matcher error, like `.not.toBe` does on the same input. `matcherHint` still throws the `TypeError`.

### How did you verify your code works?

Added a test to `test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts`, next to the existing test for the `Symbol.toPrimitive` variant on the single value path. It runs `toStrictEqual`, `toEqual`, `toMatchObject` and `matcherHint` in a child process and checks the recorded errors and the exit code.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts`: fails (the diff matchers throw the `TypeError`).
- Unfixed debug build: the child aborts on the assertion.
- `bun bd test test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts`: passes.

Also ran `expect.test.js`, `expect-extend.test.js`, `expect-extend-matcher-utils-throw.test.ts`, `expect-failure-message-angle-brackets.test.ts`, `expect-label.test.ts` (450 pass) and the snapshot tests (32 pass) with the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts:
(pass) expect does not crash when value has Symbol.toPrimitive returning a Symbol [355.42ms]
59 |     stdout: "pipe",
60 |     stderr: "pipe",
61 |   });
62 | 
63 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
64 |   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": "{"toStrictEqual":"Error: expect(received).toStrictEqual(expected)","toEqual":"Error: expect(received).toEqual(expected)","toMatchObject":"Error: expect(received).toMatchObject(expected)","matcherHint":"TypeError: Cannot convert a symbol to a string"}",
+   "exitCode": 134,
+   "stderr": 
+ "ASSERTION FAILED: Unexpected exception observed on thread Thread:0x797eee0000c0 at:
+ The exception was thrown
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts:
(pass) expect does not crash when value has Symbol.toPrimitive returning a Symbol [6.51ms]
59 |     stdout: "pipe",
60 |     stderr: "pipe",
61 |   });
62 | 
63 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
64 |   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
                                                           ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "{"toStrictEqual":"Error: expect(received).toStrictEqual(expected)","toEqual":"Error: expect(received).toEqual(expected)","toMatchObject":"Error: expect(received).toMatchObject(expected)","matcherHint":"TypeError: Cannot convert a symbol to a string"}",
+   "stdout": "{"toStrictEqual":"TypeError: Cannot convert a symbol to a string","toEqual":"TypeError: Cannot convert a symbol to a string","toMatchObject":"TypeError: Cannot convert a symbol to a string","matcherHint":"TypeError: Cannot convert a symbol to a string"}",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts:
(pass) expect does not crash when value has Symbol.toPrimitive returning a Symbol [373.82ms]
(pass) expect does not crash when value.toString() returns a Symbol while printing a diff [304.51ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [2.64s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 602ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 06s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+7d273c056
[build] done
bun test v1.4.1-canary.1 (7d273c056)

test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts:
(pass) expect does not crash when value has Symbol.toPrimitive returning a Symbol [6.35ms]
(pass) expect does not crash when value.toString() returns a Symbol while printing a diff [7.18ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [94.00ms]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/diff_format.rs             | 12 +++--
 src/runtime/test_runner/expect.rs                  | 12 ++++-
 .../test/expect-symbol-toPrimitive-crash.test.ts   | 53 ++++++++++++++++++++++
 3 files changed, 71 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/test_runner/diff_format.rs                        2      3      0
src/runtime/test_runner/expect.rs                             6      4      0
test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->