### PR TITLE
test(websocket): record the CONNECT request and tighten the assertions in the proxy tests

### DIFF
--- a/test/js/first_party/ws/ws-proxy.test.ts
+++ b/test/js/first_party/ws/ws-proxy.test.ts
@@ -1,97 +1,90 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { gc, tls as tlsCerts } from "harness";
 import type { HttpsProxyAgent as HttpsProxyAgentType } from "https-proxy-agent";
-import net from "net";
-import tls from "tls";
 import WebSocket from "ws";
-import { createConnectProxy, createTLSConnectProxy, startProxy } from "../../web/websocket/proxy-test-utils";
+import {
+  type ClientEvent,
+  connectRequest,
+  echoed,
+  failed,
+  startEchoServer,
+  startRecordingProxy,
+} from "../../web/websocket/proxy-test-utils";
 
 // Use dynamic require to avoid linter removing the import
 const { HttpsProxyAgent } = require("https-proxy-agent") as {
   HttpsProxyAgent: typeof HttpsProxyAgentType;
 };
 
-// HTTP CONNECT proxy server for WebSocket tunneling
-let proxy: net.Server;
-let authProxy: net.Server;
-let httpsProxy: tls.Server;
+// The tests below pass an explicit `proxy:` option for 127.0.0.1 and assert on
+// the CONNECT request the proxy receives. NO_PROXY applies to explicit proxies
+// too, so an ambient NO_PROXY=localhost,127.0.0.1,... must not bypass them.
+const prevNoProxy = process.env.NO_PROXY;
+const prevNoProxyLower = process.env.no_proxy;
+process.env.NO_PROXY = "";
+process.env.no_proxy = "";
+
+// Echo servers. Every proxy is started by the test that uses it, so each test
+// can read what reached its proxy.
 let wsServer: ReturnType<typeof Bun.serve>;
 let wssServer: ReturnType<typeof Bun.serve>;
-let proxyPort: number;
-let authProxyPort: number;
-let httpsProxyPort: number;
 let wsPort: number;
 let wssPort: number;
 
