### PR TITLE
url: reject URL-encoded input over the WTF decode limit instead of aborting

### DIFF
--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -30,6 +30,8 @@
 
 #include "config.h"
 #include "DOMFormData.h"
+#include "ExceptionOr.h"
+#include "URLSearchParams.h"
 #include "wtf/DebugHeap.h"
 #include <wtf/URLParser.h>
 
@@ -47,8 +49,12 @@ Ref<DOMFormData> DOMFormData::create(ScriptExecutionContext* context)
     return adoptRef(*new DOMFormData(context));
 }
 
-Ref<DOMFormData> DOMFormData::create(ScriptExecutionContext* context, const StringView& urlEncodedString)
+ExceptionOr<Ref<DOMFormData>> DOMFormData::create(ScriptExecutionContext* context, StringView urlEncodedString)
 {
+    auto check = URLSearchParams::checkURLEncodedFormLength(urlEncodedString);
+    if (check.hasException())
+        return check.releaseException();
+
     auto newFormData = adoptRef(*new DOMFormData(context));
     for (auto& entry : WTF::URLParser::parseURLEncodedForm(urlEncodedString)) {
         newFormData->append(entry.key, entry.value);

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -61,7 +61,7 @@ public:
     };
 
     static Ref<DOMFormData> create(ScriptExecutionContext*);
-    static Ref<DOMFormData> create(ScriptExecutionContext*, const StringView& urlEncodedString);
+    static ExceptionOr<Ref<DOMFormData>> create(ScriptExecutionContext*, StringView urlEncodedString);
 
     const Vector<Item>& items() const { return m_items; }
 

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -165,7 +165,7 @@ ExceptionOr<void> DOMURL::setHref(const String& url)
     m_url = WTF::move(completeURL);
     m_searchParamsDirty = false;
     if (m_searchParams)
-        m_searchParams->updateFromAssociatedURL();
+        return m_searchParams->updateFromAssociatedURL();
     return {};
 }
 
@@ -188,10 +188,14 @@ void DOMURL::flushPendingSearchParamsUpdate() const
         self->m_url.setQuery(WTF::move(serialized));
 }
 
-URLSearchParams& DOMURL::searchParams()
+ExceptionOr<URLSearchParams&> DOMURL::searchParams()
 {
-    if (!m_searchParams)
-        m_searchParams = URLSearchParams::create(search(), this);
+    if (!m_searchParams) {
+        auto searchParams = URLSearchParams::create(search(), this);
+        if (searchParams.hasException())
+            return searchParams.releaseException();
+        m_searchParams = searchParams.releaseReturnValue();
+    }
     return *m_searchParams;
 }
 

--- a/src/jsc/bindings/DOMURL.h
+++ b/src/jsc/bindings/DOMURL.h
@@ -56,7 +56,7 @@ public:
     }
     ExceptionOr<void> setHref(const String&);
 
