### PR TITLE
node:fs: name the operation's syscall in the ENAMETOOLONG for an over-long path

### DIFF
--- a/src/jsc/CallFrame.rs
+++ b/src/jsc/CallFrame.rs
@@ -240,6 +240,9 @@ pub struct ArgumentsSlice<'a> {
     pub vm: &'a VirtualMachine,
     pub all: &'a [JSValue],
     pub will_be_async: bool,
+    /// The syscall that an errno from a path converter names (`err.syscall` and
+    /// the message). A binding sets it to the syscall it is about to issue.
+    pub syscall: bun_sys::Tag,
     /// An errno a converter met under `will_be_async`; the binding rejects its promise with it.
     pub deferred_error: Option<Box<bun_sys::SystemError>>,
 }
@@ -258,6 +261,7 @@ impl<'a> ArgumentsSlice<'a> {
             vm,
             all: slice,
             will_be_async: false,
+            syscall: bun_sys::Tag::open,
             deferred_error: None,
         }
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9930,6 +9930,49 @@ pub enum NodeFSFunctionEnum {
 }
 
 impl NodeFSFunctionEnum {
+    /// The syscall this op names in its errors (`err.syscall` and the message).
+    /// An error the argument parser raises before any syscall runs names it too.
+    pub const fn syscall(self) -> sys::Tag {
+        use sys::Tag;
+        match self {
+            Self::Access | Self::Exists => Tag::access,
+            Self::AppendFile | Self::Open | Self::ReadFile | Self::WriteFile => Tag::open,
+            Self::Chmod => Tag::chmod,
+            Self::Chown => Tag::chown,
+            Self::Close => Tag::close,
+            Self::CopyFile => Tag::copyfile,
+            Self::Fchmod => Tag::fchmod,
+            Self::Fchown => Tag::fchown,
+            Self::Fdatasync => Tag::fdatasync,
+            Self::Fstat => Tag::fstat,
+            Self::Fsync => Tag::fsync,
+            Self::Ftruncate => Tag::ftruncate,
+            Self::Futimes => Tag::futime,
+            Self::Lchmod => Tag::lchmod,
+            Self::Lchown => Tag::lchown,
+            Self::Link => Tag::link,
+            Self::Lstat | Self::RealpathNonNative | Self::Rm => Tag::lstat,
+            Self::Lutimes => Tag::lutime,
+            Self::Mkdir => Tag::mkdir,
+            Self::Mkdtemp => Tag::mkdtemp,
+            Self::Read => Tag::read,
+            Self::Readdir => Tag::scandir,
+            Self::Readlink => Tag::readlink,
+            Self::Readv => Tag::readv,
+            Self::Realpath => Tag::realpath,
+            Self::Rename => Tag::rename,
+            Self::Rmdir => Tag::rmdir,
+            Self::Stat => Tag::stat,
+            Self::Statfs => Tag::statfs,
+            Self::Symlink => Tag::symlink,
+            Self::Truncate => Tag::truncate,
+            Self::Unlink => Tag::unlink,
+            Self::Utimes => Tag::utime,
+            Self::Write => Tag::write,
+            Self::Writev => Tag::writev,
+        }
+    }
+
     /// The event-loop [`TaskTag`] of the ops that are libuv requests on
     /// Windows (`UVFSRequest`) and so re-enter through the task queue; every
     /// other async op is a `bun_jsc::Job` and needs none.

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -36,6 +36,7 @@ where
     // for the duration of argument parsing on the JS thread.
     let vm: &VirtualMachine = global.bun_vm();
     let mut slice = ArgumentsSlice::init(vm, frame.arguments());
+    slice.syscall = F.syscall();
     let args = <A as FsArgument>::from_js(global, &mut slice)?;
 
     // R-2: `JsCell::with_mut` scopes the `&mut NodeFS` to the blocking
@@ -57,13 +58,13 @@ where
 /// Windows path picks `UVFSRequest` for a handful of fds-only ops while
 /// everything else uses `AsyncFSTask`, and that choice is encoded in the
 /// `async_::*` type aliases rather than derivable from `F` alone.
-fn run_async<A: FsArgument>(
+fn run_async<A: FsArgument, const F: NodeFSFunctionEnum>(
     this: &Binding,
     global: &JSGlobalObject,
     frame: &CallFrame,
     create_task: fn(&JSGlobalObject, &Binding, ThreadIsolated<A>, &mut VirtualMachine) -> JSValue,
 ) -> JsResult<JSValue> {
-    let args = match parse_async_args::<A>(global, frame) {
+    let args = match parse_async_args::<A>(global, frame, F.syscall()) {
         Ok(args) => args,
         Err(result) => return result,
     };
@@ -72,12 +73,15 @@ fn run_async<A: FsArgument>(
 }
 
 /// Parses a promise-returning binding's arguments; `Err` is what the binding returns instead.
+/// An errno the parser raises for a path names `syscall`.
 fn parse_async_args<A: FsArgument>(
     global: &JSGlobalObject,
     frame: &CallFrame,
+    syscall: bun_sys::Tag,
 ) -> Result<ThreadIsolated<A>, JsResult<JSValue>> {
     let vm: &VirtualMachine = global.bun_vm();
     let mut slice = ArgumentsSlice::init(vm, frame.arguments());
+    slice.syscall = syscall;
     let args = A::from_js_async(global, &mut slice).map_err(Err)?;
 
     let rejection = 'rejection: {
@@ -155,9 +159,12 @@ impl Binding {
 
     // ── Hand-written bindings for ops outside `NodeFSFunctionEnum` ────────
 
+    /// `cp` begins with an `lstat` of `src` (in node too), so its errors name that syscall.
+    const CP_SYSCALL: bun_sys::Tag = bun_sys::Tag::lstat;
+
     /// `callAsync(.cp)`.
     pub(crate) fn cp(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        let cp_args = match parse_async_args::<args::Cp<'static>>(global, frame) {
+        let cp_args = match parse_async_args::<args::Cp<'static>>(global, frame, Self::CP_SYSCALL) {
             Ok(args) => args,
             Err(result) => return result,
         };
@@ -174,6 +181,7 @@ impl Binding {
         // SAFETY: JS-thread borrow of the per-thread VM.
         let vm: &VirtualMachine = global.bun_vm();
         let mut slice = ArgumentsSlice::init(vm, frame.arguments());
+        slice.syscall = Self::CP_SYSCALL;
 
         // `defer args.deinit()` → `Drop` on `cp_args` (its `PathLike` fields).
         let cp_args = args::Cp::from_js(global, &mut slice)?;
@@ -192,7 +200,11 @@ impl Binding {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let rd_args = match parse_async_args::<args::Readdir<'static>>(global, frame) {
+        let rd_args = match parse_async_args::<args::Readdir<'static>>(
+            global,
+            frame,
+            NodeFSFunctionEnum::Readdir.syscall(),
+        ) {
             Ok(args) => args,
             Err(result) => return result,
         };
@@ -216,6 +228,7 @@ impl Binding {
         // SAFETY: JS-thread borrow of the per-thread VM.
         let vm: &VirtualMachine = global.bun_vm();
         let mut slice = ArgumentsSlice::init(vm, frame.arguments());
+        slice.syscall = bun_sys::Tag::watch;
 
         let watch_args = fs::Watcher::Arguments::from_js(global, &mut slice)?;
 
@@ -239,6 +252,7 @@ impl Binding {
         // SAFETY: JS-thread borrow of the per-thread VM.
         let vm: &VirtualMachine = global.bun_vm();
         let mut slice = ArgumentsSlice::init(vm, frame.arguments());
+        slice.syscall = bun_sys::Tag::stat;
 
         let wf_args = fs::StatWatcher::Arguments::from_js(global, &mut slice)?;
 
@@ -265,7 +279,7 @@ macro_rules! node_fs_bindings {
                     global: &JSGlobalObject,
                     frame: &CallFrame,
                 ) -> JsResult<JSValue> {
-                    run_async::<$Args>(this, global, frame, async_::$F::create)
+                    run_async::<$Args, { NodeFSFunctionEnum::$F }>(this, global, frame, async_::$F::create)
                 }
             )*
         }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1171,7 +1171,7 @@ impl PathLikeExt for PathLike<'_> {
         will_be_async: bool,
     ) -> JsResult<PathLike<'static>> {
         let path = path_like_from_string(global, str, will_be_async)?;
-        match Valid::path_too_long(path.slice()) {
+        match Valid::path_too_long(path.slice(), bun_sys::Tag::open) {
             Some(err) => Err(global.throw_value(err.to_error_instance(global))),
             None => Ok(path),
         }
@@ -1224,17 +1224,19 @@ fn shared_or_utf8<T>(
 pub struct Valid;
 
 impl Valid {
-    /// The ENAMETOOLONG the syscall would return: no `PathBuffer` fits this path plus its NUL.
-    pub(crate) fn path_too_long(path: &[u8]) -> Option<bun_sys::SystemError> {
+    /// The ENAMETOOLONG `syscall` would return: no `PathBuffer` fits this path plus its NUL.
+    pub(crate) fn path_too_long(
+        path: &[u8],
+        syscall: bun_sys::Tag,
+    ) -> Option<bun_sys::SystemError> {
         if path.len() < MAX_PATH_BYTES {
             return None;
         }
-        let mut system_error =
-            bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
+        Some(
+            bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, syscall)
                 .with_path(path)
-                .to_system_error();
-        system_error.syscall = bun_core::String::DEAD;
-        Some(system_error)
+                .to_system_error(),
+        )
     }
 
     /// Sync bindings throw; async ones get it as `arguments.deferred_error` and a placeholder path.
@@ -1243,7 +1245,7 @@ impl Valid {
         ctx: &JSGlobalObject,
         arguments: &mut ArgumentsSlice,
     ) -> JsResult<PathLike<'static>> {
-        let Some(err) = Self::path_too_long(path.slice()) else {
+        let Some(err) = Self::path_too_long(path.slice(), arguments.syscall) else {
             return Ok(path);
         };
         drop(path);

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1280,28 +1280,28 @@ impl Tag {
     pub const access: Tag = Tag(2);
     pub const connect: Tag = Tag(3);
     pub const chmod: Tag = Tag(4);
-    pub(crate) const chown: Tag = Tag(5);
+    pub const chown: Tag = Tag(5);
     pub const clonefile: Tag = Tag(6);
     #[cfg(not(target_os = "macos"))]
     pub(crate) const clonefileat: Tag = Tag(7);
     pub const close: Tag = Tag(8);
     pub const copy_file_range: Tag = Tag(9);
     pub const copyfile: Tag = Tag(10);
-    pub(crate) const fchmod: Tag = Tag(11);
+    pub const fchmod: Tag = Tag(11);
     pub const fchmodat: Tag = Tag(12);
-    pub(crate) const fchown: Tag = Tag(13);
+    pub const fchown: Tag = Tag(13);
     pub(crate) const fcntl: Tag = Tag(14);
     pub const fdatasync: Tag = Tag(15);
     pub const fstat: Tag = Tag(16);
     pub const fstatat: Tag = Tag(17);
     pub const fsync: Tag = Tag(18);
-    pub(crate) const ftruncate: Tag = Tag(19);
+    pub const ftruncate: Tag = Tag(19);
     #[cfg(not(windows))]
     pub(crate) const futimens: Tag = Tag(20);
     pub const getdents64: Tag = Tag(21);
     pub const getdirentries64: Tag = Tag(22);
     pub const lchmod: Tag = Tag(23);
-    pub(crate) const lchown: Tag = Tag(24);
+    pub const lchown: Tag = Tag(24);
     pub const link: Tag = Tag(25);
     pub(crate) const lseek: Tag = Tag(26);
     pub const lstat: Tag = Tag(27);
@@ -1318,8 +1318,8 @@ impl Tag {
     pub const read: Tag = Tag(38);
     pub const readlink: Tag = Tag(39);
     pub const rename: Tag = Tag(40);
-    pub(crate) const stat: Tag = Tag(41);
-    pub(crate) const statfs: Tag = Tag(42);
+    pub const stat: Tag = Tag(41);
+    pub const statfs: Tag = Tag(42);
     pub const symlink: Tag = Tag(43);
     #[cfg(not(windows))]
     pub(crate) const symlinkat: Tag = Tag(44);

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -240,8 +240,10 @@ describe.if(isWindows)("Buffer paths containing malformed byte sequences", () =>
 // produces the ENAMETOOLONG itself. Node gets that error from the syscall, so
 // it arrives through the callback like any other syscall error, and the
 // callback APIs (which call the native binding directly, unlike fs.promises'
-// async wrappers) must not throw it synchronously. The lengths clear
-// MAX_PATH_BYTES on every platform: 4096 Linux, 1024 macOS, 98302 Windows.
+// async wrappers) must not throw it synchronously. It also names the syscall
+// the operation would have issued, in `err.syscall` and in the message, the
+// same one the operation's ENOENT names. The lengths clear MAX_PATH_BYTES on
+// every platform: 4096 Linux, 1024 macOS, 98302 Windows.
 describe("callback APIs report a path longer than MAX_PATH_BYTES through the callback", () => {
   const tooLongLength = isWindows ? 100_000 : 5_000;
   const tooLong = (isWindows ? "C:\\" : "/") + Buffer.alloc(tooLongLength, "a").toString();
@@ -251,42 +253,44 @@ describe("callback APIs report a path longer than MAX_PATH_BYTES through the cal
 
   type Callback = (err: unknown) => void;
   // [name, call, whether node reports `tooLong` as `err.path` (it is the
-  // `dest` of the two-operand calls, and mkdtemp appends its suffix)]
-  const calls: [string, (cb: Callback) => void, boolean][] = [
-    ["access", cb => fs.access(tooLong, cb), true],
-    ["appendFile", cb => fs.appendFile(tooLong, "x", cb), true],
-    ["chmod", cb => fs.chmod(tooLong, 0o644, cb), true],
-    ["chown", cb => fs.chown(tooLong, 0, 0, cb), true],
-    ["copyFile", cb => fs.copyFile(tooLong, other, cb), true],
-    ["cp", cb => fs.cp(tooLong, other, cb), true],
-    ["lstat", cb => fs.lstat(tooLong, cb), true],
-    ["mkdir", cb => fs.mkdir(tooLong, cb), true],
-    ["mkdir recursive", cb => fs.mkdir(tooLong, { recursive: true }, cb), true],
-    ["mkdtemp", cb => fs.mkdtemp(tooLong, cb), false],
-    ["open", cb => fs.open(tooLong, "r", cb), true],
-    ["opendir", cb => fs.opendir(tooLong, cb), true],
-    ["readdir", cb => fs.readdir(tooLong, cb), true],
-    ["readdir recursive", cb => fs.readdir(tooLong, { recursive: true }, cb), true],
-    ["readFile", cb => fs.readFile(tooLong, cb), true],
-    ["readlink", cb => fs.readlink(tooLong, cb), true],
-    ["realpath", cb => fs.realpath(tooLong, cb), true],
-    ["realpath.native", cb => fs.realpath.native(tooLong, cb), true],
-    ["rename oldPath", cb => fs.rename(tooLong, other, cb), true],
-    ["rename newPath", cb => fs.rename(other, tooLong, cb), false],
-    ["rm", cb => fs.rm(tooLong, cb), true],
-    ["rmdir", cb => fs.rmdir(tooLong, cb), true],
-    ["stat", cb => fs.stat(tooLong, cb), true],
-    ["stat with a Buffer path", cb => fs.stat(Buffer.from(tooLong), cb), true],
-    ["stat with a file: URL path", cb => fs.stat(pathToFileURL(tooLong), cb), true],
-    ["statfs", cb => fs.statfs(tooLong, cb), true],
-    ["symlink", cb => fs.symlink(other, tooLong, cb), false],
-    ["truncate", cb => fs.truncate(tooLong, cb), true],
-    ["unlink", cb => fs.unlink(tooLong, cb), true],
-    ["utimes", cb => fs.utimes(tooLong, 0, 0, cb), true],
-    ["writeFile", cb => fs.writeFile(tooLong, "x", cb), true],
+  // `dest` of the two-operand calls, and mkdtemp appends its suffix), the
+  // `err.syscall` node reports. Exception: node's truncate is open + ftruncate
+  // and reports `open`; bun issues truncate(2) and reports that for ENOENT too]
+  const calls: [string, (cb: Callback) => void, boolean, string][] = [
+    ["access", cb => fs.access(tooLong, cb), true, "access"],
+    ["appendFile", cb => fs.appendFile(tooLong, "x", cb), true, "open"],
+    ["chmod", cb => fs.chmod(tooLong, 0o644, cb), true, "chmod"],
+    ["chown", cb => fs.chown(tooLong, 0, 0, cb), true, "chown"],
+    ["copyFile", cb => fs.copyFile(tooLong, other, cb), true, "copyfile"],
+    ["cp", cb => fs.cp(tooLong, other, cb), true, "lstat"],
+    ["lstat", cb => fs.lstat(tooLong, cb), true, "lstat"],
+    ["mkdir", cb => fs.mkdir(tooLong, cb), true, "mkdir"],
+    ["mkdir recursive", cb => fs.mkdir(tooLong, { recursive: true }, cb), true, "mkdir"],
+    ["mkdtemp", cb => fs.mkdtemp(tooLong, cb), false, "mkdtemp"],
+    ["open", cb => fs.open(tooLong, "r", cb), true, "open"],
+    ["opendir", cb => fs.opendir(tooLong, cb), true, "opendir"],
+    ["readdir", cb => fs.readdir(tooLong, cb), true, "scandir"],
+    ["readdir recursive", cb => fs.readdir(tooLong, { recursive: true }, cb), true, "scandir"],
+    ["readFile", cb => fs.readFile(tooLong, cb), true, "open"],
+    ["readlink", cb => fs.readlink(tooLong, cb), true, "readlink"],
+    ["realpath", cb => fs.realpath(tooLong, cb), true, "lstat"],
+    ["realpath.native", cb => fs.realpath.native(tooLong, cb), true, "realpath"],
+    ["rename oldPath", cb => fs.rename(tooLong, other, cb), true, "rename"],
+    ["rename newPath", cb => fs.rename(other, tooLong, cb), false, "rename"],
+    ["rm", cb => fs.rm(tooLong, cb), true, "lstat"],
+    ["rmdir", cb => fs.rmdir(tooLong, cb), true, "rmdir"],
+    ["stat", cb => fs.stat(tooLong, cb), true, "stat"],
+    ["stat with a Buffer path", cb => fs.stat(Buffer.from(tooLong), cb), true, "stat"],
+    ["stat with a file: URL path", cb => fs.stat(pathToFileURL(tooLong), cb), true, "stat"],
+    ["statfs", cb => fs.statfs(tooLong, cb), true, "statfs"],
+    ["symlink", cb => fs.symlink(other, tooLong, cb), false, "symlink"],
+    ["truncate", cb => fs.truncate(tooLong, cb), true, "truncate"],
+    ["unlink", cb => fs.unlink(tooLong, cb), true, "unlink"],
+    ["utimes", cb => fs.utimes(tooLong, 0, 0, cb), true, "utime"],
+    ["writeFile", cb => fs.writeFile(tooLong, "x", cb), true, "open"],
   ];
 
-  it.each(calls)("fs.%s", async (_, call, pathIsReported) => {
+  it.each(calls)("fs.%s", async (_, call, pathIsReported, syscall) => {
     const { promise, resolve } = Promise.withResolvers<unknown>();
     let returned = false;
     let calledBeforeReturning = false;
@@ -298,8 +302,14 @@ describe("callback APIs report a path longer than MAX_PATH_BYTES through the cal
     const err = (await promise) as NodeJS.ErrnoException;
     expect(calledBeforeReturning).toBe(false);
     expect(err.code).toBe("ENAMETOOLONG");
+    expect(err.syscall).toBe(syscall);
     if (pathIsReported) {
       expect(err.path).toBe(tooLong);
+    }
+    // opendir reshapes the stat error's message in JS; the others are the
+    // formatter's own, cut off at 4096 bytes for a path this long.
+    if (syscall !== "opendir") {
+      expect(err.message).toStartWith(`ENAMETOOLONG: name too long, ${syscall} '`);
     }
   });
 
@@ -334,11 +344,46 @@ describe("callback APIs report a path longer than MAX_PATH_BYTES through the cal
     );
   });
 
-  it("the sync variants throw it, naming the path", () => {
-    expect(() => fs.statSync(tooLong)).toThrow(expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong }));
-    expect(() => fs.statSync(Buffer.from(tooLong))).toThrow(
-      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong }),
+  it("the sync variants throw it, naming the path and the syscall", () => {
+    expect(() => fs.statSync(tooLong)).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong, syscall: "stat" }),
     );
-    expect(() => fs.renameSync(other, tooLong)).toThrow(expect.objectContaining({ code: "ENAMETOOLONG" }));
+    expect(() => fs.statSync(Buffer.from(tooLong))).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong, syscall: "stat" }),
+    );
+    expect(() => fs.renameSync(other, tooLong)).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", syscall: "rename" }),
+    );
+    expect(() => fs.readdirSync(tooLong)).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong, syscall: "scandir" }),
+    );
+    expect(() => fs.realpathSync(tooLong)).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong, syscall: "lstat" }),
+    );
+    expect(() => fs.realpathSync.native(tooLong)).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong, syscall: "realpath" }),
+    );
+    expect(() => fs.cpSync(tooLong, other)).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong, syscall: "lstat" }),
+    );
+  });
+
+  it("fs.promises rejects with it, naming the syscall", async () => {
+    await expect(fs.promises.readFile(tooLong)).rejects.toMatchObject({
+      code: "ENAMETOOLONG",
+      path: tooLong,
+      syscall: "open",
+    });
+    await expect(fs.promises.readdir(tooLong)).rejects.toMatchObject({
+      code: "ENAMETOOLONG",
+      path: tooLong,
+      syscall: "scandir",
+    });
+  });
+
+  it("fs.watch throws it synchronously, as node does", () => {
+    expect(() => fs.watch(tooLong, () => {})).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong, syscall: "watch" }),
+    );
   });
 });


