### PR TITLE
test: pin the redirect-hop TLS identity and the tunnel SNI from tls.servername

### DIFF
--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -781,11 +781,11 @@ test("HTTPS proxy tunnel keep-alive does not share tunnel across different targe
   expect(connects.sort()).toEqual([`CONNECT localhost:${serverA.port}`, `CONNECT localhost:${serverB.port}`].sort());
 });
 
-// The TLS handshake inside a CONNECT tunnel is keyed to the URL host like a
-// direct connection: the ClientHello SNI and the certificate verification use
-// the URL host, and a caller-supplied Host header only travels as an HTTP
-// field on the tunneled request.
-test("HTTPS proxy tunnel keeps a caller-supplied Host header out of SNI and certificate verification", async () => {
+// The TLS handshake inside a CONNECT tunnel is keyed like a direct connection:
+// the ClientHello SNI and the certificate verification use tls.servername when
+// set, otherwise the URL host. A caller-supplied Host header only travels as an
+// HTTP field on the tunneled request.
+test("HTTPS proxy tunnel derives the inner SNI from tls.servername or the URL host, never from the Host header", async () => {
   const seen: { sni: string | null; host: string | undefined }[] = [];
   const target = tls.createServer(
     {
@@ -807,14 +807,28 @@ test("HTTPS proxy tunnel keeps a caller-supplied Host header out of SNI and cert
   await once(target, "listening");
   try {
     const port = (target.address() as net.AddressInfo).port;
-    const res = await fetch(`https://localhost:${port}/`, {
-      proxy: httpProxyServer.url,
-      keepalive: false,
-      headers: { Host: "other.example" },
-      tls: { ca: tlsCert.cert },
-    });
-    expect(`${res.status} ${await res.text()}`).toBe("200 ok");
-    expect(seen).toEqual([{ sni: "localhost", host: "other.example" }]);
+    const get = async (url: string, init: { headers?: Record<string, string>; tls?: Record<string, string> }) => {
+      const res = await fetch(url, {
+        proxy: httpProxyServer.url,
+        keepalive: false,
+        headers: init.headers,
+        tls: { ca: tlsCert.cert, ...init.tls },
+      });
+      return `${res.status} ${await res.text()}`;
+    };
+    // DNS URL host with a foreign Host header: SNI is the URL host.
+    expect(await get(`https://localhost:${port}/`, { headers: { Host: "other.example" } })).toBe("200 ok");
+    // IP URL host with tls.servername: SNI is the servername (the documented
+    // "dial an IP, verify a name" opt-in), with or without a Host header.
+    expect(await get(`https://127.0.0.1:${port}/`, { tls: { servername: "localhost" } })).toBe("200 ok");
+    expect(
+      await get(`https://127.0.0.1:${port}/`, { headers: { Host: "other.example" }, tls: { servername: "localhost" } }),
+    ).toBe("200 ok");
+    expect(seen).toEqual([
+      { sni: "localhost", host: "other.example" },
+      { sni: "localhost", host: `127.0.0.1:${port}` },
+      { sni: "localhost", host: "other.example" },
+    ]);
   } finally {
     target.close();
   }

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -66,11 +66,14 @@ describe.concurrent("fetch-tls", () => {
     // whose certificate the callback has not approved. So a redirect chain
     // yields one observation per hop, in order. The hostname handed to the
     // callback is the URL host of that hop: a request-level Host header is an
-    // HTTP field only and never becomes the TLS identity.
+    // HTTP field only and never becomes the TLS identity. The two hops use
+    // different URL hosts, and the Host header names neither, so the second
+    // observation proves the identity is re-derived from the redirect target
+    // rather than inherited from the first hop or taken from the header.
     const verifiedHostnames: string[] = [];
-    const res = await fetch(`https://127.0.0.1:${origin.port}/`, {
+    const res = await fetch(`https://localhost:${origin.port}/`, {
       keepalive: false,
-      headers: { Host: "localhost" },
+      headers: { Host: "other.example" },
       tls: {
         ca: validTls.cert,
         checkServerIdentity(hostname: string) {
@@ -81,7 +84,7 @@ describe.concurrent("fetch-tls", () => {
     });
     expect(await res.text()).toBe("from-target");
 
-    expect(verifiedHostnames).toEqual(["127.0.0.1", "127.0.0.1"]);
+    expect(verifiedHostnames).toEqual(["localhost", "127.0.0.1"]);
     // The redirect target must see a Host header derived from its own URL,
     // not the override that was supplied for the previous origin.
     expect(receivedHostHeaders).toEqual([`127.0.0.1:${target.port}`]);


### PR DESCRIPTION
### Problem
- Test-only follow-up to #35886 (f4d864bb56), which stopped the Host request header from driving TLS SNI and certificate verification. Its self-review found two assertions that do not pin what they claim.
- The cross-origin redirect test in `fetch.tls.test.ts` verified both hops against `127.0.0.1`. It cannot tell a hop-2 identity re-derived from the redirect target from one inherited from hop 1 (the mechanism the old `clear_hostname_on_redirect` flag used to guard).
- #35886 made `tls.servername` drive the SNI inside a CONNECT tunnel for the first time (`src/http/ProxyTunnel.rs`, `on_open`). The tunnel test in `proxy.test.ts` only covered the Host header half.

### Fix
- The redirect test now dials `https://localhost` with `Host: other.example` and is redirected to `https://127.0.0.1`. The `checkServerIdentity` observations must read `["localhost", "127.0.0.1"]`. The Host value names neither host, so this fails on bun 1.4.1 (`["other.example", "127.0.0.1"]`) and would fail if hop 2 inherited hop 1's identity.
- The tunnel test adds two fetches to `https://127.0.0.1` through the proxy with `tls: { servername: "localhost" }`, one with a Host header and one without. The SNI-recording target must see `localhost` each time. Bun 1.4.1 sends no SNI for that IP dial.
- Verified: both files pass on main with the debug build. Both new assertions fail with `USE_SYSTEM_BUN=1` (1.4.1, before #35886). The change is test-only, so there is no src/ diff for a fail-before run against the current tree.

### Background
- `checkServerIdentity` receives the hostname the client verifies the peer certificate against. `fetch()` calls it once per connection in a redirect chain, so a two-hop chain yields two observations.
- The CONNECT tunnel's inner TLS handshake runs in `ProxyTunnel::on_open`. It resolves its SNI through `get_tls_hostname()` like a direct connection: `tls.servername`, else the URL host.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/proxy.test.ts' 'test/js/web/fetch/fetch.tls.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/proxy.test.ts test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/http/proxy.test.ts:
(pass) GET non-TLS proxy -> non-TLS body type undefined [703.94ms]
(pass) POST non-TLS proxy -> non-TLS body type string [695.00ms]
(pass) GET TLS proxy -> non-TLS body type undefined [794.79ms]
(pass) GET non-TLS proxy -> TLS body type undefined [901.44ms]
(pass) POST non-TLS proxy -> TLS body type string [919.98ms]
(pass) POST TLS proxy -> non-TLS body type string [337.23ms]
(pass) GET TLS proxy -> TLS body type undefined [480.26ms]
(pass) POST TLS proxy -> TLS body type string [482.75ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [517.71ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [677.25ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [647.93ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [558.68ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [1094.93ms]
(pass) proxy can handle redirects with TLS server > with chunked body #12007 [1005.02ms]
(pass) non-TLS origin redirect through HTTPS proxy forwards every hop through the proxy [86.85ms]
(pass) unsupported protocol [3.56ms]
(pass) proxy with long password (> 4096 chars) sends correct authorization [95.44ms]
(pass) proxy with long password (> 4096 chars) works correctly after redirect [109.23ms]
(pass) proxy Basic auth keeps the colon for userinfo :hunter2 > https target (CONNECT) [274.44ms]
(pass) proxy Basic auth keeps the colon for userinfo squidadmin: > http target (absolute-form) [347.25ms]
(pass) proxy Basic auth keeps the colon for userinfo :hunter2 > http target (absolute-form) [299.32ms]
(pass) proxy Basic auth keeps the colon for userinfo squidadmin:hunter2 > http target (absolute-form) [288.50ms]
(pass) proxy Basic auth keeps the 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/proxy.test.ts      | 40 +++++++++++++++++++++++++------------
 test/js/web/fetch/fetch.tls.test.ts | 11 ++++++----
 2 files changed, 34 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/js/bun/http/proxy.test.ts           2      3      0
test/js/web/fetch/fetch.tls.test.ts      2     10      0
```

</details>

<!-- robobun:evidence:end -->