### PR TITLE
Run Bun.secrets and blocking getaddrinfo work on their own thread pools

### DIFF
--- a/src/jsc/JSSecrets.rs
+++ b/src/jsc/JSSecrets.rs
@@ -6,8 +6,7 @@ use bun_threading::thread_pool::{Config, DEFAULT_THREAD_STACK_SIZE};
 use crate::{JSGlobalObject, JSValue, JsResult, Strong};
 
 /// A keyring call can wait without bound (an unlock prompt nobody answers), so
-/// the calls run on their own pool and never hold up the shared `WorkPool`.
-/// The keyring daemon serializes them, so a few threads are enough.
+/// the calls get a small pool of their own instead of the shared `WorkPool`.
 const SECRETS_POOL_THREADS: u32 = 4;
 
 // Opaque pointer to C++ SecretsJobOptions struct

--- a/src/jsc/JSSecrets.rs
+++ b/src/jsc/JSSecrets.rs
@@ -1,4 +1,18 @@
+use std::sync::OnceLock;
+
+use bun_threading::ThreadPool;
+use bun_threading::thread_pool::{Config, DEFAULT_THREAD_STACK_SIZE};
+
 use crate::{JSGlobalObject, JSValue, JsResult, Strong};
+
+/// Threads for the platform credential calls. Such a call can block without
+/// bound on something outside the process: a locked keyring whose unlock
+/// prompt nobody answers, or a Secret Service that stopped replying. On the
+/// shared `WorkPool` (one thread per core) that many stuck calls would queue
+/// every file read and hash behind them for good, so the calls get a pool of
+/// their own. The keyring daemon serializes them anyway, so a few threads are
+/// enough.
+const SECRETS_POOL_THREADS: u32 = 4;
 
 // Opaque pointer to C++ SecretsJobOptions struct
 bun_opaque::opaque_ffi! { pub struct SecretsJobOptions; }
@@ -37,6 +51,16 @@ pub(crate) struct SecretsJob {
 impl crate::JobContext for SecretsJob {
     type OffThread = Self;
     type Js = Strong;
+
+    fn pool() -> &'static ThreadPool {
+        static POOL: OnceLock<ThreadPool> = OnceLock::new();
+        POOL.get_or_init(|| {
+            ThreadPool::init(Config {
+                max_threads: SECRETS_POOL_THREADS,
+                stack_size: DEFAULT_THREAD_STACK_SIZE,
+            })
+        })
+    }
 
     fn run(this: &mut Self, done: crate::Completion<Self>) -> Option<crate::Completion<Self>> {
         Bun__SecretsJobOptions__runTask(SecretsJobOptions::opaque_mut(this.options.0));

--- a/src/jsc/JSSecrets.rs
+++ b/src/jsc/JSSecrets.rs
@@ -5,13 +5,9 @@ use bun_threading::thread_pool::{Config, DEFAULT_THREAD_STACK_SIZE};
 
 use crate::{JSGlobalObject, JSValue, JsResult, Strong};
 
-/// Threads for the platform credential calls. Such a call can block without
-/// bound on something outside the process: a locked keyring whose unlock
-/// prompt nobody answers, or a Secret Service that stopped replying. On the
-/// shared `WorkPool` (one thread per core) that many stuck calls would queue
-/// every file read and hash behind them for good, so the calls get a pool of
-/// their own. The keyring daemon serializes them anyway, so a few threads are
-/// enough.
+/// A keyring call can wait without bound (an unlock prompt nobody answers), so
+/// the calls run on their own pool and never hold up the shared `WorkPool`.
+/// The keyring daemon serializes them, so a few threads are enough.
 const SECRETS_POOL_THREADS: u32 = 4;
 
 // Opaque pointer to C++ SecretsJobOptions struct

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -1,7 +1,8 @@
 //! Work that leaves the JS thread and comes back.
 //!
 //! A [`Job`] is created on the JS thread, does its heavy part on the
-//! [`WorkPool`], and completes on the JS thread again. It holds a
+//! [`WorkPool`] (or the pool its [`JobContext::pool`] names), and completes
+//! on the JS thread again. It holds a
 //! [`Ticket`](crate::Ticket) for the whole trip, so its VM is guaranteed to be
 //! alive throughout and its completion is always delivered: `then` runs while
 //! the VM may still run script, and a completion that lands after the VM began
@@ -23,7 +24,8 @@ use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
 use bun_io::KeepAlive;
-use bun_threading::work_pool::{Task as WorkPoolTask, WorkPool};
+use bun_threading::ThreadPool;
+use bun_threading::work_pool::{Batch, Task as WorkPoolTask, WorkPool};
 
 use crate::debugger::AsyncTaskTracker;
 use crate::virtual_machine::VirtualMachine;
@@ -185,6 +187,15 @@ pub trait JobContext: Sized + 'static {
     /// can wait on something external. Only such jobs are tracked by the VM.
     const CANCELLABLE: bool = false;
 
+    /// The pool [`run`](Self::run) executes on. The shared [`WorkPool`] (one
+    /// thread per core; file I/O, hashing, DNS, everything) unless `run` can
+    /// block without bound on something outside the process, such as a
+    /// keychain prompt nobody answers. Such a job names a small pool of its
+    /// own, so the instances of it that hang hold up only each other.
+    fn pool() -> &'static ThreadPool {
+        WorkPool::get()
+    }
+
     /// Pool thread, VM not yet in its final wait when the pool reached the job
     /// (a job reached later is handed back unrun, as Node's environment
     /// cleanup `uv_cancel`s queued work). Return `done` to complete now; keep
@@ -331,7 +342,7 @@ impl<C: JobContext> Job<C> {
             if C::CANCELLABLE {
                 cx.vm().jobs.with_mut(|j| j.push(&raw mut (*job).header));
             }
-            WorkPool::schedule(&raw mut (*job).task);
+            C::pool().schedule(Batch::from(&raw mut (*job).task));
         }
     }
 

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -188,10 +188,11 @@ pub trait JobContext: Sized + 'static {
     const CANCELLABLE: bool = false;
 
     /// The pool [`run`](Self::run) executes on. The shared [`WorkPool`] (one
