### PR TITLE
which: find .com executables and stat an explicit path as spelled on Windows

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -113,8 +113,7 @@ fn get_argv0(
 
     // This mimicks libuv's behavior, which mimicks execvpe
     // Only resolve from $PATH when the command is not an absolute path.
-    // An extensionless `\` path is still completed here: libuv never appends
-    // `.cmd`/`.bat`.
+    // libuv never appends .cmd/.bat, so an extensionless `\` path is still completed here.
     let names_a_file = strings::index_of_char(argv0_to_use, b'/').is_some()
         || (cfg!(windows) && bun_which::is_windows_path_with_extension(argv0_to_use));
     let path_to_use: &[u8] = if names_a_file {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -113,9 +113,9 @@ fn get_argv0(
 
     // This mimicks libuv's behavior, which mimicks execvpe
     // Only resolve from $PATH when the command is not an absolute path.
-    // libuv never appends .cmd/.bat, so an extensionless `\` path is still completed here.
+    // libuv never appends .cmd/.bat, so a `\` path without one is still completed here.
     let names_a_file = strings::index_of_char(argv0_to_use, b'/').is_some()
-        || (cfg!(windows) && bun_which::is_windows_path_with_extension(argv0_to_use));
+        || (cfg!(windows) && bun_which::is_windows_path_with_executable_extension(argv0_to_use));
     let path_to_use: &[u8] = if names_a_file {
         b""
         // If no $PATH is provided, we fallback to the one from environ

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -112,8 +112,14 @@ fn get_argv0(
     let argv0_to_use: &[u8] = arg0.slice();
 
     // This mimicks libuv's behavior, which mimicks execvpe
-    // Only resolve from $PATH when the command is not an absolute path
-    let path_to_use: &[u8] = if strings::index_of_char(argv0_to_use, b'/').is_some() {
+    // Only resolve from $PATH when the command is not an absolute path.
+    // On Windows a `\` path that spells its extension is handed over as is
+    // too: nothing is left to complete, and libuv stats it before
+    // CreateProcessW. A `\` path without one still gets `.exe`/`.cmd`/`.bat`
+    // completed here, which libuv does not do for `.cmd`/`.bat`.
+    let names_a_file = strings::index_of_char(argv0_to_use, b'/').is_some()
+        || (cfg!(windows) && bun_which::is_windows_path_with_extension(argv0_to_use));
+    let path_to_use: &[u8] = if names_a_file {
         b""
         // If no $PATH is provided, we fallback to the one from environ
         // This is already the behavior of the PATH passed in here.

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -113,10 +113,8 @@ fn get_argv0(
 
     // This mimicks libuv's behavior, which mimicks execvpe
     // Only resolve from $PATH when the command is not an absolute path.
-    // On Windows a `\` path that spells its extension is handed over as is
-    // too: nothing is left to complete, and libuv stats it before
-    // CreateProcessW. A `\` path without one still gets `.exe`/`.cmd`/`.bat`
-    // completed here, which libuv does not do for `.cmd`/`.bat`.
+    // An extensionless `\` path is still completed here: libuv never appends
+    // `.cmd`/`.bat`.
     let names_a_file = strings::index_of_char(argv0_to_use, b'/').is_some()
         || (cfg!(windows) && bun_which::is_windows_path_with_extension(argv0_to_use));
     let path_to_use: &[u8] = if names_a_file {

--- a/src/which/lib.rs
+++ b/src/which/lib.rs
@@ -80,8 +80,7 @@ pub fn which_for_spawn<'a>(
             && !cwd.is_empty()
             && std::env::var_os("NoDefaultCurrentDirectoryInExePath").is_none()
         {
-            // The cwd is probed like one more `$PATH` directory: the same
-            // extensions, and no `.com` (see `which_win`).
+            // Probed like one more `$PATH` directory, without `.com`.
             let mut convert_buf = w_path_buffer_pool::get();
             let mut path_buf = path_buffer_pool::get();
             let spells_executable_extension = ends_with_extension(bin);
@@ -106,8 +105,7 @@ pub fn which_for_spawn<'a>(
     which(buf, path, cwd, bin)
 }
 
-/// Writes the UTF-16 result of a Windows lookup into `buf` as NUL-terminated
-/// UTF-8.
+/// Writes `result` into `buf` as NUL-terminated UTF-8.
 #[cfg(windows)]
 fn utf16_result_into<'a>(buf: &'a mut PathBuffer, result: &[u16]) -> &'a ZStr {
     let result_converted = bun_core::strings::convert_utf16_to_utf8_in_buffer(&mut buf[..], result);
@@ -200,19 +198,14 @@ pub fn which<'a>(buf: &'a mut PathBuffer, path: &[u8], cwd: &[u8], bin: &[u8]) -
     }
 }
 
-/// The extensions a bare name is completed with, in probe order.
 #[cfg(windows)]
 static WIN_EXTENSIONS_W: [&[u16]; 3] = [w!("exe"), w!("cmd"), w!("bat")];
-/// `.com` is probed on its own, after every `$PATH` directory failed the list
-/// above: the few `.com` programs left (`chcp`, `more`, `tree` in System32)
-/// do not pay for one more stat per directory on every spawn.
+/// Probed in a separate last pass over `$PATH`, so the rare `.com` program
+/// does not cost one more stat per directory on every spawn.
 #[cfg(windows)]
 static WIN_COM_EXTENSION_W: [&[u16]; 1] = [w!("com")];
-/// Every extension from the two lists above, for a name with a directory
-/// component (one directory, probed once).
 #[cfg(windows)]
 static WIN_ALL_EXTENSIONS_W: [&[u16]; 4] = [w!("exe"), w!("cmd"), w!("bat"), w!("com")];
-/// A name that ends in one of these is stat'd as spelled and never completed.
 #[cfg(windows)]
 const WIN_EXTENSIONS: [&[u8]; 4] = [b"exe", b"cmd", b"bat", b"com"];
 
@@ -234,8 +227,7 @@ pub(crate) fn ends_with_extension(str: &[u8]) -> bool {
     false
 }
 
-/// Whether the last component of `bin` carries an extension: a `.` followed
-/// by at least one character, the same test as libuv's `search_path`.
+/// libuv's `name_has_ext`: a `.` in the last component with something after it.
 fn has_extension(bin: &[u8]) -> bool {
     let name_start = strings::last_index_of_any(bin, b"/\\:").map_or(0, |i| i + 1);
     let name = &bin[name_start..];
@@ -245,10 +237,8 @@ fn has_extension(bin: &[u8]) -> bool {
     }
 }
 
-/// Whether `bin` names a file by Windows path and spells its extension
-/// (`C:\Windows\System32\chcp.com`, `.\tool.exe`). Such a name needs no
-/// lookup before `uv_spawn`: there is no `.exe`/`.cmd`/`.bat` to complete,
-/// and libuv's `search_path` stats it as spelled before `CreateProcessW`.
+/// `C:\Windows\System32\chcp.com`, `.\tool.exe`: a path with nothing left to
+/// complete, which spawn hands to libuv without a lookup.
 pub fn is_windows_path_with_extension(bin: &[u8]) -> bool {
     strings::contains_any(bin, b"/\\") && has_extension(bin)
 }
@@ -285,9 +275,7 @@ pub fn batch_arg_has_cmd_metachars(arg: &[u8]) -> bool {
     strings::contains_any(arg, b"\"%&|<>^\r\n")
 }
 
-/// Check if the WPathBuffer holds an existing file path: as spelled when
-/// `try_as_spelled`, then with each of `extensions` appended (internally used
-/// by which_win)
+/// Stats `buf[..path_size]` as spelled, then with each of `extensions` appended.
 #[cfg(windows)]
 fn search_bin<'a>(
     buf: &'a mut WPathBuffer,
@@ -382,16 +370,17 @@ pub(crate) fn which_win<'a>(
     }
     let mut path_buf = path_buffer_pool::get();
 
-    // Nothing but the file header tells an executable from a data file on
-    // Windows, so a name is only stat'd as spelled when its extension says it
-    // is executable. A name with a directory component is the exception: the
-    // caller named one file, and libuv's search_path stats it as spelled for
-    // any extension (`chcp.com`, a PE with a custom extension). A bare name
-    // keeps the extension allowlist so that a `$PATH` walk does not hand back
-    // a source file that one of its directories happens to hold.
     let spells_executable_extension = ends_with_extension(bin);
     let has_dir = strings::contains_any(bin, b"/\\");
+    // A path names one file and is stat'd as spelled for any extension, like
+    // libuv does. A bare name only with an executable one: `bun run` puts the
+    // package directory on `$PATH`, and `x.ts` in it is not a program.
     let try_as_spelled = spells_executable_extension || (has_dir && has_extension(bin));
+    let extensions: &[&[u16]] = if spells_executable_extension {
+        &[]
+    } else {
+        &WIN_ALL_EXTENSIONS_W
+    };
 
     // handle absolute paths
     if is_absolute(bin) {
@@ -405,11 +394,6 @@ pub(crate) fn which_win<'a>(
         // Capture len before re-borrowing buf (borrowck).
         let bin_utf16_len = bin_utf16.len();
         buf[bin_utf16_len] = 0;
-        let extensions: &[&[u16]] = if spells_executable_extension {
-            &[]
-        } else {
-            &WIN_ALL_EXTENSIONS_W
-        };
         return search_bin(buf, bin_utf16_len, try_as_spelled, extensions).map(|w| &*w);
     }
 
@@ -420,11 +404,6 @@ pub(crate) fn which_win<'a>(
         // SAFETY: bin_path borrow does not escape this block on the None path.
         let buf_reborrow: &'a mut WPathBuffer =
             unsafe { &mut *std::ptr::from_mut::<WPathBuffer>(buf) };
-        let extensions: &[&[u16]] = if spells_executable_extension {
-            &[]
-        } else {
-            &WIN_ALL_EXTENSIONS_W
-        };
         if let Some(bin_path) = search_bin_in_path(
             buf_reborrow,
             &mut *path_buf,
@@ -440,10 +419,7 @@ pub(crate) fn which_win<'a>(
         return None;
     }
 
-    // A spelled-out executable extension is stat'd as spelled in every `$PATH`
-    // directory. Otherwise `.exe`/`.cmd`/`.bat` are tried in every directory
-    // first, and `.com` only once all of those failed, so a lookup that
-    // succeeds today does not pay for it.
+    // `.com` gets its own pass once every directory failed `.exe`/`.cmd`/`.bat`.
     if spells_executable_extension {
         return search_bin_in_path_list(buf, &mut *path_buf, path, bin, true, &[]).map(|w| &*w);
     }

--- a/src/which/lib.rs
+++ b/src/which/lib.rs
@@ -74,25 +74,50 @@ pub fn which_for_spawn<'a>(
         // binary-planting opt-out; libuv gates its cwd search on it via
         // NeedCurrentDirectoryForExePathW (libuv/libuv#3895), so spawn must too.
         if !bin.is_empty()
+            && bin.len() < MAX_PATH_BYTES
             && !has_sep
             && !is_absolute(bin)
             && !cwd.is_empty()
             && std::env::var_os("NoDefaultCurrentDirectoryInExePath").is_none()
         {
-            let mut rel: Vec<u8> = Vec::with_capacity(bin.len() + 2);
-            rel.extend_from_slice(b"./");
-            rel.extend_from_slice(bin);
-            // PORT NOTE: NLL Polonius limitation — raw-ptr reborrow so the None
-            // branch can fall through without `buf` appearing borrowed.
-            // SAFETY: the borrow does not escape this block on the None path.
-            let buf_reborrow: &'a mut PathBuffer =
-                unsafe { &mut *std::ptr::from_mut::<PathBuffer>(buf) };
-            if let Some(found) = which(buf_reborrow, b"", cwd, &rel) {
-                return Some(found);
+            // The cwd is probed like one more `$PATH` directory: the same
+            // extensions, and no `.com` (see `which_win`).
+            let mut convert_buf = w_path_buffer_pool::get();
+            let mut path_buf = path_buffer_pool::get();
+            let spells_executable_extension = ends_with_extension(bin);
+            let extensions: &[&[u16]] = if spells_executable_extension {
+                &[]
+            } else {
+                &WIN_EXTENSIONS_W
+            };
+            if let Some(found) = search_bin_in_path(
+                &mut *convert_buf,
+                &mut *path_buf,
+                cwd,
+                bin,
+                spells_executable_extension,
+                extensions,
+            ) {
+                posix_to_platform_in_place(found);
+                return Some(utf16_result_into(buf, found));
             }
         }
     }
     which(buf, path, cwd, bin)
+}
+
+/// Writes the UTF-16 result of a Windows lookup into `buf` as NUL-terminated
+/// UTF-8.
+#[cfg(windows)]
+fn utf16_result_into<'a>(buf: &'a mut PathBuffer, result: &[u16]) -> &'a ZStr {
+    let result_converted = bun_core::strings::convert_utf16_to_utf8_in_buffer(&mut buf[..], result);
+    // Capture len/ptr before re-borrowing buf (borrowck).
+    let result_converted_len = result_converted.len();
+    let result_converted_ptr = result_converted.as_ptr();
+    buf[result_converted_len] = 0;
+    debug_assert!(result_converted_ptr == buf.as_ptr());
+    // SAFETY: buf[result_converted_len] == 0 written above
+    ZStr::from_buf(&buf[..], result_converted_len)
 }
 
 // Like /usr/bin/which but without needing to exec a child process
@@ -113,15 +138,7 @@ pub fn which<'a>(buf: &'a mut PathBuffer, path: &[u8], cwd: &[u8], bin: &[u8]) -
     {
         let mut convert_buf = w_path_buffer_pool::get();
         let result = which_win(&mut *convert_buf, path, cwd, bin)?;
-        let result_converted =
-            bun_core::strings::convert_utf16_to_utf8_in_buffer(&mut buf[..], result);
-        // Capture len/ptr before re-borrowing buf (borrowck).
-        let result_converted_len = result_converted.len();
-        let result_converted_ptr = result_converted.as_ptr();
-        buf[result_converted_len] = 0;
-        debug_assert!(result_converted_ptr == buf.as_ptr());
-        // SAFETY: buf[result_converted_len] == 0 written above
-        return Some(ZStr::from_buf(&buf[..], result_converted_len));
+        return Some(utf16_result_into(buf, result));
     }
 
     #[cfg(not(windows))]
