### PR TITLE
fetch: accept latin-1 range header values in 16-bit strings

### DIFF
--- a/src/jsc/bindings/webcore/HTTPParsers.cpp
+++ b/src/jsc/bindings/webcore/HTTPParsers.cpp
@@ -58,9 +58,14 @@ bool isValidHTTPHeaderValue(const StringView& value)
             }
         }
     } else {
+        // Match the 8-bit branch: header values are byte sequences, so any
+        // char that fits in a byte (0x80-0xFF included, per obs-text) is
+        // valid regardless of the string's internal representation. A 16-bit
+        // string here usually comes from normalize()/JSON parsing of network
+        // responses, not from characters outside latin-1.
         for (unsigned i = 0; i < value.length(); ++i) {
             c = value[i];
-            if (c == 0x00 || c == 0x0A || c == 0x0D || c > 0x7F)
+            if (c == 0x00 || c == 0x0A || c == 0x0D || c > 0xFF)
                 return false;
         }
     }

--- a/test/js/web/fetch/fetch_headers.test.js
+++ b/test/js/web/fetch/fetch_headers.test.js
@@ -34,6 +34,30 @@ describe("Headers", async () => {
     expect(() => fetch(url, { headers: { "x-test": "❤️" } })).toThrow("Header 'x-test' has invalid value: '❤️'");
   });
 
+  it("Header values in the latin-1 range are valid regardless of internal string representation", async () => {
+    const eightBit = "Operação realizada com sucesso!";
+    // normalize() returns a 16-bit string even when every char fits in latin-1;
+    // the validator used to reject it while accepting the identical 8-bit literal.
+    const sixteenBit = "Operação realizada com sucesso!".normalize("NFC");
+    expect(sixteenBit).toBe(eightBit);
+
+    const headers = new Headers();
+    expect(() => headers.set("message-summary", sixteenBit)).not.toThrow();
+    expect(headers.get("message-summary")).toBe(eightBit);
+    expect(() => new Headers({ "message-summary": sixteenBit })).not.toThrow();
+
+    // parser-produced 16-bit strings (the real-world path: values from response.json())
+    const parsed = JSON.parse(Buffer.from(JSON.stringify({ v: eightBit })).toString("utf8")).v;
+    expect(() => headers.set("x-parsed", parsed)).not.toThrow();
+
+    // chars above 0xFF stay invalid in either representation
+    expect(() => headers.set("x-test", "okĀ")).toThrow("Header 'x-test' has invalid value: 'okĀ'");
+    expect(() => headers.set("x-test", "okĀ".normalize("NFC"))).toThrow();
+
+    // round-trips through the wire like the equivalent 8-bit value
+    expect(await fetchContent({ "x-test": sixteenBit })).toBe(eightBit);
+  });
+
   it("isomorphic-encodes latin-1 (obs-text) request header values on the wire", async () => {
     // https://fetch.spec.whatwg.org/#concept-header-value
     // Values are ByteStrings: U+00E9 must go out as the single byte 0xE9, not UTF-8 0xC3 0xA9.


### PR DESCRIPTION
### What does this PR do?

Fixes #28266.

`isValidHTTPHeaderValue` treats the same string differently depending on its internal representation:

```cpp
if (value.is8Bit()) {
    // accepts any byte except NUL/LF/CR — 0x80–0xFF (obs-text) pass
} else {
    // rejected every char above 0x7F
    if (c == 0x00 || c == 0x0A || c == 0x0D || c > 0x7F)
        return false;
}
```

A 16-bit string whose chars all fit in latin-1 — the routine output of `String.prototype.normalize()`, `path.basename()`, or JSON parsing of network responses — was rejected as a header value, while the *identical* 8-bit literal is accepted:

```js
const eightBit = "ý.txt";
const sixteenBit = require("path").basename("ý.txt"); // === eightBit

new Headers().set("x", eightBit);   // ok
new Headers().set("x", sixteenBit); // TypeError: Header 'x' has invalid value: 'ý.txt'
```

This bit us in production: a proxy layer rebuilt upstream response headers with `new Headers(json.headers)`, where the values came out of `Response.prototype.json()` (16-bit strings). Any non-ASCII header value — e.g. `message-summary: Operação realizada com sucesso!` from a government procurement API — made the whole request throw, even though the upstream call had succeeded. Node accepts these values (its ByteString conversion only rejects chars above 0xFF).

The fix aligns the 16-bit branch with the 8-bit one: reject only chars above 0xFF, which cannot be represented as a single byte. Chars in 0x80–0xFF already serialize correctly on the wire — isomorphic encoding, covered by the existing "isomorphic-encodes latin-1 (obs-text) request header values on the wire" test.

Chars above 0xFF stay invalid in both representations (e.g. `"okĀ"`, `"❤️"` — existing tests unchanged).

### How did you verify your code works?

Added a regression test in `test/js/web/fetch/fetch_headers.test.js` covering:

- `Headers.set` / `new Headers(record)` with a 16-bit latin-1-range value (`"Operação realizada com sucesso!".normalize("NFC")`), asserting it round-trips via `get()`;
- a parser-produced 16-bit string (`JSON.parse` of UTF-8 bytes — the real-world path);
- a wire round-trip through `Bun.serve`;
- chars above 0xFF still throwing in both 8-bit and 16-bit representations.

The new test **fails on bun 1.4.1 as released** with `Header 'message-summary' has invalid value: 'Operação realizada com sucesso!'`, and **passes on a debug build of this branch**:

```
bun test test/js/web/fetch/fetch_headers.test.js
 9 pass
 0 fail
```

Neighbor suites `test/js/web/fetch/headers.test.ts` and `test/js/web/fetch/response.test.ts` pass unchanged (121/122; the single failure is the pre-existing `handle stack overflow` 5s timeout under an ASAN debug build, identical with and without this change).