### PR TITLE
compile: builtin module sources in a dedicated section so --bytecode covers non-host targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "bun_dotenv",
  "bun_errno",
  "bun_event_loop",
+ "bun_exe_format",
  "bun_hash",
  "bun_http_types",
  "bun_io",

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -23,6 +23,7 @@ thiserror.workspace = true
 bun_base64.workspace = true
 bun_alloc.workspace = true
 bun_errno.workspace = true
+bun_exe_format.workspace = true
 bun_analytics.workspace = true
 bun_resolver.workspace = true
 # `bun_resolve_builtins` only depends on `bun_options_types` + `bun_string`

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1285,6 +1285,8 @@ impl From<BunError> for LinkError {
 pub struct LinkerOptions {
     pub(crate) generate_bytecode_cache: bool,
     pub(crate) generate_internal_module_bytecode: bool,
+    /// See `CompileTargetBuiltins::Target`.
+    pub(crate) target_builtins: Option<std::sync::Arc<[u8]>>,
     pub(crate) bytecode_depth: u32,
     pub(crate) output_format: Format,
     pub(crate) ignore_dce_annotations: bool,
@@ -1330,6 +1332,7 @@ impl Default for LinkerOptions {
         Self {
             generate_bytecode_cache: false,
             generate_internal_module_bytecode: false,
+            target_builtins: None,
             bytecode_depth: u32::MAX,
             output_format: Format::Esm,
             ignore_dce_annotations: false,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1416,13 +1416,24 @@ pub mod bv2_impl {
                 external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
             ) -> Option<Box<[u8]>>;
 
-            /// Defined `#[no_mangle]` in `bun_jsc::cached_bytecode`: (registry id, bytecode) for the internal modules named
-            /// by `specifiers` plus their static requires.
+            /// Defined `#[no_mangle]` in `bun_jsc::cached_bytecode`: this executable's builtins section
+            /// (`bun_exe_format::builtins`).
+            safe fn __bun_jsc_host_builtins() -> &'static [u8];
+            /// Bytecode for this executable's internal module `id`, as InternalModuleRegistry consumes it.
             safe fn __bun_jsc_generate_internal_module_bytecode(
-                specifiers: &[&[u8]],
+                id: u32,
                 depth: u32,
                 external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
-            ) -> Vec<(u32, Box<[u8]>)>;
+            ) -> Option<Box<[u8]>>;
+            /// Same, for another executable's internal module given its source, registry name, url and source stamp.
+            safe fn __bun_jsc_generate_internal_module_bytecode_from_source(
+                source: &[u8],
+                name: &[u8],
+                url: &[u8],
+                source_stamp: u32,
+                depth: u32,
+                external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
+            ) -> Option<Box<[u8]>>;
 
             safe fn __bun_jsc_encoder_string_table_new() -> core::ptr::NonNull<EncoderStringTable>;
             pub(crate) safe fn __bun_jsc_destroy_bytecode_cache_vm();
@@ -1510,12 +1521,34 @@ pub mod bv2_impl {
         }
 
         #[inline]
+        pub(crate) fn host_builtins() -> &'static [u8] {
+            __bun_jsc_host_builtins()
+        }
+
+        #[inline]
         pub(crate) fn generate_internal_module_bytecode(
-            specifiers: &[&[u8]],
+            id: u32,
             depth: u32,
             external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
-        ) -> Vec<(u32, Box<[u8]>)> {
-            __bun_jsc_generate_internal_module_bytecode(specifiers, depth, external_strings)
+        ) -> Option<Box<[u8]>> {
+            __bun_jsc_generate_internal_module_bytecode(id, depth, external_strings)
+        }
+
+        #[inline]
+        pub(crate) fn generate_internal_module_bytecode_from_source(
+            module: &bun_exe_format::builtins::Module<'_>,
+            source_stamp: u32,
+            depth: u32,
+            external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
+        ) -> Option<Box<[u8]>> {
+            __bun_jsc_generate_internal_module_bytecode_from_source(
+                module.source,
+                module.name,
+                module.url,
+                source_stamp,
+                depth,
+                external_strings,
+            )
         }
 
         /// CYCLEBREAK GENUINE: `JSBundleCompletionTask` — the
@@ -3009,7 +3042,18 @@ pub mod bv2_impl {
             this.linker.options.output_format = this.transpiler.options.output_format;
             this.linker.options.generate_bytecode_cache = this.transpiler.options.bytecode;
             this.linker.options.generate_internal_module_bytecode =
-                this.transpiler.options.bytecode && this.transpiler.options.compile_target_is_host;
+                this.transpiler.options.bytecode
+                    && !matches!(
+                        this.transpiler.options.compile_target_builtins,
+                        crate::options::CompileTargetBuiltins::None
+                    );
+            this.linker.options.target_builtins =
+                match &this.transpiler.options.compile_target_builtins {
+                    crate::options::CompileTargetBuiltins::Target(section) => {
+                        Some(std::sync::Arc::clone(section))
+                    }
+                    _ => None,
+                };
             this.linker.options.bytecode_depth = this.transpiler.options.bytecode_depth;
             this.linker.options.compile_mode = this.transpiler.options.compile_mode;
             this.linker.options.metafile = this.transpiler.options.metafile;

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1408,15 +1408,32 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 }
 
 /// `--compile --bytecode`: the executable also carries ahead-of-time bytecode for the internal modules (node:fs, …) the
-/// bundle imports, so their first `require` decodes instead of parsing. One `OutputKind::BuiltinBytecode` per module;
-/// StandaloneModuleGraph::to_bytes lays them out and InternalModuleRegistry picks them up by id.
+/// bundle imports and everything those require while loading, so their first `require` decodes instead of parsing. One
+/// `OutputKind::BuiltinBytecode` per module; StandaloneModuleGraph::to_bytes lays them out and InternalModuleRegistry
+/// picks them up by id. The modules, their ids and (when compiling for another platform) their sources come from the
+/// builtins section of the executable the bundle is going into.
 fn append_internal_module_bytecode(
     c: &LinkerContext,
     output_files: &mut Vec<options::OutputFile>,
     external_strings: Option<core::ptr::NonNull<crate::bundle_v2::dispatch::EncoderStringTable>>,
 ) {
+    use crate::bundle_v2::dispatch;
+    let target_section = c.options.target_builtins.as_deref();
+    let builtins = match bun_exe_format::builtins::Builtins::parse(
+        target_section.unwrap_or_else(|| dispatch::host_builtins()),
+    ) {
+        Ok(b) => b,
+        Err(e) => {
+            debug!(
+                "Internal module bytecode: builtins section unreadable ({})",
+                <&'static str>::from(&e)
+            );
+            return;
+        }
+    };
+
     let import_records = c.graph.ast.items_import_records();
-    let mut specifiers: Vec<&[u8]> = Vec::new();
+    let mut wanted: Vec<u32> = Vec::new();
     for source_index in &c.graph.reachable_files {
         let Some(records) = import_records.get(source_index.get() as usize) else {
             continue;
@@ -1426,27 +1443,59 @@ fn append_internal_module_bytecode(
                 continue;
             }
             let text: &[u8] = record.path.text;
-            let is_builtin = record.tag == bun_ast::ImportRecordTag::Builtin
-                || text.starts_with(b"node:")
-                || text.starts_with(b"bun:")
-                || bun_resolve_builtins::HardcodedModule::Alias::has(
-                    text,
-                    crate::options::Target::Bun,
-                    Default::default(),
-                );
-            if is_builtin && !specifiers.contains(&text) {
-                specifiers.push(text);
+            let alias = bun_resolve_builtins::HardcodedModule::Alias::get(
+                text,
+                crate::options::Target::Bun,
+                Default::default(),
+            );
+            let canonical: &[u8] = match &alias {
+                // The one aliased npm specifier whose registry name is not the specifier (bundle-modules.ts).
+                Some(alias) if alias.path.as_bytes() == b"@vercel/fetch" => b"vercel_fetch",
+                Some(alias) => alias.path.as_bytes(),
+                None if record.tag == bun_ast::ImportRecordTag::Builtin
+                    || text.starts_with(b"node:")
+                    || text.starts_with(b"bun:") =>
+                {
+                    text
+                }
+                None => continue,
+            };
+            if let Some(id) = builtins.find(canonical) {
+                if !wanted.contains(&id) {
+                    wanted.push(id);
+                }
             }
         }
     }
-    if specifiers.is_empty() {
-        return;
+    let mut i = 0;
+    while i < wanted.len() {
+        for dep in builtins.dependencies(wanted[i]) {
+            if !wanted.contains(&dep) {
+                wanted.push(dep);
+            }
+        }
+        i += 1;
     }
-    for (id, bytecode) in crate::bundle_v2::dispatch::generate_internal_module_bytecode(
-        &specifiers,
-        c.options.bytecode_depth,
-        external_strings,
-    ) {
+
+    for id in wanted {
+        let bytecode = match target_section {
+            Some(_) => builtins.module(id).and_then(|m| {
+                dispatch::generate_internal_module_bytecode_from_source(
+                    &m,
+                    builtins.source_stamp,
+                    c.options.bytecode_depth,
+                    external_strings,
+                )
+            }),
+            None => dispatch::generate_internal_module_bytecode(
+                id,
+                c.options.bytecode_depth,
+                external_strings,
+            ),
+        };
+        let Some(bytecode) = bytecode else {
+            continue;
+        };
         debug!("Internal module bytecode {}: {} bytes", id, bytecode.len());
         output_files.push(options::OutputFile::init(options::OutputFileInit {
             output_path: id.to_string().into_bytes().into_boxed_slice(),

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1453,8 +1453,8 @@ fn append_internal_module_bytecode(
                 Some(alias) if alias.path.as_bytes() == b"@vercel/fetch" => b"vercel_fetch",
                 Some(alias) => alias.path.as_bytes(),
                 None if record.tag == bun_ast::ImportRecordTag::Builtin
-                    || text.starts_with(b"node:")
-                    || text.starts_with(b"bun:") =>
+                    || strings::has_prefix(text, b"node:")
+                    || strings::has_prefix(text, b"bun:") =>
                 {
                     text
                 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1113,6 +1113,18 @@ bun_core::comptime_string_map! {
     };
 }
 
+/// `--compile --bytecode`: the executable whose internal JS modules (node:fs, ...) get ahead-of-time bytecode. Their
+/// sources differ per platform, so for another platform they are read out of that bun executable's builtins section
+/// (`bun_exe_format::builtins`); `None` is a target executable without one (an older bun), which then gets no builtin
+/// bytecode.
+#[derive(Clone, Default)]
+pub enum CompileTargetBuiltins {
+    #[default]
+    Host,
+    Target(std::sync::Arc<[u8]>),
+    None,
+}
+
 /// What `--compile` resolved to for this bundle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompileMode {
@@ -1295,9 +1307,8 @@ pub struct BundleOptions<'a> {
     pub bytecode: bool,
     /// How many levels of nested functions get bytecode (`u32::MAX` = all; 0 = only each module's top level).
     pub bytecode_depth: u32,
-    /// `--compile --bytecode` for another platform: the executable's internal-module sources (and their bytecode) are that
-    /// platform's, not this one's, so don't embed bytecode generated from ours.
-    pub compile_target_is_host: bool,
+    /// `--compile --bytecode`: whose internal modules get ahead-of-time bytecode embedded alongside the bundle's.
+    pub compile_target_builtins: CompileTargetBuiltins,
 
     pub code_coverage: bool,
     pub debugger: bool,
@@ -1491,7 +1502,7 @@ impl<'a> BundleOptions<'a> {
             emit_dce_annotations: self.emit_dce_annotations,
             bytecode: self.bytecode,
             bytecode_depth: self.bytecode_depth,
-            compile_target_is_host: self.compile_target_is_host,
+            compile_target_builtins: self.compile_target_builtins.clone(),
             code_coverage: self.code_coverage,
             debugger: self.debugger,
             compile_mode: self.compile_mode,
@@ -1739,7 +1750,7 @@ impl<'a> BundleOptions<'a> {
             emit_dce_annotations: false,
             bytecode: false,
             bytecode_depth: u32::MAX,
-            compile_target_is_host: true,
+            compile_target_builtins: CompileTargetBuiltins::Host,
             code_coverage: false,
             debugger: false,
             compile_mode: CompileMode::None,

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -403,37 +403,25 @@ writeIfNotChanged(
 // frontend ~15s on the release build — millions of integer tokens to parse for
 // ~2 MB of payload.
 //
-// Layout: [builtin functions combined source][\0][module 0][\n\0][module 1][\n\0]...
-// WebCoreJSBuiltins.cpp's internalCombinedSource is the span at offset 0; the
-// internal modules follow at known offsets.
+// The blob lives in its own executable section (`__TEXT,__bun_builtins` /
+// `.bun_builtins` / `.bunblt`) and starts with a header + per-module index, so
+// that a `bun build --compile --bytecode` running on another platform can read a
+// target executable's builtin module sources (and their registry ids) straight out
+// of the file. The runtime reads the same index; nothing is stored twice. The
+// reader is src/exe_format/builtins.rs — keep the two in sync.
 //
-// In debug builds the module sources are read from disk (BUN_DYNAMIC_JS_LOAD_PATH),
-// so every module offset/length is 0. The functions span is still real in debug.
-const moduleSpans: { enumName: string; offset: number; length: number }[] = [];
-let blob: Buffer;
-{
-  const chunks: Buffer[] = [Buffer.from(functionsSource + "\0", "latin1")];
-  let offset = chunks[0].length;
-  for (const id of layoutOrder(moduleList.slice(0, nativeStartIndex), outputs)) {
-    const enumName = idToEnumName(id);
-    if (debug) {
-      moduleSpans.push({ enumName, offset: 0, length: 0 });
-      continue;
-    }
-    const out = outputs.get(id.slice(0, -3).replaceAll("/", path.sep));
-    if (!out) throw new Error(`Missing output for ${id}`);
-    checkAscii(out);
-    // Trailing "\n\0": the NUL keeps each entry a valid C string should anything
-    // downstream ever strlen into the blob.
-    const bytes = Buffer.from(out + "\n\0", "latin1");
-    chunks.push(bytes);
-    moduleSpans.push({ enumName, offset, length: bytes.length - 1 });
-    offset += bytes.length;
-  }
-  blob = Buffer.concat(chunks);
-}
-
-writeIfNotChangedBinary(path.join(CODEGEN_DIR, "InternalModuleRegistryConstants.bin"), blob);
+// Layout (little-endian u32 unless noted; offsets in the index are relative to `data`):
+//   header:  magic[8] "BUNBLTNS", version, sourceStamp, moduleCount, modulesOffset,
+//            depOffsetsOffset, depsOffset, dataOffset, dataLength, 0, 0
+//   modules: moduleCount × { nameOffset, nameLength, urlOffset, urlLength, codeOffset, codeLength }
+//   depOffsets: u16[moduleCount + 1], deps: u16[]  (see internalModuleDependencyTable)
+//   data:    [builtin functions combined source][\0][module 0][\0][module 1][\0]...[name\0url\0]...
+// WebCoreJSBuiltins.cpp's internalCombinedSource is the span at data offset 0.
+//
+// A debug build's runtime reads the module sources from disk instead (BUN_DYNAMIC_JS_LOAD_PATH), but they are still
+// here so that a debug bun works as a `--compile` target like any other.
+const BUILTINS_FORMAT_VERSION = 1;
+const BUILTINS_HEADER_SIZE = 48;
 
 // Identifies these module sources to bytecode generated from them ahead of time (bun build --compile embeds bytecode for
 // the internal modules an app uses); computed over the bundled outputs so it is meaningful in debug builds too.
@@ -470,30 +458,92 @@ const internalModuleDependencyTable = (() => {
   return { offsets, flat };
 })();
 
+let blob: Buffer;
+let blobDataOffset: number;
+{
+  type Span = { offset: number; length: number };
+  const code = new Map<string, Span>();
+  const chunks: Buffer[] = [Buffer.from(functionsSource + "\0", "latin1")];
+  let offset = chunks[0].length;
+  const push = (text: string): Span => {
+    const bytes = Buffer.from(text, "latin1");
+    const span = { offset, length: bytes.length };
+    chunks.push(bytes);
+    offset += bytes.length;
+    return span;
+  };
+  for (const id of layoutOrder(moduleList.slice(0, nativeStartIndex), outputs)) {
+    const out = outputs.get(id.slice(0, -3).replaceAll("/", path.sep));
+    if (!out) throw new Error(`Missing output for ${id}`);
+    checkAscii(out);
+    // The NUL keeps each entry a valid C string should anything downstream ever strlen into the blob.
+    const span = push(out + "\0");
+    code.set(id, { offset: span.offset, length: span.length - 1 });
+  }
+  const records: number[] = [];
+  for (const id of moduleList.slice(0, nativeStartIndex)) {
+    const name = push(idToPublicSpecifierOrEnumName(id) + "\0");
+    const url = push("builtin://" + id.replace(/\.[mc]?[tj]s$/, "").replace(/[^a-zA-Z0-9]+/g, "/") + "\0");
+    const { offset: codeOffset, length: codeLength } = code.get(id)!;
+    records.push(name.offset, name.length - 1, url.offset, url.length - 1, codeOffset, codeLength);
+  }
+  const data = Buffer.concat(chunks);
+
+  const align = (n: number, to: number) => (n + to - 1) & ~(to - 1);
+  const modulesOffset = BUILTINS_HEADER_SIZE;
+  const depOffsetsOffset = modulesOffset + records.length * 4;
+  const depsOffset = depOffsetsOffset + internalModuleDependencyTable.offsets.length * 2;
+  blobDataOffset = align(depsOffset + internalModuleDependencyTable.flat.length * 2, 16);
+
+  blob = Buffer.alloc(blobDataOffset + data.length);
+  blob.write("BUNBLTNS", 0, "latin1");
+  [
+    BUILTINS_FORMAT_VERSION,
+    internalModulesStamp,
+    nativeStartIndex,
+    modulesOffset,
+    depOffsetsOffset,
+    depsOffset,
+    blobDataOffset,
+    data.length,
+    0,
+    0,
+  ].forEach((v, i) => blob.writeUInt32LE(v >>> 0, 8 + i * 4));
+  records.forEach((v, i) => blob.writeUInt32LE(v, modulesOffset + i * 4));
+  internalModuleDependencyTable.offsets.forEach((v, i) => blob.writeUInt16LE(v, depOffsetsOffset + i * 2));
+  internalModuleDependencyTable.flat.forEach((v, i) => blob.writeUInt16LE(v, depsOffset + i * 2));
+  data.copy(blob, blobDataOffset);
+}
+
+writeIfNotChangedBinary(path.join(CODEGEN_DIR, "InternalModuleRegistryConstants.bin"), blob);
+
 writeIfNotChanged(
   path.join(CODEGEN_DIR, "InternalModuleRegistryConstants.S"),
   `// Generated by src/codegen/bundle-modules.ts
 #if defined(__APPLE__)
-.section __TEXT,__const
+.section __TEXT,__bun_builtins,regular,no_dead_strip
 #define BUN_SYM(x) _##x
 #elif defined(_WIN32)
-.section .rdata,"dr"
+.section .bunblt,"dr"
 #define BUN_SYM(x) x
 #else
 .pushsection .note.GNU-stack, "", %progbits
 .popsection
-.section .rodata
+.section .bun_builtins,"a",%progbits
 #define BUN_SYM(x) x
 #endif
 
+.globl BUN_SYM(bun_internal_modules_header)
 .globl BUN_SYM(bun_internal_modules_data)
 .p2align 4
+BUN_SYM(bun_internal_modules_header):
+.incbin "InternalModuleRegistryConstants.bin", 0, ${blobDataOffset}
 BUN_SYM(bun_internal_modules_data):
-.incbin "InternalModuleRegistryConstants.bin"
+.incbin "InternalModuleRegistryConstants.bin", ${blobDataOffset}
 `,
 );
 
-// Offset/length table. Included only by InternalModuleRegistry.cpp.
+// The C++ view of the section header/index above. Included only by InternalModuleRegistry.cpp.
 writeIfNotChanged(
   path.join(CODEGEN_DIR, "InternalModuleRegistryConstants.h"),
   `// clang-format off
@@ -501,59 +551,62 @@ writeIfNotChanged(
 #pragma once
 #include <cstdint>
 
-extern "C" const char bun_internal_modules_data[];
-
 namespace Bun {
 namespace InternalModuleRegistryConstants {
 
-static constexpr uint32_t sourceStamp = ${internalModulesStamp}u;
-static constexpr uint16_t dependencyOffsets[${nativeStartIndex + 1}] = { ${internalModuleDependencyTable.offsets.join(", ")} };
-static constexpr uint16_t dependencies[${Math.max(1, internalModuleDependencyTable.flat.length)}] = { ${internalModuleDependencyTable.flat.length ? internalModuleDependencyTable.flat.join(", ") : "0"} };
+struct Header {
+  char magic[8];
+  uint32_t version;
+  uint32_t sourceStamp;
+  uint32_t moduleCount;
+  uint32_t modulesOffset;
+  uint32_t depOffsetsOffset;
+  uint32_t depsOffset;
+  uint32_t dataOffset;
+  uint32_t dataLength;
+  uint32_t reserved[2];
+};
+static_assert(sizeof(Header) == ${BUILTINS_HEADER_SIZE});
 
-${moduleSpans
-  .map(
-    ({ enumName, offset, length }) =>
-      `static constexpr uint32_t ${enumName}CodeOffset = ${offset};\n` +
-      `static constexpr uint32_t ${enumName}CodeLength = ${length};`,
-  )
-  .join("\n")}
-
-} // namespace InternalModuleRegistryConstants
-} // namespace Bun
-`,
-);
-
-// This code slice is used in InternalModuleRegistry.cpp. It defines the loading function for modules.
-// JS modules (ids below nativeStartIndex, in enum order) come from one table so the
-// per-module code is a row of data rather than a switch arm; native modules keep a switch.
-writeIfNotChanged(
-  path.join(CODEGEN_DIR, "InternalModuleRegistry+createInternalModuleById.h"),
-  `// clang-format off
-struct InternalJSModule {
-  ASCIILiteral moduleId;
-  ASCIILiteral fileName;
-  ASCIILiteral url;
+// Offsets are relative to bun_internal_modules_data. name and url are NUL-terminated.
+struct ModuleRecord {
+  uint32_t nameOffset;
+  uint32_t nameLength;
+  uint32_t urlOffset;
+  uint32_t urlLength;
   uint32_t codeOffset;
   uint32_t codeLength;
 };
 
-static constexpr InternalJSModule internalJSModules[${nativeStartIndex}] = {
+static constexpr uint32_t moduleCount = ${nativeStartIndex};
+
+#ifdef BUN_DYNAMIC_JS_LOAD_PATH
+static constexpr const char* fileNames[moduleCount] = {
   ${moduleList
     .slice(0, nativeStartIndex)
-    .map(id => {
-      const moduleName = idToPublicSpecifierOrEnumName(id);
-      const fileBase = JSON.stringify(id.replace(/\.[mc]?[tj]s$/, ".js"));
-      const urlString = "builtin://" + id.replace(/\.[mc]?[tj]s$/, "").replace(/[^a-zA-Z0-9]+/g, "/");
-      return `{ "${moduleName}"_s, ${fileBase}_s, "${urlString}"_s, InternalModuleRegistryConstants::${idToEnumName(id)}CodeOffset, InternalModuleRegistryConstants::${idToEnumName(id)}CodeLength },`;
-    })
-    .join("\n  ")}
+    .map(id => JSON.stringify(id.replace(/\.[mc]?[tj]s$/, ".js")))
+    .join(",\n  ")}
 };
+#endif
 
+} // namespace InternalModuleRegistryConstants
+} // namespace Bun
+
+extern "C" const Bun::InternalModuleRegistryConstants::Header bun_internal_modules_header;
+extern "C" const char bun_internal_modules_data[];
+`,
+);
+
+// This code slice is used in InternalModuleRegistry.cpp. It defines the loading function for modules.
+// JS modules (ids below nativeStartIndex, in enum order) are rows of the section index above rather
+// than switch arms; native modules keep a switch.
+writeIfNotChanged(
+  path.join(CODEGEN_DIR, "InternalModuleRegistry+createInternalModuleById.h"),
+  `// clang-format off
 JSValue InternalModuleRegistry::createInternalModuleById(JSGlobalObject* globalObject, VM& vm, Field id)
 {
   if (static_cast<size_t>(id) < ${nativeStartIndex}) {
-    const InternalJSModule& m = internalJSModules[static_cast<size_t>(id)];
-    INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, m.moduleId, m.fileName, m.codeOffset, m.codeLength, m.url, static_cast<uint32_t>(id));
+    return generateInternalModule(globalObject, vm, static_cast<uint32_t>(id));
   }
   switch (id) {
     // Native modules

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -489,6 +489,8 @@ let blobDataOffset: number;
   }
   const data = Buffer.concat(chunks);
 
+  if (internalModuleDependencyTable.flat.length > 0xffff || nativeStartIndex > 0xffff)
+    throw new Error("builtins section: dependency table no longer fits its u16 entries; widen depOffsets/deps");
   const align = (n: number, to: number) => (n + to - 1) & ~(to - 1);
   const modulesOffset = BUILTINS_HEADER_SIZE;
   const depOffsetsOffset = modulesOffset + records.length * 4;

--- a/src/exe_format/builtins.rs
+++ b/src/exe_format/builtins.rs
@@ -1,0 +1,306 @@
+//! Read-only view of a bun executable's builtin JS module sources: the
+//! `__TEXT,__bun_builtins` / `.bun_builtins` / `.bunblt` section written by
+//! src/codegen/bundle-modules.ts (InternalModuleRegistryConstants.S).
+//!
+//! `bun build --compile --bytecode --target=<other platform>` uses this to
+//! generate bytecode for the *target* executable's internal modules (their
+//! sources differ per platform), so it has to work on an ELF, Mach-O or PE
+//! file from any host — no dlopen. Everything is bounds-checked up front in
+//! [`Builtins::parse`]; the accessors cannot panic on a validated view.
+
+use core::mem::size_of;
+
+use bun_core::slice_to_nul;
+
+use crate::elf::{Elf64_Ehdr, Elf64_Shdr};
+use crate::macho_types as macho;
+use crate::pe::{DOSHeader, PEHeader, SectionHeader};
+use crate::read_struct;
+
+const MAGIC: &[u8; 8] = b"BUNBLTNS";
+const FORMAT_VERSION: u32 = 1;
+const HEADER_SIZE: usize = 48;
+const RECORD_SIZE: usize = 6 * 4;
+
+const MH_MAGIC_64: u32 = 0xfeed_facf;
+const MACHO_SECTNAME: &[u8] = b"__bun_builtins";
+const ELF_SECTION_NAME: &[u8] = b".bun_builtins";
+const PE_SECTION_NAME: [u8; 8] = *b".bunblt\0";
+
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr, PartialEq, Eq)]
+pub enum BuiltinsError {
+    /// Not an ELF, Mach-O or PE file we can read.
+    #[error("UnrecognizedExecutable")]
+    UnrecognizedExecutable,
+    /// The executable has no builtins section (a bun older than this format).
+    #[error("MissingBuiltinsSection")]
+    MissingSection,
+    /// The section is there but not in a layout this bun understands.
+    #[error("InvalidBuiltinsSection")]
+    Invalid,
+    #[error("UnsupportedBuiltinsVersion")]
+    UnsupportedVersion,
+}
+
+#[derive(Clone, Copy)]
+pub struct Module<'a> {
+    /// Registry specifier, e.g. `node:fs` or `internal:streams/readable`.
+    pub name: &'a [u8],
+    /// `builtin://node/fs`
+    pub url: &'a [u8],
+    /// Latin-1 module source as InternalModuleRegistry compiles it.
+    pub source: &'a [u8],
+}
+
+/// A validated view over one executable's builtins section.
+#[derive(Clone, Copy)]
+pub struct Builtins<'a> {
+    /// Identifies these sources to bytecode generated from them (JSC's `decodeBuiltinFunction` stamp).
+    pub source_stamp: u32,
+    count: u32,
+    records: &'a [u8],
+    dep_offsets: &'a [u8],
+    deps: &'a [u8],
+    data: &'a [u8],
+}
+
+impl<'a> Builtins<'a> {
+    /// Locate and parse the builtins section of an ELF, Mach-O or PE executable image.
+    pub fn from_executable(file: &'a [u8]) -> Result<Self, BuiltinsError> {
+        Self::parse(find_section(file)?)
+    }
+
+    /// Parse a builtins section (header onward). Trailing bytes past the blob are ignored.
+    pub fn parse(section: &'a [u8]) -> Result<Self, BuiltinsError> {
+        use BuiltinsError::Invalid;
+        if section.len() < HEADER_SIZE || &section[..8] != MAGIC {
+            return Err(Invalid);
+        }
+        let field = |i: usize| u32_at(section, 8 + i * 4);
+        if field(0) != FORMAT_VERSION {
+            return Err(BuiltinsError::UnsupportedVersion);
+        }
+        let source_stamp = field(1);
+        let count = field(2);
+        let modules_offset = field(3) as usize;
+        let dep_offsets_offset = field(4) as usize;
+        let deps_offset = field(5) as usize;
+        let data_offset = field(6) as usize;
+        let data_len = field(7) as usize;
+
+        let n = count as usize;
+        let records = sub(
+            section,
+            modules_offset,
+            n.checked_mul(RECORD_SIZE).ok_or(Invalid)?,
+        )?;
+        let dep_offsets = sub(section, dep_offsets_offset, (n + 1) * 2)?;
+        let deps_len = u16_at(dep_offsets, n * 2) as usize;
+        let deps = sub(section, deps_offset, deps_len * 2)?;
+        let data = sub(section, data_offset, data_len)?;
+
+        for i in 0..n {
+            let r = &records[i * RECORD_SIZE..][..RECORD_SIZE];
+            for k in 0..3 {
+                sub(
+                    data,
+                    u32_at(r, k * 8) as usize,
+                    u32_at(r, k * 8 + 4) as usize,
+                )?;
+            }
+        }
+        let mut prev = 0;
+        for i in 0..=n {
+            let off = u16_at(dep_offsets, i * 2) as usize;
+            if off < prev || off > deps_len {
+                return Err(Invalid);
+            }
+            prev = off;
+        }
+        for i in 0..deps_len {
+            if u16_at(deps, i * 2) as u32 >= count {
+                return Err(Invalid);
+            }
+        }
+
+        Ok(Self {
+            source_stamp,
+            count,
+            records,
+            dep_offsets,
+            deps,
+            data,
+        })
+    }
+
+    /// Number of JS internal modules; ids `0..len()` are InternalModuleRegistry field indices.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    pub fn module(&self, id: u32) -> Option<Module<'a>> {
+        if id >= self.count {
+            return None;
+        }
+        let r = &self.records[id as usize * RECORD_SIZE..][..RECORD_SIZE];
+        let span =
+            |k: usize| &self.data[u32_at(r, k * 8) as usize..][..u32_at(r, k * 8 + 4) as usize];
+        Some(Module {
+            name: span(0),
+            url: span(1),
+            source: span(2),
+        })
+    }
+
+    /// The id of the module whose registry specifier is exactly `name`.
+    pub fn find(&self, name: &[u8]) -> Option<u32> {
+        (0..self.count).find(|&id| self.module(id).is_some_and(|m| m.name == name))
+    }
+
+    /// The modules `id` requires while it is being evaluated.
+    pub fn dependencies(&self, id: u32) -> impl Iterator<Item = u32> + 'a {
+        let (start, end) = if id < self.count {
+            (
+                u16_at(self.dep_offsets, id as usize * 2) as usize,
+                u16_at(self.dep_offsets, id as usize * 2 + 2) as usize,
+            )
+        } else {
+            (0, 0)
+        };
+        let deps = self.deps;
+        (start..end).map(move |i| u16_at(deps, i * 2) as u32)
+    }
+
+    pub fn modules(&self) -> impl Iterator<Item = Module<'a>> + '_ {
+        (0..self.count).filter_map(move |id| self.module(id))
+    }
+}
+
+fn u32_at(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+}
+
+fn u16_at(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap())
+}
+
+fn sub(bytes: &[u8], offset: usize, len: usize) -> Result<&[u8], BuiltinsError> {
+    offset
+        .checked_add(len)
+        .and_then(|end| bytes.get(offset..end))
+        .ok_or(BuiltinsError::Invalid)
+}
+
+fn struct_at<T: Copy>(bytes: &[u8], offset: usize) -> Result<T, BuiltinsError> {
+    Ok(read_struct(sub(bytes, offset, size_of::<T>())?))
+}
+
+/// The bytes of the builtins section in an executable image of any of the three formats bun ships as.
+pub fn find_section(file: &[u8]) -> Result<&[u8], BuiltinsError> {
+    if file.starts_with(b"\x7fELF") {
+        find_elf(file)
+    } else if file.starts_with(&MH_MAGIC_64.to_le_bytes()) {
+        find_macho(file)
+    } else if file.starts_with(b"MZ") {
+        find_pe(file)
+    } else {
+        Err(BuiltinsError::UnrecognizedExecutable)
+    }
+}
+
+fn find_elf(file: &[u8]) -> Result<&[u8], BuiltinsError> {
+    // EI_CLASS = ELFCLASS64, EI_DATA = ELFDATA2LSB: every target bun builds for.
+    if file.len() < size_of::<Elf64_Ehdr>() || file[4] != 2 || file[5] != 1 {
+        return Err(BuiltinsError::UnrecognizedExecutable);
+    }
+    let ehdr: Elf64_Ehdr = struct_at(file, 0)?;
+    let shdr = |index: usize| -> Result<Elf64_Shdr, BuiltinsError> {
+        let offset = (index * size_of::<Elf64_Shdr>())
+            .checked_add(usize::try_from(ehdr.e_shoff).map_err(|_| BuiltinsError::Invalid)?)
+            .ok_or(BuiltinsError::Invalid)?;
+        struct_at(file, offset)
+    };
+    if ehdr.e_shstrndx >= ehdr.e_shnum {
+        return Err(BuiltinsError::MissingSection);
+    }
+    let strtab_hdr = shdr(ehdr.e_shstrndx as usize)?;
+    let strtab = sub(
+        file,
+        to_usize(strtab_hdr.sh_offset)?,
+        to_usize(strtab_hdr.sh_size)?,
+    )?;
+    for i in 0..ehdr.e_shnum as usize {
+        let s = shdr(i)?;
+        let Some(name) = strtab.get(s.sh_name as usize..) else {
+            continue;
+        };
+        if slice_to_nul(name) == ELF_SECTION_NAME {
+            return sub(file, to_usize(s.sh_offset)?, to_usize(s.sh_size)?);
+        }
+    }
+    Err(BuiltinsError::MissingSection)
+}
+
+fn find_macho(file: &[u8]) -> Result<&[u8], BuiltinsError> {
+    let header: macho::mach_header_64 = struct_at(file, 0)?;
+    let mut offset = size_of::<macho::mach_header_64>();
+    for _ in 0..header.ncmds {
+        let (cmd, cmdsize) = (
+            u32_at(sub(file, offset, 8)?, 0),
+            u32_at(sub(file, offset, 8)?, 4) as usize,
+        );
+        if cmdsize < 8 {
+            return Err(BuiltinsError::Invalid);
+        }
+        if cmd == macho::LC::SEGMENT_64 {
+            let seg: macho::segment_command_64 = struct_at(file, offset)?;
+            let mut sect_offset = offset + size_of::<macho::segment_command_64>();
+            for _ in 0..seg.nsects {
+                if sect_offset + size_of::<macho::section_64>() > offset + cmdsize {
+                    return Err(BuiltinsError::Invalid);
+                }
+                let sect: macho::section_64 = struct_at(file, sect_offset)?;
+                if sect.sect_name() == MACHO_SECTNAME {
+                    return sub(file, sect.offset as usize, to_usize(sect.size)?);
+                }
+                sect_offset += size_of::<macho::section_64>();
+            }
+        }
+        offset = offset.checked_add(cmdsize).ok_or(BuiltinsError::Invalid)?;
+    }
+    Err(BuiltinsError::MissingSection)
+}
+
+fn find_pe(file: &[u8]) -> Result<&[u8], BuiltinsError> {
+    let dos: DOSHeader = struct_at(file, 0)?;
+    let pe_offset = dos.e_lfanew as usize;
+    let pe: PEHeader = struct_at(file, pe_offset)?;
+    if pe.signature != crate::pe::PE_SIGNATURE {
+        return Err(BuiltinsError::UnrecognizedExecutable);
+    }
+    let mut offset = pe_offset
+        .checked_add(size_of::<PEHeader>() + pe.size_of_optional_header as usize)
+        .ok_or(BuiltinsError::Invalid)?;
+    for _ in 0..pe.number_of_sections {
+        let s: SectionHeader = struct_at(file, offset)?;
+        if s.name == PE_SECTION_NAME {
+            // virtual_size is the payload; size_of_raw_data is that rounded up to the file alignment.
+            let len = if s.virtual_size != 0 {
+                s.virtual_size.min(s.size_of_raw_data)
+            } else {
+                s.size_of_raw_data
+            };
+            return sub(file, s.pointer_to_raw_data as usize, len as usize);
+        }
+        offset += size_of::<SectionHeader>();
+    }
+    Err(BuiltinsError::MissingSection)
+}
+
+fn to_usize(v: u64) -> Result<usize, BuiltinsError> {
+    usize::try_from(v).map_err(|_| BuiltinsError::Invalid)
+}

--- a/src/exe_format/lib.rs
+++ b/src/exe_format/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+pub mod builtins;
 pub mod elf;
 pub mod error;
 pub mod macho;

--- a/src/exe_format/pe.rs
+++ b/src/exe_format/pe.rs
@@ -143,7 +143,7 @@ pub(crate) struct SectionHeader {
     pub characteristics: u32,         // Characteristics
 }
 
-const PE_SIGNATURE: u32 = 0x0000_4550; // "PE\0\0"
+pub(crate) const PE_SIGNATURE: u32 = 0x0000_4550; // "PE\0\0"
 const DOS_SIGNATURE: u16 = 0x5A4D; // "MZ"
 const OPTIONAL_HEADER_MAGIC_64: u16 = 0x020B;
 

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -81,8 +81,23 @@ unsafe extern "C" {
         cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
         external_strings: Option<NonNull<EncoderStringTable>>,
     ) -> bool;
-    /// InternalModuleRegistry.cpp: the internal JS modules `id` statically requires.
-    fn Bun__internalModuleDependencies(id: u32, out: *mut *const u16) -> usize;
+    fn Bun__generateInternalModuleBytecodeFromSource(
+        text: *const u8,
+        text_len: usize,
+        name: *const u8,
+        name_len: usize,
+        url: *const u8,
+        url_len: usize,
+        source_stamp: u32,
+        depth: u32,
+        output_byte_code: *mut Option<NonNull<u8>>,
+        output_byte_code_size: *mut usize,
+        cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
+        external_strings: Option<NonNull<EncoderStringTable>>,
+    ) -> bool;
+
+    /// InternalModuleRegistryConstants.S: this executable's builtins section (`bun_exe_format::builtins` layout).
+    static bun_internal_modules_header: [u8; 48];
 }
 
 impl CachedBytecode {
@@ -189,80 +204,94 @@ pub(crate) fn __bun_jsc_encoder_string_table_new() -> NonNull<EncoderStringTable
     EncoderStringTable::new()
 }
 
-/// `bun build --compile --bytecode`: for the builtin module specifiers a bundle imports (e.g. `b"node:fs"`), the
-/// InternalModuleRegistry ids of those modules and everything they eagerly require, each with bytecode generated the
-/// way InternalModuleRegistry::generateModule consumes it. Specifiers that are not JS internal modules are skipped.
-/// `depth` bounds nested-function code blocks (`u32::MAX` = all of them; 0 = just each module wrapper's own).
+/// `bun build --compile --bytecode`: this executable's builtins section — header, module index and sources
+/// (`bun_exe_format::builtins::Builtins::parse` reads it).
+#[unsafe(no_mangle)]
+pub(crate) fn __bun_jsc_host_builtins() -> &'static [u8] {
+    // SAFETY: the section is `[header][index][data]`, contiguous and immutable for the life of the process; the header's
+    // dataOffset (u32 at byte 32) + dataLength (u32 at byte 36) is its total length.
+    unsafe {
+        let header = &*core::ptr::addr_of!(bun_internal_modules_header);
+        let field = |at: usize| u32::from_le_bytes(header[at..at + 4].try_into().unwrap()) as usize;
+        core::slice::from_raw_parts(header.as_ptr(), field(32) + field(36))
+    }
+}
+
+fn take_bytecode(
+    ok: bool,
+    bytes: Option<NonNull<u8>>,
+    size: usize,
+    handle: Option<NonNull<CachedBytecode>>,
+) -> Option<Box<[u8]>> {
+    let (true, Some(bytes), Some(handle)) = (ok, bytes, handle) else {
+        return None;
+    };
+    // SAFETY: `bytes[..size]` is the CachedBytecode's payload, valid until the deref below.
+    let owned = Box::<[u8]>::from(unsafe { core::slice::from_raw_parts(bytes.as_ptr(), size) });
+    CachedBytecode__deref(CachedBytecode::opaque_mut(handle.as_ptr()));
+    Some(owned)
+}
+
+/// `bun build --compile --bytecode`: bytecode for this executable's internal module `id` (an InternalModuleRegistry
+/// field index), generated the way InternalModuleRegistry consumes it. `depth` bounds nested-function code blocks
+/// (`u32::MAX` = all of them; 0 = just the module wrapper's own).
 #[unsafe(no_mangle)]
 pub(crate) fn __bun_jsc_generate_internal_module_bytecode(
-    specifiers: &[&[u8]],
+    id: u32,
     depth: u32,
     external_strings: Option<NonNull<EncoderStringTable>>,
-) -> Vec<(u32, Box<[u8]>)> {
+) -> Option<Box<[u8]>> {
     crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
-
-    let mut wanted: Vec<u32> = Vec::new();
-    let push = |id: u32, wanted: &mut Vec<u32>| {
-        if !wanted.contains(&id) {
-            wanted.push(id);
-        }
+    let mut bytes: Option<NonNull<u8>> = None;
+    let mut size: usize = 0;
+    let mut handle: Option<NonNull<CachedBytecode>> = None;
+    // SAFETY: out-params are initialized locals; C++ fills them on success.
+    let ok = unsafe {
+        Bun__generateInternalModuleBytecode(
+            id,
+            depth,
+            &raw mut bytes,
+            &raw mut size,
+            &raw mut handle,
+            external_strings,
+        )
     };
-    for specifier in specifiers {
-        let alias =
-            bun_resolve_builtins::Alias::get(specifier, bun_ast::Target::Bun, Default::default());
-        let canonical: &[u8] = match &alias {
-            Some(alias) => alias.path.as_bytes(),
-            None => specifier,
-        };
-        if let Some(tag) = crate::ResolvedSourceTag::try_from_name(canonical) {
-            if tag.0 >= crate::ResolvedSourceTag::INTERNAL_MODULE_REGISTRY_FLAG {
-                push(
-                    tag.0 - crate::ResolvedSourceTag::INTERNAL_MODULE_REGISTRY_FLAG,
-                    &mut wanted,
-                );
-            }
-        }
-    }
-    // Transitive static requires, breadth-first.
-    let mut i = 0;
-    while i < wanted.len() {
-        let mut deps: *const u16 = core::ptr::null();
-        // SAFETY: C++ returns a pointer into a static table and its length.
-        let count = unsafe { Bun__internalModuleDependencies(wanted[i], &raw mut deps) };
-        for k in 0..count {
-            // SAFETY: k < count.
-            let dep = unsafe { *deps.add(k) } as u32;
-            push(dep, &mut wanted);
-        }
-        i += 1;
-    }
+    take_bytecode(ok, bytes, size, handle)
+}
 
-    let mut out = Vec::with_capacity(wanted.len());
-    for id in wanted {
-        let mut bytes: Option<NonNull<u8>> = None;
-        let mut size: usize = 0;
-        let mut handle: Option<NonNull<CachedBytecode>> = None;
-        // SAFETY: out-params are initialized locals; C++ fills them on success.
-        if !unsafe {
-            Bun__generateInternalModuleBytecode(
-                id,
-                depth,
-                &raw mut bytes,
-                &raw mut size,
-                &raw mut handle,
-                external_strings,
-            )
-        } {
-            continue;
-        }
-        let (Some(bytes), Some(handle)) = (bytes, handle) else {
-            continue;
-        };
-        // SAFETY: `bytes[..size]` is the CachedBytecode's payload, valid until the deref below.
-        let owned = Box::<[u8]>::from(unsafe { core::slice::from_raw_parts(bytes.as_ptr(), size) });
-        CachedBytecode__deref(CachedBytecode::opaque_mut(handle.as_ptr()));
-        out.push((id, owned));
-    }
-    out
+/// Same, for an internal module of another bun executable (cross-compiling): `source`, `name` and `url` are that
+/// module's entry in the other executable's builtins section and `source_stamp` is that section's stamp.
+#[unsafe(no_mangle)]
+pub(crate) fn __bun_jsc_generate_internal_module_bytecode_from_source(
+    source: &[u8],
+    name: &[u8],
+    url: &[u8],
+    source_stamp: u32,
+    depth: u32,
+    external_strings: Option<NonNull<EncoderStringTable>>,
+) -> Option<Box<[u8]>> {
+    crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
+    crate::initialize(crate::InitializeOptions::default());
+    let mut bytes: Option<NonNull<u8>> = None;
+    let mut size: usize = 0;
+    let mut handle: Option<NonNull<CachedBytecode>> = None;
+    // SAFETY: the three slices are valid for their lengths for the duration of the call; out-params as above.
+    let ok = unsafe {
+        Bun__generateInternalModuleBytecodeFromSource(
+            source.as_ptr(),
+            source.len(),
+            name.as_ptr(),
+            name.len(),
+            url.as_ptr(),
+            url.len(),
+            source_stamp,
+            depth,
+            &raw mut bytes,
+            &raw mut size,
+            &raw mut handle,
+            external_strings,
+        )
+    };
+    take_bytecode(ok, bytes, size, handle)
 }

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -96,8 +96,8 @@ unsafe extern "C" {
         external_strings: Option<NonNull<EncoderStringTable>>,
     ) -> bool;
 
-    /// InternalModuleRegistryConstants.S: this executable's builtins section (`bun_exe_format::builtins` layout).
-    static bun_internal_modules_header: [u8; 48];
+    /// InternalModuleRegistry.cpp: this executable's builtins section (`bun_exe_format::builtins` layout).
+    fn Bun__builtinsSection(length: *mut usize) -> *const u8;
 }
 
 impl CachedBytecode {
@@ -208,12 +208,11 @@ pub(crate) fn __bun_jsc_encoder_string_table_new() -> NonNull<EncoderStringTable
 /// (`bun_exe_format::builtins::Builtins::parse` reads it).
 #[unsafe(no_mangle)]
 pub(crate) fn __bun_jsc_host_builtins() -> &'static [u8] {
-    // SAFETY: the section is `[header][index][data]`, contiguous and immutable for the life of the process; the header's
-    // dataOffset (u32 at byte 32) + dataLength (u32 at byte 36) is its total length.
+    let mut length: usize = 0;
+    // SAFETY: returns a pointer to immutable section data that lives for the whole process, and its length.
     unsafe {
-        let header = &*core::ptr::addr_of!(bun_internal_modules_header);
-        let field = |at: usize| u32::from_le_bytes(header[at..at + 4].try_into().unwrap()) as usize;
-        core::slice::from_raw_parts(header.as_ptr(), field(32) + field(36))
+        let ptr = Bun__builtinsSection(&raw mut length);
+        core::slice::from_raw_parts(ptr, length)
     }
 }
 

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -43,9 +43,9 @@ static void maybeAddCodeCoverage(JSC::VM& vm, const JSC::SourceCode& code)
 #endif
 }
 
-// The `INTERNAL_MODULE_REGISTRY_GENERATE` macro handles inlining code to compile and run a
-// JS builtin that acts as a module. In debug mode, we use a different implementation that reads
-// from the developer's filesystem. This allows reloading code without recompiling bindings.
+// JS internal modules are compiled from the sources linked into the executable's builtins section (see
+// InternalModuleRegistryConstants.h). In debug mode the sources are read from the developer's filesystem instead,
+// which allows reloading code without recompiling bindings.
 
 static std::atomic<unsigned> s_internalModulesFromBytecode { 0 };
 
@@ -65,10 +65,47 @@ static UnlinkedFunctionExecutable* createInternalModuleExecutable(JSC::VM& vm, c
     return createBuiltinExecutable(vm, source, Identifier::fromString(vm, moduleName), ImplementationVisibility::Public, ConstructorKind::None, ConstructAbility::CannotConstruct, InlineAttribute::None);
 }
 
-JSC::JSValue generateModule(JSC::JSGlobalObject* globalObject, JSC::VM& vm, const String& SOURCE, const String& moduleName, const String& urlString, uint32_t id)
+static const InternalModuleRegistryConstants::ModuleRecord& internalModuleRecord(uint32_t id)
+{
+    ASSERT(id < bun_internal_modules_header.moduleCount);
+    auto* records = reinterpret_cast<const InternalModuleRegistryConstants::ModuleRecord*>(reinterpret_cast<const char*>(&bun_internal_modules_header) + bun_internal_modules_header.modulesOffset);
+    return records[id];
+}
+
+static String internalModuleString(uint32_t offset, uint32_t length)
+{
+    return WTF::StringImpl::createWithoutCopying(std::span<const char>(bun_internal_modules_data + offset, length));
+}
+
+#ifdef BUN_DYNAMIC_JS_LOAD_PATH
+static String internalModuleSource(uint32_t id)
+{
+    const auto& m = internalModuleRecord(id);
+    String moduleName = internalModuleString(m.nameOffset, m.nameLength);
+    WTF::String file = makeString(ASCIILiteral::fromLiteralUnsafe(BUN_DYNAMIC_JS_LOAD_PATH), "/"_s, ASCIILiteral::fromLiteralUnsafe(InternalModuleRegistryConstants::fileNames[id]));
+    auto contents = WTF::FileSystemImpl::readEntireFile(file);
+    if (!contents) {
+        printf("\nFATAL: bun-debug failed to load bundled version of \"%s\" at \"%s\" (was it deleted?)\n"
+               "Please re-compile Bun to continue.\n\n",
+            moduleName.utf8().span().data(), file.utf8().span().data());
+        CRASH();
+    }
+    return WTF::String::fromUTF8(contents.value());
+}
+#else
+static String internalModuleSource(uint32_t id)
+{
+    const auto& m = internalModuleRecord(id);
+    return internalModuleString(m.codeOffset, m.codeLength);
+}
+#endif
+
+JSC::JSValue generateInternalModule(JSC::JSGlobalObject* globalObject, JSC::VM& vm, uint32_t id)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    SourceCode source = makeInternalModuleSource(SOURCE, moduleName, urlString);
+    const auto& m = internalModuleRecord(id);
+    String moduleName = internalModuleString(m.nameOffset, m.nameLength);
+    SourceCode source = makeInternalModuleSource(internalModuleSource(id), moduleName, internalModuleString(m.urlOffset, m.urlLength));
     maybeAddCodeCoverage(vm, source);
 
     UnlinkedFunctionExecutable* executable = nullptr;
@@ -77,7 +114,7 @@ JSC::JSValue generateModule(JSC::JSGlobalObject* globalObject, JSC::VM& vm, cons
     if (Bun__standaloneInternalModuleBytecode(::bunVM(globalObject), id, &cachedBytes, &cachedSize)) {
         Ref<JSC::CachedBytecode> cached = JSC::CachedBytecode::create(std::span<uint8_t> { const_cast<uint8_t*>(cachedBytes), cachedSize }, [](const void*) {}, {});
         cached->setPayloadIsPersistent();
-        executable = JSC::decodeBuiltinFunction(vm, WTF::move(cached), *source.provider(), InternalModuleRegistryConstants::sourceStamp);
+        executable = JSC::decodeBuiltinFunction(vm, WTF::move(cached), *source.provider(), bun_internal_modules_header.sourceStamp);
         if (executable)
             s_internalModulesFromBytecode.fetch_add(1, std::memory_order_relaxed);
     }
@@ -133,40 +170,6 @@ ALWAYS_INLINE JSC::JSValue generateNativeModule(
     ASSERT(defaultValue);
     return defaultValue;
 }
-
-#ifdef BUN_DYNAMIC_JS_LOAD_PATH
-static WTF::String internalModuleSourceFromDisk(const WTF::String& moduleName, WTF::String fileBase)
-{
-    WTF::String file = makeString(ASCIILiteral::fromLiteralUnsafe(BUN_DYNAMIC_JS_LOAD_PATH), "/"_s, WTF::move(fileBase));
-    auto contents = WTF::FileSystemImpl::readEntireFile(file);
-    if (!contents) {
-        printf("\nFATAL: bun-debug failed to load bundled version of \"%s\" at \"%s\" (was it deleted?)\n"
-               "Please re-compile Bun to continue.\n\n",
-            moduleName.utf8().span().data(), file.utf8().span().data());
-        CRASH();
-    }
-    return WTF::String::fromUTF8(contents.value());
-}
-
-JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, const WTF::String& moduleName, WTF::String fileBase, const WTF::String& urlString, uint32_t id)
-{
-    return generateModule(globalObject, vm, internalModuleSourceFromDisk(moduleName, WTF::move(fileBase)), moduleName, urlString, id);
-}
-#define INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, moduleId, filename, OFFSET, LENGTH, urlString, ID) \
-    return initializeInternalModuleFromDisk(globalObject, vm, moduleId, filename, urlString, ID)
-#define INTERNAL_MODULE_SOURCE(m) internalModuleSourceFromDisk(m.moduleId, m.fileName)
-#else
-
-// The module sources are linked as one read-only blob (bun_internal_modules_data,
-// see the generated InternalModuleRegistryConstants.S); each module is a span at
-// a known offset/length. createWithoutCopying is the same path the old
-// ASCIILiteral → String conversion took.
-#define INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, moduleId, filename, OFFSET, LENGTH, urlString, ID)                     \
-    return generateModule(globalObject, vm,                                                                                        \
-        WTF::String(WTF::StringImpl::createWithoutCopying(std::span<const char>(bun_internal_modules_data + (OFFSET), (LENGTH)))), \
-        moduleId, urlString, ID)
-#define INTERNAL_MODULE_SOURCE(m) WTF::String(WTF::StringImpl::createWithoutCopying(std::span<const char>(bun_internal_modules_data + m.codeOffset, m.codeLength)))
-#endif
 
 const ClassInfo InternalModuleRegistry::s_info = { "InternalModuleRegistry"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(InternalModuleRegistry) };
 
@@ -246,26 +249,19 @@ JSC::VM& vmForBytecodeCache();
 void ensureBuiltinNamesForBytecodeCache(JSC::VM&);
 }
 
-// bun build --compile: bytecode for internal JS module `id` (an index below BUN_NATIVE_MODULE_START_INDEX), generated the
-// way generateModule() will consume it. The caller owns *handle and releases it with CachedBytecode__deref.
-// `depth`: how many levels of nested functions get code blocks too (UINT32_MAX = all; 0 = only the module wrapper's own).
-extern "C" bool Bun__generateInternalModuleBytecode(uint32_t id, uint32_t depth, const uint8_t** bytes, size_t* size, JSC::CachedBytecode** handle, JSC::EncoderStringTable* externalStrings)
+static bool encodeInternalModule(const String& text, const String& moduleName, const String& url, uint32_t sourceStamp, uint32_t depth, const uint8_t** bytes, size_t* size, JSC::CachedBytecode** handle, JSC::EncoderStringTable* externalStrings)
 {
     using namespace Bun;
-    if (id >= std::size(internalJSModules))
-        return false;
-    const InternalJSModule& m = internalJSModules[id];
     JSC::VM& vm = Zig::vmForBytecodeCache();
     JSC::JSLockHolder locker(vm);
     Zig::ensureBuiltinNamesForBytecodeCache(vm);
-    String text = INTERNAL_MODULE_SOURCE(m);
-    SourceCode source = makeInternalModuleSource(text, m.moduleId, m.url);
-    UnlinkedFunctionExecutable* executable = createInternalModuleExecutable(vm, source, m.moduleId);
+    SourceCode source = makeInternalModuleSource(text, moduleName, url);
+    UnlinkedFunctionExecutable* executable = createInternalModuleExecutable(vm, source, moduleName);
     ParserError error;
     JSC::recursivelyGenerateUnlinkedCodeBlocksForFunction(vm, executable, source, error, depth);
     if (error.isValid())
         return false;
-    RefPtr<JSC::CachedBytecode> result = JSC::encodeBuiltinFunction(vm, executable, source.length(), InternalModuleRegistryConstants::sourceStamp, externalStrings, JSC::BytecodeCacheChecksums::No, JSC::BytecodeCacheUpdatable::No);
+    RefPtr<JSC::CachedBytecode> result = JSC::encodeBuiltinFunction(vm, executable, source.length(), sourceStamp, externalStrings, JSC::BytecodeCacheChecksums::No, JSC::BytecodeCacheUpdatable::No);
     if (!result)
         return false;
     result->ref();
@@ -275,15 +271,23 @@ extern "C" bool Bun__generateInternalModuleBytecode(uint32_t id, uint32_t depth,
     return true;
 }
 
-// The internal JS modules `id` statically requires (so an ahead-of-time build can include them too).
-extern "C" size_t Bun__internalModuleDependencies(uint32_t id, const uint16_t** out)
+// bun build --compile: bytecode for this executable's internal JS module `id` (an index below
+// BUN_NATIVE_MODULE_START_INDEX), generated the way generateInternalModule() will consume it. The caller owns *handle and
+// releases it with CachedBytecode__deref. `depth`: how many levels of nested functions get code blocks too
+// (UINT32_MAX = all; 0 = only the module wrapper's own).
+extern "C" bool Bun__generateInternalModuleBytecode(uint32_t id, uint32_t depth, const uint8_t** bytes, size_t* size, JSC::CachedBytecode** handle, JSC::EncoderStringTable* externalStrings)
 {
-    using namespace Bun::InternalModuleRegistryConstants;
-    if (id >= std::size(dependencyOffsets) - 1)
-        return 0;
-    *out = dependencies + dependencyOffsets[id];
-    return dependencyOffsets[id + 1] - dependencyOffsets[id];
+    using namespace Bun;
+    if (id >= bun_internal_modules_header.moduleCount)
+        return false;
+    const auto& m = internalModuleRecord(id);
+    return encodeInternalModule(internalModuleSource(id), internalModuleString(m.nameOffset, m.nameLength), internalModuleString(m.urlOffset, m.urlLength), bun_internal_modules_header.sourceStamp, depth, bytes, size, handle, externalStrings);
 }
 
-#undef INTERNAL_MODULE_REGISTRY_GENERATE
-#undef INTERNAL_MODULE_SOURCE
+// Same, for an internal module of another bun executable (cross-compiling): its source, name, url and source stamp as
+// read from that executable's builtins section.
+extern "C" bool Bun__generateInternalModuleBytecodeFromSource(const Latin1Character* text, size_t textLength, const Latin1Character* name, size_t nameLength, const Latin1Character* url, size_t urlLength, uint32_t sourceStamp, uint32_t depth, const uint8_t** bytes, size_t* size, JSC::CachedBytecode** handle, JSC::EncoderStringTable* externalStrings)
+{
+    using namespace Bun;
+    return encodeInternalModule(String({ text, textLength }), String({ name, nameLength }), String({ url, urlLength }), sourceStamp, depth, bytes, size, handle, externalStrings);
+}

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -291,3 +291,11 @@ extern "C" bool Bun__generateInternalModuleBytecodeFromSource(const Latin1Charac
     using namespace Bun;
     return encodeInternalModule(String({ text, textLength }), String({ name, nameLength }), String({ url, urlLength }), sourceStamp, depth, bytes, size, handle, externalStrings);
 }
+
+// This executable's whole builtins section (header, index, sources), for the bundler's section reader.
+extern "C" const uint8_t* Bun__builtinsSection(size_t* length)
+{
+    const auto& h = bun_internal_modules_header;
+    *length = h.dataOffset + h.dataLength;
+    return reinterpret_cast<const uint8_t*>(&h);
+}

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1154,7 +1154,7 @@ static bool initializePESection()
     PIMAGE_SECTION_HEADER sectionHeader = IMAGE_FIRST_SECTION(ntHeaders);
 
     for (int i = 0; i < ntHeaders->FileHeader.NumberOfSections; i++) {
-        if (strncmp((char*)sectionHeader->Name, ".bun", 4) == 0) {
+        if (memcmp(sectionHeader->Name, ".bun\0\0\0\0", 8) == 0) {
             // Found the .bun section
             // Section format: 8 bytes size (uint64_t) + data
             BYTE* sectionData = (BYTE*)hModule + sectionHeader->VirtualAddress;

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -988,10 +988,6 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.output_format = config.format;
         transpiler.options.bytecode = config.bytecode;
         transpiler.options.bytecode_depth = config.bytecode_depth;
-        transpiler.options.compile_target_is_host = config
-            .compile
-            .as_ref()
-            .is_none_or(|compile| compile.compile_target.is_default());
         transpiler.options.compile_mode = if config.compile.is_some() {
             options::CompileMode::Executable
         } else {
@@ -1087,6 +1083,34 @@ impl CompletionStruct for JSBundleCompletionTask {
 
         transpiler.configure_linker();
         transpiler.configure_defines()?;
+
+        // After configure_defines(): downloading the target reads proxy/TLS settings from the loaded env.
+        transpiler.options.compile_target_builtins = match &config.compile {
+            Some(compile)
+                if config.bytecode
+                    && (!compile.compile_target.is_default()
+                        || !compile.executable_path.list.is_empty()) =>
+            {
+                match bun_standalone_graph::StandaloneModuleGraph::target_builtins(
+                    &compile.compile_target,
+                    // SAFETY: `self.env` is the per-VM `DotEnv.Loader` stashed at construction; see `to_executable` below.
+                    unsafe { &mut *self.env },
+                    Some(&compile.executable_path.list[..]).filter(|p| !p.is_empty()),
+                ) {
+                    Ok(Some(section)) => options::CompileTargetBuiltins::Target(section),
+                    Ok(None) => options::CompileTargetBuiltins::None,
+                    Err(err) => {
+                        self.log.add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!("{}", bstr::BStr::new(err.slice())),
+                        );
+                        return Err(bun_bundler::Error::BuildFailed);
+                    }
+                }
+            }
+            _ => options::CompileTargetBuiltins::Host,
+        };
 
         if !transpiler.options.production {
             transpiler

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -252,8 +252,6 @@ impl BuildCommand {
 
         this_transpiler.options.bytecode = ctx.bundler_options.bytecode;
         this_transpiler.options.bytecode_depth = ctx.bundler_options.bytecode_depth;
-        this_transpiler.options.compile_target_is_host =
-            ctx.bundler_options.compile_target.is_default();
         let mut was_renamed_from_index = false;
 
         if ctx.bundler_options.compile {
@@ -457,6 +455,29 @@ impl BuildCommand {
 
         this_transpiler.configure_defines()?;
         this_transpiler.configure_linker();
+
+        // After configure_defines(): downloading the target reads proxy/TLS settings from the loaded env.
+        this_transpiler.options.compile_target_builtins = if ctx.bundler_options.compile
+            && ctx.bundler_options.bytecode
+            && (!ctx.bundler_options.compile_target.is_default()
+                || ctx.bundler_options.compile_executable_path.is_some())
+        {
+            match bun_standalone_module_graph::StandaloneModuleGraph::target_builtins(
+                &ctx.bundler_options.compile_target,
+                // SAFETY: `env` is a process-lifetime singleton.
+                unsafe { &mut *this_transpiler.env },
+                ctx.bundler_options.compile_executable_path.as_deref(),
+            ) {
+                Ok(Some(section)) => options::CompileTargetBuiltins::Target(section),
+                Ok(None) => options::CompileTargetBuiltins::None,
+                Err(err) => {
+                    Output::print_errorln(format_args!("{}", bstr::BStr::new(err.slice())));
+                    Global::exit(1);
+                }
+            }
+        } else {
+            options::CompileTargetBuiltins::Host
+        };
 
         if !this_transpiler.options.production {
             this_transpiler

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2405,9 +2405,13 @@ pub fn target_builtins(
     };
     match find_section(&file).and_then(|section| Builtins::parse(section).map(|_| section)) {
         Ok(section) => Ok(Some(std::sync::Arc::from(section))),
-        // No section: a bun from before there was one. A newer layout than this bun reads: same outcome, its internal
-        // modules load from source.
-        Err(BuiltinsError::MissingSection | BuiltinsError::UnsupportedVersion) => Ok(None),
+        // No section (a bun from before there was one), a newer layout than this bun reads, or a container this reader
+        // doesn't handle: its internal modules load from source. A section that is there but malformed is an error.
+        Err(
+            BuiltinsError::MissingSection
+            | BuiltinsError::UnsupportedVersion
+            | BuiltinsError::UnrecognizedExecutable,
+        ) => Ok(None),
         Err(e) => Err(CompileError::fmt(format_args!(
             "failed to read the builtin modules of the executable for '{}': {}",
             target, e

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1588,6 +1588,12 @@ impl CompileErrorReason {
 }
 
 impl CompileError {
+    pub fn fmt(args: core::fmt::Arguments<'_>) -> CompileError {
+        let mut v = Vec::new();
+        let _ = write!(&mut v, "{}", args);
+        CompileError::Message(v)
+    }
+
     pub fn slice(&self) -> &[u8] {
         match self {
             CompileError::Message(m) => m,
@@ -1602,9 +1608,7 @@ impl CompileResult {
     }
 
     pub fn fail_fmt(args: core::fmt::Arguments<'_>) -> CompileResult {
-        let mut v = Vec::new();
-        let _ = write!(&mut v, "{}", args);
-        CompileResult::Err(CompileError::Message(v))
+        CompileResult::Err(CompileError::fmt(args))
     }
 }
 
@@ -2318,6 +2322,99 @@ pub(crate) fn download_to_path(
     Ok(())
 }
 
+/// The bun executable a `--compile` build for `target` injects into: `self_exe_path` if given, this process for the
+/// host target, otherwise the cached download of that platform's bun at this version (fetched now if missing).
+pub fn target_executable(
+    target: &CompileTarget,
+    env: &mut bun_dotenv::Loader,
+    self_exe_path: Option<&[u8]>,
+) -> Result<bun_core::ZBox, CompileError> {
+    Ok(if let Some(path) = self_exe_path {
+        bun_core::ZBox::from_vec_with_nul(path.to_vec())
+    } else if target.is_default() {
+        match bun_core::self_exe_path() {
+            Ok(p) => bun_core::ZBox::from_vec_with_nul(p.as_bytes().to_vec()),
+            Err(e) => {
+                return Err(CompileError::fmt(format_args!(
+                    "failed to get self executable path: {}",
+                    bstr::BStr::new(e.name())
+                )));
+            }
+        }
+    } else {
+        let mut exe_path_buf = PathBuffer::uninit();
+        let mut version_str: Vec<u8> = Vec::new();
+        let _ = write!(&mut version_str, "{}", target);
+        version_str.push(0);
+        // SAFETY: trailing 0 byte appended above.
+        let version_zstr = ZStr::from_slice_with_nul(&version_str[..]);
+
+        let mut needs_download: bool = true;
+        let dest_z = target.exe_path(&mut exe_path_buf, version_zstr, env, &mut needs_download);
+
+        if needs_download {
+            if let Err(e) = download_to_path(target, env, dest_z) {
+                return Err(match e {
+                    crate::Error::TargetNotFound => CompileError::fmt(format_args!(
+                        "Target platform '{}' is not available for download. Check if this version of Bun supports this target.",
+                        target
+                    )),
+                    crate::Error::NetworkError => CompileError::fmt(format_args!(
+                        "Network error downloading executable for '{}'. Check your internet connection and proxy settings.",
+                        target
+                    )),
+                    crate::Error::InvalidResponse => CompileError::fmt(format_args!(
+                        "Downloaded file for '{}' appears to be corrupted. Please try again.",
+                        target
+                    )),
+                    crate::Error::ExtractionFailed => CompileError::fmt(format_args!(
+                        "Failed to extract executable for '{}'. The download may be incomplete.",
+                        target
+                    )),
+                    _ => CompileError::fmt(format_args!(
+                        "Failed to download '{}': {}",
+                        target,
+                        bstr::BStr::new(e.name())
+                    )),
+                });
+            }
+        }
+
+        bun_core::ZBox::from_vec_with_nul(dest_z.as_bytes().to_vec())
+    })
+}
+
+/// `--compile --bytecode` for another platform: that executable's builtins section (`bun_exe_format::builtins`), so
+/// the bundler can generate bytecode for *its* internal modules. `Ok(None)` when the executable has no section this bun
+/// can read; builtin bytecode is skipped then.
+pub fn target_builtins(
+    target: &CompileTarget,
+    env: &mut bun_dotenv::Loader,
+    self_exe_path: Option<&[u8]>,
+) -> Result<Option<std::sync::Arc<[u8]>>, CompileError> {
+    use bun_exe_format::builtins::{Builtins, BuiltinsError, find_section};
+    let exe = target_executable(target, env, self_exe_path)?;
+    let file = match bun_sys::File::read_from(Fd::cwd(), exe.as_bytes()) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return Err(CompileError::fmt(format_args!(
+                "failed to read executable for '{}': {}",
+                target, e
+            )));
+        }
+    };
+    match find_section(&file).and_then(|section| Builtins::parse(section).map(|_| section)) {
+        Ok(section) => Ok(Some(std::sync::Arc::from(section))),
+        // No section: a bun from before there was one. A newer layout than this bun reads: same outcome, its internal
+        // modules load from source.
+        Err(BuiltinsError::MissingSection | BuiltinsError::UnsupportedVersion) => Ok(None),
+        Err(e) => Err(CompileError::fmt(format_args!(
+            "failed to read the builtin modules of the executable for '{}': {}",
+            target, e
+        ))),
+    }
+}
+
 pub fn to_executable(
     target: &CompileTarget,
     output_files: &[OutputFile],
@@ -2353,60 +2450,9 @@ pub fn to_executable(
     }
     // bytes drops at end of scope
 
-    // `ZBox` always owns its bytes and drops on scope exit, so no
-    // ownership flag is needed.
-    let self_exe: bun_core::ZBox = if let Some(path) = self_exe_path {
-        bun_core::ZBox::from_vec_with_nul(path.to_vec())
-    } else if target.is_default() {
-        match bun_core::self_exe_path() {
-            Ok(p) => bun_core::ZBox::from_vec_with_nul(p.as_bytes().to_vec()),
-            Err(e) => {
-                return Ok(CompileResult::fail_fmt(format_args!(
-                    "failed to get self executable path: {}",
-                    bstr::BStr::new(e.name())
-                )));
-            }
-        }
-    } else {
-        let mut exe_path_buf = PathBuffer::uninit();
-        let mut version_str: Vec<u8> = Vec::new();
-        let _ = write!(&mut version_str, "{}", target);
-        version_str.push(0);
-        // SAFETY: trailing 0 byte appended above.
-        let version_zstr = ZStr::from_slice_with_nul(&version_str[..]);
-
-        let mut needs_download: bool = true;
-        let dest_z = target.exe_path(&mut exe_path_buf, version_zstr, env, &mut needs_download);
-
-        if needs_download {
-            if let Err(e) = download_to_path(target, env, dest_z) {
-                return Ok(match e {
-                    crate::Error::TargetNotFound => CompileResult::fail_fmt(format_args!(
-                        "Target platform '{}' is not available for download. Check if this version of Bun supports this target.",
-                        target
-                    )),
-                    crate::Error::NetworkError => CompileResult::fail_fmt(format_args!(
-                        "Network error downloading executable for '{}'. Check your internet connection and proxy settings.",
-                        target
-                    )),
-                    crate::Error::InvalidResponse => CompileResult::fail_fmt(format_args!(
-                        "Downloaded file for '{}' appears to be corrupted. Please try again.",
-                        target
-                    )),
-                    crate::Error::ExtractionFailed => CompileResult::fail_fmt(format_args!(
-                        "Failed to extract executable for '{}'. The download may be incomplete.",
-                        target
-                    )),
-                    _ => CompileResult::fail_fmt(format_args!(
-                        "Failed to download '{}': {}",
-                        target,
-                        bstr::BStr::new(e.name())
-                    )),
-                });
-            }
-        }
-
-        bun_core::ZBox::from_vec_with_nul(dest_z.as_bytes().to_vec())
+    let self_exe = match target_executable(target, env, self_exe_path) {
+        Ok(p) => p,
+        Err(e) => return Ok(CompileResult::Err(e)),
     };
 
     let mut temp_path_buf = bun_paths::path_buffer_pool::get();

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -134,6 +134,7 @@ server.close();`,
       }
       expect(exitCode).toBe(0);
     },
+    // A --compile build plus (for "cross") bytecode for ~45 internal modules: ~10s under debug+ASAN.
     60_000,
   );
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -90,9 +90,20 @@ console.log(JSON.stringify({ n, anonKB: anon }));`,
     60_000,
   );
 
-  test.each([false, true])(
+  // "cross": the target is not the host, so the internal modules' sources, ids and stamp are read out of the target
+  // executable's builtins section (here: this same bun under a different version, so the result still runs locally).
+  test.each([false, true, "cross" as const])(
     "--bytecode=%p: internal modules the app imports come from embedded bytecode",
-    async bytecode => {
+    async mode => {
+      const bytecode = mode !== false;
+      const os = isMacOS ? "darwin" : isLinux ? "linux" : isWindows ? "windows" : "unknown";
+      const cross =
+        mode === "cross"
+          ? {
+              target: `bun-${os}-${isArm64 ? "aarch64" : "x64"}${isMusl ? "-musl" : ""}-v1.0.0` as any,
+              executablePath: process.execPath,
+            }
+          : {};
       using dir = tempDir("build-compile-builtin-bytecode", {
         "app.js": `import { join } from "node:path";
 import http from "node:http";
@@ -104,7 +115,7 @@ server.close();`,
       const outfile = join(dir + "", "app");
       const result = await Bun.build({
         entrypoints: [join(dir + "", "app.js")],
-        compile: { outfile },
+        compile: { outfile, ...cross },
         bytecode,
         format: "esm",
         target: "bun",
@@ -123,6 +134,7 @@ server.close();`,
       }
       expect(exitCode).toBe(0);
     },
+    60_000,
   );
 
   test("compile with invalid target fails gracefully", async () => {


### PR DESCRIPTION
## What

`bun build --compile --bytecode` embeds ahead-of-time bytecode for the internal JS modules (`node:fs`, …) the app imports. Until now that only happened when the target was exactly the host — the internal module sources are per-platform (`process.platform`/`process.arch` are inlined), and the host had no way to read the *target* executable's. Even `--target=bun-linux-x64-baseline` on a non-baseline linux-x64 host produced 0 builtin bytecode entries.

This makes the target executable self-describing:

- The bundled builtin sources (already one `.incbin` blob) move into a dedicated section — `__TEXT,__bun_builtins` (Mach-O), `.bun_builtins` (ELF), `.bunblt` (PE) — prefixed with a 48-byte header and an index: format version, source stamp, and for each InternalModuleRegistry id the module's name, `builtin://` url and source span, plus the eager-`require` dependency table.
- `InternalModuleRegistry.cpp` reads that same header/index at runtime (the old constexpr `internalJSModules` / offset tables are gone), so nothing is duplicated and the exported index is by construction what the runtime uses.
- `bun_exe_format::builtins` finds and validates the section in an ELF / Mach-O / PE image from any host (no dlopen — works Darwin arm64 ↔ Linux x64 ↔ Windows).
- When compiling with `--bytecode` into an executable that isn't this process (a different `--target`, or `--compile-executable-path` / `executablePath`), the target executable is resolved (downloaded if needed) *before* bundling, its section is read, and builtin bytecode is generated from the target's sources, ids, dependency edges and stamp. Targets without the section (older releases) get none, as before.

The JSC-side portability of the bytecode format itself is #40270; this PR is the Bun side (knowing *what* to encode for the target).

Also: debug builds now embed the module sources in the section too (the runtime still reads from disk), so a debug bun is a valid `--compile` target; the PE `.bun` lookup in c-bindings compares the full 8-byte name instead of a 4-byte prefix.

## Verification

- `test/bundler/bun-build-compile.test.ts`: the builtin-bytecode test gains a `"cross"` variant (non-host target string + `executablePath: process.execPath`) that goes through the section reader and the from-source generator and asserts the resulting executable loads >10 internal modules from bytecode. Fails on system bun, passes on this branch.
- Manually: `--target=bun-linux-x64-baseline --compile-executable-path=<this build>` → `fromBytecode: 45` (was 0).
- Assembled the generated `.S` for `arm64-apple-macos`, `x86_64-windows-msvc` and `aarch64-linux`, linked with ld64.lld / lld-link / ld.lld, and ran the reader over the resulting Mach-O dylib, PE exe and ELF .so (plus the real debug ELF): same stamp/count/`node:fs` id/source on all four.

## Not done here

- `target_builtins` reads the whole target executable to copy out the ~2.7 MB section, and `inject()` reads it again later. Fine for a compile step; could be threaded through if it matters.
- The read-only section walkers in `builtins.rs` sit next to the mutation-oriented `.bun` walkers in elf.rs/macho.rs/pe.rs rather than sharing code with them.
