### PR TITLE
macros: log the debug "[macro] call" line through a scoped logger

### DIFF
--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1349,7 +1349,11 @@ jsimd_ycc_rgb_convert_avx2.return                    [AVX, AVX2]
 # single-digit hit here is decode noise. Ceiling [AVX] so a multi-feature leak
 # still fails. On ELF each opcode handler has its own symbol, so layout shifts
 # can move the desync between llint_op_* siblings; add them here as they trip.
-# (2 symbols)
+# llint_op_jmp_wide32 decoded a stray RDPMC (0F 33) out of the same garbage.
+# That is not a SIMD feature and the bytes move with layout, so it is a blanket
+# pass; a real -march leak would show up in the other llint_op_* symbols.
+# (3 symbols)
 # ----------------------------------------------------------------------------
 llint_op_enter_wide32  [AVX]
 llint_op_wide16_wide16  [AVX]
+llint_op_jmp_wide32

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -30,7 +30,7 @@ use bun_jsc::{
 };
 use bun_jsc::{BuildMessage, ResolveMessage};
 
-bun_core::declare_scope!(Macro, visible);
+bun_core::declare_scope!(macros, visible);
 
 const NAMESPACE_WITH_COLON: &[u8] = b"macro:";
 
@@ -901,7 +901,7 @@ impl Runner {
         id: i32,
         javascript_object: JSValue,
     ) -> Result<Expr, MacroError> {
-        bun_core::scoped_log!(Macro, "call <b>{}<r>", bstr::BStr::new(function_name));
+        bun_core::scoped_log!(macros, "call <b>{}<r>", bstr::BStr::new(function_name));
 
         // The exception holder is never read in this body (legacy from an earlier
         // exception-reporting path); a thread-local sentinel suffices.

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -30,6 +30,8 @@ use bun_jsc::{
 };
 use bun_jsc::{BuildMessage, ResolveMessage};
 
+bun_core::declare_scope!(Macro, visible);
+
 const NAMESPACE_WITH_COLON: &[u8] = b"macro:";
 
 fn is_macro_path(str: &[u8]) -> bool {
@@ -899,12 +901,7 @@ impl Runner {
         id: i32,
         javascript_object: JSValue,
     ) -> Result<Expr, MacroError> {
-        if bun_core::env::IS_DEBUG {
-            bun_core::prettyln!(
-                "<r><d>[macro]<r> call <d><b>{}<r>",
-                bstr::BStr::new(function_name)
-            );
-        }
+        bun_core::scoped_log!(Macro, "call <b>{}<r>", bstr::BStr::new(function_name));
 
         // The exception holder is never read in this body (legacy from an earlier
         // exception-reporting path); a thread-local sentinel suffices.

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -150,10 +150,10 @@ test("object argument with a sparse numeric key", async () => {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // One combined assertion so stderr (where JSC prints the exception check failure) shows up in
-  // the diff if the child aborts. Debug builds print "[macro] call take" to stdout before the
-  // script's own output, so only the tail of stdout is matched.
-  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toMatchObject({
-    stdout: expect.stringMatching(/200000\n$/),
+  // the diff if the child aborts.
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "200000\n",
+    stderr: "",
     exitCode: 0,
     signalCode: null,
   });
@@ -178,7 +178,7 @@ test("object destructuring of a macro result keeps every bound property regardle
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({ lastLine: "[2,1,1,1,2]", stderr: "" });
+  expect({ stdout, stderr }).toEqual({ stdout: "[2,1,1,1,2]\n", stderr: "" });
   expect(exitCode).toBe(0);
 });
 
@@ -199,11 +199,7 @@ describe("event loop routing around macros", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Debug builds also print "[macro] call <name>" to stdout.
-    const lines = stdout
-      .trim()
-      .split("\n")
-      .filter(line => !line.startsWith("[macro]"));
+    const lines = stdout.trim().split("\n");
     return { lines, stderr, exitCode };
   }
 

--- a/test/regression/issue/39900.test.ts
+++ b/test/regression/issue/39900.test.ts
@@ -53,8 +53,8 @@ console.log(start());
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  // The unawaited digest settles before or after the entry module's output.
-  expect(stdout.trim().split("\n").sort()).toEqual(["1", "settled"]);
+  expect(stdout).toContain("1\n");
+  expect(stdout).toContain("settled\n");
   expect(exitCode).toBe(0);
 });
 

--- a/test/regression/issue/39900.test.ts
+++ b/test/regression/issue/39900.test.ts
@@ -27,8 +27,7 @@ test.concurrent("macro that awaits crypto.subtle.digest resolves under bun run",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  // A debug build also logs "[macro] call sha" to stdout.
-  expect(stdout).toContain(`${expected}\n`);
+  expect(stdout).toBe(`${expected}\n`);
   expect(exitCode).toBe(0);
 });
 
@@ -54,8 +53,8 @@ console.log(start());
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout).toContain("1\n");
-  expect(stdout).toContain("settled\n");
+  // The unawaited digest settles before or after the entry module's output.
+  expect(stdout.trim().split("\n").sort()).toEqual(["1", "settled"]);
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- Debug builds print `[macro] call <name>` to stdout for every macro call. The print in `src/js_parser_jsc/Macro.rs` (`Runner::run`) is a plain `prettyln!` gated on `IS_DEBUG`, not a scoped logger, so `BUN_DEBUG_QUIET_LOGS=1` (set by `bunEnv` and by `bun bd`) does not silence it.
- Every test that spawns bun with a macro works around it: a `/200000\n$/` tail match, a `lastLine` pop and a `[macro]` line filter in `test/bundler/transpiler/macro-test.test.ts`, and a `toContain` in `test/regression/issue/39900.test.ts`.

