### PR TITLE
bun test --parallel: union per-function coverage across workers

### DIFF
--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -123,6 +123,14 @@ struct LineAgg {
     fragments: u32,
 }
 
+#[derive(Default, Clone, Copy)]
+struct FnAgg {
+    /// 1-based start line from the FN record.
+    line: u32,
+    /// Summed FNDA hits across fragments.
+    hits: u32,
+}
+
 #[derive(Default)]
 struct FileCoverage {
     path: Box<[u8]>,
@@ -132,6 +140,8 @@ struct FileCoverage {
     fragments: u32,
     /// 1-based line number → aggregate.
     da: ArrayHashMap<u32, LineAgg>,
+    /// Function name → aggregate, unioned from FN/FNDA records.
+    fns: StringArrayHashMap<FnAgg>,
 }
 
 impl FileCoverage {
@@ -152,15 +162,42 @@ impl FileCoverage {
         index_sort::sort_slice_unstable_by(&mut out, |a, b| a.0.cmp(&b.0));
         out
     }
+
+    /// FNF/FNH for the merged report, derived from the unioned FN/FNDA
+    /// records. Falls back to the per-fragment max when no fragment carried
+    /// per-function records.
+    fn fn_totals(&self) -> (u32, u32) {
+        if self.fns.count() == 0 {
+            return (self.fnf, self.fnh);
+        }
+        let fnf = self.fns.count() as u32;
+        let fnh = self.fns.values().iter().filter(|f| f.hits > 0).count() as u32;
+        (fnf, fnh)
+    }
+
+    /// Indices into `self.fns`, sorted by start line for stable output.
+    fn sorted_fn_indices(&self) -> Vec<usize> {
+        let mut out: Vec<usize> = (0..self.fns.count()).collect();
+        let vals = self.fns.values();
+        let keys = self.fns.keys();
+        index_sort::sort_slice_unstable_by(&mut out, |&a, &b| {
+            vals[a]
+                .line
+                .cmp(&vals[b].line)
+                .then_with(|| keys[a].as_ref().cmp(keys[b].as_ref()))
+        });
+        out
+    }
 }
 
 /// Merge per-worker LCOV fragments into a single report. Line-level (DA) merge
 /// sums hits, and keeps a zero-hit line only when every fragment covering the
-/// file agrees it is executable (see `FileCoverage::merged_lines`). FNF/FNH
-/// take the per-worker max since Bun's LCOV writer doesn't
-/// emit per-function FN/FNDA records yet, so disjoint per-worker function hits
-/// can't be unioned; this under-reports % Funcs when workers cover different
-/// functions of the same file. The non-parallel path has the same FN/FNDA gap.
+/// file agrees it is executable (see `FileCoverage::merged_lines`). Function
+/// coverage is unioned from the per-function FN/FNDA records: hits for the
+/// same function name are summed across fragments, and FNF/FNH derive from
+/// the merged set, so disjoint per-worker function hits add up instead of
+/// under-reporting % Funcs (#40586). Fragments without FN/FNDA records fall
+/// back to the per-fragment FNF/FNH max.
 pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
     chunks: &[&[u8]],
     opts: &mut CodeCoverageOptions,
@@ -212,6 +249,26 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
                             fragments: 1,
                         }
                     };
