### PR TITLE
test: speed up the 28632 MySQL leak test and cover wide prepared-statement rows

### DIFF
--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -414,6 +414,34 @@ if (isDockerEnabled()) {
           expect(dupSecond[0]).toEqual({ x: 1, y: 2, z: 3, w: 4 });
         });
 
+        test("returns every column of a wide prepared-statement result", async () => {
+          // The "more than the max inline capacity" tests above go through
+          // sql.unsafe(), the text protocol. A parameterized query runs as a
+          // prepared statement, whose binary rows carry a NULL bitmap of
+          // (columns + 9) / 8 bytes. 500 columns with 64-byte names (the MySQL
+          // identifier limit) cover a 63-byte bitmap and a row structure far
+          // past the inline property capacity.
+          await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
+          using sql = await db.reserve();
+
+          const columns = Array.from({ length: 500 }, (_, i) => `col_${i}_`.padEnd(64, "x"));
+          const filled = columns.filter((_, i) => i % 7 === 0);
+          const t = "wide_" + randomUUIDv7("hex").replaceAll("-", "");
+          await sql.unsafe(
+            `CREATE TEMPORARY TABLE ${t} (id INT PRIMARY KEY, ${columns.map(name => `${name} TINYINT`).join(", ")})`,
+          );
+          await sql.unsafe(
+            `INSERT INTO ${t} (id, ${filled.join(", ")}) VALUES (1, ${filled.map((_, i) => i).join(", ")})`,
+          );
+
+          const expected = Object.fromEntries(columns.map(name => [name, null]));
+          filled.forEach((name, i) => (expected[name] = i));
+          expect(await sql`SELECT * FROM ${sql(t)} WHERE id = ${1}`).toEqual([{ id: 1, ...expected }]);
+          expect(await sql`SELECT * FROM ${sql(t)} WHERE id = ${1}`.values()).toEqual([
+            [1, ...columns.map(name => expected[name])],
+          ]);
+        });
+
         test("Handles numeric column names", async () => {
           // deliberately out of order
           const result = await sql`select 1 as "1", 2 as "2", 3 as "3", 0 as "0"`;

--- a/test/regression/issue/28632.fixture.ts
+++ b/test/regression/issue/28632.fixture.ts
@@ -1,10 +1,18 @@
 // Child process for 28632.test.ts: re-executes one prepared statement against
-// the wide table the test created and prints the RSS growth as its last line.
-// argv: <mysql url> <column count>
+// a wide temporary table and prints the RSS growth as its last line.
+// argv: <mysql url>
 import { SQL } from "bun";
 
-const [url, columnCount] = process.argv.slice(2);
-const COLUMNS = Number(columnCount);
+const [url] = process.argv.slice(2);
+
+// The server re-sends one column definition per column with every
+// COM_STMT_EXECUTE response, and the adapter keeps an owned copy of each
+// column name (`name_or_index`). The original bug leaked that copy on every
+// re-decode, so the leak per query scales with the column count and the name
+// length. MySQL caps identifiers at 64 bytes; 500 columns stay under MariaDB's
+// table-definition size limit.
+const COLUMNS = 500;
+const columns = Array.from({ length: COLUMNS }, (_, i) => `col_${i}_`.padEnd(64, "x"));
 // The first batches let the JIT tiers, the statement cache and the heap reach
 // a steady state, so the delta measures only what the later queries keep.
 const WARMUP_QUERIES = 100;
@@ -16,15 +24,21 @@ const rss: () => number =
     ? (Bun.unsafe.memoryFootprint as () => number)
     : process.memoryUsage.rss;
 
+// `max: 1` pins the connection, so the temporary table is visible to every
+// query below and disappears with the connection.
 await using sql = new SQL({ url, max: 1 });
+await sql.unsafe(
+  `CREATE TEMPORARY TABLE leak_test_28632 (id INT PRIMARY KEY, ${columns.map(name => `${name} TINYINT`).join(", ")})`,
+);
+await sql`INSERT INTO leak_test_28632 (id) VALUES (${1})`;
 
 // `.values()` skips the per-row object build, which is not on the
 // column-definition path under test and doubles the debug-build time at 500
 // columns. Every result is checked so a broken query path fails the test
 // instead of measuring an idle process.
-const query = () => sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`.values();
+const query = () => sql`SELECT * FROM leak_test_28632 WHERE id = ${1} LIMIT 1`.values();
 function check(rows: unknown[][]) {
-  if (rows.length !== 1 || rows[0].length !== COLUMNS + 1 || rows[0][0] !== "123") {
+  if (rows.length !== 1 || rows[0].length !== COLUMNS + 1 || rows[0][0] !== 1) {
     throw new Error("unexpected result: " + JSON.stringify(rows).slice(0, 200));
   }
 }

--- a/test/regression/issue/28632.fixture.ts
+++ b/test/regression/issue/28632.fixture.ts
@@ -1,0 +1,48 @@
+// Child process for 28632.test.ts: re-executes one prepared statement against
+// the wide table the test created and prints the RSS growth as its last line.
+// argv: <mysql url> <column count>
+import { SQL } from "bun";
+
+const [url, columnCount] = process.argv.slice(2);
+const COLUMNS = Number(columnCount);
+// The first batches let the JIT tiers, the statement cache and the heap reach
+// a steady state, so the delta measures only what the later queries keep.
+const WARMUP_QUERIES = 100;
+const MEASURED_QUERIES = 300;
+const BATCH = 50;
+
+const rss: () => number =
+  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
+    ? (Bun.unsafe.memoryFootprint as () => number)
+    : process.memoryUsage.rss;
+
+await using sql = new SQL({ url, max: 1 });
+
+// `.values()` skips the per-row object build, which is not on the
+// column-definition path under test and doubles the debug-build time at 500
+// columns. Every result is checked so a broken query path fails the test
+// instead of measuring an idle process.
+const query = () => sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`.values();
+function check(rows: unknown[][]) {
+  if (rows.length !== 1 || rows[0].length !== COLUMNS + 1 || rows[0][0] !== "123") {
+    throw new Error("unexpected result: " + JSON.stringify(rows).slice(0, 200));
+  }
+}
+
+// Prepare the statement with a lone query first. A failed prepare rejects here
+// instead of stalling the queued copies behind it.
+check(await query());
+
+// The queries in a batch queue on the single connection. Each batch ends with
+// a full GC so RSS reflects native allocations rather than JS garbage.
+async function run(count: number) {
+  for (let done = 0; done < count; done += BATCH) {
+    for (const rows of await Promise.all(Array.from({ length: BATCH }, query))) check(rows);
+    Bun.gc(true);
+  }
+}
+
+await run(WARMUP_QUERIES);
+const before = rss();
+await run(MEASURED_QUERIES);
+console.log(JSON.stringify({ deltaMiB: (rss() - before) / 1024 / 1024 }));

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -1,18 +1,7 @@
 // https://github.com/oven-sh/bun/issues/28632
-import { SQL } from "bun";
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { test } from "bun:test";
 import { describeWithContainer, expectRssDeltaBelow } from "harness";
 import path from "node:path";
-
-// The server re-sends one column definition per column with every
-// COM_STMT_EXECUTE response, and the adapter keeps an owned copy of each
-// column name (`name_or_index`). The original bug leaked that copy on every
-// re-decode, so the leak per query scales with the column count and the name
-// length. MySQL caps identifiers at 64 bytes; 500 columns stay under MariaDB's
-// table-definition size limit.
-const COLUMNS = 500;
-const columns = Array.from({ length: COLUMNS }, (_, i) => `col_${i}_`.padEnd(64, "x"));
-const fixture = path.join(import.meta.dir, "28632.fixture.ts");
 
 describeWithContainer(
   "issue #28632: MySQL adapter should not leak memory on repeated queries",
@@ -21,42 +10,18 @@ describeWithContainer(
     concurrent: true,
   },
   container => {
-    let url: string;
-
-    beforeAll(async () => {
-      await container.ready;
-      url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
-      await using sql = new SQL({ url, max: 1 });
-      await sql.unsafe(`DROP TABLE IF EXISTS leak_test_28632`);
-      await sql.unsafe(
-        `CREATE TABLE leak_test_28632 (primary_id VARCHAR(255) PRIMARY KEY, ${columns.map(name => `${name} TINYINT`).join(", ")})`,
-      );
-      await sql`INSERT INTO leak_test_28632 (primary_id) VALUES (${"123"})`;
-    });
-
-    afterAll(async () => {
-      // afterAll still runs when beforeAll failed before it assigned `url`.
-      if (!url) return;
-      await using sql = new SQL({ url, max: 1 });
-      await sql.unsafe(`DROP TABLE IF EXISTS leak_test_28632`);
-    });
-
-    test("SELECT * returns the row with every column", async () => {
-      await using sql = new SQL({ url, max: 1 });
-      const objects = await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
-      expect(objects).toEqual([{ primary_id: "123", ...Object.fromEntries(columns.map(name => [name, null])) }]);
-      const values = await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`.values();
-      expect(values).toEqual([["123", ...new Array(COLUMNS).fill(null)]]);
-    });
-
     test("prepared statement re-execution should not leak name_or_index", async () => {
-      // Unfixed: one 64-byte block leaks per column per query, so the
-      // fixture's 300 measured queries over 500 columns leak 150,000 blocks:
-      // at least 9.6 MiB under mimalloc (release), and 15 to 17 MiB measured
-      // under ASAN, where each block also carries a header and redzone.
-      // Fixed: 0 to 1 MiB (release) and 0 to 3 MiB (debug/ASAN, quarantine
-      // off) after the fixture's 100-query warm-up.
-      await expectRssDeltaBelow([fixture, url, String(COLUMNS)], { release: 5, debug: 8 });
+      await container.ready;
+      const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+
+      // The fixture re-executes a prepared SELECT over a 500-column table with
+      // 64-byte column names. Unfixed: one 64-byte block leaks per column per
+      // query, so its 300 measured queries leak 150,000 blocks: at least 9.6 MiB
+      // under mimalloc (release), and 15 to 17 MiB measured under ASAN, where
+      // each block also carries a header and redzone. Fixed: 0 to 1 MiB (release)
+      // and 0 to 3 MiB (debug/ASAN, quarantine off) after the fixture's
+      // 100-query warm-up.
+      await expectRssDeltaBelow([path.join(import.meta.dir, "28632.fixture.ts"), url], { release: 5, debug: 8 });
     });
   },
 );

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -35,6 +35,8 @@ describeWithContainer(
     });
 
     afterAll(async () => {
+      // afterAll still runs when beforeAll failed before it assigned `url`.
+      if (!url) return;
       await using sql = new SQL({ url, max: 1 });
       await sql.unsafe(`DROP TABLE IF EXISTS leak_test_28632`);
     });

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -1,87 +1,60 @@
 // https://github.com/oven-sh/bun/issues/28632
 import { SQL } from "bun";
-import { beforeAll, expect, test } from "bun:test";
-import { describeWithContainer, isASAN, isDebug, isDockerEnabled, rss } from "harness";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { describeWithContainer, expectRssDeltaBelow } from "harness";
+import path from "node:path";
 
-if (isDockerEnabled()) {
-  describeWithContainer(
-    "issue #28632: MySQL adapter should not leak memory on repeated queries",
-    {
-      image: "mysql_plain",
-      concurrent: true,
-    },
-    container => {
-      let sql: SQL;
+// The server re-sends one column definition per column with every
+// COM_STMT_EXECUTE response, and the adapter keeps an owned copy of each
+// column name (`name_or_index`). The original bug leaked that copy on every
+// re-decode, so the leak per query scales with the column count and the name
+// length. MySQL caps identifiers at 64 bytes; 500 columns stay under MariaDB's
+// table-definition size limit.
+const COLUMNS = 500;
+const columns = Array.from({ length: COLUMNS }, (_, i) => `col_${i}_`.padEnd(64, "x"));
+const fixture = path.join(import.meta.dir, "28632.fixture.ts");
 
-      beforeAll(async () => {
-        await container.ready;
-        sql = new SQL({
-          url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
-          max: 1,
-        });
-      });
+describeWithContainer(
+  "issue #28632: MySQL adapter should not leak memory on repeated queries",
+  {
+    image: "mysql_plain",
+    concurrent: true,
+  },
+  container => {
+    let url: string;
 
-      test("prepared statement re-execution should not leak name_or_index", async () => {
-        // Create a wide table to amplify the per-column leak signal
-        await sql`DROP TABLE IF EXISTS leak_test_28632`;
-        await sql`CREATE TABLE leak_test_28632 (
-          primary_id VARCHAR(255) PRIMARY KEY,
-          column_alpha_bravo TEXT, column_charlie_delta TEXT, column_echo_foxtrot TEXT,
-          column_golf_hotel TEXT, column_india_juliet TEXT, column_kilo_lima TEXT,
-          column_mike_november TEXT, column_oscar_papa TEXT, column_quebec_romeo TEXT,
-          column_sierra_tango TEXT, column_uniform_victor TEXT, column_whiskey_xray TEXT,
-          column_yankee_zulu TEXT, column_one_two_three TEXT, column_four_five_six TEXT,
-          column_seven_eight TEXT, column_nine_ten TEXT, column_eleven_twelve TEXT,
-          column_thirteen_fourtn TEXT, column_fifteen_sixtn TEXT, column_seventeen TEXT,
-          column_eighteen TEXT, column_nineteen TEXT, column_twenty_extra TEXT,
-          column_twentyone TEXT, column_twentytwo TEXT, column_twentythree TEXT,
-          column_twentyfour TEXT, column_twentyfive TEXT, column_twentysix TEXT,
-          column_twentyseven TEXT, column_twentyeight TEXT, column_twentynine TEXT,
-          column_thirty_extra TEXT, column_thirtyone TEXT, column_thirtytwo TEXT,
-          column_thirtythree TEXT, column_thirtyfour TEXT, column_thirtyfive TEXT,
-          column_thirtysix TEXT, column_thirtyseven TEXT, column_thirtyeight TEXT,
-          column_thirtynine TEXT, column_forty_extra TEXT, column_fortyone TEXT,
-          column_fortytwo TEXT, column_fortythree TEXT, column_fortyfour TEXT,
-          column_fortyfive TEXT
-        )`;
-        await sql`INSERT INTO leak_test_28632 (primary_id) VALUES ('123')`;
+    beforeAll(async () => {
+      await container.ready;
+      url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+      await using sql = new SQL({ url, max: 1 });
+      await sql.unsafe(`DROP TABLE IF EXISTS leak_test_28632`);
+      await sql.unsafe(
+        `CREATE TABLE leak_test_28632 (primary_id VARCHAR(255) PRIMARY KEY, ${columns.map(name => `${name} TINYINT`).join(", ")})`,
+      );
+      await sql`INSERT INTO leak_test_28632 (primary_id) VALUES (${"123"})`;
+    });
 
-        // Warm up to stabilize RSS
-        for (let i = 0; i < 500; i++) {
-          await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
-        }
-        Bun.gc(true);
-        await Bun.sleep(50);
-        const rssAfterWarmup = rss();
+    afterAll(async () => {
+      await using sql = new SQL({ url, max: 1 });
+      await sql.unsafe(`DROP TABLE IF EXISTS leak_test_28632`);
+    });
 
-        // Run queries — each re-decodes 50 column definitions. Collect every 500
-        // so the RSS delta reflects the name_or_index leak rather than the
-        // controller's opportunistic-GC cadence (which no longer fires at this
-        // allocation volume): without this, peak uncollected garbage between
-        // opportunistic passes commits extra MarkedBlock pages that Bun.gc(true)
-        // at the end does not synchronously decommit.
-        for (let i = 0; i < 5000; i++) {
-          await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
-          if (i % 500 === 499) Bun.gc(true);
-        }
-        Bun.gc(true);
-        await Bun.sleep(50);
-        const rssAfterQueries = rss();
+    test("SELECT * returns the row with every column", async () => {
+      await using sql = new SQL({ url, max: 1 });
+      const objects = await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
+      expect(objects).toEqual([{ primary_id: "123", ...Object.fromEntries(columns.map(name => [name, null])) }]);
+      const values = await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`.values();
+      expect(values).toEqual([["123", ...new Array(COLUMNS).fill(null)]]);
+    });
 
-        const growthMB = (rssAfterQueries - rssAfterWarmup) / 1024 / 1024;
-
-        // Without the fix, ~17MB growth (50 leaked name_or_index allocs × 5000 queries).
-        // With the fix, ~7MB (allocator noise + ASAN shadow memory). Under ASAN the
-        // Rust global allocator routes every alloc through the interceptor, so the
-        // per-query free/alloc churn (row cells, etc.) lands in ASAN's 256 MB
-        // quarantine and shows up as RSS even though nothing leaks — give it 3×
-        // headroom there. Debug builds enable ASAN by default on Linux/macOS, so
-        // treat them the same. The non-ASAN bound is what guards the actual
-        // regression.
-        expect(growthMB).toBeLessThan(isASAN || isDebug ? 36 : 12);
-
-        await sql`DROP TABLE IF EXISTS leak_test_28632`.catch(() => {});
-      });
-    },
-  );
-}
+    test("prepared statement re-execution should not leak name_or_index", async () => {
+      // Unfixed: one 64-byte block leaks per column per query, so the
+      // fixture's 300 measured queries over 500 columns leak 150,000 blocks:
+      // at least 9.6 MiB under mimalloc (release), and 15 to 17 MiB measured
+      // under ASAN, where each block also carries a header and redzone.
+      // Fixed: 0 to 1 MiB (release) and 0 to 3 MiB (debug/ASAN, quarantine
+      // off) after the fixture's 100-query warm-up.
+      await expectRssDeltaBelow([fixture, url, String(COLUMNS)], { release: 5, debug: 8 });
+    });
+  },
+);