-    URLSearchParams& searchParams();
+    ExceptionOr<URLSearchParams&> searchParams();
     void markSearchParamsDirty() { m_searchParamsDirty = true; }
 
     size_t memoryCost() const

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -53,18 +53,29 @@ static constexpr size_t maxURLEncodedFormUTF8Length = (std::numeric_limits<unsig
 static_assert(WTF::isValidCapacityForVector<char16_t>(maxURLEncodedFormUTF8Length));
 static_assert(!WTF::isValidCapacityForVector<char16_t>(maxURLEncodedFormUTF8Length + 1));
 
+static size_t utf8Length(StringView string)
+{
+    if (string.is8Bit())
+        return simdutf::utf8_length_from_latin1(reinterpret_cast<const char*>(string.span8().data()), string.length());
+    return simdutf::utf8_length_from_utf16le(string.span16().data(), string.length());
+}
+
 ExceptionOr<void> URLSearchParams::checkURLEncodedFormLength(StringView input)
 {
     size_t maxLength = std::min(maxURLEncodedFormUTF8Length, Bun__stringSyntheticAllocationLimit);
     // A UTF-16 code unit is at most 3 UTF-8 bytes and a Latin-1 character at most 2.
     if (static_cast<size_t>(input.length()) * 3 <= maxLength) [[likely]]
         return {};
-    size_t utf8Length = input.is8Bit()
-        ? simdutf::utf8_length_from_latin1(reinterpret_cast<const char*>(input.span8().data()), input.length())
-        : simdutf::utf8_length_from_utf16le(input.span16().data(), input.length());
-    if (utf8Length <= maxLength) [[likely]]
-        return {};
-    return Exception { RangeError, makeString("URL-encoded data must not be longer than "_s, maxLength, " bytes as UTF-8. Received "_s, utf8Length, " bytes."_s) };
+    // The parser decodes each name and value on its own: split the same way it does.
+    for (StringView pair : input.split('&')) {
+        size_t equalIndex = pair.find('=');
+        StringView name = equalIndex == notFound ? pair : pair.left(equalIndex);
+        StringView value = equalIndex == notFound ? StringView() : pair.substring(equalIndex + 1);
+        size_t length = std::max(utf8Length(name), utf8Length(value));
+        if (length > maxLength) [[unlikely]]
+            return Exception { RangeError, makeString("A URL-encoded name or value must not be longer than "_s, maxLength, " bytes as UTF-8. Received "_s, length, " bytes."_s) };
+    }
+    return {};
 }
 
 static ExceptionOr<WTF::URLParser::URLEncodedForm> parseURLEncodedForm(const String& init)

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -47,8 +47,7 @@ extern "C" void URLSearchParams__toString(WebCore::URLSearchParams* urlSearchPar
     callback(ctx, &slice);
 }
 
-// Mirrors WTF::isValidCapacityForVector<char16_t>: String::fromUTF8ReplacingInvalidSequences
-// sizes a Vector<char16_t> by the UTF-8 byte count of each decoded name and value.
+// String::fromUTF8ReplacingInvalidSequences sizes a Vector<char16_t> by the UTF-8 byte count.
 static constexpr size_t maxURLEncodedFormUTF8Length = (std::numeric_limits<unsigned>::max() >> 1) / sizeof(char16_t);
 static_assert(WTF::isValidCapacityForVector<char16_t>(maxURLEncodedFormUTF8Length));
 static_assert(!WTF::isValidCapacityForVector<char16_t>(maxURLEncodedFormUTF8Length + 1));

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -26,6 +26,7 @@
 
 #include "DOMURL.h"
 #include <wtf/URLParser.h>
+#include <wtf/SIMDUTF.h>
 #include "helpers.h"
 #include "JSURLSearchParams.h"
 
@@ -46,9 +47,38 @@ extern "C" void URLSearchParams__toString(WebCore::URLSearchParams* urlSearchPar
     callback(ctx, &slice);
 }
 
-URLSearchParams::URLSearchParams(const String& init, DOMURL* associatedURL)
+// Mirrors WTF::isValidCapacityForVector<char16_t>: String::fromUTF8ReplacingInvalidSequences
+// sizes a Vector<char16_t> by the UTF-8 byte count of each decoded name and value.
+static constexpr size_t maxURLEncodedFormUTF8Length = (std::numeric_limits<unsigned>::max() >> 1) / sizeof(char16_t);
+static_assert(WTF::isValidCapacityForVector<char16_t>(maxURLEncodedFormUTF8Length));
+static_assert(!WTF::isValidCapacityForVector<char16_t>(maxURLEncodedFormUTF8Length + 1));
+
+ExceptionOr<void> URLSearchParams::checkURLEncodedFormLength(StringView input)
+{
+    size_t maxLength = std::min(maxURLEncodedFormUTF8Length, Bun__stringSyntheticAllocationLimit);
+    // A UTF-16 code unit is at most 3 UTF-8 bytes and a Latin-1 character at most 2.
+    if (static_cast<size_t>(input.length()) * 3 <= maxLength) [[likely]]
+        return {};
+    size_t utf8Length = input.is8Bit()
+        ? simdutf::utf8_length_from_latin1(reinterpret_cast<const char*>(input.span8().data()), input.length())
+        : simdutf::utf8_length_from_utf16le(input.span16().data(), input.length());
+    if (utf8Length <= maxLength) [[likely]]
+        return {};
+    return Exception { RangeError, makeString("URL-encoded data must not be longer than "_s, maxLength, " bytes as UTF-8. Received "_s, utf8Length, " bytes."_s) };
+}
+
+static ExceptionOr<WTF::URLParser::URLEncodedForm> parseURLEncodedForm(const String& init)
+{
+    StringView query = init.startsWith('?') ? StringView(init).substring(1) : StringView(init);
+    auto check = URLSearchParams::checkURLEncodedFormLength(query);
+    if (check.hasException())
+        return check.releaseException();
+    return WTF::URLParser::parseURLEncodedForm(query);
+}
+
+URLSearchParams::URLSearchParams(Vector<KeyValuePair<String, String>>&& pairs, DOMURL* associatedURL)
     : m_associatedURL(associatedURL)
-    , m_pairs(init.startsWith('?') ? WTF::URLParser::parseURLEncodedForm(StringView(init).substring(1)) : WTF::URLParser::parseURLEncodedForm(init))
+    , m_pairs(WTF::move(pairs))
 {
 }
 
@@ -59,6 +89,14 @@ URLSearchParams::URLSearchParams(const Vector<KeyValuePair<String, String>>& pai
 
 URLSearchParams::~URLSearchParams() = default;
 
+ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(const String& init, DOMURL* associatedURL)
+{
+    auto pairs = parseURLEncodedForm(init);
+    if (pairs.hasException())
+        return pairs.releaseException();
+    return adoptRef(*new URLSearchParams(pairs.releaseReturnValue(), associatedURL));
+}
+
 ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String>&& variant)
 {
     auto visitor = WTF::makeVisitor([&](const Vector<Vector<String>>& vector) -> ExceptionOr<Ref<URLSearchParams>> {
@@ -68,7 +106,7 @@ ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(std::variant<Vector<Ve
                 return Exception { TypeError };
             pairs.append({pair[0], pair[1]});
         }
-        return adoptRef(*new URLSearchParams(WTF::move(pairs))); }, [&](const Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<URLSearchParams>> { return adoptRef(*new URLSearchParams(pairs)); }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> { return adoptRef(*new URLSearchParams(string, nullptr)); });
+        return adoptRef(*new URLSearchParams(WTF::move(pairs))); }, [&](const Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<URLSearchParams>> { return adoptRef(*new URLSearchParams(pairs)); }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> { return create(string, nullptr); });
     return std::visit(visitor, variant);
 }
 
@@ -163,11 +201,15 @@ void URLSearchParams::updateURL()
         m_associatedURL->markSearchParamsDirty();
 }
 
