### PR TITLE
Terminal: open the pty with plain libc, drop libutil

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -440,7 +440,7 @@ When passing an existing `Terminal` object:
 
 ### Platform differences
 
-`Bun.Terminal` uses `openpty()` on Linux and macOS, and ConPTY (`CreatePseudoConsole`) on Windows. The core behavior is the same on every platform: the child sees a TTY, `write()` reaches the child's stdin, child output reaches the `data` callback, and `resize()` updates the child's view. A few details differ:
+`Bun.Terminal` uses a POSIX pseudo-terminal (`posix_openpt()`) on Linux, macOS, and FreeBSD, and ConPTY (`CreatePseudoConsole`) on Windows. The core behavior is the same on every platform: the child sees a TTY, `write()` reaches the child's stdin, child output reaches the `data` callback, and `resize()` updates the child's view. A few details differ:
 
 - **No termios on Windows.** `inputFlags`, `outputFlags`, `localFlags`, and `controlFlags` always read as `0` and setting them is a no-op. `setRawMode()` records the flag but has no effect on the child; the child controls its own console mode.
 - **No echo without a child process on Windows.** On POSIX, the kernel line discipline echoes `write()` input back to the `data` callback even with no process attached. ConPTY has no line discipline; it buffers input for the next reader. If you need echo, spawn a process that echoes.

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -96,10 +96,7 @@ function systemLibs(cfg: Config): string[] {
     // pthread/m: explicit on FreeBSD (not folded into libc).
     // execinfo: backtrace() — separate library on FreeBSD.
     // kvm/procstat/elf: process introspection for node:os and crash handler.
-    // libutil (openpty) is linked statically: its soname bumped .so.9 → .so.10
-    // between 14.x and 15.0, so a dynamic NEEDED entry from the 14.3 sysroot
-    // fails to load on 15.x (#40530). Every other lib here kept its soname.
-    libs.push("-lc", "-lpthread", "-lm", "-lexecinfo", "-lkvm", "-lprocstat", "-lelf", "-l:libutil.a");
+    libs.push("-lc", "-lpthread", "-lm", "-lexecinfo", "-lkvm", "-lprocstat", "-lelf");
   }
 
   if (cfg.windows) {

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -816,7 +816,7 @@ fn open_pty(winsize: &Winsize) -> Result<(Fd, Fd), CreatePtyError> {
             master.close();
             return Err(CreatePtyError::OpenPtyFailed);
         }
-        libc::ioctl(slave, libc::TIOCSWINSZ as _, winsize as *const Winsize);
+        libc::ioctl(slave, libc::TIOCSWINSZ as _, core::ptr::from_ref(winsize));
         Ok((master, Fd::from_native(slave)))
     }
 }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -304,22 +304,13 @@ pub(crate) struct CreateResult {
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum InitError {
     #[error("OpenPtyFailed")]
-    OpenPtyFailed,
+    OpenPtyFailed(sys::Error),
     #[error("DupFailed")]
     DupFailed,
     #[error("WriterStartFailed")]
     WriterStartFailed,
     #[error("ReaderStartFailed")]
     ReaderStartFailed,
-}
-
-impl From<CreatePtyError> for InitError {
-    fn from(e: CreatePtyError) -> Self {
-        match e {
-            CreatePtyError::OpenPtyFailed => InitError::OpenPtyFailed,
-            CreatePtyError::DupFailed => InitError::DupFailed,
-        }
-    }
 }
 
 impl Terminal {
@@ -568,7 +559,9 @@ impl Terminal {
                 Ok(result.terminal.as_ptr())
             }
             Err(err) => Err(match err {
-                InitError::OpenPtyFailed => global_object.throw(format_args!("Failed to open PTY")),
+                InitError::OpenPtyFailed(err) => {
+                    global_object.throw_value(err.to_js(global_object))
+                }
                 InitError::DupFailed => {
                     global_object.throw(format_args!("Failed to duplicate PTY file descriptor"))
                 }
@@ -771,65 +764,16 @@ pub struct PtyResult {
     pub(crate) hpcon: windows::HPCON,
 }
 
-#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
-pub enum CreatePtyError {
-    #[error("OpenPtyFailed")]
-    OpenPtyFailed,
-    #[error("DupFailed")]
-    DupFailed,
-}
-
-fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
-    #[cfg(unix)]
-    return create_pty_posix(cols, rows);
-    #[cfg(windows)]
-    return create_pty_windows(cols, rows);
-}
-
-pub use bun_core::Winsize;
-
-/// `openpty(3)` over plain libc, so no libutil is needed on Linux or FreeBSD.
 #[cfg(unix)]
-fn open_pty(winsize: &Winsize) -> Result<(Fd, Fd), CreatePtyError> {
-    // The `libc` crate does not bind this on macOS.
-    unsafe extern "C" {
-        fn ptsname_r(fd: libc::c_int, buf: *mut libc::c_char, buflen: usize) -> libc::c_int;
-    }
-    // SAFETY: plain libc calls on an fd we own; `name` is a writable buffer of
-    // the length passed.
-    unsafe {
-        let master = libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY);
-        if master < 0 {
-            return Err(CreatePtyError::OpenPtyFailed);
-        }
-        let master = Fd::from_native(master);
-        let mut name = [0u8; 128];
-        if libc::grantpt(master.native()) != 0
-            || libc::unlockpt(master.native()) != 0
-            || ptsname_r(master.native(), name.as_mut_ptr().cast(), name.len()) != 0
-        {
-            master.close();
-            return Err(CreatePtyError::OpenPtyFailed);
-        }
-        let slave = libc::open(name.as_ptr().cast(), libc::O_RDWR | libc::O_NOCTTY);
-        if slave < 0 {
-            master.close();
-            return Err(CreatePtyError::OpenPtyFailed);
-        }
-        libc::ioctl(slave, libc::TIOCSWINSZ as _, core::ptr::from_ref(winsize));
-        Ok((master, Fd::from_native(slave)))
-    }
-}
-
-#[cfg(unix)]
-fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
-    let winsize = Winsize {
+fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, InitError> {
+    let winsize = bun_core::Winsize {
         row: rows,
         col: cols,
         xpixel: 0,
         ypixel: 0,
     };
-    let (master_fd_desc, slave_fd_desc) = open_pty(&winsize)?;
+    let (master_fd_desc, slave_fd_desc) =
+        sys::posix::openpty(winsize).map_err(InitError::OpenPtyFailed)?;
     let slave_fd = slave_fd_desc.native();
 
     // Configure sensible terminal defaults matching node-pty behavior.
@@ -910,7 +854,7 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
         sys::Result::Err(_) => {
             master_fd_desc.close();
             slave_fd_desc.close();
-            return Err(CreatePtyError::DupFailed);
+            return Err(InitError::DupFailed);
         }
     };
 
@@ -920,7 +864,7 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
             master_fd_desc.close();
             slave_fd_desc.close();
             read_fd.close();
-            return Err(CreatePtyError::DupFailed);
+            return Err(InitError::DupFailed);
         }
     };
 
@@ -932,7 +876,6 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
 
     // Set close-on-exec on master side fds only
     // slave_fd should NOT have close-on-exec since child needs to inherit it
-    let _ = crate::api::bun_process::spawn_sys::set_close_on_exec(master_fd_desc);
     let _ = crate::api::bun_process::spawn_sys::set_close_on_exec(read_fd);
     let _ = crate::api::bun_process::spawn_sys::set_close_on_exec(write_fd);
 
@@ -970,7 +913,7 @@ fn create_overlapped_pipe_pair(
     // PIPE_ACCESS_INBOUND: server reads, client writes.
     // PIPE_ACCESS_OUTBOUND: server writes, client reads.
     server_access: u32,
-) -> Result<PipePair, CreatePtyError> {
+) -> Result<PipePair, InitError> {
     use windows::kernel32 as k32;
     const FILE_FLAG_FIRST_PIPE_INSTANCE: u32 = 0x00080000;
 
@@ -989,7 +932,10 @@ fn create_overlapped_pipe_pair(
             ""
         };
         if write!(cursor, r"\\.\pipe\{local}bun-conpty-{pid}-{counter}").is_err() {
-            return Err(CreatePtyError::OpenPtyFailed);
+            return Err(InitError::OpenPtyFailed(sys::Error::from_code(
+                sys::E::ENAMETOOLONG,
+                sys::Tag::openpty,
+            )));
         }
         let written = 96 - cursor.len();
         &name_utf8_buf[..written]
@@ -1014,7 +960,10 @@ fn create_overlapped_pipe_pair(
         )
     };
     if server == windows::INVALID_HANDLE_VALUE {
-        return Err(CreatePtyError::OpenPtyFailed);
+        return Err(InitError::OpenPtyFailed(sys::Error::from_code(
+            windows::get_last_errno(),
+            sys::Tag::openpty,
+        )));
     }
     let server_guard = scopeguard::guard(server, |h| unsafe {
         // SAFETY: h is a valid open HANDLE on the error path.
@@ -1040,7 +989,10 @@ fn create_overlapped_pipe_pair(
         )
     };
     if client == windows::INVALID_HANDLE_VALUE {
-        return Err(CreatePtyError::OpenPtyFailed);
+        return Err(InitError::OpenPtyFailed(sys::Error::from_code(
+            windows::get_last_errno(),
+            sys::Tag::openpty,
+        )));
     }
 
     let server = scopeguard::ScopeGuard::into_inner(server_guard);
@@ -1051,7 +1003,7 @@ fn create_overlapped_pipe_pair(
 static PIPE_SERIAL: AtomicU32 = AtomicU32::new(0);
 
 #[cfg(windows)]
-fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
+fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, InitError> {
     // Track ownership explicitly: handles are nulled out as they are closed or
     // transferred so the errdefer cleanup never double-closes.
     let mut out_server: Option<windows::HANDLE> = None;
@@ -1122,12 +1074,17 @@ fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError>
     {
         let mut pc: windows::HPCON = core::ptr::null_mut();
         // SAFETY: in_client/out_client are valid open HANDLEs; pc is a valid out-ptr.
-        if unsafe {
+        let hr = unsafe {
             windows::CreatePseudoConsole(size, in_client.unwrap(), out_client.unwrap(), 0, &mut pc)
-        } < 0
-        {
+        };
+        if hr < 0 {
             cleanup!();
-            return Err(CreatePtyError::OpenPtyFailed);
+            return Err(InitError::OpenPtyFailed(sys::Error::from_code(
+                sys::SystemErrno::init(windows::HRESULT_CODE(hr) as u32)
+                    .unwrap_or(sys::SystemErrno::EUNKNOWN)
+                    .to_e(),
+                sys::Tag::openpty,
+            )));
         }
         hpcon = Some(pc);
     }
@@ -1151,7 +1108,7 @@ fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError>
         }
         Err(_) => {
             cleanup!();
-            return Err(CreatePtyError::DupFailed);
+            return Err(InitError::DupFailed);
         }
     };
     // errdefer read_fd.close()
@@ -1161,7 +1118,7 @@ fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError>
         Ok(fd) => fd,
         Err(_) => {
             cleanup!();
-            return Err(CreatePtyError::DupFailed);
+            return Err(InitError::DupFailed);
         }
     };
 
@@ -1419,16 +1376,7 @@ impl Terminal {
                 ypixel: 0,
             };
 
-            // SAFETY: master_fd is open (closed flag checked above), TIOCSWINSZ
-            // takes a *const winsize.
-            let ioctl_result = unsafe {
-                libc::ioctl(
-                    self.master_fd.get().native(),
-                    libc::TIOCSWINSZ as _,
-                    &raw const winsize,
-                )
-            };
-            if ioctl_result != 0 {
+            if sys::posix::set_winsize(self.master_fd.get(), winsize).is_err() {
                 return Err(global_object.throw(format_args!("Failed to resize terminal")));
             }
         }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -10,7 +10,7 @@
 //! - Callbacks are stored via `values` in classes.ts, accessed via js.gc
 
 use core::cell::Cell;
-use core::ffi::{c_int, c_void};
+use core::ffi::c_void;
 #[cfg(windows)]
 use core::sync::atomic::{AtomicU32, Ordering};
 
@@ -307,8 +307,6 @@ pub enum InitError {
     OpenPtyFailed,
     #[error("DupFailed")]
     DupFailed,
-    #[error("NotSupported")]
-    NotSupported,
     #[error("WriterStartFailed")]
     WriterStartFailed,
     #[error("ReaderStartFailed")]
@@ -320,7 +318,6 @@ impl From<CreatePtyError> for InitError {
         match e {
             CreatePtyError::OpenPtyFailed => InitError::OpenPtyFailed,
             CreatePtyError::DupFailed => InitError::DupFailed,
-            CreatePtyError::NotSupported => InitError::NotSupported,
         }
     }
 }
@@ -575,9 +572,6 @@ impl Terminal {
                 InitError::DupFailed => {
                     global_object.throw(format_args!("Failed to duplicate PTY file descriptor"))
                 }
-                InitError::NotSupported => {
-                    global_object.throw(format_args!("PTY not supported on this platform"))
-                }
                 InitError::WriterStartFailed => {
                     global_object.throw(format_args!("Failed to start terminal writer"))
                 }
@@ -783,158 +777,60 @@ pub enum CreatePtyError {
     OpenPtyFailed,
     #[error("DupFailed")]
     DupFailed,
-    #[error("NotSupported")]
-    NotSupported,
 }
 
 fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
     #[cfg(unix)]
-    {
-        return create_pty_posix(cols, rows);
-    }
+    return create_pty_posix(cols, rows);
     #[cfg(windows)]
-    {
-        return create_pty_windows(cols, rows);
-    }
-    #[cfg(not(any(unix, windows)))]
-    Err(CreatePtyError::NotSupported)
-}
-
-// OpenPtyTermios is required for the openpty() extern signature even though we pass null.
-// Kept for type correctness of the C function declaration.
-#[repr(C)]
-pub struct OpenPtyTermios {
-    pub c_iflag: u32,
-    pub c_oflag: u32,
-    pub c_cflag: u32,
-    pub c_lflag: u32,
-    pub c_cc: [u8; 20],
-    pub c_ispeed: u32,
-    pub c_ospeed: u32,
+    return create_pty_windows(cols, rows);
 }
 
 pub use bun_core::Winsize;
 
-pub type OpenPtyFn = unsafe extern "C" fn(
-    amaster: *mut c_int,
-    aslave: *mut c_int,
-    name: *mut u8,
-    termp: *const OpenPtyTermios,
-    winp: *const Winsize,
-) -> c_int;
-
-/// Dynamic loading of openpty on Linux (it's in libutil which may not be linked)
-#[cfg(any(target_os = "linux", target_os = "android"))]
-mod lib_util {
-    use super::*;
-    use bun_core::ZStr;
-
-    // Per PORTING.md §Global mutable state: the flag is an AtomicBool and the
-    // handle slot an AtomicPtr (null ⇔ None — dlopen never yields a null Some).
-    // JS-thread-only.
-    static HANDLE: core::sync::atomic::AtomicPtr<c_void> =
-        core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
-    static LOADED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
-
-    fn get_handle() -> Option<*mut c_void> {
-        use core::sync::atomic::Ordering::Relaxed;
-        if LOADED.load(Relaxed) {
-            let h = HANDLE.load(Relaxed);
-            return if h.is_null() { None } else { Some(h) };
-        }
-        LOADED.store(true, Relaxed);
-
-        // Try libutil.so first (most common), then libutil.so.1
-        const LIB_NAMES: [&ZStr; 3] = [
-            bun_core::zstr!("libutil.so"),
-            bun_core::zstr!("libutil.so.1"),
-            bun_core::zstr!("libc.so.6"),
-        ];
-        for lib_name in LIB_NAMES {
-            if let Some(h) = sys::dlopen(lib_name, sys::RTLD::LAZY) {
-                HANDLE.store(h, Relaxed);
-                return Some(h);
-            }
-        }
-        None
-    }
-
-    pub(super) fn get_open_pty() -> Option<OpenPtyFn> {
-        sys::dlsym_with_handle!(OpenPtyFn, "openpty", get_handle())
-    }
-}
-
+/// `openpty(3)` over plain libc, so no libutil is needed on Linux or FreeBSD.
 #[cfg(unix)]
-fn get_open_pty_fn() -> Option<OpenPtyFn> {
-    // openpty is linked directly on macOS (libc) and FreeBSD (libutil, see
-    // scripts/build/bun.ts).
-    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-    {
-        // Declared locally (not via the `libc` crate) so the `OpenPtyFn`
-        // type unifies with the Linux dlsym path.
-        unsafe extern "C" {
-            // SAFETY precondition: out-param fd pointers must be writable and
-            // termp/winp must be null or valid — raw-pointer contract. Kept
-            // `unsafe` so the fn item coerces to `OpenPtyFn` (unsafe fn ptr).
-            pub(crate) fn openpty(
-                amaster: *mut c_int,
-                aslave: *mut c_int,
-                name: *mut u8,
-                termp: *const OpenPtyTermios,
-                winp: *const Winsize,
-            ) -> c_int;
+fn open_pty(winsize: &Winsize) -> Result<(Fd, Fd), CreatePtyError> {
+    // The `libc` crate does not bind this on macOS.
+    unsafe extern "C" {
+        fn ptsname_r(fd: libc::c_int, buf: *mut libc::c_char, buflen: usize) -> libc::c_int;
+    }
+    // SAFETY: plain libc calls on an fd we own; `name` is a writable buffer of
+    // the length passed.
+    unsafe {
+        let master = libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY);
+        if master < 0 {
+            return Err(CreatePtyError::OpenPtyFailed);
         }
-        return Some(openpty);
+        let master = Fd::from_native(master);
+        let mut name = [0u8; 128];
+        if libc::grantpt(master.native()) != 0
+            || libc::unlockpt(master.native()) != 0
+            || ptsname_r(master.native(), name.as_mut_ptr().cast(), name.len()) != 0
+        {
+            master.close();
+            return Err(CreatePtyError::OpenPtyFailed);
+        }
+        let slave = libc::open(name.as_ptr().cast(), libc::O_RDWR | libc::O_NOCTTY);
+        if slave < 0 {
+            master.close();
+            return Err(CreatePtyError::OpenPtyFailed);
+        }
+        libc::ioctl(slave, libc::TIOCSWINSZ as _, winsize as *const Winsize);
+        Ok((master, Fd::from_native(slave)))
     }
-
-    // On Linux, openpty is in libutil, which may not be linked
-    // Load it dynamically via dlopen
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    {
-        return lib_util::get_open_pty();
-    }
-
-    #[cfg(not(any(
-        target_os = "macos",
-        target_os = "linux",
-        target_os = "android",
-        target_os = "freebsd"
-    )))]
-    None
 }
 
 #[cfg(unix)]
 fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