-    /// thread per core; file I/O, hashing, DNS, everything) unless `run` can
-    /// block without bound on something outside the process, such as a
-    /// keychain prompt nobody answers. Such a job names a small pool of its
-    /// own, so the instances of it that hang hold up only each other.
+    /// thread per core; file I/O, hashing, compression, everything) unless
+    /// `run` waits on something outside the process for as long as that
+    /// takes: a keychain prompt nobody answers, a DNS resolver that does not
+    /// reply. Such a job names a pool of its own, so the instances of it that
+    /// hang hold up only each other.
     fn pool() -> &'static ThreadPool {
         WorkPool::get()
     }

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -187,12 +187,9 @@ pub trait JobContext: Sized + 'static {
     /// can wait on something external. Only such jobs are tracked by the VM.
     const CANCELLABLE: bool = false;
 
-    /// The pool [`run`](Self::run) executes on. The shared [`WorkPool`] (one
-    /// thread per core; file I/O, hashing, compression, everything) unless
-    /// `run` waits on something outside the process for as long as that
-    /// takes: a keychain prompt nobody answers, a DNS resolver that does not
-    /// reply. Such a job names a pool of its own, so the instances of it that
-    /// hang hold up only each other.
+    /// The pool [`run`](Self::run) executes on: the shared [`WorkPool`], unless
+    /// `run` waits on something outside the process for as long as that takes
+    /// (a keychain prompt, a DNS resolver). Such a job names its own pool.
     fn pool() -> &'static ThreadPool {
         WorkPool::get()
     }

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -187,9 +187,8 @@ pub trait JobContext: Sized + 'static {
     /// can wait on something external. Only such jobs are tracked by the VM.
     const CANCELLABLE: bool = false;
 
