### PR TITLE
leaksan: follow the Bun::generateModule rename to Bun::generateInternalModule

### DIFF
--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -23,14 +23,15 @@ leak:start_wqthread
 leak:CRYPTO_set_thread_local
 leak:BIO_new
 leak:_tlv_get_addr
-# Bun::generateInternalModule (InternalModuleRegistry.cpp) evaluates a builtin
-# JS module (node:fs, ...). Native state the module creates on load, such as the
-# node:fs Binding box behind $lazy("fs"), is owned by a JSC cell. JSC's heap is
-# libpas memory, which LSAN does not scan, so that state reads as a direct leak
-# whenever the VM is not torn down before exit (a macro VM inside `bun build`).
-# The entry must track the function's name: it was Bun::generateModule until
-# the rename in #40597 made the old entry match nothing.
-leak:Bun::generateInternalModule
+# Bun::generateInternalModule (InternalModuleRegistry.cpp) runs a builtin JS
+# module's top level. Covers the node:fs Binding box that $lazy("fs") hands to
+# the NodeJSFS cell: JSC cells live in libpas memory, which LSAN does not scan,
+# so the box reads as a direct leak in a VM that is never torn down (the macro
+# VM inside `bun build`). Anchored so the lambda inside
+# Bun::generateInternalModuleSourceCode does not match too. Delete once
+# `bun build` tears down its macro VM on exit or the box is LSAN-ignored where
+# it is allocated.
+leak:^Bun::generateInternalModule(
 leak:Zig::ImportMetaObject::createFromSpecifier
 leak:Zig::GlobalObject::moduleLoaderResolve
 leak:JSModuleLoader__import

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -23,7 +23,14 @@ leak:start_wqthread
 leak:CRYPTO_set_thread_local
 leak:BIO_new
 leak:_tlv_get_addr
-leak:Bun::generateModule
+# Bun::generateInternalModule (InternalModuleRegistry.cpp) evaluates a builtin
+# JS module (node:fs, ...). Native state the module creates on load, such as the
+# node:fs Binding box behind $lazy("fs"), is owned by a JSC cell. JSC's heap is
+# libpas memory, which LSAN does not scan, so that state reads as a direct leak
+# whenever the VM is not torn down before exit (a macro VM inside `bun build`).
+# The entry must track the function's name: it was Bun::generateModule until
+# the rename in #40597 made the old entry match nothing.
+leak:Bun::generateInternalModule
 leak:Zig::ImportMetaObject::createFromSpecifier
 leak:Zig::GlobalObject::moduleLoaderResolve
 leak:JSModuleLoader__import


### PR DESCRIPTION
### Problem
- `test/bundler/transpiler/macro-test.test.ts` is red on the debian 13 x64-asan lane. `bun build` with a macro that imports `node:fs` exits 134: `LeakSanitizer: detected memory leaks`, `Direct leak of 4104 byte(s)` from `Box::new` in `bun_runtime::node::node_fs_binding::create_binding` (`src/runtime/node/node_fs_binding.rs:329`).
- #40597 renamed `Bun::generateModule` to `Bun::generateInternalModule` (`src/jsc/bindings/InternalModuleRegistry.cpp:103`). `test/leaksan.supp:26` kept the old name, so the entry matched nothing. Every build with #40597 fails, including its own. Builds without it pass.

### Fix
- Replace the entry with `leak:^Bun::generateInternalModule(`. The anchor matches the function only, not the lambda in `Bun::generateInternalModuleSourceCode`, which the old entry never covered.
- The leak is a false positive and not new. The `NodeJSFS` JSC cell owns the box. The macro VM inside `bun build` is never torn down, so the finalizer never runs. Before #40597 the entry suppressed exactly this allocation (`print_suppressions=1`: `1 4104 Bun::generateModule`).
- Verified: `bun bd test test/bundler/transpiler/macro-test.test.ts` with the CI LSan environment. Old file: 21 pass, 1 fail (the CI output). New file: 22 pass, suppression used: `1 4104 ^Bun::generateInternalModule(`. CI build 106730: the asan lane passes.

### Background
- LSan reports a leak when no memory it scans (globals, stacks, TLS, its own heap chunks) points to the allocation. bmalloc uses the system allocator only when `__asan_init` is exported. bun does not export it, so JSC allocates through libpas, which LSan does not scan.
- `test/leaksan.supp` is the allowlist for that class of report. An entry matches a frame of the recorded allocation stack (30 frames in CI). `^` anchors the pattern at the start of the function name.

<details><summary>Notes</summary>

- Culprit check. Builds 106555, 106643, 106656 (#40597's own), 106687, 106693 and 106694 include 595f97b949 (#40597) and fail. Builds 106531, 106594 and 106642 include 0e395c2459 (#40511) but not #40597 and pass `macro-test.test.ts` on the asan lane (106531 job log: `test/bundler/transpiler/macro-test.test.ts (5.81s)`). The asan lane runs on PR builds only, so main never showed it.
- A debug build truncates the recorded stack before the frame (`malloc_context_size=30` reaches `JSC::profiledCall`), so locally this test leaks under LSan with any suppressions file unless `malloc_context_size` is raised. The release-asan build in CI inlines enough that the frame is recorded at position 12. The local runs above used `malloc_context_size=80` with `BUN_DESTRUCT_VM_ON_EXIT=1`, `ASAN_OPTIONS=detect_leaks=1` and `LSAN_OPTIONS=suppressions=test/leaksan.supp`.
- The rename affected no other function: `Bun::generateModule` was the only definition the old entry matched.
- Follow-ups, not done here: `bun build` could tear down its macro VM on exit under `BUN_DESTRUCT_VM_ON_EXIT`, or `create_binding` could mark the box LSan-ignored (#35159 proposes that). Either makes this entry deletable. Other entries in the file use Zig-era names (`runtime.node.node_fs_binding.Bindings(.mkdtemp).runSync`, ...) and are dead since the Rust port.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->