### PR TITLE
crash_handler: do not report generic root errors as fd exhaustion

### DIFF
--- a/src/bun_core/error.rs
+++ b/src/bun_core/error.rs
@@ -23,6 +23,10 @@ pub enum Error {
     FileNotFound,
     #[error("AccessDenied")]
     AccessDenied,
+    #[error("ProcessFdQuotaExceeded")]
+    ProcessFdQuotaExceeded,
+    #[error("SystemFdQuotaExceeded")]
+    SystemFdQuotaExceeded,
     #[error("WriteFailed")]
     WriteFailed,
     #[error("CurrentWorkingDirectoryUnlinked")]
@@ -46,6 +50,8 @@ impl Error {
             Self::NameTooLong => "NameTooLong",
             Self::FileNotFound => "FileNotFound",
             Self::AccessDenied => "AccessDenied",
+            Self::ProcessFdQuotaExceeded => "ProcessFdQuotaExceeded",
+            Self::SystemFdQuotaExceeded => "SystemFdQuotaExceeded",
             Self::WriteFailed => "WriteFailed",
             Self::CurrentWorkingDirectoryUnlinked => "CurrentWorkingDirectoryUnlinked",
             Self::Alloc(_) => "OutOfMemory",

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1363,51 +1363,10 @@ mod draft {
                 );
             }
         } else if matches!(name, b"NotOpenForReading" | b"Unexpected") {
-            // The file descriptor problem may show up as other errors
-            #[cfg(unix)]
-            {
-                // SAFETY: zeroed rlimit is valid POD (integers).
-                let limit = getrlimit_nofile().unwrap_or(bun_core::ffi::zeroed());
-
-                if limit.rlim_cur > 0 && limit.rlim_cur < (8192 * 2) {
-                    pretty_error!(
-                        "\n<r><red>error<r>: An unknown error occurred, possibly due to low max file descriptors <d>(<red>Unexpected<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 2147483646<r>\n",
-                        limit.rlim_cur,
-                    );
-
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
-                    {
-                        if let Some(user) = env_var::USER::get() {
-                            if !user.is_empty() {
-                                let user = bstr::BStr::new(user);
-                                pretty_error!(
-                                    "\nIf that still doesn't work, you may need to add these lines to /etc/security/limits.conf:\n\n <cyan>{} soft nofile 2147483646<r>\n <cyan>{} hard nofile 2147483646<r>\n",
-                                    user,
-                                    user,
-                                );
-                            }
-                        }
-                    }
-                    #[cfg(target_os = "macos")]
-                    {
-                        pretty_error!(
-                            "\nIf that still doesn't work, you may need to run:\n\n  <cyan>sudo launchctl limit maxfiles 2147483646<r>\n",
-                        );
-                    }
-                } else {
-                    err_generic!(
-                        "An unknown error occurred <d>(<red>{}<r><d>)<r>",
-                        bstr::BStr::new(name),
-                    );
-                }
-            }
-            #[cfg(not(unix))]
-            {
-                err_generic!(
-                    "An unknown error occurred <d>(<red>{}<r><d>)<r>",
-                    bstr::BStr::new(name),
-                );
-            }
+            err_generic!(
+                "An unknown error occurred <d>(<red>{}<r><d>)<r>",
+                bstr::BStr::new(name),
+            );
         } else if matches!(name, b"ENOENT" | b"FileNotFound") {
             Output::err(
                 "ENOENT",

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -50,6 +50,8 @@ impl Error {
             Self::Sys(bun_errno::SystemErrno::EACCES) => bun_core::Error::AccessDenied,
             Self::Sys(bun_errno::SystemErrno::ENAMETOOLONG) => bun_core::Error::NameTooLong,
             Self::Sys(bun_errno::SystemErrno::ENOSPC) => bun_core::Error::NoSpaceLeft,
+            Self::Sys(bun_errno::SystemErrno::EMFILE) => bun_core::Error::ProcessFdQuotaExceeded,
+            Self::Sys(bun_errno::SystemErrno::ENFILE) => bun_core::Error::SystemFdQuotaExceeded,
             _ => bun_core::Error::Unexpected,
         }
     }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -187,7 +187,14 @@ test.if(isPosix)("a generic root error is not reported as fd exhaustion under a 
       path.join(import.meta.dir, "fixture-crash.js"),
       "rootError",
     ],
-    env: noReportEnv,
+    env: {
+      ...noReportEnv,
+      // The rootError hook exits through handle_root_error, which terminates
+      // without VM teardown, so on the LSAN-validation lane the live VM's
+      // native allocations are reported as leaks and abort_on_error turns the
+      // expected exit(1) into SIGABRT.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    },
     stdio: ["ignore", "pipe", "pipe"],
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -170,6 +170,35 @@ describe.if(isPosix)("cwd deleted before startup", () => {
   });
 });
 