-    let Some(openpty_fn) = get_open_pty_fn() else {
-        return Err(CreatePtyError::NotSupported);
-    };
-
-    let mut master_fd: c_int = -1;
-    let mut slave_fd: c_int = -1;
-
     let winsize = Winsize {
         row: rows,
         col: cols,
         xpixel: 0,
         ypixel: 0,
     };
-
-    // SAFETY: openpty writes to master_fd/slave_fd; name/termp are null (allowed).
-    let result = unsafe {
-        openpty_fn(
-            &raw mut master_fd,
-            &raw mut slave_fd,
-            core::ptr::null_mut(),
-            core::ptr::null(),
-            &raw const winsize,
-        )
-    };
-    if result != 0 {
-        return Err(CreatePtyError::OpenPtyFailed);
-    }
-
-    let master_fd_desc = Fd::from_native(master_fd);
-    let slave_fd_desc = Fd::from_native(slave_fd);
+    let (master_fd_desc, slave_fd_desc) = open_pty(&winsize)?;
+    let slave_fd = slave_fd_desc.native();
 
     // Configure sensible terminal defaults matching node-pty behavior.
     // These are "cooked mode" defaults that most terminal applications expect.

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -827,8 +827,8 @@ fn spawn_maybe_sync(
                             Ok(created) => **terminal_info = Some(created),
                             Err(err) => {
                                 return Err(match err {
-                                    TerminalInitError::OpenPtyFailed => {
-                                        global_this.throw(format_args!("Failed to open PTY"))
+                                    TerminalInitError::OpenPtyFailed(err) => {
+                                        global_this.throw_value(err.to_js(global_this))
                                     }
                                     TerminalInitError::DupFailed => global_this.throw(
                                         format_args!("Failed to duplicate PTY file descriptor"),

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -833,8 +833,6 @@ fn spawn_maybe_sync(
                                     TerminalInitError::DupFailed => global_this.throw(
                                         format_args!("Failed to duplicate PTY file descriptor"),
                                     ),
-                                    TerminalInitError::NotSupported => global_this
-                                        .throw(format_args!("PTY not supported on this platform")),
                                     TerminalInitError::WriterStartFailed => global_this
                                         .throw(format_args!("Failed to start terminal writer")),
                                     TerminalInitError::ReaderStartFailed => global_this

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8116,9 +8116,11 @@ pub mod posix {
             // on the /dev/pts/N path is needed (what glibc's openpty does).
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
+                // `_IO('T', 0x41)`; the `libc` crate lacks it on Android.
+                const TIOCGPTPEER: c_int = 0x5441;
                 // SAFETY: TIOCGPTPEER takes open(2) flags by value and returns a new fd.
                 let fd = unsafe {
-                    libc::ioctl(master.native(), libc::TIOCGPTPEER as _, O::RDWR | O::NOCTTY)
+                    libc::ioctl(master.native(), TIOCGPTPEER as _, O::RDWR | O::NOCTTY)
                 };
                 if fd >= 0 {
                     return Ok(Fd::from_native(fd));

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1393,6 +1393,7 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    pub const openpty: Tag = Tag(108);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1400,7 +1401,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 109] = [
             "TODO",
             "dup",
             "access",
@@ -1510,6 +1511,7 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "openpty",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -1609,6 +1611,11 @@ mod safe_libc {
         ) -> c_int;
         pub(crate) safe fn getrlimit(resource: c_int, rlim: &mut libc::rlimit) -> c_int;
         pub(crate) safe fn setrlimit(resource: c_int, rlim: &libc::rlimit) -> c_int;
+        pub(crate) safe fn posix_openpt(flags: c_int) -> c_int;
+        pub(crate) safe fn grantpt(fd: c_int) -> c_int;
+        pub(crate) safe fn unlockpt(fd: c_int) -> c_int;
+        // Not bound by the `libc` crate on macOS. Writes at most `len` bytes.
+        pub(crate) safe fn ptsname_r(fd: c_int, buf: &mut [u8; 128], len: usize) -> c_int;
     }
 }
 
@@ -8072,6 +8079,78 @@ pub mod posix {
             return Err(super::err_with(super::Tag::ioctl));
         }
         Ok(())
+    }
+    #[cfg(unix)]
+    pub fn set_winsize(
+        fd: super::Fd,
+        winsize: bun_core::Winsize,
+    ) -> core::result::Result<(), super::Error> {
+        // SAFETY: TIOCSWINSZ reads `sizeof(winsize)` bytes from the local `winsize`
+        // (same layout as `libc::winsize`); bad fd → ENOTTY/EBADF.
+        let rc = unsafe { libc::ioctl(fd.native(), libc::TIOCSWINSZ as _, &raw const winsize) };
+        if rc != 0 {
+            return Err(super::err_with(super::Tag::ioctl));
+        }
+        Ok(())
+    }
+
+    /// `openpty(3)` over plain libc (no libutil): returns `(master, slave)`.
+    /// The master is close-on-exec; the slave is not, so a child can inherit it.
+    #[cfg(unix)]
+    pub fn openpty(
+        winsize: bun_core::Winsize,
+    ) -> core::result::Result<(super::Fd, super::Fd), super::Error> {
+        use super::{Fd, FdExt as _, O, Tag, err_with};
+        use crate::safe_libc::{grantpt, posix_openpt, ptsname_r, unlockpt};
+
+        let master = posix_openpt(O::RDWR | O::NOCTTY | O::CLOEXEC);
+        if master < 0 {
+            return Err(err_with(Tag::openpty));
+        }
+        let master = Fd::from_native(master);
+        let slave = (|| {
+            if grantpt(master.native()) != 0 || unlockpt(master.native()) != 0 {
+                return Err(err_with(Tag::openpty));
+            }
+            // Linux: get the slave from the master fd itself, so no permission
+            // on the /dev/pts/N path is needed (what glibc's openpty does).
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                // SAFETY: TIOCGPTPEER takes open(2) flags by value and returns a new fd.
+                let fd = unsafe {
+                    libc::ioctl(master.native(), libc::TIOCGPTPEER as _, O::RDWR | O::NOCTTY)
+                };
+                if fd >= 0 {
+                    return Ok(Fd::from_native(fd));
+                }
+            }
+            let mut name = [0u8; 128];
+            let len = name.len();
+            // glibc/musl return the error number (musl without setting errno);
+            // macOS/FreeBSD return -1 and set errno.
+            let rc = ptsname_r(master.native(), &mut name, len);
+            if rc != 0 {
+                let errno = if rc > 0 { rc } else { super::last_errno() };
+                return Err(super::Error::from_code_int(errno, Tag::openpty));
+            }
+            let name = bun_core::ZStr::from_cstr(
+                core::ffi::CStr::from_bytes_until_nul(&name).expect("ptsname_r NUL-terminates"),
+            );
+            super::open(name, O::RDWR | O::NOCTTY, 0)
+        })();
+        let slave = match slave {
+            Ok(slave) => slave,
+            Err(err) => {
+                master.close();
+                return Err(err);
+            }
+        };
+        if let Err(err) = set_winsize(slave, winsize) {
+            master.close();
+            slave.close();
+            return Err(err);
+        }
+        Ok((master, slave))
     }
 
     // ── rlimit ──

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8119,9 +8119,8 @@ pub mod posix {
                 // `_IO('T', 0x41)`; the `libc` crate lacks it on Android.
                 const TIOCGPTPEER: c_int = 0x5441;
                 // SAFETY: TIOCGPTPEER takes open(2) flags by value and returns a new fd.
-                let fd = unsafe {
-                    libc::ioctl(master.native(), TIOCGPTPEER as _, O::RDWR | O::NOCTTY)
-                };
+                let fd =
+                    unsafe { libc::ioctl(master.native(), TIOCGPTPEER as _, O::RDWR | O::NOCTTY) };
                 if fd >= 0 {
                     return Ok(Fd::from_native(fd));
                 }


### PR DESCRIPTION
### What does this PR do?

`Bun.Terminal` now creates its pty with `posix_openpt` / `grantpt` / `unlockpt` / `ptsname_r` + `open`, all of which are in libc on every unix target, instead of calling `openpty()` from libutil.

That removes the libutil dependency entirely:

- FreeBSD: no `-lutil` / `-l:libutil.a` on the link line any more (follow-up to #40532 / #40530 — nothing left to break across the 14→15 soname bump).
- Linux: the runtime `dlopen("libutil.so")` + `dlsym("openpty")` path is gone. On a system without the `libutil.so` dev symlink that path could fail and surface as "PTY not supported on this platform"; that error and the `NotSupported` variant are removed since every unix path now always has an implementation.
- macOS: unchanged in effect (was already libc), just goes through the same code.

No floor changes: these calls are in glibc since 2.1, musl, bionic, macOS ≥ 10.13.4, FreeBSD ≥ 12.2.

### How did you verify your code works?

- `bun bd test test/js/bun/terminal/terminal.test.ts` and `terminal-spawn.test.ts` pass on Linux x64.
- Drove the debug binary: `new Bun.Terminal({cols:100, rows:30})` + `Bun.spawn(["sh","-c","stty size; tty"])` prints `30 100` and `/dev/pts/N`.
- `cargo check -p bun_runtime --target aarch64-apple-darwin` and `--target x86_64-unknown-freebsd` are clean.
- `ldd build/debug/bun-debug | grep util` → nothing.