@@ -183,8 +200,19 @@ pub fn which<'a>(buf: &'a mut PathBuffer, path: &[u8], cwd: &[u8], bin: &[u8]) -
     }
 }
 
+/// The extensions a bare name is completed with, in probe order.
 #[cfg(windows)]
-static WIN_EXTENSIONS_W: [&[u16]; 4] = [w!("exe"), w!("cmd"), w!("bat"), w!("com")];
+static WIN_EXTENSIONS_W: [&[u16]; 3] = [w!("exe"), w!("cmd"), w!("bat")];
+/// `.com` is probed on its own, after every `$PATH` directory failed the list
+/// above: the few `.com` programs left (`chcp`, `more`, `tree` in System32)
+/// do not pay for one more stat per directory on every spawn.
+#[cfg(windows)]
+static WIN_COM_EXTENSION_W: [&[u16]; 1] = [w!("com")];
+/// Every extension from the two lists above, for a name with a directory
+/// component (one directory, probed once).
+#[cfg(windows)]
+static WIN_ALL_EXTENSIONS_W: [&[u16]; 4] = [w!("exe"), w!("cmd"), w!("bat"), w!("com")];
+/// A name that ends in one of these is stat'd as spelled and never completed.
 #[cfg(windows)]
 const WIN_EXTENSIONS: [&[u8]; 4] = [b"exe", b"cmd", b"bat", b"com"];
 
