### PR TITLE
node:wasi: refresh the memory view after grow, validate fd_seek, derive stdio types, ns timestamps, symlink policy

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -443,9 +443,15 @@ var require_wasi = __commonJS({
       }
       if (entry.filetype === void 0) {
         const stats = wasi.fstatSync(entry.real);
-        const { filetype, rightsBase, rightsInheriting } = translateFileAttributes(wasi, entry.real, stats);
+        let { filetype, rightsBase, rightsInheriting } = translateFileAttributes(wasi, entry.real, stats);
         entry.filetype = filetype;
         if (!entry.rights) {
+          // The host process shares the file offset of fd 0-2 and there is no
+          // lseek in node:fs, so a regular file on a standard descriptor reads
+          // and writes at the host's offset and cannot be seeked.
+          if (entry.real <= 2 && filetype === constants_1.WASI_FILETYPE_REGULAR_FILE) {
+            rightsBase &= ~(constants_1.WASI_RIGHT_FD_SEEK | constants_1.WASI_RIGHT_FD_TELL);
+          }
           entry.rights = {
             base: rightsBase,
             inheriting: rightsInheriting,
@@ -648,8 +654,6 @@ var require_wasi = __commonJS({
           }
           return stats;
         };
-        const isContained = (parent, child) =>
-          child === parent || child.startsWith(parent.endsWith(path.sep) ? parent : parent + path.sep);
         // Resolve a guest-supplied path against the directory backing `stats` and
         // verify the result cannot escape that directory, either lexically
         // ("..", absolute paths) or through a symlink that already exists on the
@@ -672,6 +676,8 @@ var require_wasi = __commonJS({
           }
           const base = path.resolve(stats.path);
           const resolved = path.resolve(base, rel);
+          const isContained = (parent, child) =>
+            child === parent || child.startsWith(parent.endsWith(path.sep) ? parent : parent + path.sep);
           if (!isContained(base, resolved)) {
             throw new types_1.WASIError(constants_1.WASI_ENOTCAPABLE);
           }
@@ -1194,13 +1200,17 @@ var require_wasi = __commonJS({
             this.view.setBigUint64(bufPtr, rstats.ctimeNs, true);
             return constants_1.WASI_ESUCCESS;
           }),
-          path_filestat_set_times: wrap((fd, _dirflags, pathPtr, pathLen, stAtim, stMtim, fstflags) => {
+          path_filestat_set_times: wrap((fd, dirflags, pathPtr, pathLen, stAtim, stMtim, fstflags) => {
             const stats = CHECK_FD(fd, constants_1.WASI_RIGHT_PATH_FILESTAT_SET_TIMES);
             if (!stats.path) {
               return constants_1.WASI_EINVAL;
             }
             this.refreshMemory();
-            const rstats = this.fstatSync(stats.real);
+            const p = Buffer.from(this.memory.buffer, pathPtr, pathLen).toString();
+            const follow = (dirflags & constants_1.WASI_LOOKUPFLAGS_SYMLINK_FOLLOW) !== 0;
+            const resolved = RESOLVE_PATH(stats, p, follow);
+            // A time that is not being set keeps the target's own value.
+            const rstats = follow ? fs.statSync(resolved) : fs.lstatSync(resolved);
             let atim = rstats.atime;
             let mtim = rstats.mtime;
             const n = nsToMs(now(constants_1.WASI_CLOCK_REALTIME));
@@ -1222,8 +1232,11 @@ var require_wasi = __commonJS({
             } else if ((fstflags & constants_1.WASI_FILESTAT_SET_MTIM_NOW) === constants_1.WASI_FILESTAT_SET_MTIM_NOW) {
               mtim = n;
             }
-            const p = Buffer.from(this.memory.buffer, pathPtr, pathLen).toString();
-            fs.utimesSync(RESOLVE_PATH(stats, p), new Date(atim), new Date(mtim));
+            if (follow) {
+              fs.utimesSync(resolved, new Date(atim), new Date(mtim));
+            } else {
+              fs.lutimesSync(resolved, new Date(atim), new Date(mtim));
+            }
             return constants_1.WASI_ESUCCESS;
           }),
           path_link: wrap((oldFd, _oldFlags, oldPath, oldPathLen, newFd, newPath, newPathLen) => {
@@ -1235,7 +1248,11 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            fs.linkSync(RESOLVE_PATH(ostats, op), RESOLVE_PATH(nstats, np));
+            // The old path is always resolved through a final symlink, whatever
+            // the lookup flags say: whether link(2) follows one is platform
+            // defined, and a hard link to a file outside the preopen would be
+            // a real escape.
+            fs.linkSync(RESOLVE_PATH(ostats, op), RESOLVE_PATH(nstats, np, false));
             return constants_1.WASI_ESUCCESS;
           }),
           path_open: wrap(
@@ -1440,15 +1457,14 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            const linkPath = RESOLVE_PATH(stats, np, false);
-            // The target is resolved relative to the link's own directory.
-            // Refuse one that names a host path outside the preopen, whether
-            // absolute or through "..", so the guest cannot plant an escape
-            // for other users of the directory.
-            if (!isContained(path.resolve(stats.path), path.resolve(path.dirname(linkPath), op))) {
-              return constants_1.WASI_ENOTCAPABLE;
+            // An absolute target names a host path, refuse it like Node does.
+            // A relative target is stored as written: it is interpreted only
+            // when the link is followed, and every call that follows a link
+            // checks the result against the preopen at that time.
+            if (path.isAbsolute(op)) {
+              return constants_1.WASI_EPERM;
             }
-            fs.symlinkSync(op, linkPath);
+            fs.symlinkSync(op, RESOLVE_PATH(stats, np, false));
             return constants_1.WASI_ESUCCESS;
           }),
           path_unlink_file: wrap((fd, pathPtr, pathLen) => {

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -283,6 +283,7 @@ var require_constants = __commonJS({
     exports.WASI_O_DIRECTORY = 1 << 1;
     exports.WASI_O_EXCL = 1 << 2;
     exports.WASI_O_TRUNC = 1 << 3;
+    exports.WASI_LOOKUPFLAGS_SYMLINK_FOLLOW = 1 << 0;
     exports.WASI_PREOPENTYPE_DIR = 0;
     exports.WASI_DIRCOOKIE_START = 0;
     exports.WASI_STDIN_FILENO = 0;
@@ -407,28 +408,8 @@ var require_wasi = __commonJS({
     var types_1 = require_types();
 
     var constants_1 = require_constants();
-    var STDIN_DEFAULT_RIGHTS =
-      constants_1.WASI_RIGHT_FD_DATASYNC |
-      constants_1.WASI_RIGHT_FD_READ |
-      constants_1.WASI_RIGHT_FD_SYNC |
-      constants_1.WASI_RIGHT_FD_ADVISE |
-      constants_1.WASI_RIGHT_FD_FILESTAT_GET |
-      constants_1.WASI_RIGHT_POLL_FD_READWRITE;
-    var STDOUT_DEFAULT_RIGHTS =
-      constants_1.WASI_RIGHT_FD_DATASYNC |
-      constants_1.WASI_RIGHT_FD_WRITE |
-      constants_1.WASI_RIGHT_FD_SYNC |
-      constants_1.WASI_RIGHT_FD_ADVISE |
-      constants_1.WASI_RIGHT_FD_FILESTAT_GET |
-      constants_1.WASI_RIGHT_POLL_FD_READWRITE;
-    var STDERR_DEFAULT_RIGHTS = STDOUT_DEFAULT_RIGHTS;
-    var msToNs = ms => {
-      const msInt = Math.trunc(ms);
-
-      const decimal = BigInt(Math.round((ms - msInt) * 1e6));
-      const ns = BigInt(msInt) * BigInt(1e6);
-      return ns + decimal;
-    };
+    // Largest offset lseek(2) accepts (off_t is signed 64-bit).
+    var MAX_FILE_OFFSET = (BigInt(1) << BigInt(63)) - BigInt(1);
     var nsToMs = ns => {
       if (typeof ns === "number") {
         ns = Math.trunc(ns);
@@ -462,7 +443,7 @@ var require_wasi = __commonJS({
       }
       if (entry.filetype === void 0) {
         const stats = wasi.fstatSync(entry.real);
-        const { filetype, rightsBase, rightsInheriting } = translateFileAttributes(wasi, fd, stats);
+        const { filetype, rightsBase, rightsInheriting } = translateFileAttributes(wasi, entry.real, stats);
         entry.filetype = filetype;
         if (!entry.rights) {
           entry.rights = {
@@ -582,43 +563,15 @@ var require_wasi = __commonJS({
         this.bindings = wasiConfig.bindings || defaultConfig.bindings;
         const bindings = this.bindings;
         fs = bindings.fs;
+        // The file type and rights of the standard descriptors come from the
+        // host fd on first use (see `stat`), like any descriptor from
+        // path_open. Hard-coding a character device made wasi-libc's isatty()
+        // report a tty with stdout redirected to a file or a pipe. They have
+        // no `path`, so they can never serve as the base of a path_* call.
         this.FD_MAP = /* @__PURE__ */ new Map([
-          [
-            constants_1.WASI_STDIN_FILENO,
-            {
-              real: 0,
-              filetype: constants_1.WASI_FILETYPE_CHARACTER_DEVICE,
-              rights: {
-                base: STDIN_DEFAULT_RIGHTS,
-                inheriting: BigInt(0),
-              },
-              path: "/dev/stdin",
-            },
-          ],
-          [
-            constants_1.WASI_STDOUT_FILENO,
-            {
-              real: 1,
-              filetype: constants_1.WASI_FILETYPE_CHARACTER_DEVICE,
-              rights: {
-                base: STDOUT_DEFAULT_RIGHTS,
-                inheriting: BigInt(0),
-              },
-              path: "/dev/stdout",
-            },
-          ],
-          [
-            constants_1.WASI_STDERR_FILENO,
-            {
-              real: 2,
-              filetype: constants_1.WASI_FILETYPE_CHARACTER_DEVICE,
-              rights: {
-                base: STDERR_DEFAULT_RIGHTS,
-                inheriting: BigInt(0),
-              },
-              path: "/dev/stderr",
-            },
-          ],
+          [constants_1.WASI_STDIN_FILENO, { real: 0, filetype: void 0, rights: void 0 }],
+          [constants_1.WASI_STDOUT_FILENO, { real: 1, filetype: void 0, rights: void 0 }],
+          [constants_1.WASI_STDERR_FILENO, { real: 2, filetype: void 0, rights: void 0 }],
         ]);
         const path = bindings.path;
         for (const [k, v] of Object.entries(preopens)) {
@@ -695,11 +648,18 @@ var require_wasi = __commonJS({
           }
           return stats;
         };
+        const isContained = (parent, child) =>
+          child === parent || child.startsWith(parent.endsWith(path.sep) ? parent : parent + path.sep);
         // Resolve a guest-supplied path against the directory backing `stats` and
         // verify the result cannot escape that directory, either lexically
         // ("..", absolute paths) or through a symlink that already exists on the
         // host filesystem.
-        const RESOLVE_PATH = (stats, guestPath) => {
+        //
+        // With `followFinal` false the final component is checked as the entry
+        // itself, not as what it points to. This is for calls that operate on
+        // a symlink (unlink, readlink, rename, lstat) and so never leave the
+        // parent directory, whatever the link's target is.
+        const RESOLVE_PATH = (stats, guestPath, followFinal = true) => {
           if (!stats.path) {
             throw new types_1.WASIError(constants_1.WASI_EINVAL);
           }
@@ -712,8 +672,6 @@ var require_wasi = __commonJS({
           }
           const base = path.resolve(stats.path);
           const resolved = path.resolve(base, rel);
-          const isContained = (parent, child) =>
-            child === parent || child.startsWith(parent.endsWith(path.sep) ? parent : parent + path.sep);
           if (!isContained(base, resolved)) {
             throw new types_1.WASIError(constants_1.WASI_ENOTCAPABLE);
           }
@@ -726,6 +684,10 @@ var require_wasi = __commonJS({
           } catch {}
           let probe = resolved;
           let suffix = "";
+          if (!followFinal && resolved !== base) {
+            probe = path.dirname(resolved);
+            suffix = path.sep + path.basename(resolved);
+          }
           for (;;) {
             let real;
             try {
@@ -892,24 +854,24 @@ var require_wasi = __commonJS({
             const stats = CHECK_FD(fd, constants_1.WASI_RIGHT_FD_FILESTAT_GET);
             const rstats = this.fstatSync(stats.real);
             this.refreshMemory();
-            this.view.setBigUint64(bufPtr, BigInt(rstats.dev), true);
+            this.view.setBigUint64(bufPtr, rstats.dev, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.ino), true);
+            this.view.setBigUint64(bufPtr, rstats.ino, true);
             bufPtr += 8;
             if (stats.filetype == null) {
               throw Error("stats.filetype must be set");
             }
             this.view.setUint8(bufPtr, stats.filetype);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.nlink), true);
+            this.view.setBigUint64(bufPtr, rstats.nlink, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.size), true);
+            this.view.setBigUint64(bufPtr, rstats.size, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, msToNs(rstats.atimeMs), true);
+            this.view.setBigUint64(bufPtr, rstats.atimeNs, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, msToNs(rstats.mtimeMs), true);
+            this.view.setBigUint64(bufPtr, rstats.mtimeNs, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, msToNs(rstats.ctimeMs), true);
+            this.view.setBigUint64(bufPtr, rstats.ctimeNs, true);
             return constants_1.WASI_ESUCCESS;
           }),
           fd_filestat_set_size: wrap((fd, stSize) => {
@@ -1080,6 +1042,9 @@ var require_wasi = __commonJS({
           }),
           fd_readdir: wrap((fd, bufPtr, bufLen, cookie, bufusedPtr) => {
             const stats = CHECK_FD(fd, constants_1.WASI_RIGHT_FD_READDIR);
+            if (!stats.path) {
+              return constants_1.WASI_EINVAL;
+            }
             this.refreshMemory();
             const entries = fs.readdirSync(stats.path, { withFileTypes: true });
             const startPtr = bufPtr;
@@ -1157,22 +1122,25 @@ var require_wasi = __commonJS({
           fd_seek: wrap((fd, offset, whence, newOffsetPtr) => {
             const stats = CHECK_FD(fd, constants_1.WASI_RIGHT_FD_SEEK);
             this.refreshMemory();
+            let newOffset;
             switch (whence) {
               case constants_1.WASI_WHENCE_CUR:
-                stats.offset = (stats.offset ? stats.offset : BigInt(0)) + BigInt(offset);
+                newOffset = (stats.offset ? stats.offset : BigInt(0)) + BigInt(offset);
                 break;
               case constants_1.WASI_WHENCE_END:
-                const { size } = this.fstatSync(stats.real);
-                stats.offset = BigInt(size) + BigInt(offset);
+                newOffset = this.fstatSync(stats.real).size + BigInt(offset);
                 break;
               case constants_1.WASI_WHENCE_SET:
-                stats.offset = BigInt(offset);
+                newOffset = BigInt(offset);
                 break;
+              default:
+                return constants_1.WASI_EINVAL;
             }
-            if (stats.offset == null) {
-              throw Error("stats.offset must be defined");
+            if (newOffset < BigInt(0) || newOffset > MAX_FILE_OFFSET) {
+              return constants_1.WASI_EINVAL;
             }
-            this.view.setBigUint64(newOffsetPtr, stats.offset, true);
+            stats.offset = newOffset;
+            this.view.setBigUint64(newOffsetPtr, newOffset, true);
             return constants_1.WASI_ESUCCESS;
           }),
           fd_tell: wrap((fd, offsetPtr) => {
@@ -1206,28 +1174,24 @@ var require_wasi = __commonJS({
             }
             this.refreshMemory();
             const p = Buffer.from(this.memory.buffer, pathPtr, pathLen).toString();
-            const resolved = RESOLVE_PATH(stats, p);
-            let rstats;
-            if (flags) {
-              rstats = fs.statSync(resolved);
-            } else {
-              rstats = fs.lstatSync(resolved);
-            }
-            this.view.setBigUint64(bufPtr, BigInt(rstats.dev), true);
+            const follow = (flags & constants_1.WASI_LOOKUPFLAGS_SYMLINK_FOLLOW) !== 0;
+            const resolved = RESOLVE_PATH(stats, p, follow);
+            const rstats = follow ? fs.statSync(resolved, { bigint: true }) : fs.lstatSync(resolved, { bigint: true });
+            this.view.setBigUint64(bufPtr, rstats.dev, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.ino), true);
+            this.view.setBigUint64(bufPtr, rstats.ino, true);
             bufPtr += 8;
             this.view.setUint8(bufPtr, translateFileAttributes(this, void 0, rstats).filetype);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.nlink), true);
+            this.view.setBigUint64(bufPtr, rstats.nlink, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.size), true);
+            this.view.setBigUint64(bufPtr, rstats.size, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.atime.getTime() * 1e6), true);
+            this.view.setBigUint64(bufPtr, rstats.atimeNs, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.mtime.getTime() * 1e6), true);
+            this.view.setBigUint64(bufPtr, rstats.mtimeNs, true);
             bufPtr += 8;
-            this.view.setBigUint64(bufPtr, BigInt(rstats.ctime.getTime() * 1e6), true);
+            this.view.setBigUint64(bufPtr, rstats.ctimeNs, true);
             return constants_1.WASI_ESUCCESS;
           }),
           path_filestat_set_times: wrap((fd, _dirflags, pathPtr, pathLen, stAtim, stMtim, fstflags) => {
@@ -1440,7 +1404,7 @@ var require_wasi = __commonJS({
             }
             this.refreshMemory();
             const p = Buffer.from(this.memory.buffer, pathPtr, pathLen).toString();
-            const full = RESOLVE_PATH(stats, p);
+            const full = RESOLVE_PATH(stats, p, false);
             const r = fs.readlinkSync(full);
             const used = Buffer.from(this.memory.buffer).write(r, buf, bufLen);
             this.view.setUint32(bufused, used, true);
@@ -1453,7 +1417,7 @@ var require_wasi = __commonJS({
             }
             this.refreshMemory();
             const p = Buffer.from(this.memory.buffer, pathPtr, pathLen).toString();
-            fs.rmdirSync(RESOLVE_PATH(stats, p));
+            fs.rmdirSync(RESOLVE_PATH(stats, p, false));
             return constants_1.WASI_ESUCCESS;
           }),
           path_rename: wrap((oldFd, oldPath, oldPathLen, newFd, newPath, newPathLen) => {
@@ -1465,7 +1429,7 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            fs.renameSync(RESOLVE_PATH(ostats, op), RESOLVE_PATH(nstats, np));
+            fs.renameSync(RESOLVE_PATH(ostats, op, false), RESOLVE_PATH(nstats, np, false));
             return constants_1.WASI_ESUCCESS;
           }),
           path_symlink: wrap((oldPath, oldPathLen, fd, newPath, newPathLen) => {
@@ -1476,7 +1440,15 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            fs.symlinkSync(op, RESOLVE_PATH(stats, np));
+            const linkPath = RESOLVE_PATH(stats, np, false);
+            // The target is resolved relative to the link's own directory.
+            // Refuse one that names a host path outside the preopen, whether
+            // absolute or through "..", so the guest cannot plant an escape
+            // for other users of the directory.
+            if (!isContained(path.resolve(stats.path), path.resolve(path.dirname(linkPath), op))) {
+              return constants_1.WASI_ENOTCAPABLE;
+            }
+            fs.symlinkSync(op, linkPath);
             return constants_1.WASI_ESUCCESS;
           }),
           path_unlink_file: wrap((fd, pathPtr, pathLen) => {
@@ -1486,7 +1458,7 @@ var require_wasi = __commonJS({
             }
             this.refreshMemory();
             const p = Buffer.from(this.memory.buffer, pathPtr, pathLen).toString();
-            fs.unlinkSync(RESOLVE_PATH(stats, p));
+            fs.unlinkSync(RESOLVE_PATH(stats, p, false));
             return constants_1.WASI_ESUCCESS;
           }),
           poll_oneoff: (sin, sout, nsubscriptions, neventsPtr) => {
@@ -1648,32 +1620,35 @@ var require_wasi = __commonJS({
       fstatSync(real_fd) {
         if (real_fd <= 2) {
           try {
-            return fs.fstatSync(real_fd);
+            return fs.fstatSync(real_fd, { bigint: true });
           } catch {
+            // A closed standard descriptor on the host: present it as an
+            // empty character device.
             const now = new Date();
+            const nowNs = BigInt(now.valueOf()) * BigInt(1e6);
+            const no = () => false;
             return {
-              dev: 0,
-              mode: 8592,
-              nlink: 1,
-              uid: 0,
-              gid: 0,
-              rdev: 0,
-              blksize: 65536,
-              ino: 0,
-              size: 0,
-              blocks: 0,
-              atimeMs: now.valueOf(),
-              mtimeMs: now.valueOf(),
-              ctimeMs: now.valueOf(),
-              birthtimeMs: 0,
-              atime: new Date(),
-              mtime: new Date(),
-              ctime: new Date(),
-              birthtime: new Date(0),
+              dev: BigInt(0),
+              ino: BigInt(0),
+              nlink: BigInt(1),
+              size: BigInt(0),
+              atimeNs: nowNs,
+              mtimeNs: nowNs,
+              ctimeNs: nowNs,
+              atime: now,
+              mtime: now,
+              ctime: now,
+              isBlockDevice: no,
+              isCharacterDevice: () => true,
+              isDirectory: no,
+              isFIFO: no,
+              isFile: no,
+              isSocket: no,
+              isSymbolicLink: no,
             };
           }
         }
-        return fs.fstatSync(real_fd);
+        return fs.fstatSync(real_fd, { bigint: true });
       }
       shortPause() {
         if (this.sleep == null) return;
@@ -1693,8 +1668,12 @@ var require_wasi = __commonJS({
         return fd;
       }
       refreshMemory() {
-        if (!this.view || this.view.buffer.byteLength === 0) {
-          this.view = new DataView(this.memory.buffer);
+        // memory.grow() hands out a new buffer object. A non-shared buffer is
+        // also detached, but a SharedArrayBuffer keeps its old length, so
+        // compare identity rather than byteLength.
+        const { buffer } = this.memory;
+        if (!this.view || this.view.buffer !== buffer) {
+          this.view = new DataView(buffer);
         }
       }
       setMemory(memory) {

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -446,9 +446,7 @@ var require_wasi = __commonJS({
         let { filetype, rightsBase, rightsInheriting } = translateFileAttributes(wasi, entry.real, stats);
         entry.filetype = filetype;
         if (!entry.rights) {
-          // The host process shares the file offset of fd 0-2 and there is no
-          // lseek in node:fs, so a regular file on a standard descriptor reads
-          // and writes at the host's offset and cannot be seeked.
+          // fd 0-2 read and write at the host's file offset (node:fs has no lseek).
           if (entry.real <= 2 && filetype === constants_1.WASI_FILETYPE_REGULAR_FILE) {
             rightsBase &= ~(constants_1.WASI_RIGHT_FD_SEEK | constants_1.WASI_RIGHT_FD_TELL);
           }
@@ -569,11 +567,8 @@ var require_wasi = __commonJS({
         this.bindings = wasiConfig.bindings || defaultConfig.bindings;
         const bindings = this.bindings;
         fs = bindings.fs;
-        // The file type and rights of the standard descriptors come from the
-        // host fd on first use (see `stat`), like any descriptor from
-        // path_open. Hard-coding a character device made wasi-libc's isatty()
-        // report a tty with stdout redirected to a file or a pipe. They have
-        // no `path`, so they can never serve as the base of a path_* call.
+        // fd 0-2 take their type and rights from the host fd on first use (see
+        // `stat`). Without a `path` they can never be the base of a path_* call.
         this.FD_MAP = /* @__PURE__ */ new Map([
           [constants_1.WASI_STDIN_FILENO, { real: 0, filetype: void 0, rights: void 0 }],
           [constants_1.WASI_STDOUT_FILENO, { real: 1, filetype: void 0, rights: void 0 }],
@@ -657,12 +652,8 @@ var require_wasi = __commonJS({
         // Resolve a guest-supplied path against the directory backing `stats` and
         // verify the result cannot escape that directory, either lexically
         // ("..", absolute paths) or through a symlink that already exists on the
-        // host filesystem.
-        //
-        // With `followFinal` false the final component is checked as the entry
-        // itself, not as what it points to. This is for calls that operate on
-        // a symlink (unlink, readlink, rename, lstat) and so never leave the
-        // parent directory, whatever the link's target is.
+        // host filesystem. `followFinal` false checks the final component as the
+        // entry itself, for calls that act on a symlink (unlink, readlink, ...).
         const RESOLVE_PATH = (stats, guestPath, followFinal = true) => {
           if (!stats.path) {
             throw new types_1.WASIError(constants_1.WASI_EINVAL);
@@ -1248,10 +1239,8 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            // The old path is always resolved through a final symlink, whatever
-            // the lookup flags say: whether link(2) follows one is platform
-            // defined, and a hard link to a file outside the preopen would be
-            // a real escape.
+            // Whether link(2) follows a final symlink is platform defined, so the
+            // old path is always resolved through one (a hard link must not escape).
             fs.linkSync(RESOLVE_PATH(ostats, op), RESOLVE_PATH(nstats, np, false));
             return constants_1.WASI_ESUCCESS;
           }),
@@ -1457,10 +1446,8 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            // An absolute target names a host path, refuse it like Node does.
-            // A relative target is stored as written: it is interpreted only
-            // when the link is followed, and every call that follows a link
-            // checks the result against the preopen at that time.
+            // Like Node: refuse an absolute target. A relative one is stored as
+            // written and checked by the calls that follow the link.
             if (path.isAbsolute(op)) {
               return constants_1.WASI_EPERM;
             }
@@ -1638,8 +1625,7 @@ var require_wasi = __commonJS({
           try {
             return fs.fstatSync(real_fd, { bigint: true });
           } catch {
-            // A closed standard descriptor on the host: present it as an
-            // empty character device.
+            // A closed standard descriptor: present it as an empty character device.
             const now = new Date();
             const nowNs = BigInt(now.valueOf()) * BigInt(1e6);
             const no = () => false;
@@ -1684,9 +1670,8 @@ var require_wasi = __commonJS({
         return fd;
       }
       refreshMemory() {
-        // memory.grow() hands out a new buffer object. A non-shared buffer is
-        // also detached, but a SharedArrayBuffer keeps its old length, so
-        // compare identity rather than byteLength.
+        // grow() replaces memory.buffer. A shared one keeps its byteLength, so
+        // compare identity.
         const { buffer } = this.memory;
         if (!this.view || this.view.buffer !== buffer) {
           this.view = new DataView(buffer);

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -567,8 +567,7 @@ var require_wasi = __commonJS({
         this.bindings = wasiConfig.bindings || defaultConfig.bindings;
         const bindings = this.bindings;
         fs = bindings.fs;
-        // fd 0-2 take their type and rights from the host fd on first use (see
-        // `stat`). Without a `path` they can never be the base of a path_* call.
+        // fd 0-2 get their type and rights from the host fd on first use, in `stat`.
         this.FD_MAP = /* @__PURE__ */ new Map([
           [constants_1.WASI_STDIN_FILENO, { real: 0, filetype: void 0, rights: void 0 }],
           [constants_1.WASI_STDOUT_FILENO, { real: 1, filetype: void 0, rights: void 0 }],
@@ -652,8 +651,7 @@ var require_wasi = __commonJS({
         // Resolve a guest-supplied path against the directory backing `stats` and
         // verify the result cannot escape that directory, either lexically
         // ("..", absolute paths) or through a symlink that already exists on the
-        // host filesystem. `followFinal` false checks the final component as the
-        // entry itself, for calls that act on a symlink (unlink, readlink, ...).
+        // host filesystem.
         const RESOLVE_PATH = (stats, guestPath, followFinal = true) => {
           if (!stats.path) {
             throw new types_1.WASIError(constants_1.WASI_EINVAL);
@@ -1239,8 +1237,7 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            // Whether link(2) follows a final symlink is platform defined, so the
-            // old path is always resolved through one (a hard link must not escape).
+            // link(2) may follow a final symlink (platform defined), so the old path is resolved through one.
             fs.linkSync(RESOLVE_PATH(ostats, op), RESOLVE_PATH(nstats, np, false));
             return constants_1.WASI_ESUCCESS;
           }),
@@ -1446,8 +1443,7 @@ var require_wasi = __commonJS({
             this.refreshMemory();
             const op = Buffer.from(this.memory.buffer, oldPath, oldPathLen).toString();
             const np = Buffer.from(this.memory.buffer, newPath, newPathLen).toString();
-            // Like Node: refuse an absolute target. A relative one is stored as
-            // written and checked by the calls that follow the link.
+            // Like Node: refuse an absolute target. A relative one is checked when the link is followed.
             if (path.isAbsolute(op)) {
               return constants_1.WASI_EPERM;
             }
@@ -1670,8 +1666,7 @@ var require_wasi = __commonJS({
         return fd;
       }
       refreshMemory() {
-        // grow() replaces memory.buffer. A shared one keeps its byteLength, so
-        // compare identity.
+        // grow() replaces memory.buffer, and a shared one keeps its byteLength, so compare identity.
         const { buffer } = this.memory;
         if (!this.view || this.view.buffer !== buffer) {
           this.view = new DataView(buffer);

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -36,6 +36,8 @@ it("fd_fdstat_set_rights only narrows the rights of a descriptor", () => {
   const WASI_RIGHT_FD_READ = BigInt(2);
   const allRights = BigInt.asIntN(64, BigInt("0xffffffffffffffff"));
 
+  // the rights of a standard descriptor are derived from the host fd on first use
+  expect(wasi.wasiImport.fd_fdstat_get(0, 1024)).toBe(WASI_ESUCCESS);
   const stdinRights = wasi.FD_MAP.get(0).rights;
   const baseBefore = stdinRights.base;
   const inheritingBefore = stdinRights.inheriting;
@@ -163,3 +165,240 @@ it("path_* syscalls cannot escape the preopened directory", () => {
   );
   expect(wasi.FD_MAP.has(4)).toBe(true);
 });
+
+it.each([false, true])("hostcalls see linear memory grown after the first call (shared: %p)", shared => {
+  const wasi = new WASI({ args: ["a", "bc"] });
+  const memory = new WebAssembly.Memory({ initial: 1, maximum: 2, shared });
+  wasi.setMemory(memory);
+
+  const WASI_ESUCCESS = 0;
+  const WASI_CLOCK_REALTIME = 0;
+
+  // the first call caches a view of the one-page memory
+  expect(wasi.wasiImport.args_sizes_get(0, 4)).toBe(WASI_ESUCCESS);
+  memory.grow(1);
+
+  // every pointer below lives in the page that grow() added
+  const argcPtr = 65536 + 16;
+  const argvBufSizePtr = argcPtr + 4;
+  const timePtr = argcPtr + 8;
+  expect(wasi.wasiImport.args_sizes_get(argcPtr, argvBufSizePtr)).toBe(WASI_ESUCCESS);
+  expect(wasi.wasiImport.clock_time_get(WASI_CLOCK_REALTIME, BigInt(0), timePtr)).toBe(WASI_ESUCCESS);
+
+  const view = new DataView(memory.buffer);
+  expect([view.getUint32(argcPtr, true), view.getUint32(argvBufSizePtr, true)]).toEqual([2, "a\0bc\0".length]);
+  expect(view.getBigUint64(timePtr, true)).toBeGreaterThan(BigInt(0));
+});
+
+it("fd_seek rejects an unknown whence and an offset before the start of the file", () => {
+  using dir = tempDir("wasi-seek", {
+    "f.txt": "0123456789",
+  });
+  const wasi = new WASI({ preopens: { "/": String(dir) } });
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const memory = Buffer.from(wasi.memory.buffer);
+  const view = new DataView(wasi.memory.buffer);
+
+  const WASI_ESUCCESS = 0;
+  const WASI_EINVAL = 28;
+  const WASI_WHENCE_SET = 0;
+  const WASI_WHENCE_CUR = 1;
+  const WASI_WHENCE_END = 2;
+  const INT64_MAX = (BigInt(1) << BigInt(63)) - BigInt(1);
+  const rights = BigInt(2) | BigInt(4) | BigInt(32); // FD_READ | FD_SEEK | FD_TELL
+  const preopenFd = 3;
+  const pathPtr = 1024;
+  const fdPtr = 2048;
+  const offsetPtr = 4096;
+  const iovPtr = 8192;
+  const bufPtr = 12288;
+  const nreadPtr = 16384;
+  const sentinel = BigInt(0xdead);
+
+  const len = memory.write("f.txt", pathPtr);
+  expect(wasi.wasiImport.path_open(preopenFd, 0, pathPtr, len, 0, rights, BigInt(0), 0, fdPtr)).toBe(WASI_ESUCCESS);
+  const fd = view.getUint32(fdPtr, true);
+  const seek = (offset, whence) => wasi.wasiImport.fd_seek(fd, offset, whence, offsetPtr);
+
+  // an unknown whence on a descriptor that was never seeked used to throw out of the import
+  expect(seek(BigInt(1), 3)).toBe(WASI_EINVAL);
+  expect(seek(BigInt(1), 255)).toBe(WASI_EINVAL);
+
+  expect(seek(BigInt(2), WASI_WHENCE_SET)).toBe(WASI_ESUCCESS);
+  expect(view.getBigUint64(offsetPtr, true)).toBe(BigInt(2));
+
+  // a rejected seek writes nothing and leaves the offset where it was
+  view.setBigUint64(offsetPtr, sentinel, true);
+  expect(seek(BigInt(1), 3)).toBe(WASI_EINVAL);
+  expect(seek(BigInt(-5), WASI_WHENCE_SET)).toBe(WASI_EINVAL);
+  expect(seek(BigInt(-3), WASI_WHENCE_CUR)).toBe(WASI_EINVAL);
+  expect(seek(BigInt(-11), WASI_WHENCE_END)).toBe(WASI_EINVAL);
+  expect(view.getBigUint64(offsetPtr, true)).toBe(sentinel);
+  expect(wasi.wasiImport.fd_tell(fd, offsetPtr)).toBe(WASI_ESUCCESS);
+  expect(view.getBigUint64(offsetPtr, true)).toBe(BigInt(2));
+
+  // the offset cannot leave the range of off_t
+  expect(seek(INT64_MAX, WASI_WHENCE_SET)).toBe(WASI_ESUCCESS);
+  expect(seek(BigInt(1), WASI_WHENCE_CUR)).toBe(WASI_EINVAL);
+
+  // a backwards seek from the end is valid and the next read starts there
+  expect(seek(BigInt(-3), WASI_WHENCE_END)).toBe(WASI_ESUCCESS);
+  expect(view.getBigUint64(offsetPtr, true)).toBe(BigInt(7));
+  view.setUint32(iovPtr, bufPtr, true);
+  view.setUint32(iovPtr + 4, 8, true);
+  expect(wasi.wasiImport.fd_read(fd, iovPtr, 1, nreadPtr)).toBe(WASI_ESUCCESS);
+  expect(memory.toString("utf8", bufPtr, bufPtr + view.getUint32(nreadPtr, true))).toBe("789");
+});
+
+it("fd_filestat_get and path_filestat_get report the host timestamps in nanoseconds", () => {
+  using dir = tempDir("wasi-filestat-times", {
+    "f.txt": "x",
+  });
+  const wasi = new WASI({ preopens: { "/": String(dir) } });
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const memory = Buffer.from(wasi.memory.buffer);
+  const view = new DataView(wasi.memory.buffer);
+
+  const WASI_ESUCCESS = 0;
+  const WASI_RIGHT_FD_FILESTAT_GET = BigInt(2097152);
+  const preopenFd = 3;
+  const pathPtr = 1024;
+  const fdPtr = 2048;
+  const statPtr = 4096;
+  // filestat layout: dev, ino, filetype, nlink, size, atim, mtim, ctim (8 bytes each).
+  // atim is left out: opening the file may update it on some hosts.
+  const times = () => ({
+    mtim: view.getBigUint64(statPtr + 48, true),
+    ctim: view.getBigUint64(statPtr + 56, true),
+  });
+
+  const len = memory.write("f.txt", pathPtr);
+  expect(wasi.wasiImport.path_filestat_get(preopenFd, 0, pathPtr, len, statPtr)).toBe(WASI_ESUCCESS);
+  const fromPath = times();
+  expect(
+    wasi.wasiImport.path_open(preopenFd, 0, pathPtr, len, 0, WASI_RIGHT_FD_FILESTAT_GET, BigInt(0), 0, fdPtr),
+  ).toBe(WASI_ESUCCESS);
+  expect(wasi.wasiImport.fd_filestat_get(view.getUint32(fdPtr, true), statPtr)).toBe(WASI_ESUCCESS);
+  const fromFd = times();
+
+  const host = fs.statSync(path.join(String(dir), "f.txt"), { bigint: true });
+  const expected = { mtim: host.mtimeNs, ctim: host.ctimeNs };
+  expect(fromPath).toEqual(expected);
+  expect(fromFd).toEqual(expected);
+});
+
+it("fd_fdstat_get reports the host file type of the standard descriptors", async () => {
+  using dir = tempDir("wasi-stdio-fdstat", {
+    "stdin.txt": "input",
+  });
+  const stdoutPath = path.join(String(dir), "stdout.txt");
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { WASI } = require("node:wasi");
+      const wasi = new WASI({});
+      wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+      const view = new DataView(wasi.memory.buffer);
+      const WASI_FILETYPE_CHARACTER_DEVICE = 2;
+      const WASI_RIGHT_FD_SEEK_OR_TELL = BigInt(4) | BigInt(32);
+      const out = {};
+      for (const fd of [0, 1, 2]) {
+        const errno = wasi.wasiImport.fd_fdstat_get(fd, 64);
+        const filetype = view.getUint8(64);
+        const rights = view.getBigUint64(72, true);
+        // what wasi-libc's isatty() computes from fd_fdstat_get
+        const isatty = filetype === WASI_FILETYPE_CHARACTER_DEVICE && (rights & WASI_RIGHT_FD_SEEK_OR_TELL) === BigInt(0);
+        out[fd] = { errno, filetype, isatty };
+      }
+      process.stdout.write(JSON.stringify(out));
+      `,
+    ],
+    env: bunEnv,
+    stdin: Bun.file(path.join(String(dir), "stdin.txt")),
+    stdout: Bun.file(stdoutPath),
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  const WASI_FILETYPE_REGULAR_FILE = 4;
+  const WASI_FILETYPE_SOCKET_STREAM = 6;
+  expect(JSON.parse(fs.readFileSync(stdoutPath, "utf8"))).toEqual({
+    0: { errno: 0, filetype: WASI_FILETYPE_REGULAR_FILE, isatty: false },
+    1: { errno: 0, filetype: WASI_FILETYPE_REGULAR_FILE, isatty: false },
+    2: { errno: 0, filetype: WASI_FILETYPE_SOCKET_STREAM, isatty: false },
+  });
+});
+
+it.skipIf(isWindows)(
+  "path_symlink refuses a target outside the preopen, and a link inside can be inspected and removed",
+  () => {
+    using dir = tempDir("wasi-symlink-policy", {
+      "secret.txt": "outside",
+      "sandbox/inside.txt": "inside",
+      "sandbox/sub/.keep": "",
+    });
+    const root = String(dir);
+    const sandbox = path.join(root, "sandbox");
+    // links planted before the guest runs: one to a file outside, one dangling
+    fs.symlinkSync(path.join("..", "secret.txt"), path.join(sandbox, "escape"));
+    fs.symlinkSync(path.join(root, "does-not-exist"), path.join(sandbox, "dangling"));
+
+    const wasi = new WASI({ preopens: { "/": sandbox } });
+    wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+    const memory = Buffer.from(wasi.memory.buffer);
+    const view = new DataView(wasi.memory.buffer);
+
+    const WASI_ESUCCESS = 0;
+    const WASI_ENOTCAPABLE = 76;
+    const WASI_FILETYPE_SYMBOLIC_LINK = 7;
+    const WASI_LOOKUPFLAGS_SYMLINK_FOLLOW = 1;
+    const preopenFd = 3;
+    const targetPtr = 1024;
+    const pathPtr = 2048;
+    const newPathPtr = 3072;
+    const statPtr = 4096;
+    const bufPtr = 8192;
+    const bufUsedPtr = 12288;
+    const symlink = (target, linkPath) =>
+      wasi.wasiImport.path_symlink(
+        targetPtr,
+        memory.write(target, targetPtr),
+        preopenFd,
+        pathPtr,
+        memory.write(linkPath, pathPtr),
+      );
+
+    // a target that leaves the preopen is refused, absolute or relative to the link
+    expect(symlink(path.join(root, "secret.txt"), "abs-link")).toBe(WASI_ENOTCAPABLE);
+    expect(symlink("../secret.txt", "rel-link")).toBe(WASI_ENOTCAPABLE);
+    expect(symlink("../../secret.txt", "sub/deep-link")).toBe(WASI_ENOTCAPABLE);
+    // a target that stays inside is fine, including ".." from a subdirectory
+    expect(symlink("inside.txt", "ok-link")).toBe(WASI_ESUCCESS);
+    expect(symlink("../inside.txt", "sub/up-link")).toBe(WASI_ESUCCESS);
+    expect(fs.readdirSync(sandbox).sort()).toEqual(["dangling", "escape", "inside.txt", "ok-link", "sub"]);
+    expect(fs.readFileSync(path.join(sandbox, "sub", "up-link"), "utf8")).toBe("inside");
+
+    // calls that do not follow the final component act on the link itself
+    let len = memory.write("escape", pathPtr);
+    expect(wasi.wasiImport.path_filestat_get(preopenFd, 0, pathPtr, len, statPtr)).toBe(WASI_ESUCCESS);
+    expect(view.getUint8(statPtr + 16)).toBe(WASI_FILETYPE_SYMBOLIC_LINK);
+    expect(wasi.wasiImport.path_readlink(preopenFd, pathPtr, len, bufPtr, 256, bufUsedPtr)).toBe(WASI_ESUCCESS);
+    expect(memory.toString("utf8", bufPtr, bufPtr + view.getUint32(bufUsedPtr, true))).toBe("../secret.txt");
+    // following it is still refused
+    expect(wasi.wasiImport.path_filestat_get(preopenFd, WASI_LOOKUPFLAGS_SYMLINK_FOLLOW, pathPtr, len, statPtr)).toBe(
+      WASI_ENOTCAPABLE,
+    );
+    const newLen = memory.write("renamed", newPathPtr);
+    expect(wasi.wasiImport.path_rename(preopenFd, pathPtr, len, preopenFd, newPathPtr, newLen)).toBe(WASI_ESUCCESS);
+    expect(wasi.wasiImport.path_unlink_file(preopenFd, newPathPtr, newLen)).toBe(WASI_ESUCCESS);
+    len = memory.write("dangling", pathPtr);
+    expect(wasi.wasiImport.path_unlink_file(preopenFd, pathPtr, len)).toBe(WASI_ESUCCESS);
+
+    expect(fs.readFileSync(path.join(root, "secret.txt"), "utf8")).toBe("outside");
+    expect(fs.readdirSync(sandbox).sort()).toEqual(["inside.txt", "ok-link", "sub"]);
+  },
+);

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -302,6 +302,7 @@ it("fd_fdstat_get reports the host file type of the standard descriptors", async
       wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
       const view = new DataView(wasi.memory.buffer);
       const WASI_FILETYPE_CHARACTER_DEVICE = 2;
+      const WASI_WHENCE_SET = 0;
       const WASI_RIGHT_FD_SEEK_OR_TELL = BigInt(4) | BigInt(32);
       const out = {};
       for (const fd of [0, 1, 2]) {
@@ -310,7 +311,9 @@ it("fd_fdstat_get reports the host file type of the standard descriptors", async
         const rights = view.getBigUint64(72, true);
         // what wasi-libc's isatty() computes from fd_fdstat_get
         const isatty = filetype === WASI_FILETYPE_CHARACTER_DEVICE && (rights & WASI_RIGHT_FD_SEEK_OR_TELL) === BigInt(0);
-        out[fd] = { errno, filetype, isatty };
+        // the host owns the offset of fd 0-2, so none of them can be seeked
+        const seek = wasi.wasiImport.fd_seek(fd, BigInt(0), WASI_WHENCE_SET, 128);
+        out[fd] = { errno, filetype, isatty, seek };
       }
       process.stdout.write(JSON.stringify(out));
       `,
@@ -322,83 +325,135 @@ it("fd_fdstat_get reports the host file type of the standard descriptors", async
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
 
+  const WASI_EPERM = 63;
   const WASI_FILETYPE_REGULAR_FILE = 4;
   const WASI_FILETYPE_SOCKET_STREAM = 6;
   expect(JSON.parse(fs.readFileSync(stdoutPath, "utf8"))).toEqual({
-    0: { errno: 0, filetype: WASI_FILETYPE_REGULAR_FILE, isatty: false },
-    1: { errno: 0, filetype: WASI_FILETYPE_REGULAR_FILE, isatty: false },
-    2: { errno: 0, filetype: WASI_FILETYPE_SOCKET_STREAM, isatty: false },
+    0: { errno: 0, filetype: WASI_FILETYPE_REGULAR_FILE, isatty: false, seek: WASI_EPERM },
+    1: { errno: 0, filetype: WASI_FILETYPE_REGULAR_FILE, isatty: false, seek: WASI_EPERM },
+    2: { errno: 0, filetype: WASI_FILETYPE_SOCKET_STREAM, isatty: false, seek: WASI_EPERM },
   });
+  expect(exitCode).toBe(0);
 });
 
-it.skipIf(isWindows)(
-  "path_symlink refuses a target outside the preopen, and a link inside can be inspected and removed",
-  () => {
-    using dir = tempDir("wasi-symlink-policy", {
-      "secret.txt": "outside",
-      "sandbox/inside.txt": "inside",
-      "sandbox/sub/.keep": "",
-    });
-    const root = String(dir);
-    const sandbox = path.join(root, "sandbox");
-    // links planted before the guest runs: one to a file outside, one dangling
-    fs.symlinkSync(path.join("..", "secret.txt"), path.join(sandbox, "escape"));
-    fs.symlinkSync(path.join(root, "does-not-exist"), path.join(sandbox, "dangling"));
+it.skipIf(isWindows)("symlinks: only following one is checked against the preopen", () => {
+  using dir = tempDir("wasi-symlink-policy", {
+    "secret.txt": "outside",
+    "sandbox/inside.txt": "inside",
+    "sandbox/sub/.keep": "",
+  });
+  const root = String(dir);
+  const sandbox = path.join(root, "sandbox");
+  const secret = path.join(root, "secret.txt");
+  // links planted before the guest runs: one to a file outside, one dangling
+  fs.symlinkSync(path.join("..", "secret.txt"), path.join(sandbox, "escape"));
+  fs.symlinkSync(path.join(root, "does-not-exist"), path.join(sandbox, "dangling"));
+  const secretBefore = fs.statSync(secret, { bigint: true });
 
-    const wasi = new WASI({ preopens: { "/": sandbox } });
-    wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
-    const memory = Buffer.from(wasi.memory.buffer);
-    const view = new DataView(wasi.memory.buffer);
+  const wasi = new WASI({ preopens: { "/": sandbox } });
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const memory = Buffer.from(wasi.memory.buffer);
+  const view = new DataView(wasi.memory.buffer);
 
-    const WASI_ESUCCESS = 0;
-    const WASI_ENOTCAPABLE = 76;
-    const WASI_FILETYPE_SYMBOLIC_LINK = 7;
-    const WASI_LOOKUPFLAGS_SYMLINK_FOLLOW = 1;
-    const preopenFd = 3;
-    const targetPtr = 1024;
-    const pathPtr = 2048;
-    const newPathPtr = 3072;
-    const statPtr = 4096;
-    const bufPtr = 8192;
-    const bufUsedPtr = 12288;
-    const symlink = (target, linkPath) =>
-      wasi.wasiImport.path_symlink(
-        targetPtr,
-        memory.write(target, targetPtr),
-        preopenFd,
-        pathPtr,
-        memory.write(linkPath, pathPtr),
-      );
-
-    // a target that leaves the preopen is refused, absolute or relative to the link
-    expect(symlink(path.join(root, "secret.txt"), "abs-link")).toBe(WASI_ENOTCAPABLE);
-    expect(symlink("../secret.txt", "rel-link")).toBe(WASI_ENOTCAPABLE);
-    expect(symlink("../../secret.txt", "sub/deep-link")).toBe(WASI_ENOTCAPABLE);
-    // a target that stays inside is fine, including ".." from a subdirectory
-    expect(symlink("inside.txt", "ok-link")).toBe(WASI_ESUCCESS);
-    expect(symlink("../inside.txt", "sub/up-link")).toBe(WASI_ESUCCESS);
-    expect(fs.readdirSync(sandbox).sort()).toEqual(["dangling", "escape", "inside.txt", "ok-link", "sub"]);
-    expect(fs.readFileSync(path.join(sandbox, "sub", "up-link"), "utf8")).toBe("inside");
-
-    // calls that do not follow the final component act on the link itself
-    let len = memory.write("escape", pathPtr);
-    expect(wasi.wasiImport.path_filestat_get(preopenFd, 0, pathPtr, len, statPtr)).toBe(WASI_ESUCCESS);
-    expect(view.getUint8(statPtr + 16)).toBe(WASI_FILETYPE_SYMBOLIC_LINK);
-    expect(wasi.wasiImport.path_readlink(preopenFd, pathPtr, len, bufPtr, 256, bufUsedPtr)).toBe(WASI_ESUCCESS);
-    expect(memory.toString("utf8", bufPtr, bufPtr + view.getUint32(bufUsedPtr, true))).toBe("../secret.txt");
-    // following it is still refused
-    expect(wasi.wasiImport.path_filestat_get(preopenFd, WASI_LOOKUPFLAGS_SYMLINK_FOLLOW, pathPtr, len, statPtr)).toBe(
-      WASI_ENOTCAPABLE,
+  const WASI_ESUCCESS = 0;
+  const WASI_EPERM = 63;
+  const WASI_ENOTCAPABLE = 76;
+  const WASI_FILETYPE_SYMBOLIC_LINK = 7;
+  const WASI_LOOKUPFLAGS_SYMLINK_FOLLOW = 1;
+  const WASI_FILESTAT_SET_MTIM = 4;
+  const WASI_RIGHT_FD_READ = BigInt(2);
+  const preopenFd = 3;
+  const targetPtr = 1024;
+  const pathPtr = 2048;
+  const newPathPtr = 3072;
+  const statPtr = 4096;
+  const bufPtr = 8192;
+  const bufUsedPtr = 12288;
+  const fdPtr = 16384;
+  const symlink = (target, linkPath) =>
+    wasi.wasiImport.path_symlink(
+      targetPtr,
+      memory.write(target, targetPtr),
+      preopenFd,
+      pathPtr,
+      memory.write(linkPath, pathPtr),
     );
-    const newLen = memory.write("renamed", newPathPtr);
-    expect(wasi.wasiImport.path_rename(preopenFd, pathPtr, len, preopenFd, newPathPtr, newLen)).toBe(WASI_ESUCCESS);
-    expect(wasi.wasiImport.path_unlink_file(preopenFd, newPathPtr, newLen)).toBe(WASI_ESUCCESS);
-    len = memory.write("dangling", pathPtr);
-    expect(wasi.wasiImport.path_unlink_file(preopenFd, pathPtr, len)).toBe(WASI_ESUCCESS);
+  const open = (p, lookupflags) =>
+    wasi.wasiImport.path_open(
+      preopenFd,
+      lookupflags,
+      pathPtr,
+      memory.write(p, pathPtr),
+      0,
+      WASI_RIGHT_FD_READ,
+      BigInt(0),
+      0,
+      fdPtr,
+    );
 
-    expect(fs.readFileSync(path.join(root, "secret.txt"), "utf8")).toBe("outside");
-    expect(fs.readdirSync(sandbox).sort()).toEqual(["inside.txt", "ok-link", "sub"]);
-  },
-);
+  // an absolute target is refused, as in Node. A relative one is stored as
+  // written, even when it points outside: it is checked when followed.
+  expect(symlink(secret, "abs-link")).toBe(WASI_EPERM);
+  expect(symlink("../secret.txt", "rel-link")).toBe(WASI_ESUCCESS);
+  expect(symlink("inside.txt", "ok-link")).toBe(WASI_ESUCCESS);
+  expect(symlink("../inside.txt", "sub/up-link")).toBe(WASI_ESUCCESS);
+  expect(fs.readdirSync(sandbox).sort()).toEqual(["dangling", "escape", "inside.txt", "ok-link", "rel-link", "sub"]);
+  expect(fs.readFileSync(path.join(sandbox, "sub", "up-link"), "utf8")).toBe("inside");
+  expect(open("rel-link", WASI_LOOKUPFLAGS_SYMLINK_FOLLOW)).toBe(WASI_ENOTCAPABLE);
+  expect(open("ok-link", WASI_LOOKUPFLAGS_SYMLINK_FOLLOW)).toBe(WASI_ESUCCESS);
+
+  // calls that do not follow the final component act on the link itself
+  let len = memory.write("escape", pathPtr);
+  expect(wasi.wasiImport.path_filestat_get(preopenFd, 0, pathPtr, len, statPtr)).toBe(WASI_ESUCCESS);
+  expect(view.getUint8(statPtr + 16)).toBe(WASI_FILETYPE_SYMBOLIC_LINK);
+  expect(wasi.wasiImport.path_readlink(preopenFd, pathPtr, len, bufPtr, 256, bufUsedPtr)).toBe(WASI_ESUCCESS);
+  expect(memory.toString("utf8", bufPtr, bufPtr + view.getUint32(bufUsedPtr, true))).toBe("../secret.txt");
+  const mtim = BigInt(1700000000) * BigInt(1e9);
+  expect(
+    wasi.wasiImport.path_filestat_set_times(preopenFd, 0, pathPtr, len, BigInt(0), mtim, WASI_FILESTAT_SET_MTIM),
+  ).toBe(WASI_ESUCCESS);
+  expect(fs.lstatSync(path.join(sandbox, "escape"), { bigint: true }).mtimeNs).toBe(mtim);
+  // following it is still refused
+  expect(wasi.wasiImport.path_filestat_get(preopenFd, WASI_LOOKUPFLAGS_SYMLINK_FOLLOW, pathPtr, len, statPtr)).toBe(
+    WASI_ENOTCAPABLE,
+  );
+  expect(
+    wasi.wasiImport.path_filestat_set_times(
+      preopenFd,
+      WASI_LOOKUPFLAGS_SYMLINK_FOLLOW,
+      pathPtr,
+      len,
+      BigInt(0),
+      mtim,
+      WASI_FILESTAT_SET_MTIM,
+    ),
+  ).toBe(WASI_ENOTCAPABLE);
+  const newLen = memory.write("renamed", newPathPtr);
+  expect(wasi.wasiImport.path_rename(preopenFd, pathPtr, len, preopenFd, newPathPtr, newLen)).toBe(WASI_ESUCCESS);
+  expect(wasi.wasiImport.path_unlink_file(preopenFd, newPathPtr, newLen)).toBe(WASI_ESUCCESS);
+  for (const name of ["dangling", "rel-link"]) {
+    len = memory.write(name, pathPtr);
+    expect(wasi.wasiImport.path_unlink_file(preopenFd, pathPtr, len)).toBe(WASI_ESUCCESS);
+  }
+
+  // with the follow flag the times go to the target, which must be inside
+  len = memory.write("ok-link", pathPtr);
+  expect(
+    wasi.wasiImport.path_filestat_set_times(
+      preopenFd,
+      WASI_LOOKUPFLAGS_SYMLINK_FOLLOW,
+      pathPtr,
+      len,
+      BigInt(0),
+      mtim,
+      WASI_FILESTAT_SET_MTIM,
+    ),
+  ).toBe(WASI_ESUCCESS);
+  expect(fs.statSync(path.join(sandbox, "inside.txt"), { bigint: true }).mtimeNs).toBe(mtim);
+  expect(fs.lstatSync(path.join(sandbox, "ok-link"), { bigint: true }).mtimeNs).not.toBe(mtim);
+
+  const secretAfter = fs.statSync(secret, { bigint: true });
+  expect([secretAfter.mtimeNs, fs.readFileSync(secret, "utf8")]).toEqual([secretBefore.mtimeNs, "outside"]);
+  expect(fs.readdirSync(sandbox).sort()).toEqual(["inside.txt", "ok-link", "sub"]);
+});


### PR DESCRIPTION
### Problem
- Shared linear memory: after `memory.grow()`, every hostcall that touches a new page throws `RangeError: Out of bounds access` into the guest. `refreshMemory()` (`src/js/node/wasi.ts`) only rebuilt its `DataView` when the buffer was detached. A `SharedArrayBuffer` never detaches.
- `fd_seek` returned errno 0 for an unknown `whence` and for a negative result (writing `2^64-n`). On a never-seeked descriptor it threw a plain `Error`.
- `path_filestat_get` truncated times to ms. fd 0-2 were hard-coded as tty character devices, so `isatty()` was true with stdout redirected. `unlink`, `readlink`, `rename`, `lstat` refused a symlink whose target is outside the preopen.

### Fix
- `refreshMemory()` compares buffer identity. `memory.buffer` is a new object after every grow.
- `fd_seek` returns `EINVAL` for an unknown `whence` or a result outside `[0, 2^63-1]`, and stores nothing then.
- Stats use `{ bigint: true }`. fd 0-2 get type and rights from `fstat` on first use, through the existing `stat()` path. A regular file there gets no `FD_SEEK`/`FD_TELL`: the host owns its offset.
- `RESOLVE_PATH` gets a `followFinal` flag. Calls that act on a link itself pass `false`, so only the parent goes through realpath. `path_symlink` refuses absolute targets with `EPERM`, like Node. `path_filestat_set_times` honors `SYMLINK_FOLLOW`.
- Verified: `test/js/bun/wasm/wasi.test.js` (5 new tests, fail on 1.4.1). Also `hello-wasi.wasm` with stdout to a file, `/dev/null`, a pipe, a pty.

### Background
- Bun's `node:wasi` is a JS polyfill. Each hostcall reads guest memory through `this.view`, a `DataView` over `memory.buffer`.
- A symlink target is a string the kernel interprets when the link is followed. A creation-time check cannot hold once the guest can add links. Node refuses only absolute targets. Bun also realpaths the result in `path_open`.
- wasi-libc's `isatty()` is `fd_fdstat_get` returning `CHARACTER_DEVICE` with neither `FD_SEEK` nor `FD_TELL`.

<details><summary>Notes</summary>

Oracle: Node v26.3.0, driving `wasi.getImportObject().wasi_snapshot_preview1` with a hand-assembled module that only exports a memory. Results for the same cells:

- shared memory, grow, `args_sizes_get`/`clock_time_get` in the new page: 0 (Bun: RangeError)
- `fd_seek` whence 3 / 255: 28; negative result via SET/CUR: 28; `SEEK_END -3` on a 10-byte file: 0, offset 7 (Bun before: 0, 0, 0 with offset 2^64-5)
- `path_filestat_get` and `fd_filestat_get` mtim: identical to the host `st_mtim` in ns (Bun before: `...851000064` and `...851749756` for a host `...851749745`; the second one went through a float ms value)
- `fd_fdstat_get(1)` with stdout to a file: filetype 4; to a pipe: 6 (Bun before: 2 for both)
- `path_symlink`: absolute target 63 (EPERM); `../x`, `sub/../../x`, `..`, `a/../../x` all 0. Node performs `unlink`, `readlink`, `rename`, `lstat` and `lutimes` on a link whose target is outside; Bun now does too.
- `path_filestat_set_times` with lookupflags 0 on a symlink sets the link's own time in Node and leaves the target alone.

Other details:

- `fd_seek` with a whence of 3 on a fresh descriptor threw `Error: stats.offset must be defined` out of the import. `wrap()` only converts `WASIError` and errors with a string `code`.
- The first revision of this PR refused relative symlink targets that resolve outside the preopen from the link's lexical directory. Review found a two-step bypass (`sub -> .`, then `sub/link -> ../secret`). Resolving from the real parent only moves the problem (`sub/up -> ..`, then `link -> sub/up/../secret`, or creating the link before its intermediate directories exist), so the check was dropped in favor of Node's policy plus the follow-time check.
- The first revision also advertised `FD_SEEK`/`FD_TELL` for a regular file on fd 0. `fd_read` on fd 0 reads at the host's offset, so a seek would have succeeded without effect. Before this PR such a seek failed with `EPERM`, and it still does.
- `path_link` keeps resolving its old path through a final symlink whatever the lookup flags say. Whether `link(2)` follows a symlink is platform defined, and a hard link to a file outside the preopen would be a real escape. Its new path is resolved without following, like the other calls that create a name.
- `path_filestat_set_times` took its default times (the one of atim/mtim not being set) from the directory fd. They now come from the target. Without `SYMLINK_FOLLOW` it calls `lutimes`.
- The `translateFileAttributes` call in `stat()` passed the WASI fd to `bindings.isTTY`, not the host fd. It now passes `entry.real`.
- The closed-stdio fallback in `fstatSync()` now returns BigInt fields and the `is*()` predicates, because `stat()` can reach it for fd 0-2.
- The standard descriptors carry no `path`, so they can never be the base of a `path_*` call (before, a directory passed as stdin could be listed and opened through `/dev/stdin`).
- The existing `fd_fdstat_set_rights` test read `FD_MAP.get(0).rights` before any hostcall. It now calls `fd_fdstat_get(0)` first, since the rights are derived on first use.
- Other open PRs touch `src/js/node/wasi.ts` (#39100 pointer bounds checks, #34468 iovec bounds, #34471 `clock_res_get`, #34474 `proc_exit`, #35709 the Node v26 class surface). None of them changes these behaviors. Re-verified on this build that their targets (`proc_exit` killing the host, `poll_oneoff` clock TypeError, `dev/tty` -> fd 0, `clock_res_get` byte order, iovec OOB `console.log`, missing `getImportObject`/`initialize`, `fd_renumber(x, x)`) are still present and untouched here.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/wasm/wasi.test.js

<!-- robobun:evidence:end -->