### PR TITLE
docs: add Oxford comma in design goals description

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -118,7 +118,7 @@ Browsers ship with JavaScript runtimes that implement a set of Web-specific APIs
 
 Node.js is a JavaScript runtime for non-browser environments, like servers. JavaScript programs executed by Node.js have access to a set of Node.js-specific [globals](https://nodejs.org/api/globals.html) like `Buffer`, `process`, and `__dirname` in addition to built-in modules for OS-level tasks like reading/writing files (`node:fs`) and networking (`node:net`, `node:http`). Node.js also implements a CommonJS-based module system and resolution algorithm that pre-dates JavaScript's native module system.
 
-Bun is designed as a faster, leaner, more modern replacement for Node.js.
+Bun is designed as a faster, leaner, and more modern replacement for Node.js.
 
 ## Design goals
 


### PR DESCRIPTION
Adds Oxford comma for consistency and readability: 'a faster, leaner, more modern replacement' -> 'a faster, leaner, and more modern replacement'.