### PR TITLE
test: measure the websocket blob frame size with estimateShallowMemoryUsageOf

### DIFF
--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,6 +1,6 @@
 import type { Server, ServerWebSocket, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
-import { heapStats } from "bun:jsc";
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { afterEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, forceGuardMalloc, isWindows, tempDir } from "harness";
 import net, { isIP } from "node:net";
@@ -921,7 +921,7 @@ describe("ServerWebSocket", () => {
         },
       };
     });
-    it("blob frames report their bytes to the garbage collector", async () => {
+    it.concurrent("blob frames report their bytes to the garbage collector", async () => {
       const { promise, resolve, reject } = Promise.withResolvers<Blob>();
       using server = serve({
         port: 0,
@@ -942,25 +942,16 @@ describe("ServerWebSocket", () => {
           },
         },
       });
-      // Stays alive until the end, so it is part of both measurements.
       const payload = new Uint8Array(2 * 1024 * 1024);
-      let before = 0;
       const client = new WebSocket(`ws://${server.hostname}:${server.port}`);
       client.onerror = () => reject(new Error("client error"));
-      client.onopen = () => {
-        // Both sockets exist at this point, so only the transfer separates the two measurements.
-        Bun.gc(true);
-        before = heapStats().extraMemorySize;
-        client.send(payload);
-      };
+      client.onopen = () => client.send(payload);
       try {
         const blob = await promise;
-        Bun.gc(true);
-        const reported = heapStats().extraMemorySize - before;
         expect(blob.size).toBe(payload.byteLength);
-        // Without the report this is close to 0. Memory that earlier tests release in the
-        // meantime lowers the number a little, so half the payload is the bound.
-        expect(reported).toBeGreaterThanOrEqual(payload.byteLength / 2);
+        // The same size that the blob reports to the GC when it is marked. Without the
+        // report it is the size of the wrapper, a few hundred bytes.
+        expect(estimateShallowMemoryUsageOf(blob)).toBeGreaterThanOrEqual(payload.byteLength);
       } finally {
         client.close();
       }


### PR DESCRIPTION
### Problem
- `test/js/bun/websocket/websocket-server.test.ts`, "blob frames report their bytes to the garbage collector", fails in the parallel batch and passes alone. `expect(reported).toBeGreaterThanOrEqual(1048576)` received -3523648, -3261187, -2068669, -1811053 and -827108 in one build on five lanes.
- The test compared `heapStats().extraMemorySize` before and after a 2 MiB transfer. That number covers the whole heap. With `--parallel`, the worker process runs other test files before this one (the failing batch had `websocket-server-backpressure-buffer.test.ts` and `zstd-large-decompression.test.ts`). Their teardown frees GC-visible memory between the two measurements, so the delta goes negative.

### Fix
- Assert `estimateShallowMemoryUsageOf(blob) >= payload.byteLength` instead. It reads the same `Blob__estimatedSize` value that `JSBlob::visitChildren` hands to `reportExtraMemoryVisited`, so it still checks that the frame bytes reach the GC, and nothing outside the blob can move it.
- The two `Bun.gc(true)` calls and the baseline go away. The test becomes `it.concurrent` like the rest of the block, since it no longer needs a quiet heap.
- Verified: `bun bd test test/js/bun/websocket/websocket-server.test.ts -t binaryType` (9 pass, three runs). The whole file shows the same result before and after the change on this debug build. `estimateShallowMemoryUsageOf(blob)` is 2097464 on bun 1.4.1 for a 2 MiB frame, so the wrapper is 312 bytes.

### Background
- `heapStats().extraMemorySize` is `Heap::extraMemorySize()`: the extra memory of every cell marked in the last full collection plus the live `ArrayBuffer` bytes. A full `Bun.gc(true)` recomputes it from scratch, so anything that died in between lowers it.
- `estimateShallowMemoryUsageOf` (`bun:jsc`) calls `JSCell::estimatedSizeInBytes`, which for a generated class is `Base::estimatedSize + memoryCost(wrapped)`. For `Blob` that is `reported_estimated_size`, set by `calculate_estimated_byte_size` in `BlobExt::to_js`. #39808 added the test to pin that call.
- `test/js/node/zlib/zlib-estimated-size-gc.test.ts` and `test/js/web/websocket/websocket-pong-fragmented.test.ts` check GC-reported sizes the same way.

<details><summary>Notes</summary>

Build 106450, job ":ubuntu: 25.04 aarch64 - test-bun", ran 67 files in a 3-wide parallel batch. The file took 1.97s in the batch and passed on the solo retry. Builds 106409 to 106449 carry the same annotation.

Reading the failing numbers: `reported = after - before`, and `after` includes the 2 MiB blob. So the rest of the heap shrank by 2.8 MB to 5.6 MB between the two `Bun.gc(true)` calls.

The original bound of half the payload was chosen for "memory that earlier tests release in the meantime". Within this file that is small. Across files in one worker it is not.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->