### PR DESCRIPTION
### Problem
- Every node:fs operation reports an over-long path (MAX_PATH_BYTES or more) as `ENAMETOOLONG` with `err.syscall === undefined`, and a message that says `open` for every operation: `fs.stat(p, cb)` calls back with `ENAMETOOLONG: name too long, open '/aaa...'`. Node names the syscall the operation issues (`stat`, `scandir`, `lstat`, ...), in `err.syscall` and in the message, like any other syscall error from that operation.
- The cause is `Valid::path_too_long` (src/runtime/node/types.rs:1228). The argument parser raises this error before any syscall runs, so it did not know the operation. It built the error with `Tag::open` and blanked `syscall`. #38383 moved the delivery to the callback and left this as a known gap.

### Fix
- `ArgumentsSlice` (src/jsc/CallFrame.rs) gains `syscall: bun_sys::Tag`, default `open`. The parser builds the `ENAMETOOLONG` from it, for the sync throw and for the deferred async rejection alike.
- `NodeFSFunctionEnum::syscall()` (src/runtime/node/node_fs.rs) maps each operation to the tag its own errors carry: the same one its `ENOENT` names today (`readdir` is `scandir`, `rm` and the emulated `realpath` are `lstat`, `utimes` is `utime`). `run_sync`, `run_async` and `parse_async_args` set it before they parse. `cp` uses `lstat`, `fs.watch` uses `watch`, `watchFile` uses `stat`.
- Correct because the error now reads exactly like the error the operation's first syscall would have returned for that path. All three forms (sync, callback, promise) agree. Seven `Tag` constants in `bun_sys` become `pub` so the runtime crate can name them.
- Verified: `test/js/node/fs/fs-path-length.test.ts` (31 callback operations now check `err.syscall` and the message prefix, plus sync, promise and `fs.watch` cases; 33 fail on 1.4.1, all pass with the fix). Also fs.test.ts, cp.test.ts, promises.test.js, dir.test.ts, fs-mkdir.test.ts, fs.watch.test.ts, 34 ported `test-fs-*` files, clippy, and `cargo check` for the Windows and macOS targets.

