### PR TITLE
WebSocket client: pause()/resume(), working bufferedAmount, and a ServerWebSocket drain stall fix

### DIFF
--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -338,6 +338,24 @@ socket.addEventListener("close", event => {});
 socket.addEventListener("error", event => {});
 ```
 
+### Backpressure
+
+The browser `WebSocket` API has no way to slow down a peer that sends faster than you consume: incoming messages are buffered in memory without bound. Bun adds `pause()` and `resume()`, which stop and restart reads from the underlying socket so the sender sees TCP backpressure instead. This is a Bun-specific extension. _It does not work in browsers._
+
+```ts
+const socket = new WebSocket("ws://localhost:3000");
+
+socket.addEventListener("message", event => {
+  if (!file.write(event.data)) {
+    // The file's buffer is full: stop reading until it drains.
+    socket.pause();
+    file.once("drain", () => socket.resume());
+  }
+});
+```
+
+`pause()` and `resume()` return `true` when they took effect (or will, once a connecting socket opens) and `false` when there is no socket to act on; `socket.isPaused` reports the current state. Messages already decoded when `pause()` is called may still be delivered. The `ws` package's `pause()`, `resume()`, and `isPaused` map to the same methods.
+
 ---
 
 ## Reference

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5039,6 +5039,26 @@ declare module "bun" {
     terminate(): void;
 
     /**
+     * Stops reading from the underlying socket, so the peer sees TCP
+     * backpressure instead of the client buffering in memory. Messages
+     * already received may still be dispatched. A pause before the
+     * connection opens takes effect once it does.
+     * @returns `true` if the socket was paused (or will be on open), `false` if there is no socket to pause
+     */
+    pause(): boolean;
+
+    /**
+     * Resumes reading from the underlying socket after `pause()`.
+     * @returns `true` if the socket was resumed (or will be on open), `false` if there is no socket to resume
+     */
+    resume(): boolean;
+
+    /**
+     * Whether the connection is currently paused via `pause()`.
+     */
+    readonly isPaused: boolean;
+
+    /**
      * Registers an event handler of a specific event type on the WebSocket.
      * @param type A case-sensitive string representing the event type to listen for
      * @param listener The function to be called when the event occurs

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -429,6 +429,7 @@ int us_socket_write2(struct us_socket_t *s, const char *header, int header_lengt
 
     int written = bsd_write2(us_poll_fd(&s->p), header, header_length, payload, payload_length);
     if (written != header_length + payload_length) {
+        s->flags.last_write_failed = 1;
         us_internal_rearm_writable(s);
     }
 

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1232,6 +1232,11 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.tunnel().is_some_and(|t| t.has_backpressure())
     }
 
+    pub(crate) fn buffered_amount(&self) -> usize {
+        self.send_buffer.borrow().readable_length()
+            + self.tunnel().map_or(0, |t| t.buffered_amount())
+    }
+
     pub(crate) fn pause(&self) -> bool {
         if let Some(tunnel) = self.tunnel() {
             return tunnel.pause_stream();
@@ -1639,6 +1644,12 @@ pub type WebSocketClientTLS = WebSocket<true>;
 pub fn bun__websocketclient__cancel(this: ThisPtr<crate::websocket_client::WebSocketClient>) {
     WebSocketClient::cancel(this)
 }
+// HOST_EXPORT(Bun__WebSocketClient__bufferedAmount, c)
+pub fn bun__websocketclient__buffered_amount(
+    this: &crate::websocket_client::WebSocketClient,
+) -> usize {
+    this.buffered_amount()
+}
 // HOST_EXPORT(Bun__WebSocketClient__pause, c)
 pub fn bun__websocketclient__pause(this: &crate::websocket_client::WebSocketClient) -> bool {
     this.pause()
@@ -1717,6 +1728,12 @@ pub fn bun__websocketclient__write_string(
 // HOST_EXPORT(Bun__WebSocketClientTLS__cancel, c)
 pub fn bun__websocketclienttls__cancel(this: ThisPtr<crate::websocket_client::WebSocketClientTLS>) {
     WebSocketClientTLS::cancel(this)
+}
+// HOST_EXPORT(Bun__WebSocketClientTLS__bufferedAmount, c)
+pub fn bun__websocketclienttls__buffered_amount(
+    this: &crate::websocket_client::WebSocketClientTLS,
+) -> usize {
+    this.buffered_amount()
 }
 // HOST_EXPORT(Bun__WebSocketClientTLS__pause, c)
 pub fn bun__websocketclienttls__pause(this: &crate::websocket_client::WebSocketClientTLS) -> bool {

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1232,6 +1232,20 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.tunnel().is_some_and(|t| t.has_backpressure())
     }
 
+    pub(crate) fn pause(&self) -> bool {
+        if let Some(tunnel) = self.tunnel() {
+            return tunnel.pause_stream();
+        }
+        self.tcp.get().pause_stream()
+    }
+
+    pub(crate) fn resume(&self) -> bool {
+        if let Some(tunnel) = self.tunnel() {
+            return tunnel.resume_stream();
+        }
+        self.tcp.get().resume_stream()
+    }
+
     /// Frame small unbackpressured sends on the stack; else fall back to [`Self::send_data`].
     fn send_frame(&self, bytes: Copy<'_>, payload_byte_len: usize, opcode: Opcode) {
         let frame_size = WebsocketHeader::frame_size_including_mask(payload_byte_len);
@@ -1625,6 +1639,14 @@ pub type WebSocketClientTLS = WebSocket<true>;
 pub fn bun__websocketclient__cancel(this: ThisPtr<crate::websocket_client::WebSocketClient>) {
     WebSocketClient::cancel(this)
 }
+// HOST_EXPORT(Bun__WebSocketClient__pause, c)
+pub fn bun__websocketclient__pause(this: &crate::websocket_client::WebSocketClient) -> bool {
+    this.pause()
+}
+// HOST_EXPORT(Bun__WebSocketClient__resume, c)
+pub fn bun__websocketclient__resume(this: &crate::websocket_client::WebSocketClient) -> bool {
+    this.resume()
+}
 // HOST_EXPORT(Bun__WebSocketClient__close, c)
 pub fn bun__websocketclient__close(
     this: ThisPtr<crate::websocket_client::WebSocketClient>,
@@ -1695,6 +1717,14 @@ pub fn bun__websocketclient__write_string(
 // HOST_EXPORT(Bun__WebSocketClientTLS__cancel, c)
 pub fn bun__websocketclienttls__cancel(this: ThisPtr<crate::websocket_client::WebSocketClientTLS>) {
     WebSocketClientTLS::cancel(this)
+}
+// HOST_EXPORT(Bun__WebSocketClientTLS__pause, c)
+pub fn bun__websocketclienttls__pause(this: &crate::websocket_client::WebSocketClientTLS) -> bool {
+    this.pause()
+}
+// HOST_EXPORT(Bun__WebSocketClientTLS__resume, c)
+pub fn bun__websocketclienttls__resume(this: &crate::websocket_client::WebSocketClientTLS) -> bool {
+    this.resume()
 }
 // HOST_EXPORT(Bun__WebSocketClientTLS__close, c)
 pub fn bun__websocketclienttls__close(

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -487,6 +487,22 @@ impl WebSocketProxyTunnel {
     pub(crate) fn has_backpressure(&self) -> bool {
         self.write_buffer.get().is_not_empty()
     }
+
+    pub(crate) fn pause_stream(&self) -> bool {
+        match &self.socket {
+            SocketUnion::Tcp(s) => s.pause_stream(),
+            SocketUnion::Ssl(s) => s.pause_stream(),
+            SocketUnion::None => false,
+        }
+    }
+
+    pub(crate) fn resume_stream(&self) -> bool {
+        match &self.socket {
+            SocketUnion::Tcp(s) => s.resume_stream(),
+            SocketUnion::Ssl(s) => s.resume_stream(),
+            SocketUnion::None => false,
+        }
+    }
 }
 
 // HOST_EXPORT(WebSocketProxyTunnel__setConnectedWebSocket, c)

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -488,6 +488,10 @@ impl WebSocketProxyTunnel {
         self.write_buffer.get().is_not_empty()
     }
 
+    pub(crate) fn buffered_amount(&self) -> usize {
+        self.write_buffer.get().size()
+    }
+
     pub(crate) fn pause_stream(&self) -> bool {
         match &self.socket {
             SocketUnion::Tcp(s) => s.pause_stream(),

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -719,9 +719,7 @@ class BunWebSocket extends EventEmitter {
     }
 
     this.#paused = true;
-
-    // deviation: we dont support pause()
-    emitWarning("pause()", "ws.WebSocket.pause() is not implemented in bun");
+    this.#ws.pause();
   }
 
   resume() {
@@ -732,9 +730,7 @@ class BunWebSocket extends EventEmitter {
     }
 
     this.#paused = false;
-
-    // deviation: we dont support resume()
-    emitWarning("resume()", "ws.WebSocket.resume() is not implemented in bun");
+    this.#ws.resume();
   }
 }
 Object.defineProperty(BunWebSocket, "name", { value: "WebSocket" });

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -614,6 +614,7 @@ ZIG_DECL void Bun__WebSocket__freeSSLConfig(void* sslConfig);
 #ifdef __cplusplus
 
 ZIG_DECL void Bun__WebSocketClient__cancel(WebSocketClient* arg0);
+ZIG_DECL size_t Bun__WebSocketClient__bufferedAmount(WebSocketClient* arg0);
 ZIG_DECL bool Bun__WebSocketClient__pause(WebSocketClient* arg0);
 ZIG_DECL bool Bun__WebSocketClient__resume(WebSocketClient* arg0);
 ZIG_DECL void Bun__WebSocketClient__close(WebSocketClient* arg0, uint16_t arg1, const EncodedSlice* arg2);
@@ -629,6 +630,7 @@ ZIG_DECL size_t Bun__WebSocketClient__memoryCost(WebSocketClient* arg0);
 #ifdef __cplusplus
 
 ZIG_DECL void Bun__WebSocketClientTLS__cancel(WebSocketClientTLS* arg0);
+ZIG_DECL size_t Bun__WebSocketClientTLS__bufferedAmount(WebSocketClientTLS* arg0);
 ZIG_DECL bool Bun__WebSocketClientTLS__pause(WebSocketClientTLS* arg0);
 ZIG_DECL bool Bun__WebSocketClientTLS__resume(WebSocketClientTLS* arg0);
 ZIG_DECL void Bun__WebSocketClientTLS__close(WebSocketClientTLS* arg0, uint16_t arg1, const EncodedSlice* arg2);

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -614,6 +614,8 @@ ZIG_DECL void Bun__WebSocket__freeSSLConfig(void* sslConfig);
 #ifdef __cplusplus
 
 ZIG_DECL void Bun__WebSocketClient__cancel(WebSocketClient* arg0);
+ZIG_DECL bool Bun__WebSocketClient__pause(WebSocketClient* arg0);
+ZIG_DECL bool Bun__WebSocketClient__resume(WebSocketClient* arg0);
 ZIG_DECL void Bun__WebSocketClient__close(WebSocketClient* arg0, uint16_t arg1, const EncodedSlice* arg2);
 ZIG_DECL void Bun__WebSocketClient__finalize(WebSocketClient* arg0);
 ZIG_DECL void Bun__WebSocketClient__dropConnectionWithoutCallback(WebSocketClient* arg0);
@@ -627,6 +629,8 @@ ZIG_DECL size_t Bun__WebSocketClient__memoryCost(WebSocketClient* arg0);
 #ifdef __cplusplus
 
 ZIG_DECL void Bun__WebSocketClientTLS__cancel(WebSocketClientTLS* arg0);
+ZIG_DECL bool Bun__WebSocketClientTLS__pause(WebSocketClientTLS* arg0);
+ZIG_DECL bool Bun__WebSocketClientTLS__resume(WebSocketClientTLS* arg0);
 ZIG_DECL void Bun__WebSocketClientTLS__close(WebSocketClientTLS* arg0, uint16_t arg1, const EncodedSlice* arg2);
 ZIG_DECL void Bun__WebSocketClientTLS__finalize(WebSocketClientTLS* arg0);
 ZIG_DECL void Bun__WebSocketClientTLS__dropConnectionWithoutCallback(WebSocketClientTLS* arg0);

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -79,6 +79,8 @@ static JSC_DECLARE_HOST_FUNCTION(jsWebSocketPrototypeFunction_close);
 static JSC_DECLARE_HOST_FUNCTION(jsWebSocketPrototypeFunction_ping);
 static JSC_DECLARE_HOST_FUNCTION(jsWebSocketPrototypeFunction_pong);
 static JSC_DECLARE_HOST_FUNCTION(jsWebSocketPrototypeFunction_terminate);
+static JSC_DECLARE_HOST_FUNCTION(jsWebSocketPrototypeFunction_pause);
+static JSC_DECLARE_HOST_FUNCTION(jsWebSocketPrototypeFunction_resume);
 
 // Attributes
 
@@ -87,6 +89,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsWebSocket_URL);
 static JSC_DECLARE_CUSTOM_GETTER(jsWebSocket_url);
 static JSC_DECLARE_CUSTOM_GETTER(jsWebSocket_readyState);
 static JSC_DECLARE_CUSTOM_GETTER(jsWebSocket_bufferedAmount);
+static JSC_DECLARE_CUSTOM_GETTER(jsWebSocket_isPaused);
 static JSC_DECLARE_CUSTOM_GETTER(jsWebSocket_onopen);
 static JSC_DECLARE_CUSTOM_SETTER(setJSWebSocket_onopen);
 static JSC_DECLARE_CUSTOM_GETTER(jsWebSocket_onmessage);
@@ -409,6 +412,9 @@ static const HashTableValue JSWebSocketPrototypeTableValues[] = {
     { "ping"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebSocketPrototypeFunction_ping, 1 } },
     { "pong"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebSocketPrototypeFunction_pong, 1 } },
     { "terminate"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebSocketPrototypeFunction_terminate, 0 } },
+    { "pause"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebSocketPrototypeFunction_pause, 0 } },
+    { "resume"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebSocketPrototypeFunction_resume, 0 } },
+    { "isPaused"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsWebSocket_isPaused, 0 } },
     { "CONNECTING"_s, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::ConstantInteger, NoIntrinsic, { HashTableValue::ConstantType, 0 } },
     { "OPEN"_s, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::ConstantInteger, NoIntrinsic, { HashTableValue::ConstantType, 1 } },
     { "CLOSING"_s, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::ConstantInteger, NoIntrinsic, { HashTableValue::ConstantType, 2 } },
@@ -514,6 +520,17 @@ static inline JSValue jsWebSocket_bufferedAmountGetter(JSGlobalObject& lexicalGl
 JSC_DEFINE_CUSTOM_GETTER(jsWebSocket_bufferedAmount, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSWebSocket>::get<jsWebSocket_bufferedAmountGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline JSValue jsWebSocket_isPausedGetter(JSGlobalObject& lexicalGlobalObject, JSWebSocket& thisObject)
+{
+    UNUSED_PARAM(lexicalGlobalObject);
+    return jsBoolean(thisObject.wrapped().isPaused());
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsWebSocket_isPaused, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSWebSocket>::get<jsWebSocket_isPausedGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
 
 static inline JSValue jsWebSocket_onopenGetter(JSGlobalObject& lexicalGlobalObject, JSWebSocket& thisObject)
@@ -937,6 +954,30 @@ static inline JSC::EncodedJSValue jsWebSocketPrototypeFunction_terminateBody(JSC
 JSC_DEFINE_HOST_FUNCTION(jsWebSocketPrototypeFunction_terminate, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     return IDLOperation<JSWebSocket>::call<jsWebSocketPrototypeFunction_terminateBody>(*lexicalGlobalObject, *callFrame, "terminate");
+}
+
+static inline JSC::EncodedJSValue jsWebSocketPrototypeFunction_pauseBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSWebSocket>::ClassParameter castedThis)
+{
+    UNUSED_PARAM(lexicalGlobalObject);
+    UNUSED_PARAM(callFrame);
+    return JSValue::encode(jsBoolean(castedThis->wrapped().pause()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsWebSocketPrototypeFunction_pause, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSWebSocket>::call<jsWebSocketPrototypeFunction_pauseBody>(*lexicalGlobalObject, *callFrame, "pause");
+}
+
+static inline JSC::EncodedJSValue jsWebSocketPrototypeFunction_resumeBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSWebSocket>::ClassParameter castedThis)
+{
+    UNUSED_PARAM(lexicalGlobalObject);
+    UNUSED_PARAM(callFrame);
+    return JSValue::encode(jsBoolean(castedThis->wrapped().resume()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsWebSocketPrototypeFunction_resume, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSWebSocket>::call<jsWebSocketPrototypeFunction_resumeBody>(*lexicalGlobalObject, *callFrame, "resume");
 }
 
 JSC::GCClient::IsoSubspace* JSWebSocket::subspaceForImpl(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -753,7 +753,6 @@ void WebSocket::sendWebSocketData(const char* baseAddress, size_t length, const 
     case ConnectedWebSocketKind::Client: {
         Bun__WebSocketClient__writeBinaryData(this->m_connectedWebSocket.client, reinterpret_cast<const unsigned char*>(baseAddress), length, static_cast<uint8_t>(op));
         // this->m_connectedWebSocket.client->send({ baseAddress, length }, opCode);
-        // this->m_bufferedAmount = this->m_connectedWebSocket.client->getBufferedAmount();
         break;
     }
     case ConnectedWebSocketKind::ClientSSL: {
@@ -773,7 +772,6 @@ void WebSocket::sendWebSocketString(const String& message, const Opcode op)
         auto slice = Zig::toEncodedSlice(message);
         Bun__WebSocketClient__writeString(this->m_connectedWebSocket.client, &slice, static_cast<uint8_t>(op));
         // this->m_connectedWebSocket.client->send({ baseAddress, length }, opCode);
-        // this->m_bufferedAmount = this->m_connectedWebSocket.client->getBufferedAmount();
         break;
     }
     case ConnectedWebSocketKind::ClientSSL: {
@@ -853,13 +851,11 @@ ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, c
     case ConnectedWebSocketKind::Client: {
         EncodedSlice reasonSlice = Zig::toEncodedSlice(reason);
         Bun__WebSocketClient__close(this->m_connectedWebSocket.client, code, &reasonSlice);
-        // this->m_bufferedAmount = this->m_connectedWebSocket.client->getBufferedAmount();
         break;
     }
     case ConnectedWebSocketKind::ClientSSL: {
         EncodedSlice reasonSlice = Zig::toEncodedSlice(reason);
         Bun__WebSocketClientTLS__close(this->m_connectedWebSocket.clientSSL, code, &reasonSlice);
-        // this->m_bufferedAmount = this->m_connectedWebSocket.clientSSL->getBufferedAmount();
         break;
     }
     default: {
@@ -1149,7 +1145,22 @@ WebSocket::State WebSocket::readyState() const
 
 unsigned WebSocket::bufferedAmount() const
 {
-    return saturateAdd(m_bufferedAmount, m_bufferedAmountAfterClose);
+    // Live: bytes queued in the native client (frames not yet written to the
+    // socket, plus the proxy tunnel's pending ciphertext). m_bufferedAmount
+    // only carries the leftover reported at close.
+    size_t live = 0;
+    switch (m_connectedWebSocketKind) {
+    case ConnectedWebSocketKind::Client:
+        live = Bun__WebSocketClient__bufferedAmount(m_connectedWebSocket.client);
+        break;
+    case ConnectedWebSocketKind::ClientSSL:
+        live = Bun__WebSocketClientTLS__bufferedAmount(m_connectedWebSocket.clientSSL);
+        break;
+    case ConnectedWebSocketKind::None:
+        break;
+    }
+    unsigned clamped = live > std::numeric_limits<unsigned>::max() ? std::numeric_limits<unsigned>::max() : static_cast<unsigned>(live);
+    return saturateAdd(saturateAdd(m_bufferedAmount, clamped), m_bufferedAmountAfterClose);
 }
 
 String WebSocket::protocol() const

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -888,6 +888,37 @@ ExceptionOr<void> WebSocket::terminate()
     return {};
 }
 
+bool WebSocket::pause()
+{
+    m_paused = true;
+    return applyPauseToConnectedClient();
+}
+
+bool WebSocket::resume()
+{
+    m_paused = false;
+    return applyPauseToConnectedClient();
+}
+
+// True when the socket's read state changed (or will, once a CONNECTING
+// socket opens); false when there is no socket to act on.
+bool WebSocket::applyPauseToConnectedClient()
+{
+    switch (m_connectedWebSocketKind) {
+    case ConnectedWebSocketKind::Client:
+        return m_paused
+            ? Bun__WebSocketClient__pause(m_connectedWebSocket.client)
+            : Bun__WebSocketClient__resume(m_connectedWebSocket.client);
+    case ConnectedWebSocketKind::ClientSSL:
+        return m_paused
+            ? Bun__WebSocketClientTLS__pause(m_connectedWebSocket.clientSSL)
+            : Bun__WebSocketClientTLS__resume(m_connectedWebSocket.clientSSL);
+    case ConnectedWebSocketKind::None:
+        return m_state == CONNECTING;
+    }
+    return false;
+}
+
 void WebSocket::cancelUpgradeClient()
 {
     auto* upgradeClient = std::exchange(m_upgradeClient, nullptr);
@@ -1497,6 +1528,8 @@ void WebSocket::didConnect(us_socket_t* socket, void* bufferedData, const PerMes
         this->m_connectedWebSocket.client = Bun__WebSocketClient__init(reinterpret_cast<CppWebSocket*>(this), socket, this->scriptExecutionContext()->jsGlobalObject(), bufferedData, deflate_params, customSSLCtx);
         this->m_connectedWebSocketKind = ConnectedWebSocketKind::Client;
     }
+    if (m_paused)
+        applyPauseToConnectedClient();
 
     this->didConnect();
 }
@@ -1684,6 +1717,8 @@ void WebSocket::didConnectWithTunnel(void* tunnel, void* bufferedData, const Per
         bufferedData,
         deflate_params);
     this->m_connectedWebSocketKind = ConnectedWebSocketKind::Client;
+    if (m_paused)
+        applyPauseToConnectedClient();
 
     // IMPORTANT: Call didConnect() BEFORE setting the connected websocket on the tunnel.
     // didConnect() sets m_state = OPEN, and messages are dropped if state != OPEN.

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -180,6 +180,12 @@ public:
 
     ExceptionOr<void> close(std::optional<unsigned short> code, const String& reason);
     ExceptionOr<void> terminate();
+    // Receive-side flow control (non-standard; mirrors Bun.Socket). pause()
+    // stops kernel reads so TCP backpressure reaches the peer; frames already
+    // decoded still dispatch. Before OPEN it latches and applies on connect.
+    bool pause();
+    bool resume();
+    bool isPaused() const { return m_paused; }
 
     void setProtocol(const String& protocol);
 
@@ -328,8 +334,10 @@ private:
     // Drop the in-flight upgrade / the connected client without a closing handshake. Neither
     // dispatches anything itself; the native side may call back synchronously.
     void cancelUpgradeClient();
+    bool applyPauseToConnectedClient();
     void cancelConnectedClient();
     bool m_rejectUnauthorized { false };
+    bool m_paused { false };
     // Default matches pre-existing behavior: advertise permessage-deflate in the upgrade
     // request. Set to false by ws.WebSocket callers passing `perMessageDeflate: false`.
     bool m_offerPerMessageDeflate { true };

--- a/test/js/web/websocket/websocket-buffered-amount.test.ts
+++ b/test/js/web/websocket/websocket-buffered-amount.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "bun:test";
+import { tls } from "harness";
+import crypto from "node:crypto";
+import net from "node:net";
+import nodeTls from "node:tls";
+
+const CHUNK = new Uint8Array(64 * 1024);
+const TOTAL = 1024; // 64 MiB, far past any socket/TLS buffer
+const TOTAL_BYTES = TOTAL * CHUNK.byteLength;
+// Each binary frame is header (10 bytes for a 64 KiB payload) + 4-byte mask + payload.
+const FRAMING_PER_CHUNK = 14;
+
+// A raw origin that completes the WebSocket upgrade and then reads only when
+// told to, so the client's send side has to queue. It sees plaintext frames
+// (TLS, when any, terminates here or at the proxy), so the byte count it
+// resolves on is payload plus framing.
+function rawOrigin(secure: boolean) {
+  const { promise: upgraded, resolve: resolveUpgraded } = Promise.withResolvers<net.Socket>();
+  let received = 0;
+  const { promise: gotAll, resolve: resolveGotAll } = Promise.withResolvers<void>();
+  function onConnection(sock: net.Socket) {
+    sock.once("data", head => {
+      const key = /Sec-WebSocket-Key: (.+)\r\n/.exec(head.toString("latin1"))![1].trim();
+      const accept = crypto
+        .createHash("sha1")
+        .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+        .digest("base64");
+      sock.write(
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+          `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+      );
+      sock.pause();
+      sock.on("data", (chunk: Buffer) => {
+        received += chunk.length;
+        if (received >= TOTAL * (CHUNK.byteLength + FRAMING_PER_CHUNK)) resolveGotAll();
+      });
+      resolveUpgraded(sock);
+    });
+    sock.on("error", () => {});
+  }
+  const server = secure
+    ? nodeTls.createServer({ key: tls.key, cert: tls.cert }, onConnection)
+    : net.createServer(onConnection);
+  return {
+    listen: () =>
+      new Promise<number>(resolve =>
+        server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
+      ),
+    upgraded,
+    gotAll,
+    close: () => server.close(),
+  };
+}
+
+async function pipingConnectProxy(secure: boolean): Promise<{ port: number; close(): void }> {
+  function onConnection(client: net.Socket) {
+    client.once("data", head => {
+      const match = /^CONNECT ([^:]+):(\d+) /.exec(head.toString("latin1"));
+      if (!match) {
+        client.destroy();
+        return;
+      }
+      const upstream = net.connect(Number(match[2]), match[1], () => {
+        client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        client.pipe(upstream);
+        upstream.pipe(client);
+      });
+      upstream.on("error", () => client.destroy());
+      client.on("error", () => upstream.destroy());
+    });
+  }
+  const server = secure
+    ? nodeTls.createServer({ key: tls.key, cert: tls.cert }, onConnection)
+    : net.createServer(onConnection);
+  const port = await new Promise<number>(resolve =>
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
+  );
+  return { port, close: () => server.close() };
+}
+
+function open(ws: WebSocket): Promise<void> {
+  return new Promise(resolve => (ws.onopen = () => resolve()));
+}
+
+const MODES = [
+  { name: "ws", secure: false, proxy: null },
+  { name: "wss", secure: true, proxy: null },
+  { name: "wss via http:// proxy", secure: true, proxy: "http" },
+  { name: "wss via https:// proxy", secure: true, proxy: "https" },
+  { name: "ws via https:// proxy", secure: false, proxy: "https" },
+] as const;
+
+for (const mode of MODES) {
+  describe(`WebSocket.bufferedAmount (${mode.name})`, () => {
+    it("counts bytes the peer has not accepted and drains to 0", async () => {
+      const origin = rawOrigin(mode.secure);
+      const originPort = await origin.listen();
+      const proxy = mode.proxy ? await pipingConnectProxy(mode.proxy === "https") : undefined;
+      try {
+        const ws = new WebSocket(`${mode.secure ? "wss" : "ws"}://127.0.0.1:${originPort}`, {
+          tls: { rejectUnauthorized: false },
+          ...(proxy ? { proxy: `${mode.proxy}://127.0.0.1:${proxy.port}` } : {}),
+        });
+        await open(ws);
+        const peer = await origin.upgraded;
+        expect(ws.bufferedAmount).toBe(0);
+
+        for (let i = 0; i < TOTAL; i++) ws.send(CHUNK);
+
+        // The kernel and any proxy absorbed some; the rest is ours to report.
+        const queued = ws.bufferedAmount;
+        expect(queued).toBeGreaterThan(TOTAL_BYTES / 2);
+        expect(queued).toBeLessThanOrEqual(TOTAL * (CHUNK.byteLength + FRAMING_PER_CHUNK));
+
+        // Only what the kernel can still absorb drains while the peer isn't reading.
+        await new Promise(resolve => setImmediate(resolve));
+        expect(ws.bufferedAmount).toBeLessThanOrEqual(queued);
+        expect(ws.bufferedAmount).toBeGreaterThan(TOTAL_BYTES / 2);
+
+        peer.resume();
+        await origin.gotAll;
+        expect(ws.bufferedAmount).toBe(0);
+        ws.close();
+      } finally {
+        proxy?.close();
+        origin.close();
+      }
+    }, 60_000);
+  });
+}
+
+describe("WebSocket.bufferedAmount", () => {
+  it("is 0 once a small message has been written", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response();
+      },
+      websocket: {
+        message(ws, message) {
+          ws.send(message);
+        },
+      },
+    });
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    await open(ws);
+    const { promise: echoed, resolve } = Promise.withResolvers<string>();
+    ws.onmessage = ({ data }) => resolve(data);
+    ws.send("hello");
+    expect(await echoed).toBe("hello");
+    expect(ws.bufferedAmount).toBe(0);
+    ws.close();
+  });
+
+  it("ws package reports the same number", async () => {
+    const { WebSocket: WS } = await import("ws");
+    const origin = rawOrigin(false);
+    const originPort = await origin.listen();
+    try {
+      const ws = new WS(`ws://127.0.0.1:${originPort}`);
+      await new Promise(resolve => ws.once("open", resolve));
+      const peer = await origin.upgraded;
+      expect(ws.bufferedAmount).toBe(0);
+      for (let i = 0; i < TOTAL; i++) ws.send(CHUNK);
+      expect(ws.bufferedAmount).toBeGreaterThan(TOTAL_BYTES / 2);
+      peer.resume();
+      await origin.gotAll;
+      expect(ws.bufferedAmount).toBe(0);
+      ws.close();
+    } finally {
+      origin.close();
+    }
+  }, 60_000);
+});

