### PR TITLE
Bun.serve(http3): reset the stream when a response body fails mid-body

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -120,6 +120,7 @@ struct us_quic_stream_s {
     struct us_quic_hset *hset;
     int headers_delivered;
     int fin_delivered;
+    int peer_reset;
     /* ext follows */
 };
 
@@ -671,7 +672,10 @@ static void us_quic_on_reset(lsquic_stream_t *stream, lsquic_stream_ctx_t *h, in
      *         read half stays open so the response/request that arrived
      *         alongside STOP_SENDING is still delivered. Closing here
      *         would drop it. */
-    if (h && stream && how == 0) lsquic_stream_close(stream);
+    if (h && stream && how == 0) {
+        ((us_quic_stream_t *) h)->peer_reset = 1;
+        lsquic_stream_close(stream);
+    }
 }
 
 /* ───── public API ───── */
@@ -1081,15 +1085,18 @@ void us_quic_stream_close(us_quic_stream_t *s) {
 /* From lsquic_stream.h (not in the public header). */
 void lsquic_stream_maybe_reset(struct lsquic_stream *, uint64_t error_code, int);
 
-/* Abort the send half with RESET_STREAM(H3_REQUEST_CANCELLED) instead of
- * FIN. lsquic_stream_close/shutdown queue FIN after the buffered tail,
- * which is a protocol error if a content-length was advertised and the
- * client is abandoning the upload short — the server's lsquic will
- * CONNECTION_CLOSE on the mismatch (RFC 9114 §4.1.2). RESET_STREAM is
- * the wire-level "I'm cancelling this send" and lets the server treat it
- * as a stream-level cancellation rather than a malformed message. */
-void us_quic_stream_reset(us_quic_stream_t *s) {
-    if (s->stream) lsquic_stream_maybe_reset(s->stream, 0x10C, 1);
+/* lsquic_stream_close/shutdown queue FIN after the buffered tail. For a
+ * client abandoning an upload short of its advertised content-length that
+ * is a protocol error the server answers with CONNECTION_CLOSE (RFC 9114
+ * §4.1.2); for a server whose response body failed it is a complete-looking
+ * truncated message. RESET_STREAM is the wire-level "this send is aborted"
+ * and lets the peer treat it as a stream-level failure. */
+void us_quic_stream_reset(us_quic_stream_t *s, uint64_t error_code) {
+    if (s->stream) lsquic_stream_maybe_reset(s->stream, error_code, 1);
+}
+
+int us_quic_stream_peer_reset(us_quic_stream_t *s) {
+    return s->peer_reset;
 }
 
 int us_quic_stream_has_unacked(us_quic_stream_t *s) {

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -121,6 +121,7 @@ struct us_quic_stream_s {
     int headers_delivered;
     int fin_delivered;
     int peer_reset;
+    uint64_t peer_reset_code;
     /* ext follows */
 };
 
@@ -673,7 +674,9 @@ static void us_quic_on_reset(lsquic_stream_t *stream, lsquic_stream_ctx_t *h, in
      *         alongside STOP_SENDING is still delivered. Closing here
      *         would drop it. */
     if (h && stream && how == 0) {
-        ((us_quic_stream_t *) h)->peer_reset = 1;
+        us_quic_stream_t *s = (us_quic_stream_t *) h;
+        s->peer_reset = 1;
+        s->peer_reset_code = lsquic_stream_get_error_code(stream);
         lsquic_stream_close(stream);
     }
 }
@@ -1095,7 +1098,8 @@ void us_quic_stream_reset(us_quic_stream_t *s, uint64_t error_code) {
     if (s->stream) lsquic_stream_maybe_reset(s->stream, error_code, 1);
 }
 
-int us_quic_stream_peer_reset(us_quic_stream_t *s) {
+int us_quic_stream_peer_reset(us_quic_stream_t *s, uint64_t *code) {
+    *code = s->peer_reset_code;
     return s->peer_reset;
 }
 

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -143,7 +143,19 @@ void us_quic_stream_shutdown(us_quic_stream_t *s);
 void us_quic_stream_flush(us_quic_stream_t *s);
 void us_quic_stream_shutdown_read(us_quic_stream_t *s);
 void us_quic_stream_close(us_quic_stream_t *s);
-void us_quic_stream_reset(us_quic_stream_t *s);
+
+/* HTTP/3 error codes (RFC 9114 §8.1) for us_quic_stream_reset. */
+#define US_H3_INTERNAL_ERROR 0x102
+#define US_H3_REQUEST_CANCELLED 0x10C
+
+/* Abort the send half with RESET_STREAM(error_code) and close the stream.
+ * us_quic_stream_close/shutdown queue a FIN, and in HTTP/3 a FIN marks a
+ * complete message; RESET_STREAM is the only way to tell the peer that the
+ * bytes it has are not the whole message. */
+void us_quic_stream_reset(us_quic_stream_t *s, uint64_t error_code);
+/* Non-zero once the peer has sent RESET_STREAM for the half we read from.
+ * The stream then closes without on_stream_data ever reporting fin. */
+int us_quic_stream_peer_reset(us_quic_stream_t *s);
 int us_quic_stream_has_unacked(us_quic_stream_t *s);
 
 void *us_quic_stream_ext(us_quic_stream_t *s);

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -144,18 +144,16 @@ void us_quic_stream_flush(us_quic_stream_t *s);
 void us_quic_stream_shutdown_read(us_quic_stream_t *s);
 void us_quic_stream_close(us_quic_stream_t *s);
 
-/* HTTP/3 error codes (RFC 9114 §8.1) for us_quic_stream_reset. */
-#define US_H3_INTERNAL_ERROR 0x102
-#define US_H3_REQUEST_CANCELLED 0x10C
-
 /* Abort the send half with RESET_STREAM(error_code) and close the stream.
  * us_quic_stream_close/shutdown queue a FIN, and in HTTP/3 a FIN marks a
  * complete message; RESET_STREAM is the only way to tell the peer that the
- * bytes it has are not the whole message. */
+ * bytes it has are not the whole message. error_code is an application
+ * (RFC 9114 §8.1) code; the caller picks it. */
 void us_quic_stream_reset(us_quic_stream_t *s, uint64_t error_code);
-/* Non-zero once the peer has sent RESET_STREAM for the half we read from.
- * The stream then closes without on_stream_data ever reporting fin. */
-int us_quic_stream_peer_reset(us_quic_stream_t *s);
+/* Non-zero once the peer has sent RESET_STREAM for the half we read from,
+ * with its error code in *code. The stream then closes without
+ * on_stream_data ever reporting fin. */
+int us_quic_stream_peer_reset(us_quic_stream_t *s, uint64_t *code);
 int us_quic_stream_has_unacked(us_quic_stream_t *s);
 
 void *us_quic_stream_ext(us_quic_stream_t *s);

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -290,20 +290,26 @@ impl ClientSession {
 
     /// The lsquic stream closed without a FIN: a delivered FIN detaches the
     /// stream inside `deliver`, so a stream still attached here got none.
-    /// Before the response headers, `deliver` retries the stale-session race.
-    /// After them the body is truncated and the request fails, as H2 does
-    /// with `HTTP2StreamReset`.
-    pub(crate) fn on_stream_closed(&mut self, stream: *mut Stream, peer_reset: bool) {
+    /// `peer_reset` is the code of the peer's RESET_STREAM, if it sent one.
+    ///
+    /// Before the response headers, `deliver` retries the request once when
+    /// the connection went away under it (the stale-session race) or the
+    /// server promised it did no application processing (H3_REQUEST_REJECTED,
+    /// RFC 9114 section 8.1). Any other reset may have reached the handler, so
+    /// the request is not re-sent, as H2 retries only REFUSED_STREAM. After
+    /// the headers the body is truncated and the request fails.
+    pub(crate) fn on_stream_closed(&mut self, stream: *mut Stream, peer_reset: Option<u64>) {
         let st = stream_mut(stream);
         let Some(client_ptr) = st.client else {
             return self.detach(stream);
         };
-        if !st.headers_delivered {
+        let retryable = peer_reset.is_none_or(|c| c == quic::H3ErrorCode::RequestRejected as u64);
+        if !st.headers_delivered && retryable {
             return self.deliver(stream, true);
         }
         let err = if client_mut(client_ptr).signals.get(Signal::Aborted) {
             crate::Error::Aborted
-        } else if peer_reset {
+        } else if peer_reset.is_some() {
             crate::Error::HTTP3StreamReset
         } else {
             crate::Error::ConnectionClosed

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -288,16 +288,13 @@ impl ClientSession {
         false
     }
 
-    /// The lsquic stream closed without a FIN: a delivered FIN detaches the
-    /// stream inside `deliver`, so a stream still attached here got none.
-    /// `peer_reset` is the code of the peer's RESET_STREAM, if it sent one.
-    ///
-    /// Before the response headers, `deliver` retries the request once when
-    /// the connection went away under it (the stale-session race) or the
-    /// server promised it did no application processing (H3_REQUEST_REJECTED,
-    /// RFC 9114 section 8.1). Any other reset may have reached the handler, so
-    /// the request is not re-sent, as H2 retries only REFUSED_STREAM. After
-    /// the headers the body is truncated and the request fails.
+    /// The lsquic stream closed without a FIN (a delivered FIN detaches the
+    /// stream inside `deliver`). `peer_reset` is the peer's RESET_STREAM code.
+    /// Before the response headers `deliver` re-sends the request once, but
+    /// only when no reset arrived (stale session) or the code is
+    /// H3_REQUEST_REJECTED, the one code that promises the server did no
+    /// application processing (RFC 9114 section 8.1; h2 retries only
+    /// REFUSED_STREAM). Otherwise the request fails.
     pub(crate) fn on_stream_closed(&mut self, stream: *mut Stream, peer_reset: Option<u64>) {
         let st = stream_mut(stream);
         let Some(client_ptr) = st.client else {

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -188,7 +188,7 @@ impl ClientSession {
             // is the correct "I'm abandoning this send half" so lsquic reaps
             // the stream instead of leaking it on the pooled session.
             if !request_body_done {
-                qs.reset();
+                qs.reset(quic::H3ErrorCode::RequestCancelled);
             }
         }
         st.qstream = None;
@@ -288,10 +288,37 @@ impl ClientSession {
         false
     }
 
-    /// Runs from inside lsquic's process_conns via on_stream_{headers,data,close}.
-    /// `done` = the lsquic stream is gone; deliver whatever is buffered then
-    /// detach. Mirrors H2's `ClientSession.deliverStream` so the HTTPClient state
-    /// machine sees the same call sequence regardless of transport.
+    /// The lsquic stream is gone and no FIN reached `on_stream_data` (a FIN
+    /// detaches the stream inside `deliver`, so `on_stream_close` never sees
+    /// an attached stream after one). The peer sent RESET_STREAM, or the
+    /// connection closed under the stream. Before the response headers this
+    /// is the stale-session race that `deliver` retries. After them the body
+    /// is truncated: the H3 twin of an HTTP/1 close without the last chunk,
+    /// and of H2's RST_STREAM mid-body (`HTTP2StreamReset`).
+    pub(crate) fn on_stream_closed(&mut self, stream: *mut Stream, peer_reset: bool) {
+        let st = stream_mut(stream);
+        let Some(client_ptr) = st.client else {
+            return self.detach(stream);
+        };
+        if !st.headers_delivered {
+            return self.deliver(stream, true);
+        }
+        let err = if client_mut(client_ptr).signals.get(Signal::Aborted) {
+            crate::Error::Aborted
+        } else if peer_reset {
+            crate::Error::HTTP3StreamReset
+        } else {
+            crate::Error::ConnectionClosed
+        };
+        self.fail(stream, err);
+    }
+
+    /// Runs from inside lsquic's process_conns via on_stream_{headers,data}
+    /// and, before the response headers arrive, `on_stream_closed`. `done` =
+    /// the peer's FIN arrived (or the stream is gone before headers); deliver
+    /// whatever is buffered then detach. Mirrors H2's
+    /// `ClientSession.deliverStream` so the HTTPClient state machine sees the
+    /// same call sequence regardless of transport.
     pub(crate) fn deliver(&mut self, stream: *mut Stream, done: bool) {
         let st = stream_mut(stream);
         let Some(client_ptr) = st.client else {

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -288,13 +288,11 @@ impl ClientSession {
         false
     }
 
-    /// The lsquic stream is gone and no FIN reached `on_stream_data` (a FIN
-    /// detaches the stream inside `deliver`, so `on_stream_close` never sees
-    /// an attached stream after one). The peer sent RESET_STREAM, or the
-    /// connection closed under the stream. Before the response headers this
-    /// is the stale-session race that `deliver` retries. After them the body
-    /// is truncated: the H3 twin of an HTTP/1 close without the last chunk,
-    /// and of H2's RST_STREAM mid-body (`HTTP2StreamReset`).
+    /// The lsquic stream closed without a FIN: a delivered FIN detaches the
+    /// stream inside `deliver`, so a stream still attached here got none.
+    /// Before the response headers, `deliver` retries the stale-session race.
+    /// After them the body is truncated and the request fails, as H2 does
+    /// with `HTTP2StreamReset`.
     pub(crate) fn on_stream_closed(&mut self, stream: *mut Stream, peer_reset: bool) {
         let st = stream_mut(stream);
         let Some(client_ptr) = st.client else {
@@ -313,12 +311,10 @@ impl ClientSession {
         self.fail(stream, err);
     }
 
-    /// Runs from inside lsquic's process_conns via on_stream_{headers,data}
-    /// and, before the response headers arrive, `on_stream_closed`. `done` =
-    /// the peer's FIN arrived (or the stream is gone before headers); deliver
-    /// whatever is buffered then detach. Mirrors H2's
-    /// `ClientSession.deliverStream` so the HTTPClient state machine sees the
-    /// same call sequence regardless of transport.
+    /// Runs from inside lsquic's process_conns via on_stream_{headers,data},
+    /// and via `on_stream_closed` before the response headers. `done` = the
+    /// peer's FIN arrived; deliver whatever is buffered then detach. Mirrors
+    /// H2's `ClientSession.deliverStream`.
     pub(crate) fn deliver(&mut self, stream: *mut Stream, done: bool) {
         let st = stream_mut(stream);
         let Some(client_ptr) = st.client else {

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -311,7 +311,7 @@ extern "C" fn on_stream_close(s: *mut quic::Stream) {
     stream.qstream = None;
     bun_core::scoped_log!(
         h3_client,
-        "stream_close status={} delivered={} peer_reset={}",
+        "stream_close status={} delivered={} peer_reset={:?}",
         stream.status_code,
         stream.headers_delivered,
         peer_reset,

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -306,13 +306,15 @@ extern "C" fn on_stream_writable(s: *mut quic::Stream) {
 extern "C" fn on_stream_close(s: *mut quic::Stream) {
     let s = qstream_arg(s);
     let Some(stream) = stream_of(s) else { return };
+    let peer_reset = s.peer_reset();
     *s.ext::<Stream>() = None;
     stream.qstream = None;
     bun_core::scoped_log!(
         h3_client,
-        "stream_close status={} delivered={}",
+        "stream_close status={} delivered={} peer_reset={}",
         stream.status_code,
         stream.headers_delivered,
+        peer_reset,
     );
-    stream.session_mut().deliver(stream, true);
+    stream.session_mut().on_stream_closed(stream, peer_reset);
 }

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -203,8 +203,10 @@ impl Response {
         let ip = unsafe { bun_core::ffi::slice(ip_ptr, len) };
         Some(SocketAddress::new(ip, port, is_ipv6))
     }
+    /// The body failed after the response started: `RESET_STREAM`, the
+    /// HTTP/3 form of HTTP/1's close without the terminating chunk.
     pub(crate) fn force_close(&mut self) {
-        c::uws_h3_res_force_close(self)
+        c::uws_h3_res_force_close(self, crate::quic::H3ErrorCode::InternalError as u64)
     }
 
     pub(crate) fn on_writable<UD, H>(&mut self, _handler: H, ud: *mut UD)
@@ -691,7 +693,7 @@ mod c {
         pub(super) safe fn uws_h3_res_state(res: &mut Response) -> State;
         pub(super) fn uws_h3_res_end(res: *mut Response, p: *const u8, n: usize, close: bool);
         pub(super) safe fn uws_h3_res_end_stream(res: &mut Response, close: bool);
-        pub(super) safe fn uws_h3_res_force_close(res: &mut Response);
+        pub(super) safe fn uws_h3_res_force_close(res: &mut Response, error_code: u64);
         pub(super) fn uws_h3_res_try_end(
             res: *mut Response,
             p: *const u8,

--- a/src/uws_sys/libuwsockets_h3.cpp
+++ b/src/uws_sys/libuwsockets_h3.cpp
@@ -116,13 +116,12 @@ void uws_h3_res_end_stream(uws_h3_res_t* res, bool close_connection)
     r->sendTerminatingChunk(close_connection);
 }
 
-/* The body failed after the response started. A FIN would deliver the
- * truncated body as a complete message; RESET_STREAM is the HTTP/3 form of
- * HTTP/1's close without the terminating chunk. */
-void uws_h3_res_force_close(uws_h3_res_t* res)
+/* RESET_STREAM(error_code), not FIN: in HTTP/3 a FIN would deliver the
+ * bytes sent so far as a complete message. */
+void uws_h3_res_force_close(uws_h3_res_t* res, uint64_t error_code)
 {
     ((Http3Response*)res)->clearOnWritableAndAborted();
-    us_quic_stream_reset((us_quic_stream_t*)res, US_H3_INTERNAL_ERROR);
+    us_quic_stream_reset((us_quic_stream_t*)res, error_code);
 }
 
 bool uws_h3_res_try_end(uws_h3_res_t* res, const char* bytes, size_t len, size_t total_len, bool close)

--- a/src/uws_sys/libuwsockets_h3.cpp
+++ b/src/uws_sys/libuwsockets_h3.cpp
@@ -116,10 +116,14 @@ void uws_h3_res_end_stream(uws_h3_res_t* res, bool close_connection)
     r->sendTerminatingChunk(close_connection);
 }
 
+/* Server-side failure after the response started (a body stream errored,
+ * a file read failed). HTTP/1 closes the socket without the terminating
+ * chunk; the HTTP/3 equivalent is RESET_STREAM, since a FIN would hand the
+ * client the truncated body as a complete message. */
 void uws_h3_res_force_close(uws_h3_res_t* res)
 {
     ((Http3Response*)res)->clearOnWritableAndAborted();
-    us_quic_stream_close((us_quic_stream_t*)res);
+    us_quic_stream_reset((us_quic_stream_t*)res, US_H3_INTERNAL_ERROR);
 }
 
 bool uws_h3_res_try_end(uws_h3_res_t* res, const char* bytes, size_t len, size_t total_len, bool close)

--- a/src/uws_sys/libuwsockets_h3.cpp
+++ b/src/uws_sys/libuwsockets_h3.cpp
@@ -116,10 +116,9 @@ void uws_h3_res_end_stream(uws_h3_res_t* res, bool close_connection)
     r->sendTerminatingChunk(close_connection);
 }
 
-/* Server-side failure after the response started (a body stream errored,
- * a file read failed). HTTP/1 closes the socket without the terminating
- * chunk; the HTTP/3 equivalent is RESET_STREAM, since a FIN would hand the
- * client the truncated body as a complete message. */
+/* The body failed after the response started. A FIN would deliver the
+ * truncated body as a complete message; RESET_STREAM is the HTTP/3 form of
+ * HTTP/1's close without the terminating chunk. */
 void uws_h3_res_force_close(uws_h3_res_t* res)
 {
     ((Http3Response*)res)->clearOnWritableAndAborted();

--- a/src/uws_sys/quic.rs
+++ b/src/uws_sys/quic.rs
@@ -22,6 +22,7 @@ pub mod stream;
 pub use self::context::Context;
 pub use self::pending_connect::PendingConnect;
 pub use self::socket::Socket;
+pub use self::stream::H3ErrorCode;
 pub use self::stream::Stream;
 
 pub use self::header::Header;

--- a/src/uws_sys/quic/Stream.rs
+++ b/src/uws_sys/quic/Stream.rs
@@ -11,11 +11,13 @@ bun_opaque::opaque_ffi! {
     pub struct Stream;
 }
 
-/// HTTP/3 error codes (RFC 9114 §8.1) for `RESET_STREAM`; the `US_H3_*` values in `quic.h`.
+/// HTTP/3 error codes (RFC 9114 §8.1) carried by `RESET_STREAM`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u64)]
 pub enum H3ErrorCode {
     InternalError = 0x102,
+    /// The server did no application processing; the request can be re-sent.
+    RequestRejected = 0x10B,
     RequestCancelled = 0x10C,
 }
 
@@ -28,7 +30,7 @@ unsafe extern "C" {
     safe fn us_quic_stream_shutdown(s: &mut Stream);
     safe fn us_quic_stream_close(s: &mut Stream);
     safe fn us_quic_stream_reset(s: &mut Stream, error_code: u64);
-    safe fn us_quic_stream_peer_reset(s: &mut Stream) -> c_int;
+    safe fn us_quic_stream_peer_reset(s: &mut Stream, code: &mut u64) -> c_int;
     safe fn us_quic_stream_header_count(s: &mut Stream) -> c_uint;
     safe fn us_quic_stream_header(s: &mut Stream, i: c_uint) -> *const Header;
     safe fn us_quic_stream_ext(s: &mut Stream) -> *mut c_void;
@@ -67,10 +69,11 @@ impl Stream {
         us_quic_stream_reset(self, error_code as u64)
     }
 
-    /// The peer sent `RESET_STREAM` for our read half. `on_stream_close` then
-    /// follows with no `fin` from `on_stream_data`.
-    pub fn peer_reset(&mut self) -> bool {
-        us_quic_stream_peer_reset(self) != 0
+    /// The error code of the `RESET_STREAM` the peer sent for our read half.
+    /// `on_stream_close` then follows with no `fin` from `on_stream_data`.
+    pub fn peer_reset(&mut self) -> Option<u64> {
+        let mut code = 0u64;
+        (us_quic_stream_peer_reset(self, &mut code) != 0).then_some(code)
     }
 
     pub fn header_count(&mut self) -> c_uint {

--- a/src/uws_sys/quic/Stream.rs
+++ b/src/uws_sys/quic/Stream.rs
@@ -11,14 +11,11 @@ bun_opaque::opaque_ffi! {
     pub struct Stream;
 }
 
-/// HTTP/3 error codes (RFC 9114 §8.1) carried by `RESET_STREAM`. Mirrors the
-/// `US_H3_*` constants in `quic.h`.
+/// HTTP/3 error codes (RFC 9114 §8.1) for `RESET_STREAM`; the `US_H3_*` values in `quic.h`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u64)]
 pub enum H3ErrorCode {
-    /// The HTTP stack failed while producing the message.
     InternalError = 0x102,
-    /// The request or its response is cancelled by the sender.
     RequestCancelled = 0x10C,
 }
 
@@ -64,16 +61,14 @@ impl Stream {
         us_quic_stream_close(self)
     }
 
-    /// Abort the send half with `RESET_STREAM(error_code)` and close the
-    /// stream. Unlike [`Stream::close`], the peer does not see a FIN, which in
-    /// HTTP/3 would mark the bytes sent so far as a complete message.
+    /// `RESET_STREAM(error_code)` and close. Unlike [`Stream::close`] the peer
+    /// sees no FIN, which in HTTP/3 would mark the message complete.
     pub fn reset(&mut self, error_code: H3ErrorCode) {
         us_quic_stream_reset(self, error_code as u64)
     }
 
-    /// True once the peer has sent `RESET_STREAM` for the half we read from.
-    /// `on_stream_close` then follows without `on_stream_data` ever reporting
-    /// `fin`.
+    /// The peer sent `RESET_STREAM` for our read half. `on_stream_close` then
+    /// follows with no `fin` from `on_stream_data`.
     pub fn peer_reset(&mut self) -> bool {
         us_quic_stream_peer_reset(self) != 0
     }

--- a/src/uws_sys/quic/Stream.rs
+++ b/src/uws_sys/quic/Stream.rs
@@ -11,6 +11,17 @@ bun_opaque::opaque_ffi! {
     pub struct Stream;
 }
 
+/// HTTP/3 error codes (RFC 9114 §8.1) carried by `RESET_STREAM`. Mirrors the
+/// `US_H3_*` constants in `quic.h`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u64)]
+pub enum H3ErrorCode {
+    /// The HTTP stack failed while producing the message.
+    InternalError = 0x102,
+    /// The request or its response is cancelled by the sender.
+    RequestCancelled = 0x10C,
+}
+
 // `Stream` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so `&mut Stream` is
 // ABI-identical to a non-null `*mut Stream` with no `noalias`/`readonly`
 // attribute. Shims taking only the handle + value types are `safe fn`; the
@@ -19,7 +30,8 @@ unsafe extern "C" {
     safe fn us_quic_stream_socket(s: &mut Stream) -> *mut Socket;
     safe fn us_quic_stream_shutdown(s: &mut Stream);
     safe fn us_quic_stream_close(s: &mut Stream);
-    safe fn us_quic_stream_reset(s: &mut Stream);
+    safe fn us_quic_stream_reset(s: &mut Stream, error_code: u64);
+    safe fn us_quic_stream_peer_reset(s: &mut Stream) -> c_int;
     safe fn us_quic_stream_header_count(s: &mut Stream) -> c_uint;
     safe fn us_quic_stream_header(s: &mut Stream, i: c_uint) -> *const Header;
     safe fn us_quic_stream_ext(s: &mut Stream) -> *mut c_void;
@@ -52,8 +64,18 @@ impl Stream {
         us_quic_stream_close(self)
     }
 
-    pub fn reset(&mut self) {
-        us_quic_stream_reset(self)
+    /// Abort the send half with `RESET_STREAM(error_code)` and close the
+    /// stream. Unlike [`Stream::close`], the peer does not see a FIN, which in
+    /// HTTP/3 would mark the bytes sent so far as a complete message.
+    pub fn reset(&mut self, error_code: H3ErrorCode) {
+        us_quic_stream_reset(self, error_code as u64)
+    }
+
+    /// True once the peer has sent `RESET_STREAM` for the half we read from.
+    /// `on_stream_close` then follows without `on_stream_data` ever reporting
+    /// `fin`.
+    pub fn peer_reset(&mut self) -> bool {
+        us_quic_stream_peer_reset(self) != 0
     }
 
     pub fn header_count(&mut self) -> c_uint {

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1451,6 +1451,99 @@ describe("Bun.serve HTTP/3 request validation", () => {
   });
 });
 
+// A Response body stream that fails after the status and some bytes went out
+// cannot be replaced by error(). The transport has to tell the client that the
+// message is incomplete: HTTP/1 closes the socket without the last chunk. In
+// HTTP/3 a FIN is a complete message, so the stream has to end with
+// RESET_STREAM(H3_INTERNAL_ERROR) instead.
+describe("Bun.serve HTTP/3 response body error after the first chunk", () => {
+  const script = `
+    const tls = ${JSON.stringify(tls)};
+    const server = Bun.serve({
+      port: 0, tls, http3: true, http1: false,
+      routes: {
+        "/ok": () => new Response("ok"),
+        "/mid-body-error": () => {
+          let pulls = 0;
+          return new Response(new ReadableStream({
+            async pull(c) {
+              // Yield to the event loop so the previous chunk is on the wire
+              // before the next one (or the error) is produced.
+              await Bun.sleep(10);
+              if (pulls++ < 2) c.enqueue(new Uint8Array(1024).fill(65));
+              else c.error(new Error("boom"));
+            },
+          }));
+        },
+      },
+    });
+    console.error("PORT=" + server.port);
+    process.stdin.on("data", () => {});
+    ${STOP_ON_STDIN_END}
+  `;
+
+  // Raw HTTP/3 client: reports how the response stream ended on the wire.
+  async function h3ReadBody(port: number, path: string) {
+    await using endpoint = new QuicEndpoint();
+    const client = await connect(`127.0.0.1:${port}`, {
+      endpoint,
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 5 },
+      onerror() {},
+    });
+    await client.opened;
+    let status = "";
+    const stream = await client.createBidirectionalStream({
+      headers: requestHeaders(path),
+      onheaders(received: Record<string, string>) {
+        status = received[":status"];
+      },
+    });
+    stream.closed.catch(() => {});
+    // A reset discards body bytes the reader has not consumed yet (RFC 9000
+    // section 3.2), so only how the stream ended is deterministic.
+    let end = "fin";
+    try {
+      for await (const _ of stream as AsyncIterable<Uint8Array[]>) {
+      }
+    } catch (e) {
+      end = `${(e as Error & { code?: string }).code}: ${(e as Error).message}`;
+    }
+    client.close().catch(() => {});
+    return { status, end };
+  }
+
+  test("fetch() sees the status, then the body read rejects", async () => {
+    await withCustomServer(script, async (port, _send, waitForStderr) => {
+      const res = await fetchH3(port, "/mid-body-error");
+      const body = await res.text().then(
+        text => ({ resolved: text.length }),
+        (e: Error & { code?: string }) => ({ rejected: e.code }),
+      );
+      // The handler's error still reaches the server's error reporting.
+      await waitForStderr(/boom/);
+      // Only the one stream was reset; the connection stays usable.
+      const after = await fetchH3(port, "/ok");
+      expect({ status: res.status, body, after: await after.text() }).toEqual({
+        status: 200,
+        body: { rejected: "HTTP3StreamReset" },
+        after: "ok",
+      });
+    });
+  });
+
+  test("the stream ends with RESET_STREAM(H3_INTERNAL_ERROR), not FIN", async () => {
+    await withCustomServer(script, async port => {
+      const result = await h3ReadBody(port, "/mid-body-error");
+      expect(result).toEqual({
+        status: "200",
+        end: "ERR_QUIC_STREAM_RESET: The QUIC stream was reset by the peer with error code 258",
+      });
+    });
+  });
+});
+
 // The HTTP/3 twin of the HTTP/1 cases in websocket-server.test.ts: ws.close()
 // runs close() before it returns, and a request handler that calls it must still
 // run to completion before the nextTick and promise callbacks it queued. The

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1457,21 +1457,30 @@ describe("Bun.serve HTTP/3 request validation", () => {
 // HTTP/3 a FIN is a complete message, so the stream has to end with
 // RESET_STREAM(H3_INTERNAL_ERROR) instead.
 describe("Bun.serve HTTP/3 response body error after the first chunk", () => {
+  // The body source sends one chunk and then waits. It errors only once the
+  // client, which by then holds the status and that chunk, requests
+  // /release. No timing assumption orders the wire.
   const script = `
     const tls = ${JSON.stringify(tls)};
+    const { promise: released, resolve: release } = Promise.withResolvers();
     const server = Bun.serve({
       port: 0, tls, http3: true, http1: false,
       routes: {
         "/ok": () => new Response("ok"),
+        "/release": () => {
+          release();
+          return new Response("released");
+        },
         "/mid-body-error": () => {
           let pulls = 0;
           return new Response(new ReadableStream({
             async pull(c) {
-              // Yield to the event loop so the previous chunk is on the wire
-              // before the next one (or the error) is produced.
-              await Bun.sleep(10);
-              if (pulls++ < 2) c.enqueue(new Uint8Array(1024).fill(65));
-              else c.error(new Error("boom"));
+              if (pulls++ === 0) {
+                c.enqueue(new Uint8Array(1024).fill(65));
+                return;
+              }
+              await released;
+              c.error(new Error("boom"));
             },
           }));
         },
@@ -1482,7 +1491,10 @@ describe("Bun.serve HTTP/3 response body error after the first chunk", () => {
     ${STOP_ON_STDIN_END}
   `;
 
-  // Raw HTTP/3 client: reports how the response stream ended on the wire.
+  const release = (port: number) => fetchH3(port, "/release").then(r => r.text());
+
+  // Raw HTTP/3 client: reads the first chunk, asks the server to fail the
+  // body, and reports how the response stream ended on the wire.
   async function h3ReadBody(port: number, path: string) {
     await using endpoint = new QuicEndpoint();
     const client = await connect(`127.0.0.1:${port}`, {
@@ -1500,34 +1512,46 @@ describe("Bun.serve HTTP/3 response body error after the first chunk", () => {
         status = received[":status"];
       },
     });
-    stream.closed.catch(() => {});
-    // A reset discards body bytes the reader has not consumed yet (RFC 9000
-    // section 3.2), so only how the stream ended is deterministic.
-    let end = "fin";
+    // `closed` rejects with the RESET_STREAM error code when the peer resets.
+    const closed = stream.closed.then(
+      () => "fin",
+      (e: Error & { code?: string; errorCode?: bigint }) => ({ code: e.code, errorCode: Number(e.errorCode) }),
+    );
+    let firstChunkReceived = false;
+    let read = "fin";
     try {
       for await (const _ of stream as AsyncIterable<Uint8Array[]>) {
+        if (!firstChunkReceived) {
+          firstChunkReceived = true;
+          await release(port);
+        }
       }
     } catch (e) {
-      end = `${(e as Error & { code?: string }).code}: ${(e as Error).message}`;
+      read = (e as Error & { code?: string }).code ?? "unknown";
     }
+    const result = { status, firstChunkReceived, read, closed: await closed };
     client.close().catch(() => {});
-    return { status, end };
+    return result;
   }
 
   test("fetch() sees the status, then the body read rejects", async () => {
     await withCustomServer(script, async (port, _send, waitForStderr) => {
       const res = await fetchH3(port, "/mid-body-error");
-      const body = await res.text().then(
-        text => ({ resolved: text.length }),
+      const reader = res.body!.getReader();
+      const first = await reader.read();
+      await release(port);
+      const rest = await reader.read().then(
+        ({ done }) => ({ resolved: done ? "done" : "chunk" }),
         (e: Error & { code?: string }) => ({ rejected: e.code }),
       );
       // The handler's error still reaches the server's error reporting.
       await waitForStderr(/boom/);
       // Only the one stream was reset; the connection stays usable.
-      const after = await fetchH3(port, "/ok");
-      expect({ status: res.status, body, after: await after.text() }).toEqual({
+      const after = await fetchH3(port, "/ok").then(r => r.text());
+      expect({ status: res.status, firstChunkReceived: !first.done, rest, after }).toEqual({
         status: 200,
-        body: { rejected: "HTTP3StreamReset" },
+        firstChunkReceived: true,
+        rest: { rejected: "HTTP3StreamReset" },
         after: "ok",
       });
     });
@@ -1538,7 +1562,9 @@ describe("Bun.serve HTTP/3 response body error after the first chunk", () => {
       const result = await h3ReadBody(port, "/mid-body-error");
       expect(result).toEqual({
         status: "200",
-        end: "ERR_QUIC_STREAM_RESET: The QUIC stream was reset by the peer with error code 258",
+        firstChunkReceived: true,
+        read: "ERR_QUIC_STREAM_RESET",
+        closed: { code: "ERR_QUIC_APPLICATION_ERROR", errorCode: 258 },
       });
     });
   });

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -1,6 +1,10 @@
 import { gunzipSync, gzipSync, type Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir, tls } from "harness";
+import { createPrivateKey } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { listen, QuicError } from "node:quic";
 
 // In-process server with `http1: false` so the build under test binds UDP only.
 // A fetch that silently fell back to HTTP/1.1 would get ECONNREFUSED, which
@@ -669,6 +673,57 @@ test("retries on a fresh session when a pooled session is stale (port reuse)", a
   } finally {
     void b.stop(true);
   }
+});
+
+// In HTTP/3 only a FIN completes a message. A response stream that goes away
+// after the headers without one (the server sent RESET_STREAM, or the
+// connection closed) carries a truncated body, and the body read must fail
+// the way HTTP2StreamReset does for h2 instead of resolving with the bytes
+// received so far.
+describe("response stream ends without FIN", () => {
+  const keysDir = join(import.meta.dir, "..", "..", "node", "test", "fixtures", "keys");
+  const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
+  const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
+
+  // A node:quic HTTP/3 server whose response is "200", the body "partial",
+  // then `end(stream)`. The body is flushed before `end` runs: the server
+  // yields to the event loop, which is where lsquic packetizes writes.
+  async function fetchFromServerThat(end: (stream: any, session: any) => void) {
+    await using server = await listen(
+      async session => {
+        session.onstream = (stream: any) => stream.closed.catch(() => {});
+        await session.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 1 },
+        async onheaders(this: any) {
+          this.sendHeaders({ ":status": "200" });
+          this.writer.writeSync(new TextEncoder().encode("partial"));
+          await Bun.sleep(10);
+          end(this, this.session);
+        },
+      },
+    );
+    const res = await fetch(`https://127.0.0.1:${server.address.port}/`, h3);
+    const body = await res.text().then(
+      text => ({ resolved: text }),
+      (e: Error & { code?: string }) => ({ rejected: e.code }),
+    );
+    return { status: res.status, body };
+  }
+
+  test("RESET_STREAM mid-body rejects the body read with HTTP3StreamReset", async () => {
+    const result = await fetchFromServerThat(stream =>
+      stream.destroy(new QuicError("body failed", { errorCode: 0x102 })),
+    );
+    expect(result).toEqual({ status: 200, body: { rejected: "HTTP3StreamReset" } });
+  });
+
+  test("CONNECTION_CLOSE mid-body rejects the body read with ECONNRESET", async () => {
+    const result = await fetchFromServerThat((_stream, session) => session.close({ code: 0x100, type: "application" }));
+    expect(result).toEqual({ status: 200, body: { rejected: "ECONNRESET" } });
+  });
 });
 
 // Subprocess so the experimental flag is process-scoped and the in-process

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -739,6 +739,57 @@ describe("response stream ends without FIN", () => {
     const result = await fetchFromServerThat((_stream, session) => session.close({ code: 0x100, type: "application" }));
     expect(result).toEqual({ status: 200, first: "partial", rest: { rejected: "ECONNRESET" } });
   });
+
+  // RESET_STREAM before the response headers. Only H3_REQUEST_REJECTED (0x10B)
+  // promises that the server did no application processing (RFC 9114 section
+  // 8.1), so only that code may re-send the request, as h2 retries only
+  // REFUSED_STREAM. Any other code fails the request without a second copy.
+  async function postToServerThatResetsWith(errorCode: number) {
+    const requests: string[] = [];
+    await using server = await listen(
+      async session => {
+        session.onstream = (stream: any) => stream.closed.catch(() => {});
+        await session.closed.catch(() => {});
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        transportParams: { maxIdleTimeout: 1 },
+        onheaders(this: any, headers: Record<string, string>) {
+          requests.push(`${headers[":method"]} ${headers[":path"]}`);
+          if (requests.length === 1) {
+            this.destroy(new QuicError("rejected", { errorCode }));
+            return;
+          }
+          this.sendHeaders({ ":status": "200" });
+          this.writer.writeSync(new TextEncoder().encode("second attempt"));
+          this.writer.endSync();
+        },
+      },
+    );
+    const result = await fetch(`https://127.0.0.1:${server.address.port}/submit`, {
+      ...h3,
+      method: "POST",
+      body: "payload",
+    }).then(
+      async res => ({ resolved: `${res.status} ${await res.text()}` }),
+      (e: Error & { code?: string }) => ({ rejected: e.code }),
+    );
+    return { result, requests };
+  }
+
+  test("RESET_STREAM(H3_REQUEST_REJECTED) before the headers re-sends the request once", async () => {
+    expect(await postToServerThatResetsWith(0x10b)).toEqual({
+      result: { resolved: "200 second attempt" },
+      requests: ["POST /submit", "POST /submit"],
+    });
+  });
+
+  test("RESET_STREAM(H3_INTERNAL_ERROR) before the headers fails without a second copy of the request", async () => {
+    expect(await postToServerThatResetsWith(0x102)).toEqual({
+      result: { rejected: "HTTP3StreamReset" },
+      requests: ["POST /submit"],
+    });
+  });
 });
 
 // Subprocess so the experimental flag is process-scoped and the in-process

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -685,10 +685,12 @@ describe("response stream ends without FIN", () => {
   const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
   const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
 
-  // A node:quic HTTP/3 server whose response is "200", the body "partial",
-  // then `end(stream)`. The body is flushed before `end` runs: the server
-  // yields to the event loop, which is where lsquic packetizes writes.
+  // A node:quic HTTP/3 server whose response is "200" and the body "partial".
+  // It runs `end(stream, session)` only once the client, which by then holds
+  // the status and that chunk, requests /release. No timing assumption orders
+  // the wire.
   async function fetchFromServerThat(end: (stream: any, session: any) => void) {
+    const { promise: released, resolve: release } = Promise.withResolvers<void>();
     await using server = await listen(
       async session => {
         session.onstream = (stream: any) => stream.closed.catch(() => {});
@@ -697,32 +699,45 @@ describe("response stream ends without FIN", () => {
       {
         sni: { "*": { keys: [key], certs: [cert] } },
         transportParams: { maxIdleTimeout: 1 },
-        async onheaders(this: any) {
+        async onheaders(this: any, headers: Record<string, string>) {
           this.sendHeaders({ ":status": "200" });
+          if (headers[":path"] === "/release") {
+            this.writer.endSync();
+            release();
+            return;
+          }
           this.writer.writeSync(new TextEncoder().encode("partial"));
-          await Bun.sleep(10);
+          await released;
           end(this, this.session);
         },
       },
     );
-    const res = await fetch(`https://127.0.0.1:${server.address.port}/`, h3);
-    const body = await res.text().then(
-      text => ({ resolved: text }),
+    const base = `https://127.0.0.1:${server.address.port}`;
+    const res = await fetch(`${base}/`, h3);
+    const reader = res.body!.getReader();
+    const first = await reader.read();
+    // Its response can be lost to the CONNECTION_CLOSE case, so it is not
+    // awaited: the first stream's read is what reports the outcome.
+    fetch(`${base}/release`, h3)
+      .then(r => r.text())
+      .catch(() => {});
+    const rest = await reader.read().then(
+      ({ done }) => ({ resolved: done ? "done" : "chunk" }),
       (e: Error & { code?: string }) => ({ rejected: e.code }),
     );
-    return { status: res.status, body };
+    return { status: res.status, first: new TextDecoder().decode(first.value), rest };
   }
 
   test("RESET_STREAM mid-body rejects the body read with HTTP3StreamReset", async () => {
     const result = await fetchFromServerThat(stream =>
       stream.destroy(new QuicError("body failed", { errorCode: 0x102 })),
     );
-    expect(result).toEqual({ status: 200, body: { rejected: "HTTP3StreamReset" } });
+    expect(result).toEqual({ status: 200, first: "partial", rest: { rejected: "HTTP3StreamReset" } });
   });
 
   test("CONNECTION_CLOSE mid-body rejects the body read with ECONNRESET", async () => {
     const result = await fetchFromServerThat((_stream, session) => session.close({ code: 0x100, type: "application" }));
-    expect(result).toEqual({ status: 200, body: { rejected: "ECONNRESET" } });
+    expect(result).toEqual({ status: 200, first: "partial", rest: { rejected: "ECONNRESET" } });
   });
 });
 


### PR DESCRIPTION
### Problem
- Over HTTP/3, a `Bun.serve` Response body stream that errors after some chunks were sent is delivered as a complete message. `fetch(url, { protocol: "http3" })` resolves with status 200 and `res.text()` resolves with the bytes sent so far. HTTP/1.1 closes the connection without the chunked terminator for the same case, so the client sees `ECONNRESET`.
- Cause: `RequestContext::force_close()` is the "signal an incomplete message" path. For H3 it reached `uws_h3_res_force_close` (`src/uws_sys/libuwsockets_h3.cpp`), which called `us_quic_stream_close()`. That queues a FIN after the buffered tail, and in HTTP/3 a FIN is the end-of-message marker.
- Second cause: the H3 fetch client (`src/http/h3_client/callbacks.rs`, `on_stream_close`) treated every stream close after the response headers as a clean end of body, even a peer RESET_STREAM or a CONNECTION_CLOSE. Before the headers it re-sent the request once for any close, including a RESET_STREAM that means the server may have run the handler.

### Fix
- `uws_h3_res_force_close` sends `RESET_STREAM(H3_INTERNAL_ERROR)`. `us_quic_stream_reset` takes the code as a parameter, `quic.c` records a peer RESET_STREAM with its code, and the codes live in one place: the Rust `H3ErrorCode` enum in `src/uws_sys/quic/Stream.rs`.
- The client's `on_stream_close` now calls `ClientSession::on_stream_closed` with the peer's reset code. A FIN always detaches the stream inside `deliver`, so a stream still attached at close never got one. After the headers the request fails with `HTTP3StreamReset` (peer reset) or `ConnectionClosed` (`ECONNRESET` in JS, the HTTP/1.1 code for a connection dropped mid-body). Before the headers it is re-sent once only when the connection went away or the code is `H3_REQUEST_REJECTED`, the one code that promises no application processing (RFC 9114 section 8.1). The h2 client retries only `REFUSED_STREAM` the same way.
- Correct because RFC 9114 section 4.1 defines a message as complete only at a FIN, and RESET_STREAM is the stream-level abort. The HTTP/2 server work in #40137 sends `RST_STREAM(INTERNAL_ERROR)` from `force_close` for the same reason.
- Verified: `test/js/bun/http/serve-http3.test.ts` (2 new tests: `fetch()` body read rejects, `node:quic` sees `RESET_STREAM` code 258) and `test/js/web/fetch/fetch-http3-client.test.ts` (4 new tests against a `node:quic` server: RESET_STREAM mid-body, CONNECTION_CLOSE mid-body, pre-header reset with 0x10B re-sent once, with 0x102 not re-sent). Five fail with main's `src/` and `packages/`. Also ran the full `serve-http3`, `fetch-http3-*`, and `test/js/node/quic` suites and `bun run rust:check-all`.

### Background
- In HTTP/3 each request is one bidirectional QUIC stream. The response ends with the stream's FIN. There is no chunked framing, so the peer cannot tell a truncated body from a complete one unless the sender aborts the stream with `RESET_STREAM(error code)` (RFC 9000 section 3.2, RFC 9114 section 8.1).
- `us_quic_stream_close` (`packages/bun-usockets/src/quic.c`) wraps `lsquic_stream_close`, which shuts down both halves and queues a FIN. `us_quic_stream_reset` wraps `lsquic_stream_maybe_reset`, which drops the unsent tail and queues `RESET_STREAM` instead.
- lsquic reports a received RESET_STREAM through `on_reset(how=0)` and later calls `on_close`. It never reports a FIN for that stream, so `on_stream_data(fin=1)` does not run. The fetch client learns of a FIN only through that callback.
- The pre-header retry (`ClientSession::retry_or_fail`) exists for a pooled session that went stale (GOAWAY, stateless reset, port reuse). It re-sends the request on a fresh session, so it is safe only when the server did not process the first copy.

<details><summary>Notes</summary>

Repro on main (debug build): `status=200 body-resolved len=2048` for a stream that enqueues two 1 KiB chunks and then calls `controller.error()`. With the fix: `fetch()` resolves with status 200, `res.text()` rejects with `code: "HTTP3StreamReset"`, and a following request on the same connection succeeds.

A `node:quic` client reading the same response gets `ERR_QUIC_STREAM_RESET` from its iterator and its `closed` promise rejects with `ERR_QUIC_APPLICATION_ERROR`, `errorCode` 258 (0x102). It discards body bytes its reader has not consumed when the reset arrives (RFC 9000 section 3.2 allows this), so the test asserts the status and how the stream ended, not a byte count. The fixtures order the wire without a sleep: the body source fails only after the client, which by then holds the status and the first chunk, requests `/release`.

The "error before the first chunk" case is unchanged here: it still takes `end_stream()` and sends headers plus FIN, so the client sees a 200 with an empty body. #40596 routes that case through `force_close()` for HTTP/1.1 and leaves the H3 close semantics to this PR. With both, `Bun.serve` sends `RESET_STREAM(H3_INTERNAL_ERROR)` before the headers and this client fails with `HTTP3StreamReset` without re-sending the request. On the client code of main a pre-header reset re-sends the request once (verified against a `node:quic` server: two POSTs reach the handler), so this PR should land before #40596.

`FileResponseStream.rs` also calls `force_close()` when a file read fails mid-response, so that path now resets the H3 stream too.

Client side: the `Aborted` check in `on_stream_closed` keeps the order `deliver` had (an aborted request reports `Aborted`, not the transport error). `fail()` calls `Stream::abort()`, which is a no-op here because `qstream` was already cleared, so the dying lsquic stream is not touched. The `H3_REQUEST_REJECTED` retry test pins the existing retry path (it passes on main too); the `H3_INTERNAL_ERROR` one fails on main.

Suites run with the debug build: `test/js/bun/http/serve-http3.test.ts` (54 pass), `test/js/web/fetch/fetch-http3-client.test.ts` (60 pass), `fetch-http3-adversarial`, `fetch-http3-cold-post`, `fetch-http3-syscall-fault`, `test/js/node/quic/` (49 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts" "test/js/web/fetch/fetch-http3-client.test.ts"
bun test v1.4.1 (731aa92da)

test/js/bun/http/serve-http3.test.ts:
(node:125557) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [1421.00ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1456.79ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1367.81ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1429.09ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1380.98ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1400.27ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1377.36ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1485.40ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2291.92ms]
(pass) Bun.serve HTTP/3 > maxRequ
... (truncated)

release without fix: 1 failed, 1 skipped
bun test v1.4.1-canary.1 (405ec97a0)

test/js/bun/http/serve-http3.test.ts:
(node:126356) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [137.42ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [137.55ms]
(pass) Bun.serve HTTP/3 > 204 with no body [137.90ms]
(pass) Bun.serve HTTP/3 > query string is preserved [136.67ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [150.70ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [148.98ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [134.31ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [139.70ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1046.67ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [139.22ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [146.79ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [145.25ms]
(pass) Bun.serve HTTP/3
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts" "test/js/web/fetch/fetch-http3-client.test.ts"
bun test v1.4.1 (731aa92da)

test/js/bun/http/serve-http3.test.ts:
(node:131846) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [1420.02ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1448.14ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1446.76ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1399.96ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1388.91ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1395.56ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1365.43ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1452.12ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2288.76ms]
(pass) Bun.serve HTTP/3 > maxRequ
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 591ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/14] cc obj/packages/bun-usockets/src/loop.c.o
[2/14] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/14] cc obj/packages/bun-usockets/src/quic.c.o
[4/14] gen cpp.rs (cppbind)
[4/14] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/quic.c             |  31 ++++---
 packages/bun-usockets/src/quic.h             |  12 ++-
 src/http/h3_client/ClientSession.rs          |  36 ++++++--
 src/http/h3_client/callbacks.rs              |   6 +-
 src/uws_sys/h3.rs                            |   6 +-
 src/uws_sys/libuwsockets_h3.cpp              |   6 +-
 src/uws_sys/quic.rs                          |   1 +
 src/uws_sys/quic/Stream.rs                   |  26 +++++-
 test/js/bun/http/serve-http3.test.ts         | 119 ++++++++++++++++++++++++++
 test/js/web/fetch/fetch-http3-client.test.ts | 121 +++++++++++++++++++++++++++
 10 files changed, 339 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-usockets/src/quic.c                  6      7      0
packages/bun-usockets/src/quic.h                  2      3      0
src/http/h3_client/ClientSession.rs               6      7      0
src/http/h3_client/callbacks.rs                   2      3      0
src/uws_sys/h3.rs                                 2      2      0
src/uws_sys/libuwsockets_h3.cpp                   3      4      0
src/uws_sys/quic.rs                               1      2      0
src/uws_sys/quic/Stream.rs                        4      9      0
test/js/bun/http/serve-http3.test.ts              6      6      0
test/js/web/fetch/fetch-http3-client.test.ts      4      5      0
```

</details>

<!-- robobun:evidence:end -->