### PR TITLE
streams: error on a detached chunk instead of consuming it as empty

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -321,6 +321,33 @@ static JSC::JSUint8Array* encodeStringToUint8Array(JSC::VM& vm, JSGlobalObject* 
     RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(resultBuffer), 0, byteLength));
 }
 
+// The bytes of a binary chunk. False (with no exception) for a non-binary chunk; false with the
+// detached-chunk TypeError pending when the chunk's ArrayBuffer has been detached since it was
+// enqueued, so the consumer rejects instead of producing empty output.
+static bool binaryChunkSpan(JSGlobalObject* globalObject, JSValue chunk, std::span<const uint8_t>& out)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
+        if (view->isDetached()) [[unlikely]] {
+            throwDetachedChunkError(globalObject, scope);
+            return false;
+        }
+        out = view->span();
+        return true;
+    }
+    if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
+        auto* impl = jsBuffer->impl();
+        if (!impl || impl->isDetached()) [[unlikely]] {
+            throwDetachedChunkError(globalObject, scope);
+            return false;
+        }
+        out = impl->span();
+        return true;
+    }
+    return false;
+}
+
 static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue chunk, WTF::Vector<uint8_t>& bytes)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -333,24 +360,17 @@ static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue 
         }
         return true;
     }
-    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-        if (!view->isDetached() && !bytes.tryAppend(view->span())) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return false;
-        }
-        return true;
+    std::span<const uint8_t> span;
+    if (!binaryChunkSpan(globalObject, chunk, span)) {
+        RETURN_IF_EXCEPTION(scope, false);
+        throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
+        return false;
     }
-    if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-        if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached()) {
-            if (!bytes.tryAppend(impl->span())) [[unlikely]] {
-                throwOutOfMemoryError(globalObject, scope);
-                return false;
-            }
-        }
-        return true;
+    if (!bytes.tryAppend(span)) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return false;
     }
-    throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
-    return false;
+    return true;
 }
 
 // The N-chunk concatenation shared by toArrayBuffer / toBytes (the concatArrayBuffers /
@@ -382,15 +402,13 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
             continue;
         }
         stringChunks.append({ WTF::String(), 0 });
-        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk))
-            total += view->isDetached() ? 0 : view->byteLength();
-        else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-            auto* impl = jsBuffer->impl();
-            total += (impl && !impl->isDetached()) ? impl->byteLength() : 0;
-        } else {
+        std::span<const uint8_t> span;
+        if (!binaryChunkSpan(globalObject, chunk, span)) {
+            RETURN_IF_EXCEPTION(scope, {});
             throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
             return {};
         }
+        total += span.size();
     }
     if (values.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
@@ -421,14 +439,12 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
             }
             continue;
         }
-        JSValue chunk = values.at(i);
-        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-            if (!view->isDetached())
-                bytes.append(view->span());
-        } else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-            if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
-                bytes.append(impl->span());
-        }
+        // No user code ran since the sizing pass, so the chunk is still a binary chunk and
+        // still attached.
+        std::span<const uint8_t> span;
+        binaryChunkSpan(globalObject, values.at(i), span);
+        RETURN_IF_EXCEPTION(scope, {});
+        bytes.append(span);
     }
     if (asUint8Array) {
         // Buffer-backed from birth: a later `.buffer` access never has to change modes.
@@ -446,21 +462,6 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
         return {};
     }
     return JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(buffer));
-}
-
-static bool binaryChunkSpan(JSValue chunk, std::span<const uint8_t>& out)
-{
-    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-        if (!view->isDetached())
-            out = view->span();
-        return true;
-    }
-    if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-        if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
-            out = impl->span();
-        return true;
-    }
-    return false;
 }
 
 // The toArrayBuffer chunk-array converter (RS:157-206).