-void URLSearchParams::updateFromAssociatedURL()
+ExceptionOr<void> URLSearchParams::updateFromAssociatedURL()
 {
     ASSERT(m_associatedURL);
-    String search = m_associatedURL->search();
-    m_pairs = search.startsWith('?') ? WTF::URLParser::parseURLEncodedForm(StringView(search).substring(1)) : WTF::URLParser::parseURLEncodedForm(search);
+    m_pairs.clear();
+    auto pairs = parseURLEncodedForm(m_associatedURL->search());
+    if (pairs.hasException())
+        return pairs.releaseException();
+    m_pairs = pairs.releaseReturnValue();
+    return {};
 }
 
 std::optional<KeyValuePair<String, String>> URLSearchParams::Iterator::next()

--- a/src/jsc/bindings/URLSearchParams.h
+++ b/src/jsc/bindings/URLSearchParams.h
@@ -41,10 +41,11 @@ public:
     ~URLSearchParams();
 
     static ExceptionOr<Ref<URLSearchParams>> create(std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String>&&);
-    static Ref<URLSearchParams> create(const String& string, DOMURL* associatedURL)
-    {
-        return adoptRef(*new URLSearchParams(string, associatedURL));
-    }
+    static ExceptionOr<Ref<URLSearchParams>> create(const String& string, DOMURL* associatedURL);
+
+    // WTF::URLParser::parseURLEncodedForm RELEASE_ASSERTs, instead of failing, on a
+    // name or value whose UTF-8 form does not fit a WTF::Vector. Call before parsing.
+    static ExceptionOr<void> checkURLEncodedFormLength(StringView);
 
     void append(const String& name, const String& value);
     void remove(const StringView name, const String& value = {});
@@ -53,7 +54,7 @@ public:
     bool has(const StringView name, const String& value = {}) const;
     void set(const String& name, const String& value);
     String toString() const;
-    void updateFromAssociatedURL();
+    ExceptionOr<void> updateFromAssociatedURL();
     void sort();
     size_t size() const { return m_pairs.size(); }
     size_t memoryCost() const;
@@ -72,7 +73,7 @@ public:
 
 private:
     const Vector<KeyValuePair<String, String>>& pairs() const { return m_pairs; }
-    URLSearchParams(const String&, DOMURL*);
+    URLSearchParams(Vector<KeyValuePair<String, String>>&&, DOMURL*);
     URLSearchParams(const Vector<KeyValuePair<String, String>>&);
     void updateURL();
 

--- a/src/jsc/bindings/URLSearchParams.h
+++ b/src/jsc/bindings/URLSearchParams.h
@@ -43,8 +43,7 @@ public:
     static ExceptionOr<Ref<URLSearchParams>> create(std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String>&&);
     static ExceptionOr<Ref<URLSearchParams>> create(const String& string, DOMURL* associatedURL);
 
-    // WTF::URLParser::parseURLEncodedForm RELEASE_ASSERTs, instead of failing, on a
-    // name or value whose UTF-8 form does not fit a WTF::Vector. Call before parsing.
+    // WTF::URLParser::parseURLEncodedForm RELEASE_ASSERTs on a name or value whose UTF-8 form does not fit a Vector.
     static ExceptionOr<void> checkURLEncodedFormLength(StringView);
 
     void append(const String& name, const String& value);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6409,8 +6409,13 @@ CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__createFromURLQuery(JSC::JSGlo
         auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
         return Bun::ERR::STRING_TOO_LONG(scope, globalObject);
     }
