### PR TITLE
bun-types: defer Event and EventTarget to lib.dom when it is loaded

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -66,6 +66,82 @@ declare module "bun" {
     type LibEmptyOrReadableStreamBYOBRequest = LibDomIsLoaded extends true
       ? {}
       : import("node:stream/web").ReadableStreamBYOBRequest;
+
+    /**
+     * The Node.js-flavored members of the global `Event`. The global interface
+     * picks them up only when lib.dom.d.ts is not loaded: lib.dom declares
+     * `composedPath(): EventTarget[]`, which is incompatible with the tuple
+     * type below, so when lib.dom is loaded its declarations win.
+     */
+    interface BunEvent {
+      /** This is not used in Node.js and is provided purely for completeness. */
+      readonly bubbles: boolean;
+      /** Alias for event.stopPropagation(). This is not used in Node.js and is provided purely for completeness. */
+      cancelBubble: boolean;
+      /** True if the event was created with the cancelable option */
+      readonly cancelable: boolean;
+      /** This is not used in Node.js and is provided purely for completeness. */
+      readonly composed: boolean;
+      /** Returns an array containing the current EventTarget as the only entry or empty if the event is not being dispatched. This is not used in Node.js and is provided purely for completeness. */
+      composedPath(): [EventTarget?];
+      /** Alias for event.target. */
+      readonly currentTarget: EventTarget | null;
+      /** `true` if `cancelable` is `true` and `event.preventDefault()` has been called. */
+      readonly defaultPrevented: boolean;
+      /** This is not used in Node.js and is provided purely for completeness. */
+      readonly eventPhase: number;
+      /** The `AbortSignal` "abort" event is emitted with `isTrusted` set to `true`. The value is `false` in all other cases. */
+      readonly isTrusted: boolean;
+      /** Sets the `defaultPrevented` property to `true` if `cancelable` is `true`. */
+      preventDefault(): void;
+      /** This is not used in Node.js and is provided purely for completeness. */
+      returnValue: boolean;
+      /** Alias for event.target. */
+      readonly srcElement: EventTarget | null;
+      /** Stops the invocation of event listeners after the current one completes. */
+      stopImmediatePropagation(): void;
+      /** This is not used in Node.js and is provided purely for completeness. */
+      stopPropagation(): void;
+      /** The `EventTarget` dispatching the event */
+      readonly target: EventTarget | null;
+      /** The millisecond timestamp when the Event object was created. */
+      readonly timeStamp: number;
+      /** The type of event, for example "click", "hashchange", or "submit". */
+      readonly type: string;
+    }
+
+    type LibEmptyOrBunEvent = LibDomIsLoaded extends true ? {} : BunEvent;
+
+    /**
+     * The Node.js-flavored members of the global `EventTarget`, used only when
+     * lib.dom.d.ts is not loaded, same as {@link BunEvent}.
+     */
+    interface BunEventTarget {
+      /**
+       * Adds a new handler for the `type` event. Any given `listener` is added only once per `type` and per `capture` option value.
+       *
+       * If the `once` option is true, the `listener` is removed after the next time a `type` event is dispatched.
+       *
+       * The `capture` option is not used by Node.js in any functional way other than tracking registered event listeners per the `EventTarget` specification.
+       * Specifically, the `capture` option is used as part of the key when registering a `listener`.
+       * Any individual `listener` may be added once with `capture = false`, and once with `capture = true`.
+       */
+      addEventListener(
+        type: string,
+        listener: Bun.EventListener | Bun.EventListenerObject,
+        options?: Bun.AddEventListenerOptions | boolean,
+      ): void;
+      /** Dispatches a synthetic event `event` to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise. */
+      dispatchEvent(event: Event): boolean;
+      /** Removes the event listener in target's event listener list with the same type, callback, and options. */
+      removeEventListener(
+        type: string,
+        listener: Bun.EventListener | Bun.EventListenerObject,
+        options?: Bun.EventListenerOptions | boolean,
+      ): void;
+    }
+
+    type LibEmptyOrBunEventTarget = LibDomIsLoaded extends true ? {} : BunEventTarget;
   }
 }
 
@@ -270,42 +346,7 @@ declare var TextDecoder: Bun.__internal.UseLibDomIfAvailable<
   }
 >;
 
