### PR TITLE
url: throw a RangeError instead of aborting when URLSearchParams or FormData outgrows its Vector

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-520-bc1d8ce5";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/DOMFormData.rs
+++ b/src/jsc/DOMFormData.rs
@@ -15,8 +15,6 @@ unsafe extern "C" {
         arg1: &EncodedSlice,
     ) -> JSValue;
     safe fn WebCore__DOMFormData__fromJS(js_value0: JSValue) -> *mut DOMFormData;
-    // Both append functions return `false` after throwing a RangeError when the
-    // FormData holds as many entries as its backing Vector can grow to.
     safe fn WebCore__DOMFormData__append(
         arg0: &mut DOMFormData,
         arg1: &JSGlobalObject,

--- a/src/jsc/DOMFormData.rs
+++ b/src/jsc/DOMFormData.rs
@@ -15,11 +15,14 @@ unsafe extern "C" {
         arg1: &EncodedSlice,
     ) -> JSValue;
     safe fn WebCore__DOMFormData__fromJS(js_value0: JSValue) -> *mut DOMFormData;
+    // Both append functions return `false` after throwing a RangeError when the
+    // FormData holds as many entries as its backing Vector can grow to.
     safe fn WebCore__DOMFormData__append(
         arg0: &mut DOMFormData,
-        arg1: &EncodedSlice,
+        arg1: &JSGlobalObject,
         arg2: &EncodedSlice,
-    );
+        arg3: &EncodedSlice,
+    ) -> bool;
     // safe: `DOMFormData`/`JSGlobalObject` are opaque `UnsafeCell`-backed ZST
     // handles; `&EncodedSlice` is ABI-identical to non-null `*const EncodedSlice` and
     // C++ only reads the named struct via `toStringCopy`. `arg3` is an opaque
@@ -31,7 +34,7 @@ unsafe extern "C" {
         arg2: &EncodedSlice,
         arg3: *mut c_void,
         arg4: &EncodedSlice,
-    );
+    ) -> bool;
     safe fn WebCore__DOMFormData__count(arg0: &mut DOMFormData) -> usize;
 }
 
@@ -64,18 +67,29 @@ impl DOMFormData {
         (!p.is_null()).then(|| DOMFormData::opaque_mut(p))
     }
 
-    pub fn append(&mut self, name_: &EncodedSlice, value_: &EncodedSlice) {
-        WebCore__DOMFormData__append(self, name_, value_)
+    #[track_caller]
+    pub fn append(
+        &mut self,
+        global: &JSGlobalObject,
+        name_: &EncodedSlice,
+        value_: &EncodedSlice,
+    ) -> JsResult<()> {
+        crate::call_false_is_throw(global, || {
+            WebCore__DOMFormData__append(self, global, name_, value_)
+        })
     }
 
+    #[track_caller]
     pub fn append_blob(
         &mut self,
         global: &JSGlobalObject,
         name_: &EncodedSlice,
         blob: *mut c_void,
         filename_: &EncodedSlice,
-    ) {
-        WebCore__DOMFormData__appendBlob(self, global, name_, blob, filename_);
+    ) -> JsResult<()> {
+        crate::call_false_is_throw(global, || {
+            WebCore__DOMFormData__appendBlob(self, global, name_, blob, filename_)
+        })
     }
 
     pub fn count(&mut self) -> usize {

--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -43,20 +43,30 @@ DOMFormData::DOMFormData(ScriptExecutionContext* context)
 {
 }
 
+static size_t maxItems()
+{
+    return Bun::maxVectorSize<DOMFormData::Item>();
+}
+
+static Exception tooManyItems()
+{
+    return Exception { RangeError, "FormData maximum size exceeded"_s };
+}
+
 Ref<DOMFormData> DOMFormData::create(ScriptExecutionContext* context)
 {
     return adoptRef(*new DOMFormData(context));
 }
 
-// WTF::URLParser::parseURLEncodedForm would fill an unbounded Vector first.
 ExceptionOr<Ref<DOMFormData>> DOMFormData::create(ScriptExecutionContext* context, StringView urlEncodedString)
 {
+    auto form = WTF::URLParser::tryParseURLEncodedForm(urlEncodedString, maxItems());
+    if (!form) [[unlikely]]
+        return tooManyItems();
+
     auto newFormData = adoptRef(*new DOMFormData(context));
-    for (StringView bytes : urlEncodedString.split('&')) {
-        auto nameAndValue = WTF::URLParser::parseQueryNameAndValue(bytes);
-        if (!nameAndValue)
-            continue;
-        auto result = newFormData->append(nameAndValue->key, nameAndValue->value);
+    for (auto& entry : *form) {
+        auto result = newFormData->append(entry.key, entry.value);
         if (result.hasException()) [[unlikely]]
             return result.releaseException();
     }
@@ -101,9 +111,8 @@ static auto createStringEntry(const String& name, const String& value) -> DOMFor
 
 ExceptionOr<void> DOMFormData::appendItem(Item&& item)
 {
-    size_t maxSize = Bun::maxVectorSize<Item>();
-    if (!Bun::appendWithinLimit(m_items, WTF::move(item), maxSize)) [[unlikely]]
-        return Exception { RangeError, makeString("FormData cannot hold more than "_s, maxSize, " entries."_s) };
+    if (m_items.size() >= maxItems() || !m_items.tryAppend(WTF::move(item))) [[unlikely]]
+        return tooManyItems();
     return {};
 }
 

--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -30,6 +30,7 @@
 
 #include "config.h"
 #include "DOMFormData.h"
+#include "VectorSizeLimit.h"
 #include "wtf/DebugHeap.h"
 #include <wtf/URLParser.h>
 
@@ -47,11 +48,18 @@ Ref<DOMFormData> DOMFormData::create(ScriptExecutionContext* context)
     return adoptRef(*new DOMFormData(context));
 }
 
-Ref<DOMFormData> DOMFormData::create(ScriptExecutionContext* context, const StringView& urlEncodedString)
+// Same as WTF::URLParser::parseURLEncodedForm, but each pair goes straight into
+// m_items so the entry count is bounded and no second Vector is filled.
+ExceptionOr<Ref<DOMFormData>> DOMFormData::create(ScriptExecutionContext* context, StringView urlEncodedString)
 {
     auto newFormData = adoptRef(*new DOMFormData(context));
-    for (auto& entry : WTF::URLParser::parseURLEncodedForm(urlEncodedString)) {
-        newFormData->append(entry.key, entry.value);
+    for (StringView bytes : urlEncodedString.split('&')) {
+        auto nameAndValue = WTF::URLParser::parseQueryNameAndValue(bytes);
+        if (!nameAndValue)
+            continue;
+        auto result = newFormData->append(nameAndValue->key, nameAndValue->value);
+        if (result.hasException()) [[unlikely]]
+            return result.releaseException();
     }
 
     return newFormData;
@@ -92,15 +100,23 @@ static auto createStringEntry(const String& name, const String& value) -> DOMFor
     };
 }
 
-void DOMFormData::append(const String& name, const String& value)
+ExceptionOr<void> DOMFormData::appendItem(Item&& item)
 {
-    m_items.append(createStringEntry(name, value));
+    size_t maxSize = Bun::maxVectorSize<Item>();
+    if (!Bun::appendWithinLimit(m_items, WTF::move(item), maxSize)) [[unlikely]]
+        return Exception { RangeError, makeString("FormData cannot hold more than "_s, maxSize, " entries."_s) };
+    return {};
 }
 
-void DOMFormData::append(const String& name, RefPtr<Blob> blob, const String& filename)
+ExceptionOr<void> DOMFormData::append(const String& name, const String& value)
+{
+    return appendItem(createStringEntry(name, value));
+}
+
+ExceptionOr<void> DOMFormData::append(const String& name, RefPtr<Blob> blob, const String& filename)
 {
     blob->setFileName(replaceUnpairedSurrogatesWithReplacementCharacter(String(filename)));
-    m_items.append({ replaceUnpairedSurrogatesWithReplacementCharacter(String(name)), blob });
+    return appendItem({ replaceUnpairedSurrogatesWithReplacementCharacter(String(name)), blob });
 }
 void DOMFormData::remove(const StringView name)
 {
@@ -141,18 +157,18 @@ bool DOMFormData::has(const StringView name)
     return false;
 }
 
-void DOMFormData::set(const String& name, const String& value)
+ExceptionOr<void> DOMFormData::set(const String& name, const String& value)
 {
-    set(name, { name, value });
+    return set(name, { name, value });
 }
 
-void DOMFormData::set(const String& name, RefPtr<Blob> blob, const String& filename)
+ExceptionOr<void> DOMFormData::set(const String& name, RefPtr<Blob> blob, const String& filename)
 {
     blob->setFileName(filename);
-    set(name, { name, blob });
+    return set(name, { name, blob });
 }
 
-void DOMFormData::set(const String& name, Item&& item)
+ExceptionOr<void> DOMFormData::set(const String& name, Item&& item)
 {
     std::optional<size_t> initialMatchLocation;
 
@@ -171,10 +187,10 @@ void DOMFormData::set(const String& name, Item&& item)
             return item.name == name;
         },
             *initialMatchLocation + 1);
-        return;
+        return {};
     }
 
-    m_items.append(WTF::move(item));
+    return appendItem(WTF::move(item));
 }
 
 DOMFormData::Iterator::Iterator(DOMFormData& target)

--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -48,8 +48,7 @@ Ref<DOMFormData> DOMFormData::create(ScriptExecutionContext* context)
     return adoptRef(*new DOMFormData(context));
 }
 
-// Same as WTF::URLParser::parseURLEncodedForm, but each pair goes straight into
-// m_items so the entry count is bounded and no second Vector is filled.
+// WTF::URLParser::parseURLEncodedForm would fill an unbounded Vector first.
 ExceptionOr<Ref<DOMFormData>> DOMFormData::create(ScriptExecutionContext* context, StringView urlEncodedString)
 {
     auto newFormData = adoptRef(*new DOMFormData(context));

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "ContextDestructionObserver.h"
+#include "ExceptionOr.h"
 #include <variant>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -40,7 +41,6 @@ namespace WebCore {
 
 class ScriptExecutionContext;
 
-template<typename> class ExceptionOr;
 class HTMLElement;
 class HTMLFormElement;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMFormData);
@@ -61,18 +61,19 @@ public:
     };
 
     static Ref<DOMFormData> create(ScriptExecutionContext*);
-    static Ref<DOMFormData> create(ScriptExecutionContext*, const StringView& urlEncodedString);
+    static ExceptionOr<Ref<DOMFormData>> create(ScriptExecutionContext*, StringView urlEncodedString);
 
     const Vector<Item>& items() const { return m_items; }
 
-    void append(const String& name, const String& value);
-    void append(const String& name, RefPtr<Blob>, const String& filename = {});
+    // append and set throw a RangeError when the entry count would exceed what a Vector can grow to.
+    ExceptionOr<void> append(const String& name, const String& value);
+    ExceptionOr<void> append(const String& name, RefPtr<Blob>, const String& filename = {});
     void remove(const StringView name);
     std::optional<FormDataEntryValue> get(const StringView name);
     Vector<FormDataEntryValue> getAll(const StringView name);
     bool has(const StringView name);