+                } else if line.starts_with(b"FN:") {
+                    // FN:<line>,<name>
+                    let Some((ln_s, name)) = strings::split_once_char(&line[3..], b',') else {
+                        continue;
+                    };
+                    let Ok(ln) = strings::parse_int::<u32>(ln_s, 10) else {
+                        continue;
+                    };
+                    let gop = bun_core::handle_oom(fc.fns.get_or_put(name));
+                    gop.value_ptr.line = ln;
+                } else if line.starts_with(b"FNDA:") {
+                    // FNDA:<hits>,<name>
+                    let Some((cnt_s, name)) = strings::split_once_char(&line[5..], b',') else {
+                        continue;
+                    };
+                    let Ok(cnt) = strings::parse_int::<u32>(cnt_s, 10) else {
+                        continue;
+                    };
+                    let gop = bun_core::handle_oom(fc.fns.get_or_put(name));
+                    gop.value_ptr.hits = gop.value_ptr.hits.saturating_add(cnt);
                 } else if line.starts_with(b"FNF:") {
                     fc.fnf = fc
                         .fnf
@@ -274,13 +331,26 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
                 for &i in &order {
                     let fc = &by_file.values()[i];
                     let lines = &merged[i];
-                    let _ = write!(
-                        &mut w,
-                        "TN:\nSF:{}\nFNF:{}\nFNH:{}\n",
-                        BStr::new(&fc.path),
-                        fc.fnf,
-                        fc.fnh
-                    );
+                    let _ = write!(&mut w, "TN:\nSF:{}\n", BStr::new(&fc.path));
+                    let fn_order = fc.sorted_fn_indices();
+                    for &j in &fn_order {
+                        let _ = writeln!(
+                            &mut w,
+                            "FN:{},{}",
+                            fc.fns.values()[j].line,
+                            BStr::new(&fc.fns.keys()[j])
+                        );
+                    }
+                    for &j in &fn_order {
+                        let _ = writeln!(
+                            &mut w,
+                            "FNDA:{},{}",
+                            fc.fns.values()[j].hits,
+                            BStr::new(&fc.fns.keys()[j])
+                        );
+                    }
+                    let (fnf, fnh) = fc.fn_totals();
+                    let _ = write!(&mut w, "FNF:{}\nFNH:{}\n", fnf, fnh);
                     let mut lh: u32 = 0;
                     for &(ln, hits) in lines {
                         lh += (hits > 0) as u32;
@@ -306,11 +376,12 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
     debug_assert_eq!(order.len(), fracs.len());
     for (&i, frac) in order.iter().zip(fracs.iter_mut()) {
         let fc = &by_file.values()[i];
+        let (fnf, fnh) = fc.fn_totals();
         let lf: f64 = merged[i].len() as f64;
         let lh_: f64 = merged[i].iter().filter(|&&(_, hits)| hits > 0).count() as f64;
         *frac = CoverageFraction {
-            functions: if fc.fnf > 0 {
-                fc.fnh as f64 / fc.fnf as f64
+            functions: if fnf > 0 {
+                fnh as f64 / fnf as f64
             } else {
                 1.0
             },

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -163,9 +163,8 @@ impl FileCoverage {
         out
     }
 
-    /// FNF/FNH for the merged report, derived from the unioned FN/FNDA
-    /// records. Falls back to the per-fragment max when no fragment carried
-    /// per-function records.
+    /// FNF/FNH from the unioned FN/FNDA records, or the per-fragment max
+    /// when no fragment carried per-function records.
     fn fn_totals(&self) -> (u32, u32) {
         if self.fns.count() == 0 {
             return (self.fnf, self.fnh);
@@ -190,14 +189,11 @@ impl FileCoverage {
     }
 }
 
-/// Merge per-worker LCOV fragments into a single report. Line-level (DA) merge
-/// sums hits, and keeps a zero-hit line only when every fragment covering the
-/// file agrees it is executable (see `FileCoverage::merged_lines`). Function
-/// coverage is unioned from the per-function FN/FNDA records: hits for the
-/// same function name are summed across fragments, and FNF/FNH derive from
-/// the merged set, so disjoint per-worker function hits add up instead of
-/// under-reporting % Funcs (#40586). Fragments without FN/FNDA records fall
-/// back to the per-fragment FNF/FNH max.
+/// Merge per-worker LCOV fragments into a single report. DA hits are summed,
+/// and a zero-hit line is kept only when every fragment covering the file
+/// agrees it is executable (see `FileCoverage::merged_lines`). FNDA hits are
+/// summed per function name, so disjoint per-worker function hits add up
+/// instead of under-reporting % Funcs (#40586).
 pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
     chunks: &[&[u8]],
     opts: &mut CodeCoverageOptions,

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -313,19 +313,25 @@ pub mod lcov {
         writer.write_all(b"\n")?;
 
         // JSC does not expose function names, so synthesize one from the
-        // 1-based start line. Ranges that start on the same line collapse into
-        // one record. The parallel merge unions FNDA hits across workers by
-        // name, so disjoint per-worker function coverage adds up (#40586).
-        let mut fn_records: Vec<(u32, bool)> = Vec::with_capacity(report.functions.len());
+        // 1-based start line plus the start byte offset in the generated
+        // source. The offset keeps distinct functions that start on the same
+        // line distinct and collapses only true duplicate ranges (a relinked
+        // CodeBlock). It is stable across workers for the same file, so the
+        // parallel merge can union FNDA hits by name (#40586).
+        let mut fn_records: Vec<(u32, u32, bool)> = Vec::with_capacity(report.functions.len());
         for function in &report.functions {
             if function.start_line != u32::MAX {
-                fn_records.push((function.start_line + 1, function.executed));
+                fn_records.push((
+                    function.start_line + 1,
+                    function.start_offset,
+                    function.executed,
+                ));
             }
         }
-        index_sort::sort_slice_unstable_by(&mut fn_records, |a, b| a.0.cmp(&b.0));
+        index_sort::sort_slice_unstable_by(&mut fn_records, |a, b| (a.0, a.1).cmp(&(b.0, b.1)));
         fn_records.dedup_by(|next, prev| {
-            if next.0 == prev.0 {
-                prev.1 |= next.1;
+            if next.0 == prev.0 && next.1 == prev.1 {
+                prev.2 |= next.2;
                 true
             } else {
                 false
@@ -333,13 +339,19 @@ pub mod lcov {
         });
 
         // FN: line number,function name
-        for &(line, _) in &fn_records {
-            writeln!(writer, "FN:{},(anonymous_{})", line, line)?;
+        for &(line, offset, _) in &fn_records {
+            writeln!(writer, "FN:{},(anonymous_{}_{})", line, line, offset)?;
         }
 
         // FNDA: execution count,function name
-        for &(line, executed) in &fn_records {
-            writeln!(writer, "FNDA:{},(anonymous_{})", u32::from(executed), line)?;
+        for &(line, offset, executed) in &fn_records {
+            writeln!(
+                writer,
+                "FNDA:{},(anonymous_{}_{})",
+                u32::from(executed),
+                line,
+                offset
+            )?;
         }
 
         // FNF: functions found
@@ -349,7 +361,10 @@ pub mod lcov {
         writeln!(
             writer,
             "FNH:{}",
-            fn_records.iter().filter(|&&(_, executed)| executed).count()
+            fn_records
+                .iter()
+                .filter(|&&(_, _, executed)| executed)
+                .count()
         )?;
 
         // ** Track all executable lines **
@@ -629,6 +644,7 @@ impl ByteRangeMapping {
 
                 functions.push(FunctionBlock {
                     start_line: min_line,
+                    start_offset: u32::try_from(min).expect("int cast"),
                     executed: did_fn_execute,
                 });
 
@@ -807,6 +823,7 @@ impl ByteRangeMapping {
 
                 functions.push(FunctionBlock {
                     start_line: min_line,
+                    start_offset: u32::try_from(min).expect("int cast"),
                     executed: did_fn_execute,
                 });
                 if did_fn_execute {
@@ -941,11 +958,14 @@ pub use bun_options_types::code_coverage_options::Fraction;
 pub struct Block {}
 
 /// Per-function coverage for the LCOV writer. JSC reports byte ranges only
-/// (no names), so the start line doubles as the function's identity when the
-/// parallel merge unions hits across workers.
+/// (no names), so the start line and start offset double as the function's
+/// identity when the parallel merge unions hits across workers.
 #[derive(Clone, Copy)]
 pub struct FunctionBlock {
     /// 0-based start line; `u32::MAX` when the range maps to no line.
     pub(crate) start_line: u32,
+    /// Start byte offset in the generated source. Distinguishes functions
+    /// that start on the same line.
+    pub(crate) start_offset: u32,
     pub(crate) executed: bool,
 }

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -5,6 +5,7 @@ use core::ptr::NonNull;
 use bun_ast::Loc;
 use bun_collections::VecExt;
 use bun_collections::bit_set::DynamicBitSet;
+use bun_collections::index_sort;
 use bun_core::{self, Utf8Bytes};
 use bun_jsc::{JSGlobalObject, JSValue, VM, bun_string_jsc};
 use bun_sourcemap::{
@@ -33,7 +34,7 @@ pub struct Report<'a> {
     pub(crate) executable_lines: Bitset,
     pub(crate) lines_which_have_executed: Bitset,
     pub(crate) line_hits: LinesHits,
-    pub(crate) functions: Vec<Block>,
+    pub(crate) functions: Vec<FunctionBlock>,
     pub(crate) functions_which_have_executed: Bitset,
     pub(crate) stmts_which_have_executed: Bitset,
     pub(crate) stmts: Vec<Block>,
@@ -311,17 +312,44 @@ pub mod lcov {
         }
         writer.write_all(b"\n")?;
 
-        // ** Per-function coverage not supported yet, since JSC does not support function names yet. **
+        // JSC does not expose function names, so synthesize one from the
+        // 1-based start line. Ranges that start on the same line collapse into
+        // one record. The parallel merge unions FNDA hits across workers by
+        // name, so disjoint per-worker function coverage adds up (#40586).
+        let mut fn_records: Vec<(u32, bool)> = Vec::with_capacity(report.functions.len());
+        for function in &report.functions {
+            if function.start_line != u32::MAX {
+                fn_records.push((function.start_line + 1, function.executed));
+            }
+        }
+        index_sort::sort_slice_unstable_by(&mut fn_records, |a, b| a.0.cmp(&b.0));
+        fn_records.dedup_by(|next, prev| {
+            if next.0 == prev.0 {
+                prev.1 |= next.1;
+                true
+            } else {
+                false
+            }
+        });
+
         // FN: line number,function name
+        for &(line, _) in &fn_records {
+            writeln!(writer, "FN:{},(anonymous_{})", line, line)?;
+        }
+
+        // FNDA: execution count,function name
+        for &(line, executed) in &fn_records {
+            writeln!(writer, "FNDA:{},(anonymous_{})", u32::from(executed), line)?;
+        }
 
         // FNF: functions found
-        writeln!(writer, "FNF:{}", report.functions.len())?;
+        writeln!(writer, "FNF:{}", fn_records.len())?;
 
         // FNH: functions hit
         writeln!(
             writer,
             "FNH:{}",
-            report.functions_which_have_executed.count()
+            fn_records.iter().filter(|&&(_, executed)| executed).count()
         )?;
 
         // ** Track all executable lines **
@@ -490,7 +518,7 @@ impl ByteRangeMapping {
                 .get(source_url);
         let mut line_hits: LinesHits;
 
-        let mut functions: Vec<Block> = Vec::new();
+        let mut functions: Vec<FunctionBlock> = Vec::new();
         functions.reserve_exact(function_blocks.len());
         let mut functions_which_have_executed: Bitset = Bitset::init_empty(function_blocks.len())?;
         let mut stmts_which_have_executed: Bitset = Bitset::init_empty(blocks.len())?;
@@ -599,7 +627,10 @@ impl ByteRangeMapping {
                     }
                 }
 
-                functions.push(Block {});
+                functions.push(FunctionBlock {
+                    start_line: min_line,
+                    executed: did_fn_execute,
+                });
 
                 if did_fn_execute {
                     functions_which_have_executed.set(i);
@@ -774,7 +805,10 @@ impl ByteRangeMapping {
                     }
                 }
 
-                functions.push(Block {});
+                functions.push(FunctionBlock {
+                    start_line: min_line,
+                    executed: did_fn_execute,
+                });
                 if did_fn_execute {
                     functions_which_have_executed.set(i);
                 }
@@ -905,3 +939,13 @@ pub use bun_options_types::code_coverage_options::Fraction;
 
 #[derive(Clone, Copy, Default)]
 pub struct Block {}
+
+/// Per-function coverage for the LCOV writer. JSC reports byte ranges only
+/// (no names), so the start line doubles as the function's identity when the
+/// parallel merge unions hits across workers.
+#[derive(Clone, Copy)]
+pub struct FunctionBlock {
+    /// 0-based start line; `u32::MAX` when the range maps to no line.
+    pub(crate) start_line: u32,
+    pub(crate) executed: bool,
+}

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -312,12 +312,10 @@ pub mod lcov {
         }
         writer.write_all(b"\n")?;
 
-        // JSC does not expose function names, so synthesize one from the
-        // 1-based start line plus the start byte offset in the generated
-        // source. The offset keeps distinct functions that start on the same
-        // line distinct and collapses only true duplicate ranges (a relinked
-        // CodeBlock). It is stable across workers for the same file, so the
-        // parallel merge can union FNDA hits by name (#40586).
+        // JSC does not expose function names. Synthesize one from the 1-based
+        // start line plus the generated-source start offset: stable across
+        // workers, so the parallel merge unions FNDA hits by name, and unique
+        // per function, so same-line functions stay distinct (#40586).
         let mut fn_records: Vec<(u32, u32, bool)> = Vec::with_capacity(report.functions.len());
         for function in &report.functions {
             if function.start_line != u32::MAX {
@@ -957,15 +955,12 @@ pub use bun_options_types::code_coverage_options::Fraction;
 #[derive(Clone, Copy, Default)]
 pub struct Block {}
 
-/// Per-function coverage for the LCOV writer. JSC reports byte ranges only
-/// (no names), so the start line and start offset double as the function's
-/// identity when the parallel merge unions hits across workers.
+/// Per-function coverage for the LCOV writer.
 #[derive(Clone, Copy)]
 pub struct FunctionBlock {
     /// 0-based start line; `u32::MAX` when the range maps to no line.
     pub(crate) start_line: u32,
-    /// Start byte offset in the generated source. Distinguishes functions
-    /// that start on the same line.
+    /// Start byte offset in the generated source; distinguishes same-line functions.
     pub(crate) start_offset: u32,
     pub(crate) executed: bool,
 }

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`lcov coverage reporter: lcov-coverage-reporter-output 1`] = `
 "TN:
 SF:demo1.ts
-FN:2,(anonymous_2)
-FNDA:0,(anonymous_2)
+FN:2,(anonymous_2_1)
+FNDA:0,(anonymous_2_1)
 FNF:1
 FNH:0
 DA:2,19
@@ -15,10 +15,10 @@ LH:3
 end_of_record
 TN:
 SF:demo2.ts
-FN:4,(anonymous_4)
-FN:9,(anonymous_9)
-FNDA:1,(anonymous_4)
-FNDA:0,(anonymous_9)
+FN:4,(anonymous_4_36)
+FN:9,(anonymous_9_78)
+FNDA:1,(anonymous_4_36)
+FNDA:0,(anonymous_9_78)
 FNF:2
 FNH:1
 DA:2,28

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -3,6 +3,8 @@
 exports[`lcov coverage reporter: lcov-coverage-reporter-output 1`] = `
 "TN:
 SF:demo1.ts
+FN:2,(anonymous_2)
+FNDA:0,(anonymous_2)
 FNF:1
 FNH:0
 DA:2,19
@@ -13,6 +15,10 @@ LH:3
 end_of_record
 TN:
 SF:demo2.ts
+FN:4,(anonymous_4)
+FN:9,(anonymous_9)
+FNDA:1,(anonymous_4)
+FNDA:0,(anonymous_9)
 FNF:2
 FNH:1
 DA:2,28

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -383,8 +383,8 @@ test("should call both functions", () => {
   expect(lcovContent).toMatchInlineSnapshot(`
 "TN:
 SF:include-me.ts
-FN:2,(anonymous_2)
-FNDA:1,(anonymous_2)
+FN:2,(anonymous_2_7)
+FNDA:1,(anonymous_2_7)
 FNF:1
 FNH:1
 DA:2,11
@@ -394,8 +394,8 @@ LH:2
 end_of_record
 TN:
 SF:test.test.ts
-FN:6,(anonymous_6)
-FNDA:1,(anonymous_6)
+FN:6,(anonymous_6_158)
+FNDA:1,(anonymous_6_158)
 FNF:1
 FNH:1
 DA:2,40
@@ -656,7 +656,7 @@ test("--parallel merges function coverage across workers", async () => {
     "bunfig.toml": `[test]
 coverageThreshold = { lines = 1.0, functions = 1.0 }
 `,
-    "subject.ts": `await Bun.sleep(250);
+    "subject.ts": `await Bun.sleep(500);
 export function first() {
   return 1;
 }
@@ -668,6 +668,8 @@ export function second() {
 import { expect, test } from "bun:test";
 import { first } from "./subject.ts";
 
+await Bun.write("pid-first.txt", String(process.pid));
+
 test("calls first", () => {
   expect(first()).toBe(1);
 });
@@ -676,21 +678,41 @@ test("calls first", () => {
 import { expect, test } from "bun:test";
 import { second } from "./subject.ts";
 
+await Bun.write("pid-second.txt", String(process.pid));
+
 test("calls second", () => {
   expect(second()).toBe(2);
 });
 `,
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=text", "--coverage-reporter=lcov", "--parallel=2"],
-    // Spawn both workers at once so each takes one test file. The 250ms
-    // top-level sleep in subject.ts keeps the first worker busy so the
-    // second file is not picked up by the same worker.
-    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
-    cwd: String(dir),
-    stderr: "pipe",
-  });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // The union is only exercised when the two files run in different worker
+  // processes: a single worker hits both functions on its own. The 500ms
+  // top-level sleep in subject.ts keeps the first worker busy so the second
+  // file goes to the second worker (spawned at once via
+  // BUN_TEST_PARALLEL_SCALE_MS=0). Each test file records its pid; retry the
+  // run if scheduling still collapsed onto one worker.
+  let stderr = "";
+  let exitCode = -1;
+  let pids = new Set<string>();
+  for (let attempt = 0; attempt < 3 && pids.size < 2; attempt++) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=text", "--coverage-reporter=lcov", "--parallel=2"],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    pids = new Set(
+      await Promise.all([
+        Bun.file(path.join(String(dir), "pid-first.txt")).text(),
+        Bun.file(path.join(String(dir), "pid-second.txt")).text(),
+      ]),
+    );
+  }
+  // Precondition: the two test files ran in distinct workers.
+  expect(pids.size).toBe(2);
 
   expect(stderr).toContain("2 pass");
   const lcov = readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8");

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -383,6 +383,8 @@ test("should call both functions", () => {
   expect(lcovContent).toMatchInlineSnapshot(`
 "TN:
 SF:include-me.ts
+FN:2,(anonymous_2)
+FNDA:1,(anonymous_2)
 FNF:1
 FNH:1
 DA:2,11
@@ -392,6 +394,8 @@ LH:2
 end_of_record
 TN:
 SF:test.test.ts
+FN:6,(anonymous_6)
+FNDA:1,(anonymous_6)
 FNF:1
 FNH:1
 DA:2,40
@@ -638,6 +642,62 @@ test("only imports the function", () => {
   expect(record).not.toContain("DA:5,");
   expect(record).toMatch(/LF:4\nLH:4\n/);
 
+  expect(stderr).toMatch(/ subject\.ts +\| +100\.00 +\| +100\.00 +\| +\n/);
+  expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/40586
+// Each worker executes a different function of the same module. The merge
+// must union per-function FNDA hits across workers. Taking one worker's FNH
+// under-reported % Funcs and failed a 100% coverageThreshold with zero test
+// failures.
+test("--parallel merges function coverage across workers", async () => {
+  using dir = tempDir("cov-parallel-fn-merge", {
+    "bunfig.toml": `[test]
+coverageThreshold = { lines = 1.0, functions = 1.0 }
+`,
+    "subject.ts": `await Bun.sleep(250);
+export function first() {
+  return 1;
+}
+export function second() {
+  return 2;
+}
+`,
+    "first.test.ts": `
+import { expect, test } from "bun:test";
+import { first } from "./subject.ts";
+
+test("calls first", () => {
+  expect(first()).toBe(1);
+});
+`,
+    "second.test.ts": `
+import { expect, test } from "bun:test";
+import { second } from "./subject.ts";
+
+test("calls second", () => {
+  expect(second()).toBe(2);
+});
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=text", "--coverage-reporter=lcov", "--parallel=2"],
+    // Spawn both workers at once so each takes one test file. The 250ms
+    // top-level sleep in subject.ts keeps the first worker busy so the
+    // second file is not picked up by the same worker.
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("2 pass");
+  const lcov = readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8");
+  const record = lcov.split("end_of_record").find(r => r.includes("SF:subject.ts"));
+  expect(record).toBeDefined();
+  // Both functions are hit once the per-worker FNDA records are unioned.
+  expect(record).toMatch(/FNF:2\nFNH:2\n/);
   expect(stderr).toMatch(/ subject\.ts +\| +100\.00 +\| +100\.00 +\| +\n/);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `bun test --parallel` under-reports % Funcs against the serial baseline, so a `coverageThreshold` near 100% fails with 0 test failures (#40586).
- Bun's LCOV writer (`src/sourcemap_jsc/CodeCoverage.rs`) emits only `FNF:`/`FNH:` totals. The coordinator merge (`src/runtime/cli/test/parallel/aggregate.rs`) cannot union function hits across workers, so it takes the per-worker max of FNH. When workers execute disjoint functions of one file, the merged FNH is one worker's count.

### Fix
- Emit per-function `FN:`/`FNDA:` records. JSC exposes function byte ranges but no names, so the record is named `(anonymous_<line>_<offset>)` from the 1-based start line and the generated-source start offset. The offset keeps two functions that start on the same line distinct, and the name is stable across workers.
- In the merge, union FN/FNDA by name: sum hits across fragments, derive FNF/FNH from the merged set, and write the records into the merged lcov.info. Fragments without FN/FNDA fall back to the old max.
- Correct because a function executed by any worker is an executed function. This matches how the merge already sums DA line hits.
- Verified: new test in `test/cli/test/coverage.test.ts`. It asserts the two files ran in distinct worker processes, and fails on stock bun with `FNH:1`. Also all of `coverage.test.ts` and `parallel.test.ts`.

### Background
- Under `--parallel`, each worker renders its own LCOV chunk and streams it over IPC. The coordinator parses the chunks and produces the text table, the threshold verdict, and lcov.info.
- `FNF`/`FNH` are LCOV totals: functions found and functions hit. `FN`/`FNDA` are the per-function records they summarize.
- The per-worker max was added with the #39930 line-merge fix as a stopgap and documented this exact gap.

<details><summary>Notes</summary>

- Reproduced with 4 test files that each call one of 4 functions in one module, spread across workers: serial reports `FNF:4 FNH:4`, parallel reported `FNH:1` and failed a 100% threshold with 0 test failures.
- The serial LCOV output gains the same FN/FNDA records (snapshots updated). True duplicate ranges (a relinked CodeBlock reporting the same function twice) collapse into one record.
- The reporter also saw a smaller % Lines gap. I could not reproduce it; DA merging sums hits and kept 100% lines in every cross-worker probe. The % Funcs gap alone fails the threshold and explains the report.
- Open PR #35725 (lcov DA execution counts, #3373) touches the same writer and also adds FN/FNDA. It is a month old with red CI and a larger scope. This PR only fixes the parallel merge gap. The two will conflict trivially in the writer.
- The test pins `BUN_TEST_PARALLEL_SCALE_MS=0` so both workers spawn at once, uses a 500ms top-level import sleep so the files land on different workers, records each file's pid, and retries up to 3 times if scheduling still collapsed onto one worker.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
bun test v1.4.1 (adc354d99)

test/cli/test/coverage.test.ts:
bun test v1.4.1 (adc354d99)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [271.00ms]
(pass) coverage crash [368.14ms]
bun test v1.4.1 (adc354d99)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [219.00ms]
50 |     },
51 |     stdio: ["inherit", "inherit", "inherit"],
52 |   });
53 |   expect(result.exitCode).toBe(0);
54 |   expect(result.signalCode).toBeUndefined();
55 |   expect(normalizeBunSnapshot(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8"), dir)).toMatchSnapshot(
                                                                                                         ^
error: expect(received).toMatchSnapshot(expected)
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (a6ca53c75)

test/cli/test/coverage.test.ts:
bun test v1.4.1-canary.1 (a6ca53c75)

demo.test.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [3.00ms]
(pass) coverage crash [6.35ms]
bun test v1.4.1-canary.1 (a6ca53c75)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [3.00ms]
50 |     },
51 |     stdio: ["inherit", "inherit", "inherit"],
52 |   });
53 |   expect(result.exitCode).toBe(0);
54 |   expect(result.signalCode).toBeUndefined();
55 |   expect(normalizeBunSnapshot(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8"), dir)).toMatchSnapshot(
                                                                                                         ^
error: expect(received).toMatchSnapshot(expected)

  
  "TN:
  SF:demo1.ts
- FN:2,(anonymous_2_1)
- FNDA:0,(anonymous_2_1)
+ FN:2,(anonymous_2)
+ FNDA:0,(anonymous_2)
  FNF:1
  FNH:0
  DA:2,19
  DA:3,16
  DA:4,1
  LF:3
  LH:3
  end_of_record
  TN:
  SF:demo2.ts
- FN:4,(anonymous_4_36)
- FN:9,(anonymous_9_78)
- FNDA:1,(anonymous_4_36)
- FNDA:0,(anonymous_9_78)
+ FN:4,(anonymous_4)
+ FN:9,(anonymous_9)
+ FNDA:1,(anonymous_4)
+ FNDA:0,(anonymous_9)
  FNF:2
  FNH:1
  DA:2,28
  DA:4,1
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
bun test v1.4.1 (adc354d99)

test/cli/test/coverage.test.ts:
bun test v1.4.1 (adc354d99)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [214.00ms]
(pass) coverage crash [311.35ms]
bun test v1.4.1 (adc354d99)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [228.00ms]
(pass) lcov coverage reporter [292.72ms]
(pass) coverage excludes node_modules directory [332.73ms]
(pass) coveragePathIgnorePatterns - single pattern string [361.76ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [366.70ms]
(pass) coveragePathIgnorePatterns - array of patterns [299.44ms]
(pass) coveragePathIgnorePatterns - glob patterns [300.30ms]
(pass) coveragePathIgnorePatterns - lcov reporter [294.14ms]
(pass) cov
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 607ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_pat
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test/parallel/aggregate.rs        | 99 +++++++++++++++++++----
 src/sourcemap_jsc/CodeCoverage.rs                 | 73 +++++++++++++++--
 test/cli/test/__snapshots__/coverage.test.ts.snap |  6 ++
 test/cli/test/coverage.test.ts                    | 82 +++++++++++++++++++
 4 files changed, 237 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/runtime/cli/test/parallel/aggregate.rs             2      5      0
src/sourcemap_jsc/CodeCoverage.rs                      6     10      0
test/cli/test/__snapshots__/coverage.test.ts.snap      0      0      0
test/cli/test/coverage.test.ts                         3      3      0
```

</details>

**root cause** · written by the author bot

When running under --parallel, Bun's LCOV writer emitted no per-function FN/FNDA records, so the aggregator could only take the per-worker maximum of FNF/FNH counts, which discards function hits when different workers exercise disjoint functions in the same file and under-reports the merged function coverage. The fix makes the LCOV writer synthesize a stable, unique function name from the function's start line and generated-source start offset, giving the merge step a key that is consistent across workers. The aggregator then unions FNDA records by name and sums their hits, so function cove…

<!-- robobun:evidence:end -->