### PR TITLE
shell: resolve commands and which through one PATH lookup on the shell environment

### DIFF
--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -5,7 +5,6 @@
 //! are processed.
 
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
-use crate::shell::env_str::EnvStr;
 use crate::shell::interpreter::{Interpreter, NodeId};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -203,18 +202,8 @@ struct SearchEnv {
 impl SearchEnv {
     fn load(interp: &Interpreter, cmd: NodeId) -> Self {
         let shell = Builtin::shell(interp, cmd);
-        // `EnvMap::get` refs the returned string; balance it.
-        let path_env = shell
-            .export_env
-            .get(EnvStr::init_slice(b"PATH"))
-            .map(|s| {
-                let v = s.slice().to_vec();
-                s.deref();
-                v
-            })
-            .unwrap_or_default();
         Self {
-            path_env,
+            path_env: shell.get_path(interp.event_loop),
             cwd: shell.cwd().to_vec(),
         }
     }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2082,14 +2082,8 @@ impl ShellExecEnv {
             })
     }
 
-    /// The `PATH` that resolves an external command (and a `which` operand):
-    /// a `PATH=... cmd` prefix first, then `export_env`, then the process
-    /// environment. `_PATH_DEFPATH` on POSIX when none of them has one
-    /// (Android often has no PATH). An explicit `PATH=""` searches nothing.
-    ///
-    /// `EnvMap` lookups are case-insensitive on Windows, so `PATH` written by
-    /// `export` or `.env()` is found under the `Path` key the process
-    /// environment uses there.
+    /// PATH for argv[0] resolution and `which`. `EnvMap` is case-insensitive
+    /// on Windows, so `export PATH=` is found under the process's `Path` key.
     pub(crate) fn get_path(&self, event_loop: EventLoopHandle) -> Vec<u8> {
         use crate::shell::env_str::EnvStr;
         let key = EnvStr::init_slice(b"PATH");
@@ -2109,6 +2103,7 @@ impl ShellExecEnv {
             if let Some(path) = (*event_loop.env()).get(b"PATH") {
                 path.to_vec()
             } else if cfg!(unix) {
+                // Android often has no PATH at all.
                 core::ffi::CStr::from_ptr(crate::shell::subproc::BUN_DEFAULT_PATH_FOR_SPAWN)
                     .to_bytes()
                     .to_vec()

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2082,8 +2082,7 @@ impl ShellExecEnv {
             })
     }
 
-    /// PATH for argv[0] resolution and `which`. `EnvMap` is case-insensitive
-    /// on Windows, so `export PATH=` is found under the process's `Path` key.
+    /// The PATH that resolves argv[0] and `which` operands.
     pub(crate) fn get_path(&self, event_loop: EventLoopHandle) -> Vec<u8> {
         use crate::shell::env_str::EnvStr;
         let key = EnvStr::init_slice(b"PATH");

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2081,6 +2081,42 @@ impl ShellExecEnv {
                 })
             })
     }
