### PR TITLE
test: do not set the Accessor attribute on an indexed spyOn data property

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1543,8 +1543,6 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             if (hasValue)
                 attributes = slot.attributes();
 
-            attributes |= PropertyAttribute::Accessor;
-
             if (JSModuleNamespaceObject* moduleNamespaceObject = tryJSDynamicCast<JSModuleNamespaceObject*>(object)) {
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
@@ -1552,7 +1550,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 // For indexed properties, set the mock directly instead of wrapping in GetterSetter
                 object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
             } else {
-                object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
+                object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes | PropertyAttribute::Accessor);
             }
 
             // mock->setName(propertyKey.publicName());

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1157,6 +1157,41 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    test("spyOn works with indexed properties that hold a non-function value", () => {
+      const arr = [1, 2, 3];
+      const fn = spyOn(arr, 0);
+      expect(arr[0]).toBe(fn);
+      expect(Object.getOwnPropertyDescriptor(arr, 0)).toEqual({
+        value: fn,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(arr[0]()).toBe(1);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      arr[0] = 42;
+      expect(arr[0]).toBe(42);
+
+      fn.mockRestore();
+      expect(arr[0]).toBe(1);
+    });
+
+    test("spyOn works with a missing indexed property", () => {
+      const obj = {};
+      const fn = spyOn(obj, 169);
+      expect(obj[169]).toBe(fn);
+      expect(spyOn(obj, 169)).toBe(fn);
+      expect(obj[169]()).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      obj[169] = "x";
+      expect(obj[169]).toBe("x");
+
+      fn.mockRestore();
+      expect(obj[169]).toBeUndefined();
+    });
+
     // The engine serves a function's `prototype` property specially, so it cannot be
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {


### PR DESCRIPTION
### What does this PR do?

`spyOn(target, index)` with an array index key stores the mock itself as a data property. The non-callable path (the target value is not a function, or the property does not exist) still ORed `PropertyAttribute::Accessor` into the attributes before the `putDirectIndex` call. The sparse map entry then had the `Accessor` bit and a plain function value.

Two things went wrong with that entry:

- A read of the property. `SparseArrayEntry::get` sees a non-`GetterSetter` value and calls `PropertySlot::setValue` with the `Accessor` bit. Debug builds hit the assertion at `PropertySlot.h:226`.
- A write to the property. `SparseArrayEntry::put` sees the `Accessor` bit and calls `callSetter` on the mock as if it were a `GetterSetter`. Release builds segfault at address `0x38`.

The fix adds the `Accessor` bit only on the `putDirectAccessor` path, where the value is a real `GetterSetter`. The indexed path and the module namespace path keep the original attributes.

Repro on the current release build:

```js
const { spyOn } = require("bun:test");
const obj = {};
spyOn(obj, 169);
obj[169] = "x"; // segfault
```

Found by the fuzzer (fingerprint `PropertySlot.h(226)`).

### How did you verify your code works?

- `bun bd test test/js/bun/test/mock-fn.test.js`: 88 pass.
- The new test `spyOn works with a missing indexed property` segfaults with `USE_SYSTEM_BUN=1 bun test`.
- Both new tests hit the `PropertySlot.h:226` assertion on the unfixed debug build.
- The fuzzer script runs clean on the fixed debug build.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.1 (731aa92da)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [2.21ms]
(pass) mock() > mock [6.72ms]
(pass) mock() > checks the this value > mock [6.82ms]
(pass) mock() > checks the this value > _protoImpl [0.70ms]
(pass) mock() > checks the this value > getMockImplementation [1.10ms]
(pass) mock() > checks the this value > getMockName [1.31ms]
(pass) mock() > checks the this value > mockClear [0.61ms]
(pass) mock() > checks the this value > mockReset [0.56ms]
(pass) mock() > checks the this value > mockRestore [0.62ms]
(pass) mock() > checks the this value > mockImplementation [0.60ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.79ms]
(pass) mock() > checks the this value > withImplementation [0.54ms]
(pass) mock() > checks the this value > mockName [0.61ms]
(pass) mock() > checks the this value > mockReturnThis [0.53ms]
(pass) mock() > checks the this value > mockReturnValue [0.47ms]
(pass) mock() > checks the this value
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.1-canary.1 (731aa92da)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.02ms]
(pass) mock() > mock [0.09ms]
(pass) mock() > checks the this value > mock [0.11ms]
(pass) mock() > checks the this value > _protoImpl [0.01ms]
(pass) mock() > checks the this value > getMockImplementation [0.02ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce [0.03ms]
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the this value
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.1 (731aa92da)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.92ms]
(pass) mock() > mock [6.86ms]
(pass) mock() > checks the this value > mock [6.81ms]
(pass) mock() > checks the this value > _protoImpl [0.71ms]
(pass) mock() > checks the this value > getMockImplementation [1.10ms]
(pass) mock() > checks the this value > getMockName [1.03ms]
(pass) mock() > checks the this value > mockClear [0.58ms]
(pass) mock() > checks the this value > mockReset [0.56ms]
(pass) mock() > checks the this value > mockRestore [0.60ms]
(pass) mock() > checks the this value > mockImplementation [0.60ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.78ms]
(pass) mock() > checks the this value > withImplementation [0.64ms]
(pass) mock() > checks the this value > mockName [0.60ms]
(pass) mock() > checks the this value > mockReturnThis [0.51ms]
(pass) mock() > checks the this value > mockReturnValue [0.48ms]
(pass) mock() > checks the this value
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2e16e11a50
  features     baseline

23 deps, 129 codegen, 1172 objects in 745ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (731aa92da)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (731aa92da)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (731aa92da)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] gen .bind.ts → GeneratedBindings.cpp
[8/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1217] fetch zlib
[zlib] up to date
[11/1217] fetch tinycc
[t
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp |  4 +---
 test/js/bun/test/mock-fn.test.js    | 35 +++++++++++++++++++++++++++++++++++
 2 files changed, 36 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp      2      1      0
test/js/bun/test/mock-fn.test.js         1      1      0
```

</details>

<!-- robobun:evidence:end -->