### PR TITLE
bundler: an entry point that is only `module.exports = require(...)` produces a module, not an empty file

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2611,6 +2611,7 @@ pub mod parse_worker {
         };
         opts.code_splitting = topts.code_splitting;
         opts.module_type = task.module_type;
+        opts.is_entry_point = task.is_entry_point;
 
         task.jsx.parse = loader.is_jsx();
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4961,6 +4961,7 @@ pub mod bv2_impl {
                                 loader: Some(loader),
                                 tree_shaking: this.linker.options.tree_shaking,
                                 known_target: resolve.import_record.original_target,
+                                is_entry_point: resolve.import_record.kind == ImportKind::EntryPointBuild,
                                 ..Default::default()
                             };
                             // Arena-owned.

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4961,7 +4961,8 @@ pub mod bv2_impl {
                                 loader: Some(loader),
                                 tree_shaking: this.linker.options.tree_shaking,
                                 known_target: resolve.import_record.original_target,
-                                is_entry_point: resolve.import_record.kind == ImportKind::EntryPointBuild,
+                                is_entry_point: resolve.import_record.kind
+                                    == ImportKind::EntryPointBuild,
                                 ..Default::default()
                             };
                             // Arena-owned.

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1588,6 +1588,7 @@ impl<'a> Transpiler<'a> {
                     framework: None,
                     repl_mode: self.options.repl_mode,
                     lower_toml_datetimes: false,
+                    is_entry_point: false,
                 };
 
                 opts.features.emit_decorator_metadata = this_parse.emit_decorator_metadata;

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -107,6 +107,10 @@ pub struct Options<'a> {
 
     /// Lower `toml_datetime`-tagged strings in a lazy-export AST to `Temporal.*.from` calls.
     pub lower_toml_datetimes: bool,
+
+    /// A bundle entry point: its own output is needed, so a `module.exports = require(...)`-only file stays a real
+    /// module rather than becoming a redirect to what it re-exports.
+    pub is_entry_point: bool,
 }
 
 impl<'a> Default for Options<'a> {
@@ -139,6 +143,7 @@ impl<'a> Default for Options<'a> {
             framework: None,
             repl_mode: false,
             lower_toml_datetimes: false,
+            is_entry_point: false,
         }
     }
 }
@@ -223,6 +228,7 @@ impl<'a> Options<'a> {
             framework: self.framework,
             repl_mode: self.repl_mode,
             lower_toml_datetimes: self.lower_toml_datetimes,
+            is_entry_point: self.is_entry_point,
         }
     }
 
@@ -295,6 +301,7 @@ impl<'a> Options<'a> {
             framework: None,
             repl_mode: false,
             lower_toml_datetimes: loader == options::Loader::Toml,
+            is_entry_point: false,
         };
         opts.jsx.parse = loader.is_jsx();
         opts
@@ -1412,7 +1419,9 @@ impl<'a> Parser<'a> {
 
                                     None
                                 };
