### PR TITLE
resolver: bust the real-path alias of a symlinked directory with the dir cache

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2445,12 +2445,9 @@ impl<'a> Resolver<'a> {
     /// See `assertValidCacheKey` for requirements on the input
     pub fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
         Self::assert_valid_cache_key(path);
-        // A directory reached through a symlink is cached under two keys: the
-        // path as given and its real path (`DirInfo.abs_real_path`). Resolving
-        // a file in it returns the realpath'd result, which a follow-up
-        // resolve looks up under the real-path key. Bust that alias too, or it
-        // keeps serving a stale listing after this bust. Read the alias before
-        // `remove` drops the `DirInfo`.
+        // A symlinked directory is also cached under its real path
+        // (`DirInfo.abs_real_path`), and resolve results are realpath'd, so a
+        // follow-up resolve reads the real-path key. Bust that alias too.
         let real_path: Option<&'static [u8]> = self
             .dir_cache_mut()
             .get(path)

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2445,16 +2445,38 @@ impl<'a> Resolver<'a> {
     /// See `assertValidCacheKey` for requirements on the input
     pub fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
         Self::assert_valid_cache_key(path);
+        // A directory reached through a symlink is cached under two keys: the
+        // path as given and its real path (`DirInfo.abs_real_path`). Resolving
+        // a file in it returns the realpath'd result, which a follow-up
+        // resolve looks up under the real-path key. Bust that alias too, or it
+        // keeps serving a stale listing after this bust. Read the alias before
+        // `remove` drops the `DirInfo`.
+        let real_path: Option<&'static [u8]> = self
+            .dir_cache_mut()
+            .get(path)
+            .map(|info| {
+                bun_paths::string_paths::without_trailing_slash_windows_path(info.abs_real_path)
+            })
+            .filter(|real| !real.is_empty() && *real != path);
         let first_bust = self.fs_mut().fs.bust_entries_cache(path);
         let second_bust = self.dir_cache_mut().remove(path);
+        let alias_bust = match real_path {
+            Some(real) => {
+                let a = self.fs_mut().fs.bust_entries_cache(real);
+                let b = self.dir_cache_mut().remove(real);
+                a || b
+            }
+            None => false,
+        };
         bun_core::scoped_log!(
             ResolverDev,
-            "Bust {} = {}, {}",
+            "Bust {} = {}, {}, alias {}",
             bstr::BStr::new(path),
             first_bust,
-            second_bust
+            second_bust,
+            alias_bust
         );
-        first_bust || second_bust
+        first_bust || second_bust || alias_bust
     }
 
     /// bust both the named file and a parent directory, because `./hello` can resolve

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2454,9 +2454,7 @@ impl<'a> Resolver<'a> {
         let real_path: Option<&'static [u8]> = self
             .dir_cache_mut()
             .get(path)
-            .map(|info| {
-                bun_paths::string_paths::without_trailing_slash_windows_path(info.abs_real_path)
-            })
+            .map(|info| strings::without_trailing_slash_windows_path(info.abs_real_path))
             .filter(|real| !real.is_empty() && *real != path);
         let first_bust = self.fs_mut().fs.bust_entries_cache(path);
         let second_bust = self.dir_cache_mut().remove(path);

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -899,6 +899,52 @@ describe.if(isWindows)("#30839 - imports entry pointing at a scoped package", ()
   });
 });
 
+// A directory reached through a symlink is cached under two keys: the symlink
+// path and its real path. Requiring a file in it caches both listings; when a
+// sibling file is created afterwards, only the symlink-side key was busted, so
+// the follow-up resolve of the realpath'd result hit a stale listing and
+// failed with "Cannot find module ... from ''". macOS always hits this because
+// os.tmpdir() is behind the /var -> /private/var symlink.
+// https://github.com/oven-sh/bun/issues/40585
+it("requires a newly created sibling .ts file in a directory behind a symlink", async () => {
+  using dir = tempDir("resolve-symlink-alias", {
+    "main.ts": `
+      import { mkdir, writeFile } from "node:fs/promises";
+      import { createRequire } from "node:module";
+      import { join } from "node:path";
+      import { pathToFileURL } from "node:url";
+
+      const dir = join(import.meta.dir, "link", "warm");
+      await mkdir(dir, { recursive: true });
+      const a = join(dir, "a.ts");
+      await writeFile(a, "export const A = 1;\\n");
+      createRequire(pathToFileURL(a).href)(a);
+      const b = join(dir, "b.ts");
+      await writeFile(b, "export const B = 2;\\n");
+      const result = createRequire(pathToFileURL(b).href)(b);
+      console.log(JSON.stringify(result));
+    `,
+  });
+  const root = String(dir);
+  mkdirSync(join(root, "real"));
+  // The symlink must exist before the child process starts, like /var on
+  // macOS. "junction" is the Windows-appropriate symlink kind for directories.
+  symlinkSync(join(root, "real"), join(root, "link"), "junction");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe('{"B":2}\n');
+  expect(exitCode).toBe(0);
+});
+
 // dirInfoCachedMaybeLog reads the rfs.entries cache without checking the union
 // tag. If readDirectory() previously failed with a non-ENOENT error (e.g.
 // EACCES), a `.err` variant is stored there; re-resolving the directory after


