### PR TITLE
bundler: keep an unused Symbol.for(x) call unless x is a primitive literal

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -293,6 +293,7 @@ pub enum CallUnwrap {
     #[default]
     Never,
     IfUnused,
+    /// `Symbol.for`: removable like `IfUnused` but printed without `@__PURE__`. The ECall visit resets it to `Never` unless every argument is a primitive literal.
     IfUnusedAndToStringSafe,
 }
 

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2380,22 +2380,6 @@ impl Data {
         }
     }
 
-    pub fn is_safe_to_string(&self) -> bool {
-        match self {
-            // rope strings can throw when toString is called.
-            Data::EString(str) => str.next.is_none(),
-
-            Data::ENumber(_)
-            | Data::EBoolean(_)
-            | Data::EBranchBoolean(_)
-            | Data::EUndefined(_)
-            | Data::ENull(_) => true,
-            // BigInt is deliberately excluded as a large enough BigInt could throw an out of memory error.
-            //
-            _ => false,
-        }
-    }
-
     pub fn known_primitive(&self) -> PrimitiveType {
         self.known_primitive_with_check(bun_core::StackCheck::init())
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5465,11 +5465,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // can be removed. The annotation causes us to ignore the target.
                 if ex.can_be_unwrapped_if_unused != js_ast::CanBeUnwrapped::Never {
                     for arg in ex.args.slice() {
-                        if !(self.expr_can_be_removed_if_unused_without_dce_check(arg)
-                            || (ex.can_be_unwrapped_if_unused
-                                == js_ast::CanBeUnwrapped::IfUnusedAndToStringSafe
-                                && arg.data.is_safe_to_string()))
-                        {
+                        if !self.expr_can_be_removed_if_unused_without_dce_check(arg) {
                             return false;
                         }
                     }
@@ -5481,11 +5477,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // can be removed. The annotation causes us to ignore the target.
                 if ex.can_be_unwrapped_if_unused != js_ast::CanBeUnwrapped::Never {
                     for arg in ex.args.slice() {
-                        if !(self.expr_can_be_removed_if_unused_without_dce_check(arg)
-                            || (ex.can_be_unwrapped_if_unused
-                                == js_ast::CanBeUnwrapped::IfUnusedAndToStringSafe
-                                && arg.data.is_safe_to_string()))
-                        {
+                        if !self.expr_can_be_removed_if_unused_without_dce_check(arg) {
                             return false;
                         }
                     }

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -224,44 +224,14 @@ impl SideEffects {
                 // A call that has been marked "__PURE__" can be removed if all arguments
                 // can be removed. The annotation causes us to ignore the target.
                 if call.can_be_unwrapped_if_unused != CallUnwrap::Never {
-                    if call.args.len_u32() > 0 {
-                        let joined = Self::join_all_simplified(p, &call.args);
-                        if let Some(j) = &joined {
-                            if call.can_be_unwrapped_if_unused
-                                == CallUnwrap::IfUnusedAndToStringSafe
-                            {
-                                // For now, only support this for 1 argument.
-                                if j.data.is_safe_to_string() {
-                                    return None;
-                                }
-                            }
-                        }
-                        return joined;
-                    } else {
-                        return None;
-                    }
+                    return Self::join_all_simplified(p, &call.args);
                 }
             }
             ExprData::ENew(call) => {
                 // A call that has been marked "__PURE__" can be removed if all arguments
                 // can be removed. The annotation causes us to ignore the target.
                 if call.can_be_unwrapped_if_unused != CallUnwrap::Never {
-                    if call.args.len_u32() > 0 {
-                        let joined = Self::join_all_simplified(p, &call.args);
-                        if let Some(j) = &joined {
-                            if call.can_be_unwrapped_if_unused
-                                == CallUnwrap::IfUnusedAndToStringSafe
-                            {
-                                // For now, only support this for 1 argument.
-                                if j.data.is_safe_to_string() {
-                                    return None;
-                                }
-                            }
-                        }
-                        return joined;
-                    } else {
-                        return None;
-                    }
+                    return Self::join_all_simplified(p, &call.args);
                 }
             }
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1994,6 +1994,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // `Symbol.for(x)` runs ToString(x), which can run user code or throw, unless `x` is a primitive.
+        if e_.can_be_unwrapped_if_unused == E::CallUnwrap::IfUnusedAndToStringSafe
+            && !e_
+                .args
+                .slice()
+                .iter()
+                .all(|arg| arg.unwrap_inlined().is_primitive_literal())
+        {
+            e_.can_be_unwrapped_if_unused = E::CallUnwrap::Never;
+        }
+
         // Handle `feature("FLAG_NAME")` calls from `import { feature } from "bun:bundle"`
         // Check if the bundler_feature_flag_ref is set before calling the function
         // to avoid stack memory usage from copying values back and forth.

--- a/test/bundler/bundler_minify_symbol_for.test.ts
+++ b/test/bundler/bundler_minify_symbol_for.test.ts
@@ -1,64 +1,59 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { itBundled } from "./expectBundled";
 
+// `minifySyntax` drops an unused `Symbol.for(x)` call only when every argument
+// is a primitive literal. `Symbol.for(x)` runs ToString(x), so a call with any
+// other argument stays as written: an object argument can run user code and a
+// symbol argument throws. Every case pins the exact output. expectBundled runs
+// backend:"api" cases serially, so only the two CLI cases (production,
+// --no-bundle) at the end overlap. Keep them adjacent.
 describe("bundler", () => {
-  describe("minify/Symbol.for", () => {
-    // Test basic Symbol.for removal when unused
+  describe.concurrent("minify/Symbol.for", () => {
     itBundled("minify/SymbolForUnused", {
       files: {
         "/entry.js": /* js */ `
-          // These should be removed when minifySyntax is true
           Symbol.for("test1");
           Symbol.for("test2");
           Symbol.for(\`test3\`);
-          Symbol.for("test" + 4); // This has a side effect (string concatenation)
-          
-          // Keep reference to prove concatenation happened
+          Symbol.for("test" + 4);
+
           var sideEffect = "test" + 4;
           Symbol.for(sideEffect);
-          
-          // These should NOT be removed (used values)
+
           const s1 = Symbol.for("used1");
           let s2 = Symbol.for("used2");
           var s3 = Symbol.for("used3");
-          
-          // Function argument - should not be removed
+
           console.log(Symbol.for("argument"));
-          
-          // Property access - should not be removed
+
           const obj = { prop: Symbol.for("property") };
-          
-          // Return value - should not be removed
+
           function getSymbol() {
             return Symbol.for("return");
           }
-          
+
           capture(s1, s2, s3, obj.prop, getSymbol(), sideEffect);
         `,
       },
       minifySyntax: true,
       onAfterBundle(api) {
-        const output = api.readFile("/out.js");
-
-        // Should remove unused Symbol.for calls
-        expect(output).not.toContain('Symbol.for("test1")');
-        expect(output).not.toContain('Symbol.for("test2")');
-        expect(output).not.toContain("Symbol.for(`test3`)");
-
-        // Should keep the concatenation because sideEffect variable is used
-        expect(output).toContain("test4");
-
-        // Should keep used Symbol.for calls
-        expect(output).toContain('Symbol.for("used1")');
-        expect(output).toContain('Symbol.for("used2")');
-        expect(output).toContain('Symbol.for("used3")');
-        expect(output).toContain('Symbol.for("argument")');
-        expect(output).toContain('Symbol.for("property")');
-        expect(output).toContain('Symbol.for("return")');
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// entry.js
+          var sideEffect = "test4";
+          Symbol.for(sideEffect);
+          var s1 = Symbol.for("used1"), s2 = Symbol.for("used2"), s3 = Symbol.for("used3");
+          console.log(Symbol.for("argument"));
+          var obj = { prop: Symbol.for("property") };
+          function getSymbol() {
+            return Symbol.for("return");
+          }
+          capture(s1, s2, s3, obj.prop, getSymbol(), sideEffect);
+          "
+        `);
       },
     });
 
-    // Test that Symbol.for is not removed when minifySyntax is false
     itBundled("minify/SymbolForNoMinifySyntax", {
       files: {
         "/entry.js": /* js */ `
@@ -70,271 +65,343 @@ describe("bundler", () => {
       },
       minifySyntax: false,
       onAfterBundle(api) {
-        const output = api.readFile("/out.js");
-
-        // Should keep all Symbol.for calls when minifySyntax is false
-        expect(output).toContain('Symbol.for("test1")');
-        expect(output).toContain('Symbol.for("test2")');
-        expect(output).toContain('Symbol.for("test3")');
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// entry.js
+          Symbol.for("test1");
+          Symbol.for("test2");
+          var s = Symbol.for("test3");
+          capture(s);
+          "
+        `);
       },
     });
 
-    // Test interaction with other minification options
     itBundled("minify/SymbolForWithWhitespace", {
       files: {
         "/entry.js": /* js */ `
-          // Unused calls should be removed
           Symbol.for("remove-me-1");
           Symbol.for("remove-me-2");
-          
-          // Used call should remain
+
           const sym = Symbol.for("keep-me");
-          
-          // Test with complex expressions
+
           const ab = "a" + "b";
-          Symbol.for(ab); // Keep the variable to ensure concatenation happens
+          Symbol.for(ab);
           Symbol.for(\`template\`);
-          
+
           capture(sym, ab);
         `,
       },
       minifySyntax: true,
       minifyWhitespace: true,
       onAfterBundle(api) {
-        const output = api.readFile("/out.js");
-
-        // Should remove unused calls
-        expect(output).not.toContain("remove-me-1");
-        expect(output).not.toContain("remove-me-2");
-
-        // Should keep used call
-        expect(output).toContain('Symbol.for("keep-me")');
-
-        // Should keep side effect (the concatenation is kept because ab is used)
-        expect(output).toContain("ab");
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "var sym=Symbol.for("keep-me"),ab="ab";Symbol.for(ab);capture(sym,ab);
+          "
+        `);
       },
     });
 
-    // Test edge cases
     itBundled("minify/SymbolForEdgeCases", {
       files: {
         "/entry.js": /* js */ `
-          // Optional chaining - these are preserved because optional chaining has observable behavior
           Symbol?.for("optional1");
           Symbol?.for?.("optional2");
-          
-          // In conditional - these should be optimized based on the condition
+
           true && Symbol.for("conditional1");
           false || Symbol.for("conditional2");
-          
-          // In ternary - these should be optimized based on the condition
+
           true ? Symbol.for("ternary1") : null;
           false ? null : Symbol.for("ternary2");
-          
-          // Nested calls
+
           Symbol.for(Symbol.for("nested"));
-          
-          // With spread
+          Symbol.for(Symbol.iterator);
+          Symbol.for(1n);
+          Symbol.for("x", sideEffect());
+          Symbol.for({ toString() { return "object"; } });
+
           const arr = [...[Symbol.for("spread")]];
-          
-          // Property key
+
           const obj = {
             [Symbol.for("key")]: "value"
           };
-          
+
           capture(arr, obj);
         `,
       },
       minifySyntax: true,
       onAfterBundle(api) {
-        const output = api.readFile("/out.js");
-
-        // Optional chaining preserves the call because it has observable behavior (checking if Symbol exists)
-        expect(output).toContain("optional1");
-        expect(output).toContain("optional2");
-
-        // All the conditional/ternary expressions were optimized away completely
-        // because they evaluate to unused Symbol.for calls
-        expect(output).not.toContain("conditional1");
-        expect(output).not.toContain("conditional2");
-        expect(output).not.toContain("ternary1");
-        expect(output).not.toContain("ternary2");
-
-        // Nested call was also optimized away
-        expect(output).not.toContain("nested");
-
-        // Used in spread - should keep
-        expect(output).toContain('Symbol.for("spread")');
-
-        // Used as property key - should keep
-        expect(output).toContain('Symbol.for("key")');
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// entry.js
+          Symbol?.for("optional1");
+          Symbol?.for?.("optional2");
+          Symbol.for(Symbol.for("nested"));
+          Symbol.for(Symbol.iterator);
+          Symbol.for("x", sideEffect());
+          Symbol.for({ toString() {
+            return "object";
+          } });
+          var arr = [Symbol.for("spread")], obj = {
+            [Symbol.for("key")]: "value"
+          };
+          capture(arr, obj);
+          "
+        `);
       },
     });
 
-    // Test that Symbol.keyFor is not affected (it's still in the property access list)
+    // An inlined enum member is the literal it inlines to.
+    itBundled("minify/SymbolForInlinedEnum", {
+      files: {
+        "/entry.ts": /* ts */ `
+          const enum Key {
+            Element = "react.element",
+            Count = 2,
+          }
+
+          Symbol.for(Key.Element);
+          Symbol.for(Key.Count);
+
+          const used = Symbol.for(Key.Element);
+          capture(used);
+        `,
+      },
+      minifySyntax: true,
+      onAfterBundle(api) {
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// entry.ts
+          var used = Symbol.for("react.element" /* Element */);
+          capture(used);
+          "
+        `);
+      },
+    });
+
     itBundled("minify/SymbolKeyForNotAffected", {
       files: {
         "/entry.js": /* js */ `
-          // Symbol.keyFor should still be removed as a property access
           Symbol.keyFor;
-          
-          // But not when called
+
           const sym = Symbol.for("test");
           const key = Symbol.keyFor(sym);
-          
+
           capture(key);
         `,
       },
       minifySyntax: true,
       onAfterBundle(api) {
-        const output = api.readFile("/out.js");
-
-        // The unused property access "Symbol.keyFor;" should be removed
-        // But the function call "Symbol.keyFor(sym)" should remain
-        // So we should find exactly one occurrence of "Symbol.keyFor"
-        const keyForMatches = output.match(/Symbol\.keyFor/g) || [];
-        expect(keyForMatches.length).toBe(1);
-
-        // Function call should remain
-        expect(output).toContain("Symbol.keyFor(");
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// entry.js
+          var sym = Symbol.for("test"), key = Symbol.keyFor(sym);
+          capture(key);
+          "
+        `);
       },
     });
 
-    // Test interaction with production mode
-    itBundled("minify/SymbolForProduction", {
-      files: {
-        "/entry.js": /* js */ `
-          // Unused
-          Symbol.for("remove-in-prod");
-          
-          // Used
-          const s = Symbol.for("keep-in-prod");
-          
-          // Side effects
-          Symbol.for(someGlobal);
-          
-          capture(s);
-        `,
-      },
-      production: true, // This enables minifySyntax
-      onAfterBundle(api) {
-        const output = api.readFile("/out.js");
-
-        // Should remove unused
-        expect(output).not.toContain("remove-in-prod");
-
-        // Should keep used
-        expect(output).toContain("keep-in-prod");
-
-        // Should keep side effects
-        expect(output).toContain("someGlobal");
-      },
-    });
-
-    // Test with bundling disabled (transform mode)
-    itBundled("minify/SymbolForTransformMode", {
-      files: {
-        "/entry.js": /* js */ `
-          Symbol.for("unused");
-          const used = Symbol.for("used");
-          export { used };
-        `,
-      },
-      bundling: false,
-      minifySyntax: true,
-      onAfterBundle(api) {
-        const output = api.readFile("/out.js");
-
-        // Should remove unused in transform mode too
-        expect(output).not.toContain('"unused"');
-
-        // Should keep used
-        expect(output).toContain('Symbol.for("used")');
-      },
-    });
-
-    // Test interaction with tree shaking
     itBundled("minify/SymbolForTreeShaking", {
       files: {
         "/entry.js": /* js */ `
           import { sym } from "./lib.js";
-          
-          // This should be removed
+
           Symbol.for("entry-unused");
-          
+
           capture(sym);
         `,
         "/lib.js": /* js */ `
-          // This should be removed (unused export)
           export const unused = Symbol.for("lib-unused-export");
-          
-          // This should be kept (used export)
+
           export const sym = Symbol.for("lib-used-export");
-          
-          // This should be removed (not exported)
+
           Symbol.for("lib-internal");
         `,
       },
       minifySyntax: true,
       treeShaking: true,
       onAfterBundle(api) {
-        const output = api.readFile("/out.js");
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// lib.js
+          var sym = Symbol.for("lib-used-export");
 
-        // Should remove all unused Symbol.for calls
-        expect(output).not.toContain("entry-unused");
-        expect(output).not.toContain("lib-unused-export");
-        expect(output).not.toContain("lib-internal");
-
-        // Should keep used Symbol.for call
-        expect(output).toContain("lib-used-export");
+          // entry.js
+          capture(sym);
+          "
+        `);
       },
     });
 
-    // Test that Symbol.for is still called at runtime when overridden
+    // The kept calls still happen at runtime. The string-literal calls are
+    // dropped at bundle time, so the override counts only the two used ones.
     itBundled("minify/SymbolForRuntimeOverride", {
       files: {
         "/entry.js": /* js */ `
           let callCount = 0;
           const originalSymbolFor = Symbol.for;
-          
-          // Override Symbol.for to count calls
+
           Symbol.for = function(key) {
             callCount++;
             return originalSymbolFor.call(this, key);
           };
-          
-          // These unused calls should be removed at bundle time
+
           Symbol.for("unused1");
           Symbol.for("unused2");
-          
-          // These used calls should remain and increment callCount
+
           const s1 = Symbol.for("used1");
           const s2 = Symbol.for("used2");
-          
-          // Restore original
+
           Symbol.for = originalSymbolFor;
-          
-          // Verify that Symbol.for was called for the used symbols
-          if (callCount !== 2) {
-            throw new Error(\`Expected 2 calls to Symbol.for, got \${callCount}\`);
-          }
-          
-          // Verify the symbols work correctly
-          if (s1 !== Symbol.for("used1")) {
-            throw new Error("Symbol s1 mismatch");
-          }
-          if (s2 !== Symbol.for("used2")) {
-            throw new Error("Symbol s2 mismatch");
-          }
-          
-          console.log("PASS");
+
+          console.log(callCount, s1 === Symbol.for("used1"), s2 === Symbol.for("used2"));
         `,
       },
-
       minifySyntax: true,
+      onAfterBundle(api) {
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// entry.js
+          var callCount = 0, originalSymbolFor = Symbol.for;
+          Symbol.for = function(key) {
+            return callCount++, originalSymbolFor.call(this, key);
+          };
+          var s1 = Symbol.for("used1"), s2 = Symbol.for("used2");
+          Symbol.for = originalSymbolFor;
+          console.log(callCount, s1 === Symbol.for("used1"), s2 === Symbol.for("used2"));
+          "
+        `);
+      },
       run: {
-        stdout: "PASS",
+        stdout: "2 true true",
+      },
+    });
+
+    // ToString on a non-primitive argument is observable, so those unused
+    // calls survive and behave like the source at runtime.
+    itBundled("minify/SymbolForNonPrimitiveArgument", {
+      files: {
+        "/entry.js": /* js */ `
+          const obj = {
+            toString() {
+              console.log("toString ran");
+              return "object";
+            },
+          };
+          Symbol.for(obj);
+
+          try {
+            Symbol.for(Symbol.for("nested"));
+            console.log("no throw");
+          } catch (e) {
+            console.log(e.constructor.name);
+          }
+
+          try {
+            Symbol.for(undefinedGlobal);
+            console.log("no throw");
+          } catch (e) {
+            console.log(e.constructor.name);
+          }
+        `,
+      },
+      minifySyntax: true,
+      onAfterBundle(api) {
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "// entry.js
+          var obj = {
+            toString() {
+              return console.log("toString ran"), "object";
+            }
+          };
+          Symbol.for(obj);
+          try {
+            Symbol.for(Symbol.for("nested")), console.log("no throw");
+          } catch (e) {
+            console.log(e.constructor.name);
+          }
+          try {
+            Symbol.for(undefinedGlobal), console.log("no throw");
+          } catch (e) {
+            console.log(e.constructor.name);
+          }
+          "
+        `);
+      },
+      run: {
+        stdout: "toString ran\nTypeError\nReferenceError",
+      },
+    });
+
+    // --production turns on all three minify flags.
+    itBundled("minify/SymbolForProduction", {
+      files: {
+        "/entry.js": /* js */ `
+          Symbol.for("remove-in-prod");
+
+          const s = Symbol.for("keep-in-prod");
+
+          Symbol.for(someGlobal);
+
+          capture(s);
+        `,
+      },
+      production: true,
+      onAfterBundle(api) {
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "var o=Symbol.for("keep-in-prod");Symbol.for(someGlobal);capture(o);
+          "
+        `);
+      },
+    });
+
+    itBundled("minify/SymbolForTransformMode", {
+      files: {
+        "/entry.js": /* js */ `
+          Symbol.for("unused");
+          const used = Symbol.for("used");
+          Symbol.for(used);
+          export { used };
+        `,
+      },
+      bundling: false,
+      minifySyntax: true,
+      onAfterBundle(api) {
+        api.expectFile("/out.js").toMatchInlineSnapshot(`
+          "const used = Symbol.for("used");
+          Symbol.for(used);
+
+          export { used };
+          "
+        `);
       },
     });
   });
+});
+
+// `bun run` transpiles with minifySyntax on, so the runtime path takes the same decision.
+test("bun -e keeps an unused Symbol.for call whose argument is not a primitive", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const obj = {
+          toString() {
+            console.log("toString ran");
+            return "object";
+          },
+        };
+        Symbol.for(obj);
+
+        try {
+          Symbol.for(Symbol.for("nested"));
+          console.log("no throw");
+        } catch (e) {
+          console.log(e.constructor.name);
+        }
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("toString ran\nTypeError\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- With `minifySyntax`, an unused `Symbol.for(x)` is replaced by the side effects of `x` for any `x`. `Symbol.for` runs `ToString(x)`, so the output skips a user `toString` on an object argument, swallows the `TypeError` of `Symbol.for(Symbol.for("a"))`, and turns `Symbol.for(someGlobal)` into `someGlobal`. `bun file.js` does the same: the runtime transpiler turns `minifySyntax` on for bun targets (`src/bundler/options.rs:1888`).
- The `IfUnusedAndToStringSafe` check never restricted anything: `simplify_unused_expr` (`scan_side_effects.rs:223`) ran it on the already simplified arguments, which a literal never survives, and `expr_can_be_removed_if_unused_without_dce_check` (`p.rs:5463`) ORed it with the generic check. No report exists. Pinning the existing test file's outputs exposed it.

### Fix
- The ECall visit (`src/js_parser/visit/visit_expr.rs`) resets the marker to `Never` unless every argument is a primitive literal. It runs after the arguments are visited, so a folded string or an inlined `const enum` member counts as its literal. `known_global.rs` decides `new Date(x)` the same way.
- Both consumers go back to the plain "unwrappable or not" shape. The `Symbol.for`-only `is_safe_to_string` predicate goes away.
- Correct because `ToString` is unobservable only for primitives. The bundle-size win from #20888 (`Symbol.for("react.element")`) and `__PURE__` calls are unchanged.
- Verified: `test/bundler/bundler_minify_symbol_for.test.ts` (12 cases, exact output per case, three runtime checks, 7 fail on main). Also `bundler_minify`, `bundler_jsx`, `bundler_cjs2esm`, `bundler_edgecase`, `bundler_regressions`, `esbuild/dce`, `esbuild/default`, `transpiler`: 0 failures.

### Background
- `CallUnwrap` (`src/ast/e.rs`) marks how an unused call may go away. `IfUnused` is the `__PURE__` rule: drop the call, keep the side effects of its arguments. Only `Symbol.for` gets `IfUnusedAndToStringSafe` (`defines_table.rs`). The printer emits `/* @__PURE__ */` for `IfUnused` only, so the variants stay separate.
- `simplify_unused_expr` rewrites an unused expression. `expr_can_be_removed_if_unused_without_dce_check` answers whether a whole expression can vanish, which tree shaking uses.

<details><summary>Notes</summary>

**Repro on main** (`bun build --minify-syntax`, then run the output, or run the file with `bun` directly):

```js
const o = { toString() { console.log("toString ran"); return "k"; } };
Symbol.for(o);                      // main: dropped. fixed: kept, prints "toString ran"
Symbol.for(Symbol.for("nested"));   // main: dropped. fixed: kept, throws TypeError like node
Symbol.for(someGlobal);             // main: `someGlobal;`. fixed: kept
Symbol.for("x", sideEffect());      // main: `sideEffect();`. fixed: kept as written
Symbol.for("a" + "b"); Symbol.for(`t`); Symbol.for(1); Symbol.for(1n); Symbol.for(null); Symbol.for();  // dropped on both
```

Released bun 1.4.1 running the first three lines as a script prints nothing for the first call and `no throw` for the second. Node prints `toString ran` and throws.

**Why the producer.** The marker has one producer (the define copied onto the EDot, then onto the ECall at `visit_expr.rs:1913-1919`) and two consumers. The first version of this fix re-derived the primitive rule in both consumers through two new helpers. The self-review pointed at `src/ast/known_global.rs:301-331`, where `new Date(x)` is decided once at the producer from the visited arguments. This version does the same and deletes the helpers and the predicate: +12/-50 lines under `src/`.

**Behavior changes.** Unused `Symbol.for(x)` with a non-literal `x` stays. `Symbol.for("x", sideEffect())` stays whole instead of becoming `sideEffect();`. `Symbol.for(1n)` is now dropped like the other literals (BigInt was excluded by the old predicate with an OOM comment that does not apply to a literal in the source).

**How this PR got here.** It started as a rewrite of the test file after a report that it took 23s on the Windows 2019 x64 lane. That number belongs to `bundler_splitting.test.ts` (`test/expected-durations.json`). This file runs 0 tests on Windows because every `itBundled` case is dropped before it registers (#34552), 70ms on release Linux and 1.4s under ASAN. The test-only version is in this PR's history before the first force push (32641d0c).

**Test file.** Nine of the cases keep the original inputs from #20888. `SymbolForEdgeCases` adds `Symbol.iterator`, `1n`, a two-argument call, and an object literal. `SymbolForInlinedEnum` pins that a `const enum` member counts as a literal. `SymbolForNonPrimitiveArgument` runs its bundle: `toString ran`, `TypeError`, `ReferenceError`. The last test runs the same program through `bun -e` for the runtime path. `SymbolForRuntimeOverride` prints `2 true true` (the two string-literal calls are still dropped, as before). The two CLI cases overlap under `describe.concurrent`; expectBundled runs the API cases serially.

**Timings.** Debug ASAN build, linux-x64: 12 cases in 5.3s wall, of which about 2.3s is process startup plus JSC lazily compiling `expectBundled`'s async body on the first case. CI build 106899 of the previous version: 936ms on the x64-asan lane.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify_symbol_for.test.ts
bun test v1.4.1 (731aa92da)

test/bundler/bundler_minify_symbol_for.test.ts:
36 |           capture(s1, s2, s3, obj.prop, getSymbol(), sideEffect);
37 |         `,
38 |       },
39 |       minifySyntax: true,
40 |       onAfterBundle(api) {
41 |         api.expectFile("/out.js").toMatchInlineSnapshot(`
                                       ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "// entry.js
- var sideEffect = "test4";
- Symbol.for(sideEffect);
- var s1 = Symbol.for("used1"), s2 = Symbol.for("used2"), s3 = Symbol.for("used3");
+ var sideEffect = "test4", s1 = Symbol.for("used1"), s2 = Symbol.for("used2"), s3 = Symbol.for("used3");
  console.log(Symbol.for("argument"));
  var obj = { prop: Symbol.for("property") };
  function getSymbol() {
    return Symbol.for("return");
  }
  capture(s1, s2, s3, obj.prop, getSymbol(), sideEffect);
  "
  

- Expected  - 3
+ Received  + 1

      at onAfterBundle (/workspace/bun/test/bundler/bundler_minify_symbol_for.test.ts:41:35)
 
... (truncated)

release without fix: 7 FAILED
bun test v1.4.1-canary.1 (731aa92da)

test/bundler/bundler_minify_symbol_for.test.ts:
36 |           capture(s1, s2, s3, obj.prop, getSymbol(), sideEffect);
37 |         `,
38 |       },
39 |       minifySyntax: true,
40 |       onAfterBundle(api) {
41 |         api.expectFile("/out.js").toMatchInlineSnapshot(`
                                       ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "// entry.js
- var sideEffect = "test4";
- Symbol.for(sideEffect);
- var s1 = Symbol.for("used1"), s2 = Symbol.for("used2"), s3 = Symbol.for("used3");
+ var sideEffect = "test4", s1 = Symbol.for("used1"), s2 = Symbol.for("used2"), s3 = Symbol.for("used3");
  console.log(Symbol.for("argument"));
  var obj = { prop: Symbol.for("property") };
  function getSymbol() {
    return Symbol.for("return");
  }
  capture(s1, s2, s3, obj.prop, getSymbol(), sideEffect);
  "
  

- Expected  - 3
+ Received  + 1

      at onAfterBundle (/workspace/bun/test/bundler/bundler_minify_symbol_for.test.ts:41:35)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1602:13)
(fail) bundler > minify/Symbol.for > minify/SymbolForUnused [13.43ms]
(pass) bundler > minify/Sy
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify_symbol_for.test.ts
bun test v1.4.1 (731aa92da)

test/bundler/bundler_minify_symbol_for.test.ts:
(pass) bundler > minify/Symbol.for > minify/SymbolForUnused [524.76ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForNoMinifySyntax [108.73ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForWithWhitespace [89.96ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForEdgeCases [99.11ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForInlinedEnum [89.68ms]
(pass) bundler > minify/Symbol.for > minify/SymbolKeyForNotAffected [83.01ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForTreeShaking [89.20ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForRuntimeOverride [370.82ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForNonPrimitiveArgument [437.08ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForTransformMode [158.52ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForProduction [278.45ms]
(pass) bun -e keeps an unused Symbol.for call whose argument is not a primitive 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 614ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/139] gen ErrorCode+*.h
[2/139] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/139] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2Fram
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                   |   1 +
 src/ast/expr.rs                                |  16 -
 src/js_parser/p.rs                             |  12 +-
 src/js_parser/scan/scan_side_effects.rs        |  34 +-
 src/js_parser/visit/visit_expr.rs              |  11 +
 test/bundler/bundler_minify_symbol_for.test.ts | 459 ++++++++++++++-----------
 6 files changed, 279 insertions(+), 254 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/ast/e.rs                                        1      1      0
src/ast/expr.rs                                     3      4      0
src/js_parser/p.rs                                  2      2      0
src/js_parser/scan/scan_side_effects.rs             4      3      0
src/js_parser/visit/visit_expr.rs                   3      1      0
test/bundler/bundler_minify_symbol_for.test.ts      6      6      0
```

</details>

<!-- robobun:evidence:end -->