### PR TITLE
Add --no-ffi-cc and make --no-addons disable bun:ffi cc()

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -4370,7 +4370,14 @@
     },
     {
       "name": "no-addons",
-      "description": "Throw an error if process.dlopen is called, and disable export condition \"node-addons\"",
+      "description": "Throw an error if process.dlopen or bun:ffi cc() is called, and disable export condition \"node-addons\"",
+      "hasValue": false,
+      "required": false,
+      "multiple": false
+    },
+    {
+      "name": "no-ffi-cc",
+      "description": "Throw an error if bun:ffi cc() is called (disables the C compiler)",
       "hasValue": false,
       "required": false,
       "multiple": false

--- a/docs/runtime/c-compiler.mdx
+++ b/docs/runtime/c-compiler.mdx
@@ -201,3 +201,13 @@ cc({
   },
 });
 ```
+
+### Disabling `cc`
+
+Pass `--no-ffi-cc` to disable the C compiler for a process. Any call to `cc()` then throws an error with the code `ERR_FFI_CC_DISABLED`. The `--no-addons` flag also disables `cc()`, in addition to `process.dlopen`.
+
+```sh
+bun --no-ffi-cc ./app.ts
+```
+
+Workers inherit the setting from their parent. A Worker can also set it for itself with `execArgv: ["--no-ffi-cc"]`. Standalone executables can bake it in with `bun build --compile --compile-exec-argv="--no-ffi-cc"`.

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -94,7 +94,12 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--no-addons" type="boolean">
-  Throw an error if <code>process.dlopen</code> is called, and disable export condition <code>node-addons</code>
+  Throw an error if <code>process.dlopen</code> or <code>bun:ffi</code> <code>cc()</code> is called, and disable export
+  condition <code>node-addons</code>
+</ParamField>
+
+<ParamField path="--no-ffi-cc" type="boolean">
+  Throw an error if <code>bun:ffi</code> <code>cc()</code> is called (disables the C compiler)
 </ParamField>
 
 <ParamField path="--unhandled-rejections" type="string">

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2102,6 +2102,15 @@ extern crate alloc;
 /// casts back on the other side of each hook.
 pub type RuntimeState = *mut c_void;
 
+/// Runtime flags a Worker's `execArgv` can set. `true` means allowed.
+#[derive(Copy, Clone, Debug)]
+pub struct WorkerExecArgvFlags {
+    /// `!--no-addons`
+    pub allow_addons: bool,
+    /// `!--no-ffi-cc`
+    pub allow_ffi_cc: bool,
+}
+
 pub struct RuntimeHooks {
     /// `bun.api.Timer.All.init()` + `Body.Value.HiveAllocator.init()` +
     /// `configureDebugger()` — everything `init()` does that names a
@@ -2222,16 +2231,14 @@ pub struct RuntimeHooks {
         transpiler: *mut Transpiler<'static>,
         graph: &'static dyn bun_resolver::StandaloneModuleGraph,
     ),
-    /// Parse `execArgv` against the `RunCommand`
-    /// param table and return the resulting `allow_addons` value
-    /// (`!args.flag("--no-addons")`), or `None` if parsing failed.
-    /// The param table lives in
-    /// `bun_runtime::cli` (forward-dep). Only `--no-addons` is honoured;
-    /// the caller writes the returned bool back into
-    /// `transform_options.allow_addons` so the override semantics
-    /// ("override the existing even if it was set") match.
-    pub parse_worker_exec_argv_allow_addons:
-        unsafe fn(exec_argv: &[bun_core::WTFStringImpl]) -> Option<bool>,
+    /// Parse a Worker's `execArgv` and return the runtime flags it carries,
+    /// or `None` if parsing failed. The param table lives in
+    /// `bun_runtime::cli` (forward-dep). Only `--no-addons` and
+    /// `--no-ffi-cc` are honoured; the caller ANDs each returned bool into
+    /// the worker's `transform_options`, so a parent that disabled a
+    /// feature keeps it disabled in the worker.
+    pub parse_worker_exec_argv_flags:
+        unsafe fn(exec_argv: &[bun_core::WTFStringImpl]) -> Option<WorkerExecArgvFlags>,
     /// `CronJob.clearAllForVM(vm, .teardown)`. `CronJob` lives in
     /// `bun_runtime::api::cron`.
     pub stop_cron_for_vm_teardown: fn(vm: &mut VirtualMachine),
@@ -3498,6 +3505,13 @@ impl VirtualMachine {
             .transform_options
             .allow_addons
             .unwrap_or(true)
+    }
+
+    /// Whether `bun:ffi` `cc()` may compile C source. Both `--no-ffi-cc` and
+    /// `--no-addons` disable it.
+    pub fn allow_ffi_cc(&self) -> bool {
+        let opts = &self.transpiler.options.transform_options;
+        opts.allow_ffi_cc.unwrap_or(true) && opts.allow_addons.unwrap_or(true)
     }
 
     /// Whether to warn when a previously-unhandled rejection later gains a handler.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2231,12 +2231,8 @@ pub struct RuntimeHooks {
         transpiler: *mut Transpiler<'static>,
         graph: &'static dyn bun_resolver::StandaloneModuleGraph,
     ),
-    /// Parse a Worker's `execArgv` and return the runtime flags it carries,
-    /// or `None` if parsing failed. The param table lives in
-    /// `bun_runtime::cli` (forward-dep). Only `--no-addons` and
-    /// `--no-ffi-cc` are honoured; the caller ANDs each returned bool into
-    /// the worker's `transform_options`, so a parent that disabled a
-    /// feature keeps it disabled in the worker.
+    /// Parse a Worker's `execArgv` for the flags in [`WorkerExecArgvFlags`].
+    /// `None` if parsing failed.
     pub parse_worker_exec_argv_flags:
         unsafe fn(exec_argv: &[bun_core::WTFStringImpl]) -> Option<WorkerExecArgvFlags>,
     /// `CronJob.clearAllForVM(vm, .teardown)`. `CronJob` lives in
@@ -3507,8 +3503,7 @@ impl VirtualMachine {
             .unwrap_or(true)
     }
 
-    /// Whether `bun:ffi` `cc()` may compile C source. Both `--no-ffi-cc` and
-    /// `--no-addons` disable it.
+    /// Whether `bun:ffi` `cc()` is allowed (`--no-ffi-cc` and `--no-addons` disable it).
     pub fn allow_ffi_cc(&self) -> bool {
         let opts = &self.transpiler.options.transform_options;
         opts.allow_ffi_cc.unwrap_or(true) && opts.allow_addons.unwrap_or(true)

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -361,5 +361,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INSPECTOR_NOT_WORKER", Error],
   ["ERR_INSPECTOR_COMMAND", Error],
   ["ERR_REDIS_SERVER_ERROR", Error, "RedisError"],
+  ["ERR_FFI_CC_DISABLED", Error],
 ];
 export default errors;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -355,8 +355,7 @@ impl WebWorker {
         if !inherit_exec_argv {
             let hooks = runtime_hooks().expect("RuntimeHooks not installed");
             // SAFETY: caller passed valid (ptr,len) borrowed from C++ WorkerOptions;
-            // the hook only reads the slice. `None` on parse failure keeps the
-            // parent's settings.
+            // the hook only reads the slice.
             let parsed = unsafe {
                 (hooks.parse_worker_exec_argv_flags)(bun_core::ffi::slice(
                     exec_argv_ptr,

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -355,17 +355,19 @@ impl WebWorker {
         if !inherit_exec_argv {
             let hooks = runtime_hooks().expect("RuntimeHooks not installed");
             // SAFETY: caller passed valid (ptr,len) borrowed from C++ WorkerOptions;
-            // the hook only reads the slice. Only honours `--no-addons` today;
-            // `None` on parse failure keeps the parent's setting.
+            // the hook only reads the slice. `None` on parse failure keeps the
+            // parent's settings.
             let parsed = unsafe {
-                (hooks.parse_worker_exec_argv_allow_addons)(bun_core::ffi::slice(
+                (hooks.parse_worker_exec_argv_flags)(bun_core::ffi::slice(
                     exec_argv_ptr,
                     exec_argv_len,
                 ))
             };
-            if let Some(allow) = parsed {
-                let parent_allows = transform_options.allow_addons.unwrap_or(true);
-                transform_options.allow_addons = Some(parent_allows && allow);
+            if let Some(flags) = parsed {
+                let parent_allows_addons = transform_options.allow_addons.unwrap_or(true);
+                transform_options.allow_addons = Some(parent_allows_addons && flags.allow_addons);
+                let parent_allows_ffi_cc = transform_options.allow_ffi_cc.unwrap_or(true);
+                transform_options.allow_ffi_cc = Some(parent_allows_ffi_cc && flags.allow_ffi_cc);
             }
         }
         // The worker's `process.env` starts as a copy of the parent's now (as in

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -129,6 +129,8 @@ pub mod api {
 
         /// from `--no-addons`. `None` == `true`.
         pub allow_addons: Option<bool>,
+        /// from `--no-ffi-cc`. `None` == `true`.
+        pub allow_ffi_cc: Option<bool>,
         /// from `--unhandled-rejections`; default is `Bun`.
         pub unhandled_rejections: Option<UnhandledRejections>,
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -277,7 +277,10 @@ const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--redis-preconnect                Preconnect to $REDIS_URL at startup"),
     parse_param!("--sql-preconnect                  Preconnect to PostgreSQL at startup"),
     parse_param!(
-        "--no-addons                       Throw an error if process.dlopen is called, and disable export condition \"node-addons\""
+        "--no-addons                       Throw an error if process.dlopen or bun:ffi cc() is called, and disable export condition \"node-addons\""
+    ),
+    parse_param!(
+        "--no-ffi-cc                       Throw an error if bun:ffi cc() is called (disables the C compiler)"
     ),
     parse_param!(
         "--unhandled-rejections <STR>      One of \"strict\", \"throw\", \"warn\", \"none\", or \"warn-with-error-code\""
@@ -1086,9 +1089,13 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         }
 
         if args.flag(b"--no-addons") {
-            // used for disabling process.dlopen and
+            // used for disabling process.dlopen and bun:ffi cc(), and
             // for disabling export condition "node-addons"
             opts.allow_addons = Some(false);
+        }
+
+        if args.flag(b"--no-ffi-cc") {
+            opts.allow_ffi_cc = Some(false);
         }
 
         if let Some(unhandled_rejections) = args.option(b"--unhandled-rejections") {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -388,6 +388,9 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     if ctx.args.allow_addons == Some(false) {
         argv.push(lit(b"--no-addons\0"));
     }
+    if ctx.args.allow_ffi_cc == Some(false) {
+        argv.push(lit(b"--no-ffi-cc\0"));
+    }
     if matches!(ctx.debug.macros, MacroOptions::Disable) {
         argv.push(lit(b"--no-macros\0"));
     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2263,7 +2263,7 @@ impl TestCommand {
                 // Clone (not take): ParallelRunner::run_as_coordinator → build_worker_argv
                 // reads ctx.args.{conditions,define,loaders,tsconfig_override,drop,
                 // main_fields,extension_order,env_files,feature_flags,preserve_symlinks,
-                // allow_addons,disable_default_env_files,jsx} after this point to forward
+                // allow_addons,allow_ffi_cc,disable_default_env_files,jsx} after this point to forward
                 // them to workers.
                 transform_options: ctx.args.clone(),
                 debugger: core::mem::take(&mut ctx.runtime_options.debugger),

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -14,8 +14,8 @@ use bun_core::{EncodedSlice, ZStr};
 use bun_core::{ZBox, env_var, fmt as bun_fmt, zstr};
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{
-    self as jsc, CallFrame, EncodedSliceJsc, JSGlobalObject, JSObject, JSPropertyIterator, JSValue,
-    JsCell, JsClass, JsError, JsResult, SystemError,
+    self as jsc, CallFrame, EncodedSliceJsc, ErrorCode, JSGlobalObject, JSObject,
+    JSPropertyIterator, JSValue, JsCell, JsClass, JsError, JsResult, SystemError,
 };
 #[cfg(target_os = "macos")]
 use bun_paths as path;
@@ -985,6 +985,16 @@ impl FFI {
     // `bun_ffi_cc(__g, __f)` call, which doesn't resolve inside `impl FFI`.
     // The C-ABI shim (`Bun__FFI__cc`) is supplied by the `.classes.ts` codegen.
     pub fn bun_ffi_cc(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        if !global_this.bun_vm().allow_ffi_cc() {
+            return Err(global_this
+                .err(
+                    ErrorCode::FFI_CC_DISABLED,
+                    format_args!(
+                        "Cannot compile C code because the bun:ffi C compiler is disabled."
+                    ),
+                )
+                .throw());
+        }
         if !bun_core::Environment::ENABLE_TINYCC {
             return Err(global_this.throw(format_args!(
                 "bun:ffi cc() is not available in this build (TinyCC is disabled)"

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -28,6 +28,7 @@ use bun_jsc::module_loader::{ArenaResetGuard, FetchFlags, TranspileArgs, Transpi
 use bun_jsc::resolved_source::Bytecode;
 use bun_jsc::virtual_machine::{
     InitOptions, RuntimeHooks, RuntimeState as OpaqueRuntimeState, SweepResult, VirtualMachine,
+    WorkerExecArgvFlags,
 };
 use bun_jsc::{
     AnyPromise, ErrorableResolvedSource, JSGlobalObject, JSInternalPromise, JSModuleLoader,
@@ -1524,7 +1525,7 @@ static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     console_print_runtime_object,
     load_standalone_sourcemap,
     apply_standalone_runtime_flags,
-    parse_worker_exec_argv_allow_addons,
+    parse_worker_exec_argv_flags,
     stop_cron_for_vm_teardown,
     cron_clear_all_reload,
     retroactively_report_discovered_tests,
@@ -1564,26 +1565,27 @@ unsafe fn apply_standalone_runtime_flags(
     crate::run_main::apply_standalone_runtime_flags(unsafe { &mut *transpiler }, graph);
 }
 
-/// Parse a Worker's `execArgv` against the
-/// `RunCommand` param table and return `!args.flag("--no-addons")`, or `None`
-/// on parse error.
+/// Parse a Worker's `execArgv` and return the `--no-addons` / `--no-ffi-cc`
+/// flags it carries, or `None` on parse error.
 ///
 /// Note: the Rust `bun_clap::parse_ex` port currently constrains
 /// `ArgIter<'static>` (parsed values are stored by reference), which would