@@ -208,7 +236,6 @@ pub(crate) fn ends_with_extension(str: &[u8]) -> bool {
 
 /// Whether the last component of `bin` carries an extension: a `.` followed
 /// by at least one character, the same test as libuv's `search_path`.
-#[cfg(windows)]
 fn has_extension(bin: &[u8]) -> bool {
     let name_start = strings::last_index_of_any(bin, b"/\\:").map_or(0, |i| i + 1);
     let name = &bin[name_start..];
@@ -216,6 +243,14 @@ fn has_extension(bin: &[u8]) -> bool {
         Some(dot) => dot + 1 < name.len(),
         None => false,
     }
+}
+
+/// Whether `bin` names a file by Windows path and spells its extension
+/// (`C:\Windows\System32\chcp.com`, `.\tool.exe`). Such a name needs no
+/// lookup before `uv_spawn`: there is no `.exe`/`.cmd`/`.bat` to complete,
+/// and libuv's `search_path` stats it as spelled before `CreateProcessW`.
+pub fn is_windows_path_with_extension(bin: &[u8]) -> bool {
+    strings::contains_any(bin, b"/\\") && has_extension(bin)
 }
 
 /// Returns true when `path` names a Windows batch script (`.cmd` / `.bat`).
@@ -250,14 +285,16 @@ pub fn batch_arg_has_cmd_metachars(arg: &[u8]) -> bool {
     strings::contains_any(arg, b"\"%&|<>^\r\n")
 }
 
-/// Check if the WPathBuffer holds a existing file path, checking also for windows extensions variants like .exe, .cmd, .bat and .com (internally used by which_win)
+/// Check if the WPathBuffer holds an existing file path: as spelled when
+/// `try_as_spelled`, then with each of `extensions` appended (internally used
+/// by which_win)
 #[cfg(windows)]
-fn search_bin(
-    buf: &mut WPathBuffer,
+fn search_bin<'a>(
+    buf: &'a mut WPathBuffer,
     path_size: usize,
     try_as_spelled: bool,
-    check_windows_extensions: bool,
-) -> Option<&mut [u16]> {
+    extensions: &[&[u16]],
+) -> Option<&'a mut [u16]> {
     {
         if try_as_spelled {
             // SAFETY: caller wrote NUL at buf[path_size]
@@ -266,17 +303,15 @@ fn search_bin(
             }
         }
 
-        if check_windows_extensions {
+        if !extensions.is_empty() {
             buf[path_size] = b'.' as u16;
-            buf[path_size + 1 + 3] = 0;
-            for ext in WIN_EXTENSIONS_W {
-                buf[path_size + 1..path_size + 1 + 3].copy_from_slice(ext);
-                // SAFETY: buf[path_size + 1 + ext.len()] == 0 written above
-                if bun_sys::exists_os_path(
-                    WStr::from_buf(&buf[..], path_size + 1 + ext.len()),
-                    true,
-                ) {
-                    return Some(&mut buf[..path_size + 1 + ext.len()]);
+            for ext in extensions {
+                let end = path_size + 1 + ext.len();
+                buf[path_size + 1..end].copy_from_slice(ext);
+                buf[end] = 0;
+                // SAFETY: buf[end] == 0 written above
+                if bun_sys::exists_os_path(WStr::from_buf(&buf[..], end), true) {
+                    return Some(&mut buf[..end]);
                 }
             }
         }
@@ -292,7 +327,7 @@ fn search_bin_in_path<'a>(
     path: &[u8],
     bin: &[u8],
     try_as_spelled: bool,
-    check_windows_extensions: bool,
+    extensions: &[&[u16]],
 ) -> Option<&'a mut [u16]> {
     if path.is_empty() {
         return None;
@@ -305,7 +340,7 @@ fn search_bin_in_path<'a>(
     } else {
         path
     };
-    let tail_units = if check_windows_extensions { 5 } else { 1 };
+    let tail_units = if extensions.is_empty() { 1 } else { 5 };
     if segment.len() + 1 + bin.len() + tail_units > buf.len()
         && bun_core::strings::element_length_utf8_into_utf16(segment)
             + 1
@@ -329,7 +364,7 @@ fn search_bin_in_path<'a>(
     let path_size = segment_utf16_len + 1 + bin_utf16.len();
     buf[path_size] = 0;
 
-    search_bin(buf, path_size, try_as_spelled, check_windows_extensions)
+    search_bin(buf, path_size, try_as_spelled, extensions)
 }
 
 /// This is the windows version of `which`.
@@ -357,7 +392,6 @@ pub(crate) fn which_win<'a>(
     let spells_executable_extension = ends_with_extension(bin);
     let has_dir = strings::contains_any(bin, b"/\\");
     let try_as_spelled = spells_executable_extension || (has_dir && has_extension(bin));
-    let check_windows_extensions = !spells_executable_extension;
 
     // handle absolute paths
     if is_absolute(bin) {
@@ -371,8 +405,12 @@ pub(crate) fn which_win<'a>(
         // Capture len before re-borrowing buf (borrowck).
         let bin_utf16_len = bin_utf16.len();
         buf[bin_utf16_len] = 0;
-        return search_bin(buf, bin_utf16_len, try_as_spelled, check_windows_extensions)
-            .map(|w| &*w);
+        let extensions: &[&[u16]] = if spells_executable_extension {
+            &[]
+        } else {
+            &WIN_ALL_EXTENSIONS_W
+        };
+        return search_bin(buf, bin_utf16_len, try_as_spelled, extensions).map(|w| &*w);
     }
 
     // check if bin is in cwd
@@ -382,13 +420,18 @@ pub(crate) fn which_win<'a>(
         // SAFETY: bin_path borrow does not escape this block on the None path.
         let buf_reborrow: &'a mut WPathBuffer =
             unsafe { &mut *std::ptr::from_mut::<WPathBuffer>(buf) };
+        let extensions: &[&[u16]] = if spells_executable_extension {
+            &[]
+        } else {
+            &WIN_ALL_EXTENSIONS_W
+        };
         if let Some(bin_path) = search_bin_in_path(
             buf_reborrow,
             &mut *path_buf,
             cwd,
             strings::without_prefix_comptime(bin, b"./"),
             try_as_spelled,
-            check_windows_extensions,
+            extensions,
         ) {
             posix_to_platform_in_place(bin_path);
             return Some(&*bin_path);
@@ -397,7 +440,41 @@ pub(crate) fn which_win<'a>(
         return None;
     }
 
-    // iterate over system path delimiter
+    // A spelled-out executable extension is stat'd as spelled in every `$PATH`
+    // directory. Otherwise `.exe`/`.cmd`/`.bat` are tried in every directory
+    // first, and `.com` only once all of those failed, so a lookup that
+    // succeeds today does not pay for it.
+    if spells_executable_extension {
+        return search_bin_in_path_list(buf, &mut *path_buf, path, bin, true, &[]).map(|w| &*w);
+    }
+    // NLL/Polonius limitation — raw-ptr reborrow so the None branch can fall
+    // through without `buf` appearing borrowed.
+    // SAFETY: bin_path borrow does not escape this block on the None path.
+    let buf_reborrow: &'a mut WPathBuffer = unsafe { &mut *std::ptr::from_mut::<WPathBuffer>(buf) };
+    if let Some(bin_path) = search_bin_in_path_list(
+        buf_reborrow,
+        &mut *path_buf,
+        path,
+        bin,
+        false,
+        &WIN_EXTENSIONS_W,
+    ) {
+        return Some(&*bin_path);
+    }
+    search_bin_in_path_list(buf, &mut *path_buf, path, bin, false, &WIN_COM_EXTENSION_W)
+        .map(|w| &*w)
+}
+
+/// `search_bin_in_path` over every `;`-separated directory of `path`.
+#[cfg(windows)]
+fn search_bin_in_path_list<'a>(
+    buf: &'a mut WPathBuffer,
+    path_buf: &mut PathBuffer,
+    path: &[u8],
+    bin: &[u8],
+    try_as_spelled: bool,
+    extensions: &[&[u16]],
+) -> Option<&'a mut [u16]> {
     for segment_part in strings::tokenize(path, b";") {
         // NLL/Polonius limitation — re-borrowing `buf` across loop iterations
         // when returning a reference tied to its lifetime.
@@ -406,15 +483,14 @@ pub(crate) fn which_win<'a>(
             unsafe { &mut *std::ptr::from_mut::<WPathBuffer>(buf) };
         if let Some(bin_path) = search_bin_in_path(
             buf_reborrow,
-            &mut *path_buf,
+            path_buf,
             segment_part,
             bin,
             try_as_spelled,
-            check_windows_extensions,
+            extensions,
         ) {
-            return Some(&*bin_path);
+            return Some(bin_path);
         }
     }
-
     None
 }