-beforeAll(async () => {
-  // Create HTTP CONNECT proxy
-  proxy = createConnectProxy();
-  proxyPort = await startProxy(proxy);
-
-  // Create HTTP CONNECT proxy with auth
-  authProxy = createConnectProxy({ requireAuth: true });
-  authProxyPort = await startProxy(authProxy);
-
-  // Create HTTPS CONNECT proxy
-  httpsProxy = createTLSConnectProxy();
-  httpsProxyPort = await startProxy(httpsProxy);
-
-  // Create WebSocket echo server
-  wsServer = Bun.serve({
-    port: 0,
-    fetch(req, server) {
-      if (server.upgrade(req)) {
-        return;
-      }
-      return new Response("Expected WebSocket", { status: 400 });
-    },
-    websocket: {
-      message(ws, message) {
-        // Echo back
-        ws.send(message);
-      },
-      open(ws) {
-        ws.send("connected");
-      },
-    },
-  });
+beforeAll(() => {
+  wsServer = startEchoServer();
   wsPort = wsServer.port;
-
-  // Create secure WebSocket echo server (wss://)
-  wssServer = Bun.serve({
-    port: 0,
-    tls: {
-      key: tlsCerts.key,
-      cert: tlsCerts.cert,
-    },
-    fetch(req, server) {
-      if (server.upgrade(req)) {
-        return;
-      }
-      return new Response("Expected WebSocket", { status: 400 });
-    },
-    websocket: {
-      message(ws, message) {
-        // Echo back
-        ws.send(message);
-      },
-      open(ws) {
-        ws.send("connected");
-      },
-    },
-  });
+  wssServer = startEchoServer({ tls: true });
   wssPort = wssServer.port;
 });
 
 afterAll(() => {
-  proxy?.close();
-  authProxy?.close();
-  httpsProxy?.close();
   wsServer?.stop(true);
   wssServer?.stop(true);
+  if (prevNoProxy !== undefined) process.env.NO_PROXY = prevNoProxy;
+  if (prevNoProxyLower !== undefined) process.env.no_proxy = prevNoProxyLower;
 });
 
+/**
+ * `clientEvents` for the ws package client, which reports through its
+ * EventEmitter API: messages as Buffers, and wasClean as a third close argument.
+ */
+function wsEvents(ws: WebSocket): Promise<ClientEvent[]> {
+  const events: ClientEvent[] = [];
+  const { promise, resolve } = Promise.withResolvers<ClientEvent[]>();
+  ws.on("message", (data: Buffer) => {
+    events.push(data.toString());
+  });
+  ws.on("error", (err: Error) => {
+    events.push({ error: err.message });
+  });
+  ws.on("close", (code: number, reason: Buffer, wasClean?: boolean) => {
+    events.push({ code, reason: String(reason), wasClean: wasClean === true });
+    resolve(events);
+  });
+  return promise;
+}
+
+/** Sends `message` once open and closes after the echo arrives. A working tunnel produces `echoed(message)`. */
+function wsEchoSession(ws: WebSocket, message: string): Promise<ClientEvent[]> {
+  ws.on("open", () => ws.send(message));
+  ws.on("message", (data: Buffer) => {
+    if (data.toString() === message) ws.close(1000);
+  });
+  return wsEvents(ws);
+}
+
+/** For a connection that must fail: an unexpected open is closed at once so the assertion reports it. */
+function wsFailingSession(ws: WebSocket): Promise<ClientEvent[]> {
+  ws.on("open", () => ws.close(1000));
+  return wsEvents(ws);
+}
+
 describe("ws package proxy API", () => {
+  // These checks only exercise the constructor. close() follows at once, so
+  // nothing needs to listen on the proxy port.
+  const proxyPort = 1;
+
   test("accepts proxy option as string (HTTP proxy)", () => {
     const ws = new WebSocket("ws://example.com", {
       proxy: `http://127.0.0.1:${proxyPort}`,
@@ -102,7 +95,7 @@ describe("ws package proxy API", () => {
 
   test("accepts proxy option as string (HTTPS proxy)", () => {
     const ws = new WebSocket("ws://example.com", {
-      proxy: `https://127.0.0.1:${httpsProxyPort}`,
+      proxy: `https://127.0.0.1:${proxyPort}`,
       tls: { rejectUnauthorized: false },
     });
     expect(ws.readyState).toBe(WebSocket.CONNECTING);
@@ -119,7 +112,7 @@ describe("ws package proxy API", () => {
 
   test("accepts proxy URL with credentials", () => {
     const ws = new WebSocket("ws://example.com", {
-      proxy: `http://user:pass@127.0.0.1:${authProxyPort}`,
+      proxy: `http://user:pass@127.0.0.1:${proxyPort}`,
     });
     expect(ws.readyState).toBe(WebSocket.CONNECTING);
     ws.close();
@@ -139,462 +132,209 @@ describe("ws package proxy API", () => {
       new WebSocket("ws://example.com", {
         proxy: "not-a-valid-url",
       });
-    }).toThrow(SyntaxError);
+    }).toThrow(expect.objectContaining({ name: "SyntaxError", message: "Invalid proxy URL: not-a-valid-url" }));
   });
 });
 
 describe("ws package through HTTP CONNECT proxy", () => {
   test("ws:// through HTTP proxy", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
+    using recorded = await startRecordingProxy();
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://127.0.0.1:${proxyPort}`,
+      proxy: `http://127.0.0.1:${recorded.port}`,
     });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello from ws client");
+    expect({ events: await wsEchoSession(ws, "hello from ws client"), requests: recorded.requests }).toEqual({
+      events: echoed("hello from ws client"),
+      requests: [connectRequest(wsPort)],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello from ws client");
     gc();
   });
 
   test("ws:// through HTTP proxy with auth", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
+    using recorded = await startRecordingProxy({ requireAuth: true });
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://proxy_user:proxy_pass@127.0.0.1:${authProxyPort}`,
+      proxy: `http://proxy_user:proxy_pass@127.0.0.1:${recorded.port}`,
     });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello with auth via ws");
+    expect({ events: await wsEchoSession(ws, "hello with auth via ws"), requests: recorded.requests }).toEqual({
+      events: echoed("hello with auth via ws"),
+      requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("proxy_user:proxy_pass")}` })],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello with auth via ws");
     gc();
   });
 
   test("proxy auth failure returns error", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    let sawError = false;
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://127.0.0.1:${authProxyPort}`, // No auth provided
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const url = `ws://127.0.0.1:${wsPort}`;
+    const ws = new WebSocket(url, {
+      proxy: `http://127.0.0.1:${recorded.port}`, // No auth provided
     });
-
-    ws.on("open", () => {
-      ws.close();
-      reject(new Error("Expected proxy auth failure, but connection opened"));
+    // The proxy answered 407 to a CONNECT without credentials.
+    expect({ events: await wsFailingSession(ws), requests: recorded.requests }).toEqual({
+      events: failed(url, "Proxy connection failed", 1006),
+      requests: [connectRequest(wsPort)],
     });
-
-    ws.on("error", () => {
-      sawError = true;
-      ws.close();
-    });
-
-    ws.on("close", () => {
-      if (sawError) {
-        resolve();
-      } else {
-        reject(new Error("Expected proxy auth failure (error event), got clean close instead"));
-      }
-    });
-
-    await promise;
     gc();
   });
 
   test("proxy wrong credentials returns error", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    let sawError = false;
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://wrong_user:wrong_pass@127.0.0.1:${authProxyPort}`,
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const url = `ws://127.0.0.1:${wsPort}`;
+    const ws = new WebSocket(url, {
+      proxy: `http://wrong_user:wrong_pass@127.0.0.1:${recorded.port}`,
     });
-
-    ws.on("open", () => {
-      ws.close();
-      reject(new Error("Expected proxy auth failure, but connection opened"));
+    // The credentials were sent, and the proxy answered 403.
+    expect({ events: await wsFailingSession(ws), requests: recorded.requests }).toEqual({
+      events: failed(url, "Proxy connection failed", 1006),
+      requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("wrong_user:wrong_pass")}` })],
     });
-
-    ws.on("error", () => {
-      sawError = true;
-      ws.close();
-    });
-
-    ws.on("close", () => {
-      if (sawError) {
-        resolve();
-      } else {
-        reject(new Error("Expected proxy auth failure (error event), got clean close instead"));
-      }
-    });
-
-    await promise;
     gc();
   });
 });
 
 describe("ws package wss:// through HTTP proxy (TLS tunnel)", () => {
   test("wss:// through HTTP proxy", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
+    using recorded = await startRecordingProxy();
     const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
-      proxy: `http://127.0.0.1:${proxyPort}`,
-      tls: {
-        rejectUnauthorized: false, // Trust self-signed cert
-      },
+      proxy: `http://127.0.0.1:${recorded.port}`,
+      tls: { rejectUnauthorized: false }, // Trust self-signed cert
     });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello via tls tunnel from ws");
+    expect({ events: await wsEchoSession(ws, "hello via tls tunnel from ws"), requests: recorded.requests }).toEqual({
+      events: echoed("hello via tls tunnel from ws"),
+      requests: [connectRequest(wssPort)],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello via tls tunnel from ws");
     gc();
   });
 });
 
 describe("ws package through HTTPS proxy (TLS proxy)", () => {
   test("ws:// through HTTPS proxy with CA certificate", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
+    using recorded = await startRecordingProxy({ tls: true });
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `https://127.0.0.1:${httpsProxyPort}`,
-      tls: {
-        ca: tlsCerts.cert, // Trust self-signed proxy cert
-      },
+      proxy: `https://127.0.0.1:${recorded.port}`,
+      tls: { ca: tlsCerts.cert }, // Trust self-signed proxy cert
     });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello via https proxy from ws");
+    expect({ events: await wsEchoSession(ws, "hello via https proxy from ws"), requests: recorded.requests }).toEqual({
+      events: echoed("hello via https proxy from ws"),
+      requests: [connectRequest(wsPort)],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello via https proxy from ws");
     gc();
   });
 
   test("ws:// through HTTPS proxy with rejectUnauthorized: false", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
+    using recorded = await startRecordingProxy({ tls: true });
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `https://127.0.0.1:${httpsProxyPort}`,
-      tls: {
-        rejectUnauthorized: false, // Skip TLS verification for proxy
-      },
+      proxy: `https://127.0.0.1:${recorded.port}`,
+      tls: { rejectUnauthorized: false }, // Skip TLS verification for proxy
     });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello via https proxy no verify from ws");
+    expect({
+      events: await wsEchoSession(ws, "hello via https proxy no verify from ws"),
+      requests: recorded.requests,
+    }).toEqual({
+      events: echoed("hello via https proxy no verify from ws"),
+      requests: [connectRequest(wsPort)],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello via https proxy no verify from ws");
     gc();
   });
 
   test("ws:// through HTTPS proxy fails without CA certificate", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    let sawError = false;
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `https://127.0.0.1:${httpsProxyPort}`,
-      // No CA certificate - should fail (self-signed cert not trusted)
+    using recorded = await startRecordingProxy({ tls: true });
+    const url = `ws://127.0.0.1:${wsPort}`;
+    const ws = new WebSocket(url, {
+      proxy: `https://127.0.0.1:${recorded.port}`,
+      // No CA certificate: the proxy's self-signed certificate is not trusted.
     });
-
-    ws.on("open", () => {
-      ws.close();
-      reject(new Error("Expected TLS verification failure, but connection opened"));
+    // The client reached the proxy and gave up inside the TLS handshake, before any CONNECT.
+    expect({
+      events: await wsFailingSession(ws),
+      connections: recorded.connections,
+      requests: recorded.requests,
+    }).toEqual({
+      events: failed(url, "TLS handshake failed", 1015),
+      connections: 1,
+      requests: [],
     });
-
-    ws.on("error", () => {
-      sawError = true;
-      ws.close();
-    });
-
-    ws.on("close", () => {
-      if (sawError) {
-        resolve();
-      } else {
-        reject(new Error("Expected TLS verification failure (error event), got clean close instead"));
-      }
-    });
-
-    await promise;
     gc();
   });
 });
 
 describe("ws package with HttpsProxyAgent", () => {
   test("ws:// through HttpsProxyAgent", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const agent = new HttpsProxyAgent(`http://127.0.0.1:${proxyPort}`);
+    using recorded = await startRecordingProxy();
+    const agent = new HttpsProxyAgent(`http://127.0.0.1:${recorded.port}`);
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, { agent });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello from ws via HttpsProxyAgent");
+    expect({
+      events: await wsEchoSession(ws, "hello from ws via HttpsProxyAgent"),
+      requests: recorded.requests,
+    }).toEqual({
+      events: echoed("hello from ws via HttpsProxyAgent"),
+      requests: [connectRequest(wsPort)],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello from ws via HttpsProxyAgent");
     gc();
   });
 
   test("wss:// through HttpsProxyAgent with rejectUnauthorized", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const agent = new HttpsProxyAgent(`http://127.0.0.1:${proxyPort}`, {
+    using recorded = await startRecordingProxy();
+    const agent = new HttpsProxyAgent(`http://127.0.0.1:${recorded.port}`, {
       rejectUnauthorized: false,
     });
     const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, { agent });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello from wss via HttpsProxyAgent");
+    expect({
+      events: await wsEchoSession(ws, "hello from wss via HttpsProxyAgent"),
+      requests: recorded.requests,
+    }).toEqual({
+      events: echoed("hello from wss via HttpsProxyAgent"),
+      requests: [connectRequest(wssPort)],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello from wss via HttpsProxyAgent");
     gc();
   });
 
   test("HttpsProxyAgent with authentication", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const agent = new HttpsProxyAgent(`http://proxy_user:proxy_pass@127.0.0.1:${authProxyPort}`);
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const agent = new HttpsProxyAgent(`http://proxy_user:proxy_pass@127.0.0.1:${recorded.port}`);
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, { agent });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello from ws with auth via HttpsProxyAgent");
+    expect({
+      events: await wsEchoSession(ws, "hello from ws with auth via HttpsProxyAgent"),
+      requests: recorded.requests,
+    }).toEqual({
+      events: echoed("hello from ws with auth via HttpsProxyAgent"),
+      requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("proxy_user:proxy_pass")}` })],
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello from ws with auth via HttpsProxyAgent");
     gc();
   });
 
   test("HttpsProxyAgent with agent.proxy as URL object", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
+    using recorded = await startRecordingProxy();
     // HttpsProxyAgent stores the proxy URL as a URL object in agent.proxy
-    const agent = new HttpsProxyAgent(`http://127.0.0.1:${proxyPort}`);
-    // Verify the agent has the proxy property as a URL object
-    expect(agent.proxy).toBeDefined();
-    expect(typeof agent.proxy).toBe("object");
-    expect(agent.proxy.href).toContain(`127.0.0.1:${proxyPort}`);
+    const agent = new HttpsProxyAgent(`http://127.0.0.1:${recorded.port}`);
+    expect(agent.proxy).toBeInstanceOf(URL);
+    expect(agent.proxy.href).toBe(`http://127.0.0.1:${recorded.port}/`);
 
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, { agent });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello via agent with URL object");
-    });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello via agent with URL object");
+    expect({ events: await wsEchoSession(ws, "hello via agent with URL object"), requests: recorded.requests }).toEqual(
+      {
+        events: echoed("hello via agent with URL object"),
+        requests: [connectRequest(wsPort)],
+      },
+    );
     gc();
   });
 
   test("explicit proxy option takes precedence over agent", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    // Create agent pointing to wrong port (that doesn't exist)
-    const agent = new HttpsProxyAgent(`http://127.0.0.1:1`);
-    // But use explicit proxy option with correct port
+    using agentProxy = await startRecordingProxy();
+    using explicitProxy = await startRecordingProxy();
+    const agent = new HttpsProxyAgent(`http://127.0.0.1:${agentProxy.port}`);
     const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
       agent,
-      proxy: `http://127.0.0.1:${proxyPort}`, // This should take precedence
+      proxy: `http://127.0.0.1:${explicitProxy.port}`, // This should take precedence
     });
-
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("explicit proxy wins");
+    expect({
+      events: await wsEchoSession(ws, "explicit proxy wins"),
+      explicitRequests: explicitProxy.requests,
+      agentConnections: agentProxy.connections,
+    }).toEqual({
+      events: echoed("explicit proxy wins"),
+      explicitRequests: [connectRequest(wsPort)],
+      agentConnections: 0,
     });
-
-    ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
-    });
-
-    ws.on("error", (err: Error) => {
-      reject(err);
-    });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("explicit proxy wins");
     gc();
   });
 });

--- a/test/js/web/websocket/proxy-test-utils.ts
+++ b/test/js/web/websocket/proxy-test-utils.ts
@@ -142,15 +142,10 @@ export function createConnectProxy(options: ConnectProxyOptions = {}): net.Serve
     : net.createServer(onClient);
 }
 
-/** An HTTPS CONNECT proxy: `createConnectProxy` behind TLS. */
-export function createTLSConnectProxy(options: Omit<ConnectProxyOptions, "tls"> = {}): tls.Server {
-  return createConnectProxy({ ...options, tls: true }) as tls.Server;
-}
-
 /**
  * Helper to start a proxy server and get its port.
  */
-export async function startProxy(server: net.Server | tls.Server): Promise<number> {
+export async function startProxy(server: net.Server): Promise<number> {
   return new Promise<number>(resolve => {
     server.listen(0, "127.0.0.1", () => {
       const addr = server.address() as net.AddressInfo;

--- a/test/js/web/websocket/proxy-test-utils.ts
+++ b/test/js/web/websocket/proxy-test-utils.ts
@@ -1,14 +1,24 @@
 /**
- * Shared utilities for WebSocket proxy tests.
- * Used by both websocket-proxy.test.ts and ws-proxy.test.ts
+ * Shared utilities for the WebSocket proxy tests: websocket-proxy.test.ts,
+ * ws-proxy.test.ts and websocket-syscall-fault.test.ts.
  */
 
 import { tls as tlsCerts } from "harness";
 import net from "net";
 import tls from "tls";
 
+/** One CONNECT request as the proxy read it. Header names are lowercased. */
+export interface ConnectRequest {
+  requestLine: string;
+  headers: Record<string, string>;
+}
+
 export interface ConnectProxyOptions {
   requireAuth?: boolean;
+  /** Terminate TLS in front of the proxy (an HTTPS proxy), with the harness certificate. */
+  tls?: boolean;
+  /** Observes every CONNECT request the proxy reads, before the proxy answers it. */
+  onConnectRequest?: (request: ConnectRequest) => void;
   /**
    * Intercepts the bytes flowing target -> client once the tunnel is up. Call
    * `forward` to deliver bytes to the client. Defaults to forwarding every
@@ -18,11 +28,12 @@ export interface ConnectProxyOptions {
 }
 
 /**
- * Create an HTTP CONNECT proxy server using Node's net module.
- * This proxy handles the CONNECT method to establish tunnels for WebSocket connections.
+ * Create an HTTP CONNECT proxy server using Node's net module (tls module with
+ * `tls: true`). This proxy handles the CONNECT method to establish tunnels for
+ * WebSocket connections.
  */
 export function createConnectProxy(options: ConnectProxyOptions = {}): net.Server {
-  return net.createServer(clientSocket => {
+  const onClient = (clientSocket: net.Socket) => {
     let buffer = Buffer.alloc(0);
     let tunnelEstablished = false;
     let targetSocket: net.Socket | null = null;
@@ -54,6 +65,8 @@ export function createConnectProxy(options: ConnectProxyOptions = {}): net.Serve
           headers[line.substring(0, colonIdx).toLowerCase()] = line.substring(colonIdx + 2);
         }
       }
+
+      options.onConnectRequest?.({ requestLine, headers });
 
       // Check for CONNECT method
       const match = requestLine.match(/^CONNECT\s+([^:]+):(\d+)\s+HTTP/);
@@ -122,79 +135,16 @@ export function createConnectProxy(options: ConnectProxyOptions = {}): net.Serve
     clientSocket.on("error", () => {
       targetSocket?.destroy();
     });
-  });
+  };
+
+  return options.tls
+    ? tls.createServer({ key: tlsCerts.key, cert: tlsCerts.cert }, onClient)
+    : net.createServer(onClient);
 }
 
-/**
- * Create an HTTPS CONNECT proxy server using Node's tls module.
- * This proxy handles TLS-encrypted CONNECT tunnels.
- */
-export function createTLSConnectProxy(): tls.Server {
-  return tls.createServer(
-    {
-      key: tlsCerts.key,
-      cert: tlsCerts.cert,
-    },
-    clientSocket => {
-      let buffer = Buffer.alloc(0);
-      let tunnelEstablished = false;
-      let targetSocket: net.Socket | null = null;
-
-      clientSocket.on("data", data => {
-        if (tunnelEstablished && targetSocket) {
-          targetSocket.write(data);
-          return;
-        }
-
-        buffer = Buffer.concat([buffer, data]);
-        const bufferStr = buffer.toString();
-
-        const headerEnd = bufferStr.indexOf("\r\n\r\n");
-        if (headerEnd === -1) return;
-
-        const headerPart = bufferStr.substring(0, headerEnd);
-        const lines = headerPart.split("\r\n");
-        const requestLine = lines[0];
-
-        const match = requestLine.match(/^CONNECT\s+([^:]+):(\d+)\s+HTTP/);
-        if (!match) {
-          clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
-          clientSocket.end();
-          return;
-        }
-
-        const [, targetHost, targetPort] = match;
-        const remainingData = buffer.subarray(headerEnd + 4);
-
-        targetSocket = net.connect(parseInt(targetPort), targetHost, () => {
-          clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-          tunnelEstablished = true;
-
-          if (remainingData.length > 0) {
-            targetSocket!.write(remainingData);
-          }
-
-          targetSocket!.on("data", chunk => {
-            clientSocket.write(chunk);
-          });
-        });
-
-        targetSocket.on("error", () => {
-          if (!tunnelEstablished) {
-            clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
-          }
-          clientSocket.end();
-        });
-
-        targetSocket.on("close", () => clientSocket.destroy());
-        clientSocket.on("close", () => targetSocket?.destroy());
-      });
-
-      clientSocket.on("error", () => {
-        targetSocket?.destroy();
-      });
-    },
-  );
+/** An HTTPS CONNECT proxy: `createConnectProxy` behind TLS. */
+export function createTLSConnectProxy(options: Omit<ConnectProxyOptions, "tls"> = {}): tls.Server {
+  return createConnectProxy({ ...options, tls: true }) as tls.Server;
 }
 
 /**
@@ -207,4 +157,119 @@ export async function startProxy(server: net.Server | tls.Server): Promise<numbe
       resolve(addr.port);
     });
   });
+}
+
+/**
+ * Starts a CONNECT proxy for one test and records every connection it accepts
+ * and every CONNECT request it reads, so a test can assert what the client
+ * sent to the proxy and not only that the tunnel came up. Dispose to close it.
+ */
+export async function startRecordingProxy(options: ConnectProxyOptions = {}) {
+  const requests: ConnectRequest[] = [];
+  let connections = 0;
+  const proxy = createConnectProxy({
+    ...options,
+    onConnectRequest(request) {
+      requests.push(request);
+      options.onConnectRequest?.(request);
+    },
+  });
+  proxy.on("connection", () => {
+    connections++;
+  });
+  const port = await startProxy(proxy);
+  return {
+    port,
+    requests,
+    get connections() {
+      return connections;
+    },
+    [Symbol.dispose]() {
+      proxy.close();
+    },
+  };
+}
+
+/** The CONNECT request a client has to send to tunnel to `127.0.0.1:port`. */
+export function connectRequest(port: number, headers: Record<string, string> = {}): ConnectRequest {
+  return {
+    requestLine: `CONNECT 127.0.0.1:${port} HTTP/1.1`,
+    headers: { host: `127.0.0.1:${port}`, "proxy-connection": "Keep-Alive", ...headers },
+  };
+}
+
+/** A WebSocket echo server. It greets each client with "connected", then echoes every message. */
+export function startEchoServer(options: { tls?: boolean } = {}) {
+  return Bun.serve({
+    port: 0,
+    ...(options.tls ? { tls: { key: tlsCerts.key, cert: tlsCerts.cert } } : {}),
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("Expected WebSocket", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        ws.send("connected");
+      },
+      message(ws, message) {
+        ws.send(message);
+      },
+    },
+  });
+}
+
+export type ClientEvent = string | { error: string } | { code: number; reason: string; wasClean: boolean };
+
+/**
+ * Everything the client observes, in order: each message as a string, each
+ * error event as `{ error }` and the close event last. Resolves on close.
+ */
+export function clientEvents(ws: WebSocket): Promise<ClientEvent[]> {
+  const events: ClientEvent[] = [];
+  const { promise, resolve } = Promise.withResolvers<ClientEvent[]>();
+  ws.addEventListener("message", event => {
+    events.push(String(event.data));
+  });
+  ws.addEventListener("error", event => {
+    events.push({ error: (event as ErrorEvent).message });
+  });
+  ws.addEventListener("close", event => {
+    events.push({ code: event.code, reason: event.reason, wasClean: event.wasClean });
+    resolve(events);
+  });
+  return promise;
+}
+
+/**
+ * Sends `message` once open and closes after the echo arrives. A working
+ * tunnel to an echo server produces `echoed(message)`.
+ */
+export function echoSession(ws: WebSocket, message: string): Promise<ClientEvent[]> {
+  ws.addEventListener("open", () => ws.send(message));
+  ws.addEventListener("message", event => {
+    if (String(event.data) === message) ws.close(1000);
+  });
+  return clientEvents(ws);
+}
+
+/**
+ * For a connection that must fail: should it open after all, it is closed at
+ * once so the assertion reports the open instead of the test timing out.
+ */
+export function failingSession(ws: WebSocket): Promise<ClientEvent[]> {
+  ws.addEventListener("open", () => ws.close(1000));
+  return clientEvents(ws);
+}
+
+/** The echo server greets first, echoes the message, then the client closes cleanly. */
+export function echoed(message: string): ClientEvent[] {
+  return ["connected", message, { code: 1000, reason: "", wasClean: true }];
+}
+
+/** A connection the proxy refused, or whose TLS handshake with the proxy failed. */
+export function failed(url: string, reason: string, code: number): ClientEvent[] {
+  return [
+    { error: `WebSocket connection to '${new URL(url).href}' failed: ${reason}` },
+    { code, reason, wasClean: false },
+  ];
 }

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -2,9 +2,19 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as harness from "harness";
 import { tls as tlsCerts } from "harness";
 import type { HttpsProxyAgent as HttpsProxyAgentType } from "https-proxy-agent";
-import net from "net";
-import tls from "tls";
-import { type ConnectProxyOptions, createConnectProxy, createTLSConnectProxy, startProxy } from "./proxy-test-utils";
+import {
+  type ClientEvent,
+  clientEvents,
+  connectRequest,
+  createConnectProxy,
+  echoSession,
+  echoed,
+  failed,
+  failingSession,
+  startEchoServer,
+  startProxy,
+  startRecordingProxy,
+} from "./proxy-test-utils";
 // Use dynamic require to avoid linter removing the import
 const { HttpsProxyAgent } = require("https-proxy-agent") as {
   HttpsProxyAgent: typeof HttpsProxyAgentType;
@@ -27,199 +37,38 @@ const prevNoProxyLower = process.env.no_proxy;
 process.env.NO_PROXY = "";
 process.env.no_proxy = "";
 
-// HTTP CONNECT proxy server for WebSocket tunneling
-let proxy: net.Server;
-let authProxy: net.Server;
+// Echo servers. Every proxy is started by the test that uses it, so each test
+// can read what reached its proxy.
 let wsServer: ReturnType<typeof Bun.serve>;
 let wssServer: ReturnType<typeof Bun.serve>;
-let proxyPort: number;
-let authProxyPort: number;
 let wsPort: number;
 let wssPort: number;
 
-beforeAll(async () => {
-  // Create HTTP CONNECT proxy
-  proxy = createConnectProxy();
-  proxyPort = await startProxy(proxy);
-
-  // Create HTTP CONNECT proxy with auth
-  authProxy = createConnectProxy({ requireAuth: true });
-  authProxyPort = await startProxy(authProxy);
-
-  // Create WebSocket echo server
-  wsServer = Bun.serve({
-    port: 0,
-    fetch(req, server) {
-      if (server.upgrade(req)) {
-        return;
-      }
-      return new Response("Expected WebSocket", { status: 400 });
-    },
-    websocket: {
-      message(ws, message) {
-        // Echo back
-        ws.send(message);
-      },
-      open(ws) {
-        ws.send("connected");
-      },
-    },
-  });
+beforeAll(() => {
+  wsServer = startEchoServer();
   wsPort = wsServer.port;
-
-  // Create secure WebSocket echo server (wss://)
-  wssServer = Bun.serve({
-    port: 0,
-    tls: {
-      key: tlsCerts.key,
-      cert: tlsCerts.cert,
-    },
-    fetch(req, server) {
-      if (server.upgrade(req)) {
-        return;
-      }
-      return new Response("Expected WebSocket", { status: 400 });
-    },
-    websocket: {
-      message(ws, message) {
-        // Echo back
-        ws.send(message);
-      },
-      open(ws) {
-        ws.send("connected");
-      },
-    },
-  });
+  wssServer = startEchoServer({ tls: true });
   wssPort = wssServer.port;
 });
 
 afterAll(() => {
-  proxy?.close();
-  authProxy?.close();
   wsServer?.stop(true);
   wssServer?.stop(true);
   if (prevNoProxy !== undefined) process.env.NO_PROXY = prevNoProxy;
   if (prevNoProxyLower !== undefined) process.env.no_proxy = prevNoProxyLower;
 });
 
-type ClientEvent = string | { error: string } | { code: number; reason: string; wasClean: boolean };
-
-/**
- * Everything the client observes, in order: each message as a string, each
- * error event as `{ error }` and the close event last. Resolves on close.
- */
-function clientEvents(ws: WebSocket): Promise<ClientEvent[]> {
-  const events: ClientEvent[] = [];
-  const { promise, resolve } = Promise.withResolvers<ClientEvent[]>();
-  ws.addEventListener("message", event => {
-    events.push(String(event.data));
-  });
-  ws.addEventListener("error", event => {
-    events.push({ error: (event as ErrorEvent).message });
-  });
-  ws.addEventListener("close", event => {
-    events.push({ code: event.code, reason: event.reason, wasClean: event.wasClean });
-    resolve(events);
-  });
-  return promise;
-}
-
 function closeCodeOf(events: ClientEvent[]): number | undefined {
   const last = events[events.length - 1];
   return typeof last === "object" && "code" in last ? last.code : undefined;
 }
 
-/**
- * Connects to one of the echo servers, sends `message` once open and closes
- * after the echo arrives. A working tunnel produces `echoed(message)`.
- */
-function echoSession(url: string, options: Bun.WebSocketOptions, message: string): Promise<ClientEvent[]> {
-  const ws = new WebSocket(url, options);
-  ws.addEventListener("open", () => ws.send(message));
-  ws.addEventListener("message", event => {
-    if (String(event.data) === message) ws.close(1000);
-  });
-  return clientEvents(ws);
-}
-
-/** The echo server greets first, echoes the message, then the client closes cleanly. */
-function echoed(message: string): ClientEvent[] {
-  return ["connected", message, { code: 1000, reason: "", wasClean: true }];
-}
-
-/**
- * Connects where the connection must fail and returns the client's events once
- * it closes. Should it open after all, it is closed at once so the assertion
- * reports the open instead of the test timing out.
- */
-function failingSession(url: string, options: Bun.WebSocketOptions): Promise<ClientEvent[]> {
-  const ws = new WebSocket(url, options);
-  ws.addEventListener("open", () => ws.close(1000));
-  return clientEvents(ws);
-}
-
-/** A connection the proxy refused, or whose TLS handshake with the proxy failed. */
-function failed(url: string, reason: string, code: number): ClientEvent[] {
-  return [
-    { error: `WebSocket connection to '${new URL(url).href}' failed: ${reason}` },
-    { code, reason, wasClean: false },
-  ];
-}
-
-interface ConnectRequest {
-  requestLine: string;
-  headers: Record<string, string>;
-}
-
-/** The CONNECT request the client has to send to tunnel to the echo server on `port`. */
-function connectRequest(port: number, headers: Record<string, string> = {}): ConnectRequest {
-  return {
-    requestLine: `CONNECT 127.0.0.1:${port} HTTP/1.1`,
-    headers: { host: `127.0.0.1:${port}`, "proxy-connection": "Keep-Alive", ...headers },
-  };
-}
-
-/**
- * Starts an HTTP CONNECT proxy for one test and records every connection it
- * accepts and every CONNECT request it reads, so a test can assert what the
- * client sent to the proxy and not only that the tunnel came up.
- */
-async function startRecordingProxy(options: ConnectProxyOptions = {}) {
-  const proxy = createConnectProxy(options);
-  const requests: ConnectRequest[] = [];
-  let connections = 0;
-  proxy.on("connection", socket => {
-    connections++;
-    let head = "";
-    const onData = (chunk: Buffer) => {
-      head += chunk.toString("latin1");
-      const end = head.indexOf("\r\n\r\n");
-      if (end === -1) return;
-      socket.off("data", onData);
-      const [requestLine, ...headerLines] = head.slice(0, end).split("\r\n");
-      const headers: Record<string, string> = {};
-      for (const line of headerLines) {
-        const colon = line.indexOf(":");
-        headers[line.slice(0, colon).toLowerCase()] = line.slice(colon + 1).trim();
-      }
-      requests.push({ requestLine, headers });
-    };
-    socket.on("data", onData);
-  });
-  const port = await startProxy(proxy);
-  return {
-    port,
-    requests,
-    get connections() {
-      return connections;
-    },
-    [Symbol.dispose]() {
-      proxy.close();
-    },
-  };
-}
-
 describe("WebSocket proxy API", () => {
+  // These checks only exercise the constructor. close() follows at once, so
+  // nothing needs to listen on the proxy port.
+  const proxyPort = 1;
+  const authProxyPort = 1;
+
   test("accepts proxy option as string (HTTP proxy)", () => {
     const ws = new WebSocket("ws://example.com", {
       proxy: `http://127.0.0.1:${proxyPort}`,
@@ -334,23 +183,23 @@ describe("WebSocket proxy API", () => {
 
 describe("WebSocket through HTTP CONNECT proxy", () => {
   test("ws:// through HTTP proxy", async () => {
-    const events = await echoSession(
-      `ws://127.0.0.1:${wsPort}`,
-      { proxy: `http://127.0.0.1:${proxyPort}` },
-      "hello from client",
-    );
-    expect(events).toEqual(echoed("hello from client"));
+    using recorded = await startRecordingProxy();
+    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+      proxy: `http://127.0.0.1:${recorded.port}`,
+    });
+    expect({ events: await echoSession(ws, "hello from client"), requests: recorded.requests }).toEqual({
+      events: echoed("hello from client"),
+      requests: [connectRequest(wsPort)],
+    });
     gc();
   });
 
   test("ws:// through HTTP proxy with auth", async () => {
     using recorded = await startRecordingProxy({ requireAuth: true });
-    const events = await echoSession(
-      `ws://127.0.0.1:${wsPort}`,
-      { proxy: `http://proxy_user:proxy_pass@127.0.0.1:${recorded.port}` },
-      "hello with auth",
-    );
-    expect({ events, requests: recorded.requests }).toEqual({
+    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+      proxy: `http://proxy_user:proxy_pass@127.0.0.1:${recorded.port}`,
+    });
+    expect({ events: await echoSession(ws, "hello with auth"), requests: recorded.requests }).toEqual({
       events: echoed("hello with auth"),
       requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("proxy_user:proxy_pass")}` })],
     });
@@ -359,17 +208,13 @@ describe("WebSocket through HTTP CONNECT proxy", () => {
 
   test("ws:// through proxy with custom headers", async () => {
     using recorded = await startRecordingProxy();
-    const events = await echoSession(
-      `ws://127.0.0.1:${wsPort}`,
-      {
-        proxy: {
-          url: `http://127.0.0.1:${recorded.port}`,
-          headers: { "X-Custom-Proxy-Header": "test-value" },
-        },
+    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+      proxy: {
+        url: `http://127.0.0.1:${recorded.port}`,
+        headers: { "X-Custom-Proxy-Header": "test-value" },
       },
-      "hello with a proxy header",
-    );
-    expect({ events, requests: recorded.requests }).toEqual({
+    });
+    expect({ events: await echoSession(ws, "hello with a proxy header"), requests: recorded.requests }).toEqual({
       events: echoed("hello with a proxy header"),
       requests: [connectRequest(wsPort, { "x-custom-proxy-header": "test-value" })],
     });
@@ -379,17 +224,13 @@ describe("WebSocket through HTTP CONNECT proxy", () => {
   test("ws:// through proxy with Headers class instance", async () => {
     using recorded = await startRecordingProxy();
     const headers = new Headers({ "X-Custom-Proxy-Header": "test-value-from-headers-class" });
-    const events = await echoSession(
-      `ws://127.0.0.1:${wsPort}`,
-      {
-        proxy: {
-          url: `http://127.0.0.1:${recorded.port}`,
-          headers: headers,
-        },
+    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+      proxy: {
+        url: `http://127.0.0.1:${recorded.port}`,
+        headers: headers,
       },
-      "hello with a Headers instance",
-    );
-    expect({ events, requests: recorded.requests }).toEqual({
+    });
+    expect({ events: await echoSession(ws, "hello with a Headers instance"), requests: recorded.requests }).toEqual({
       events: echoed("hello with a Headers instance"),
       requests: [connectRequest(wsPort, { "x-custom-proxy-header": "test-value-from-headers-class" })],
     });
@@ -399,11 +240,11 @@ describe("WebSocket through HTTP CONNECT proxy", () => {
   test("proxy auth failure returns error", async () => {
     using recorded = await startRecordingProxy({ requireAuth: true });
     const url = `ws://127.0.0.1:${wsPort}`;
-    const events = await failingSession(url, {
+    const ws = new WebSocket(url, {
       proxy: `http://127.0.0.1:${recorded.port}`, // No auth provided
     });
     // The proxy answered 407 to a CONNECT without credentials.
-    expect({ events, requests: recorded.requests }).toEqual({
+    expect({ events: await failingSession(ws), requests: recorded.requests }).toEqual({
       events: failed(url, "Proxy connection failed", 1006),
       requests: [connectRequest(wsPort)],
     });
@@ -413,11 +254,11 @@ describe("WebSocket through HTTP CONNECT proxy", () => {
   test("proxy wrong credentials returns error", async () => {
     using recorded = await startRecordingProxy({ requireAuth: true });
     const url = `ws://127.0.0.1:${wsPort}`;
-    const events = await failingSession(url, {
+    const ws = new WebSocket(url, {
       proxy: `http://wrong_user:wrong_pass@127.0.0.1:${recorded.port}`,
     });
     // The credentials were sent, and the proxy answered 403.
-    expect({ events, requests: recorded.requests }).toEqual({
+    expect({ events: await failingSession(ws), requests: recorded.requests }).toEqual({
       events: failed(url, "Proxy connection failed", 1006),
       requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("wrong_user:wrong_pass")}` })],
     });
@@ -431,13 +272,16 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
   // negotiated inside the tunnel to the wss:// target server.
 
   test("wss:// through HTTP proxy", async () => {
-    // Local wss:// server with a self-signed certificate, so verification is off.
-    const events = await echoSession(
-      `wss://127.0.0.1:${wssPort}`,
-      { proxy: `http://127.0.0.1:${proxyPort}`, tls: { rejectUnauthorized: false } },
-      "hello via tls tunnel",
-    );
-    expect(events).toEqual(echoed("hello via tls tunnel"));
+    using recorded = await startRecordingProxy();
+    const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
+      proxy: `http://127.0.0.1:${recorded.port}`,
+      // The wss:// server uses a self-signed certificate.
+      tls: { rejectUnauthorized: false },
+    });
+    expect({ events: await echoSession(ws, "hello via tls tunnel"), requests: recorded.requests }).toEqual({
+      events: echoed("hello via tls tunnel"),
+      requests: [connectRequest(wssPort)],
+    });
     gc();
   });
 
@@ -481,8 +325,9 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
       },
     });
 
+    using recorded = await startRecordingProxy();
     const ws = new WebSocket(`wss://127.0.0.1:${pingServer.port}`, {
-      proxy: `http://127.0.0.1:${proxyPort}`,
+      proxy: `http://127.0.0.1:${recorded.port}`,
       tls: { rejectUnauthorized: false },
     });
     ws.addEventListener("open", () => ws.send("ready"));
@@ -495,10 +340,11 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
     // anything, so the server's close is only awaited after a clean close.
     const serverCloseCode = closeCodeOf(events) === 1000 ? await serverClosed.promise : "client did not close cleanly";
     // The pong reached the server before the close frame did.
-    expect({ events, pongs, serverCloseCode }).toEqual({
+    expect({ events, pongs, serverCloseCode, requests: recorded.requests }).toEqual({
       events: ["after-ping", { code: 1000, reason: "", wasClean: true }],
       pongs: 1,
       serverCloseCode: 1000,
+      requests: [connectRequest(pingServer.port)],
     });
     gc();
   });
@@ -709,53 +555,50 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
 describe("WebSocket through HTTPS proxy (TLS proxy)", () => {
   // These tests verify WebSocket connections through HTTPS (TLS) proxy servers
 
-  let httpsProxy: tls.Server;
-  let httpsProxyPort: number;
-
-  beforeAll(async () => {
-    // Create HTTPS CONNECT proxy
-    httpsProxy = createTLSConnectProxy();
-    httpsProxyPort = await startProxy(httpsProxy);
-  });
-
-  afterAll(() => {
-    httpsProxy?.close();
-  });
-
   test("ws:// through HTTPS proxy with CA certificate", async () => {
-    const events = await echoSession(
-      `ws://127.0.0.1:${wsPort}`,
-      {
-        proxy: `https://127.0.0.1:${httpsProxyPort}`,
-        // Trust the self-signed certificate used by the proxy
-        tls: { ca: tlsCerts.cert },
-      },
-      "hello via https proxy",
-    );
-    expect(events).toEqual(echoed("hello via https proxy"));
+    using recorded = await startRecordingProxy({ tls: true });
+    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+      proxy: `https://127.0.0.1:${recorded.port}`,
+      // Trust the self-signed certificate used by the proxy
+      tls: { ca: tlsCerts.cert },
+    });
+    expect({ events: await echoSession(ws, "hello via https proxy"), requests: recorded.requests }).toEqual({
+      events: echoed("hello via https proxy"),
+      requests: [connectRequest(wsPort)],
+    });
     gc();
   });
 
   test("ws:// through HTTPS proxy fails without CA certificate", async () => {
+    using recorded = await startRecordingProxy({ tls: true });
     const url = `ws://127.0.0.1:${wsPort}`;
-    const events = await failingSession(url, {
-      proxy: `https://127.0.0.1:${httpsProxyPort}`,
+    const ws = new WebSocket(url, {
+      proxy: `https://127.0.0.1:${recorded.port}`,
       // No CA certificate: the proxy's self-signed certificate is not trusted.
     });
-    expect(events).toEqual(failed(url, "TLS handshake failed", 1015));
+    // The client reached the proxy and gave up inside the TLS handshake, before any CONNECT.
+    expect({
+      events: await failingSession(ws),
+      connections: recorded.connections,
+      requests: recorded.requests,
+    }).toEqual({
+      events: failed(url, "TLS handshake failed", 1015),
+      connections: 1,
+      requests: [],
+    });
     gc();
   });
 
   test("ws:// through HTTPS proxy with rejectUnauthorized: false", async () => {
-    const events = await echoSession(
-      `ws://127.0.0.1:${wsPort}`,
-      {
-        proxy: `https://127.0.0.1:${httpsProxyPort}`,
-        tls: { rejectUnauthorized: false }, // Skip TLS verification for the proxy
-      },
-      "hello via https proxy no verify",
-    );
-    expect(events).toEqual(echoed("hello via https proxy no verify"));
+    using recorded = await startRecordingProxy({ tls: true });
+    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+      proxy: `https://127.0.0.1:${recorded.port}`,
+      tls: { rejectUnauthorized: false }, // Skip TLS verification for the proxy
+    });
+    expect({ events: await echoSession(ws, "hello via https proxy no verify"), requests: recorded.requests }).toEqual({
+      events: echoed("hello via https proxy no verify"),
+      requests: [connectRequest(wsPort)],
+    });
     gc();
   });
 });

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -4,7 +4,7 @@ import { tls as tlsCerts } from "harness";
 import type { HttpsProxyAgent as HttpsProxyAgentType } from "https-proxy-agent";
 import net from "net";
 import tls from "tls";
-import { createConnectProxy, createTLSConnectProxy, startProxy } from "./proxy-test-utils";
+import { type ConnectProxyOptions, createConnectProxy, createTLSConnectProxy, startProxy } from "./proxy-test-utils";
 // Use dynamic require to avoid linter removing the import
 const { HttpsProxyAgent } = require("https-proxy-agent") as {
   HttpsProxyAgent: typeof HttpsProxyAgentType;
@@ -102,6 +102,123 @@ afterAll(() => {
   if (prevNoProxyLower !== undefined) process.env.no_proxy = prevNoProxyLower;
 });
 
+type ClientEvent = string | { error: string } | { code: number; reason: string; wasClean: boolean };
+
+/**
+ * Everything the client observes, in order: each message as a string, each
+ * error event as `{ error }` and the close event last. Resolves on close.
+ */
+function clientEvents(ws: WebSocket): Promise<ClientEvent[]> {
+  const events: ClientEvent[] = [];
+  const { promise, resolve } = Promise.withResolvers<ClientEvent[]>();
+  ws.addEventListener("message", event => {
+    events.push(String(event.data));
+  });
+  ws.addEventListener("error", event => {
+    events.push({ error: (event as ErrorEvent).message });
+  });
+  ws.addEventListener("close", event => {
+    events.push({ code: event.code, reason: event.reason, wasClean: event.wasClean });
+    resolve(events);
+  });
+  return promise;
+}
+
+function closeCodeOf(events: ClientEvent[]): number | undefined {
+  const last = events[events.length - 1];
+  return typeof last === "object" && "code" in last ? last.code : undefined;
+}
+
+/**
+ * Connects to one of the echo servers, sends `message` once open and closes
+ * after the echo arrives. A working tunnel produces `echoed(message)`.
+ */
+function echoSession(url: string, options: Bun.WebSocketOptions, message: string): Promise<ClientEvent[]> {
+  const ws = new WebSocket(url, options);
+  ws.addEventListener("open", () => ws.send(message));
+  ws.addEventListener("message", event => {
+    if (String(event.data) === message) ws.close(1000);
+  });
+  return clientEvents(ws);
+}
+
+/** The echo server greets first, echoes the message, then the client closes cleanly. */
+function echoed(message: string): ClientEvent[] {
+  return ["connected", message, { code: 1000, reason: "", wasClean: true }];
+}
+
+/**
+ * Connects where the connection must fail and returns the client's events once
+ * it closes. Should it open after all, it is closed at once so the assertion
+ * reports the open instead of the test timing out.
+ */
+function failingSession(url: string, options: Bun.WebSocketOptions): Promise<ClientEvent[]> {
+  const ws = new WebSocket(url, options);
+  ws.addEventListener("open", () => ws.close(1000));
+  return clientEvents(ws);
+}
+
+/** A connection the proxy refused, or whose TLS handshake with the proxy failed. */
+function failed(url: string, reason: string, code: number): ClientEvent[] {
+  return [
+    { error: `WebSocket connection to '${new URL(url).href}' failed: ${reason}` },
+    { code, reason, wasClean: false },
+  ];
+}
+
+interface ConnectRequest {
+  requestLine: string;
+  headers: Record<string, string>;
+}
+
+/** The CONNECT request the client has to send to tunnel to the echo server on `port`. */
+function connectRequest(port: number, headers: Record<string, string> = {}): ConnectRequest {
+  return {
+    requestLine: `CONNECT 127.0.0.1:${port} HTTP/1.1`,
+    headers: { host: `127.0.0.1:${port}`, "proxy-connection": "Keep-Alive", ...headers },
+  };
+}
+
+/**
+ * Starts an HTTP CONNECT proxy for one test and records every connection it
+ * accepts and every CONNECT request it reads, so a test can assert what the
+ * client sent to the proxy and not only that the tunnel came up.
+ */
+async function startRecordingProxy(options: ConnectProxyOptions = {}) {
+  const proxy = createConnectProxy(options);
+  const requests: ConnectRequest[] = [];
+  let connections = 0;
+  proxy.on("connection", socket => {
+    connections++;
+    let head = "";
+    const onData = (chunk: Buffer) => {
+      head += chunk.toString("latin1");
+      const end = head.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      socket.off("data", onData);
+      const [requestLine, ...headerLines] = head.slice(0, end).split("\r\n");
+      const headers: Record<string, string> = {};
+      for (const line of headerLines) {
+        const colon = line.indexOf(":");
+        headers[line.slice(0, colon).toLowerCase()] = line.slice(colon + 1).trim();
+      }
+      requests.push({ requestLine, headers });
+    };
+    socket.on("data", onData);
+  });
+  const port = await startProxy(proxy);
+  return {
+    port,
+    requests,
+    get connections() {
+      return connections;
+    },
+    [Symbol.dispose]() {
+      proxy.close();
+    },
+  };
+}
+
 describe("WebSocket proxy API", () => {
   test("accepts proxy option as string (HTTP proxy)", () => {
     const ws = new WebSocket("ws://example.com", {
@@ -186,7 +303,7 @@ describe("WebSocket proxy API", () => {
       new WebSocket("ws://example.com", {
         proxy: "not-a-valid-url",
       });
-    }).toThrow(SyntaxError);
+    }).toThrow(expect.objectContaining({ name: "SyntaxError", message: "Invalid proxy URL: not-a-valid-url" }));
   });
 
   test.each(["socks5", "socks4", "socks5h", "ftp", "ws", "gopher"])(
@@ -217,177 +334,93 @@ describe("WebSocket proxy API", () => {
 
 describe("WebSocket through HTTP CONNECT proxy", () => {
   test("ws:// through HTTP proxy", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://127.0.0.1:${proxyPort}`,
-    });
-
-    const receivedMessages: string[] = [];
-
-    ws.onopen = () => {
-      ws.send("hello from client");
-    };
-
-    ws.onmessage = event => {
-      receivedMessages.push(String(event.data));
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    };
-
-    ws.onclose = () => {
-      resolve(receivedMessages);
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello from client");
+    const events = await echoSession(
+      `ws://127.0.0.1:${wsPort}`,
+      { proxy: `http://127.0.0.1:${proxyPort}` },
+      "hello from client",
+    );
+    expect(events).toEqual(echoed("hello from client"));
     gc();
   });
 
   test("ws:// through HTTP proxy with auth", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://proxy_user:proxy_pass@127.0.0.1:${authProxyPort}`,
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const events = await echoSession(
+      `ws://127.0.0.1:${wsPort}`,
+      { proxy: `http://proxy_user:proxy_pass@127.0.0.1:${recorded.port}` },
+      "hello with auth",
+    );
+    expect({ events, requests: recorded.requests }).toEqual({
+      events: echoed("hello with auth"),
+      requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("proxy_user:proxy_pass")}` })],
     });
-
-    const receivedMessages: string[] = [];
-
-    ws.onopen = () => {
-      ws.send("hello with auth");
-    };
-
-    ws.onmessage = event => {
-      receivedMessages.push(String(event.data));
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    };
-
-    ws.onclose = () => {
-      resolve(receivedMessages);
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello with auth");
     gc();
   });
 
   test("ws:// through proxy with custom headers", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: {
-        url: `http://127.0.0.1:${proxyPort}`,
-        headers: { "X-Custom-Proxy-Header": "test-value" },
+    using recorded = await startRecordingProxy();
+    const events = await echoSession(
+      `ws://127.0.0.1:${wsPort}`,
+      {
+        proxy: {
+          url: `http://127.0.0.1:${recorded.port}`,
+          headers: { "X-Custom-Proxy-Header": "test-value" },
+        },
       },
+      "hello with a proxy header",
+    );
+    expect({ events, requests: recorded.requests }).toEqual({
+      events: echoed("hello with a proxy header"),
+      requests: [connectRequest(wsPort, { "x-custom-proxy-header": "test-value" })],
     });
-
-    ws.onopen = () => {
-      ws.close();
-      resolve();
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    await promise;
     gc();
   });
 
   test("ws:// through proxy with Headers class instance", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-
+    using recorded = await startRecordingProxy();
     const headers = new Headers({ "X-Custom-Proxy-Header": "test-value-from-headers-class" });
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: {
-        url: `http://127.0.0.1:${proxyPort}`,
-        headers: headers,
+    const events = await echoSession(
+      `ws://127.0.0.1:${wsPort}`,
+      {
+        proxy: {
+          url: `http://127.0.0.1:${recorded.port}`,
+          headers: headers,
+        },
       },
+      "hello with a Headers instance",
+    );
+    expect({ events, requests: recorded.requests }).toEqual({
+      events: echoed("hello with a Headers instance"),
+      requests: [connectRequest(wsPort, { "x-custom-proxy-header": "test-value-from-headers-class" })],
     });
-
-    ws.onopen = () => {
-      ws.close();
-      resolve();
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    await promise;
     gc();
   });
 
   test("proxy auth failure returns error", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    let sawError = false;
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://127.0.0.1:${authProxyPort}`, // No auth provided
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const url = `ws://127.0.0.1:${wsPort}`;
+    const events = await failingSession(url, {
+      proxy: `http://127.0.0.1:${recorded.port}`, // No auth provided
     });
-
-    ws.onopen = () => {
-      ws.close();
-      reject(new Error("Expected proxy auth failure, but connection opened"));
-    };
-
-    ws.onerror = () => {
-      sawError = true;
-      ws.close();
-    };
-
-    ws.onclose = () => {
-      if (sawError) {
-        resolve();
-      } else {
-        reject(new Error("Expected proxy auth failure (error event), got clean close instead"));
-      }
-    };
-
-    await promise;
+    // The proxy answered 407 to a CONNECT without credentials.
+    expect({ events, requests: recorded.requests }).toEqual({
+      events: failed(url, "Proxy connection failed", 1006),
+      requests: [connectRequest(wsPort)],
+    });
     gc();
   });
 
   test("proxy wrong credentials returns error", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    let sawError = false;
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `http://wrong_user:wrong_pass@127.0.0.1:${authProxyPort}`,
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const url = `ws://127.0.0.1:${wsPort}`;
+    const events = await failingSession(url, {
+      proxy: `http://wrong_user:wrong_pass@127.0.0.1:${recorded.port}`,
     });
-
-    ws.onopen = () => {
-      ws.close();
-      reject(new Error("Expected proxy auth failure, but connection opened"));
-    };
-
-    ws.onerror = () => {
-      sawError = true;
-      ws.close();
-    };
-
-    ws.onclose = () => {
-      if (sawError) {
-        resolve();
-      } else {
-        reject(new Error("Expected proxy auth failure (error event), got clean close instead"));
-      }
-    };
-
-    await promise;
+    // The credentials were sent, and the proxy answered 403.
+    expect({ events, requests: recorded.requests }).toEqual({
+      events: failed(url, "Proxy connection failed", 1006),
+      requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("wrong_user:wrong_pass")}` })],
+    });
     gc();
   });
 });
@@ -398,41 +431,13 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
   // negotiated inside the tunnel to the wss:// target server.
 
   test("wss:// through HTTP proxy", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    // Use local wss:// server with self-signed cert
-    const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
-      proxy: `http://127.0.0.1:${proxyPort}`,
-      tls: {
-        // Trust the self-signed certificate used by the wss:// server
-        rejectUnauthorized: false,
-      },
-    });
-
-    const receivedMessages: string[] = [];
-
-    ws.onopen = () => {
-      ws.send("hello via tls tunnel");
-    };
-
-    ws.onmessage = event => {
-      receivedMessages.push(String(event.data));
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    };
-
-    ws.onclose = () => {
-      resolve(receivedMessages);
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello via tls tunnel");
+    // Local wss:// server with a self-signed certificate, so verification is off.
+    const events = await echoSession(
+      `wss://127.0.0.1:${wssPort}`,
+      { proxy: `http://127.0.0.1:${proxyPort}`, tls: { rejectUnauthorized: false } },
+      "hello via tls tunnel",
+    );
+    expect(events).toEqual(echoed("hello via tls tunnel"));
     gc();
   });
 
@@ -443,6 +448,8 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
     // through proxy_tunnel). Detached sockets return true for isClosed(), so
     // sendPong would immediately dispatch a 1006 close instead of sending the
     // pong through the tunnel.
+    let pongs = 0;
+    const serverClosed = Promise.withResolvers<number>();
     using pingServer = Bun.serve({
       port: 0,
       tls: {
@@ -465,39 +472,34 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
             ws.send("after-ping");
           }
         },
+        pong() {
+          pongs++;
+        },
+        close(_ws, code) {
+          serverClosed.resolve(code);
+        },
       },
     });
-
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
 
     const ws = new WebSocket(`wss://127.0.0.1:${pingServer.port}`, {
       proxy: `http://127.0.0.1:${proxyPort}`,
       tls: { rejectUnauthorized: false },
     });
+    ws.addEventListener("open", () => ws.send("ready"));
+    ws.addEventListener("message", event => {
+      if (String(event.data) === "after-ping") ws.close(1000);
+    });
 
-    ws.onopen = () => {
-      ws.send("ready");
-    };
-
-    ws.onmessage = event => {
-      if (String(event.data) === "after-ping") {
-        ws.close(1000);
-      }
-    };
-
-    ws.onclose = event => {
-      if (event.code === 1000) {
-        resolve();
-      } else {
-        reject(new Error(`Unexpected close code: ${event.code}`));
-      }
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    await promise;
+    const events = await clientEvents(ws);
+    // A client that failed the connection itself never tells the server
+    // anything, so the server's close is only awaited after a clean close.
+    const serverCloseCode = closeCodeOf(events) === 1000 ? await serverClosed.promise : "client did not close cleanly";
+    // The pong reached the server before the close frame did.
+    expect({ events, pongs, serverCloseCode }).toEqual({
+      events: ["after-ping", { code: 1000, reason: "", wasClean: true }],
+      pongs: 1,
+      serverCloseCode: 1000,
+    });
     gc();
   });
 
@@ -721,108 +723,39 @@ describe("WebSocket through HTTPS proxy (TLS proxy)", () => {
   });
 
   test("ws:// through HTTPS proxy with CA certificate", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `https://127.0.0.1:${httpsProxyPort}`,
-      tls: {
+    const events = await echoSession(
+      `ws://127.0.0.1:${wsPort}`,
+      {
+        proxy: `https://127.0.0.1:${httpsProxyPort}`,
         // Trust the self-signed certificate used by the proxy
-        ca: tlsCerts.cert,
+        tls: { ca: tlsCerts.cert },
       },
-    });
-
-    const receivedMessages: string[] = [];
-
-    ws.onopen = () => {
-      ws.send("hello via https proxy");
-    };
-
-    ws.onmessage = event => {
-      receivedMessages.push(String(event.data));
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    };
-
-    ws.onclose = () => {
-      resolve(receivedMessages);
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello via https proxy");
+      "hello via https proxy",
+    );
+    expect(events).toEqual(echoed("hello via https proxy"));
     gc();
   });
 
   test("ws:// through HTTPS proxy fails without CA certificate", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    let sawError = false;
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+    const url = `ws://127.0.0.1:${wsPort}`;
+    const events = await failingSession(url, {
       proxy: `https://127.0.0.1:${httpsProxyPort}`,
-      // No CA certificate - should fail (self-signed cert not trusted)
+      // No CA certificate: the proxy's self-signed certificate is not trusted.
     });
-
-    ws.onopen = () => {
-      ws.close();
-      reject(new Error("Expected TLS verification failure, but connection opened"));
-    };
-
-    ws.onerror = () => {
-      sawError = true;
-      ws.close();
-    };
-
-    ws.onclose = () => {
-      if (sawError) {
-        resolve();
-      } else {
-        reject(new Error("Expected TLS verification failure (error event), got clean close instead"));
-      }
-    };
-
-    await promise;
+    expect(events).toEqual(failed(url, "TLS handshake failed", 1015));
     gc();
   });
 
   test("ws:// through HTTPS proxy with rejectUnauthorized: false", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
-      proxy: `https://127.0.0.1:${httpsProxyPort}`,
-      tls: {
-        rejectUnauthorized: false, // Skip TLS verification for proxy
+    const events = await echoSession(
+      `ws://127.0.0.1:${wsPort}`,
+      {
+        proxy: `https://127.0.0.1:${httpsProxyPort}`,
+        tls: { rejectUnauthorized: false }, // Skip TLS verification for the proxy
       },
-    });
-
-    const receivedMessages: string[] = [];
-
-    ws.onopen = () => {
-      ws.send("hello via https proxy no verify");
-    };
-
-    ws.onmessage = event => {
-      receivedMessages.push(String(event.data));
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
-    };
-
-    ws.onclose = () => {
-      resolve(receivedMessages);
-    };
-
-    ws.onerror = event => {
-      reject(event);
-    };
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello via https proxy no verify");
+      "hello via https proxy no verify",
+    );
+    expect(events).toEqual(echoed("hello via https proxy no verify"));
     gc();
   });
 });
@@ -930,118 +863,73 @@ describe("ws module with HttpsProxyAgent", () => {
   const WS = require("ws");
 
   test("ws module passes agent to native WebSocket", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-
-    const agent = new HttpsProxyAgent(`http://127.0.0.1:${proxyPort}`);
+    using recorded = await startRecordingProxy();
+    const agent = new HttpsProxyAgent(`http://127.0.0.1:${recorded.port}`);
     const ws = new WS(`ws://127.0.0.1:${wsPort}`, { agent });
 
-    const receivedMessages: string[] = [];
-
-    ws.on("open", () => {
-      ws.send("hello from ws module via agent");
-    });
-
+    const events: unknown[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    ws.on("open", () => ws.send("hello from ws module via agent"));
     ws.on("message", (data: Buffer) => {
-      receivedMessages.push(data.toString());
-      if (receivedMessages.length === 2) {
-        ws.close();
-      }
+      events.push(data.toString());
+      if (events.length === 2) ws.close(1000);
     });
-
-    ws.on("close", () => {
-      resolve(receivedMessages);
+    ws.on("error", (err: Error) => events.push({ error: err.message }));
+    ws.on("close", (code: number, reason: Buffer) => {
+      events.push({ code, reason: String(reason) });
+      resolve();
     });
+    await promise;
 
-    ws.on("error", (err: Error) => {
-      reject(err);
+    // The CONNECT request proves the connection went through the agent's proxy.
+    expect({ events, requests: recorded.requests }).toEqual({
+      events: ["connected", "hello from ws module via agent", { code: 1000, reason: "" }],
+      requests: [connectRequest(wsPort)],
     });
-
-    const messages = await promise;
-    expect(messages).toContain("connected");
-    expect(messages).toContain("hello from ws module via agent");
     gc();
   });
 });
 
 describe.concurrent("WebSocket NO_PROXY bypass", () => {
-  test("NO_PROXY matching hostname bypasses explicit proxy for ws://", async () => {
-    // authProxy requires credentials; if NO_PROXY works, the WebSocket bypasses
-    // the proxy and connects directly. If NO_PROXY doesn't work, the proxy
-    // rejects with 407 and the WebSocket errors.
+  // Each child connects to the echo server through an auth proxy it has no
+  // credentials for. When NO_PROXY applies, the proxy never sees a connection
+  // and the echo server greets the child. When it does not apply, the proxy
+  // answers the CONNECT with 407 and the child reports the failure.
+  const childScript = (proxyPort: number) => `
+    const ws = new WebSocket("ws://127.0.0.1:${wsPort}", { proxy: "http://127.0.0.1:${proxyPort}" });
+    ws.onmessage = event => { console.log("message:", event.data); ws.close(1000); };
+    ws.onerror = event => console.log("error:", event.message);
+    ws.onclose = event => console.log("close:", event.code, JSON.stringify(event.reason));
+  `;
+
+  test.each([
+    ["NO_PROXY matching hostname bypasses explicit proxy for ws://", () => "127.0.0.1", "direct"],
+    ["NO_PROXY matching host:port bypasses proxy for ws://", () => `127.0.0.1:${wsPort}`, "direct"],
+    ["NO_PROXY not matching still uses proxy (auth fails)", () => "other.host.com", "proxied"],
+    ["NO_PROXY=* bypasses all proxies", () => "*", "direct"],
+  ] as const)("%s", async (_, noProxy, outcome) => {
+    using recorded = await startRecordingProxy({ requireAuth: true });
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const ws = new WebSocket("ws://127.0.0.1:${wsPort}", { proxy: "http://127.0.0.1:${authProxyPort}" });
-         ws.onopen = () => { ws.close(); process.exit(0); };
-         ws.onerror = () => { process.exit(1); };`,
-      ],
-      env: { ...bunEnv, NO_PROXY: "127.0.0.1" },
+      cmd: [bunExe(), "-e", childScript(recorded.port)],
+      // The lowercase variable takes precedence over NO_PROXY, so an ambient
+      // no_proxy=127.0.0.1 must not reach the child.
+      env: { ...bunEnv, NO_PROXY: noProxy(), no_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) console.error("stderr:", stderr);
-    expect(exitCode).toBe(0);
-  });
-
-  test("NO_PROXY matching host:port bypasses proxy for ws://", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const ws = new WebSocket("ws://127.0.0.1:${wsPort}", { proxy: "http://127.0.0.1:${authProxyPort}" });
-         ws.onopen = () => { ws.close(); process.exit(0); };
-         ws.onerror = () => { process.exit(1); };`,
-      ],
-      env: { ...bunEnv, NO_PROXY: `127.0.0.1:${wsPort}` },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) console.error("stderr:", stderr);
-    expect(exitCode).toBe(0);
-  });
-
-  test("NO_PROXY not matching still uses proxy (auth fails)", async () => {
-    // NO_PROXY doesn't match the target, so the WebSocket should go through
-    // the auth proxy without credentials, which rejects with 407.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const ws = new WebSocket("ws://127.0.0.1:${wsPort}", { proxy: "http://127.0.0.1:${authProxyPort}" });
-         ws.onopen = () => { process.exit(1); };
-         ws.onerror = () => { process.exit(0); };`,
-      ],
-      env: { ...bunEnv, NO_PROXY: "other.host.com" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const exitCode = await proc.exited;
-    // exit(0) means onerror fired, proving the proxy was used (and auth failed)
-    expect(exitCode).toBe(0);
-  });
-
-  test("NO_PROXY=* bypasses all proxies", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const ws = new WebSocket("ws://127.0.0.1:${wsPort}", { proxy: "http://127.0.0.1:${authProxyPort}" });
-         ws.onopen = () => { ws.close(); process.exit(0); };
-         ws.onerror = () => { process.exit(1); };`,
-      ],
-      env: { ...bunEnv, NO_PROXY: "*" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) console.error("stderr:", stderr);
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode, proxyConnections: recorded.connections }).toEqual(
+      outcome === "direct"
+        ? { stdout: `message: connected\nclose: 1000 ""\n`, stderr: "", exitCode: 0, proxyConnections: 0 }
+        : {
+            stdout:
+              `error: WebSocket connection to 'ws://127.0.0.1:${wsPort}/' failed: Proxy connection failed\n` +
+              `close: 1006 "Proxy connection failed"\n`,
+            stderr: "",
+            exitCode: 0,
+            proxyConnections: 1,
+          },
+    );
   });
 });


### PR DESCRIPTION
### Problem
- `websocket-proxy.test.ts` and its twin `test/js/first_party/ws/ws-proxy.test.ts` check outcomes loosely: `toContain` on the message list, "some error fired" on the failure paths, no check that a proxy header reached the proxy, no `expect()` in the ping regression test, and NO_PROXY children that exit 0 or 1.
- No test checks that the proxy was used. With this container's ambient `NO_PROXY=localhost,127.0.0.1,...`, 16 of the 19 twin tests pass with the proxy bypassed and the other 3 fail.
- The file was reported as a 163 s test on darwin aarch64 (build 106656). The runner log shows 199 ms there, and 117 to 208 ms across the last five main builds. No speed change is needed.

### Fix
- `proxy-test-utils.ts` exposes the CONNECT request it already parses through an `onConnectRequest` hook, folds the TLS proxy into `createConnectProxy({ tls: true })`, and exports `startRecordingProxy` (port, requests, connection count), `connectRequest`, `startEchoServer` and the client event helpers.
- Every tunneling test starts its own recording proxy and asserts the CONNECT request (target, headers, `Proxy-Authorization`) next to one exact event list: `["connected", message, { code: 1000, reason: "", wasClean: true }]`. Failure paths assert the error message and close event (1006 "Proxy connection failed", 1015 "TLS handshake failed") and close an unexpected open at once.
- The NO_PROXY children print their events. The test compares stdout, stderr, exit code and the proxy's connection count (0 bypassed, 1 used). The twin clears the ambient NO_PROXY, and "explicit proxy wins" checks that the agent's proxy saw no connection.
- Verified: `bun bd test` on both files and the two other importers of the helper, 57 pass. Release: 0.27 s for both files (0.22 s + 0.17 s before). Every new assertion fails under a mutation of its input (details below).

### Background
- `createConnectProxy` is a Node `net` (or `tls`) server that parses one CONNECT request, answers 407, 403 or 200, and pipes the client to the target. The hook runs after the parse and before the answer.
- NO_PROXY also applies to an explicit `proxy:` option, and bun reads `no_proxy` before `NO_PROXY` (`src/dotenv/env_loader.rs:374`). #37439 moves the clearing into the harness. This PR keeps the module-level clearing in both files until it lands.

<details><summary>Notes</summary>

**The 163 s figure.** Buildkite build 106656, job `:darwin: any aarch64 - test-bun` (01a04234-72d1): the runner log has the file at `[299/3162]`, `Ran 38 tests across 1 file. [199.00ms]`, and the Buildkite timestamps around it span 206 ms. The other darwin aarch64 job of that build did not run the file. Darwin x64 in the same build: 221 ms. Darwin aarch64 in the last five main builds: 106385 185 ms, 106512 208 ms, 106596 119 ms, 106656 199 ms, 106692 117 ms. The per-test sum of the file is about 0.16 s, so the reported number is most likely the junit suite time read in the wrong unit.

**Local timing (this container).** Release (`USE_SYSTEM_BUN=1 bun test`): websocket-proxy 0.24 to 0.39 s before, 0.21 to 0.28 s after; ws-proxy 0.16 to 0.18 s before; both files together 0.26 to 0.28 s after (5 runs). Debug (`bun bd test`): websocket-proxy 6.1 to 6.4 s before, 6.0 s after; ws-proxy 5.3 s after; both together with the CI env (`BUN_GARBAGE_COLLECTOR_LEVEL=1 BUN_JSC_randomIntegrityAuditRate=1.0`) 8.5 s, 3 runs. About 2.7 s of the debug time of websocket-proxy is module load (`https-proxy-agent`, `ws`, `docker/index.ts`) plus `beforeAll`. The slowest tests are the four NO_PROXY children (0.3 s each in debug, they already run concurrently). Nothing else is converted to `concurrent`: the TLS tunnel regression tests depend on event loop ordering (the `setImmediate` spin and the held burst), and there is nothing to gain on a 0.2 s file.

**Mutations checked against the new assertions** (each run on a copy of the file with the release binary, all fail in under 15 ms):
- client sends no custom header: `ws:// through proxy with custom headers` fails on the recorded CONNECT request.
- `NO_PROXY=other.host.com` in a "direct" case: fails on stdout and `proxyConnections: 1`.
- ambient `no_proxy=127.0.0.1` in the "proxied" case: fails on stdout and `proxyConnections: 0`.
- server never pings: `pongs: 0`.
- right credentials in `proxy wrong credentials returns error`, the CA given in `fails without CA certificate` (both files): fail with the open and clean close in the event list. Before this change the same mutation hung until the 5 s timeout.
- twin, `explicit proxy option takes precedence over agent` with the explicit option pointing at the agent's proxy: fails on `explicitRequests: []`.
- twin, process-level `no_proxy=127.0.0.1` left in place: 13 of 19 tests fail on `requests: []` (before this change all 16 through-proxy tests passed that way).

**Scope.** Three test files, no runtime change. `createTLSConnectProxy` is gone: its only callers were the two rewritten files, and `createConnectProxy({ tls: true })` replaces it. The Docker Squid section of websocket-proxy.test.ts is untouched (it cannot run here). The constructor checks in both `proxy API` sections now use port 1 (nothing needs to listen: `close()` follows at once) instead of the shared fixtures, which are gone. `tsc -p test/tsconfig.json` reports the same classes of errors on these files before and after (the test tsconfig resolves the DOM `WebSocket` constructor and `@types/ws`, so every `proxy:` option already errors on main; the helper's `socket.on("data")` Buffer typing is unchanged).

**Review.** A self-review of the first revision found the recorder in the wrong layer (a second CONNECT parser in the test file, unusable by the twin and by the TLS proxy) and three sessions still on the unrecorded shared proxy. This revision moves the recording into the helper, migrates those sessions and the HTTPS proxy tests, and applies the same assertions to the twin.

**Open PRs that touch these files:** #37439 (proxy env isolation, edits the NO_PROXY env code in both files), #37638 (adds tests after `rejects invalid proxy URL`), #37504 and #37487 (add tests after the ping test in websocket-proxy.test.ts). The NO_PROXY block and the ping test are rewritten here, so those PRs need a small rebase.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/first_party/ws/ws-proxy.test.ts' 'test/js/web/websocket/websocket-proxy.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/first_party/ws/ws-proxy.test.ts test/js/web/websocket/websocket-proxy.test.ts
bun test v1.4.1 (731aa92da)

test/js/first_party/ws/ws-proxy.test.ts:
(pass) ws package proxy API > accepts proxy option as string (HTTP proxy) [30.17ms]
(pass) ws package proxy API > accepts proxy option as string (HTTPS proxy) [4.89ms]
(pass) ws package proxy API > accepts proxy option with object containing url [2.64ms]
(pass) ws package proxy API > accepts proxy URL with credentials [3.22ms]
(pass) ws package proxy API > can combine proxy with headers and protocols [4.25ms]
(pass) ws package proxy API > rejects invalid proxy URL [4.66ms]
(pass) ws package through HTTP CONNECT proxy > ws:// through HTTP proxy [493.11ms]
(pass) ws package through HTTP CONNECT proxy > ws:// through HTTP proxy with auth [192.90ms]
(pass) ws package through HTTP CONNECT proxy > proxy auth failure returns error [102.68ms]
(pass) ws package through HTTP CONNECT proxy > proxy wrong credentials returns error [85.41ms]
(pass) ws package wss:// through HTTP proxy (TLS tunnel) > wss:// through HTTP proxy [113.43ms]
(pass) ws package through HTTPS proxy (TLS proxy) > ws:// through HTTPS proxy with CA certificate [246.55ms]
(pass) ws package through HTTPS proxy (TLS proxy) > ws:// through HTTPS proxy with rejectUnauthorized: false [130.83ms]
(pass) ws package through HTTPS proxy (TLS proxy) > ws:// through HTTPS proxy fails without CA certificate [92.43ms]
(pass) ws package with HttpsProxyAgent > ws:// through HttpsProxyAgent [133.63ms]
(pass) ws package with HttpsProxyAgent > wss:// through HttpsProxyAgent with rejectUnauthorized [111.82ms]
(pass) ws package with HttpsProxyAgent > HttpsProxyAgent with authentication [101.82ms]
(pass) ws package with HttpsProxyAgent > HttpsProxyAgent with agent.proxy as URL object [116.92ms]
(pass) ws package with HttpsProxyAgent > explicit proxy option takes precedence over agent [113
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/first_party/ws/ws-proxy.test.ts       | 606 +++++++-----------------
 test/js/web/websocket/proxy-test-utils.ts     | 210 ++++++---
 test/js/web/websocket/websocket-proxy.test.ts | 641 ++++++++------------------
 3 files changed, 494 insertions(+), 963 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/first_party/ws/ws-proxy.test.ts            1      1      0
test/js/web/websocket/proxy-test-utils.ts          2      3      0
test/js/web/websocket/websocket-proxy.test.ts      7     11      0
```

</details>

<!-- robobun:evidence:end -->