### PR DESCRIPTION
### Problem
- `test/regression/issue/28632.test.ts` runs 5,500 sequential 50-column queries in the test process. A debug build needs 11.1 s, past the 5 s default timeout, so `bun bd test` fails on it.
- Its margins are thin. Under ASAN the fixed build grows 27.8 MiB against a 36 MiB bound, and 38.4 MiB with the original leak restored. Most of that is freed per-row buffers that ASAN's quarantine keeps resident.
- It asserts only the RSS delta. A query path that returns nothing still passes.

### Fix
- Measure in a child fixture through the harness's `expectRssDeltaBelow`, which turns the ASAN quarantine off. The fixture owns a `CREATE TEMPORARY TABLE` on its pinned connection and checks every result.
- Amplify the leak per query: 500 columns with 64-byte names (MySQL's identifier limit), 300 measured queries. The original leak loses one 64-byte block per column per query: 150,000 blocks, at least 9.6 MiB under mimalloc and 15 to 17 MiB measured under ASAN, against bounds of 5 and 8 MiB. The fixed build grows 0 to 3 MiB.
- Add a wide prepared-statement case to `test/js/sql/sql-mysql.test.ts`: a 500-column row with a mixed NULL pattern, asserted in object and `.values()` form on all three MySQL images. The existing wide-row tests there use `sql.unsafe()`, the text protocol, so the binary row path had no coverage past 64 columns.
- Verified: `bun bd test test/regression/issue/28632.test.ts`: 3.2 s (was 11.1 s), file 5.4 s (was 13.7 s). Release: file 0.35 s (was 0.78 s). With the leak restored, the test fails at 16.0 MiB.

### Background
- Every `COM_STMT_EXECUTE` response carries one column definition per result column. The adapter re-decodes them into the cached `MySQLStatement` and keeps an owned copy of each name as `name_or_index`. Issue #28632 was that copy leaking on each re-decode.
- `expectRssDeltaBelow` (`test/harness.ts`) spawns `bunExe()` on a fixture that prints `{"deltaMiB"}`, with `ASAN_OPTIONS=quarantine_size_mb=0`. The quarantine delays reuse of freed memory, so freed bytes count as RSS growth.
- The ASAN CI lane runs with `detect_leaks=1`, and LeakSanitizer reports the original leak after a few queries in any MySQL test (verified with the leak restored). The RSS guard remains the only check for growth that stays reachable. If you would rather rely on LSAN alone, drop the regression file and keep the sql-mysql case.
- The file-level `isDockerEnabled()` gate is gone: `describeWithContainer` skips on its own, and the gate hid the test from the `BUN_TEST_SERVICE_mysql_plain` override. #37123 drops the same gate in ten files.

<details><summary>Notes</summary>

**The reported 101 s on darwin x64 is a measurement artifact.** In build #106656 the darwin x64 shard printed `Ran 0 tests across 1 file. [52.00ms]` for this file (no docker on darwin). The slow-test parser charged the `625 files in parallel` batch that followed to this file. #35418 fixes that parser and lists this file as an example. Real CI times from the same build: debian 13 x64 0.74 s, debian 13 x64-asan 4.0 s, debian 13 aarch64 skipped (26 ms). On this branch (builds 106802, 106813) the test body takes 0.3 s (x64) and 0.6 s (x64-asan) once the container is ready.

**Why not just fewer queries.** The leak signal is proportional to column decodes (columns x queries), and so is the debug-build cost: about 6 ms per 500-column response (roughly 11 us per column definition under ASAN) plus about 1 ms per query. Pipelining does not apply: the MySQL adapter keeps one command in flight per connection (`MySQLRequestQueue::can_pipeline` requires `is_ready_for_query`, which `advance` clears before the check). Batching 50 queries through `Promise.all` only removes the per-query event-loop turnaround (12% in debug, 2.8x in release). The gains come from 64-byte names (2.7x the leaked bytes per column against 20-byte names), no quarantine noise (so the bound drops from 36 to 8 MiB), and a 100-query warm-up (release noise drops from 2 to 4 MiB at 20 warm-up queries to 0 to 1 MiB at 100).

**Measurements, fixed debug build, quarantine off, 500 columns, 300 measured queries:** -0.1, 3.0, 0.9 MiB (100 warm-up), 1.9, 2.0, 2.0 MiB (50 warm-up). Release: 0, 1, 0 MiB (100 warm-up). Leak restored (debug): 15.0, 16.0, 17.0 MiB. Leak restored, old test shape (debug): 38.4 MiB against the 36 MiB bound.

**Restoring the leak for the check:** in `ColumnDefinition41::decode_internal`, rebuild `name_or_index` on every decode and `std::mem::forget(std::mem::replace(&mut self.name_or_index, rebuilt))`, which is the original bug's overwrite-without-free. With `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 BUN_DESTRUCT_VM_ON_EXIT=1`, five executions of a 4-column SELECT on that build exit 134 with `LeakSanitizer: detected memory leaks ... ColumnIdentifier::init ... ColumnDefinition41.rs:202`. Without those variables LSAN does not run at exit.

**Location.** The file stays in `test/regression/issue/` to keep this change small. The leak existed from the adapter's first commit, so by `test/CLAUDE.md` a move to `test/js/sql/` next to `sql-mysql-query-string-leak.test.ts` would fit the convention better. That move also needs the `regression/issue/28632` entry in `test/docker/prestart-map.mjs` updated, so it is left for a follow-up or for this PR if you prefer it here.

**Two things found on the way, not changed here.** (1) #40634: when two or more queued queries share a prepared statement whose prepare fails (for example the table does not exist), only the first rejects. The others never settle and `sql.close()` hangs. The fixture runs one lone query before the batches so a bad table fails fast instead of hanging. (2) Under a debug build, the same script is about 30% slower through `bun -e` than from a file (1.9 s against 1.2 s for the warm-up phase). Release shows no difference. The fixture is a file for that reason.
</details>