--- a/src/which/lib.rs
+++ b/src/which/lib.rs
@@ -80,7 +80,8 @@ pub fn which_for_spawn<'a>(
             && !cwd.is_empty()
             && std::env::var_os("NoDefaultCurrentDirectoryInExePath").is_none()
         {
-            // Probed like one more `$PATH` directory, without `.com`.
+            // The cwd is one more `$PATH` directory: `.exe`/`.cmd`/`.bat` before the
+            // walk, `.com` after it.
             let mut convert_buf = w_path_buffer_pool::get();
             let mut path_buf = path_buffer_pool::get();
             let spells_executable_extension = ends_with_extension(bin);
@@ -100,6 +101,22 @@ pub fn which_for_spawn<'a>(
                 posix_to_platform_in_place(found);
                 return Some(utf16_result_into(buf, found));
             }
+            if let Some(found) = which_win(&mut *convert_buf, path, cwd, bin) {
+                return Some(utf16_result_into(buf, found));
+            }
+            if spells_executable_extension {
+                return None;
+            }
+            let found = search_bin_in_path(
+                &mut *convert_buf,
+                &mut *path_buf,
+                cwd,
+                bin,
+                false,
+                &WIN_COM_EXTENSION_W,
+            )?;
+            posix_to_platform_in_place(found);
+            return Some(utf16_result_into(buf, found));
         }
     }
     which(buf, path, cwd, bin)
