### PR TITLE
test(install): share the starting trees of bun-prune.test.ts and assert full layouts

### DIFF
--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -292,7 +292,7 @@ const trees = {
 // Every entry of a node_modules folder, as paths relative to it: a package folder (scope folders flattened), a file,
 // a bin as `.bin/<name>` (one row on Windows too, where it is a shim pair), a store entry, and a link with its
 // target relative to the link. Recurses into each package's own node_modules and into the store, so one list covers
-// the whole tree a prune touches.
+// the whole tree a prune touches. A scope, `.bin` or store folder that is left empty is listed by its own name.
 function layout(dir: string, folder = "node_modules") {
   const rows: string[] = [];
   const pkg = (entry: Dirent, parent: string, prefix: string) => {
@@ -309,23 +309,38 @@ function layout(dir: string, folder = "node_modules") {
       rows.push(rel);
     }
   };
+  const orEmpty = (rel: string, list: () => void) => {
+    const before = rows.length;
+    list();
+    if (rows.length === before) rows.push(rel);
+  };
   const walk = (nm: string, prefix: string) => {
     if (!lstatSync(nm, { throwIfNoEntry: false })?.isDirectory()) return;
     for (const entry of readdirSync(nm, { withFileTypes: true })) {
       const path = join(nm, entry.name);
+      const rel = prefix + entry.name;
       if (!entry.isDirectory()) {
         pkg(entry, nm, prefix);
       } else if (entry.name.startsWith("@")) {
-        for (const scoped of readdirSync(path, { withFileTypes: true })) pkg(scoped, path, `${prefix}${entry.name}/`);
+        orEmpty(rel, () => {
+          for (const scoped of readdirSync(path, { withFileTypes: true })) pkg(scoped, path, `${rel}/`);
+        });
       } else if (entry.name === ".bin") {
-        for (const bin of new Set(readdirSync(path).map(name => name.replace(/\.(exe|bunx)$/, "")))) {
-          rows.push(`${prefix}.bin/${bin}`);
-        }
+        orEmpty(rel, () => {
+          for (const bin of new Set(readdirSync(path).map(name => name.replace(/\.(exe|bunx)$/, "")))) {
+            rows.push(`${rel}/${bin}`);
+          }
+        });
       } else if (entry.name === ".bun") {
-        for (const stored of readdirSync(path, { withFileTypes: true })) {
-          if (stored.name === "node_modules") walk(join(path, stored.name), `${prefix}.bun/node_modules/`);
-          else pkg(stored, path, `${prefix}.bun/`);
-        }
+        orEmpty(rel, () => {
+          for (const stored of readdirSync(path, { withFileTypes: true })) {
+            if (stored.name === "node_modules") {
+              orEmpty(`${rel}/node_modules`, () => walk(join(path, stored.name), `${rel}/node_modules/`));
+            } else {
+              pkg(stored, path, `${rel}/`);
+            }
+          }
+        });
       } else {
         pkg(entry, nm, prefix);
       }
@@ -1227,7 +1242,8 @@ test.concurrent(
   `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(layout(dir)).toEqual(["no-deps"]);
+    // The emptied scope folder goes with its package; the emptied .bin folder is a dot entry and stays.
+    expect(layout(dir)).toEqual([".bin", "no-deps"]);
     expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "2.0.0" });
     const { out: installOut } = await runBunInstall(installEnv(dir), dir, { savesLockfile: false });
     expect(installOut).toContain("no changes");
@@ -1251,7 +1267,7 @@ test.concurrent("hoisted: removing only a scoped package also removes its bin li
   `);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(layout(dir)).toEqual(["no-deps"]);
+  expect(layout(dir)).toEqual([".bin", "no-deps"]);
 });
 
 test.concurrent(
@@ -1301,6 +1317,7 @@ test.concurrent(
     expect(exitCode).toBe(0);
     expect(layout(dir)).toMatchInlineSnapshot(`
       [
+        ".bin",
         ".bun/no-deps@2.0.0",
         ".bun/no-deps@2.0.0/node_modules/no-deps",
         ".bun/node_modules/no-deps -> ../no-deps@2.0.0/node_modules/no-deps",
@@ -2394,6 +2411,7 @@ test.concurrent("isolated + publicHoistPattern: hoisted links follow their store
     [
       ".bun/no-deps@1.0.0",
       ".bun/no-deps@1.0.0/node_modules/no-deps",
+      ".bun/node_modules",
       "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
     ]
   `);
@@ -2942,6 +2960,7 @@ test.concurrent(
     const pruned = layout(dir);
     expect(pruned).toMatchInlineSnapshot(`
       [
+        ".bin",
         ".bun/node_modules/uses-what-bin -> ../uses-what-bin@1.0.0/node_modules/uses-what-bin",
         ".bun/node_modules/what-bin -> ../what-bin@1.0.0/node_modules/what-bin",
         ".bun/uses-what-bin@1.0.0",
@@ -3061,7 +3080,7 @@ test.concurrent("refuses to prune an isolated install with the hoisted linker", 
   `);
   expect(same.stderr).toBe("");
   expect(same.exitCode).toBe(0);
-  expect(layout(dir)).toEqual([]);
+  expect(layout(dir)).toEqual([".bun/node_modules"]);
 });
 
 // pnpm#5960
@@ -3077,25 +3096,31 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
     expect(await file(join(nm, "aliased", "package.json")).json()).toMatchObject({ version: "1.0.0" });
     expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "2.0.0" });
     const installed = layout(dir);
-    const hoistLink = ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps";
+    const hoistLink = (version: string) => `.bun/node_modules/no-deps -> ../no-deps@${version}/node_modules/no-deps`;
     // Both versions are direct dependencies under the real name, so which one the hidden-hoist `no-deps` link points at
-    // depends on the install's order. Prune only removes entries: a link at the dev 2.0.0 goes with it, one at the
-    // alias's 1.0.0 stays, and the production install that follows is what points a new link at 1.0.0.
+    // depends on the install's order. Prune only removes entries: a link at the dev 2.0.0 goes with it and leaves the
+    // hidden hoist folder empty, one at the alias's 1.0.0 stays, and the production install that follows is what
+    // points a new link at 1.0.0.
     const hoisted = linker === "hoisted";
-    const pruned = hoisted ? ["aliased"] : installed.filter(row => !row.includes("no-deps@2.0.0"));
+    const kept = [
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      "aliased -> .bun/no-deps@1.0.0/node_modules/no-deps",
+    ];
     expect(installed).toEqual(
       hoisted
         ? ["aliased", "no-deps"]
         : [
-            ".bun/no-deps@1.0.0",
-            ".bun/no-deps@1.0.0/node_modules/no-deps",
+            ...kept,
             ".bun/no-deps@2.0.0",
             ".bun/no-deps@2.0.0/node_modules/no-deps",
-            expect.stringMatching(/^\.bun\/node_modules\/no-deps -> \.\.\/no-deps@[12]\.0\.0\/node_modules\/no-deps$/),
-            "aliased -> .bun/no-deps@1.0.0/node_modules/no-deps",
+            installed.includes(hoistLink("2.0.0")) ? hoistLink("2.0.0") : hoistLink("1.0.0"),
             "no-deps -> .bun/no-deps@2.0.0/node_modules/no-deps",
-          ],
+          ].toSorted(),
     );
+    const pruned = hoisted
+      ? ["aliased"]
+      : [...kept, installed.includes(hoistLink("2.0.0")) ? ".bun/node_modules" : hoistLink("1.0.0")].toSorted();
 
     const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", linker);
     expect(lines(stdout)).toStrictEqual([BANNER, "", "- no-deps@2.0.0", REMOVED(1, hoisted ? 2 : 4)]);
@@ -3104,7 +3129,7 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
     expect(layout(dir)).toEqual(pruned);
     expect(await file(join(nm, "aliased", "package.json")).json()).toMatchObject({ version: "1.0.0" });
     await expectProductionInstallIsNoop(dir);
-    expect(layout(dir)).toEqual(hoisted ? pruned : [...new Set([...pruned, hoistLink])].toSorted());
+    expect(layout(dir)).toEqual(hoisted ? pruned : [...kept, hoistLink("1.0.0")].toSorted());
   },
 );
 

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -131,10 +131,17 @@ function expectBinRemoved(nm: string, name: string) {
 
 type BunfigOpts = NonNullable<Parameters<VerdaccioRegistry["createTestDir"]>[0]>["bunfigOpts"];
 
+// Writes the manifest and installs it: with a linker flag through `install`, otherwise through the harness's
+// `runBunInstall`, which also checks that the lockfile was saved.
+async function installInto(dir: string, packageJson: string, pkgJson: Record<string, unknown>, linker?: Linker) {
+  await write(packageJson, JSON.stringify(pkgJson));
+  if (linker) await install(dir, "--linker", linker);
+  else await runBunInstall(installEnv(dir), dir);
+}
+
 async function setup(pkgJson: Record<string, unknown>, bunfigOpts?: BunfigOpts) {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts });
-  await write(packageJson, JSON.stringify(pkgJson));
-  await runBunInstall(installEnv(packageDir), packageDir);
+  await installInto(packageDir, packageJson, pkgJson);
   return packageDir;
 }
 
@@ -156,8 +163,7 @@ type Linker = "hoisted" | "isolated";
 
 async function setupWithLinker(linker: Linker, pkgJson: Record<string, unknown>, bunfigOpts?: BunfigOpts) {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker, ...bunfigOpts } });
-  await write(packageJson, JSON.stringify(pkgJson));
-  await install(packageDir, "--linker", linker);
+  await installInto(packageDir, packageJson, pkgJson, linker);
   return packageDir;
 }
 
@@ -172,17 +178,22 @@ function writeWorkspaces(dir: string, packageJson: string, { root, packages }: W
   ]);
 }
 
+async function installWorkspacesInto(dir: string, packageJson: string, linker: Linker, workspaces: Workspaces) {
+  await writeWorkspaces(dir, packageJson, workspaces);
+  await install(dir, "--linker", linker);
+}
+
 async function setupWorkspaces(linker: Linker, workspaces: Workspaces) {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
-  await writeWorkspaces(packageDir, packageJson, workspaces);
-  await install(packageDir, "--linker", linker);
+  await installWorkspacesInto(packageDir, packageJson, linker, workspaces);
   return packageDir;
 }
 
 // Copies an installed project into the empty directory `dest` so that the copy stands on its own. A relative link is
