### PR TITLE
install(hoisted): install file: folders with the default backend instead of one symlink per file

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -502,7 +502,7 @@ rm -rf node_modules
 bun install --backend copyfile
 ```
 
-**`symlink`** is typically only used for `file:` dependencies internally (for example `file:../foo` and transitive `file:` dependencies). `link:` dependencies do not use this backend; Bun installs them as a single symlink to the linked directory.
+**`symlink`** symlinks each file instead of copying it. Without the flag, Bun only uses it for a package that depends on itself (`"pkg": "file:."`). Other `file:` folders, inside or outside the project, use the default backend, so their files resolve their dependencies from the project's `node_modules`. `link:` dependencies do not use this backend; Bun installs them as a single symlink to the linked directory.
 
 If you install with `--backend=symlink`, Node.js won't resolve node_modules of dependencies unless each dependency has its own node_modules folder or you pass `--preserve-symlinks` to `node` or `bun`. See [Node.js documentation on `--preserve-symlinks`](https://nodejs.org/api/cli.html#--preserve-symlinks).
 

--- a/docs/pm/global-cache.mdx
+++ b/docs/pm/global-cache.mdx
@@ -58,7 +58,7 @@ Configure this with the `--backend` flag, which all of Bun's package management 
 - **`clonefile`**: Default on macOS.
 - **`clonefile_each_dir`**: Similar to `clonefile`, except it clones each file individually per directory. It is only available on macOS and tends to perform slower than `clonefile`.
 - **`copyfile`**: The fallback used when any of the above fail. It is the slowest option. On macOS, it uses `fcopyfile()`; on Linux it uses `copy_file_range()`.
-- **`symlink`**: Symlinks each file instead of copying it. Only hoisted installs use it: `--backend=symlink` applies it to every package (macOS and Linux; Windows ignores the flag); without the flag, Bun uses it only for `file:` dependencies outside the project directory (for example `file:../foo`) and for transitive `file:` dependencies.
+- **`symlink`**: Symlinks each file instead of copying it. Only hoisted installs use it: `--backend=symlink` applies it to every package (macOS and Linux; Windows ignores the flag); without the flag, Bun uses it only for a package that depends on itself (`"pkg": "file:."`). Other `file:` folders, inside or outside the project directory, are installed with the default backend. A folder that contains the project (`"pkg": "file:.."`) is installed without its `node_modules`.
 
 If you install with `--backend=symlink`, Node.js doesn't resolve node_modules of dependencies unless each dependency has its own `node_modules` folder or you pass `--preserve-symlinks` to `node`. See [Node.js documentation on `--preserve-symlinks`](https://nodejs.org/api/cli.html#--preserve-symlinks).
 

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -82,8 +82,8 @@ pub enum Method {
     /// - it reads each dir twice incase the first pass modifies it
     Copyfile,
 
-    /// Used for file: when file: points to a parent directory
-    /// example: "file:../"
+    /// One symlink per file into the source folder. Used for `--backend=symlink`
+    /// and for a package that depends on itself (`file:.`).
     Symlink,
 }
 
@@ -1004,6 +1004,31 @@ impl<'a> PackageInstall<'a> {
             == self.package_name.slice(&self.lockfile.buffers.string_bytes)
     }
 
+    /// The source is a `file:` folder that contains the destination `node_modules`
+    /// (`"pkg": "file:../"`). A walk into that `node_modules` would install the
+    /// destination into itself.
+    fn source_folder_contains_destination(&self, destination_dir: &Dir) -> bool {
+        // Only `file:` folder sources resolve relative to the cwd.
+        if self.cache_dir != Fd::cwd() {
+            return false;
+        }
+        // fd-derived paths: the destination can sit behind a workspace symlink
+        // (node_modules/a -> packages/a), which a lexical compare misses.
+        let Ok(source_dir) = open_dir(self.cache_dir, self.cache_dir_subpath) else {
+            return false;
+        };
+        let mut source_buf = bun_paths::path_buffer_pool::get();
+        let mut dest_buf = bun_paths::path_buffer_pool::get();
+        let (Ok(source), Ok(node_modules_dir)) = (
+            sys::get_fd_path(source_dir.fd(), &mut source_buf),
+            sys::get_fd_path(destination_dir.fd(), &mut dest_buf),
+        ) else {
+            return false;
+        };
+        path::resolve_path::is_parent_or_equal(source, node_modules_dir)
+            != path::resolve_path::ParentEqual::Unrelated
+    }
+
     // ───────────────────────────── install backends ─────────────────────────────
 
     #[cfg(target_os = "macos")]
@@ -1015,10 +1040,16 @@ impl<'a> PackageInstall<'a> {
             Ok(d) => d,
             Err(err) => return Ok(InstallResult::fail(err, Step::OpeningCacheDir, None)),
         };
+        let skip_dirs: &[&OSPathSlice] = if self.source_folder_contains_destination(destination_dir)
+        {
+            &[bun_paths::os_path_literal!("node_modules")]
+        } else {
+            &[]
+        };
         let mut walker_ = match walker_skippable::walk_owned(
             cached_package_dir,
             &[] as &[&OSPathSlice],
-            &[] as &[&OSPathSlice],
+            skip_dirs,
         ) {
             Ok(w) => w,
             Err(err) => return Ok(InstallResult::fail(err.into(), Step::OpeningCacheDir, None)),
@@ -1079,8 +1110,11 @@ impl<'a> PackageInstall<'a> {
             Ok(d) => d,
             Err(err) => return Ok(InstallResult::fail(err.into(), Step::OpeningDestDir, None)),
         };
-        if let Err(err) = copy(&subdir, &mut walker_) {
-            return Ok(InstallResult::fail(err, Step::CopyingFiles, None));
+        match copy(&subdir, &mut walker_) {
+            Ok(()) => {}
+            // `install()` falls back to copyfile only on `Err(NotSupported)`.
+            Err(crate::Error::NotSupported) => return Err(crate::Error::NotSupported),
+            Err(err) => return Ok(InstallResult::fail(err, Step::CopyingFiles, None)),
         }
 
         Ok(InstallResult::Success)
@@ -1089,6 +1123,12 @@ impl<'a> PackageInstall<'a> {
     // https://www.unix.com/man-page/mojave/2/fclonefileat/
     #[cfg(target_os = "macos")]
     fn install_with_clonefile(&mut self, destination_dir: &Dir) -> crate::Result<InstallResult> {
+        if self.source_folder_contains_destination(destination_dir) {
+            // A whole-directory clone cannot skip `node_modules`; the
+            // per-directory walk can.
+            return self.install_with_clonefile_each_dir(destination_dir);
+        }
+
         if self.destination_dir_subpath.as_bytes()[0] == b'@' {
             if let Some(slash) = strings::index_of_char_z(self.destination_dir_subpath, SEP) {
                 let slash = slash as usize;
@@ -1153,29 +1193,11 @@ impl<'a> PackageInstall<'a> {
             Err(err) => return Err(Failure::boxed(err, Step::OpeningCacheDir, None)),
         };
 
-        // `bun.OSPathLiteral("node_modules")` — u8 on posix / u16 on windows.
-        #[cfg(windows)]
-        const NODE_MODULES_LIT: &OSPathSlice = &[
-            b'n' as u16,
-            b'o' as u16,
-            b'd' as u16,
-            b'e' as u16,
-            b'_' as u16,
-            b'm' as u16,
-            b'o' as u16,
-            b'd' as u16,
-            b'u' as u16,
-            b'l' as u16,
-            b'e' as u16,
-            b's' as u16,
-        ];
-        #[cfg(not(windows))]
-        const NODE_MODULES_LIT: &OSPathSlice = b"node_modules";
-        let skip_dirs: &[&OSPathSlice] = if method == Method::Symlink
-            && self.cache_dir_subpath.len() == 1
-            && self.cache_dir_subpath.as_bytes()[0] == b'.'
+        let skip_dirs: &[&OSPathSlice] = if (method == Method::Symlink
+            && self.cache_dir_subpath.as_bytes() == b".")
+            || self.source_folder_contains_destination(destination_dir)
         {
-            &[NODE_MODULES_LIT]
+            &[bun_paths::os_path_literal!("node_modules")]
         } else {
             &[]
         };
@@ -2232,9 +2254,7 @@ impl<'a> PackageInstall<'a> {
     }
 
     pub(crate) fn get_install_method(&self) -> Method {
-        if self.cache_dir_subpath.as_bytes() == b"."
-            || self.cache_dir_subpath.as_bytes().starts_with(b"..")
-        {
+        if self.cache_dir_subpath.as_bytes() == b"." {
             Method::Symlink
         } else {
             Self::supported_method()
@@ -2315,17 +2335,16 @@ impl<'a> PackageInstall<'a> {
             self.uninstall_before_install(destination_dir);
         }
 
+        // Only the macOS and POSIX fallbacks below lower the method.
+        #[cfg(not(windows))]
         let mut supported_method_to_use = method_;
+        #[cfg(windows)]
+        let supported_method_to_use = method_;
 
+        #[cfg(not(windows))]
         let is_folder = resolution_tag == resolution::Tag::Folder;
-
-        if is_folder
-            && !self
-                .lockfile
-                .is_workspace_tree_id(self.node_modules.tree_id)
-        {
-            supported_method_to_use = Method::Symlink;
-        }
+        #[cfg(windows)]
+        let _ = resolution_tag;
 
         match supported_method_to_use {
             Method::Clonefile => {

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2241,6 +2241,14 @@ impl<'a> PackageInstall<'a> {
         }
     }
 
+    /// A folder is linked from its own directory, so its failure says nothing about the cache.
+    #[cfg(not(windows))]
+    fn remember_copyfile_fallback(is_folder: bool) {
+        if !is_folder {
+            Self::set_supported_method(Method::Copyfile);
+        }
+    }
+
     pub(crate) fn package_missing_from_cache(
         &mut self,
         manager: &mut PackageManager,
@@ -2309,7 +2317,9 @@ impl<'a> PackageInstall<'a> {
 
         let mut supported_method_to_use = method_;
 
-        if resolution_tag == resolution::Tag::Folder
+        let is_folder = resolution_tag == resolution::Tag::Folder;
+
+        if is_folder
             && !self
                 .lockfile
                 .is_workspace_tree_id(self.node_modules.tree_id)
@@ -2327,7 +2337,7 @@ impl<'a> PackageInstall<'a> {
                         Ok(result) => return result,
                         Err(err) => {
                             if err == crate::Error::NotSupported {
-                                Self::set_supported_method(Method::Copyfile);
+                                Self::remember_copyfile_fallback(is_folder);
                                 supported_method_to_use = Method::Copyfile;
                             } else if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
                                 return InstallResult::fail(
@@ -2349,7 +2359,7 @@ impl<'a> PackageInstall<'a> {
                         Ok(result) => return result,
                         Err(err) => {
                             if err == crate::Error::NotSupported {
-                                Self::set_supported_method(Method::Copyfile);
+                                Self::remember_copyfile_fallback(is_folder);
                                 supported_method_to_use = Method::Copyfile;
                             } else if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
                                 return InstallResult::fail(
@@ -2372,8 +2382,12 @@ impl<'a> PackageInstall<'a> {
                         #[cfg(not(windows))]
                         {
                             if err == crate::Error::NotSameFileSystem {
-                                Self::set_supported_method(Method::Copyfile);
+                                Self::remember_copyfile_fallback(is_folder);
                                 supported_method_to_use = Method::Copyfile;
+                                // copyfile's O_TRUNC would empty the source through the files already linked.
+                                if self.destination_dir_subpath.as_bytes() != b"." {
+                                    self.uninstall_before_install(destination_dir);
+                                }
                                 break 'outer;
                             }
                         }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1824,8 +1824,7 @@ impl<'a> PackageInstaller<'a> {
                         || (resolution.tag == resolution::Tag::Folder
                             && !self.lockfile().is_workspace_tree_id(self.current_tree_id))
                     {
-                        // This is a transitive folder dependency. It is installed with a single symlink to the target folder/file,
-                        // and is not hoisted.
+                        // This is a transitive folder dependency. It is not hoisted.
                         //
                         // A transitive `Resolution::Folder` declared by a local `file:` package
                         // is relative to the top-level dir (`Package::parse` normalized it), so

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -97,3 +97,118 @@ describe.skipIf(!isLinux || isMusl || !cc)("hardlink backend falls back to copyf
     }
   }
 });
+
+// A folder dependency is linked from its own directory, not from the cache.
+describe.skipIf(!isLinux || isMusl || !cc)("hardlink backend, folder dependency that cannot be hardlinked", () => {
+  // `linkat` fails with EXDEV when `fail` (a C expression over `calls`,
+  // `oldpath`, `newpath`) is true. Other calls go to the real `linkat`.
+  const shimC = (fail: string) => /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <string.h>
+
+int linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath,
+           int flags) {
+  static int calls = 0;
+  calls++;
+  if (${fail}) {
+    errno = EXDEV;
+    return -1;
+  }
+  int (*real)(int, const char *, int, const char *, int) = dlsym(RTLD_NEXT, "linkat");
+  return real(olddirfd, oldpath, newdirfd, newpath, flags);
+}
+`;
+
+  async function installWithShim(dir: string, expectedInstalled: string) {
+    {
+      await using compile = Bun.spawn({
+        cmd: [cc!, "-shared", "-fPIC", "-o", "shim.so", "shim.c", "-ldl"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [compileOut, compileErr, compileExit] = await Promise.all([
+        compile.stdout.text(),
+        compile.stderr.text(),
+        compile.exited,
+      ]);
+      if (compileExit !== 0) {
+        throw new Error(`shim compile failed: ${compileOut}${compileErr}`);
+      }
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--backend", "hardlink", "--linker", "hoisted"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(dir, "cache"),
+        LD_PRELOAD: [join(dir, "shim.so"), bunEnv.LD_PRELOAD].filter(Boolean).join(":"),
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("EXDEV");
+    expect(stdout).toContain(expectedInstalled);
+    expect(exitCode).toBe(0);
+  }
+
+  // The folder is on another file system: only this package falls back to
+  // copying. Packages from the cache keep using hardlinks.
+  test.concurrent("does not switch the remaining packages to copyfile", async () => {
+    // Packages install in name order: `aaa-local` hits EXDEV before `zzz-bar`
+    // is linked from the cache.
+    using dir = tempDir("hardlink-xdev-folder", {
+      "shim.c": shimC(`strstr(oldpath, "xdev-marker") || strstr(newpath, "xdev-marker")`),
+      "package.json": JSON.stringify({
+        name: "hardlink-xdev-folder-test",
+        dependencies: { "aaa-local": "file:./aaa-local", "zzz-bar": "file:./bar-0.0.2.tgz" },
+      }),
+      "aaa-local/package.json": JSON.stringify({ name: "aaa-local", version: "1.2.3" }),
+      "aaa-local/xdev-marker.js": "module.exports = 1;",
+    });
+    cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
+
+    await installWithShim(String(dir), "2 packages installed");
+
+    // The folder was copied: nlink === 1.
+    expect(statSync(join(String(dir), "node_modules", "aaa-local", "xdev-marker.js")).nlink).toBe(1);
+    // The package after it is still hardlinked from the cache: nlink >= 2.
+    const fromCache = join(String(dir), "node_modules", "zzz-bar", "package.json");
+    expect(await Bun.file(fromCache).json()).toMatchObject({ name: "bar", version: "0.0.2" });
+    expect(statSync(fromCache).nlink).toBeGreaterThanOrEqual(2);
+  });
+
+  // The first file of the folder is hardlinked, then `linkat` fails. The copy
+  // that follows must not truncate the source through that hardlink.
+  test.concurrent(
+    "keeps the source files intact when the fallback to copyfile starts after a partial link",
+    async () => {
+      const files = {
+        "package.json": JSON.stringify({ name: "local", version: "1.2.3" }),
+        "index.js": "module.exports = require('./other.js') + ' from index';",
+        "other.js": "module.exports = 'other';",
+      };
+      using dir = tempDir("hardlink-partial-folder", {
+        "shim.c": shimC("calls == 2"),
+        "package.json": JSON.stringify({
+          name: "hardlink-partial-folder-test",
+          dependencies: { local: "file:./local" },
+        }),
+        ...Object.fromEntries(Object.entries(files).map(([name, content]) => [`local/${name}`, content])),
+      });
+
+      await installWithShim(String(dir), "1 package installed");
+
+      for (const [name, content] of Object.entries(files)) {
+        expect(await Bun.file(join(String(dir), "local", name)).text()).toBe(content);
+        const installed = join(String(dir), "node_modules", "local", name);
+        expect(await Bun.file(installed).text()).toBe(content);
+        expect(statSync(installed).nlink).toBe(1);
+      }
+    },
+  );
+});

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4744,64 +4744,45 @@ describe("hoisting", async () => {
 });
 
 describe("transitive file dependencies", () => {
+  // The nested copy of a transitive `file:` folder is linked or copied like any
+  // other package. Only a package that depends on itself (`file:.`) is symlinked.
+  const files = {
+    "name": "files",
+    "version": "1.1.1",
+    "dependencies": {
+      "no-deps": "2.0.0",
+    },
+  };
+
   async function checkHoistedFiles() {
-    const aliasedFileDepFilesPackageJson = join(
-      packageDir,
-      "node_modules",
-      "aliased-file-dep",
-      "node_modules",
-      "files",
-      "the-files",
-      "package.json",
-    );
     const results = await Promise.all([
-      (
-        await lstat(join(packageDir, "node_modules", "file-dep", "node_modules", "files", "package.json"))
-      ).isSymbolicLink(),
+      file(join(packageDir, "node_modules", "file-dep", "node_modules", "files", "package.json")).json(),
       readdirSorted(join(packageDir, "node_modules", "missing-file-dep", "node_modules")),
       exists(join(packageDir, "node_modules", "aliased-file-dep", "package.json")),
-      isWindows
-        ? file(await readlink(aliasedFileDepFilesPackageJson)).json()
-        : file(aliasedFileDepFilesPackageJson).json(),
-      (
-        await lstat(
-          join(packageDir, "node_modules", "@scoped", "file-dep", "node_modules", "@scoped", "files", "package.json"),
-        )
-      ).isSymbolicLink(),
-      (
-        await lstat(
-          join(
-            packageDir,
-            "node_modules",
-            "@another-scope",
-            "file-dep",
-            "node_modules",
-            "@scoped",
-            "files",
-            "package.json",
-          ),
-        )
-      ).isSymbolicLink(),
+      file(
+        join(packageDir, "node_modules", "aliased-file-dep", "node_modules", "files", "the-files", "package.json"),
+      ).json(),
+      file(
+        join(packageDir, "node_modules", "@scoped", "file-dep", "node_modules", "@scoped", "files", "package.json"),
+      ).json(),
+      file(
+        join(
+          packageDir,
+          "node_modules",
+          "@another-scope",
+          "file-dep",
+          "node_modules",
+          "@scoped",
+          "files",
+          "package.json",
+        ),
+      ).json(),
       (
         await lstat(join(packageDir, "node_modules", "self-file-dep", "node_modules", "self-file-dep", "package.json"))
       ).isSymbolicLink(),
     ]);
 
-    expect(results).toEqual([
-      true,
-      [],
-      true,
-      {
-        "name": "files",
-        "version": "1.1.1",
-        "dependencies": {
-          "no-deps": "2.0.0",
-        },
-      },
-      true,
-      true,
-      true,
-    ]);
+    expect(results).toEqual([files, [], true, files, files, files, true]);
   }
 
   async function checkUnhoistedFiles() {
@@ -4814,46 +4795,41 @@ describe("transitive file dependencies", () => {
       file(join(packageDir, "node_modules", "@another-scope", "file-dep", "package.json")).json(),
       file(join(packageDir, "node_modules", "self-file-dep", "package.json")).json(),
 
-      (
-        await lstat(join(packageDir, "pkg1", "node_modules", "file-dep", "node_modules", "files", "package.json"))
-      ).isSymbolicLink(),
+      file(join(packageDir, "pkg1", "node_modules", "file-dep", "node_modules", "files", "package.json")).json(),
       readdirSorted(join(packageDir, "pkg1", "node_modules", "missing-file-dep", "node_modules")), // []
       file(join(packageDir, "pkg1", "node_modules", "aliased-file-dep", "package.json")).json(),
+      // `aliased-file-dep` depends on itself: `files: "file:."`.
       (
         await lstat(
           join(packageDir, "pkg1", "node_modules", "aliased-file-dep", "node_modules", "files", "package.json"),
         )
       ).isSymbolicLink(),
-      (
-        await lstat(
-          join(
-            packageDir,
-            "pkg1",
-            "node_modules",
-            "@scoped",
-            "file-dep",
-            "node_modules",
-            "@scoped",
-            "files",
-            "package.json",
-          ),
-        )
-      ).isSymbolicLink(),
-      (
-        await lstat(
-          join(
-            packageDir,
-            "pkg1",
-            "node_modules",
-            "@another-scope",
-            "file-dep",
-            "node_modules",
-            "@scoped",
-            "files",
-            "package.json",
-          ),
-        )
-      ).isSymbolicLink(),
+      file(
+        join(
+          packageDir,
+          "pkg1",
+          "node_modules",
+          "@scoped",
+          "file-dep",
+          "node_modules",
+          "@scoped",
+          "files",
+          "package.json",
+        ),
+      ).json(),
+      file(
+        join(
+          packageDir,
+          "pkg1",
+          "node_modules",
+          "@another-scope",
+          "file-dep",
+          "node_modules",
+          "@scoped",
+          "files",
+          "package.json",
+        ),
+      ).json(),
       (
         await lstat(
           join(packageDir, "pkg1", "node_modules", "self-file-dep", "node_modules", "self-file-dep", "package.json"),
@@ -4864,12 +4840,12 @@ describe("transitive file dependencies", () => {
 
     const expected = [
       ...(Array(7).fill({ name: "a-dep", version: "1.0.1" }) as any),
-      true,
+      files,
       [] as string[],
       { name: "file-dep", version: "1.0.1", dependencies: { files: "file:." } },
       true,
-      true,
-      true,
+      files,
+      files,
       true,
       [
         "@another-scope",

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,7 +1,7 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
 import { readFileSync, readlinkSync, realpathSync, statSync } from "fs";
-import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
+import { access, cp, exists, lstat, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
   bunExe,
@@ -10332,6 +10332,236 @@ it("does not install transitive file: dependencies with overlong folder targets"
   expect(exitCode).toBe(1);
 });
 
+it("reinstalls a file: dependency pointing at an ancestor directory", async () => {
+  // "sample" depends on its own parent package via `file:../`, so the copy
+  // source contains the destination node_modules. The walk must skip
+  // node_modules directories: descending into them copied every installed
+  // package into node_modules/poto itself, and on reinstall raced the
+  // asynchronous deletion of the renamed previous install (ENOENT).
+  using dir = tempDir("file-dep-ancestor", {
+    "package.json": JSON.stringify({ name: "poto", version: "1.0.0" }),
+    "index.js": "module.exports = 'poto';",
+    "sample/package.json": JSON.stringify({
+      name: "sample",
+      version: "1.0.0",
+      dependencies: { poto: "file:../" },
+    }),
+  });
+  const projectDir = join(String(dir), "sample");
+
+  for (let i = 0; i < 3; i++) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("ENOENT");
+    expect(err).not.toContain("Failed to install");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    // The copy contains the package's files but never a snapshot of the
+    // project's own node_modules.
+    expect(await exists(join(projectDir, "node_modules", "poto", "package.json"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "index.js"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "sample", "node_modules"))).toBe(false);
+  }
+
+  // The installed copy resolves at runtime.
+  await using runProc = spawn({
+    cmd: [bunExe(), "-e", "console.log(require('poto'))"],
+    cwd: projectDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  expect(runErr).toBe("");
+  expect(runOut).toBe("poto\n");
+  expect(runExit).toBe(0);
+});
+
+it("reinstalls a file: dependency on an ancestor directory resolved to an absolute path", async () => {
+  // Folder paths parsed from package.json are normalized relative to the
+  // project (`file:../` becomes `..`), but resolutions parsed from a lockfile
+  // are verbatim. Both walks must skip the project's node_modules when the
+  // source contains the destination.
+  using dir = tempDir("file-dep-ancestor-abs", {
+    "package.json": JSON.stringify({ name: "poto", version: "1.0.0" }),
+    "index.js": "module.exports = 'poto';",
+    "sample/package.json": "",
+  });
+  // On case-insensitive filesystems, containment must be detected even when
+  // the lockfile spells the ancestor path with different casing. Flip only the
+  // ASCII basename and keep the real spelling where the flipped path does not
+  // resolve (case-sensitive filesystems).
+  const realRoot = String(dir).replaceAll("\\", "/");
+  const basenameStart = realRoot.lastIndexOf("/") + 1;
+  const flipped = realRoot.slice(0, basenameStart) + realRoot.slice(basenameStart).toUpperCase();
+  const root = (await exists(flipped)) ? flipped : realRoot;
+  const projectDir = join(String(dir), "sample");
+  await write(
+    join(projectDir, "package.json"),
+    JSON.stringify({
+      name: "sample",
+      version: "1.0.0",
+      dependencies: { poto: "file:" + root },
+    }),
+  );
+  await write(
+    join(projectDir, "bun.lock"),
+    JSON.stringify({
+      lockfileVersion: 2,
+      configVersion: 1,
+      workspaces: { "": { name: "sample", dependencies: { poto: "file:" + root } } },
+      packages: { poto: ["poto@file:" + root, {}] },
+    }),
+  );
+
+  for (let i = 0; i < 3; i++) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("ENOENT");
+    expect(err).not.toContain("Failed to install");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    expect(await exists(join(projectDir, "node_modules", "poto", "package.json"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "index.js"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "sample", "node_modules"))).toBe(false);
+  }
+});
+
+for (const backend of [null, "hardlink", "copyfile"]) {
+  it(`installs a workspace member's file: dependency on an ancestor behind the workspace symlink${backend ? ` (--backend ${backend})` : ""}`, async () => {
+    // packages/ is itself a package ("x") and member packages/a depends on it
+    // via `file:../`, while the root depends on a different "x", so the
+    // member's copy cannot hoist and installs at node_modules/a/node_modules/x.
+    // node_modules/a is a symlink to packages/a, so the destination physically
+    // lives inside the copy source; containment must be detected through the
+    // symlink or the install self-copies and fails.
+    using dir = tempDir("file-dep-ws-ancestor", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+        dependencies: { x: "file:./other-x" },
+      }),
+      "other-x/package.json": JSON.stringify({ name: "x", version: "2.0.0" }),
+      "other-x/index.js": "module.exports = 'other-x';",
+      "packages/package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "packages/index.js": "module.exports = 'packages-x';",
+      "packages/a/package.json": JSON.stringify({
+        name: "a",
+        version: "1.0.0",
+        dependencies: { x: "file:../" },
+      }),
+    });
+
+    for (let i = 0; i < 2; i++) {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--linker", "hoisted", ...(backend ? ["--backend", backend] : [])],
+        cwd: String(dir),
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+      expect(err).not.toContain("ENOENT");
+      expect(err).not.toContain("Failed to install");
+      expect(out).toContain("installed");
+      expect(exitCode).toBe(0);
+
+      const nested = join(String(dir), "node_modules", "a", "node_modules", "x");
+      expect(await Bun.file(join(nested, "package.json")).json()).toMatchObject({ name: "x", version: "1.0.0" });
+      // Never a self-copy of the member's own node_modules.
+      expect(await exists(join(nested, "a", "node_modules"))).toBe(false);
+    }
+  });
+}
+
+it("preserves a vendored node_modules inside a file: folder dependency", async () => {
+  // The node_modules skip only engages when the source contains the
+  // destination: an ordinary folder dependency that ships its own
+  // node_modules keeps it, through the copy walk (absolute lockfile path).
+  using dir = tempDir("file-dep-vendored", {
+    "sibling/package.json": JSON.stringify({ name: "sibling", version: "1.0.0" }),
+    "sibling/index.js": "module.exports = require('vendored-pkg');",
+    "sibling/node_modules/vendored-pkg/package.json": JSON.stringify({
+      name: "vendored-pkg",
+      version: "1.0.0",
+    }),
+    "sibling/node_modules/vendored-pkg/index.js": "module.exports = 'vendored';",
+    "app/package.json": "",
+  });
+  const sibAbs = String(dir).replaceAll("\\", "/") + "/sibling";
+  const projectDir = join(String(dir), "app");
+  await write(
+    join(projectDir, "package.json"),
+    JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { sibling: "file:" + sibAbs },
+    }),
+  );
+  await write(
+    join(projectDir, "bun.lock"),
+    JSON.stringify({
+      lockfileVersion: 2,
+      configVersion: 1,
+      workspaces: { "": { name: "app", dependencies: { sibling: "file:" + sibAbs } } },
+      packages: { sibling: ["sibling@file:" + sibAbs, {}] },
+    }),
+  );
+
+  for (let i = 0; i < 2; i++) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("Failed to install");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    expect(
+      await exists(join(projectDir, "node_modules", "sibling", "node_modules", "vendored-pkg", "package.json")),
+    ).toBe(true);
+  }
+
+  await using runProc = spawn({
+    cmd: [bunExe(), "-e", "console.log(require('sibling'))"],
+    cwd: projectDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  expect(runErr).toBe("");
+  expect(runOut).toBe("vendored\n");
+  expect(runExit).toBe(0);
+});
+
 for (const field of ["resolutions", "overrides"]) {
   it(`installs a file: dependency pointing outside the project when it came from root package.json "${field}"`, async () => {
     // `overrides` / `resolutions` can only be declared in the root package.json,
@@ -10713,6 +10943,59 @@ it("installs the transitive file: dependency of a file: dependency", async () =>
   }
 });
 
+it("a transitive file: dependency resolves the other transitive file: dependencies next to it", async () => {
+  // `b` and `c` are installed nested under node_modules/a/node_modules. A
+  // module resolves `require()` from the realpath of its file: had `b` been a
+  // symlink into packages/b, the walk up from there would miss `c`.
+  using dir = tempDir("transitive-file-dep-siblings", {
+    "package.json": JSON.stringify({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: { a: "file:./packages/a" },
+    }),
+    "packages/a/package.json": JSON.stringify({
+      name: "a",
+      version: "1.0.0",
+      dependencies: { b: "file:../b", c: "file:../c" },
+    }),
+    "packages/a/index.js": `module.exports = "a->" + require("b");`,
+    "packages/b/package.json": JSON.stringify({ name: "b", version: "1.0.0" }),
+    "packages/b/index.js": `module.exports = "b->" + require("c");`,
+    "packages/c/package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+    "packages/c/index.js": `module.exports = "c";`,
+  });
+
+  for (const args of [["install"], ["install", "--frozen-lockfile"]]) {
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+
+    await using proc = spawn({
+      cmd: [bunExe(), ...args, "--linker=hoisted"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("3 packages installed");
+    expect(exitCode).toBe(0);
+
+    expect(await readdirSorted(join(String(dir), "node_modules", "a", "node_modules"))).toEqual(["b", "c"]);
+
+    await using runProc = spawn({
+      cmd: [bunExe(), "--no-install", "-e", `console.log(require("a"))`],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+    expect(runErr).toBe("");
+    expect(runOut).toBe("a->b->c\n");
+    expect(runExit).toBe(0);
+  }
+});
+
 const fileDepCycleFixture = {
   "package.json": JSON.stringify({
     name: "my-app",
@@ -10996,6 +11279,152 @@ describe.concurrent("file: tarball declared by a file: folder dependency", () =>
     expect(installed).toEqual(["bar@0.0.2", "bar@0.0.2"]);
     expect(lockfile).toContain('"lib": ["lib@file:vendor/lib", { "dependencies": { "tool": "^1.0.0" } }]');
     expect(lockfile).toContain('"tool": ["bar@./tool.tgz", {}, "sha512-');
+  });
+});
+
+describe.concurrent("file: folder dependency outside the project (hoisted linker)", () => {
+  // A module resolves `require()` from the realpath of its file. When a folder
+  // dependency is installed as one symlink per file into a folder outside the
+  // project, that realpath is outside the project too, and the walk up from it
+  // never reaches the project's node_modules. The files have to be linked or
+  // copied instead, like a folder dependency inside the project.
+  const tarball = readFileSync(join(import.meta.dir, "bar-0.0.2.tgz"));
+
+  // The cache lives next to the project, never inside a folder that gets installed.
+  async function install(projectDir: string, cacheDir: string, args: string[] = []) {
+    await rm(join(projectDir, "node_modules"), { recursive: true, force: true });
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted", ...args],
+      cwd: projectDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+    });
+    const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    return out;
+  }
+
+  // `--no-install`: a module that fails to resolve must not be fetched from the registry.
+  async function run(projectDir: string, code: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "--no-install", "-e", code],
+      cwd: projectDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(err).toBe("");
+    expect(exitCode).toBe(0);
+    return out.trim();
+  }
+
+  it("resolves its dependencies from the project's node_modules", async () => {
+    using dir = tempDir("folder-dep-outside", {
+      "plugin/package.json": JSON.stringify({
+        name: "plugin",
+        version: "1.0.0",
+        main: "index.js",
+        // `tool` is hoisted to the project's node_modules. `helper` is a folder
+        // dependency, so it is nested under node_modules/plugin/node_modules.
+        dependencies: { tool: "file:./tool.tgz", helper: "file:../project/vendor/helper" },
+      }),
+      "plugin/index.js": `
+        const tool = require("tool/package.json");
+        module.exports = tool.name + "@" + tool.version + " " + require("helper");
+      `,
+      "plugin/tool.tgz": tarball,
+      "project/package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: { plugin: "file:../plugin" },
+      }),
+      "project/vendor/helper/package.json": JSON.stringify({ name: "helper", version: "1.0.0", main: "index.js" }),
+      "project/vendor/helper/index.js": `module.exports = "helper";`,
+    });
+    const projectDir = join(String(dir), "project");
+
+    for (const args of [[], ["--frozen-lockfile"]]) {
+      const out = await install(projectDir, join(String(dir), ".bun-cache"), args);
+      expect(out).toContain("3 packages installed");
+
+      expect(await run(projectDir, `console.log(require("plugin"))`)).toBe("bar@0.0.2 helper");
+
+      const pluginDir = join(projectDir, "node_modules", "plugin");
+      expect((await lstat(join(pluginDir, "index.js"))).isSymbolicLink()).toBe(false);
+      expect(await readdirSorted(pluginDir)).toEqual(["index.js", "node_modules", "package.json", "tool.tgz"]);
+      expect(await readdirSorted(join(pluginDir, "node_modules"))).toEqual(["helper"]);
+      expect(await exists(join(projectDir, "node_modules", "tool", "package.json"))).toBe(true);
+      // Nothing is written into the folder the dependency was installed from.
+      expect(await readdirSorted(join(String(dir), "plugin"))).toEqual(["index.js", "package.json", "tool.tgz"]);
+    }
+  });
+
+  it("keeps the node_modules the folder ships", async () => {
+    // A folder that has its own installed dependencies resolves them from its
+    // own node_modules, which the install copies along with the rest.
+    using dir = tempDir("folder-dep-outside-vendored", {
+      "sibling/package.json": JSON.stringify({ name: "sibling", version: "1.0.0", main: "index.js" }),
+      "sibling/index.js": `module.exports = require("vendored-pkg");`,
+      "sibling/node_modules/vendored-pkg/package.json": JSON.stringify({ name: "vendored-pkg", version: "1.0.0" }),
+      "sibling/node_modules/vendored-pkg/index.js": `module.exports = "vendored";`,
+      "project/package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: { sibling: "file:../sibling" },
+      }),
+    });
+    const projectDir = join(String(dir), "project");
+
+    for (const args of [[], ["--frozen-lockfile"]]) {
+      const out = await install(projectDir, join(String(dir), ".bun-cache"), args);
+      expect(out).toContain("1 package installed");
+
+      expect(await run(projectDir, `console.log(require("sibling"))`)).toBe("vendored");
+      expect(await readdirSorted(join(projectDir, "node_modules", "sibling", "node_modules", "vendored-pkg"))).toEqual([
+        "index.js",
+        "package.json",
+      ]);
+    }
+  });
+
+  it("links a transitive folder dependency outside the project, supplied by a root override, the same way", async () => {
+    // `shared` is nested under node_modules/pkg-a/node_modules. It requires
+    // `dep`, which only the project's node_modules has.
+    using dir = tempDir("folder-dep-outside-nested", {
+      "shared/package.json": JSON.stringify({ name: "shared", version: "1.0.0", main: "index.js" }),
+      "shared/index.js": `module.exports = "shared->" + require("dep");`,
+      "project/package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: { "pkg-a": "file:./pkg-a", dep: "file:./vendor/dep" },
+        overrides: { shared: "file:../shared" },
+      }),
+      "project/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        main: "index.js",
+        dependencies: { shared: "1.0.0" },
+      }),
+      "project/pkg-a/index.js": `module.exports = "pkg-a->" + require("shared");`,
+      "project/vendor/dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0", main: "index.js" }),
+      "project/vendor/dep/index.js": `module.exports = "dep";`,
+    });
+    const projectDir = join(String(dir), "project");
+
+    for (const args of [[], ["--frozen-lockfile"]]) {
+      const out = await install(projectDir, join(String(dir), ".bun-cache"), args);
+      expect(out).toContain("3 packages installed");
+
+      expect(await run(projectDir, `console.log(require("pkg-a"))`)).toBe("pkg-a->shared->dep");
+
+      const sharedDir = join(projectDir, "node_modules", "pkg-a", "node_modules", "shared");
+      expect(await readdirSorted(sharedDir)).toEqual(["index.js", "package.json"]);
+      expect((await lstat(join(sharedDir, "index.js"))).isSymbolicLink()).toBe(false);
+      expect(await readdirSorted(join(String(dir), "shared"))).toEqual(["index.js", "package.json"]);
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- With the hoisted linker, a `file:` dependency outside the project (`file:../packages/plugin`) cannot load its own dependencies: `error: Cannot find package 'shared-lib' from '/abs/packages/plugin/index.js'`. On Windows the install fails with `EPERM: failed copying files from cache to destination` (#13379).
- Cause: `get_install_method` (`src/install/PackageInstall.rs`) selects the symlink backend for a folder path that starts with `..`, one symlink per file into the source folder. A module loads from the realpath of its file, so `require()` walks up from `/abs/packages/plugin` and never reaches the project's `node_modules`. On Windows those symlinks need elevated rights.
- `install()` forces the same backend on every transitive folder dependency. Inside the project it breaks the same way: `a` depends on `file:../b` and `file:../c`, `b` requires `c`, and `require()` from `packages/b/index.js` never sees `node_modules/a/node_modules/c`.

### Fix
- `file:` folders use the default backend (hardlink, clonefile, copy) like any other package. The symlink backend stays for `--backend=symlink` and for a package that depends on itself (`file:.`).
- Correct because the installed files then have their realpath under `node_modules/<name>/`, where the normal walk finds nested and hoisted dependencies. Node resolves from the realpath too. pnpm and yarn copy `file:` folders. A folder that ships its own `node_modules` keeps it, as before.
- A folder that contains the project (`"pkg": "file:.."`) would copy the destination into itself. `source_folder_contains_destination` (from #37127, fd-derived paths so a workspace symlink is seen through) makes the walk skip `node_modules`. On macOS such a folder goes through the per-directory clone, which can skip; a whole-tree `clonefile` cannot.
- Verified: 10 tests in `test/cli/install/bun-install.test.ts`, 8 fail on main and 2 pin the vendored `node_modules` behavior. `test/cli/install/bun-install-registry.test.ts` now checks the content of nested transitive folders instead of their symlink layout.

### Background
- A `file:` dependency resolves to a `Folder` package. Its lockfile path is relative to the project root: outside the project it starts with `../`. A transitive folder dependency is never hoisted, so it is installed under the declaring package's `node_modules`.
- The install backends (`Method`) are `clonefile`, `hardlink`, `copyfile`, and `symlink`. `supported_method()` is the process-global default.
- The walker in `init_install_dir` mirrors the source folder into `node_modules/<name>`. `skip_dirs` names directories it does not enter.

<details><summary>Notes</summary>

Repro on bun 1.4.1 (no network):

```
mkdir -p x/root/vendor/shared-lib x/packages/plugin
echo '{"name":"shared-lib","version":"1.0.0"}' > x/root/vendor/shared-lib/package.json
echo '{"name":"plugin","version":"1.0.0"}' > x/packages/plugin/package.json
echo 'module.exports = require("shared-lib/package.json").name;' > x/packages/plugin/index.js
cd x/root
echo '{"name":"root","dependencies":{"plugin":"file:../packages/plugin","shared-lib":"file:./vendor/shared-lib"}}' > package.json
bun install && bun -e 'console.log(require("plugin"))'
# error: Cannot find module 'shared-lib/package.json' from '/.../x/packages/plugin/index.js'
```

`ls -la node_modules/plugin` shows `index.js -> /abs/x/packages/plugin/index.js`. The same happens when the plugin declares the dependency itself and it is installed nested under `node_modules/plugin/node_modules/`, when a transitive folder outside the project is supplied by a root override (#32452), and for the in-project transitive case in the third Problem bullet (`Cannot find package 'c' from .../packages/b/index.js` on 1.4.1).

The symlink rule for `..` dates from the 2022 commit that added the symlink backend (12dbc1ed7b), together with the rule for `file:.`. The README of that commit already noted that Node does not resolve the dependencies of a symlinked package without `--preserve-symlinks`. Bun's `--preserve-symlinks` is a no-op today (#36755). Transitive folders were forced onto the backend by #10445.

Behavior change: edits to a file in the source folder still show up through a hardlink (same inode) but not through a clone or copy, and a new file in the source folder needs a reinstall. That is how a `file:` folder inside the project and the isolated linker already behave. A folder of the root or of a workspace is reinstalled on every `bun install` (verify compares the folder path to the package.json version, which never matches), so the first install with this change also replaces a per-file-symlink layout left by an older bun. #40025 adds path-style `link:../x` for users who want the realpath semantics in package.json.

Relation to #37127: that PR adds the containment predicate and the four tests for a folder that contains the destination (`file:../` ancestor, absolute lockfile path, a workspace member behind the workspace symlink, a vendored `node_modules` that must survive). This PR includes them unchanged, because hardlinking a `..` folder needs the skip to stay finite (the per-file symlink walk stopped at ENAMETOOLONG and reported success; a hardlink walk fails the install). Without a containment check, skipping `node_modules` for every `..` folder broke `file:../sibling` folders that ship their own `node_modules`, which is how such folders resolve their dependencies on 1.4.1. The first revision of this PR had that regression. #37127 can be closed when this lands.

This branch includes #40663 (the fallback to copyfile emptied the source through a partial hardlink, and switched the process-wide backend for a folder on another file system). Those changes matter more once `file:../foo` goes through the hardlink backend. The diff here shrinks to its own changes when #40663 lands.

Suites run with the fix (debug build): `bun-install` (network-dependent bitbucket/gitlab/badssl tests fail on main too), `bun-install-registry`, `migration/migrate` (including `external-link--root`, which asserts the source folder gets no `node_modules`), `overrides`, `nested-overrides`, `bun-add`, `bun-remove`, `bun-patch`, `bun-install-patch`, `isolated-install`, `bun-install-hardlink-fallback`, `bun-lock`, `bun-workspaces`, `bun-update`, `bun-dedupe`.

Docs: `docs/pm/cli/install.mdx` and `docs/pm/global-cache.mdx` described the symlink backend as used for `file:../foo` and transitive `file:` dependencies. Updated.

Fixes #13379

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts, test/cli/install/bun-install-registry.test.ts, test/cli/install/bun-install-hardlink-fallback.test.ts

<!-- robobun:evidence:end -->