+// A generic root error must stay generic. The handler used to report any
+// `Unexpected`/`NotOpenForReading` root error as possible fd exhaustion
+// whenever RLIMIT_NOFILE was below 16384 (a normal default), sending users
+// toward ulimit changes unrelated to the real failure (issue #40625). Real
+// EMFILE/ENFILE keep the explicit ProcessFdQuotaExceeded/SystemFdQuotaExceeded
+// guidance.
+test.if(isPosix)("a generic root error is not reported as fd exhaustion under a low fd limit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      "/bin/sh",
+      "-c",
+      `ulimit -n 4096 && exec "$@"`,
+      "--",
+      bunExe(),
+      path.join(import.meta.dir, "fixture-crash.js"),
+      "rootError",
+    ],
+    env: noReportEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("An unknown error occurred (Unexpected)");
+  expect(stderr).not.toContain("file descriptors");
+  expect(stderr).not.toContain("ulimit");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
+});
+
 // Windows: the VEH handler must walk the stack from the fault CONTEXT record
 // (RtlVirtualUnwind), not from inside the handler. When the fault is in an
 // external DLL the old RtlCaptureStackBackTrace path could stop at


### PR DESCRIPTION
### Problem

- On Unix, any root error named `Unexpected` or `NotOpenForReading` is reported as `An unknown error occurred, possibly due to low max file descriptors (Unexpected)` with `ulimit` advice, whenever the soft `RLIMIT_NOFILE` is below 16384. Nothing checks the errno or the open descriptor count (`src/crash_handler/lib.rs:1365`).
- 4096 is a normal limit, so almost any user with a default system gets fd advice for any unexpected error. #6601 collects reports of this message from `bun add`, `bunx`, and OpenCode.

### Fix

- Remove the rlimit heuristic. `Unexpected` and `NotOpenForReading` now always print the generic `An unknown error occurred (<name>)` message.
- Keep real fd exhaustion explicit: the resolver collapsed `EMFILE` and `ENFILE` into `bun_core::Error::Unexpected` (`src/resolver/error.rs:53`). It now maps them to the new `bun_core::Error::ProcessFdQuotaExceeded` and `SystemFdQuotaExceeded` variants, so the handler's existing fd branches print the detailed guidance.
- Verified: new test in `test/cli/run/run-crash-handler.test.ts` runs the `rootError` hook under `ulimit -n 4096`. Stock bun prints the fd advice, the fixed build prints the generic message. The full file (28 tests) and `crash-report-command-char.test.ts` pass, and `cargo check --workspace` is clean.

### Background

- `handle_root_error` (`src/crash_handler/lib.rs`) runs when `main` returns an error. It matches the error name and picks a user-facing message: `ProcessFdQuotaExceeded` and `SystemFdQuotaExceeded` get fd-limit guidance, and unknown names get a generic line.
- `bun_core::Error` cannot depend on `bun_errno`, so it keeps local errno-category names (`FileNotFound`, `AccessDenied`, ...). The two new variants follow that pattern. Per POSIX, `EMFILE` is the per-process limit and `ENFILE` is the system-wide one, which matches the two handler branches.
- Open PR #37339 changes the suggested limit values in these hints. It keeps the heuristic, so the two changes are independent. They touch neighboring lines and one will need a trivial rebase.

<details><summary>Notes</summary>

Reproduction on an unfixed build:

```
$ bash -c 'ulimit -Hn 4096; ulimit -Sn 4096; BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun test/cli/run/fixture-crash.js rootError'
error: An unknown error occurred, possibly due to low max file descriptors (Unexpected)

Current limit: 4096

To fix this, try running:

  ulimit -n 2147483646
```

The repro caps the hard limit too because bun raises the soft limit to the hard limit at startup.

The heuristic dates back to the Zig crash handler ("The file descriptor problem may show up as other errors"). It fires for the threshold `rlim_cur < 8192 * 2`. No existing test asserted the fd guidance for `Unexpected`.

The resolver mapping matters because resolver I/O errors reach `handle_root_error` through `resolver::Error::into_core`, which previously turned every errno except ENOENT/EACCES/ENAMETOOLONG/ENOSPC into `Unexpected`. With the heuristic gone, a genuine `EMFILE` during resolution would otherwise have printed only the generic line. A deterministic test for that path would need to exhaust descriptors mid-resolution, which is not reliable in CI, so it is covered by the error-name mapping and the existing fd branches instead.

`node_fs.rs` has its own separate errno-to-name table and is not touched.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->