### PR TITLE
test: clean up compile-node-compile-cache.test.ts

### DIFF
--- a/test/bundler/compile-node-compile-cache.test.ts
+++ b/test/bundler/compile-node-compile-cache.test.ts
@@ -1,57 +1,72 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-// Standalone executables ship their modules embedded, so NODE_COMPILE_CACHE in
-// the surrounding environment could only ever cache externally loaded JS —
-// while pulling the whole runtime encode/decode machinery into an app that
-// never asked for it. Compiled binaries ignore the variable; plain `bun` still
-// honors it.
-test("NODE_COMPILE_CACHE is ignored by compiled executables and honored by bun", () => {
-  const dir = tempDirWithFiles("compile-node-compile-cache", {
-    "app.js": `
+// `bun build --compile` copies the whole bun binary (~1GB under debug+ASAN),
+// which blows the 5s default.
+const TIMEOUT = 60_000;
+
+// The compile cache settings of the outer shell must not decide the outcome.
+const env = { ...bunEnv };
+delete env.NODE_COMPILE_CACHE;
+delete env.NODE_COMPILE_CACHE_PORTABLE;
+delete env.NODE_DISABLE_COMPILE_CACHE;
+
+test(
+  "NODE_COMPILE_CACHE is ignored by compiled executables and honored by bun",
+  () => {
+    // The app loads a module from outside the executable: the only code the
+    // on-disk cache could hold for a standalone binary.
+    using dir = tempDir("compile-node-compile-cache", {
+      "app.js": `
         const ext = require(process.env.EXT_MOD);
         console.log("APP_OK", ext.value);
       `,
-    "extmod.cjs": `module.exports = { value: 42 };`,
-    "cache-standalone/.keep": "",
-    "cache-bun/.keep": "",
-  });
+      "extmod.cjs": `module.exports = { value: 42 };`,
+      "cache-standalone/.keep": "",
+      "cache-bun/.keep": "",
+    });
+    const cwd = String(dir);
 
-  const build = Bun.spawnSync({
-    cmd: [bunExe(), "build", "--compile", "./app.js", "--outfile=app-compiled"],
-    env: bunEnv,
-    cwd: dir,
-  });
-  expect(build.exitCode).toBe(0);
+    const build = Bun.spawnSync({
+      cmd: [bunExe(), "build", "--compile", "./app.js", "--outfile=app-compiled"],
+      env,
+      cwd,
+    });
+    expect(build.stderr.toString()).toBe("");
+    expect(build.exitCode).toBe(0);
 
-  const standalone = Bun.spawnSync({
-    cmd: [join(dir, "app-compiled")],
-    env: {
-      ...bunEnv,
-      EXT_MOD: join(dir, "extmod.cjs"),
-      NODE_COMPILE_CACHE: join(dir, "cache-standalone"),
-      // Debug ASAN builds embed an @executable_path rpath for asan-dyld-shim.dylib;
-      // the standalone exe lives elsewhere, so point dyld back at the build dir.
-      DYLD_FALLBACK_LIBRARY_PATH: dirname(bunExe()),
-    },
-    cwd: dir,
-  });
-  expect(standalone.stdout.toString()).toContain("APP_OK 42");
-  expect(standalone.exitCode).toBe(0);
-  expect(readdirSync(join(dir, "cache-standalone"))).toEqual([".keep"]);
+    const standalone = Bun.spawnSync({
+      cmd: [join(cwd, "app-compiled")],
+      env: {
+        ...env,
+        EXT_MOD: join(cwd, "extmod.cjs"),
+        NODE_COMPILE_CACHE: join(cwd, "cache-standalone"),
+        // Debug ASAN builds embed an @executable_path rpath for asan-dyld-shim.dylib;
+        // the standalone exe lives elsewhere, so point dyld back at the build dir.
+        DYLD_FALLBACK_LIBRARY_PATH: dirname(bunExe()),
+      },
+      cwd,
+    });
+    expect(standalone.stdout.toString()).toContain("APP_OK 42");
+    expect(standalone.stderr.toString()).toBe("");
+    expect(standalone.exitCode).toBe(0);
+    expect(readdirSync(join(cwd, "cache-standalone"))).toEqual([".keep"]);
 
-  const plain = Bun.spawnSync({
-    cmd: [bunExe(), "app.js"],
-    env: {
-      ...bunEnv,
-      EXT_MOD: join(dir, "extmod.cjs"),
-      NODE_COMPILE_CACHE: join(dir, "cache-bun"),
-    },
-    cwd: dir,
-  });
-  expect(plain.stdout.toString()).toContain("APP_OK 42");
-  expect(plain.exitCode).toBe(0);
-  expect(readdirSync(join(dir, "cache-bun")).length).toBeGreaterThan(1);
-}, 240_000);
+    const plain = Bun.spawnSync({
+      cmd: [bunExe(), "app.js"],
+      env: {
+        ...env,
+        EXT_MOD: join(cwd, "extmod.cjs"),
+        NODE_COMPILE_CACHE: join(cwd, "cache-bun"),
+      },
+      cwd,
+    });
+    expect(plain.stdout.toString()).toContain("APP_OK 42");
+    expect(plain.stderr.toString()).toBe("");
+    expect(plain.exitCode).toBe(0);
+    expect(readdirSync(join(cwd, "cache-bun")).length).toBeGreaterThan(1);
+  },
+  TIMEOUT,
+);

--- a/test/bundler/compile-node-compile-cache.test.ts
+++ b/test/bundler/compile-node-compile-cache.test.ts
@@ -12,6 +12,7 @@ const env = { ...bunEnv };
 delete env.NODE_COMPILE_CACHE;
 delete env.NODE_COMPILE_CACHE_PORTABLE;
 delete env.NODE_DISABLE_COMPILE_CACHE;
+delete env.NODE_DEBUG_NATIVE;
 
 test(
   "NODE_COMPILE_CACHE is ignored by compiled executables and honored by bun",


### PR DESCRIPTION
### Problem
- #40563 merged with its test, `test/bundler/compile-node-compile-cache.test.ts`, in a rough shape. The header comment restated the PR description. The bot review threads on the PR were never addressed.
- The test used `tempDirWithFiles`, which has no disposal. Each run left the compiled binary (777MB under debug+ASAN) in the temp dir. It also spread `bunEnv` into the spawns unchanged, so a `NODE_DISABLE_COMPILE_CACHE` in the outer shell made the plain `bun` half fail.

### Fix
- Replace the five-line header comment with one line that explains the one non-obvious part of the test: the app loads a module from outside the executable, because that is the only code the on-disk cache could ever hold for a standalone binary.
- Use `using dir = tempDir(...)` like the sibling `compile-*.test.ts` files. Delete `NODE_COMPILE_CACHE`, `NODE_COMPILE_CACHE_PORTABLE`, `NODE_DISABLE_COMPILE_CACHE` and `NODE_DEBUG_NATIVE` from the spawn env. The first three follow `test/js/node/module/node-module-module.test.js`. The last one turns on `[compile cache]` log lines on stderr, which the new `stderr` assertions would catch.
- Assert `stderr` before the exit code on each of the three spawns. Lower the per-test timeout from 240s to the 60s the sibling compile tests use, with the same one-line reason. The default 5s is not enough: the test takes 5.3s under debug+ASAN here, most of it the binary copy in `bun build --compile`.
- Verified: `bun bd test test/bundler/compile-node-compile-cache.test.ts` passes, also with `NODE_DISABLE_COMPILE_CACHE=1 NODE_COMPILE_CACHE_PORTABLE=1 NODE_DEBUG_NATIVE=COMPILE_CACHE` in the outer env. No `compile-node-compile-cache_*` directory remains in the temp dir after the run. No change under `src/`.

### Background
- `NODE_COMPILE_CACHE` points `bun` at an on-disk cache of JSC bytecode for the modules it loads. #40563 made standalone executables (`bun build --compile`) ignore the variable, because their modules ship embedded with their own bytecode.
- `tempDir` from `harness` returns a `DisposableString`. `using` removes the directory when the block ends. `tempDirWithFiles` returns a plain string and removes nothing.
- `bunEnv` spreads `process.env`, so any compile cache setting of the shell that runs the tests reaches the child process unless the test removes it.

<details><summary>Notes</summary>

Review threads on #40563 that this addresses: the `using dir = tempDir` thread, the inherited `NODE_DISABLE_COMPILE_CACHE` thread, and the stderr-before-exit-code thread. Two threads asked to drop the `240_000` timeout entirely. The timeout stays, at the sibling value of 60s, because `bun build --compile` copies the whole debug binary and the run takes 5.3s locally under ASAN, above the 5s default. `compile-asset-bunfs.test.ts` and `compile-sourcemap-internal.test.ts` use the same 60s with the same comment.

Leftover check: after one run of the old test, `/tmp/compile-node-compile-cache_2bLwVT` held 777MB. After a run of the new test, no such directory remains.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/compile-node-compile-cache.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/compile-node-compile-cache.test.ts
bun test v1.4.1 (adc354d99)

test/bundler/compile-node-compile-cache.test.ts:
(pass) NODE_COMPILE_CACHE is ignored by compiled executables and honored by bun [5399.89ms]

 1 pass
 0 fail
 10 expect() calls
Ran 1 test across 1 file. [8.63s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/compile-node-compile-cache.test.ts | 110 ++++++++++++++----------
 1 file changed, 63 insertions(+), 47 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/bundler/compile-node-compile-cache.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->