@@ -486,7 +487,9 @@ static JSValue convertChunksToArrayBuffer(JSGlobalObject* globalObject, JSValue 
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
         std::span<const uint8_t> span;
-        if (binaryChunkSpan(chunk, span)) {
+        bool isBinary = binaryChunkSpan(globalObject, chunk, span);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (isBinary) {
             auto copied = JSC::ArrayBuffer::tryCreate(span);
             if (!copied) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
@@ -518,7 +521,9 @@ static JSValue convertChunksToBytes(JSGlobalObject* globalObject, JSValue chunks
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
         std::span<const uint8_t> span;
-        if (binaryChunkSpan(chunk, span)) {
+        bool isBinary = binaryChunkSpan(globalObject, chunk, span);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (isBinary) {
             auto copied = JSC::ArrayBuffer::tryCreate(span);
             if (!copied) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
@@ -562,7 +567,9 @@ static JSValue convertChunksToText(JSGlobalObject* globalObject, JSValue chunksV
             RELEASE_AND_RETURN(scope, jsString(vm, stripped));
         }
         std::span<const uint8_t> span;
-        if (binaryChunkSpan(chunk, span)) {
+        bool isBinary = binaryChunkSpan(globalObject, chunk, span);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (isBinary) {
             if (exceedsStringLimit(span.size())) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return {};
@@ -658,16 +665,13 @@ static JSValue textAccumulatorWrite(JSC::VM& vm, JSGlobalObject* globalObject, J
         }
         return jsNumber(length);
     }
-    size_t byteLength = 0;
-    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk))
-        byteLength = view->isDetached() ? 0 : view->byteLength();
-    else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-        auto* impl = jsBuffer->impl();
-        byteLength = impl ? impl->byteLength() : 0;
-    } else {
+    std::span<const uint8_t> span;
+    if (!binaryChunkSpan(globalObject, chunk, span)) {
+        RETURN_IF_EXCEPTION(scope, {});
         throwTypeError(globalObject, scope, "Expected text, ArrayBuffer or ArrayBufferView"_s);
         return {};
     }
+    size_t byteLength = span.size();
     if (byteLength) {
         accumulator.hasBuffer = true;
         JSC::JSString* flushedRope = nullptr;
@@ -1493,6 +1497,19 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToBlobFulfilled, (J
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    // The Blob constructor reads a detached part as empty (WebIDL "get a copy of the bytes"),
+    // which for a stream chunk would hide lost data behind an empty blob.
+    if (auto* chunks = dynamicDowncast<JSArray>(callFrame->argument(0))) {
+        unsigned length = chunks->length();
+        for (unsigned i = 0; i < length; i++) {
+            JSValue chunk = chunks->getIndex(globalObject, i);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (Bun::WebStreams::isDetachedBufferSource(chunk)) [[unlikely]] {
+                Bun::WebStreams::throwDetachedChunkError(globalObject, scope);
+                return {};
+            }
+        }
+    }
     MarkedArgumentBuffer arguments;
     arguments.append(callFrame->argument(0));
     JSObject* blob = JSC::construct(globalObject, defaultGlobalObject(globalObject)->JSBlobConstructor(), arguments, "Blob is not constructible"_s);

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -361,8 +361,9 @@ static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue 
         return true;
     }
     std::span<const uint8_t> span;
-    if (!binaryChunkSpan(globalObject, chunk, span)) {
-        RETURN_IF_EXCEPTION(scope, false);
+    bool isBinary = binaryChunkSpan(globalObject, chunk, span);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!isBinary) {
         throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
         return false;
     }
@@ -403,8 +404,9 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
         }
         stringChunks.append({ WTF::String(), 0 });
         std::span<const uint8_t> span;
-        if (!binaryChunkSpan(globalObject, chunk, span)) {
-            RETURN_IF_EXCEPTION(scope, {});
+        bool isBinary = binaryChunkSpan(globalObject, chunk, span);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!isBinary) {
             throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
             return {};
         }
@@ -666,8 +668,9 @@ static JSValue textAccumulatorWrite(JSC::VM& vm, JSGlobalObject* globalObject, J
         return jsNumber(length);
     }
     std::span<const uint8_t> span;
-    if (!binaryChunkSpan(globalObject, chunk, span)) {
-        RETURN_IF_EXCEPTION(scope, {});
+    bool isBinary = binaryChunkSpan(globalObject, chunk, span);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!isBinary) {
         throwTypeError(globalObject, scope, "Expected text, ArrayBuffer or ArrayBufferView"_s);
         return {};
     }

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1699,8 +1699,13 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundOneShotDirectWrite, (JSGlobalO
     const auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(0));
     if (sink->m_closed)
         return JSValue::encode(jsUndefined());
+    JSValue chunk = callFrame->argument(1);
+    if (Bun::WebStreams::isDetachedBufferSource(chunk)) [[unlikely]] {
+        Bun::WebStreams::throwDetachedChunkError(globalObject, scope);
+        return {};
+    }
     MarkedArgumentBuffer arguments;
-    arguments.append(callFrame->argument(1));
+    arguments.append(chunk);
     RELEASE_AND_RETURN(scope, JSValue::encode(Bun::WebStreams::invokeMethod(vm, globalObject, sink->m_arrayBufferSink.get(), builtinNames(vm).writePublicName(), arguments)));
 }
 

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -321,9 +321,7 @@ static JSC::JSUint8Array* encodeStringToUint8Array(JSC::VM& vm, JSGlobalObject* 
     RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(resultBuffer), 0, byteLength));
 }
 
-// The bytes of a binary chunk. False (with no exception) for a non-binary chunk; false with the
-// detached-chunk TypeError pending when the chunk's ArrayBuffer has been detached since it was
-// enqueued, so the consumer rejects instead of producing empty output.
+// False for a non-binary chunk; false with a TypeError pending for a detached one.
 static bool binaryChunkSpan(JSGlobalObject* globalObject, JSValue chunk, std::span<const uint8_t>& out)
 {
     auto& vm = getVM(globalObject);
@@ -441,8 +439,6 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
             }
             continue;
         }
-        // No user code ran since the sizing pass, so the chunk is still a binary chunk and
-        // still attached.
         std::span<const uint8_t> span;
         binaryChunkSpan(globalObject, values.at(i), span);
         RETURN_IF_EXCEPTION(scope, {});
@@ -1500,8 +1496,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToBlobFulfilled, (J
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // The Blob constructor reads a detached part as empty (WebIDL "get a copy of the bytes"),
-    // which for a stream chunk would hide lost data behind an empty blob.
+    // new Blob() reads a detached part as empty.
     if (auto* chunks = dynamicDowncast<JSArray>(callFrame->argument(0))) {
         unsigned length = chunks->length();
         for (unsigned i = 0; i < length; i++) {

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -899,8 +899,6 @@ static void rsisAbrupt(JSC::VM&, JSGlobalObject*, JSReadStreamIntoSinkOperation*
 static JSValue rsisSinkWrite(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue chunk)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // Both sink paths below read a detached view or buffer as 0 bytes, which would end the
-    // sink successfully with the chunk's data gone.
     if (isDetachedBufferSource(chunk)) [[unlikely]] {
         throwDetachedChunkError(globalObject, scope);
         return {};

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -898,16 +898,23 @@ static void rsisAbrupt(JSC::VM&, JSGlobalObject*, JSReadStreamIntoSinkOperation*
 
 static JSValue rsisSinkWrite(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue chunk)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // Both sink paths below read a detached view or buffer as 0 bytes, which would end the
+    // sink successfully with the chunk's data gone.
+    if (isDetachedBufferSource(chunk)) [[unlikely]] {
+        throwDetachedChunkError(globalObject, scope);
+        return {};
+    }
     if (auto* view = dynamicDowncast<JSArrayBufferView>(chunk)) {
         if (auto* ctrl = dynamicDowncast<WebCore::JSReadableSinkControllerBase>(op->m_sink.get())) {
             if (void* sinkPtr = ctrl->wrapped())
-                return JSValue::decode(Bun__NativeTransformSink__writeBytes(static_cast<uint8_t>(ctrl->sinkId()), sinkPtr, globalObject, static_cast<const uint8_t*>(view->vector()), view->byteLength()));
+                RELEASE_AND_RETURN(scope, JSValue::decode(Bun__NativeTransformSink__writeBytes(static_cast<uint8_t>(ctrl->sinkId()), sinkPtr, globalObject, static_cast<const uint8_t*>(view->vector()), view->byteLength())));
         }
     }
     MarkedArgumentBuffer args;
     args.append(chunk);
     ASSERT(!args.hasOverflowed());
-    return invokeMethod(vm, globalObject, op->m_sink.get(), builtinNames(vm).writePublicName(), args);
+    RELEASE_AND_RETURN(scope, invokeMethod(vm, globalObject, op->m_sink.get(), builtinNames(vm).writePublicName(), args));
 }
 
 static JSValue rsisSinkEnd(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op)

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -232,6 +232,11 @@ static JSValue writeToArraySink(JSGlobalObject* globalObject, JSDirectStreamCont
 
 static JSValue writeToDirectSink(JSGlobalObject* globalObject, JSDirectStreamController* controller, JSValue chunk)
 {
+    if (Bun::WebStreams::isDetachedBufferSource(chunk)) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+        Bun::WebStreams::throwDetachedChunkError(globalObject, scope);
+        return {};
+    }
     switch (controller->m_sinkKind) {
     case DirectSinkKind::ArrayBuffer:
         return writeToArrayBufferSink(globalObject, controller, chunk);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -284,13 +284,15 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
             String string = asString(value)->value(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             appended = Bun::WebStreams::appendUTF8WithinStringLimit(string, bytes);
+        } else if (Bun::WebStreams::isDetachedBufferSource(value)) [[unlikely]] {
+            // The sink holds the chunk instead of copying it at write(); the bytes write()
+            // counted are gone.
+            Bun::WebStreams::throwDetachedChunkError(globalObject, scope);
+            return String();
         } else if (auto* view = dynamicDowncast<JSArrayBufferView>(value)) {
-            if (!view->isDetached())
-                appended = bytes.tryAppend(view->span());
+            appended = bytes.tryAppend(view->span());
         } else if (auto* buffer = dynamicDowncast<JSArrayBuffer>(value)) {
-            auto* impl = buffer->impl();
-            if (impl && !impl->isDetached())
-                appended = bytes.tryAppend(impl->span());
+            appended = bytes.tryAppend(buffer->impl()->span());
         }
         if (!appended) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -285,8 +285,7 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
             RETURN_IF_EXCEPTION(scope, {});
             appended = Bun::WebStreams::appendUTF8WithinStringLimit(string, bytes);
         } else if (Bun::WebStreams::isDetachedBufferSource(value)) [[unlikely]] {
-            // The sink holds the chunk instead of copying it at write(); the bytes write()
-            // counted are gone.
+            // write() kept a reference, not a copy; the bytes it counted are gone.
             Bun::WebStreams::throwDetachedChunkError(globalObject, scope);
             return String();
         } else if (auto* view = dynamicDowncast<JSArrayBufferView>(value)) {

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1027,17 +1027,17 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
         return;
-    // WebIDL "get a copy of the bytes held by the buffer source": a detached
-    // buffer is still a BufferSource whose bytes are the empty sequence.
     std::span<const uint8_t> bytes;
-    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-        if (!view->isDetached())
-            bytes = view->span();
-    } else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-        if (buffer->impl() && !buffer->impl()->isDetached())
-            bytes = buffer->impl()->span();
-    } else {
-        auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not a BufferSource"_s);
+    JSObject* error = nullptr;
+    if (isDetachedBufferSource(chunk)) [[unlikely]]
+        error = createDetachedChunkError(globalObject);
+    else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk))
+        bytes = view->span();
+    else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk))
+        bytes = buffer->impl()->span();
+    else
+        error = createTypeError(globalObject, "Body.textStream() received a chunk that is not a BufferSource"_s);
+    if (error) {
         RETURN_IF_EXCEPTION(scope, void());
         // Error the output first so any second pending TextDecode read request's
         // closeSteps (fired by cancelling the source) no-ops on canCloseOrEnqueue.

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -126,8 +126,7 @@ bool isNonNegativeNumber(JSC::JSValue); // userJS: no — WebStreamsMisc.cpp
 RefPtr<JSC::ArrayBuffer> transferArrayBufferImpl(JSC::JSGlobalObject*, JSC::ArrayBuffer&); // userJS: no — WebStreamsMisc.cpp
 bool canTransferArrayBuffer(JSC::ArrayBuffer&); // userJS: no — WebStreamsMisc.cpp
 // spec CanTransferArrayBuffer(O) — pure.
-// An ArrayBuffer / ArrayBufferView chunk whose buffer was detached (transferred, or a
-// WebAssembly.Memory that grew). Native consumers error on it instead of reading 0 bytes. Pure.
+// An ArrayBuffer / ArrayBufferView chunk whose buffer was detached (transfer, Memory.grow). Pure.
 bool isDetachedBufferSource(JSC::JSValue chunk); // userJS: no — WebStreamsMisc.cpp
 JSC::JSObject* createDetachedChunkError(JSC::JSGlobalObject*); // userJS: no — WebStreamsMisc.cpp
 void throwDetachedChunkError(JSC::JSGlobalObject*, JSC::ThrowScope&); // userJS: no — WebStreamsMisc.cpp

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -126,6 +126,14 @@ bool isNonNegativeNumber(JSC::JSValue); // userJS: no — WebStreamsMisc.cpp
 RefPtr<JSC::ArrayBuffer> transferArrayBufferImpl(JSC::JSGlobalObject*, JSC::ArrayBuffer&); // userJS: no — WebStreamsMisc.cpp
 bool canTransferArrayBuffer(JSC::ArrayBuffer&); // userJS: no — WebStreamsMisc.cpp
 // spec CanTransferArrayBuffer(O) — pure.
+// An ArrayBuffer / ArrayBufferView chunk whose backing store has been detached (transferred,
+// or a WebAssembly.Memory that grew) has no bytes left. Every native consumer that copies
+// chunk bytes out of a stream errors on one instead of reading it as empty, which would
+// silently drop the producer's data. Pure.
+bool isDetachedBufferSource(JSC::JSValue chunk); // userJS: no — WebStreamsMisc.cpp
+// The TypeError those consumers throw (or error the stream with) for such a chunk.
+JSC::JSObject* createDetachedChunkError(JSC::JSGlobalObject*); // userJS: no — WebStreamsMisc.cpp
+void throwDetachedChunkError(JSC::JSGlobalObject*, JSC::ThrowScope&); // userJS: no — WebStreamsMisc.cpp
 // spec CloneAsUint8Array(O) — allocation-throws only.
 JSC::JSUint8Array* cloneAsUint8Array(JSC::JSGlobalObject*, JSC::JSArrayBufferView*); // userJS: no — WebStreamsMisc.cpp
 // spec StructuredClone(v): no caller — every tee path passes cloneForBranch2 = false.

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -126,12 +126,9 @@ bool isNonNegativeNumber(JSC::JSValue); // userJS: no — WebStreamsMisc.cpp
 RefPtr<JSC::ArrayBuffer> transferArrayBufferImpl(JSC::JSGlobalObject*, JSC::ArrayBuffer&); // userJS: no — WebStreamsMisc.cpp
 bool canTransferArrayBuffer(JSC::ArrayBuffer&); // userJS: no — WebStreamsMisc.cpp
 // spec CanTransferArrayBuffer(O) — pure.
-// An ArrayBuffer / ArrayBufferView chunk whose backing store has been detached (transferred,
-// or a WebAssembly.Memory that grew) has no bytes left. Every native consumer that copies
-// chunk bytes out of a stream errors on one instead of reading it as empty, which would
-// silently drop the producer's data. Pure.
+// An ArrayBuffer / ArrayBufferView chunk whose buffer was detached (transferred, or a
+// WebAssembly.Memory that grew). Native consumers error on it instead of reading 0 bytes. Pure.
 bool isDetachedBufferSource(JSC::JSValue chunk); // userJS: no — WebStreamsMisc.cpp
-// The TypeError those consumers throw (or error the stream with) for such a chunk.
 JSC::JSObject* createDetachedChunkError(JSC::JSGlobalObject*); // userJS: no — WebStreamsMisc.cpp
 void throwDetachedChunkError(JSC::JSGlobalObject*, JSC::ThrowScope&); // userJS: no — WebStreamsMisc.cpp
 // spec CloneAsUint8Array(O) — allocation-throws only.

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -172,6 +172,29 @@ bool canTransferArrayBuffer(JSC::ArrayBuffer& buffer)
     return !buffer.isDetached() && buffer.isDetachable();
 }
 
+bool isDetachedBufferSource(JSValue chunk)
+{
+    if (auto* view = dynamicDowncast<JSArrayBufferView>(chunk))
+        return view->isDetached();
+    if (auto* buffer = dynamicDowncast<JSArrayBuffer>(chunk)) {
+        auto* impl = buffer->impl();
+        return !impl || impl->isDetached();
+    }
+    return false;
+}
+
+static constexpr ASCIILiteral detachedChunkMessage = "Cannot read a ReadableStream chunk whose ArrayBuffer has been detached"_s;
+
+JSObject* createDetachedChunkError(JSGlobalObject* globalObject)
+{
+    return createTypeError(globalObject, detachedChunkMessage);
+}
+
+void throwDetachedChunkError(JSGlobalObject* globalObject, ThrowScope& scope)
+{
+    throwTypeError(globalObject, scope, detachedChunkMessage);
+}
+
 // spec TransferArrayBuffer(O) = ArrayBufferCopyAndDetach(O, undefined, fixed-length):
 // resizability must NOT survive the transfer, or a later user resize() invalidates every
 // byte length the byte controller recorded. No JSArrayBuffer wrapper cell is created.

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -530,7 +530,7 @@ for (const { body, fn } of bodyTypes) {
         }).toThrow(TypeError);
         expect(cancelled).toBeInstanceOf(TypeError);
       });
