### PR TITLE
bundler: do not treat an entry point as a barrel

### DIFF
--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -120,6 +120,19 @@ fn apply_barrel_optimization_impl(
     if !is_explicit && !is_side_effects_false {
         return Ok(());
     }
+    // An entry point's exports are the public interface of the build. No file
+    // imports an entry point, so nothing seeds `requested_exports` for it and a
+    // deferred record would never be un-deferred. The linked output would then
+    // emit the export clause with the re-exported bindings shaken away.
+    if this
+        .graph
+        .entry_points
+        .iter()
+        .any(|ep| ep.get() == source_index)
+    {
+        return Ok(());
+    }
+
     let ast = &mut result.ast;
     if ast.import_records.len() == 0 {
         return Ok(());

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -1914,4 +1914,37 @@ describe("bundler", () => {
     },
     run: { stdout: "gamma BETA_STAR_MARKER" },
   });
+
+  // --- Entry points are never barrels ---
+  // An entry point's exports are the public interface of the build. Nothing
+  // imports an entry point, so a deferred record would never be un-deferred
+  // and the output would export bindings that were shaken away.
+  // https://github.com/oven-sh/bun/issues/40578
+
+  itBundled("barrel/EntryPointPureReExportSideEffectsFalse", {
+    files: {
+      "/entry.ts": /* ts */ `export { a } from './a';`,
+      "/a.ts": /* ts */ `export const a = 1;`,
+      "/package.json": JSON.stringify({ name: "repro", sideEffects: false }),
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("a = 1");
+    },
+  });
+
+  itBundled("barrel/EntryPointImportThenExportSideEffectsFalse", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { a } from './a';
+        export { a };
+      `,
+      "/a.ts": /* ts */ `export const a = 1;`,
+      "/package.json": JSON.stringify({ name: "repro", sideEffects: false }),
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("a = 1");
+    },
+  });
 });


### PR DESCRIPTION
### Problem

- An entry point covered by `sideEffects: false` whose exports are all re-exports produces a chunk that is only the export clause: `export { a };` with no declaration. The build succeeds and the chunk fails at evaluation with `"a" is not declared in this file`.
- The barrel import optimization (`src/bundler/barrel_imports.rs:95`) treats the entry point itself as a barrel and marks its re-export records `IS_UNUSED`. Un-deferral is driven by importers, and nothing imports an entry point, so the records stay deferred. `resolve_import_records` then clears their `source_index` and the linker shakes the bindings away, while the export clause is still emitted from the resolved export aliases.

### Fix

- `apply_barrel_optimization` returns early when the parsed file is in `graph.entry_points`. An entry point's exports are the public interface of the build, so none of its re-exports can be deferred.
- Barrels that are not entry points keep the optimization. The existing test `barrel/EntryPointIsBarrel` already states this intent, but it enables neither `sideEffects: false` nor `optimizeImports`, so it never exercised it.
- Verified: two new tests in `test/bundler/bundler_barrel.test.ts` (both fail on current main). Also ran `bundler_barrel`, `bundler_splitting`, `bundler_edgecase`, and `test/bake/dev/bundle.test.ts`, all green.

### Background

- The barrel optimization (from the `optimizeImports` work) detects files whose named exports are all re-exports and defers parsing of their submodules. A deferred import record gets `IS_UNUSED`.
- `requested_exports` tracks which names importers request from each file. When an importer requests a name from a barrel, a BFS un-defers the matching record and resolves it.
- The linker emits the export clause of an ESM entry from its resolved export aliases, independent of whether the parts that declare those symbols survived tree shaking. That is why the broken output still lists the exports.

<details><summary>Notes</summary>

Reproduction (issue #40578):

```
package.json   { "type": "module", "sideEffects": false }
src/a.ts       export const a = 1;
src/index.ts   export { a } from './a';
```

`Bun.build({ entrypoints: ["src/index.ts"] })` emits only `export { a };`. With `BUN_DEBUG_barrel=1` the log shows `barrel detected: repro (source=1, 1 deferred, 0 needed)` for the entry file. With `BUN_DEBUG_TreeShake=1` the tree shaker never reaches `src/a.ts` because `advance_import_tracker` returns `External` for an `IS_UNUSED` record, so the entry's import never binds to the export in `a.ts`.

The variant `import { a } from './a'; export { a };` breaks the same way and is covered by the second test. `export * from './a'` was never affected because export star records are never deferred. A local declaration in the entry rescues it because the file then fails the pure-barrel check.

The fix also holds for dynamic import entry points under code splitting: the importing file records `import()` targets as `RequestedExports::All`, which disables deferral for them.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_barrel.test.ts
bun test v1.4.1 (adc354d99)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [593.83ms]
(pass) bundler > barrel/AllExportsNeeded [118.10ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [94.67ms]
(pass) bundler > barrel/NoOptimizationWithoutSideEffects [105.64ms]
(pass) bundler > barrel/ExportStarLoadsAll [88.56ms]
(pass) bundler > barrel/NonBarrelWithLocalExports [86.53ms]
(pass) bundler > barrel/NamespaceImportLoadsAll [102.60ms]
(pass) bundler > barrel/OutputEquivalence [131.51ms]
(pass) bundler > barrel/DefaultReExport [131.47ms]
(pass) bundler > barrel/ImportThenExport [236.79ms]
(pass) bundler > barrel/ReExportChain [103.48ms]
(pass) bundler > barrel/StarWithNamedFromSameSource [94.74ms]
(pass) bundler > barrel/SideEffectOnlyImport [131.25ms]
(pass) bundler > barrel/MultipleImporters [197.85ms]
(pass) bundler > barrel/CircularExports [419.25ms]
(pass) bundler > barrel/CircularStarExports [427.11ms]
(pass) bundler > barrel/NamespaceReExportCycl
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [32.93ms]
(pass) bundler > barrel/AllExportsNeeded [29.88ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [15.30ms]
(pass) bundler > barrel/NoOptimizationWithoutSideEffects [4.34ms]
(pass) bundler > barrel/ExportStarLoadsAll [16.37ms]
(pass) bundler > barrel/NonBarrelWithLocalExports [8.13ms]
(pass) bundler > barrel/NamespaceImportLoadsAll [27.69ms]
(pass) bundler > barrel/OutputEquivalence [74.93ms]
(pass) bundler > barrel/DefaultReExport [71.90ms]
(pass) bundler > barrel/ImportThenExport [12.39ms]
(pass) bundler > barrel/ReExportChain [12.54ms]
(pass) bundler > barrel/StarWithNamedFromSameSource [3.91ms]
(pass) bundler > barrel/SideEffectOnlyImport [41.60ms]
(pass) bundler > barrel/MultipleImporters [16.07ms]
(pass) bundler > barrel/CircularExports [36.61ms]
(pass) bundler > barrel/CircularStarExports [11.17ms]
(pass) bundler > barrel/NamespaceReExportCycleThroughStarTarget [17.35ms]
(pass) bundler > barrel/SelfReExport [21.58ms]
(pass) bundler > barrel/DynamicImportInSubmodule [25.17ms]
(pass) bundler > barrel/DynamicImportWit
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_barrel.test.ts
bun test v1.4.1 (adc354d99)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [641.03ms]
(pass) bundler > barrel/AllExportsNeeded [126.32ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [122.25ms]
(pass) bundler > barrel/NoOptimizationWithoutSideEffects [122.22ms]
(pass) bundler > barrel/ExportStarLoadsAll [95.20ms]
(pass) bundler > barrel/NonBarrelWithLocalExports [93.14ms]
(pass) bundler > barrel/NamespaceImportLoadsAll [107.80ms]
(pass) bundler > barrel/OutputEquivalence [111.71ms]
(pass) bundler > barrel/DefaultReExport [97.79ms]
(pass) bundler > barrel/ImportThenExport [99.93ms]
(pass) bundler > barrel/ReExportChain [103.91ms]
(pass) bundler > barrel/StarWithNamedFromSameSource [89.16ms]
(pass) bundler > barrel/SideEffectOnlyImport [148.50ms]
(pass) bundler > barrel/MultipleImporters [123.90ms]
(pass) bundler > barrel/CircularExports [384.21ms]
(pass) bundler > barrel/CircularStarExports [477.47ms]
(pass) bundler > barrel/NamespaceReExportCycle
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 663ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/barrel_imports.rs       | 13 +++++++++++++
 test/bundler/bundler_barrel.test.ts | 33 +++++++++++++++++++++++++++++++++
 2 files changed, 46 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/bundler/barrel_imports.rs            1      1      0
test/bundler/bundler_barrel.test.ts      2      2      0
```

</details>

**root cause** · written by the author bot

# Root cause of bug and how the fix addresses it **Files changed:** `src/bundler/barrel_imports.rs`, `test/bundler/bundler_barrel.test.ts` **Answer:** When a package declares a sideEffects field that does not cover a module, the barrel import optimization defers resolution of that module's re-export import records, but entry points were not exempted, so a pure re-export entry module had its bindings deferred and never materialized while the linker still emitted the export clause, producing a chunk that exports an undeclared name. The fix adds an early return in apply_barrel_optimization_imp…

<!-- robobun:evidence:end -->