-    void set(const String& name, const String& value);
-    void set(const String& name, RefPtr<Blob>, const String& filename = {});
+    ExceptionOr<void> set(const String& name, const String& value);
+    ExceptionOr<void> set(const String& name, RefPtr<Blob>, const String& filename = {});
 
     size_t count() const { return m_items.size(); }
     size_t memoryCost() const;
@@ -94,7 +95,8 @@ public:
 private:
     explicit DOMFormData(ScriptExecutionContext*);
 
-    void set(const String& name, Item&&);
+    ExceptionOr<void> appendItem(Item&&);
+    ExceptionOr<void> set(const String& name, Item&&);
 
     Vector<Item> m_items;
 };

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -174,12 +174,16 @@ ExceptionOr<void> DOMURL::setFullURL(const URL& fullURL)
     return setURL(WTF::move(completeURL));
 }
 
+// The query is parsed before the URL is stored, so a failure leaves both the URL and the params as they were.
 ExceptionOr<void> DOMURL::setURL(URL&& url)
 {
+    if (m_searchParams) {
+        auto result = m_searchParams->updateFromQuery(url.query());
+        if (result.hasException()) [[unlikely]]
+            return result;
+    }
     m_url = WTF::move(url);
     m_searchParamsDirty = false;
-    if (m_searchParams)
-        return m_searchParams->updateFromAssociatedURL();
     return {};
 }
 

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -165,7 +165,7 @@ ExceptionOr<void> DOMURL::setHref(const String& url)
     m_url = WTF::move(completeURL);
     m_searchParamsDirty = false;
     if (m_searchParams)
-        m_searchParams->updateFromAssociatedURL();
+        return m_searchParams->updateFromAssociatedURL();
     return {};
 }
 
@@ -188,10 +188,14 @@ void DOMURL::flushPendingSearchParamsUpdate() const
         self->m_url.setQuery(WTF::move(serialized));
 }
 
-URLSearchParams& DOMURL::searchParams()
+ExceptionOr<URLSearchParams&> DOMURL::searchParams()
 {
-    if (!m_searchParams)
-        m_searchParams = URLSearchParams::create(search(), this);
+    if (!m_searchParams) {
+        auto searchParams = URLSearchParams::create(search(), this);
+        if (searchParams.hasException()) [[unlikely]]
+            return searchParams.releaseException();
+        m_searchParams = searchParams.releaseReturnValue();
+    }
     return *m_searchParams;
 }
 

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -162,7 +162,21 @@ ExceptionOr<void> DOMURL::setHref(const String& url)
     URL completeURL { URL {}, url };
     if (!completeURL.isValid() || !hasValidParsedHost(completeURL, url))
         return Exception { InvalidURLError, url };
-    m_url = WTF::move(completeURL);
+    return setURL(WTF::move(completeURL));
+}
+
+// The URL component setters ignore a value that does not give a valid URL, per the URL spec.
+ExceptionOr<void> DOMURL::setFullURL(const URL& fullURL)
+{
+    URL completeURL { URL {}, fullURL.string() };
+    if (!completeURL.isValid() || !hasValidParsedHost(completeURL, fullURL.string()))
+        return {};
+    return setURL(WTF::move(completeURL));
+}
+
+ExceptionOr<void> DOMURL::setURL(URL&& url)
+{
+    m_url = WTF::move(url);
     m_searchParamsDirty = false;
     if (m_searchParams)
         return m_searchParams->updateFromAssociatedURL();

--- a/src/jsc/bindings/DOMURL.h
+++ b/src/jsc/bindings/DOMURL.h
@@ -56,7 +56,7 @@ public:
     }
     ExceptionOr<void> setHref(const String&);
 
-    URLSearchParams& searchParams();
+    ExceptionOr<URLSearchParams&> searchParams();
     void markSearchParamsDirty() { m_searchParamsDirty = true; }
 
     size_t memoryCost() const

--- a/src/jsc/bindings/DOMURL.h
+++ b/src/jsc/bindings/DOMURL.h
@@ -77,7 +77,8 @@ private:
         flushPendingSearchParamsUpdate();
         return m_url;
     }
-    void setFullURL(const URL& fullURL) final { setHref(fullURL.string()); }
+    ExceptionOr<void> setFullURL(const URL&) final;
+    ExceptionOr<void> setURL(URL&&);
     void flushPendingSearchParamsUpdate() const;
 
     URL m_url;

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -63,11 +63,11 @@ String URLDecomposition::protocol() const
     return makeString(fullURL.protocol(), ':');
 }
 
-void URLDecomposition::setProtocol(StringView value)
+ExceptionOr<void> URLDecomposition::setProtocol(StringView value)
 {
     URL copy = fullURL();
     copy.setProtocol(value);
-    setFullURL(copy);
+    return setFullURL(copy);
 }
 
 String URLDecomposition::username() const
@@ -75,13 +75,13 @@ String URLDecomposition::username() const
     return fullURL().encodedUser().toString();
 }
 
-void URLDecomposition::setUsername(StringView user)
+ExceptionOr<void> URLDecomposition::setUsername(StringView user)
 {
     auto fullURL = this->fullURL();
     if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
-        return;
+        return {};
     fullURL.setUser(user);
-    setFullURL(fullURL);
+    return setFullURL(fullURL);
 }
 
 String URLDecomposition::password() const
@@ -89,13 +89,13 @@ String URLDecomposition::password() const
     return fullURL().encodedPassword().toString();
 }
 
-void URLDecomposition::setPassword(StringView password)
+ExceptionOr<void> URLDecomposition::setPassword(StringView password)
 {
     auto fullURL = this->fullURL();
     if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
-        return;
+        return {};
     fullURL.setPassword(password);
-    setFullURL(fullURL);
+    return setFullURL(fullURL);
 }
 
 String URLDecomposition::host() const
@@ -113,18 +113,18 @@ static unsigned countASCIIDigits(StringView string)
     return length;
 }
 
-void URLDecomposition::setHost(StringView value)
+ExceptionOr<void> URLDecomposition::setHost(StringView value)
 {
     auto fullURL = this->fullURL();
     if (value.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
-        return;
+        return {};
 
     size_t separator = value.reverseFind(':');
     if (!separator)
-        return;
+        return {};
 
     if (fullURL.hasOpaquePath())
-        return;
+        return {};
 
     // No port if no colon or rightmost colon is within the IPv6 section.
     size_t ipv6Separator = value.reverseFind(']');
@@ -133,7 +133,7 @@ void URLDecomposition::setHost(StringView value)
     else {
         // Multiple colons are acceptable only in case of IPv6.
         if (value.find(':') != separator && ipv6Separator == notFound)
-            return;
+            return {};
         unsigned portLength = countASCIIDigits(value.substring(separator + 1));
         if (!portLength) {
             fullURL.setHost(value.left(separator));
@@ -146,7 +146,8 @@ void URLDecomposition::setHost(StringView value)
         }
     }
     if (fullURL.isValid() && hasAcceptableHost(fullURL))
-        setFullURL(fullURL);
+        return setFullURL(fullURL);
+    return {};
 }
 
 String URLDecomposition::hostname() const
@@ -154,16 +155,17 @@ String URLDecomposition::hostname() const
     return fullURL().host().toString();
 }
 
-void URLDecomposition::setHostname(StringView host)
+ExceptionOr<void> URLDecomposition::setHostname(StringView host)
 {
     auto fullURL = this->fullURL();
     if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
-        return;
+        return {};
     if (fullURL.hasOpaquePath())
-        return;
+        return {};
     fullURL.setHost(host);
     if (fullURL.isValid() && hasAcceptableHost(fullURL))
-        setFullURL(fullURL);
+        return setFullURL(fullURL);
+    return {};
 }
 
 String URLDecomposition::port() const
@@ -201,16 +203,16 @@ std::optional<std::optional<uint16_t>> URLDecomposition::parsePort(StringView st
     return { { static_cast<uint16_t>(port) } };
 }
 
-void URLDecomposition::setPort(StringView value)
+ExceptionOr<void> URLDecomposition::setPort(StringView value)
 {
     auto fullURL = this->fullURL();
     if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
-        return;
+        return {};
     auto port = parsePort(value, fullURL.protocol());
     if (!port)
-        return;
+        return {};
     fullURL.setPort(*port);
-    setFullURL(fullURL);
+    return setFullURL(fullURL);
 }
 
 String URLDecomposition::pathname() const
@@ -218,13 +220,13 @@ String URLDecomposition::pathname() const
     return fullURL().path().toString();
 }
 
-void URLDecomposition::setPathname(StringView value)
+ExceptionOr<void> URLDecomposition::setPathname(StringView value)
 {
     auto fullURL = this->fullURL();
     if (fullURL.hasOpaquePath())
-        return;
+        return {};
     fullURL.setPath(value);
-    setFullURL(fullURL);
+    return setFullURL(fullURL);
 }
 
 String URLDecomposition::search() const
@@ -233,7 +235,7 @@ String URLDecomposition::search() const
     return fullURL.query().isEmpty() ? emptyString() : fullURL.queryWithLeadingQuestionMark().toString();
 }
 
-void URLDecomposition::setSearch(const String& value)
+ExceptionOr<void> URLDecomposition::setSearch(const String& value)
 {
     auto fullURL = this->fullURL();
     if (value.isEmpty()) {
@@ -243,7 +245,7 @@ void URLDecomposition::setSearch(const String& value)
         // Make sure that '#' in the query does not leak to the hash.
         fullURL.setQuery(makeStringByReplacingAll(value, '#', "%23"_s));
     }
-    setFullURL(fullURL);
+    return setFullURL(fullURL);
 }
 
 String URLDecomposition::hash() const
@@ -252,14 +254,14 @@ String URLDecomposition::hash() const
     return fullURL.fragmentIdentifier().isEmpty() ? emptyString() : fullURL.fragmentIdentifierWithLeadingNumberSign().toString();
 }
 
-void URLDecomposition::setHash(StringView value)
+ExceptionOr<void> URLDecomposition::setHash(StringView value)
 {
     auto fullURL = this->fullURL();
     if (value.isEmpty())
         fullURL.removeFragmentIdentifier();
     else
         fullURL.setFragmentIdentifier(value.startsWith('#') ? value.substring(1) : value);
-    setFullURL(fullURL);
+    return setFullURL(fullURL);
 }
 
 }

--- a/src/jsc/bindings/URLDecomposition.h
+++ b/src/jsc/bindings/URLDecomposition.h
@@ -27,6 +27,7 @@
 
 #include "root.h"
 
+#include "ExceptionOr.h"
 #include <wtf/URL.h>
 
 #include <wtf/Forward.h>
@@ -42,38 +43,39 @@ public:
     String origin() const;
 
     WEBCORE_EXPORT String protocol() const;
-    void setProtocol(StringView);
+    ExceptionOr<void> setProtocol(StringView);
 
     String username() const;