-// kept. An absolute link into `source` (bun writes those for the cache's index, and for workspace and store links on
-// Windows) is pointed at the copy; `fs.cpSync` would leave both kinds pointing into `source`. A directory link is
-// recreated as a junction on Windows, which needs no privilege, like the fallback `bun install` itself uses.
+// kept as it is. An absolute link into `source` (bun writes those for the cache's index, and for workspace and store
+// links on Windows) is pointed at the same entry of the copy; `fs.cpSync` would leave both kinds pointing into
+// `source`. An absolute directory link is recreated as a junction, which needs no privilege, like the fallback `bun
+// install` itself uses. The harness's `copyTreeSync` (#39741) is this same algorithm.
 function copyTree(source: string, dest: string) {
   const root = realpathSync.native(source);
   const copy = (from: string, to: string) => {
@@ -191,14 +202,16 @@ function copyTree(source: string, dest: string) {
       const entryTo = join(to, entry.name);
       if (entry.isSymbolicLink()) {
         let target = readlinkSync(entryFrom);
-        const isDir = statSync(entryFrom, { throwIfNoEntry: false })?.isDirectory() ?? false;
+        const linkKind = statSync(entryFrom, { throwIfNoEntry: false })?.isDirectory() ? "dir" : "file";
         if (isAbsolute(target)) {
           const inside = relative(root, target);
           if (!inside.startsWith("..") && !isAbsolute(inside)) target = join(dest, inside);
+          symlinkSync(target, entryTo, linkKind === "dir" ? "junction" : "file");
+        } else {
+          symlinkSync(target, entryTo, linkKind);
         }
-        symlinkSync(target, entryTo, isDir ? "junction" : "file");
       } else if (entry.isDirectory()) {
-        mkdirSync(entryTo);
+        mkdirSync(entryTo, { recursive: true });
         copy(entryFrom, entryTo);
       } else {
         copyFileSync(entryFrom, entryTo);
@@ -208,85 +221,78 @@ function copyTree(source: string, dest: string) {
   copy(source, dest);
 }
 
-// A starting tree that several cases share. It is installed once, on first use, and every case gets its own copy,
-// cache included, so a case starts the way its own install would have left it. The copied bunfig names the
-// original's cache folder, so the copy gets one that names its own.
-function shared(build: () => Promise<string>) {
+// A starting tree that several cases share. `build` installs it into a test directory once, on first use; every case
+// then gets its own copy, cache included, with a bunfig of its own, so it starts the way its own install would have
+// left it.
+function shared(bunfigOpts: BunfigOpts, build: (dir: string, packageJson: string) => Promise<void>) {
   let source: Promise<string> | undefined;
   return async () => {
-    const from = await (source ??= build());
+    source ??= registry.createTestDir({ bunfigOpts }).then(async ({ packageDir, packageJson }) => {
+      await build(packageDir, packageJson);
+      return packageDir;
+    });
     const dir = String(tempDir("verdaccio-test-", {}));
-    copyTree(from, dir);
-    const { install } = Bun.TOML.parse(readFileSync(join(dir, "bunfig.toml"), "utf8")) as {
-      install: Record<string, unknown>;
-    };
-    writeFileSync(
-      join(dir, "bunfig.toml"),
-      Bun.TOML.stringify({ install: { ...install, cache: join(dir, ".bun-cache") } })!,
-    );
+    copyTree(await source, dir);
+    await registry.writeBunfig(dir, bunfigOpts);
     return dir;
   };
 }
 
-const perLinker = (build: (linker: Linker) => Promise<string>) =>
-  Object.fromEntries(linkers.map(linker => [linker, shared(() => build(linker))])) as Record<
-    Linker,
-    () => Promise<string>
-  >;
+// A shared tree from one manifest, installed the way `setup` (no linker) or `setupWithLinker` installs it.
+const packageTree = (pkgJson: Record<string, unknown>, linker?: Linker) =>
+  shared(linker && { linker }, (dir, packageJson) => installInto(dir, packageJson, pkgJson, linker));
+const workspaceTree = (linker: Linker, workspaces: Workspaces) =>
+  shared({ linker }, (dir, packageJson) => installWorkspacesInto(dir, packageJson, linker, workspaces));
+const perLinker = (tree: (linker: Linker) => () => Promise<string>) =>
+  Object.fromEntries(linkers.map(linker => [linker, tree(linker)])) as Record<Linker, () => Promise<string>>;
 
 const trees = {
-  noDeps: shared(() => setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } })),
-  oneDepNoDeps2: shared(() => setup({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } })),
-  noDepsScopedBin: shared(() =>
-    setup({ name: "foo", dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" } }),
+  noDeps: packageTree({ name: "foo", dependencies: { "no-deps": "1.0.0" } }),
+  oneDepNoDeps2: packageTree({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } }),
+  noDepsScopedBin: packageTree({ name: "foo", dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" } }),
+  devBins: packageTree({
+    name: "foo",
+    dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" },
+    devDependencies: { "one-fixed-dep-bins": "1.0.0", "what-bin": "1.0.0" },
+  }),
+  prodAndDev: packageTree({
+    name: "foo",
+    dependencies: { "no-deps": "1.0.0" },
+    devDependencies: { "one-fixed-dep": "1.0.0" },
+  }),
+  devRootProdNested: packageTree({
+    name: "foo",
+    dependencies: { "one-fixed-dep": "1.0.0" },
+    devDependencies: { "no-deps": "2.0.0" },
+  }),
+  native: packageTree({ name: "foo", dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" } }),
+  isolatedNoDeps: packageTree({ name: "foo", dependencies: { "no-deps": "1.0.0" } }, "isolated"),
+  isolatedDevOneDep: packageTree(
+    { name: "foo", dependencies: { "no-deps": "1.0.0" }, devDependencies: { "one-dep": "1.0.0" } },
+    "isolated",
   ),
-  devBins: shared(() =>
-    setup({
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" },
-      devDependencies: { "one-fixed-dep-bins": "1.0.0", "what-bin": "1.0.0" },
-    }),
-  ),
-  prodAndDev: shared(() =>
-    setup({ name: "foo", dependencies: { "no-deps": "1.0.0" }, devDependencies: { "one-fixed-dep": "1.0.0" } }),
-  ),
-  devRootProdNested: shared(() =>
-    setup({ name: "foo", dependencies: { "one-fixed-dep": "1.0.0" }, devDependencies: { "no-deps": "2.0.0" } }),
-  ),
-  native: shared(() =>
-    setup({ name: "foo", dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" } }),
-  ),
-  isolatedNoDeps: shared(() => setupWithLinker("isolated", { name: "foo", dependencies: { "no-deps": "1.0.0" } })),
-  isolatedDevOneDep: shared(() =>
-    setupWithLinker("isolated", {
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0" },
-      devDependencies: { "one-dep": "1.0.0" },
-    }),
-  ),
-  isolatedNative: shared(() =>
-    setupWithLinker("isolated", {
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" },
-    }),
+  isolatedNative: packageTree(
+    { name: "foo", dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" } },
+    "isolated",
   ),
   optional: perLinker(linker =>
-    setupWithLinker(linker, {
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0" },
-      optionalDependencies: { "a-dep": "1.0.1" },
-      devDependencies: { "one-fixed-dep": "1.0.0" },
-    }),
+    packageTree(
+      {
+        name: "foo",
+        dependencies: { "no-deps": "1.0.0" },
+        optionalDependencies: { "a-dep": "1.0.1" },
+        devDependencies: { "one-fixed-dep": "1.0.0" },
+      },
+      linker,
+    ),
   ),
   peerDepsFixed: perLinker(linker =>
-    setupWithLinker(linker, { name: "foo", dependencies: { "peer-deps-fixed": "1.0.0" } }),
+    packageTree({ name: "foo", dependencies: { "peer-deps-fixed": "1.0.0" } }, linker),
   ),
-  hoistedRootAndA: shared(() =>
-    setupWorkspaces("hoisted", {
-      root: { dependencies: { "no-deps": "2.0.0" } },
-      packages: { a: { dependencies: { "no-deps": "1.0.0" } } },
-    }),
-  ),
+  hoistedRootAndA: workspaceTree("hoisted", {
+    root: { dependencies: { "no-deps": "2.0.0" } },
+    packages: { a: { dependencies: { "no-deps": "1.0.0" } } },
+  }),
 };
 
 // Every entry of a node_modules folder, as paths relative to it: a package folder (scope folders flattened), a file,
@@ -1381,7 +1387,7 @@ const appLinksTool = {
     tool: {},
   },
 };
-const appLinksToolTree = shared(() => setupWorkspaces("isolated", appLinksTool));
+const appLinksToolTree = workspaceTree("isolated", appLinksTool);
 
 test.concurrent(
   "isolated + workspaces: --production removes a workspace's registry devDependency and its dev-only workspace link, keeps prod links",
@@ -1776,7 +1782,7 @@ const prunedCheckout = (app: Record<string, unknown>) => ({
     other: { dependencies: { "left-pad": "1.0.0" } },
   },
 });
-const prunedCheckoutTree = perLinker(linker => setupWorkspaces(linker, prunedCheckout({})));
+const prunedCheckoutTree = perLinker(linker => workspaceTree(linker, prunedCheckout({})));
 
 // The hoisted root folder, and the isolated store and app folder, of a prunedCheckout tree once `other` is gone from disk.
 const prunedCheckoutHoisted = ["app -> ../packages/app", "left-pad", "no-deps", "other -> ../packages/other"];

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -5,18 +5,22 @@ import {
   chmodSync,
   closeSync,
   copyFileSync,
+  type Dirent,
   existsSync,
   lstatSync,
   mkdirSync,
   openSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
+  realpathSync,
   renameSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const registry = new VerdaccioRegistry();
@@ -175,6 +179,169 @@ async function setupWorkspaces(linker: Linker, workspaces: Workspaces) {
   return packageDir;
 }
 
+// Copies an installed project into the empty directory `dest` so that the copy stands on its own. A relative link is
+// kept. An absolute link into `source` (bun writes those for the cache's index, and for workspace and store links on
+// Windows) is pointed at the copy; `fs.cpSync` would leave both kinds pointing into `source`. A directory link is
+// recreated as a junction on Windows, which needs no privilege, like the fallback `bun install` itself uses.
+function copyTree(source: string, dest: string) {
+  const root = realpathSync.native(source);
+  const copy = (from: string, to: string) => {
+    for (const entry of readdirSync(from, { withFileTypes: true })) {
+      const entryFrom = join(from, entry.name);
+      const entryTo = join(to, entry.name);
+      if (entry.isSymbolicLink()) {
+        let target = readlinkSync(entryFrom);
+        const isDir = statSync(entryFrom, { throwIfNoEntry: false })?.isDirectory() ?? false;
+        if (isAbsolute(target)) {
+          const inside = relative(root, target);
+          if (!inside.startsWith("..") && !isAbsolute(inside)) target = join(dest, inside);
+        }
+        symlinkSync(target, entryTo, isDir ? "junction" : "file");
+      } else if (entry.isDirectory()) {
+        mkdirSync(entryTo);
+        copy(entryFrom, entryTo);
+      } else {
+        copyFileSync(entryFrom, entryTo);
+      }
+    }
+  };
+  copy(source, dest);
+}
+
+// A starting tree that several cases share. It is installed once, on first use, and every case gets its own copy,
+// cache included, so a case starts the way its own install would have left it. The copied bunfig names the
+// original's cache folder, so the copy gets one that names its own.
+function shared(build: () => Promise<string>) {
+  let source: Promise<string> | undefined;
+  return async () => {
+    const from = await (source ??= build());
+    const dir = String(tempDir("verdaccio-test-", {}));
+    copyTree(from, dir);
+    const { install } = Bun.TOML.parse(readFileSync(join(dir, "bunfig.toml"), "utf8")) as {
+      install: Record<string, unknown>;
+    };
+    writeFileSync(
+      join(dir, "bunfig.toml"),
+      Bun.TOML.stringify({ install: { ...install, cache: join(dir, ".bun-cache") } })!,
+    );
+    return dir;
+  };
+}
+
+const perLinker = (build: (linker: Linker) => Promise<string>) =>
+  Object.fromEntries(linkers.map(linker => [linker, shared(() => build(linker))])) as Record<
+    Linker,
+    () => Promise<string>
+  >;
+
+const trees = {
+  noDeps: shared(() => setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } })),
+  oneDepNoDeps2: shared(() => setup({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } })),
+  noDepsScopedBin: shared(() =>
+    setup({ name: "foo", dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" } }),
+  ),
+  devBins: shared(() =>
+    setup({
+      name: "foo",
+      dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" },
+      devDependencies: { "one-fixed-dep-bins": "1.0.0", "what-bin": "1.0.0" },
+    }),
+  ),
+  prodAndDev: shared(() =>
+    setup({ name: "foo", dependencies: { "no-deps": "1.0.0" }, devDependencies: { "one-fixed-dep": "1.0.0" } }),
+  ),
+  devRootProdNested: shared(() =>
+    setup({ name: "foo", dependencies: { "one-fixed-dep": "1.0.0" }, devDependencies: { "no-deps": "2.0.0" } }),
+  ),
+  native: shared(() =>
+    setup({ name: "foo", dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" } }),
+  ),
+  isolatedNoDeps: shared(() => setupWithLinker("isolated", { name: "foo", dependencies: { "no-deps": "1.0.0" } })),
+  isolatedDevOneDep: shared(() =>
+    setupWithLinker("isolated", {
+      name: "foo",
+      dependencies: { "no-deps": "1.0.0" },
+      devDependencies: { "one-dep": "1.0.0" },
+    }),
+  ),
+  isolatedNative: shared(() =>
+    setupWithLinker("isolated", {
+      name: "foo",
+      dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" },
+    }),
+  ),
+  optional: perLinker(linker =>
+    setupWithLinker(linker, {
+      name: "foo",
+      dependencies: { "no-deps": "1.0.0" },
+      optionalDependencies: { "a-dep": "1.0.1" },
+      devDependencies: { "one-fixed-dep": "1.0.0" },
+    }),
+  ),
+  peerDepsFixed: perLinker(linker =>
+    setupWithLinker(linker, { name: "foo", dependencies: { "peer-deps-fixed": "1.0.0" } }),
+  ),
+  hoistedRootAndA: shared(() =>
+    setupWorkspaces("hoisted", {
+      root: { dependencies: { "no-deps": "2.0.0" } },
+      packages: { a: { dependencies: { "no-deps": "1.0.0" } } },
+    }),
+  ),
+};
+
+// Every entry of a node_modules folder, as paths relative to it: a package folder (scope folders flattened), a file,
+// a bin as `.bin/<name>` (one row on Windows too, where it is a shim pair), a store entry, and a link with its
+// target relative to the link. Recurses into each package's own node_modules and into the store, so one list covers
+// the whole tree a prune touches.
+function layout(dir: string, folder = "node_modules") {
+  const rows: string[] = [];
+  const pkg = (entry: Dirent, parent: string, prefix: string) => {
+    const path = join(parent, entry.name);
+    const rel = prefix + entry.name;
+    if (entry.isSymbolicLink()) {
+      let target = readlinkSync(path);
+      if (isAbsolute(target)) target = relative(dirname(path), target);
+      rows.push(`${rel} -> ${target.replaceAll("\\", "/")}`);
+    } else if (entry.isDirectory()) {
+      rows.push(rel);
+      walk(join(path, "node_modules"), `${rel}/node_modules/`);
+    } else {
+      rows.push(rel);
+    }
+  };
+  const walk = (nm: string, prefix: string) => {
+    if (!lstatSync(nm, { throwIfNoEntry: false })?.isDirectory()) return;
+    for (const entry of readdirSync(nm, { withFileTypes: true })) {
+      const path = join(nm, entry.name);
+      if (!entry.isDirectory()) {
+        pkg(entry, nm, prefix);
+      } else if (entry.name.startsWith("@")) {
+        for (const scoped of readdirSync(path, { withFileTypes: true })) pkg(scoped, path, `${prefix}${entry.name}/`);
+      } else if (entry.name === ".bin") {
+        for (const bin of new Set(readdirSync(path).map(name => name.replace(/\.(exe|bunx)$/, "")))) {
+          rows.push(`${prefix}.bin/${bin}`);
+        }
+      } else if (entry.name === ".bun") {
+        for (const stored of readdirSync(path, { withFileTypes: true })) {
+          if (stored.name === "node_modules") walk(join(path, stored.name), `${prefix}.bun/node_modules/`);
+          else pkg(stored, path, `${prefix}.bun/`);
+        }
+      } else {
+        pkg(entry, nm, prefix);
+      }
+    }
+  };
+  walk(join(dir, folder), "");
+  return rows.toSorted();
+}
+
+// What is at `path`: "link" whatever it points at, "dir", "file", or undefined when there is nothing. `existsSync`
+// follows a link, so it cannot tell a removed link from a dangling one.
+function kind(path: string) {
+  const stat = lstatSync(path, { throwIfNoEntry: false });
+  return stat === undefined ? undefined : stat.isSymbolicLink() ? "link" : stat.isDirectory() ? "dir" : "file";
+}
+
 function expectRefused({ stdout, stderr, exitCode }: Awaited<ReturnType<typeof prune>>) {
   expect(normalizeBunSnapshot(stderr)).toBe(`${OUT_OF_SYNC}\n${OUT_OF_SYNC_NOTE}`);
   expect(out(stdout)).toBe(BANNER);
@@ -264,16 +431,19 @@ const storeEntries = (dir: string) =>
     .toSorted();
 
 test.concurrent("removes extraneous packages, keeps everything the lockfile installs", async () => {
-  const dir = await setup({
-    name: "foo",
-    dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" },
-  });
+  const dir = await trees.noDepsScopedBin();
   const nm = join(dir, "node_modules");
-  const planted = [
-    plant(dir, "node_modules/junk"),
-    plant(dir, "node_modules/@scoped/junk"),
-    plant(dir, "node_modules/@other/thing"),
-  ];
+  const installed = layout(dir);
+  expect(installed).toMatchInlineSnapshot(`
+    [
+      ".bin/has-bin-entry",
+      "@scoped/has-bin-entry",
+      "no-deps",
+    ]
+  `);
+  plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/@scoped/junk");
+  plant(dir, "node_modules/@other/thing");
   writeFileSync(join(nm, "README.txt"), "");
   plant(dir, "node_modules/.cache/x");
   const lockBefore = await lock(dir);
@@ -288,58 +458,66 @@ test.concurrent("removes extraneous packages, keeps everything the lockfile inst
     3 packages removed (checked 5 installed packages)"
   `);
   expect(first.stdout).toMatch(/\(checked 5 installed packages\) \[\d+(\.\d+)?m?s\]\n?$/);
+  expect(first.stderr).toBe("");
   expect(first.exitCode).toBe(0);
 
-  for (const path of planted) {
-    expect(existsSync(path)).toBeFalse();
-  }
-  expect(existsSync(join(nm, "@other"))).toBeFalse();
-  expect(existsSync(join(nm, "no-deps"))).toBeTrue();
-  expect(existsSync(join(nm, "@scoped", "has-bin-entry"))).toBeTrue();
-  expect(existsSync(join(nm, "README.txt"))).toBeTrue();
+  // The emptied @other scope folder goes with its package; files and dot folders are not packages and stay.
+  expect(layout(dir)).toEqual([...installed, ".cache", "README.txt"].toSorted());
   expect(existsSync(join(nm, ".cache", "x"))).toBeTrue();
-  expectBinInstalled(nm, "has-bin-entry");
   expect(await lock(dir)).toBe(lockBefore);
 
   const second = await prune(dir);
-  expect(out(second.stdout)).toEndWith(NOTHING(2, 1));
+  expect(lines(second.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
   expect(second.stdout).toMatch(/\(nothing to prune\) \[\d+(\.\d+)?m?s\]\n?$/);
+  expect(second.stderr).toBe("");
   expect(second.exitCode).toBe(0);
 });
 
 test.concurrent("prunes nested node_modules folders the tree installs into", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } });
+  const dir = await trees.oneDepNoDeps2();
   const nested = join(dir, "node_modules", "one-dep", "node_modules", "no-deps");
   expect(await file(join(nested, "package.json")).json()).toMatchObject({ version: "1.0.1" });
-  const junk = plant(dir, "node_modules/one-dep/node_modules/junk");
+  const installed = layout(dir);
+  expect(installed).toMatchInlineSnapshot(`
+    [
+      "no-deps",
+      "one-dep",
+      "one-dep/node_modules/no-deps",
+    ]
+  `);
+  plant(dir, "node_modules/one-dep/node_modules/junk");
 
-  const { stdout, exitCode } = await prune(dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - junk (node_modules/one-dep/node_modules)
     1 package removed (checked 4 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(join(nested, "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual(installed);
 });
 
 test.concurrent.each([["--production"], ["--prod"], ["--omit=dev"]])(
   "%s removes packages only reachable through devDependencies",
   async (...flags: string[]) => {
-    const dir = await setup({
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" },
-      devDependencies: { "one-fixed-dep-bins": "1.0.0", "what-bin": "1.0.0" },
-    });
-    const nm = join(dir, "node_modules");
-    expect(existsSync(join(nm, "no-deps-bins"))).toBeTrue();
-    expectBinInstalled(nm, "what-bin");
-    expectBinInstalled(nm, "has-bin-entry");
+    const dir = await trees.devBins();
+    // no-deps-bins' tarball lacks its bin file, and bun install skips bin links whose target is missing.
+    expect(layout(dir)).toMatchInlineSnapshot(`
+      [
+        ".bin/has-bin-entry",
+        ".bin/what-bin",
+        "@scoped/has-bin-entry",
+        "no-deps",
+        "no-deps-bins",
+        "one-fixed-dep-bins",
+        "what-bin",
+      ]
+    `);
     const lockBefore = await lock(dir);
 
-    const { stdout, exitCode } = await prune(dir, ...flags);
+    const { stdout, stderr, exitCode } = await prune(dir, ...flags);
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
@@ -348,16 +526,11 @@ test.concurrent.each([["--production"], ["--prod"], ["--omit=dev"]])(
       - what-bin@1.0.0
       3 packages removed (checked 5 installed packages)"
     `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
-    expect(existsSync(join(nm, "no-deps"))).toBeTrue();
-    expect(existsSync(join(nm, "@scoped", "has-bin-entry"))).toBeTrue();
-    expect(existsSync(join(nm, "no-deps-bins"))).toBeFalse();
-    expect(existsSync(join(nm, "one-fixed-dep-bins"))).toBeFalse();
-    expect(existsSync(join(nm, "what-bin"))).toBeFalse();
     // pnpm#2326: bins of removed packages are cleaned up, on Windows too (shim files instead of links).
-    expectBinRemoved(nm, "what-bin");
-    expectBinInstalled(nm, "has-bin-entry");
+    expect(layout(dir)).toEqual([".bin/has-bin-entry", "@scoped/has-bin-entry", "no-deps"]);
 
     await expectProductionInstallIsNoop(dir);
     expect(await lock(dir)).toBe(lockBefore);
@@ -365,36 +538,32 @@ test.concurrent.each([["--production"], ["--prod"], ["--omit=dev"]])(
 );
 
 test.concurrent("--production keeps a package that prod and dev both need", async () => {
-  const pkg = {
-    name: "foo",
-    dependencies: { "no-deps": "1.0.0" },
-    devDependencies: { "one-fixed-dep": "1.0.0" },
-  };
-  const [dir, plainDir] = await Promise.all([setup(pkg), setup(pkg)]);
+  const [dir, plainDir] = await Promise.all([trees.prodAndDev(), trees.prodAndDev()]);
+  expect(layout(dir)).toEqual(["no-deps", "one-fixed-dep"]);
 
-  const production = await prune(dir, "--production");
+  const [production, plain] = await Promise.all([prune(dir, "--production"), prune(plainDir)]);
   expect(out(production.stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - one-fixed-dep@1.0.0
     1 package removed (checked 2 installed packages)"
   `);
+  expect(production.stderr).toBe("");
   expect(production.exitCode).toBe(0);
-  expect(existsSync(join(dir, "node_modules", "no-deps"))).toBeTrue();
-  expect(existsSync(join(dir, "node_modules", "one-fixed-dep"))).toBeFalse();
+  expect(layout(dir)).toEqual(["no-deps"]);
 
-  const plain = await prune(plainDir);
   expect(out(plain.stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     Done! Checked 2 installed packages across 1 folder (nothing to prune)"
   `);
+  expect(plain.stderr).toBe("");
   expect(plain.exitCode).toBe(0);
-  expect(existsSync(join(plainDir, "node_modules", "one-fixed-dep"))).toBeTrue();
+  expect(layout(plainDir)).toEqual(["no-deps", "one-fixed-dep"]);
 });
 
 test.concurrent("--dry-run prints without deleting; --silent deletes without printing", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
+  const dir = await trees.noDeps();
   const junk = plant(dir, "node_modules/junk");
 
   const dryRun = await prune(dir, "--dry-run");
@@ -418,6 +587,7 @@ test.concurrent("--dry-run prints without deleting; --silent deletes without pri
     CAN_BE_REMOVED(1, 2),
     APPLY_HINT("--linker", "hoisted"),
   ]);
+  expect(withFlags.stderr).toBe("");
   expect(withFlags.exitCode).toBe(0);
   expect(existsSync(junk)).toBeTrue();
 
@@ -425,96 +595,105 @@ test.concurrent("--dry-run prints without deleting; --silent deletes without pri
   expect(silentDryRun.stdout).toBe("");
   expect(silentDryRun.stderr).toBe("");
   expect(silentDryRun.exitCode).toBe(0);
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(dir)).toEqual(["junk", "no-deps"]);
 
   const silent = await prune(dir, "--silent");
   expect(silent.stdout).toBe("");
   expect(silent.stderr).toBe("");
   expect(silent.exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
+  expect(layout(dir)).toEqual(["no-deps"]);
 
   const clean = await prune(dir, "--dry-run");
   expect(lines(clean.stdout)).toStrictEqual([BANNER, "", NOTHING(1, 1)]);
+  expect(clean.stderr).toBe("");
   expect(clean.exitCode).toBe(0);
 });
 
 test.concurrent("nothing to prune when node_modules is missing or clean", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  await write(packageJson, JSON.stringify({ name: "foo", dependencies: { "no-deps": "1.0.0" } }));
-  await install(packageDir, "--lockfile-only");
-  const nm = join(packageDir, "node_modules");
-  rmSync(nm, { recursive: true, force: true });
-  expect(existsSync(join(packageDir, "bun.lock"))).toBeTrue();
+  const [missingDir, cleanDir] = await Promise.all([trees.noDeps(), trees.noDeps()]);
+  const nm = join(missingDir, "node_modules");
+  rmSync(nm, { recursive: true });
+  expect(existsSync(join(missingDir, "bun.lock"))).toBeTrue();
 
-  const missing = await prune(packageDir);
+  const [missing, clean] = await Promise.all([prune(missingDir), prune(cleanDir, "--production")]);
   expect(out(missing.stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     Done! No node_modules folder (nothing to prune)"
   `);
+  expect(missing.stderr).toBe("");
   expect(missing.exitCode).toBe(0);
   expect(existsSync(nm)).toBeFalse();
 
-  const cleanDir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
-  const clean = await prune(cleanDir, "--production");
   expect(out(clean.stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     Done! Checked 1 installed package across 1 folder (nothing to prune)"
   `);
+  expect(clean.stderr).toBe("");
   expect(clean.exitCode).toBe(0);
-  expect(existsSync(join(cleanDir, "node_modules", "no-deps"))).toBeTrue();
+  expect(layout(cleanDir)).toEqual(["no-deps"]);
 });
 
 test.concurrent("never follows symlinks out of node_modules", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
+  const dir = await trees.noDeps();
   const nm = join(dir, "node_modules");
   const outside = join(dir, "outside");
   mkdirSync(outside);
   writeFileSync(join(outside, "keep.txt"), "keep");
   const link = join(nm, "linked-junk");
   symlinkSync(outside, link, "junction");
-  expect(isSymlink(link)).toBeTrue();
+  expect(layout(dir)).toEqual(["linked-junk -> ../outside", "no-deps"]);
 
-  const { stdout, exitCode } = await prune(dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - linked-junk
     1 package removed (checked 2 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(() => lstatSync(link)).toThrow();
-  expect(existsSync(join(outside, "keep.txt"))).toBeTrue();
-  expect(existsSync(join(nm, "no-deps"))).toBeTrue();
+  expect(layout(dir)).toEqual(["no-deps"]);
+  expect(readdirSync(outside)).toEqual(["keep.txt"]);
 });
 
 test.concurrent("refuses to run without a lockfile", async () => {
   const [{ packageDir: noLockDir, packageJson }, installedDir] = await Promise.all([
     registry.createTestDir(),
-    setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } }),
+    trees.noDeps(),
   ]);
   await write(packageJson, JSON.stringify({ name: "foo", dependencies: { "no-deps": "1.0.0" } }));
-  const junk = plant(noLockDir, "node_modules/junk");
+  plant(noLockDir, "node_modules/junk");
 
-  const noLock = await prune(noLockDir);
+  const [noLock, silentNoLock, help, ...positionals] = await Promise.all([
+    prune(noLockDir),
+    prune(noLockDir, "--silent"),
+    prune(noLockDir, "--help"),
+    prune(installedDir, "foo"),
+    prune(installedDir, "foo", "--silent"),
+  ]);
   expect(normalizeBunSnapshot(noLock.stderr)).toMatchInlineSnapshot(`
     "error: missing lockfile, nothing to prune
     note: run 'bun install' first"
   `);
   expect(out(noLock.stdout)).toBe(BANNER);
   expect(noLock.exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
 
-  const silentNoLock = await prune(noLockDir, "--silent");
   expect(silentNoLock.stdout).toBe("");
   expect(silentNoLock.stderr).toBe("");
   expect(silentNoLock.exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
+
+  expect(help.stdout).toContain("bun prune");
+  expect(help.stdout).toContain("--production");
+  expect(help.stdout).toContain("--linker");
+  expect(help.stdout).toContain("--filter");
+  expect(help.stderr).toBe("");
+  expect(help.exitCode).toBe(0);
+  expect(layout(noLockDir)).toEqual(["junk"]);
 
   // Usage errors are the one class --silent does not suppress.
-  for (const args of [["foo"], ["foo", "--silent"]]) {
-    const positional = await prune(installedDir, ...args);
+  for (const positional of positionals) {
     expect(normalizeBunSnapshot(positional.stderr)).toMatchInlineSnapshot(`
       "error: bun prune does not take arguments, it always prunes the whole node_modules
       note: run 'bun prune --help' for more information"
@@ -522,15 +701,7 @@ test.concurrent("refuses to run without a lockfile", async () => {
     expect(positional.stdout).toBe("");
     expect(positional.exitCode).toBe(1);
   }
-  expect(existsSync(join(installedDir, "node_modules", "no-deps"))).toBeTrue();
-
-  const help = await prune(noLockDir, "--help");
-  expect(help.stdout).toContain("bun prune");
-  expect(help.stdout).toContain("--production");
-  expect(help.stdout).toContain("--linker");
-  expect(help.stdout).toContain("--filter");
-  expect(help.exitCode).toBe(0);
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(installedDir)).toEqual(["no-deps"]);
 });
 
 // pnpm#9796: hoisted keeps the root's workspace links under --production because they are root->workspace prod edges; the isolated per-importer dev link case is below.
@@ -552,14 +723,11 @@ test.concurrent("workspaces: prunes workspace folders, keeps workspace links, ru
     ),
   ]);
   await runBunInstall(installEnv(dir), dir);
-  const nm = join(dir, "node_modules");
-  const workspaceNoDeps = join(dir, "packages", "a", "node_modules", "no-deps");
-  expect(isSymlink(join(nm, "a"))).toBeTrue();
-  expect(existsSync(workspaceNoDeps)).toBeTrue();
-  expect(existsSync(join(nm, "a-dep"))).toBeTrue();
-  const junk = plant(dir, "packages/a/node_modules/junk");
+  expect(layout(dir)).toEqual(["a -> ../packages/a", "a-dep", "no-deps"]);
+  expect(layout(dir, "packages/a/node_modules")).toEqual(["no-deps"]);
+  plant(dir, "packages/a/node_modules/junk");
 
-  const { stdout, exitCode } = await prune(join(dir, "packages", "a"), "--production");
+  const { stdout, stderr, exitCode } = await prune(join(dir, "packages", "a"), "--production");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -567,53 +735,87 @@ test.concurrent("workspaces: prunes workspace folders, keeps workspace links, ru
     - junk (node_modules/a/node_modules)
     2 packages removed (checked 5 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 
-  expect(isSymlink(join(nm, "a"))).toBeTrue();
-  expect(existsSync(workspaceNoDeps)).toBeTrue();
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(join(nm, "a-dep"))).toBeFalse();
+  expect(layout(dir)).toEqual(["a -> ../packages/a", "no-deps"]);
+  expect(layout(dir, "packages/a/node_modules")).toEqual(["no-deps"]);
 });
 
 test.concurrent("keeps dependencies bundled inside a package", async () => {
   const dir = await setup({ name: "foo", dependencies: { "bundled-transitive": "1.0.0" } });
-  const bundled = join(dir, "node_modules", "bundled-transitive", "node_modules", "no-deps", "package.json");
-  expect(existsSync(bundled)).toBeTrue();
+  const installed = layout(dir);
+  expect(installed).toMatchInlineSnapshot(`
+    [
+      "bundled-transitive",
+      "bundled-transitive/node_modules/no-deps",
+      "no-deps",
+      "one-dep",
+    ]
+  `);
 
-  const { stdout, exitCode } = await prune(dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     Done! Checked 3 installed packages across 1 folder (nothing to prune)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(bundled)).toBeTrue();
+  expect(layout(dir)).toEqual(installed);
 });
 
 // pnpm#881: --production also removes dev-only entries from the store.
 test.concurrent("isolated linker: removes unused store entries and their links", async () => {
-  const dir = await setup(
-    { name: "foo", dependencies: { "no-deps": "1.0.0" }, devDependencies: { "one-dep": "1.0.0" } },
-    { linker: "isolated" },
-  );
-  const nm = join(dir, "node_modules");
-  const store = join(nm, ".bun");
-  expect(existsSync(join(store, "one-dep@1.0.0"))).toBeTrue();
-  expect(existsSync(join(store, "no-deps@1.0.1"))).toBeTrue();
-  expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
-  expect(isSymlink(join(nm, "one-dep"))).toBeTrue();
+  const dir = await trees.isolatedDevOneDep();
+  const store = join(dir, "node_modules", ".bun");
+  expect(layout(dir)).toMatchInlineSnapshot(`
+    [
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      ".bun/no-deps@1.0.1",
+      ".bun/no-deps@1.0.1/node_modules/no-deps",
+      ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+      ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+      ".bun/one-dep@1.0.0",
+      ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+      ".bun/one-dep@1.0.0/node_modules/one-dep",
+      "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+      "one-dep -> .bun/one-dep@1.0.0/node_modules/one-dep",
+    ]
+  `);
 
   plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
-  const peerVariant = plant(dir, "node_modules/.bun/no-deps@1.0.0+0123456789abcdef/node_modules/no-deps");
-  const junkReal = plant(dir, "node_modules/junk-real");
-  const hiddenHoist = join(store, "node_modules");
-  mkdirSync(hiddenHoist, { recursive: true });
+  plant(dir, "node_modules/.bun/no-deps@1.0.0+0123456789abcdef/node_modules/no-deps");
+  plant(dir, "node_modules/junk-real");
   const zzz = plant(dir, "node_modules/.bun/zzz@1.0.0/node_modules/zzz");
-  symlinkSync(zzz, join(hiddenHoist, "zzz"), "junction");
-  expect(isSymlink(join(hiddenHoist, "zzz"))).toBeTrue();
+  symlinkSync(zzz, join(store, "node_modules", "zzz"), "junction");
+  expect(layout(dir)).toMatchInlineSnapshot(`
+    [
+      ".bun/junk@1.0.0",
+      ".bun/junk@1.0.0/node_modules/junk",
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0+0123456789abcdef",
+      ".bun/no-deps@1.0.0+0123456789abcdef/node_modules/no-deps",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      ".bun/no-deps@1.0.1",
+      ".bun/no-deps@1.0.1/node_modules/no-deps",
+      ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+      ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+      ".bun/node_modules/zzz -> ../zzz@1.0.0/node_modules/zzz",
+      ".bun/one-dep@1.0.0",
+      ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+      ".bun/one-dep@1.0.0/node_modules/one-dep",
+      ".bun/zzz@1.0.0",
+      ".bun/zzz@1.0.0/node_modules/zzz",
+      "junk-real",
+      "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+      "one-dep -> .bun/one-dep@1.0.0/node_modules/one-dep",
+    ]
+  `);
   const lockBefore = await lock(dir);
 
-  const { stdout, exitCode } = await prune(dir, "--production");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -625,29 +827,24 @@ test.concurrent("isolated linker: removes unused store entries and their links",
     - zzz@1.0.0
     6 packages removed (checked 9 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 
-  expect(existsSync(join(store, "junk@1.0.0"))).toBeFalse();
-  expect(existsSync(join(store, "zzz@1.0.0"))).toBeFalse();
-  expect(existsSync(join(store, "no-deps@1.0.1"))).toBeFalse();
-  expect(existsSync(join(store, "one-dep@1.0.0"))).toBeFalse();
-  expect(existsSync(junkReal)).toBeFalse();
-  expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
-  expect(existsSync(peerVariant)).toBeFalse();
-  expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-  expect(existsSync(hiddenHoist)).toBeTrue();
-  expect(() => lstatSync(join(hiddenHoist, "zzz"))).toThrow();
+  expect(layout(dir)).toMatchInlineSnapshot(`
+    [
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+      "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+    ]
+  `);
   expect(await lock(dir)).toBe(lockBefore);
 
   await expectProductionInstallIsNoop(dir);
 });
 
 test.concurrent("isolated linker: --verbose does not print the store build timings", async () => {
-  const dir = await setup(
-    { name: "foo", dependencies: { "no-deps": "1.0.0" }, devDependencies: { "one-dep": "1.0.0" } },
-    { linker: "isolated" },
-  );
+  const dir = await trees.isolatedDevOneDep();
 
   // `--production` makes prune build the store twice (once with every
   // dependency type, once with the production set); `bun install --verbose`
@@ -687,7 +884,7 @@ test.concurrent("isolated linker: prune removes the peer-hash variants a peer bu
   expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
   expect(existsSync(join(store, "no-deps@1.0.1"))).toBeTrue();
 
-  const { stdout, exitCode } = await prune(dir, "--linker", "isolated");
+  const { stdout, stderr, exitCode } = await prune(dir, "--linker", "isolated");
   expect(out(stdout).split("\n")).toStrictEqual([
     "bun prune <version> (<revision>)",
     "",
@@ -695,10 +892,9 @@ test.concurrent("isolated linker: prune removes the peer-hash variants a peer bu
     `- ${before}`,
     "2 packages removed (checked 6 installed packages)",
   ]);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(peerEntries()).toStrictEqual([after]);
-  expect(existsSync(join(store, "no-deps@1.0.0"))).toBeFalse();
-  expect(existsSync(join(store, "no-deps@1.0.1"))).toBeTrue();
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", after]);
   expect(await install(dir, "--linker", "isolated")).toContain("no changes");
 });
 
@@ -708,20 +904,26 @@ test.concurrent("isolated linker + global store: unlinks the store link, never d
     { linker: "isolated", globalStore: true },
   );
   const storeEntry = join(dir, "node_modules", ".bun", "one-dep@1.0.0");
-  expect(isSymlink(storeEntry)).toBeTrue();
+  expect(kind(storeEntry)).toBe("link");
   const linksDir = join(installEnv(dir).BUN_INSTALL_CACHE_DIR, "links");
   const globalEntry = readdirSync(linksDir).find(name => name.startsWith("one-dep@1.0.0-"));
   expect(globalEntry).toBeDefined();
   const globalPkgJson = join(linksDir, globalEntry!, "node_modules", "one-dep", "package.json");
   expect(existsSync(globalPkgJson)).toBeTrue();
 
-  const { stdout, exitCode } = await prune(dir, "--production");
-  expect(out(stdout)).toContain("- one-dep@1.0.0");
-  expect(out(stdout)).toEndWith("2 packages removed (checked 3 installed packages)");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production");
+  expect(out(stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - no-deps@1.0.1
+    - one-dep@1.0.0
+    2 packages removed (checked 3 installed packages)"
+  `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 
-  expect(() => lstatSync(storeEntry)).toThrow();
-  expect(lstatSync(join(linksDir, globalEntry!)).isDirectory()).toBeTrue();
+  expect(kind(storeEntry)).toBeUndefined();
+  expect(kind(join(linksDir, globalEntry!))).toBe("dir");
   expect(await file(globalPkgJson).json()).toMatchObject({ name: "one-dep", version: "1.0.0" });
 });
 
@@ -731,16 +933,43 @@ test.concurrent("isolated linker: bins of removed packages are removed, live one
     dependencies: { "@scoped/has-bin-entry": "1.0.0" },
     devDependencies: { "what-bin": "1.0.0" },
   });
-  const nm = join(dir, "node_modules");
-  expectBinInstalled(nm, "what-bin");
-  expectBinInstalled(nm, "has-bin-entry");
+  expect(layout(dir)).toMatchInlineSnapshot(`
+    [
+      ".bin/has-bin-entry",
+      ".bin/what-bin",
+      ".bun/@scoped+has-bin-entry@1.0.0",
+      ".bun/@scoped+has-bin-entry@1.0.0/node_modules/.bin/has-bin-entry",
+      ".bun/@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+      ".bun/node_modules/@scoped/has-bin-entry -> ../../@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+      ".bun/node_modules/what-bin -> ../what-bin@1.0.0/node_modules/what-bin",
+      ".bun/what-bin@1.0.0",
+      ".bun/what-bin@1.0.0/node_modules/.bin/what-bin",
+      ".bun/what-bin@1.0.0/node_modules/what-bin",
+      "@scoped/has-bin-entry -> ../.bun/@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+      "what-bin -> .bun/what-bin@1.0.0/node_modules/what-bin",
+    ]
+  `);
 
-  const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
-  expect(out(stdout)).toEndWith("- what-bin@1.0.0\n1 package removed (checked 4 installed packages)");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+  expect(out(stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - what-bin@1.0.0
+    1 package removed (checked 4 installed packages)"
+  `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 
-  expectBinRemoved(nm, "what-bin");
-  expectBinInstalled(nm, "has-bin-entry");
+  expect(layout(dir)).toMatchInlineSnapshot(`
+    [
+      ".bin/has-bin-entry",
+      ".bun/@scoped+has-bin-entry@1.0.0",
+      ".bun/@scoped+has-bin-entry@1.0.0/node_modules/.bin/has-bin-entry",
+      ".bun/@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+      ".bun/node_modules/@scoped/has-bin-entry -> ../../@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+      "@scoped/has-bin-entry -> ../.bun/@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+    ]
+  `);
 });
 
 test.concurrent("hoisted: dot entries and files are never touched even when the lockfile is empty", async () => {
@@ -763,11 +992,11 @@ test.concurrent("hoisted: dot entries and files are never touched even when the 
   ]);
   const nm = join(dir, "node_modules");
   mkdirSync(nm);
-  const junk = plant(dir, "node_modules/junk");
-  const emptyStore = plant(dir, "node_modules/.bun/node_modules/whatever");
+  plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/.bun/node_modules/whatever");
   const cache = plant(dir, "node_modules/.cache/whatever@1.0.0");
-  const integrity = join(nm, ".yarn-integrity");
-  writeFileSync(integrity, "");
+  writeFileSync(join(nm, ".yarn-integrity"), "");
+  expect(layout(dir)).toEqual([".bun/node_modules/whatever", ".cache", ".yarn-integrity", "junk"]);
 
   const { stdout, stderr, exitCode } = await prune(dir);
   expect(stderr).toBe("");
@@ -778,26 +1007,32 @@ test.concurrent("hoisted: dot entries and files are never touched even when the 
     1 package removed (checked 1 installed package)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(emptyStore)).toBeTrue();
-  expect(existsSync(cache)).toBeTrue();
-  expect(existsSync(integrity)).toBeTrue();
+  expect(layout(dir)).toEqual([".bun/node_modules/whatever", ".cache", ".yarn-integrity"]);
+  expect(existsSync(join(cache, "package.json"))).toBeTrue();
 });
 
 // A hoisted prune over a tree whose store still holds entries would report the store as checked without looking at it.
 test.concurrent(
   "hoisted: refuses up front when node_modules/.bun holds store entries, even with nothing to remove",
   async () => {
-    const dir = await setupWithLinker("isolated", { name: "foo", dependencies: { "no-deps": "1.0.0" } });
-    const nm = join(dir, "node_modules");
-    expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0"]);
+    const dir = await trees.isolatedNoDeps();
+    const installed = layout(dir);
+    expect(installed).toMatchInlineSnapshot(`
+      [
+        ".bun/no-deps@1.0.0",
+        ".bun/no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+        "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+      ]
+    `);
 
-    for (const flags of [
-      ["--linker", "hoisted"],
-      ["--linker", "hoisted", "--dry-run"],
-      ["--linker", "hoisted", "--production"],
-    ]) {
-      const { stdout, stderr, exitCode } = await prune(dir, ...flags);
+    const [silent, ...refused] = await Promise.all([
+      prune(dir, "--linker", "hoisted", "--silent"),
+      prune(dir, "--linker", "hoisted"),
+      prune(dir, "--linker", "hoisted", "--dry-run"),
+      prune(dir, "--linker", "hoisted", "--production"),
+    ]);
+    for (const { stdout, stderr, exitCode } of refused) {
       expect(out(stdout)).toBe(BANNER);
       expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
       "error: node_modules was installed with the isolated linker, but bun prune would use the hoisted linker
@@ -805,23 +1040,23 @@ test.concurrent(
     `);
       expect(exitCode).toBe(1);
     }
-    const silent = await prune(dir, "--linker", "hoisted", "--silent");
     expect(silent.stdout).toBe("");
     expect(silent.stderr).toBe("");
     expect(silent.exitCode).toBe(1);
-    expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0"]);
-    expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
+    expect(layout(dir)).toEqual(installed);
 
     const same = await prune(dir, "--linker", "isolated");
     expect(lines(same.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 2)]);
+    expect(same.stderr).toBe("");
     expect(same.exitCode).toBe(0);
+    expect(layout(dir)).toEqual(installed);
   },
 );
 
 test.concurrent(
   "hoisted: a nested tree owned by a package that was replaced with a symlink is not walked",
   async () => {
-    const dir = await setup({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } });
+    const dir = await trees.oneDepNoDeps2();
     const nm = join(dir, "node_modules");
     expect(existsSync(join(nm, "one-dep", "node_modules", "no-deps"))).toBeTrue();
     rmSync(join(nm, "one-dep"), { recursive: true });
@@ -829,28 +1064,31 @@ test.concurrent(
       "package.json": JSON.stringify({ name: "one-dep", version: "1.0.0" }),
     });
     plant(outside, "node_modules/no-deps");
-    const keepMe = plant(outside, "node_modules/keep-me");
+    plant(outside, "node_modules/keep-me");
+    const before = layout(dir);
+    expect(before).toEqual(["no-deps", "one-dep -> ../outside/one-dep"]);
 
-    const { stdout, exitCode } = await prune(dir);
+    const { stdout, stderr, exitCode } = await prune(dir);
     expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     Done! Checked 2 installed packages across 1 folder (nothing to prune)"
   `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(existsSync(keepMe)).toBeTrue();
-    expect(isSymlink(join(nm, "one-dep"))).toBeTrue();
+    expect(layout(dir)).toEqual(before);
+    expect(layout(outside)).toEqual(["keep-me", "no-deps"]);
   },
 );
 
 test.concurrent("hoisted: a symlinked scope dir is unlinked, not followed", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
-  const nm = join(dir, "node_modules");
+  const dir = await trees.noDeps();
   const outside = linkOutside(dir, "node_modules/@fake");
-  const inner = plant(outside, "thing");
+  plant(outside, "thing");
   plant(dir, "node_modules/@real/junk");
+  expect(layout(dir)).toEqual(["@fake -> ../outside/@fake", "@real/junk", "no-deps"]);
 
-  const { stdout, exitCode } = await prune(dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -858,32 +1096,28 @@ test.concurrent("hoisted: a symlinked scope dir is unlinked, not followed", asyn
     - @real/junk
     2 packages removed (checked 3 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(() => lstatSync(join(nm, "@fake"))).toThrow();
-  expect(existsSync(inner)).toBeTrue();
-  expect(existsSync(join(nm, "@real"))).toBeFalse();
+  expect(layout(dir)).toEqual(["no-deps"]);
+  expect(readdirSync(outside)).toEqual(["thing"]);
 });
 
 test.concurrent(
   "hoisted: a workspace's nested folder is pruned where bun.lock says the workspace is, not through node_modules/<name>",
   async () => {
-    const dir = await setupWorkspaces("hoisted", {
-      root: { dependencies: { "no-deps": "2.0.0" } },
-      packages: { a: { dependencies: { "no-deps": "1.0.0" } } },
-    });
+    const dir = await trees.hoistedRootAndA();
     const link = join(dir, "node_modules", "a");
-    const workspaceNoDeps = join(dir, "packages", "a", "node_modules", "no-deps", "package.json");
-    expect(isSymlink(link)).toBeTrue();
-    expect(existsSync(workspaceNoDeps)).toBeTrue();
-    const junk = plant(dir, "packages/a/node_modules/junk");
+    expect(layout(dir)).toEqual(["a -> ../packages/a", "no-deps"]);
+    expect(layout(dir, "packages/a/node_modules")).toEqual(["no-deps"]);
+    plant(dir, "packages/a/node_modules/junk");
 
     // `bun link a` run from another checkout leaves node_modules/a pointing at that checkout, which has a node_modules of its own.
     rmSync(link);
     const other = linkOutside(dir, "node_modules/a", {
       "package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
     });
-    const victim = plant(other, "node_modules/victim");
-    const otherNoDeps = plant(other, "node_modules/no-deps");
+    plant(other, "node_modules/victim");
+    plant(other, "node_modules/no-deps");
 
     const dryRun = await prune(dir, "--dry-run", "--linker", "hoisted");
     expect(out(dryRun.stdout)).toMatchInlineSnapshot(`
@@ -893,52 +1127,53 @@ test.concurrent(
       1 package can be removed (checked 4 installed packages)
         bun prune --linker hoisted"
     `);
+    expect(dryRun.stderr).toBe("");
     expect(dryRun.exitCode).toBe(0);
+    expect(layout(dir, "packages/a/node_modules")).toEqual(["junk", "no-deps"]);
 
     // bun.lock records workspace folders relative to the root; prune chdirs there first, so running it from inside a workspace resolves them the same way.
-    const { stdout, exitCode } = await prune({ dir, cwd: join(dir, "packages", "a") }, "--linker", "hoisted");
+    const { stdout, stderr, exitCode } = await prune({ dir, cwd: join(dir, "packages", "a") }, "--linker", "hoisted");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
       - junk (node_modules/a/node_modules)
       1 package removed (checked 4 installed packages)"
     `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
-    expect(existsSync(workspaceNoDeps)).toBeTrue();
-    expect(existsSync(join(victim, "package.json"))).toBeTrue();
-    expect(existsSync(join(otherNoDeps, "package.json"))).toBeTrue();
-    expect(isSymlink(link)).toBeTrue();
+    expect(layout(dir)).toEqual(["a -> ../outside/a", "no-deps"]);
+    expect(layout(dir, "packages/a/node_modules")).toEqual(["no-deps"]);
+    expect(layout(other)).toEqual(["no-deps", "victim"]);
   },
 );
 
 test.concurrent.skipIf(isWindows)("a symlinked .bin directory is never cleaned through", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
-  const nm = join(dir, "node_modules");
-  expect(existsSync(join(nm, ".bin"))).toBeFalse();
+  const dir = await trees.noDeps();
+  expect(layout(dir)).toEqual(["no-deps"]);
   const outsideBins = linkOutside(dir, "node_modules/.bin");
   const dangling = join(outsideBins, "dangling");
   symlinkSync("./does-not-exist", dangling);
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
 
-  const { stdout, exitCode } = await prune(dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - junk
     1 package removed (checked 2 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(isSymlink(dangling)).toBeTrue();
-  expect(isSymlink(join(nm, ".bin"))).toBeTrue();
+  expect(layout(dir)).toEqual([".bin -> ../outside/.bin", "no-deps"]);
+  expect(kind(dangling)).toBe("link");
 });
 
 test.concurrent("isolated: extraneous symlinks are removed even when the store is clean", async () => {
-  const dir = await setupWithLinker("isolated", { name: "foo", dependencies: { "no-deps": "1.0.0" } });
-  const nm = join(dir, "node_modules");
+  const dir = await trees.isolatedNoDeps();
+  const installed = layout(dir);
   const outside = linkOutside(dir, "node_modules/ext", { "keep.txt": "keep" });
   const scopedOutside = linkOutside(dir, "node_modules/@ext/thing", { "keep.txt": "keep" });
+  expect(layout(dir)).toEqual([...installed, "@ext/thing -> ../../outside/thing", "ext -> ../outside/ext"].toSorted());
 
   const first = await prune(dir, "--linker", "isolated");
   expect(out(first.stdout)).toMatchInlineSnapshot(`
@@ -948,15 +1183,15 @@ test.concurrent("isolated: extraneous symlinks are removed even when the store i
     - ext
     2 packages removed (checked 4 installed packages)"
   `);
+  expect(first.stderr).toBe("");
   expect(first.exitCode).toBe(0);
-  expect(() => lstatSync(join(nm, "ext"))).toThrow();
-  expect(existsSync(join(nm, "@ext"))).toBeFalse();
-  expect(existsSync(join(outside, "keep.txt"))).toBeTrue();
-  expect(existsSync(join(scopedOutside, "keep.txt"))).toBeTrue();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual(installed);
+  expect(readdirSync(outside)).toEqual(["keep.txt"]);
+  expect(readdirSync(scopedOutside)).toEqual(["keep.txt"]);
 
   const second = await prune(dir, "--linker", "isolated");
-  expect(out(second.stdout)).toEndWith(NOTHING(2, 2));
+  expect(lines(second.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 2)]);
+  expect(second.stderr).toBe("");
   expect(second.exitCode).toBe(0);
 });
 
@@ -968,13 +1203,21 @@ test.concurrent(
       dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0", "@scoped/has-bin-entry": "1.0.0" },
     });
     const nm = join(dir, "node_modules");
-    expect(existsSync(join(nm, "one-dep", "node_modules", "no-deps"))).toBeTrue();
+    const installed = layout(dir);
+    expect(installed).toMatchInlineSnapshot(`
+      [
+        ".bin/has-bin-entry",
+        "@scoped/has-bin-entry",
+        "no-deps",
+        "one-dep",
+        "one-dep/node_modules/no-deps",
+      ]
+    `);
     await write(join(dir, "package.json"), JSON.stringify({ name: "foo", dependencies: { "no-deps": "2.0.0" } }));
     await install(dir, "--lockfile-only");
-    expect(existsSync(join(nm, "one-dep"))).toBeTrue();
-    expect(existsSync(join(nm, "@scoped", "has-bin-entry"))).toBeTrue();
+    expect(layout(dir)).toEqual(installed);
 
-    const { stdout, exitCode } = await prune(dir);
+    const { stdout, stderr, exitCode } = await prune(dir);
     expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -982,11 +1225,10 @@ test.concurrent(
     - one-dep@1.0.0
     2 packages removed (checked 3 installed packages)"
   `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(existsSync(join(nm, "one-dep"))).toBeFalse();
-    expect(existsSync(join(nm, "@scoped"))).toBeFalse();
+    expect(layout(dir)).toEqual(["no-deps"]);
     expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "2.0.0" });
-    expectBinRemoved(nm, "has-bin-entry");
     const { out: installOut } = await runBunInstall(installEnv(dir), dir, { savesLockfile: false });
     expect(installOut).toContain("no changes");
   },
@@ -998,19 +1240,18 @@ test.concurrent("hoisted: removing only a scoped package also removes its bin li
     dependencies: { "no-deps": "1.0.0" },
     devDependencies: { "@scoped/has-bin-entry": "1.0.0" },
   });
-  const nm = join(dir, "node_modules");
-  expectBinInstalled(nm, "has-bin-entry");
+  expect(layout(dir)).toEqual([".bin/has-bin-entry", "@scoped/has-bin-entry", "no-deps"]);
 
-  const { stdout, exitCode } = await prune(dir, "--production");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - @scoped/has-bin-entry@1.0.0
     1 package removed (checked 2 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(join(nm, "@scoped"))).toBeFalse();
-  expectBinRemoved(nm, "has-bin-entry");
+  expect(layout(dir)).toEqual(["no-deps"]);
 });
 
 test.concurrent(
@@ -1021,13 +1262,33 @@ test.concurrent(
       dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0", "@scoped/has-bin-entry": "1.0.0" },
     });
     const nm = join(dir, "node_modules");
-    const store = join(nm, ".bun");
+    const installed = layout(dir);
+    expect(installed).toMatchInlineSnapshot(`
+      [
+        ".bin/has-bin-entry",
+        ".bun/@scoped+has-bin-entry@1.0.0",
+        ".bun/@scoped+has-bin-entry@1.0.0/node_modules/.bin/has-bin-entry",
+        ".bun/@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+        ".bun/no-deps@1.0.1",
+        ".bun/no-deps@1.0.1/node_modules/no-deps",
+        ".bun/no-deps@2.0.0",
+        ".bun/no-deps@2.0.0/node_modules/no-deps",
+        ".bun/node_modules/@scoped/has-bin-entry -> ../../@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+        ".bun/node_modules/no-deps -> ../no-deps@2.0.0/node_modules/no-deps",
+        ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+        ".bun/one-dep@1.0.0",
+        ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+        ".bun/one-dep@1.0.0/node_modules/one-dep",
+        "@scoped/has-bin-entry -> ../.bun/@scoped+has-bin-entry@1.0.0/node_modules/@scoped/has-bin-entry",
+        "no-deps -> .bun/no-deps@2.0.0/node_modules/no-deps",
+        "one-dep -> .bun/one-dep@1.0.0/node_modules/one-dep",
+      ]
+    `);
     await write(join(dir, "package.json"), JSON.stringify({ name: "foo", dependencies: { "no-deps": "2.0.0" } }));
     await install(dir, "--lockfile-only", "--linker", "isolated");
-    expect(isSymlink(join(nm, "one-dep"))).toBeTrue();
-    expect(isSymlink(join(nm, "@scoped", "has-bin-entry"))).toBeTrue();
+    expect(layout(dir)).toEqual(installed);
 
-    const { stdout, exitCode } = await prune(dir, "--linker", "isolated");
+    const { stdout, stderr, exitCode } = await prune(dir, "--linker", "isolated");
     expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -1036,12 +1297,17 @@ test.concurrent(
     - one-dep@1.0.0
     3 packages removed (checked 7 installed packages)"
   `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
-    expect(existsSync(join(nm, "@scoped"))).toBeFalse();
-    expect(existsSync(join(store, "no-deps@2.0.0"))).toBeTrue();
+    expect(layout(dir)).toMatchInlineSnapshot(`
+      [
+        ".bun/no-deps@2.0.0",
+        ".bun/no-deps@2.0.0/node_modules/no-deps",
+        ".bun/node_modules/no-deps -> ../no-deps@2.0.0/node_modules/no-deps",
+        "no-deps -> .bun/no-deps@2.0.0/node_modules/no-deps",
+      ]
+    `);
     expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "2.0.0" });
-    expectBinRemoved(nm, "has-bin-entry");
   },
 );
 
@@ -1059,19 +1325,23 @@ test.concurrent("hoisted: --production empties a workspace folder that only held
   ]);
   await install(dir, "--linker", "hoisted");
   const nm = join(dir, "node_modules");
-  const nested = join(dir, "packages", "a", "node_modules", "no-deps");
-  expect(await file(join(nested, "package.json")).json()).toMatchObject({ version: "1.0.0" });
+  expect(layout(dir)).toEqual(["a -> ../packages/a", "no-deps"]);
+  expect(layout(dir, "packages/a/node_modules")).toEqual(["no-deps"]);
+  expect(await file(join(dir, "packages", "a", "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.0.0",
+  });
 
-  const { stdout, exitCode } = await prune(dir, "--production", "--linker", "hoisted");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "hoisted");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - no-deps@1.0.0 (packages/a/node_modules)
     1 package removed (checked 3 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(nested)).toBeFalse();
-  expect(isSymlink(join(nm, "a"))).toBeTrue();
+  expect(layout(dir)).toEqual(["a -> ../packages/a", "no-deps"]);
+  expect(layout(dir, "packages/a/node_modules")).toEqual([]);
   expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "2.0.0" });
   await expectProductionInstallIsNoop(dir);
 });
@@ -1086,19 +1356,35 @@ const appLinksTool = {
     tool: {},
   },
 };
+const appLinksToolTree = shared(() => setupWorkspaces("isolated", appLinksTool));
 
 test.concurrent(
   "isolated + workspaces: --production removes a workspace's registry devDependency and its dev-only workspace link, keeps prod links",
   async () => {
-    const dir = await setupWorkspaces("isolated", appLinksTool);
+    const dir = await appLinksToolTree();
     const app = join(dir, "packages", "app");
-    const appNm = join(app, "node_modules");
-    expect(existsSync(join(dir, "node_modules", ".bun"))).toBeTrue();
-    expect(isSymlink(join(appNm, "a-dep"))).toBeTrue();
-    expect(isSymlink(join(appNm, "tool"))).toBeTrue();
+    expect(layout(dir)).toMatchInlineSnapshot(`
+      [
+        ".bun/a-dep@1.0.1",
+        ".bun/a-dep@1.0.1/node_modules/a-dep",
+        ".bun/no-deps@1.0.0",
+        ".bun/no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/a-dep -> ../a-dep@1.0.1/node_modules/a-dep",
+        ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+      ]
+    `);
+    expect(layout(app)).toMatchInlineSnapshot(`
+      [
+        "a-dep -> ../../../node_modules/.bun/a-dep@1.0.1/node_modules/a-dep",
+        "lib -> ../../lib",
+        "no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps",
+        "tool -> ../../tool",
+      ]
+    `);
 
     const plain = await prune(dir, "--linker", "isolated");
-    expect(out(plain.stdout)).toEndWith(NOTHING(6, 3));
+    expect(lines(plain.stdout)).toStrictEqual([BANNER, "", NOTHING(6, 3)]);
+    expect(plain.stderr).toBe("");
     expect(plain.exitCode).toBe(0);
 
     const dryRun = await prune(dir, "--production", "--dry-run", "--linker", "isolated");
@@ -1110,10 +1396,11 @@ test.concurrent(
       2 packages can be removed (checked 6 installed packages)
         bun prune --production --linker isolated"
     `);
+    expect(dryRun.stderr).toBe("");
     expect(dryRun.exitCode).toBe(0);
-    expect(isSymlink(join(appNm, "tool"))).toBeTrue();
+    expect(kind(join(app, "node_modules", "tool"))).toBe("link");
 
-    const { stdout, exitCode } = await prune({ dir, cwd: app }, "--production", "--linker", "isolated");
+    const { stdout, stderr, exitCode } = await prune({ dir, cwd: app }, "--production", "--linker", "isolated");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
@@ -1121,37 +1408,58 @@ test.concurrent(
       - tool@1.0.0 (packages/app/node_modules)
       2 packages removed (checked 6 installed packages)"
     `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(() => lstatSync(join(appNm, "a-dep"))).toThrow();
-    expect(() => lstatSync(join(appNm, "tool"))).toThrow();
-    expect(existsSync(join(appNm, "no-deps", "package.json"))).toBeTrue();
-    expect(existsSync(join(appNm, "lib", "package.json"))).toBeTrue();
+    const pruned = layout(dir);
+    const prunedApp = layout(app);
+    expect(pruned).toMatchInlineSnapshot(`
+      [
+        ".bun/no-deps@1.0.0",
+        ".bun/no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+      ]
+    `);
+    expect(prunedApp).toMatchInlineSnapshot(`
+      [
+        "lib -> ../../lib",
+        "no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps",
+      ]
+    `);
     expect(existsSync(join(dir, "packages", "tool", "package.json"))).toBeTrue();
 
     const again = await prune(dir, "--production", "--linker", "isolated");
-    expect(out(again.stdout)).toEndWith(NOTHING(3, 3));
+    expect(lines(again.stdout)).toStrictEqual([BANNER, "", NOTHING(3, 3)]);
+    expect(again.stderr).toBe("");
     expect(again.exitCode).toBe(0);
     await expectProductionInstallIsNoop(dir);
-    expect(() => lstatSync(join(appNm, "tool"))).toThrow();
+    expect(layout(dir)).toEqual(pruned);
+    expect(layout(app)).toEqual(prunedApp);
   },
 );
 
 test.concurrent("isolated: a real directory named like a workspace is never deleted", async () => {
-  const dir = await setupWorkspaces("isolated", appLinksTool);
-  const appNm = join(dir, "packages", "app", "node_modules");
-  rmSync(join(appNm, "tool"));
+  const dir = await appLinksToolTree();
+  const app = join(dir, "packages", "app");
+  rmSync(join(app, "node_modules", "tool"));
   const planted = plant(dir, "packages/app/node_modules/tool");
 
-  const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - a-dep@1.0.1
     1 package removed (checked 6 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
+  expect(layout(app)).toMatchInlineSnapshot(`
+    [
+      "lib -> ../../lib",
+      "no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps",
+      "tool",
+    ]
+  `);
   expect(existsSync(join(planted, "package.json"))).toBeTrue();
-  expect(existsSync(join(appNm, "lib", "package.json"))).toBeTrue();
 });
 
 test.concurrent(
@@ -1174,36 +1482,39 @@ test.concurrent(
       ),
       setupWorkspaces("isolated", scoped({ devDependencies: { "@scope/tool": "workspace:*" } })),
     ]);
-    const mixedScope = join(mixedDir, "packages", "app", "node_modules", "@scope");
-    const devOnlyScope = join(devOnlyDir, "packages", "app", "node_modules", "@scope");
-    expect(isSymlink(join(mixedScope, "tool"))).toBeTrue();
-    expect(isSymlink(join(devOnlyScope, "tool"))).toBeTrue();
+    const mixedApp = join(mixedDir, "packages", "app");
+    const devOnlyApp = join(devOnlyDir, "packages", "app");
+    const noDepsLink = "no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps";
+    expect(layout(mixedApp)).toEqual(["@scope/lib -> ../../../lib", "@scope/tool -> ../../../tool", noDepsLink]);
+    expect(layout(devOnlyApp)).toEqual(["@scope/tool -> ../../../tool", noDepsLink]);
 
-    const mixed = await prune(mixedDir, "--production", "--linker", "isolated");
+    const [mixed, devOnly] = await Promise.all([
+      prune(mixedDir, "--production", "--linker", "isolated"),
+      prune(devOnlyDir, "--production", "--linker", "isolated"),
+    ]);
     expect(out(mixed.stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
       - @scope/tool@1.0.0 (packages/app/node_modules)
       1 package removed (checked 4 installed packages)"
     `);
+    expect(mixed.stderr).toBe("");
     expect(mixed.exitCode).toBe(0);
-    expect(() => lstatSync(join(mixedScope, "tool"))).toThrow();
-    expect(existsSync(join(mixedScope, "lib", "package.json"))).toBeTrue();
+    expect(layout(mixedApp)).toEqual(["@scope/lib -> ../../../lib", noDepsLink]);
     expect(existsSync(join(mixedDir, "packages", "tool", "package.json"))).toBeTrue();
-    await expectProductionInstallIsNoop(mixedDir);
 
-    const devOnly = await prune(devOnlyDir, "--production", "--linker", "isolated");
     expect(out(devOnly.stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
       - @scope/tool@1.0.0 (packages/app/node_modules)
       1 package removed (checked 3 installed packages)"
     `);
+    expect(devOnly.stderr).toBe("");
     expect(devOnly.exitCode).toBe(0);
-    expect(existsSync(devOnlyScope)).toBeFalse();
-    expect(existsSync(join(devOnlyDir, "packages", "app", "node_modules", "no-deps", "package.json"))).toBeTrue();
+    expect(layout(devOnlyApp)).toEqual([noDepsLink]);
     expect(existsSync(join(devOnlyDir, "packages", "tool", "package.json"))).toBeTrue();
-    await expectProductionInstallIsNoop(devOnlyDir);
+
+    await Promise.all([expectProductionInstallIsNoop(mixedDir), expectProductionInstallIsNoop(devOnlyDir)]);
   },
 );
 
@@ -1217,24 +1528,31 @@ test.concurrent(
         tool: {},
       },
     });
-    const appTool = join(dir, "packages", "app", "node_modules", "tool");
-    const bTool = join(dir, "packages", "b", "node_modules", "tool");
-    expect(isSymlink(appTool)).toBeTrue();
-    expect(isSymlink(bTool)).toBeTrue();
+    const app = join(dir, "packages", "app");
+    const b = join(dir, "packages", "b");
+    expect(layout(app)).toEqual(["tool -> ../../tool"]);
+    const bInstalled = layout(b);
+    expect(bInstalled).toMatchInlineSnapshot(`
+      [
+        "no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps",
+        "tool -> ../../tool",
+      ]
+    `);
 
-    const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+    const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
       - tool@1.0.0 (packages/app/node_modules)
       1 package removed (checked 4 installed packages)"
     `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(() => lstatSync(appTool)).toThrow();
-    expect(await file(join(bTool, "package.json")).json()).toMatchObject({ name: "tool" });
+    expect(layout(app)).toEqual([]);
+    expect(layout(b)).toEqual(bInstalled);
     await expectProductionInstallIsNoop(dir);
-    expect(() => lstatSync(appTool)).toThrow();
-    expect(isSymlink(bTool)).toBeTrue();
+    expect(layout(app)).toEqual([]);
+    expect(layout(b)).toEqual(bInstalled);
   },
 );
 
@@ -1248,52 +1566,64 @@ test.concurrent.each(linkers)(
         tool: { dependencies: { "no-deps": "1.0.0" } },
       },
     });
-    const appTool = join(dir, "packages", "app", "node_modules", "tool");
-    const rootTool = join(dir, "node_modules", "tool");
-    expect(isSymlink(rootTool)).toBeTrue();
-    const toolNoDeps =
+    const app = join(dir, "packages", "app");
+    const tool = join(dir, "packages", "tool");
+    const installed = { root: layout(dir), app: layout(app), tool: layout(tool) };
+    expect(installed).toEqual(
       linker === "hoisted"
-        ? join(dir, "node_modules", "no-deps", "package.json")
-        : join(dir, "packages", "tool", "node_modules", "no-deps", "package.json");
-    expect(existsSync(toolNoDeps)).toBeTrue();
+        ? { root: ["app -> ../packages/app", "no-deps", "tool -> ../packages/tool"], app: [], tool: [] }
+        : {
+            root: [
+              ".bun/no-deps@1.0.0",
+              ".bun/no-deps@1.0.0/node_modules/no-deps",
+              ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+              "tool -> ../packages/tool",
+            ],
+            app: ["tool -> ../../tool"],
+            tool: ["no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps"],
+          },
+    );
 
     const first = await prune(dir, "--production", "--linker", linker);
-    if (linker === "hoisted") {
-      expect(out(first.stdout)).toEndWith(NOTHING(3, 1));
-      expect(isSymlink(rootTool)).toBeTrue();
-    } else {
-      expect(out(first.stdout)).toEndWith(`- tool@1.0.0 (packages/app/node_modules)\n${REMOVED(1, 4)}`);
-      expect(() => lstatSync(appTool)).toThrow();
-    }
+    expect(lines(first.stdout)).toStrictEqual(
+      linker === "hoisted"
+        ? [BANNER, "", NOTHING(3, 1)]
+        : [BANNER, "", "- tool@1.0.0 (packages/app/node_modules)", REMOVED(1, 4)],
+    );
+    expect(first.stderr).toBe("");
     expect(first.exitCode).toBe(0);
-    expect(existsSync(toolNoDeps)).toBeTrue();
-    expect(existsSync(join(dir, "packages", "tool", "package.json"))).toBeTrue();
+    // The hoisted linker links every workspace into the root folder, so the app's dev edge has no link of its own to remove.
+    const pruned = { ...installed, app: linker === "hoisted" ? installed.app : [] };
+    expect({ root: layout(dir), app: layout(app), tool: layout(tool) }).toEqual(pruned);
+    expect(existsSync(join(tool, "package.json"))).toBeTrue();
 
     const second = await prune(dir, "--production", "--linker", linker);
-    expect(out(second.stdout)).toEndWith(linker === "hoisted" ? NOTHING(3, 1) : NOTHING(3, 4));
+    expect(lines(second.stdout)).toStrictEqual([BANNER, "", linker === "hoisted" ? NOTHING(3, 1) : NOTHING(3, 4)]);
+    expect(second.stderr).toBe("");
     expect(second.exitCode).toBe(0);
     await expectProductionInstallIsNoop(dir);
-    expect(existsSync(toolNoDeps)).toBeTrue();
+    expect({ root: layout(dir), app: layout(app), tool: layout(tool) }).toEqual(pruned);
   },
 );
 
 test.concurrent.each(linkers)("%s: refuses when package.json changed since bun.lock was written", async linker => {
   const dir = await setupWithLinker(linker, { name: "foo", dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } });
-  const junk = plant(dir, "node_modules/junk");
-  const aDep = join(dir, "node_modules", "a-dep");
+  plant(dir, "node_modules/junk");
+  const before = layout(dir);
   await write(join(dir, "package.json"), JSON.stringify({ name: "foo", dependencies: { "no-deps": "1.0.0" } }));
   const lockBefore = await lock(dir);
 
-  expectRefused(await prune(dir, "--linker", linker));
-  expectRefused(await prune(dir, "--dry-run", "--linker", linker));
-  expect(existsSync(junk)).toBeTrue();
-  expect(existsSync(join(aDep, "package.json"))).toBeTrue();
-
-  const silent = await prune(dir, "--silent", "--linker", linker);
+  const [plain, dryRun, silent] = await Promise.all([
+    prune(dir, "--linker", linker),
+    prune(dir, "--dry-run", "--linker", linker),
+    prune(dir, "--silent", "--linker", linker),
+  ]);
+  expectRefused(plain);
+  expectRefused(dryRun);
   expect(silent.stdout).toBe("");
   expect(silent.stderr).toBe("");
   expect(silent.exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(dir)).toEqual(before);
   expect(await lock(dir)).toBe(lockBefore);
 
   await install(dir, "--lockfile-only", "--linker", linker);
@@ -1308,8 +1638,16 @@ test.concurrent.each(linkers)("%s: refuses when package.json changed since bun.l
   ]);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(() => lstatSync(aDep)).toThrow();
+  expect(layout(dir)).toEqual(
+    linker === "hoisted"
+      ? ["no-deps"]
+      : [
+          ".bun/no-deps@1.0.0",
+          ".bun/no-deps@1.0.0/node_modules/no-deps",
+          ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+          "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+        ],
+  );
 });
 
 test.concurrent.each([
@@ -1317,13 +1655,13 @@ test.concurrent.each([
   ["a range changes but still matches the installed version", { dependencies: { "no-deps": "^1.0.0" } }],
   ["an override is added", { dependencies: { "no-deps": "1.0.0" }, overrides: { "no-deps": "1.0.0" } }],
 ] as const)("refuses when %s", async (_, edited) => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
-  const junk = plant(dir, "node_modules/junk");
+  const dir = await trees.noDeps();
+  plant(dir, "node_modules/junk");
   const lockBefore = await lock(dir);
   await write(join(dir, "package.json"), JSON.stringify({ name: "foo", ...edited }));
 
   expectRefused(await prune(dir));
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(dir)).toEqual(["junk", "no-deps"]);
   expect(await lock(dir)).toBe(lockBefore);
 });
 
@@ -1333,12 +1671,12 @@ test.concurrent("refuses when a catalog entry changed", async () => {
     packages: { a: { dependencies: { "no-deps": "catalog:" } } },
   });
   const dir = await setupWorkspaces("hoisted", catalogRoot("1.0.0"));
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
   const lockBefore = await lock(dir);
   await writeWorkspaces(dir, join(dir, "package.json"), catalogRoot("1.0.1"));
 
   expectRefused(await prune(dir, "--linker", "hoisted"));
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(dir)).toEqual(["a -> ../packages/a", "junk", "no-deps"]);
   expect(await lock(dir)).toBe(lockBefore);
 });
 
@@ -1350,26 +1688,32 @@ test.concurrent("refuses when a workspace's package.json changed, from any cwd a
       b: { dependencies: { "a-dep": "1.0.1" } },
     },
   });
-  const junk = plant(dir, "packages/a/node_modules/junk");
-  const aDep = join(dir, "node_modules", "a-dep");
-  expect(existsSync(aDep)).toBeTrue();
+  plant(dir, "packages/a/node_modules/junk");
+  const before = { root: layout(dir), a: layout(dir, "packages/a/node_modules") };
+  expect(before).toEqual({
+    root: ["a -> ../packages/a", "a-dep", "b -> ../packages/b", "no-deps"],
+    a: ["junk", "no-deps"],
+  });
   await write(join(dir, "packages", "b", "package.json"), JSON.stringify({ name: "b", version: "1.0.0" }));
 
-  expectRefused(await prune(dir, "--linker", "hoisted"));
-  expectRefused(await prune({ dir, cwd: join(dir, "packages", "a") }, "--linker", "hoisted"));
-  expectRefused(await prune(dir, "--filter", "a", "--linker", "hoisted"));
-  expect(existsSync(junk)).toBeTrue();
-  expect(existsSync(aDep)).toBeTrue();
+  const refused = await Promise.all([
+    prune(dir, "--linker", "hoisted"),
+    prune({ dir, cwd: join(dir, "packages", "a") }, "--linker", "hoisted"),
+    prune(dir, "--filter", "a", "--linker", "hoisted"),
+  ]);
+  for (const result of refused) expectRefused(result);
+  expect({ root: layout(dir), a: layout(dir, "packages/a/node_modules") }).toEqual(before);
 });
 
 test.concurrent.each(linkers)("%s: a workspace lifecycle script is not out of sync", async linker => {
   const dir = await setupWorkspaces(linker, {
     packages: { a: { dependencies: { "no-deps": "1.0.0" }, scripts: { postinstall: "echo ok" } } },
   });
-  const junk = plant(dir, "node_modules/junk");
+  const installed = layout(dir);
+  plant(dir, "node_modules/junk");
 
   const { stdout, stderr, exitCode } = await prune(dir, "--linker", linker);
-  expect(stderr).not.toContain(OUT_OF_SYNC);
+  expect(stderr).toBe("");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -1377,7 +1721,7 @@ test.concurrent.each(linkers)("%s: a workspace lifecycle script is not out of sy
     1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
+  expect(layout(dir)).toEqual(installed);
 });
 
 test.concurrent("trustedDependencies stripped from bun.lock is not out of sync", async () => {
@@ -1387,10 +1731,10 @@ test.concurrent("trustedDependencies stripped from bun.lock is not out of sync",
   const stripped = before.replace(/\n  "trustedDependencies": \[\n(?:    [^\n]*\n)*  \],/, "");
   expect(stripped).not.toContain('"trustedDependencies"');
   await write(join(dir, "bun.lock"), stripped);
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
 
   const { stdout, stderr, exitCode } = await prune(dir);
-  expect(stderr).not.toContain(OUT_OF_SYNC);
+  expect(stderr).toBe("");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -1398,7 +1742,7 @@ test.concurrent("trustedDependencies stripped from bun.lock is not out of sync",
     1 package removed (checked 2 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
+  expect(layout(dir)).toEqual(["no-deps"]);
 });
 
 const prunedCheckout = (app: Record<string, unknown>) => ({
@@ -1407,45 +1751,50 @@ const prunedCheckout = (app: Record<string, unknown>) => ({
     other: { dependencies: { "left-pad": "1.0.0" } },
   },
 });
+const prunedCheckoutTree = perLinker(linker => setupWorkspaces(linker, prunedCheckout({})));
+
+// The hoisted root folder, and the isolated store and app folder, of a prunedCheckout tree once `other` is gone from disk.
+const prunedCheckoutHoisted = ["app -> ../packages/app", "left-pad", "no-deps", "other -> ../packages/other"];
+const prunedCheckoutIsolated = [
+  ".bun/left-pad@1.0.0",
+  ".bun/left-pad@1.0.0/node_modules/left-pad",
+  ".bun/no-deps@1.0.0",
+  ".bun/no-deps@1.0.0/node_modules/no-deps",
+  ".bun/node_modules/left-pad -> ../left-pad@1.0.0/node_modules/left-pad",
+  ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+];
+const prunedCheckoutApp = ["no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps"];
 
 test.concurrent("prunes a checkout whose bun.lock lists a workspace that is no longer on disk", async () => {
-  const dir = await setupWorkspaces("hoisted", prunedCheckout({}));
-  const nm = join(dir, "node_modules");
+  const dir = await prunedCheckoutTree.hoisted();
   rmSync(join(dir, "packages", "other"), { recursive: true });
-  expect(isSymlink(join(nm, "other"))).toBeTrue();
-  expect(existsSync(join(nm, "left-pad", "package.json"))).toBeTrue();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
+  expect(layout(dir)).toEqual([...prunedCheckoutHoisted, "junk"].toSorted());
 
   const { lines: merged, exitCode } = await pruneMerged(dir, "--linker", "hoisted");
   expect(merged).toStrictEqual([BANNER, "", PRUNED_NOTE, "- junk", "- left-pad@1.0.0", "- other", REMOVED(3, 5)]);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(join(nm, "left-pad"))).toBeFalse();
-  expect(() => lstatSync(join(nm, "other"))).toThrow();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-  expect(isSymlink(join(nm, "app"))).toBeTrue();
+  expect(layout(dir)).toEqual(["app -> ../packages/app", "no-deps"]);
 
   await install(dir, "--frozen-lockfile", "--linker", "hoisted");
-  expect(existsSync(join(nm, "left-pad"))).toBeFalse();
-  expect(() => lstatSync(join(nm, "other"))).toThrow();
+  expect(layout(dir)).toEqual(["app -> ../packages/app", "no-deps"]);
 
   const second = await prune(dir, "--linker", "hoisted");
-  expect(out(second.stdout)).toEndWith(NOTHING(2, 1));
+  expect(lines(second.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
+  expect(normalizeBunSnapshot(second.stderr)).toBe(PRUNED_NOTE);
   expect(second.exitCode).toBe(0);
 });
 
 test.concurrent("isolated: a workspace missing from disk no longer keeps its store entries", async () => {
-  const dir = await setupWorkspaces("isolated", prunedCheckout({}));
-  const store = join(dir, "node_modules", ".bun");
-  const appNoDeps = join(dir, "packages", "app", "node_modules", "no-deps", "package.json");
+  const dir = await prunedCheckoutTree.isolated();
+  const app = join(dir, "packages", "app");
   rmSync(join(dir, "packages", "other"), { recursive: true });
-  expect(existsSync(join(store, "left-pad@1.0.0"))).toBeTrue();
-  expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
+  expect(layout(dir)).toEqual([...prunedCheckoutIsolated, "junk"]);
+  expect(layout(app)).toEqual(prunedCheckoutApp);
 
   const { stdout, stderr, exitCode } = await prune(dir, "--linker", "isolated");
-  expect(stderr).toContain(PRUNED_NOTE);
+  expect(normalizeBunSnapshot(stderr)).toBe(PRUNED_NOTE);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -1454,27 +1803,31 @@ test.concurrent("isolated: a workspace missing from disk no longer keeps its sto
     2 packages removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(join(store, "left-pad@1.0.0"))).toBeFalse();
-  expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
-  expect(existsSync(appNoDeps)).toBeTrue();
+  const pruned = [
+    ".bun/no-deps@1.0.0",
+    ".bun/no-deps@1.0.0/node_modules/no-deps",
+    ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+  ];
+  expect(layout(dir)).toEqual(pruned);
+  expect(layout(app)).toEqual(prunedCheckoutApp);
 
   await install(dir, "--frozen-lockfile", "--linker", "isolated");
-  expect(existsSync(join(store, "left-pad@1.0.0"))).toBeFalse();
-  expect(existsSync(appNoDeps)).toBeTrue();
+  expect(layout(dir)).toEqual(pruned);
+  expect(layout(app)).toEqual(prunedCheckoutApp);
 
   const second = await prune(dir, "--linker", "isolated");
-  expect(out(second.stdout)).toEndWith(NOTHING(2, 3));
+  expect(lines(second.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 3)]);
+  expect(normalizeBunSnapshot(second.stderr)).toBe(PRUNED_NOTE);
   expect(second.exitCode).toBe(0);
 });
 
 test.concurrent("hoisted: --filter on a pruned checkout does not protect the missing workspace", async () => {
-  const dir = await setupWorkspaces("hoisted", prunedCheckout({}));
-  const nm = join(dir, "node_modules");
+  const dir = await prunedCheckoutTree.hoisted();
   rmSync(join(dir, "packages", "other"), { recursive: true });
+  expect(layout(dir)).toEqual(prunedCheckoutHoisted);
 
   const { stdout, stderr, exitCode } = await prune(dir, "--filter", "app", "--linker", "hoisted");
-  expect(stderr).toContain(PRUNED_NOTE);
+  expect(normalizeBunSnapshot(stderr)).toBe(PRUNED_NOTE);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -1483,24 +1836,24 @@ test.concurrent("hoisted: --filter on a pruned checkout does not protect the mis
     2 packages removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(join(nm, "left-pad"))).toBeFalse();
-  expect(() => lstatSync(join(nm, "other"))).toThrow();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-  expect(isSymlink(join(nm, "app"))).toBeTrue();
+  expect(layout(dir)).toEqual(["app -> ../packages/app", "no-deps"]);
 });
 
 test.concurrent("a survivor depending on a missing workspace makes prune fail like install does", async () => {
   const dir = await setupWorkspaces("hoisted", prunedCheckout({ other: "workspace:*" }));
   rmSync(join(dir, "packages", "other"), { recursive: true });
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
+  const before = layout(dir);
+  expect(before).toEqual([...prunedCheckoutHoisted, "junk"].toSorted());
 
   const { stdout, stderr, exitCode } = await prune(dir, "--linker", "hoisted");
-  expect(stderr).toContain(
-    'workspace "app" depends on workspace "other" (packages/other), which is listed in bun.lock but not on disk',
-  );
-  expect(out(stdout)).not.toMatch(/^- /m);
+  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+    "error: workspace "app" depends on workspace "other" (packages/other), which is listed in bun.lock but not on disk
+    note: a pruned checkout must keep every workspace that its remaining workspaces depend on"
+  `);
+  expect(out(stdout)).toBe(BANNER);
   expect(exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(dir)).toEqual(before);
 });
 
 test.concurrent(
@@ -1512,26 +1865,27 @@ test.concurrent(
         shared: {},
       },
     });