-                                if let Some(id) = redirect_import_record_index {
+                                if let Some(id) = redirect_import_record_index
+                                    && !p.options.is_entry_point
+                                {
                                     part.symbol_uses = Default::default();
                                     return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
                                         import_records: p.import_records.move_to_baby_list(p.arena),

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -182,7 +182,7 @@ describe("bundler", () => {
     },
     entryPoints: ["/a.js", "/b.js"],
     outdir: "/out",
-    run: { file: "/user.mjs", stdout: "a bar\\nb bar" },
+    run: { file: "/user.mjs", stdout: "a bar\nb bar" },
   });
   itBundled("cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting", {
     files: {
@@ -205,7 +205,7 @@ describe("bundler", () => {
     entryPoints: ["/a.js", "/b.js"],
     outdir: "/out",
     splitting: true,
-    run: { file: "/user.mjs", stdout: "a bar\\nb bar" },
+    run: { file: "/user.mjs", stdout: "a bar\nb bar" },
   });
   // Two re-export-only entry points over the same target: two modules, one shared target.
   itBundled("cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints", {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -160,6 +160,48 @@ describe("bundler", () => {
     outfile: "/out.js",
     run: { file: "/user.mjs", stdout: "bar bar" },
   });
+  // An entry point that another entry point imports: still a module of its own (parsed once, as an entry point),
+  // and the importer links to it rather than past it.
+  for (const splitting of [false, true]) {
+    itBundled(`cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint${splitting ? "Splitting" : ""}`, {
+      files: {
+        "/a.js": /* js */ `
+          import lib from './b.js';
+          console.log('a', lib.foo);
+        `,
+        "/b.js": /* js */ `
+          module.exports = require('./library.js')
+        `,
+        "/library.js": /* js */ `
+          module.exports = { foo: 'bar' };
+        `,
+        "/user.mjs": /* js */ `
+          await import('./out/a.js');
+          const b = await import('./out/b.js');
+          console.log('b', b.default.foo);
+        `,
+      },
+      entryPoints: ["/a.js", "/b.js"],
+      outdir: "/out",
+      splitting,
+      run: { file: "/user.mjs", stdout: "a bar\nb bar" },
+    });
+  }
+  // Two re-export-only entry points over the same target: two modules, one shared target.
+  itBundled("cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints", {
+    files: {
+      "/a.js": `module.exports = require('./library.js')`,
+      "/b.js": `module.exports = require('./library.js')`,
+      "/library.js": `module.exports = { foo: 'bar' };`,
+      "/user.mjs": /* js */ `
+        const [a, b] = await Promise.all([import('./out/a.js'), import('./out/b.js')]);
+        console.log(a.default.foo, b.default.foo);
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    outdir: "/out",
+    run: { file: "/user.mjs", stdout: "bar bar" },
+  });
   itBundled("cjs2esm/ModuleExportsBasedOnNodeEnvProduction", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -162,31 +162,51 @@ describe("bundler", () => {
   });
   // An entry point that another entry point imports: still a module of its own (parsed once, as an entry point),
   // and the importer links to it rather than past it.
-  for (const splitting of [false, true]) {
-    itBundled(`cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint${splitting ? "Splitting" : ""}`, {
-      files: {
-        "/a.js": /* js */ `
-          import lib from './b.js';
-          console.log('a', lib.foo);
-        `,
-        "/b.js": /* js */ `
-          module.exports = require('./library.js')
-        `,
-        "/library.js": /* js */ `
-          module.exports = { foo: 'bar' };
-        `,
-        "/user.mjs": /* js */ `
-          await import('./out/a.js');
-          const b = await import('./out/b.js');
-          console.log('b', b.default.foo);
-        `,
-      },
-      entryPoints: ["/a.js", "/b.js"],
-      outdir: "/out",
-      splitting,
-      run: { file: "/user.mjs", stdout: "a bar\nb bar" },
-    });
-  }
+  itBundled("cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint", {
+    files: {
+      "/a.js": /* js */ `
+        import lib from './b.js';
+        console.log('a', lib.foo);
+      `,
+      "/b.js": /* js */ `
+        module.exports = require('./library.js')
+      `,
+      "/library.js": /* js */ `
+        module.exports = { foo: 'bar' };
+      `,
+      "/user.mjs": /* js */ `
+        await import('./out/a.js');
+        const b = await import('./out/b.js');
+        console.log('b', b.default.foo);
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    outdir: "/out",
+    run: { file: "/user.mjs", stdout: "a bar\\nb bar" },
+  });
+  itBundled("cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting", {
+    files: {
+      "/a.js": /* js */ `
+        import lib from './b.js';
+        console.log('a', lib.foo);
+      `,
+      "/b.js": /* js */ `
+        module.exports = require('./library.js')
+      `,
+      "/library.js": /* js */ `
+        module.exports = { foo: 'bar' };
+      `,
+      "/user.mjs": /* js */ `
+        await import('./out/a.js');
+        const b = await import('./out/b.js');
+        console.log('b', b.default.foo);
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    outdir: "/out",
+    splitting: true,
+    run: { file: "/user.mjs", stdout: "a bar\\nb bar" },
+  });
   // Two re-export-only entry points over the same target: two modules, one shared target.
   itBundled("cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints", {
     files: {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -141,6 +141,25 @@ describe("bundler", () => {
       stdout: "bar",
     },
   });
+  // The same file as an entry point is a module in its own right, not only a redirect for its importers.
+  itBundled("cjs2esm/ModuleExportsEqualsRequireEntryPoint", {
+    files: {
+      "/entry.cjs": /* js */ `
+        /*! banner */
+        "use strict";
+        module.exports = require('./library.js')
+      `,
+      "/library.js": /* js */ `
+        module.exports = { foo: 'bar' };
+      `,
+      "/user.mjs": /* js */ `
+        import lib from './out.js';
+        console.log(lib.foo, require('./out.js').default.foo);
+      `,
+    },
+    outfile: "/out.js",
+    run: { file: "/user.mjs", stdout: "bar bar" },
+  });
   itBundled("cjs2esm/ModuleExportsBasedOnNodeEnvProduction", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
## What

A CommonJS file whose only statement is `module.exports = require("./x")` (comments and directives aside) is parsed as a *redirect*: importers link straight to `./x` and the file itself contributes nothing. That is right for an imported file, but when the file is an **entry point** nothing was emitted at all — `bun build ./index.cjs` printed just `// @bun` (or an empty file for `--target=node/browser`). Typical shape: a package `index.js` that does `module.exports = require('./lib/express')`, built directly.

The parser now knows whether it is parsing a bundle entry point (`Options::is_entry_point`, set from `ParseTask`) and keeps such a file as an ordinary module; imported files still become redirects.

Before / after, `bun build --target=bun a.cjs` with `a.cjs` = `module.exports = require("./dep.cjs")`:

```js
// @bun
```
```js
// @bun
var __commonJS = …;
// dep.cjs
var require_dep = __commonJS(function(exports, module) { module.exports = { hello: 1 }; });
// a.cjs
var require_a = __commonJS(function(exports, module) { module.exports = require_dep(); });
export default require_a();
```

## Test

`bundler_cjs2esm.test.ts` › `cjs2esm/ModuleExportsEqualsRequireEntryPoint` (fails on 1.4: the output has no default export). The existing `cjs2esm/ModuleExportsEqualsRequire` (redirect for an imported file) still passes.