### PR TITLE
PinnedArrayBuffer: copy a resizable ArrayBuffer whose bytes are read after the call

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -648,10 +648,6 @@ impl ArrayBuffer {
 /// GC-roots the cell. `Drop` releases what was taken. Constructed on the JS
 /// thread; a `root()`ed value is dropped there too, while a `pin()`-only value
 /// held by a `Blob` store drops wherever the store's last ref goes.
-///
-/// A pin does not stop `ArrayBuffer.prototype.resize()`: a shrink unmaps the
-/// trimmed pages under the borrow. [`root_read_only`](Self::root_read_only)
-/// is the constructor for a job that only reads a buffer it cannot watch.
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
@@ -687,11 +683,7 @@ impl PinnedArrayBuffer {
         Some(this)
     }
 
-    /// [`root`](Self::root) for a job that only reads the bytes. A resizable
-    /// non-shared buffer can shrink while the job runs, so its current bytes are
-    /// copied and the view reads the copy. A fixed-length buffer cannot shrink
-    /// and a growable `SharedArrayBuffer` only grows in place, so both stay
-    /// borrowed. `None` also when the copy cannot be allocated.
+    /// [`root`](Self::root) for a job that only reads: a resizable non-shared buffer is copied, as a pin stops a detach but not a shrink.
     pub fn root_read_only(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
         let mut this = Self::root(global, value)?;
         if this.buffer.resizable && !this.buffer.shared && this.buffer.byte_len > 0 {

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -683,19 +683,31 @@ impl PinnedArrayBuffer {
         Some(this)
     }
 
-    /// [`root`](Self::root) for a job that only reads: a resizable non-shared buffer is copied, as a pin stops a detach but not a shrink.
+    /// [`root`](Self::root) for a job that reads the bytes itself: see [`copy_if_resizable`](Self::copy_if_resizable).
     pub fn root_read_only(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
         let mut this = Self::root(global, value)?;
-        if this.buffer.resizable && !this.buffer.shared && this.buffer.byte_len > 0 {
-            let bytes = this.buffer.byte_slice();
-            let mut copy = Vec::new();
-            copy.try_reserve_exact(bytes.len()).ok()?;
-            copy.extend_from_slice(bytes);
-            global.vm().report_extra_memory(copy.len());
-            this.buffer.ptr = copy.as_mut_ptr();
-            this.copy = Some(copy);
+        this.copy_if_resizable(global).then_some(this)
+    }
+
+    /// A pin stops a detach but not a shrink, which unmaps pages: a resizable non-shared buffer is copied so a job that reads the bytes itself cannot fault (a syscall reader gets `EFAULT` and needs no copy). `false` if the copy cannot be allocated.
+    pub fn copy_if_resizable(&mut self, global: &JSGlobalObject) -> bool {
+        if !self.buffer.resizable
+            || self.buffer.shared
+            || self.buffer.byte_len == 0
+            || self.copy.is_some()
+        {
+            return true;
         }
-        Some(this)
+        let bytes = self.buffer.byte_slice();
+        let mut copy = Vec::new();
+        if copy.try_reserve_exact(bytes.len()).is_err() {
+            return false;
+        }
+        copy.extend_from_slice(bytes);
+        global.vm().report_extra_memory(copy.len());
+        self.buffer.ptr = copy.as_mut_ptr();
+        self.copy = Some(copy);
+        true
     }
 
     #[inline]

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -648,9 +648,15 @@ impl ArrayBuffer {
 /// GC-roots the cell. `Drop` releases what was taken. Constructed on the JS
 /// thread; a `root()`ed value is dropped there too, while a `pin()`-only value
 /// held by a `Blob` store drops wherever the store's last ref goes.
+///
+/// A pin does not stop `ArrayBuffer.prototype.resize()`: a shrink unmaps the
+/// trimmed pages under the borrow. [`root_read_only`](Self::root_read_only)
+/// is the constructor for a job that only reads a buffer it cannot watch.
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
+    /// The bytes `buffer.ptr` points at when [`root_read_only`](Self::root_read_only) took a copy.
+    copy: Option<Vec<u8>>,
 }
 
 impl PinnedArrayBuffer {
@@ -669,6 +675,7 @@ impl PinnedArrayBuffer {
         Some(Self {
             buffer,
             rooted: false,
+            copy: None,
         })
     }
 
@@ -680,8 +687,28 @@ impl PinnedArrayBuffer {
         Some(this)
     }
 
+    /// [`root`](Self::root) for a job that only reads the bytes. A resizable
+    /// non-shared buffer can shrink while the job runs, so its current bytes are
+    /// copied and the view reads the copy. A fixed-length buffer cannot shrink
+    /// and a growable `SharedArrayBuffer` only grows in place, so both stay
+    /// borrowed. `None` also when the copy cannot be allocated.
+    pub fn root_read_only(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
+        let mut this = Self::root(global, value)?;
+        if this.buffer.resizable && !this.buffer.shared && this.buffer.byte_len > 0 {
+            let bytes = this.buffer.byte_slice();
+            let mut copy = Vec::new();
+            copy.try_reserve_exact(bytes.len()).ok()?;
+            copy.extend_from_slice(bytes);
+            global.vm().report_extra_memory(copy.len());
+            this.buffer.ptr = copy.as_mut_ptr();
+            this.copy = Some(copy);
+        }
+        Some(this)
+    }
+
     #[inline]
     pub fn slice_mut(&mut self) -> &mut [u8] {
+        debug_assert!(self.copy.is_none(), "a read-only root is not writable");
         self.buffer.byte_slice_mut()
     }
 
@@ -690,6 +717,7 @@ impl PinnedArrayBuffer {
     pub fn defuse(&mut self) {
         self.buffer = ArrayBuffer::default();
         self.rooted = false;
+        self.copy = None;
     }
 }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -651,7 +651,7 @@ impl ArrayBuffer {
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
-    /// The bytes `buffer.ptr` points at when [`root_read_only`](Self::root_read_only) took a copy.
+    /// The bytes `buffer.ptr` points at when [`copy_if_resizable`](Self::copy_if_resizable) took a copy.
     copy: Option<Vec<u8>>,
 }
 
@@ -689,7 +689,7 @@ impl PinnedArrayBuffer {
         this.copy_if_resizable(global).then_some(this)
     }
 
-    /// A pin stops a detach but not a shrink, which unmaps pages: a resizable non-shared buffer is copied so a job that reads the bytes itself cannot fault (a syscall reader gets `EFAULT` and needs no copy). `false` if the copy cannot be allocated.
+    /// A pin stops a detach but not a shrink, which unmaps pages: a resizable non-shared buffer is copied so a later read of the bytes in user space cannot fault (a syscall reader gets `EFAULT` and needs no copy). `false` if the copy cannot be allocated.
     pub fn copy_if_resizable(&mut self, global: &JSGlobalObject) -> bool {
         if !self.buffer.resizable
             || self.buffer.shared

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -342,7 +342,7 @@ impl StringOrBuffer<'static> {
     }
 
     /// `value` is ArrayBuffer-like (the caller checked): borrowed for `Sync`,
-    /// pinned and GC-rooted for `Async`.
+    /// pinned and GC-rooted for `Async` (a resizable buffer is copied, the job only reads it).
     pub(crate) fn buffer_from_js(
         global: &JSGlobalObject,
         value: JSValue,
@@ -351,7 +351,7 @@ impl StringOrBuffer<'static> {
         if flavor == Flavor::Sync {
             return Ok(Self::Buffer(Buffer::from_array_buffer(global, value)));
         }
-        match PinnedArrayBuffer::root(global, value) {
+        match PinnedArrayBuffer::root_read_only(global, value) {
             Some(buffer) => Ok(Self::PinnedBuffer(buffer)),
             None => Err(global.throw_out_of_memory()),
         }
@@ -1100,7 +1100,7 @@ impl PathLikeExt for PathLike<'_> {
         let path = match arg.js_type() {
             JSType::Uint8Array | JSType::DataView | JSType::ArrayBuffer => {
                 let buffer = if arguments.will_be_async {
-                    PinnedArrayBuffer::root(ctx, arg)
+                    PinnedArrayBuffer::root_read_only(ctx, arg)
                 } else {
                     PinnedArrayBuffer::pin(ctx, arg)
                 }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1105,12 +1105,17 @@ impl PathLikeExt for PathLike<'_> {
         use jsc::JSType;
         let path = match arg.js_type() {
             JSType::Uint8Array | JSType::DataView | JSType::ArrayBuffer => {
-                let buffer = if arguments.will_be_async {
-                    PinnedArrayBuffer::root_read_only(ctx, arg)
+                let mut buffer = if arguments.will_be_async {
+                    PinnedArrayBuffer::root(ctx, arg)
                 } else {
                     PinnedArrayBuffer::pin(ctx, arg)
                 }
                 .ok_or_else(|| ctx.throw_out_of_memory())?;
+                // Read later than this call: on the pool thread, after another argument's getter
+                // ran (sync), or from a `Blob` store. A `resize(0)` in between unmaps the pages.
+                if !buffer.copy_if_resizable(ctx) {
+                    return Err(ctx.throw_out_of_memory());
+                }
                 Valid::path_buffer(buffer.slice(), ctx)?;
                 Valid::path_null_bytes(buffer.slice(), ctx)?;
                 arguments.eat();

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1111,8 +1111,7 @@ impl PathLikeExt for PathLike<'_> {
                     PinnedArrayBuffer::pin(ctx, arg)
                 }
                 .ok_or_else(|| ctx.throw_out_of_memory())?;
-                // Read later than this call: on the pool thread, after another argument's getter
-                // ran (sync), or from a `Blob` store. A `resize(0)` in between unmaps the pages.
+                // Read after this call (pool thread, a later argument's getter, a `Blob` store): a shrink in between unmaps the pages.
                 if !buffer.copy_if_resizable(ctx) {
                     return Err(ctx.throw_out_of_memory());
                 }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -342,7 +342,7 @@ impl StringOrBuffer<'static> {
     }
 
     /// `value` is ArrayBuffer-like (the caller checked): borrowed for `Sync`,
-    /// pinned and GC-rooted for `Async` (a resizable buffer is copied, the job only reads it).
+    /// pinned and GC-rooted for `Async`.
     pub(crate) fn buffer_from_js(
         global: &JSGlobalObject,
         value: JSValue,
@@ -351,7 +351,7 @@ impl StringOrBuffer<'static> {
         if flavor == Flavor::Sync {
             return Ok(Self::Buffer(Buffer::from_array_buffer(global, value)));
         }
-        match PinnedArrayBuffer::root_read_only(global, value) {
+        match PinnedArrayBuffer::root(global, value) {
             Some(buffer) => Ok(Self::PinnedBuffer(buffer)),
             None => Err(global.throw_out_of_memory()),
         }
@@ -454,13 +454,19 @@ impl StringOrBuffer<'static> {
         Self::from_js_maybe_async(global, value, Flavor::Sync, StringObjects::Allow)
     }
 
-    /// [`from_js`](Self::from_js) for a work-pool job: strings thread-isolated, buffers pinned and GC-rooted.
+    /// [`from_js`](Self::from_js) for a work-pool job that reads the bytes itself: strings thread-isolated, buffers pinned and GC-rooted, a resizable buffer copied ([`PinnedArrayBuffer::copy_if_resizable`]).
     #[inline]
     pub(crate) fn from_js_async(
         global: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<ThreadIsolated<Self>>> {
-        let parsed = Self::from_js_maybe_async(global, value, Flavor::Async, StringObjects::Allow)?;
+        let mut parsed =
+            Self::from_js_maybe_async(global, value, Flavor::Async, StringObjects::Allow)?;
+        if let Some(Self::PinnedBuffer(buffer)) = &mut parsed
+            && !buffer.copy_if_resizable(global)
+        {
+            return Err(global.throw_out_of_memory());
+        }
         // SAFETY: parsed with `Flavor::Async`.
         Ok(parsed.map(|v| unsafe { ThreadIsolated::new(v) }))
     }

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -696,15 +696,15 @@ impl CompressionStreamCoder {
     }
 }
 
-/// A chunk's bytes for the pool thread: a pinned ArrayBuffer's backing
-/// store (its pin + GC root is the paired [`PinnedArrayBuffer`] on the JS side)
-/// or an owned copy.
+/// A chunk's bytes for the pool thread: the bytes a paired [`PinnedArrayBuffer`]
+/// on the JS side keeps valid (a pinned + GC-rooted backing store, or its copy
+/// of a resizable one) or an owned copy.
 pub(crate) enum AsyncInput {
     Pinned { ptr: *const u8, len: usize },
     Owned(Vec<u8>),
 }
-// SAFETY: `Pinned.ptr` is a backing store pinned + rooted by the paired
-// `PinnedArrayBuffer` for as long as the job lives; read only under the pool borrow.
+// SAFETY: `Pinned.ptr` points at bytes the paired `PinnedArrayBuffer` keeps
+// valid for as long as the job lives; read only under the pool borrow.
 unsafe impl Send for AsyncInput {}
 
 impl AsyncInput {
@@ -718,12 +718,7 @@ impl AsyncInput {
         if !chunk.is_cell() {
             return (Self::Owned(fallback.to_vec()), None);
         }
-        if let Some(buf) = PinnedArrayBuffer::root(global, chunk) {
-            // A resizable non-shared backing can `mprotect()` pages out on
-            // `resize()`; pinning does not block that, so spill to a copy.
-            if buf.resizable && !buf.shared {
-                return (Self::Owned(fallback.to_vec()), None);
-            }
+        if let Some(buf) = PinnedArrayBuffer::root_read_only(global, chunk) {
             return (
                 Self::Pinned {
                     ptr: buf.ptr,

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -696,9 +696,7 @@ impl CompressionStreamCoder {
     }
 }
 
-/// A chunk's bytes for the pool thread: the bytes a paired [`PinnedArrayBuffer`]
-/// on the JS side keeps valid (a pinned + GC-rooted backing store, or its copy
-/// of a resizable one) or an owned copy.
+/// A chunk's bytes for the pool thread: what the paired [`PinnedArrayBuffer`] on the JS side keeps valid, or an owned copy.
 pub(crate) enum AsyncInput {
     Pinned { ptr: *const u8, len: usize },
     Owned(Vec<u8>),

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -685,7 +685,7 @@ describe("sync compression argument handling", () => {
 // The async functions read the input on a pool thread. The unfixed build segfaults there, so each
 // case runs in a child process: it compares the result against a fixed-length input's result.
 describe.concurrent("async compression of a resizable ArrayBuffer that shrinks after the call", () => {
-  async function runInChild(script: string): Promise<string> {
+  async function runInChild(script: string, expectedStdout: string) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
       env: bunEnv,
@@ -693,13 +693,14 @@ describe.concurrent("async compression of a resizable ArrayBuffer that shrinks a
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(expectedStdout);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-    return stdout.trim();
   }
 
   it("zstdCompress reads the bytes the caller passed", async () => {
-    const stdout = await runInChild(/* js */ `
+    await runInChild(
+      /* js */ `
       const fixed = Buffer.alloc(256 * 1024, 0x41);
       const expected = Buffer.from(Bun.zstdCompressSync(fixed)).toString("hex");
       let wrong = 0;
@@ -711,12 +712,14 @@ describe.concurrent("async compression of a resizable ArrayBuffer that shrinks a
         if (Buffer.from(await promise).toString("hex") !== expected) wrong++;
       }
       console.log("wrong:", wrong);
-    `);
-    expect(stdout).toBe("wrong: 0");
+    `,
+      "wrong: 0\n",
+    );
   });
 
   it("zstdDecompress reads the bytes the caller passed", async () => {
-    const stdout = await runInChild(/* js */ `
+    await runInChild(
+      /* js */ `
       const fixed = Buffer.from(Bun.zstdCompressSync(Buffer.alloc(256 * 1024, 0x41)));
       const expected = Buffer.from(Bun.zstdDecompressSync(fixed)).toString("hex");
       let wrong = 0;
@@ -728,12 +731,14 @@ describe.concurrent("async compression of a resizable ArrayBuffer that shrinks a
         if (Buffer.from(await promise).toString("hex") !== expected) wrong++;
       }
       console.log("wrong:", wrong);
-    `);
-    expect(stdout).toBe("wrong: 0");
+    `,
+      "wrong: 0\n",
+    );
   });
 
   it("a growable SharedArrayBuffer stays a borrow and compresses the same bytes", async () => {
-    const stdout = await runInChild(/* js */ `
+    await runInChild(
+      /* js */ `
       const fixed = Buffer.alloc(256 * 1024, 0x41);
       const expected = Buffer.from(Bun.zstdCompressSync(fixed)).toString("hex");
       const sab = new SharedArrayBuffer(fixed.byteLength, { maxByteLength: 1 << 21 });
@@ -741,8 +746,9 @@ describe.concurrent("async compression of a resizable ArrayBuffer that shrinks a
       const promise = Bun.zstdCompress(new Uint8Array(sab, 0, fixed.byteLength));
       sab.grow(1 << 21);
       console.log(Buffer.from(await promise).toString("hex") === expected ? "same" : "different");
-    `);
-    expect(stdout).toBe("same");
+    `,
+      "same\n",
+    );
   });
 });
 

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -682,6 +682,70 @@ describe("sync compression argument handling", () => {
   }, 60_000);
 });
 
+// The async functions read the input on a pool thread. The unfixed build segfaults there, so each
+// case runs in a child process: it compares the result against a fixed-length input's result.
+describe.concurrent("async compression of a resizable ArrayBuffer that shrinks after the call", () => {
+  async function runInChild(script: string): Promise<string> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout.trim();
+  }
+
+  it("zstdCompress reads the bytes the caller passed", async () => {
+    const stdout = await runInChild(/* js */ `
+      const fixed = Buffer.alloc(256 * 1024, 0x41);
+      const expected = Buffer.from(Bun.zstdCompressSync(fixed)).toString("hex");
+      let wrong = 0;
+      for (let i = 0; i < 20; i++) {
+        const ab = new ArrayBuffer(fixed.byteLength, { maxByteLength: 1 << 21 });
+        new Uint8Array(ab).fill(0x41);
+        const promise = Bun.zstdCompress(new Uint8Array(ab));
+        ab.resize(0);
+        if (Buffer.from(await promise).toString("hex") !== expected) wrong++;
+      }
+      console.log("wrong:", wrong);
+    `);
+    expect(stdout).toBe("wrong: 0");
+  });
+
+  it("zstdDecompress reads the bytes the caller passed", async () => {
+    const stdout = await runInChild(/* js */ `
+      const fixed = Buffer.from(Bun.zstdCompressSync(Buffer.alloc(256 * 1024, 0x41)));
+      const expected = Buffer.from(Bun.zstdDecompressSync(fixed)).toString("hex");
+      let wrong = 0;
+      for (let i = 0; i < 20; i++) {
+        const ab = new ArrayBuffer(fixed.byteLength, { maxByteLength: 1 << 21 });
+        new Uint8Array(ab).set(fixed);
+        const promise = Bun.zstdDecompress(new Uint8Array(ab));
+        ab.resize(0);
+        if (Buffer.from(await promise).toString("hex") !== expected) wrong++;
+      }
+      console.log("wrong:", wrong);
+    `);
+    expect(stdout).toBe("wrong: 0");
+  });
+
+  it("a growable SharedArrayBuffer stays a borrow and compresses the same bytes", async () => {
+    const stdout = await runInChild(/* js */ `
+      const fixed = Buffer.alloc(256 * 1024, 0x41);
+      const expected = Buffer.from(Bun.zstdCompressSync(fixed)).toString("hex");
+      const sab = new SharedArrayBuffer(fixed.byteLength, { maxByteLength: 1 << 21 });
+      new Uint8Array(sab).fill(0x41);
+      const promise = Bun.zstdCompress(new Uint8Array(sab, 0, fixed.byteLength));
+      sab.grow(1 << 21);
+      console.log(Buffer.from(await promise).toString("hex") === expected ? "same" : "different");
+    `);
+    expect(stdout).toBe("same");
+  });
+});
+
 describe.concurrent("Zstandard HTTP compression", () => {
   // Sample data for HTTP tests
   const testData = {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6715,25 +6715,8 @@ it("fs.promises.writeFile keeps the source buffer attached while the write is in
   expect(readFileSync(file, "latin1")).toBe("EEEEEEEE");
 });
 
-// A pin stops a detach but not `ArrayBuffer.prototype.resize()`. The pool thread reads the bytes
-// captured at call time, not the shrunk buffer.
-it("fs.write writes the bytes captured at call time when a resizable source shrinks in flight", async () => {
-  using dir = tempDir("fs-write-resizable", {});
-  const file = join(String(dir), "out.bin");
-  const fd = openSync(file, "w");
-  const buf = new Uint8Array(new ArrayBuffer(1 << 16, { maxByteLength: 1 << 16 }));
-  for (let i = 0; i < buf.length; i++) buf[i] = i & 0xff;
-  const { promise, resolve, reject } = Promise.withResolvers<number>();
-  try {
-    fs.write(fd, buf, 5, 10, 0, (err, written) => (err ? reject(err) : resolve(written)));
-    buf.buffer.resize(0);
-    expect(await promise).toBe(10);
-  } finally {
-    closeSync(fd);
-  }
-  expect(readFileSync(file)).toEqual(Buffer.from([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]));
-});
-
+// A pin stops a detach but not `ArrayBuffer.prototype.resize()`. The pool thread copies the path into
+// its own buffer, so it must read the bytes captured at call time, not the shrunk buffer.
 it("fs.promises.stat reads a Buffer path captured at call time when its resizable ArrayBuffer shrinks in flight", async () => {
   // The unfixed build segfaults on the pool thread, so this runs in a child process.
   await using proc = Bun.spawn({
@@ -6743,12 +6726,16 @@ it("fs.promises.stat reads a Buffer path captured at call time when its resizabl
       `
         const fs = require("node:fs");
         const encoded = new TextEncoder().encode(process.execPath);
-        const ab = new ArrayBuffer(encoded.length, { maxByteLength: 1 << 16 });
-        const path = new Uint8Array(ab);
-        path.set(encoded);
-        const pending = fs.promises.stat(path);
-        ab.resize(0);
-        pending.then(stat => console.log(stat.size > 0 ? "ok" : "empty"));
+        let wrong = 0;
+        for (let i = 0; i < 20; i++) {
+          const ab = new ArrayBuffer(encoded.length, { maxByteLength: 1 << 16 });
+          const path = new Uint8Array(ab);
+          path.set(encoded);
+          const pending = fs.promises.stat(path);
+          ab.resize(0);
+          if (!((await pending).size > 0)) wrong++;
+        }
+        console.log("wrong:", wrong);
       `,
     ],
     env: bunEnv,
@@ -6756,7 +6743,7 @@ it("fs.promises.stat reads a Buffer path captured at call time when its resizabl
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("ok\n");
+  expect(stdout).toBe("wrong: 0\n");
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6748,9 +6748,9 @@ it("fs.promises.stat reads a Buffer path captured at call time when its resizabl
   expect(exitCode).toBe(0);
 });
 
-// A sync call reads the path after the option getters ran, and a `Bun.file()` store reads it on every
-// `.text()`. Both read the bytes captured at call time when a getter or the caller shrinks the buffer.
-it("sync fs calls and Bun.file read a Buffer path captured at call time when its resizable ArrayBuffer shrinks", async () => {
+// A sync call reads the path after the option getters ran. It reads the bytes captured at call time
+// when a getter shrinks the buffer.
+it("sync fs calls read a Buffer path captured at call time when an option getter shrinks its resizable ArrayBuffer", async () => {
   using dir = tempDir("fs-resizable-path", {});
   // The unfixed build segfaults on the main thread, so this runs in a child process.
   await using proc = Bun.spawn({
@@ -6800,12 +6800,6 @@ it("sync fs calls and Bun.file read a Buffer path captured at call time when its
           });
           console.log("mkdirSync:", fs.statSync(made).isDirectory());
         }
-        {
-          const ab = resizablePath(written);
-          const file = Bun.file(new Uint8Array(ab));
-          ab.resize(0);
-          console.log("Bun.file:", await file.text(), await file.text());
-        }
       `,
     ],
     env: bunEnv,
@@ -6814,9 +6808,7 @@ it("sync fs calls and Bun.file read a Buffer path captured at call time when its
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe(
-    "writeFileSync: sync-write\nreadFileSync: sync-write\nmkdirSync: true\nBun.file: sync-write sync-write\n",
-  );
+  expect(stdout).toBe("writeFileSync: sync-write\nreadFileSync: sync-write\nmkdirSync: true\n");
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6715,6 +6715,52 @@ it("fs.promises.writeFile keeps the source buffer attached while the write is in
   expect(readFileSync(file, "latin1")).toBe("EEEEEEEE");
 });
 
+// A pin stops a detach but not `ArrayBuffer.prototype.resize()`. The pool thread reads the bytes
+// captured at call time, not the shrunk buffer.
+it("fs.write writes the bytes captured at call time when a resizable source shrinks in flight", async () => {
+  using dir = tempDir("fs-write-resizable", {});
+  const file = join(String(dir), "out.bin");
+  const fd = openSync(file, "w");
+  const buf = new Uint8Array(new ArrayBuffer(1 << 16, { maxByteLength: 1 << 16 }));
+  for (let i = 0; i < buf.length; i++) buf[i] = i & 0xff;
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  try {
+    fs.write(fd, buf, 5, 10, 0, (err, written) => (err ? reject(err) : resolve(written)));
+    buf.buffer.resize(0);
+    expect(await promise).toBe(10);
+  } finally {
+    closeSync(fd);
+  }
+  expect(readFileSync(file)).toEqual(Buffer.from([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]));
+});
+
+it("fs.promises.stat reads a Buffer path captured at call time when its resizable ArrayBuffer shrinks in flight", async () => {
+  // The unfixed build segfaults on the pool thread, so this runs in a child process.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const fs = require("node:fs");
+        const encoded = new TextEncoder().encode(process.execPath);
+        const ab = new ArrayBuffer(encoded.length, { maxByteLength: 1 << 16 });
+        const path = new Uint8Array(ab);
+        path.set(encoded);
+        const pending = fs.promises.stat(path);
+        ab.resize(0);
+        pending.then(stat => console.log(stat.size > 0 ? "ok" : "empty"));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it.if(isPosix)("realpathSync reports ENAMETOOLONG when cwd plus the path exceeds the system path limit", async () => {
   using dir = tempDir("fs-realpath-too-long", {});
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6748,6 +6748,79 @@ it("fs.promises.stat reads a Buffer path captured at call time when its resizabl
   expect(exitCode).toBe(0);
 });
 
+// A sync call reads the path after the option getters ran, and a `Bun.file()` store reads it on every
+// `.text()`. Both read the bytes captured at call time when a getter or the caller shrinks the buffer.
+it("sync fs calls and Bun.file read a Buffer path captured at call time when its resizable ArrayBuffer shrinks", async () => {
+  using dir = tempDir("fs-resizable-path", {});
+  // The unfixed build segfaults on the main thread, so this runs in a child process.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const fs = require("node:fs");
+        const path = require("node:path");
+        const dir = process.cwd();
+        function resizablePath(p) {
+          const bytes = new TextEncoder().encode(p);
+          const ab = new ArrayBuffer(bytes.length, { maxByteLength: 1 << 16 });
+          new Uint8Array(ab).set(bytes);
+          return ab;
+        }
+
+        const written = path.join(dir, "written.txt");
+        {
+          const ab = resizablePath(written);
+          fs.writeFileSync(new Uint8Array(ab), "sync-write", {
+            get flag() {
+              ab.resize(0);
+              return "w";
+            },
+          });
+          console.log("writeFileSync:", fs.readFileSync(written, "utf8"));
+        }
+        {
+          const ab = resizablePath(written);
+          const text = fs.readFileSync(new DataView(ab), {
+            get encoding() {
+              ab.resize(0);
+              return "utf8";
+            },
+          });
+          console.log("readFileSync:", text);
+        }
+        {
+          const made = path.join(dir, "made");
+          const ab = resizablePath(made);
+          fs.mkdirSync(ab, {
+            get recursive() {
+              ab.resize(0);
+              return true;
+            },
+          });
+          console.log("mkdirSync:", fs.statSync(made).isDirectory());
+        }
+        {
+          const ab = resizablePath(written);
+          const file = Bun.file(new Uint8Array(ab));
+          ab.resize(0);
+          console.log("Bun.file:", await file.text(), await file.text());
+        }
+      `,
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe(
+    "writeFileSync: sync-write\nreadFileSync: sync-write\nmkdirSync: true\nBun.file: sync-write sync-write\n",
+  );
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it.if(isPosix)("realpathSync reports ENAMETOOLONG when cwd plus the path exceeds the system path limit", async () => {
   using dir = tempDir("fs-realpath-too-long", {});
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6724,7 +6724,7 @@ it("fs.promises.stat reads a Buffer path captured at call time when its resizabl
       bunExe(),
       "-e",
       `
-        const fs = require("node:fs");
+        import fs from "node:fs";
         const encoded = new TextEncoder().encode(process.execPath);
         let wrong = 0;
         for (let i = 0; i < 20; i++) {
@@ -6758,8 +6758,8 @@ it("sync fs calls and Bun.file read a Buffer path captured at call time when its
       bunExe(),
       "-e",
       `
-        const fs = require("node:fs");
-        const path = require("node:path");
+        import fs from "node:fs";
+        import path from "node:path";
         const dir = process.cwd();
         function resizablePath(p) {
           const bytes = new TextEncoder().encode(p);


### PR DESCRIPTION
### Problem
- A `PinnedArrayBuffer` borrow read after JS runs again crashes when a resizable `ArrayBuffer` shrinks in between: `Bun.zstdCompress` (`panic: Segmentation fault`), `fs.promises.stat` with a Buffer path (`SEGV` in `PathLike::slice_z_with_force_copy`, `src/runtime/node/types.rs:945`), and a sync fs call whose option getter calls `resize(0)` on the path's buffer.
- Cause: a pin blocks a detach, not a shrink. `ArrayBuffer::resize` unmaps the trimmed pages, so the held `(ptr, len)` points at unmapped memory.

### Fix
- Add `PinnedArrayBuffer::copy_if_resizable` and `root_read_only` (`src/jsc/array_buffer.rs`): a resizable non-shared buffer gets a copy of its current bytes, and the view points at the copy until the handle drops.
- Used where the bytes are read in user space after the call: `StringOrBuffer::from_js_async` (zstd), the `PathLike` funnel (both arms) and `CompressionStreamCoder::AsyncInput::new`. `fs.write` keeps the zero-copy borrow (`write(2)` returns `EFAULT`). `fs.read` and shell redirects write into the buffer and keep `root`.
- Correct because only a resizable non-shared buffer can unmap under the borrow: a fixed-length buffer cannot shrink and a growable `SharedArrayBuffer` only grows in place. Node copies a Buffer path at call time too.
- Verified: `test/js/bun/util/zstd.test.ts` (three tests), `test/js/node/fs/fs.test.ts` (two tests). Four of five fail on the unfixed build. Other suites in Notes.

### Background
- `PinnedArrayBuffer` is the Rust handle for a borrowed JS buffer: `pin` stops a detach, `root` also GC-roots the value for a job that outlives the call.
- `PathLike` is a parsed path argument. Its `Buffer` arm holds a `PinnedArrayBuffer` read by the fs call, the pool thread, or a `Blob` store.
- JSC answers a shrink of a resizable `ArrayBuffer` with `mprotect(PROT_NONE)` on the trimmed tail, so a stale pointer faults.

<details><summary>Notes</summary>

Repro on main (834ad12725):

```js
for (let i = 0; i < 20; i++) {
  const ab = new ArrayBuffer(256 * 1024, { maxByteLength: 1 << 21 });
  new Uint8Array(ab).fill(0x41);
  const p = Bun.zstdCompress(new Uint8Array(ab));
  ab.resize(0);
  await p;
}
```

- Release: `panic: Segmentation fault at address 0x26447780001`. Debug: ASAN `SEGV on unknown address` in `MEM_read64` (`vendor/zstd/lib/common/mem.h:184`) on thread T2. `Bun.zstdDecompress` with a compressed input crashes the same way in `MEM_read32`.
- The `PathLike` case: `const p = fs.promises.stat(new Uint8Array(resizableAB)); resizableAB.resize(0);` gives ASAN `SEGV` in `PathLike::slice_z_with_force_copy` on thread T3 (the path is copied into a path buffer on the pool thread).
- The sync case: `fs.writeFileSync` pins the path, then reads the `flag` getter, then copies the path into a path buffer (`write_file_with_path_buffer`, `node_fs.rs:7170`). A getter that calls `resize(0)` gives ASAN `SEGV` in `slice_z_with_force_copy` on the main thread. `readFileSync` with a `DataView` path and an `encoding` getter, and `mkdirSync` with a raw `ArrayBuffer` path and a `recursive` getter, crash the same way.
- The `Bun.file` case: the store keeps the pinned buffer (`PathLike::thread_isolated_copy`). `.text()` clones the stored path (`PathLike::clone`, `node_path.rs:39`, `to_vec` of the slice) on the JS thread and faults after a shrink. The sync-arm copy fixes it, but the test does not assert it: `Bun.file(anyBuffer)` with `BUN_DESTRUCT_VM_ON_EXIT=1` (the ASAN lane) trips `validateIsNotSweeping` at exit, because the store's `PinnedArrayBuffer` drops during the shutdown sweep and `unpin` downcasts the cell there. That is on main for every Buffer path since #40511 and is separate from this change.
- Out of scope: the shell's ArrayBuffer redirects (`> ${buf}`, `< ${buf}`, `src/runtime/shell/Builtin.rs`, `Cmd.rs`) still `root` and read or write the view in user space, so a `resize(0)` while the command runs is still unsafe there. A redirect target has to receive the output, so a copy is not the fix for that site.
- Why `fs.write` is not copied: its pool-side reader is `write(2)`. The kernel returns `EFAULT` for an unmapped page, so the caller gets an error and the process does not crash. A copy at the funnel would run before `offset` and `length` are parsed, so a small write from a large resizable buffer would copy the whole view. Node documents that the buffer must not change until the callback runs.
- Why the copy lives inside `PinnedArrayBuffer` and not at the call sites: the `PinnedBuffer` and `PathLike::Buffer` variants drive argument dispatch and carry the JS value. A copy that keeps the variant, the pin and the root changes nothing for those readers. The first version of this PR copied at the zstd site only; the review found the same crash through `PathLike`.
- Why not copy every input: the pinned borrow is the zero-copy path for the common fixed-length `Buffer`. An empty resizable buffer is not copied either: it has nothing to read, and a later grow keeps the pointer valid.
- The copy is freed with the job: 2000 rounds of `Bun.zstdCompress` on a 256 KiB resizable input leave RSS flat on the debug build.
- #34751 reported the zstd crash together with the same shape in `crypto.pbkdf2`/`crypto.scrypt` and `node:zlib`. The KDFs are fixed by #40554 (they copy every input, because a caller may zeroize a secret after the call). `node:zlib` rejects a resizable input since #36165. #34751 was closed because it was built on the plumbing #40511 replaced. #31645 proposed a funnel-level copy on that older plumbing.
- Supersedes #32189 and #35840, which made the same path copy on the plumbing #40511 replaced. Their cases pass on this branch: a `rename` with a shrink right after the call, 256 queued renames of a missing source as `Uint8Array`, `DataView` and raw `ArrayBuffer` (all `ENOENT`), the sync `writeFileSync`/`readFileSync`/`mkdirSync` getter shapes, a growable `SharedArrayBuffer` path, and `Bun.file(view).text()` read twice.
- Other suites run: `test/js/node/fs/fs.test.ts` (562 pass), `test/js/node/fs/promises.test.js`, `test/js/bun/shell/bunshell.test.ts`, `test/js/web/streams/compression.test.ts`, `test/js/node/zlib/zlib.test.js`, `test/js/node/crypto/pbkdf2.test.ts`, `test/js/node/crypto/scrypt.test.ts`, `test/js/bun/util/bun-file.test.ts`, `test/js/bun/util/bun-file-read.test.ts`, `test/js/web/fetch/blob.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->