-    const nm = join(dir, "node_modules");
-    expect(isSymlink(join(nm, "app"))).toBeTrue();
-    expect(isSymlink(join(nm, "shared"))).toBeTrue();
-    expect(isSymlink(join(nm, "shared-alias"))).toBeTrue();
+    expect(layout(dir)).toEqual([
+      "app -> ../packages/app",
+      "shared -> ../packages/shared",
+      "shared-alias -> ../packages/shared",
+    ]);
 
-    const { stdout, exitCode } = await prune(dir, "--production", "--linker", "hoisted");
+    const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "hoisted");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
       - shared-alias@1.0.0
       1 package removed (checked 3 installed packages)"
     `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(isSymlink(join(nm, "app"))).toBeTrue();
-    expect(isSymlink(join(nm, "shared"))).toBeTrue();
-    expect(() => lstatSync(join(nm, "shared-alias"))).toThrow();
+    expect(layout(dir)).toEqual(["app -> ../packages/app", "shared -> ../packages/shared"]);
     await expectProductionInstallIsNoop(dir);
 
     const second = await prune(dir, "--production", "--linker", "hoisted");
-    expect(out(second.stdout)).toEndWith(NOTHING(2, 1));
+    expect(lines(second.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
+    expect(second.stderr).toBe("");
     expect(second.exitCode).toBe(0);
   },
 );
@@ -1547,14 +1901,20 @@ test.concurrent(
       },
     });
     const nm = join(dir, "node_modules");
-    const aJunk = plant(dir, "packages/a/node_modules/junk");
-    const bJunk = plant(dir, "packages/b/node_modules/junk");
-    const stillInstalled = () => {
-      expect(isSymlink(join(nm, "a"))).toBeTrue();
-      expect(isSymlink(join(nm, "b"))).toBeTrue();
-      expect(existsSync(join(dir, "packages", "a", "node_modules", "no-deps", "package.json"))).toBeTrue();
-      expect(existsSync(join(dir, "packages", "b", "node_modules", "no-deps", "package.json"))).toBeTrue();
-    };
+    plant(dir, "packages/a/node_modules/junk");
+    plant(dir, "packages/b/node_modules/junk");
+    const folders = () => ({
+      root: layout(dir),
+      a: layout(dir, "packages/a/node_modules"),
+      b: layout(dir, "packages/b/node_modules"),
+    });
+    // one-fixed-dep needs no-deps 1.0.0 while the root holds 2.0.0, so its copy is nested.
+    const oneFixedDep = ["one-fixed-dep", "one-fixed-dep/node_modules/no-deps"];
+    expect(folders()).toEqual({
+      root: ["a -> ../packages/a", "a-dep", "b -> ../packages/b", "left-pad", "no-deps", ...oneFixedDep],
+      a: ["junk", "no-deps"],
+      b: ["junk", "no-deps"],
+    });
 
     const onlyA = await prune(dir, "--production", "--filter", "a", "--linker", "hoisted");
     expect(out(onlyA.stdout)).toMatchInlineSnapshot(`
