### PR TITLE
errno(windows): spell E like SystemErrno so messages say ENOENT, not NOENT

### DIFF
--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -503,6 +503,16 @@ mod errno_name_tests {
         }
     }
 
+    /// Matters on Windows, where `E` is a separate enum with unprefixed variant names.
+    #[test]
+    fn e_spells_like_system_errno() {
+        assert_eq!(<&'static str>::from(E::ENOENT), "ENOENT");
+        assert_eq!(<&'static str>::from(E::E2BIG), "E2BIG");
+        assert_eq!(<&'static str>::from(E::SUCCESS), "SUCCESS");
+        #[cfg(windows)]
+        assert_eq!(<&'static str>::from(E::UV_ENOENT), "UV_ENOENT");
+    }
+
     #[test]
     fn coreutils_map() {
         assert_eq!(

--- a/src/errno/windows_errno.rs
+++ b/src/errno/windows_errno.rs
@@ -85,18 +85,7 @@ macro_rules! __errno_enum_with_uv_tail {
 
 for_each_uv_errno! { __errno_enum_with_uv_tail {
 #[repr(u16)]
-#[derive(
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    Debug,
-    strum::IntoStaticStr,
-    strum::EnumString,
-    strum::FromRepr,
-    enum_map::Enum,
-)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, strum::FromRepr, enum_map::Enum)]
 pub enum E {
     SUCCESS = 0,
     PERM = 1,
@@ -106,7 +95,6 @@ pub enum E {
     IO = 5,
     NXIO = 6,
     // Rust identifiers cannot start with a digit.
-    #[strum(serialize = "2BIG")]
     _2BIG = 7,
     NOEXEC = 8,
     BADF = 9,
@@ -330,6 +318,22 @@ impl E {
     pub const EUNKNOWN: E = E::UNKNOWN;
     pub const ECHARSET: E = E::CHARSET;
     pub const EFTYPE: E = E::FTYPE;
+}
+
+/// `ENOENT`, as the POSIX alias `E = SystemErrno` spells it, not the variant name `NOENT`.
+impl From<E> for &'static str {
+    #[inline]
+    fn from(e: E) -> &'static str {
+        // Same discriminant set; `SystemErrno::to_e` is the reverse cast.
+        <&'static str>::from(SystemErrno::from_raw(e as u16))
+    }
+}
+
+impl From<&E> for &'static str {
+    #[inline]
+    fn from(e: &E) -> &'static str {
+        <&'static str>::from(*e)
+    }
 }
 
 /// Mirrors `bun_errno::posix` on POSIX targets so callers can `use

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -386,7 +386,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             bstr::BStr::new(self.script_name()),
             bstr::BStr::new(&self.package_name),
             err.errno,
-            <&'static str>::from(err.get_errno()),
+            bstr::BStr::new(err.name()),
         );
         Output::flush();
         self.maybe_finished();

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -453,7 +453,7 @@ impl WorkspaceMap {
                             loc,
                             "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
                             BStr::new(user_pattern),
-                            <&'static str>::from(e.get_errno()),
+                            BStr::new(e.name()),
                         );
                         return Err(crate::Error::GlobError);
                     }
@@ -469,7 +469,7 @@ impl WorkspaceMap {
                         loc,
                         "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
                         BStr::new(user_pattern),
-                        <&'static str>::from(e.get_errno()),
+                        BStr::new(e.name()),
                     );
                     return Err(crate::Error::GlobError);
                 }
@@ -485,7 +485,7 @@ impl WorkspaceMap {
                                 loc,
                                 "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
                                 BStr::new(user_pattern),
-                                <&'static str>::from(e.get_errno()),
+                                BStr::new(e.name()),
                             );
                             return Err(crate::Error::GlobError);
                         }

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -172,7 +172,7 @@ impl Stdio {
 
                         bun_core::debug_warn!(
                             "Failed to write to memfd: {}",
-                            <&'static str>::from(err.get_errno()),
+                            bstr::BStr::new(err.name()),
                         );
                         fd.close();
                         return false;

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -189,7 +189,7 @@ trait CronJobBase: Sized + bun_ptr::AnyRefCounted {
             let _ = write!(
                 &mut msg,
                 "Failed to read process output: {}",
-                <&'static str>::from(err.get_errno())
+                bstr::BStr::new(err.name())
             );
             self.err_msg().set(Some(msg));
         }
@@ -393,7 +393,7 @@ impl CronJobBase for CronRegisterJob {
             Status::Err(err) => {
                 self.set_err(format_args!(
                     "Process error: {}",
-                    <&'static str>::from(err.get_errno())
+                    bstr::BStr::new(err.name())
                 ));
                 return JobAction::Finish;
             }
@@ -1125,7 +1125,7 @@ impl CronJobBase for CronRemoveJob {
             Status::Err(err) => {
                 self.set_err(format_args!(
                     "Process error: {}",
-                    <&'static str>::from(err.get_errno())
+                    bstr::BStr::new(err.name())
                 ));
                 return JobAction::Finish;
             }

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -931,7 +931,7 @@ fn describe_status<'b>(buf: &'b mut [u8; 32], status: &SpawnStatus) -> &'b [u8] 
                 &buf[..buf.len() - remaining]
             }
         }
