### PR TITLE
Make Crypto.prototype members configurable

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2399,7 +2399,7 @@ void GlobalObject::finishCreation(VM& vm)
                  init.vm,
                  Identifier::fromString(init.vm, "subtle"_s),
                  JSC::CustomGetterSetter::create(init.vm, getterSubtleCrypto, setterSubtleCrypto),
-                 PropertyAttribute::DontDelete | PropertyAttribute::CustomAccessor);
+                 static_cast<unsigned>(PropertyAttribute::CustomAccessor));
 
              init.set(crypto);
          } },

--- a/src/runtime/crypto/crypto.classes.ts
+++ b/src/runtime/crypto/crypto.classes.ts
@@ -40,8 +40,10 @@ export default [
     finalize: true,
 
     proto: {
+      // Web IDL requires regular operations to be configurable.
       getRandomValues: {
         fn: "getRandomValues",
+        configurable: true,
         // https://discord.com/channels/876711213126520882/1276103693665828894/1276133319033229363
         // https://discord.com/channels/876711213126520882/1276103693665828894/1276127092047609919
         // DOMJIT: {
@@ -53,6 +55,7 @@ export default [
       randomUUID: {
         fn: "randomUUID",
         length: 1,
+        configurable: true,
         DOMJIT: {
           returns: "JSString",
           "pure": false,
@@ -61,6 +64,7 @@ export default [
       },
       timingSafeEqual: {
         fn: "timingSafeEqual",
+        configurable: true,
         DOMJIT: {
           returns: "JSValue",
           "pure": false,

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -20,6 +20,31 @@ describe("Crypto.prototype property descriptors", () => {
     expect(d).toMatchObject({ writable: true, enumerable: true, configurable: true });
   });
 
+  it("subtle is configurable", () => {
+    const proto = Object.getPrototypeOf(globalThis.crypto);
+    const d = Object.getOwnPropertyDescriptor(proto, "subtle")!;
+    expect(d).toMatchObject({ enumerable: true, configurable: true });
+  });
+
+  it("subtle can be deleted", async () => {
+    // Mutate the prototype in a subprocess so this process keeps its crypto intact.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const proto = Object.getPrototypeOf(globalThis.crypto);
+         console.log(Reflect.deleteProperty(proto, "subtle"));
+         console.log(typeof globalThis.crypto.subtle);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true\nundefined\n");
+    expect(exitCode).toBe(0);
+  });
+
   it("randomUUID can be deleted and redefined", async () => {
     // Mutate the prototype in a subprocess so this process keeps its crypto intact.
     await using proc = Bun.spawn({

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -11,6 +11,43 @@ it("crypto.subtle setter should not throw", () => {
   expect(globalThis.crypto.subtle).toBe(subtle);
 });
 
+// https://github.com/oven-sh/bun/issues/40612
+describe("Crypto.prototype property descriptors", () => {
+  // Web IDL: a regular operation is writable, enumerable, and configurable.
+  it.each(["getRandomValues", "randomUUID", "timingSafeEqual"])("%s is configurable", method => {
+    const proto = Object.getPrototypeOf(globalThis.crypto);
+    const d = Object.getOwnPropertyDescriptor(proto, method);
+    expect(d).toMatchObject({ writable: true, enumerable: true, configurable: true });
+  });
+
+  it("randomUUID can be deleted and redefined", async () => {
+    // Mutate the prototype in a subprocess so this process keeps its crypto intact.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const proto = Object.getPrototypeOf(globalThis.crypto);
+         const original = proto.randomUUID;
+         console.log(Reflect.deleteProperty(proto, "randomUUID"));
+         console.log(typeof globalThis.crypto.randomUUID);
+         Object.defineProperty(proto, "randomUUID", {
+           value: original,
+           writable: true,
+           enumerable: true,
+           configurable: true,
+         });
+         console.log(typeof globalThis.crypto.randomUUID);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true\nundefined\nfunction\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("Web Crypto", () => {
   // https://github.com/oven-sh/bun/issues/3795
   it("keeps event loop alive", () => {


### PR DESCRIPTION
### Problem

- `Crypto.prototype.randomUUID`, `getRandomValues`, and `timingSafeEqual` report `configurable: false`. `Reflect.deleteProperty` returns `false`, a strict-mode `delete` throws `TypeError`, and `Object.defineProperty` throws `TypeError: Attempting to change configurable attribute of unconfigurable property`. Node and browsers expose them as configurable. Web IDL requires that for regular operations.
- The cause is the class codegen default. `src/codegen/generate-classes.ts:184` sets `configurable = false` for every field, and line 195 turns that into `PropertyAttribute::DontDelete`. The `Crypto` define in `src/runtime/crypto/crypto.classes.ts` never overrides it.

### Fix

- Set `configurable: true` on the three proto members of the `Crypto` define. The codegen then omits `DontDelete` from the hash table entries.
- The change is scoped to `Crypto`. The codegen default also covers Bun-specific classes (CryptoHasher, SHA*) where non-configurable may be intentional, so the default stays.
- This matches WebCore: its generated bindings emit DOMJIT operations (for example `getElementById`) without `DontDelete`.
- Verified: `test/js/web/crypto/web-crypto.test.ts` (4 new tests, all fail on stock bun). Also ran `test/js/bun/jsc/domjit.test.ts` and `test/js/node/crypto/crypto.test.ts`.

### Background

- Bun's native classes are generated from `*.classes.ts` files by `src/codegen/generate-classes.ts`. Each proto entry becomes a JSC `HashTableValue` row with property attributes.
- JSC property attributes are inverted flags: `DontDelete` means non-configurable, `DontEnum` means non-enumerable. A function property without `ReadOnly` is writable, so only the `DontDelete` bit was wrong here.
- `randomUUID` and `timingSafeEqual` carry DOMJIT signatures (a JIT fast path). A configurable DOMJIT function is the normal case in WebCore, so removing `DontDelete` does not affect the JIT.

<details><summary>Notes</summary>

- Repro before the fix: all three members report `{writable: true, enumerable: true, configurable: false}` and `Reflect.deleteProperty` returns `false` with no change.
- `test/js/bun/jsc/domjit.test.ts` shows 10 failures locally, all 5s timeouts on the 1,000,000-iteration tier under the debug ASAN build, including tests this change does not touch (TextDecoder, FFI, NodeVM). The lower iteration tiers of the Crypto tests pass.
- `test/js/node/crypto/crypto.test.ts`: 403 pass, 0 fail.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.1 (731aa92da)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.48ms]
15 | describe("Crypto.prototype property descriptors", () => {
16 |   // Web IDL: a regular operation is writable, enumerable, and configurable.
17 |   it.each(["getRandomValues", "randomUUID", "timingSafeEqual"])("%s is configurable", method => {
18 |     const proto = Object.getPrototypeOf(globalThis.crypto);
19 |     const d = Object.getOwnPropertyDescriptor(proto, method);
20 |     expect(d).toMatchObject({ writable: true, enumerable: true, configurable: true });
                   ^
error: expect(received).toMatchObject(expected)

  {
-   "configurable": true,
+   "configurable": false,
    "enumerable": true,
+   "value": [Function: getRandomValues],
    "writable": true,
  }

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/crypto/web-crypto.test.ts:20:15)
(fail) Crypto.prototype property descriptors > getRandomValues is configurable [5.41
... (truncated)

release without fix: 6 FAILED
bun test v1.4.1-canary.1 (731aa92da)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.07ms]
15 | describe("Crypto.prototype property descriptors", () => {
16 |   // Web IDL: a regular operation is writable, enumerable, and configurable.
17 |   it.each(["getRandomValues", "randomUUID", "timingSafeEqual"])("%s is configurable", method => {
18 |     const proto = Object.getPrototypeOf(globalThis.crypto);
19 |     const d = Object.getOwnPropertyDescriptor(proto, method);
20 |     expect(d).toMatchObject({ writable: true, enumerable: true, configurable: true });
                   ^
error: expect(received).toMatchObject(expected)

  {
-   "configurable": true,
+   "configurable": false,
    "enumerable": true,
+   "value": [Function: getRandomValues],
    "writable": true,
  }

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/crypto/web-crypto.test.ts:20:15)
(fail) Crypto.prototype property descriptors > getRandomValues is configurable [0.25ms]
15 | describe("Crypto.prototype property descriptors", () => {
16 |   // Web IDL: a regular operation is writable, enumerable, and configurable.
17 |   it.eac
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.1 (731aa92da)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.24ms]
(pass) Crypto.prototype property descriptors > getRandomValues is configurable [2.17ms]
(pass) Crypto.prototype property descriptors > randomUUID is configurable [0.42ms]
(pass) Crypto.prototype property descriptors > timingSafeEqual is configurable [0.27ms]
(pass) Crypto.prototype property descriptors > subtle is configurable [2.31ms]
(pass) Crypto.prototype property descriptors > subtle can be deleted [339.12ms]
(pass) Crypto.prototype property descriptors > randomUUID can be deleted and redefined [331.26ms]
(pass) Web Crypto > keeps event loop alive [289.07ms]
(pass) Web Crypto > has globals [2.81ms]
(pass) Web Crypto > should encrypt and decrypt [21.54ms]
(pass) Web Crypto > should verify and sign [37.41ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.14ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 592ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/126] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp  |  2 +-
 src/runtime/crypto/crypto.classes.ts  |  4 +++
 test/js/web/crypto/web-crypto.test.ts | 62 +++++++++++++++++++++++++++++++++++
 3 files changed, 67 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp       1      2      0
src/runtime/crypto/crypto.classes.ts       1      1      0
test/js/web/crypto/web-crypto.test.ts      1      3      0
```

</details>

**root cause** · written by the author bot

The four members of `Crypto.prototype` were installed with JavaScriptCore's `DontDelete` attribute, which surfaces as `configurable: false` and contradicts Web IDL's requirement that interface operations and attributes be configurable, so they could not be deleted or redefined as they can in Node and browsers. The three methods (`getRandomValues`, `randomUUID`, `timingSafeEqual`) picked up `DontDelete` from the class definition defaults in `crypto.classes.ts`, while the `subtle` accessor received it through a separate `putDirectCustomAccessor` call in `ZigGlobalObject.cpp`. The fix marks th…

<!-- robobun:evidence:end -->