### PR TITLE
fix(install): prevent .bun-tag-* sentinels from leaking into patches

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -367,14 +367,15 @@ pub fn do_patch_commit(
         };
 
         let mut bunpatchtagbuf: BuntagHashBuf = BuntagHashBuf::default();
-        // If the package was already patched then it might have a ".bun-tag-XXXXXXXX"
-        // we need to rename this out and back too.
+        let mut bun_patch_tag_owned: Option<Box<[u8]>> = None;
         let bun_patch_tag: Option<&[u8]> = 'has_bun_patch_tag: {
             let name_and_version_hash = string_hash(&patch_key);
             let patch_tag: &[u8] = 'patch_tag: {
                 if let Some(patchdep) = lockfile.patched_dependencies.get(&name_and_version_hash) {
                     if let Some(hash) = patchdep.patchfile_hash() {
-                        break 'patch_tag &*buntaghashbuf_make(&mut bunpatchtagbuf, hash);
+                        let tag = buntaghashbuf_make(&mut bunpatchtagbuf, hash);
+                        bun_patch_tag_owned = Some(tag.into());
+                        break 'patch_tag &*tag;
                     }
                 }
                 break 'has_bun_patch_tag None;
@@ -409,8 +410,6 @@ pub fn do_patch_commit(
             }
             break 'has_bun_patch_tag Some(patch_tag);
         };