### Background
- `ArgumentsSlice` is the cursor a native binding walks over a call's arguments. node:fs bindings set `will_be_async` on it so path strings are copied thread-safe, and #38383 added `deferred_error` so a path errno met while parsing for an async call becomes a rejected promise instead of a throw.
- `bun_sys::Tag` is the syscall name on a `bun_sys::Error`. `to_system_error` turns it into `err.syscall` and into the `, <syscall> '<path>'` part of the node-style message.
- Every fs operation copies its path into a fixed `PathBuffer` right before the syscall, so the parser rejects a path of `MAX_PATH_BYTES` or more up front. The kernel's limit is the same (PATH_MAX), so the early `ENAMETOOLONG` is the error the syscall would have produced. Only its name was missing.

<details><summary>Notes</summary>

Node 26.3.0 and this branch, `err.syscall` for a 5001-byte path on Linux, callback form (identical for sync and promise forms):

```
access access | appendFile open | chmod chmod | chown chown | copyFile copyfile
cp lstat | lstat lstat | mkdir mkdir | mkdtemp mkdtemp | open open | opendir opendir
readdir scandir | readFile open | readlink readlink | realpath lstat
realpath.native realpath | rename rename | rm lstat | rmdir rmdir | stat stat
statfs statfs | symlink symlink | link link | unlink unlink | utimes utime
lutimes lutime | lchown lchown | writeFile open
```

Differences that remain, all pre-existing and out of scope here:
- `truncate`: node's truncate is open + ftruncate and names `open`. Bun issues truncate(2) and names `truncate`, for `ENOENT` as well as for this error.
- `fs.promises.realpath`: bun routes it through the emulated realpath (`lstat`), node through the native one (`realpath`).
- The message of a Linux-length path is still cut at 4096 bytes by the formatter in `to_system_error` (#38201 fixes that). `opendir` reshapes the stat error's message in JS and only does so on an un-truncated message, so its message still names `stat` until #38201 lands. Its `err.syscall` is `opendir` already.
- `fs.watchFile(tooLong)` does not throw in node. Bun throws `ENAMETOOLONG`; it now names `stat`.

Other callers of the path parser (`Bun.file`, `Bun.write`, S3 keys, static routes) keep the default `open`: their message already said `open`, and `err.syscall` is now `"open"` instead of `undefined`.

The two S3 tests in `test/js/bun/s3/s3.test.ts` that fail in this container fail because its egress proxy denies the S3 host. They do not touch path parsing.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs-path-length.test.ts

<!-- robobun:evidence:end -->