### PR TITLE
test: take three heap-stat tests out of the parallel batch

### DIFF
--- a/test/parallel-allowlist.json
+++ b/test/parallel-allowlist.json
@@ -9,7 +9,7 @@
     "stats": {
       "dirs": 250,
       "files": 1513,
-      "excluded": 366
+      "excluded": 369
     }
   },
   "dirs": [
@@ -384,6 +384,7 @@
     "js/bun/md/md-edge-cases.test.ts",
     "js/bun/net/socket-retention.test.ts",
     "js/bun/net/socket.test.ts",
+    "js/bun/net/tcp-server.test.ts",
     "js/bun/plugin/plugins.test.ts",
     "js/bun/resolve/bun-main-entry-point.test.ts",
     "js/bun/resolve/import-custom-condition.test.ts",
@@ -433,6 +434,7 @@
     "js/bun/util/password.test.ts",
     "js/bun/util/text-loader.test.ts",
     "js/bun/websocket/websocket-server-rsv-frames.test.ts",
+    "js/bun/websocket/websocket-server.test.ts",
     "js/bun/webview/webview-chrome.test.ts",
     "js/bun/xml/xml-test-suite.test.ts",
     "js/bun/yaml/yaml.test.ts",
@@ -575,6 +577,7 @@
     "js/web/websocket/websocket-proxy.test.ts",
     "js/web/workers/performance-observer-leak.test.ts",
     "js/web/workers/structured-clone.test.ts",
+    "js/web/workers/structuredClone-classes.test.ts",
     "js/web/workers/worker-late-completion.test.ts",
     "js/web/workers/worker-terminate-funnels.test.ts",
     "js/web/workers/worker.test.ts",

--- a/test/parallel-denylist.txt
+++ b/test/parallel-denylist.txt
@@ -61,6 +61,7 @@ js/bun/io/fetch/fetch-abort-slow-connect.test.ts
 js/bun/jsc/string-noAtomize.test.ts
 js/bun/md/md-edge-cases.test.ts
 js/bun/net/socket-retention.test.ts
+js/bun/net/tcp-server.test.ts
 js/bun/plugin/plugins.test.ts
 js/bun/resolve/bun-main-entry-point.test.ts
 js/bun/resolve/import-custom-condition.test.ts
@@ -100,6 +101,7 @@ js/bun/util/filesystem_router.test.ts
 js/bun/util/inspect-error-leak.test.js
 js/bun/util/text-loader.test.ts
 js/bun/websocket/websocket-server-rsv-frames.test.ts
+js/bun/websocket/websocket-server.test.ts
 js/bun/xml/xml-test-suite.test.ts
 js/bun/yaml/yaml.test.ts
 js/node/assert/deep-equal.test.ts
@@ -170,6 +172,7 @@ js/web/fetch/fetch-proxy-tls-intern-race.test.ts
 js/web/fetch/fetch-tls-abortsignal-timeout.test.ts
 js/web/fetch/utf8-bom.test.ts
 js/web/streams/streams-leak.test.ts
+js/web/workers/structuredClone-classes.test.ts
 js/web/workers/worker-late-completion.test.ts
 js/web/workers/worker-terminate-funnels.test.ts
 js/web/workers/worker.test.ts


### PR DESCRIPTION
### What does this PR do?

Since #37483 fixed the runner dropping batch failures for files with several `describe` blocks, every build annotates these as "failed in the parallel batch … passed alone" on most platforms:

- `js/bun/websocket/websocket-server.test.ts` — "blob frames report their bytes to the garbage collector" asserts a `heapStats().extraMemorySize` delta ≥ 1 MB across a 2 MB transfer
- `js/bun/net/tcp-server.test.ts` — "should not leak memory" asserts `objectTypeCounts.Listener <= 2` / `TCPSocket <= 2`
- `js/web/workers/structuredClone-classes.test.ts` — intermittently, same shape

`bun test --parallel` workers run many files in one process and heap (per-file isolation swaps the global, not the VM), so process-wide heap statistics include other files' objects and garbage: a `Listener` from an earlier file in the same worker, or memory freed between the two `extraMemorySize` samples. The assertions are fine when the file runs on its own, which is how the runner re-runs them today after the batch failure. These three files go to `test/parallel-denylist.txt` and `excludeFiles`, as #40419 did for five others; their directories stay in the batch.

History for reference: zero such annotations in the 34 `main` builds before #37483 landed; 5–6 platforms per build for the websocket test and 3 for tcp-server in every build since. Nothing in the runtime changed in that window (the adjacent WebKit bump's own PR build, on the old runner, shows none).

### How did you verify your code works?

Confirmed all three were batched (`js/bun/net`, `js/bun/websocket`, `js/web/workers` are in `dirs`, the files were not in `excludeFiles`) and are now excluded; the annotation for them should be gone from this PR's CI.