-        // deferred restore — one-off rename-back logic on every exit
-        // path of `'brk`. Captures borrow into stack buffers.
         scopeguard::defer! {
             if has_nested_node_modules || bun_patch_tag.is_some() {
                 let new_folder_handle = match Dir::cwd().open_dir(new_folder, sys::OpenDirOptions::default()) {
@@ -595,10 +594,12 @@ pub fn do_patch_commit(
     }
 
     let patchfile_path: Box<[u8]> = Box::<[u8]>::from(path_in_patches_dir.as_bytes());
-    let _ = sys::unlink(resolve_path::join_z::<platform::Auto>(&[
-        changes_dir,
-        b".bun-patch-tag",
-    ]));
+    if let Some(patch_tag) = bun_patch_tag_owned {
+        let _ = sys::unlink(resolve_path::join_z::<platform::Auto>(&[
+            changes_dir,
+            &patch_tag[..],
+        ]));
+    }
 
     Ok(Some(PatchCommitResult {
         patch_key: patch_key.into_boxed_slice(),

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -374,7 +374,6 @@ pub fn do_patch_commit(
                 if let Some(patchdep) = lockfile.patched_dependencies.get(&name_and_version_hash) {
                     if let Some(hash) = patchdep.patchfile_hash() {
                         let tag = buntaghashbuf_make(&mut bunpatchtagbuf, hash);
-                        bun_patch_tag_owned = Some(tag.into());
                         break 'patch_tag &*tag;
                     }
                 }
@@ -408,6 +407,7 @@ pub fn do_patch_commit(
                 );
                 break 'has_bun_patch_tag None;
             }
+            bun_patch_tag_owned = Some(Box::from(patch_tag));
             break 'has_bun_patch_tag Some(patch_tag);
         };
         scopeguard::defer! {
@@ -595,10 +595,15 @@ pub fn do_patch_commit(
 
     let patchfile_path: Box<[u8]> = Box::<[u8]>::from(path_in_patches_dir.as_bytes());
     if let Some(patch_tag) = bun_patch_tag_owned {
-        let _ = sys::unlink(resolve_path::join_z::<platform::Auto>(&[
+        if let Err(e) = sys::unlink(resolve_path::join_z::<platform::Auto>(&[
             changes_dir,
             &patch_tag[..],
-        ]));
+        ])) {
+            if e.get_errno() != sys::E::ENOENT {
+                Output::err(e, "failed to remove patch tag sentinel", ());
+                Global::crash();
+            }
+        }
     }
 
     Ok(Some(PatchCommitResult {

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -288,6 +288,7 @@ pub fn do_patch_commit(
     )
     .expect("formatting into a Vec is infallible");
 
+    let mut bun_patch_tag_owned: Option<Box<[u8]>> = None;
     let patchfile_contents: Vec<u8> = 'brk: {
         let new_folder = changes_dir;
         let mut buf2 = PathBuffer::uninit();
@@ -367,7 +368,6 @@ pub fn do_patch_commit(
         };
 
         let mut bunpatchtagbuf: BuntagHashBuf = BuntagHashBuf::default();
-        let mut bun_patch_tag_owned: Option<Box<[u8]>> = None;
         let bun_patch_tag: Option<&[u8]> = 'has_bun_patch_tag: {
             let name_and_version_hash = string_hash(&patch_key);
             let patch_tag: &[u8] = 'patch_tag: {

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -738,47 +738,33 @@ module.exports = function isOdd(i) {
   });
 
   // https://github.com/oven-sh/bun/issues/19327
-  for (const { layout, dependencies, patchArg, pkgPath, patchfile } of [
-    {
-      layout: "a top-level dependency",
-      dependencies: { "is-odd": "3.0.1" },
-      patchArg: "is-odd@3.0.1",
-      pkgPath: "node_modules/is-odd",
-      patchfile: "is-odd@3.0.1.patch",
-    },
-    {
-      layout: "a nested dependency",
-      dependencies: { "is-even": "1.0.0", "is-odd": "3.0.1" },
-      patchArg: "is-odd@0.1.2",
-      pkgPath: "node_modules/is-even/node_modules/is-odd",
-      patchfile: "is-odd@0.1.2.patch",
-    },
-  ]) {
-    test(`should not leak the .bun-tag sentinel into the patch file of ${layout}`, async () => {
-      await using tempdir = tempDir("buntag", {
-        "package.json": JSON.stringify({ "name": "bun-patch-test", "version": "1.0.0", dependencies }),
-      });
-
-      const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(tempdir), ".bun-cache") };
-      await $`${bunExe()} i`.env(env).cwd(tempdir);
-
-      const pkgDir = join(String(tempdir), pkgPath);
-      const patchfilePath = join(String(tempdir), "patches", patchfile);
-      const sentinels = () => readdirSync(pkgDir).filter(name => name.startsWith(".bun-tag-"));
-
-      // `bun i` writes the sentinel, so a leak needs a second `--commit`.
-      for (const cycle of [0, 1]) {
-        expectNoError(await $`${bunExe()} patch ${patchArg}`.env(env).cwd(tempdir));
-        appendFileSync(join(pkgDir, "index.js"), `console.log(${cycle})\n`);
-        expectNoError(await $`${bunExe()} patch --commit ${pkgPath}`.env(env).cwd(tempdir));
-
-        expect(readFileSync(patchfilePath, "utf8")).not.toMatch(/\.bun-tag-[0-9a-f]+/);
-
-        await $`${bunExe()} i`.env(env).cwd(tempdir);
-        expect(sentinels()).toHaveLength(1);
-      }
+  test("should not leak .bun-tag sentinel or accumulate tags across patch cycles", async () => {
+    await using tempdir = tempDir("buntag", {
+      "package.json": JSON.stringify({
+        "name": "bun-patch-test",
+        "version": "1.0.0",
+        "dependencies": { "is-odd": "3.0.1" },
+      }),
     });
-  }
+
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(tempdir), ".bun-cache") };
+    await $`${bunExe()} i`.env(env).cwd(tempdir);
+
+    const pkgDir = join(String(tempdir), "node_modules/is-odd");
+    const patchfilePath = join(String(tempdir), "patches/is-odd@3.0.1.patch");
+    const sentinels = () => readdirSync(pkgDir).filter(name => name.startsWith(".bun-tag-"));
+
+    for (const cycle of [0, 1]) {
+      expectNoError(await $`${bunExe()} patch is-odd@3.0.1`.env(env).cwd(tempdir));
+      appendFileSync(join(pkgDir, "index.js"), `console.log(${cycle})\n`);
+      expectNoError(await $`${bunExe()} patch --commit ${pkgDir}`.env(env).cwd(tempdir));
+
+      expect(readFileSync(patchfilePath, "utf8")).not.toMatch(/\.bun-tag-[0-9a-f]+/);
+
+      await $`${bunExe()} i`.env(env).cwd(tempdir);
+      expect(sentinels()).toHaveLength(1);
+    }
+  });
 
   test("bad patch arg", async () => {
     await using tempdir = tempDir("lol", {

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -737,33 +737,49 @@ module.exports = function isOdd(i) {
     expect(stdout.toString()).toContain("hi\nhello\n");
   });
 
-  // https://github.com/oven-sh/bun/issues/19327
-  test("should not leak .bun-tag sentinel or accumulate tags across patch cycles", async () => {
-    await using tempdir = tempDir("buntag", {
-      "package.json": JSON.stringify({
-        "name": "bun-patch-test",
-        "version": "1.0.0",
-        "dependencies": { "is-odd": "3.0.1" },
-      }),
+  describe(".bun-tag sentinel leak test", () => {
+    const registry = new VerdaccioRegistry();
+
+    beforeAll(async () => {
+      await registry.start();
     });
 
-    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(tempdir), ".bun-cache") };
-    await $`${bunExe()} i`.env(env).cwd(tempdir);
+    afterAll(() => {
+      registry.stop();
+    });
 
-    const pkgDir = join(String(tempdir), "node_modules/is-odd");
-    const patchfilePath = join(String(tempdir), "patches/is-odd@3.0.1.patch");
-    const sentinels = () => readdirSync(pkgDir).filter(name => name.startsWith(".bun-tag-"));
+    // https://github.com/oven-sh/bun/issues/19327
+    test("should not leak .bun-tag sentinel or accumulate tags across patch cycles", async () => {
+      await using tempdir = tempDir("buntag", {
+        "package.json": JSON.stringify({
+          "name": "bun-patch-test",
+          "version": "1.0.0",
+          "dependencies": { "basic-1": "1.0.0" },
+        }),
+      });
 
-    for (const cycle of [0, 1]) {
-      expectNoError(await $`${bunExe()} patch is-odd@3.0.1`.env(env).cwd(tempdir));
-      appendFileSync(join(pkgDir, "index.js"), `console.log(${cycle})\n`);
-      expectNoError(await $`${bunExe()} patch --commit ${pkgDir}`.env(env).cwd(tempdir));
-
-      expect(readFileSync(patchfilePath, "utf8")).not.toMatch(/\.bun-tag-[0-9a-f]+/);
-
+      const env = {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(tempdir), ".bun-cache"),
+        BUN_CONFIG_REGISTRY: registry.registryUrl(),
+      };
       await $`${bunExe()} i`.env(env).cwd(tempdir);
-      expect(sentinels()).toHaveLength(1);
-    }
+
+      const pkgDir = join(String(tempdir), "node_modules/basic-1");
+      const patchfilePath = join(String(tempdir), "patches/basic-1@1.0.0.patch");
+      const sentinels = () => readdirSync(pkgDir).filter(name => name.startsWith(".bun-tag-"));
+
+      for (const cycle of [0, 1]) {
+        expectNoError(await $`${bunExe()} patch basic-1@1.0.0`.env(env).cwd(tempdir));
+        appendFileSync(join(pkgDir, "index.js"), `console.log(${cycle})\n`);
+        expectNoError(await $`${bunExe()} patch --commit ${pkgDir}`.env(env).cwd(tempdir));
+
+        expect(readFileSync(patchfilePath, "utf8")).not.toMatch(/\.bun-tag-[0-9a-f]+/);
+
+        await $`${bunExe()} i`.env(env).cwd(tempdir);
+        expect(sentinels()).toHaveLength(1);
+      }
+    });
   });
 
   test("bad patch arg", async () => {

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,6 +1,6 @@
 import { $, ShellOutput } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { lstatSync, readFileSync } from "fs";
+import { appendFileSync, lstatSync, readdirSync, readFileSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDir, VerdaccioRegistry } from "harness";
 import { isAbsolute, join, sep } from "path";
 
@@ -736,6 +736,49 @@ module.exports = function isOdd(i) {
     const { stdout } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(tempdir).throws(false);
     expect(stdout.toString()).toContain("hi\nhello\n");
   });
+
+  // https://github.com/oven-sh/bun/issues/19327
+  for (const { layout, dependencies, patchArg, pkgPath, patchfile } of [
+    {
+      layout: "a top-level dependency",
+      dependencies: { "is-odd": "3.0.1" },
+      patchArg: "is-odd@3.0.1",
+      pkgPath: "node_modules/is-odd",
+      patchfile: "is-odd@3.0.1.patch",
+    },
+    {
+      layout: "a nested dependency",
+      dependencies: { "is-even": "1.0.0", "is-odd": "3.0.1" },
+      patchArg: "is-odd@0.1.2",
+      pkgPath: "node_modules/is-even/node_modules/is-odd",
+      patchfile: "is-odd@0.1.2.patch",
+    },
+  ]) {
+    test(`should not leak the .bun-tag sentinel into the patch file of ${layout}`, async () => {
+      await using tempdir = tempDir("buntag", {
+        "package.json": JSON.stringify({ "name": "bun-patch-test", "version": "1.0.0", dependencies }),
+      });
+
+      const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(tempdir), ".bun-cache") };
+      await $`${bunExe()} i`.env(env).cwd(tempdir);
+
+      const pkgDir = join(String(tempdir), pkgPath);
+      const patchfilePath = join(String(tempdir), "patches", patchfile);
+      const sentinels = () => readdirSync(pkgDir).filter(name => name.startsWith(".bun-tag-"));
+
+      // `bun i` writes the sentinel, so a leak needs a second `--commit`.
+      for (const cycle of [0, 1]) {
+        expectNoError(await $`${bunExe()} patch ${patchArg}`.env(env).cwd(tempdir));
+        appendFileSync(join(pkgDir, "index.js"), `console.log(${cycle})\n`);
+        expectNoError(await $`${bunExe()} patch --commit ${pkgPath}`.env(env).cwd(tempdir));
+
+        expect(readFileSync(patchfilePath, "utf8")).not.toMatch(/\.bun-tag-[0-9a-f]+/);
+
+        await $`${bunExe()} i`.env(env).cwd(tempdir);
+        expect(sentinels()).toHaveLength(1);
+      }
+    });
+  }
 
   test("bad patch arg", async () => {
     await using tempdir = tempDir("lol", {


### PR DESCRIPTION
Fixes #19327

## Problem

`.bun-tag-*` sentinels leak into patch diffs and accumulate with each `bun patch --commit`.

## Root Cause

`do_patch_commit` attempted to delete the tag after generating the patch (line 642), but used the wrong filename:
- Tried to delete: `.bun-patch-tag`
- Actual filename: `.bun-tag-<hash>`

The deletion silently failed every time. Each commit wrote a new sentinel → accumulation.

## Solution

Fixed the deletion to use the correct filename reconstructed from `patchfile_hash()`:

```rust
if let Some(patch_tag) = bun_patch_tag_owned {
    let _ = sys::unlink(resolve_path::join_z(&[
        changes_dir,
        &patch_tag[..],  // ← now uses .bun-tag-HASH
    ]));
}
```

## Limitations

**Prevents future accumulation** but does not clean up existing accumulated tags from the bug. Packages with multiple stale tags will clean up gradually as new patches overwrite them.

Manual cleanup: `find node_modules -name '.bun-tag-*' -delete`

## Testing

- New regression test: 2 patch→commit cycles, asserts exactly 1 tag after each cycle
- Verified on production repo (nfl-fe): 3 cycles, no accumulation
- All existing tests pass