-    void setUsername(StringView);
+    ExceptionOr<void> setUsername(StringView);
 
     String password() const;
-    void setPassword(StringView);
+    ExceptionOr<void> setPassword(StringView);
 
     WEBCORE_EXPORT String host() const;
-    void setHost(StringView);
+    ExceptionOr<void> setHost(StringView);
 
     WEBCORE_EXPORT String hostname() const;
-    void setHostname(StringView);
+    ExceptionOr<void> setHostname(StringView);
 
     WEBCORE_EXPORT String port() const;
-    void setPort(StringView);
+    ExceptionOr<void> setPort(StringView);
 
     WEBCORE_EXPORT String pathname() const;
-    void setPathname(StringView);
+    ExceptionOr<void> setPathname(StringView);
 
     WEBCORE_EXPORT String search() const;
-    void setSearch(const String&);
+    ExceptionOr<void> setSearch(const String&);
 
     WEBCORE_EXPORT String hash() const;
-    void setHash(StringView);
+    ExceptionOr<void> setHash(StringView);
 
 protected:
     virtual ~URLDecomposition() = default;
 
 private:
     virtual URL fullURL() const = 0;
-    virtual void setFullURL(const URL&) = 0;
+    // The URL setters forward the result: a query too large for URLSearchParams is the one failure.
+    virtual ExceptionOr<void> setFullURL(const URL&) = 0;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -32,16 +32,20 @@
 
 namespace WebCore {
 
-static Exception tooManyPairs(size_t maxSize)
+static size_t maxPairs()
 {
-    return Exception { RangeError, makeString("URLSearchParams cannot hold more than "_s, maxSize, " entries."_s) };
+    return Bun::maxVectorSize<KeyValuePair<String, String>>();
+}
+
+static Exception tooManyPairs()
+{
+    return Exception { RangeError, "URLSearchParams maximum size exceeded"_s };
 }
 
 static ExceptionOr<void> appendPair(Vector<KeyValuePair<String, String>>& pairs, KeyValuePair<String, String>&& pair)
 {
-    size_t maxSize = Bun::maxVectorSize<KeyValuePair<String, String>>();
-    if (!Bun::appendWithinLimit(pairs, WTF::move(pair), maxSize)) [[unlikely]]
-        return tooManyPairs(maxSize);
+    if (pairs.size() >= maxPairs() || !pairs.tryAppend(WTF::move(pair))) [[unlikely]]
+        return tooManyPairs();
     return {};
 }
 
@@ -60,24 +64,13 @@ extern "C" void URLSearchParams__toString(WebCore::URLSearchParams* urlSearchPar
     callback(ctx, &slice);
 }
 
-// Same as WTF::URLParser::parseURLEncodedForm, with the pair count bounded.
-static ExceptionOr<Vector<KeyValuePair<String, String>>> parseURLEncodedForm(StringView input)
-{
-    Vector<KeyValuePair<String, String>> pairs;
-    for (StringView bytes : input.split('&')) {
-        auto nameAndValue = WTF::URLParser::parseQueryNameAndValue(bytes);
-        if (!nameAndValue)
-            continue;
-        auto result = appendPair(pairs, WTF::move(*nameAndValue));
-        if (result.hasException()) [[unlikely]]
-            return result.releaseException();
-    }
-    return pairs;
-}
-
 static ExceptionOr<Vector<KeyValuePair<String, String>>> parseSearch(const String& init)
 {
-    return parseURLEncodedForm(init.startsWith('?') ? StringView(init).substring(1) : StringView(init));
+    StringView query = init.startsWith('?') ? StringView(init).substring(1) : StringView(init);
+    auto pairs = WTF::URLParser::tryParseURLEncodedForm(query, maxPairs());
+    if (!pairs) [[unlikely]]
+        return tooManyPairs();
+    return WTF::move(*pairs);
 }
 
 URLSearchParams::URLSearchParams(Vector<KeyValuePair<String, String>>&& pairs, DOMURL* associatedURL)
@@ -113,9 +106,8 @@ ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(std::variant<Vector<Ve
                 return result.releaseException();
         }
         return adoptRef(*new URLSearchParams(WTF::move(pairs))); }, [&](const Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<URLSearchParams>> {
-        size_t maxSize = Bun::maxVectorSize<KeyValuePair<String, String>>();
-        if (pairs.size() > maxSize) [[unlikely]]
-            return tooManyPairs(maxSize);
+        if (pairs.size() > maxPairs()) [[unlikely]]
+            return tooManyPairs();
         return adoptRef(*new URLSearchParams(pairs)); }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> { return create(string, nullptr); });
     return std::visit(visitor, variant);
 }

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -204,15 +204,12 @@ void URLSearchParams::updateURL()
         m_associatedURL->markSearchParamsDirty();
 }
 
-ExceptionOr<void> URLSearchParams::updateFromAssociatedURL()
+ExceptionOr<void> URLSearchParams::updateFromQuery(StringView query)
 {
-    ASSERT(m_associatedURL);
-    // The URL is already updated. A failed parse leaves the params empty, not stale.
-    m_pairs.clear();
-    auto pairs = parseSearch(m_associatedURL->search());
-    if (pairs.hasException()) [[unlikely]]
-        return pairs.releaseException();
-    m_pairs = pairs.releaseReturnValue();
+    auto pairs = WTF::URLParser::tryParseURLEncodedForm(query, maxPairs());
+    if (!pairs) [[unlikely]]
+        return tooManyPairs();
+    m_pairs = WTF::move(*pairs);
     return {};
 }
 

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -32,11 +32,16 @@
 
 namespace WebCore {
 
+static Exception tooManyPairs(size_t maxSize)
+{
+    return Exception { RangeError, makeString("URLSearchParams cannot hold more than "_s, maxSize, " entries."_s) };
+}
+
 static ExceptionOr<void> appendPair(Vector<KeyValuePair<String, String>>& pairs, KeyValuePair<String, String>&& pair)
 {
     size_t maxSize = Bun::maxVectorSize<KeyValuePair<String, String>>();
     if (!Bun::appendWithinLimit(pairs, WTF::move(pair), maxSize)) [[unlikely]]
-        return Exception { RangeError, makeString("URLSearchParams cannot hold more than "_s, maxSize, " entries."_s) };
+        return tooManyPairs(maxSize);
     return {};
 }
 
@@ -107,7 +112,11 @@ ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(std::variant<Vector<Ve
             if (result.hasException()) [[unlikely]]
                 return result.releaseException();
         }
-        return adoptRef(*new URLSearchParams(WTF::move(pairs))); }, [&](const Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<URLSearchParams>> { return adoptRef(*new URLSearchParams(pairs)); }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> { return create(string, nullptr); });
+        return adoptRef(*new URLSearchParams(WTF::move(pairs))); }, [&](const Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<URLSearchParams>> {
+        size_t maxSize = Bun::maxVectorSize<KeyValuePair<String, String>>();
+        if (pairs.size() > maxSize) [[unlikely]]
+            return tooManyPairs(maxSize);
+        return adoptRef(*new URLSearchParams(pairs)); }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> { return create(string, nullptr); });
     return std::visit(visitor, variant);
 }
 

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -28,8 +28,17 @@
 #include <wtf/URLParser.h>
 #include "helpers.h"
 #include "JSURLSearchParams.h"
+#include "VectorSizeLimit.h"
 
 namespace WebCore {
+
+static ExceptionOr<void> appendPair(Vector<KeyValuePair<String, String>>& pairs, KeyValuePair<String, String>&& pair)
+{
+    size_t maxSize = Bun::maxVectorSize<KeyValuePair<String, String>>();
+    if (!Bun::appendWithinLimit(pairs, WTF::move(pair), maxSize)) [[unlikely]]
+        return Exception { RangeError, makeString("URLSearchParams cannot hold more than "_s, maxSize, " entries."_s) };
+    return {};
+}
 
 extern "C" WebCore::URLSearchParams* URLSearchParams__fromJS(JSC::EncodedJSValue value)
 {
@@ -46,9 +55,29 @@ extern "C" void URLSearchParams__toString(WebCore::URLSearchParams* urlSearchPar
     callback(ctx, &slice);
 }
 
-URLSearchParams::URLSearchParams(const String& init, DOMURL* associatedURL)
+// Same as WTF::URLParser::parseURLEncodedForm, with the pair count bounded.
+static ExceptionOr<Vector<KeyValuePair<String, String>>> parseURLEncodedForm(StringView input)
+{
+    Vector<KeyValuePair<String, String>> pairs;
+    for (StringView bytes : input.split('&')) {
+        auto nameAndValue = WTF::URLParser::parseQueryNameAndValue(bytes);
+        if (!nameAndValue)
+            continue;
+        auto result = appendPair(pairs, WTF::move(*nameAndValue));
+        if (result.hasException()) [[unlikely]]
+            return result.releaseException();
+    }
+    return pairs;
+}
+
+static ExceptionOr<Vector<KeyValuePair<String, String>>> parseSearch(const String& init)
+{
+    return parseURLEncodedForm(init.startsWith('?') ? StringView(init).substring(1) : StringView(init));
+}
+
+URLSearchParams::URLSearchParams(Vector<KeyValuePair<String, String>>&& pairs, DOMURL* associatedURL)
     : m_associatedURL(associatedURL)
-    , m_pairs(init.startsWith('?') ? WTF::URLParser::parseURLEncodedForm(StringView(init).substring(1)) : WTF::URLParser::parseURLEncodedForm(init))
+    , m_pairs(WTF::move(pairs))
 {
 }
 
@@ -59,6 +88,14 @@ URLSearchParams::URLSearchParams(const Vector<KeyValuePair<String, String>>& pai
 
 URLSearchParams::~URLSearchParams() = default;
 
+ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(const String& init, DOMURL* associatedURL)
+{
+    auto pairs = parseSearch(init);
+    if (pairs.hasException())
+        return pairs.releaseException();
+    return adoptRef(*new URLSearchParams(pairs.releaseReturnValue(), associatedURL));
+}
+
 ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String>&& variant)
 {
     auto visitor = WTF::makeVisitor([&](const Vector<Vector<String>>& vector) -> ExceptionOr<Ref<URLSearchParams>> {
@@ -66,9 +103,11 @@ ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(std::variant<Vector<Ve
         for (const auto& pair : vector) {
             if (pair.size() != 2)
                 return Exception { TypeError };
-            pairs.append({pair[0], pair[1]});
+            auto result = appendPair(pairs, { pair[0], pair[1] });
+            if (result.hasException()) [[unlikely]]
+                return result.releaseException();
         }
-        return adoptRef(*new URLSearchParams(WTF::move(pairs))); }, [&](const Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<URLSearchParams>> { return adoptRef(*new URLSearchParams(pairs)); }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> { return adoptRef(*new URLSearchParams(string, nullptr)); });
+        return adoptRef(*new URLSearchParams(WTF::move(pairs))); }, [&](const Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<URLSearchParams>> { return adoptRef(*new URLSearchParams(pairs)); }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> { return create(string, nullptr); });
     return std::visit(visitor, variant);
 }
 
@@ -99,7 +138,7 @@ void URLSearchParams::sort()
     needsSorting = false;
 }
 
-void URLSearchParams::set(const String& name, const String& value)
+ExceptionOr<void> URLSearchParams::set(const String& name, const String& value)
 {
     for (auto& pair : m_pairs) {
         if (pair.key != name)
@@ -117,18 +156,19 @@ void URLSearchParams::set(const String& name, const String& value)
         });
         updateURL();
         needsSorting = true;
-        return;
+        return {};
     }
-    m_pairs.append({ name, value });
-    needsSorting = true;
-    updateURL();
+    return append(name, value);
 }
 