@@ -1564,13 +1924,14 @@ test.concurrent(
       - junk (node_modules/a/node_modules)
       2 packages removed (checked 8 installed packages)"
     `);
+    expect(onlyA.stderr).toBe("");
     expect(onlyA.exitCode).toBe(0);
-    expect(existsSync(aJunk)).toBeFalse();
-    expect(existsSync(bJunk)).toBeTrue();
-    expect(existsSync(join(nm, "left-pad"))).toBeTrue();
-    expect(existsSync(join(nm, "one-fixed-dep"))).toBeTrue();
+    expect(folders()).toEqual({
+      root: ["a -> ../packages/a", "b -> ../packages/b", "left-pad", "no-deps", ...oneFixedDep],
+      a: ["no-deps"],
+      b: ["junk", "no-deps"],
+    });
     expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "2.0.0" });
-    stillInstalled();
 
     const onlyRoot = await prune(dir, "--production", "--filter", "root", "--linker", "hoisted");
     expect(out(onlyRoot.stdout)).toMatchInlineSnapshot(`
@@ -1579,9 +1940,13 @@ test.concurrent(
       - left-pad@1.0.0
       1 package removed (checked 5 installed packages)"
     `);
+    expect(onlyRoot.stderr).toBe("");
     expect(onlyRoot.exitCode).toBe(0);
-    expect(existsSync(bJunk)).toBeTrue();
-    expect(existsSync(join(nm, "one-fixed-dep"))).toBeTrue();
+    expect(folders()).toEqual({
+      root: ["a -> ../packages/a", "b -> ../packages/b", "no-deps", ...oneFixedDep],
+      a: ["no-deps"],
+      b: ["junk", "no-deps"],
+    });
 
     const everything = await prune(dir, "--production", "--linker", "hoisted");
     expect(out(everything.stdout)).toMatchInlineSnapshot(`
@@ -1591,10 +1956,16 @@ test.concurrent(
       - one-fixed-dep@1.0.0
       2 packages removed (checked 7 installed packages)"
     `);
+    expect(everything.stderr).toBe("");
     expect(everything.exitCode).toBe(0);
-    expect(existsSync(bJunk)).toBeFalse();
-    stillInstalled();
+    const pruned = {
+      root: ["a -> ../packages/a", "b -> ../packages/b", "no-deps"],
+      a: ["no-deps"],
+      b: ["no-deps"],
+    };
+    expect(folders()).toEqual(pruned);
     await expectProductionInstallIsNoop(dir);
+    expect(folders()).toEqual(pruned);
   },
 );
 
@@ -1607,9 +1978,17 @@ test.concurrent(
         b: { devDependencies: { "a-dep": "1.0.1", "left-pad": "1.0.0" } },
       },
     });
-    const store = join(dir, "node_modules", ".bun");
-    const aNm = join(dir, "packages", "a", "node_modules");
-    const bNm = join(dir, "packages", "b", "node_modules");
+    const folders = () => ({
+      store: storeEntries(dir),
+      a: layout(dir, "packages/a/node_modules"),
+      b: layout(dir, "packages/b/node_modules"),
+    });
+    const link = (name: string, entry: string) => `${name} -> ../../../node_modules/.bun/${entry}/node_modules/${name}`;
+    expect(folders()).toEqual({
+      store: ["a-dep@1.0.1", "left-pad@1.0.0", "no-deps@1.0.0", "one-fixed-dep@1.0.0"],
+      a: [link("a-dep", "a-dep@1.0.1"), link("no-deps", "no-deps@1.0.0"), link("one-fixed-dep", "one-fixed-dep@1.0.0")],
+      b: [link("a-dep", "a-dep@1.0.1"), link("left-pad", "left-pad@1.0.0")],
+    });
 
     const onlyA = await prune(dir, "--production", "--filter", "a", "--linker", "isolated");
     expect(out(onlyA.stdout)).toMatchInlineSnapshot(`
@@ -1619,15 +1998,13 @@ test.concurrent(
       - one-fixed-dep@1.0.0
       2 packages removed (checked 7 installed packages)"
     `);
+    expect(onlyA.stderr).toBe("");
     expect(onlyA.exitCode).toBe(0);
-    expect(existsSync(join(store, "a-dep@1.0.1"))).toBeTrue();
-    expect(existsSync(join(store, "left-pad@1.0.0"))).toBeTrue();
-    expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
-    expect(existsSync(join(bNm, "a-dep", "package.json"))).toBeTrue();
-    expect(existsSync(join(bNm, "left-pad", "package.json"))).toBeTrue();
-    expect(() => lstatSync(join(aNm, "a-dep"))).toThrow();
-    expect(() => lstatSync(join(aNm, "one-fixed-dep"))).toThrow();
-    expect(existsSync(join(aNm, "no-deps", "package.json"))).toBeTrue();
+    expect(folders()).toEqual({
+      store: ["a-dep@1.0.1", "left-pad@1.0.0", "no-deps@1.0.0"],
+      a: [link("no-deps", "no-deps@1.0.0")],
+      b: [link("a-dep", "a-dep@1.0.1"), link("left-pad", "left-pad@1.0.0")],
+    });
 
     const everything = await prune(dir, "--production", "--linker", "isolated");
     expect(out(everything.stdout)).toMatchInlineSnapshot(`
@@ -1637,11 +2014,12 @@ test.concurrent(
       - left-pad@1.0.0
       2 packages removed (checked 6 installed packages)"
     `);
+    expect(everything.stderr).toBe("");
     expect(everything.exitCode).toBe(0);
-    expect(() => lstatSync(join(bNm, "a-dep"))).toThrow();
-    expect(() => lstatSync(join(bNm, "left-pad"))).toThrow();
-    expect(existsSync(join(aNm, "no-deps", "package.json"))).toBeTrue();
+    const pruned = { store: ["no-deps@1.0.0"], a: [link("no-deps", "no-deps@1.0.0")], b: [] };
+    expect(folders()).toEqual(pruned);
     await expectProductionInstallIsNoop(dir);
+    expect(folders()).toEqual(pruned);
   },
 );
 
@@ -1650,9 +2028,18 @@ test.concurrent(
   async () => {
     const pkg = { dependencies: { "no-deps": "1.0.0" }, devDependencies: { "a-dep": "1.0.1" } };
     const dir = await setupWorkspaces("isolated", { packages: { selected: pkg, unselected: pkg } });
-    const storeEntry = join(dir, "node_modules", ".bun", "a-dep@1.0.1");
-    const selectedADep = join(dir, "packages", "selected", "node_modules", "a-dep");
-    const unselectedADep = join(dir, "packages", "unselected", "node_modules", "a-dep");
+    const folders = () => ({
+      store: storeEntries(dir),
+      selected: layout(dir, "packages/selected/node_modules"),
+      unselected: layout(dir, "packages/unselected/node_modules"),
+    });
+    const aDep = "a-dep -> ../../../node_modules/.bun/a-dep@1.0.1/node_modules/a-dep";
+    const noDeps = "no-deps -> ../../../node_modules/.bun/no-deps@1.0.0/node_modules/no-deps";
+    expect(folders()).toEqual({
+      store: ["a-dep@1.0.1", "no-deps@1.0.0"],
+      selected: [aDep, noDeps],
+      unselected: [aDep, noDeps],
+    });
 
     const first = await prune(dir, "--production", "--filter", "selected", "--linker", "isolated");
     expect(out(first.stdout)).toMatchInlineSnapshot(`
@@ -1661,10 +2048,13 @@ test.concurrent(
       - a-dep@1.0.1 (packages/selected/node_modules)
       1 package removed (checked 4 installed packages)"
     `);
+    expect(first.stderr).toBe("");
     expect(first.exitCode).toBe(0);
-    expect(() => lstatSync(selectedADep)).toThrow();
-    expect(existsSync(join(unselectedADep, "package.json"))).toBeTrue();
-    expect(existsSync(storeEntry)).toBeTrue();
+    expect(folders()).toEqual({
+      store: ["a-dep@1.0.1", "no-deps@1.0.0"],
+      selected: [noDeps],
+      unselected: [aDep, noDeps],
+    });
 
     const second = await prune(dir, "--production", "--filter", "unselected", "--linker", "isolated");
     expect(out(second.stdout)).toMatchInlineSnapshot(`
@@ -1673,9 +2063,9 @@ test.concurrent(
       - a-dep@1.0.1 (packages/unselected/node_modules)
       1 package removed (checked 4 installed packages)"
     `);
+    expect(second.stderr).toBe("");
     expect(second.exitCode).toBe(0);
-    expect(() => lstatSync(unselectedADep)).toThrow();
-    expect(existsSync(storeEntry)).toBeTrue();
+    expect(folders()).toEqual({ store: ["a-dep@1.0.1", "no-deps@1.0.0"], selected: [noDeps], unselected: [noDeps] });
 
     const everything = await prune(dir, "--production", "--linker", "isolated");
     expect(out(everything.stdout)).toMatchInlineSnapshot(`
@@ -1684,12 +2074,12 @@ test.concurrent(
       - a-dep@1.0.1
       1 package removed (checked 4 installed packages)"
     `);
+    expect(everything.stderr).toBe("");
     expect(everything.exitCode).toBe(0);
-    expect(existsSync(storeEntry)).toBeFalse();
-    for (const ws of ["selected", "unselected"]) {
-      expect(existsSync(join(dir, "packages", ws, "node_modules", "no-deps", "package.json"))).toBeTrue();
-    }
+    const pruned = { store: ["no-deps@1.0.0"], selected: [noDeps], unselected: [noDeps] };
+    expect(folders()).toEqual(pruned);
     await expectProductionInstallIsNoop(dir);
+    expect(folders()).toEqual(pruned);
   },
 );
 
@@ -1731,6 +2121,7 @@ test.concurrent.each(linkers)(
 
     const byPath = await prune(dir, "--filter", "./packages/app", "--linker", linker);
     expect(lines(byPath.stdout)).toStrictEqual(removed(appRows, sharedAndApp));
+    expect(byPath.stderr).toBe("");
     expect(byPath.exitCode).toBe(0);
     expect(existsSync(appJunk)).toBeFalse();
     expect(existsSync(libJunk)).toBeTrue();
@@ -1741,12 +2132,14 @@ test.concurrent.each(linkers)(
 
     const byGlob = await prune({ dir, cwd: join(dir, "packages", "app") }, "--filter", "li*", "--linker", linker);
     expect(lines(byGlob.stdout)).toStrictEqual(removed([shown("lib", "lib-junk")], linker === "hoisted" ? 5 : 4));
+    expect(byGlob.stderr).toBe("");
     expect(byGlob.exitCode).toBe(0);
     expect(existsSync(libJunk)).toBeFalse();
 
     if (linker === "isolated") {
       const root = await prune(dir, "--filter", "./", "--linker", linker);
       expect(lines(root.stdout)).toStrictEqual(removed(["- root-junk"], 4));
+      expect(root.stderr).toBe("");
       expect(root.exitCode).toBe(0);
     }
     expect(existsSync(rootJunk)).toBeFalse();
@@ -1757,11 +2150,10 @@ test.concurrent.each(linkers)(
 );
 
 test.concurrent("hoisted: --filter with no match is an error; path filters resolve against the cwd", async () => {
-  const dir = await setupWorkspaces("hoisted", {
-    root: { dependencies: { "no-deps": "2.0.0" } },
-    packages: { a: { dependencies: { "no-deps": "1.0.0" } } },
-  });
-  const junk = plant(dir, "packages/a/node_modules/junk");
+  const dir = await trees.hoistedRootAndA();
+  plant(dir, "packages/a/node_modules/junk");
+  const before = { root: layout(dir), a: layout(dir, "packages/a/node_modules") };
+  expect(before).toEqual({ root: ["a -> ../packages/a", "no-deps"], a: ["junk", "no-deps"] });
   const listing = (...flags: string[]) => [
     BANNER,
     "",
@@ -1770,26 +2162,32 @@ test.concurrent("hoisted: --filter with no match is an error; path filters resol
     APPLY_HINT(...flags, "--linker", "hoisted"),
   ];
 
-  const noMatch = await prune(dir, "--filter", "nope", "--linker", "hoisted");
+  const [noMatch, noneMatch, silentNoMatch] = await Promise.all([
+    prune(dir, "--filter", "nope", "--linker", "hoisted"),
+    prune(dir, "--filter", "nope", "--filter", "nada", "--linker", "hoisted"),
+    prune(dir, "--filter", "nope", "--silent", "--linker", "hoisted"),
+  ]);
   expect(normalizeBunSnapshot(noMatch.stderr)).toBe('error: No workspace packages matched the filter "nope"');
   expect(out(noMatch.stdout)).toBe(BANNER);
   expect(noMatch.exitCode).toBe(1);
 
-  const noneMatch = await prune(dir, "--filter", "nope", "--filter", "nada", "--linker", "hoisted");
   expect(normalizeBunSnapshot(noneMatch.stderr)).toBe(
     'error: No workspace packages matched the filters "nope", "nada"',
   );
   expect(out(noneMatch.stdout)).toBe(BANNER);
   expect(noneMatch.exitCode).toBe(1);
 
-  const silentNoMatch = await prune(dir, "--filter", "nope", "--silent", "--linker", "hoisted");
   expect(silentNoMatch.stdout).toBe("");
   expect(silentNoMatch.stderr).toBe("");
   expect(silentNoMatch.exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
+  expect({ root: layout(dir), a: layout(dir, "packages/a/node_modules") }).toEqual(before);
 
-  // A typo next to a real name is not fatal, but it is reported before the verdict.
-  const someMatch = await pruneMerged(dir, "--filter", "a", "--filter", "nope", "--dry-run", "--linker", "hoisted");
+  const [someMatch, fromRoot, fromInside] = await Promise.all([
+    // A typo next to a real name is not fatal, but it is reported before the verdict.
+    pruneMerged(dir, "--filter", "a", "--filter", "nope", "--dry-run", "--linker", "hoisted"),
+    prune(dir, "--filter", "./packages/a", "--dry-run", "--linker", "hoisted"),
+    prune({ dir, cwd: join(dir, "packages", "a") }, "--filter", ".", "--dry-run", "--linker", "hoisted"),
+  ]);
   expect(someMatch.lines).toStrictEqual([
     BANNER,
     "",
@@ -1799,26 +2197,15 @@ test.concurrent("hoisted: --filter with no match is an error; path filters resol
     APPLY_HINT("--filter", "a", "--filter", "nope", "--linker", "hoisted"),
   ]);
   expect(someMatch.exitCode).toBe(0);
-  expect(existsSync(junk)).toBeTrue();
 
-  const fromRoot = await prune(dir, "--filter", "./packages/a", "--dry-run", "--linker", "hoisted");
   expect(fromRoot.stderr).toBe("");
   expect(lines(fromRoot.stdout)).toStrictEqual(listing("--filter", "./packages/a"));
   expect(fromRoot.exitCode).toBe(0);
-  expect(existsSync(junk)).toBeTrue();
 
-  const fromInside = await prune(
-    { dir, cwd: join(dir, "packages", "a") },
-    "--filter",
-    ".",
-    "--dry-run",
-    "--linker",
-    "hoisted",
-  );
   expect(fromInside.stderr).toBe("");
   expect(lines(fromInside.stdout)).toStrictEqual(listing("--filter", "."));
   expect(fromInside.exitCode).toBe(0);
-  expect(existsSync(junk)).toBeTrue();
+  expect({ root: layout(dir), a: layout(dir, "packages/a/node_modules") }).toEqual(before);
 
   const { stdout, stderr, exitCode } = await prune(dir, "--filter", "a", "--linker", "hoisted");
   expect(stderr).toBe("");
@@ -1829,7 +2216,7 @@ test.concurrent("hoisted: --filter with no match is an error; path filters resol
     1 package removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
+  expect({ root: layout(dir), a: layout(dir, "packages/a/node_modules") }).toEqual({ ...before, a: ["no-deps"] });
 });
 
 test.concurrent.each(linkers)(
@@ -1838,7 +2225,8 @@ test.concurrent.each(linkers)(
     const dir = await setupWorkspaces(linker, {
       packages: { app: { dependencies: { "no-deps": "1.0.0" } }, lib: {} },
     });
-    const junk = plant(dir, "packages/app/node_modules/junk");
+    const installed = layout(dir, "packages/app/node_modules");
+    plant(dir, "packages/app/node_modules/junk");
 
     const { stdout, stderr, exitCode } = await prune(dir, "--filter", "app", "--filter", "nope", "--linker", linker);
     expect(normalizeBunSnapshot(stderr)).toBe('warn: No workspace packages matched the filter "nope"');
@@ -1850,7 +2238,7 @@ test.concurrent.each(linkers)(
       REMOVED(1, linker === "hoisted" ? 4 : 3),
     ]);
     expect(exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
+    expect(layout(dir, "packages/app/node_modules")).toEqual(installed);
 
     const silent = await prune(dir, "--filter", "app", "--filter", "nope", "--silent", "--linker", linker);
     expect(silent.stdout).toBe("");
@@ -1862,45 +2250,62 @@ test.concurrent.each(linkers)(
 test.concurrent.each(["hoisted", "isolated"] as Linker[])(
   "%s: optionalDependencies survive --production and go away with --omit=optional",
   async linker => {
-    const pkg = {
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0" },
-      optionalDependencies: { "a-dep": "1.0.1" },
-      devDependencies: { "one-fixed-dep": "1.0.0" },
-    };
-    const [prodDir, omitDir] = await Promise.all([setupWithLinker(linker, pkg), setupWithLinker(linker, pkg)]);
-    const removed = (row: string) => [BANNER, "", row, REMOVED(1, linker === "hoisted" ? 3 : 6)];
+    const [prodDir, omitDir] = await Promise.all([trees.optional[linker](), trees.optional[linker]()]);
+    const hoisted = linker === "hoisted";
+    // Under the isolated linker a package is its store entry, the hidden-hoist link to it, and the root link.
+    const aDep = [
+      ".bun/a-dep@1.0.1",
+      ".bun/a-dep@1.0.1/node_modules/a-dep",
+      ".bun/node_modules/a-dep -> ../a-dep@1.0.1/node_modules/a-dep",
+      "a-dep -> .bun/a-dep@1.0.1/node_modules/a-dep",
+    ];
+    const noDeps = [
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+      "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+    ];
+    const oneFixedDep = [
+      ".bun/node_modules/one-fixed-dep -> ../one-fixed-dep@1.0.0/node_modules/one-fixed-dep",
+      ".bun/one-fixed-dep@1.0.0",
+      ".bun/one-fixed-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.0/node_modules/no-deps",
+      ".bun/one-fixed-dep@1.0.0/node_modules/one-fixed-dep",
+      "one-fixed-dep -> .bun/one-fixed-dep@1.0.0/node_modules/one-fixed-dep",
+    ];
+    const installed = layout(prodDir);
+    expect(installed).toEqual(
+      hoisted ? ["a-dep", "no-deps", "one-fixed-dep"] : [...aDep, ...noDeps, ...oneFixedDep].toSorted(),
+    );
+    expect(layout(omitDir)).toEqual(installed);
+    const removed = (row: string) => [BANNER, "", row, REMOVED(1, hoisted ? 3 : 6)];
 
-    const production = await prune(prodDir, "--production", "--linker", linker);
+    const [production, omit] = await Promise.all([
+      prune(prodDir, "--production", "--linker", linker),
+      prune(omitDir, "--omit=optional", "--linker", linker),
+    ]);
     expect(lines(production.stdout)).toStrictEqual(removed("- one-fixed-dep@1.0.0"));
+    expect(production.stderr).toBe("");
     expect(production.exitCode).toBe(0);
-    expect(existsSync(join(prodDir, "node_modules", "a-dep", "package.json"))).toBeTrue();
-    expect(existsSync(join(prodDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
+    expect(layout(prodDir)).toEqual(hoisted ? ["a-dep", "no-deps"] : [...aDep, ...noDeps].toSorted());
 
-    const omit = await prune(omitDir, "--omit=optional", "--linker", linker);
     expect(lines(omit.stdout)).toStrictEqual(removed("- a-dep@1.0.1"));
+    expect(omit.stderr).toBe("");
     expect(omit.exitCode).toBe(0);
-    expect(() => lstatSync(join(omitDir, "node_modules", "a-dep"))).toThrow();
-    expect(existsSync(join(omitDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
-    expect(existsSync(join(omitDir, "node_modules", "one-fixed-dep", "package.json"))).toBeTrue();
+    expect(layout(omitDir)).toEqual(hoisted ? ["no-deps", "one-fixed-dep"] : [...noDeps, ...oneFixedDep].toSorted());
   },
 );
 
 test.concurrent.each([["--os=aix"], ["--cpu=s390x"]])(
   "%s removes packages that are disabled for that platform, plain prune keeps them",
   async (flag: string) => {
-    const dir = await setup({
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" },
-    });
-    const nm = join(dir, "node_modules");
-    const native = join(nm, "test-postinstall-skip-native");
-    expect(existsSync(native)).toBeTrue();
+    const dir = await trees.native();
+    expect(layout(dir)).toEqual(["no-deps", "test-postinstall-skip-native"]);
 
     const host = await prune(dir);
-    expect(out(host.stdout)).toEndWith(NOTHING(2, 1));
+    expect(lines(host.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
+    expect(host.stderr).toBe("");
     expect(host.exitCode).toBe(0);
-    expect(existsSync(native)).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps", "test-postinstall-skip-native"]);
 
     const other = await prune(dir, flag);
     expect(out(other.stdout)).toMatchInlineSnapshot(`
@@ -1909,9 +2314,9 @@ test.concurrent.each([["--os=aix"], ["--cpu=s390x"]])(
       - test-postinstall-skip-native@1.0.0
       1 package removed (checked 2 installed packages)"
     `);
+    expect(other.stderr).toBe("");
     expect(other.exitCode).toBe(0);
-    expect(existsSync(native)).toBeFalse();
-    expect(existsSync(join(nm, "no-deps"))).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps"]);
     expect(await install(dir, flag)).toContain("no changes");
   },
 );
@@ -1928,19 +2333,20 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
       name: "no-deps",
       version: "1.0.0",
     });
-    const junk = plant(dir, "node_modules/junk");
+    const installed = layout(dir);
+    plant(dir, "node_modules/junk");
 
-    const { stdout, exitCode } = await prune(dir, "--linker", linker);
+    const { stdout, stderr, exitCode } = await prune(dir, "--linker", linker);
     expect(out(stdout)).toBe(`bun prune <version> (<revision>)\n\n- junk\n${REMOVED(1, linker === "hoisted" ? 4 : 6)}`);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
+    expect(layout(dir)).toEqual(installed);
     expect(await file(join(nm, "my-alias", "package.json")).json()).toMatchObject({
       name: "no-deps",
       version: "1.0.0",
     });
     if (linker === "isolated") {
-      expect(existsSync(join(nm, ".bun", "no-deps@1.0.0"))).toBeTrue();
-      expect(existsSync(join(nm, ".bun", "no-deps@1.0.1"))).toBeTrue();
+      expect(storeEntries(dir)).toEqual(["no-deps@1.0.0", "no-deps@1.0.1", "one-dep@1.0.0"]);
     }
   },
 );
@@ -1952,13 +2358,27 @@ test.concurrent("isolated + publicHoistPattern: hoisted links follow their store
     { publicHoistPattern: ["no-deps"], hoistPattern: ["one-dep"] },
   );
   const nm = join(dir, "node_modules");
-  const store = join(nm, ".bun");
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-  expect(isSymlink(join(store, "node_modules", "one-dep"))).toBeTrue();
+  const installed = layout(dir);
+  expect(installed).toMatchInlineSnapshot(`
+    [
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      ".bun/no-deps@1.0.1",
+      ".bun/no-deps@1.0.1/node_modules/no-deps",
+      ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+      ".bun/one-dep@1.0.0",
+      ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+      ".bun/one-dep@1.0.0/node_modules/one-dep",
+      "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+      "one-dep -> .bun/one-dep@1.0.0/node_modules/one-dep",
+    ]
+  `);
 
   const clean = await prune(dir, "--linker", "isolated");
-  expect(out(clean.stdout)).toEndWith(NOTHING(5, 2));
+  expect(lines(clean.stdout)).toStrictEqual([BANNER, "", NOTHING(5, 2)]);
+  expect(clean.stderr).toBe("");
   expect(clean.exitCode).toBe(0);
+  expect(layout(dir)).toEqual(installed);
 
   const production = await prune(dir, "--production", "--linker", "isolated");
   expect(out(production.stdout)).toMatchInlineSnapshot(`
@@ -1968,18 +2388,24 @@ test.concurrent("isolated + publicHoistPattern: hoisted links follow their store
     - one-dep@1.0.0
     2 packages removed (checked 5 installed packages)"
   `);
+  expect(production.stderr).toBe("");
   expect(production.exitCode).toBe(0);
-  expect(() => lstatSync(join(store, "node_modules", "one-dep"))).toThrow();
-  expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
+  expect(layout(dir)).toMatchInlineSnapshot(`
+    [
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+    ]
+  `);
   expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "1.0.0" });
 });
 
 test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
   "a failed deletion is reported, the rest is removed, exit code 1",
   async () => {
-    const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
+    const dir = await trees.noDeps();
     const nm = join(dir, "node_modules");
-    const junkA = plant(dir, "node_modules/junk-a");
+    plant(dir, "node_modules/junk-a");
     const inner = plant(dir, "node_modules/junk-b/inner");
     const junkB = join(nm, "junk-b");
     chmodSync(junkB, 0o555);
@@ -1995,28 +2421,30 @@ test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
         "1 package removed, 1 failed (checked 3 installed packages)",
       ]);
       expect(exitCode).toBe(1);
-      expect(existsSync(junkA)).toBeFalse();
-      expect(existsSync(inner)).toBeTrue();
+      expect(layout(dir)).toEqual(["junk-b", "no-deps"]);
+      expect(existsSync(join(inner, "package.json"))).toBeTrue();
 
       // --silent still reports what could not be removed; the exit code alone would hide which entry it was.
       const silent = await prune(dir, "--silent");
       expect(silent.stdout).toBe("");
       expect(normalizeBunSnapshot(silent.stderr)).toMatch(failure);
       expect(silent.exitCode).toBe(1);
-      expect(existsSync(inner)).toBeTrue();
+      expect(layout(dir)).toEqual(["junk-b", "no-deps"]);
+      expect(existsSync(join(inner, "package.json"))).toBeTrue();
     } finally {
       chmodSync(junkB, 0o755);
     }
 
-    const { stdout, exitCode } = await prune(dir);
+    const { stdout, stderr, exitCode } = await prune(dir);
     expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - junk-b
     1 package removed (checked 2 installed packages)"
   `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(existsSync(junkB)).toBeFalse();
+    expect(layout(dir)).toEqual(["no-deps"]);
   },
 );
 
@@ -2033,9 +2461,9 @@ test.concurrent("never runs the project's lifecycle scripts", async () => {
     },
   });
   const ran = join(dir, "ran.txt");
-  expect(existsSync(ran)).toBeTrue();
+  expect(await file(ran).text()).toBe("PRE\nPOST\nPREPARE\n");
   rmSync(ran);
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
 
   const plain = await prune(dir);
   expect(out(plain.stdout)).toMatchInlineSnapshot(`
@@ -2044,8 +2472,9 @@ test.concurrent("never runs the project's lifecycle scripts", async () => {
     - junk
     1 package removed (checked 3 installed packages)"
   `);
+  expect(plain.stderr).toBe("");
   expect(plain.exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
+  expect(layout(dir)).toEqual(["a-dep", "no-deps"]);
   expect(existsSync(ran)).toBeFalse();
 
   const production = await prune(dir, "--production");
@@ -2055,36 +2484,55 @@ test.concurrent("never runs the project's lifecycle scripts", async () => {
     - a-dep@1.0.1
     1 package removed (checked 2 installed packages)"
   `);
+  expect(production.stderr).toBe("");
   expect(production.exitCode).toBe(0);
+  expect(layout(dir)).toEqual(["no-deps"]);
   expect(existsSync(ran)).toBeFalse();
 });
 
 test.concurrent.each(["hoisted", "isolated"] as Linker[])(
   "%s: --omit=peer removes what bun install --omit=peer would not install",
   async linker => {
-    const pkg = { name: "foo", dependencies: { "peer-deps-fixed": "1.0.0" } };
-    const [dir, plainDir] = await Promise.all([setupWithLinker(linker, pkg), setupWithLinker(linker, pkg)]);
-    const nm = join(dir, "node_modules");
-    const installedNoDeps = () =>
+    const [dir, plainDir] = await Promise.all([trees.peerDepsFixed[linker](), trees.peerDepsFixed[linker]()]);
+    const installed = layout(dir);
+    // The store key of a package with a peer carries a hash of the peer resolution.
+    const entry = linker === "isolated" ? storeEntries(dir).find(name => name.startsWith("peer-deps-fixed@"))! : "";
+    const consumer = [
+      `.bun/${entry}`,
+      `.bun/${entry}/node_modules/no-deps -> ../../no-deps@1.1.0/node_modules/no-deps`,
+      `.bun/${entry}/node_modules/peer-deps-fixed`,
+      `.bun/node_modules/peer-deps-fixed -> ../${entry}/node_modules/peer-deps-fixed`,
+      `peer-deps-fixed -> .bun/${entry}/node_modules/peer-deps-fixed`,
+    ];
+    if (linker === "isolated") expect(entry).toMatch(/^peer-deps-fixed@1\.0\.0\+[0-9a-f]{16}$/);
+    expect(installed).toEqual(
       linker === "hoisted"
-        ? existsSync(join(nm, "no-deps"))
-        : readdirSync(join(nm, ".bun")).some(name => name.startsWith("no-deps@"));
-    expect(existsSync(join(nm, "peer-deps-fixed", "package.json"))).toBeTrue();
-    expect(installedNoDeps()).toBeTrue();
+        ? ["no-deps", "peer-deps-fixed"]
+        : [
+            ".bun/no-deps@1.1.0",
+            ".bun/no-deps@1.1.0/node_modules/no-deps",
+            ".bun/node_modules/no-deps -> ../no-deps@1.1.0/node_modules/no-deps",
+            ...consumer,
+          ].toSorted(),
+    );
+    expect(layout(plainDir)).toEqual(installed);
 
-    const omit = await prune(dir, "--omit=peer", "--linker", linker);
+    const [omit, plain] = await Promise.all([
+      prune(dir, "--omit=peer", "--linker", linker),
+      prune(plainDir, "--linker", linker),
+    ]);
     expect(lines(omit.stdout)).toStrictEqual([BANNER, "", "- no-deps@1.1.0", REMOVED(1, linker === "hoisted" ? 2 : 3)]);
+    expect(omit.stderr).toBe("");
     expect(omit.exitCode).toBe(0);
-    expect(installedNoDeps()).toBeFalse();
-    expect(() => lstatSync(join(nm, "no-deps"))).toThrow();
-    expect(existsSync(join(nm, "peer-deps-fixed", "package.json"))).toBeTrue();
+    expect(layout(dir)).toEqual(linker === "hoisted" ? ["peer-deps-fixed"] : consumer.toSorted());
     if (linker === "hoisted") {
       expect(await install(dir, "--omit=peer")).toContain("no changes");
     }
 
-    const plain = await prune(plainDir, "--linker", linker);
-    expect(out(plain.stdout)).toEndWith(linker === "hoisted" ? NOTHING(2, 1) : NOTHING(3, 2));
+    expect(lines(plain.stdout)).toStrictEqual([BANNER, "", linker === "hoisted" ? NOTHING(2, 1) : NOTHING(3, 2)]);
+    expect(plain.stderr).toBe("");
     expect(plain.exitCode).toBe(0);
+    expect(layout(plainDir)).toEqual(installed);
   },
 );
 
@@ -2107,25 +2555,27 @@ test.concurrent.each(["peer-deps-fixed", "optional-peer-deps"])(
     const peerLink = join(store, entry, "node_modules", "no-deps", "package.json");
     expect(existsSync(peerLink)).toBeTrue();
 
-    const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+    const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
     expect(out(stdout).split("\n")).toStrictEqual([
       "bun prune <version> (<revision>)",
       "",
       "- no-deps@1.0.0",
       "1 package removed (checked 4 installed packages)",
     ]);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0", entry]);
-    expect(() => lstatSync(join(nm, "no-deps"))).toThrow();
+    expect(kind(join(nm, "no-deps"))).toBeUndefined();
     expect(existsSync(peerLink)).toBeTrue();
     expect(await file(join(nm, consumer, "package.json")).json()).toMatchObject({ name: consumer, version: "1.0.0" });
 
     await expectProductionInstallIsNoop(dir);
     expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0", entry]);
-    expect(() => lstatSync(join(nm, "no-deps"))).toThrow();
+    expect(kind(join(nm, "no-deps"))).toBeUndefined();
 
     const again = await prune(dir, "--production", "--linker", "isolated");
-    expect(out(again.stdout)).toEndWith(NOTHING(3, 2));
+    expect(lines(again.stdout)).toStrictEqual([BANNER, "", NOTHING(3, 2)]);
+    expect(again.stderr).toBe("");
     expect(again.exitCode).toBe(0);
   },
 );
@@ -2153,11 +2603,12 @@ test.concurrent(
     expect(rest).toStrictEqual([]);
     expect(productionEntry).toMatch(/^peer-deps-fixed@1\.0\.0\+[0-9a-f]{16}$/);
     expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "one-dep@1.0.0", productionEntry]);
-    expect(() => lstatSync(join(nm, "no-deps"))).toThrow();
+    expect(kind(join(nm, "no-deps"))).toBeUndefined();
     const productionTree = storeTree();
 
     const noop = await prune(dir, "--production", "--linker", "isolated");
-    expect(out(noop.stdout)).toEndWith(NOTHING(5, 2));
+    expect(lines(noop.stdout)).toStrictEqual([BANNER, "", NOTHING(5, 2)]);
+    expect(noop.stderr).toBe("");
     expect(noop.exitCode).toBe(0);
     expect(storeTree()).toStrictEqual(productionTree);
     await expectProductionInstallIsNoop(dir);
@@ -2170,10 +2621,10 @@ test.concurrent(
     expect(storeEntries(dir)).toStrictEqual(
       ["a-dep@1.0.1", "no-deps@1.0.1", "no-deps@2.0.0", "one-dep@1.0.0", productionEntry, fullEntry].toSorted(),
     );
-    expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
-    expect(isSymlink(join(nm, "a-dep"))).toBeTrue();
+    expect(kind(join(nm, "no-deps"))).toBe("link");
+    expect(kind(join(nm, "a-dep"))).toBe("link");
 
-    const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+    const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
     expect(out(stdout).split("\n")).toStrictEqual([
       "bun prune <version> (<revision>)",
       "",
@@ -2181,10 +2632,11 @@ test.concurrent(
       "- no-deps@2.0.0",
       "2 packages removed (checked 10 installed packages)",
     ]);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "one-dep@1.0.0", productionEntry, fullEntry].toSorted());
-    expect(() => lstatSync(join(nm, "no-deps"))).toThrow();
-    expect(() => lstatSync(join(nm, "a-dep"))).toThrow();
+    expect(kind(join(nm, "no-deps"))).toBeUndefined();
+    expect(kind(join(nm, "a-dep"))).toBeUndefined();
     expect(await file(join(nm, "peer-deps-fixed", "package.json")).json()).toMatchObject({ version: "1.0.0" });
     await expectProductionInstallIsNoop(dir);
   },
@@ -2209,7 +2661,7 @@ test.concurrent("isolated: --production removes the stale peer-hash variant and 
   const after = variants.find(entry => entry !== before)!;
   expect(storeEntries(dir)).toStrictEqual(["a-dep@1.0.1", "no-deps@1.0.0", "no-deps@1.0.1", ...variants].toSorted());
 
-  const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
   expect(out(stdout).split("\n")).toStrictEqual([
     "bun prune <version> (<revision>)",
     "",
@@ -2218,6 +2670,7 @@ test.concurrent("isolated: --production removes the stale peer-hash variant and 
     `- ${before}`,
     "3 packages removed (checked 8 installed packages)",
   ]);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
   expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", after]);
   expect(await file(join(store, "no-deps@1.0.1", "node_modules", "no-deps", "package.json")).json()).toMatchObject({
@@ -2243,25 +2696,26 @@ test.concurrent("keeps dependencies bundled inside a file: dependency", async ()
   await runBunInstall(installEnv(dir), dir);
   const inner = join(dir, "node_modules", "local", "node_modules", "inner", "package.json");
   expect(existsSync(inner)).toBeTrue();
-  const junk = plant(dir, "node_modules/junk");
+  expect(layout(dir)).toEqual(["local", "local/node_modules/inner"]);
+  plant(dir, "node_modules/junk");
 
-  const { stdout, exitCode } = await prune(dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - junk
     1 package removed (checked 2 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(inner)).toBeTrue();
+  expect(layout(dir)).toEqual(["local", "local/node_modules/inner"]);
 });
 
 // pnpm#13676
 test.concurrent(
   "hoisted: a nested copy is kept while the root copy is still the old version and removed once bun install replaced it",
   async () => {
-    const dir = await setup({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } });
+    const dir = await trees.oneDepNoDeps2();
     const nm = join(dir, "node_modules");
     const nested = join(nm, "one-dep", "node_modules", "no-deps");
     const rootPkgJson = join(nm, "no-deps", "package.json");
@@ -2272,7 +2726,7 @@ test.concurrent(
       JSON.stringify({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "1.0.1" } }),
     );
     await install(dir, "--lockfile-only");
-    expect(existsSync(nested)).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps", "one-dep", "one-dep/node_modules/no-deps"]);
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
 
     // The reason the copy was kept comes before the verdict, as it would on a terminal.
@@ -2285,12 +2739,12 @@ test.concurrent(
       NOTHING(3, 2),
     ]);
     expect(stale.exitCode).toBe(0);
-    expect(existsSync(join(nested, "package.json"))).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps", "one-dep", "one-dep/node_modules/no-deps"]);
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
 
     await install(dir);
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "1.0.1" });
-    expect(existsSync(nested)).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps", "one-dep", "one-dep/node_modules/no-deps"]);
 
     const { stdout, stderr, exitCode } = await prune(dir);
     expect(out(stdout)).toMatchInlineSnapshot(`
@@ -2301,25 +2755,28 @@ test.concurrent(
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(existsSync(nested)).toBeFalse();
-    expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
-    expect(existsSync(rootPkgJson)).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps", "one-dep"]);
+    expect(await file(rootPkgJson).json()).toMatchObject({ version: "1.0.1" });
   },
 );
 
 test.concurrent(
   "hoisted: --production keeps the nested copy a production package resolves to while the root holds the dev version",
   async () => {
-    const pkg = { name: "foo", dependencies: { "one-fixed-dep": "1.0.0" }, devDependencies: { "no-deps": "2.0.0" } };
-    const [dir, silentDir] = await Promise.all([setup(pkg), setup(pkg)]);
+    const [dir, silentDir] = await Promise.all([trees.devRootProdNested(), trees.devRootProdNested()]);
     const rootPkgJson = join(dir, "node_modules", "no-deps", "package.json");
     const nestedPkgJson = join(dir, "node_modules", "one-fixed-dep", "node_modules", "no-deps", "package.json");
+    const installed = ["no-deps", "one-fixed-dep", "one-fixed-dep/node_modules/no-deps"];
+    expect(layout(dir)).toEqual(installed);
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
     expect(await file(nestedPkgJson).json()).toMatchObject({ version: "1.0.0" });
 
     // The root copy is the one a full install hoists there, not a stale tree:
     // no "is not the version bun.lock expects" warning, no install hint.
-    const { stdout, stderr, exitCode } = await prune(dir, "--production");
+    const [{ stdout, stderr, exitCode }, silent] = await Promise.all([
+      prune(dir, "--production"),
+      prune(silentDir, "--production", "--silent"),
+    ]);
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
@@ -2327,8 +2784,14 @@ test.concurrent(
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
+    expect(layout(dir)).toEqual(installed);
     expect(await file(nestedPkgJson).json()).toMatchObject({ version: "1.0.0" });
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
+
+    expect(silent.stdout).toBe("");
+    expect(silent.stderr).toBe("");
+    expect(silent.exitCode).toBe(0);
+    expect(layout(silentDir)).toEqual(installed);
 
     // A root copy whose version the lockfile does not know anywhere is a
     // genuinely stale tree and still warns under --production.
@@ -2338,18 +2801,12 @@ test.concurrent(
     expect(out(stale.stderr)).toBe(
       `${WARN("node_modules/no-deps", "node_modules/one-fixed-dep/node_modules/no-deps")}\n${NOTE}`,
     );
+    expect(lines(stale.stdout)).toStrictEqual([BANNER, "", NOTHING(3, 2)]);
     expect(stale.exitCode).toBe(0);
     await write(rootPkgJson, JSON.stringify(rootPkg));
 
     await runBunInstall(installEnv(dir), dir, { production: true });
-
-    const silent = await prune(silentDir, "--production", "--silent");
-    expect(silent.stdout).toBe("");
-    expect(silent.stderr).toBe("");
-    expect(silent.exitCode).toBe(0);
-    expect(
-      existsSync(join(silentDir, "node_modules", "one-fixed-dep", "node_modules", "no-deps", "package.json")),
-    ).toBeTrue();
+    expect(layout(dir)).toEqual(installed);
   },
 );
 
@@ -2370,8 +2827,8 @@ test.concurrent(
       JSON.stringify({ name: "foo", dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0", "a-dep": "1.0.1" } }),
     );
     await install(dir, "--lockfile-only");
-    const shadowed = plant(dir, "node_modules/one-dep/node_modules/a-dep");
-    const junk = plant(dir, "node_modules/one-dep/node_modules/junk");
+    plant(dir, "node_modules/one-dep/node_modules/a-dep");
+    plant(dir, "node_modules/one-dep/node_modules/junk");
 
     const { lines: merged, exitCode } = await pruneMerged(dir);
     expect(merged).toStrictEqual([
@@ -2383,8 +2840,13 @@ test.concurrent(
       REMOVED(1, 6),
     ]);
     expect(exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
-    expect(existsSync(shadowed)).toBeTrue();
+    expect(layout(dir)).toEqual([
+      "a-dep",
+      "no-deps",
+      "one-dep",
+      "one-dep/node_modules/a-dep",
+      "one-dep/node_modules/no-deps",
+    ]);
     expect(await file(join(nestedNoDeps, "package.json")).json()).toMatchObject({ version: "1.0.1" });
     expect(await file(join(nm, "a-dep", "package.json")).json()).toMatchObject({ version: "1.0.2" });
   },
@@ -2421,8 +2883,9 @@ test.concurrent(
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
+    expect(layout(dir)).toEqual(["a -> ../packages/a", "no-deps"]);
+    expect(layout(dir, "packages/a/node_modules")).toEqual(["no-deps"]);
     expect(await file(workspacePkgJson).json()).toMatchObject({ version: "1.0.0" });
-    expect(isSymlink(join(nm, "a"))).toBeTrue();
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
   },
 );
@@ -2436,11 +2899,23 @@ test.concurrent(
       dependencies: { "uses-what-bin": "1.0.0" },
       devDependencies: { "what-bin": "1.0.0" },
     });
-    const nm = join(dir, "node_modules");
-    const store = join(nm, ".bun");
-    expect(isSymlink(join(nm, "what-bin"))).toBeTrue();
-    expect(existsSync(join(store, "what-bin@1.0.0"))).toBeTrue();
-    expectBinInstalled(nm, "what-bin");
+    const installed = layout(dir);
+    expect(installed).toMatchInlineSnapshot(`
+      [
+        ".bin/what-bin",
+        ".bun/node_modules/uses-what-bin -> ../uses-what-bin@1.0.0/node_modules/uses-what-bin",
+        ".bun/node_modules/what-bin -> ../what-bin@1.0.0/node_modules/what-bin",
+        ".bun/uses-what-bin@1.0.0",
+        ".bun/uses-what-bin@1.0.0/node_modules/.bin/what-bin",
+        ".bun/uses-what-bin@1.0.0/node_modules/uses-what-bin",
+        ".bun/uses-what-bin@1.0.0/node_modules/what-bin -> ../../what-bin@1.0.0/node_modules/what-bin",
+        ".bun/what-bin@1.0.0",
+        ".bun/what-bin@1.0.0/node_modules/.bin/what-bin",
+        ".bun/what-bin@1.0.0/node_modules/what-bin",
+        "uses-what-bin -> .bun/uses-what-bin@1.0.0/node_modules/uses-what-bin",
+        "what-bin -> .bun/what-bin@1.0.0/node_modules/what-bin",
+      ]
+    `);
 
     const dryRun = await prune(dir, "--production", "--dry-run", "--linker", "isolated");
     expect(out(dryRun.stdout)).toMatchInlineSnapshot(`
@@ -2450,43 +2925,61 @@ test.concurrent(
       1 package can be removed (checked 4 installed packages)
         bun prune --production --linker isolated"
     `);
+    expect(dryRun.stderr).toBe("");
     expect(dryRun.exitCode).toBe(0);
-    expect(isSymlink(join(nm, "what-bin"))).toBeTrue();
-    expectBinInstalled(nm, "what-bin");
+    expect(layout(dir)).toEqual(installed);
 
-    const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+    const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
       - what-bin@1.0.0
       1 package removed (checked 4 installed packages)"
     `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(() => lstatSync(join(nm, "what-bin"))).toThrow();
-    expect(existsSync(join(store, "what-bin@1.0.0"))).toBeTrue();
-    expect(existsSync(join(store, "uses-what-bin@1.0.0", "node_modules", "what-bin", "package.json"))).toBeTrue();
-    expect(existsSync(join(nm, "uses-what-bin", "package.json"))).toBeTrue();
-    expectBinRemoved(nm, "what-bin");
+    const pruned = layout(dir);
+    expect(pruned).toMatchInlineSnapshot(`
+      [
+        ".bun/node_modules/uses-what-bin -> ../uses-what-bin@1.0.0/node_modules/uses-what-bin",
+        ".bun/node_modules/what-bin -> ../what-bin@1.0.0/node_modules/what-bin",
+        ".bun/uses-what-bin@1.0.0",
+        ".bun/uses-what-bin@1.0.0/node_modules/.bin/what-bin",
+        ".bun/uses-what-bin@1.0.0/node_modules/uses-what-bin",
+        ".bun/uses-what-bin@1.0.0/node_modules/what-bin -> ../../what-bin@1.0.0/node_modules/what-bin",
+        ".bun/what-bin@1.0.0",
+        ".bun/what-bin@1.0.0/node_modules/.bin/what-bin",
+        ".bun/what-bin@1.0.0/node_modules/what-bin",
+        "uses-what-bin -> .bun/uses-what-bin@1.0.0/node_modules/uses-what-bin",
+      ]
+    `);
 
     const again = await prune(dir, "--production", "--linker", "isolated");
-    expect(out(again.stdout)).toEndWith(NOTHING(3, 2));
+    expect(lines(again.stdout)).toStrictEqual([BANNER, "", NOTHING(3, 2)]);
+    expect(again.stderr).toBe("");
     expect(again.exitCode).toBe(0);
     await expectProductionInstallIsNoop(dir);
+    expect(layout(dir)).toEqual(pruned);
   },
 );
 
 // pnpm#13676
 test.concurrent("hoisted: nested node_modules of packages without a tree node are pruned", async () => {
-  const dir = await setup({
-    name: "foo",
-    dependencies: { "no-deps": "1.0.0", "@scoped/has-bin-entry": "1.0.0" },
-  });
+  const dir = await trees.noDepsScopedBin();
   const nm = join(dir, "node_modules");
-  const junk = plant(dir, "node_modules/no-deps/node_modules/junk");
-  const scopedJunk = plant(dir, "node_modules/@scoped/has-bin-entry/node_modules/@other/thing");
+  plant(dir, "node_modules/no-deps/node_modules/junk");
+  plant(dir, "node_modules/@scoped/has-bin-entry/node_modules/@other/thing");
   writeFileSync(join(nm, "no-deps", "node_modules", "keep.txt"), "");
+  expect(layout(dir)).toEqual([
+    ".bin/has-bin-entry",
+    "@scoped/has-bin-entry",
+    "@scoped/has-bin-entry/node_modules/@other/thing",
+    "no-deps",
+    "no-deps/node_modules/junk",
+    "no-deps/node_modules/keep.txt",
+  ]);
 
-  const { stdout, exitCode } = await prune(dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -2494,53 +2987,68 @@ test.concurrent("hoisted: nested node_modules of packages without a tree node ar
     - junk (node_modules/no-deps/node_modules)
     2 packages removed (checked 4 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(scopedJunk)).toBeFalse();
+  expect(layout(dir)).toEqual([
+    ".bin/has-bin-entry",
+    "@scoped/has-bin-entry",
+    "no-deps",
+    "no-deps/node_modules/keep.txt",
+  ]);
   expect(existsSync(join(nm, "@scoped", "has-bin-entry", "node_modules", "@other"))).toBeFalse();
-  expect(existsSync(join(nm, "no-deps", "node_modules", "keep.txt"))).toBeTrue();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-  expect(existsSync(join(nm, "@scoped", "has-bin-entry", "package.json"))).toBeTrue();
 });
 
 // pnpm#8307
 test.concurrent("refuses to prune a hoisted install with the isolated linker", async () => {
   const dir = await setupWithLinker("hoisted", { name: "foo", dependencies: { "one-dep": "1.0.0" } });
-  const nm = join(dir, "node_modules");
-  const hoisted = join(nm, "no-deps", "package.json");
-  expect(existsSync(hoisted)).toBeTrue();
-  expect(existsSync(join(nm, ".bun"))).toBeFalse();
+  expect(layout(dir)).toEqual(["no-deps", "one-dep"]);
 
-  for (const flags of [
-    ["--linker", "isolated"],
-    ["--linker", "isolated", "--dry-run"],
-  ]) {
-    const { stdout, stderr, exitCode } = await prune(dir, ...flags);
+  const refused = await Promise.all([
+    prune(dir, "--linker", "isolated"),
+    prune(dir, "--linker", "isolated", "--dry-run"),
+  ]);
+  for (const { stdout, stderr, exitCode } of refused) {
     expect(out(stdout)).toMatchInlineSnapshot(`"bun prune <version> (<revision>)"`);
-    expect(stderr).toContain("node_modules was installed with the hoisted linker");
-    expect(stderr).toContain("bun prune --linker hoisted");
+    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+      "error: node_modules was installed with the hoisted linker, but bun prune would use the isolated linker
+      note: run 'bun prune --linker hoisted' to prune it as-is, or 'bun install' to reinstall with the isolated linker"
+    `);
     expect(exitCode).toBe(1);
-    expect(existsSync(hoisted)).toBeTrue();
   }
+  expect(layout(dir)).toEqual(["no-deps", "one-dep"]);
 
   const same = await prune(dir, "--linker", "hoisted");
-  expect(out(same.stdout)).toEndWith(NOTHING(2, 1));
+  expect(lines(same.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
+  expect(same.stderr).toBe("");
   expect(same.exitCode).toBe(0);
+  expect(layout(dir)).toEqual(["no-deps", "one-dep"]);
 });
 
 // pnpm#8307
 test.concurrent("refuses to prune an isolated install with the hoisted linker", async () => {
   const dir = await setupWithLinker("isolated", { name: "foo", devDependencies: { "one-dep": "1.0.0" } });
-  const nm = join(dir, "node_modules");
-  expect(isSymlink(join(nm, "one-dep"))).toBeTrue();
+  const installed = layout(dir);
+  expect(installed).toMatchInlineSnapshot(`
+    [
+      ".bun/no-deps@1.0.1",
+      ".bun/no-deps@1.0.1/node_modules/no-deps",
+      ".bun/node_modules/no-deps -> ../no-deps@1.0.1/node_modules/no-deps",
+      ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+      ".bun/one-dep@1.0.0",
+      ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+      ".bun/one-dep@1.0.0/node_modules/one-dep",
+      "one-dep -> .bun/one-dep@1.0.0/node_modules/one-dep",
+    ]
+  `);
 
   const mismatch = await prune(dir, "--production", "--linker", "hoisted");
   expect(out(mismatch.stdout)).toMatchInlineSnapshot(`"bun prune <version> (<revision>)"`);
-  expect(mismatch.stderr).toContain("node_modules was installed with the isolated linker");
-  expect(mismatch.stderr).toContain("bun prune --linker isolated");
+  expect(normalizeBunSnapshot(mismatch.stderr)).toMatchInlineSnapshot(`
+    "error: node_modules was installed with the isolated linker, but bun prune would use the hoisted linker
+    note: run 'bun prune --linker isolated' to prune it as-is, or 'bun install' to reinstall with the hoisted linker"
+  `);
   expect(mismatch.exitCode).toBe(1);
-  expect(isSymlink(join(nm, "one-dep"))).toBeTrue();
-  expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual(installed);
 
   const same = await prune(dir, "--production", "--linker", "isolated");
   expect(out(same.stdout)).toMatchInlineSnapshot(`
@@ -2550,8 +3058,9 @@ test.concurrent("refuses to prune an isolated install with the hoisted linker", 
     - one-dep@1.0.0
     2 packages removed (checked 3 installed packages)"
   `);
+  expect(same.stderr).toBe("");
   expect(same.exitCode).toBe(0);
-  expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
+  expect(layout(dir)).toEqual([]);
 });
 
 // pnpm#5960
@@ -2566,16 +3075,35 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
     const nm = join(dir, "node_modules");
     expect(await file(join(nm, "aliased", "package.json")).json()).toMatchObject({ version: "1.0.0" });
     expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "2.0.0" });
+    const installed = layout(dir);
+    const hoistLink = ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps";
+    // Both versions are direct dependencies under the real name, so which one the hidden-hoist `no-deps` link points at
+    // depends on the install's order. Prune only removes entries: a link at the dev 2.0.0 goes with it, one at the
+    // alias's 1.0.0 stays, and the production install that follows is what points a new link at 1.0.0.
+    const hoisted = linker === "hoisted";
+    const pruned = hoisted ? ["aliased"] : installed.filter(row => !row.includes("no-deps@2.0.0"));
+    expect(installed).toEqual(
+      hoisted
+        ? ["aliased", "no-deps"]
+        : [
+            ".bun/no-deps@1.0.0",
+            ".bun/no-deps@1.0.0/node_modules/no-deps",
+            ".bun/no-deps@2.0.0",
+            ".bun/no-deps@2.0.0/node_modules/no-deps",
+            expect.stringMatching(/^\.bun\/node_modules\/no-deps -> \.\.\/no-deps@[12]\.0\.0\/node_modules\/no-deps$/),
+            "aliased -> .bun/no-deps@1.0.0/node_modules/no-deps",
+            "no-deps -> .bun/no-deps@2.0.0/node_modules/no-deps",
+          ],
+    );
 
-    const { stdout, exitCode } = await prune(dir, "--production", "--linker", linker);
-    expect(lines(stdout)).toStrictEqual([BANNER, "", "- no-deps@2.0.0", REMOVED(1, linker === "hoisted" ? 2 : 4)]);
+    const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", linker);
+    expect(lines(stdout)).toStrictEqual([BANNER, "", "- no-deps@2.0.0", REMOVED(1, hoisted ? 2 : 4)]);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(() => lstatSync(join(nm, "no-deps"))).toThrow();
+    expect(layout(dir)).toEqual(pruned);
     expect(await file(join(nm, "aliased", "package.json")).json()).toMatchObject({ version: "1.0.0" });
-    if (linker === "isolated") {
-      expect(existsSync(join(nm, ".bun", "no-deps@1.0.0"))).toBeTrue();
-    }
     await expectProductionInstallIsNoop(dir);
+    expect(layout(dir)).toEqual(hoisted ? pruned : [...new Set([...pruned, hoistLink])].toSorted());
   },
 );
 
@@ -2604,15 +3132,17 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
       write(join(dir, "packages", "app", "package.json"), appJson("b")),
     ]);
     await install(dir, "--lockfile-only", "--linker", linker);
-    expect(isSymlink(staleLink)).toBeTrue();
+    expect(kind(staleLink)).toBe("link");
     expect(existsSync(staleLink)).toBeFalse();
+    const before = layout(dir, linkFolder);
 
-    const { stdout, exitCode } = await prune(dir, "--linker", linker);
+    const { stdout, stderr, exitCode } = await prune(dir, "--linker", linker);
     // A dangling link has no package.json to read a version from; only a non-root folder is named.
     const row = linker === "hoisted" ? "- a" : `- a (${linkFolder})`;
     expect(lines(stdout)).toStrictEqual([BANNER, "", row, REMOVED(1, 3)]);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(() => lstatSync(staleLink)).toThrow();
+    expect(layout(dir, linkFolder)).toEqual(before.filter(entry => !entry.startsWith("a ")));
     expect(existsSync(join(dir, "packages", "b", "package.json"))).toBeTrue();
     const noDeps =
       linker === "hoisted"
@@ -2691,12 +3221,14 @@ test.concurrent(
     });
     await install(dir);
     expect(await lock(dir)).toContain('"configVersion": 1,');
-    const store = join(dir, "node_modules", ".bun");
     expect(storeEntries(dir)).toStrictEqual(["a-dep@1.0.1", "no-deps@1.0.1", "one-dep@1.0.0"]);
-    const junk = plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
+    const a = join(dir, "packages", "a");
+    const oneDep = "one-dep -> ../../../node_modules/.bun/one-dep@1.0.0/node_modules/one-dep";
+    expect(layout(a)).toEqual(["a-dep -> ../../../node_modules/.bun/a-dep@1.0.1/node_modules/a-dep", oneDep]);
+    plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
 
     const { stdout, stderr, exitCode } = await prune(dir, "--production");
-    expect(stderr).not.toContain("linker");
+    expect(stderr).toBe("");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
@@ -2705,11 +3237,8 @@ test.concurrent(
       2 packages removed (checked 6 installed packages)"
     `);
     expect(exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
-    expect(existsSync(join(store, "a-dep@1.0.1"))).toBeFalse();
-    expect(existsSync(join(store, "one-dep@1.0.0"))).toBeTrue();
-    expect(() => lstatSync(join(dir, "packages", "a", "node_modules", "a-dep"))).toThrow();
-    expect(existsSync(join(dir, "packages", "a", "node_modules", "one-dep", "package.json"))).toBeTrue();
+    expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "one-dep@1.0.0"]);
+    expect(layout(a)).toEqual([oneDep]);
     await expectProductionInstallIsNoop(dir);
   },
 );
@@ -2726,16 +3255,27 @@ test.concurrent(
     expect(before).toContain('"configVersion": 1,');
     await write(join(dir, "bun.lock"), before.replace('  "configVersion": 1,\n', ""));
     const nm = join(dir, "node_modules");
-    expect(existsSync(join(nm, ".bun"))).toBeFalse();
-    expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-    const junk = plant(dir, "node_modules/junk");
+    expect(layout(dir)).toEqual(["a -> ../packages/a", "a-dep", "no-deps", "one-dep"]);
+    plant(dir, "node_modules/junk");
     plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
 
     // The refusal names the linker that was picked.
     const withStore = await prune(dir, "--production");
-    expect(withStore.stderr).toContain("but bun prune would use the hoisted linker");
+    expect(normalizeBunSnapshot(withStore.stderr)).toMatchInlineSnapshot(`
+      "error: node_modules was installed with the isolated linker, but bun prune would use the hoisted linker
+      note: run 'bun prune --linker isolated' to prune it as-is, or 'bun install' to reinstall with the hoisted linker"
+    `);
+    expect(out(withStore.stdout)).toBe(BANNER);
     expect(withStore.exitCode).toBe(1);
-    expect(existsSync(junk)).toBeTrue();
+    expect(layout(dir)).toEqual([
+      ".bun/junk@1.0.0",
+      ".bun/junk@1.0.0/node_modules/junk",
+      "a -> ../packages/a",
+      "a-dep",
+      "junk",
+      "no-deps",
+      "one-dep",
+    ]);
     rmSync(join(nm, ".bun"), { recursive: true });
 
     const { stdout, stderr, exitCode } = await prune(dir, "--production");
@@ -2748,10 +3288,7 @@ test.concurrent(
       2 packages removed (checked 5 installed packages)"
     `);
     expect(exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
-    expect(existsSync(join(nm, "a-dep"))).toBeFalse();
-    expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-    expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
+    expect(layout(dir)).toEqual(["a -> ../packages/a", "no-deps", "one-dep"]);
   },
 );
 
@@ -2759,15 +3296,25 @@ test.concurrent("without --linker, a project without workspaces is pruned with t
   const dir = await setup({ name: "foo", dependencies: { "one-dep": "1.0.0" }, devDependencies: { "a-dep": "1.0.1" } });
   expect(await lock(dir)).toContain('"configVersion": 1,');
   const nm = join(dir, "node_modules");
-  expect(existsSync(join(nm, ".bun"))).toBeFalse();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
-  const junk = plant(dir, "node_modules/junk");
+  expect(layout(dir)).toEqual(["a-dep", "no-deps", "one-dep"]);
+  plant(dir, "node_modules/junk");
   plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
 
   const withStore = await prune(dir, "--production");
-  expect(withStore.stderr).toContain("but bun prune would use the hoisted linker");
+  expect(normalizeBunSnapshot(withStore.stderr)).toMatchInlineSnapshot(`
+    "error: node_modules was installed with the isolated linker, but bun prune would use the hoisted linker
+    note: run 'bun prune --linker isolated' to prune it as-is, or 'bun install' to reinstall with the hoisted linker"
+  `);
+  expect(out(withStore.stdout)).toBe(BANNER);
   expect(withStore.exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(dir)).toEqual([
+    ".bun/junk@1.0.0",
+    ".bun/junk@1.0.0/node_modules/junk",
+    "a-dep",
+    "junk",
+    "no-deps",
+    "one-dep",
+  ]);
   rmSync(join(nm, ".bun"), { recursive: true });
 
   const { stdout, stderr, exitCode } = await prune(dir, "--production");
@@ -2780,27 +3327,32 @@ test.concurrent("without --linker, a project without workspaces is pruned with t
     2 packages removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(join(nm, "a-dep"))).toBeFalse();
-  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual(["no-deps", "one-dep"]);
 });
 
 test.concurrent.each([["--os=aix"], ["--cpu=s390x"]])(
   "isolated: %s removes the store entry and link of a package disabled for that platform, plain prune keeps them",
   async (flag: string) => {
-    const dir = await setupWithLinker("isolated", {
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0", "test-postinstall-skip-native": "1.0.0" },
-    });
-    const nm = join(dir, "node_modules");
-    const store = join(nm, ".bun");
-    expect(isSymlink(join(nm, "test-postinstall-skip-native"))).toBeTrue();
-    expect(existsSync(join(store, "test-postinstall-skip-native@1.0.0"))).toBeTrue();
+    const dir = await trees.isolatedNative();
+    const installed = layout(dir);
+    expect(installed).toMatchInlineSnapshot(`
+      [
+        ".bun/no-deps@1.0.0",
+        ".bun/no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/test-postinstall-skip-native -> ../test-postinstall-skip-native@1.0.0/node_modules/test-postinstall-skip-native",
+        ".bun/test-postinstall-skip-native@1.0.0",
+        ".bun/test-postinstall-skip-native@1.0.0/node_modules/test-postinstall-skip-native",
+        "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+        "test-postinstall-skip-native -> .bun/test-postinstall-skip-native@1.0.0/node_modules/test-postinstall-skip-native",
+      ]
+    `);
 
     const host = await prune(dir, "--linker", "isolated");
-    expect(out(host.stdout)).toEndWith(NOTHING(4, 2));
+    expect(lines(host.stdout)).toStrictEqual([BANNER, "", NOTHING(4, 2)]);
+    expect(host.stderr).toBe("");
     expect(host.exitCode).toBe(0);
-    expect(existsSync(join(store, "test-postinstall-skip-native@1.0.0"))).toBeTrue();
+    expect(layout(dir)).toEqual(installed);
 
     const other = await prune(dir, flag, "--linker", "isolated");
     expect(out(other.stdout)).toMatchInlineSnapshot(`
@@ -2809,11 +3361,14 @@ test.concurrent.each([["--os=aix"], ["--cpu=s390x"]])(
       - test-postinstall-skip-native@1.0.0
       1 package removed (checked 4 installed packages)"
     `);
+    expect(other.stderr).toBe("");
     expect(other.exitCode).toBe(0);
-    expect(existsSync(join(store, "test-postinstall-skip-native@1.0.0"))).toBeFalse();
-    expect(() => lstatSync(join(nm, "test-postinstall-skip-native"))).toThrow();
-    expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
-    expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
+    expect(layout(dir)).toEqual([
+      ".bun/no-deps@1.0.0",
+      ".bun/no-deps@1.0.0/node_modules/no-deps",
+      ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+      "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+    ]);
     expect(await install(dir, flag, "--linker", "isolated")).toContain("no changes");
   },
 );
@@ -2835,14 +3390,35 @@ test.concurrent("isolated: keeps dependencies bundled inside a package, with and
   );
   expect(existsSync(bundled)).toBeTrue();
 
+  const tree = layout(dir);
+  expect(tree).toMatchInlineSnapshot(`
+    [
+      ".bun/bundled-transitive@1.0.0",
+      ".bun/bundled-transitive@1.0.0/node_modules/bundled-transitive",
+      ".bun/bundled-transitive@1.0.0/node_modules/bundled-transitive/node_modules/no-deps",
+      ".bun/bundled-transitive@1.0.0/node_modules/one-dep -> ../../one-dep@1.0.0/node_modules/one-dep",
+      ".bun/no-deps@1.0.1",
+      ".bun/no-deps@1.0.1/node_modules/no-deps",
+      ".bun/node_modules/bundled-transitive -> ../bundled-transitive@1.0.0/node_modules/bundled-transitive",
+      ".bun/node_modules/no-deps -> ../no-deps@1.0.1/node_modules/no-deps",
+      ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+      ".bun/one-dep@1.0.0",
+      ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+      ".bun/one-dep@1.0.0/node_modules/one-dep",
+      "bundled-transitive -> .bun/bundled-transitive@1.0.0/node_modules/bundled-transitive",
+    ]
+  `);
+
   for (const flags of [[], ["--production"]]) {
-    const { stdout, exitCode } = await prune(dir, ...flags, "--linker", "isolated");
-    expect(out(stdout)).toEndWith(NOTHING(4, 2));
+    const { stdout, stderr, exitCode } = await prune(dir, ...flags, "--linker", "isolated");
+    expect(lines(stdout)).toStrictEqual([BANNER, "", NOTHING(4, 2)]);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(storeEntries(dir)).toStrictEqual(installed);
+    expect(layout(dir)).toEqual(tree);
     expect(existsSync(bundled)).toBeTrue();
   }
   await expectProductionInstallIsNoop(dir);
+  expect(layout(dir)).toEqual(tree);
 });
 
 test.concurrent("hoisted: the nested tree of a package with bundled dependencies is not walked", async () => {
@@ -2854,11 +3430,21 @@ test.concurrent("hoisted: the nested tree of a package with bundled dependencies
   expect(await file(join(nm, "one-dep", "node_modules", "no-deps", "package.json")).json()).toMatchObject({
     version: "1.0.1",
   });
-  const junk = plant(dir, "node_modules/bundled-transitive/node_modules/junk");
-  const oneDepJunk = plant(dir, "node_modules/one-dep/node_modules/junk");
+  const installed = layout(dir);
+  expect(installed).toMatchInlineSnapshot(`
+    [
+      "bundled-transitive",
+      "bundled-transitive/node_modules/no-deps",
+      "no-deps",
+      "one-dep",
+      "one-dep/node_modules/no-deps",
+    ]
+  `);
+  plant(dir, "node_modules/bundled-transitive/node_modules/junk");
+  plant(dir, "node_modules/one-dep/node_modules/junk");
 
   const { stdout, stderr, exitCode } = await prune(dir);
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -2866,9 +3452,7 @@ test.concurrent("hoisted: the nested tree of a package with bundled dependencies
     1 package removed (checked 5 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeTrue();
-  expect(existsSync(oneDepJunk)).toBeFalse();
-  expect(existsSync(join(bundledNm, "no-deps", "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual([...installed, "bundled-transitive/node_modules/junk"].toSorted());
 });
 
 test.concurrent(
@@ -2883,20 +3467,21 @@ test.concurrent(
     const tag = await file(rootTag).text();
     expect(tag).toMatch(/^[0-9a-f]{40}$/);
     expect(await lock(dir)).toContain(tag);
-    const nested = plant(dir, "node_modules/no-deps/node_modules/git-pkg");
+    plant(dir, "node_modules/no-deps/node_modules/git-pkg");
     writeFileSync(rootTag, "0000000000000000000000000000000000000000");
+    expect(layout(dir)).toEqual(["git-pkg", "no-deps", "no-deps/node_modules/git-pkg"]);
 
     const stale = await prune(dir, "--linker", "hoisted");
-    expect(out(stale.stdout)).toEndWith(NOTHING(3, 2));
+    expect(lines(stale.stdout)).toStrictEqual([BANNER, "", NOTHING(3, 2)]);
     expect(out(stale.stderr)).toBe(
       `${WARN("node_modules/git-pkg", "node_modules/no-deps/node_modules/git-pkg")}\n${NOTE}`,
     );
     expect(stale.exitCode).toBe(0);
-    expect(existsSync(nested)).toBeTrue();
+    expect(layout(dir)).toEqual(["git-pkg", "no-deps", "no-deps/node_modules/git-pkg"]);
 
     writeFileSync(rootTag, tag);
     const { stdout, stderr, exitCode } = await prune(dir, "--linker", "hoisted");
-    expect(stderr).not.toContain("warn:");
+    expect(stderr).toBe("");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
@@ -2904,7 +3489,7 @@ test.concurrent(
       1 package removed (checked 3 installed packages)"
     `);
     expect(exitCode).toBe(0);
-    expect(existsSync(nested)).toBeFalse();
+    expect(layout(dir)).toEqual(["git-pkg", "no-deps"]);
     expect(existsSync(join(nm, "git-pkg", "package.json"))).toBeTrue();
   },
 );
@@ -2924,8 +3509,8 @@ test.concurrent(
     const nm = join(dir, "node_modules");
     const rootPkgJson = join(nm, "left-pad", "package.json");
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "1.0.0" });
-    const nested = plant(dir, "node_modules/no-deps/node_modules/left-pad");
-    const junk = plant(dir, "node_modules/no-deps/node_modules/junk");
+    plant(dir, "node_modules/no-deps/node_modules/left-pad");
+    plant(dir, "node_modules/no-deps/node_modules/junk");
 
     const kept = "node_modules/no-deps/node_modules/left-pad";
 
@@ -2939,8 +3524,7 @@ test.concurrent(
     ]);
     expect(out(missing.stderr)).toBe(`${MISSING_WARN("node_modules/left-pad", kept)}\n${NOTE}`);
     expect(missing.exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
-    expect(existsSync(nested)).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps", "no-deps/node_modules/left-pad"]);
 
     renameSync(join(dir, "left-pad.moved"), join(nm, "left-pad"));
     renameSync(rootPkgJson, join(nm, "left-pad", "package.json.bak"));
@@ -2948,7 +3532,7 @@ test.concurrent(
     expect(lines(mismatch.stdout)).toStrictEqual([BANNER, "", NOTHING(3, 2)]);
     expect(out(mismatch.stderr)).toBe(`${WARN("node_modules/left-pad", kept)}\n${NOTE}`);
     expect(mismatch.exitCode).toBe(0);
-    expect(existsSync(nested)).toBeTrue();
+    expect(layout(dir)).toEqual(["left-pad", "no-deps", "no-deps/node_modules/left-pad"]);
 
     renameSync(join(nm, "left-pad", "package.json.bak"), rootPkgJson);
     const { stdout, stderr, exitCode } = await prune(dir, "--linker", "hoisted");
@@ -2960,7 +3544,7 @@ test.concurrent(
       1 package removed (checked 3 installed packages)"
     `);
     expect(exitCode).toBe(0);
-    expect(existsSync(nested)).toBeFalse();
+    expect(layout(dir)).toEqual(["left-pad", "no-deps"]);
     expect(existsSync(rootPkgJson)).toBeTrue();
   },
 );
@@ -2979,12 +3563,11 @@ test.concurrent("hoisted: a nested copy of a link: dependency is removed when th
   const installed = await run(env, dir, "install", "--linker", "hoisted");
   expect(installed.stderr).not.toContain("error:");
   expect(installed.exitCode).toBe(0);
-  const nm = join(dir, "node_modules");
-  expect(isSymlink(join(nm, "linked"))).toBeTrue();
-  const nested = plant(dir, "node_modules/no-deps/node_modules/linked");
+  expect(layout(dir)).toEqual(["linked -> ../linked", "no-deps"]);
+  plant(dir, "node_modules/no-deps/node_modules/linked");
 
   const { stdout, stderr, exitCode } = await prune(dir, "--linker", "hoisted");
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -2992,13 +3575,12 @@ test.concurrent("hoisted: a nested copy of a link: dependency is removed when th
     1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(nested)).toBeFalse();
-  expect(isSymlink(join(nm, "linked"))).toBeTrue();
+  expect(layout(dir)).toEqual(["linked -> ../linked", "no-deps"]);
   expect(await file(join(dir, "linked", "package.json")).json()).toStrictEqual({ name: "linked", version: "1.0.0" });
 });
 
 test.concurrent("hoisted: a nested copy left behind by an override to a tarball is removed", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "2.0.0", "one-dep": "1.0.0" } });
+  const dir = await trees.oneDepNoDeps2();
   const nm = join(dir, "node_modules");
   const nested = join(nm, "one-dep", "node_modules", "no-deps");
   expect(await file(join(nested, "package.json")).json()).toMatchObject({ version: "1.0.1" });
@@ -3015,10 +3597,10 @@ test.concurrent("hoisted: a nested copy left behind by an override to a tarball 
   await install(dir);
   expect(await lock(dir)).not.toContain('"one-dep/no-deps"');
   expect(await lock(dir)).toContain("no-deps-2.0.0.tgz");
-  expect(existsSync(join(nested, "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual(["no-deps", "one-dep", "one-dep/node_modules/no-deps"]);
 
   const { stdout, stderr, exitCode } = await prune(dir);
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -3026,7 +3608,7 @@ test.concurrent("hoisted: a nested copy left behind by an override to a tarball 
     1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(nested)).toBeFalse();
+  expect(layout(dir)).toEqual(["no-deps", "one-dep"]);
   expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ name: "no-deps" });
 });
 
@@ -3040,10 +3622,10 @@ test.concurrent(
       version: "1.0.0+123",
     });
     expect(await lock(dir)).toContain('"no-deps-build-metadata@1.0.0"');
-    const nested = plant(dir, "node_modules/no-deps/node_modules/no-deps-build-metadata");
+    plant(dir, "node_modules/no-deps/node_modules/no-deps-build-metadata");
 
     const { stdout, stderr, exitCode } = await prune(dir);
-    expect(stderr).not.toContain("warn:");
+    expect(stderr).toBe("");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
@@ -3051,8 +3633,7 @@ test.concurrent(
       1 package removed (checked 3 installed packages)"
     `);
     expect(exitCode).toBe(0);
-    expect(existsSync(nested)).toBeFalse();
-    expect(existsSync(join(nm, "no-deps-build-metadata", "package.json"))).toBeTrue();
+    expect(layout(dir)).toEqual(["no-deps", "no-deps-build-metadata"]);
   },
 );
 
@@ -3065,14 +3646,31 @@ test.concurrent(
       { publicHoistPattern: ["no-deps"] },
     );
     const nm = join(dir, "node_modules");
-    const store = join(nm, ".bun");
-    expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
+    const installed = layout(dir);
+    expect(installed).toMatchInlineSnapshot(`
+      [
+        ".bun/a-dep@1.0.1",
+        ".bun/a-dep@1.0.1/node_modules/a-dep",
+        ".bun/no-deps@1.0.1",
+        ".bun/no-deps@1.0.1/node_modules/no-deps",
+        ".bun/node_modules/a-dep -> ../a-dep@1.0.1/node_modules/a-dep",
+        ".bun/node_modules/no-deps -> ../no-deps@1.0.1/node_modules/no-deps",
+        ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+        ".bun/one-dep@1.0.0",
+        ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+        ".bun/one-dep@1.0.0/node_modules/one-dep",
+        "a-dep -> .bun/a-dep@1.0.1/node_modules/a-dep",
+        "no-deps -> .bun/no-deps@1.0.1/node_modules/no-deps",
+        "one-dep -> .bun/one-dep@1.0.0/node_modules/one-dep",
+      ]
+    `);
     expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "1.0.1" });
 
     const plain = await prune(dir, "--linker", "isolated");
-    expect(out(plain.stdout)).toEndWith(NOTHING(6, 2));
+    expect(lines(plain.stdout)).toStrictEqual([BANNER, "", NOTHING(6, 2)]);
+    expect(plain.stderr).toBe("");
     expect(plain.exitCode).toBe(0);
-    expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
+    expect(layout(dir)).toEqual(installed);
 
     const production = await prune(dir, "--production", "--linker", "isolated");
     expect(out(production.stdout)).toMatchInlineSnapshot(`
@@ -3082,11 +3680,16 @@ test.concurrent(
       - one-dep@1.0.0
       2 packages removed (checked 6 installed packages)"
     `);
+    expect(production.stderr).toBe("");
     expect(production.exitCode).toBe(0);
-    expect(existsSync(join(store, "no-deps@1.0.1"))).toBeFalse();
-    expect(() => lstatSync(join(nm, "no-deps"))).toThrow();
-    expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
-    expect(existsSync(join(nm, "a-dep", "package.json"))).toBeTrue();
+    expect(layout(dir)).toMatchInlineSnapshot(`
+      [
+        ".bun/a-dep@1.0.1",
+        ".bun/a-dep@1.0.1/node_modules/a-dep",
+        ".bun/node_modules/a-dep -> ../a-dep@1.0.1/node_modules/a-dep",
+        "a-dep -> .bun/a-dep@1.0.1/node_modules/a-dep",
+      ]
+    `);
     await expectProductionInstallIsNoop(dir);
   },
 );
@@ -3094,24 +3697,41 @@ test.concurrent(
 test.concurrent(
   "isolated: an unwanted entry's peer-hash variant and scoped hidden-hoist links follow it out",
   async () => {
-    const dir = await setupWithLinker("isolated", {
-      name: "foo",
-      dependencies: { "no-deps": "1.0.0" },
-      devDependencies: { "one-dep": "1.0.0" },
-    });
+    const dir = await trees.isolatedDevOneDep();
     const store = join(dir, "node_modules", ".bun");
     const hiddenHoist = join(store, "node_modules");
-    const variant = plant(dir, "node_modules/.bun/one-dep@1.0.0+0123456789abcdef/node_modules/one-dep");
+    plant(dir, "node_modules/.bun/one-dep@1.0.0+0123456789abcdef/node_modules/one-dep");
     const scopedEntry = plant(dir, "node_modules/.bun/@scope+zzz@1.0.0/node_modules/@scope/zzz");
-    const scopedLink = join(hiddenHoist, "@scope", "zzz");
     mkdirSync(join(hiddenHoist, "@scope"), { recursive: true });
-    symlinkSync(scopedEntry, scopedLink, "junction");
-    const liveLink = join(hiddenHoist, "@scope", "no-deps");
-    symlinkSync(join(store, "no-deps@1.0.0", "node_modules", "no-deps"), liveLink, "junction");
-    expect(isSymlink(scopedLink)).toBeTrue();
-    expect(existsSync(join(liveLink, "package.json"))).toBeTrue();
+    symlinkSync(scopedEntry, join(hiddenHoist, "@scope", "zzz"), "junction");
+    symlinkSync(
+      join(store, "no-deps@1.0.0", "node_modules", "no-deps"),
+      join(hiddenHoist, "@scope", "no-deps"),
+      "junction",
+    );
+    expect(layout(dir)).toMatchInlineSnapshot(`
+      [
+        ".bun/@scope+zzz@1.0.0",
+        ".bun/@scope+zzz@1.0.0/node_modules/@scope/zzz",
+        ".bun/no-deps@1.0.0",
+        ".bun/no-deps@1.0.0/node_modules/no-deps",
+        ".bun/no-deps@1.0.1",
+        ".bun/no-deps@1.0.1/node_modules/no-deps",
+        ".bun/node_modules/@scope/no-deps -> ../../no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/@scope/zzz -> ../../@scope+zzz@1.0.0/node_modules/@scope/zzz",
+        ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/one-dep -> ../one-dep@1.0.0/node_modules/one-dep",
+        ".bun/one-dep@1.0.0",
+        ".bun/one-dep@1.0.0+0123456789abcdef",
+        ".bun/one-dep@1.0.0+0123456789abcdef/node_modules/one-dep",
+        ".bun/one-dep@1.0.0/node_modules/no-deps -> ../../no-deps@1.0.1/node_modules/no-deps",
+        ".bun/one-dep@1.0.0/node_modules/one-dep",
+        "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+        "one-dep -> .bun/one-dep@1.0.0/node_modules/one-dep",
+      ]
+    `);
 
-    const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+    const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
@@ -3121,29 +3741,29 @@ test.concurrent(
       - one-dep@1.0.0+0123456789abcdef
       4 packages removed (checked 7 installed packages)"
     `);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    expect(existsSync(variant)).toBeFalse();
-    expect(existsSync(join(store, "one-dep@1.0.0+0123456789abcdef"))).toBeFalse();
-    expect(existsSync(join(store, "@scope+zzz@1.0.0"))).toBeFalse();
-    expect(() => lstatSync(scopedLink)).toThrow();
-    expect(existsSync(join(liveLink, "package.json"))).toBeTrue();
-    expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
+    expect(layout(dir)).toMatchInlineSnapshot(`
+      [
+        ".bun/no-deps@1.0.0",
+        ".bun/no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/@scope/no-deps -> ../../no-deps@1.0.0/node_modules/no-deps",
+        ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+        "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+      ]
+    `);
   },
 );
 
 test.concurrent("isolated: an emptied scope dir of dangling hidden-hoist links is removed", async () => {
-  const dir = await setupWithLinker("isolated", {
-    name: "foo",
-    dependencies: { "no-deps": "1.0.0" },
-    devDependencies: { "one-dep": "1.0.0" },
-  });
+  const dir = await trees.isolatedDevOneDep();
   const store = join(dir, "node_modules", ".bun");
   const scopeDir = join(store, "node_modules", "@scope");
   const scopedEntry = plant(dir, "node_modules/.bun/@scope+zzz@1.0.0/node_modules/@scope/zzz");
   mkdirSync(scopeDir, { recursive: true });
   symlinkSync(scopedEntry, join(scopeDir, "zzz"), "junction");
 
-  const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
+  const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "isolated");
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -3152,20 +3772,25 @@ test.concurrent("isolated: an emptied scope dir of dangling hidden-hoist links i
     - one-dep@1.0.0
     3 packages removed (checked 6 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(scopeDir)).toBeFalse();
-  expect(existsSync(join(store, "node_modules"))).toBeTrue();
+  expect(layout(dir)).toEqual([
+    ".bun/no-deps@1.0.0",
+    ".bun/no-deps@1.0.0/node_modules/no-deps",
+    ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+    "no-deps -> .bun/no-deps@1.0.0/node_modules/no-deps",
+  ]);
+  expect(kind(scopeDir)).toBeUndefined();
+  expect(kind(join(store, "node_modules"))).toBe("dir");
 });
 
 test.concurrent("isolated: --filter on a pruned checkout does not protect the missing workspace", async () => {
-  const dir = await setupWorkspaces("isolated", prunedCheckout({}));
-  const store = join(dir, "node_modules", ".bun");
+  const dir = await prunedCheckoutTree.isolated();
   rmSync(join(dir, "packages", "other"), { recursive: true });
-  expect(existsSync(join(store, "left-pad@1.0.0"))).toBeTrue();
+  expect(layout(dir)).toEqual(prunedCheckoutIsolated);
 
   const { stdout, stderr, exitCode } = await prune(dir, "--filter", "app", "--linker", "isolated");
-  expect(stderr).toContain(PRUNED_NOTE);
-  expect(stderr).not.toContain(OUT_OF_SYNC);
+  expect(normalizeBunSnapshot(stderr)).toBe(PRUNED_NOTE);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -3173,11 +3798,15 @@ test.concurrent("isolated: --filter on a pruned checkout does not protect the mi
     1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
-  expect(existsSync(join(store, "left-pad@1.0.0"))).toBeFalse();
-  expect(existsSync(join(store, "no-deps@1.0.0"))).toBeTrue();
-  expect(existsSync(join(dir, "packages", "app", "node_modules", "no-deps", "package.json"))).toBeTrue();
+  const pruned = [
+    ".bun/no-deps@1.0.0",
+    ".bun/no-deps@1.0.0/node_modules/no-deps",
+    ".bun/node_modules/no-deps -> ../no-deps@1.0.0/node_modules/no-deps",
+  ];
+  expect(layout(dir)).toEqual(pruned);
+  expect(layout(join(dir, "packages", "app"))).toEqual(prunedCheckoutApp);
   await install(dir, "--frozen-lockfile", "--linker", "isolated");
-  expect(existsSync(join(store, "left-pad@1.0.0"))).toBeFalse();
+  expect(layout(dir)).toEqual(pruned);
 });
 
 test.concurrent.each(linkers)(
@@ -3220,63 +3849,67 @@ test.concurrent.each(linkers)(
 );
 
 test.concurrent("a lockfile that fails to parse is an error and nothing is deleted", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
-  const junk = plant(dir, "node_modules/junk");
+  const dir = await trees.noDeps();
+  plant(dir, "node_modules/junk");
   await write(join(dir, "bun.lock"), "{ this is not a lockfile");
 
-  const { stdout, stderr, exitCode } = await prune(dir);
-  expect(stderr).toContain("error: failed to load lockfile: ");
+  const [{ stdout, stderr, exitCode }, silent] = await Promise.all([prune(dir), prune(dir, "--silent")]);
+  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+    "1 | { this is not a lockfile
+          ^
+    error: Expected string but found "this"
+        at bun.lock:1:3
+    error: failed to load lockfile: ParserError"
+  `);
   expect(out(stdout)).toMatchInlineSnapshot(`"bun prune <version> (<revision>)"`);
   expect(exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
 
-  const silent = await prune(dir, "--silent");
   expect(silent.stdout).toBe("");
   expect(silent.stderr).toBe("");
   expect(silent.exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
+  expect(layout(dir)).toEqual(["junk", "no-deps"]);
 });
 
 test.concurrent("missing package.json is an error; --cwd prunes another directory", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
+  const dir = await trees.noDeps();
   using empty = tempDir("prune-empty", {});
-  const junk = plant(dir, "node_modules/junk");
+  plant(dir, "node_modules/junk");
 
-  const missing = await prune(String(empty));
+  const [missing, silent] = await Promise.all([prune(String(empty)), prune(String(empty), "--silent")]);
   expect(normalizeBunSnapshot(missing.stderr)).toBe("error: missing package.json, nothing to prune");
   expect(missing.stdout).toBe("");
   expect(missing.exitCode).toBe(1);
 
   // Like the missing-lockfile refusal, this is a state of the project rather than a usage error, so --silent applies.
-  const silent = await prune(String(empty), "--silent");
   expect(silent.stdout).toBe("");
   expect(silent.stderr).toBe("");
   expect(silent.exitCode).toBe(1);
+  expect(readdirSync(String(empty))).toEqual([]);
 
-  const { stdout, exitCode } = await prune({ dir, cwd: String(empty) }, "--cwd", dir);
+  const { stdout, stderr, exitCode } = await prune({ dir, cwd: String(empty) }, "--cwd", dir);
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - junk
     1 package removed (checked 2 installed packages)"
   `);
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(junk)).toBeFalse();
-  expect(existsSync(join(dir, "node_modules", "no-deps", "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual(["no-deps"]);
+  expect(readdirSync(String(empty))).toEqual([]);
 });
 
 test.concurrent("a node_modules that is a file is an error", async () => {
-  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
+  const dir = await trees.noDeps();
   const nm = join(dir, "node_modules");
   rmSync(nm, { recursive: true });
   writeFileSync(nm, "not a directory");
 
-  const { stdout, stderr, exitCode } = await prune(dir);
-  expect(stderr).toContain("failed to open node_modules");
+  const [{ stdout, stderr, exitCode }, silent] = await Promise.all([prune(dir), prune(dir, "--silent")]);
+  expect(normalizeBunSnapshot(stderr)).toMatch(/^E[A-Z]+: .+: failed to open node_modules \(open\)$/);
   expect(out(stdout)).toMatchInlineSnapshot(`"bun prune <version> (<revision>)"`);
   expect(exitCode).toBe(1);
 
-  const silent = await prune(dir, "--silent");
   expect(silent.stdout).toBe("");
   expect(silent.stderr).toBe("");
   expect(silent.exitCode).toBe(1);
@@ -3291,22 +3924,22 @@ test.concurrent(
       dependencies: { "no-deps": "1.0.0" },
       scripts: { prune: "echo SCRIPT_RAN" },
     });
-    const junk = plant(dir, "node_modules/junk");
+    plant(dir, "node_modules/junk");
 
     const pruned = await bun(dir, "prune");
-    expect(pruned.stdout).not.toContain("SCRIPT_RAN");
     expect(out(pruned.stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
       - junk
       1 package removed (checked 2 installed packages)"
     `);
+    expect(pruned.stderr).toBe("");
     expect(pruned.exitCode).toBe(0);
-    expect(existsSync(junk)).toBeFalse();
+    expect(layout(dir)).toEqual(["no-deps"]);
 
     const script = await bun(dir, "run", "prune");
-    expect(script.stdout).toContain("SCRIPT_RAN");
-    expect(script.stdout).not.toContain("Checked");
+    expect(script.stdout).toBe("SCRIPT_RAN\n");
+    expect(normalizeBunSnapshot(script.stderr)).toBe("$ echo SCRIPT_RAN");
     expect(script.exitCode).toBe(0);
   },
 );
@@ -3319,12 +3952,14 @@ test.concurrent("--no-optional is not --omit=optional", async () => {
     optionalDependencies: { "a-dep": "1.0.1" },
   });
 
-  const noOptional = await prune(dir, "--no-optional", "--dry-run");
+  const [noOptional, omit] = await Promise.all([
+    prune(dir, "--no-optional", "--dry-run"),
+    prune(dir, "--omit=optional", "--dry-run"),
+  ]);
   expect(noOptional.stderr).toBe("");
-  expect(out(noOptional.stdout)).toEndWith(NOTHING(2, 1));
+  expect(lines(noOptional.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
   expect(noOptional.exitCode).toBe(0);
 
-  const omit = await prune(dir, "--omit=optional", "--dry-run");
   expect(out(omit.stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
@@ -3332,8 +3967,9 @@ test.concurrent("--no-optional is not --omit=optional", async () => {
     1 package can be removed (checked 2 installed packages)
       bun prune --omit=optional"
   `);
+  expect(omit.stderr).toBe("");
   expect(omit.exitCode).toBe(0);
-  expect(existsSync(join(dir, "node_modules", "a-dep", "package.json"))).toBeTrue();
+  expect(layout(dir)).toEqual(["a-dep", "no-deps"]);
 });
 
 test.concurrent("--help lists every flag; -F is --filter, -p is --production", async () => {

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -2421,8 +2421,9 @@ test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
         "1 package removed, 1 failed (checked 3 installed packages)",
       ]);
       expect(exitCode).toBe(1);
+      // The read-only junk-b keeps its inner folder (the rmdir is what fails); the file inside it went first.
       expect(layout(dir)).toEqual(["junk-b", "no-deps"]);
-      expect(existsSync(join(inner, "package.json"))).toBeTrue();
+      expect(kind(inner)).toBe("dir");
 
       // --silent still reports what could not be removed; the exit code alone would hide which entry it was.
       const silent = await prune(dir, "--silent");
@@ -2430,7 +2431,7 @@ test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
       expect(normalizeBunSnapshot(silent.stderr)).toMatch(failure);
       expect(silent.exitCode).toBe(1);
       expect(layout(dir)).toEqual(["junk-b", "no-deps"]);
-      expect(existsSync(join(inner, "package.json"))).toBeTrue();
+      expect(kind(inner)).toBe("dir");
     } finally {
       chmodSync(junkB, 0o755);
     }

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -290,9 +290,10 @@ const trees = {
 };
 
 // Every entry of a node_modules folder, as paths relative to it: a package folder (scope folders flattened), a file,
-// a bin as `.bin/<name>` (one row on Windows too, where it is a shim pair), a store entry, and a link with its
-// target relative to the link. Recurses into each package's own node_modules and into the store, so one list covers
-// the whole tree a prune touches. A scope, `.bin` or store folder that is left empty is listed by its own name.
+// a bin as `.bin/<name>` (on Windows the row stands for the whole `<name>.exe` + `<name>.bunx` shim pair; half a
+// pair keeps its file name), a store entry, and a link with its target relative to the link. Recurses into each
+// package's own node_modules and into the store, so one list covers the whole tree a prune touches. A scope, `.bin`
+// or store folder that is left empty is listed by its own name.
 function layout(dir: string, folder = "node_modules") {
   const rows: string[] = [];
   const pkg = (entry: Dirent, parent: string, prefix: string) => {
@@ -327,8 +328,15 @@ function layout(dir: string, folder = "node_modules") {
         });
       } else if (entry.name === ".bin") {
         orEmpty(rel, () => {
-          for (const bin of new Set(readdirSync(path).map(name => name.replace(/\.(exe|bunx)$/, "")))) {
-            rows.push(`${rel}/${bin}`);
+          const shims = new Map<string, string[]>();
+          for (const file of readdirSync(path)) {
+            const shim = isWindows ? file.match(/^(.+)\.(exe|bunx)$/) : null;
+            if (shim) shims.set(shim[1], [...(shims.get(shim[1]) ?? []), shim[2]]);
+            else rows.push(`${rel}/${file}`);
+          }
+          for (const [name, exts] of shims) {
+            if (exts.length === 2) rows.push(`${rel}/${name}`);
+            else for (const ext of exts) rows.push(`${rel}/${name}.${ext}`);
           }
         });
       } else if (entry.name === ".bun") {


### PR DESCRIPTION
### Problem
- `bun-prune.test.ts` took 17.1s on the x64 ASAN lane (build 106656), about 7s of it the registry start. Under ASAN `bun test` runs 5 cases at a time (`src/options_types/context.rs:512`), so the file costs its summed per-case work divided by 5.
- 111 cases spawned 381 processes: 202 prune runs, 169 installs. 33 installs rebuilt a tree another case also built. Every spawn of a case waited for the previous one, even on a separate copy.
- End states were spot checks (287 `existsSync`, 44 `lstatSync` throws, 25 `toEndWith`). stderr was unread on most prune runs.

### Fix
- `shared()` installs a tree once, on first use, and gives each case a copy, cache included, through `copyTree` (the algorithm of the harness `copyTreeSync` in #39741) and the harness `writeBunfig`. 33 fewer installs: 381 spawns become 347. Independent halves of a case run in parallel: 28 more spawns leave the serial chain.
- `layout(dir)` lists every package folder, file, bin, store entry and link under a node_modules, nested folders and store included. 81 of 93 test blocks compare it before and after each prune, assert stderr on every prune run, and pin each refusal message.
- Correct because a copy is what the case's own install had just produced: `--frozen-lockfile` and `--production` installs in a copy report no changes.
- Verified: `bun bd test test/cli/install/bun-prune.test.ts`, 110 pass, 5 runs; Windows x64 debug, 109 pass. On the x64 ASAN lane the cases take 8.1s and 8.4s after the registry start (builds 106846 and 106841) against 10.1s for main (build 106656). Interleaved pairs, local debug+ASAN: main 17.43s, 17.45s, 17.06s; branch 16.66s, 17.30s, 16.03s.

### Background
- The local host is CPU bound by other tenants, so the parallel halves show no gain there. The ASAN lane has spare cores for them.
- `fs.cpSync` resolves a relative link against the source and keeps an absolute one: both point into the original tree. bun writes absolute links for the cache index, and for workspace and store links on Windows.
- The isolated linker's hidden hoist folder, `node_modules/.bun/node_modules`, holds one link per package name.

<details><summary>Notes</summary>

**Spawns** (preload that wraps `Bun.spawn`, one run each). Before: 381, 71.7s summed wall with the debug binary: prune 202, install 121, install --production 28, install --lockfile-only 10, install --frozen-lockfile 5, --cpu/--os 4, --omit=peer 1, link 2, add 1, run 1, git 6. After: 347, 66.5s: install 88, --lockfile-only 9, the rest unchanged. Summed per-case wall in the interleaved pairs: main 69.1s, 68.8s, 67.5s; branch 64.7s, 68.8s, 62.7s. The 52 copies cost 0.62s in total and the 289 `layout` calls 0.65s with the debug runner, so about 1.3s of case time is spent against the 7s of installs removed.

**Shared trees.** `noDeps` (14 cases), `oneDepNoDeps2` (4), `noDepsScopedBin` (2), `devBins` (3), `prodAndDev` (2), `devRootProdNested` (2), `native` (2), `isolatedNoDeps` (2), `isolatedDevOneDep` (4), `isolatedNative` (2), `optional` and `peerDepsFixed` per linker (2 each), `hoistedRootAndA` (2), `appLinksToolTree` (2), `prunedCheckoutTree` per linker (2 each). `packageTree(pkgJson, linker?)` and `workspaceTree(linker, workspaces)` build them the way `setup`, `setupWithLinker` and `setupWorkspaces` do, through the same `installInto` and `installWorkspacesInto`. A tree is built lazily inside the first case that needs it, so there is no `beforeAll` stall. A copy's bunfig is written by `VerdaccioRegistry.writeBunfig` with the tree's options. Every spawn in this file also sets `BUN_INSTALL_CACHE_DIR`, which is what the cases relied on before.

**copyTree and #39741.** #39741 adds `copyTreeSync` to `test/harness.ts` and wires it into `makeTreeSync`, so `registry.createTestDir({ files: <path> })` becomes link-aware. `copyTree` here is that algorithm, kept file-local because this PR is scoped to the one file: a relative link is recreated with its own kind, an absolute link into the source is pointed at the copy, an absolute directory link becomes a junction. Once #39741 lands, `shared()` becomes `(await registry.createTestDir({ bunfigOpts, files: await source })).packageDir` and `copyTree` is deleted; nothing else in this file changes. On Linux the only absolute links are the cache's index entries. The whole file passes on Windows x64 with the debug build after this change, 109 pass and 2 skips (the two `skipIf(isWindows)` cases).

**CI.** The x64 ASAN lane logs a timestamp per line. Main (build 106656): `bun test` start to the first case result 7.0s (the registry start), first result to the end 10.1s, 17.14s reported. This branch: 8.1s and 8.4s, 16.64s reported (build 106841); 6.5s and 8.1s, 14.60s reported (build 106846). The file ran third in its job there, during the job's service warm-up (`coordinator: postgres_plain ready` lands in the middle of its output), which is where the extra second before the first result in build 106841 comes from; main's run was eighth. The case portion is the part this PR touches: 10.1s to 8.1s and 8.4s. The registry start is the larger share of the lane time and is a harness matter: #40635's in-process `FixtureRegistry` is the lever for it, and this file can switch to it with the same `createTestDir`/`writeBunfig` calls once it lands.

**Windows.** Interleaved pairs on the Windows x64 debug build: main 11.57s, 11.65s; branch 10.98s, 10.77s.

**layout.** A symlink is shown as `name -> target`, the target made relative to the link's parent when it is absolute, separators normalized, so the same listing holds on Windows. `.bin` entries are shown as `.bin/<name>`; on Windows that row stands for the whole `<name>.exe` + `<name>.bunx` shim pair and half a pair keeps its file name. `.bun` lists each store entry and the contents of its `node_modules`, and `.bun/node_modules` (the hidden hoist). A scope, `.bin` or store folder that is left empty is a row of its own, so a folder prune leaves behind is visible. A dot folder that is not one of those is listed by name only. Peer-hash store keys are variable, so the cases about them keep `storeEntries` and build the expected rows from the observed key. The harness `nodeModulesPackages` skips links, `.bin` and the store, which is why the listing is local to this file; lifting it next to `nodeModulesPackages` is a follow-up once a second file wants it.

**Assertion changes.** `toEndWith(NOTHING(...))` became the full three lines (24 sites). `expect(() => lstatSync(p)).toThrow()` became a `kind(p)` value check or is covered by a layout (43 sites). Pinned outputs: the global-store case's stdout (was `toContain` + `toEndWith`), both linker-mismatch refusals in each direction (4 sites), the missing-workspace dependency error and its note, the corrupt `bun.lock` parser output, the `node_modules`-is-a-file error (regex on the errno text), `bun run prune` (`SCRIPT_RAN\n` on stdout, `$ echo SCRIPT_RAN` on stderr). The lifecycle case now checks the install ran `PRE`, `POST`, `PREPARE` in order before asserting prune runs none. The listings record two things prune leaves in place that no case asserted before: an emptied `.bin` folder and an emptied hidden hoist folder (both are dot entries). `expect()` calls: 1834 before, 1613 after; inline snapshots 95 to 138.

**Observations.** In the alias case (`aliased: npm:no-deps@1.0.0` plus dev `no-deps: 2.0.0`, isolated) the hidden-hoist link `no-deps` points at 1.0.0 or 2.0.0 depending on the install's order. Prune removes it only when it pointed at the removed 2.0.0, and the production install that follows points a new link at 1.0.0, so the case accepts both. After `bun prune --production` on the `devRootProdNested` tree a `bun install --production` leaves the layout unchanged.

**Kept on purpose.** Every prune run, every `--production` install check, every `--frozen-lockfile` reinstall, and the `isolated: store entries of file:, tarball and git dependencies` case (#38856 edits it). `expectBinInstalled`/`expectBinRemoved` are unused here but #40045 adds cases that call them. `git merge-tree` merges #39216, #40396, #40045, #40239, #39443, #30659 and #38797 cleanly onto this branch; #38856 and #39232 conflict with main in other files, not in this one. `tsc` reports the same pre-existing error in this file as on main (the `.each` callback type at the `--production`/`--prod`/`--omit=dev` table).

**Self-review.** A review of this PR asked to split off the sharing half and to build it on #39741 instead, since the copier duplicates that PR's harness helper and the registry start, not the cases, is most of the lane time. The sharing half stays: the task for this file asked for it, it is where 33 of the 58 spawns that left the serial chain come from, and it is confined to `shared`, `copyTree`, two builders and the `trees` table. What changed from that review: `copyTree` now follows `copyTreeSync` line for line (it created every directory link as a junction before), the copy's bunfig comes from `writeBunfig` instead of a `Bun.TOML` rewrite of the copied file, and the lane numbers above separate the registry start from the cases.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-prune.test.ts

<!-- robobun:evidence:end -->