-interface Event {
-  /** This is not used in Node.js and is provided purely for completeness. */
-  readonly bubbles: boolean;
-  /** Alias for event.stopPropagation(). This is not used in Node.js and is provided purely for completeness. */
-  cancelBubble: boolean;
-  /** True if the event was created with the cancelable option */
-  readonly cancelable: boolean;
-  /** This is not used in Node.js and is provided purely for completeness. */
-  readonly composed: boolean;
-  /** Returns an array containing the current EventTarget as the only entry or empty if the event is not being dispatched. This is not used in Node.js and is provided purely for completeness. */
-  composedPath(): [EventTarget?];
-  /** Alias for event.target. */
-  readonly currentTarget: EventTarget | null;
-  /** `true` if `cancelable` is `true` and `event.preventDefault()` has been called. */
-  readonly defaultPrevented: boolean;
-  /** This is not used in Node.js and is provided purely for completeness. */
-  readonly eventPhase: number;
-  /** The `AbortSignal` "abort" event is emitted with `isTrusted` set to `true`. The value is `false` in all other cases. */
-  readonly isTrusted: boolean;
-  /** Sets the `defaultPrevented` property to `true` if `cancelable` is `true`. */
-  preventDefault(): void;
-  /** This is not used in Node.js and is provided purely for completeness. */
-  returnValue: boolean;
-  /** Alias for event.target. */
-  readonly srcElement: EventTarget | null;
-  /** Stops the invocation of event listeners after the current one completes. */
-  stopImmediatePropagation(): void;
-  /** This is not used in Node.js and is provided purely for completeness. */
-  stopPropagation(): void;
-  /** The `EventTarget` dispatching the event */
-  readonly target: EventTarget | null;
-  /** The millisecond timestamp when the Event object was created. */
-  readonly timeStamp: number;
-  /** The type of event, for example "click", "hashchange", or "submit". */
-  readonly type: string;
-}
+interface Event extends Bun.__internal.LibEmptyOrBunEvent {}
 declare var Event: {
   prototype: Event;
   readonly NONE: 0;
@@ -315,30 +356,7 @@ declare var Event: {
   new (type: string, eventInitDict?: Bun.EventInit): Event;
 };
 
-interface EventTarget {
-  /**
-   * Adds a new handler for the `type` event. Any given `listener` is added only once per `type` and per `capture` option value.
-   *
-   * If the `once` option is true, the `listener` is removed after the next time a `type` event is dispatched.
-   *
-   * The `capture` option is not used by Node.js in any functional way other than tracking registered event listeners per the `EventTarget` specification.
-   * Specifically, the `capture` option is used as part of the key when registering a `listener`.
-   * Any individual `listener` may be added once with `capture = false`, and once with `capture = true`.
-   */
-  addEventListener(
-    type: string,
-    listener: EventListener | EventListenerObject,
-    options?: AddEventListenerOptions | boolean,
-  ): void;
-  /** Dispatches a synthetic event `event` to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise. */
-  dispatchEvent(event: Event): boolean;
-  /** Removes the event listener in target's event listener list with the same type, callback, and options. */
-  removeEventListener(
-    type: string,
-    listener: EventListener | EventListenerObject,
-    options?: Bun.EventListenerOptions | boolean,
-  ): void;
-}
+interface EventTarget extends Bun.__internal.LibEmptyOrBunEventTarget {}
 declare var EventTarget: {
   prototype: EventTarget;
   new (): EventTarget;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -474,6 +474,56 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Runs on debug builds too, same as the Bun.mmap block above.
+  describe("Event and EventTarget", () => {
+    async function checkEventFixture(name: string, lib: string[], source: string) {
+      const checkDir = join(TEMP_DIR, name);
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["event-check.ts"];
+      tsconfig.compilerOptions.lib = lib;
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "event-check.ts": source,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    }
+
+    test("lib.dom's composedPath() declaration wins when lib.dom is loaded", async () => {
+      await checkEventFixture(
+        "event-lib-dom-check",
+        ["ESNext", "DOM"],
+        `// lib.dom declares composedPath(): EventTarget[]. The Node-style tuple
+         // declaration must not merge into it (#40574).
+         declare const fullPath: EventTarget[];
+         export const composed: ReturnType<Event["composedPath"]> = fullPath;`,
+      );
+    });
+
+    test("the Node-style composedPath() tuple applies without lib.dom", async () => {
+      await checkEventFixture(
+        "event-no-lib-dom-check",
+        ["ESNext"],
+        `declare const e: Event;
+         export const composed: [EventTarget?] = e.composedPath();`,
+      );
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/dom.ts
+++ b/test/integration/bun-types/fixture/dom.ts
@@ -23,3 +23,15 @@ INSPECT_MAX_BYTES;
   const r = Response.json({ hello: "world" });
   r.body;
 }
+
+{
+  // #40574: with lib.dom loaded, its `composedPath(): EventTarget[]` must win.
+  // Without lib.dom, the Node-style tuple type applies.
+  const fullPath = [] as EventTarget[];
+  fullPath satisfies Bun.__internal.LibDomIsLoaded extends true
+    ? ReturnType<Event["composedPath"]>
+    : EventTarget[];
+  new Event("test").composedPath() satisfies Bun.__internal.LibDomIsLoaded extends true
+    ? EventTarget[]
+    : [EventTarget?];
+}


### PR DESCRIPTION
### Problem
- With `lib: ["dom"]`, the global `Event` merges lib.dom's `composedPath(): EventTarget[]` with bun-types' `composedPath(): [EventTarget?]` (packages/bun-types/globals.d.ts:283). `ReturnType<Event["composedPath"]>` resolves to the tuple, so a real DOM path is rejected: `error TS2322: Type 'EventTarget[]' is not assignable to type '[(EventTarget | undefined)?]'.`
- Every DOM type that extends `EventTarget` (`Node`, `Element`, `Document`) inherits the problem. Fixes #40574.

### Fix
- Move the Node-style `Event` and `EventTarget` members into `Bun.__internal.BunEvent` and `BunEventTarget`, gated on `LibDomIsLoaded`. The global interfaces extend the gated types, so with lib.dom loaded bun-types contributes `{}` and lib.dom's declarations win.
- This is the pattern the file already uses for `ReadableStream`, `CompressionStream`, and `TextDecoder` (`LibEmptyOr*` on `LibDomIsLoaded`).
- Without lib.dom nothing changes: the tuple type and all other members stay as before.
- Verified: `test/integration/bun-types/bun-types.test.ts` gets two new tsc checks (with and without lib.dom) plus a fixture check in `fixture/dom.ts`. The with-dom check fails on main with the exact TS2322 above. All 19 tests in the file pass with the fix.

### Background
- bun-types declares globals that also exist in lib.dom. For conflicting ones it detects lib.dom through `typeof globalThis extends { onabort: any }` (`Bun.__internal.LibDomIsLoaded`) and contributes an empty type when lib.dom is present.
- `Event` and `EventTarget` were bare global interfaces, so they merged with lib.dom instead of deferring. Methods with different signatures merge as overloads, which is why tsc reports no merge error, only an unsatisfiable overload pair.
- The `declare var Event` and `declare var EventTarget` constructors stay as they are. Their types are identical to lib.dom's, so the merge of the value declarations was never the problem.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.1 (adc354d99)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.92ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.21ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [747.11ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [771.61ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [39.04ms]
497 |       });
498 | 
499 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
500 | 
501 |       expect(stderr.trim()).toBe("");
502 |       expect(stdout.trim()).toBe("");
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [0.10ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.23ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [3637.24ms]
(pass) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts [696.04ms]
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [76.78ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [63.86ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [0.83ms]
497 |       });
498 | 
499 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
500 | 
501 |       expect(stderr.trim()).toBe("");
502 |       expect(stdout.trim()).toBe("");
                                  ^
error: expect(received).toBe(expected)

- ""
+ "event-check.ts(4,23): error TS2322: Type 'EventTarget[]' is not 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.1 (adc354d99)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.37ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.33ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [938.07ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [1058.21ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [42.60ms]
(pass) @types/bun integration test > Event and EventTarget > lib.dom's composedPath() declaration wins when lib.dom is loaded [797.98ms]
(pass) @types/bun integration test > Event and EventTarget > the Node-style composedPath() tuple app
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 678ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/globals.d.ts              | 138 +++++++++++++++------------
 test/integration/bun-types/bun-types.test.ts |  50 ++++++++++
 test/integration/bun-types/fixture/dom.ts    |  12 +++
 3 files changed, 140 insertions(+), 60 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/globals.d.ts                   1      2      0
test/integration/bun-types/bun-types.test.ts      1      1      0
test/integration/bun-types/fixture/dom.ts         1      1      0
```

</details>

**root cause** · written by the author bot

The bug was that bun-types declared its Node-style Event and EventTarget members directly on the global interfaces, so when lib.dom was also loaded the declarations merged and the Node-flavoured composedPath(): [EventTarget?] signature conflicted with lib.dom's composedPath(): EventTarget[], making the merged type unsatisfiable by any DOM implementation. The fix moves those member bodies into Bun.__internal.BunEvent and BunEventTarget behind the existing LibDomIsLoaded conditional, following the same pattern already used for types like ReadableStream and TextDecoder. As a result, the global…

<!-- robobun:evidence:end -->