### PR TITLE
bundler: fix quadratic naming of unminified cross-chunk bindings that share a source name

### DIFF
--- a/src/bundler/linker_context/crossChunkNames.rs
+++ b/src/bundler/linker_context/crossChunkNames.rs
@@ -93,12 +93,20 @@ pub(crate) fn assign_unminified(
             .slice();
         let base = bun_core::MutableString::ensure_valid_identifier(original)?;
         let mut name: &[u8] = &base;
-        let mut tries = 1u32;
-        while used.contains_key(name) {
-            tries += 1;
-            buf.clear();
-            buf.extend_from_slice(&base);
-            write!(&mut buf, "{tries}").expect("Vec<u8> write");
+        // `used[base]` remembers the last suffix handed out for `base`, so a
+        // run of bindings sharing one name does not re-probe 2, 3, ... each time.
+        if let Some(last) = used.get(&*base).copied() {
+            let mut tries = last.max(1);
+            loop {
+                tries += 1;
+                buf.clear();
+                buf.extend_from_slice(&base);
+                write!(&mut buf, "{tries}").expect("Vec<u8> write");
+                if !used.contains_key(buf.as_slice()) {
+                    break;
+                }
+            }
+            used.put(&base, tries)?;
             name = &buf;
         }
         used.put(name, 1)?;


### PR DESCRIPTION
Follow-up to #40518. `assign_unminified` numbered each cross-chunk binding by probing `name2`, `name3`, … from 2 every time, so N bindings with the same source name (e.g. 20k modules each exporting `shared`, imported across two entry points) cost O(N²) hash lookups. It now remembers the last suffix handed out per base name, as `NumberScope` does.

`test/bundler/bundler_splitting.test.ts` › `splitting/ManyCrossChunkExportAliasCollisions` (20,000 colliding names, 15 s budget) is the guard: release x64 went 0.52 s (1.4.0) → 9.5 s (#40518) and it timed out / was marked flaky on macOS aarch64 in #40519's CI; debug build: >300 s → 11 s with this change. Output unchanged (same names, same program result).