### PR TITLE
resolver: do not apply user externals to macro imports

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -129,7 +129,7 @@ impl MacroContext {
                 break 'brk replacement.path.as_bytes();
             }
 
-            let resolve_result = match resolver.resolve(
+            let resolve_result = match resolver.resolve_for_macro(
                 source_dir,
                 import_record_path_without_macro_prefix,
                 bun_ast::ImportKind::Stmt,
@@ -457,17 +457,25 @@ impl Macro {
             (*vm).load_macro_entry_point(input_specifier, function_name, specifier, hash)
         }?;
 
-        // SAFETY: `loaded_result` is a live heap-allocated `JSInternalPromise`
-        // returned by `loadAndEvaluateModule`; `jsc_vm` is the live JSC VM.
-        let unwrapped = unsafe {
-            (*loaded_result).unwrap(&*(*vm).jsc_vm, jsc::PromiseUnwrapMode::LeaveUnhandled)
-        };
-        if let jsc::PromiseResult::Rejected(result) = unwrapped {
-            // SAFETY: `vm.global` is the live per-thread global; `loaded_result`
-            // is a live promise cell.
-            unsafe {
-                (*vm).unhandled_rejection(&*(*vm).global, result, (*loaded_result).to_js());
+        // The unwrap reads JSC heap state and the rejection handler runs JS
+        // (it allocates `JSC::Weak`s), so both need the API lock; `call()`
+        // only takes it for the macro invocation itself, after init.
+        // SAFETY: `vm` is the per-thread VM; `loaded_result` is a live
+        // heap-allocated `JSInternalPromise` returned by
+        // `loadAndEvaluateModule`; `vm.global` is the live per-thread global.
+        let rejected = unsafe { &*vm }.run_with_api_lock(|| {
+            let unwrapped = unsafe {
+                (*loaded_result).unwrap(&*(*vm).jsc_vm, jsc::PromiseUnwrapMode::LeaveUnhandled)
+            };
+            if let jsc::PromiseResult::Rejected(result) = unwrapped {
+                unsafe {
+                    (*vm).unhandled_rejection(&*(*vm).global, result, (*loaded_result).to_js());
+                }
+                return true;
             }
+            false
+        });
+        if rejected {
             return Err(crate::Error::MacroLoadError);
         }
 

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -460,14 +460,17 @@ impl Macro {
         // The unwrap reads JSC heap state and the rejection handler runs JS
         // (it allocates `JSC::Weak`s), so both need the API lock; `call()`
         // only takes it for the macro invocation itself, after init.
-        // SAFETY: `vm` is the per-thread VM; `loaded_result` is a live
-        // heap-allocated `JSInternalPromise` returned by
-        // `loadAndEvaluateModule`; `vm.global` is the live per-thread global.
+        // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
         let rejected = unsafe { &*vm }.run_with_api_lock(|| {
+            // SAFETY: `loaded_result` is a live heap-allocated
+            // `JSInternalPromise` returned by `loadAndEvaluateModule`;
+            // `jsc_vm` is the live JSC VM.
             let unwrapped = unsafe {
                 (*loaded_result).unwrap(&*(*vm).jsc_vm, jsc::PromiseUnwrapMode::LeaveUnhandled)
             };
             if let jsc::PromiseResult::Rejected(result) = unwrapped {
+                // SAFETY: `vm.global` is the live per-thread global;
+                // `loaded_result` is a live promise cell.
                 unsafe {
                     (*vm).unhandled_rejection(&*(*vm).global, result, (*loaded_result).to_js());
                 }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -576,9 +576,8 @@ pub struct Resolver<'a> {
     /// When this is null, it is as if it is set to `&.{ path.dirname(referrer) }`.
     pub custom_dir_paths: Option<&'a [bun_core::String]>,
 
-    /// Transient per-resolve flag set by [`Self::resolve_for_macro`]: user
-    /// externals (`--external` patterns and exact names, `packages:
-    /// "external"`) are not applied, so the path resolves to a real module.
+    /// Set by [`Self::resolve_for_macro`]; disables the user external checks
+    /// for the duration of one resolve.
     pub(crate) ignore_user_externals: bool,
 }
 
@@ -1509,11 +1508,9 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// [`Self::resolve`], but user externals (`--external` patterns and exact
-    /// names, `packages: "external"`) are not applied. A macro import runs at
-    /// build time and is inlined, so it never appears in the output; marking
-    /// it external would hand the macro loader an unresolved specifier
-    /// (#40626).
+    /// [`Self::resolve`] without user externals (`--external`, `packages:
+    /// "external"`). A macro runs at build time and is inlined, so its import
+    /// must resolve to a real module (#40626).
     pub fn resolve_for_macro(
         &mut self,
         source_dir: &[u8],

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -575,6 +575,11 @@ pub struct Resolver<'a> {
     ///
     /// When this is null, it is as if it is set to `&.{ path.dirname(referrer) }`.
     pub custom_dir_paths: Option<&'a [bun_core::String]>,
+
+    /// Transient per-resolve flag set by [`Self::resolve_for_macro`]: user
+    /// externals (`--external` patterns and exact names, `packages:
+    /// "external"`) are not applied, so the path resolves to a real module.
+    pub(crate) ignore_user_externals: bool,
 }
 
 /// RAII guard returned by [`Resolver::scoped_log`]. Restores the previous
@@ -650,6 +655,7 @@ impl<'a> Resolver<'a> {
             // Transient per-resolve scratch (only set for `require(..., {paths})`);
             // never carried across worker init.
             custom_dir_paths: None,
+            ignore_user_externals: false,
         }
     }
 
@@ -936,10 +942,14 @@ impl<'a> Resolver<'a> {
             standalone_module_graph: None,
             prefer_module_field: true,
             custom_dir_paths: None,
+            ignore_user_externals: false,
         }
     }
 
     pub(crate) fn is_external_pattern(&self, import_path: &[u8]) -> bool {
+        if self.ignore_user_externals {
+            return false;
+        }
         if self.opts.packages == options::Packages::External && is_package_path(import_path) {
             return true;
         }
@@ -950,6 +960,9 @@ impl<'a> Resolver<'a> {
     /// pattern. Does NOT consider `packages = external`; use
     /// `isExternalPattern` for the combined check.
     pub(crate) fn matches_user_external_pattern(&self, import_path: &[u8]) -> bool {
+        if self.ignore_user_externals {
+            return false;
+        }
         for pattern in self.opts.external.patterns.iter() {
             if import_path.len() >= pattern.prefix.len() + pattern.suffix.len()
                 && (import_path.starts_with(pattern.prefix.as_ref())
@@ -1496,6 +1509,24 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// [`Self::resolve`], but user externals (`--external` patterns and exact
+    /// names, `packages: "external"`) are not applied. A macro import runs at
+    /// build time and is inlined, so it never appears in the output; marking
+    /// it external would hand the macro loader an unresolved specifier
+    /// (#40626).
+    pub fn resolve_for_macro(
+        &mut self,
+        source_dir: &[u8],
+        import_path: &[u8],
+        kind: ast::ImportKind,
+    ) -> crate::CrateResult<Result> {
+        let previous = self.ignore_user_externals;
+        self.ignore_user_externals = true;
+        let result = self.resolve(source_dir, import_path, kind);
+        self.ignore_user_externals = previous;
+        result
+    }
+
     /// Runs a resolution but also checking if a Bun Bake framework has an
     /// override. This is used in one place in the bundler.
     pub fn resolve_with_framework(
@@ -1800,7 +1831,8 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            if self.opts.external.abs_paths.count() > 0
+            if !self.ignore_user_externals
+                && self.opts.external.abs_paths.count() > 0
                 && self.opts.external.abs_paths.contains(import_path)
             {
                 // If the string literal in the source text is an absolute path and has
@@ -1965,7 +1997,8 @@ impl<'a> Resolver<'a> {
             }
 
             // Check for external packages first
-            if self.opts.external.node_modules.count() > 0
+            if !self.ignore_user_externals
+            && self.opts.external.node_modules.count() > 0
             // Imports like "process/" need to resolve to the filesystem, not a builtin
             && !import_path.ends_with(b"/")
             {
@@ -2059,7 +2092,8 @@ impl<'a> Resolver<'a> {
             return ResultUnion::NotFound;
         };
 
-        if self.opts.external.abs_paths.count() > 0
+        if !self.ignore_user_externals
+            && self.opts.external.abs_paths.count() > 0
             && self.opts.external.abs_paths.contains(abs_path)
         {
             // If the string literal in the source text is an absolute path and has

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2653,6 +2653,53 @@ describe("bundler", () => {
     target: "bun",
     run: { stdout: '[true,true,null,"{\\"__proto__\\":{\\"x\\":1},\\"a\\":2}"]' },
   });
+  // https://github.com/oven-sh/bun/issues/40626
+  // A wildcard --external must not apply to a macro import: the macro runs at
+  // build time and is inlined. The entry lives in a subdirectory because the
+  // bug only showed when the cwd was not the importing file's directory.
+  itBundled("edgecase/MacroWithWildcardExternal", {
+    files: {
+      "/src/entry.ts": /* js */ `
+        import { identity } from "./macro.ts" with { type: "macro" };
+        console.log(identity("abc"));
+      `,
+      "/src/macro.ts": /* js */ `
+        export function identity(arg: any) {
+          return arg;
+        }
+      `,
+    },
+    entryPoints: ["/src/entry.ts"],
+    target: "bun",
+    external: ["*"],
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toContain("macro");
+    },
+    run: { stdout: "abc" },
+  });
+  // https://github.com/oven-sh/bun/issues/40626
+  // A macro module that fails to load must produce a build error, not crash.
+  // A resolution failure rejects the macro load with a ResolveMessage, and
+  // handling that rejection allocates a JSC Weak, so the handler must hold
+  // the JSC API lock (debug builds asserted without it).
+  itBundled("edgecase/MacroLoadErrorDoesNotCrash", {
+    files: {
+      "/entry.ts": /* js */ `
+        import { identity } from "./macro.ts" with { type: "macro" };
+        console.log(identity("abc"));
+      `,
+      "/macro.ts": /* js */ `
+        import { x } from "./missing.ts";
+        export function identity(arg: any) {
+          return x ?? arg;
+        }
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/entry.ts": ['"MacroLoadError" error in macro'],
+    },
+  });
   itBundled("edgecase/NodeBuiltinWithoutPrefix", {
     files: {
       "/entry.ts": `


### PR DESCRIPTION
### Problem
- `bun build --target=bun --external '*'` fails on a macro import: `Error importing macro` / `Cannot find module './macro.ts' from 'macro//cbc95b4090049d73.js'`. The same happens with `--external '*.ts'` and `Bun.build({ external: ["*"] })`. On a debug build the error path also aborts: `ASSERTION FAILED: container.vm().currentThreadIsHoldingAPILock()` in `WeakSetInlines.h(37)`.
- The resolver marks the macro specifier as external (`src/resolver/resolver.rs:1221`) and returns it unresolved. The generated macro entry point then does `await import('./macro.ts')`, which resolves against the cwd, not the importing file's directory.
- `Macro::init` (`src/js_parser_jsc/Macro.rs`) unwraps the load promise and calls `unhandled_rejection` without the JSC API lock. A ResolveMessage rejection allocates a `JSC::Weak` there, which asserts in debug builds. Fixes #40626.

### Fix
- `Macro::call` resolves through the new `Resolver::resolve_for_macro`, which sets a transient flag. The flag turns off the user external checks: `--external` wildcard patterns, exact names, absolute paths, and `packages: "external"`.
- This is correct because a macro runs at build time and is inlined. It never appears in the output, so there is nothing for `--external` to apply to. Entry points already skip the same checks for the same reason (#12734).
- `Macro::init` now holds the API lock around the promise unwrap and the rejection handler, the same way the macro invocation itself already does.
- Verified: `test/bundler/bundler_edgecase.test.ts` (`MacroWithWildcardExternal`, `MacroLoadErrorDoesNotCrash`). Both fail on an unfixed debug build. Also ran the full `bundler_edgecase.test.ts`, `transpiler/macro-test.test.ts`, `bun-build-api.test.ts`, and `test/js/bun/resolve/build-error.test.ts`.

### Background
- A macro import (`with { type: "macro" }`) runs the imported module in a build-time JSC VM and splices the call result into the AST. The bundler generates a synthetic entry module (`macro//<hash>.js`) that imports the macro path, so that path must be absolute.
- The external checks sit at several points in the resolver: a wildcard pattern and `packages: "external"` check before relative resolution, and exact name and absolute path checks inside it. The new flag gates all of them and nothing else (`http://` and data URLs still resolve as external).
- The JSC API lock must be held by the thread that touches the JS heap. The bundler calls the macro from a parse worker, so the lock is taken explicitly around each JSC section. The load error path was the one section without it.

<details><summary>Notes</summary>

- Repro: `src/entry.ts` imports `./macro.ts` with `{ type: "macro" }`, then `bun build --target=bun --external '*' src/entry.ts` from the project root. Running from inside `src/` masks the bug because the cwd-relative fallback import happens to find the file.
- An exact `--external ./macro.ts` never triggered it: exact relative names are not matched by the resolver-level pattern check.
- A macro module that throws a plain `Error` at load time does not trip the lock assertion. Only a rejection that carries a `ResolveMessage` (a missing import inside the macro module) allocates the `Weak`. The new `MacroLoadErrorDoesNotCrash` test uses a missing import for that reason.
- The two bytecode test failures in `bun-build-api.test.ts` (`function record on an encoder page boundary`, `repeated builds don't retain the generated code`) time out at 5s on an unmodified main debug build as well. They are unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (b99371011)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [660.60ms]
(pass) bundler > edgecase/EmptyCommonJSModule [569.42ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [550.11ms]
(pass) bundler > edgecase/ImportStarFunction [375.57ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [389.82ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [120.57ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [467.80ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [250.81ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [326.84ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [229.42ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [110.97ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [471.46ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [386.31ms]
(pass) bundler >
... (truncated)

release without fix: 7 failed, 11 skipped
bun test v1.4.3-canary.1 (b99371011)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [57.75ms]
(pass) bundler > edgecase/EmptyCommonJSModule [23.92ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [23.45ms]
(pass) bundler > edgecase/ImportStarFunction [14.35ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [16.30ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [8.17ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [15.12ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [21.92ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [12.85ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [39.71ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [25.58ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [42.27ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [11.58ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [5.12ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [2.63ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (b99371011)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [565.52ms]
(pass) bundler > edgecase/EmptyCommonJSModule [427.99ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [479.43ms]
(pass) bundler > edgecase/ImportStarFunction [526.95ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [480.45ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [242.23ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [461.44ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [236.73ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [305.69ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [366.64ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [166.08ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [429.49ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [445.39ms]
(pass) bundler >
... (truncated)

release with fix: 11 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     54ba0bc3c7
  features     baseline

23 deps, 131 codegen, 1176 objects in 1578ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] gen bindgenv2
[2/1248] install /workspace/bun
bun install v1.4.3-canary.1 (b99371011)

Checked 22 installs across 61 packages (no changes) [14.00ms]
[3/1248] fetch zlib
[zlib] up to date
[4/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1248] fetch tinycc
[tinycc] up to date
[6/1247] gen ErrorCode+*.h
[7/1247] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (b99371011)

Checked 1 install across 2 packages (no changes) [8.00ms]
[8/1247] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (b99371011)

Checked 111 installs across 104 packages (no changes) [30.00ms]
[9/1247] gen .bind.ts → GeneratedBindings.cpp
[10/1247] gen node-fallbacks/react-refresh.js
Bundled 1 module in 12ms

  react-refresh.js  4.81 KB  (entry point)

[11/1247] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/co
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser_jsc/Macro.rs            | 33 ++++++++++++++++--------
 src/resolver/resolver.rs              | 37 ++++++++++++++++++++++++---
 test/bundler/bundler_edgecase.test.ts | 47 +++++++++++++++++++++++++++++++++++
 3 files changed, 103 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js_parser_jsc/Macro.rs                 4      3      3
src/resolver/resolver.rs                   4      7      3
test/bundler/bundler_edgecase.test.ts      1      4      3
```

</details>

**root cause** · written by the author bot

Wildcard `--external` patterns were applied to import records before macro imports were resolved, so a macro specifier such as `./macro.ts` was marked external and handed to the macro runner unresolved, where the generated entry point's `await import('./macro.ts')` resolved against the working directory instead of the importing file's directory and failed to load. The fix exempts macro imports from the external check so they are always resolved to an absolute path relative to the importing file before the macro runs, letting the macro execute at build time and be inlined as it is without `-…

<!-- robobun:evidence:end -->