-void URLSearchParams::append(const String& name, const String& value)
+ExceptionOr<void> URLSearchParams::append(const String& name, const String& value)
 {
-    m_pairs.append({ name, value });
+    auto result = appendPair(m_pairs, { name, value });
+    if (result.hasException()) [[unlikely]]
+        return result;
     updateURL();
     needsSorting = true;
+    return {};
 }
 
 Vector<String> URLSearchParams::getAll(const StringView name) const
@@ -163,11 +203,16 @@ void URLSearchParams::updateURL()
         m_associatedURL->markSearchParamsDirty();
 }
 
-void URLSearchParams::updateFromAssociatedURL()
+ExceptionOr<void> URLSearchParams::updateFromAssociatedURL()
 {
     ASSERT(m_associatedURL);
-    String search = m_associatedURL->search();
-    m_pairs = search.startsWith('?') ? WTF::URLParser::parseURLEncodedForm(StringView(search).substring(1)) : WTF::URLParser::parseURLEncodedForm(search);
+    // The URL is already updated. A failed parse leaves the params empty, not stale.
+    m_pairs.clear();
+    auto pairs = parseSearch(m_associatedURL->search());
+    if (pairs.hasException()) [[unlikely]]
+        return pairs.releaseException();
+    m_pairs = pairs.releaseReturnValue();
+    return {};
 }
 
 std::optional<KeyValuePair<String, String>> URLSearchParams::Iterator::next()

--- a/src/jsc/bindings/URLSearchParams.h
+++ b/src/jsc/bindings/URLSearchParams.h
@@ -41,19 +41,17 @@ public:
     ~URLSearchParams();
 
     static ExceptionOr<Ref<URLSearchParams>> create(std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String>&&);
-    static Ref<URLSearchParams> create(const String& string, DOMURL* associatedURL)
-    {
-        return adoptRef(*new URLSearchParams(string, associatedURL));
-    }
+    static ExceptionOr<Ref<URLSearchParams>> create(const String& string, DOMURL* associatedURL);
 
-    void append(const String& name, const String& value);
+    // create, append and set throw a RangeError when the pair count would exceed what a Vector can grow to.
+    ExceptionOr<void> append(const String& name, const String& value);
     void remove(const StringView name, const String& value = {});
     String get(const StringView name) const;
     Vector<String> getAll(const StringView name) const;
     bool has(const StringView name, const String& value = {}) const;
-    void set(const String& name, const String& value);
+    ExceptionOr<void> set(const String& name, const String& value);
     String toString() const;
-    void updateFromAssociatedURL();
+    ExceptionOr<void> updateFromAssociatedURL();
     void sort();
     size_t size() const { return m_pairs.size(); }
     size_t memoryCost() const;
@@ -72,7 +70,7 @@ public:
 
 private:
     const Vector<KeyValuePair<String, String>>& pairs() const { return m_pairs; }
-    URLSearchParams(const String&, DOMURL*);
+    URLSearchParams(Vector<KeyValuePair<String, String>>&&, DOMURL* = nullptr);
     URLSearchParams(const Vector<KeyValuePair<String, String>>&);
     void updateURL();
 

--- a/src/jsc/bindings/URLSearchParams.h
+++ b/src/jsc/bindings/URLSearchParams.h
@@ -51,7 +51,8 @@ public:
     bool has(const StringView name, const String& value = {}) const;
     ExceptionOr<void> set(const String& name, const String& value);
     String toString() const;
-    ExceptionOr<void> updateFromAssociatedURL();
+    // Replaces the pairs with the parse of a URL query. On failure the pairs are unchanged.
+    ExceptionOr<void> updateFromQuery(StringView query);
     void sort();
     size_t size() const { return m_pairs.size(); }
     size_t memoryCost() const;

--- a/src/jsc/bindings/VectorSizeLimit.h
+++ b/src/jsc/bindings/VectorSizeLimit.h
@@ -7,8 +7,7 @@ extern "C" size_t Bun__stringSyntheticAllocationLimit;
 
 namespace Bun {
 
-// WTF::Vector::append CRASH()es once a 1.5x growth step asks for more than
-// isValidCapacityForVector<T> (INT32_MAX bytes). These two bound the size instead.
+// Vector::append CRASH()es once a 1.5x growth step passes isValidCapacityForVector<T>. These bound the size instead.
 
 // Follows Bun__stringSyntheticAllocationLimit so tests reach the limit with small inputs.
 template<typename T>

--- a/src/jsc/bindings/VectorSizeLimit.h
+++ b/src/jsc/bindings/VectorSizeLimit.h
@@ -7,8 +7,7 @@ extern "C" size_t Bun__stringSyntheticAllocationLimit;
 
 namespace Bun {
 
-// The most elements a Vector<T> can hold (INT32_MAX bytes), lowered with
-// Bun__stringSyntheticAllocationLimit so tests reach the bound with small inputs.
+// The most elements a Vector<T> can hold, lowered by Bun__stringSyntheticAllocationLimit so tests reach it cheaply.
 template<typename T>
 size_t maxVectorSize()
 {

--- a/src/jsc/bindings/VectorSizeLimit.h
+++ b/src/jsc/bindings/VectorSizeLimit.h
@@ -7,9 +7,8 @@ extern "C" size_t Bun__stringSyntheticAllocationLimit;
 
 namespace Bun {
 
-// Vector::append CRASH()es once a 1.5x growth step passes isValidCapacityForVector<T>. These bound the size instead.
-
-// Follows Bun__stringSyntheticAllocationLimit so tests reach the limit with small inputs.
+// The most elements a Vector<T> can hold (INT32_MAX bytes), lowered with
+// Bun__stringSyntheticAllocationLimit so tests reach the bound with small inputs.
 template<typename T>
 size_t maxVectorSize()
 {
@@ -17,18 +16,6 @@ size_t maxVectorSize()
     static_assert(WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T)));
     static_assert(!WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T) + 1));
     return std::min(maxBytes, Bun__stringSyntheticAllocationLimit) / sizeof(T);
-}
-
-// The growth step of Vector::expandCapacity, capped at maxSize.
-template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc, typename U>
-[[nodiscard]] bool appendWithinLimit(WTF::Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>& vector, U&& item, size_t maxSize)
-{
-    if (vector.size() >= maxSize) [[unlikely]]
-        return false;
-    if (vector.size() == vector.capacity())
-        vector.reserveCapacity(std::min(maxSize, std::max(minCapacity, Malloc::nextCapacity(vector.capacity()))));
-    vector.append(std::forward<U>(item));
-    return true;
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/VectorSizeLimit.h
+++ b/src/jsc/bindings/VectorSizeLimit.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "root.h"
+#include <wtf/Vector.h>
+
+extern "C" size_t Bun__stringSyntheticAllocationLimit;
+
+namespace Bun {
+
+// WTF::Vector::append CRASH()es when its 1.5x growth step asks for a capacity over
+// WTF::isValidCapacityForVector<T>, which caps the buffer at INT32_MAX bytes. A
+// Vector filled from user input uses these two functions to throw instead.
+
+// The largest size a Vector<T> may reach. It follows Bun__stringSyntheticAllocationLimit
+// so that tests can reach the limit with small inputs.
+template<typename T>
+size_t maxVectorSize()
+{
+    constexpr size_t maxBytes = std::numeric_limits<unsigned>::max() >> 1;
+    static_assert(WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T)));
+    static_assert(!WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T) + 1));
+    return std::min(maxBytes, Bun__stringSyntheticAllocationLimit) / sizeof(T);
+}
+
+// Appends item unless the Vector already holds maxSize elements. The growth step is
+// the same as Vector::expandCapacity, capped at maxSize, so the Vector never asks
+// for a capacity it cannot have.
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc, typename U>
+[[nodiscard]] bool appendWithinLimit(WTF::Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>& vector, U&& item, size_t maxSize)
+{
+    if (vector.size() >= maxSize) [[unlikely]]
+        return false;
+    if (vector.size() == vector.capacity())
+        vector.reserveCapacity(std::min(maxSize, std::max(minCapacity, Malloc::nextCapacity(vector.capacity()))));
+    vector.append(std::forward<U>(item));
+    return true;
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/VectorSizeLimit.h
+++ b/src/jsc/bindings/VectorSizeLimit.h
@@ -7,12 +7,10 @@ extern "C" size_t Bun__stringSyntheticAllocationLimit;
 
 namespace Bun {
 
-// WTF::Vector::append CRASH()es when its 1.5x growth step asks for a capacity over
-// WTF::isValidCapacityForVector<T>, which caps the buffer at INT32_MAX bytes. A
-// Vector filled from user input uses these two functions to throw instead.
+// WTF::Vector::append CRASH()es once a 1.5x growth step asks for more than
+// isValidCapacityForVector<T> (INT32_MAX bytes). These two bound the size instead.
 
-// The largest size a Vector<T> may reach. It follows Bun__stringSyntheticAllocationLimit
-// so that tests can reach the limit with small inputs.
+// Follows Bun__stringSyntheticAllocationLimit so tests reach the limit with small inputs.
 template<typename T>
 size_t maxVectorSize()
 {
@@ -22,9 +20,7 @@ size_t maxVectorSize()
     return std::min(maxBytes, Bun__stringSyntheticAllocationLimit) / sizeof(T);
 }
 
-// Appends item unless the Vector already holds maxSize elements. The growth step is
-// the same as Vector::expandCapacity, capped at maxSize, so the Vector never asks
-// for a capacity it cannot have.
+// The growth step of Vector::expandCapacity, capped at maxSize.
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc, typename U>
 [[nodiscard]] bool appendWithinLimit(WTF::Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>& vector, U&& item, size_t maxSize)
 {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6372,15 +6372,28 @@ extern "C" int JSC__JSValue__DateNowISOString(JSC::JSGlobalObject* globalObject,
 
 #pragma mark - WebCore::DOMFormData
 
-CPP_DECL void WebCore__DOMFormData__append(WebCore::DOMFormData* arg0, const EncodedSlice* arg1, const EncodedSlice* arg2)
+// Both append functions return false after throwing when the FormData is full.
+CPP_DECL bool WebCore__DOMFormData__append(WebCore::DOMFormData* arg0, JSC::JSGlobalObject* globalObject, const EncodedSlice* arg1, const EncodedSlice* arg2)
 {
-    arg0->append(toStringCopy(*arg1), toStringCopy(*arg2));
+    auto throwScope = DECLARE_THROW_SCOPE(globalObject->vm());
+    auto result = arg0->append(toStringCopy(*arg1), toStringCopy(*arg2));
+    if (result.hasException()) [[unlikely]] {
+        WebCore::propagateException(*globalObject, throwScope, result.releaseException());
+        return false;
+    }
+    return true;
 }
 
-CPP_DECL void WebCore__DOMFormData__appendBlob(WebCore::DOMFormData* arg0, JSC::JSGlobalObject* arg1, const EncodedSlice* arg2, void* blobValueInner, const EncodedSlice* fileName)
+CPP_DECL bool WebCore__DOMFormData__appendBlob(WebCore::DOMFormData* arg0, JSC::JSGlobalObject* arg1, const EncodedSlice* arg2, void* blobValueInner, const EncodedSlice* fileName)
 {
+    auto throwScope = DECLARE_THROW_SCOPE(arg1->vm());
     RefPtr<Blob> blob = WebCore::Blob::create(blobValueInner);
-    arg0->append(toStringCopy(*arg2), blob, toStringCopy(*fileName));
+    auto result = arg0->append(toStringCopy(*arg2), blob, toStringCopy(*fileName));
+    if (result.hasException()) [[unlikely]] {
+        WebCore::propagateException(*arg1, throwScope, result.releaseException());
+        return false;
+    }
+    return true;
 }
 CPP_DECL size_t WebCore__DOMFormData__count(WebCore::DOMFormData* arg0)
 {
@@ -6409,8 +6422,13 @@ CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__createFromURLQuery(JSC::JSGlo
         auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
         return Bun::ERR::STRING_TOO_LONG(scope, globalObject);
     }
-    auto formData = DOMFormData::create(globalObject->scriptExecutionContext(), WTF::move(str));
-    return JSValue::encode(toJSNewlyCreated(arg0, globalObject, WTF::move(formData)));
+    auto formData = DOMFormData::create(globalObject->scriptExecutionContext(), str);
+    if (formData.hasException()) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+        WebCore::propagateException(*globalObject, scope, formData.releaseException());
+        return {};
+    }
+    return JSValue::encode(toJSNewlyCreated(arg0, globalObject, formData.releaseReturnValue()));
 }
 
 CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__create(JSC::JSGlobalObject* arg0)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -56,8 +56,8 @@ CPP_DECL BunString WebCore__DOMURL__fileSystemPath(WebCore::DOMURL* arg0, int* e
 
 #pragma mark - WebCore::DOMFormData
 
-CPP_DECL void WebCore__DOMFormData__append(WebCore::DOMFormData* arg0, const EncodedSlice* arg1, const EncodedSlice* arg2);
-CPP_DECL void WebCore__DOMFormData__appendBlob(WebCore::DOMFormData* arg0, JSC::JSGlobalObject* arg1, const EncodedSlice* arg2, void* arg3, const EncodedSlice* arg4);
+CPP_DECL bool WebCore__DOMFormData__append(WebCore::DOMFormData* arg0, JSC::JSGlobalObject* arg1, const EncodedSlice* arg2, const EncodedSlice* arg3);
+CPP_DECL bool WebCore__DOMFormData__appendBlob(WebCore::DOMFormData* arg0, JSC::JSGlobalObject* arg1, const EncodedSlice* arg2, void* arg3, const EncodedSlice* arg4);
 CPP_DECL size_t WebCore__DOMFormData__count(WebCore::DOMFormData* arg0);
 CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__create(JSC::JSGlobalObject* arg0);
 CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__createFromURLQuery(JSC::JSGlobalObject* arg0, const EncodedSlice* arg1);

--- a/src/jsc/bindings/webcore/JSDOMConvertRecord.h
+++ b/src/jsc/bindings/webcore/JSDOMConvertRecord.h
@@ -188,7 +188,10 @@ private:
                     UNUSED_VARIABLE(resultMap);
 
                 // 5. Otherwise, append to result a mapping (typedKey, typedValue).
-                result.append({ WTF::move(typedKey), WTF::move(typedValue) });
+                if (!result.tryAppend({ WTF::move(typedKey), WTF::move(typedValue) })) [[unlikely]] {
+                    throwTypeError(&lexicalGlobalObject, scope);
+                    return {};
+                }
             }
 
             return result;
@@ -242,7 +245,10 @@ private:
                     UNUSED_VARIABLE(resultMap);
 
                 // 5. Otherwise, append to result a mapping (typedKey, typedValue).
-                result.append({ WTF::move(typedKey), WTF::move(typedValue) });
+                if (!result.tryAppend({ WTF::move(typedKey), WTF::move(typedValue) })) [[unlikely]] {
+                    throwTypeError(&lexicalGlobalObject, scope);
+                    return {};
+                }
             }
         }
 

--- a/src/jsc/bindings/webcore/JSDOMConvertSequences.h
+++ b/src/jsc/bindings/webcore/JSDOMConvertSequences.h
@@ -88,11 +88,18 @@ struct SequenceTraits<
         T&& element)
     {
         ASSERT(index == sequence.size());
+        bool appended;
         if constexpr (std::is_same_v<std::decay_t<T>, JSC::JSValue>) {
             // `JSValue` should not be stored on the heap.
-            sequence.append(JSC::Strong { JSC::getVM(&lexicalGlobalObject), element });
+            appended = sequence.tryAppend(JSC::Strong { JSC::getVM(&lexicalGlobalObject), element });
         } else {
-            sequence.append(std::forward<T>(element));
+            appended = sequence.tryAppend(std::forward<T>(element));
+        }
+        // Same failure as reserveExact: the Vector cannot grow to hold the element.
+        if (!appended) [[unlikely]] {
+            auto& vm = JSC::getVM(&lexicalGlobalObject);
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            throwTypeError(&lexicalGlobalObject, scope);
         }
     }
 };