--- a/test/js/web/websocket/websocket-pause.test.ts
+++ b/test/js/web/websocket/websocket-pause.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "bun:test";
+import { tls } from "harness";
+import net from "node:net";
+import nodeTls from "node:tls";
+
+const CHUNK = new Uint8Array(64 * 1024);
+const TOTAL = 4096; // 256 MiB, far past any socket/TLS buffer
+const TOTAL_BYTES = TOTAL * CHUNK.byteLength;
+
+type Signals = {
+  stream: PromiseWithResolvers<Bun.ServerWebSocket<Signals>>;
+  backpressured: PromiseWithResolvers<void>;
+  drained: PromiseWithResolvers<void>;
+};
+
+// Streams TOTAL chunks. send() returning -1 means the chunk was enqueued
+// under backpressure; wait for the drain callback instead of re-sending.
+// The waiter is armed before send() because drain can fire synchronously
+// inside it on a plain TCP socket.
+async function sendAll(ws: Bun.ServerWebSocket<Signals>): Promise<number> {
+  let backpressured = 0;
+  for (let i = 0; i < TOTAL; i++) {
+    ws.data.drained = Promise.withResolvers();
+    if (ws.send(CHUNK) === -1) {
+      backpressured++;
+      ws.data.backpressured.resolve();
+      await ws.data.drained.promise;
+    }
+  }
+  return backpressured;
+}
+
+// Every connection to this server echoes messages; the stream connection
+// (first to open) is handed back through `signals.stream`.
+function streamServer(signals: Signals, secure: boolean) {
+  return Bun.serve<Signals>({
+    port: 0,
+    ...(secure ? { tls } : {}),
+    fetch(req, server) {
+      if (server.upgrade(req, { data: signals })) return;
+      return new Response();
+    },
+    websocket: {
+      open(ws) {
+        ws.data.stream.resolve(ws);
+      },
+      message(ws, message) {
+        ws.send(message);
+      },
+      drain(ws) {
+        ws.data.drained.resolve();
+      },
+    },
+  });
+}
+
+// A CONNECT proxy that pipes both directions, so backpressure propagates
+// end to end: with the client paused, the origin server's send() must back
+// up through the proxy. (proxy-test-utils copies with on("data") → write(),
+// which would absorb the whole stream in memory instead.)
+async function pipingConnectProxy(secure: boolean): Promise<{ port: number; close(): void }> {
+  function onConnection(client: net.Socket) {
+    client.once("data", head => {
+      const match = /^CONNECT ([^:]+):(\d+) /.exec(head.toString("latin1"));
+      if (!match) {
+        client.destroy();
+        return;
+      }
+      const upstream = net.connect(Number(match[2]), match[1], () => {
+        client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        client.pipe(upstream);
+        upstream.pipe(client);
+      });
+      upstream.on("error", () => client.destroy());
+      client.on("error", () => upstream.destroy());
+    });
+  }
+  const server = secure
+    ? nodeTls.createServer({ key: tls.key, cert: tls.cert }, onConnection)
+    : net.createServer(onConnection);
+  const port = await new Promise<number>(resolve =>
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
+  );
+  return { port, close: () => server.close() };
+}
+
+// Forces the event loop through `n` I/O roundtrips without a timer. A
+// paused socket that still had readable data would be delivered during
+// these polls, so "nothing arrived across N roundtrips" is the assertion.
+async function ioRoundtrips(clock: WebSocket, n: number): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    clock.onmessage = () => resolve();
+    clock.send("tick");
+    await promise;
+  }
+}
+
+function open(ws: WebSocket): Promise<void> {
+  return new Promise(resolve => (ws.onopen = () => resolve()));
+}
+
+// Minimal surface shared by the global WebSocket and the `ws` package.
+type Pausable = {
+  pause(): unknown;
+  resume(): unknown;
+  readonly isPaused: boolean;
+};
+
+// The scenario every variant runs: the peer streams TOTAL_BYTES at us while
+// paused; we must see the peer block on TCP (its send() backpressures) with
+// our received count frozen far below the total, then drain it all on resume.
+async function expectPauseHolds({
+  ws,
+  signals,
+  clock,
+  getReceived,
+  done,
+}: {
+  ws: Pausable;
+  signals: Signals;
+  clock: WebSocket;
+  getReceived: () => number;
+  done: Promise<void>;
+}) {
+  const stream = await signals.stream.promise;
+  const serverDone = sendAll(stream);
+
+  expect(ws.isPaused).toBe(true);
+  // The peer's send() went to -1: our kernel receive buffer is full and the
+  // TCP window is closed. Frames decoded before the pause may already have
+  // dispatched; nothing more may arrive from here on.
+  await signals.backpressured.promise;
+  const baseline = getReceived();
+  await ioRoundtrips(clock, 20);
+  expect(getReceived()).toBe(baseline);
+  // Far below the total: the peer is blocked on TCP, not buffering in us.
+  expect(baseline).toBeLessThan(TOTAL_BYTES / 8);
+
+  ws.resume();
+  expect(ws.isPaused).toBe(false);
+  await done;
+  expect(getReceived()).toBe(TOTAL_BYTES);
+  expect(await serverDone).toBeGreaterThan(0);
+}
+
+function newSignals(): Signals {
+  return {
+    stream: Promise.withResolvers(),
+    backpressured: Promise.withResolvers(),
+    drained: Promise.withResolvers(),
+  };
+}
+
+// Each mode lands on a different socket underneath the WebSocket:
+//   ws / wss           — uSockets TCP / TLS socket, adopted directly
+//   wss via http://    — WebSocketProxyTunnel over a plain proxy socket (TLS in the tunnel)
+//   wss via https://   — WebSocketProxyTunnel over a TLS proxy socket (TLS in TLS)
+//   ws  via https://   — TLS socket to the proxy, no tunnel (ProxyTLS → ClientSSL)
+// pause() has to reach the bottom one in every case.
+const MODES = [
+  { name: "ws", secure: false, proxy: null },
+  { name: "wss", secure: true, proxy: null },
+  { name: "wss via http:// proxy", secure: true, proxy: "http" },
+  { name: "wss via https:// proxy", secure: true, proxy: "https" },
+  { name: "ws via https:// proxy", secure: false, proxy: "https" },
+] as const;
+
+for (const mode of MODES) {
+  const { secure } = mode;
+  describe(`WebSocket.pause() / resume() (${mode.name})`, () => {
+    it("stops reads while paused and drains after resume", async () => {
+      const proxy = mode.proxy ? await pipingConnectProxy(mode.proxy === "https") : undefined;
+      try {
+        const signals = newSignals();
+        using server = streamServer(signals, secure);
+        const url = `${secure ? "wss" : "ws"}://localhost:${server.port}`;
+        const options = {
+          tls: { rejectUnauthorized: false },
+          ...(proxy ? { proxy: `${mode.proxy}://127.0.0.1:${proxy.port}` } : {}),
+        };
+
+        const ws = new WebSocket(url, options);
+        ws.binaryType = "arraybuffer";
+        let received = 0;
+        const { promise: done, resolve: resolveDone } = Promise.withResolvers<void>();
+        ws.onmessage = ({ data }) => {
+          received += (data as ArrayBuffer).byteLength;
+          if (received >= TOTAL_BYTES) resolveDone();
+        };
+        await open(ws);
+        const clock = new WebSocket(url, options);
+        await open(clock);
+
+        expect(ws.isPaused).toBe(false);
+        expect(ws.pause()).toBe(true);
+        await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done });
+
+        ws.close();
+        clock.close();
+      } finally {
+        proxy?.close();
+      }
+    }, 60_000);
+
+    it("pause() and resume() are idempotent", async () => {
+      const proxy = mode.proxy ? await pipingConnectProxy(mode.proxy === "https") : undefined;
+      try {
+        const signals = newSignals();
+        using server = streamServer(signals, secure);
+        const url = `${secure ? "wss" : "ws"}://localhost:${server.port}`;
+        const options = {
+          tls: { rejectUnauthorized: false },
+          ...(proxy ? { proxy: `${mode.proxy}://127.0.0.1:${proxy.port}` } : {}),
+        };
+        const ws = new WebSocket(url, options);
+        await open(ws);
+        expect(ws.resume()).toBe(true);
+        expect(ws.isPaused).toBe(false);
+        expect(ws.pause()).toBe(true);
+        expect(ws.pause()).toBe(true);
+        expect(ws.isPaused).toBe(true);
+        expect(ws.resume()).toBe(true);
+        expect(ws.resume()).toBe(true);
+        expect(ws.isPaused).toBe(false);
+
+        // Still a working connection after the churn.
+        const { promise: echoed, resolve } = Promise.withResolvers<string>();
+        ws.onmessage = ({ data }) => resolve(data);
+        ws.send("still alive");
+        expect(await echoed).toBe("still alive");
+
+        const closed = new Promise(resolve => (ws.onclose = resolve));
+        ws.close();
+        await closed;
+        expect(ws.pause()).toBe(false);
+        expect(ws.resume()).toBe(false);
+      } finally {
+        proxy?.close();
+      }
+    });
+  });
+}
+
+describe("WebSocket.pause() before open", () => {
+  it("latches and applies once connected", async () => {
+    const signals = newSignals();
+    using server = streamServer(signals, false);
+    const url = `ws://localhost:${server.port}`;
+
+    const ws = new WebSocket(url);
+    ws.binaryType = "arraybuffer";
+    expect(ws.pause()).toBe(true);
+    expect(ws.isPaused).toBe(true);
+    let received = 0;
+    const { promise: done, resolve: resolveDone } = Promise.withResolvers<void>();
+    ws.onmessage = ({ data }) => {
+      received += (data as ArrayBuffer).byteLength;
+      if (received >= TOTAL_BYTES) resolveDone();
+    };
+    await open(ws);
+    expect(ws.isPaused).toBe(true);
+    const clock = new WebSocket(url);
+    await open(clock);
+
+    await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done });
+    ws.close();
+    clock.close();
+  }, 60_000);
+
+  it("resume() before open clears the latch", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response();
+      },
+      websocket: {
+        open(ws) {
+          ws.send("a");
+        },
+        message() {},
+      },
+    });
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    expect(ws.pause()).toBe(true);
+    expect(ws.resume()).toBe(true);
+    expect(ws.isPaused).toBe(false);
+    const { promise: got, resolve } = Promise.withResolvers<string>();
+    ws.onmessage = ({ data }) => resolve(data);
+    expect(await got).toBe("a");
+    ws.close();
+  });
+
+  it("a latched pause is dropped when the connection fails", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("nope", { status: 403 });
+      },
+      websocket: { message() {} },
+    });
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    expect(ws.pause()).toBe(true);
+    const closed = new Promise(resolve => (ws.onclose = resolve));
+    ws.onerror = () => {};
+    await closed;
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+    expect(ws.pause()).toBe(false);
+    expect(ws.resume()).toBe(false);
+  });
+});
+
+describe("ws package", () => {
+  it("pause()/resume()/isPaused reach the socket", async () => {
+    const { WebSocket: WS } = await import("ws");
+    const signals = newSignals();
+    using server = streamServer(signals, false);
+    const url = `ws://localhost:${server.port}`;
+
+    const ws = new WS(url);
+    let received = 0;
+    const { promise: done, resolve: resolveDone } = Promise.withResolvers<void>();
+    ws.on("message", (data: Buffer) => {
+      received += data.byteLength;
+      if (received >= TOTAL_BYTES) resolveDone();
+    });
+    await new Promise(resolve => ws.once("open", resolve));
+    const clock = new WebSocket(url);
+    await open(clock);
+
+    expect(ws.isPaused).toBe(false);
+    ws.pause();
+    await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done });
+    ws.close();
+    clock.close();
+  }, 60_000);
+});