@@ -205,10 +222,8 @@ static WIN_EXTENSIONS_W: [&[u16]; 3] = [w!("exe"), w!("cmd"), w!("bat")];
 static WIN_COM_EXTENSION_W: [&[u16]; 1] = [w!("com")];
 #[cfg(windows)]
 static WIN_ALL_EXTENSIONS_W: [&[u16]; 4] = [w!("exe"), w!("cmd"), w!("bat"), w!("com")];
-#[cfg(windows)]
 const WIN_EXTENSIONS: [&[u8]; 4] = [b"exe", b"cmd", b"bat", b"com"];
 
-#[cfg(windows)]
 pub(crate) fn ends_with_extension(str: &[u8]) -> bool {
     if str.len() < 4 {
         return false;
@@ -227,6 +242,7 @@ pub(crate) fn ends_with_extension(str: &[u8]) -> bool {
 }
 
 /// libuv's `name_has_ext`: a `.` in the last component with something after it.
+#[cfg(windows)]
 fn has_extension(bin: &[u8]) -> bool {
     let name_start = strings::last_index_of_any(bin, b"/\\:").map_or(0, |i| i + 1);
     let name = &bin[name_start..];
@@ -237,8 +253,8 @@ fn has_extension(bin: &[u8]) -> bool {
 }
 
 /// `C:\Windows\System32\chcp.com`: nothing to complete, spawn skips the lookup.
-pub fn is_windows_path_with_extension(bin: &[u8]) -> bool {
-    strings::contains_any(bin, b"/\\") && has_extension(bin)
+pub fn is_windows_path_with_executable_extension(bin: &[u8]) -> bool {
+    strings::contains_any(bin, b"/\\") && ends_with_extension(bin)
 }
 
 /// Returns true when `path` names a Windows batch script (`.cmd` / `.bat`).

--- a/src/which/lib.rs
+++ b/src/which/lib.rs
@@ -200,8 +200,7 @@ pub fn which<'a>(buf: &'a mut PathBuffer, path: &[u8], cwd: &[u8], bin: &[u8]) -
 
 #[cfg(windows)]
 static WIN_EXTENSIONS_W: [&[u16]; 3] = [w!("exe"), w!("cmd"), w!("bat")];
-/// Probed in a separate last pass over `$PATH`, so the rare `.com` program
-/// does not cost one more stat per directory on every spawn.
+/// Probed in a last pass over `$PATH`: the rare `.com` is not worth a stat per directory.
 #[cfg(windows)]
 static WIN_COM_EXTENSION_W: [&[u16]; 1] = [w!("com")];
 #[cfg(windows)]
@@ -237,8 +236,7 @@ fn has_extension(bin: &[u8]) -> bool {
     }
 }
 
-/// `C:\Windows\System32\chcp.com`, `.\tool.exe`: a path with nothing left to
-/// complete, which spawn hands to libuv without a lookup.
+/// `C:\Windows\System32\chcp.com`: nothing to complete, spawn skips the lookup.
 pub fn is_windows_path_with_extension(bin: &[u8]) -> bool {
     strings::contains_any(bin, b"/\\") && has_extension(bin)
 }
@@ -372,9 +370,7 @@ pub(crate) fn which_win<'a>(
 
     let spells_executable_extension = ends_with_extension(bin);
     let has_dir = strings::contains_any(bin, b"/\\");
-    // A path names one file and is stat'd as spelled for any extension, like
-    // libuv does. A bare name only with an executable one: `bun run` puts the
-    // package directory on `$PATH`, and `x.ts` in it is not a program.
+    // `bun run` puts the package dir on `$PATH`, so a bare `x.ts` must not match.
     let try_as_spelled = spells_executable_extension || (has_dir && has_extension(bin));
     let extensions: &[&[u16]] = if spells_executable_extension {
         &[]

--- a/src/which/lib.rs
+++ b/src/which/lib.rs
@@ -184,9 +184,9 @@ pub fn which<'a>(buf: &'a mut PathBuffer, path: &[u8], cwd: &[u8], bin: &[u8]) -
 }
 
 #[cfg(windows)]
-static WIN_EXTENSIONS_W: [&[u16]; 3] = [w!("exe"), w!("cmd"), w!("bat")];
+static WIN_EXTENSIONS_W: [&[u16]; 4] = [w!("exe"), w!("cmd"), w!("bat"), w!("com")];
 #[cfg(windows)]
-const WIN_EXTENSIONS: [&[u8]; 3] = [b"exe", b"cmd", b"bat"];
+const WIN_EXTENSIONS: [&[u8]; 4] = [b"exe", b"cmd", b"bat", b"com"];
 
 #[cfg(windows)]
 pub(crate) fn ends_with_extension(str: &[u8]) -> bool {
@@ -204,6 +204,18 @@ pub(crate) fn ends_with_extension(str: &[u8]) -> bool {
         }
     }
     false
+}
+
+/// Whether the last component of `bin` carries an extension: a `.` followed
+/// by at least one character, the same test as libuv's `search_path`.
+#[cfg(windows)]
+fn has_extension(bin: &[u8]) -> bool {
+    let name_start = strings::last_index_of_any(bin, b"/\\:").map_or(0, |i| i + 1);
+    let name = &bin[name_start..];
+    match strings::index_of_char_usize(name, b'.') {
+        Some(dot) => dot + 1 < name.len(),
+        None => false,
+    }
 }
 
 /// Returns true when `path` names a Windows batch script (`.cmd` / `.bat`).
