### PR TITLE
tls: send the TLS 1.3 final handshake flight and the first secureConnect write in one segment

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -100,6 +100,12 @@ struct loop_ssl_data {
   unsigned int ssl_write_batch_len;
   unsigned int ssl_write_batch_cap;
   int ssl_write_batching;
+  /* The socket whose sealed records fill ssl_write_batch. The slot is shared
+   * per-loop, so a flush must only ever deliver the batch to this socket, and
+   * a batching region entered for another socket flushes these records to
+   * their owner first (BIO_s_custom_write). Meaningful while
+   * ssl_write_batch_len > 0. */
+  struct us_socket_t *ssl_write_batch_owner;
 
   /* Single spill slot: ciphertext a partial batch flush could not deliver.
    * SSL believes these records were written, so they MUST reach this exact
@@ -583,6 +589,7 @@ static inline struct us_ssl_reneg_state_t *us_reneg_state(SSL *ssl) {
 extern void us_internal_socket_raw_shutdown(struct us_socket_t *s);
 
 static void ssl_update_handshake(struct us_socket_t *s);
+static int ssl_flush_write_batch(struct loop_ssl_data *loop_ssl_data, struct us_socket_t *s);
 static int us_ssl_inline_reject_tripped(struct us_socket_t *s);
 static inline int ssl_gone(struct us_socket_t *s);
 
@@ -621,7 +628,10 @@ static long BIO_s_custom_ctrl(BIO *bio, int cmd, long num, void *user) {
  * from inside SSL_do_handshake/SSL_read: user JS that writes to or destroys a
  * different TLS socket on the same loop re-points loop_ssl_data->ssl_socket
  * (and may consume the read-input window), and the interrupted handshake's
- * next BIO_write would otherwise land on that other socket's fd. */
+ * next BIO_write would otherwise land on that other socket's fd. The batching
+ * flag is saved-and-zeroed so a write or close_notify for a different socket
+ * inside the callback goes to that socket's fd via the per-record BIO path
+ * instead of appending to the interrupted handshake's batch. */
 void us_internal_ssl_loop_state_save(void *ssl_ptr, void **out) {
   SSL *ssl = (SSL *)ssl_ptr;
   struct loop_ssl_data *d = (struct loop_ssl_data *)BIO_get_data(SSL_get_wbio(ssl));
@@ -630,6 +640,8 @@ void us_internal_ssl_loop_state_save(void *ssl_ptr, void **out) {
   out[2] = d ? (void *)d->ssl_read_input : NULL;
   out[3] = d ? (void *)(uintptr_t)d->ssl_read_input_length : NULL;
   out[4] = d ? (void *)(uintptr_t)d->ssl_read_input_offset : NULL;
+  out[5] = d ? (void *)(uintptr_t)d->ssl_write_batching : NULL;
+  if (d) d->ssl_write_batching = 0;
 }
 
 void us_internal_ssl_loop_state_restore(void **saved) {
@@ -639,6 +651,7 @@ void us_internal_ssl_loop_state_restore(void **saved) {
   d->ssl_read_input = (char *)saved[2];
   d->ssl_read_input_length = (unsigned int)(uintptr_t)saved[3];
   d->ssl_read_input_offset = (unsigned int)(uintptr_t)saved[4];
+  d->ssl_write_batching = (int)(uintptr_t)saved[5];
 }
 
 static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
@@ -664,10 +677,22 @@ static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
     return length;
   }
 
-  if (loop_ssl_data->ssl_write_batching) {
+  if (loop_ssl_data->ssl_write_batching &&
+      loop_ssl_data->ssl_write_batch_len &&
+      loop_ssl_data->ssl_write_batch_owner != loop_ssl_data->ssl_socket) {
+    /* The batch holds another socket's records (a JS callback in this
+     * dispatch wrote to a second TLS socket on the same loop while the
+     * first socket's flight was held). Deliver them to their owner first so
+     * each socket's records stay in order. */
+    ssl_flush_write_batch(loop_ssl_data, loop_ssl_data->ssl_write_batch_owner);
+  }
+
+  if (loop_ssl_data->ssl_write_batching && loop_ssl_data->ssl_spill_owner == NULL) {
     /* Append the sealed record; the batch hits the kernel once, after
      * SSL_write returns. Reporting the full length keeps BoringSSL sealing
-     * the next record instead of parking a partial one. */
+     * the next record instead of parking a partial one. Skipped while a
+     * spill occupies the slot: a later short flush could not park its
+     * remainder without clobbering that socket's pending ciphertext. */
     unsigned int needed = loop_ssl_data->ssl_write_batch_len + (unsigned int)length;
     if (needed > loop_ssl_data->ssl_write_batch_cap) {
       unsigned int new_cap = loop_ssl_data->ssl_write_batch_cap ? loop_ssl_data->ssl_write_batch_cap : 65536;
@@ -688,6 +713,7 @@ static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
     }
     memcpy(loop_ssl_data->ssl_write_batch + loop_ssl_data->ssl_write_batch_len, data, (size_t)length);
     loop_ssl_data->ssl_write_batch_len = needed;
+    loop_ssl_data->ssl_write_batch_owner = loop_ssl_data->ssl_socket;
     BIO_clear_retry_flags(bio);
     return length;
   }
@@ -709,11 +735,26 @@ static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
 static int ssl_flush_write_batch(struct loop_ssl_data *loop_ssl_data, struct us_socket_t *s) {
   unsigned int len = loop_ssl_data->ssl_write_batch_len;
   if (!len) return 1;
+  if (loop_ssl_data->ssl_write_batch_owner != s) {
+    /* Not this socket's records (SSL_write failed before sealing anything
+     * while another socket's flight was held): leave them for their owner's
+     * own flush point. */
+    return 1;
+  }
   loop_ssl_data->ssl_write_batch_len = 0;
+  loop_ssl_data->ssl_write_batch_owner = NULL;
   int written = us_socket_raw_write(s, loop_ssl_data->ssl_write_batch, (int)len);
   if (written < 0) written = 0;
   if ((unsigned int)written < len) {
     unsigned int remainder = len - (unsigned int)written;
+    if (loop_ssl_data->ssl_spill_owner) {
+      /* The spill slot is already another socket's (a re-entrant JS region
+       * produced one between the entry-time gate and this flush).
+       * Overwriting it would leak and corrupt that socket's stream; this
+       * socket's remainder is undeliverable. */
+      s->ssl_fatal_error = 1;
+      return 0;
+    }
     char *spill = us_malloc(remainder);
     if (!spill) {
       /* Out of memory with ciphertext in flight: the connection cannot stay
@@ -729,6 +770,17 @@ static int ssl_flush_write_batch(struct loop_ssl_data *loop_ssl_data, struct us_
     return 0;
   }
   return 1;
+}
+
+/* Drop the batch slot when its owner dies without reaching a flush point
+ * (error/RST teardown), or when a destroy from inside the handshake cancels
+ * the held flight. The buffer itself is loop-owned and reused. */
+static void ssl_release_batch(struct us_loop_t *loop, struct us_socket_t *s) {
+  struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)loop->data.ssl_data;
+  if (loop_ssl_data && loop_ssl_data->ssl_write_batch_owner == s) {
+    loop_ssl_data->ssl_write_batch_len = 0;
+    loop_ssl_data->ssl_write_batch_owner = NULL;
+  }
 }
 
 /* Try to drain the spill slot for `s`. Returns 1 when clear (or not ours),
@@ -773,6 +825,9 @@ void us_internal_ssl_socket_relocated(struct us_loop_t *loop, struct us_socket_t
   if (!loop_ssl_data) return;
   if (loop_ssl_data->ssl_spill_owner == old_s) {
     loop_ssl_data->ssl_spill_owner = new_s;
+  }
+  if (loop_ssl_data->ssl_write_batch_owner == old_s) {
+    loop_ssl_data->ssl_write_batch_owner = new_s;
   }
   if (loop_ssl_data->ssl_last_fatal_error_owner == (void *)old_s) {
     loop_ssl_data->ssl_last_fatal_error_owner = (void *)new_s;
@@ -1607,6 +1662,7 @@ void us_internal_ssl_detach(struct us_socket_t *s) {
    * owns or the loop-wide slot dangles (batching permanently disabled, and a
    * reused socket address would drain the dead socket's records). */
   ssl_release_spill(s->group->loop, s);
+  ssl_release_batch(s->group->loop, s);
   if (s->ssl) {
     if (s->ssl_in_use) {
       /* SSL_do_handshake/SSL_read is on the stack (a JS callback run from
@@ -1907,6 +1963,17 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
     s->ssl_pending_detach = 1;
     s->ssl_pending_close_code = (unsigned char) code;
     return s;
+  }
+  {
+    /* Ciphertext batched in this dispatch and still held (the handshake's
+     * final flight, a fatal alert sealed by a failing SSL_read) goes to the
+     * wire before the close_notify/FIN this teardown sends. A partial write
+     * spills; the graceful-close deferral below then waits for the drain. */
+    struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
+    if (loop_ssl_data && loop_ssl_data->ssl_write_batch_len &&
+        loop_ssl_data->ssl_write_batch_owner == s && !us_socket_is_closed(s)) {
+      ssl_flush_write_batch(loop_ssl_data, s);
+    }
   }
   /* Neither node's `_handle.close()` (FAST_SHUTDOWN, no reason) nor a graceful
    * close (code 0: peer close_notify / end-completion) may cut off spilled
@@ -2275,12 +2342,45 @@ struct us_socket_t *us_internal_ssl_on_data(struct us_socket_t *s, char *data, i
   int read = 0;
 restart:
   while (1) {
+    /* While the handshake is pending, SSL_read seals this side's outbound
+     * flight (TLS 1.3 client Certificate/Finished, server Hello flight).
+     * Batch those records instead of raw-writing each: when the handshake
+     * completes in this read, the flight is HELD across the on_handshake
+     * dispatch below, so a write the JS callback issues appends to it and
+     * us_internal_ssl_write flushes flight + first application data in ONE
+     * kernel write (one TCP segment). Two segments let a peer that tears
+     * down right after the handshake (node's post-verify destroy, #40653)
+     * close with the second segment unread, which turns its FIN teardown
+     * into an RST and a bogus ECONNRESET at this side. Node's memory BIO
+     * drained once per cycle has the same single-segment shape. Gated on a
+     * free spill slot like us_internal_ssl_write, so a short flush cannot
+     * clobber another socket's pending ciphertext. */
+    int hs_batching = s->ssl_handshake_state == HANDSHAKE_PENDING &&
+                      !loop_ssl_data->ssl_write_batching &&
+                      !loop_ssl_data->ssl_spill_owner;
+    if (hs_batching) loop_ssl_data->ssl_write_batching = 1;
     unsigned char ssl_was_in_use = s->ssl_in_use;
     s->ssl_in_use = 1;
     int just_read = SSL_read(s_ssl(s),
                              loop_ssl_data->ssl_read_output + LIBUS_RECV_BUFFER_PADDING + read,
                              LIBUS_RECV_BUFFER_LENGTH - read);
     s->ssl_in_use = ssl_was_in_use;
+    if (hs_batching) {
+      loop_ssl_data->ssl_write_batching = 0;
+      if (s->ssl_pending_detach) {
+        /* Destroyed from a callback inside the read: the flight is cancelled
+         * with the connection (the BIO swallows post-detach records the same
+         * way). */
+        ssl_release_batch(s->group->loop, s);
+      } else if (!(s->ssl && s->ssl_handshake_state == HANDSHAKE_PENDING &&
+                   SSL_is_init_finished(s_ssl(s)))) {
+        /* The handshake did not complete in this read (or already reported):
+         * send this round's flight now so the peer can progress. */
+        ssl_flush_write_batch(loop_ssl_data, s);
+      }
+      /* else: handshake just completed - hold the flight for the
+       * on_handshake dispatch below. */
+    }
     if (!ssl_was_in_use && s->ssl_pending_detach) {
       /* A callback run from inside this read destroyed the socket; perform
        * the deferred close now and stop processing. */
@@ -2334,7 +2434,13 @@ restart:
                * finishes immediately). With SENT_SHUTDOWN both directions are
                * closed and nothing is left to hold open: fall through so the
                * deferred graceful close (code 0, no FIN sent) completes here
-               * instead of waiting for a FIN that may never come. */
+               * instead of waiting for a FIN that may never come. A flight
+               * held by this read's handshake batching must not be parked
+               * past this return. */
+              if (loop_ssl_data->ssl_write_batch_len &&
+                  loop_ssl_data->ssl_write_batch_owner == s) {
+                ssl_flush_write_batch(loop_ssl_data, s);
+              }
               return s;
             }
           }
@@ -2370,6 +2476,12 @@ restart:
           ssl_trigger_handshake(s, 1);
           if (ssl_gone(s)) return NULL;
           loop_ssl_data->ssl_socket = s;
+          /* The callback ran with the flight held: a write it issued already
+           * flushed flight + data together; send whatever is still held. */
+          if (loop_ssl_data->ssl_write_batch_len &&
+              loop_ssl_data->ssl_write_batch_owner == s) {
+            ssl_flush_write_batch(loop_ssl_data, s);
+          }
         }
         if (!read) break;
 
@@ -2407,6 +2519,12 @@ restart:
       loop_ssl_data->ssl_read_input_length = saved_length;
       loop_ssl_data->ssl_read_input_offset = saved_offset;
       loop_ssl_data->ssl_socket = s;
+      /* Same as the no-data completion above: send what the callback's own
+       * write did not already flush of the held flight. */
+      if (loop_ssl_data->ssl_write_batch_len &&
+          loop_ssl_data->ssl_write_batch_owner == s) {
+        ssl_flush_write_batch(loop_ssl_data, s);
+      }
     }
 
     read += just_read;
@@ -2530,6 +2648,7 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
    * we report as written are honest up to one bounded spill. Reporting a
    * whole large write as consumed while its ciphertext sat in memory let the
    * layers above fire 'finish' and close before the data reached the wire. */
+  int outer_batching = loop_ssl_data->ssl_write_batching;
   int batching = (loop_ssl_data->ssl_spill_owner == NULL);
   loop_ssl_data->ssl_write_batching = batching;
 
@@ -2543,9 +2662,10 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
     last_ssl_written = SSL_write(s_ssl(s), data + total, chunk);
     s->ssl_in_use = 0;
     if (s->ssl_pending_detach) {
-      /* Closed from inside the call: drop this write's records and close now. */
-      loop_ssl_data->ssl_write_batching = 0;
-      loop_ssl_data->ssl_write_batch_len = 0;
+      /* Closed from inside the call: drop this write's records (and any held
+       * flight of ours they extend) and close now. */
+      loop_ssl_data->ssl_write_batching = outer_batching;
+      ssl_release_batch(s->group->loop, s);
       s->ssl_pending_detach = 0;
       us_socket_close(s, s->ssl_pending_close_code, NULL);
       return 0;
@@ -2560,7 +2680,7 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
       if (s->ssl_fatal_error) break;
     }
   }
-  loop_ssl_data->ssl_write_batching = 0;
+  loop_ssl_data->ssl_write_batching = outer_batching;
   if (batching) {
     ssl_flush_write_batch(loop_ssl_data, s);
   }
@@ -2587,9 +2707,16 @@ void us_internal_ssl_shutdown(struct us_socket_t *s) {
 
   /* Spilled ciphertext is data the layers above already count as written;
    * a FIN/close_notify now would cut it off. Finish the shutdown from the
-   * writable event once the spill drains. */
+   * writable event once the spill drains. A held batch (an end() issued
+   * from the on_handshake callback while the final flight is still parked)
+   * is the same kind of debt: flush it first so the close_notify and FIN
+   * below follow the flight, not precede it. */
   {
     struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
+    if (loop_ssl_data && loop_ssl_data->ssl_write_batch_len &&
+        loop_ssl_data->ssl_write_batch_owner == s) {
+      ssl_flush_write_batch(loop_ssl_data, s);
+    }
     if (loop_ssl_data && loop_ssl_data->ssl_spill_owner == s) {
       if (!ssl_drain_spill(loop_ssl_data, s)) {
         s->ssl_shutdown_after_spill = 1;
@@ -2908,7 +3035,7 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
   struct loop_ssl_data *cb_lsd = (struct loop_ssl_data *)BIO_get_data(SSL_get_wbio(ssl));
   struct us_socket_t *cb_socket = cb_lsd ? cb_lsd->ssl_socket : NULL;
 
-  void *saved_loop_state[5];
+  void *saved_loop_state[6];
   us_internal_ssl_loop_state_save(ssl, saved_loop_state);
   int abort_handshake = 0;
   SSL_CTX *dyn =

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -632,6 +632,8 @@ static long BIO_s_custom_ctrl(BIO *bio, int cmd, long num, void *user) {
  * flag is saved-and-zeroed so a write or close_notify for a different socket
  * inside the callback goes to that socket's fd via the per-record BIO path
  * instead of appending to the interrupted handshake's batch. */
+int us_internal_ssl_loop_state_slots(void) { return US_SSL_LOOP_STATE_SLOTS; }
+
 void us_internal_ssl_loop_state_save(void *ssl_ptr, void **out) {
   SSL *ssl = (SSL *)ssl_ptr;
   struct loop_ssl_data *d = (struct loop_ssl_data *)BIO_get_data(SSL_get_wbio(ssl));
@@ -3035,7 +3037,7 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
   struct loop_ssl_data *cb_lsd = (struct loop_ssl_data *)BIO_get_data(SSL_get_wbio(ssl));
   struct us_socket_t *cb_socket = cb_lsd ? cb_lsd->ssl_socket : NULL;
 
-  void *saved_loop_state[6];
+  void *saved_loop_state[US_SSL_LOOP_STATE_SLOTS];
   us_internal_ssl_loop_state_save(ssl, saved_loop_state);
   int abort_handshake = 0;
   SSL_CTX *dyn =

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -480,9 +480,9 @@ void us_internal_socket_group_unlink_connecting_socket(us_socket_group_r group, 
 
 int us_raw_root_certs(struct us_cert_string_t **out);
 
-/* Save/restore the per-loop BIO routing state around in-handshake JS
- * callbacks (SNI / ALPN). Defined in crypto/openssl.c. */
-void us_internal_ssl_loop_state_save(void *ssl, void **out5);
-void us_internal_ssl_loop_state_restore(void **saved5);
+/* Save/restore the per-loop BIO routing state (6 slots) around in-handshake
+ * JS callbacks (SNI / ALPN). Defined in crypto/openssl.c. */
+void us_internal_ssl_loop_state_save(void *ssl, void **out6);
+void us_internal_ssl_loop_state_restore(void **saved6);
 
 #endif // INTERNAL_H

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -480,9 +480,14 @@ void us_internal_socket_group_unlink_connecting_socket(us_socket_group_r group, 
 
 int us_raw_root_certs(struct us_cert_string_t **out);
 
-/* Save/restore the per-loop BIO routing state (6 slots) around in-handshake
- * JS callbacks (SNI / ALPN). Defined in crypto/openssl.c. */
-void us_internal_ssl_loop_state_save(void *ssl, void **out6);
-void us_internal_ssl_loop_state_restore(void **saved6);
+/* Save/restore the per-loop BIO routing state around in-handshake JS
+ * callbacks (SNI / ALPN). Defined in crypto/openssl.c. The snapshot is an
+ * opaque void*[US_SSL_LOOP_STATE_SLOTS] the caller provides; Rust callers
+ * size their array from us_internal_ssl_loop_state_slots() in a debug
+ * assertion so growth cannot silently corrupt a caller's stack. */
+#define US_SSL_LOOP_STATE_SLOTS 6
+int us_internal_ssl_loop_state_slots(void);
+void us_internal_ssl_loop_state_save(void *ssl, void **out);
+void us_internal_ssl_loop_state_restore(void **saved);
 
 #endif // INTERNAL_H

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -154,7 +154,8 @@ extern "C" fn select_alpn_callback(
                 tls_socket_functions::ffi::us_internal_ssl_loop_state_slots(),
                 "loop-state snapshot size drifted from US_SSL_LOOP_STATE_SLOTS in internal.h"
             );
-            let mut saved_loop_state: [*mut c_void; LOOP_STATE_SLOTS] = [core::ptr::null_mut(); LOOP_STATE_SLOTS];
+            let mut saved_loop_state: [*mut c_void; LOOP_STATE_SLOTS] =
+                [core::ptr::null_mut(); LOOP_STATE_SLOTS];
             if matches!(this.socket.get().socket, uws::InternalSocket::Connected(_)) {
                 tls_socket_functions::ffi::us_internal_ssl_loop_state_save(
                     boringssl_sys::SSL::opaque_ref(ssl),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -148,7 +148,13 @@ extern "C" fn select_alpn_callback(
             // below has exited, since this guard is declared first. Connected
             // usockets only: UpgradedDuplex/Pipe own mem BIOs whose BIO_get_data
             // is a BUF_MEM*, not loop_ssl_data.
-            let mut saved_loop_state: [*mut c_void; 6] = [core::ptr::null_mut(); 6];
+            const LOOP_STATE_SLOTS: usize = 6; // US_SSL_LOOP_STATE_SLOTS
+            debug_assert_eq!(
+                LOOP_STATE_SLOTS as core::ffi::c_int,
+                tls_socket_functions::ffi::us_internal_ssl_loop_state_slots(),
+                "loop-state snapshot size drifted from US_SSL_LOOP_STATE_SLOTS in internal.h"
+            );
+            let mut saved_loop_state: [*mut c_void; LOOP_STATE_SLOTS] = [core::ptr::null_mut(); LOOP_STATE_SLOTS];
             if matches!(this.socket.get().socket, uws::InternalSocket::Connected(_)) {
                 tls_socket_functions::ffi::us_internal_ssl_loop_state_save(
                     boringssl_sys::SSL::opaque_ref(ssl),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -148,7 +148,7 @@ extern "C" fn select_alpn_callback(
             // below has exited, since this guard is declared first. Connected
             // usockets only: UpgradedDuplex/Pipe own mem BIOs whose BIO_get_data
             // is a BUF_MEM*, not loop_ssl_data.
-            let mut saved_loop_state: [*mut c_void; 5] = [core::ptr::null_mut(); 5];
+            let mut saved_loop_state: [*mut c_void; 6] = [core::ptr::null_mut(); 6];
             if matches!(this.socket.get().socket, uws::InternalSocket::Connected(_)) {
                 tls_socket_functions::ffi::us_internal_ssl_loop_state_save(
                     boringssl_sys::SSL::opaque_ref(ssl),

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -184,10 +184,13 @@ pub(super) mod ffi {
             out_len: &mut c_uint,
         );
         pub(crate) safe fn SSL_get_ex_data(ssl: &SSL, idx: c_int) -> *mut c_void;
-        /// Save/restore the per-loop BIO routing state (6 slots) around
-        /// in-handshake JS callbacks (defined in usockets' openssl.c).
-        pub(crate) safe fn us_internal_ssl_loop_state_save(ssl: &SSL, out6: *mut *mut c_void);
-        pub(crate) safe fn us_internal_ssl_loop_state_restore(saved6: *mut *mut c_void);
+        /// Save/restore the per-loop BIO routing state around in-handshake JS
+        /// callbacks (defined in usockets' openssl.c). The caller's snapshot
+        /// array must have exactly `us_internal_ssl_loop_state_slots()`
+        /// elements (US_SSL_LOOP_STATE_SLOTS in internal.h).
+        pub(crate) safe fn us_internal_ssl_loop_state_slots() -> c_int;
+        pub(crate) safe fn us_internal_ssl_loop_state_save(ssl: &SSL, out: *mut *mut c_void);
+        pub(crate) safe fn us_internal_ssl_loop_state_restore(saved: *mut *mut c_void);
         pub(crate) safe fn SSL_renegotiate(ssl: &SSL) -> c_int;
         pub(crate) safe fn SSL_set_renegotiate_mode(
             ssl: &SSL,

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -184,10 +184,10 @@ pub(super) mod ffi {
             out_len: &mut c_uint,
         );
         pub(crate) safe fn SSL_get_ex_data(ssl: &SSL, idx: c_int) -> *mut c_void;
-        /// Save/restore the per-loop BIO routing state around in-handshake JS
-        /// callbacks (defined in usockets' openssl.c).
-        pub(crate) safe fn us_internal_ssl_loop_state_save(ssl: &SSL, out5: *mut *mut c_void);
-        pub(crate) safe fn us_internal_ssl_loop_state_restore(saved5: *mut *mut c_void);
+        /// Save/restore the per-loop BIO routing state (6 slots) around
+        /// in-handshake JS callbacks (defined in usockets' openssl.c).
+        pub(crate) safe fn us_internal_ssl_loop_state_save(ssl: &SSL, out6: *mut *mut c_void);
+        pub(crate) safe fn us_internal_ssl_loop_state_restore(saved6: *mut *mut c_void);
         pub(crate) safe fn SSL_renegotiate(ssl: &SSL) -> c_int;
         pub(crate) safe fn SSL_set_renegotiate_mode(
             ssl: &SSL,

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1755,12 +1755,115 @@ it("TLS 1.3 client coalesces its final handshake flight with the first write fro
     // ClientHello, then ONE segment carrying change_cipher_spec + Finished +
     // the "HELLO" application record. On the unfixed client the flight and
     // the application record are two sends, so the server's data arrives in
-    // a third chunk.
+    // a third chunk. Note: the two unfixed sends can coalesce in the kernel
+    // when this process is descheduled between them (a heavily loaded
+    // machine), so a PASS discriminates reliably only on an unloaded one. A
+    // split of the single fixed send cannot happen: 1.3KB is far below the
+    // loopback MTU and the receive buffer.
     expect(await chunksWhenServerGotData).toBe(2);
   } finally {
     proxy.close();
     server.close();
   }
+});
+
+// Hard path of the batching fix: a write to a SECOND TLS socket on the same
+// loop, issued from inside 'secureConnect' while the first socket's final
+// flight is still held in the shared batch. The BIO must deliver the held
+// flight to its owner before it takes the slot for the second socket, or one
+// socket's ciphertext lands on the other's fd and both connections die.
+it("a write to a second TLS socket from inside secureConnect keeps both streams intact (#40653)", async () => {
+  const tlsOptions = {
+    key: COMMON_CERT_.key,
+    cert: COMMON_CERT_.cert,
+    minVersion: "TLSv1.3" as const,
+    maxVersion: "TLSv1.3" as const,
+  };
+  const first = Promise.withResolvers<string>();
+  const second = Promise.withResolvers<string>();
+  function makeServer(got: (data: string) => void) {
+    const server = tls.createServer(tlsOptions, socket => {
+      socket.on("data", data => {
+        got(data.toString());
+        socket.end();
+      });
+      socket.on("error", () => {});
+    });
+    return server;
+  }
+  const server1 = makeServer(first.resolve);
+  const server2 = makeServer(second.resolve);
+  await once(server1.listen(0, "127.0.0.1"), "listening");
+  await once(server2.listen(0, "127.0.0.1"), "listening");
+
+  try {
+    const connectOptions = {
+      host: "127.0.0.1",
+      rejectUnauthorized: false,
+      minVersion: "TLSv1.3" as const,
+      maxVersion: "TLSv1.3" as const,
+    };
+    // Establish the second socket fully first.
+    const client2 = tlsConnect({ ...connectOptions, port: (server2.address() as AddressInfo).port });
+    await once(client2, "secureConnect");
+    client2.on("error", () => {});
+
+    const client1 = tlsConnect({ ...connectOptions, port: (server1.address() as AddressInfo).port });
+    client1.on("error", () => {});
+    client1.on("secureConnect", () => {
+      // Foreign-owner write while client1's flight is held in the batch.
+      client2.write("to-second");
+      client1.write("to-first");
+    });
+
+    expect(await first.promise).toBe("to-first");
+    expect(await second.promise).toBe("to-second");
+    await Promise.all([once(client1, "close"), once(client2, "close")]);
+  } finally {
+    server1.close();
+    server2.close();
+  }
+});
+
+// Hard path of the batching fix: end() called synchronously from the
+// handshake callback, with the final flight still held in the batch. The
+// shutdown path must flush the held flight before it sends close_notify and
+// FIN; in the wrong order the server never completes the handshake. The Bun
+// socket API is used because its end() reaches the TLS shutdown inside the
+// same dispatch.
+it("ending a TLS 1.3 socket from its handshake callback still completes the server's handshake (#40653)", async () => {
+  const serverSaw = Promise.withResolvers<string>();
+  const clientClosed = Promise.withResolvers<void>();
+  await using listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    tls: { key: COMMON_CERT_.key, cert: COMMON_CERT_.cert },
+    socket: {
+      handshake(_socket, success, authorizationError) {
+        serverSaw.resolve(success ? "handshake" : `fail:${authorizationError}`);
+      },
+      data() {},
+      error() {},
+      close() {},
+    },
+  });
+  await Bun.connect({
+    hostname: "127.0.0.1",
+    port: listener.port,
+    tls: { rejectUnauthorized: false },
+    socket: {
+      handshake(socket) {
+        socket.end();
+      },
+      data() {},
+      error() {},
+      close() {
+        clientClosed.resolve();
+      },
+    },
+  });
+  expect(await serverSaw.promise).toBe("handshake");
+  await clientClosed.promise;
 });
 
 // End-to-end shape of the issue: a Node TLS 1.3 server that rejects the

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN } from "harness";
+import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN, nodeExe, tempDir } from "harness";
 import https from "https";
 import net from "net";
 import { join } from "path";
@@ -1668,3 +1668,174 @@ describe.concurrent("a client paused while connecting", () => {
     });
   });
 });
+
+// #40653: a TLS 1.3 client must send its final handshake flight and the first
+// write issued from the 'secureConnect' callback in ONE TCP segment, like
+// Node does through its memory BIO. Two segments let a server that tears the
+// connection down right after the handshake (Node's post-verify destroy of a
+// rejected client certificate) close with the second segment unread, which
+// turns its FIN teardown into an RST and a bogus 'read ECONNRESET' at the
+// client. A raw TCP proxy in front of the server records the client's segment
+// boundaries: the client child's writes are milliseconds apart when they are
+// separate sends, so each reaches the proxy as its own 'data' chunk.
+it("TLS 1.3 client coalesces its final handshake flight with the first write from secureConnect into one segment (#40653)", async () => {
+  // Resolves with the number of client-to-server chunks the proxy had
+  // forwarded by the time the server's plaintext 'data' event fired.
+  const { promise: chunksWhenServerGotData, resolve: reportChunks } = Promise.withResolvers<number>();
+
+  // Client-to-server chunk sizes as the proxy receives them. One recv per
+  // arriving segment: the proxy is idle between the child's sends.
+  const upstreamChunks: number[] = [];
+
+  const server = tls.createServer({
+    key: COMMON_CERT_.key,
+    cert: COMMON_CERT_.cert,
+    minVersion: "TLSv1.3",
+    maxVersion: "TLSv1.3",
+  });
+  server.on("secureConnection", socket => {
+    socket.on("data", () => {
+      reportChunks(upstreamChunks.length);
+      socket.end();
+    });
+    socket.on("error", () => {});
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const serverPort = (server.address() as AddressInfo).port;
+
+  const proxy = net.createServer({ allowHalfOpen: true }, client => {
+    const upstream = net.connect({ port: serverPort, host: "127.0.0.1", allowHalfOpen: true });
+    client.on("data", data => {
+      upstreamChunks.push(data.length);
+      upstream.write(data);
+    });
+    upstream.on("data", data => client.write(data));
+    client.on("end", () => upstream.end());
+    upstream.on("end", () => client.end());
+    client.on("error", () => {});
+    upstream.on("error", () => {});
+  });
+  await new Promise<void>(resolve => proxy.listen(0, "127.0.0.1", resolve));
+  const proxyPort = (proxy.address() as AddressInfo).port;
+
+  try {
+    const clientScript = `
+      const tls = require("node:tls");
+      const events = [];
+      const socket = tls.connect({
+        host: "127.0.0.1",
+        port: ${proxyPort},
+        rejectUnauthorized: false,
+        minVersion: "TLSv1.3",
+        maxVersion: "TLSv1.3",
+      });
+      socket.on("secureConnect", () => {
+        events.push("secureConnect");
+        socket.write("HELLO");
+      });
+      socket.on("data", () => events.push("data"));
+      socket.on("end", () => events.push("end"));
+      socket.on("error", error => events.push("error:" + error.code));
+      socket.on("close", hadError => {
+        events.push("close:" + hadError);
+        console.log(events.join(","));
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", clientScript],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("secureConnect,end,close:false");
+    expect(exitCode).toBe(0);
+
+    // ClientHello, then ONE segment carrying change_cipher_spec + Finished +
+    // the "HELLO" application record. On the unfixed client the flight and
+    // the application record are two sends, so the server's data arrives in
+    // a third chunk.
+    expect(await chunksWhenServerGotData).toBe(2);
+  } finally {
+    proxy.close();
+    server.close();
+  }
+});
+
+// End-to-end shape of the issue: a Node TLS 1.3 server that rejects the
+// client's certificate does so AFTER the client saw 'secureConnect' (TLS 1.3
+// clients finish first), and destroys the raw socket with no close_notify.
+// With the coalesced segment above, the server closes with an empty receive
+// buffer, so the client sees a bare FIN and reports a clean 'end'. The server
+// must be Node: it is Node's post-verify destroy (bare close, no
+// SSL_shutdown) that produces this teardown shape.
+it.skipIf(!nodeExe())(
+  "TLS 1.3 client sees 'end', not ECONNRESET, when the server tears down right after rejecting its certificate (#40653)",
+  async () => {
+    using dir = tempDir("tls13-bare-fin", {
+      "server.mjs": `
+        import tls from "node:tls";
+        const server = tls.createServer({
+          key: ${JSON.stringify(COMMON_CERT_.key)},
+          cert: ${JSON.stringify(COMMON_CERT_.cert)},
+          // No 'ca': the client's self-signed cert fails verification.
+          requestCert: true,
+          rejectUnauthorized: true,
+          minVersion: "TLSv1.3",
+          maxVersion: "TLSv1.3",
+        });
+        server.on("tlsClientError", () => {});
+        server.listen(0, "127.0.0.1", () => {
+          console.log(server.address().port);
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [nodeExe()!, "server.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let out = "";
+    while (!out.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out += decoder.decode(value);
+    }
+    const port = parseInt(out.trim(), 10);
+    expect(port).toBeGreaterThan(0);
+
+    // The bug is a race between the client's second segment and the server's
+    // destroy. One clean run proves little; five runs failed 5/5 before the
+    // fix on Linux and 20/20 in the report on macOS.
+    for (let i = 0; i < 5; i++) {
+      const events: string[] = [];
+      await new Promise<void>(resolve => {
+        const socket = tlsConnect({
+          host: "127.0.0.1",
+          port,
+          rejectUnauthorized: false,
+          key: COMMON_CERT_.key,
+          cert: COMMON_CERT_.cert,
+          minVersion: "TLSv1.3",
+          maxVersion: "TLSv1.3",
+        });
+        socket.on("secureConnect", () => {
+          events.push("secureConnect");
+          socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        });
+        socket.on("error", error => events.push(`error:${(error as NodeJS.ErrnoException).code}`));
+        socket.on("end", () => events.push("end"));
+        socket.on("close", hadError => {
+          events.push(`close:${hadError}`);
+          resolve();
+        });
+      });
+      expect(events).toEqual(["secureConnect", "end", "close:false"]);
+    }
+  },
+);

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1700,7 +1700,7 @@ it("TLS 1.3 client coalesces its final handshake flight with the first write fro
     });
     socket.on("error", () => {});
   });
-  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  await once(server.listen(0, "127.0.0.1"), "listening");
   const serverPort = (server.address() as AddressInfo).port;
 
   const proxy = net.createServer({ allowHalfOpen: true }, client => {
@@ -1715,7 +1715,7 @@ it("TLS 1.3 client coalesces its final handshake flight with the first write fro
     client.on("error", () => {});
     upstream.on("error", () => {});
   });
-  await new Promise<void>(resolve => proxy.listen(0, "127.0.0.1", resolve));
+  await once(proxy.listen(0, "127.0.0.1"), "listening");
   const proxyPort = (proxy.address() as AddressInfo).port;
 
   try {


### PR DESCRIPTION
### Problem

- A TLS 1.3 `tls.connect()` client whose certificate the server rejects reports `error: read ECONNRESET` and `close(true)`. A Node client in the same exchange reports a clean `end` and `close(false)` (#40653, reproduced 5/5 on Linux, 20/20 by the reporter on macOS).
- The client sends its final handshake flight and the write from `secureConnect` as two TCP segments: the custom BIO (`BIO_s_custom_write`, `packages/bun-usockets/src/crypto/openssl.c`) raw-writes the flight from inside `SSL_read`, before the handshake event reaches JS. The server rejects the certificate after reading segment one and destroys the socket with segment two unread. Linux then sends an RST instead of a FIN, and the RST is a real ECONNRESET at the client.

### Fix

- Batch the records `SSL_read` seals while the handshake is pending. When the handshake completes in that read, hold the batch across the `on_handshake` dispatch. A write the callback issues appends to the held flight, and the existing flush in `us_internal_ssl_write` sends flight plus first application data in one kernel write. This is the segment shape Node produces through its memory BIO.
- Any other outcome of the read flushes the batch at once. The close and shutdown paths flush a held batch before their close_notify/FIN. An error teardown or a destroy from inside the handshake drops it. A new `ssl_write_batch_owner` field pins the shared per-loop batch to one socket, and the loop-state save/zero keeps re-entrant JS (SNI/ALPN callbacks) from mixing another socket's records into a held flight. The snapshot size is now exported and debug-asserted at the Rust call site.
- Verified: four new tests in `test/js/node/tls/node-tls-connect.test.ts`. The segment-count test fails on main (3 chunks, expected 2). The cross-socket-write and end-from-handshake tests cover the shared-slot hard paths. The issue's script prints `secureConnect -> write -> end -> close:false` 10/10 with the debug build. Also ran `test/js/node/tls/`, `node-http2.test.js`, `fetch.tls.test.ts`, `bun-serve-ssl.test.ts`, and the upstream `test-tls-*`/`test-https-*` suites.

### Background

- usockets gives every TLS socket on a loop the same BIO pair. `loop_ssl_data->ssl_socket` routes `BIO_s_custom_write` output to the right fd. `ssl_write_batching` already existed for `us_internal_ssl_write`: it collects sealed records and writes them once.
- The spill slot holds ciphertext a partial batch flush could not deliver. SSL counts those bytes as written, so they must reach that exact socket, in order. Batching is gated on a free spill slot for that reason.
- In TLS 1.3 the client finishes first: it sees `secureConnect` one round trip before the server decides on the client certificate. That is why the rejection lands after the client already wrote application data.

<details><summary>Notes</summary>

- Diagnosis: an `LD_PRELOAD` shim logging `send`/`recv` shows Node's client writes flight + app data as one `write(1253)` while Bun issues `send(1152)` then `send(57)`. The server (Node in both runs) reads 1253 in one chunk from the Node client, but only 1152 from the Bun client before it destroys.
- The RST path needs the second segment to arrive inside the window between the server reading the flight and destroying the socket. Release builds hit it almost always. Debug builds are slow enough that the server's FIN usually wins, and Linux masks the late RST (`SOCK_DONE` is checked before `sk_err` in `tcp_recvmsg`). The gate-facing test therefore counts the client's segments through a raw in-test TCP proxy. The count discriminates reliably on an unloaded machine; under heavy CPU load the two unfixed sends can coalesce in the kernel, so a green run on a loaded machine is weaker evidence than the idle fail-before recorded here (20/20 fail on the unfixed build when idle). The end-to-end Node-server repro is kept as a second test, `skipIf(!nodeExe())`.
- Related, not the same bug: #40412 covers the send side of a destroyed TLS socket (bare FIN, no close_notify). #35378 holds the flight so a verify-rejecting client's destroy can recall it; it parks the flight in the spill slot and drains it before the callback's write, so it still produces two segments and does not fix #40653. This PR's batch-owner hold subsumes most of that machinery. #35378 should be restacked on top of this as a flush-vs-release policy decision at `us_internal_ssl_close` rather than rebased mechanically.
- Follow-up direction for this file: a per-socket outbound-ciphertext buffer would delete the shared batch/spill slots, both owner fields, the loop-state save slots for routing, and the cross-socket double-spill fatal path. Worth doing before more features extend the shared-slot surface.
- Pre-existing failures seen during the sweep, identical on an unmodified build: `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname" (ECONNREFUSED in this environment), `test/js/bun/net/` hostname-resolution failures (13, same set on system bun), `test-tls-client-allow-partial-trust-chain.js` (node:test runner), and `test-https-timeout.js` (hangs on a main debug build too).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.1 (731aa92da)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [3.82ms]
(pass) should thow ECONNRESET if FIN is received before handshake [346.19ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.78ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [106.76ms]
(pass) should be able to grab the JSStreamSocket constructor [12.46ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [82.50ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [77.93ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port a
... (truncated)

release without fix: 2 failed, 18 skipped
bun test v1.4.1-canary.1 (731aa92da)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.03ms]
(pass) should thow ECONNRESET if FIN is received before handshake [6.30ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.15ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [3.27ms]
(pass) should be able to grab the JSStreamSocket constructor [0.22ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [4.43ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [3.11ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.1 (731aa92da)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.71ms]
(pass) should thow ECONNRESET if FIN is received before handshake [362.37ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [8.06ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [115.84ms]
(pass) should be able to grab the JSStreamSocket constructor [13.31ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [87.82ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [85.23ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port a
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 863ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] cc obj/packages/bun-usockets/src/bsd.c.o
[2/25] cc obj/packages/bun-usockets/src/context.c.o
[3/25] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[4/25] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[5/25] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[6/25] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[7/25] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[8/25] cc obj/packages/bun-usockets/src/fault_inject.c.o
[9/25] cxx obj/src/jsc/bindings/bindings.cpp.o
[10/25] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[11/25] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[12/25] cc obj/packages/bun-usockets/src/loop.c.o
[13/25] cc obj/packages/bun-usockets/src/quic.c.o
[14/25] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[15/25] cc obj/packages/bun-usockets/src/udp.c.o
[16/25] cc obj/packages/bun-usockets/src/socket.c.o
[17/25] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[18/25] cxx obj/unified/UnifiedSource-src_j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c    | 149 +++++++++++++-
 packages/bun-usockets/src/internal/internal.h |  11 +-
 src/runtime/socket/socket_body.rs             |   9 +-
 src/runtime/socket/tls_socket_functions.rs    |   9 +-
 test/js/node/tls/node-tls-connect.test.ts     | 276 +++++++++++++++++++++++++-
 5 files changed, 436 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c         9     21      0
packages/bun-usockets/src/internal/internal.h      2      3      0
src/runtime/socket/socket_body.rs                  2      2      0
src/runtime/socket/tls_socket_functions.rs         2      3      0
test/js/node/tls/node-tls-connect.test.ts          2      9      0
```

</details>

<!-- robobun:evidence:end -->