--- a/test/js/web/websocket/websocket-server-send-from-drain.test.ts
+++ b/test/js/web/websocket/websocket-server-send-from-drain.test.ts
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test";
+import net from "node:net";
+
+const CHUNK = new Uint8Array(64 * 1024);
+const TOTAL = 1024; // 64 MiB
+
+// A send() that partial-writes from inside the drain handler must keep the
+// socket polling for writable. us_socket_write2 (the header+payload writev
+// path large frames take) used to rearm the poll without setting
+// last_write_failed, so the writable dispatch that invoked drain then
+// deregistered writable on its way out and the connection stalled forever.
+it("ServerWebSocket.send() that backpressures inside drain keeps draining", async () => {
+  const { promise: finished, resolve } = Promise.withResolvers<{ drains: number; backpressured: number }>();
+  const { promise: firstBackpressure, resolve: resolveFirstBackpressure } = Promise.withResolvers<void>();
+  let i = 0;
+  let drains = 0;
+  let backpressured = 0;
+  function pump(ws: Bun.ServerWebSocket<undefined>) {
+    while (i < TOTAL) {
+      i++;
+      if (ws.send(CHUNK) === -1) {
+        backpressured++;
+        resolveFirstBackpressure();
+        return;
+      }
+    }
+    resolve({ drains, backpressured });
+  }
+  using server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response();
+    },
+    websocket: {
+      open(ws) {
+        pump(ws);
+      },
+      message() {},
+      drain(ws) {
+        drains++;
+        pump(ws);
+      },
+    },
+  });
+
+  // A raw client: complete the upgrade, don't read until the server has hit
+  // backpressure (so the TCP window is closed), then read everything.
+  let received = 0;
+  const { promise: gotAll, resolve: resolveGotAll } = Promise.withResolvers<void>();
+  const sock = net.connect(server.port, "127.0.0.1", async () => {
+    sock.write(
+      "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+    );
+    sock.pause();
+    await firstBackpressure;
+    sock.resume();
+  });
+  sock.on("data", (chunk: Buffer) => {
+    received += chunk.length;
+    if (received >= TOTAL * CHUNK.byteLength) resolveGotAll();
+  });
+
+  const { drains: drainCount, backpressured: backpressureCount } = await finished;
+  await gotAll;
+  expect(backpressureCount).toBeGreaterThan(0);
+  expect(drainCount).toBe(backpressureCount);
+  sock.destroy();
+}, 30_000);


