### PR TITLE
test: run the serial macro-test spawn cases concurrently and assert exact output

### DIFF
--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -202,7 +202,25 @@ test.concurrent(
 // and whatever a macro started but did not await is adopted by the regular loop once the macro returns
 // (or it is stranded and its keep-alive holds the process open). These run the macro in the main VM:
 // the entry file's macros, or a module require()d so it transpiles on the main thread.
-describe.concurrent("event loop routing around macros", () => {
+describe("event loop routing around macros", () => {
+  async function run(files: Record<string, string>, env: Record<string, string> = {}) {
+    using dir = tempDir("macro-loops", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "index.ts"],
+      env: { ...bunEnv, ...env },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug builds also print "[macro] call <name>" to stdout.
+    const lines = stdout
+      .trim()
+      .split("\n")
+      .filter(line => !line.startsWith("[macro]"));
+    return { lines, stderr, exitCode };
+  }
+
   const unawaited: [name: string, macroSource: string][] = [
     [
       "an fs.promises call inside the macro",
@@ -257,30 +275,29 @@ describe.concurrent("event loop routing around macros", () => {
     ],
   ];
 
-  test.each(unawaited)("%s that it does not await still lets the process exit", async (_name, macroSource) => {
-    await using server = Bun.serve({ port: 0, fetch: () => new Response("settled") });
-    using dir = tempDir("macro-loops", {
-      "m.ts": macroSource,
-      "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log("value", m());\n`,
-    });
-    const { stdout, ...rest } = await runBun(String(dir), ["run", "index.ts"], {
-      MACRO_TEST_URL: server.url.href,
-    });
-    // The continuation runs on the macro loop if the work finishes while the macro is still being waited
-    // on and on the regular loop otherwise, so its position relative to the entry module's output varies.
-    expect({ lines: stdout.trim().split("\n").sort(), ...rest }).toEqual({
-      lines: ["settled", "value 1"],
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
+  test.concurrent.each(unawaited)(
+    "%s that it does not await still lets the process exit",
+    async (_name, macroSource) => {
+      await using server = Bun.serve({ port: 0, fetch: () => new Response("settled") });
+      const { lines, stderr, exitCode } = await run(
+        {
+          "m.ts": macroSource,
+          "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log("value", m());\n`,
+        },
+        { MACRO_TEST_URL: server.url.href },
+      );
+      // The continuation runs on the macro loop if the work finishes while the macro is still being waited
+      // on and on the regular loop otherwise, so its position relative to the entry module's output varies.
+      expect({ lines: lines.sort(), stderr }).toEqual({ lines: ["settled", "value 1"], stderr: "" });
+      expect(exitCode).toBe(0);
+    },
+  );
 
   // The program's digest finishes (microseconds, on the work queue) while the macro is parked in its
   // 200 ms wait. Its callback belongs to the program: it must run after require() returns, not inside
   // the macro's wait underneath the transpiler, so the macro never sees "program" in the log.
-  test("a program completion that arrives during a macro waits for the macro to return", async () => {
-    using dir = tempDir("macro-loops", {
+  test.concurrent("a program completion that arrives during a macro waits for the macro to return", async () => {
+    const { lines, stderr, exitCode } = await run({
       "m.ts": [
         `export async function probe() {`,
         `  await Bun.sleep(200);`,
@@ -297,19 +314,15 @@ describe.concurrent("event loop routing around macros", () => {
         `console.log(seen, JSON.stringify(globalThis.log));`,
       ].join("\n"),
     });
-    expect(await runBun(String(dir), ["run", "index.ts"])).toEqual({
-      stdout: `[] ["required","program"]\n`,
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
+    expect({ lines, stderr }).toEqual({ lines: [`[] ["required","program"]`], stderr: "" });
+    expect(exitCode).toBe(0);
   });
 
   // If a program callback did run mid-macro, work it started there would be routed to the macro loop and,
   // finishing after the macro returned, would need the regular loop to adopt it. Either way the chain
   // must complete and the process must exit.
-  test("work chained off a program completion across a macro completes", async () => {
-    using dir = tempDir("macro-loops", {
+  test.concurrent("work chained off a program completion across a macro completes", async () => {
+    const { lines, stderr, exitCode } = await run({
       "m.ts": `export async function probe() {\n  await Bun.sleep(200);\n  return 1;\n}\n`,
       "with-macro.ts": `import { probe } from "./m.ts" with { type: "macro" };\nexport const value = probe();\n`,
       "index.ts": [
@@ -322,12 +335,8 @@ describe.concurrent("event loop routing around macros", () => {
         `console.log(value, await chained);`,
       ].join("\n"),
     });
-    expect(await runBun(String(dir), ["run", "index.ts"])).toEqual({
-      stdout: "1 chained\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
+    expect({ lines, stderr }).toEqual({ lines: ["1 chained"], stderr: "" });
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -263,13 +263,17 @@ describe.concurrent("event loop routing around macros", () => {
       "m.ts": macroSource,
       "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log("value", m());\n`,
     });
-    const { stdout, stderr, exitCode } = await runBun(String(dir), ["run", "index.ts"], {
+    const { stdout, ...rest } = await runBun(String(dir), ["run", "index.ts"], {
       MACRO_TEST_URL: server.url.href,
     });
     // The continuation runs on the macro loop if the work finishes while the macro is still being waited
     // on and on the regular loop otherwise, so its position relative to the entry module's output varies.
-    expect({ lines: stdout.trim().split("\n").sort(), stderr }).toEqual({ lines: ["settled", "value 1"], stderr: "" });
-    expect(exitCode).toBe(0);
+    expect({ lines: stdout.trim().split("\n").sort(), ...rest }).toEqual({
+      lines: ["settled", "value 1"],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 
   // The program's digest finishes (microseconds, on the work queue) while the macro is parked in its

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,7 +1,7 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { existsSync } from "node:fs";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import defaultMacro, {
   addStrings,
@@ -133,54 +133,68 @@ test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
 });
 
-// A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside
-// JSC__JSValue__putToPropertyKey take a path that can throw, so the binding must check for
-// an exception. BUN_JSC_validateExceptionChecks=1 aborts the child if the check is missing.
-test("object argument with a sparse numeric key", async () => {
-  using dir = tempDir("macro-sparse-key", {
-    "take.ts": `export function take(o: any) {\n  return Object.keys(o).join(",");\n}\n`,
-    "index.ts": `import { take } from "./take.ts" with { type: "macro" };\nconsole.log(take({ 200000: 1 }));\n`,
-  });
+// Every test from here on works in its own temp dir (a bun child, or Bun.build in this process), so
+// they all run concurrently. Debug builds print "[macro] call <name>" to stdout for each macro call;
+// it is dropped so stdout can be matched exactly.
+async function runBun(cwd: string, cmd: string[], env: Record<string, string> = {}) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "run", "index.ts"],
-    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
-    cwd: String(dir),
+    cmd: [bunExe(), ...cmd],
+    env: { ...bunEnv, ...env },
+    cwd,
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return {
+    stdout: stdout
+      .split("\n")
+      .filter(line => !line.startsWith("[macro]"))
+      .join("\n"),
+    stderr,
+    exitCode,
+    signalCode: proc.signalCode,
+  };
+}
+
+// A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside
+// JSC__JSValue__putToPropertyKey take a path that can throw, so the binding must check for
+// an exception. BUN_JSC_validateExceptionChecks=1 aborts the child if the check is missing.
+test.concurrent("object argument with a sparse numeric key", async () => {
+  using dir = tempDir("macro-sparse-key", {
+    "take.ts": `export function take(o: any) {\n  return Object.keys(o).join(",");\n}\n`,
+    "index.ts": `import { take } from "./take.ts" with { type: "macro" };\nconsole.log(take({ 200000: 1 }));\n`,
+  });
   // One combined assertion so stderr (where JSC prints the exception check failure) shows up in
-  // the diff if the child aborts. Debug builds print "[macro] call take" to stdout before the
-  // script's own output, so only the tail of stdout is matched.
-  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toMatchObject({
-    stdout: expect.stringMatching(/200000\n$/),
+  // the diff if the child aborts.
+  expect(await runBun(String(dir), ["run", "index.ts"], { BUN_JSC_validateExceptionChecks: "1" })).toEqual({
+    stdout: "200000\n",
+    stderr: "",
     exitCode: 0,
     signalCode: null,
   });
 });
 
-test("object destructuring of a macro result keeps every bound property regardless of key order or repeated keys", async () => {
-  using dir = tempDir("macro-destructure-object", {
-    "m.ts": `export function m() {\n  return { a: 1, c: 2 };\n}\n`,
-    "index.ts": [
-      `import { m } from "./m.ts" with { type: "macro" };`,
-      `const { c, a } = m();`,
-      `const { a: x, a: y, c: z } = m();`,
-      `console.log(JSON.stringify([c, a, x, y, z]));`,
-      ``,
-    ].join("\n"),
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "run", "index.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({ lastLine: "[2,1,1,1,2]", stderr: "" });
-  expect(exitCode).toBe(0);
-});
+test.concurrent(
+  "object destructuring of a macro result keeps every bound property regardless of key order or repeated keys",
+  async () => {
+    using dir = tempDir("macro-destructure-object", {
+      "m.ts": `export function m() {\n  return { a: 1, c: 2 };\n}\n`,
+      "index.ts": [
+        `import { m } from "./m.ts" with { type: "macro" };`,
+        `const { c, a } = m();`,
+        `const { a: x, a: y, c: z } = m();`,
+        `console.log(JSON.stringify([c, a, x, y, z]));`,
+        ``,
+      ].join("\n"),
+    });
+    expect(await runBun(String(dir), ["run", "index.ts"])).toEqual({
+      stdout: "[2,1,1,1,2]\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+);
 
 // A macro's `await` is serviced by the VM's macro event loop, so completions have to be routed by which
 // loop was current when their work started: what the macro started goes to the macro loop (or the wait
@@ -188,25 +202,7 @@ test("object destructuring of a macro result keeps every bound property regardle
 // and whatever a macro started but did not await is adopted by the regular loop once the macro returns
 // (or it is stranded and its keep-alive holds the process open). These run the macro in the main VM:
 // the entry file's macros, or a module require()d so it transpiles on the main thread.
-describe("event loop routing around macros", () => {
-  async function run(files: Record<string, string>, env: Record<string, string> = {}) {
-    using dir = tempDir("macro-loops", files);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "index.ts"],
-      env: { ...bunEnv, ...env },
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Debug builds also print "[macro] call <name>" to stdout.
-    const lines = stdout
-      .trim()
-      .split("\n")
-      .filter(line => !line.startsWith("[macro]"));
-    return { lines, stderr, exitCode };
-  }
-
+describe.concurrent("event loop routing around macros", () => {
   const unawaited: [name: string, macroSource: string][] = [
     [
       "an fs.promises call inside the macro",
@@ -261,29 +257,26 @@ describe("event loop routing around macros", () => {
     ],
   ];
 
-  test.concurrent.each(unawaited)(
-    "%s that it does not await still lets the process exit",
-    async (_name, macroSource) => {
-      await using server = Bun.serve({ port: 0, fetch: () => new Response("settled") });
-      const { lines, stderr, exitCode } = await run(
-        {
-          "m.ts": macroSource,
-          "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log("value", m());\n`,
-        },
-        { MACRO_TEST_URL: server.url.href },
-      );
-      // The continuation runs on the macro loop if the work finishes while the macro is still being waited
-      // on and on the regular loop otherwise, so its position relative to the entry module's output varies.
-      expect({ lines: lines.sort(), stderr }).toEqual({ lines: ["settled", "value 1"], stderr: "" });
-      expect(exitCode).toBe(0);
-    },
-  );
+  test.each(unawaited)("%s that it does not await still lets the process exit", async (_name, macroSource) => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("settled") });
+    using dir = tempDir("macro-loops", {
+      "m.ts": macroSource,
+      "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log("value", m());\n`,
+    });
+    const { stdout, stderr, exitCode } = await runBun(String(dir), ["run", "index.ts"], {
+      MACRO_TEST_URL: server.url.href,
+    });
+    // The continuation runs on the macro loop if the work finishes while the macro is still being waited
+    // on and on the regular loop otherwise, so its position relative to the entry module's output varies.
+    expect({ lines: stdout.trim().split("\n").sort(), stderr }).toEqual({ lines: ["settled", "value 1"], stderr: "" });
+    expect(exitCode).toBe(0);
+  });
 
   // The program's digest finishes (microseconds, on the work queue) while the macro is parked in its
   // 200 ms wait. Its callback belongs to the program: it must run after require() returns, not inside
   // the macro's wait underneath the transpiler, so the macro never sees "program" in the log.
-  test.concurrent("a program completion that arrives during a macro waits for the macro to return", async () => {
-    const { lines, stderr, exitCode } = await run({
+  test("a program completion that arrives during a macro waits for the macro to return", async () => {
+    using dir = tempDir("macro-loops", {
       "m.ts": [
         `export async function probe() {`,
         `  await Bun.sleep(200);`,
@@ -300,15 +293,19 @@ describe("event loop routing around macros", () => {
         `console.log(seen, JSON.stringify(globalThis.log));`,
       ].join("\n"),
     });
-    expect({ lines, stderr }).toEqual({ lines: [`[] ["required","program"]`], stderr: "" });
-    expect(exitCode).toBe(0);
+    expect(await runBun(String(dir), ["run", "index.ts"])).toEqual({
+      stdout: `[] ["required","program"]\n`,
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 
   // If a program callback did run mid-macro, work it started there would be routed to the macro loop and,
   // finishing after the macro returned, would need the regular loop to adopt it. Either way the chain
   // must complete and the process must exit.
-  test.concurrent("work chained off a program completion across a macro completes", async () => {
-    const { lines, stderr, exitCode } = await run({
+  test("work chained off a program completion across a macro completes", async () => {
+    using dir = tempDir("macro-loops", {
       "m.ts": `export async function probe() {\n  await Bun.sleep(200);\n  return 1;\n}\n`,
       "with-macro.ts": `import { probe } from "./m.ts" with { type: "macro" };\nexport const value = probe();\n`,
       "index.ts": [
@@ -321,92 +318,91 @@ describe("event loop routing around macros", () => {
         `console.log(value, await chained);`,
       ].join("\n"),
     });
-    expect({ lines, stderr }).toEqual({ lines: ["1 chained"], stderr: "" });
-    expect(exitCode).toBe(0);
+    expect(await runBun(String(dir), ["run", "index.ts"])).toEqual({
+      stdout: "1 chained\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 });
 
-describe("--no-macros", () => {
+describe.concurrent("--no-macros", () => {
+  // The macro leaves MACRO_RAN next to itself when it runs, so whether it ran is checked on disk and
+  // not only through the bundle text.
   const files = {
-    "macro.ts": `
-      import { writeFileSync } from "node:fs";
-      export function f() {
-        writeFileSync("MACRO_RAN", "macro executed");
-        return "INLINED_RESULT";
-      }
-    `,
-    "entry.ts": `
-      import { f } from "./macro.ts" with { type: "macro" };
-      console.log(f());
-    `,
+    "macro.ts": [
+      `import { writeFileSync } from "node:fs";`,
+      `import { join } from "node:path";`,
+      `export function f() {`,
+      `  writeFileSync(join(import.meta.dir, "MACRO_RAN"), "macro executed");`,
+      `  return "INLINED_RESULT";`,
+      `}`,
+    ].join("\n"),
+    "entry.ts": `import { f } from "./macro.ts" with { type: "macro" };\nconsole.log(f());\n`,
   };
 
   test("bun build --no-macros refuses to run macros", async () => {
     using dir = tempDir("bundler-no-macros-cli", files);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--no-macros", "./entry.ts", "--outdir", "dist"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toMatchObject({
-      stderr: expect.stringContaining("Macros are disabled"),
-      exitCode: 1,
-    });
-    expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(false);
-    expect(existsSync(path.join(String(dir), "dist", "entry.js"))).toBe(false);
+    const { stdout, stderr, exitCode } = await runBun(String(dir), [
+      "build",
+      "--no-macros",
+      "./entry.ts",
+      "--outdir",
+      "dist",
+    ]);
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "2 | console.log(f());
+                      ^
+      error: Macros are disabled
+          at <dir>/entry.ts:2:13"
+    `);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+    // Neither the macro's side effect nor the bundle was written.
+    expect(readdirSync(String(dir)).sort()).toEqual(["entry.ts", "macro.ts"]);
   });
 
-  test("Bun.build({ macros: false }) refuses to run macros", async () => {
-    using dir = tempDir("bundler-no-macros-api", {
-      ...files,
-      "build.ts": `
-        const result = await Bun.build({
-          entrypoints: ["./entry.ts"],
-          outdir: "./dist",
-          macros: false,
-          throw: false,
-        });
-        console.log(JSON.stringify({
-          success: result.success,
-          logs: result.logs.map(l => l.message),
-        }));
-      `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "build.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const parsed = JSON.parse(stdout.trim().split("\n").pop()!);
-    expect({ parsed, stderr, exitCode }).toMatchObject({
-      parsed: {
+  test.each([
+    [
+      "{ macros: false } refuses to run macros",
+      { macros: false },
+      {
         success: false,
-        logs: expect.arrayContaining([expect.stringContaining("Macros are disabled")]),
+        logs: [{ message: "Macros are disabled", file: "entry.ts", line: 2, column: 13 }],
+        outputs: [],
+        macroRan: false,
       },
-      exitCode: 0,
+    ],
+    [
+      "no macros option runs macros",
+      {},
+      {
+        success: true,
+        logs: [],
+        outputs: [`console.log("INLINED_RESULT");\n`],
+        macroRan: true,
+      },
+    ],
+  ])("Bun.build() with %s", async (_name, options, expected) => {
+    using dir = tempDir("bundler-no-macros-api", files);
+    const result = await Bun.build({
+      entrypoints: [path.join(String(dir), "entry.ts")],
+      // Without minify the bundle starts with a "// <path>" comment relative to the cwd.
+      minify: true,
+      throw: false,
+      ...options,
     });
-    expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(false);
-  });
-
-  test("bun build without --no-macros still runs macros", async () => {
-    using dir = tempDir("bundler-macros-enabled", files);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "./entry.ts", "--outdir", "dist"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
-    const out = await Bun.file(path.join(String(dir), "dist", "entry.js")).text();
-    expect(out).toContain("INLINED_RESULT");
-    expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(true);
+    expect({
+      success: result.success,
+      logs: result.logs.map(log => ({
+        message: log.message,
+        file: path.basename(log.position!.file),
+        line: log.position!.line,
+        column: log.position!.column,
+      })),
+      outputs: await Promise.all(result.outputs.map(output => output.text())),
+      macroRan: existsSync(path.join(String(dir), "MACRO_RAN")),
+    }).toEqual(expected);
   });
 });

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -382,7 +382,7 @@ describe.concurrent("--no-macros", () => {
       { macros: false },
       {
         success: false,
-        logs: [{ message: "Macros are disabled", file: "entry.ts", line: 2, column: 13 }],
+        logs: [{ message: "Macros are disabled", position: { file: "entry.ts", line: 2, column: 13 } }],
         outputs: [],
         macroRan: false,
       },
@@ -410,9 +410,11 @@ describe.concurrent("--no-macros", () => {
       success: result.success,
       logs: result.logs.map(log => ({
         message: log.message,
-        file: path.basename(log.position!.file),
-        line: log.position!.line,
-        column: log.position!.column,
+        position: log.position && {
+          file: path.basename(log.position.file),
+          line: log.position.line,
+          column: log.position.column,
+        },
       })),
       outputs: await Promise.all(result.outputs.map(output => output.text())),
       macroRan: existsSync(path.join(String(dir), "MACRO_RAN")),


### PR DESCRIPTION
### Problem
- Five tests in `test/bundler/transpiler/macro-test.test.ts` spawn a bun child or run a build one after another: the sparse-key test, the destructuring test, and the three `--no-macros` tests. The other seven spawn tests already run concurrently.
- Their assertions were loose: exit code only, tail and last-line matches, `stringContaining`, `toContain`.
- The 42 s this file showed on the debian 13 x64-asan lane (build #106656) was the LeakSanitizer abort of a `bun build` child (the main break #40614 fixes) plus CI retries, not the tests.

### Fix
- The two standalone tests are `test.concurrent` and the `--no-macros` block is `describe.concurrent`, so all twelve spawn tests form one concurrent group.
- The two `Bun.build()` cases of the `--no-macros` block run in this process through one `test.each`. The `bun build --no-macros` spawn stays, since it covers the CLI flag.
- Each child test asserts stdout, stderr, exit code and signal code with one `toEqual`. The refusal case snapshots the exact build error. The `Bun.build()` cases assert the result object and the macro's marker file.
- The "event loop routing around macros" block is unchanged. Its tests were already concurrent, and #40059 changes its expected values.
- Verified: `bun bd test test/bundler/transpiler/macro-test.test.ts`, local debug build: 5.29 s to 5.58 s before, 3.74 s to 3.85 s after. The asan lane stays red until #40614 lands, since the in-process `Bun.build()` runs the same `node:fs` macro. With #40614's suppression the file passes 10 of 10 local runs under `detect_leaks=1`.

### Background
- `bun test` runs consecutive concurrent tests as one group, up to `--max-concurrency` (20). A non-concurrent test or a `beforeAll`/`afterAll` hook ends the group, a `describe` boundary does not.

<details><summary>Notes</summary>

- The LeakSanitizer report: `Direct leak of 4104 byte(s)` from `Box::new` in `bun_runtime::node::node_fs_binding::create_binding`. The box belongs to the `NodeJSFS` cell of the macro VM, which is never torn down. `test/leaksan.supp` covered it through `leak:Bun::generateModule` until #40597 renamed that function to `Bun::generateInternalModule`. #40614 renames the entry. On main the same leak aborts the `bun build` child of the old file on every asan build since #40597.
- `test/expected-durations.json` records 8990 ms for this file on the asan lane and 150 ms by default. On build #106656 the runner reported 5.06 s, 3.9 s of it in the aborted child. On the asan lane the runner reports 0.9 s for the new file (build #106766).
- Debug builds print `[macro] call <name>` to stdout for every macro call (`src/js_parser_jsc/Macro.rs`, a `prettyln!` that `BUN_DEBUG_QUIET_LOGS` does not silence). The `runBun` helper drops those lines so stdout can be compared exactly, as the event-loop block's `run()` already did. Moving that print to a `scoped_log!` is a separate change, after which both filters can go.
- The CLI default (macros on without a flag) is covered by the `itBundled` macro cases and `test/regression/issue/03830.test.ts`, which spawn `bun build` with a macro.
- The macro in the `--no-macros` block writes `MACRO_RAN` next to itself with `import.meta.dir`, so the marker lands in the temp dir whether the build runs in a child or in the test process.
- `toMatchInlineSnapshot` works inside concurrent tests. Only the file snapshot matchers need the active test name.
- The `Bun.build()` cases pass `minify: true` because the unminified bundle starts with a `// <path>` comment relative to the cwd, which varies between machines.
- A one-test file that imports `harness` costs 2.03 s on the local debug build, so about 2 s of the remaining 3.8 s is fixed cost.
- While measuring I ran `bun build --target=bun --external '*'` on this file. A wildcard `--external` also marks the macro import as external, so the macro host imports `./macro.ts` relative to the cwd and fails unless the cwd is the source dir. Filed as #40626.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 5 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/transpiler/macro-test.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/transpiler/macro-test.test.ts
bun test v1.4.1 (731aa92da)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call addStringsUTF16
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call default
[macro] call default
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call ireturnapromise
(pass) bun builtins can be used in macros [2.29ms]
(pass) lati
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/transpiler/macro-test.test.ts | 229 +++++++++++++++--------------
 1 file changed, 120 insertions(+), 109 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
test/bundler/transpiler/macro-test.test.ts      8     13      0
```

</details>

<!-- robobun:evidence:end -->