@@ -238,17 +250,16 @@ pub fn batch_arg_has_cmd_metachars(arg: &[u8]) -> bool {
     strings::contains_any(arg, b"\"%&|<>^\r\n")
 }
 
-/// Check if the WPathBuffer holds a existing file path, checking also for windows extensions variants like .exe, .cmd and .bat (internally used by which_win)
+/// Check if the WPathBuffer holds a existing file path, checking also for windows extensions variants like .exe, .cmd, .bat and .com (internally used by which_win)
 #[cfg(windows)]
 fn search_bin(
     buf: &mut WPathBuffer,
     path_size: usize,
+    try_as_spelled: bool,
     check_windows_extensions: bool,
 ) -> Option<&mut [u16]> {
     {
-        if !check_windows_extensions {
-            // On Windows, files without extensions are not executable
-            // Therefore, we should only care about this check when the file already has an extension.
+        if try_as_spelled {
             // SAFETY: caller wrote NUL at buf[path_size]
             if bun_sys::exists_os_path(WStr::from_buf(&buf[..], path_size), true) {
                 return Some(&mut buf[..path_size]);
@@ -280,6 +291,7 @@ fn search_bin_in_path<'a>(
     path_buf: &mut PathBuffer,
     path: &[u8],
     bin: &[u8],
+    try_as_spelled: bool,
     check_windows_extensions: bool,
 ) -> Option<&'a mut [u16]> {
     if path.is_empty() {
@@ -317,7 +329,7 @@ fn search_bin_in_path<'a>(
     let path_size = segment_utf16_len + 1 + bin_utf16.len();
     buf[path_size] = 0;
 
-    search_bin(buf, path_size, check_windows_extensions)
+    search_bin(buf, path_size, try_as_spelled, check_windows_extensions)
 }
 
 /// This is the windows version of `which`.
@@ -335,7 +347,17 @@ pub(crate) fn which_win<'a>(
     }
     let mut path_buf = path_buffer_pool::get();
 
-    let check_windows_extensions = !ends_with_extension(bin);
+    // Nothing but the file header tells an executable from a data file on
+    // Windows, so a name is only stat'd as spelled when its extension says it
+    // is executable. A name with a directory component is the exception: the
+    // caller named one file, and libuv's search_path stats it as spelled for
+    // any extension (`chcp.com`, a PE with a custom extension). A bare name
+    // keeps the extension allowlist so that a `$PATH` walk does not hand back
+    // a source file that one of its directories happens to hold.
+    let spells_executable_extension = ends_with_extension(bin);
+    let has_dir = strings::contains_any(bin, b"/\\");
+    let try_as_spelled = spells_executable_extension || (has_dir && has_extension(bin));
+    let check_windows_extensions = !spells_executable_extension;
 
     // handle absolute paths
     if is_absolute(bin) {
@@ -349,11 +371,12 @@ pub(crate) fn which_win<'a>(
         // Capture len before re-borrowing buf (borrowck).
         let bin_utf16_len = bin_utf16.len();
         buf[bin_utf16_len] = 0;
-        return search_bin(buf, bin_utf16_len, check_windows_extensions).map(|w| &*w);
+        return search_bin(buf, bin_utf16_len, try_as_spelled, check_windows_extensions)
+            .map(|w| &*w);
     }
 
     // check if bin is in cwd
-    if strings::index_of_char(bin, b'/').is_some() || strings::index_of_char(bin, b'\\').is_some() {
+    if has_dir {
         // NLL/Polonius limitation — raw-ptr reborrow so the None branch can
         // fall through without `buf` appearing borrowed.
         // SAFETY: bin_path borrow does not escape this block on the None path.
@@ -364,6 +387,7 @@ pub(crate) fn which_win<'a>(
             &mut *path_buf,
             cwd,
             strings::without_prefix_comptime(bin, b"./"),
+            try_as_spelled,
             check_windows_extensions,
         ) {
             posix_to_platform_in_place(bin_path);
@@ -385,6 +409,7 @@ pub(crate) fn which_win<'a>(
             &mut *path_buf,
             segment_part,
             bin,
+            try_as_spelled,
             check_windows_extensions,
         ) {
             return Some(&*bin_path);

--- a/src/which/lib.rs
+++ b/src/which/lib.rs
@@ -80,8 +80,7 @@ pub fn which_for_spawn<'a>(
             && !cwd.is_empty()
             && std::env::var_os("NoDefaultCurrentDirectoryInExePath").is_none()
         {
-            // The cwd is one more `$PATH` directory: `.exe`/`.cmd`/`.bat` before the
-            // walk, `.com` after it.
+            // One more `$PATH` directory: .exe/.cmd/.bat before the walk, .com after it.
             let mut convert_buf = w_path_buffer_pool::get();
             let mut path_buf = path_buffer_pool::get();
             let spells_executable_extension = ends_with_extension(bin);

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -46,6 +46,44 @@ if (isWindows) {
     expect(which(exe, { PATH: dir })).toBe(process.execPath);
   });
 
+  // `chcp.com`, `tree.com` and `more.com` live in System32 with no `.exe`
+  // sibling, so `.com` has to be probed like libuv does. A path with a
+  // directory is stat'd as spelled whatever its extension (libuv again), a
+  // bare $PATH name only with an executable extension.
+  test("which finds .com executables, bare or spelled, relative or absolute", () => {
+    using dir = tempDir("which-com", {
+      "tool.com": "",
+      "dotted.name.exe": "",
+      "custom.bin": "",
+    });
+    const base = String(dir);
+    expect({
+      bare: which("tool", { PATH: base }),
+      spelled: which("tool.com", { PATH: base }),
+      absolute: which(join(base, "tool.com")),
+      relative: which("./tool.com", { cwd: base }),
+      dotted_bare: which("dotted.name", { PATH: base }),
+      dotted_spelled: which("dotted.name.exe", { PATH: base }),
+      custom_absolute: which(join(base, "custom.bin")),
+      custom_bare: which("custom.bin", { PATH: base }),
+      custom_no_ext: which("custom", { PATH: base }),
+      missing: which("tool.exe", { PATH: base }),
+      system: which("chcp")?.toLowerCase(),
+    }).toEqual({
+      bare: join(base, "tool.com"),
+      spelled: join(base, "tool.com"),
+      absolute: join(base, "tool.com"),
+      relative: join(base, "tool.com"),
+      dotted_bare: join(base, "dotted.name.exe"),
+      dotted_spelled: join(base, "dotted.name.exe"),
+      custom_absolute: join(base, "custom.bin"),
+      custom_bare: null,
+      custom_no_ext: null,
+      missing: null,
+      system: join(process.env.SystemRoot ?? "C:\\Windows", "System32", "chcp.com").toLowerCase(),
+    });
+  });
+
   // Non-name-surrogate reparse tags (APPEXECLINK) must be treated as existing;
   // only name surrogates (symlinks, mount points) are followed. bun:ffi is
   // unavailable on Windows arm64.

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -47,16 +47,21 @@ if (isWindows) {
   });
 
   // `chcp.com`, `tree.com` and `more.com` live in System32 with no `.exe`
-  // sibling, so `.com` has to be probed like libuv does. A path with a
-  // directory is stat'd as spelled whatever its extension (libuv again), a
-  // bare $PATH name only with an executable extension.
+  // sibling, so `.com` has to be probed like libuv does. It is probed after
+  // every $PATH directory failed `.exe`/`.cmd`/`.bat`, so a later `.exe` wins
+  // over an earlier `.com`. A path with a directory is stat'd as spelled
+  // whatever its extension (libuv again), a bare $PATH name only with an
+  // executable extension.
   test("which finds .com executables, bare or spelled, relative or absolute", () => {
     using dir = tempDir("which-com", {
       "tool.com": "",
       "dotted.name.exe": "",
       "custom.bin": "",
+      "both.com": "",
+      "later/both.exe": "",
     });
     const base = String(dir);
+    const later = join(base, "later");
     expect({
       bare: which("tool", { PATH: base }),
       spelled: which("tool.com", { PATH: base }),
@@ -67,6 +72,8 @@ if (isWindows) {
       custom_absolute: which(join(base, "custom.bin")),
       custom_bare: which("custom.bin", { PATH: base }),
       custom_no_ext: which("custom", { PATH: base }),
+      exe_in_later_dir_wins: which("both", { PATH: `${base};${later}` }),
+      com_alone: which("both", { PATH: base }),
       missing: which("tool.exe", { PATH: base }),
       system: which("chcp")?.toLowerCase(),
     }).toEqual({
@@ -79,6 +86,8 @@ if (isWindows) {
       custom_absolute: join(base, "custom.bin"),
       custom_bare: null,
       custom_no_ext: null,
+      exe_in_later_dir_wins: join(later, "both.exe"),
+      com_alone: join(base, "both.com"),
       missing: null,
       system: join(process.env.SystemRoot ?? "C:\\Windows", "System32", "chcp.com").toLowerCase(),
     });

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -2,7 +2,7 @@ import { $, which } from "bun";
 import { dlopen, ptr } from "bun:ffi";
 import { expect, test } from "bun:test";
 import { isArm64, isIntelMacOS, isWindows, tempDir, tmpdirSync } from "harness";
-import { chmodSync, existsSync, mkdirSync, realpathSync, rmdirSync, rmSync, symlinkSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, realpathSync, rmdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -90,6 +90,27 @@ if (isWindows) {
       com_alone: join(base, "both.com"),
       missing: null,
       system: join(process.env.SystemRoot ?? "C:\\Windows", "System32", "chcp.com").toLowerCase(),
+    });
+  });
+
+  // Spawn resolves like which: a dotted `\` path without an executable
+  // extension still completes to `.cmd`, and a `.com` in the cwd is found
+  // once the $PATH walk failed.
+  test("spawn completes a dotted path to .cmd and finds a .com in the cwd", () => {
+    const chcp = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "chcp.com");
+    using dir = tempDir("which-spawn", { "deploy.prod.cmd": "@echo cmd-ok\r\n" });
+    const base = String(dir);
+    copyFileSync(chcp, join(base, "whichtest.com"));
+    const run = (cmd: string[]) =>
+      Bun.spawnSync(cmd, { cwd: base, stdout: "pipe", stderr: "pipe" }).stdout.toString().trim();
+    expect({
+      which_dotted: which(join(base, "deploy.prod")),
+      spawn_dotted: run([join(base, "deploy.prod")]),
+      spawn_com_in_cwd: run(["whichtest"]),
+    }).toEqual({
+      which_dotted: join(base, "deploy.prod.cmd"),
+      spawn_dotted: "cmd-ok",
+      spawn_com_in_cwd: expect.stringMatching(/\d+$/),
     });
   });
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -729,6 +729,32 @@ describe("execFileSync()", () => {
     });
     expect(result.trim()).toBe("data: hello world!");
   });
+
+  // chcp.com is a PE executable with a .com extension and no .exe sibling.
+  // child_process always passes an env object, so the lookup runs in Bun's
+  // which, not libuv's, and it has to accept the extension as spelled. A PE
+  // named by path runs whatever its extension, as CreateProcessW only reads
+  // the file header.
+  it.if(isWindows)("runs a .com executable by absolute path or bare name", () => {
+    const chcp = path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "chcp.com");
+    expect(chcp).toContain("\\");
+    using dir = tempDir("child-process-com", {});
+    const custom = path.join(String(dir), "chcp-copy.bin");
+    fs.copyFileSync(chcp, custom);
+    const run = (file: string) => execFileSync(file, [], { encoding: "utf8" }).trim();
+    const codePage = expect.stringMatching(/^Active code page: \d+$/);
+    expect({
+      absolute: run(chcp),
+      bare: run("chcp"),
+      spelled: run("chcp.com"),
+      custom_extension: run(custom),
+    }).toEqual({
+      absolute: codePage,
+      bare: codePage,
+      spelled: codePage,
+      custom_extension: codePage,
+    });
+  });
 });
 
 describe("execSync()", () => {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -742,7 +742,9 @@ describe("execFileSync()", () => {
     const custom = path.join(String(dir), "chcp-copy.bin");
     fs.copyFileSync(chcp, custom);
     const run = (file: string) => execFileSync(file, [], { encoding: "utf8" }).trim();
-    const codePage = expect.stringMatching(/^Active code page: \d+$/);
+    // The label is localized ("Active code page", "Aktive Codepage", ...).
+    // Only the number is stable.
+    const codePage = expect.stringMatching(/\d+$/);
     expect({
       absolute: run(chcp),
       bare: run("chcp"),


### PR DESCRIPTION
### Problem
- On Windows, `execFileSync("C:\\Windows\\System32\\chcp.com")` throws `ENOENT: Executable not found in $PATH`. So do the bare names `chcp`, `chcp.com`, `tree` and `more`, through `node:child_process`, `Bun.spawn` and `Bun.which`. Node runs all of them. Bun 1.3.13 ran the `child_process` ones.
- `search_bin` (`src/which/lib.rs`) only stats a name as spelled when it ends in `.exe`, `.cmd` or `.bat`. Every other name gets those three extensions appended and nothing else, so `chcp.com` is never probed: not by bare name, not spelled out, not by absolute path.
- `child_process` used to reach libuv's search because its env object spells the key `Path`. Since #31587 the spawn bindings match that key case-insensitively, so the lookup runs in Bun's search instead.

### Fix
- `get_argv0` hands a `\` path that ends in `.exe`, `.cmd`, `.bat` or `.com` to libuv without a lookup, as it already does for `/` paths. No Bun syscall: libuv stats it once before `CreateProcessW`. Any other `\` path (`C:\scripts\deploy.prod`, `C:\x\tool`) is still completed here, because libuv never appends `.cmd`/`.bat`.
- A bare name is probed with `.exe`/`.cmd`/`.bat` in the cwd and in every `$PATH` directory first, and with `.com` in a second pass (`$PATH`, then cwd) only when all of those failed. A lookup that succeeds today makes the same syscalls as before.
- In `which` itself (`Bun.which`, the shell, `bun run`), a path with a directory is stat'd as spelled for any extension, as libuv does. A bare name keeps the executable-extension allowlist: `bun run` puts the package root on `$PATH`, and `bun run x.ts` from a subdirectory must not spawn `x.ts` from there.
- Verified on Windows x64 with a debug build: `test/js/bun/util/which.test.ts` (lookup rules, `.com` precedence, a dotted path that completes to `.cmd`, a `.com` in the cwd) and `test/js/node/child_process/child_process.test.ts` (the new cases fail on the 1.4.1 canary). Also `bun-run.test.ts`, `spawn.test.ts`, `spawnSync.test.ts`, `spawn-env.test.ts`, `null-byte-injection.test.ts` and the shell `which` test: 616 pass, 0 fail.

### Background
- `bun_which::which_win` is the Windows executable search behind `Bun.which`, `Bun.spawn`, `node:child_process`, the shell and `bun run`. It walks `$PATH` itself and hands the resolved path to `uv_spawn`.
- libuv's `search_path` (`src/win/process.c`) stats a name that carries an extension as spelled, then appends `.com` and `.exe`. It never appends `.cmd` or `.bat`. Bun appends those two on purpose, so npm shims resolve.
- Windows has no executable bit. For a bare name, the extension is the only signal that a `$PATH` entry is a program and not a data file.

<details><summary>Notes</summary>

Repro on the 1.4.1 canary, Windows Server 2019:

```
"chcp"                           ENOENT Executable not found in $PATH
"chcp.com"                       ENOENT
"C:\\Windows\\System32\\chcp.com" ENOENT
"C:/Windows/System32/chcp.com"   runs (no lookup: get_argv0 treats `/` as a path)
Bun.which("chcp")                null
```

Node 26 on the same box runs all five spellings, and also a copy of `chcp.com` renamed to `chcp-copy.bin`, both by absolute path and by bare name from `$PATH`. This PR runs it by path. The bare-name case stays ENOENT, a deliberate trade for `bun run` and `Bun.which` not returning source files (see Fix).

Syscall budget, compared with main: a bare name found in the cwd or `$PATH` makes the same `GetFileAttributesW` calls as before. A bare name found nowhere makes one more per directory plus one for the cwd (the `.com` pass). A `\` path that ends in an executable extension makes none in Bun (before: one, or three that failed for `.com`). Any other `\` path makes up to five instead of three: the name as spelled, then four extensions.

`.com` in an earlier `$PATH` directory loses to `.exe` in a later one. libuv and cmd.exe order by directory first. Both files with the same stem in different `$PATH` directories is not a real layout, and `which.test.ts` pins the choice.

With the pass-through, a missing `C:\x\foo.exe` fails with libuv's `ENOENT ... uv_spawn` instead of Bun's `Executable not found in $PATH`, the same as a `/` path does today.

The new tests are Windows-only. They cannot fail on Linux, where the literal stat and no extension probing already apply.

`cargo clippy -p bun_which` on Windows reports one pre-existing `disallowed_methods` on `std::env::var_os` at `which_for_spawn` (from #31587). Not touched here.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts, test/js/bun/util/which.test.ts

<!-- robobun:evidence:end -->