-    /// The pool [`run`](Self::run) executes on: the shared [`WorkPool`], unless
-    /// `run` waits on something outside the process for as long as that takes
-    /// (a keychain prompt, a DNS resolver). Such a job names its own pool.
+    /// The pool [`run`](Self::run) executes on. A job that waits on something
+    /// outside the process (a keychain prompt, a DNS resolver) names its own.
     fn pool() -> &'static ThreadPool {
         WorkPool::get()
     }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -975,9 +975,8 @@ pub mod get_addr_info_request {
         type OffThread = Self;
         type Js = LibcRequest;
 
-        /// `getaddrinfo` holds its thread for the whole resolver timeout when the
-        /// resolver does not answer. Lookups run on their own pool, sized like
-        /// the shared one, so they never hold up the `WorkPool`'s file I/O.
+        /// `getaddrinfo` waits out the resolver timeout when nothing answers. A
+        /// pool of their own keeps such lookups off the shared `WorkPool`.
         fn pool() -> &'static ThreadPool {
             static POOL: OnceLock<ThreadPool> = OnceLock::new();
             POOL.get_or_init(|| {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -919,6 +919,14 @@ pub struct GetAddrInfoRequest {
 }
 
 pub mod get_addr_info_request {
+    #[cfg(not(windows))]
+    use std::sync::OnceLock;
+
+    #[cfg(not(windows))]
+    use bun_threading::ThreadPool;
+    #[cfg(not(windows))]
+    use bun_threading::thread_pool::{Config, DEFAULT_THREAD_STACK_SIZE};
+
     use super::*;
 
     /// The blocking `getaddrinfo` of one libc-backend lookup, run on the pool.
@@ -966,6 +974,23 @@ pub mod get_addr_info_request {
     impl bun_jsc::JobContext for LibcLookup {
         type OffThread = Self;
         type Js = LibcRequest;
+
+        /// `getaddrinfo` holds its thread until the resolver answers, which
+        /// against one that does not is the whole resolver timeout, per
+        /// lookup. The lookups get a pool of their own, the size of the shared
+        /// one so their throughput does not change. A stream of them against a
+        /// dead resolver then occupies only this pool, and file I/O on the
+        /// shared `WorkPool` keeps flowing.
+        fn pool() -> &'static ThreadPool {
+            static POOL: OnceLock<ThreadPool> = OnceLock::new();
+            POOL.get_or_init(|| {
+                ThreadPool::init(Config {
+                    max_threads: u32::from(bun::get_thread_count()),
+                    stack_size: DEFAULT_THREAD_STACK_SIZE,
+                })
+            })
+        }
+
         fn run(
             this: &mut Self,
             done: bun_jsc::Completion<Self>,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -975,12 +975,9 @@ pub mod get_addr_info_request {
         type OffThread = Self;
         type Js = LibcRequest;
 
-        /// `getaddrinfo` holds its thread until the resolver answers, which
-        /// against one that does not is the whole resolver timeout, per
-        /// lookup. The lookups get a pool of their own, the size of the shared
-        /// one so their throughput does not change. A stream of them against a
-        /// dead resolver then occupies only this pool, and file I/O on the
-        /// shared `WorkPool` keeps flowing.
+        /// `getaddrinfo` holds its thread for the whole resolver timeout when the
+        /// resolver does not answer. Lookups run on their own pool, sized like
+        /// the shared one, so they never hold up the `WorkPool`'s file I/O.
         fn pool() -> &'static ThreadPool {
             static POOL: OnceLock<ThreadPool> = OnceLock::new();
             POOL.get_or_init(|| {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -81,13 +81,19 @@ fn global_resolver(global_this: &JSGlobalObject) -> &Resolver {
     &gd.resolver
 }
 
-/// Send-wrapper for raw pointers handed to the threaded work pool. The DNS
-/// `Request` is heap-allocated and only touched under `global_cache().lock()`,
-/// so crossing threads is sound — Rust just can't see that through `*mut T`.
-#[repr(transparent)]
-struct SendPtr<T>(*mut T);
-// SAFETY: see type doc — synchronization is provided by `global_cache()`.
-unsafe impl<T> Send for SendPtr<T> {}
+/// The pool every blocking `getaddrinfo` runs on, the size of the shared
+/// `WorkPool`. A call waits out the resolver timeout when nothing answers, so
+/// lookups against a dead resolver stall only each other, never file I/O.
+fn getaddrinfo_pool() -> &'static bun_threading::ThreadPool {
+    use bun_threading::thread_pool::{Config, DEFAULT_THREAD_STACK_SIZE};
+    static POOL: std::sync::OnceLock<bun_threading::ThreadPool> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        bun_threading::ThreadPool::init(Config {
+            max_threads: u32::from(bun::get_thread_count()),
+            stack_size: DEFAULT_THREAD_STACK_SIZE,
+        })
+    })
+}
 
 /// Bridge the JS-thread `VirtualMachine` to the aio-level `EventLoopCtx` used
 /// by `KeepAlive` / `FilePoll`. The DNS resolver always runs on the JS event
@@ -919,14 +925,6 @@ pub struct GetAddrInfoRequest {
 }
 
 pub mod get_addr_info_request {
-    #[cfg(not(windows))]
-    use std::sync::OnceLock;
-
-    #[cfg(not(windows))]
-    use bun_threading::ThreadPool;
-    #[cfg(not(windows))]
-    use bun_threading::thread_pool::{Config, DEFAULT_THREAD_STACK_SIZE};
-
     use super::*;
 
     /// The blocking `getaddrinfo` of one libc-backend lookup, run on the pool.
@@ -975,16 +973,8 @@ pub mod get_addr_info_request {
         type OffThread = Self;
         type Js = LibcRequest;
 
-        /// `getaddrinfo` waits out the resolver timeout when nothing answers. A
-        /// pool of their own keeps such lookups off the shared `WorkPool`.
-        fn pool() -> &'static ThreadPool {
-            static POOL: OnceLock<ThreadPool> = OnceLock::new();
-            POOL.get_or_init(|| {
-                ThreadPool::init(Config {
-                    max_threads: u32::from(bun::get_thread_count()),
-                    stack_size: DEFAULT_THREAD_STACK_SIZE,
-                })
-            })
+        fn pool() -> &'static bun_threading::ThreadPool {
+            getaddrinfo_pool()
         }
 
         fn run(
@@ -2143,6 +2133,8 @@ pub mod internal {
     }
 
     pub struct Request {
+        /// The `getaddrinfo` of this entry, queued on [`getaddrinfo_pool`].
+        pub(crate) work_task: bun_threading::WorkPoolTask,
         pub(crate) key: RequestKeyOwned,
         pub(crate) result: Option<RequestResult>,
         /// Owns the `[ResultEntry; N]` packed by `process_results`; `result.info`
@@ -2168,6 +2160,10 @@ pub mod internal {
     impl Request {
         pub(crate) fn new(key: RequestKeyOwned, refcount: u32, created_at: u32) -> *mut Self {
             bun_core::heap::into_raw(Box::new(Self {
+                work_task: bun_threading::WorkPoolTask {
+                    node: Default::default(),
+                    callback: run_from_pool,
+                },
                 key,
                 result: None,
                 result_buf: None,
@@ -3032,14 +3028,24 @@ pub mod internal {
         Some(req)
     }
 
-    /// getaddrinfo() on the work pool; the result reaches every waiter through
-    /// the global cache, whichever thread asked. Also how a lookup whose
+    /// getaddrinfo() on the getaddrinfo pool; the result reaches every waiter
+    /// through the global cache, whichever thread asked. Also how a lookup whose
     /// per-thread mDNSResponder connection went away with its thread is
     /// finished (see `SharedConnection::close_for_terminate`).
     pub(super) fn run_on_work_pool(req: *mut Request) {
-        let _ = bun_threading::work_pool::WorkPool::go(SendPtr(req), |r: SendPtr<Request>| {
-            work_pool_callback(r.0)
-        });
+        // SAFETY: `req` is a live heap cache entry that is queued at most once at
+        // a time; it holds no VM state (every reader goes through `global_cache()`).
+        unsafe {
+            getaddrinfo_pool().schedule(bun_threading::thread_pool::Batch::from(
+                &raw mut (*req).work_task,
+            ))
+        };
+    }
+
+    unsafe fn run_from_pool(task: *mut bun_threading::WorkPoolTask) {
+        // SAFETY: only reachable through the `work_task.callback` slot set in
+        // `Request::new`; the pool calls back with exactly that field.
+        work_pool_callback(unsafe { bun_core::from_field_ptr!(Request, work_task, task) });
     }
 
     #[host_fn]

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2067,6 +2067,31 @@ export async function readdirSorted(path: string): Promise<string[]> {
 }
 
 /**
+ * Reads `stream` until `enough(text)` holds or the stream ends, and returns the
+ * text read so far. Releases the reader, so the rest of the stream stays
+ * readable. For a subprocess pipe whose writer never closes: read up to a
+ * marker line, then act.
+ */
+export async function readUntil(
+  stream: ReadableStream<Uint8Array>,
+  enough: (text: string) => boolean,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let text = "";
+  try {
+    while (!enough(text)) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return text;
+}
+
+/**
  * Helper function for making automatically lazily-executed promises.
  *
  * The difference is that the promise has not already started to be evaluated when it is created,

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -102,11 +102,10 @@
     "HTTPThread::schedule": 1
   },
   "src/runtime/dns_jsc/dns.rs": {
-    "WorkPool::schedule*": 1,
     "unsafe impl Send": [
-      "GlobalCache",
-      "SendPtr<T>"
-    ]
+      "GlobalCache"
+    ],
+    "worker_pool.schedule(Batch)": 1
   },
   "src/runtime/image/Image.rs": {
     "unsafe impl Send": [

--- a/test/js/bun/secrets.test.ts
+++ b/test/js/bun/secrets.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isCI, isLinux, isMacOS, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isCI, isLinux, isMacOS, isWindows, readUntil, tempDir } from "harness";
 import { join } from "node:path";
 
 // Helper to determine if we should use unrestricted keychain access
@@ -381,22 +381,6 @@ const text = await Bun.file(import.meta.path).text();
 clearTimeout(watchdog);
 report({ starved: false, read: text.length > 0 });
 `;
-
-async function readUntil(stream: ReadableStream<Uint8Array>, enough: (text: string) => boolean): Promise<string> {
-  const decoder = new TextDecoder();
-  const reader = stream.getReader();
-  let text = "";
-  try {
-    while (!enough(text)) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      text += decoder.decode(value, { stream: true });
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return text;
-}
 
 test.skipIf(!isLinux || !cc)("hung keyring calls do not starve the work pool", async () => {
   using dir = tempDir("secrets-hung-keyring", {

--- a/test/js/bun/secrets.test.ts
+++ b/test/js/bun/secrets.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { isCI, isMacOS, isWindows } from "harness";
+import { bunEnv, bunExe, isCI, isLinux, isMacOS, isWindows, tempDir } from "harness";
+import { join } from "node:path";
 
 // Helper to determine if we should use unrestricted keychain access
 // This is needed for macOS CI environments where user interaction is not available
@@ -298,4 +299,152 @@ test.todoIf(isCI && !isWindows)("Bun.secrets handles concurrent operations", asy
   }
 
   await Promise.all(promises);
+});
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// A libsecret whose calls never return: what a locked keyring with an unlock
+// prompt nobody answers, or a Secret Service that stopped replying, looks like
+// to Bun. Each call reports itself on stderr first, so the test knows when the
+// threads that took the calls are stuck for good.
+const LIBSECRET_STUB_C = /* c */ `
+#include <stddef.h>
+#include <unistd.h>
+
+static void hang(void) {
+    (void)write(2, "hung\\n", 5);
+    for (;;) pause();
+}
+
+int secret_password_store_sync(const void* schema, const char* collection, const char* label,
+    const char* password, void* cancellable, void** error, ...) {
+    hang();
+    return 0;
+}
+
+char* secret_password_lookup_sync(const void* schema, void* cancellable, void** error, ...) {
+    hang();
+    return NULL;
+}
+
+int secret_password_clear_sync(const void* schema, void* cancellable, void** error, ...) {
+    hang();
+    return 0;
+}
+
+void secret_password_free(char* password) {}
+`;
+
+// SecretsLinux.cpp dlopens GLib and GObject before libsecret and dlsyms these
+// from GLib. None of them runs once the lookup hangs, so the stubs do nothing.
+const GLIB_STUB_C = /* c */ `
+#include <stddef.h>
+
+void g_error_free(void* error) {}
+void g_free(void* mem) {}
+void* g_hash_table_new(void* hash_func, void* key_equal_func) { return NULL; }
+void g_hash_table_destroy(void* hash_table) {}
+void* g_hash_table_lookup(void* hash_table, void* key) { return NULL; }
+void g_hash_table_insert(void* hash_table, void* key, void* value) {}
+void g_list_free(void* list) {}
+void g_list_free_full(void* list, void (*free_func)(void*)) {}
+unsigned int g_str_hash(void* v) { return 0; }
+int g_str_equal(void* v1, void* v2) { return 0; }
+`;
+
+// The shared work pool is pinned to this many threads (UV_THREADPOOL_SIZE).
+const WORK_POOL_THREADS = 2;
+
+// More calls than the work pool and the secrets pool have threads between
+// them, so some are queued whichever pool they run on.
+const STARVATION_FIXTURE = /* js */ `
+function report(result) {
+  console.log(JSON.stringify(result));
+  process.exit(result.starved === false ? 0 : 1);
+}
+
+for (let i = 0; i < 8; i++) {
+  Bun.secrets.get({ service: "svc-" + i, name: "n" }).then(
+    value => report({ unexpected: "resolved", value }),
+    error => report({ unexpected: "rejected", code: error.code, message: error.message }),
+  );
+}
+
+// The test closes stdin once ${WORK_POOL_THREADS} calls are inside libsecret.
+// Stdin is a pipe, so the event loop reads it, not the work pool.
+await Bun.stdin.stream().getReader().read();
+
+// Bun.file().text() runs on the work pool. The stuck calls hold the event loop
+// open forever, so a read that never completes is turned into a report.
+const watchdog = setTimeout(() => report({ starved: true }), 10_000);
+const text = await Bun.file(import.meta.path).text();
+clearTimeout(watchdog);
+report({ starved: false, read: text.length > 0 });
+`;
+
+async function readUntil(stream: ReadableStream<Uint8Array>, enough: (text: string) => boolean): Promise<string> {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let text = "";
+  try {
+    while (!enough(text)) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return text;
+}
+
+test.skipIf(!isLinux || !cc)("hung keyring calls do not starve the work pool", async () => {
+  using dir = tempDir("secrets-hung-keyring", {
+    "libsecret_stub.c": LIBSECRET_STUB_C,
+    "glib_stub.c": GLIB_STUB_C,
+    "fixture.js": STARVATION_FIXTURE,
+  });
+  const root = String(dir);
+  const stubs: [source: string, soname: string][] = [
+    ["libsecret_stub.c", "libsecret-1.so.0"],
+    ["glib_stub.c", "libglib-2.0.so.0"],
+    ["glib_stub.c", "libgobject-2.0.so.0"],
+  ];
+  for (const [source, soname] of stubs) {
+    await using ccProc = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", join(root, soname), join(root, source)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+    if (ccExit !== 0) throw new Error(`${soname} compile failed: ${ccErr || ccOut}`);
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    cwd: root,
+    env: {
+      ...bunEnv,
+      LD_LIBRARY_PATH: bunEnv.LD_LIBRARY_PATH ? `${root}:${bunEnv.LD_LIBRARY_PATH}` : root,
+      UV_THREADPOOL_SIZE: String(WORK_POOL_THREADS),
+    },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Wait until one call per work pool thread is stuck inside libsecret. A
+  // fixture that exits before that printed why on stdout.
+  const saturated = await Promise.race([
+    readUntil(proc.stderr, text => text.split("hung\n").length > WORK_POOL_THREADS).then(() => true),
+    proc.exited.then(() => false),
+  ]);
+  if (saturated) proc.stdin.end();
+
+  // The fixture cannot exit on its own under BUN_DESTRUCT_VM_ON_EXIT: the VM
+  // teardown waits for the stuck calls. Read its verdict, then kill it.
+  const verdict = await readUntil(proc.stdout, text => text.includes("\n"));
+  proc.kill();
+  expect(verdict.trim()).toBe(JSON.stringify({ starved: false, read: true }));
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,5 +1,5 @@
-import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isWindows, readUntil, tempDir } from "harness";
 import * as dgram from "node:dgram";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
@@ -1031,13 +1031,14 @@ describe("pending cache", () => {
   });
 });
 
-// dns.lookup() is getaddrinfo(3) on a pool thread, and getaddrinfo holds that
-// thread until the resolver answers. Lookups must not share the work pool with
+// dns.lookup() is getaddrinfo(3) on a pool thread, and so is the resolver
+// behind every socket connect (fetch, Bun.connect, node:net). getaddrinfo holds
+// that thread until the resolver answers. Neither must share the work pool with
 // file I/O: once one thread per core is waiting on a dead resolver, every
 // Bun.file read would queue behind them. The LD_PRELOAD shim below is the
 // resolver that never answers. Each call reports itself on stderr first, so the
 // test knows when the threads that took the calls are stuck for good.
-describe.skipIf(!isLinux)("lookup against an unresponsive resolver", () => {
+describe.skipIf(!isLinux)("getaddrinfo against an unresponsive resolver", () => {
   const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
   const GETADDRINFO_SHIM_C = /* c */ `
@@ -1054,8 +1055,9 @@ int getaddrinfo(const char* node, const char* service, const struct addrinfo* hi
   // The shared work pool is pinned to this many threads (UV_THREADPOOL_SIZE).
   const WORK_POOL_THREADS = 2;
 
-  // More lookups than the work pool has threads, so some are queued whichever
-  // pool they run on.
+  // More calls than the work pool has threads, so some are queued whichever
+  // pool they run on. argv[2] picks the API: dns.lookup() goes through the
+  // libc lookup job, fetch() through the connect resolver.
   const STARVATION_FIXTURE = /* js */ `
 import dns from "node:dns";
 
@@ -1064,72 +1066,72 @@ function report(result) {
   process.exit(result.starved === false ? 0 : 1);
 }
 
+const start =
+  process.argv[2] === "fetch" ? name => fetch("http://" + name + "/") : name => dns.promises.lookup(name);
 for (let i = 0; i < 8; i++) {
-  dns.promises.lookup("host-" + i + ".invalid").then(
-    value => report({ unexpected: "resolved", value }),
+  start("host-" + i + ".invalid").then(
+    () => report({ unexpected: "resolved" }),
     error => report({ unexpected: "rejected", code: error.code, message: error.message }),
   );
 }
 
-// The test closes stdin once ${WORK_POOL_THREADS} lookups are inside getaddrinfo.
+// The test closes stdin once ${WORK_POOL_THREADS} calls are inside getaddrinfo.
 // Stdin is a pipe, so the event loop reads it, not the work pool.
 await Bun.stdin.stream().getReader().read();
 
-// Bun.file().text() runs on the work pool. The stuck lookups hold the event
-// loop open forever, so a read that never completes is turned into a report.
+// Bun.file().text() runs on the work pool. The stuck calls hold the event loop
+// open forever, so a read that never completes is turned into a report.
 const watchdog = setTimeout(() => report({ starved: true }), 10_000);
 const text = await Bun.file(import.meta.path).text();
 clearTimeout(watchdog);
 report({ starved: false, read: text.length > 0 });
 `;
 
-  async function readUntil(stream, enough) {
-    const decoder = new TextDecoder();
-    const reader = stream.getReader();
-    let text = "";
-    try {
-      while (!enough(text)) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        text += decoder.decode(value, { stream: true });
-      }
-    } finally {
-      reader.releaseLock();
-    }
-    return text;
-  }
+  let dir;
+  let shimPath;
 
-  test.skipIf(!cc)("does not starve the work pool", async () => {
-    using dir = tempDir("dns-unresponsive-resolver", {
+  beforeAll(async () => {
+    if (!cc) return;
+    dir = tempDir("dns-unresponsive-resolver", {
       "shim.c": GETADDRINFO_SHIM_C,
       "fixture.js": STARVATION_FIXTURE,
     });
-    const root = String(dir);
-    const shimPath = join(root, "shim.so");
+    shimPath = join(String(dir), "shim.so");
     await using ccProc = Bun.spawn({
-      cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(root, "shim.c")],
+      cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c")],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
     if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  });
 
+  afterAll(() => {
+    dir?.[Symbol.dispose]();
+  });
+
+  test.concurrent.skipIf(!cc).each(["lookup", "fetch"])("%s does not starve the work pool", async api => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.js"],
-      cwd: root,
+      cmd: [bunExe(), "fixture.js", api],
+      cwd: String(dir),
       env: {
         ...bunEnv,
         LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
         UV_THREADPOOL_SIZE: String(WORK_POOL_THREADS),
+        // An inherited proxy would make every fetch resolve the one proxy host.
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
       },
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",
     });
 
-    // Wait until one lookup per work pool thread is stuck inside getaddrinfo.
-    // A fixture that exits before that printed why on stdout.
+    // Wait until one call per work pool thread is stuck inside getaddrinfo. A
+    // fixture that exits before that printed why on stdout.
     const saturated = await Promise.race([
       readUntil(proc.stderr, text => text.split("hung\n").length > WORK_POOL_THREADS).then(() => true),
       proc.exited.then(() => false),
@@ -1137,7 +1139,7 @@ report({ starved: false, read: text.length > 0 });
     if (saturated) proc.stdin.end();
 
     // The fixture cannot exit on its own under BUN_DESTRUCT_VM_ON_EXIT: the VM
-    // teardown waits for the stuck lookups. Read its verdict, then kill it.
+    // teardown waits for the stuck calls. Read its verdict, then kill it.
     const verdict = await readUntil(proc.stdout, text => text.includes("\n"));
     proc.kill();
     expect(verdict.trim()).toBe(JSON.stringify({ starved: false, read: true }));

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,11 +1,12 @@
 import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import * as dgram from "node:dgram";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
 import { once } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
+import { join } from "node:path";
 import * as util from "node:util";
 
 beforeAll(() => {
@@ -1027,5 +1028,118 @@ describe("pending cache", () => {
   test.concurrent("concurrent lookup() of the same name all settle", async () => {
     const results = await Promise.all(Array.from({ length: 8 }, () => dns_promises.lookup("localhost", { family: 4 })));
     expect(results).toEqual(Array(8).fill({ address: "127.0.0.1", family: 4 }));
+  });
+});
+
+// dns.lookup() is getaddrinfo(3) on a pool thread, and getaddrinfo holds that
+// thread until the resolver answers. Lookups must not share the work pool with
+// file I/O: once one thread per core is waiting on a dead resolver, every
+// Bun.file read would queue behind them. The LD_PRELOAD shim below is the
+// resolver that never answers. Each call reports itself on stderr first, so the
+// test knows when the threads that took the calls are stuck for good.
+describe.skipIf(!isLinux)("lookup against an unresponsive resolver", () => {
+  const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+  const GETADDRINFO_SHIM_C = /* c */ `
+#include <unistd.h>
+
+struct addrinfo;
+
+int getaddrinfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res) {
+    (void)write(2, "hung\\n", 5);
+    for (;;) pause();
+}
+`;
+
+  // The shared work pool is pinned to this many threads (UV_THREADPOOL_SIZE).
+  const WORK_POOL_THREADS = 2;
+
+  // More lookups than the work pool has threads, so some are queued whichever
+  // pool they run on.
+  const STARVATION_FIXTURE = /* js */ `
+import dns from "node:dns";
+
+function report(result) {
+  console.log(JSON.stringify(result));
+  process.exit(result.starved === false ? 0 : 1);
+}
+
+for (let i = 0; i < 8; i++) {
+  dns.promises.lookup("host-" + i + ".invalid").then(
+    value => report({ unexpected: "resolved", value }),
+    error => report({ unexpected: "rejected", code: error.code, message: error.message }),
+  );
+}
+
+// The test closes stdin once ${WORK_POOL_THREADS} lookups are inside getaddrinfo.
+// Stdin is a pipe, so the event loop reads it, not the work pool.
+await Bun.stdin.stream().getReader().read();
+
+// Bun.file().text() runs on the work pool. The stuck lookups hold the event
+// loop open forever, so a read that never completes is turned into a report.
+const watchdog = setTimeout(() => report({ starved: true }), 10_000);
+const text = await Bun.file(import.meta.path).text();
+clearTimeout(watchdog);
+report({ starved: false, read: text.length > 0 });
+`;
+
+  async function readUntil(stream, enough) {
+    const decoder = new TextDecoder();
+    const reader = stream.getReader();
+    let text = "";
+    try {
+      while (!enough(text)) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    return text;
+  }
+
+  test.skipIf(!cc)("does not starve the work pool", async () => {
+    using dir = tempDir("dns-unresponsive-resolver", {
+      "shim.c": GETADDRINFO_SHIM_C,
+      "fixture.js": STARVATION_FIXTURE,
+    });
+    const root = String(dir);
+    const shimPath = join(root, "shim.so");
+    await using ccProc = Bun.spawn({
+      cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(root, "shim.c")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+    if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      cwd: root,
+      env: {
+        ...bunEnv,
+        LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
+        UV_THREADPOOL_SIZE: String(WORK_POOL_THREADS),
+      },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Wait until one lookup per work pool thread is stuck inside getaddrinfo.
+    // A fixture that exits before that printed why on stdout.
+    const saturated = await Promise.race([
+      readUntil(proc.stderr, text => text.split("hung\n").length > WORK_POOL_THREADS).then(() => true),
+      proc.exited.then(() => false),
+    ]);
+    if (saturated) proc.stdin.end();
+
+    // The fixture cannot exit on its own under BUN_DESTRUCT_VM_ON_EXIT: the VM
+    // teardown waits for the stuck lookups. Read its verdict, then kill it.
+    const verdict = await readUntil(proc.stdout, text => text.includes("\n"));
+    proc.kill();
+    expect(verdict.trim()).toBe(JSON.stringify({ starved: false, read: true }));
   });
 });


### PR DESCRIPTION
### Problem
- Two kinds of work block a work pool thread for as long as something outside the process takes. `Bun.secrets` waits inside the platform keyring library, without bound when a locked keyring's unlock prompt is never answered. `getaddrinfo` waits for the whole resolver timeout when the resolver does not answer. It runs on the pool for `dns.lookup` (and `Bun.dns.lookup` with the `system` or `libc` backend) and for the resolver behind every socket connect (`fetch`, `Bun.connect`, `node:net`, `dns.prefetch`). The pool has one thread per core. Once that many calls are stuck, every other pool job queues behind them: `Bun.file().text()`, `fs.promises.readFile`, `Bun.password.hash`, compression. With a stub libsecret whose calls never return, 16 `Bun.secrets.get` calls on an 8 core box stop all file reads. A 4 core laptop needs 4. A stream of lookups against a dead resolver does the same.
- The cause is `Job::schedule` (`src/jsc/job.rs`), which puts every `Job<C>` on the single shared `WorkPool`, and `internal::run_on_work_pool` (`src/runtime/dns_jsc/dns.rs`), which put the connect resolver's `getaddrinfo` there through `WorkPool::go`.

### Fix
- `JobContext` gets a `pool()` hook that names the pool `run` executes on. The default is the shared `WorkPool`, so no other job changes.
- `SecretsJob` names a pool of its own with four threads. Every blocking `getaddrinfo` (the `LibcLookup` job and the connect resolver's cache entry, which now carries its own intrusive pool task) runs on one `getaddrinfo_pool()` the size of the shared pool (`get_thread_count()`, so `UV_THREADPOOL_SIZE` still applies), so lookup throughput does not change. Both pools are lazy: no thread exists until the first call. Stuck calls now hold up only calls of the same kind.
- Correct because the jobs keep the same ticket and completion path. Only the thread they run on changes. Windows is unchanged: its lookups go through libuv's own pool.
- Verified: `test/js/bun/secrets.test.ts`, new test `hung keyring calls do not starve the work pool`, and `test/js/node/dns/node-dns.test.js`, new tests `getaddrinfo against an unresponsive resolver > lookup|fetch does not starve the work pool`. All three time out on 1.4.1, the `fetch` one also on this branch before the connect resolver moved, and all pass in about 0.4 s with the fix. Also `resolve-dns.test.ts` (offline cases), `fs/promises.test.js`, `worker-shutdown-post-leak.test.ts`, `password.test.ts`, `bun-write.test.js`, the `vm-thread-door` source lint, `cargo clippy -p bun_jsc -p bun_runtime`.

### Background
- A `Job<C>` is how a VM runs work off its thread: `run` on a pool thread, then `then` back on the JS thread. `JobContext` is the per kind trait (`SecretsJob`, `LibcLookup`, `ReadFile`, ...).
- The `WorkPool` is a process wide `ThreadPool` sized to `get_thread_count()` (the core count, or `UV_THREADPOOL_SIZE`). Threads spawn on demand and never exit. A task that blocks keeps its thread, so N blocked tasks on an N thread pool stop the queue.
- On Linux `Bun.secrets` calls libsecret's synchronous API over D-Bus, which waits for the Secret Service with no timeout, including for a user to answer an unlock prompt. `node:dns`'s `lookup` always uses the `system` backend, which on Linux is `getaddrinfo` on the pool (`Bun.dns.lookup` defaults to c-ares there, and switches to `system` for `localhost`, `.local` names and IPv6 literals).

<details><summary>Notes</summary>

- The secrets test stubs `libsecret-1.so.0`, `libglib-2.0.so.0` and `libgobject-2.0.so.0` with `cc` and points `LD_LIBRARY_PATH` at them. Every `*_sync` call writes `hung` to stderr and then loops on `pause()`. The dns test does the same with an `LD_PRELOAD` shim for `getaddrinfo`. Both pin the shared pool to two threads with `UV_THREADPOOL_SIZE=2`, start eight calls, wait for two `hung` lines, then close the fixture's stdin. The fixture then reads a file with `Bun.file().text()` and reports whether the read completed. Without the fix the read never completes.
- `Bun.stdin.text()` also runs on the work pool, so the fixtures read stdin through `Bun.stdin.stream()`, which the event loop serves. The stream reader the tests share is `readUntil` in the harness.
- The `vm-thread-door` inventory changes for `dns.rs`: the `WorkPool::go` call and its `SendPtr` become one `schedule(Batch::from(..))` of the entry's own task. The entry holds no VM state, every reader goes through the global cache.
- The fixtures cannot exit by themselves under `BUN_DESTRUCT_VM_ON_EXIT=1` (the CI ASAN lanes set it): the VM teardown waits for every job, including the stuck ones. The tests read the verdict line and kill the fixture.
- `Bun.write(path, "small string")` never reaches the pool, which is why that one liner does not show the hang. Larger writes and every read do.
- This does not add a timeout to the keyring calls. A hung call still hangs its own promise, and a process whose teardown waits for jobs still waits for it. That is a separate change.
- Related open PRs that touch the same files for different reasons: #38312 (teardown does not wait on blocked file jobs), #36256 (CPU headroom for the work pool).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js, test/js/bun/secrets.test.ts

<!-- robobun:evidence:end -->