### PR TITLE
Bump WebKit to 2da33d53e33e

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "76882271d74a6e7f5ca09db301d64302b1f4cd67";
+export const WEBKIT_VERSION = "2da33d53e33e71055d66f4b84537aa8cb0b0e99d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### What does this PR do?

Bumps WebKit from `76882271d74a` to `2da33d53e33e` — one commit:

- oven-sh/WebKit#519 — Bytecode cache: build 1-3 character inline atoms from the slot's bytes, not from the loaded word

### How did you verify your code works?

Release `autobuild-2da33d53e33e71055d66f4b84537aa8cb0b0e99d` is published with all 42 prebuilt assets; CI builds against it.