### PR TITLE
Report parser errors on the async module transpile path

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -926,8 +926,7 @@ impl TranspilerJob {
             }
         }
 
-        // Errors logged after the AST exists (duplicate export names, `import` next
-        // to `module.exports`) must still fail the load, as in `transpile_source_code_inner`.
+        // The parser can log errors and still return an AST.
         if transpiler.log().errors > 0 {
             self.parse_error = Some(crate::CrateError::ParseError);
             return;

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -926,6 +926,15 @@ impl TranspilerJob {
             }
         }
 
+        // The parser can log an error and still return an AST (an `import`
+        // statement next to `module.exports`, a React Compiler failure). The
+        // sync path in `transpile_source_code_inner` rejects the file at this
+        // point; do the same instead of handing the printed output to JSC.
+        if transpiler.log().errors > 0 {
+            self.parse_error = Some(crate::CrateError::ParseError);
+            return;
+        }
+
         // SAFETY: leaf scalar field read; see `vm` note above. Inlined
         // `VirtualMachine::use_isolation_source_provider_cache` to avoid forming
         // `&VirtualMachine`.

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -926,10 +926,8 @@ impl TranspilerJob {
             }
         }
 
-        // The parser can log an error and still return an AST (an `import`
-        // statement next to `module.exports`, a React Compiler failure). The
-        // sync path in `transpile_source_code_inner` rejects the file at this
-        // point; do the same instead of handing the printed output to JSC.
+        // Errors logged after the AST exists (duplicate export names, `import` next
+        // to `module.exports`) must still fail the load, as in `transpile_source_code_inner`.
         if transpiler.log().errors > 0 {
             self.parse_error = Some(crate::CrateError::ParseError);
             return;

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -68,6 +68,78 @@ test("import with many build errors keeps AggregateError entries alive across GC
   expect(exitCode).toBe(0);
 });
 
