### PR TITLE
run: load bunfig.toml for --filter, --workspaces, --parallel and --sequential

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -177,7 +177,14 @@ pub fn load_config(
                         || (!ctx.positionals.is_empty()
                             && options::DEFAULT_LOADERS
                                 .contains_key(bun_paths::extension(&ctx.positionals[0])))
-                )))
+                ))
+            // "bun [run] --filter/--workspaces/--parallel/--sequential": these
+            // dispatch to their own runners right after argument parsing and
+            // never reach the lazy load in `RunCommand::exec_with_cfg`. Loading
+            // here keeps the `[run]` flags applied later in `Arguments::parse`
+            // (`--bun`, `--elide-lines`, ...) ahead of the file.
+            || (matches!(cmd, CommandTag::RunCommand | CommandTag::AutoCommand)
+                && (ctx.parallel || ctx.sequential || ctx.workspaces || !ctx.filters.is_empty())))
     {
         config_path_ = b"bunfig.toml";
         auto_loaded = true;

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1210,3 +1210,82 @@ describe("output timing", () => {
     expect(Date.now() - start).toBeLessThan(15000);
   });
 });
+
+describe("auto-discovered bunfig.toml [run] section", () => {
+  // With `run.bun = true` bun puts a `node` shim on PATH, so `typeof Bun`
+  // tells which binary ran the script.
+  const typeofBun = `node -e "console.log('Bun is ' + typeof Bun)"`;
+
+  function workspace(prefix: string, bunfig: string) {
+    return tempDir(prefix, {
+      "bunfig.toml": bunfig,
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      packages: {
+        dep0: {
+          "index.js": Array(20).fill("console.log('log_line');").join("\n"),
+          "package.json": JSON.stringify({
+            name: "dep0",
+            scripts: { script: typeofBun, lines: `${bunExe()} run index.js` },
+          }),
+        },
+      },
+    });
+  }
+
+  function run(dir: string, args: string[], env: Record<string, string | undefined> = {}) {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), ...args],
+      env: { ...bunEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return { exitCode, stdout: stdout.toString(), stderr: stderr.toString() };
+  }
+
+  test.each([
+    ["bun run --filter", ["run", "--filter", "dep0", "script"]],
+    ["bun --filter", ["--filter", "dep0", "script"]],
+    ["bun run --workspaces", ["run", "--workspaces", "script"]],
+  ])("%s applies [run] bun = true", (_, args) => {
+    using dir = workspace("filter-bunfig-run-bun", "[run]\nbun = true\n");
+    const r = run(String(dir), args);
+    expect(r.stdout).toContain("Bun is object");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("--bun on the CLI wins over [run] bun = false", () => {
+    using dir = workspace("filter-bunfig-cli-bun", "[run]\nbun = false\n");
+    const r = run(String(dir), ["run", "--bun", "--filter", "dep0", "script"]);
+    expect(r.stdout).toContain("Bun is object");
+    expect(r.exitCode).toBe(0);
+  });
+
+  // Elision only happens on a terminal. On POSIX FORCE_COLOR=1 turns the
+  // terminal renderer on for a pipe; on Windows it stays off (see runElideLinesTest).
+  test.skipIf(isWindows)("[run] elide-lines = 0 disables elision for --filter", () => {
+    using dir = workspace("filter-bunfig-elide", "[run]\nelide-lines = 0\n");
+    const r = run(String(dir), ["run", "--filter", "dep0", "lines"], { FORCE_COLOR: "1", NO_COLOR: "0" });
+    expect(r.stdout).not.toMatch(/lines elided/);
+    expect(r.stdout).toMatch(/(?:log_line[\s\S]*?){20}/);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("--elide-lines on the CLI wins over [run] elide-lines", () => {
+    using dir = workspace("filter-bunfig-cli-elide", "[run]\nelide-lines = 0\n");
+    const r = run(String(dir), ["run", "--elide-lines", "15", "--filter", "dep0", "lines"], {
+      FORCE_COLOR: "1",
+      NO_COLOR: "0",
+    });
+    expect(r.stdout).toMatch(/\[5 lines elided\]/);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a malformed bunfig.toml fails the run", () => {
+    using dir = workspace("filter-bunfig-malformed", '[run]\nbun = "yes"\n');
+    const r = run(String(dir), ["run", "--filter", "dep0", "script"]);
+    expect(r.stderr).toContain("Expected boolean");
+    expect(r.stdout).not.toContain("Bun is");
+    expect(r.exitCode).toBe(1);
+  });
+});

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2143,3 +2143,50 @@ describe("workspace integration", () => {
     expect(r.exitCode).toBe(0);
   });
 });
+
+// ─── BUNFIG [run] SECTION ─────────────────────────────────────────────────────
+
+// Serial: debug builds recreate the shared `node` shim dir on every `--bun`
+// run, so concurrent `--bun` processes can race each other.
+describe("auto-discovered bunfig.toml [run] section", () => {
+  // With `run.bun = true` bun puts a `node` shim on PATH, so `typeof Bun`
+  // tells which binary ran the script.
+  const typeofBun = `node -e "console.log('Bun is ' + typeof Bun)"`;
+
+  // Script names that are not also `bun` subcommand aliases (`bun a` is `bun add`).
+  test.each([
+    ["bun run --parallel", ["run", "--parallel", "one", "two"]],
+    ["bun --parallel", ["--parallel", "one", "two"]],
+    ["bun run --sequential", ["run", "--sequential", "one", "two"]],
+  ])("%s applies [run] bun = true", async (_, args) => {
+    using dir = tempDir("mr-bunfig-run-bun", {
+      "bunfig.toml": "[run]\nbun = true\n",
+      "package.json": JSON.stringify({ scripts: { one: typeofBun, two: typeofBun } }),
+    });
+    const r = await runMulti(args, String(dir));
+    expectPrefixed(r.stdout, "one", "Bun is object");
+    expectPrefixed(r.stdout, "two", "Bun is object");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("--bun on the CLI wins over [run] bun = false", async () => {
+    using dir = tempDir("mr-bunfig-cli-bun", {
+      "bunfig.toml": "[run]\nbun = false\n",
+      "package.json": JSON.stringify({ scripts: { one: typeofBun } }),
+    });
+    const r = await runMulti(["run", "--bun", "--parallel", "one"], String(dir));
+    expectPrefixed(r.stdout, "one", "Bun is object");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a malformed bunfig.toml fails the run", async () => {
+    using dir = tempDir("mr-bunfig-malformed", {
+      "bunfig.toml": '[run]\nbun = "yes"\n',
+      "package.json": JSON.stringify({ scripts: { one: typeofBun } }),
+    });
+    const r = await runMulti(["run", "--parallel", "one"], String(dir));
+    expect(r.stderr).toContain("Expected boolean");
+    expect(r.stdout).not.toContain("Bun is");
+    expect(r.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #17918
Fixes #31479
Supersedes #31480

### Problem
- `bun run --filter <pkg> <script>`, `bun --filter`, `--workspaces`, `--parallel` and `--sequential` ignore an auto-discovered `bunfig.toml`. `[run] bun = true`, `elide-lines`, `shell`, `silent` and `noOrphans` are dead for these runners unless `--config=` is passed. Copying the file into each package directory does not help: the parent process decides these settings.
- Cause: `exec_auto_or_run` (`src/runtime/cli/mod.rs:1430`) dispatches to `multi_run::run` and `filter_run::run_scripts_with_filter` right after argument parsing. The lazy `bunfig.toml` load for `bun run <script>` lives in `RunCommand::exec_with_cfg` (`src/runtime/cli/run_command.rs:2312`), which these paths never reach. `load_config` (`src/bunfig/arguments.rs:169`) only auto-loads for `bun test`, `bun <file>` and the install commands.

### Fix
- Extend the auto-load condition in `load_config` with: run or auto command, and one of `parallel`, `sequential`, `workspaces`, or a non-empty `filters`. These fields are set before `load_config_with_cmd_args` runs.
- The file now loads inside `Arguments::parse`, the same place `bun test` and `bun <file>` load it. `--bun`, `--elide-lines`, `--shell` and `--silent` are applied after that call, so a CLI flag still wins over its `[run]` key.
- A malformed `bunfig.toml` now fails these runs with the parser error and exit code 1, the same as `bun test` and `bun run -c=bunfig.toml`.
- Verified: `test/cli/run/filter-workspace.test.ts` (7 new tests, 5 fail on 1.4.1) and `test/cli/run/multi-run.test.ts` (5 new, 4 fail on 1.4.1). Also `test/cli/install/bun-run-bunfig.test.ts`, `test/config/bunfig/`, `test/cli/run/env.test.ts`, `no-envfile.test.ts`, `run-shell.test.ts`.

### Background
- `bunfig.toml` is read from the working directory. `Arguments::parse` loads it for commands in `ALWAYS_LOADS_CONFIG`. `bun run <script>` is not in that table and loads it later, in `exec_with_cfg`.
- `[run] bun = true` puts a `node` shim that points at bun on `PATH`. The tests use `node -e "console.log(typeof Bun)"` to see which binary ran.
- Elision (`elide-lines`) only happens when stdout is a terminal. On POSIX, `FORCE_COLOR=1` turns the terminal renderer on for a pipe, which the existing elision tests rely on.

<details><summary>Notes</summary>

- Repro on 1.4.1: workspace root `bunfig.toml` with `[run]\nbun = true`, package script `node -e "console.log('Bun is', typeof Bun)"`. `bun run --filter a hello` prints `Bun is undefined`. `bun run -c=bunfig.toml --filter a hello` prints `Bun is object`. `bun run --parallel hello hello2` and `--sequential` print `Bun is undefined` too. Plain `bun run hello` prints `Bun is object`.
- Two precedence tests (`--bun` over `bun = false`, `--elide-lines 15` over `elide-lines = 0`) pass before and after. They guard against the inverted precedence that the exec-time load has for plain `bun run` (#33198).
- Top-level keys in the same file (`env = false`, `preload`, `define`) are parsed for the parent too. Only `env` changes what the parent does: it stops loading the root `.env` files that the child scripts otherwise inherit, which is what the key documents.
- #31480 added the same load inside `run_scripts_with_filter` with a snapshot of the two CLI values. It covered `--filter` only and predates the `tempDirWithFiles` removal. Loading during argument parsing needs no snapshot and covers `--parallel` and `--sequential`.
- Debug builds recreate `/tmp/bun-node-debug` on every `--bun` run (`src/install/lib.rs:564`), so concurrent `--bun` processes can race each other. The multi-run tests are serial because of that. Reported separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/multi-run.test.ts, test/cli/run/filter-workspace.test.ts

<!-- robobun:evidence:end -->