### PR TITLE
darwin: register Bun__onExit through __cxa_atexit instead of atexit()

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -16,6 +16,9 @@
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#if OS(DARWIN)
+#include <mach-o/loader.h>
+#endif
 #else
 #include <uv.h>
 #include <windows.h>
@@ -632,6 +635,11 @@ extern "C" void Bun__lockThreadSuspensionForExit()
 
 extern "C" int32_t bun_is_stdio_null[3] = { 0, 0, 0 };
 
+#if OS(DARWIN)
+extern "C" int __cxa_atexit(void (*)(void*), void*, void*);
+extern "C" struct mach_header __dso_handle;
+#endif
+
 extern "C" void bun_initialize_process()
 {
     // Disable printf() buffering. We buffer it ourselves.
@@ -752,7 +760,12 @@ extern "C" void bun_initialize_process()
     Bun__setCTRLHandler(1);
 #endif
 
-#if OS(DARWIN) || ASAN_ENABLED
+#if OS(DARWIN)
+    // atexit() on macOS dladdr()s the handler, a linear walk of this executable's
+    // symbol table (~0.5ms with symbols). __cxa_atexit lands on the same LIFO
+    // list without the lookup, as the compiler does for static destructors.
+    __cxa_atexit([](void*) { Bun__onExit(); }, nullptr, &__dso_handle);
+#elif ASAN_ENABLED
     atexit(Bun__onExit);
 #elif !OS(WINDOWS)
     at_quick_exit(Bun__onExit);


### PR DESCRIPTION
On macOS, `atexit()` calls `dladdr()` on the handler to record which image registered it. dyld resolves that with a linear walk of the executable's symbol table, which costs ~0.5 ms per process start on a bun-profile binary (94k symbols; ~1.3 ms on larger symbolized builds) and is pure overhead: libc only uses the `dladdr` result for `__cxa_atexit`-style entries, never for `atexit` ones.

Register `Bun__onExit` with `__cxa_atexit(fn, nullptr, &__dso_handle)` — the same call the compiler emits for static destructors. The handler lands on the same LIFO list, so it runs at the same point of `exit()` in the same order; `dlclose` of a dylib still doesn't fire it since our image is never unloaded.

### Measurements (release build, M4)

Handler registration cost inside the real binary (measured by interposing `atexit`/`__cxa_atexit` via `DYLD_INSERT_LIBRARIES`, n=20):

| binary | before | after |
|---|---|---|
| bun-profile (94k symbols) | 494 µs (median; 3.3 ms cold) | 41 ns |
| bun (stripped, 698 symbols) | 1.2 µs | 41 ns |

End-to-end `bun -e ''` (`hyperfine -N`, 1000 runs):

| | min | p10 | median | user |
|---|---|---|---|---|
| profile before | 4.84 ms | 5.46 | 7.68 | 2.17 ms |
| profile after | 4.36 ms | 5.20 | 7.17 | 1.82 ms |
| stripped before | 4.86 ms | 5.39 | 7.78 | 1.82 ms |
| stripped after | 4.79 ms | 5.40 | 7.77 | 1.82 ms |

### Verification

Exit behavior is identical before/after (output diffed between the baseline release binary and the patched debug binary):

- stdout flush on `process.exit`, normal exit, uncaught exception, exit from a timer; `process.exitCode` + `exit` event
- exit callbacks run (`BUN_FEATURE_FLAG_NO_ORPHANS=1` kills the spawned child at exit; without the flag it survives)
- termios restored after `process.stdin.setRawMode(true); process.exit()` on a PTY (`stty -a` shows `icanon echo`)
- `bun:ffi` `dlopen` + `close()` of a dylib does not fire the exit handler early
- `test/cli/run/no-orphans.test.ts` and `test/js/node/process/process.test.js` pass
