### PR TITLE
install: dedupe a peer bound to a folder package instead of nesting a second copy

### DIFF
--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -798,9 +798,8 @@ impl Tree {
                 }
 
                 if pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder {
-                    // A peer resolved to a folder package may have been bound to an ancestor's
-                    // existing edge for the same package. Dedupe against that placement instead
-                    // of nesting a second copy. A peer no ancestor edge provides still nests.
+                    // A peer an ancestor edge already provides dedupes instead of nesting
+                    // a second copy of the folder (#40561).
                     if dependency.behavior.is_peer()
                         && matches!(
                             Tree::hoist_dependency::<true, METHOD>(

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -797,12 +797,26 @@ impl Tree {
                     continue 'dep;
                 }
 
-                // Peer edges are excluded: a peer resolved to a folder package was bound to an
-                // importer's existing edge, so it must dedupe against that placement instead of
-                // nesting a second copy of the folder.
-                if !dependency.behavior.is_peer()
-                    && pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder
-                {
+                if pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder {
+                    // A peer resolved to a folder package may have been bound to an ancestor's
+                    // existing edge for the same package. Dedupe against that placement instead
+                    // of nesting a second copy. A peer no ancestor edge provides still nests.
+                    if dependency.behavior.is_peer()
+                        && matches!(
+                            Tree::hoist_dependency::<true, METHOD>(
+                                next_id,
+                                hoist_root_id,
+                                pkg_id,
+                                dep_id,
+                                resolution_list,
+                                builder,
+                            ),
+                            HoistDependencyResult::Hoisted
+                        )
+                    {
+                        break 'hoisted HoistDependencyResult::Hoisted;
+                    }
+
                     // Folder packages never hoist, so a cycle between them would nest forever.
                     let mut tree_id = next_id;
                     while tree_id != INVALID_ID {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -797,7 +797,12 @@ impl Tree {
                     continue 'dep;
                 }
 
-                if pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder {
+                // Peer edges are excluded: a peer resolved to a folder package was bound to an
+                // importer's existing edge, so it must dedupe against that placement instead of
+                // nesting a second copy of the folder.
+                if !dependency.behavior.is_peer()
+                    && pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder
+                {
                     // Folder packages never hoist, so a cycle between them would nest forever.
                     let mut tree_id = next_id;
                     while tree_id != INVALID_ID {

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -1645,7 +1645,8 @@ ${variants}`;
       );
       expect(migrated).toContain(`"has-peer/peer": ["peer@file:vendor/peer", {}]`);
       expect(migrated).toContain(`"with/peer": ["peer@file:vendor/peer", {}]`);
-      expect(migrated).toContain(`"with/has-peer/peer": ["peer@file:vendor/peer", {}]`);
+      // the peer of with/has-peer dedupes against the sibling copy at with/peer
+      expect(migrated).not.toContain(`"with/has-peer/peer"`);
       expect(migrated).not.toContain(`"optionalPeers"`);
 
       const install = await run(packageDir, "install", "--frozen-lockfile");

--- a/test/regression/issue/40561.test.ts
+++ b/test/regression/issue/40561.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/40561
+// A `catalog:` peer dependency inside a `file:` folder dependency caused the
+// hoister to nest a second copy of a sibling absolute-path `file:` dependency,
+// which the installer refused with "unsafe folder path".
+test("catalog: peer inside a file: dep does not break a sibling absolute file: dep", async () => {
+  using dir = tempDir("issue-40561", {
+    "external/dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+    "project/packages/local/package.json": JSON.stringify({
+      name: "local",
+      version: "0.0.0",
+      peerDependencies: { dep: "catalog:" },
+    }),
+  });
+  const base = String(dir);
+  await Bun.write(
+    `${base}/project/package.json`,
+    JSON.stringify({
+      name: "proj",
+      private: true,
+      dependencies: {
+        local: "file:./packages/local",
+        dep: `file:${base}/external/dep`,
+      },
+    }),
+  );
+
+  async function install() {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: `${base}/project`,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  // fresh install
+  {
+    const [stdout, stderr, exitCode] = await install();
+    expect(stderr).not.toContain("unsafe folder path");
+    expect(stdout).toContain("2 packages installed");
+    expect(exitCode).toBe(0);
+  }
+
+  // install again from the saved lockfile
+  {
+    const [, stderr, exitCode] = await install();
+    expect(stderr).not.toContain("unsafe folder path");
+    expect(exitCode).toBe(0);
+  }
+});


### PR DESCRIPTION
Fixes #40561.

### Problem
- A `catalog:` peer dependency inside a `file:` folder dependency makes `bun install` fail with `error: refusing to install dependency dep with unsafe folder path` for a sibling absolute-path `file:` dependency. Regression from 1.3.14 to 1.4.0.
- Since 302d15da2e, a `catalog:` peer of a non-workspace package becomes an optional `*` peer that binds to the importer's copy. The first hoist pass binds it to the root's folder package. Every later hoist pass hits the "Folder packages never hoist" short-circuit in `src/install/lockfile/Tree.rs` before any dedupe runs, so the peer edge gets a second nested placement of the same folder package. The installer refuses that nested copy because its relative path (`../external/dep`) escapes the package directory.

### Fix
- Before the folder short-circuit nests a peer edge, run `hoist_dependency`. If it returns `Hoisted`, an ancestor edge already provides the same package, so the peer dedupes against that placement and no second copy is placed.
- Any other result keeps the old behavior: the folder copy nests under the dependent. A peer can be the only route to a folder package (the dependent's own nested copy), and that layout is pinned by the lockb and migration tests.
- Verified: `test/regression/issue/40561.test.ts` fails on the released bun with the exact error and passes with the fix. Also ran the catalogs, hoist, lockb, migration, workspaces, lock, dedupe, prune, isolated-install, and bun-install suites.

### Background
- The hoisted tree builder (`Tree.rs`) walks each package's dependency edges and either hoists an edge to an ancestor `node_modules` or places a new copy in the current tree.
- Folder (`file:` directory) packages are never hoisted. Two folder packages that depend on each other would otherwise nest forever, so the builder places them without consulting `hoist_dependency`.
- An optional peer with no resolution late-binds during the first hoist pass to whatever package an ancestor edge with the same name resolved to. That binding persists in the lockfile's resolution buffer across the later hoist passes that drive the install.

<details><summary>Notes</summary>

Repro from the issue:

```bash
base=$(mktemp -d)
mkdir -p $base/external/dep $base/project/packages/local
printf '{"name":"dep","version":"1.0.0"}' > $base/external/dep/package.json
printf '{"name":"local","version":"0.0.0","peerDependencies":{"dep":"catalog:"}}' > $base/project/packages/local/package.json
printf '{"name":"proj","private":true,"dependencies":{"local":"file:./packages/local","dep":"file:%s/external/dep"}}' "$base" > $base/project/package.json
cd $base/project && bun install
```

Why a concrete range (`"1.0.0"`) does not reproduce: a required peer is not `OPTIONAL`, so unresolved it is skipped by the tree builder, and the deferred peer resolver never binds a required peer to a folder package (`Resolution::satisfies_dependency_version` rejects folder resolutions and the incorrect-peer fallback only fires for npm, git, and github tags).

Chain in detail:
1. `CatalogMap::strip_reference` (`src/install/lockfile/CatalogMap.rs`) rewrites the `catalog:` peer of the non-workspace `file:` package to an optional `*` peer. This serializes as `"optionalPeers": ["dep"]`.
2. The `Resolvable` hoist pass binds the unresolved optional peer to the root's `dep` edge, a folder package, through `HoistDependencyResult::Resolve` with no tag check. That binding is the intended "bind to the importer's copy" semantics.
3. The filter hoist pass that drives the install now sees the peer edge as a resolved folder package and breaks to `Placement` at the folder short-circuit, before `hoist_dependency` can dedupe. That is the second copy.
4. `PackageInstaller.rs` (the `Tag::Folder` arm) refuses the placement in a non-workspace tree because `../external/dep` escapes the package dir.

First iteration (57e3a1e9) excluded every peer edge from the folder short-circuit. CI showed that is too broad: when no ancestor provides the package, the peer is the only route to it, and the copy then hoisted to the root instead of nesting under the dependent. Three tests pin the nested layout (`bun-lockb.test.ts`, `migration/migrate.test.ts`, `migration/pnpm-lock-v9.test.ts`). The second commit (27c3c2ff) narrows the change: dedupe only on a `Hoisted` result, nest otherwise. `hoist_dependency` has no side effects, so probing it first is safe.

One test expectation changed: in `pnpm-lock-v9.test.ts`, "a peer met in one importer and unmet in another is bound from the met variant" expected a third copy at `with/has-peer/peer` even though `with/peer` is the same package. With the dedupe, the peer binds to the sibling copy and the nested entry is gone. The behavior the test pins (the peer binds from the met variant, no `optionalPeers`, the isolated store links the peer) is unchanged.

Suites run with the fix: `test/regression/issue/40561.test.ts`, `catalogs.test.ts`, `hoist.test.ts`, `bun-add-catalog.test.ts`, `public-hoist-pattern.test.ts`, `test-dev-peer-dependency-priority.test.ts`, `bun-workspaces.test.ts`, `bun-lock.test.ts`, `bun-lockb.test.ts`, `bun-dedupe.test.ts`, `bun-prune.test.ts`, `isolated-install.test.ts`, `migration/*`, `bun-install.test.ts`. The only local failures are network-dependent tests (public registry access) that fail identically without the fix.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts" "test/regression/issue/40561.test.ts"
bun test v1.4.1 (adc354d99)

test/regression/issue/40561.test.ts:
39 |   }
40 | 
41 |   // fresh install
42 |   {
43 |     const [stdout, stderr, exitCode] = await install();
44 |     expect(stderr).not.toContain("unsafe folder path");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "unsafe folder path"
Received: "error: refusing to install dependency dep with unsafe folder path \"../external/dep\"\nSaved lockfile\n"

      at <anonymous> (/workspace/bun/test/regression/issue/40561.test.ts:44:24)
(fail) catalog: peer inside a file: dep does not break a sibling absolute file: dep [240.44ms]

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [309.57ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [493.40ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [179.90ms]
(
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/regression/issue/40561.test.ts:
39 |   }
40 | 
41 |   // fresh install
42 |   {
43 |     const [stdout, stderr, exitCode] = await install();
44 |     expect(stderr).not.toContain("unsafe folder path");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "unsafe folder path"
Received: "error: refusing to install dependency dep with unsafe folder path \"../external/dep\"\nSaved lockfile\n"

      at <anonymous> (/workspace/bun/test/regression/issue/40561.test.ts:44:24)
(fail) catalog: peer inside a file: dep does not break a sibling absolute file: dep [7.58ms]

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [6.35ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [37.14ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [3.21ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [2.97ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [2.68ms]
(pass) pnpm-lock.yaml v9 > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts" "test/regression/issue/40561.test.ts"
bun test v1.4.1 (adc354d99)

test/regression/issue/40561.test.ts:
(pass) catalog: peer inside a file: dep does not break a sibling absolute file: dep [437.16ms]

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [258.63ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [545.16ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [196.70ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [178.06ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [243.06ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [218.07ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [180.84ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs re
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 650ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/lockfile/Tree.rs                    | 18 ++++++++
 test/cli/install/migration/pnpm-lock-v9.test.ts |  3 +-
 test/regression/issue/40561.test.ts             | 55 +++++++++++++++++++++++++
 3 files changed, 75 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/install/lockfile/Tree.rs                         5      4      0
test/cli/install/migration/pnpm-lock-v9.test.ts      1      1      0
test/regression/issue/40561.test.ts                  0      2      0
```

</details>

**root cause** · written by the author bot

The installer treated a peer dependency that resolved to a folder package as requiring its own folder placement, so it tried to nest a second copy of the package and computed a relative path that escaped the install root, which tripped the unsafe folder path guard. The fix routes such peers through the regular hoisting and deduplication path in Tree::process_subtree, so a folder package already provided by an ancestor edge satisfies the peer instead of being placed again. With no duplicate placement, no escaping relative path is generated and the install succeeds.

<!-- robobun:evidence:end -->