### PR DESCRIPTION
### What does this PR do?

Three commits, all about WebSocket backpressure.

**1. Adds `pause()`, `resume()`, and `isPaused` to the client `WebSocket`**, mirroring `Bun.Socket`.

The browser `WebSocket` API has send-side backpressure (`bufferedAmount`) but no receive-side control: a peer that sends faster than you consume buffers in memory without bound, which matters for proxies/relays that pipe WebSocket frames into a slower local socket. `pause()` stops kernel reads on the underlying socket so the sender sees TCP backpressure; `resume()` restarts them. Works on every socket a client `WebSocket` can sit on — plain TCP, TLS, `wss://` through an `http://` CONNECT proxy (TLS inside the `WebSocketProxyTunnel`), `wss://` through an `https://` proxy (TLS in TLS), and `ws://` through an `https://` proxy. A pause before open latches and applies once connected.

Both return `true` when they took effect (or will, on open) and `false` when there's no socket to act on. Frames already decoded when `pause()` is called may still dispatch.

The `ws` package shim's `pause()` / `resume()` / `isPaused` now reach the socket instead of emitting a not-implemented warning.

**2. Fixes `WebSocket.bufferedAmount` always reading `0` while open.** `m_bufferedAmount` was only assigned in `didClose()`; the live hookups to the native client were commented out. 256 MiB `send()` into a peer that never reads reported `bufferedAmount: 0` with RSS up ~1 GB, so there was no signal to throttle on. It now reads the native client's queue on each access (frames not yet written, plus the proxy tunnel's pending ciphertext). The `ws` package's `bufferedAmount` inherits the fix.

