### PR TITLE
Ignore NODE_COMPILE_CACHE in standalone executables

### DIFF
--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -300,6 +300,11 @@ pub fn init_from_env_once() {
                 ENABLED.store(1, Ordering::Relaxed);
                 return;
             }
+            if crate::virtual_machine::standalone_module_graph().is_some() {
+                cclog!("[compile cache] Disabled in standalone executables.\n");
+                ENABLED.store(1, Ordering::Relaxed);
+                return;
+            }
             let _ = enable_with_dir(dir, portable_from_env());
         } else {
             ENABLED.store(1, Ordering::Relaxed);

--- a/test/bundler/compile-node-compile-cache.test.ts
+++ b/test/bundler/compile-node-compile-cache.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+// Standalone executables ship their modules embedded, so NODE_COMPILE_CACHE in
+// the surrounding environment could only ever cache externally loaded JS —
+// while pulling the whole runtime encode/decode machinery into an app that
+// never asked for it. Compiled binaries ignore the variable; plain `bun` still
+// honors it.
+test("NODE_COMPILE_CACHE is ignored by compiled executables and honored by bun", () => {
+  const dir = tempDirWithFiles("compile-node-compile-cache", {
+    "app.js": `
+        const ext = require(process.env.EXT_MOD);
+        console.log("APP_OK", ext.value);
+      `,
+    "extmod.cjs": `module.exports = { value: 42 };`,
+    "cache-standalone/.keep": "",
+    "cache-bun/.keep": "",
+  });
+
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), "build", "--compile", "./app.js", "--outfile=app-compiled"],
+    env: bunEnv,
+    cwd: dir,
+  });
+  expect(build.exitCode).toBe(0);
+
+  const standalone = Bun.spawnSync({
+    cmd: [join(dir, "app-compiled")],
+    env: {
+      ...bunEnv,
+      EXT_MOD: join(dir, "extmod.cjs"),
+      NODE_COMPILE_CACHE: join(dir, "cache-standalone"),
+      // Debug ASAN builds embed an @executable_path rpath for asan-dyld-shim.dylib;
+      // the standalone exe lives elsewhere, so point dyld back at the build dir.
+      DYLD_FALLBACK_LIBRARY_PATH: dirname(bunExe()),
+    },
+    cwd: dir,
+  });
+  expect(standalone.stdout.toString()).toContain("APP_OK 42");
+  expect(standalone.exitCode).toBe(0);
+  expect(readdirSync(join(dir, "cache-standalone"))).toEqual([".keep"]);
+
+  const plain = Bun.spawnSync({
+    cmd: [bunExe(), "app.js"],
+    env: {
+      ...bunEnv,
+      EXT_MOD: join(dir, "extmod.cjs"),
+      NODE_COMPILE_CACHE: join(dir, "cache-bun"),
+    },
+    cwd: dir,
+  });
+  expect(plain.stdout.toString()).toContain("APP_OK 42");
+  expect(plain.exitCode).toBe(0);
+  expect(readdirSync(join(dir, "cache-bun")).length).toBeGreaterThan(1);
+}, 240_000);

--- a/test/bundler/compile-node-compile-cache.test.ts
+++ b/test/bundler/compile-node-compile-cache.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 // Standalone executables ship their modules embedded, so NODE_COMPILE_CACHE in
 // the surrounding environment could only ever cache externally loaded JS —


### PR DESCRIPTION
### What does this PR do?

Compiled executables (`bun build --compile`) now ignore `NODE_COMPILE_CACHE` from the surrounding environment. Plain `bun` still honors it.

A standalone binary's modules ship embedded, with their own bytecode, so the on-disk compile cache can never serve them — the env var could only ever cache externally loaded JS (e.g. a `BUN_OPTIONS=--preload` script), while pulling the whole runtime bytecode encode/decode machinery into an app that never opted into it. An app-agnostic env var silently changing what a shipped binary executes is surprising for the people distributing those binaries; if an embedder wants the cache for external files, that should be an explicit compile-time choice rather than ambient environment.

The check sits in `init_from_env_once` next to the existing `NODE_DISABLE_COMPILE_CACHE` gate and logs under `NODE_DEBUG_NATIVE=COMPILE_CACHE`:

```
[compile cache] Disabled in standalone executables.
```

### How did you verify your code works?

New test `test/bundler/compile-node-compile-cache.test.ts`: compiles a standalone app that `require()`s an external file at runtime, runs it with `NODE_COMPILE_CACHE` pointed at a fresh directory, and asserts the directory stays empty — then runs the same script under plain `bun` with the same env and asserts the cache populates. Also verified manually: the compiled app prints the disabled log line under `NODE_DEBUG_NATIVE=COMPILE_CACHE` and behaves identically otherwise.