### PR TITLE
docs: remove dead StricJS guide link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ bun upgrade --canary
   - [Build an app with SolidStart and Bun](https://bun.com/guides/ecosystem/solidstart)
   - [Build an app with TanStack Start and Bun](https://bun.com/guides/ecosystem/tanstack-start)
   - [Build an HTTP server using Elysia and Bun](https://bun.com/guides/ecosystem/elysia)
-  - [Build an HTTP server using StricJS and Bun](https://bun.com/guides/ecosystem/stric)
   - [Containerize a Bun application with Docker](https://bun.com/guides/ecosystem/docker)
   - [Build an HTTP server using Express and Bun](https://bun.com/guides/ecosystem/express)
   - [Use Neon Postgres through Drizzle ORM](https://bun.com/guides/ecosystem/neon-drizzle)


### PR DESCRIPTION
## What does this PR do?

Removes a dead guide link from the README's ecosystem guides list:

- `https://bun.com/guides/ecosystem/stric` → **HTTP 404**

The guide was removed from bun.com (the live guides index no longer lists it), and the StricJS framework itself is discontinued — its router repo is archived and the last npm publish of `@stricjs/router` was in October 2023. No replacement URL exists, so the entry is removed.

## How did you verify your code works?

Docs-only change; verified the URL returns 404 and the remaining links render correctly.
