### PR TITLE
docs: improve phrasing in quickstart overview

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,7 +5,7 @@ description: Build your first app with Bun
 
 ## Overview
 
-Build a minimal HTTP server with `Bun.serve`, run it locally, then evolve it by installing a package.
+Build a minimal HTTP server with `Bun.serve`, run it locally, and then evolve it by installing a package.
 
 <Info>Prerequisites: Bun installed and available on your `PATH`. See [installation](/installation) for setup.</Info>
 


### PR DESCRIPTION
Improves phrasing: adds 'and' before 'then evolve'.