### PR TITLE
bundler: stop a sideEffects array from enabling the barrel optimization

### DIFF
--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -256,8 +256,15 @@ pub enum SideEffects {
     HasSideEffects,
 
     /// This file was listed as not having side effects by a "package.json"
-    /// file in one of our containing directories with a "sideEffects" field.
+    /// file in one of our containing directories with `"sideEffects": false`.
     NoSideEffectsPackageJson,
+
+    /// This file does not match any entry of a "sideEffects" array in a
+    /// "package.json" file in one of our containing directories. Unused
+    /// imports of this file can still be removed, but other files in the
+    /// same package can be side-effectful, so the barrel optimization must
+    /// not defer this file's re-exports without resolving them.
+    NoSideEffectsPackageJsonArray,
 
     /// This file is considered to have no side effects because the AST was empty
     /// after parsing finished. This should be the case for ".d.ts" files.

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6750,8 +6750,10 @@ fn primary_side_effects(
 ) -> SideEffects {
     if side_effects.has_side_effects(path) {
         SideEffects::HasSideEffects
-    } else {
+    } else if matches!(side_effects, crate::package_json::SideEffects::False) {
         SideEffects::NoSideEffectsPackageJson
+    } else {
+        SideEffects::NoSideEffectsPackageJsonArray
     }
 }
 

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -88,6 +88,96 @@ describe("bundler", () => {
     },
   });
 
