### PR TITLE
paths: stop the recursive mkdir walk when a parent exists but its child is still not found

### DIFF
--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -158,8 +158,11 @@ macro_rules! cclog {
     };
 }
 
+/// `ENOENT`, not the bare `NOENT` that `<&str>::from(E)` yields on Windows.
 fn errno_name(e: &sys::Error) -> &'static str {
-    <&'static str>::from(e.get_errno())
+    e.get_error_code_tag_name()
+        .map(|(name, _)| name)
+        .unwrap_or("UNKNOWN")
 }
 
 /// Read-log tail for an I/O error; ENOENT uses Node's exact wording.

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -196,11 +196,9 @@ pub enum MakePathStep<E> {
 /// Starts at `it.last()`; on `Created`/`Exists` advances via `next()`
 /// (returning `Ok(())` when there is none), on `NotFound(e)` steps back via
 /// `previous()` (returning `Err(e)` when there is none — i.e. the very first
-/// component's parent does not exist). After the walk has advanced, a
-/// `NotFound` returns `Err(e)` at once: the parent exists but cannot hold
-/// children (a dangling symlink, procfs), so stepping back cannot make progress.
-/// That `e` belongs to the component the walk stalled on, which is the first
-/// missing component, not always the original target.
+/// component's parent does not exist). Once the walk has advanced, a
+/// `NotFound(e)` is final and returns that component's `e`: its parent exists
+/// but cannot hold children (a dangling symlink, procfs).
 ///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must
@@ -440,10 +438,8 @@ mod tests {
 
     #[test]
     fn make_path_stops_on_a_middle_component_after_two_steps_back() {
-        // `/proc/nonexistent/out`, or `dangling/cc/<tag>`: the target's parent
-        // is missing too, and the first existing ancestor cannot hold it. The
-        // guard fires on the middle component, not on the original target, so
-        // the returned error is the one for `/a/b`.
+        // `/proc/nonexistent/out`: the target's parent is missing too, so the
+        // guard fires on the middle component and returns its error.
         let it = ComponentIterator::init(&b"/a/b/c"[..], PathFormat::Posix).unwrap();
         let mut attempts: Vec<&[u8]> = vec![];
         let r = make_path_with(it, |p| {

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -199,6 +199,8 @@ pub enum MakePathStep<E> {
 /// component's parent does not exist). After the walk has advanced, a
 /// `NotFound` returns `Err(e)` at once: the parent exists but cannot hold
 /// children (a dangling symlink, procfs), so stepping back cannot make progress.
+/// That `e` belongs to the component the walk stalled on, which is the first
+/// missing component, not always the original target.
 ///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must
@@ -434,6 +436,30 @@ mod tests {
         });
         assert_eq!(r, Err(&b"/a/b/c"[..]));
         assert_eq!(attempts, vec![&b"/a/b/c"[..], &b"/a/b"[..], &b"/a/b/c"[..]]);
+    }
+
+    #[test]
+    fn make_path_stops_on_a_middle_component_after_two_steps_back() {
+        // `/proc/nonexistent/out`, or `dangling/cc/<tag>`: the target's parent
+        // is missing too, and the first existing ancestor cannot hold it. The
+        // guard fires on the middle component, not on the original target, so
+        // the returned error is the one for `/a/b`.
+        let it = ComponentIterator::init(&b"/a/b/c"[..], PathFormat::Posix).unwrap();
+        let mut attempts: Vec<&[u8]> = vec![];
+        let r = make_path_with(it, |p| {
+            attempts.push(p);
+            assert!(attempts.len() < 100, "runaway loop");
+            match p {
+                b"/a" => Ok(MakePathStep::Exists),
+                b"/a/b" | b"/a/b/c" => Ok(MakePathStep::NotFound(p)),
+                _ => unreachable!(),
+            }
+        });
+        assert_eq!(r, Err(&b"/a/b"[..]));
+        assert_eq!(
+            attempts,
+            vec![&b"/a/b/c"[..], &b"/a/b"[..], &b"/a"[..], &b"/a/b"[..]]
+        );
     }
 
     #[test]

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -184,7 +184,8 @@ pub enum MakePathStep<E> {
     /// Directory already exists (`EEXIST`). Walk advances forward.
     Exists,
     /// A parent is missing (`ENOENT`). Walk steps back one component;
-    /// if there is no previous component the carried error is returned.
+    /// if there is no previous component, or the parent already reported
+    /// `Created`/`Exists` on this walk, the carried error is returned.
     NotFound(E),
 }
 
@@ -197,6 +198,12 @@ pub enum MakePathStep<E> {
 /// `previous()` (returning `Err(e)` when there is none — i.e. the very first
 /// component's parent does not exist).
 ///
+/// Once the walk has advanced forward, a `NotFound` is final: the parent just
+/// reported `Created`/`Exists`, so stepping back would only repeat the same
+/// pair of results forever. This is what a dangling symlink (EEXIST for the
+/// link, ENOENT below it), procfs, or on Windows a regular file in place of a
+/// directory produce.
+///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must
 /// copy into a scratch buffer.
@@ -207,14 +214,17 @@ pub fn make_path_with<'a, T: PathChar, E>(
     let Some(mut comp) = it.last() else {
         return Ok(());
     };
+    let mut advanced = false;
     loop {
         match mkdir(comp.path)? {
             MakePathStep::Created | MakePathStep::Exists => {
+                advanced = true;
                 comp = match it.next() {
                     Some(c) => c,
                     None => return Ok(()),
                 };
             }
+            MakePathStep::NotFound(e) if advanced => return Err(e),
             MakePathStep::NotFound(e) => {
                 comp = match it.previous() {
                     Some(c) => c,
@@ -375,5 +385,86 @@ mod tests {
         assert_eq!(it.next().unwrap().name, b"b");
         assert_eq!(it.next().unwrap().name, b"c");
         assert!(it.next().is_none());
+    }
+
+    #[test]
+    fn make_path_creates_missing_parents() {
+        // Only the cwd exists: the walk backs up to `a`, then creates forward.
+        let it = ComponentIterator::init(&b"a/b/c"[..], PathFormat::Posix).unwrap();
+        let mut created: Vec<&[u8]> = vec![];
+        let mut attempts: Vec<&[u8]> = vec![];
+        let r = make_path_with::<u8, ()>(it, |p| {
+            attempts.push(p);
+            let parent: &[u8] = match p {
+                b"a" => b"",
+                b"a/b" => b"a",
+                b"a/b/c" => b"a/b",
+                _ => unreachable!(),
+            };
+            if parent.is_empty() || created.contains(&parent) {
+                created.push(p);
+                Ok(MakePathStep::Created)
+            } else {
+                Ok(MakePathStep::NotFound(()))
+            }
+        });
+        assert_eq!(r, Ok(()));
+        assert_eq!(
+            attempts,
+            vec![
+                &b"a/b/c"[..],
+                &b"a/b"[..],
+                &b"a"[..],
+                &b"a/b"[..],
+                &b"a/b/c"[..]
+            ]
+        );
+        assert_eq!(created, vec![&b"a"[..], &b"a/b"[..], &b"a/b/c"[..]]);
+    }
+
+    #[test]
+    fn make_path_stops_when_parent_exists_but_child_is_not_found() {
+        // `/a/b` is a dangling symlink: EEXIST for itself, ENOENT for any
+        // child. The walk must not bounce between the two forever.
+        let it = ComponentIterator::init(&b"/a/b/c"[..], PathFormat::Posix).unwrap();
+        let mut attempts: Vec<&[u8]> = vec![];
+        let r = make_path_with(it, |p| {
+            attempts.push(p);
+            assert!(attempts.len() < 100, "runaway loop");
+            match p {
+                b"/a" | b"/a/b" => Ok(MakePathStep::Exists),
+                b"/a/b/c" => Ok(MakePathStep::NotFound(p)),
+                _ => unreachable!(),
+            }
+        });
+        assert_eq!(r, Err(&b"/a/b/c"[..]));
+        assert_eq!(attempts, vec![&b"/a/b/c"[..], &b"/a/b"[..], &b"/a/b/c"[..]]);
+    }
+
+    #[test]
+    fn make_path_stops_when_open_if_parent_succeeds_but_child_is_not_found() {
+        // `NtCreateFile(FILE_OPEN_IF)` reports `Created` for an existing
+        // directory too, so the guard must not depend on `Exists`.
+        let it = ComponentIterator::init(&b"x\\link\\out"[..], PathFormat::Windows).unwrap();
+        let mut attempts = 0u32;
+        let r = make_path_with(it, |p| {
+            attempts += 1;
+            assert!(attempts < 100, "runaway loop");
+            match p {
+                b"x" | b"x\\link" => Ok(MakePathStep::Created),
+                b"x\\link\\out" => Ok(MakePathStep::NotFound(())),
+                _ => unreachable!(),
+            }
+        });
+        assert_eq!(r, Err(()));
+        assert_eq!(attempts, 3);
+    }
+
+    #[test]
+    fn make_path_reports_missing_root_parent() {
+        // Nothing under the cwd exists: the first component's error comes back.
+        let it = ComponentIterator::init(&b"a/b"[..], PathFormat::Posix).unwrap();
+        let r = make_path_with(it, |p| Ok(MakePathStep::NotFound(p)));
+        assert_eq!(r, Err(&b"a"[..]));
     }
 }

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -183,9 +183,9 @@ pub enum MakePathStep<E> {
     Created,
     /// Directory already exists (`EEXIST`). Walk advances forward.
     Exists,
-    /// A parent is missing (`ENOENT`). Walk steps back one component;
-    /// if there is no previous component, or the parent already reported
-    /// `Created`/`Exists` on this walk, the carried error is returned.
+    /// A parent is missing (`ENOENT`). Walk steps back one component; if
+    /// there is none, or the walk already advanced forward, the carried error
+    /// is returned.
     NotFound(E),
 }
 
@@ -196,13 +196,9 @@ pub enum MakePathStep<E> {
 /// Starts at `it.last()`; on `Created`/`Exists` advances via `next()`
 /// (returning `Ok(())` when there is none), on `NotFound(e)` steps back via
 /// `previous()` (returning `Err(e)` when there is none — i.e. the very first
-/// component's parent does not exist).
-///
-/// Once the walk has advanced forward, a `NotFound` is final: the parent just
-/// reported `Created`/`Exists`, so stepping back would only repeat the same
-/// pair of results forever. This is what a dangling symlink (EEXIST for the
-/// link, ENOENT below it), procfs, or on Windows a regular file in place of a
-/// directory produce.
+/// component's parent does not exist). After the walk has advanced, a
+/// `NotFound` returns `Err(e)` at once: the parent exists but cannot hold
+/// children (a dangling symlink, procfs), so stepping back cannot make progress.
 ///
 /// `mkdir` is invoked with `component.path`: a borrowed prefix slice into the
 /// original input, never NUL-terminated. Callers that need a sentinel must
@@ -424,8 +420,7 @@ mod tests {
 
     #[test]
     fn make_path_stops_when_parent_exists_but_child_is_not_found() {
-        // `/a/b` is a dangling symlink: EEXIST for itself, ENOENT for any
-        // child. The walk must not bounce between the two forever.
+        // `/a/b` is a dangling symlink: EEXIST for itself, ENOENT below it.
         let it = ComponentIterator::init(&b"/a/b/c"[..], PathFormat::Posix).unwrap();
         let mut attempts: Vec<&[u8]> = vec![];
         let r = make_path_with(it, |p| {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -527,6 +527,31 @@ describe("Bun.build", () => {
     Bun.gc(true);
   });
 
+  test("outdir under a dangling symlink fails with ENOENT instead of never settling", async () => {
+    // mkdir on the link reports EEXIST, mkdir below it reports ENOENT. The
+    // recursive mkdir used to retry that pair forever and the build promise
+    // never settled. Run in a child so the spin cannot take the runner down.
+    using dir = tempDir("build-outdir-dangling", {
+      "index.js": `console.log("built");`,
+      "build.js": `
+        const r = await Bun.build({ entrypoints: ["./index.js"], outdir: "./dangling/out", throw: false });
+        console.log(r.success, r.logs.map(l => l.message).join("\\n"));
+      `,
+    });
+    symlinkSync(join(String(dir), "does-not-exist"), join(String(dir), "dangling"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("false Failed to create output directory ENOENT");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("BuildArtifact properties", async () => {
     Bun.gc(true);
     const outdir = tempDirWithFiles("build-artifact-properties", {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -443,6 +443,26 @@ test("--outdir build succeeds when the output directory already exists with prio
   expect(out).not.toContain("stale");
 });
 
+// mkdir on a dangling symlink reports EEXIST, mkdir below it reports ENOENT.
+// The recursive mkdir behind --outdir used to retry that pair forever.
+test("--outdir fails with ENOENT when a parent of the output directory is a dangling symlink", async () => {
+  using dir = tempDir("build-outdir-dangling-symlink", {
+    "entry.ts": `console.log("built");`,
+  });
+  fs.symlinkSync(path.join(String(dir), "does-not-exist"), path.join(String(dir), "dangling"));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry.ts", "--outdir", path.join("dangling", "out")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("Failed to create output directory ENOENT");
+  expect(exitCode).toBe(1);
+});
+
 test("multi-entry build writes each entry point into the output directory", async () => {
   using dir = tempDir("build-multi-entry-outdir", {
     "a.ts": `export const a: number = 1;\nconsole.log("A" + a);`,

--- a/test/cli/install/bun-install-cache-dir.test.ts
+++ b/test/cli/install/bun-install-cache-dir.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
+import { join } from "node:path";
+
+// mkdir on a dangling symlink reports EEXIST, mkdir below it reports ENOENT.
+// The recursive mkdir behind the install cache directory used to retry that
+// pair forever, so `bun install` sat at 100% CPU before resolving anything.
+// The folder dependency keeps the install off the network.
+test("install completes when BUN_INSTALL_CACHE_DIR is under a dangling symlink", async () => {
+  using dir = tempDir("install-cache-dir-dangling", {
+    "proj/package.json": JSON.stringify({
+      name: "x",
+      version: "1.0.0",
+      dependencies: { localdep: "file:./localdep" },
+    }),
+    "proj/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.2.3" }),
+  });
+  symlinkSync(join(String(dir), "does-not-exist"), join(String(dir), "dangling"));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: join(String(dir), "proj"),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), "dangling", "cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr }).toMatchObject({ stdout: expect.stringContaining("1 package installed") });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -215,6 +215,50 @@ console.log("survived", require("./late.js"));`,
     },
   );
 
+  test("compile cache under a dangling symlink is reported as FAILED, not retried forever", async () => {
+    // mkdir on the link reports EEXIST, mkdir below it reports ENOENT. The
+    // recursive mkdir used to bounce between the two forever, so a bad
+    // NODE_COMPILE_CACHE hung every process before any user code ran.
+    using dir = tempDir("compile-cache-dangling", {
+      "main.js": `
+        const Module = require("node:module");
+        const r = Module.enableCompileCache(process.env.CACHE_DIR);
+        console.log(r.status === Module.constants.compileCacheStatus.FAILED, r.message);
+      `,
+    });
+    const link = path.join(String(dir), "dangling");
+    fs.symlinkSync(path.join(String(dir), "does-not-exist"), link);
+    const cacheDir = path.join(link, "cc");
+    const env = { ...bunEnv };
+    delete env.NODE_COMPILE_CACHE;
+
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", "console.log('started')"],
+        env: { ...env, NODE_COMPILE_CACHE: cacheDir },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("started\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.js"],
+        env: { ...env, CACHE_DIR: cacheDir },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("true Cannot create cache directory: ENOENT\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+  });
+
   test.skipIf(!isWindows)("enableCompileCache default dir prefers TEMP over TMP like os.tmpdir", async () => {
     using dir = tempDir("compile-cache-tmporder", {});
     const temp = path.join(String(dir), "from-temp");


### PR DESCRIPTION
### Problem
- Since 1.4.0, bun spins at 100% CPU forever when the recursive mkdir helper meets a parent that exists but cannot hold children: a dangling symlink, a path under `/proc`, or a regular file on Windows. `bun build --outdir=./dangling/out` never exits. `NODE_COMPILE_CACHE=./dangling/cc bun app.js` hangs before user code runs. `Bun.build`, `--compile --outfile`, `enableCompileCache()`, and `bun install` with such a `BUN_INSTALL_CACHE_DIR` hit the same loop.
- The cause is `make_path_with` in `src/paths/component_iterator.rs:203`. It steps back on ENOENT and forward on EEXIST or success, with no check that the retry can do better. strace shows `mkdirat("dangling/out") = ENOENT` then `mkdirat("dangling") = EEXIST`, 22,000 times per second.

### Fix
- Once the walk has advanced forward, a `NotFound` is final. The parent just reported `Created` or `Exists`, so stepping back can only repeat the same two results. The walk returns the child's ENOENT, as 1.3.14 did.
- The guard does not depend on `Exists`: the Windows libarchive variant uses `NtCreateFile(FILE_OPEN_IF)` and reports `Created` for an existing directory too.
- Verified: one new test each in `test/bundler/cli.test.ts`, `test/bundler/bun-build-api.test.ts`, `test/js/node/module/node-module-module.test.js`, and the new `test/cli/install/bun-install-cache-dir.test.ts`. 1.4.1 times out on all four. Also the `bun_paths` unit tests, `archive.test.ts`, `transpiler-cache.test.ts`.

### Background
- `make_path_with` is the one `mkdir -p` walk behind `Dir::make_path`, `Dir::make_open_path`, and the libarchive UTF-16 variant. The caller supplies the per-prefix mkdir as a closure that returns `Created`, `Exists`, or `NotFound`.
- The walk starts at the last component. ENOENT means a parent is missing, so it steps back. Success or EEXIST means the prefix is in place, so it steps forward. On a healthy filesystem every step forward is a new directory, so the walk terminates.
- `node:fs` `mkdirSync({ recursive: true })` is not affected. It has its own forward pass in `node_fs.rs`.

<details><summary>Notes</summary>

- #36162 carried the same three line change to `make_path_with` plus a policy change to the `bun install` cache directory: error out when an explicit `BUN_INSTALL_CACHE_DIR` or bunfig `install.cache.dir` cannot be created, warn and fall back for an implicit one. It was conflicting with main and is closed in favor of this PR. The policy change is a separate proposal. This PR keeps the existing behavior: the walk returns ENOENT and `ensure_cache_directory` falls back to `node_modules/.cache`, as 1.3.x did. `test/cli/install/bun-install-cache-dir.test.ts` covers that entry point with a `file:` folder dependency, so it stays off the network.
- Reproduction with the released binary (Linux and Windows both spin):

  ```sh
  cd "$(mktemp -d)"; echo 'console.log("hi")' > hello.js
  ln -s "$PWD/does-not-exist" dangling
  timeout -s KILL 5 bun build hello.js --outdir=./dangling/out; echo rc=$?   # rc=137
  NODE_COMPILE_CACHE="$PWD/dangling/cc" timeout -s KILL 5 bun hello.js       # never prints hi
  ```

- With the fix, each form terminates at once. 1.3.14 printed `Failed to create output directory FileNotFound` for the first one.

  ```
  bun build hello.js --outdir=./dangling/out
  error: Failed to create output directory ENOENT "./dangling/out"
  NODE_COMPILE_CACHE=$PWD/dangling/cc bun hello.js
  hi
  bun build hello.js --outdir=/proc/nonexistent/out
  error: Failed to create output directory ENOENT "/proc/nonexistent/out"
  require("node:module").enableCompileCache("./dangling/cc")
  {"status":0,"message":"Cannot create cache directory: ENOENT"}
  ```

- `BUN_RUNTIME_TRANSPILER_CACHE_PATH` goes through the same `make_open_path` and is fixed too.
- The hang in #39357 (`bun install` through a subst drive or cross-drive junction on Windows) is the same loop: the isolated linker builds a path with a bogus `C:` component in the middle, `NtCreateFile` reports `STATUS_OBJECT_NAME_INVALID`, which maps to ENOENT, and the walk bounces against the existing parent. This guard turns that hang into an error. It does not close #39357: the root cause there, the project root resolved through a different drive letter, is the `PackageManager.rs` change in #39361.
- #39361 also carries a guard in `make_path_with`: a `last_not_found` marker that is cleared on `Created`. The libarchive Windows walker (`make_path_u16` in `src/libarchive/lib.rs`) uses `NtCreateFile(FILE_OPEN_IF)` and reports `Created` for a directory that already exists, so that marker is cleared on every step back and the walk does not terminate there. The `advanced` flag here is set on `Created` and `Exists` alike. This PR should land first and #39361 should drop its `component_iterator.rs` hunk and the `make_path_terminates_on_uncreatable_component` test.
- The unit test `make_path_stops_on_a_middle_component_after_two_steps_back` pins the `/proc/nonexistent/out` and `dangling/cc/<tag>` shape: the target and its parent are both missing, and the first existing ancestor cannot hold children. The guard fires on the middle component, so the returned error is that component's. A guard that only made the original target final passes the other unit tests and still spins on this shape.
- The compile cache test exposed a second, Windows-only defect: `enableCompileCache` reported `Cannot create cache directory: NOENT`. On Windows `E` is its own enum with bare variant names, so `<&str>::from(e.get_errno())` drops the `E`. `errno_name` in `NodeCompileCache.rs` now uses `get_error_code_tag_name`, the accessor behind `sys::Error::name()`. #40602 fixes the `From<E> for &str` impl itself and the other nine call sites. The two merge in either order.
- The old Zig `std.fs.Dir.makePath` stat'ed the path on EEXIST and returned the stat error, which is how 1.3.14 reported FileNotFound. A stat does not help for `/proc/nonexistent/x` (the parent is a real directory), so this PR detects the lack of progress in the walk itself. It also saves the extra syscall on every EEXIST.
- A race where another process creates the missing parent between the child's ENOENT and the parent's mkdir still works: the parent reports `Exists`, the walk moves forward, and the child is created on the retry. Only a second ENOENT on the same child after that is fatal.
- The `bun-build-api.test.ts` run also shows two bytecode tests that time out at 5 s under this debug+ASAN build. Their fixture completes in 28 s when run by hand, and the output directory is created fine. That is the slow machine, not this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js, test/bundler/cli.test.ts, test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