### Fix
- `declare_scope!(macros, visible)` plus `scoped_log!(macros, "call <b>{}<r>", ...)` replace the `IS_DEBUG` branch. The line reads `[macros] call identity` in a debug build with logs on. `BUN_DEBUG_QUIET_LOGS=1` turns it off, `BUN_DEBUG_macros=1` turns it on alone. Release builds dead-strip the body as before. The scope is not named `Macro` because that is already the struct in this module.
- Correct because this is the logging convention `src/CLAUDE.md` names for debug output, and the print carries no information outside debugging.
- The three workarounds in `macro-test.test.ts` and the `toContain` of the awaited case in `39900.test.ts` become exact stdout assertions. On a debug build the old binary fails each of them with the `[macro] call` line in the diff.
- Verified: `bun bd test` on `39900.test.ts` and `macro-test.test.ts`, plus `transpiler.test.js`, `scope-mismatch-panic.test.ts`, the `bun-build-api` and `bundler_edgecase` macro cases, and `03830`, `22656`, `26360`.

### Background
- A scoped logger is a static declared with `declare_scope!(Name, visible|hidden)`. `scoped_log!(Name, ...)` prints `[name] ...` when the scope is visible. `BUN_DEBUG_<Name>`, `BUN_DEBUG_ALL` and `BUN_DEBUG_QUIET_LOGS` decide visibility at runtime, and the whole body is gone in release builds.
- `bunEnv` in `test/harness.ts` sets `BUN_DEBUG_QUIET_LOGS=1`, so tests never see scoped logs from the bun they spawn.

<details><summary>Notes</summary>

- Scoped logs go to the same stream as the old print (stdout), so a developer running a debug build by hand sees the same line in the same place. The log also prints from bundler worker threads, as the old print did.
- The unawaited case of `39900.test.ts` keeps main's two `toContain` checks. Whether its `settled` line prints before exit is timing, and #40059 relaxes that assertion for the same reason.
- #40059 moves the print inside `Macro.rs` and keeps it a `prettyln!` with an `Output::flush()`, and adds one more `[macro]` filter to `macro-test.test.ts`. On rebase it replaces the moved print with the `scoped_log!` and drops its filter. #40623 rewrites the two standalone tests of `macro-test.test.ts` with a helper that carries the same filter, which it drops on rebase.
- `src/runtime/cli/upgrade_command.rs` has three more `IS_DEBUG`-gated `prettyln!` sites, on the `bun upgrade` path no test reaches. They are left for a separate change.
- `scripts/verify-baseline-static/allowlist-x64.txt` gains `llint_op_jmp_wide32`. The static ISA scan of this branch's linux-x64 build decoded one `RDPMC` out of the opcode id embedded at the start of that LLInt handler (build #107047). The layout shift from the Rust change moved the known decode desync onto this symbol. It joins the two `llint_op_*` entries already listed for the same reason, as a blanket pass because misdecoded bytes have no feature to bound.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 5 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts "test/regression/issue/39900.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/165] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/165] gen cpp.rs (cppbind)
[3/165] gen JS modules (bundle-modules)
Preprocess modules (8571ms)
Bundle modules (186ms)
Postprocesss modules (57ms)
Bundle Functions (429ms)
Generate Code (36ms)