**3. Fixes `ServerWebSocket` hanging when `send()` backpressures from inside `drain`.** `us_socket_write2` (the writev path `WebSocket::send` takes for larger frames) re-armed the writable poll on a partial write but didn't set `last_write_failed`; when that happened inside a writable dispatch — a `send()` in the drain handler, or in a microtask it queued — the loop saw the flag clear on exit and deregistered writable, so the queued bytes never flushed and `drain` never fired again. Reproduces on 1.4.1. One-line fix; every other partial-write site already set the flag.

### How did you verify your code works?

All new tests are timer-free (every wait is a promise resolved by a socket event; "time passing" is N echo roundtrips on a second connection). Proxy variants use a small piping CONNECT proxy so backpressure really propagates end to end.

- `test/js/web/websocket/websocket-pause.test.ts`: origin streams 256 MiB; client pauses, waits for the origin's `send()` to report backpressure, asserts its received count is frozen and far below the total across 20 I/O roundtrips, then resumes and drains everything. Run for all five socket topologies, plus pause/resume idempotency and post-close `false`, pause-before-open latch, resume-before-open, latched pause on a failed connect, and the `ws` package.
- `test/js/web/websocket/websocket-buffered-amount.test.ts`: 64 MiB into a raw origin that doesn't read; `bufferedAmount` must report more than half of it and at most payload+framing, then drain to 0 once the origin reads. All five topologies plus the `ws` package and the small-message-is-0 case. 6/7 fail on 1.4.1.
- `test/js/web/websocket/websocket-server-send-from-drain.test.ts`: regression for the drain stall — times out on 1.4.1, passes with the fix.
- Existing websocket suites + `test/js/third_party/ws`: 278 pass, 0 fail.