### PR TITLE
Check for import statements in a CommonJS file after the import scanner runs

### DIFF
--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -88,8 +88,8 @@ impl JavaScript {
 
         let result = match parser.parse() {
             Ok(r) => {
-                // The parser halts on every logged error, so an AST never comes with one.
-                debug_assert!(!matches!(r, js_parser::Result::Ast(_)) || temp_log.errors == 0);
+                // The parser halts on every logged error.
+                debug_assert_eq!(temp_log.errors, 0);
                 r
             }
             Err(err) => {

--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -88,8 +88,7 @@ impl JavaScript {
 
         let result = match parser.parse() {
             Ok(r) => {
-                // Every phase of the parse halts on a logged error, so callers
-                // may run or cache an AST without checking the log.
+                // The parser halts on every logged error, so an AST never comes with one.
                 debug_assert!(!matches!(r, js_parser::Result::Ast(_)) || temp_log.errors == 0);
                 r
             }

--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -87,7 +87,12 @@ impl JavaScript {
         };
 
         let result = match parser.parse() {
-            Ok(r) => r,
+            Ok(r) => {
+                // Every phase of the parse halts on a logged error, so callers
+                // may run or cache an AST without checking the log.
+                debug_assert!(!matches!(r, js_parser::Result::Ast(_)) || temp_log.errors == 0);
+                r
+            }
             Err(err) => {
                 // `Parser::parse` consumes `self`, so `parser` is gone in this
                 // arm. The `&'a mut temp_log` it held is released, so read

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -62,8 +62,7 @@ pub struct Parser<'a> {
     pub(crate) source: &'a bun_ast::Source,
     pub(crate) define: &'a Define,
     pub(crate) bump: &'a Arena,
-    /// `log.errors` before the priming `lexer.next()` in `init`. An error the
-    /// lexer logs for the first token must count against the parse too.
+    /// `log.errors` before the priming `lexer.next()` in `init`.
     pub(crate) orig_error_count: u32,
 }
 

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -777,6 +777,11 @@ impl<'a> Parser<'a> {
             p.lexer.next()?;
         }
 
+        // The first token may already have logged an error; halt before the early returns below.
+        if p.log().errors > orig_error_count {
+            return Err(crate::Error::SyntaxError);
+        }
+
         // Detect a leading "// @bun" pragma
         if p.options.features.dont_bundle_twice {
             if let Some(pragma) = Self::has_bun_pragma(&source.contents, !hashbang.is_empty()) {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -62,6 +62,9 @@ pub struct Parser<'a> {
     pub(crate) source: &'a bun_ast::Source,
     pub(crate) define: &'a Define,
     pub(crate) bump: &'a Arena,
+    /// `log.errors` before the priming `lexer.next()` in `init`. An error the
+    /// lexer logs for the first token must count against the parse too.
+    pub(crate) orig_error_count: u32,
 }
 
 pub struct Options<'a> {
@@ -314,6 +317,7 @@ impl<'a> Parser<'a> {
         bump: &'a Arena,
     ) -> Result<Parser<'a>, Error> {
         source.check_parseable_len(log, "File")?;
+        let orig_error_count = log.errors;
         let mut lexer = js_lexer::Lexer::init_without_reading(log, source, bump);
         // Must be set before the priming `next()` so leading comments are seen.
         lexer.track_comments = options.features.minify_identifiers;
@@ -330,6 +334,7 @@ impl<'a> Parser<'a> {
             define,
             source,
             log: log_ptr,
+            orig_error_count,
         })
     }
 }
@@ -741,11 +746,9 @@ impl<'a> Parser<'a> {
             source,
             define,
             bump,
+            orig_error_count,
         } = self;
 
-        // `lexer.log` aliases `log`; route through the centralised
-        // `Lexer::log()` accessor so this site stays safe.
-        let orig_error_count = lexer.log().errors;
         // `P.log` and `Lexer.log` are both `NonNull<Log>` (see P.rs / lexer.rs
         // field docs), so handing the same raw pointer to both is defined —
         // no `&mut` is materialized.

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2157,8 +2157,7 @@ impl<'a> Parser<'a> {
         let ast = p.to_ast(&mut parts, exports_kind, wrap_mode, hashbang)?;
 
         if reject_import_statements {
-            // An empty range marks a record the parser generated (the JSX runtime
-            // import). Only an import the user wrote gets this error.
+            // An empty range marks a parser-generated record, like the JSX runtime import.
             let import_record: Option<&ImportRecord> =
                 ast.import_records.as_slice().iter().find(|import_record| {
                     !import_record

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1555,9 +1555,7 @@ impl<'a> Parser<'a> {
             p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate > 0;
 
         let mut wrap_mode: WrapMode = WrapMode::None;
-        // An `import` statement cannot be printed inside Bun's CommonJS wrapper.
-        // Checked after `to_ast`, once the import scanner has marked
-        // TypeScript type-only imports as unused.
+        // Checked after `to_ast`, which marks TypeScript type-only imports unused.
         let mut reject_import_statements = false;
 
         if p.is_deoptimized_commonjs() {
@@ -2231,8 +2229,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Errors logged during `to_ast` (duplicate export names) or just above
-        // halt here too, like the parse-phase and visit-phase checks.
+        // If there were errors during to_ast, also halt here
         if p.log().errors > orig_error_count {
             return Err(crate::Error::SyntaxError);
         }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2157,12 +2157,15 @@ impl<'a> Parser<'a> {
         let ast = p.to_ast(&mut parts, exports_kind, wrap_mode, hashbang)?;
 
         if reject_import_statements {
+            // An empty range marks a record the parser generated (the JSX runtime
+            // import). Only an import the user wrote gets this error.
             let import_record: Option<&ImportRecord> =
                 ast.import_records.as_slice().iter().find(|import_record| {
                     !import_record
                         .flags
                         .intersects(ImportRecordFlags::IS_INTERNAL | ImportRecordFlags::IS_UNUSED)
                         && import_record.kind == bun_ast::ImportKind::Stmt
+                        && !import_record.range.is_empty()
                 });
 
             if let Some(record) = import_record {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1555,6 +1555,10 @@ impl<'a> Parser<'a> {
             p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate > 0;
 
         let mut wrap_mode: WrapMode = WrapMode::None;
+        // An `import` statement cannot be printed inside Bun's CommonJS wrapper.
+        // Checked after `to_ast`, once the import scanner has marked
+        // TypeScript type-only imports as unused.
+        let mut reject_import_statements = false;
 
         if p.is_deoptimized_commonjs() {
             exports_kind = js_ast::ExportsKind::Cjs;
@@ -1565,87 +1569,7 @@ impl<'a> Parser<'a> {
             exports_kind = js_ast::ExportsKind::Cjs;
             if p.options.features.commonjs_at_runtime {
                 wrap_mode = WrapMode::BunCommonjs;
-
-                let import_record: Option<&ImportRecord> = 'brk: {
-                    for import_record in p.import_records.items() {
-                        if import_record.flags.intersects(
-                            ImportRecordFlags::IS_INTERNAL | ImportRecordFlags::IS_UNUSED,
-                        ) {
-                            continue;
-                        }
-                        if import_record.kind == bun_ast::ImportKind::Stmt {
-                            break 'brk Some(import_record);
-                        }
-                    }
-
-                    None
-                };
-
-                // make it an error to use an import statement with a commonjs exports usage
-                if let Some(record) = import_record {
-                    // find the usage of the export symbol
-
-                    let mut notes = BumpVec::<bun_ast::Data>::new_in(p.arena);
-
-                    notes.push(bun_ast::Data {
-                        text: {
-                            use std::io::Write;
-                            let mut v = Vec::<u8>::new();
-                            let _ = write!(
-                                &mut v,
-                                "Try require({}) instead",
-                                bun_core::fmt::QuotedFormatter {
-                                    text: record.path.text
-                                }
-                            );
-                            std::borrow::Cow::Owned(v)
-                        },
-                        ..Default::default()
-                    });
-
-                    if uses_module_ref {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because 'module' was used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    if uses_exports_ref {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because 'exports' was used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    if p.has_top_level_return {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because top-level return was used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    if p.has_with_scope {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because a \"with\" statement is used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    p.log().add_range_error_with_notes(
-                        Some(p.source),
-                        record.range,
-                        b"Cannot use import statement with CommonJS-only features".as_slice(),
-                        notes.into_iter().collect::<Vec<_>>().into_boxed_slice(),
-                    );
-                }
+                reject_import_statements = true;
             }
         } else {
             match p.options.module_type {
@@ -2232,12 +2156,88 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Ok(crate::Result::Ast(p.to_ast(
-            &mut parts,
-            exports_kind,
-            wrap_mode,
-            hashbang,
-        )?))
+        let ast = p.to_ast(&mut parts, exports_kind, wrap_mode, hashbang)?;
+
+        if reject_import_statements {
+            let import_record: Option<&ImportRecord> =
+                ast.import_records.as_slice().iter().find(|import_record| {
+                    !import_record
+                        .flags
+                        .intersects(ImportRecordFlags::IS_INTERNAL | ImportRecordFlags::IS_UNUSED)
+                        && import_record.kind == bun_ast::ImportKind::Stmt
+                });
+
+            if let Some(record) = import_record {
+                let mut notes = BumpVec::<bun_ast::Data>::new_in(p.arena);
+
+                notes.push(bun_ast::Data {
+                    text: {
+                        use std::io::Write;
+                        let mut v = Vec::<u8>::new();
+                        let _ = write!(
+                            &mut v,
+                            "Try require({}) instead",
+                            bun_core::fmt::QuotedFormatter {
+                                text: record.path.text
+                            }
+                        );
+                        std::borrow::Cow::Owned(v)
+                    },
+                    ..Default::default()
+                });
+
+                if uses_module_ref {
+                    notes.push(bun_ast::Data {
+                        text: std::borrow::Cow::Borrowed(
+                            b"This file is CommonJS because 'module' was used",
+                        ),
+                        ..Default::default()
+                    });
+                }
+
+                if uses_exports_ref {
+                    notes.push(bun_ast::Data {
+                        text: std::borrow::Cow::Borrowed(
+                            b"This file is CommonJS because 'exports' was used",
+                        ),
+                        ..Default::default()
+                    });
+                }
+
+                if p.has_top_level_return {
+                    notes.push(bun_ast::Data {
+                        text: std::borrow::Cow::Borrowed(
+                            b"This file is CommonJS because top-level return was used",
+                        ),
+                        ..Default::default()
+                    });
+                }
+
+                if p.has_with_scope {
+                    notes.push(bun_ast::Data {
+                        text: std::borrow::Cow::Borrowed(
+                            b"This file is CommonJS because a \"with\" statement is used",
+                        ),
+                        ..Default::default()
+                    });
+                }
+
+                p.log().add_range_error_with_notes(
+                    Some(p.source),
+                    record.range,
+                    b"Cannot use import statement with CommonJS-only features".as_slice(),
+                    notes.into_iter().collect::<Vec<_>>().into_boxed_slice(),
+                );
+            }
+        }
+
+        // Errors logged during `to_ast` (duplicate export names) or just above
+        // halt here too, like the parse-phase and visit-phase checks.
+        if p.log().errors > orig_error_count {
+            return Err(crate::Error::SyntaxError);
+        }
+
+        Ok(crate::Result::Ast(ast))
     }
 
     // associated fn (was `&self` reading `self.lexer.source.contents`)

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1688,6 +1688,7 @@ pub fn new_lazy_export_ast_impl<'bump>(
         define,
         source,
         log: log_ptr,
+        orig_error_count: 0,
     };
     let result = match parser.to_lazy_export_ast(expr, runtime_api_call, symbols) {
         Ok(r) => r,

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -926,12 +926,6 @@ impl TranspilerJob {
             }
         }
 
-        // The parser can log errors and still return an AST.
-        if transpiler.log().errors > 0 {
-            self.parse_error = Some(crate::CrateError::ParseError);
-            return;
-        }
-
         // SAFETY: leaf scalar field read; see `vm` note above. Inlined
         // `VirtualMachine::use_isolation_source_provider_cache` to avoid forming
         // `&VirtualMachine`.

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -83,21 +83,29 @@ describe("transpiler cache", () => {
   });
   test("does not cache a file whose parse logged an error", async () => {
     // The parser reports the `import` next to `module.exports` after it has
-    // built the AST. Nothing may be printed or cached for such a file, or a
+    // built the AST, and the lexer reports `0foo` while the parser is being
+    // constructed. Nothing may be printed or cached for such a file, or a
     // later run would serve the broken output from the cache without the error.
     const filler = "\n//" + Buffer.alloc(5 * 1024, "f").toString();
     writeFileSync(join(temp_dir, "dep.js"), `export const x = 1;`);
     writeFileSync(join(temp_dir, "mixed.js"), `import { x } from "./dep.js";\nmodule.exports = { x };` + filler);
+    writeFileSync(join(temp_dir, "first.js"), `\\u0030foo = 1;` + filler);
     writeFileSync(
       join(temp_dir, "main.js"),
       `const out = {};
-       try { await import("./mixed.js"); } catch (e) { out.import = [e.name, e.message]; }
-       try { require("./mixed.js"); } catch (e) { out.require = [e.name, e.message]; }
+       for (const file of ["./mixed.js", "./first.js"]) {
+         try { await import(file); } catch (e) { out["import " + file] = [e.name, e.message]; }
+         try { require(file); } catch (e) { out["require " + file] = [e.name, e.message]; }
+       }
        console.log(JSON.stringify(out));`,
     );
+    const mixed = ["BuildMessage", "Cannot use import statement with CommonJS-only features"];
+    const first = ["BuildMessage", 'Invalid identifier: "0foo"'];
     const expected = JSON.stringify({
-      import: ["BuildMessage", "Cannot use import statement with CommonJS-only features"],
-      require: ["BuildMessage", "Cannot use import statement with CommonJS-only features"],
+      "import ./mixed.js": mixed,
+      "require ./mixed.js": mixed,
+      "import ./first.js": first,
+      "require ./first.js": first,
     });
     expect(await bunRun(join(temp_dir, "main.js"), env)).toSpawn(expected);
     expect(await bunRun(join(temp_dir, "main.js"), env)).toSpawn(expected);

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -81,6 +81,28 @@ describe("transpiler cache", () => {
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("a");
     expect(!existsSync(cache_dir)).toBeTrue();
   });
+  test("does not cache a file whose parse logged an error", async () => {
+    // The parser reports the `import` next to `module.exports` after it has
+    // built the AST. Nothing may be printed or cached for such a file, or a
+    // later run would serve the broken output from the cache without the error.
+    const filler = "\n//" + Buffer.alloc(5 * 1024, "f").toString();
+    writeFileSync(join(temp_dir, "dep.js"), `export const x = 1;`);
+    writeFileSync(join(temp_dir, "mixed.js"), `import { x } from "./dep.js";\nmodule.exports = { x };` + filler);
+    writeFileSync(
+      join(temp_dir, "main.js"),
+      `const out = {};
+       try { await import("./mixed.js"); } catch (e) { out.import = [e.name, e.message]; }
+       try { require("./mixed.js"); } catch (e) { out.require = [e.name, e.message]; }
+       console.log(JSON.stringify(out));`,
+    );
+    const expected = JSON.stringify({
+      import: ["BuildMessage", "Cannot use import statement with CommonJS-only features"],
+      require: ["BuildMessage", "Cannot use import statement with CommonJS-only features"],
+    });
+    expect(await bunRun(join(temp_dir, "main.js"), env)).toSpawn(expected);
+    expect(await bunRun(join(temp_dir, "main.js"), env)).toSpawn(expected);
+    expect(!existsSync(cache_dir)).toBeTrue();
+  });
   test("it is indeed content addressable", async () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("b");

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -219,8 +219,8 @@ test.concurrent("a type-only import next to module.exports loads on every path",
 
   if (exitCode !== 0) console.error(stderr);
   expect(JSON.parse(stdout)).toEqual({ import: { f: { x: 1 } }, require: { f: { x: 1 } } });
-  expect(exitCode).toBe(0);
   expect(directStderr).toBe("");
+  expect(exitCode).toBe(0);
   expect(directExitCode).toBe(0);
 });
 

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -247,6 +247,43 @@ test.concurrent("JSX next to module.exports is not blamed on a runtime import", 
   expect(stderr).not.toContain("Try require(");
 });
 
+// The lexer reads the first token while the parser is constructed. An error it
+// logs there still has to fail the parse, on both load paths.
+test.concurrent("a lexer error on the first token rejects import() and require()", async () => {
+  using dir = tempDir("build-error-first-token", {
+    // `\u0030foo` spells the identifier `0foo`.
+    "bad.js": `\\u0030foo = 1;\nconsole.log("loaded");`,
+    "main.js": `
+      const out = {};
+      try {
+        await import("./bad.js");
+      } catch (e) {
+        out.import = [e.name, e.message];
+      }
+      try {
+        require("./bad.js");
+      } catch (e) {
+        out.require = [e.name, e.message];
+      }
+      console.log(JSON.stringify(out));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) console.error(stderr);
+  const expected = ["BuildMessage", 'Invalid identifier: "0foo"'];
+  expect(JSON.parse(stdout)).toEqual({ import: expected, require: expected });
+  expect(exitCode).toBe(0);
+});
+
 test("BuildMessage finalize frees with the same allocator it was created with", async () => {
   // BuildMessage.create() clones the message with the passed allocator
   // but finalize() was freeing it with bun.default_allocator and never

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -240,11 +240,14 @@ test.concurrent("JSX next to module.exports is not blamed on a runtime import", 
     stderr: "pipe",
   });
 
-  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  // The file still fails to load: the generated import is printed inside the
+  // CommonJS wrapper, and JSC rejects that. The error must not name it.
   expect(stdout).toBe("");
   expect(stderr).not.toContain("Cannot use import statement with CommonJS-only features");
   expect(stderr).not.toContain("Try require(");
+  expect(exitCode).toBe(1);
 });
 
 // The lexer reads the first token while the parser is constructed. An error it

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -218,7 +218,7 @@ test.concurrent("a type-only import next to module.exports loads on every path",
     direct.exited,
   ]);
 
-  if (exitCode !== 0) console.error(stderr);
+  expect(stderr).toBe("");
   expect(JSON.parse(stdout)).toEqual({ import: { f: { x: 1 } }, require: { f: { x: 1 } } });
   expect(directStdout).toBe("");
   expect(directStderr).toBe("");
@@ -285,7 +285,7 @@ test.concurrent("a lexer error on the first token rejects import() and require()
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  if (exitCode !== 0) console.error(stderr);
+  expect(stderr).toBe("");
   const expected = ["BuildMessage", 'Invalid identifier: "0foo"'];
   expect(JSON.parse(stdout)).toEqual({
     "import ./bad.js": expected,

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -226,6 +226,27 @@ test.concurrent("a type-only import next to module.exports loads on every path",
   expect(directExitCode).toBe(0);
 });
 
+// The parser adds the JSX runtime import itself. It must not be reported as
+// an import statement the user should replace with require().
+test.concurrent("JSX next to module.exports is not blamed on a runtime import", async () => {
+  using dir = tempDir("build-error-jsx-cjs", {
+    "mixed.tsx": `const el = <div />;\nmodule.exports = { el };`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "mixed.tsx"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(stderr).not.toContain("Cannot use import statement with CommonJS-only features");
+  expect(stderr).not.toContain("Try require(");
+});
+
 test("BuildMessage finalize frees with the same allocator it was created with", async () => {
   // BuildMessage.create() clones the message with the passed allocator
   // but finalize() was freeing it with bun.default_allocator and never

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -182,6 +182,48 @@ test("import whose transpile log holds a resolve error rejects with a ResolveMes
   ]);
 });
 
+// TypeScript drops an import whose bindings are only used as types. Such a file
+// is plain CommonJS after transpilation, so the `import` must not be reported
+// as a conflict with `module.exports`.
+test.concurrent("a type-only import next to module.exports loads on every path", async () => {
+  using dir = tempDir("build-error-type-only-import", {
+    "types.ts": `export interface Foo { x: number }`,
+    "mixed.ts": `import { Foo } from "./types";\nconst f: Foo = { x: 1 };\nmodule.exports = { f };`,
+    "main.ts": `
+      const viaImport = (await import("./mixed.ts")).default;
+      const viaRequire = require("./mixed.ts");
+      console.log(JSON.stringify({ import: viaImport, require: viaRequire }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  await using direct = Bun.spawn({
+    cmd: [bunExe(), "mixed.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode, directStderr, directExitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+    direct.stderr.text(),
+    direct.exited,
+  ]);
+
+  if (exitCode !== 0) console.error(stderr);
+  expect(JSON.parse(stdout)).toEqual({ import: { f: { x: 1 } }, require: { f: { x: 1 } } });
+  expect(exitCode).toBe(0);
+  expect(directStderr).toBe("");
+  expect(directExitCode).toBe(0);
+});
+
 test("BuildMessage finalize frees with the same allocator it was created with", async () => {
   // BuildMessage.create() clones the message with the passed allocator
   // but finalize() was freeing it with bun.default_allocator and never

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -251,22 +251,26 @@ test.concurrent("JSX next to module.exports is not blamed on a runtime import", 
 });
 
 // The lexer reads the first token while the parser is constructed. An error it
-// logs there still has to fail the parse, on both load paths.
+// logs there still has to fail the parse, on both load paths, also when the
+// `// @bun` pragma makes the parser hand the file over without parsing it.
 test.concurrent("a lexer error on the first token rejects import() and require()", async () => {
   using dir = tempDir("build-error-first-token", {
     // `\u0030foo` spells the identifier `0foo`.
     "bad.js": `\\u0030foo = 1;\nconsole.log("loaded");`,
+    "prebundled.js": `// @bun\n\\u0030foo = 1;\nconsole.log("loaded");`,
     "main.js": `
       const out = {};
-      try {
-        await import("./bad.js");
-      } catch (e) {
-        out.import = [e.name, e.message];
-      }
-      try {
-        require("./bad.js");
-      } catch (e) {
-        out.require = [e.name, e.message];
+      for (const file of ["./bad.js", "./prebundled.js"]) {
+        try {
+          await import(file);
+        } catch (e) {
+          out["import " + file] = [e.name, e.message];
+        }
+        try {
+          require(file);
+        } catch (e) {
+          out["require " + file] = [e.name, e.message];
+        }
       }
       console.log(JSON.stringify(out));
     `,
@@ -283,7 +287,12 @@ test.concurrent("a lexer error on the first token rejects import() and require()
 
   if (exitCode !== 0) console.error(stderr);
   const expected = ["BuildMessage", 'Invalid identifier: "0foo"'];
-  expect(JSON.parse(stdout)).toEqual({ import: expected, require: expected });
+  expect(JSON.parse(stdout)).toEqual({
+    "import ./bad.js": expected,
+    "require ./bad.js": expected,
+    "import ./prebundled.js": expected,
+    "require ./prebundled.js": expected,
+  });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -209,16 +209,18 @@ test.concurrent("a type-only import next to module.exports loads on every path",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode, directStderr, directExitCode] = await Promise.all([
+  const [stdout, stderr, exitCode, directStdout, directStderr, directExitCode] = await Promise.all([
     proc.stdout.text(),
     proc.stderr.text(),
     proc.exited,
+    direct.stdout.text(),
     direct.stderr.text(),
     direct.exited,
   ]);
 
   if (exitCode !== 0) console.error(stderr);
   expect(JSON.parse(stdout)).toEqual({ import: { f: { x: 1 } }, require: { f: { x: 1 } } });
+  expect(directStdout).toBe("");
   expect(directStderr).toBe("");
   expect(exitCode).toBe(0);
   expect(directExitCode).toBe(0);


### PR DESCRIPTION
### Problem
- A `.ts` file with an import that is only used as a type, next to `module.exports`, fails to load with `Cannot use import statement with CommonJS-only features`. TypeScript drops such an import, so the transpiled file is plain CommonJS. `require()` and the entry point have rejected it for a long time. Since #40568, `import` and `import()` reject it too. On 1.4.1 they loaded it.
- Cause: the check ran in `P::_parse` before `to_ast` (`src/js_parser/parse/parse_entry.rs:1569`). The import scanner inside `to_ast` is what marks an elided TypeScript import `IS_UNUSED` (`src/js_parser/scan/scan_imports.rs:287`), so the check saw every import as live.

### Fix
- Run the check after `to_ast`, over `ast.import_records`. The `IS_INTERNAL | IS_UNUSED` skip now sees the scanner's result. Records with an empty range are skipped too: the parser generates them (the JSX runtime import), and the user cannot replace those with `require()`. The error text and notes are unchanged.
- Make the parser fail on every logged error. `_parse` now halts after `to_ast` as it already does after the parse and visit phases (`parse_entry.rs:849`, `:1110`). `Parser::init` takes the error baseline before the priming `lexer.next()`, and `_parse` checks it right after the hashbang, before the `// @bun` pragma and transpiler cache returns, so an error on the first token (`\u0030foo`, an out-of-range `\u{110000}` escape) counts on every path. Before, such a file came back as an `Ok` result with an error in the log. A debug assertion in `cache::JavaScript::parse` pins the invariant.
- Correct because the decision is made from the same records the printer emits. A file that prints with no `import` statement runs as CommonJS, as it did before. A file that keeps one is still rejected on all paths. Every caller already treats a parse that fails this way as a build error with the log attached.
- Drop the `log().errors > 0` check #40568 added to `RuntimeTranspilerStore`. The parser no longer returns an AST with a logged error, so it was dead.
- Verified: `test/js/bun/resolve/build-error.test.ts` (type-only import case fails on main, passes here; JSX and first-token cases, the latter also through a `// @bun` file), `test/cli/run/transpiler-cache.test.ts` (no cache entry for a file whose parse logged an error). Also ran `test/js/bun/typescript/`, `test/bundler/transpiler/`, `test/js/bun/resolve/`, the CJS/ESM tests in `test/cli/run/`, `test/js/node/module/` and eight bundler suites.

### Background
- `P::_parse` has three phases: parse statements, visit, and `to_ast` (final assembly). `to_ast` runs the import scanner, which records exports and drops TypeScript imports with no value use by marking their record `IS_UNUSED`. `Parser::init` reads the first token before `_parse` starts.
- A file that uses a CommonJS-only feature (`module`, `exports`, top-level `return`) is printed inside a function wrapper. An `import` statement is invalid there, so the parser reports the mix.
- `cache::JavaScript::parse` maps a parser `Err` to `Ok(None)` and keeps the log. The runtime turns that into a `BuildMessage` rejection, the bundler into a failed build.

<details><summary>Notes</summary>

Repro:

```ts
// types.ts
export interface Foo { x: number }
// mixed.ts
import { Foo } from "./types";
const f: Foo = { x: 1 };
module.exports = { f };
// main.ts
console.log((await import("./mixed.ts")).default);
```

1.4.1: `import()` prints `{ f: { x: 1 } }`, `require()` and `bun mixed.ts` fail. main (4dd0588): all three fail. This branch: all three load.

Cases probed on this branch, via `import()`: `import type { Foo }` plus `module.exports` loads. `import { Foo, x }` with `x` used as a value plus `module.exports` is rejected. A bare `import "./dep"` plus `module.exports` is rejected. A `.js` file with an unused `import` plus `module.exports` is rejected (JavaScript keeps unused imports at runtime). `import { Foo }` plus `exports.f = ...` loads.

`commonjs_at_runtime` is only set by the two runtime module loaders (`src/runtime/jsc_hooks.rs:2652`, `src/jsc/RuntimeTranspilerStore.rs:808`), so the relocated check cannot fire in the bundler or the dev server.

A `.tsx` file with JSX next to `module.exports` fails on 1.4.1 and on main with JSC's `SyntaxError`, because the generated `import { jsxDEV } from "react/jsx-dev-runtime"` is printed inside the wrapper. Without the empty-range skip this branch reported it as `Cannot use import statement with CommonJS-only features` with `note: Try require("react/jsx-dev-runtime") instead` and no location. With the skip it fails as before. #38012 makes that case work by binding the helpers with `require()`.

The first-token hole, found in review: `Parser::init` calls `lexer.next()` once, and `_parse` took its baseline only afterwards. `Lexer::next` logs `Invalid identifier` and `Unicode escape sequence is out of range` and returns `Ok`, so on the first token none of the halt checks saw them. With the `RuntimeTranspilerStore` check gone, `import()` of `\u{110000}abc; console.log("ran"); module.exports = {}` executed the file and `import()` of `\u0030foo = 1;` handed `0foo = 1;` to JSC and wrote it to the transpiler cache, while `require()` rejected both. Taking the baseline in `Parser::init` closes it for every caller.

The sync path's own post-parse check at `src/runtime/jsc_hooks.rs:2761` is now redundant as well. It is left alone here to keep this change small.

The new transpiler-cache test fails on 1.4.1 (the first run writes a cache entry for the broken output and reports JSC's `SyntaxError`). On main it already passes through the `RuntimeTranspilerStore` check. It pins the invariant now that the parser carries it.

In this container the `load the same empty JS file 2000 times` test in `test/js/bun/resolve/` times out at its 5 s limit on the debug ASAN build, with or without this change.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts test/js/bun/resolve/build-error.test.ts
bun test v1.4.1 (adc354d99)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [714.38ms]
(pass) transpiler cache > works with empty files [676.10ms]
(pass) transpiler cache > ignores files under the minimum cache size [287.06ms]
(pass) transpiler cache > does not cache a file whose parse logged an error [728.86ms]
(pass) transpiler cache > it is indeed content addressable [1019.22ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1519.04ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [607.75ms]
(pass) transpiler cache > works if the cache is not user-readable [898.43ms]
(pass) transpiler cache > works if the cache is not user-writable [313.39ms]
(pass) transpiler cache > does not inline process.env [706.01ms]
(pass) transpiler cache > --feature flag invalidates cache [1828.32ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > re
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (eea7b4e54)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [12.85ms]
(pass) transpiler cache > works with empty files [12.35ms]
(pass) transpiler cache > ignores files under the minimum cache size [5.73ms]
(pass) transpiler cache > does not cache a file whose parse logged an error [14.92ms]
(pass) transpiler cache > it is indeed content addressable [16.48ms]
(pass) transpiler cache > doing 50 buns at once does not crash [30.94ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [12.67ms]
(pass) transpiler cache > works if the cache is not user-readable [15.92ms]
(pass) transpiler cache > works if the cache is not user-writable [5.67ms]
(pass) transpiler cache > does not inline process.env [10.93ms]
(pass) transpiler cache > --feature flag invalidates cache [31.07ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extensions is still consulted [13.66ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > unknown extensions still use the file loader [15.44ms]
(pass) rejects cached module 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts test/js/bun/resolve/build-error.test.ts
bun test v1.4.1 (adc354d99)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [639.93ms]
(pass) transpiler cache > works with empty files [668.27ms]
(pass) transpiler cache > ignores files under the minimum cache size [277.73ms]
(pass) transpiler cache > does not cache a file whose parse logged an error [838.80ms]
(pass) transpiler cache > it is indeed content addressable [903.84ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1531.88ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [684.08ms]
(pass) transpiler cache > works if the cache is not user-readable [990.27ms]
(pass) transpiler cache > works if the cache is not user-writable [311.96ms]
(pass) transpiler cache > does not inline process.env [617.38ms]
(pass) transpiler cache > --feature flag invalidates cache [1829.45ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > req
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 588ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/cache.rs                    |   6 +-
 src/js_parser/parse/parse_entry.rs      | 186 ++++++++++++++++----------------
 src/js_parser/parser.rs                 |   1 +
 src/jsc/RuntimeTranspilerStore.rs       |   6 --
 test/cli/run/transpiler-cache.test.ts   |  30 ++++++
 test/js/bun/resolve/build-error.test.ts | 114 ++++++++++++++++++++
 6 files changed, 246 insertions(+), 97 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/bundler/cache.rs                         4      3      0
src/js_parser/parse/parse_entry.rs          11     13      0
src/js_parser/parser.rs                      1      2      0
src/jsc/RuntimeTranspilerStore.rs            8      7      0
test/cli/run/transpiler-cache.test.ts        3      2      0
test/js/bun/resolve/build-error.test.ts      9     10      0
```

</details>

<!-- robobun:evidence:end -->