+
+    /// The `PATH` that resolves an external command (and a `which` operand):
+    /// a `PATH=... cmd` prefix first, then `export_env`, then the process
+    /// environment. `_PATH_DEFPATH` on POSIX when none of them has one
+    /// (Android often has no PATH). An explicit `PATH=""` searches nothing.
+    ///
+    /// `EnvMap` lookups are case-insensitive on Windows, so `PATH` written by
+    /// `export` or `.env()` is found under the `Path` key the process
+    /// environment uses there.
+    pub(crate) fn get_path(&self, event_loop: EventLoopHandle) -> Vec<u8> {
+        use crate::shell::env_str::EnvStr;
+        let key = EnvStr::init_slice(b"PATH");
+        if let Some(path) = self
+            .cmd_local_env
+            .get(key)
+            .or_else(|| self.export_env.get(key))
+        {
+            // `EnvMap::get` refs the returned string; balance it.
+            let bytes = path.slice().to_vec();
+            path.deref();
+            return bytes;
+        }
+        // SAFETY: `event_loop.env()` is the VM's long-lived `Loader`, and
+        // `BUN_DEFAULT_PATH_FOR_SPAWN` is a NUL-terminated C-string constant.
+        unsafe {
+            if let Some(path) = (*event_loop.env()).get(b"PATH") {
+                path.to_vec()
+            } else if cfg!(unix) {
+                core::ffi::CStr::from_ptr(crate::shell::subproc::BUN_DEFAULT_PATH_FOR_SPAWN)
+                    .to_bytes()
+                    .to_vec()
+            } else {
+                Vec::new()
+            }
+        }
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -467,15 +467,16 @@ impl Cmd {
         {
             let env = interp.as_cmd_mut(this).base.shell_mut();
             let mut iter = env.export_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
+            spawn_args.fill_env(&mut iter);
             let mut iter = env.cmd_local_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
+            spawn_args.fill_env(&mut iter);
         }
 
-        // Resolve argv[0] via PATH (`bun_which::which`).
+        // Resolve argv[0] via the shell's PATH (`bun_which::which`).
         let resolved: Option<Vec<u8>> = {
+            let path = interp.as_cmd(this).base.shell().get_path(event_loop);
             let mut path_buf = bun_paths::path_buffer_pool::get();
-            match bun_which::which(&mut *path_buf, spawn_args.path, spawn_args.cwd, &first_arg) {
+            match bun_which::which(&mut *path_buf, &path, spawn_args.cwd, &first_arg) {
                 Some(z) => Some(z.as_bytes().to_vec()),
                 None if &first_arg[..] == b"bun" || &first_arg[..] == b"bun-debug" => {
                     bun_core::self_exe_path()

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1391,7 +1391,6 @@ pub struct SpawnArgs<'a> {
     pub(crate) cwd: &'a [u8],
     pub(crate) stdio: [Stdio; 3],
     pub(crate) lazy: bool,
-    pub path: &'a [u8],
     // ipc_mode: IPCMode,
     // ipc_callback: JSValue,
 }
@@ -1412,22 +1411,6 @@ impl<'a> SpawnArgs<'a> {
             cwd: event_loop.top_level_dir(),
             stdio: [Stdio::Ignore, Stdio::Pipe, Stdio::Inherit],
             lazy: false,
-            // PATH unset → fall back to _PATH_DEFPATH on POSIX (Android often
-            // has no PATH). PATH="" (explicit empty) is preserved — that's a
-            // deliberate "search nothing" and substituting a default would
-            // change argv[0] resolution on existing platforms.
-            // SAFETY: `event_loop.env()` returns the long-lived `*mut Loader`
-            // owned by the VM (valid for the lifetime of the spawn args), and
-            // `BUN_DEFAULT_PATH_FOR_SPAWN` is a NUL-terminated C-string constant.
-            path: unsafe {
-                if let Some(p) = (*event_loop.env()).get(b"PATH") {
-                    p
-                } else if cfg!(unix) {
-                    core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN).to_bytes()
-                } else {
-                    b""
-                }
-            },
             // .ipc_mode = IPCMode.none,
             // .ipc_callback = .zero,
         };
@@ -1441,20 +1424,12 @@ impl<'a> SpawnArgs<'a> {
 
     /// `object_iter` should be a some type with the following fields:
     /// - `next() bool`
-    pub(crate) fn fill_env<const DISABLE_PATH_LOOKUP_FOR_ARV0: bool>(
-        &mut self,
-        env_iter: &mut crate::shell::env_map::Iterator<'_>,
-    ) {
+    pub(crate) fn fill_env(&mut self, env_iter: &mut crate::shell::env_map::Iterator<'_>) {
         self.override_env = true;
         // Note: `bun_collections::array_hash_map::Iter` doesn't impl
         // `ExactSizeIterator`; use `size_hint` for the reservation.
         self.env_array
             .reserve_exact(env_iter.size_hint().0.saturating_sub(self.env_array.len()));
-
-        if DISABLE_PATH_LOOKUP_FOR_ARV0 {
-            // If the env object does not include a $PATH, it must disable path lookup for argv[0]
-            self.path = b"";
-        }
 
         while let Some(entry) = env_iter.next() {
             let key = entry.key_ptr.slice();
@@ -1473,18 +1448,6 @@ impl<'a> SpawnArgs<'a> {
             line[key.len() + 1..len].copy_from_slice(value);
             line[len] = 0;
             let line: &'a [u8] = line;
-
-            // Windows environment variable names are case-insensitive, and
-            // `EnvMap` keeps the casing of the first insert (`Path` from the
-            // process environment), so `export PATH=...` lands under `Path`.
-            let is_path = if cfg!(windows) {
-                bun_core::strings::eql_case_insensitive_ascii_check_length(key, b"PATH")
-            } else {
-                key == b"PATH"
-            };
-            if is_path {
-                self.path = &line[key.len() + 1..len];
-            }
 
             self.env_array.push(line.as_ptr().cast::<c_char>());
         }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1474,8 +1474,16 @@ impl<'a> SpawnArgs<'a> {
             line[len] = 0;
             let line: &'a [u8] = line;
 
-            if key == b"PATH" {
-                self.path = &line[b"PATH=".len()..len];
+            // Windows environment variable names are case-insensitive, and
+            // `EnvMap` keeps the casing of the first insert (`Path` from the
+            // process environment), so `export PATH=...` lands under `Path`.
+            let is_path = if cfg!(windows) {
+                bun_core::strings::eql_case_insensitive_ascii_check_length(key, b"PATH")
+            } else {
+                key == b"PATH"
+            };
+            if is_path {
+                self.path = &line[key.len() + 1..len];
             }
 
             self.env_array.push(line.as_ptr().cast::<c_char>());

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3286,3 +3286,83 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
     expect(exitCode).toBe(0);
   }
 });
+
+// Windows stores the variable as `Path`. The shell env map is case-insensitive
+// there and keeps the key casing of the first insert, so a `PATH` written by
+// `.env()`, `export`, or `process.env` lands under the `Path` key.
+describe.concurrent.skipIf(!isWindows)("external command resolution on Windows uses PATH under any key casing", () => {
+  const envWithoutPath: Record<string, string> = {};
+  for (const [key, value] of Object.entries(bunEnv)) {
+    if (key.toLowerCase() !== "path" && value !== undefined) envWithoutPath[key] = value;
+  }
+  const processPath = process.env.PATH!;
+  const toolDir = (name: string, message: string, dirPrefix = name) =>
+    tempDir(`shell-argv0-${dirPrefix}`, { [`${name}.cmd`]: `@echo ${message}\r\n` });
+
+  test(".env() with a Path key", async () => {
+    using dir = toolDir("onlyintool-pathkey", "from-Path-key");
+    const { stdout, stderr, exitCode } = await $`onlyintool-pathkey`
+      .env({ ...envWithoutPath, Path: `${String(dir)};${processPath}` })
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim()).toBe("from-Path-key");
+    expect(exitCode).toBe(0);
+  });
+
+  test(".env() with PATH added to an env that already has Path", async () => {
+    using dir = toolDir("onlyintool-bothkeys", "from-PATH-over-Path");
+    const { stdout, stderr, exitCode } = await $`onlyintool-bothkeys`
+      .env({ ...envWithoutPath, Path: processPath, PATH: `${String(dir)};${processPath}` })
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim()).toBe("from-PATH-over-Path");
+    expect(exitCode).toBe(0);
+  });
+
+  test("export PATH over an env that has Path", async () => {
+    using dir = toolDir("onlyintool-export", "from-export");
+    const { stdout, stderr, exitCode } = await $`export PATH=${`${String(dir)};${processPath}`}; onlyintool-export`
+      .env({ ...envWithoutPath, Path: processPath })
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim()).toBe("from-export");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a PATH= prefix still beats export", async () => {
+    using prefixDir = toolDir("onlyintool-priority", "from-prefix", "priority-prefix");
+    using exportDir = toolDir("onlyintool-priority", "from-export", "priority-export");
+    const exportPath = `${String(exportDir)};${processPath}`;
+    const prefixPath = `${String(prefixDir)};${processPath}`;
+    const { stdout, stderr, exitCode } = await $`export PATH=${exportPath}; PATH=${prefixPath} onlyintool-priority`
+      .env({ ...envWithoutPath, Path: processPath })
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim()).toBe("from-prefix");
+    expect(exitCode).toBe(0);
+  });
+
+  test("process.env.PATH set at runtime", async () => {
+    using dir = toolDir("onlyintool-runtime", "from-runtime");
+    const code = `
+      import { $ } from "bun";
+      process.env.PATH = ${JSON.stringify(String(dir))} + ";" + process.env.PATH;
+      const { stdout, stderr, exitCode } = await $\`onlyintool-runtime\`.quiet().nothrow();
+      console.log(JSON.stringify({ stdout: stdout.toString().trim(), stderr: stderr.toString(), exitCode }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: { ...envWithoutPath, Path: processPath },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ stdout: "from-runtime", stderr: "", exitCode: 0 });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3365,4 +3365,26 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows u
     expect(JSON.parse(stdout)).toEqual({ stdout: "from-runtime", stderr: "", exitCode: 0 });
     expect(exitCode).toBe(0);
   });
+
+  // `bun run <script>` runs package.json scripts through the Bun shell on
+  // Windows, with the shell environment seeded from the process environment.
+  test("export PATH in a package.json script", async () => {
+    using dir = toolDir("onlyintool-script", "from-script");
+    using project = tempDir("shell-argv0-project", {
+      "package.json": JSON.stringify({
+        scripts: { tool: `export PATH='${String(dir)};${processPath}'; onlyintool-script` },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--silent", "run", "tool"],
+      env: { ...envWithoutPath, Path: processPath },
+      cwd: String(project),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("from-script");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/shell/commands/which.test.ts
+++ b/test/js/bun/shell/commands/which.test.ts
@@ -55,6 +55,45 @@ test.concurrent("which searches $PATH for bare names and the shell cwd for ./ na
   expect(exitCode).toBe(0);
 });
 
+// `which` resolves through the same PATH as running the command does: a
+// `PATH=... cmd` prefix, then the exported environment, then the process
+// environment when the shell environment has no PATH at all.
+test.concurrent("which honors a PATH= prefix assignment", async () => {
+  using dir = tempDir("which-prefix", searchTree);
+  const { pathDir } = searchDirs(String(dir));
+
+  const { stdout, exitCode } = await $`PATH=${pathDir} which tool`
+    .env({ ...bunEnv, PATH: "" })
+    .quiet()
+    .nothrow();
+  expect(stdout.toString()).toBe(`${join(pathDir, exe)}\n`);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("which falls back to the process PATH when the shell environment has no PATH", async () => {
+  using dir = tempDir("which-process-path", searchTree);
+  const { pathDir } = searchDirs(String(dir));
+
+  // Windows spells the variable `Path`, so drop every spelling before setting it.
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => key.toLowerCase() !== "path"));
+    const { stdout, exitCode } = await $\`which tool\`.env(env).quiet().nothrow();
+    console.log(JSON.stringify({ stdout: stdout.toString(), exitCode }));
+  `;
+  const env = Object.fromEntries(Object.entries(bunEnv).filter(([key]) => key.toLowerCase() !== "path"));
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...env, PATH: pathDir },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ stdout: `${join(pathDir, exe)}\n`, exitCode: 0 });
+  expect(exitCode).toBe(0);
+});
+
 test.skipIf(isWindows)("which with an absolute path at the platform path length limit reports not found", async () => {
   const fixture = /* ts */ `
     import { $ } from "bun";


### PR DESCRIPTION
### Problem
- On Windows, `export PATH=...`, `` $`cmd`.env({ ...process.env, PATH }) `` and a runtime `process.env.PATH` change do not affect command lookup in Bun Shell: `bun: command not found: <cmd>`, while `which` finds the command. Also in `bun run <script>` (Bun Shell on Windows).
- Cause: two PATH lookups. `SpawnArgs::fill_env` scraped `PATH` from the env map byte for byte (`src/runtime/shell/subproc.rs:1477`), `which` read the map. Windows spells the variable `Path`. `EnvMap` is case-insensitive there and keeps the first key casing, so the scrape never saw `export PATH=...`. `which` also ignored a `PATH=... cmd` prefix and had no process PATH fallback.

### Fix
- Add `ShellExecEnv::get_path` (`interpreter.rs`): prefix assignment, then exported environment, then process environment. Both `Cmd.rs` (argv[0]) and the `which` builtin call it.
- Delete `SpawnArgs.path`, the scrape in `fill_env`, and the unused `DISABLE_PATH_LOOKUP_FOR_ARV0` generic.
- Correct because the map lookup is what `export`, `.env()` and `which` already use, so the Windows casing rule lives only in `EnvMap.rs`. Prefix still beats export, and the process PATH fallback stays. `which` now uses the PATH the command runs with.
- Verified: `test/js/bun/shell/bunshell.test.ts` (6 Windows-only tests, 5 fail on main) and `test/js/bun/shell/commands/which.test.ts` (2 tests, fail on main everywhere). Shell suites pass on Linux and Windows.

### Background
- `cmd_local_env` holds `VAR=value cmd` prefix assignments for one command. `export_env` is the exported environment, seeded from `process.env` (JS) or the process env loader (`bun run`). `fill_env` copies both into the child's environment block.
- Replaces #36509, whose `Cmd.rs` change landed in #36165 (closed #9747, #10865, #25885). Prior work: #32200 by @elibarzilay.

<details><summary>Notes</summary>

Repro on Windows with the canary at 731aa92da (`process.env` has `Path`, each case runs a `mytool.cmd` shim):

```
.env() PATH: exit=1 stdout="" stderr="bun: command not found: mytool"
.env() Path: exit=1 stdout="" stderr="bun: command not found: mytool"
.env() PATH only-key: exit=0 stdout="hello-from-mytool" stderr=""
export PATH: exit=1 stdout="" stderr="bun: command not found: mytool"
export Path: exit=1 stdout="" stderr="bun: command not found: mytool"
PATH= prefix: exit=0 stdout="hello-from-mytool" stderr=""
which after export: exit=0 stdout="C:\\...\\mytool.cmd"
$.env PATH: exit=1 stdout="" stderr="bun: command not found: mytool"
process.env.PATH mutation: exit=1 stdout="" stderr="bun: command not found: mytool"
```

The `PATH= prefix` form worked on main because `cmd_local_env` is a fresh map whose key is spelled `PATH`. `.env()` with an object that has no `Path` key worked for the same reason.

Behavior that changes for `which`: `PATH=<dir> which tool` now searches `<dir>` (bash does the same, `which` inherits the prefix), and `which` in a shell environment without PATH now searches the process PATH, which is what running the command already did.

Behavior that does not change: an explicit `PATH=""` still searches nothing, a shell environment without PATH still resolves commands against the process PATH (`_PATH_DEFPATH` on POSIX when the process has none either), and the prefix assignment still beats `export`.

The first version of this PR only made the `fill_env` comparison case-insensitive on Windows (like `Bun.spawn` does in `js_bun_spawn_bindings.rs:2150`). Review pointed out that this was a second copy of the `EnvMap` key rule and that `which` had a third PATH lookup, so the PR moved to one helper.

The Windows tests build their env from `bunEnv` with every PATH-like key removed and add `Path` explicitly, so they do not depend on the casing the CI agent uses. The POSIX exec cases are covered by the existing test from #36165.

Other suites run: `test/js/bun/shell/` on Linux (576 pass, 3 `ls` failures that also fail on main as root or under load) and `bunshell.test.ts`, `which.test.ts`, `rm.test.ts` on Windows (5 `tilde_expansion` failures there are pre-existing, no `HOME` in that environment, and one `rm` test trips on a debug-only warning).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/commands/which.test.ts, test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->