-    auto formData = DOMFormData::create(globalObject->scriptExecutionContext(), WTF::move(str));
-    return JSValue::encode(toJSNewlyCreated(arg0, globalObject, WTF::move(formData)));
+    auto formData = DOMFormData::create(globalObject->scriptExecutionContext(), str);
+    if (formData.hasException()) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+        WebCore::propagateException(*globalObject, scope, formData.releaseException());
+        return {};
+    }
+    return JSValue::encode(toJSNewlyCreated(arg0, globalObject, formData.releaseReturnValue()));
 }
 
 CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__create(JSC::JSGlobalObject* arg0)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2866,6 +2866,7 @@ impl BlobExt for Blob {
         let buf = unsafe { &*buf };
         match crate::webcore::form_data::FormData::to_js(global, buf, &encoder.encoding) {
             Ok(v) => v,
+            Err(crate::Error::JSError) => global.take_error(jsc::JsError::Thrown),
             Err(err) => {
                 global.create_error_instance(format_args!("FormData encoding failed: {err}"))
             }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2064,6 +2064,11 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         let js_value =
             match webcore::form_data::FormData::to_js(global_object, blob.slice(), &encoding) {
                 Ok(v) => v,
+                Err(crate::Error::JSError) => {
+                    blob.detach();
+                    let error = global_object.take_error(jsc::JsError::Thrown);
+                    return Ok(JSPromise::rejected_promise(global_object, error).to_js());
+                }
                 Err(err) => {
                     blob.detach();
                     return Ok(global_object

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -40,6 +40,11 @@ impl AsyncFormDataExt for AsyncFormData {
 
         let js_value = match FormData::to_js(global, data, &self.encoding) {
             Ok(v) => v,
+            Err(crate::Error::JSError) => {
+                scoped_log!(FormData, "AsnycFormData.toJS -> failed ");
+                promise.reject(global, global.take_error(JsError::Thrown))?;
+                return Ok(());
+            }
             Err(e) => {
                 scoped_log!(FormData, "AsnycFormData.toJS -> failed ");
                 promise.reject(

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1013,7 +1013,7 @@ describe("USVString conversion of lone surrogates", () => {
 describe("URL-encoded bodies longer than the string limit", () => {
   const LIMIT = 1024 * 1024;
   const tooLong = (received: number) =>
-    `RangeError: URL-encoded data must not be longer than ${LIMIT} bytes as UTF-8. Received ${received} bytes.`;
+    `RangeError: A URL-encoded name or value must not be longer than ${LIMIT} bytes as UTF-8. Received ${received} bytes.`;
 
   it("rejects from every formData() entry point instead of crashing", async () => {
     await using proc = Bun.spawn({
@@ -1097,7 +1097,7 @@ describe("URL-encoded bodies longer than the string limit", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout:
-        "RangeError: URL-encoded data must not be longer than 1073741823 bytes as UTF-8. Received 1073741826 bytes.\n",
+        "RangeError: A URL-encoded name or value must not be longer than 1073741823 bytes as UTF-8. Received 1073741826 bytes.\n",
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1058,8 +1058,10 @@ describe("URL-encoded bodies longer than the string limit", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: JSON.parse(stdout), stderr, exitCode }).toEqual({
-      stdout: {
+    // Keep stderr and the exit code in the diff when the child aborts before it prints.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toEqual({
+      results: {
         "FormData.from(bytes) at limit": "",
         "FormData.from(bytes) past limit": tooLong(LIMIT + 2),
         "FormData.from(string) past limit": tooLong(LIMIT + 2),

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { totalmem } from "node:os";
 import { join } from "path";
 
 describe("FormData", () => {
@@ -1002,5 +1003,103 @@ describe("USVString conversion of lone surrogates", () => {
     expect(formData.get("\u{1F600}")).toBe("emoji");
     expect(formData.getAll("\u{1F600}")).toEqual(["emoji"]);
     expect(formData.get("\uFFFD")).toBeNull();
+  });
+});
+
+// WTF's URL-encoded form parser RELEASE_ASSERTs when the UTF-8 form of a name or
+// value does not fit a WTF::Vector (1 GiB - 1 bytes), so Bun rejects such a body
+// with a RangeError before parsing. The limit follows the synthetic allocation
+// limit so that every entry point can be exercised with megabyte inputs.
+describe("URL-encoded bodies longer than the string limit", () => {
+  const LIMIT = 1024 * 1024;
+  const tooLong = (received: number) =>
+    `RangeError: URL-encoded data must not be longer than ${LIMIT} bytes as UTF-8. Received ${received} bytes.`;
+
+  it("rejects from every formData() entry point instead of crashing", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
+        setSyntheticAllocationLimitForTesting(${LIMIT});
+        const out = {};
+        const attempt = async (label, f) => {
+          try {
+            out[label] = await f();
+          } catch (e) {
+            out[label] = e.constructor.name + ": " + e.message;
+          }
+        };
+        // "é" is one UTF-16 unit but 2 UTF-8 bytes, so these bodies pass the
+        // character-count check on the way into a WTF::String and reach the
+        // UTF-8 byte check of the parser.
+        const latin1 = n => Buffer.alloc(n * 2, "é");
+        const atLimit = latin1(${LIMIT / 2});
+        const pastLimit = latin1(${LIMIT / 2} + 1);
+        const type = "application/x-www-form-urlencoded";
+
+        await attempt("FormData.from(bytes) at limit", () => FormData.from(atLimit).get(atLimit.toString()));
+        await attempt("FormData.from(bytes) past limit", () => FormData.from(pastLimit).get("x"));
+        await attempt("FormData.from(string) past limit", () => FormData.from(pastLimit.toString()).get("x"));
+        await attempt("Response.formData() past limit", () =>
+          new Response(pastLimit, { headers: { "content-type": type } }).formData());
+        await attempt("Request.formData() past limit", () =>
+          new Request("http://x/", { method: "POST", body: pastLimit, headers: { "content-type": type } }).formData());
+        await attempt("Blob.formData() past limit", () => new Blob([pastLimit], { type }).formData());
+        const stream = new ReadableStream({ start(c) { c.enqueue(pastLimit); c.close(); } });
+        await attempt("streamed Response.formData() past limit", () =>
+          new Response(stream, { headers: { "content-type": type } }).formData());
+        console.log(JSON.stringify(out));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: JSON.parse(stdout), stderr, exitCode }).toEqual({
+      stdout: {
+        "FormData.from(bytes) at limit": "",
+        "FormData.from(bytes) past limit": tooLong(LIMIT + 2),
+        "FormData.from(string) past limit": tooLong(LIMIT + 2),
+        "Response.formData() past limit": tooLong(LIMIT + 2),
+        "Request.formData() past limit": tooLong(LIMIT + 2),
+        "Blob.formData() past limit": tooLong(LIMIT + 2),
+        "streamed Response.formData() past limit": tooLong(LIMIT + 2),
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The input Fuzzilli found. The real limit needs a 1 GiB buffer, so this runs
+  // only on large machines.
+  it.skipIf(totalmem() < 10 * 1024 ** 3)("FormData.from throws a RangeError at the real limit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        try {
+          FormData.from(new ArrayBuffer(1073741826));
+          console.log("no error");
+        } catch (e) {
+          console.log(e.constructor.name + ": " + e.message);
+        }
+        Bun.gc(true);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout:
+        "RangeError: URL-encoded data must not be longer than 1073741823 bytes as UTF-8. Received 1073741826 bytes.\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { totalmem } from "node:os";
 
 describe("URLSearchParams", () => {
   it("does not crash when calling .toJSON() on a URLSearchParams object with a large number of properties", () => {
@@ -305,4 +307,118 @@ it(".has second argument", () => {
   expect(params.has("a", 3)).toBe(false);
   expect(params.has("b", 3)).toBe(true);
   expect(params.has("b", 4)).toBe(false);
+});
+
+// WTF's URL-encoded form parser RELEASE_ASSERTs when the UTF-8 form of a name or
+// value does not fit a WTF::Vector (1 GiB - 1 bytes), so Bun rejects such input
+// with a RangeError before parsing. The limit follows the synthetic allocation
+// limit so that every entry point can be exercised with megabyte inputs.
+describe("URL-encoded input longer than the string limit", () => {
+  const LIMIT = 1024 * 1024;
+  const tooLong = (received: number) =>
+    `RangeError: URL-encoded data must not be longer than ${LIMIT} bytes as UTF-8. Received ${received} bytes.`;
+
+  it("throws a RangeError from every parser entry point, at the UTF-8 byte limit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
+        setSyntheticAllocationLimitForTesting(${LIMIT});
+        const out = {};
+        const attempt = (label, f) => {
+          try {
+            out[label] = f();
+          } catch (e) {
+            out[label] = e.constructor.name + ": " + e.message;
+          }
+        };
+        const ascii = n => Buffer.alloc(n, "a").toString();
+        // One Latin-1 character is 2 UTF-8 bytes, one UTF-16 unit of "€" is 3.
+        const latin1 = n => Buffer.alloc(n * 2, "é").toString();
+        const utf16 = n => Buffer.alloc(n * 3, "€").toString();
+
+        attempt("ascii at limit", () => new URLSearchParams(ascii(${LIMIT})).size);
+        attempt("ascii past limit", () => new URLSearchParams(ascii(${LIMIT} + 1)).size);
+        attempt("leading ? is not counted", () => new URLSearchParams("?" + ascii(${LIMIT})).size);
+        attempt("latin1 at limit", () => new URLSearchParams(latin1(${LIMIT / 2})).size);
+        attempt("latin1 past limit", () => new URLSearchParams(latin1(${LIMIT / 2} + 1)).size);
+        attempt("utf16 at limit", () => new URLSearchParams(utf16(349525)).size);
+        attempt("utf16 past limit", () => new URLSearchParams(utf16(349526)).size);
+        attempt("url.searchParams at limit", () => new URL("http://x/?" + ascii(${LIMIT})).searchParams.size);
+        attempt("url.searchParams past limit", () => new URL("http://x/?" + ascii(${LIMIT} + 1)).searchParams.size);
+
+        const url = new URL("http://x/?a=1");
+        const params = url.searchParams;
+        attempt("url.href= past limit", () => { url.href = "http://x/?" + ascii(${LIMIT} + 1); });
+        out["url.href= past limit leaves the url set and the params empty"] = {
+          search: url.search.length,
+          size: params.size,
+          sameObject: url.searchParams === params,
+        };
+        attempt("url.href= at limit", () => { url.href = "http://x/?" + ascii(${LIMIT}); return params.size; });
+        // Component setters return void, so the params only empty out.
+        attempt("url.search= past limit", () => { url.search = ascii(${LIMIT} + 1); return params.size; });
+        console.log(JSON.stringify(out));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: JSON.parse(stdout), stderr, exitCode }).toEqual({
+      stdout: {
+        "ascii at limit": 1,
+        "ascii past limit": tooLong(LIMIT + 1),
+        "leading ? is not counted": 1,
+        "latin1 at limit": 1,
+        "latin1 past limit": tooLong(LIMIT + 2),
+        "utf16 at limit": 1,
+        "utf16 past limit": tooLong(LIMIT + 2),
+        "url.searchParams at limit": 1,
+        "url.searchParams past limit": tooLong(LIMIT + 1),
+        "url.href= past limit": tooLong(LIMIT + 1),
+        "url.href= past limit leaves the url set and the params empty": {
+          search: LIMIT + 2,
+          size: 0,
+          sameObject: true,
+        },
+        "url.href= at limit": 1,
+        "url.search= past limit": 0,
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The real limit needs a 1 GiB string, so this runs only on large machines.
+  it.skipIf(totalmem() < 10 * 1024 ** 3)("throws a RangeError at the real limit instead of crashing", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const input = Buffer.alloc(2 ** 30, "a").toString();
+        try {
+          new URLSearchParams(input);
+          console.log("no error");
+        } catch (e) {
+          console.log(e.constructor.name + ": " + e.message);
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout:
+        "RangeError: URL-encoded data must not be longer than 1073741823 bytes as UTF-8. Received 1073741824 bytes.\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -346,6 +346,9 @@ describe("URL-encoded input longer than the string limit", () => {
         attempt("latin1 past limit", () => new URLSearchParams(latin1(${LIMIT / 2} + 1)).size);
         attempt("utf16 at limit", () => new URLSearchParams(utf16(349525)).size);
         attempt("utf16 past limit", () => new URLSearchParams(utf16(349526)).size);
+        // WTF converts the encoded text to UTF-8 before it percent-decodes, so the
+        // encoded length is the one that counts.
+        attempt("percent-encoded past limit", () => new URLSearchParams(Buffer.alloc(${LIMIT} + 2, "%41").toString()).size);
         // The limit applies to one name or value, not to the whole input.
         attempt("two names at limit", () => new URLSearchParams(ascii(${LIMIT}) + "&" + ascii(${LIMIT})).size);
         attempt("name and value at limit", () => new URLSearchParams(ascii(${LIMIT}) + "=" + ascii(${LIMIT})).size);
@@ -372,8 +375,10 @@ describe("URL-encoded input longer than the string limit", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: JSON.parse(stdout), stderr, exitCode }).toEqual({
-      stdout: {
+    // Keep stderr and the exit code in the diff when the child aborts before it prints.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toEqual({
+      results: {
         "ascii at limit": 1,
         "ascii past limit": tooLong(LIMIT + 1),
         "leading ? is not counted": 1,
@@ -381,6 +386,7 @@ describe("URL-encoded input longer than the string limit", () => {
         "latin1 past limit": tooLong(LIMIT + 2),
         "utf16 at limit": 1,
         "utf16 past limit": tooLong(LIMIT + 2),
+        "percent-encoded past limit": tooLong(LIMIT + 2),
         "two names at limit": 2,
         "name and value at limit": 1,
         "one value past limit among pairs": tooLong(LIMIT + 1),

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -316,7 +316,7 @@ it(".has second argument", () => {
 describe("URL-encoded input longer than the string limit", () => {
   const LIMIT = 1024 * 1024;
   const tooLong = (received: number) =>
-    `RangeError: URL-encoded data must not be longer than ${LIMIT} bytes as UTF-8. Received ${received} bytes.`;
+    `RangeError: A URL-encoded name or value must not be longer than ${LIMIT} bytes as UTF-8. Received ${received} bytes.`;
 
   it("throws a RangeError from every parser entry point, at the UTF-8 byte limit", async () => {
     await using proc = Bun.spawn({
@@ -346,6 +346,10 @@ describe("URL-encoded input longer than the string limit", () => {
         attempt("latin1 past limit", () => new URLSearchParams(latin1(${LIMIT / 2} + 1)).size);
         attempt("utf16 at limit", () => new URLSearchParams(utf16(349525)).size);
         attempt("utf16 past limit", () => new URLSearchParams(utf16(349526)).size);
+        // The limit applies to one name or value, not to the whole input.
+        attempt("two names at limit", () => new URLSearchParams(ascii(${LIMIT}) + "&" + ascii(${LIMIT})).size);
+        attempt("name and value at limit", () => new URLSearchParams(ascii(${LIMIT}) + "=" + ascii(${LIMIT})).size);
+        attempt("one value past limit among pairs", () => new URLSearchParams("a=1&b=" + ascii(${LIMIT} + 1) + "&c=2").size);
         attempt("url.searchParams at limit", () => new URL("http://x/?" + ascii(${LIMIT})).searchParams.size);
         attempt("url.searchParams past limit", () => new URL("http://x/?" + ascii(${LIMIT} + 1)).searchParams.size);
 
@@ -377,6 +381,9 @@ describe("URL-encoded input longer than the string limit", () => {
         "latin1 past limit": tooLong(LIMIT + 2),
         "utf16 at limit": 1,
         "utf16 past limit": tooLong(LIMIT + 2),
+        "two names at limit": 2,
+        "name and value at limit": 1,
+        "one value past limit among pairs": tooLong(LIMIT + 1),
         "url.searchParams at limit": 1,
         "url.searchParams past limit": tooLong(LIMIT + 1),
         "url.href= past limit": tooLong(LIMIT + 1),
@@ -416,7 +423,7 @@ describe("URL-encoded input longer than the string limit", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout:
-        "RangeError: URL-encoded data must not be longer than 1073741823 bytes as UTF-8. Received 1073741824 bytes.\n",
+        "RangeError: A URL-encoded name or value must not be longer than 1073741823 bytes as UTF-8. Received 1073741824 bytes.\n",
       stderr: "",
       exitCode: 0,
     });


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found abort in URL-encoded form parsing.

```js
FormData.from(new ArrayBuffer(1073741826));
// ASSERTION FAILED: expectedString
// vendor/WebKit/Source/WTF/wtf/text/StringView.cpp(121) : CString WTF::StringView::utf8(ConversionMode) const
```

`WTF::URLParser::parseURLEncodedForm` splits the input on `&`, then on the first `=`, and runs `formURLDecode` on each name and value. `formURLDecode` calls `StringView::utf8()`, which `RELEASE_ASSERT`s when the conversion fails. The conversion fails when the UTF-8 buffer does not fit a `WTF::Vector`: for an 8-bit string that is `2 * length > INT32_MAX`, for a 16-bit string it is the exact UTF-8 byte count. After percent-decoding, `String::fromUTF8ReplacingInvalidSequences` sizes a `Vector<char16_t>` by the UTF-8 byte count, and that `Vector` constructor crashes past `2^30 - 1` elements. So any name or value whose UTF-8 form is longer than 1073741823 bytes aborts the process. The `if (utf8.isNull())` check in `formURLDecode` shows the parser was written to skip such a pair, but `utf8()` no longer returns null on failure.

The same parser sits behind every URL-encoded entry point in Bun, and each one aborted with the same input:

- `new URLSearchParams(string)`
- `url.searchParams` (first access)
- `url.href = ...` and `url.search = ...` after `url.searchParams` was accessed
- `FormData.from(bytes | string)` with no boundary
- `Response.formData()`, `Request.formData()`, `Blob.formData()` with an `application/x-www-form-urlencoded` body, buffered or streamed

WebKit is a prebuilt dependency, so the fix is on Bun's side: `URLSearchParams::checkURLEncodedFormLength(StringView)` splits the input the way the parser does and returns a `RangeError` when the UTF-8 length of one name or value exceeds `(UINT_MAX >> 1) / sizeof(char16_t)`, the same bound as `WTF::isValidCapacityForVector<char16_t>`. Two `static_assert`s tie the constant to that WTF function. The check is per name and value, not per input, so input over the limit in total still parses when each part fits, as it did before. The check also honors `Bun__stringSyntheticAllocationLimit`, like `toString()` in `helpers.h`, so tests can reach it with megabyte inputs. Inputs shorter than a third of the limit skip the split and the length pass, since a UTF-16 code unit is at most 3 UTF-8 bytes.

Every call of `WTF::URLParser::parseURLEncodedForm` now goes through the check:

- `URLSearchParams::create(String, DOMURL*)` and `updateFromAssociatedURL()` return `ExceptionOr`. `DOMURL::searchParams()` returns `ExceptionOr<URLSearchParams&>` and the existing `toJS` overload in the getter propagates it. `DOMURL::setHref` propagates the result of `updateFromAssociatedURL()`. The list of pairs is emptied before the parse, in the order the URL spec gives for the `href` setter, so a failed parse leaves the URL set and the params empty instead of stale.
- `DOMFormData::create(ScriptExecutionContext*, StringView)` returns `ExceptionOr<Ref<DOMFormData>>`. `WebCore__DOMFormData__createFromURLQuery` throws it.

Error message:

```
RangeError: A URL-encoded name or value must not be longer than 1073741823 bytes as UTF-8. Received 1073741826 bytes.
```

The Rust callers of `FormData::to_js` did not handle a thrown C++ exception. On `Error::JSError` they built a second error (`"FormData parse error JSError"`) while the first one was still pending, which trips `assert_exception_presence_matches` in debug builds and surfaces as a synchronous throw in release builds. `Body.rs` (buffered body), `FormData.rs` (streamed body) and `Blob.rs` now take the pending exception with `take_error` and reject the promise with it. This path was already reachable with the existing `ERR_STRING_TOO_LONG` throw from the same C++ function.

### Known limitations

- The URL component setters (`url.search = ...`) return `void` per the URL spec and go through `URLDecomposition::setFullURL`, which has no error channel. When such a setter produces a query over the limit on a URL whose `searchParams` object exists, the params come out empty and no error is thrown. The URL itself is updated. Making those setters throw would change the `URLDecomposition` interface for a case that needs a 1 GiB assignment, so this PR leaves it as is.
- The check measures the encoded UTF-8 length of each part, which is what `StringView::utf8()` allocates for. For an 8-bit string that is exactly the WTF condition. A 16-bit string that is all ASCII and over 1 GiB of characters per part is rejected here, while WTF would have decoded it when the percent-decoded result stays ASCII. JSC only produces such a string by slicing or replacing a string that once held a non-Latin-1 character.
- The pairs `Vector` in the same parser has its own capacity limit. `new URLSearchParams("a=&".repeat(116597314))` (350 MB, about 6 GiB of heap) aborts on the base branch and on this branch when the `Vector` growth step crosses `isValidCapacityForVector`. 116597313 pairs parse. The same abort happens with `params.append()` in a loop, so it is a collection size limit and not a decode limit. This PR does not address it.

### How did you verify your code works?

Before, in the debug build:

```
$ bun-debug /tmp/crash.js
ASSERTION FAILED: expectedString
vendor/WebKit/Source/WTF/wtf/text/StringView.cpp(121) : CString WTF::StringView::utf8(ConversionMode) const
```

After:

```
$ bun-debug /tmp/crash.js
RangeError: A URL-encoded name or value must not be longer than 1073741823 bytes as UTF-8. Received 1073741826 bytes.
```

New tests in `test/js/web/html/URLSearchParams.test.ts` and `test/js/web/html/FormData.test.ts`, each in a spawned process:

- With `setSyntheticAllocationLimitForTesting(1 MiB)`: at the limit parses, one byte past throws, for ASCII, Latin-1 (2 bytes per character) and UTF-16 (3 bytes per unit) input, through `new URLSearchParams()`, a leading `?`, `url.searchParams`, `url.href =`, `url.search =`, `FormData.from(bytes | string)`, `Response.formData()`, `Request.formData()`, `Blob.formData()` and a streamed `Response.formData()`. Two names at the limit (2 MiB in total) and a name plus a value at the limit parse. One value past the limit among small pairs throws.
- With the real limit: `FormData.from(new ArrayBuffer(1073741826))` (the fuzzer input) and `new URLSearchParams()` of a 1 GiB string throw the `RangeError`. These two skip on machines with less than 10 GiB of memory, like the other 1 GiB tests in the suite.

All four new tests fail on the current release build: the real-limit children exit with code 134, and the synthetic-limit children parse the input without an error. They pass with `bun bd test`. `BUN_JSC_validateExceptionChecks=1` is clean on every path.

A successful parse of exactly 1073741823 bytes is not tested with a real string: it allocates about 6 GiB and takes over a minute in a debug build. The synthetic-limit tests cover that boundary. A test with hundreds of thousands of pairs is not viable either: WTF's parser costs about 66 µs per pair in a debug build.

Existing suites pass: `test/js/web/html/URLSearchParams.test.ts`, `test/js/web/html/FormData.test.ts`, `test/js/web/html/FormData-multipart-serialization.test.ts`, `test/js/web/url/url.test.ts`, `test/js/web/url/url-wpt-constructor.test.ts`, `test/js/web/fetch/body.test.ts`, `test/js/web/fetch/utf8-bom.test.ts`, `test/js/web/fetch/form-data-boundary-crash.test.ts`, `test/js/deno/url/urlsearchparams.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts test/js/web/html/URLSearchParams.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [4.31ms]
(pass) FormData > should be able to append a Blob [8.12ms]
(pass) FormData > should be able to set a Blob [6.28ms]
(pass) FormData > should be able to set a string [2.85ms]
(pass) FormData > should get filename from file [3.84ms]
(pass) FormData > should use the correct filenames [5.78ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [15.92ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [38.75ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.84ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [4.80ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.91ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.18ms]
(pass) FormDa
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (6fb93791a)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.12ms]
(pass) FormData > should be able to append a Blob [0.17ms]
(pass) FormData > should be able to set a Blob [0.10ms]
(pass) FormData > should be able to set a string [0.04ms]
(pass) FormData > should get filename from file [0.05ms]
(pass) FormData > should use the correct filenames [0.05ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.28ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [4.50ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.07ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.07ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.04ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.05ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts test/js/web/html/URLSearchParams.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.76ms]
(pass) FormData > should be able to append a Blob [7.92ms]
(pass) FormData > should be able to set a Blob [6.15ms]
(pass) FormData > should be able to set a string [2.89ms]
(pass) FormData > should get filename from file [3.87ms]
(pass) FormData > should use the correct filenames [5.04ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [14.99ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [30.14ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.45ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.09ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.61ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.21ms]
(pass) FormDa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/33] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 243 extern-C blocks audited
[2/33] gen cpp.rs (cppbind)
[3/33] gen JS modules (bundle-modules)
Preprocess modules (8059ms)
Bundle modules (56ms)
Postprocesss modules (182ms)
Bundle Functions (569ms)
Generate Code (48ms)

[8.93s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/28] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/DOMFormData.cpp         |   8 +-
 src/jsc/bindings/DOMFormData.h           |   2 +-
 src/jsc/bindings/DOMURL.cpp              |  12 ++-
 src/jsc/bindings/DOMURL.h                |   2 +-
 src/jsc/bindings/URLSearchParams.cpp     |  64 +++++++++++++--
 src/jsc/bindings/URLSearchParams.h       |  12 +--
 src/jsc/bindings/bindings.cpp            |   9 ++-
 src/runtime/webcore/Blob.rs              |   1 +
 src/runtime/webcore/Body.rs              |   5 ++
 src/runtime/webcore/FormData.rs          |   5 ++
 test/js/web/html/FormData.test.ts        | 101 ++++++++++++++++++++++++
 test/js/web/html/URLSearchParams.test.ts | 129 +++++++++++++++++++++++++++++++
 12 files changed, 329 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/bindings/DOMFormData.cpp              1      2      0
src/jsc/bindings/DOMFormData.h                1      2      0
src/jsc/bindings/DOMURL.cpp                   1      2      0
src/jsc/bindings/DOMURL.h                     1      1      0
src/jsc/bindings/URLSearchParams.cpp          2      7      0
src/jsc/bindings/URLSearchParams.h            2      4      0
src/jsc/bindings/bindings.cpp                 1      1      0
src/runtime/webcore/Blob.rs                   1      1      0
src/runtime/webcore/Body.rs                   1      1      0
src/runtime/webcore/FormData.rs               1      1      0
test/js/web/html/FormData.test.ts             2      3      0
test/js/web/html/URLSearchParams.test.ts      3     10      0
```

</details>

<!-- robobun:evidence:end -->