[9.29s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/164] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[26/164] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (7cca1d225)

test/regression/issue/39900.test.ts:
(pass) macro that awaits crypto.subtle.digest of under 64 bytes resolves [8.26ms]
(pass) macro that starts crypto.subtle.digest without awaiting still exits [9.43ms]
(pass) macro that awaits crypto.subtle.digest resolves under bun run [10.97ms]
(pass) macro that awaits WebAssembly.instantiate resolves [8.09ms]
(pass) macro that awaits crypto.subtle.sign resolves [6.28ms]
(pass) macro that awaits crypto.subtle.digest resolves under Bun.build [9.57ms]
(pass) macro that awaits MessageChannel resolves [6.42ms]
(pass) macro that awaits BroadcastChannel resolves [7.99ms]
(pass) macro that awaits Worker resolves [10.44ms]
(pass) macro that awaits a BroadcastChannel message from a Worker resolves [9.46ms]
(pass) macro that awaits a MessagePort transferred to a Worker resolves [10.32ms]
(pass) macro that awaits Atomics.waitAsync resolves [16.11ms]

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.03ms]
(pass) latin1 string [0.01ms]
(pass) ascii string
(pass) type coercion [0.04ms]
(pass) escaping [0.16ms]
(pass) utf16 string
(pass) import aliases [0.02ms]
(pass)
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts "test/regression/issue/39900.test.ts"
bun test v1.4.1 (731aa92da)

test/regression/issue/39900.test.ts:
(pass) macro that starts crypto.subtle.digest without awaiting still exits [314.40ms]
(pass) macro that awaits crypto.subtle.digest resolves under bun run [387.02ms]
(pass) macro that awaits WebAssembly.instantiate resolves [280.24ms]
(pass) macro that awaits crypto.subtle.digest of under 64 bytes resolves [314.42ms]
(pass) macro that awaits BroadcastChannel resolves [286.73ms]
(pass) macro that awaits crypto.subtle.digest resolves under Bun.build [668.72ms]
(pass) macro that awaits crypto.subtle.sign resolves [370.71ms]
(pass) macro that awaits Atomics.waitAsync resolves [390.67ms]
(pass) macro that awaits MessageChannel resolves [370.50ms]
(pass) macro that awaits Worker resolves [455.49ms]
(pass) macro that awaits a MessagePort transferred to a Worker resolves [440.24ms]
(pass) macro that awaits a BroadcastChannel message from a Worker resolves [454.88ms]

test/bundler/transpiler/macro-te
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 631ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (7978ms)
Bundle modules (48ms)
Postprocesss modules (124ms)
Bundle Functions (475ms)
Generate Code (39ms)

[8.67s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/verify-baseline-static/allowlist-x64.txt |  6 +++++-
 src/js_parser_jsc/Macro.rs                       |  9 +++------
 test/bundler/transpiler/macro-test.test.ts       | 16 ++++++----------
 test/regression/issue/39900.test.ts              |  3 +--
 4 files changed, 15 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
scripts/verify-baseline-static/allowlist-x64.txt      1      1      0
src/js_parser_jsc/Macro.rs                            4      2      0
test/bundler/transpiler/macro-test.test.ts            8     13      0
test/regression/issue/39900.test.ts                   2      4      0
```

</details>

<!-- robobun:evidence:end -->