### PR TITLE
Fix debug assertion when a BunString error message is empty

### DIFF
--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -148,21 +148,23 @@ extern "C" JSC::EncodedJSValue BunString__toErrorInstance(const BunString* str, 
         // Allocation failed or the message exceeds the maximum string length.
         return {};
     }
-    JSC::JSObject* result = nullptr;
+    JSC::ErrorType type = JSC::ErrorType::Error;
     switch (kind) {
     case BunErrorKind::Error:
-        result = JSC::createError(globalObject, message);
+        type = JSC::ErrorType::Error;
         break;
     case BunErrorKind::TypeError:
-        result = JSC::createTypeError(globalObject, message);
+        type = JSC::ErrorType::TypeError;
         break;
     case BunErrorKind::SyntaxError:
-        result = JSC::createSyntaxError(globalObject, message);
+        type = JSC::ErrorType::SyntaxError;
         break;
     case BunErrorKind::RangeError:
-        result = JSC::createRangeError(globalObject, message);
+        type = JSC::ErrorType::RangeError;
         break;
     }
+    // Not JSC::createError(): it asserts the message is not empty, and `new Error("")` is valid.
+    JSC::JSObject* result = JSC::ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(type), message, JSValue(), nullptr, JSC::TypeNothing, type, true);
     JSC::EnsureStillAliveScope ensureAlive(result);
     return JSValue::encode(result);
 }

--- a/test/js/bun/test/expect-unreaachable.test.ts
+++ b/test/js/bun/test/expect-unreaachable.test.ts
@@ -7,3 +7,15 @@ test("expect.unreachable()", () => {
   expect(() => expect.unreachable(error)).toThrow(error);
   expect(() => expect.unreachable()).toThrow("reached unreachable code");
 });
+
+test("expect.unreachable('') throws an UnreachableError with an empty message", () => {
+  let error: Error | undefined;
+  try {
+    expect.unreachable("");
+  } catch (e) {
+    error = e as Error;
+  }
+  expect(error).toBeInstanceOf(Error);
+  expect(error!.name).toBe("UnreachableError");
+  expect(error!.message).toBe("");
+});

--- a/test/js/bun/test/expect-unreaachable.test.ts
+++ b/test/js/bun/test/expect-unreaachable.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("expect.unreachable()", () => {
   expect(expect.unreachable).toBeTypeOf("function");
@@ -8,14 +9,26 @@ test("expect.unreachable()", () => {
   expect(() => expect.unreachable()).toThrow("reached unreachable code");
 });
 
-test("expect.unreachable('') throws an UnreachableError with an empty message", () => {
-  let error: Error | undefined;
-  try {
-    expect.unreachable("");
-  } catch (e) {
-    error = e as Error;
-  }
-  expect(error).toBeInstanceOf(Error);
-  expect(error!.name).toBe("UnreachableError");
-  expect(error!.message).toBe("");
+// Spawned: an empty message used to trip a debug assertion in JSC::createError and abort the process.
+test("expect.unreachable('') throws an UnreachableError with an empty message", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `try {
+        Bun.jest(import.meta.path).expect.unreachable("");
+      } catch (e) {
+        console.log(JSON.stringify({ name: e.name, message: e.message, isError: e instanceof Error }));
+      }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe('{"name":"UnreachableError","message":"","isError":true}\n');
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a debug assertion failure in `BunString__toErrorInstance` (`src/jsc/bindings/BunString.cpp`). The fuzzer found it with `expect.unreachable("")`.

```
ASSERTION FAILED: !message.isEmpty()
vendor/WebKit/Source/JavaScriptCore/runtime/Error.cpp(41) : JSObject *JSC::createError(JSGlobalObject *, const String &, ErrorInstance::SourceAppender)
```

`BunString__toErrorInstance` is the shared path for `String::to_error_instance` and its TypeError, SyntaxError, and RangeError siblings. It called `JSC::createError` and friends. Those JSC helpers assert that the message is not empty. An empty `BunString` converts to a null `WTF::String`, so any caller that forwards an empty string aborts a debug build. `expect.unreachable(reason)` forwards the user's string as is, so `expect.unreachable("")` reached the assertion.

The fix constructs the `ErrorInstance` directly, with the error structure for the requested type. `JSC::createError(globalObject, message)` is exactly `ErrorInstance::create(vm, globalObject->errorStructure(type), message, JSValue(), nullptr, TypeNothing, type, true)` plus the assertion, so the result is the same object for a non-empty message. The napi bindings already use this pattern for the same reason (`createErrorWithCode` in `src/jsc/bindings/napi.cpp`).

Release builds do not compile the assertion, so their behavior does not change. `expect.unreachable("")` throws an `UnreachableError` with an empty `message` there before and after this change.

### How did you verify your code works?

- Reproduced the abort with the debug fuzz build: `Bun.jest().expect.unreachable("")`.
- With the fix, the same script throws `UnreachableError` and exits with code 1. The debug build now matches the release build for an empty, a custom, and an omitted message.
- Added a test to `test/js/bun/test/expect-unreaachable.test.ts`. On the unfixed debug build the test process aborts with the assertion. With the fix it passes (`bun bd test`). The release build has no assertions, so the test also passes with `USE_SYSTEM_BUN=1`. The failure is only visible in a debug build.
- `bun bd test test/js/bun/test/expect.test.js`: 415 pass, 0 fail.
- Ran the regression test under `BUN_JSC_validateExceptionChecks=1`: pass.
- Checked a Worker with a parse error (the `to_syntax_error_instance` path): the error event is identical between the release build and the fixed debug build.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-unreaachable.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/test/expect-unreaachable.test.ts:
(pass) expect.unreachable() [17.52ms]
26 |     stderr: "pipe",
27 |   });
28 | 
29 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
30 | 
31 |   expect(stdout).toBe('{"name":"UnreachableError","message":"","isError":true}\n');
                      ^
error: expect(received).toBe(expected)

- "{"name":"UnreachableError","message":"","isError":true}
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-unreaachable.test.ts:31:18)
(fail) expect.unreachable('') throws an UnreachableError with an empty message [399.66ms]

 1 pass
 1 fail
 5 expect() calls
Ran 2 tests across 1 file. [2.45s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.1-canary.1 (adc354d99)

test/js/bun/test/expect-unreaachable.test.ts:
(pass) expect.unreachable() [0.11ms]
(pass) expect.unreachable('') throws an UnreachableError with an empty message [6.47ms]

 2 pass
 0 fail
 7 expect() calls
Ran 2 tests across 1 file. [87.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-unreaachable.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/test/expect-unreaachable.test.ts:
(pass) expect.unreachable() [37.45ms]
(pass) expect.unreachable('') throws an UnreachableError with an empty message [286.10ms]

 2 pass
 0 fail
 7 expect() calls
Ran 2 tests across 1 file. [2.37s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 594ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunString.cpp               | 12 +++++++-----
 test/js/bun/test/expect-unreaachable.test.ts | 25 +++++++++++++++++++++++++
 2 files changed, 32 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/BunString.cpp                    1      1      0
test/js/bun/test/expect-unreaachable.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->