### PR TITLE
bundler: add [serve.static] splitting, align Bun.build compile options with the CLI

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -522,6 +522,17 @@ sourcemap = "linked" # serve sourcemaps in production too
 # sourcemap = false      # never generate sourcemaps
 ```
 
+## Code splitting
+
+By default, each HTML route is bundled into one JavaScript chunk, and dynamic `import()` calls are inlined. Set the `splitting` option to emit shared code and dynamic imports as separate chunks, like `splitting: true` in `Bun.build()`:
+
+```toml title="bunfig.toml" icon="settings"
+[serve.static]
+splitting = true
+```
+
+This applies when `development` is not `true` in `Bun.serve()`. The HMR development server loads modules on its own and ignores this option.
+
 ## How It Works
 
 Bun uses `HTMLRewriter` to scan for `<script>` and `<link>` tags in HTML files and uses them as entrypoints for Bun's bundler. Bun then generates an optimized bundle for the JavaScript/TypeScript/TSX/JSX and CSS files and serves the result.

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1604,8 +1604,9 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(hmr) = serve_obj.get(b"hmr") {
-            if let Some(v) = hmr.as_bool() {
-                self.ctx.args.serve_hmr = Some(v);
+            match hmr.as_bool() {
+                Some(v) => self.ctx.args.serve_hmr = Some(v),
+                None => self.add_error(hmr.loc, b"Expected hmr to be a boolean")?,
             }
         }
 
@@ -1616,15 +1617,30 @@ impl<'a> Parser<'a> {
                 self.ctx.args.serve_minify_identifiers = Some(v);
             } else if minify.is_object() {
                 if let Some(syntax) = minify.get(b"syntax") {
-                    self.ctx.args.serve_minify_syntax = Some(syntax.as_bool().unwrap_or(false));
+                    match syntax.as_bool() {
+                        Some(v) => self.ctx.args.serve_minify_syntax = Some(v),
+                        None => {
+                            self.add_error(syntax.loc, b"Expected minify.syntax to be a boolean")?
+                        }
+                    }
                 }
                 if let Some(whitespace) = minify.get(b"whitespace") {
-                    self.ctx.args.serve_minify_whitespace =
-                        Some(whitespace.as_bool().unwrap_or(false));
+                    match whitespace.as_bool() {
+                        Some(v) => self.ctx.args.serve_minify_whitespace = Some(v),
+                        None => self.add_error(
+                            whitespace.loc,
+                            b"Expected minify.whitespace to be a boolean",
+                        )?,
+                    }
                 }
                 if let Some(identifiers) = minify.get(b"identifiers") {
-                    self.ctx.args.serve_minify_identifiers =
-                        Some(identifiers.as_bool().unwrap_or(false));
+                    match identifiers.as_bool() {
+                        Some(v) => self.ctx.args.serve_minify_identifiers = Some(v),
+                        None => self.add_error(
+                            identifiers.loc,
+                            b"Expected minify.identifiers to be a boolean",
+                        )?,
+                    }
                 }
             } else {
                 self.add_error(minify.loc, b"Expected minify to be boolean or object")?;
@@ -1658,14 +1674,22 @@ impl<'a> Parser<'a> {
             }
         }
 
+        if let Some(splitting) = serve_obj.get(b"splitting") {
+            match splitting.as_bool() {
+                Some(v) => self.ctx.args.serve_splitting = v,
+                None => self.add_error(splitting.loc, b"Expected splitting to be a boolean")?,
+            }
+        }
+
         if let Some(expr) = serve_obj.get(b"define") {
             self.ctx.args.serve_define = Some(self.parse_define_map(&expr)?);
         }
         self.ctx.args.bunfig_path = Box::<[u8]>::from(self.source.path.text);
 
         if let Some(public_path) = serve_obj.get(b"publicPath") {
-            if let Some(v) = public_path.as_string(self.bump) {
-                self.ctx.args.serve_public_path = Some(v.into());
+            match public_path.as_string(self.bump) {
+                Some(v) => self.ctx.args.serve_public_path = Some(v.into()),
+                None => self.add_error(public_path.loc, b"Expected publicPath to be a string")?,
             }
         }
 

--- a/src/collections/string_map.rs
+++ b/src/collections/string_map.rs
@@ -33,6 +33,11 @@ impl StringMap {
         self.map.count()
     }
 
+    #[inline]
+    pub fn contains_key(&self, key: &[u8]) -> bool {
+        self.map.contains_key(key)
+    }
+
     /// Dupe `value`; `key` is duped on miss regardless (`Box<[u8]>` forces a
     /// copy), so the `dupe_keys` flag is kept for API parity only.
     pub fn insert(&mut self, key: &[u8], value: &[u8]) -> Result<(), AllocError> {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -357,19 +357,8 @@ pub mod js_bundler {
                     this.windows_hide_console = hide_console.to_boolean();
                 }
 
-                // The metadata below is written with the Win32 resource API, so like the
-                // `--windows-*` CLI flags it needs a Windows host and a Windows target.
-                for name in [
-                    "icon",
-                    "title",
-                    "publisher",
-                    "version",
-                    "description",
-                    "copyright",
-                ] {
-                    if windows.get_own_truthy(global_this, name)?.is_none() {
-                        continue;
-                    }
+                // `set_windows_metadata` is Win32-only, so the host and the target must be Windows.
+                let metadata_allowed = |name: &str| -> JsResult<()> {
                     if !cfg!(windows) {
                         return Err(global_this.throw_invalid_arguments(format_args!(
                             "compile.windows.{name} is only available when compiling on Windows"
@@ -380,11 +369,11 @@ pub mod js_bundler {
                             "compile.windows.{name} requires a Windows compile target"
                         )));
                     }
-                }
+                    Ok(())
+                };
 
-                if let Some(windows_icon_path) =
-                    windows.get_own(global_this, &BunString::static_("icon"))?
-                {
+                if let Some(windows_icon_path) = windows.get_own_truthy(global_this, "icon")? {
+                    metadata_allowed("icon")?;
                     let slice = windows_icon_path.to_utf8(global_this)?;
                     let path_z = bun_core::ZBox::from_bytes(slice.slice());
                     if bun_sys::exists_at_type(bun_sys::Fd::cwd(), path_z.as_zstr())
@@ -399,37 +388,34 @@ pub mod js_bundler {
                     this.windows_icon_path.append_slice_exact(slice.slice())?;
                 }
 
-                if let Some(windows_title) =
-                    windows.get_own(global_this, &BunString::static_("title"))?
-                {
+                if let Some(windows_title) = windows.get_own_truthy(global_this, "title")? {
+                    metadata_allowed("title")?;
                     let slice = windows_title.to_utf8(global_this)?;
                     this.windows_title.append_slice_exact(slice.slice())?;
                 }
 
-                if let Some(windows_publisher) =
-                    windows.get_own(global_this, &BunString::static_("publisher"))?
-                {
+                if let Some(windows_publisher) = windows.get_own_truthy(global_this, "publisher")? {
+                    metadata_allowed("publisher")?;
                     let slice = windows_publisher.to_utf8(global_this)?;
                     this.windows_publisher.append_slice_exact(slice.slice())?;
                 }
 
-                if let Some(windows_version) =
-                    windows.get_own(global_this, &BunString::static_("version"))?
-                {
+                if let Some(windows_version) = windows.get_own_truthy(global_this, "version")? {
+                    metadata_allowed("version")?;
                     let slice = windows_version.to_utf8(global_this)?;
                     this.windows_version.append_slice_exact(slice.slice())?;
                 }
 
                 if let Some(windows_description) =
-                    windows.get_own(global_this, &BunString::static_("description"))?
+                    windows.get_own_truthy(global_this, "description")?
                 {
+                    metadata_allowed("description")?;
                     let slice = windows_description.to_utf8(global_this)?;
                     this.windows_description.append_slice_exact(slice.slice())?;
                 }
 
-                if let Some(windows_copyright) =
-                    windows.get_own(global_this, &BunString::static_("copyright"))?
-                {
+                if let Some(windows_copyright) = windows.get_own_truthy(global_this, "copyright")? {
+                    metadata_allowed("copyright")?;
                     let slice = windows_copyright.to_utf8(global_this)?;
                     this.windows_copyright.append_slice_exact(slice.slice())?;
                 }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -831,6 +831,11 @@ pub mod js_bundler {
                         "format must be 'cjs' or 'esm' when bytecode is true."
                     )));
                 }
+
+                // CommonJS output defaults to the node target, like `--format=cjs`.
+                if format == options::Format::Cjs && !did_set_target && !this.bytecode {
+                    this.target = Target::Node;
+                }
             }
 
             if let Some(hot) = config.get_boolean_loose(global_this, "splitting")? {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -343,10 +343,43 @@ pub mod js_bundler {
                         .throw_invalid_arguments(format_args!("windows must be an object")));
                 }
 
+                let is_windows_target =
+                    this.compile_target.os == bun_core::env::OperatingSystem::Windows;
+
                 if let Some(hide_console) =
                     windows.get_own(global_this, &BunString::static_("hideConsole"))?
                 {
+                    if !is_windows_target && hide_console.to_boolean() {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "compile.windows.hideConsole requires a Windows compile target"
+                        )));
+                    }
                     this.windows_hide_console = hide_console.to_boolean();
+                }
+
+                // The metadata below is written with the Win32 resource API, so like the
+                // `--windows-*` CLI flags it needs a Windows host and a Windows target.
+                for name in [
+                    "icon",
+                    "title",
+                    "publisher",
+                    "version",
+                    "description",
+                    "copyright",
+                ] {
+                    if windows.get_own_truthy(global_this, name)?.is_none() {
+                        continue;
+                    }
+                    if !cfg!(windows) {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "compile.windows.{name} is only available when compiling on Windows"
+                        )));
+                    }
+                    if !is_windows_target {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "compile.windows.{name} requires a Windows compile target"
+                        )));
+                    }
                 }
 
                 if let Some(windows_icon_path) =
@@ -1229,11 +1262,14 @@ pub mod js_bundler {
                 if !is_standalone_html {
                     this.target = Target::Bun;
 
+                    // A user `define` for one of these keys wins, like `--define` on the CLI.
                     let define_keys = compile.compile_target.define_keys();
                     let define_values = compile.compile_target.define_values();
                     debug_assert_eq!(define_keys.len(), define_values.len());
                     for (key, value) in define_keys.iter().zip(define_values) {
-                        this.define.insert(key, value)?;
+                        if !this.define.contains_key(key) {
+                            this.define.insert(key, value)?;
+                        }
                     }
 
                     let base_public_path = StandaloneModuleGraph::target_base_public_path(

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2509,7 +2509,6 @@ fn parse_build_command_options(
                 Output::flush();
             }
             options::Format::Cjs => {
-                // `parse` returns `opts`, so a write to `ctx.args` here is lost.
                 if opts.target.is_none() {
                     opts.target = Some(api::Target::Node);
                 }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2509,8 +2509,9 @@ fn parse_build_command_options(
                 Output::flush();
             }
             options::Format::Cjs => {
-                if ctx.args.target.is_none() {
-                    ctx.args.target = Some(api::Target::Node);
+                // `parse` returns `opts`, so a write to `ctx.args` here is lost.
+                if opts.target.is_none() {
+                    opts.target = Some(api::Target::Node);
                 }
             }
             _ => {}

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -66,11 +66,11 @@ NS.then(({ fn: fn2 }) => {
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"g9c33042"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"7gfnt0h6"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"2ksyc1td"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"g9c33042"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -814,6 +814,23 @@ describe("Bun.build", () => {
     },
   );
 
+  // Documented in docs/bundler/index.mdx: with `format: "cjs"` the default
+  // target is node, so node builtins stay as require() calls.
+  test.concurrent('format: "cjs" defaults the target to node', async () => {
+    using dir = tempDir("format-cjs-default-target", {
+      "index.js": `import fs from "node:fs";\nconsole.log(typeof fs.readFileSync);`,
+    });
+    const build = async (target?: "browser") => {
+      const result = await Bun.build({ entrypoints: [join(String(dir), "index.js")], format: "cjs", target });
+      expect(result.success).toBe(true);
+      return await result.outputs[0].text();
+    };
+
+    expect(await build()).toContain('require("node:fs")');
+    // An explicit browser target still stubs out the builtin.
+    expect(await build("browser")).not.toContain('require("node:fs")');
+  });
+
   test.concurrent("errors are returned as an array", async () => {
     const x = await buildNoThrow({
       entrypoints: [join(import.meta.dir, "does-not-exist.ts")],

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -125,6 +125,68 @@ server.close();`,
     },
   );
 