+// "Cannot use import statement with CommonJS-only features" is logged after
+// the parser has already produced an AST. The async transpile path behind
+// `import` and `import()` used to skip the log check that `require()` does, so
+// JSC got the `import` inside the CommonJS wrapper and threw its own
+// SyntaxError instead.
+const mixedModuleFiles = {
+  "dep.js": `export const x = 42;`,
+  "mixed.js": `import { x } from "./dep.js";\nmodule.exports = { x };`,
+};
+
+test.concurrent(
+  "import() of a file that mixes import with module.exports rejects with the parser's error",
+  async () => {
+    using dir = tempDir("build-error-mixed-import", {
+      ...mixedModuleFiles,
+      "main.js": `
+      const out = {};
+      try {
+        await import("./mixed.js");
+      } catch (e) {
+        out.import = [e.name, e.message];
+      }
+      try {
+        require("./mixed.js");
+      } catch (e) {
+        out.require = [e.name, e.message];
+      }
+      console.log(JSON.stringify(out));
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0) console.error(stderr);
+    const expected = ["BuildMessage", "Cannot use import statement with CommonJS-only features"];
+    expect(JSON.parse(stdout)).toEqual({ import: expected, require: expected });
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent(
+  "unhandled import() of a file that mixes import with module.exports prints the parser's notes",
+  async () => {
+    using dir = tempDir("build-error-mixed-uncaught", {
+      ...mixedModuleFiles,
+      "main.js": `import("./mixed.js");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain("error: Cannot use import statement with CommonJS-only features");
+    expect(stderr).toContain(`note: Try require("./dep.js") instead`);
+    expect(stderr).toContain("note: This file is CommonJS because 'module' was used");
+    expect(exitCode).toBe(1);
+  },
+);
+
 test("BuildMessage finalize frees with the same allocator it was created with", async () => {
   // BuildMessage.create() clones the message with the passed allocator
   // but finalize() was freeing it with bun.default_allocator and never

--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -262,15 +262,14 @@ describe("through export merge", () => {
             ["c." + fmt]: "export const value = 'c';",
           });
 
+          // Both the entry point and a file it imports report the parser's
+          // error. The import path used to hand the file to JSC, which
+          // reported "Cannot export a duplicate name 'value'." instead.
           for (const file of ["main." + fmt, "a." + fmt]) {
             test.concurrent(file, async () => {
               const result = await run([bunExe(), file], dir);
 
-              expect(result.stderr.trim()).toInclude(
-                file === "a." + fmt
-                  ? 'error: Multiple exports with the same name "value"\n' // bun's syntax error
-                  : "SyntaxError: Cannot export a duplicate name 'value'.\n", // jsc's syntax error
-              );
+              expect(result.stderr.trim()).toInclude('error: Multiple exports with the same name "value"\n');
 
               expect(result.exitCode).toBe(1);
             });


### PR DESCRIPTION
### Problem
- `import("./mixed.js")` or `import "./mixed.js"`, where `mixed.js` has an `import` statement next to `module.exports`, rejects with `SyntaxError: Unexpected token '{'. import call expects one or two arguments.` `require("./mixed.js")` throws the parser's `BuildMessage` for the same file: `Cannot use import statement with CommonJS-only features`, with the `Try require(...)` note. This is the message behind the `import()` reports in #20718. Older versions failed the same input with `TypeError: Expected CommonJS module to have a function wrapper`.
- Cause: the parser logs this error after it has built the AST (`src/js_parser/parse/parse_entry.rs:1642`), so the parse still returns a result. The sync path checks `log.errors > 0` after the parse (`src/runtime/jsc_hooks.rs:2761`). The async path in `TranspilerJob::run` (`src/jsc/RuntimeTranspilerStore.rs`) did not. It printed the `import` inside the CommonJS wrapper and handed that to JSC. The failed `import()` also left that module behind, so a later `require()` of the same file got the JSC error too.

### Fix
- After the parse in `TranspilerJob::run`, return with `parse_error = ParseError` when the log has errors. `AsyncModule::fulfill` then builds the rejection from the log, the same way it does for a parse that fails outright.
- Correct because it mirrors the sync path. Parse-phase and visit-phase errors already abort the parse (`parse_entry.rs:849` and `:1110`). Three errors are logged later and reach this point with an AST: `Multiple exports with the same name` (from the import scanner in `P::to_ast`), the CommonJS-only import error, and a React Compiler failure. `require()` and the entry point already reject all three.
- `test/js/bun/typescript/type-export.test.ts` ("through export merge") expected JSC's `Cannot export a duplicate name 'value'.` when the file was imported and Bun's `Multiple exports with the same name "value"` when it was run directly. It now expects Bun's error on both paths.
- Verified: `test/js/bun/resolve/build-error.test.ts` (two new tests, both fail on the unfixed build) and `type-export.test.ts`. Also ran `test/js/bun/resolve/`, the CJS/ESM tests in `test/cli/run/`, `test/js/node/module/` and `test/bundler/transpiler/react-compiler.test.ts`.

### Background
- Bun transpiles a module on one of two paths. `require()` and the entry point use `transpile_source_code_inner` on the JS thread. `import` and `import()` use `RuntimeTranspilerStore`: a `TranspilerJob` parses and prints on a worker thread and posts the result back to the JS thread.
- A file that uses a CommonJS-only feature (`module`, `exports`, top-level `return`) is printed inside the wrapper `(function(exports, require, module, __filename, __dirname) { ... })`. An `import` statement is not valid inside a function, so the parser reports the mix as an error with a note that names the feature.
- `bun_ast::Log` collects the diagnostics of one transpile. A `BuildMessage` is the JS error built from one log entry (message, location, notes). `process_fetch_log` turns a log with errors into the rejection value.

<details><summary>Notes</summary>

Repro from #20718, reduced to local files:

```ts
// a.ts
import("./b.ts");
// b.ts
import { X } from "./x.ts";
module.exports = { d: new X() };
```

Before: `SyntaxError: Unexpected token '{'. import call expects one or two arguments.` After: `error: Cannot use import statement with CommonJS-only features` plus `note: Try require("./x.ts") instead` and `note: This file is CommonJS because 'module' was used`, exit code 1. `bun b.ts` already printed that output before this change.

Order matters on the unfixed build: `require` first gives the `BuildMessage`, then `import()` gives the JSC error. `import()` first gives the JSC error for both, because the failed async load registers the CommonJS module. The new test runs `import()` first and expects the `BuildMessage` from both.

Node rejects the same file. With `.cjs` or `"type": "commonjs"` it is `SyntaxError: Cannot use import statement outside a module`. With module detection it runs as ESM and `module.exports` throws `ReferenceError: module is not defined in ES module scope`.

The duplicate export case: `export const value = 1; export {value};` imported from another file. Before, JSC reported `SyntaxError: Cannot export a duplicate name 'value'.` Now the parser's error with its `"value" was originally exported here` note is reported, as `bun a.js` already did. The first CI run caught this through the old expectation in `type-export.test.ts`.

In this container (debug ASAN build, 12 cores) `load-same-js-file-a-lot.test.ts` and the leak tests in `require-cache.test.ts` time out. The `require()` variants, which do not touch this code, time out the same way, so the timeouts are machine speed. The `via import()` AST leak test passes.

</details>