+  // A "sideEffects" array must not enable barrel deferral: a deferred
+  // re-export target may itself be listed in the array. See #40650.
+  itBundled("barrel/SideEffectsArrayKeepsListedReExport", {
+    files: {
+      "/entry.js": /* js */ `
+        import { plain } from 'effectful';
+        console.log(plain('x'));
+      `,
+      "/node_modules/effectful/package.json": JSON.stringify({
+        name: "effectful",
+        main: "./src/index.js",
+        sideEffects: ["./src/effect.js"],
+      }),
+      "/node_modules/effectful/src/index.js": /* js */ `
+        export { plain } from './plain.js';
+        export { TABLE } from './effect.js';
+      `,
+      "/node_modules/effectful/src/plain.js": /* js */ `
+        export const plain = s => s + "!";
+      `,
+      "/node_modules/effectful/src/effect.js": /* js */ `
+        export const TABLE = {};
+        TABLE.marker = "THE_SIDE_EFFECT_RAN";
+      `,
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("THE_SIDE_EFFECT_RAN");
+    },
+  });
+
+  itBundled("barrel/SideEffectsArrayGlobKeepsListedReExport", {
+    files: {
+      "/entry.js": /* js */ `
+        import { plain } from 'effectful';
+        console.log(plain('x'));
+      `,
+      "/node_modules/effectful/package.json": JSON.stringify({
+        name: "effectful",
+        main: "./src/index.js",
+        sideEffects: ["**/effect.js"],
+      }),
+      "/node_modules/effectful/src/index.js": /* js */ `
+        export { plain } from './plain.js';
+        export { TABLE } from './effect.js';
+      `,
+      "/node_modules/effectful/src/plain.js": /* js */ `
+        export const plain = s => s + "!";
+      `,
+      "/node_modules/effectful/src/effect.js": /* js */ `
+        export const TABLE = {};
+        TABLE.marker = "THE_SIDE_EFFECT_RAN";
+      `,
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("THE_SIDE_EFFECT_RAN");
+    },
+  });
+
+  // A module the array does not list is still tree-shaken away.
+  itBundled("barrel/SideEffectsArrayDropsUnlistedReExport", {
+    files: {
+      "/entry.js": /* js */ `
+        import { plain } from 'effectful';
+        console.log(plain('x'));
+      `,
+      "/node_modules/effectful/package.json": JSON.stringify({
+        name: "effectful",
+        main: "./src/index.js",
+        sideEffects: ["./src/plain.js"],
+      }),
+      "/node_modules/effectful/src/index.js": /* js */ `
+        export { plain } from './plain.js';
+        export { TABLE } from './effect.js';
+      `,
+      "/node_modules/effectful/src/plain.js": /* js */ `
+        export const plain = s => s + "!";
+      `,
+      "/node_modules/effectful/src/effect.js": /* js */ `
+        export const TABLE = {};
+        TABLE.marker = "THE_SIDE_EFFECT_RAN";
+      `,
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").not.toContain("THE_SIDE_EFFECT_RAN");
+    },
+  });
+
   itBundled("barrel/NoOptimizationWithoutSideEffects", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- A package.json `sideEffects` array behaves like `sideEffects: false`. A module the array names is tree-shaken away when it is only reachable through a pure re-export barrel. Reported in #40650.
- The resolver gives a file that does not match the array the same verdict, `SideEffects::NoSideEffectsPackageJson`, as a file in a `sideEffects: false` package (`src/resolver/resolver.rs:6747`). `apply_barrel_optimization` (`src/bundler/barrel_imports.rs:119`) reads that verdict and defers the barrel's unused re-export records before resolution, so a listed target is never loaded and its own array match never runs.

### Fix
- Add a new verdict, `SideEffects::NoSideEffectsPackageJsonArray`, for a file that does not match a `sideEffects` array. The resolver returns it instead of `NoSideEffectsPackageJson` for the array form.
- The barrel optimization compares against `NoSideEffectsPackageJson` only, so an array no longer enables deferral. The barrel's re-exports are resolved, and a listed target gets `HasSideEffects` from its own array match.
- Every other consumer compares against `HasSideEffects`, so the linker still tree-shakes an unlisted file. The unlisted-module case keeps its behavior.
- Verified: three new tests in `test/bundler/bundler_barrel.test.ts` (exact entry, glob entry, unlisted entry). Stock bun fails the first two. Also ran all of `bundler_barrel.test.ts`, `esbuild/dce.test.ts`, `bundler_edgecase.test.ts`, and `test/bake/dev/bundle.test.ts`.

### Background
- A barrel is a file whose named exports are all re-exports. The barrel optimization marks re-export records that no importer requests as unused, so those modules are never resolved or parsed.
- The deferral is sound only when the whole package is side-effect free: `sideEffects: false`, or an explicit `optimizeImports` entry. With an array, a deferred target can itself be listed, and that can only be seen after resolution.
- esbuild and webpack keep a listed module in this graph. Bun dropped it, and the failure shows up at runtime as a missing registration.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_barrel.test.ts
bun test v1.4.1 (731aa92da)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [572.01ms]
(pass) bundler > barrel/AllExportsNeeded [102.85ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [90.90ms]
113 |         TABLE.marker = "THE_SIDE_EFFECT_RAN";
114 |       `,
115 |     },
116 |     outdir: "/out",
117 |     onAfterBundle(api) {
118 |       api.expectFile("/out/entry.js").toContain("THE_SIDE_EFFECT_RAN");
                                            ^
error: expect(received).toContain(expected)

Expected to contain: "THE_SIDE_EFFECT_RAN"
Received: "// node_modules/effectful/src/plain.js\nvar plain = (s) => s + \"!\";\n// entry.js\nconsole.log(plain(\"x\"));\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_barrel.test.ts:118:39)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1602:13)
(fail) bundler > barrel/SideEffectsArrayKeepsListedReExport [114.70ms]
142 |         TABLE.marker = "THE_SIDE_EFFECT_RAN";
143 |     
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (731aa92da)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [14.20ms]
(pass) bundler > barrel/AllExportsNeeded [4.58ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [3.72ms]
113 |         TABLE.marker = "THE_SIDE_EFFECT_RAN";
114 |       `,
115 |     },
116 |     outdir: "/out",
117 |     onAfterBundle(api) {
118 |       api.expectFile("/out/entry.js").toContain("THE_SIDE_EFFECT_RAN");
                                            ^
error: expect(received).toContain(expected)

Expected to contain: "THE_SIDE_EFFECT_RAN"
Received: "// node_modules/effectful/src/plain.js\nvar plain = (s) => s + \"!\";\n// entry.js\nconsole.log(plain(\"x\"));\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_barrel.test.ts:118:39)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1602:13)
(fail) bundler > barrel/SideEffectsArrayKeepsListedReExport [4.41ms]
142 |         TABLE.marker = "THE_SIDE_EFFECT_RAN";
143 |       `,
144 |     },
145 |     outdir: "/out",
146 |     onAfterBundle(api) {
147 |       api.expectFile("/out/entry.js").toContain("THE_SIDE_EFFECT_RAN");
             
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_barrel.test.ts
bun test v1.4.1 (731aa92da)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [544.65ms]
(pass) bundler > barrel/AllExportsNeeded [114.34ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [95.28ms]
(pass) bundler > barrel/SideEffectsArrayKeepsListedReExport [97.20ms]
(pass) bundler > barrel/SideEffectsArrayGlobKeepsListedReExport [98.06ms]
(pass) bundler > barrel/SideEffectsArrayDropsUnlistedReExport [97.06ms]
(pass) bundler > barrel/NoOptimizationWithoutSideEffects [100.99ms]
(pass) bundler > barrel/ExportStarLoadsAll [86.88ms]
(pass) bundler > barrel/NonBarrelWithLocalExports [82.91ms]
(pass) bundler > barrel/NamespaceImportLoadsAll [82.74ms]
(pass) bundler > barrel/OutputEquivalence [94.47ms]
(pass) bundler > barrel/DefaultReExport [96.48ms]
(pass) bundler > barrel/ImportThenExport [98.37ms]
(pass) bundler > barrel/ReExportChain [110.52ms]
(pass) bundler > barrel/StarWithNamedFromSameSource [83.17ms]
(pass) bundler > barrel/SideEffectOnlyImport [89
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     83ef366431
  features     baseline

23 deps, 129 codegen, 1172 objects in 901ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (731aa92da)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (731aa92da)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (731aa92da)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[9/1217] gen .bind.ts → GeneratedBindings.cpp
[10/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.l
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/loader.rs                   |  9 +++-
 src/resolver/resolver.rs            |  4 +-
 test/bundler/bundler_barrel.test.ts | 90 +++++++++++++++++++++++++++++++++++++
 3 files changed, 101 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/ast/loader.rs                        1      2      0
src/resolver/resolver.rs                 1      1      0
test/bundler/bundler_barrel.test.ts      1      1      0
```

</details>

**root cause** · written by the author bot

The resolver returned the same verdict for a file in a package with `sideEffects: false` and a file that simply did not match a package's `sideEffects` array, so the barrel optimization treated any array-form package as fully pure and deferred unused re-export records before the named module could be resolved and evaluated. The fix introduces a distinct verdict, `NoSideEffectsPackageJsonArray`, which the resolver returns for the array form, and the barrel check only accepts the package-wide `sideEffects: false` verdict, so array-form packages no longer trigger deferral. All other consumers …

<!-- robobun:evidence:end -->