+  // `--define` on the CLI wins over the compile target's own defines. The API has to agree.
+  test("a user define for a compile-target key wins", async () => {
+    using dir = tempDir("build-compile-user-define", {
+      "app.js": `console.log(process.platform, process.arch);`,
+    });
+    const outfile = join(String(dir), "app");
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "app.js")],
+      compile: { outfile },
+      define: { "process.platform": JSON.stringify("fake-platform") },
+    });
+    expect(result.success).toBe(true);
+
+    await using proc = Bun.spawn({
+      cmd: [result.outputs[0].path],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: `fake-platform ${process.arch}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The metadata is written with the Win32 resource API. The CLI rejects the
+  // `--windows-*` flags on other hosts and for other targets; the API used to
+  // accept them and drop them.
+  test.skipIf(isWindows)("compile.windows metadata on a non-Windows host is an error", async () => {
+    using dir = tempDir("build-compile-windows-host", {
+      "app.js": `console.log("hi");`,
+    });
+    expect(() =>
+      Bun.build({
+        entrypoints: [join(String(dir), "app.js")],
+        compile: { target: "bun-windows-x64", outfile: join(String(dir), "app.exe"), windows: { title: "My App" } },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`"compile.windows.title is only available when compiling on Windows"`);
+  });
+
+  test("compile.windows options for a non-Windows target are an error", async () => {
+    using dir = tempDir("build-compile-windows-target", {
+      "app.js": `console.log("hi");`,
+    });
+    const build = (windows: Record<string, unknown>) =>
+      Bun.build({
+        entrypoints: [join(String(dir), "app.js")],
+        compile: { target: "bun-linux-x64", outfile: join(String(dir), "app"), windows },
+      });
+    expect(() => build({ hideConsole: true })).toThrowErrorMatchingInlineSnapshot(
+      `"compile.windows.hideConsole requires a Windows compile target"`,
+    );
+    if (isWindows) {
+      expect(() => build({ icon: join(String(dir), "app.js") })).toThrowErrorMatchingInlineSnapshot(
+        `"compile.windows.icon requires a Windows compile target"`,
+      );
+    }
+  });
+
   test("compile with invalid target fails gracefully", async () => {
     using dir = tempDir("build-compile-invalid", {
       "index.js": `console.log("test");`,

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -178,6 +178,31 @@ console.log(utils());`,
       expect(output).toContain("Hello from nested!");
     });
 