-/// force leaking the per-call UTF-8 copies of `exec_argv`. Spec only ever
-/// reads the single `--no-addons` flag from the result (per the in-tree
-/// `// TODO: currently this only checks for --no-addons`), so this body scans
-/// the converted argv directly with the same `stop_after_positional_at = 1`
+/// force leaking the per-call UTF-8 copies of `exec_argv`. Only these two
+/// boolean flags are read from a Worker's `execArgv`, so this body scans the
+/// converted argv directly with the same `stop_after_positional_at = 1`
 /// short-circuit. Full clap routing can return when `ComptimeClap` grows a
 /// borrowed-lifetime variant.
 ///
 /// # Safety
 /// Each `WTFStringImpl` in `exec_argv` is a live WTF string (the C++
 /// `Worker::create` array, kept alive for the worker's lifetime).
-unsafe fn parse_worker_exec_argv_allow_addons(
+unsafe fn parse_worker_exec_argv_flags(
     exec_argv: &[bun_core::WTFStringImpl],
-) -> Option<bool> {
-    let mut no_addons = false;
+) -> Option<WorkerExecArgvFlags> {
+    let mut flags = WorkerExecArgvFlags {
+        allow_addons: true,
+        allow_ffi_cc: true,
+    };
     for &arg in exec_argv {
         if arg.is_null() {
             continue;
@@ -1599,11 +1601,12 @@ unsafe fn parse_worker_exec_argv_allow_addons(
             break;
         }
         if bytes == b"--no-addons" {
-            no_addons = true;
+            flags.allow_addons = false;
+        } else if bytes == b"--no-ffi-cc" {
+            flags.allow_ffi_cc = false;
         }
     }
-    // Override `allow_addons` unconditionally on successful parse.
-    Some(!no_addons)
+    Some(flags)
 }
 
 /// `jsc.API.cron.CronJob.clearAllForVM(vm, .teardown)` —

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1565,16 +1565,8 @@ unsafe fn apply_standalone_runtime_flags(
     crate::run_main::apply_standalone_runtime_flags(unsafe { &mut *transpiler }, graph);
 }
 
-/// Parse a Worker's `execArgv` and return the `--no-addons` / `--no-ffi-cc`
-/// flags it carries, or `None` on parse error.
-///
-/// Note: the Rust `bun_clap::parse_ex` port currently constrains
-/// `ArgIter<'static>` (parsed values are stored by reference), which would
-/// force leaking the per-call UTF-8 copies of `exec_argv`. Only these two
-/// boolean flags are read from a Worker's `execArgv`, so this body scans the
-/// converted argv directly with the same `stop_after_positional_at = 1`
-/// short-circuit. Full clap routing can return when `ComptimeClap` grows a
-/// borrowed-lifetime variant.
+/// Scan a Worker's `execArgv` for `--no-addons` and `--no-ffi-cc`. Like the
+/// CLI parser, the scan stops at the first positional.
 ///
 /// # Safety
 /// Each `WTFStringImpl` in `exec_argv` is a live WTF string (the C++
@@ -1593,7 +1585,6 @@ unsafe fn parse_worker_exec_argv_flags(
         // SAFETY: per fn contract — `arg` is a live `WTFStringImpl*`.
         let owned = unsafe { &*arg }.to_owned_slice_z();
         let bytes = owned.as_bytes();
-        // `stop_after_positional_at = 1` — first non-flag token ends parsing.
         if bytes.first() != Some(&b'-') {
             break;
         }

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1189,3 +1189,109 @@ describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", ()
     expect(exitCode).toBe(0);
   });
 });