### PR DESCRIPTION
### Problem

- The first `require()` or `import()` of a newly created sibling `.ts` file fails with `Cannot find module '...' from ''` when the directory sits behind a symlink. macOS always hits this because `os.tmpdir()` is behind `/var -> /private/var`. Fixes #40585.
- The resolver caches a symlinked directory under two keys: the symlink path and its real path (`DirInfo.abs_real_path`). `bust_dir_cache` (`src/resolver/resolver.rs:2446`) only invalidated the key it was given, so the real-path key kept a stale listing taken before the new file existed.

### Fix

- `bust_dir_cache` now reads `abs_real_path` from the cached `DirInfo` before it removes the entry. If the alias differs from the given path, it busts the alias's entries cache and dir cache too.
- This is correct because the two keys name the same physical directory. An invalidation of one without the other leaves the cache inconsistent, and the resolver hands realpath'd results to follow-up resolves that look up the real-path key.
- The alias lookup is one dir-cache `get` per bust. A real directory has an empty `abs_real_path`, so the common case does no extra work.
- Verified: `test/js/bun/resolve/resolve.test.ts` (new test, fails on stock bun). Also the full `test/js/bun/resolve/` suite and `test/cli/hot/`.

### Background

- The failure needs two resolve stages. `require(b.ts)` resolves the symlink path, and the retry logic busts the symlink-side key and finds the file. The resolver returns the realpath'd result. The module loader then resolves that result with an empty referrer, which has no retry, and it hits the stale real-path listing.
- The bug fires once per process per directory pairing. Later attempts skip the realpath step (the parent's cached listing does not contain the new temp directory, so the symlink chain is not detected), so they never consult the real-path key.
- The symlink must exist before the process starts. A symlink created in-process is absent from the already-cached parent listing, so no realpathing happens. That is why `/var` on macOS reproduces it deterministically and a plain `/tmp` path on linux does not.

<details><summary>Notes</summary>

Reproduction on linux needs a stand-in for the macOS `/var` symlink, created before bun starts:

```sh
mkdir -p /tmp/private-root && ln -s /tmp/private-root /tmp/var-link
```

Then the issue's verbatim repro script fails on attempt 1 and passes on attempts 2 and 3, matching the report:

```
attempt1 FAILED ResolveMessage: Cannot find module '/tmp/private-root/probe-warm-XXX/b.ts' from ''
attempt2 ok {"B":2}
attempt3 ok {"B":2}
```

Resolver trace (`BUN_DEBUG_RESOLVER=1`) for attempt 1:

```
resolve(/tmp/var-link/W/a.ts, require-call) = /tmp/private-root/W/a.ts
resolve(/tmp/private-root/W/a.ts, from: ./) = /tmp/private-root/W/a.ts   <- caches real-path listing {a.ts}
Bust /tmp/var-link/W = true, true                                        <- retry bust, symlink key only
resolve(/tmp/var-link/W/b.ts, require-call) = /tmp/private-root/W/b.ts
FAILED: Cannot find module '/tmp/private-root/W/b.ts' from ''            <- stale real-path listing
```

The second-stage resolve has referrer `''`, so `retry_on_not_found` in `VirtualMachine::resolve` is false (`is_absolute(source_to_use)` fails) and no bust-and-retry happens there. Fixing the bust to cover the alias repairs every bust call site (VM retry, hot reloader, dev server, filesystem router) in one place.

`test/js/bun/resolve/load-same-js-file-a-lot.test.ts` ("load the same empty JS file 2000 times") times out at 5s in the local debug+ASAN run both with and without this diff. It is a pre-existing debug-build timeout, not related.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->