### PR TITLE
bundler: don't create a code-splitting chunk for a file with no live parts

### DIFF
--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -228,6 +228,14 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
             }
         }
     }
+    // ...and live files that contribute no code to any chunk (every part
+    // tree-shaken), which esbuild lists too.
+    for source_index in c.graph.reachable_files.slice() {
+        let i = source_index.get() as usize;
+        if i < sources.len() && i != 0 && c.graph.files_live.is_set(i) {
+            seen_sources.set(i);
+        }
+    }
 
     // Write inputs
     let mut source_index: u32 = 0;

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -314,6 +314,12 @@ pub(crate) fn compute_chunks(
                     }
 
                     if this.graph.code_splitting {
+                        // A file none of whose parts survived tree shaking contributes
+                        // no code; giving it a chunk would emit an empty file (and two
+                        // such chunks share a content hash).
+                        if this.graph.parts_live[source_index.get() as usize].count() == 0 {
+                            continue;
+                        }
                         let js_chunk_key =
                             temp.alloc_slice_copy(entry_bits.bytes(this.graph.entry_points.len()));
                         let js_chunk_entry = js_chunks.get_or_put(js_chunk_key)?;

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -305,7 +305,12 @@ pub(crate) fn compute_chunks(
     let contributes_code = {
         let mut bits = AutoBitSet::init_empty(this.graph.files.len())?;
         let parts = this.graph.ast.items_parts();
-        for source_index in this.graph.reachable_files.slice() {
+        let reachable: &[Index] = if this.graph.code_splitting {
+            this.graph.reachable_files.slice()
+        } else {
+            &[]
+        };
+        for source_index in reachable {
             let i = source_index.get() as usize;
             let parts_live = &this.graph.parts_live[i];
             if parts[i].as_slice().iter().enumerate().any(|(p, part)| {

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -298,6 +298,25 @@ pub(crate) fn compute_chunks(
     let css_asts = this.graph.ast.items_css();
     let ast_targets = this.graph.ast.items_target();
 
+    // Files with at least one part that will be printed. A file with none
+    // (nothing survived tree shaking, or only bare imports of unwrapped files
+    // did) gets no code-splitting chunk: it would be an empty file, and two
+    // such chunks share a content hash.
+    let contributes_code = {
+        let mut bits = AutoBitSet::init_empty(this.graph.files.len())?;
+        let parts = this.graph.ast.items_parts();
+        for source_index in this.graph.reachable_files.slice() {
+            let i = source_index.get() as usize;
+            let parts_live = &this.graph.parts_live[i];
+            if parts[i].as_slice().iter().enumerate().any(|(p, part)| {
+                parts_live.is_set(p) && this.should_include_part(source_index.get(), part)
+            }) {
+                bits.set(i);
+            }
+        }
+        bits
+    };
+
     // reshaped for borrowck — re-borrow file_entry_bits after the loop above mutated it
     let file_entry_bits: &mut [AutoBitSet] = this.graph.files.items_entry_bits_mut();
 
@@ -314,10 +333,7 @@ pub(crate) fn compute_chunks(
                     }
 
                     if this.graph.code_splitting {
-                        // A file none of whose parts survived tree shaking contributes
-                        // no code; giving it a chunk would emit an empty file (and two
-                        // such chunks share a content hash).
-                        if this.graph.parts_live[source_index.get() as usize].count() == 0 {
+                        if !contributes_code.is_set(source_index.get() as usize) {
                             continue;
                         }
                         let js_chunk_key =

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -66,11 +66,11 @@ NS.then(({ fn: fn2 }) => {
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"g9c33042"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"7gfnt0h6"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"2ksyc1td"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"g9c33042"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -801,7 +801,7 @@ describe("bundler", () => {
   // with the same content hash ("Multiple files share the same output path").
   itBundled("splitting/NoChunkForFilesWithNoLiveParts", {
     files: {
-      "/entry.js": `import('./a.js'); import('./b.js'); import('./e.js')`,
+      "/entry.js": `await import('./a.js'); await import('./b.js'); await import('./e.js')`,
       "/a.js": `import './c.js'; import './d.js'; console.log('a')`,
       "/b.js": `import './c.js'; console.log('b')`,
       "/e.js": `import './d.js'; console.log('e')`,

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -796,6 +796,29 @@ describe("bundler", () => {
       expect(readdirSync(api.outdir).filter(f => f.endsWith(".js"))).toHaveLength(2);
     },
   });
+  // A file whose every part was tree-shaken gets no chunk: two such files
+  // reached by different sets of entries used to become two empty chunks
+  // with the same content hash ("Multiple files share the same output path").
+  itBundled("splitting/NoChunkForFilesWithNoLiveParts", {
+    files: {
+      "/entry.js": `import('./a.js'); import('./b.js'); import('./e.js')`,
+      "/a.js": `import './c.js'; import './d.js'; console.log('a')`,
+      "/b.js": `import './c.js'; console.log('b')`,
+      "/e.js": `import './d.js'; console.log('e')`,
+      "/c.js": `export function dead() {}`,
+      "/d.js": `export function dead() {}`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    minifySyntax: true,
+    outdir: "/out",
+    chunkNaming: "chunk-[hash].[ext]",
+    onAfterBundle(api) {
+      // entry + the three import() targets; nothing for c.js / d.js
+      expect(readdirSync(api.outdir).filter(f => f.endsWith(".js"))).toHaveLength(4);
+    },
+    run: { file: "/out/entry.js", stdout: "a\nb\ne" },
+  });
   // An entry point with exports of its own keeps its module namespace as
   // written: shared code is not folded into it (which would add exports),
   // but the chunks that are always loaded with it still fold into one.

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -803,7 +803,7 @@ describe("bundler", () => {
     files: {
       "/entry.js": `await import('./a.js'); await import('./b.js'); await import('./e.js')`,
       "/a.js": `import './c.js'; import './d.js'; console.log('a')`,
-      "/b.js": `import './c.js'; console.log('b')`,
+      "/b.js": `import './c.js'; import './shared.js'; console.log('b')`,
       "/e.js": `import './d.js'; console.log('e')`,
       "/c.js": `export function dead() {}`,
       // only live part is a bare import of an unwrapped file: prints nothing either

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -806,7 +806,9 @@ describe("bundler", () => {
       "/b.js": `import './c.js'; console.log('b')`,
       "/e.js": `import './d.js'; console.log('e')`,
       "/c.js": `export function dead() {}`,
-      "/d.js": `export function dead() {}`,
+      // only live part is a bare import of an unwrapped file: prints nothing either
+      "/d.js": `import './shared.js'; export function dead() {}`,
+      "/shared.js": `console.log('shared')`,
     },
     entryPoints: ["/entry.js"],
     splitting: true,
@@ -814,10 +816,10 @@ describe("bundler", () => {
     outdir: "/out",
     chunkNaming: "chunk-[hash].[ext]",
     onAfterBundle(api) {
-      // entry + the three import() targets; nothing for c.js / d.js
-      expect(readdirSync(api.outdir).filter(f => f.endsWith(".js"))).toHaveLength(4);
+      // entry + the three import() targets + shared.js's chunk; nothing for c.js / d.js
+      expect(readdirSync(api.outdir).filter(f => f.endsWith(".js"))).toHaveLength(5);
     },
-    run: { file: "/out/entry.js", stdout: "a\nb\ne" },
+    run: { file: "/out/entry.js", stdout: "shared\na\nb\ne" },
   });
   // An entry point with exports of its own keeps its module namespace as
   // written: shared code is not folded into it (which would add exports),


### PR DESCRIPTION
### What does this PR do?

With `--splitting`, chunk membership was assigned per *reachable file*, so a file whose every part was removed by tree shaking (e.g. `export function dead(){}` imported only for side effects it doesn't have) still created — or joined — a chunk containing nothing but the banner and `export{};`. Two such chunks have byte-identical content and therefore the same `[hash]`, and the build fails with **"Multiple files share the same output path"**. esbuild builds chunks from live parts; this does the same by skipping part-less files when assigning chunks, so the empty chunk and the bare `import "./chunk-….js"` its importers carried are simply not emitted.

Pre-existing (the repro below fails on 1.4.0 as well); recent splitting changes (#40519, #40518) just make real apps more likely to produce two of them.

```
entry.js:  import('./a.js'); import('./b.js'); import('./e.js')
a.js:      import './c.js'; import './d.js'
b.js:      import './c.js'
e.js:      import './d.js'
c.js/d.js: export function dead() {}      → two empty chunks, same [hash]
```

### How did you verify your code works?

New `splitting/NoChunkForFilesWithNoLiveParts` (fails on system bun, passes here); `bundler_splitting`, `esbuild/splitting`, `bundler_compile_splitting`, `bundler_html`, `esbuild/dce`, `bundler_edgecase`, `bake/dev-and-prod` green (352 tests).