+
+// The gate runs before any option is read or any C is compiled, so these do
+// not need a working TinyCC and run under ASan too. Without the gate, the
+// empty `symbols` object makes cc() fail with a plain validation error, which
+// is the control for "cc() was not blocked".
+describe.concurrent("disabling cc()", () => {
+  // `report` receives one string: the error code, or the message for an
+  // error without a code, or "no-error".
+  const probeWith = (report: string) => /* js */ `
+    const { cc } = require("bun:ffi");
+    try {
+      cc({ source: "does-not-exist.c", symbols: {} });
+      ${report}("no-error");
+    } catch (e) {
+      ${report}(e.code ?? e.message);
+    }
+  `;
+  const probe = probeWith("console.log");
+
+  async function run(...args: string[]): Promise<[stdout: string, stderr: string, exitCode: number]> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  it("cc() is allowed by default", async () => {
+    const [stdout, stderr, exitCode] = await run("-e", probe);
+    expect(stdout).toBe("Expected at least one exported symbol\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("--no-ffi-cc makes cc() throw ERR_FFI_CC_DISABLED", async () => {
+    const [stdout, stderr, exitCode] = await run("--no-ffi-cc", "-e", probe);
+    expect(stdout).toBe("ERR_FFI_CC_DISABLED\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("--no-addons makes cc() throw ERR_FFI_CC_DISABLED", async () => {
+    const [stdout, stderr, exitCode] = await run("--no-addons", "-e", probe);
+    expect(stdout).toBe("ERR_FFI_CC_DISABLED\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("the error message names the disabled compiler", async () => {
+    const [stdout, stderr, exitCode] = await run(
+      "--no-ffi-cc",
+      "-p",
+      'require("bun:ffi").cc({ source: "does-not-exist.c", symbols: {} })',
+    );
+    expect(stdout).toBe("");
+    expect(stderr).toContain("error: Cannot compile C code because the bun:ffi C compiler is disabled.");
+    expect(stderr).toContain('code: "ERR_FFI_CC_DISABLED"');
+    expect(exitCode).toBe(1);
+  });
+
+  it("BUN_OPTIONS=--no-ffi-cc makes cc() throw ERR_FFI_CC_DISABLED", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", probe],
+      env: { ...bunEnv, BUN_OPTIONS: "--no-ffi-cc" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("ERR_FFI_CC_DISABLED\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // The Worker runs the probe and posts its one line back to the parent.
+  const workerHost = (execArgv: string) => /* js */ `
+    const { Worker } = require("node:worker_threads");
+    const source = ${JSON.stringify(probeWith("require('node:worker_threads').parentPort.postMessage"))};
+    const worker = new Worker(source, { eval: true, execArgv: ${execArgv} });
+    worker.on("message", msg => {
+      console.log(msg);
+      worker.terminate();
+    });
+  `;
+
+  it("--no-ffi-cc stays in effect inside a Worker with an empty execArgv", async () => {
+    const [stdout, stderr, exitCode] = await run("--no-ffi-cc", "-e", workerHost("[]"));
+    expect(stdout).toBe("ERR_FFI_CC_DISABLED\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("--no-addons stays in effect inside a Worker with an empty execArgv", async () => {
+    const [stdout, stderr, exitCode] = await run("--no-addons", "-e", workerHost("[]"));
+    expect(stdout).toBe("ERR_FFI_CC_DISABLED\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("a Worker can disable cc() for itself with execArgv", async () => {
+    const [stdout, stderr, exitCode] = await run("-e", workerHost('["--no-ffi-cc"]'));
+    expect(stdout).toBe("ERR_FFI_CC_DISABLED\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("a Worker cannot re-enable cc() that its parent disabled", async () => {
+    const [stdout, stderr, exitCode] = await run("--no-ffi-cc", "-e", workerHost('["--smol"]'));
+    expect(stdout).toBe("ERR_FFI_CC_DISABLED\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1260,14 +1260,26 @@ describe.concurrent("disabling cc()", () => {
     expect(exitCode).toBe(0);
   });
 
-  // The Worker runs the probe and posts its one line back to the parent.
+  // The Worker runs the probe and posts its one line back to the parent. A
+  // worker that fails before it posts is reported on stdout instead of
+  // hanging the process.
   const workerHost = (execArgv: string) => /* js */ `
     const { Worker } = require("node:worker_threads");
     const source = ${JSON.stringify(probeWith("require('node:worker_threads').parentPort.postMessage"))};
     const worker = new Worker(source, { eval: true, execArgv: ${execArgv} });
+    let reported = false;
     worker.on("message", msg => {
+      reported = true;
       console.log(msg);
       worker.terminate();
+    });
+    worker.on("error", e => {
+      reported = true;
+      console.log("worker error: " + (e.code ?? e.message));
+      worker.terminate();
+    });
+    worker.on("exit", code => {
+      if (!reported) console.log("worker exited with " + code + " before posting");
     });
   `;
 


### PR DESCRIPTION
### Problem
- There is no way to stop a Bun process from compiling and running C at runtime. `cc()` in `bun:ffi` takes a C source file, compiles it with the embedded TinyCC, and links the result into the process. A user who runs untrusted JavaScript asked for a release that can block this.
- `--no-addons` blocks `process.dlopen` (`src/jsc/bindings/BunProcess.cpp:416`) but not `cc()`, so it does not block native code either.

### Fix
- Adds `--no-ffi-cc`. It is parsed like `--no-addons` (`src/runtime/cli/Arguments.rs`) and stored as `allow_ffi_cc` on `TransformOptions`, next to `allow_addons`.
- `FFI::bun_ffi_cc` (`src/runtime/ffi/ffi_body.rs`) now checks `VirtualMachine::allow_ffi_cc()` first. The check is false when either `--no-ffi-cc` or `--no-addons` is set. It throws `Cannot compile C code because the bun:ffi C compiler is disabled.` with the new code `ERR_FFI_CC_DISABLED`, before any option is read or TinyCC runs.
- Workers inherit both flags from the parent and can set either through `execArgv`. A Worker cannot re-enable a flag its parent disabled. The existing `execArgv` hook now returns both flags instead of one bool. `bun test --parallel` forwards the flag to its workers.
- Verified: `test/js/bun/ffi/cc.test.ts` (`disabling cc()`, 9 cases, 7 fail on bun 1.4.1). Also `no-addons.test.ts`, `error-code-mirror.test.ts`, `worker_threads.test.ts`, and the `node-addons` resolution test.

### Background
- `cc()` is the only path that compiles user-supplied C. `dlopen`, `CFunction`, and `linkSymbols` call into existing native code through the engine and do not use TinyCC. `JSCallback` does use TinyCC, but only for Bun's own generated trampolines, so it is not gated.
- `TransformOptions` is the option bag the CLI fills and the runtime reads through `vm.transpiler.options.transform_options`. A Worker gets a clone of its parent's copy, which is how the flag reaches it.
- The flag goes through the normal argument parser, so `BUN_OPTIONS="--no-ffi-cc"` and `bun build --compile --compile-exec-argv="--no-ffi-cc"` work without extra code. Both are covered in the test or were checked by hand.

<details><summary>Notes</summary>

- With the flag set, `cc()` with arguments the JS wrapper rejects (no `source`, not an object) still throws that validation error first. The wrapper in `src/js/bun/ffi.ts` runs before the native entry. Nothing is compiled in either case.
- Docs: the flag is listed in `docs/snippets/cli/run.mdx`, and `docs/runtime/c-compiler.mdx` has a new "Disabling cc" section. `completions/bun-cli.json` has the new flag.
- The test block does not compile any C, so it runs under ASan and on Windows. The control case calls `cc()` with an empty `symbols` object and expects the native validation error, which proves the gate is off by default.
- Two tests in `test/js/web/workers/worker.test.ts` ("a message flood from a worker does not starve the parent's event loop" and "preload with an un-awaited import() does not open message delivery before the entry runs") fail locally under the debug ASan build on this machine and pass with the release build. They do not use `execArgv`, and `new Worker(url)` without `execArgv` never reaches the changed code.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->