@@ -263,6 +270,7 @@ struct SequenceConverter {
                 auto convertedValue = Bun::convertIDL<IDLType>(lexicalGlobalObject, indexValue, elementCtx);
                 RETURN_IF_EXCEPTION(scope, {});
                 Traits::append(lexicalGlobalObject, result, i, WTF::move(convertedValue));
+                RETURN_IF_EXCEPTION(scope, {});
             }
             return result;
         }
@@ -278,6 +286,7 @@ struct SequenceConverter {
             auto convertedValue = Bun::convertIDL<IDLType>(lexicalGlobalObject, indexValue, elementCtx);
             RETURN_IF_EXCEPTION(scope, {});
             Traits::append(lexicalGlobalObject, result, i, WTF::move(convertedValue));
+            RETURN_IF_EXCEPTION(scope, {});
         }
         return result;
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2810,6 +2810,7 @@ impl BlobExt for Blob {
         let buf = unsafe { &*buf };
         match crate::webcore::form_data::FormData::to_js(global, buf, &encoder.encoding) {
             Ok(v) => v,
+            Err(crate::Error::JSError) => global.take_error(jsc::JsError::Thrown),
             Err(err) => {
                 global.create_error_instance(format_args!("FormData encoding failed: {err}"))
             }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2064,6 +2064,11 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         let js_value =
             match webcore::form_data::FormData::to_js(global_object, blob.slice(), &encoding) {
                 Ok(v) => v,
+                Err(crate::Error::JSError) => {
+                    blob.detach();
+                    let error = global_object.take_error(jsc::JsError::Thrown);
+                    return Ok(JSPromise::rejected_promise(global_object, error).to_js());
+                }
                 Err(err) => {
                     blob.detach();
                     return Ok(global_object

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -40,6 +40,11 @@ impl AsyncFormDataExt for AsyncFormData {
 
         let js_value = match FormData::to_js(global, data, &self.encoding) {
             Ok(v) => v,
+            Err(crate::Error::JSError) => {
+                scoped_log!(FormData, "AsnycFormData.toJS -> failed ");
+                promise.reject(global, global.take_error(JsError::Thrown))?;
+                return Ok(());
+            }
             Err(e) => {
                 scoped_log!(FormData, "AsnycFormData.toJS -> failed ");
                 promise.reject(
@@ -163,10 +168,15 @@ pub(crate) fn to_js_from_multipart_data(
     struct Wrapper<'a> {
         global: &'a JSGlobalObject,
         form: &'a mut DOMFormData,
+        /// Set once an append threw. The remaining entries are skipped.
+        threw: bool,
     }
 
     impl<'a> Wrapper<'a> {
         fn on_entry(wrap: &mut Self, name: bun_semver::String, field: &Field<'_>, buf: &[u8]) {
+            if wrap.threw {
+                return;
+            }
             let value_str: &[u8] = field.value;
             let key = EncodedSlice::utf8(name.slice(buf));
 
@@ -202,7 +212,7 @@ pub(crate) fn to_js_from_multipart_data(
                     }
                 }
 
-                wrap.form.append_blob(
+                let result = wrap.form.append_blob(
                     wrap.global,
                     &key,
                     (&raw mut blob).cast::<c_void>(),
@@ -210,6 +220,7 @@ pub(crate) fn to_js_from_multipart_data(
                 );
                 // `append_blob` dupes the content type; release this stack-local.
                 blob.detach();
+                wrap.threw = result.is_err();
             } else {
                 let value = EncodedSlice::utf8(
                     // > Each part whose `Content-Disposition` header does not
@@ -221,15 +232,24 @@ pub(crate) fn to_js_from_multipart_data(
                     // > `charset` parameter.
                     strings::without_utf8_bom(value_str),
                 );
-                wrap.form.append(&key, &value);
+                wrap.threw = wrap.form.append(wrap.global, &key, &value).is_err();
             }
         }
     }
 
     {
-        let mut wrap = Wrapper { global, form };
+        let mut wrap = Wrapper {
+            global,
+            form,
+            threw: false,
+        };
 
-        if let Err(e) = for_each_multipart_entry(input, boundary, &mut wrap, Wrapper::on_entry) {
+        let parsed = for_each_multipart_entry(input, boundary, &mut wrap, Wrapper::on_entry);
+        // A pending JS exception wins over a parse error found after it.
+        if wrap.threw {
+            return Err(crate::Error::JSError);
+        }
+        if let Err(e) = parsed {
             scoped_log!(FormData, "failed to parse multipart data");
             return Err(e);
         }

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1005,14 +1005,14 @@ describe("USVString conversion of lone surrogates", () => {
   });
 });
 
-// The entries live in a WTF::Vector, which aborts the process when a growth step
-// asks for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError at the
-// last size the Vector can hold instead. The limit follows the synthetic
-// allocation limit (1 MiB is its floor), so 43690 entries of 24 bytes reach it.
+// The entries live in a WTF::Vector, which aborted the process when a growth step
+// asked for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError once
+// the Vector cannot grow instead. The limit follows the synthetic allocation
+// limit (1 MiB is its floor), so 43690 entries of 24 bytes reach it.
 describe("entry count limit", () => {
   const LIMIT = 1024 * 1024;
   const MAX = Math.floor(LIMIT / 24);
-  const tooMany = `FormData cannot hold more than ${MAX} entries.`;
+  const tooMany = "FormData maximum size exceeded";
   // Each child parses 43690 entries, 3 to 7 s in a debug build, past the 5 s default.
   // The work cannot shrink: 1 MiB is the smallest synthetic limit.
   const TIMEOUT = 60_000;

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1009,11 +1009,13 @@ describe("USVString conversion of lone surrogates", () => {
 // asks for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError at the
 // last size the Vector can hold instead. The limit follows the synthetic
 // allocation limit (1 MiB is its floor), so 43690 entries of 24 bytes reach it.
-// Each child parses tens of thousands of entries, which takes seconds in a debug build.
 describe("entry count limit", () => {
   const LIMIT = 1024 * 1024;
   const MAX = Math.floor(LIMIT / 24);
   const tooMany = `FormData cannot hold more than ${MAX} entries.`;
+  // Each child parses 43690 entries, 3 to 7 s in a debug build, past the 5 s default.
+  // The work cannot shrink: 1 MiB is the smallest synthetic limit.
+  const TIMEOUT = 60_000;
   const preamble = `
     import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
     setSyntheticAllocationLimitForTesting(${LIMIT});
@@ -1076,19 +1078,19 @@ describe("entry count limit", () => {
         has: false,
       });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
     "FormData.from throws one pair past the limit",
     async () => {
       const out = await run(`
-        out.string = threw(() => FormData.from(pairs(MAX + 1)));
         out.bytes = threw(() => FormData.from(Buffer.from(pairs(MAX + 1))));
+        out.ok = [...FormData.from(pairs(3)).keys()].length;
       `);
-      expect(out).toEqual({ string: tooMany, bytes: tooMany });
+      expect(out).toEqual({ bytes: tooMany, ok: 3 });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
@@ -1112,7 +1114,7 @@ describe("entry count limit", () => {
         entries: [["b", "1"]],
       });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
@@ -1124,20 +1126,30 @@ describe("entry count limit", () => {
       `);
       expect(out).toEqual({ response: tooMany, ok: 3 });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
-    "Request.formData() and Blob.formData() reject a URL-encoded body past the limit",
+    "Request.formData() rejects a URL-encoded body past the limit",
     async () => {
       const out = await run(`
         const request = new Request("http://example.com/", { method: "POST", body: pairs(MAX + 1), headers: urlencoded });
         out.request = await rejected(request.formData());
+      `);
+      expect(out).toEqual({ request: tooMany });
+    },
+    TIMEOUT,
+  );
+
+  it.concurrent(
+    "Blob.formData() rejects a URL-encoded body past the limit",
+    async () => {
+      const out = await run(`
         out.blob = await rejected(new Blob([pairs(MAX + 1)], { type: urlencoded["content-type"] }).formData());
       `);
-      expect(out).toEqual({ request: tooMany, blob: tooMany });
+      expect(out).toEqual({ blob: tooMany });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
@@ -1156,19 +1168,29 @@ describe("entry count limit", () => {
       `);
       expect(out).toEqual({ streamed: tooMany });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
-    "multipart bodies hit the same limit",
+    "FormData.from parses a multipart body with exactly the limit and throws one part past it",
     async () => {
       const out = await run(`
-        out.from = threw(() => FormData.from(multipart(MAX + 1), "foo"));
-        out.response = await rejected(new Response(multipart(MAX + 1), { headers: multipartType }).formData());
         out.ok = [...FormData.from(multipart(MAX), "foo").keys()].length;
+        out.from = threw(() => FormData.from(multipart(MAX + 1), "foo"));
       `);
-      expect(out).toEqual({ from: tooMany, response: tooMany, ok: MAX });
+      expect(out).toEqual({ ok: MAX, from: tooMany });
     },
-    60_000,
+    TIMEOUT,
+  );
+
+  it.concurrent(
+    "Response.formData() rejects a multipart body one part past the limit",
+    async () => {
+      const out = await run(`
+        out.response = await rejected(new Response(multipart(MAX + 1), { headers: multipartType }).formData());
+      `);
+      expect(out).toEqual({ response: tooMany });
+    },
+    TIMEOUT,
   );
 });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1004,3 +1004,171 @@ describe("USVString conversion of lone surrogates", () => {
     expect(formData.get("\uFFFD")).toBeNull();
   });
 });
+
+// The entries live in a WTF::Vector, which aborts the process when a growth step
+// asks for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError at the
+// last size the Vector can hold instead. The limit follows the synthetic
+// allocation limit (1 MiB is its floor), so 43690 entries of 24 bytes reach it.
+// Each child parses tens of thousands of entries, which takes seconds in a debug build.
+describe("entry count limit", () => {
+  const LIMIT = 1024 * 1024;
+  const MAX = Math.floor(LIMIT / 24);
+  const tooMany = `FormData cannot hold more than ${MAX} entries.`;
+  const preamble = `
+    import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
+    setSyntheticAllocationLimitForTesting(${LIMIT});
+    const MAX = ${MAX};
+    const pairs = n => Buffer.alloc(2 * n, "a&").toString();
+    const PART = '--foo\\r\\nContent-Disposition: form-data; name="a"\\r\\n\\r\\n\\r\\n';
+    const multipart = n => Buffer.concat([Buffer.alloc(n * PART.length, PART), Buffer.from("--foo--\\r\\n")]);
+    const urlencoded = { "content-type": "application/x-www-form-urlencoded" };
+    const multipartType = { "content-type": "multipart/form-data; boundary=foo" };
+    const message = e => (e instanceof RangeError ? e.message : String(e));
+    const threw = fn => {
+      try {
+        fn();
+        return null;
+      } catch (e) {
+        return message(e);
+      }
+    };
+    const rejected = promise => promise.then(() => null, message);
+    const out = {};
+  `;
+
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `${preamble}\n${script}\nconsole.log(JSON.stringify(out));`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  it.concurrent(
+    "parses a body with exactly the limit, then append and set throw",
+    async () => {
+      const out = await run(`
+        const form = FormData.from(pairs(MAX));
+        out.count = [...form.keys()].length;
+        out.appendString = threw(() => form.append("b", "1"));
+        out.appendBlob = threw(() => form.append("b", new Blob(["x"]), "x.txt"));
+        out.setNew = threw(() => form.set("b", "1"));
+        out.setExisting = threw(() => form.set("a", "1"));
+        out.setExistingBlob = threw(() => form.set("a", new Blob(["x"]), "x.txt"));
+        out.countAfter = [...form.keys()].length;
+        out.name = form.get("a").name;
+        out.has = form.has("b");
+      `);
+      expect(out).toEqual({
+        count: MAX,
+        appendString: tooMany,
+        appendBlob: tooMany,
+        setNew: tooMany,
+        setExisting: null,
+        setExistingBlob: null,
+        countAfter: 1,
+        name: "x.txt",
+        has: false,
+      });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "FormData.from throws one pair past the limit",
+    async () => {
+      const out = await run(`
+        out.string = threw(() => FormData.from(pairs(MAX + 1)));
+        out.bytes = threw(() => FormData.from(Buffer.from(pairs(MAX + 1))));
+      `);
+      expect(out).toEqual({ string: tooMany, bytes: tooMany });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "throws from append once the limit is reached",
+    async () => {
+      const out = await run(`
+        const form = new FormData();
+        for (let i = 0; i < MAX; i++) form.append("a", "");
+        out.count = [...form.keys()].length;
+        out.append = threw(() => form.append("a", ""));
+        out.countAfter = [...form.keys()].length;
+        form.delete("a");
+        out.appendAfterDelete = threw(() => form.append("b", "1"));
+        out.entries = [...form];
+      `);
+      expect(out).toEqual({
+        count: MAX,
+        append: tooMany,
+        countAfter: MAX,
+        appendAfterDelete: null,
+        entries: [["b", "1"]],
+      });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "Response.formData() rejects a URL-encoded body one pair past the limit",
+    async () => {
+      const out = await run(`
+        out.response = await rejected(new Response(pairs(MAX + 1), { headers: urlencoded }).formData());
+        out.ok = [...(await new Response(pairs(3), { headers: urlencoded }).formData()).keys()].length;
+      `);
+      expect(out).toEqual({ response: tooMany, ok: 3 });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "Request.formData() and Blob.formData() reject a URL-encoded body past the limit",
+    async () => {
+      const out = await run(`
+        const request = new Request("http://example.com/", { method: "POST", body: pairs(MAX + 1), headers: urlencoded });
+        out.request = await rejected(request.formData());
+        out.blob = await rejected(new Blob([pairs(MAX + 1)], { type: urlencoded["content-type"] }).formData());
+      `);
+      expect(out).toEqual({ request: tooMany, blob: tooMany });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "a streamed Response.formData() rejects a URL-encoded body past the limit",
+    async () => {
+      const out = await run(`
+        const body = Buffer.from(pairs(MAX + 1));
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(body.subarray(0, body.length >> 1));
+            controller.enqueue(body.subarray(body.length >> 1));
+            controller.close();
+          },
+        });
+        out.streamed = await rejected(new Response(stream, { headers: urlencoded }).formData());
+      `);
+      expect(out).toEqual({ streamed: tooMany });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "multipart bodies hit the same limit",
+    async () => {
+      const out = await run(`
+        out.from = threw(() => FormData.from(multipart(MAX + 1), "foo"));
+        out.response = await rejected(new Response(multipart(MAX + 1), { headers: multipartType }).formData());
+        out.ok = [...FormData.from(multipart(MAX), "foo").keys()].length;
+      `);
+      expect(out).toEqual({ from: tooMany, response: tooMany, ok: MAX });
+    },
+    60_000,
+  );
+});

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -379,9 +379,8 @@ describe("entry count limit", () => {
     async () => {
       const out = await run(`
         out.string = threw(() => new URLSearchParams("?" + pairs(MAX + 1)));
-        out.record = new URLSearchParams({ a: "1", b: "2" }).size;
       `);
-      expect(out).toEqual({ string: tooMany, record: 2 });
+      expect(out).toEqual({ string: tooMany });
     },
     TIMEOUT,
   );
@@ -392,9 +391,23 @@ describe("entry count limit", () => {
       const out = await run(`
         const list = Array.from({ length: MAX + 1 }, () => ["a", ""]);
         out.sequence = threw(() => new URLSearchParams(list));
-        out.size = new URLSearchParams(list.slice(1)).size;
+        out.sequenceAtLimit = new URLSearchParams(list.slice(1)).size;
       `);
-      expect(out).toEqual({ sequence: tooMany, size: MAX });
+      expect(out).toEqual({ sequence: tooMany, sequenceAtLimit: MAX });
+    },
+    TIMEOUT,
+  );
+
+  it.concurrent(
+    "the record constructor throws one pair past the limit",
+    async () => {
+      const out = await run(`
+        const record = Object.fromEntries(Array.from({ length: MAX + 1 }, (_, i) => [String(i), ""]));
+        out.record = threw(() => new URLSearchParams(record));
+        delete record[0];
+        out.recordAtLimit = new URLSearchParams(record).size;
+      `);
+      expect(out).toEqual({ record: tooMany, recordAtLimit: MAX });
     },
     TIMEOUT,
   );

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -312,11 +312,13 @@ it(".has second argument", () => {
 // asks for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError at
 // the last size the Vector can hold instead. The limit follows the synthetic
 // allocation limit (1 MiB is its floor), so 65536 pairs of 16 bytes reach it.
-// Each child parses tens of thousands of pairs, which takes seconds in a debug build.
 describe("entry count limit", () => {
   const LIMIT = 1024 * 1024;
   const MAX = LIMIT / 16;
   const tooMany = `URLSearchParams cannot hold more than ${MAX} entries.`;
+  // Each child parses 65536 pairs, 3 to 7 s in a debug build, past the 5 s default.
+  // The work cannot shrink: 1 MiB is the smallest synthetic limit.
+  const TIMEOUT = 60_000;
   const preamble = `
     import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
     setSyntheticAllocationLimitForTesting(${LIMIT});
@@ -369,21 +371,32 @@ describe("entry count limit", () => {
         has: false,
       });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
-    "throws from the constructor one pair past the limit",
+    "the string constructor throws one pair past the limit",
     async () => {
       const out = await run(`
         out.string = threw(() => new URLSearchParams("?" + pairs(MAX + 1)));
-        const list = Array.from({ length: MAX + 1 }, () => ["a", ""]);
-        out.sequence = threw(() => new URLSearchParams(list));
         out.record = new URLSearchParams({ a: "1", b: "2" }).size;
       `);
-      expect(out).toEqual({ string: tooMany, sequence: tooMany, record: 2 });
+      expect(out).toEqual({ string: tooMany, record: 2 });
     },
-    60_000,
+    TIMEOUT,
+  );
+
+  it.concurrent(
+    "the sequence constructor throws one pair past the limit",
+    async () => {
+      const out = await run(`
+        const list = Array.from({ length: MAX + 1 }, () => ["a", ""]);
+        out.sequence = threw(() => new URLSearchParams(list));
+        out.size = new URLSearchParams(list.slice(1)).size;
+      `);
+      expect(out).toEqual({ sequence: tooMany, size: MAX });
+    },
+    TIMEOUT,
   );
 
   it.concurrent(
@@ -401,7 +414,7 @@ describe("entry count limit", () => {
       `);
       expect(out).toEqual({ size: MAX, append: tooMany, sizeAfter: MAX, appendAfterDelete: null, string: "b=1" });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
@@ -422,7 +435,7 @@ describe("entry count limit", () => {
         size: 1,
       });
     },
-    60_000,
+    TIMEOUT,
   );
 
   it.concurrent(
@@ -444,6 +457,6 @@ describe("entry count limit", () => {
         getAfterHref: "2",
       });
     },
-    60_000,
+    TIMEOUT,
   );
 });

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("URLSearchParams", () => {
   it("does not crash when calling .toJSON() on a URLSearchParams object with a large number of properties", () => {
@@ -305,4 +306,144 @@ it(".has second argument", () => {
   expect(params.has("a", 3)).toBe(false);
   expect(params.has("b", 3)).toBe(true);
   expect(params.has("b", 4)).toBe(false);
+});
+
+// The pairs live in a WTF::Vector, which aborts the process when a growth step
+// asks for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError at
+// the last size the Vector can hold instead. The limit follows the synthetic
+// allocation limit (1 MiB is its floor), so 65536 pairs of 16 bytes reach it.
+// Each child parses tens of thousands of pairs, which takes seconds in a debug build.
+describe("entry count limit", () => {
+  const LIMIT = 1024 * 1024;
+  const MAX = LIMIT / 16;
+  const tooMany = `URLSearchParams cannot hold more than ${MAX} entries.`;
+  const preamble = `
+    import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
+    setSyntheticAllocationLimitForTesting(${LIMIT});
+    const MAX = ${MAX};
+    const pairs = n => Buffer.alloc(2 * n, "a&").toString();
+    const threw = fn => {
+      try {
+        fn();
+        return null;
+      } catch (e) {
+        return e instanceof RangeError ? e.message : String(e);
+      }
+    };
+    const out = {};
+  `;
+
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `${preamble}\n${script}\nconsole.log(JSON.stringify(out));`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  it.concurrent(
+    "parses a string with exactly the limit, then append and set throw",
+    async () => {
+      const out = await run(`
+        const params = new URLSearchParams(pairs(MAX));
+        out.size = params.size;
+        out.append = threw(() => params.append("b", "1"));
+        out.setNew = threw(() => params.set("b", "1"));
+        out.setExisting = threw(() => params.set("a", "1"));
+        out.sizeAfter = params.size;
+        out.first = params.get("a");
+        out.has = params.has("b");
+      `);
+      expect(out).toEqual({
+        size: MAX,
+        append: tooMany,
+        setNew: tooMany,
+        setExisting: null,
+        sizeAfter: 1,
+        first: "1",
+        has: false,
+      });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "throws from the constructor one pair past the limit",
+    async () => {
+      const out = await run(`
+        out.string = threw(() => new URLSearchParams("?" + pairs(MAX + 1)));
+        const list = Array.from({ length: MAX + 1 }, () => ["a", ""]);
+        out.sequence = threw(() => new URLSearchParams(list));
+        out.record = new URLSearchParams({ a: "1", b: "2" }).size;
+      `);
+      expect(out).toEqual({ string: tooMany, sequence: tooMany, record: 2 });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "throws from append once the limit is reached",
+    async () => {
+      const out = await run(`
+        const params = new URLSearchParams();
+        for (let i = 0; i < MAX; i++) params.append("a", "");
+        out.size = params.size;
+        out.append = threw(() => params.append("a", ""));
+        out.sizeAfter = params.size;
+        params.delete("a");
+        out.appendAfterDelete = threw(() => params.append("b", "1"));
+        out.string = params.toString();
+      `);
+      expect(out).toEqual({ size: MAX, append: tooMany, sizeAfter: MAX, appendAfterDelete: null, string: "b=1" });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "url.searchParams throws when the query has too many pairs",
+    async () => {
+      const out = await run(`
+        const url = new URL("http://example.com/?" + pairs(MAX + 1));
+        out.searchLength = url.search.length;
+        out.searchParams = threw(() => url.searchParams);
+        out.searchParamsAgain = threw(() => url.searchParams);
+        url.search = "a=1";
+        out.size = url.searchParams.size;
+      `);
+      expect(out).toEqual({
+        searchLength: 1 + 2 * (MAX + 1),
+        searchParams: tooMany,
+        searchParamsAgain: tooMany,
+        size: 1,
+      });
+    },
+    60_000,
+  );
+
+  it.concurrent(
+    "url.href throws when the new query has too many pairs",
+    async () => {
+      const out = await run(`
+        const url = new URL("http://example.com/?a=1");
+        const params = url.searchParams;
+        out.href = threw(() => { url.href = "http://example.com/?" + pairs(MAX + 1); });
+        out.searchLength = url.search.length;
+        out.sizeAfterFailedHref = params.size;
+        url.href = "http://example.com/?b=2";
+        out.getAfterHref = params.get("b");
+      `);
+      expect(out).toEqual({
+        href: tooMany,
+        searchLength: 1 + 2 * (MAX + 1),
+        sizeAfterFailedHref: 0,
+        getAfterHref: "2",
+      });
+    },
+    60_000,
+  );
 });

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -308,14 +308,14 @@ it(".has second argument", () => {
   expect(params.has("b", 4)).toBe(false);
 });
 
-// The pairs live in a WTF::Vector, which aborts the process when a growth step
-// asks for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError at
-// the last size the Vector can hold instead. The limit follows the synthetic
-// allocation limit (1 MiB is its floor), so 65536 pairs of 16 bytes reach it.
+// The pairs live in a WTF::Vector, which aborted the process when a growth step
+// asked for a capacity over its INT32_MAX-byte cap. Bun throws a RangeError once
+// the Vector cannot grow instead. The limit follows the synthetic allocation
+// limit (1 MiB is its floor), so 65536 pairs of 16 bytes reach it.
 describe("entry count limit", () => {
   const LIMIT = 1024 * 1024;
   const MAX = LIMIT / 16;
-  const tooMany = `URLSearchParams cannot hold more than ${MAX} entries.`;
+  const tooMany = "URLSearchParams maximum size exceeded";
   // Each child parses 65536 pairs, 3 to 7 s in a debug build, past the 5 s default.
   // The work cannot shrink: 1 MiB is the smallest synthetic limit.
   const TIMEOUT = 60_000;
@@ -446,6 +446,28 @@ describe("entry count limit", () => {
         searchParams: tooMany,
         searchParamsAgain: tooMany,
         size: 1,
+      });
+    },
+    TIMEOUT,
+  );
+
+  it.concurrent(
+    "url.search throws when the new query has too many pairs",
+    async () => {
+      const out = await run(`
+        const url = new URL("http://example.com/?a=1");
+        const params = url.searchParams;
+        out.search = threw(() => { url.search = pairs(MAX + 1); });
+        out.searchLength = url.search.length;
+        out.sizeAfterFailedSearch = params.size;
+        url.search = "b=2";
+        out.getAfterSearch = params.get("b");
+      `);
+      expect(out).toEqual({
+        search: tooMany,
+        searchLength: 1 + 2 * (MAX + 1),
+        sizeAfterFailedSearch: 0,
+        getAfterSearch: "2",
       });
     },
     TIMEOUT,

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -452,21 +452,21 @@ describe("entry count limit", () => {
   );
 
   it.concurrent(
-    "url.search throws when the new query has too many pairs",
+    "url.search throws when the new query has too many pairs and leaves the URL as it was",
     async () => {
       const out = await run(`
         const url = new URL("http://example.com/?a=1");
         const params = url.searchParams;
         out.search = threw(() => { url.search = pairs(MAX + 1); });
-        out.searchLength = url.search.length;
-        out.sizeAfterFailedSearch = params.size;
+        out.href = url.href;
+        out.entries = [...params];
         url.search = "b=2";
         out.getAfterSearch = params.get("b");
       `);
       expect(out).toEqual({
         search: tooMany,
-        searchLength: 1 + 2 * (MAX + 1),
-        sizeAfterFailedSearch: 0,
+        href: "http://example.com/?a=1",
+        entries: [["a", "1"]],
         getAfterSearch: "2",
       });
     },
@@ -474,21 +474,21 @@ describe("entry count limit", () => {
   );
 
   it.concurrent(
-    "url.href throws when the new query has too many pairs",
+    "url.href throws when the new query has too many pairs and leaves the URL as it was",
     async () => {
       const out = await run(`
         const url = new URL("http://example.com/?a=1");
         const params = url.searchParams;
-        out.href = threw(() => { url.href = "http://example.com/?" + pairs(MAX + 1); });
-        out.searchLength = url.search.length;
-        out.sizeAfterFailedHref = params.size;
+        out.href = threw(() => { url.href = "http://other.example/path?" + pairs(MAX + 1); });
+        out.hrefAfter = url.href;
+        out.entries = [...params];
         url.href = "http://example.com/?b=2";
         out.getAfterHref = params.get("b");
       `);
       expect(out).toEqual({
         href: tooMany,
-        searchLength: 1 + 2 * (MAX + 1),
-        sizeAfterFailedHref: 0,
+        hrefAfter: "http://example.com/?a=1",
+        entries: [["a", "1"]],
         getAfterHref: "2",
       });
     },


### PR DESCRIPTION
### Problem
- `new URLSearchParams("a=&".repeat(116597314))` aborts the process (exit 134, `panic(main thread): abort() called`) instead of throwing. 116597313 pairs parse. `FormData.from()` of the same input aborts at 77731543 entries. `params.append()`, `params.set()`, `form.append()`, `form.set()`, `url.searchParams`, `url.href =`, `url.search =`, `new URLSearchParams(iterable | record)`, and `Response`, `Request` and `Blob` `.formData()` reach the same abort. The repro needs a 350 MB string and about 6 GiB of heap.
- The pairs live in a `WTF::Vector`. `Vector::append` grows the buffer by 1.5x and `allocateBuffer` (`vendor/WebKit/Source/WTF/wtf/Vector.h:226`) calls `CRASH()` when the new capacity is over `isValidCapacityForVector<T>`, the INT32_MAX-byte cap. `WTF::URLParser::parseURLEncodedForm` appends that way, and so do the Bun bindings and the IDL sequence and record converters.

### Fix
- oven-sh/WebKit#520 adds `URLParser::tryParseURLEncodedForm(input, maxPairs)`. It appends with `tryAppend` and returns `nullopt` past `maxPairs` or once the `Vector` cannot grow. `parseURLEncodedForm` keeps its signature and returns an empty form instead of crashing. This PR pins its preview build (`autobuild-preview-pr-520-bc1d8ce5`, the current pin `ceb9f90f` plus that one commit). The pin moves to the merged sha before this lands.
- `URLSearchParams` and `DOMFormData` call it and throw `RangeError: URLSearchParams maximum size exceeded` (or `FormData maximum size exceeded`) on `nullopt`. `append()` and `set()` use `tryAppend` with the same check, so an allocation failure throws too. `maxPairs` follows `Bun__stringSyntheticAllocationLimit`, which is how the tests reach the bound with 65536 pairs. `DOMURL::searchParams()`, `DOMURL::setHref()`, the `URLDecomposition` setters, the FFI append functions and the Rust `.formData()` callers propagate the exception.
- The IDL sequence and record converters (`JSDOMConvertSequences.h`, `JSDOMConvertRecord.h`) append with `tryAppend` and throw the TypeError their `reserveExact` already throws, so the conversion of a huge iterable or record no longer aborts before the constructor runs.
- Correct because every `Vector` on these paths now reports a failed growth instead of crashing, and each report becomes a JS exception at the API that was called. V8 throws `RangeError: Map maximum size exceeded` in the same situation.
- Verified: `test/js/web/html/URLSearchParams.test.ts` and `test/js/web/html/FormData.test.ts` (17 new tests, all fail on the release build). Also `test/js/web/url/`, `test/js/deno/url/`, `test/js/node/url/`, `urlpattern`, `fetch/headers`, `FormData-multipart-serialization`, `fetch/body`, `fetch/body-mixin-errors`, `fetch/blob`, `fetch/blob-oom`, `fetch/form-data-boundary-crash`, `fetch/utf8-bom`.

### Background
- `WTF::Vector<T>` is WebKit's growable array. `isValidCapacityForVector<T>` is `capacity * sizeof(T) <= INT32_MAX`. `append` CRASH()es past that. `tryAppend` returns false instead, for an invalid capacity and for an allocation failure.
- WebKit is a prebuilt dependency. `scripts/build/deps/webkit.ts` pins a tag of oven-sh/WebKit. A PR there publishes an `autobuild-preview-pr-N-<sha>` release that Bun can pin (#40253 did the same).
- `Bun__stringSyntheticAllocationLimit` is the process-wide cap that `setSyntheticAllocationLimitForTesting` from `bun:internal-for-testing` lowers, to 1 MiB at the least. `Bun::maxVectorSize<T>()` is `min(INT32_MAX, that limit) / sizeof(T)`: 65536 pairs of 16 bytes and 43690 FormData entries of 24 bytes under the test limit.
- `ExceptionOr<T>` is WebCore's result type. The JS bindings (`toJS<IDLUndefined>` lambdas, `invokeFunctorPropagatingExceptionIfNecessary` in the URL setters) already turn an `ExceptionOr<void>` into a thrown JS exception, so the generated-style binding files need no change.

<details><summary>Notes</summary>

- Before, with the release build: `new URLSearchParams(Buffer.alloc(3 * 116597314, "a=&").toString())` exits 134 after 18 s at 6.3 GB RSS. 116597313 pairs parse.
- Growth sequence from the default minimum capacity 16: 16, 24, ..., 77731542, 116597313, 174895969. `sizeof(KeyValuePair<String, String>)` is 16, so the cap is 134217727 pairs and `tryAppend` fails at the step to 174895969. `sizeof(DOMFormData::Item)` is 24, so the old growth crossed the cap from 77731542.
- The WebKit change also makes `formURLDecode` use `tryGetUTF8` and check the `char16_t` `Vector` capacity, which removes the abort of #40567 at its root (`FormData.from(new ArrayBuffer(1073741826))`). A name or value that cannot be decoded is skipped, which is what the original `if (utf8.isNull())` check intended. #40567 throws a RangeError for that input instead; the two PRs now conflict only in `URLSearchParams::create`, `updateFromAssociatedURL` and `DOMFormData::create`, and the second one to land rebases.
- `URLDecomposition::setFullURL` used to return void, so a failed re-parse after `url.search = ...` left the params empty and reported success. The setters now return `ExceptionOr<void>`. `DOMURL::setURL` parses the new query before it stores the URL, so a failed `url.href =` or `url.search =` leaves both the URL and the params as they were. `DOMURL::setFullURL` still ignores a value that does not give a valid URL, per the URL spec.
- The real limit is not tested. Reaching it needs about 6 GiB and, at 77 us per pair in a debug build, hours. The synthetic limit tests cover the boundary at 65536 and 43690 entries. Each child parses tens of thousands of pairs, 3 to 7 s in a debug build, so the tests are concurrent and carry a 60 s timeout, named once per file with the reason.
- `BUN_JSC_validateExceptionChecks=1` is clean on every path: constructor (string, array, generator and record), `append`, `set`, `url.searchParams`, `url.href =`, `url.search =`, `FormData.from` (string, bytes, multipart), `Response`/`Request`/`Blob.formData()`, streamed `Response.formData()`, and multipart `Response.formData()`.
- CI: `test/cli/run/require-cache.test.ts` is red on one lane per run (an RSS check on `require()`, and a 30 s timeout on the ASAN lane). This diff does not touch that path. It is reported for triage on main.
</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 6 · 20 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 17 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts test/js/web/html/URLSearchParams.test.ts
bun test v1.4.1 (65362b53b)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.57ms]
(pass) FormData > should be able to append a Blob [7.76ms]
(pass) FormData > should be able to set a Blob [6.35ms]
(pass) FormData > should be able to set a string [2.37ms]
(pass) FormData > should get filename from file [3.86ms]
(pass) FormData > should use the correct filenames [4.85ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [14.15ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [29.49ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.86ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [6.79ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [2.81ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [4.13ms]
(pass) FormDa
... (truncated)

release without fix: 17 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.05ms]
(pass) FormData > should be able to append a Blob [0.12ms]
(pass) FormData > should be able to set a Blob [0.07ms]
(pass) FormData > should be able to set a string [0.04ms]
(pass) FormData > should get filename from file [0.05ms]
(pass) FormData > should use the correct filenames [0.07ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.26ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.61ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.05ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.05ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.03ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts test/js/web/html/URLSearchParams.test.ts
bun test v1.4.1 (65362b53b)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.30ms]
(pass) FormData > should be able to append a Blob [7.88ms]
(pass) FormData > should be able to set a Blob [6.64ms]
(pass) FormData > should be able to set a string [2.29ms]
(pass) FormData > should get filename from file [3.63ms]
(pass) FormData > should use the correct filenames [4.80ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [13.62ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [28.38ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.90ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [4.92ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.93ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.01ms]
(pass) FormDa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3349c2ec26
  features     baseline

23 deps, 131 codegen, 1172 objects in 858ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 9ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                     |   2 +-
 src/jsc/DOMFormData.rs                           |  26 +++-
 src/jsc/bindings/DOMFormData.cpp                 |  52 +++++--
 src/jsc/bindings/DOMFormData.h                   |  16 +-
 src/jsc/bindings/DOMURL.cpp                      |  34 +++-
 src/jsc/bindings/DOMURL.h                        |   5 +-
 src/jsc/bindings/URLDecomposition.cpp            |  60 +++----
 src/jsc/bindings/URLDecomposition.h              |  22 +--
 src/jsc/bindings/URLSearchParams.cpp             |  73 +++++++--
 src/jsc/bindings/URLSearchParams.h               |  15 +-
 src/jsc/bindings/VectorSizeLimit.h               |  20 +++
 src/jsc/bindings/bindings.cpp                    |  30 +++-
 src/jsc/bindings/headers.h                       |   4 +-
 src/jsc/bindings/webcore/JSDOMConvertRecord.h    |  10 +-
 src/jsc/bindings/webcore/JSDOMConvertSequences.h |  13 +-
 src/runtime/webcore/Blob.rs                      |   1 +
 src/runtime/webcore/Body.rs                      |   5 +
 src/runtime/webcore/FormData.rs                  |  28 +++-
 test/js/web/html/FormData.test.ts                | 190 +++++++++++++++++++++++
 test/js/web/html/URLSearchParams.test.ts         | 189 ++++++++++++++++++++++
 20 files changed, 680 insertions(+), 115 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
scripts/build/deps/webkit.ts                          1      2      0
src/jsc/DOMFormData.rs                                1      3      0
src/jsc/bindings/DOMFormData.cpp                      2      4      0
src/jsc/bindings/DOMFormData.h                        1      3      0
src/jsc/bindings/DOMURL.cpp                           2      3      0
src/jsc/bindings/DOMURL.h                             1      1      0
src/jsc/bindings/URLDecomposition.cpp                 1      0      0
src/jsc/bindings/URLDecomposition.h                   0      0      0
src/jsc/bindings/URLSearchParams.cpp                  5      8      0
src/jsc/bindings/URLSearchParams.h                    1      5      0
src/jsc/bindings/VectorSizeLimit.h                    0      5      0
src/jsc/bindings/bindings.cpp                         1      2      0
src/jsc/bindings/headers.h                            1      2      0
src/jsc/bindings/webcore/JSDOMConvertRecord.h         0      0      0
src/jsc/bindings/webcore/JSDOMConvertSequences.h      2      2      0
src/runtime/webcore/Blob.rs                           1      2      0
(+ 4 more files)
```

</details>

<!-- robobun:evidence:end -->