-      test("treats a detached BufferSource chunk as empty", async () => {
+      test("errors on a detached BufferSource chunk instead of decoding it as empty", async () => {
         const view = new Uint8Array([0x68, 0x69]);
         structuredClone(view, { transfer: [view.buffer] });
         const input = new ReadableStream({
@@ -540,7 +540,12 @@ for (const { body, fn } of bodyTypes) {
             controller.close();
           },
         });
-        expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("!");
+        await expect(Array.fromAsync(fn(input).textStream())).rejects.toThrow(
+          expect.objectContaining({
+            name: "TypeError",
+            message: "Cannot read a ReadableStream chunk whose ArrayBuffer has been detached",
+          }),
+        );
       });
       test("accepts raw ArrayBuffer chunks from a ReadableStream body", async () => {
         const input = new ReadableStream({

--- a/test/js/web/fetch/stream-fast-path.test.ts
+++ b/test/js/web/fetch/stream-fast-path.test.ts
@@ -21,6 +21,10 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
     structuredClone(buf, { transfer: [buf] });
     return buf;
   };
+  const detachedChunkError = expect.objectContaining({
+    name: "TypeError",
+    message: "Cannot read a ReadableStream chunk whose ArrayBuffer has been detached",
+  });
 
   describe.each([
     ["Response.bytes()", (s: ReadableStream) => new Response(s).bytes()],
@@ -76,12 +80,9 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       expect(backing[100]).toBe(0x11);
     });
 
-    test("detached chunk yields a fresh empty result", async () => {
+    test("detached chunk rejects", async () => {
       const src = detached();
-      const out = await consume(one(src));
-      expect(out.buffer).not.toBe(src);
-      expect(out.byteLength).toBe(0);
-      expect(out.buffer.detached).toBe(false);
+      await expect(async () => consume(one(src))).toThrow(detachedChunkError);
     });
 
     test("transferring the result does not detach the producer", async () => {
@@ -148,13 +149,9 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       expect(backing[100]).toBe(0x11);
     });
 
-    test("detached chunk yields a fresh empty result", async () => {
+    test("detached chunk rejects", async () => {
       const src = detached();
-      const out = await consume(one(src));
-      expect(out).toBeInstanceOf(ArrayBuffer);
-      expect(out).not.toBe(src);
-      expect(out.byteLength).toBe(0);
-      expect((out as ArrayBuffer).detached).toBe(false);
+      await expect(async () => consume(one(src))).toThrow(detachedChunkError);
     });
 
     test("transferring the result does not detach the producer", async () => {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1417,6 +1417,25 @@ describe("a chunk whose ArrayBuffer is detached after it was enqueued", () => {
     await expect(Bun.readableStreamToText(stream)).rejects.toThrow(detachedError);
   });
 
+  it("a direct stream's controller.write() rejects a chunk that is already detached", async () => {
+    const directSource = () => {
+      const chunk = new Uint8Array([104, 105]);
+      structuredClone(chunk.buffer, { transfer: [chunk.buffer] });
+      return new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          controller.write(chunk);
+          controller.close();
+        },
+      });
+    };
+    await expect(Bun.readableStreamToText(directSource())).rejects.toThrow(detachedError);
+    await expect(Bun.readableStreamToArrayBuffer(directSource())).rejects.toThrow(detachedError);
+    await expect(Bun.readableStreamToBytes(directSource())).rejects.toThrow(detachedError);
+    await expect(Bun.readableStreamToBlob(directSource())).rejects.toThrow(detachedError);
+    await expect(new Response(directSource()).text()).rejects.toThrow(detachedError);
+  });
+
   it("Bun.serve reports the error instead of silently sending an empty body", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1323,10 +1323,133 @@ describe("multi-chunk consumers produce exactly the concatenated bytes", () => {
     // The chunk array is available synchronously, so the failure is synchronous too.
     expect(() => Bun.readableStreamToBytes(source([new Uint8Array([9]), chunk]))).toThrow(
       expect.objectContaining({
-        code: "ERR_INVALID_STATE",
-        message: "Invalid state: Cannot validate on a detached buffer",
+        name: "TypeError",
+        message: "Cannot read a ReadableStream chunk whose ArrayBuffer has been detached",
       }),
     );
+  });
+});
+
+describe("a chunk whose ArrayBuffer is detached after it was enqueued", () => {
+  const message = "Cannot read a ReadableStream chunk whose ArrayBuffer has been detached";
+  const detachedError = expect.objectContaining({ name: "TypeError", message });
+
+  // The producer enqueues a view, then transfers its buffer away (a WebAssembly.Memory.grow()
+  // detaches the same way). The chunk the consumer dequeues has no bytes left, so reading it as
+  // empty would report success for a body whose data is gone.
+  const detachedSource = (...before) =>
+    new ReadableStream({
+      pull(controller) {
+        const chunk = new Uint8Array(65536).fill(7);
+        for (const other of before) controller.enqueue(other);
+        controller.enqueue(chunk);
+        structuredClone(chunk.buffer, { transfer: [chunk.buffer] });
+        controller.close();
+      },
+    });
+
+  it("Bun.readableStreamTo* reject", async () => {
+    await expect(Bun.readableStreamToArrayBuffer(detachedSource())).rejects.toThrow(detachedError);
+    await expect(Bun.readableStreamToBytes(detachedSource())).rejects.toThrow(detachedError);
+    await expect(Bun.readableStreamToText(detachedSource())).rejects.toThrow(detachedError);
+    await expect(Bun.readableStreamToBlob(detachedSource())).rejects.toThrow(detachedError);
+    await expect(Bun.readableStreamToJSON(detachedSource())).rejects.toThrow(detachedError);
+  });
+
+  it("Response and Request body consumers reject", async () => {
+    await expect(new Response(detachedSource()).arrayBuffer()).rejects.toThrow(detachedError);
+    await expect(new Response(detachedSource()).bytes()).rejects.toThrow(detachedError);
+    await expect(new Response(detachedSource()).text()).rejects.toThrow(detachedError);
+    await expect(new Response(detachedSource()).blob()).rejects.toThrow(detachedError);
+    await expect(new Response(detachedSource()).json()).rejects.toThrow(detachedError);
+    const request = new Request("http://localhost/", { method: "POST", body: detachedSource(), duplex: "half" });
+    await expect(request.arrayBuffer()).rejects.toThrow(detachedError);
+  });
+
+  it("the detached chunk is found among attached chunks too", async () => {
+    // Two binary chunks and a string before the detached one take the concatenation and the
+    // mixed text paths instead of the single-chunk path.
+    await expect(new Response(detachedSource(new Uint8Array([1, 2]))).arrayBuffer()).rejects.toThrow(detachedError);
+    await expect(new Response(detachedSource("ab")).bytes()).rejects.toThrow(detachedError);
+    await expect(new Response(detachedSource(new Uint8Array([1, 2]))).text()).rejects.toThrow(detachedError);
+    await expect(new Response(detachedSource("ab")).text()).rejects.toThrow(detachedError);
+  });
+
+  it("Response.textStream() errors", async () => {
+    const reader = new Response(detachedSource()).textStream().getReader();
+    await expect(reader.read()).rejects.toThrow(detachedError);
+  });
+
+  it("Bun.write(path, Response) rejects", async () => {
+    using dir = tempDir("detached-chunk", {});
+    await expect(Bun.write(join(String(dir), "out.bin"), new Response(detachedSource()))).rejects.toThrow(
+      detachedError,
+    );
+  });
+
+  it("fetch() with a streaming request body rejects", async () => {
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        return new Response(String((await req.arrayBuffer()).byteLength));
+      },
+    });
+    await expect(fetch(server.url, { method: "POST", body: detachedSource(), duplex: "half" })).rejects.toThrow(
+      detachedError,
+    );
+  });
+
+  it("HTMLRewriter.transform() rejects", async () => {
+    const transformed = new HTMLRewriter().transform(new Response(detachedSource()));
+    await expect(transformed.arrayBuffer()).rejects.toThrow(detachedError);
+  });
+
+  it("a direct stream's text consumer rejects when a written chunk is detached before close()", async () => {
+    const chunk = new Uint8Array([104, 105]);
+    const stream = new ReadableStream({
+      type: "direct",
+      pull(controller) {
+        controller.write(chunk);
+        structuredClone(chunk.buffer, { transfer: [chunk.buffer] });
+        controller.close();
+      },
+    });
+    await expect(Bun.readableStreamToText(stream)).rejects.toThrow(detachedError);
+  });
+
+  it("Bun.serve reports the error instead of silently sending an empty body", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        using server = Bun.serve({
+          port: 0,
+          fetch() {
+            const chunk = new Uint8Array(65536).fill(7);
+            return new Response(
+              new ReadableStream({
+                pull(controller) {
+                  controller.enqueue(chunk);
+                  structuredClone(chunk.buffer, { transfer: [chunk.buffer] });
+                  controller.close();
+                },
+              }),
+            );
+          },
+        });
+        const response = await fetch(server.url);
+        console.log(JSON.stringify({ bytes: (await response.arrayBuffer()).byteLength }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(message);
+    expect(JSON.parse(stdout)).toEqual({ bytes: 0 });
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem
- A `ReadableStream` chunk whose `ArrayBuffer` is detached after `enqueue()` (a `structuredClone` transfer, or a `WebAssembly.Memory.grow()`) is read as 0 bytes by every native consumer. `Bun.serve` answers `200` with an empty body, `fetch(url, { body: stream })` uploads 0 bytes, `Response(stream).arrayBuffer()` resolves to 0 bytes, `Bun.write`, `Bun.spawn({ stdin })`, `HTMLRewriter.transform` and `Bun.readableStreamTo*` all report success with the data gone. Node rejects with a `TypeError` in every equivalent consumer.
- The cause is the chunk extraction code. `rsisSinkWrite` (`BunStreamSource.cpp:899`) hands the detached view's null vector and 0 length to the sink. `appendChunkBytes`, `concatenateChunks`, `binaryChunkSpan` and `textAccumulatorWrite` (`BunStreamConsumers.cpp:324` to `466`) each test `isDetached()` and count 0 bytes. Only the all-binary multi-chunk path already threw, as `Error [ERR_INVALID_STATE]` from `Bun.concatArrayBuffers`.

### Fix
- Add `isDetachedBufferSource` and `throwDetachedChunkError` (`WebStreamsMisc.cpp`). A detached chunk now throws `TypeError: Cannot read a ReadableStream chunk whose ArrayBuffer has been detached`.
- Apply it where bytes leave a chunk: the `readStreamIntoSink` pump (so the pump rejects, cancels the source and closes the sink with the error), the `readableStreamTo*` and `Body` consumers including `blob()`, `Body.textStream()`, and a `type: "direct"` stream's `controller.write()` (plus its text sink, when a chunk it holds is detached before `close()`).
- Correct because a detached buffer has no bytes left to copy. The spec's "bytes represented by chunk" is undefined for it, and reading it as empty hides lost data behind a success status. `TextDecoderStream` and `new Blob([...])` keep their WebIDL behavior (a detached `BufferSource` is empty); they are not stream consumers.
- Verified: `test/js/web/streams/streams.test.js` (11 new or updated tests fail on stock bun), `test/js/web/fetch/body.test.ts` and `test/js/web/fetch/stream-fast-path.test.ts`. Also `test/js/web/streams/`, `body-stream.test.ts`, `serve.test.ts`, `serve-direct-readable-stream.test.ts`, `spawn-stdin-readable-stream.test.ts`, `html-rewriter.test.js`, `filesink.test.ts`, `arraybuffersink.test.ts`.

### Background
- A default `ReadableStream` does not copy chunks on `enqueue()`. The consumer dequeues the same `Uint8Array` the producer created. If the producer transfers that buffer before the consumer reads it, JSC zeroes the view's length and nulls its vector. `isDetached()` is the only sign that data was there.
- `readStreamIntoSink` (`BunStreamSource.cpp`) is the one pump that feeds every native sink: the HTTP response sinks, `FetchRequestBodySink`, `FileSink`, `NetworkSink` (S3), the HTMLRewriter pipe. Its `rsisSinkWrite` copies each chunk into the sink. A throw there goes to `rsisAbrupt`, the pump's catch path.
- `BunStreamConsumers.cpp` backs `Bun.readableStreamTo*` and the `Body` methods. It collects all chunks into an array, then converts them in one pass. The conversion runs no user code, so a chunk that is attached at the start of the pass stays attached.
- `Bun.serve` already logs a stream error and ends the response. After this change a detached chunk takes that same path. The status is still `200` when nothing was flushed yet. Whether the server should answer `500` in that case is a separate question.

<details><summary>Notes</summary>

- `Bun.readableStreamToArray()` and `reader.read()` still return the detached view itself. They hand chunks to JS unchanged, as Node does.
- Before this change: 1 chunk, or a string mixed with binary chunks, was silent. 2 or more all-binary chunks threw `Error [ERR_INVALID_STATE] Invalid state: Cannot validate on a detached buffer` from `Bun.concatArrayBuffers`. The updated test "a detached chunk throws" covers that case with the new `TypeError`.
- `test/js/web/fetch/body.test.ts` had a test "treats a detached BufferSource chunk as empty" for `textStream()`. It was added on a review suggestion to match `pipeThrough(new TextDecoderStream())`. This PR flips it to the error, so `textStream()` agrees with `text()`. `TextDecoderStream` itself is unchanged.
- The buffer consumers (`arrayBuffer()`, `bytes()`) throw synchronously when the chunk array is already complete, and reject otherwise. That is pre-existing (the code comments it as deliberate) and applies to the new error the same way. Text consumers always reject.
- `Bun.spawn({ stdin: stream })` swallows the pump's rejection today, as it does for any stream error. The child sees EOF and the error is not reported.
- `test/js/web/fetch/stream-fast-path.test.ts` asserted that a single detached chunk yields a fresh empty result (the 1.4.0 fix for returning the caller's detached buffer). It now asserts the rejection.
- A direct stream piped straight into a native sink (`Bun.serve`, `Bun.write`, fetch upload) hands that sink to `pull()` as the controller. Its `write()` is the sink API (`ArrayBufferSink.write()`, `FileSink.write()`): a detached input writes 0 bytes and returns 0, unchanged here. The in-process direct consumers (`text()`, `arrayBuffer()`, `bytes()`, `blob()`) reject it.
- Local failures in `serve.test.ts` (4) and `fetch.test.ts` are environment only (IPv6, `localhost` resolution, root port binding, egress proxy). They fail the same way with stock bun.
- The ASAN debug build times out `streams-leak.test.ts` "reading and writing to a pipe" and `bun-write.test.js` "copyFileRange ... large files" at 5 s both with and without this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js, test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->