-        SpawnStatus::Err(e) => <&'static str>::from(e.get_errno()).as_bytes(),
+        SpawnStatus::Err(e) => e.name(),
         SpawnStatus::Running => b"running",
     }
 }

--- a/src/sys_jsc/error_jsc.rs
+++ b/src/sys_jsc/error_jsc.rs
@@ -129,7 +129,6 @@ pub mod TestingAPIs {
         {
             let code: core::ffi::c_int = arguments[0].to_int32();
             let result = bun_sys::windows::translate_uv_error_to_e(code);
-            // @tagName(result) → IntoStaticStr derive on the E enum.
             return bun_string_jsc::create_utf8_for_js(
                 global,
                 <&'static str>::from(result).as_bytes(),

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -39,6 +39,20 @@ test("bad workspace path", () => {
   expect(exitCode).toBe(1);
 });
 
+// The glob walker opens the literal prefix of an absolute pattern before it walks it. When
+// that directory is missing, the error names the errno by its node spelling on every
+// platform (Windows used to print the bare variant name, "NOENT").
+test("glob entry under a missing directory reports the errno name", async () => {
+  using dir = tempDir("bad-workspace-glob-missing-root", {});
+  const entry = `${String(dir).replaceAll("\\", "/")}/missing/*`;
+  writeFileSync(join(String(dir), "package.json"), rootPackageJson([entry]));
+
+  const { stderr, exitCode } = await runInstall(String(dir));
+
+  expect(stderr).toContain(`error: Failed to run workspace pattern ${entry} due to error ENOENT`);
+  expect(exitCode).toBe(1);
+});
+
 test("non-string workspaces entry prints the error without literal markup", async () => {
   using dir = tempDir("bad-workspace-non-string", {
     "package.json": JSON.stringify({ name: "hey", workspaces: [123] }),

--- a/test/js/node/fs/rm-windows-ntstatus.test.ts
+++ b/test/js/node/fs/rm-windows-ntstatus.test.ts
@@ -20,31 +20,31 @@ import path from "node:path";
 test.skipIf(!isWindows)("translateNtStatusToE maps delete-related NTSTATUS codes to errno", () => {
   // Existing explicit mappings must keep working.
   expect(translateNtStatusToE(0x00000000)).toBe("SUCCESS"); // STATUS_SUCCESS
-  expect(translateNtStatusToE(0xc0000022)).toBe("PERM"); // STATUS_ACCESS_DENIED
-  expect(translateNtStatusToE(0xc00000ba)).toBe("ISDIR"); // STATUS_FILE_IS_A_DIRECTORY
-  expect(translateNtStatusToE(0xc0000034)).toBe("NOENT"); // STATUS_OBJECT_NAME_NOT_FOUND
-  expect(translateNtStatusToE(0xc0000101)).toBe("NOTEMPTY"); // STATUS_DIRECTORY_NOT_EMPTY
-  expect(translateNtStatusToE(0xc0000056)).toBe("BUSY"); // STATUS_DELETE_PENDING
-  expect(translateNtStatusToE(0xc0000043)).toBe("BUSY"); // STATUS_SHARING_VIOLATION
+  expect(translateNtStatusToE(0xc0000022)).toBe("EPERM"); // STATUS_ACCESS_DENIED
+  expect(translateNtStatusToE(0xc00000ba)).toBe("EISDIR"); // STATUS_FILE_IS_A_DIRECTORY
+  expect(translateNtStatusToE(0xc0000034)).toBe("ENOENT"); // STATUS_OBJECT_NAME_NOT_FOUND
+  expect(translateNtStatusToE(0xc0000101)).toBe("ENOTEMPTY"); // STATUS_DIRECTORY_NOT_EMPTY
+  expect(translateNtStatusToE(0xc0000056)).toBe("EBUSY"); // STATUS_DELETE_PENDING
+  expect(translateNtStatusToE(0xc0000043)).toBe("EBUSY"); // STATUS_SHARING_VIOLATION
 
   // STATUS_CANNOT_DELETE: FILE_ATTRIBUTE_READONLY on a filesystem that rejected
   // FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE (e.g. FAT32), or a memory-mapped
   // section exists. libuv maps the equivalent Win32 error (ERROR_ACCESS_DENIED)
   // to EPERM, so fs.rm should surface EPERM, not EFAULT.
-  expect(translateNtStatusToE(0xc0000121)).toBe("PERM");
+  expect(translateNtStatusToE(0xc0000121)).toBe("EPERM");
 
   // Status codes not in the explicit table: fall through RtlNtStatusToDosError
   // to the libuv Win32->errno table. None of these should be UNKNOWN.
   // STATUS_DISK_FULL -> ERROR_DISK_FULL -> ENOSPC
-  expect(translateNtStatusToE(0xc000007f)).toBe("NOSPC");
+  expect(translateNtStatusToE(0xc000007f)).toBe("ENOSPC");
   // STATUS_NO_SUCH_FILE -> ERROR_FILE_NOT_FOUND -> ENOENT
-  expect(translateNtStatusToE(0xc000000f)).toBe("NOENT");
+  expect(translateNtStatusToE(0xc000000f)).toBe("ENOENT");
   // STATUS_TOO_MANY_OPENED_FILES -> ERROR_TOO_MANY_OPEN_FILES -> EMFILE
-  expect(translateNtStatusToE(0xc000011f)).toBe("MFILE");
+  expect(translateNtStatusToE(0xc000011f)).toBe("EMFILE");
   // STATUS_NOT_SUPPORTED -> ERROR_NOT_SUPPORTED -> ENOTSUP
-  expect(translateNtStatusToE(0xc00000bb)).toBe("NOTSUP");
+  expect(translateNtStatusToE(0xc00000bb)).toBe("ENOTSUP");
   // STATUS_MEDIA_WRITE_PROTECTED -> ERROR_WRITE_PROTECT -> EROFS
-  expect(translateNtStatusToE(0xc00000a2)).toBe("ROFS");
+  expect(translateNtStatusToE(0xc00000a2)).toBe("EROFS");
 
   // RtlNtStatusToDosError collapses STATUS_NOT_IMPLEMENTED,
   // STATUS_INVALID_DEVICE_REQUEST and STATUS_ILLEGAL_FUNCTION to
@@ -53,14 +53,14 @@ test.skipIf(!isWindows)("translateNtStatusToE maps delete-related NTSTATUS codes
   // driver did not implement the request, not that the target is a
   // directory; mapping to ISDIR would livelock recursive fs.rm by flipping
   // treat_as_dir. They must surface as NOTSUP.
-  expect(translateNtStatusToE(0xc0000002)).toBe("NOTSUP"); // STATUS_NOT_IMPLEMENTED
-  expect(translateNtStatusToE(0xc0000010)).toBe("NOTSUP"); // STATUS_INVALID_DEVICE_REQUEST
-  expect(translateNtStatusToE(0xc00000af)).toBe("NOTSUP"); // STATUS_ILLEGAL_FUNCTION
+  expect(translateNtStatusToE(0xc0000002)).toBe("ENOTSUP"); // STATUS_NOT_IMPLEMENTED
+  expect(translateNtStatusToE(0xc0000010)).toBe("ENOTSUP"); // STATUS_INVALID_DEVICE_REQUEST
+  expect(translateNtStatusToE(0xc00000af)).toBe("ENOTSUP"); // STATUS_ILLEGAL_FUNCTION
 
   // A status that RtlNtStatusToDosError does not recognise maps to
-  // ERROR_MR_MID_NOT_FOUND, which has no errno, so we still get UNKNOWN
-  // (not a panic).
-  expect(translateNtStatusToE(0xcfffffff)).toBe("UNKNOWN");
+  // ERROR_MR_MID_NOT_FOUND, which has no errno, so we still get E::UNKNOWN
+  // (not a panic). It prints with SystemErrno's spelling, like every variant.
+  expect(translateNtStatusToE(0xcfffffff)).toBe("EUNKNOWN");
 });
 
 test.skipIf(isWindows)("translateNtStatusToE is a no-op off Windows", () => {

--- a/test/js/node/fs/translate-uv-error-windows.test.ts
+++ b/test/js/node/fs/translate-uv-error-windows.test.ts
@@ -10,17 +10,18 @@ import { expect, test } from "bun:test";
 import { isWindows } from "harness";
 
 test.skipIf(!isWindows)("translateUVErrorToE falls back to UNKNOWN for unmapped libuv codes", () => {
-  // Sanity: known mappings still work.
-  expect(translateUVErrorToE(-4058)).toBe("NOENT"); // UV_ENOENT
-  expect(translateUVErrorToE(-4083)).toBe("BADF"); // UV_EBADF
-  expect(translateUVErrorToE(-4094)).toBe("UNKNOWN"); // UV_UNKNOWN
+  // Sanity: known mappings still work. The hook prints the variant with
+  // SystemErrno's spelling (`ENOENT`, not the Rust identifier `NOENT`).
+  expect(translateUVErrorToE(-4058)).toBe("ENOENT"); // UV_ENOENT
+  expect(translateUVErrorToE(-4083)).toBe("EBADF"); // UV_EBADF
+  expect(translateUVErrorToE(-4094)).toBe("EUNKNOWN"); // UV_UNKNOWN
 
-  // Unmapped codes must not panic; they fall back to UNKNOWN.
-  expect(translateUVErrorToE(-4021)).toBe("UNKNOWN"); // one past UV_ENOEXEC (-4022)
-  expect(translateUVErrorToE(-4097)).toBe("UNKNOWN"); // one past UV_ERRNO_MAX (-4096)
-  expect(translateUVErrorToE(-4000)).toBe("UNKNOWN"); // gap no UV_E* constant occupies
-  expect(translateUVErrorToE(-123456)).toBe("UNKNOWN"); // negation outside u16 range
-  expect(translateUVErrorToE(-2147483648)).toBe("UNKNOWN"); // INT_MIN: wrapping negation, no overflow
+  // Unmapped codes must not panic; they fall back to E::UNKNOWN.
+  expect(translateUVErrorToE(-4021)).toBe("EUNKNOWN"); // one past UV_ENOEXEC (-4022)
+  expect(translateUVErrorToE(-4097)).toBe("EUNKNOWN"); // one past UV_ERRNO_MAX (-4096)
+  expect(translateUVErrorToE(-4000)).toBe("EUNKNOWN"); // gap no UV_E* constant occupies
+  expect(translateUVErrorToE(-123456)).toBe("EUNKNOWN"); // negation outside u16 range
+  expect(translateUVErrorToE(-2147483648)).toBe("EUNKNOWN"); // INT_MIN: wrapping negation, no overflow
 });
 
 test.skipIf(isWindows)("translateUVErrorToE is a no-op off Windows", () => {


### PR DESCRIPTION
### Problem
- On Windows, user-visible messages spell the errno without the `E` prefix. `bun install` with `"workspaces": ["C:/missing/*"]` prints `Failed to run workspace pattern C:/missing/* due to error NOENT`. POSIX prints `ENOENT`.
- Cause: on Windows `bun_errno::E` is its own enum with unprefixed variant names (`NOENT`), and its `strum::IntoStaticStr` derive made `<&str>::from(e)` return that name (`src/errno/windows_errno.rs:95`). On POSIX `E` is `type E = SystemErrno`, so the same expression returns `ENOENT`. Nine messages built their name with `<&'static str>::from(err.get_errno())`.

### Fix
- Replace the derive with `impl From<E> for &'static str` that returns `SystemErrno`'s name for the same discriminant. The two enums share one discriminant set (`SystemErrno::to_e` casts the other way, and all 138 dense variants match). Every `<&str>::from(E)` on Windows now prints `ENOENT`. The unused `strum::EnumString` derive goes too.
- The nine sites switch to `bun_sys::Error::name()` (`src/sys/Error.rs:321`), the accessor the rest of the tree uses. It also translates libuv-sourced errnos and reports an unmapped value as `UNKNOWN`, which `get_errno()` cannot.
- The two `bun:internal-for-testing` hooks that print an `E` (`src/sys_jsc/error_jsc.rs`) keep doing so. Their Windows-only tests now expect `EPERM`, `ENOENT`, `EUNKNOWN`.
- Verified on windows-x64: `bad-workspace.test.ts` (new test), `translate-uv-error-windows.test.ts` and `rm-windows-ntstatus.test.ts` fail with bun 1.4.1 and pass with the debug build. Also `error-name-from-libuv.test.ts`, and `cron.test.ts` on Linux.

### Background
- `bun_sys::Error::get_errno()` returns the errno as `E` for `match` arms. `name()` returns the user-visible code.
- On Windows, `E` (bare names) and `SystemErrno` (E-prefixed names) are two `#[repr(u16)]` enums with the same discriminants. `pub const ENOENT: E = E::NOENT` aliases let cross-platform code compile. POSIX has no second enum.
- strum's `IntoStaticStr` derive turns an enum value into its Rust variant name.

<details><summary>Notes</summary>

- Repro with the released bun 1.4.1 on windows-x64:

  ```
  > echo { "name": "root", "workspaces": ["C:/nonexistent-dir-xyz/*"] } > package.json
  > bun install
  error: Failed to run workspace pattern C:/nonexistent-dir-xyz/* due to error NOENT
  ```

  With this change the same command prints `due to error ENOENT`, as Linux does.

- The nine sites: `src/install/lockfile/Package/WorkspaceMap.rs:456,472,488`, `src/install/lifecycle_script_runner.rs:389`, `src/runtime/api/cron.rs:192,396,1128`, `src/runtime/cli/test/parallel/Coordinator.rs:934`, `src/runtime/api/bun/spawn/stdio.rs:175`. A tenth, `src/jsc/NodeCompileCache.rs:162`, is left as is: the `From<E>` impl corrects its output, and #40600 switches it to `get_error_code_tag_name()`.
- `stdio.rs:175` is inside `#[cfg(linux)]`, so its output was already right. It is changed for consistency with the other sites.
- `EUNKNOWN` in the hook tests is `SystemErrno::EUNKNOWN`'s current name, the same string `err.code` carries today. #39340 renames it to `UNKNOWN` and should update these assertions with the rest.
- `cargo test -p bun_errno` gains `e_spells_like_system_errno`. It is trivially true on POSIX and checks the new impl on a Windows host. `cargo test` for one crate does not link on Windows today (bun_core needs the C++ symbols), so the hook tests are the Windows coverage in CI.
- The bug is Windows-only. On Linux every test in this PR passes with and without the change.
- Edge cases where `name()` and the old expression differed on Windows: an error with `from_libuv` set printed `UV_ENOENT`, `name()` prints `ENOENT`. An unmapped discriminant printed `SUCCESS`, `name()` prints `UNKNOWN`.
- `bun-install-lifecycle-scripts.test.ts` on Linux: 119 pass, 3 fail because `node` is not on PATH in the container (`node: command not found`). Unrelated to this change.
- A first version of this PR added a source lint that banned `str>::from(...get_errno())`. A review pointed out that the spelling is a property of the type and that the lint had no positive control and missed the let-bound form, so the type-level fix above replaced it.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/translate-uv-error-windows.test.ts, test/js/node/fs/rm-windows-ntstatus.test.ts, test/cli/install/bad-workspace.test.ts

<!-- robobun:evidence:end -->