+    // Documented in docs/bundler/index.mdx: with `--format=cjs` the default
+    // target is node, so node builtins stay as require() calls.
+    test("--format=cjs defaults the target to node", async () => {
+      using dir = tempDir("bun-build-format-cjs-target", {
+        "index.js": `import fs from "node:fs";\nconsole.log(typeof fs.readFileSync);`,
+      });
+      const build = async (...extraArgs: string[]) => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "build", "./index.js", "--format=cjs", ...extraArgs],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+        return stdout;
+      };
+
+      expect(await build()).toContain('require("node:fs")');
+      // An explicit browser target still stubs out the builtin.
+      expect(await build("--target=browser")).not.toContain('require("node:fs")');
+    });
+
     test("__dirname and __filename are printed correctly", async () => {
       using baseDirPath = tempDir("bun-build-dirname-filename", {
         "我": {

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -8,6 +8,10 @@ describe.concurrent("bunfig.toml type-mismatch error messages", () => {
     [`telemetry = "no"`, "expected boolean but received string"],
     [`define = 3`, "expected object but received number"],
     [`[serve]\nport = "abc"`, "expected number but received string"],
+    [`[serve.static]\nsplitting = "yes"`, "Expected splitting to be a boolean"],
+    [`[serve.static]\nhmr = "yes"`, "Expected hmr to be a boolean"],
+    [`[serve.static]\npublicPath = 1`, "Expected publicPath to be a string"],
+    [`[serve.static]\nminify = { syntax = "yes" }`, "Expected minify.syntax to be a boolean"],
   ];
 
   test.each(cases)("%s -> %s", async (config, expected) => {

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1579,4 +1579,49 @@ describe("production headers and import.meta.env", () => {
     );
     expect(results).toEqual(cases.map(([, , expected]) => expected));
   });
+
+  test("bunfig [serve.static] splitting puts a dynamic import in its own chunk", async () => {
+    const run = async (bunfig: string) => {
+      const dir = tempDirWithFiles("html-splitting", {
+        "index.html": `<!DOCTYPE html><html><body><script type="module" src="./app.ts"></script></body></html>`,
+        "app.ts": `import("./lazy.ts").then(m => console.log(m.lazy));`,
+        "lazy.ts": `export const lazy = "lazy-module-loaded";`,
+        "bunfig.toml": bunfig,
+        "serve.ts": /*js*/ `
+          import index from "./index.html";
+          const server = Bun.serve({ port: 0, development: false, routes: { "/": index } });
+          const base = server.url.href;
+          const html = await (await fetch(base)).text();
+          const jsPath = html.match(/src="([^"]+\\.js)"/)[1];
+          const js = await (await fetch(new URL(jsPath, base))).text();
+          const chunk = js.match(/import\\("([^"]+\\.js)"\\)/);
+          console.log(JSON.stringify({
+            hasChunkImport: chunk !== null,
+            inlinedLazy: js.includes("lazy-module-loaded"),
+            chunkStatus: chunk ? (await fetch(new URL(chunk[1], base))).status : null,
+          }));
+          await server.stop(true);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "serve.ts"],
+        env: { ...bunEnv, NODE_ENV: undefined },
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) throw new Error(stdout + "\n" + stderr);
+      return JSON.parse(stdout) as { hasChunkImport: boolean; inlinedLazy: boolean; chunkStatus: number | null };
+    };
+
+    const [on, off] = await Promise.all([
+      run(`[serve.static]\nsplitting = true`),
+      run(`[serve.static]\nsplitting = false`),
+    ]);
+    expect({ on, off }).toEqual({
+      on: { hasChunkImport: true, inlinedLazy: false, chunkStatus: 200 },
+      off: { hasChunkImport: false, inlinedLazy: true, chunkStatus: null },
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- Some bundler options are accepted by one entry point and then dropped. `bunfig.toml` `[serve.static] splitting = true` has no effect: `HTMLBundle.rs:415` reads `serve_splitting`, but `bunfig.rs` never writes it, and an unknown key in `[serve.static]` is ignored. `hmr`, `publicPath` and the `minify` sub-keys with a wrong type are ignored too (`bunfig.rs:1606-1670`).
- `--format=cjs` is documented to default the target to node (docs/bundler/index.mdx, "format: cjs"). The CLI wrote that default into `ctx.args.target` (`Arguments.rs:2512`) after `parse` had cloned `ctx.args` into `opts`, so the write was lost and `node:fs` was stubbed out as `(() => ({}))`. `Bun.build({ format: "cjs" })` never applied the default.
- `Bun.build({ compile })` differs from `bun build --compile`. The compile target's `process.platform` / `process.arch` / `process.versions.bun` defines are inserted after the user `define` map (`JSBundler.rs:1251-1256`) and overwrite it. The CLI prepends them, so the user's `--define` wins (`build_command.rs:88-114`). `compile.windows.icon` / `title` / `publisher` / `version` / `description` / `copyright` are accepted on every host and target, but `set_windows_metadata` only runs on a Windows host (`StandaloneModuleGraph.rs:2518-2541`). The CLI rejects the `--windows-*` flags in those cases (`Arguments.rs:2348-2458`).

### Fix
- `bunfig.rs`: parse `[serve.static] splitting` into `serve_splitting`. `hmr`, `publicPath`, `minify.syntax`, `minify.whitespace` and `minify.identifiers` now add a bunfig error on a wrong type, like `minify` and `sourcemap` already do.
- `Arguments.rs`: write the cjs default into `opts.target`. `JSBundler.rs`: `format: "cjs"` sets the node target unless `target` was given or `bytecode` is on.
- `JSBundler.rs`: skip a compile-target define when the user `define` map already has the key (`StringMap::contains_key` is new). `compile.windows.hideConsole: true` throws for a non-Windows target. The six metadata keys throw on a non-Windows host and for a non-Windows target, with the same conditions as the CLI flags.
- Verified: `test/js/bun/http/bun-serve-html.test.ts` (splitting), `test/config/bunfig/bunfig-errors.test.ts` (4 cases), `test/bundler/cli.test.ts` and `test/bundler/bun-build-api.test.ts` (cjs target), `test/bundler/bun-build-compile.test.ts` (3 tests). All 10 new tests fail on the stock bun. Also ran the full `bun-serve-html`, `bun-serve-static`, `bunfig`, `cli`, `bun-build-compile`, `bundler_cjs`, `esbuild/loader` and `react-compiler` suites.

### Background
- `[serve.static]` is the bunfig section for HTML imports in `Bun.serve`. `HTMLBundle` turns its keys into a `Bun.build` config when `development` is not `true`. Every output file, including a split chunk, becomes a static route, so splitting needs no other change.
- `Arguments::parse` clones `ctx.args` into a local `opts`, applies the flags to it and returns it. The caller stores the result back into `ctx.args`. A flag handler that writes to `ctx.args` instead of `opts` has no effect.
- A compile target carries three defines so `process.platform` and friends fold to the target values at bundle time. The CLI lets an explicit `--define` replace them. The API now does the same.
- The Windows metadata is written with `rescle`, a Win32 resource editor, after the executable is moved into place. It is compiled in on Windows hosts only. `hideConsole` patches the PE subsystem field and works from any host, so it only needs a Windows target.

<details><summary>Notes</summary>

This comes out of an option parity census across `bun build`, `Bun.build()`, bunfig, HTML imports and `--compile`. Related fixes that are already open as separate PRs and not repeated here: #38606 (`Bun.build({ tsconfig })`), #40474 (`Bun.build({ production })`), #40503 (`--keep-names` with the `__name` helper), #35628 (warn when `--compile` overrides `--target`).

The dev server (`development: true`) reads only `env` and `define` from `[serve.static]`. `minify`, `sourcemap`, `publicPath` and now `splitting` apply to the production and `hmr: false` paths. The docs for `splitting` say so, like the existing minify note.

The `--bytecode` handler in `Arguments.rs` has the same lost write to `ctx.args.target`. It is harmless because `build_command.rs:71-74` forces the bun target for bytecode and compile, and moving it to `opts` would skip the "target must be 'bun' when bytecode is true" check that runs later, so it is left alone.

`itBundled` always passes an explicit `--target`, so the cjs default does not change any ported esbuild test. The direct `Bun.build` tests with `format: "cjs"` all pass a target too.

Existing tests that set `compile.windows.*` run on Windows hosts with a Windows target only (`compile-windows-metadata.test.ts`, `compile-outfile-subdirs.test.ts`), so the new checks do not change them.

The last commit re-pins the three `BuildArtifact properties` hash snapshots in `test/bundler/__snapshots__/bun-build-api.test.ts.snap`. #40518 changed `final_chunk_hashes` (`src/bundler/LinkerContext.rs`), so the hash moved for identical output bytes on main. The CI runner hides that failure on main (#37483), and #40545 carries the same re-pin. It is included here so this PR's CI runs green.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/cli.test.ts, test/bundler/bun-build-compile.test.ts, test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->