### PR TITLE
Bun.serve: never terminate a failed body stream as a complete message

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1001,11 +1001,8 @@ where
         let has_responded = resp.has_responded();
 
         // The status line is already committed (a direct ReadableStream's
-        // pull() threw synchronously after do_render_stream wrote headers).
-        // error() cannot replace a response whose status is on the wire;
-        // report the failure and close without the terminating chunk so the
-        // client observes an incomplete message instead of a second header
-        // block spliced into the chunked body.
+        // pull() threw synchronously after do_render_stream wrote headers), so
+        // error() cannot replace it: report the failure and close instead.
         if !has_responded && self.flags.has_written_status() {
             if !value.is_empty_or_undefined_or_null()
                 && let Some(server) = self.server.get()
@@ -1285,14 +1282,10 @@ where
         }
     }
 
-    /// The body source failed after the status line was committed. The
-    /// terminating chunk would turn the truncated body into a complete,
-    /// successful-looking message (RFC 9112 section 7), so while the response
-    /// is still pending close the connection instead and let the client see
-    /// an incomplete message. Whether any body bytes went out first does not
-    /// matter: an empty chunked body with a terminator is just as complete.
-    /// Once the sink already ended the response there is nothing left to
-    /// signal and `end_stream()` only releases the context.
+    /// The body failed after the status line was committed. A terminating
+    /// chunk would make the truncated body look complete (RFC 9112 section 7),
+    /// so close the connection while the response is still pending. Once the
+    /// sink already ended it, `end_stream()` only releases the context.
     pub(crate) fn close_incomplete_stream(&self) {
         if let Some(resp) = self.resp.get() {
             if resp.state().is_response_pending() {
@@ -3356,9 +3349,7 @@ where
                 this.run_error_handler(js_err);
                 return;
             }
-            // Same as handle_reject_stream: error() cannot replace a
-            // committed status, so report the failure and close without the
-            // terminating chunk.
+            // Committed status: report and close, like handle_reject_stream.
             let global_this = this.server().global_this();
             let js_err = err.to_js(global_this);
             if !js_err.is_empty_or_undefined_or_null() {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3004,50 +3004,9 @@ where
             self.render_metadata();
         }
 
-        if DEBUG_MODE {
-            if let Some(server) = self.server.get() {
-                if !err.is_empty_or_undefined_or_null() {
-                    let server = &*server;
-                    let mut exception_list: jsc::ExceptionList = Vec::new();
-                    server
-                        .vm()
-                        .as_mut()
-                        .run_error_handler(err, Some(&mut exception_list));
-
-                    // The fallback page below writes into `resp`, which must
-                    // not be dereferenced once the sink has already ended the
-                    // response (see `end_already_responded_stream`).
-                    if !ended_response && server.dev_server().is_some() {
-                        // Render the error fallback HTML page like renderDefaultError does
-                        if !self.flags.has_written_status() {
-                            self.flags.set_has_written_status(true);
-                            if let Some(resp) = self.resp.get() {
-                                resp.write_status(b"500 Internal Server Error");
-                                resp.write_header(
-                                    b"content-type",
-                                    &bun_http_types::MimeType::HTML.value,
-                                );
-                            }
-                        }
-
-                        let bb = DevErrorPage {
-                            message: b"Stream error during server-side rendering",
-                            cwd: bun_resolver::fs::FileSystem::get().top_level_dir,
-                            exceptions: &exception_list,
-                            log: None,
-                        }
-                        .render();
-
-                        if let Some(resp) = self.resp.get() {
-                            // SAFETY: FFI handle
-                            resp.write(&bb);
-                        }
-
-                        self.end_stream(self.should_close_connection());
-                        return;
-                    }
-                }
-            }
+        // Production mode keeps this asynchronous JS path quiet.
+        if DEBUG_MODE && self.report_committed_body_error(err, !ended_response) {
+            return;
         }
         // HTTP/1 only: the sink already fully ended the response, so `resp`
         // can no longer be dereferenced (see `end_already_responded_stream`).
@@ -3058,6 +3017,45 @@ where
             return;
         }
         self.close_incomplete_stream();
+    }
+
+    /// Reports a body failure that arrived after the status line was
+    /// committed, so `error()` can no longer answer. Under a bake dev server
+    /// the error page is appended to the body and the response ends normally:
+    /// returns `true`, and the caller must not touch `resp` again.
+    /// `resp_writable` is false once the sink has already ended the response
+    /// (see `end_already_responded_stream`).
+    fn report_committed_body_error(&self, err: JSValue, resp_writable: bool) -> bool {
+        if err.is_empty_or_undefined_or_null() {
+            return false;
+        }
+        let server = self.server();
+        if !DEBUG_MODE || !resp_writable || server.dev_server().is_none() {
+            server.vm().as_mut().run_error_handler(err, None);
+            return false;
+        }
+
+        let mut exception_list: jsc::ExceptionList = Vec::new();
+        server
+            .vm()
+            .as_mut()
+            .run_error_handler(err, Some(&mut exception_list));
+
+        let bb = DevErrorPage {
+            message: b"Stream error during server-side rendering",
+            cwd: bun_resolver::fs::FileSystem::get().top_level_dir,
+            exceptions: &exception_list,
+            log: None,
+        }
+        .render();
+
+        if let Some(resp) = self.resp.get() {
+            // SAFETY: FFI handle
+            resp.write(&bb);
+        }
+
+        self.end_stream(self.should_close_connection());
+        true
     }
 
     pub(crate) fn do_render_with_body(
@@ -3346,11 +3344,11 @@ where
                 this.run_error_handler(js_err);
                 return;
             }
-            // Committed status: report and close, like handle_reject_stream.
+            // Committed status: report in both modes, then close like
+            // handle_reject_stream.
             let global_this = this.server().global_this();
-            let js_err = err.to_js(global_this);
-            if !js_err.is_empty_or_undefined_or_null() {
-                this.server().vm().as_mut().run_error_handler(js_err, None);
+            if this.report_committed_body_error(err.to_js(global_this), true) {
+                return;
             }
             this.close_incomplete_stream();
             return;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1000,9 +1000,8 @@ where
         // SAFETY: FFI handle, just checked Some
         let has_responded = resp.has_responded();
 
-        // The status line is already committed (a direct ReadableStream's
-        // pull() threw synchronously after do_render_stream wrote headers), so
-        // error() cannot replace it: report the failure and close instead.
+        // The status line is already committed (a direct stream's pull() threw
+        // synchronously after the headers were written): report and close.
         if !has_responded && self.flags.has_written_status() {
             if !value.is_empty_or_undefined_or_null()
                 && let Some(server) = self.server.get()
@@ -1282,10 +1281,8 @@ where
         }
     }
 
-    /// The body failed after the status line was committed. A terminating
-    /// chunk would make the truncated body look complete (RFC 9112 section 7),
-    /// so close the connection while the response is still pending. Once the
-    /// sink already ended it, `end_stream()` only releases the context.
+    /// Closes a response whose body failed after the status line was committed.
+    /// Never the terminating chunk: it would make a truncated body look complete.
     pub(crate) fn close_incomplete_stream(&self) {
         if let Some(resp) = self.resp.get() {
             if resp.state().is_response_pending() {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1003,21 +1003,16 @@ where
         // The status line is already committed (a direct ReadableStream's
         // pull() threw synchronously after do_render_stream wrote headers).
         // error() cannot replace a response whose status is on the wire;
-        // report the failure and terminate the body so the client observes an
-        // incomplete message instead of a second header block spliced into
-        // the chunked body.
+        // report the failure and close without the terminating chunk so the
+        // client observes an incomplete message instead of a second header
+        // block spliced into the chunked body.
         if !has_responded && self.flags.has_written_status() {
             if !value.is_empty_or_undefined_or_null()
                 && let Some(server) = self.server.get()
             {
                 server.vm().as_mut().run_error_handler(value, None);
             }
-            let state = resp.state();
-            if state.is_http_write_called() && state.is_response_pending() {
-                self.force_close();
-            } else {
-                self.end_stream(self.should_close_connection());
-            }
+            self.close_incomplete_stream();
             return;
         }
 
@@ -1288,6 +1283,24 @@ where
             self.end_request_streaming_and_drain();
             self.deref();
         }
+    }
+
+    /// The body source failed after the status line was committed. The
+    /// terminating chunk would turn the truncated body into a complete,
+    /// successful-looking message (RFC 9112 section 7), so while the response
+    /// is still pending close the connection instead and let the client see
+    /// an incomplete message. Whether any body bytes went out first does not
+    /// matter: an empty chunked body with a terminator is just as complete.
+    /// Once the sink already ended the response there is nothing left to
+    /// signal and `end_stream()` only releases the context.
+    pub(crate) fn close_incomplete_stream(&self) {
+        if let Some(resp) = self.resp.get() {
+            if resp.state().is_response_pending() {
+                self.force_close();
+                return;
+            }
+        }
+        self.end_stream(self.should_close_connection());
     }
 
     fn on_writable_complete_response_buffer(
@@ -3054,17 +3067,7 @@ where
             self.end_already_responded_stream();
             return;
         }
-        // Body bytes were already written: close without the terminating chunk
-        // (RFC 9112 section 7) so the client sees an incomplete message, not a
-        // truncated body that looks like a complete, successful response.
-        if let Some(resp) = self.resp.get() {
-            let state = resp.state();
-            if state.is_http_write_called() && state.is_response_pending() {
-                self.force_close();
-                return;
-            }
-        }
-        self.end_stream(self.should_close_connection());
+        self.close_incomplete_stream();
     }
 
     pub(crate) fn do_render_with_body(
@@ -3353,13 +3356,16 @@ where
                 this.run_error_handler(js_err);
                 return;
             }
-            if let Some(resp) = this.resp.get() {
-                let state = resp.state();
-                if state.is_http_write_called() && state.is_response_pending() {
-                    this.force_close();
-                    return;
-                }
+            // Same as handle_reject_stream: error() cannot replace a
+            // committed status, so report the failure and close without the
+            // terminating chunk.
+            let global_this = this.server().global_this();
+            let js_err = err.to_js(global_this);
+            if !js_err.is_empty_or_undefined_or_null() {
+                this.server().vm().as_mut().run_error_handler(js_err, None);
             }
+            this.close_incomplete_stream();
+            return;
         } else if !this.flags.has_written_status() {
             // Upstream ended cleanly before any chunk: flush the deferred
             // status/headers so the client sees them before the terminator.

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3020,11 +3020,8 @@ where
     }
 
     /// Reports a body failure that arrived after the status line was
-    /// committed, so `error()` can no longer answer. Under a bake dev server
-    /// the error page is appended to the body and the response ends normally:
-    /// returns `true`, and the caller must not touch `resp` again.
-    /// `resp_writable` is false once the sink has already ended the response
-    /// (see `end_already_responded_stream`).
+    /// committed. Under a bake dev server the error page ends the response:
+    /// returns `true`, and `resp` must not be touched again.
     fn report_committed_body_error(&self, err: JSValue, resp_writable: bool) -> bool {
         if err.is_empty_or_undefined_or_null() {
             return false;
@@ -3344,8 +3341,7 @@ where
                 this.run_error_handler(js_err);
                 return;
             }
-            // Committed status: report in both modes, then close like
-            // handle_reject_stream.
+            // Committed status: report in both modes, then close.
             let global_this = this.server().global_this();
             if this.report_committed_body_error(err.to_js(global_this), true) {
                 return;

--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -114,10 +114,17 @@ describe.concurrent("Streaming body via", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("async generator function throws an error but continues to send the headers", async () => {
+  // The generator fails before producing any chunk. The status and headers
+  // were already committed to uWS, so the server closes the connection without
+  // a complete response instead of sending them with an empty body and a clean
+  // chunked terminator.
+  test("async generator function throws an error before its first chunk closes the connection", async () => {
+    let outcome: string | undefined;
     const onMessage = mock(async url => {
-      const response = await fetch(url);
-      expect(response.headers.get("X-Hey")).toBe("123");
+      outcome = await fetch(url).then(
+        response => `resolved ${response.status}`,
+        () => "rejected",
+      );
       subprocess?.kill();
     });
 
@@ -132,6 +139,7 @@ describe.concurrent("Streaming body via", () => {
 
     let [exitCode, stderr] = await Promise.all([subprocess.exited, subprocess.stderr.text()]);
     expect(exitCode).toBeInteger();
+    expect(outcome).toBe("rejected");
     expect(stderr).toContain("error: Oops");
     expect(onMessage).toHaveBeenCalledTimes(1);
   });

--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -123,7 +123,7 @@ describe.concurrent("Streaming body via", () => {
     const onMessage = mock(async url => {
       outcome = await fetch(url).then(
         response => `resolved ${response.status}`,
-        () => "rejected",
+        (err: any) => `rejected ${err.code}`,
       );
       subprocess?.kill();
     });
@@ -139,7 +139,7 @@ describe.concurrent("Streaming body via", () => {
 
     let [exitCode, stderr] = await Promise.all([subprocess.exited, subprocess.stderr.text()]);
     expect(exitCode).toBeInteger();
-    expect(outcome).toBe("rejected");
+    expect(outcome).toBe("rejected ECONNRESET");
     expect(stderr).toContain("error: Oops");
     expect(onMessage).toHaveBeenCalledTimes(1);
   });

--- a/test/js/bun/http/readable-stream-throws.fixture.js
+++ b/test/js/bun/http/readable-stream-throws.fixture.js
@@ -2,6 +2,7 @@ const server = Bun.serve({
   port: 0,
   idleTimeout: 0,
   error(err) {
+    console.error("error handler called");
     return new Response("Failed", { status: 555 });
   },
 

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -793,7 +793,7 @@ describe("sync pull() throw after status is written does not re-render error()",
     expect(exitCode).toBe(0);
   });
 
-  test("no body bytes flushed: stream is ended without splicing error() headers", async () => {
+  test("no body bytes flushed: connection is force-closed without splicing error() headers", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture(`throw new Error("boom");`)],
       env: bunEnv,
@@ -803,11 +803,12 @@ describe("sync pull() throw after status is written does not re-render error()",
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("error: boom");
     const { wire, errorHandlerCalls } = JSON.parse(stdout);
-    // Status 200 was already written; the stream is ended empty. The error()
-    // response's status (500), headers, and body must not appear on the wire.
-    expect(wire).not.toContain("x-err");
-    expect(wire).not.toContain("FROM-ERROR-HANDLER");
-    expect(wire.startsWith("HTTP/1.1 200 OK\r\n")).toBe(true);
+    // Status 200 was already written to the corked response, so error() cannot
+    // replace it. Ending the stream here would send that 200 with an empty
+    // chunked body and a clean terminator: a complete-looking response for a
+    // body that failed. The connection is closed instead, and since the status
+    // never left the cork buffer the client sees an empty reply.
+    expect(wire).toBe("");
     expect(errorHandlerCalls).toBe(0);
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/http/serve-stream-body-error-fixture.html
+++ b/test/js/bun/http/serve-stream-body-error-fixture.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<!-- Imported by serve-stream-body-error-fixture.ts purely so that Bun.serve runs a dev server; never requested. -->
+<title>dev server page</title>

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -135,7 +135,10 @@ await using server = Bun.serve({
     errorCb++;
     return new Response("err-body", { status: 500 });
   },
-  fetch() {
+  fetch(req) {
+    if (new URL(req.url).pathname === "/ok") {
+      return new Response("ok");
+    }
     return new Response(source());
   },
 });
@@ -143,12 +146,12 @@ await using server = Bun.serve({
 // Sends one request over a raw socket and returns everything received before
 // the server closed the connection, so the test can assert on the HTTP
 // framing. A forced close (ECONNRESET) is an expected, asserted-on outcome
-// for the mid-stream variant, so socket errors are not fatal.
-function rawRequest(abort: boolean): Promise<string> {
+// for the erroring variants, so socket errors are not fatal.
+function rawRequest(path: string, abort: boolean): Promise<string> {
   const chunks: Buffer[] = [];
   return new Promise(resolve => {
     const sock = net.connect(server.port, "127.0.0.1", () => {
-      sock.write("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+      sock.write(`GET ${path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`);
     });
     sock.on("data", d => {
       chunks.push(d);
@@ -165,12 +168,11 @@ function rawRequest(abort: boolean): Promise<string> {
   });
 }
 
-const wire = await rawRequest(clientAborts);
+const wire = await rawRequest("/", clientAborts);
 if (clientAborts) await cancelRan.promise;
-// A second request proves the server is still accepting and answering. For the
-// cancel variants the body stream never self-terminates, so abort that one too;
-// only the status line is asserted.
-const secondWire = await rawRequest(clientAborts);
+// A second request to a healthy route proves the server is still accepting
+// and answering; only its status line is asserted.
+const secondWire = await rawRequest("/ok", false);
 
 // Cycle the event loop so any stray rejected promise reaches the
 // unhandledRejection reporter before we declare success.

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -17,6 +17,14 @@ const development = process.argv[3] === "development";
 // wire. Called from the raw request's data handler below.
 let midStreamResolve: (() => void) | undefined;
 
+// Set by the pending-error-after-headers variant so it only errors once the
+// status line has provably reached the client socket. (uWS terminates the
+// header block only with the first body byte, so a blank line never arrives
+// for this variant.) The forced close that follows sends a RST, and a RST can
+// discard data the peer has not read yet (Windows always does), so the error
+// must not race the client's read.
+let statusLineReceivedResolve: (() => void) | undefined;
+
 // Set by the cancel variants: resolved once the source's cancel() has run, so
 // the test observes any resulting rejection before declaring success.
 const cancelRan = Promise.withResolvers<void>();
@@ -62,6 +70,17 @@ const sources: Record<string, () => ReadableStream> = {
       },
       { highWaterMark: 0 },
     ),
+  // The first pull() is pending when the server flushes the headers; the
+  // source then errors without ever producing a chunk.
+  "pending-error-after-headers": () =>
+    new ReadableStream({
+      async pull(c) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        statusLineReceivedResolve = resolve;
+        await promise;
+        c.error(new Error("boom"));
+      },
+    }),
   // Errors only after a chunk has already been flushed to the client.
   "mid-stream-reject": () =>
     new ReadableStream({
@@ -155,7 +174,12 @@ function rawRequest(path: string, abort: boolean): Promise<string> {
     });
     sock.on("data", d => {
       chunks.push(d);
-      if (Buffer.concat(chunks).includes("chunk-a")) {
+      const received = Buffer.concat(chunks);
+      if (received.includes("\r\n")) {
+        statusLineReceivedResolve?.();
+        statusLineReceivedResolve = undefined;
+      }
+      if (received.includes("chunk-a")) {
         midStreamResolve?.();
         // The cancel variants tear down the socket once a body chunk has
         // provably reached the client, so the server's onAborted path fires

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -1,28 +1,45 @@
 // An error thrown by a ReadableStream used as a Response body must never
 // escape as a global unhandledRejection. Bun's default unhandledRejection
 // policy exits the process, so before the fix a single bad request took the
-// entire server down.
+// entire server down. The `nativeBodies` variants pin the same wire and
+// reporting contract for bodies Bun.serve streams without a JS ReadableStream.
 //
-// argv[2]: variant name (see `sources` below)
-// argv[3]: "development" to run the server with development: true
+// argv[2]: variant name (see `sources` and `nativeBodies` below)
+// argv[3..]: "development" to run the server with development: true;
+//            "dev-server" to also give it an HTML route, which makes the
+//            development server run a bake dev server (the requests below
+//            still go to fetch())
 //
 // Prints a single JSON object on stdout and exits 0.
 import net from "node:net";
+import devServerPage from "./serve-stream-body-error-fixture.html";
 
 const variant = process.argv[2];
-const development = process.argv[3] === "development";
+const flags = process.argv.slice(3);
+const development = flags.includes("development");
+const devServer = flags.includes("dev-server");
 
-// Set by the mid-stream variant so it only errors once its chunk has provably
-// reached the client socket, i.e. after the 200 response is committed on the
-// wire. Called from the raw request's data handler below.
+// Set by the mid-stream variants so they only error once their chunk has
+// provably reached the client socket, i.e. after the 200 response is committed
+// on the wire. Called from the raw request's data handler below.
 let midStreamResolve: (() => void) | undefined;
 
-// Set by the pending-error-after-headers variant so it only errors once the
-// status line has provably reached the client socket. (uWS terminates the
-// header block only with the first body byte, so a blank line never arrives
-// for this variant.) The forced close that follows sends a RST, and a RST can
-// discard data the peer has not read yet (Windows always does), so the error
-// must not race the client's read.
+// Arms `midStreamResolve` for one request. Every mid-stream variant calls this
+// before it emits "chunk-a", so the resolver is in place by the time the
+// client can see the chunk.
+function chunkReachedClient(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  midStreamResolve = resolve;
+  return promise;
+}
+
+// Set by the variants that fail after the status line but before any body byte
+// (pending-error-after-headers, proxied-fetch-after-status) so they only error
+// once the status line has provably reached the client socket. (uWS terminates
+// the header block only with the first body byte, so a blank line never
+// arrives for these variants.) The forced close that follows sends a RST, and
+// a RST can discard data the peer has not read yet (Windows always does), so
+// the error must not race the client's read.
 let statusLineReceivedResolve: (() => void) | undefined;
 
 // Set by the cancel variants: resolved once the source's cancel() has run, so
@@ -85,10 +102,9 @@ const sources: Record<string, () => ReadableStream> = {
   "mid-stream-reject": () =>
     new ReadableStream({
       async pull(c) {
-        const { promise, resolve } = Promise.withResolvers<void>();
-        midStreamResolve = resolve;
+        const reached = chunkReachedClient();
         c.enqueue("chunk-a");
-        await promise;
+        await reached;
         throw new Error("boom");
       },
     }),
@@ -131,8 +147,92 @@ const sources: Record<string, () => ReadableStream> = {
     }),
 };
 
+// HTMLRewriter input that lets the rewritten "<b>chunk-a</b>" reach the client
+// before delivering the element whose handler fails.
+function rewriterInput(): ReadableStream {
+  const reached = chunkReachedClient();
+  let pulls = 0;
+  return new ReadableStream({
+    async pull(c) {
+      if (pulls++ === 0) {
+        c.enqueue("<b>chunk-a</b>");
+        return;
+      }
+      await reached;
+      c.enqueue("<p>x</p>");
+      c.close();
+    },
+  });
+}
+
+function rewriterResponse(element: () => void | Promise<void>): Response {
+  return new HTMLRewriter()
+    .on("p", { element })
+    .transform(new Response(rewriterInput(), { headers: { "content-type": "text/html" } }));
+}
+
+// Upstream for the proxied variants: a scratch server for one request that
+// answers with `firstWrite` (announcing more body than it will ever send), so
+// the fetch() body fails deterministically when `fail()` closes the connection.
+async function fetchFromFailingUpstream(firstWrite: string) {
+  const sockets: net.Socket[] = [];
+  const upstream = net.createServer(socket => {
+    sockets.push(socket);
+    socket.resume();
+    socket.on("error", () => {});
+    socket.write(firstWrite);
+  });
+  await new Promise<void>(resolve => upstream.listen(0, "127.0.0.1", resolve));
+  // Must never be what keeps the process alive if fail() is not reached.
+  upstream.unref();
+  const { port } = upstream.address() as net.AddressInfo;
+  const res = await fetch(`http://127.0.0.1:${port}/`);
+  return {
+    res,
+    fail() {
+      for (const socket of sockets) socket.end();
+      upstream.close();
+    },
+  };
+}
+
+// Bodies Bun.serve streams natively (no JS ReadableStream pump) whose producer
+// fails after the status line is committed. error() can no longer answer, so
+// the failure is reported and the connection is closed without the terminating
+// chunk, whether or not a body byte went out first.
+const nativeBodies: Record<string, () => Response | Promise<Response>> = {
+  "rewriter-mid-stream-throw": () =>
+    rewriterResponse(() => {
+      throw new Error("boom");
+    }),
+  "rewriter-mid-stream-reject": () =>
+    rewriterResponse(async () => {
+      await Bun.sleep(0);
+      throw new Error("boom");
+    }),
+  // `return fetch(...)` whose upstream dies once its first chunk has made it
+  // through to our client.
+  "proxied-fetch-mid-stream": async () => {
+    const reached = chunkReachedClient();
+    const { res, fail } = await fetchFromFailingUpstream("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nchunk-a");
+    reached.then(fail);
+    return res;
+  },
+  // Same, but the upstream dies before producing a single body byte. Bun.serve
+  // commits the status as soon as it attaches to a fetch() body, so the client
+  // has the status line and then the connection closes with no body at all.
+  "proxied-fetch-after-status": async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    statusLineReceivedResolve = resolve;
+    const { res, fail } = await fetchFromFailingUpstream("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n");
+    promise.then(fail);
+    return res;
+  },
+};
+
 const source = sources[variant];
-if (!source) {
+const nativeBody = nativeBodies[variant];
+if (!source && !nativeBody) {
   console.error(`unknown variant: ${variant}`);
   process.exit(3);
 }
@@ -150,6 +250,7 @@ let errorCb = 0;
 await using server = Bun.serve({
   port: 0,
   development,
+  ...(devServer ? { routes: { "/dev-server-page": devServerPage } } : {}),
   error() {
     errorCb++;
     return new Response("err-body", { status: 500 });
@@ -158,7 +259,7 @@ await using server = Bun.serve({
     if (new URL(req.url).pathname === "/ok") {
       return new Response("ok");
     }
-    return new Response(source());
+    return nativeBody ? nativeBody() : new Response(source());
   },
 });
 

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -13,6 +13,9 @@
 //      Response's status and headers plus an empty chunked body with a clean
 //      terminator: a complete, successful-looking response for a body that
 //      failed.
+// The natively streamed bodies further down (HTMLRewriter, proxied fetch) pin
+// the same contract for the non-ReadableStream path, which also dropped the
+// producer's error without reporting it.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 import { join } from "node:path";
@@ -93,80 +96,70 @@ test.concurrent("pending-error-after-headers: headers go out, the body is not te
   expect(exitCode).toBe(0);
 });
 
-// A native byte stream body (here: a proxied upstream fetch body) whose
-// producer fails before the first chunk. The downstream client used to get a
-// clean, empty 200 and nothing was reported. Now the upstream failure is
-// reported and the downstream connection is closed without the terminator.
-test.concurrent("proxied upstream body that fails before its first chunk is not forwarded as complete", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `import net from "node:net";
-      // The upstream answers with headers only. Its connection is dropped once
-      // the proxied headers have provably reached the downstream client, so
-      // the body fails before its first chunk and the forced close (a RST,
-      // which can discard unread data on the peer) cannot race the client's
-      // read. uWS terminates the header block only with the first body byte,
-      // so no blank line ever arrives here.
-      let dropUpstream;
-      const upstream = net.createServer(sock => {
-        sock.once("data", () => {
-          sock.write("HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
-          dropUpstream = () => sock.destroy();
-        });
-      });
-      await new Promise(resolve => upstream.listen(0, "127.0.0.1", resolve));
-      const server = Bun.serve({
-        port: 0,
-        development: false,
-        error() { return new Response("err-body", { status: 500 }); },
-        async fetch() {
-          const up = await fetch("http://127.0.0.1:" + upstream.address().port + "/");
-          return new Response(up.body, { status: up.status, headers: { "x-proxied": "1" } });
+// Bodies that Bun.serve streams natively (an HTMLRewriter transform, a proxied
+// fetch() Response) reach the server through RequestContext::end_chunk rather
+// than handle_reject_stream. Their status is committed before the body starts,
+// so error() cannot answer. Before the fix end_chunk dropped the error (a
+// rewriter handler that threw after the first byte left no trace anywhere) and
+// a producer that failed before its first chunk went out as a clean, empty 200.
+// Now the failure is reported in both modes and the connection is closed
+// without the terminating chunk, with whatever body bytes were already out.
+//
+// [variant, body bytes on the wire, what the report must name]
+const nativeBodies = [
+  ["rewriter-mid-stream-throw", "e\r\n<b>chunk-a</b>\r\n", "boom"],
+  ["rewriter-mid-stream-reject", "e\r\n<b>chunk-a</b>\r\n", "boom"],
+  ["proxied-fetch-mid-stream", "7\r\nchunk-a\r\n", "ECONNRESET"],
+  ["proxied-fetch-after-status", "", "ECONNRESET"],
+] as const;
+
+for (const flags of [[], ["development"]]) {
+  const mode = flags.length ? "development" : "production";
+  test.concurrent.each(nativeBodies)(
+    `%s in ${mode} mode: reported, and the body is not terminated as complete`,
+    async (variant, body, reported) => {
+      const { stdout, stderr, exitCode } = await runFixture(variant, ...flags);
+      expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+        result: {
+          statusLine: "HTTP/1.1 200 OK",
+          cleanChunkedTerminator: false,
+          body,
+          errorCb: 0,
+          unhandled: 0,
+          secondStatusLine: "HTTP/1.1 200 OK",
         },
+        exitCode: 0,
       });
-      const wire = await new Promise(resolve => {
-        let buf = "";
-        const sock = net.connect(server.port, "127.0.0.1", () => {
-          sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
-        });
-        sock.on("data", d => {
-          buf += d.toString("latin1");
-          if (/x-proxied: 1\\r\\n/i.test(buf)) {
-            dropUpstream?.();
-            dropUpstream = undefined;
-          }
-        });
-        sock.on("error", () => {});
-        sock.on("close", () => resolve(buf));
-      });
-      const [head, ...body] = wire.split("\\r\\n\\r\\n");
-      console.log(JSON.stringify({
-        statusLine: head.split("\\r\\n")[0],
-        proxied: /x-proxied: 1/i.test(head),
-        body: body.join("\\r\\n\\r\\n"),
-        cleanChunkedTerminator: wire.endsWith("0\\r\\n\\r\\n"),
-      }));
-      server.stop(true);
-      upstream.close();`,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+      expect(stderr).toContain(reported);
+    },
+  );
+}
+
+// When the development server also runs a bake dev server (it has an HTML
+// route), the report additionally renders the dev error page as the rest of
+// the body and ends the response normally, so the browser shows the error
+// after whatever was already streamed. The JS stream has always taken this
+// branch; the native body now goes through the same code.
+test.concurrent.each([
+  ["rewriter-mid-stream-throw", "e\r\n<b>chunk-a</b>\r\n"],
+  ["mid-stream-reject", "7\r\nchunk-a\r\n"],
+])("%s under a dev server: the error page is appended to the body", async (variant, firstChunk) => {
+  const { stdout, stderr, exitCode } = await runFixture(variant, "development", "dev-server");
+  const { body, ...result } = JSON.parse(stdout);
+  expect({ result, exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: true,
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // The proxy's status and headers are flushed as soon as the upstream headers
-  // arrive, so they are on the wire; the body must then end incomplete.
-  expect(JSON.parse(stdout)).toEqual({
-    statusLine: "HTTP/1.1 200 OK",
-    proxied: true,
-    body: "",
-    cleanChunkedTerminator: false,
-  });
-  // The upstream failure is reported instead of being swallowed.
-  expect(stderr).toContain("ECONNRESET");
-  expect(exitCode).toBe(0);
+  expect(body).toStartWith(firstChunk);
+  expect(body).toContain("Stream error during server-side rendering");
+  expect(body).toContain("boom");
+  expect(stderr).toContain("boom");
 });
 
 // The body errors after a chunk has already been flushed to the client. The

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -1,5 +1,6 @@
 // A `Response` body backed by a `ReadableStream` whose source errors must not
-// take the whole server down. Before the fix:
+// take the whole server down, and must never reach the client as a complete
+// message. Before the fixes:
 //   1. The rejection from the stream pump was never given a handler, so it
 //      reached the global unhandledRejection reporter, whose default policy
 //      exits the process: one bad request was a whole-process outage.
@@ -8,6 +9,10 @@
 //   3. A body that errored after chunks were already sent was still terminated
 //      with a clean `0\r\n\r\n`, so the client could not tell the truncated
 //      body apart from a complete one.
+//   4. A body that errored before any chunk was sent went out as the
+//      Response's status and headers plus an empty chunked body with a clean
+//      terminator: a complete, successful-looking response for a body that
+//      failed.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 import { join } from "node:path";
@@ -25,25 +30,25 @@ async function runFixture(variant: string, ...extra: string[]) {
   return { stdout, stderr, exitCode };
 }
 
-// The wire-level contract for a stream source that errors before producing any
-// body bytes is unchanged: the Response's own status and headers go out with
-// an empty chunked body and the server `error()` callback is NOT invoked (see
-// "throw on pull renders headers, does not call error handler" in
-// serve.test.ts). What changes is that the rejection no longer reaches the
-// unhandledRejection reporter; it is reported directly instead.
+// A stream source that errors before producing any body bytes. The status and
+// headers were already handed to uWS (corked) when the error arrives, so the
+// server `error()` callback cannot supply a replacement and is NOT invoked.
+// The connection is closed before anything reaches the wire: the client sees
+// an empty reply, never a complete 200 with an empty body. The rejection does
+// not reach the unhandledRejection reporter; it is reported directly instead.
 test.concurrent.each([
   "pull-throw",
   "pull-async-reject",
   "controller-error",
   "start-async-reject",
   "deferred-pull-throw",
-])("%s: the rejection is handled and the error is still reported", async variant => {
+])("%s: the connection is closed without a complete response and the error is reported", async variant => {
   const { stdout, stderr, exitCode } = await runFixture(variant);
   expect({ result: JSON.parse(stdout), exitCode }).toEqual({
     result: {
-      statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: true,
-      body: "0\r\n\r\n",
+      statusLine: "",
+      cleanChunkedTerminator: false,
+      body: "",
       errorCb: 0,
       unhandled: 0,
       secondStatusLine: "HTTP/1.1 200 OK",
@@ -56,13 +61,13 @@ test.concurrent.each([
 });
 
 // Same under `development: true` (the DEBUG RequestContext monomorphization).
-test.concurrent("pull-throw in development mode: the rejection is handled", async () => {
+test.concurrent("pull-throw in development mode: the connection is closed without a complete response", async () => {
   const { stdout, stderr, exitCode } = await runFixture("pull-throw", "development");
   expect({ result: JSON.parse(stdout), exitCode }).toEqual({
     result: {
-      statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: true,
-      body: "0\r\n\r\n",
+      statusLine: "",
+      cleanChunkedTerminator: false,
+      body: "",
       errorCb: 0,
       unhandled: 0,
       secondStatusLine: "HTTP/1.1 200 OK",
@@ -70,6 +75,134 @@ test.concurrent("pull-throw in development mode: the rejection is handled", asyn
     exitCode: 0,
   });
   expect(stderr).toContain("boom");
+});
+
+// The headers are already on the wire (the first pull() was still pending
+// when the server flushed them) and the source then errors without ever
+// producing a chunk. The 200 is irrevocable, so the connection is closed
+// without the terminating chunk: headers, then an incomplete body.
+test.concurrent(
+  "async error before the first chunk: headers go out, the body is not terminated as complete",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import net from "node:net";
+      const server = Bun.serve({
+        port: 0,
+        development: false,
+        error() { return new Response("err-body", { status: 500 }); },
+        fetch() {
+          return new Response(new ReadableStream({
+            async pull(c) { await Bun.sleep(20); c.error(new Error("boom")); },
+          }), { headers: { "x-marker": "1" } });
+        },
+      });
+      const wire = await new Promise(resolve => {
+        let buf = "";
+        const sock = net.connect(server.port, "127.0.0.1", () => {
+          sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+        });
+        sock.on("data", d => (buf += d.toString("latin1")));
+        sock.on("error", () => {});
+        sock.on("close", () => resolve(buf));
+      });
+      const [head, ...body] = wire.split("\\r\\n\\r\\n");
+      console.log(JSON.stringify({
+        statusLine: head.split("\\r\\n")[0],
+        marker: /x-marker: 1/i.test(head),
+        body: body.join("\\r\\n\\r\\n"),
+        cleanChunkedTerminator: wire.endsWith("0\\r\\n\\r\\n"),
+      }));
+      server.stop(true);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // No stderr assertion: see the mid-stream test below for why this path is
+    // quiet with `development: false`.
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        marker: true,
+        body: "",
+        cleanChunkedTerminator: false,
+      },
+      exitCode: 0,
+    });
+  },
+);
+
+// A native byte stream body (here: a proxied upstream fetch body) whose
+// producer fails before the first chunk. The downstream client used to get a
+// clean, empty 200 and nothing was reported. Now the upstream failure is
+// reported and the downstream connection is closed without the terminator.
+test.concurrent("proxied upstream body that fails before its first chunk is not forwarded as complete", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import net from "node:net";
+      // The upstream answers with headers only; the proxy drops the connection
+      // once fetch() has parsed them, so the body fails before its first chunk.
+      let dropUpstream;
+      const upstream = net.createServer(sock => {
+        sock.once("data", () => {
+          sock.write("HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
+          dropUpstream = () => sock.destroy();
+        });
+      });
+      await new Promise(resolve => upstream.listen(0, "127.0.0.1", resolve));
+      const server = Bun.serve({
+        port: 0,
+        development: false,
+        error() { return new Response("err-body", { status: 500 }); },
+        async fetch() {
+          const up = await fetch("http://127.0.0.1:" + upstream.address().port + "/");
+          dropUpstream();
+          return new Response(up.body, { status: up.status, headers: { "x-proxied": "1" } });
+        },
+      });
+      const wire = await new Promise(resolve => {
+        let buf = "";
+        const sock = net.connect(server.port, "127.0.0.1", () => {
+          sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+        });
+        sock.on("data", d => (buf += d.toString("latin1")));
+        sock.on("error", () => {});
+        sock.on("close", () => resolve(buf));
+      });
+      const [head, ...body] = wire.split("\\r\\n\\r\\n");
+      console.log(JSON.stringify({
+        statusLine: head.split("\\r\\n")[0],
+        proxied: /x-proxied: 1/i.test(head),
+        body: body.join("\\r\\n\\r\\n"),
+        cleanChunkedTerminator: wire.endsWith("0\\r\\n\\r\\n"),
+      }));
+      server.stop(true);
+      upstream.close();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The proxy's status and headers are flushed as soon as the upstream headers
+  // arrive, so they are on the wire; the body must then end incomplete.
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      proxied: true,
+      body: "",
+      cleanChunkedTerminator: false,
+    },
+    exitCode: 0,
+  });
+  // The upstream failure is reported instead of being swallowed.
+  expect(stderr).toContain("ECONNRESET");
 });
 
 // The body errors after a chunk has already been flushed to the client. The
@@ -218,16 +351,21 @@ test.concurrent("a stream body error does not kill the server process", async ()
       `const server = Bun.serve({
         port: 0,
         development: false,
-        fetch() {
+        fetch(req) {
+          if (new URL(req.url).pathname === "/ok") return new Response("ok");
           return new Response(new ReadableStream({ pull() { throw new Error("boom"); } }));
         },
       });
-      const res = await fetch(server.url);
-      await res.arrayBuffer();
+      // The failed body closes the connection without a complete response.
+      const first = await fetch(server.url).then(
+        res => res.arrayBuffer().then(() => "complete"),
+        () => "rejected",
+      );
       // Tick the event loop past the unhandledRejection checkpoint that used
       // to exit the process before this line was reached.
       for (let i = 0; i < 10; i++) await Bun.sleep(0);
-      console.log("alive", res.status);
+      const res = await fetch(new URL("/ok", server.url));
+      console.log("alive", first, res.status);
       server.stop(true);`,
     ],
     env: bunEnv,
@@ -235,7 +373,7 @@ test.concurrent("a stream body error does not kill the server process", async ()
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "alive 200\n", exitCode: 0 });
+  expect({ stdout, exitCode }).toEqual({ stdout: "alive rejected 200\n", exitCode: 0 });
   // The error must still be surfaced to the operator.
   expect(stderr).toContain("boom");
 });

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -81,60 +81,23 @@ test.concurrent("pull-throw in development mode: the connection is closed withou
 // when the server flushed them) and the source then errors without ever
 // producing a chunk. The 200 is irrevocable, so the connection is closed
 // without the terminating chunk: headers, then an incomplete body.
-test.concurrent(
-  "async error before the first chunk: headers go out, the body is not terminated as complete",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `import net from "node:net";
-      const server = Bun.serve({
-        port: 0,
-        development: false,
-        error() { return new Response("err-body", { status: 500 }); },
-        fetch() {
-          return new Response(new ReadableStream({
-            async pull(c) { await Bun.sleep(20); c.error(new Error("boom")); },
-          }), { headers: { "x-marker": "1" } });
-        },
-      });
-      const wire = await new Promise(resolve => {
-        let buf = "";
-        const sock = net.connect(server.port, "127.0.0.1", () => {
-          sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
-        });
-        sock.on("data", d => (buf += d.toString("latin1")));
-        sock.on("error", () => {});
-        sock.on("close", () => resolve(buf));
-      });
-      const [head, ...body] = wire.split("\\r\\n\\r\\n");
-      console.log(JSON.stringify({
-        statusLine: head.split("\\r\\n")[0],
-        marker: /x-marker: 1/i.test(head),
-        body: body.join("\\r\\n\\r\\n"),
-        cleanChunkedTerminator: wire.endsWith("0\\r\\n\\r\\n"),
-      }));
-      server.stop(true);`,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // No stderr assertion: see the mid-stream test below for why this path is
-    // quiet with `development: false`.
-    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-      result: {
-        statusLine: "HTTP/1.1 200 OK",
-        marker: true,
-        body: "",
-        cleanChunkedTerminator: false,
-      },
-      exitCode: 0,
-    });
-  },
-);
+//
+// No stderr assertion: see the mid-stream test below for why this path is
+// quiet with `development: false`.
+test.concurrent("pending-error-after-headers: headers go out, the body is not terminated as complete", async () => {
+  const { stdout, exitCode } = await runFixture("pending-error-after-headers");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: false,
+      body: "",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+});
 
 // A native byte stream body (here: a proxied upstream fetch body) whose
 // producer fails before the first chunk. The downstream client used to get a
@@ -146,8 +109,12 @@ test.concurrent("proxied upstream body that fails before its first chunk is not 
       bunExe(),
       "-e",
       `import net from "node:net";
-      // The upstream answers with headers only; the proxy drops the connection
-      // once fetch() has parsed them, so the body fails before its first chunk.
+      // The upstream answers with headers only. Its connection is dropped once
+      // the proxied headers have provably reached the downstream client, so
+      // the body fails before its first chunk and the forced close (a RST,
+      // which can discard unread data on the peer) cannot race the client's
+      // read. uWS terminates the header block only with the first body byte,
+      // so no blank line ever arrives here.
       let dropUpstream;
       const upstream = net.createServer(sock => {
         sock.once("data", () => {
@@ -162,7 +129,6 @@ test.concurrent("proxied upstream body that fails before its first chunk is not 
         error() { return new Response("err-body", { status: 500 }); },
         async fetch() {
           const up = await fetch("http://127.0.0.1:" + upstream.address().port + "/");
-          dropUpstream();
           return new Response(up.body, { status: up.status, headers: { "x-proxied": "1" } });
         },
       });
@@ -171,7 +137,13 @@ test.concurrent("proxied upstream body that fails before its first chunk is not 
         const sock = net.connect(server.port, "127.0.0.1", () => {
           sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
         });
-        sock.on("data", d => (buf += d.toString("latin1")));
+        sock.on("data", d => {
+          buf += d.toString("latin1");
+          if (/x-proxied: 1\\r\\n/i.test(buf)) {
+            dropUpstream?.();
+            dropUpstream = undefined;
+          }
+        });
         sock.on("error", () => {});
         sock.on("close", () => resolve(buf));
       });
@@ -359,7 +331,7 @@ test.concurrent("a stream body error does not kill the server process", async ()
       // The failed body closes the connection without a complete response.
       const first = await fetch(server.url).then(
         res => res.arrayBuffer().then(() => "complete"),
-        () => "rejected",
+        err => "rejected " + err.code,
       );
       // Tick the event loop past the unhandledRejection checkpoint that used
       // to exit the process before this line was reached.
@@ -373,7 +345,7 @@ test.concurrent("a stream body error does not kill the server process", async ()
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "alive rejected 200\n", exitCode: 0 });
+  expect({ stdout, exitCode }).toEqual({ stdout: "alive rejected ECONNRESET 200\n", exitCode: 0 });
   // The error must still be surfaced to the operator.
   expect(stderr).toContain("boom");
 });

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -44,37 +44,33 @@ test.concurrent.each([
   "deferred-pull-throw",
 ])("%s: the connection is closed without a complete response and the error is reported", async variant => {
   const { stdout, stderr, exitCode } = await runFixture(variant);
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "",
-      cleanChunkedTerminator: false,
-      body: "",
-      errorCb: 0,
-      unhandled: 0,
-      secondStatusLine: "HTTP/1.1 200 OK",
-    },
-    exitCode: 0,
+  expect(JSON.parse(stdout)).toEqual({
+    statusLine: "",
+    cleanChunkedTerminator: false,
+    body: "",
+    errorCb: 0,
+    unhandled: 0,
+    secondStatusLine: "HTTP/1.1 200 OK",
   });
   // With `development: false` the unhandledRejection report used to be the
   // only place the error surfaced; it must still reach stderr without it.
   expect(stderr).toContain("boom");
+  expect(exitCode).toBe(0);
 });
 
 // Same under `development: true` (the DEBUG RequestContext monomorphization).
 test.concurrent("pull-throw in development mode: the connection is closed without a complete response", async () => {
   const { stdout, stderr, exitCode } = await runFixture("pull-throw", "development");
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "",
-      cleanChunkedTerminator: false,
-      body: "",
-      errorCb: 0,
-      unhandled: 0,
-      secondStatusLine: "HTTP/1.1 200 OK",
-    },
-    exitCode: 0,
+  expect(JSON.parse(stdout)).toEqual({
+    statusLine: "",
+    cleanChunkedTerminator: false,
+    body: "",
+    errorCb: 0,
+    unhandled: 0,
+    secondStatusLine: "HTTP/1.1 200 OK",
   });
   expect(stderr).toContain("boom");
+  expect(exitCode).toBe(0);
 });
 
 // The headers are already on the wire (the first pull() was still pending
@@ -86,17 +82,15 @@ test.concurrent("pull-throw in development mode: the connection is closed withou
 // quiet with `development: false`.
 test.concurrent("pending-error-after-headers: headers go out, the body is not terminated as complete", async () => {
   const { stdout, exitCode } = await runFixture("pending-error-after-headers");
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: false,
-      body: "",
-      errorCb: 0,
-      unhandled: 0,
-      secondStatusLine: "HTTP/1.1 200 OK",
-    },
-    exitCode: 0,
+  expect(JSON.parse(stdout)).toEqual({
+    statusLine: "HTTP/1.1 200 OK",
+    cleanChunkedTerminator: false,
+    body: "",
+    errorCb: 0,
+    unhandled: 0,
+    secondStatusLine: "HTTP/1.1 200 OK",
   });
+  expect(exitCode).toBe(0);
 });
 
 // A native byte stream body (here: a proxied upstream fetch body) whose
@@ -164,17 +158,15 @@ test.concurrent("proxied upstream body that fails before its first chunk is not 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // The proxy's status and headers are flushed as soon as the upstream headers
   // arrive, so they are on the wire; the body must then end incomplete.
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "HTTP/1.1 200 OK",
-      proxied: true,
-      body: "",
-      cleanChunkedTerminator: false,
-    },
-    exitCode: 0,
+  expect(JSON.parse(stdout)).toEqual({
+    statusLine: "HTTP/1.1 200 OK",
+    proxied: true,
+    body: "",
+    cleanChunkedTerminator: false,
   });
   // The upstream failure is reported instead of being swallowed.
   expect(stderr).toContain("ECONNRESET");
+  expect(exitCode).toBe(0);
 });
 
 // The body errors after a chunk has already been flushed to the client. The
@@ -345,9 +337,10 @@ test.concurrent("a stream body error does not kill the server process", async ()
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "alive rejected ECONNRESET 200\n", exitCode: 0 });
+  expect(stdout).toBe("alive rejected ECONNRESET 200\n");
   // The error must still be surfaced to the operator.
   expect(stderr).toContain("boom");
+  expect(exitCode).toBe(0);
 });
 
 // An already-rejected async fetch handler reaches handle_reject synchronously

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -631,7 +631,7 @@ describe("streaming", () => {
       const onMessage = mock(async url => {
         outcome = await fetch(url).then(
           response => `resolved ${response.status}`,
-          () => "rejected",
+          (err: any) => `rejected ${err.code}`,
         );
         subprocess.kill();
       });
@@ -647,7 +647,7 @@ describe("streaming", () => {
 
       let [exitCode, stderr] = await Promise.all([subprocess.exited, subprocess.stderr.text()]);
       expect(exitCode).toBeInteger();
-      expect(outcome).toBe("rejected");
+      expect(outcome).toBe("rejected ECONNRESET");
       expect(stderr).toContain("error: Oops");
       expect(stderr).not.toContain("error handler called");
       expect(onMessage).toHaveBeenCalled();
@@ -662,7 +662,7 @@ describe("streaming", () => {
         const url = new URL("write", href);
         outcome = await fetch(url).then(
           response => `resolved ${response.status}`,
-          () => "rejected",
+          (err: any) => `rejected ${err.code}`,
         );
         subprocess.kill();
       });
@@ -678,7 +678,7 @@ describe("streaming", () => {
 
       let [exitCode, stderr] = await Promise.all([subprocess.exited, subprocess.stderr.text()]);
       expect(exitCode).toBeInteger();
-      expect(outcome).toBe("rejected");
+      expect(outcome).toBe("rejected ECONNRESET");
       expect(stderr).toContain("error: Oops");
       expect(stderr).not.toContain("error handler called");
       expect(onMessage).toHaveBeenCalled();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -622,12 +622,17 @@ it.each([
 
 describe("streaming", () => {
   describe("error handler", () => {
-    it("throw on pull renders headers, does not call error handler", async () => {
+    // The body source fails before any byte is written. The Response's status
+    // and headers are already committed to uWS, so error() cannot replace them
+    // and is not called; the connection is closed without a complete response
+    // so the client cannot mistake the failed body for an empty one.
+    it("throw on pull closes the connection, does not call error handler", async () => {
+      let outcome: string | undefined;
       const onMessage = mock(async url => {
-        const response = await fetch(url);
-        expect(response.status).toBe(402);
-        expect(response.headers.get("X-Hey")).toBe("123");
-        expect(response.text()).resolves.toBe("");
+        outcome = await fetch(url).then(
+          response => `resolved ${response.status}`,
+          () => "rejected",
+        );
         subprocess.kill();
       });
 
@@ -642,17 +647,23 @@ describe("streaming", () => {
 
       let [exitCode, stderr] = await Promise.all([subprocess.exited, subprocess.stderr.text()]);
       expect(exitCode).toBeInteger();
+      expect(outcome).toBe("rejected");
       expect(stderr).toContain("error: Oops");
+      expect(stderr).not.toContain("error handler called");
       expect(onMessage).toHaveBeenCalled();
     });
 
-    it("throw on pull after writing should not call the error handler", async () => {
+    // pull() queues two chunks, requests close, then throws: per the streams
+    // spec the error wins and the queued chunks are discarded, so this is the
+    // same "failed before any byte" case as above.
+    it("throw on pull after writing closes the connection, does not call the error handler", async () => {
+      let outcome: string | undefined;
       const onMessage = mock(async href => {
         const url = new URL("write", href);
-        const response = await fetch(url);
-        expect(response.status).toBe(402);
-        expect(response.headers.get("X-Hey")).toBe("123");
-        expect(response.text()).resolves.toBe("");
+        outcome = await fetch(url).then(
+          response => `resolved ${response.status}`,
+          () => "rejected",
+        );
         subprocess.kill();
       });
 
@@ -667,7 +678,9 @@ describe("streaming", () => {
 
       let [exitCode, stderr] = await Promise.all([subprocess.exited, subprocess.stderr.text()]);
       expect(exitCode).toBeInteger();
+      expect(outcome).toBe("rejected");
       expect(stderr).toContain("error: Oops");
+      expect(stderr).not.toContain("error handler called");
       expect(onMessage).toHaveBeenCalled();
     });
 

--- a/test/js/web/encoding/text-encoder-stream.test.ts
+++ b/test/js/web/encoding/text-encoder-stream.test.ts
@@ -408,7 +408,10 @@ describe.skipIf(!isASAN)("a failed output buffer allocation errors the stream in
       });
       const results = {};
       for (const name of Object.keys(inputs)) {
-        await fetch(new URL(name, server.url)).then(response => response.arrayBuffer(), () => {});
+        // The failed body closes the connection without a complete response:
+        // fetch() itself or the body read rejects, depending on whether the
+        // headers were already flushed.
+        await fetch(new URL(name, server.url)).then(response => response.arrayBuffer()).catch(() => {});
         results[name] = await cancelReasons[name];
       }
       results.afterwards = Array.from(await (await fetch(new URL("small", server.url))).bytes());


### PR DESCRIPTION
### Problem
- A `Bun.serve` Response whose body stream fails before any body byte is written is delivered to the client as a complete message: the Response's status and headers, `Transfer-Encoding: chunked`, an empty body and a clean `0\r\n\r\n`. `curl` exits 0. A proxied upstream body that dies before its first chunk is forwarded the same way, and nothing is reported. Only a failure after the first body byte closed the connection without the terminator (#32842).
- Cause: three sites in `src/runtime/server/RequestContext.rs` handle a body failure after the status line is committed (`handle_reject` for a direct stream's synchronous `pull()` throw, `handle_reject_stream` for a JS stream, `end_chunk` for a native byte stream). Each force-closed only when `is_http_write_called()` and otherwise called `end_stream()`, which writes the terminating chunk.

### Fix
- The three sites share a new `close_incomplete_stream`: while the response is still pending, `force_close()` the connection, whether or not body bytes went out first. Once the sink has already ended the response, `end_stream()` only releases the context, as before.
- Correct because a chunked message is complete only with its terminator (RFC 9112 section 7). An empty chunked body with a terminator is as complete as a truncated one. Closing without it is the only way HTTP/1.1 can signal an incomplete message. When the status is still in the cork buffer, the close discards it and the client sees an empty reply, the same as Node's `res.destroy()` before the headers flush.
- `end_chunk` (HTMLRewriter output, a proxied `fetch()` body) no longer drops the producer's error: it reports it in both modes through the shared `report_committed_body_error`, which also gives native bodies the bake dev server error page that JS streams already had. This carries the remaining parts of #39442, closed in favor of this PR.
- Verified: `test/js/bun/http/serve-stream-body-error.test.ts` (JS stream variants, pending error after the headers, HTMLRewriter and proxied fetch bodies in both modes, two dev server rows; 17 of 26 fail on stock bun). Also `serve.test.ts`, `serve-direct-readable-stream.test.ts`, `async-iterator-stream.test.ts`, `serve-http3.test.ts`, `serve-error-handler-stream.test.ts`, `serve-stream-reject-flush-leak.test.ts`, `text-encoder-stream.test.ts`, `html-rewriter.test.js`.

### Background
- `RequestContext` is the per-request state of `Bun.serve`. `do_render_stream` writes the Response's status and headers into the corked uWS response before it attaches the body stream, so by the time a body error arrives `has_written_status()` is already true and `error()` cannot supply a replacement. That contract is unchanged here: `error()` is still not called once the status is committed.
- uWS corks a socket while a request handler runs: writes go to a per-socket buffer that is flushed when the handler returns. `force_close()` closes the socket directly and drops that buffer, so a synchronous failure leaves nothing on the wire. An asynchronous failure arrives after the flush, so the client gets the headers and then a reset.
- Behavior change: the tests that pinned the old contract ("throw on pull renders headers", "async generator ... continues to send the headers", the pre-first-byte variants in `serve-stream-body-error.test.ts`) now expect the connection to close without a complete response.

<details><summary>Notes</summary>

Wire before the fix, for `new Response(new ReadableStream({ start(c) { c.enqueue(chunk); c.error(new Error("boom")); } }))`:

```
HTTP/1.1 200 OK
Content-Type: text/plain;charset=utf-8
Date: ...
Transfer-Encoding: chunked

0
```

After: the connection closes with 0 bytes sent (the status was still corked). For a stream whose first `pull()` is asynchronous, the headers were already flushed, so the client gets `HTTP/1.1 200 OK` plus headers and then a connection reset with no terminating chunk. Both are incomplete messages. The error reaches stderr through the existing reporters; the production-mode asynchronous JS path stays quiet, as today.

The forced close sends a RST, and a RST discards data the peer has not read yet (always on Windows). The tests that expect the status line on the wire before the failure therefore trigger the failure from the client's data handler, once the status line has arrived. uWS terminates the header block only with the first body byte, so those tests wait for the status line, not for a blank line.

Dev server exception: under a bake dev server (`development: true` plus an HTML route), a body that fails after the status is committed gets the dev error page appended and the response ends normally, so the browser shows the error after what was already streamed. JS streams always did this; native bodies now take the same branch.

Probed sources, all now closed incomplete: `controller.error` in `start`, synchronous and asynchronous `pull()` throw, async generator throw, `Readable.toWeb` of an erroring node stream, a throwing `TransformStream`, `DecompressionStream` on bad bytes, a `type: "direct"` stream that throws, an HTMLRewriter handler that throws or rejects after the first byte, a proxied upstream fetch body reset before and after its first chunk. `Bun.file()` on a missing path already reaches `error()` and answers 500 (unchanged). A user `Content-Length` header on a stream Response is ignored in favor of chunked framing, so it does not change the outcome.

Related PRs in this area: #35229 deferred the status line until the first body byte so that `error()` can answer a pre-first-byte failure with a 500 (a larger change to `do_render_stream` and the sink), closed in favor of this PR; that design remains a possible follow-up. #38003 touches the same sites for the stored-ByteStream-error case. This PR only enforces the framing invariant; it does not decide whether `error()` should be reachable for these failures.

HTTP/3 is not fixed by this change: `uws_h3_res_force_close` closes the QUIC stream with a FIN, which is a complete message in HTTP/3. That is tracked separately in #40598.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->