### PR TITLE
bundler: drop a dynamic entry from a chunk key when every importer is preceded by the key

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -267,7 +267,6 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
       // exists for cargo's dep-info on $shim_dest, not for restat.
     });
   }
-
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -175,18 +175,6 @@ function windowsShimDestPath(cfg: Config): string {
   return resolve(cfg.cwd, "src", "install", "windows-shim", "bun_shim_impl.exe");
 }
 
-/**
- * Path to the `rustup` binary that owns `cfg.cargo`, or `undefined` if
- * `cfg.cargo` isn't a rustup proxy (a distro/Homebrew cargo, say).
- * `rustup target add` is only meaningful when rustup is the toolchain
- * manager — `rust_build_cross` requires it; everyone else gets `rust_build`.
- */
-function findRustup(cfg: Config): string | undefined {
-  if (cfg.cargo === undefined) return undefined;
-  const rustup = join(dirname(cfg.cargo), `rustup${cfg.host.exeSuffix}`);
-  return existsSync(rustup) ? rustup : undefined;
-}
-
 // ───────────────────────────────────────────────────────────────────────────
 // Paths
 // ───────────────────────────────────────────────────────────────────────────
@@ -243,47 +231,6 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
     restat: true,
   });
 
-  // Variant that ensures the pinned toolchain (and `rust-std` for
-  // `$rust_target` when it has a prebuilt one) is fully installed before
-  // building. CI agents pin the toolchain via `RUSTUP_TOOLCHAIN`, which
-  // bypasses `rust-toolchain.toml`'s `targets`/`components` install list, and
-  // rustup-proxy auto-install can leave a *partial* toolchain dir (rustc/cargo
-  // present, no `rust-std`, no `lib/rustlib/multirust-channel-manifest.toml`).
-  // That surfaces as either `error[E0463]: can't find crate for core` (cargo
-  // ran, no std) or `error: Missing manifest in toolchain '<channel>-<host>'`
-  // (rustup-proxy refused to even resolve cargo). `rustup toolchain install`
-  // repairs both, and is an offline ~70ms no-op when the toolchain is already
-  // complete. No `--force`: that means "update even if the manifest lacks a
-  // component", which re-fetches the channel manifest on every build.
-  //
-  // `$rust_target_arg` is `--target <triple>` for Tier 1/2 (also installs the
-  // prebuilt `rust-std-<triple>`), and empty for Tier 3 (no prebuilt; cargo
-  // gets `-Zbuild-std` instead — see emitRust). Both still get `rust-src`
-  // (needed for `-Zbuild-std`).
-  //
-  // Only registered when `cfg.rustToolchain` is pinned and `cfg.cargo` is a
-  // rustup proxy — otherwise there's no channel to install / no `rustup` to
-  // call, and toolchain management is the user's problem.
-  // `--console` on the rustup step too: it's sequential with cargo (both
-  // sides of `&&`) and the rule already takes the console pool, so there's
-  // no interleaving risk — and `--console` inherits stdio directly, which
-  // matters because stream.ts's pipe path can drop a fast-failing child's
-  // output (it `process.exit()`s on `close` before the async stdout writes
-  // drain). Without it, a failed `toolchain install` shows no error at all.
-  //
-  // No `--profile minimal`: the agent already has the default profile, and
-  // rustup applies `--profile` to the install spec, not just first-install —
-  // requesting a *narrower* profile on a reinstall is asking for
-  // trouble. We only care that `rust-src` and `rust-std-<triple>` exist on
-  // top of whatever profile is there.
-  //
-  // Windows: ninja spawns commands via CreateProcess directly (no shell), so
-  // `&&` would be passed as a literal argument to the first node.exe — rustup
-  // then sees the second half of the chain as extra argv and rejects
-  // `--experimental-strip-types`. Wrap in `cmd /c "..."` so cmd.exe handles
-  // the chain (cmd's quote-stripping rule removes only the outermost pair,
-  // preserving the embedded `"..."` around paths/env values). Same pattern as
-  // codegen.ts / bun.ts.
   // Windows .bin/ shim PE: cargo build → copy into the source tree for
   // `include_bytes!`. One rule does both; cargo's own output path and the
   // source-tree copy are undeclared side effects (see below for what $out is).
@@ -321,20 +268,6 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
     });
   }
 
-  const rustup = findRustup(cfg);
-  if (rustup !== undefined && cfg.rustToolchain !== undefined) {
-    // `-q` + `--no-self-update` silence the five `info:` lines rustup prints
-    // on every no-op reinstall; warnings/errors still show.
-    const chain =
-      `${stream} --console $env ${q(rustup)} -q toolchain install ${cfg.rustToolchain} --no-self-update --component rust-src $rust_target_arg && ` +
-      `${stream} --console --cwd=$cwd $env ${q(cfg.cargo)} build $args`;
-    n.rule("rust_build_cross", {
-      command: hostWin ? `cmd /c "${chain}"` : chain,
-      description: "cargo bun_runtime → $label ($rust_target_arg)",
-      pool: "console",
-      restat: true,
-    });
-  }
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -894,20 +827,9 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   }
 
   // ─── Emit build node ───
-  // When the toolchain is rustup-managed and pinned, route through
-  // `rust_build_cross`, which does `rustup toolchain install ...`
-  // before cargo. That makes the first build after a `rust-toolchain.toml`
-  // channel bump (and a partially auto-installed toolchain) self-heal —
-  // see the rule comment above. Tier 1/2 also pass `--target <triple>` so
-  // the prebuilt `rust-std` for the cross triple is installed; Tier 3 omits
-  // it (no prebuilt — cargo gets `-Zbuild-std` instead) and just gets
-  // `rust-src`. Local builds without rustup, or without a pinned channel,
-  // fall back to plain `rust_build` and trust whatever toolchain `cfg.cargo`
-  // resolves to.
-  const useCrossRule = findRustup(cfg) !== undefined && cfg.rustToolchain !== undefined;
   n.build({
     outputs: [lib],
-    rule: useCrossRule ? "rust_build_cross" : "rust_build",
+    rule: "rust_build",
     inputs: [],
     // Cargo binary itself + every .rs/Cargo.toml so editing one re-invokes
     // (cargo's own fingerprinting then decides what to actually recompile).
@@ -920,7 +842,6 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     vars: {
       cwd: cfg.cwd,
       args: quoteArgs(args, hostWin),
-      ...(useCrossRule ? { rust_target_arg: tier3 ? "" : `--target ${triple}` } : {}),
       label: `${cfg.libPrefix}bun_runtime${cfg.libSuffix}`,
       env: Object.entries(env)
         .map(([k, v]) => `--env=${k}=${quote(v, hostWin)}`)

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -202,14 +202,17 @@ fn collect_newly_loaded(
 /// entry load more code), the second only for chunks smaller than
 /// `min_chunk_size` (summed source bytes):
 ///
-/// 1. An `import()` entry point `D` is redundant in a key when some other entry
-///    in that key is guaranteed to already be loaded whenever `D` is loaded
-///    (`guaranteed` below). Keys that are equal after dropping their redundant
-///    entries describe chunks that are always loaded together: with one user
-///    entry `main` and a lazy `import("./x")` only reachable from `main`, the
-///    `{main, x}` chunk is loaded iff `main` runs, the same as `main`'s own
-///    chunk, so its files can live there and `x`'s chunk imports what it needs
-///    from the `main` chunk.
+/// 1. An `import()` entry point `D` is redundant in a key when, whichever way
+///    `D` gets loaded, some other entry in that key has already been loaded
+///    (`preceded` below: every importer of `D` is in the key, or is itself only
+///    reachable through the key). Keys that are equal after dropping their
+///    redundant entries describe chunks that are always loaded together: with
+///    one user entry `main` and a lazy `import("./x")` only reachable from
+///    `main`, the `{main, x}` chunk is loaded iff `main` runs, the same as
+///    `main`'s own chunk, so its files can live there and `x`'s chunk imports
+///    what it needs from the `main` chunk. Different entries may cover
+///    different importers: with `import("./cmd")` in both `main` and a lazy
+///    `repl`, the `{main, repl, cmd}` chunk loads iff `main` or `repl` does.
 /// 2. A chunk whose live parts have no top-level side effects may join a chunk
 ///    loaded by a superset of its entries, as long as everything it imports is
 ///    already loaded wherever that target is (or is side-effect free too); the
@@ -307,6 +310,10 @@ pub(crate) fn merge_small_chunks(
             }
         }
     }
+    // A self-`import()` cannot be the load that comes first.
+    for (entry_id, importers) in importer_bits.iter_mut().enumerate() {
+        importers.unset(entry_id);
+    }
 
     // An entry whose chunk (or a chunk it imports) uses top-level await can
     // still be mid-evaluation when an `import()` it started links, so it
@@ -321,57 +328,61 @@ pub(crate) fn merge_small_chunks(
         }
     }
 
-    // `guaranteed[D]`: entries that are already evaluated whenever the dynamic
-    // entry `D` is loaded, excluding `D` itself. Greatest fixpoint of
-    //   guaranteed[D] = ∩ over importers E of D: ({E} ∪ guaranteed[E])
-    // where an importer is an entry that statically reaches a file holding an
-    // `import()` of D. User entries are process roots, even when something
-    // also `import()`s them: nothing precedes them. A dynamic entry no live
-    // code imports is left alone (empty set).
-    let mut guaranteed: Vec<AutoBitSet> = Vec::with_capacity(entry_points_len);
+    // A dynamic entry can stand in for its importers when some live code
+    // `import()`s it, nothing `require()`s it, and no importer is mid-evaluation
+    // at a top-level await while it loads.
     let has_guarantors = |entry_id: usize| {
         is_dynamic_entry(entry_id)
             && !required_sync.is_set(entry_id)
             && importer_bits[entry_id].find_first_set().is_some()
+            && !importer_bits[entry_id].has_intersection(&awaits)
     };
+    // The dynamic entries with guarantors that each entry `import()`s.
+    let mut dependents: Vec<Vec<u32>> = vec![Vec::new(); entry_points_len];
     for entry_id in 0..entry_points_len {
-        let mut bits = AutoBitSet::init_empty(entry_points_len)?;
-        if has_guarantors(entry_id) {
-            bits.set_all(true);
-            bits.unset(entry_id);
+        if !has_guarantors(entry_id) {
+            continue;
         }
-        guaranteed.push(bits);
-    }
-    let mut next = AutoBitSet::init_empty(entry_points_len)?;
-    loop {
-        let mut changed = false;
-        for (entry_id, importers) in importer_bits.iter().enumerate() {
-            if !has_guarantors(entry_id) {
-                continue;
-            }
-            next.set_all(true);
-            let mut iter = importers.iterator::<true, true>();
-            while let Some(importer) = iter.next() {
-                if awaits.is_set(importer) {
-                    next.set_all(false);
-                    break;
-                }
-                let keep = next.is_set(importer);
-                next.set_intersection(&guaranteed[importer]);
-                if keep {
-                    next.set(importer);
-                }
-            }
-            next.unset(entry_id);
-            if !next.eql(&guaranteed[entry_id]) {
-                core::mem::swap(&mut guaranteed[entry_id], &mut next);
-                changed = true;
-            }
-        }
-        if !changed {
-            break;
+        let mut iter = importer_bits[entry_id].iterator::<true, true>();
+        while let Some(importer) = iter.next() {
+            dependents[importer].push(entry_id as u32);
         }
     }
+    // `preceded(key)`: entries some member of `key` is guaranteed to have loaded
+    // before — the key itself plus, to a fixpoint, every dynamic entry all of
+    // whose importers are already in the set. An entry only reachable through a
+    // cycle of such entries never loads at all, so it counts too. `missing`
+    // counts each dependent's importers not yet in the set; `stamp` resets it
+    // per key in O(1).
+    let importer_count: Vec<u32> = importer_bits.iter().map(|b| b.count() as u32).collect();
+    let mut missing: Vec<u32> = vec![0; entry_points_len];
+    let mut stamp: Vec<u32> = vec![0; entry_points_len];
+    let mut epoch: u32 = 0;
+    let mut worklist: Vec<usize> = Vec::new();
+    let mut preceded = |key: &AutoBitSet| -> crate::Result<AutoBitSet> {
+        epoch += 1;
+        let mut set = key.clone()?;
+        worklist.clear();
+        let mut iter = key.iterator::<true, true>();
+        while let Some(entry_id) = iter.next() {
+            worklist.push(entry_id);
+        }
+        while let Some(entry_id) = worklist.pop() {
+            for &dependent in &dependents[entry_id] {
+                let dependent = dependent as usize;
+                if stamp[dependent] != epoch {
+                    stamp[dependent] = epoch;
+                    missing[dependent] = importer_count[dependent];
+                }
+                missing[dependent] -= 1;
+                if missing[dependent] == 0 && !set.is_set(dependent) {
+                    set.set(dependent);
+                    worklist.push(dependent);
+                }
+            }
+        }
+        Ok(set)
+    };
 
     // Group the live JS files by their chunk key, and the groups by their
     // load-condition class (the key with redundant dynamic entries removed).
@@ -440,12 +451,15 @@ pub(crate) fn merge_small_chunks(
                 }
             }
             MapEntry::Vacant(entry) => {
-                // Drop each dynamic entry that some entry still in `class` is
-                // guaranteed to precede; `guaranteed[d]` never contains `d`.
+                // Drop each dynamic entry whose every importer is preceded by
+                // the key.
                 let mut class = bits.clone()?;
+                let preceded_by_key = preceded(bits)?;
                 let mut iter = bits.iterator::<true, true>();
                 while let Some(entry_id) = iter.next() {
-                    if is_dynamic_entry(entry_id) && class.has_intersection(&guaranteed[entry_id]) {
+                    if has_guarantors(entry_id)
+                        && importer_bits[entry_id].subset_of(&preceded_by_key)
+                    {
                         class.unset(entry_id);
                     }
                 }

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -194,6 +194,68 @@ fn collect_newly_loaded(
     true
 }
 
+const UNREACHED: u32 = u32::MAX;
+
+/// Immediate dominator of each node reachable from `root` (Cooper, Harvey &
+/// Kennedy, "A Simple, Fast Dominance Algorithm"); `UNREACHED` elsewhere.
+fn immediate_dominators<'a>(
+    len: usize,
+    successors: impl Fn(usize) -> &'a [u32],
+    root: usize,
+    mut predecessors: impl FnMut(usize, &mut dyn FnMut(usize)),
+) -> Vec<u32> {
+    let mut postorder: Vec<u32> = vec![UNREACHED; len];
+    let mut order: Vec<u32> = Vec::with_capacity(len);
+    let mut stack: Vec<(usize, usize)> = vec![(root, 0)];
+    postorder[root] = 0;
+    while let Some((node, next)) = stack.last_mut() {
+        if let Some(&succ) = successors(*node).get(*next) {
+            *next += 1;
+            if postorder[succ as usize] == UNREACHED {
+                postorder[succ as usize] = 0;
+                stack.push((succ as usize, 0));
+            }
+        } else {
+            postorder[*node] = order.len() as u32;
+            order.push(*node as u32);
+            stack.pop();
+        }
+    }
+    let mut idom: Vec<u32> = vec![UNREACHED; len];
+    idom[root] = root as u32;
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for &node in order.iter().rev().skip(1) {
+            let mut new_idom = UNREACHED;
+            predecessors(node as usize, &mut |pred| {
+                if idom[pred] == UNREACHED {
+                    return;
+                }
+                if new_idom == UNREACHED {
+                    new_idom = pred as u32;
+                    return;
+                }
+                let (mut a, mut b) = (pred as u32, new_idom);
+                while a != b {
+                    while postorder[a as usize] < postorder[b as usize] {
+                        a = idom[a as usize];
+                    }
+                    while postorder[b as usize] < postorder[a as usize] {
+                        b = idom[b as usize];
+                    }
+                }
+                new_idom = a;
+            });
+            if idom[node as usize] != new_idom {
+                idom[node as usize] = new_idom;
+                changed = true;
+            }
+        }
+    }
+    idom
+}
+
 /// Folds code-splitting chunks into other chunks where that is unobservable,
 /// so fewer modules are loaded at runtime.
 ///
@@ -334,7 +396,6 @@ pub(crate) fn merge_small_chunks(
     // at a top-level await while it loads. Every other entry is a root: it may
     // be the first thing loaded (a user entry), or nothing says what precedes it.
     let mut guaranteed = AutoBitSet::init_empty(entry_points_len)?;
-    let mut roots: Vec<usize> = Vec::new();
     for entry_id in 0..entry_points_len {
         if is_dynamic_entry(entry_id)
             && !required_sync.is_set(entry_id)
@@ -342,73 +403,114 @@ pub(crate) fn merge_small_chunks(
             && !importer_bits[entry_id].has_intersection(&awaits)
         {
             guaranteed.set(entry_id);
-        } else {
-            roots.push(entry_id);
         }
     }
-    // The guaranteed entries each entry `import()`s.
-    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); entry_points_len];
+    // The `import()` graph over entries as CSR (`successors_of(n)` =
+    // `edges[offsets[n]..offsets[n + 1]]`): a virtual root precedes every
+    // root, and each importer precedes the guaranteed entries it `import()`s.
+    let vroot = entry_points_len;
+    let offsets: &mut [u32] = temp.alloc_slice_fill_copy(entry_points_len + 3, 0u32);
     for entry_id in 0..entry_points_len {
         if !guaranteed.is_set(entry_id) {
+            offsets[vroot + 2] += 1;
             continue;
         }
         let mut iter = importer_bits[entry_id].iterator::<true, true>();
         while let Some(importer) = iter.next() {
-            dependents[importer].push(entry_id);
+            offsets[importer + 2] += 1;
         }
     }
+    for i in 2..offsets.len() {
+        offsets[i] += offsets[i - 1];
+    }
+    let edges: &mut [u32] = temp.alloc_slice_fill_copy(offsets[offsets.len() - 1] as usize, 0u32);
+    for entry_id in 0..entry_points_len {
+        if !guaranteed.is_set(entry_id) {
+            edges[offsets[vroot + 1] as usize] = entry_id as u32;
+            offsets[vroot + 1] += 1;
+            continue;
+        }
+        let mut iter = importer_bits[entry_id].iterator::<true, true>();
+        while let Some(importer) = iter.next() {
+            edges[offsets[importer + 1] as usize] = entry_id as u32;
+            offsets[importer + 1] += 1;
+        }
+    }
+    let successors = |node: usize| &edges[offsets[node] as usize..offsets[node + 1] as usize];
+    let idom = immediate_dominators(
+        entry_points_len + 1,
+        successors,
+        vroot,
+        |entry_id, each: &mut dyn FnMut(usize)| {
+            if guaranteed.is_set(entry_id) {
+                let mut iter = importer_bits[entry_id].iterator::<true, true>();
+                while let Some(importer) = iter.next() {
+                    each(importer);
+                }
+            } else {
+                each(vroot);
+            }
+        },
+    );
+
     // `load_class(key)`: `key` minus each guaranteed entry none of whose
     // importers a root reaches through `import()`s without passing through the
     // key; such an importer ran after some entry of the key, so that entry's
     // chunk was loaded first. (An importer cycle no root reaches never loads,
     // so it does not count either.) A key whose every entry is redundant is
     // never loaded and left alone.
-    let mut reached: Vec<u32> = vec![0; entry_points_len];
+    let mut seen: Vec<u32> = vec![0; entry_points_len];
     let mut epoch: u32 = 0;
     let mut worklist: Vec<usize> = Vec::new();
-    let mut candidates: Vec<usize> = Vec::new();
     let mut load_class = |key: &AutoBitSet| -> crate::Result<AutoBitSet> {
         let mut class = key.clone()?;
-        candidates.clear();
-        let mut iter = key.iterator::<true, true>();
-        while let Some(entry_id) = iter.next() {
-            if guaranteed.is_set(entry_id) {
-                candidates.push(entry_id);
+        let mut dropped = false;
+        let mut candidates = key.iterator::<true, true>();
+        while let Some(entry_id) = candidates.next() {
+            if !guaranteed.is_set(entry_id) {
+                continue;
             }
-        }
-        if candidates.is_empty() {
-            return Ok(class);
-        }
-        epoch += 1;
-        worklist.clear();
-        for &root in &roots {
-            if !key.is_set(root) {
-                reached[root] = epoch;
-                worklist.push(root);
-            }
-        }
-        while let Some(entry_id) = worklist.pop() {
-            for &dependent in &dependents[entry_id] {
-                if !key.is_set(dependent) && reached[dependent] != epoch {
-                    reached[dependent] = epoch;
-                    worklist.push(dependent);
+            // Fast path: a key entry dominates `entry_id`, or nothing loads it.
+            let mut up = idom[entry_id];
+            let mut preceded = up == UNREACHED;
+            while !preceded && up as usize != vroot {
+                if key.is_set(up as usize) {
+                    preceded = true;
+                } else {
+                    up = idom[up as usize];
                 }
             }
-        }
-        for &entry_id in &candidates {
-            let mut iter = importer_bits[entry_id].iterator::<true, true>();
-            let mut preceded = true;
-            while let Some(importer) = iter.next() {
-                if reached[importer] == epoch {
-                    preceded = false;
-                    break;
+            if !preceded {
+                // Walk importers backward, stopping at the key; a root reached
+                // this way loads `entry_id` before anything in the key.
+                preceded = true;
+                epoch += 1;
+                worklist.clear();
+                worklist.push(entry_id);
+                'walk: while let Some(below) = worklist.pop() {
+                    let mut iter = importer_bits[below].iterator::<true, true>();
+                    while let Some(importer) = iter.next() {
+                        if key.is_set(importer)
+                            || seen[importer] == epoch
+                            || idom[importer] == UNREACHED
+                        {
+                            continue;
+                        }
+                        if !guaranteed.is_set(importer) {
+                            preceded = false;
+                            break 'walk;
+                        }
+                        seen[importer] = epoch;
+                        worklist.push(importer);
+                    }
                 }
             }
             if preceded {
                 class.unset(entry_id);
+                dropped = true;
             }
         }
-        if class.find_first_set().is_none() {
+        if dropped && class.find_first_set().is_none() {
             return Ok(key.clone()?);
         }
         Ok(class)

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -204,15 +204,16 @@ fn collect_newly_loaded(
 ///
 /// 1. An `import()` entry point `D` is redundant in a key when, whichever way
 ///    `D` gets loaded, some other entry in that key has already been loaded
-///    (`preceded` below: every importer of `D` is in the key, or is itself only
-///    reachable through the key). Keys that are equal after dropping their
-///    redundant entries describe chunks that are always loaded together: with
-///    one user entry `main` and a lazy `import("./x")` only reachable from
-///    `main`, the `{main, x}` chunk is loaded iff `main` runs, the same as
-///    `main`'s own chunk, so its files can live there and `x`'s chunk imports
-///    what it needs from the `main` chunk. Different entries may cover
-///    different importers: with `import("./cmd")` in both `main` and a lazy
-///    `repl`, the `{main, repl, cmd}` chunk loads iff `main` or `repl` does.
+///    (`load_class` below: no importer of `D` can be reached from a process
+///    root without passing through the key). Keys that are equal
+///    after dropping their redundant entries describe chunks that are always
+///    loaded together: with one user entry `main` and a lazy `import("./x")`
+///    only reachable from `main`, the `{main, x}` chunk is loaded iff `main`
+///    runs, the same as `main`'s own chunk, so its files can live there and
+///    `x`'s chunk imports what it needs from the `main` chunk. Different
+///    entries may cover different importers: with `import("./cmd")` in both
+///    `main` and a lazy `repl`, the `{main, repl, cmd}` chunk loads iff `main`
+///    or `repl` does.
 /// 2. A chunk whose live parts have no top-level side effects may join a chunk
 ///    loaded by a superset of its entries, as long as everything it imports is
 ///    already loaded wherever that target is (or is side-effect free too); the
@@ -330,58 +331,87 @@ pub(crate) fn merge_small_chunks(
 
     // A dynamic entry can stand in for its importers when some live code
     // `import()`s it, nothing `require()`s it, and no importer is mid-evaluation
-    // at a top-level await while it loads.
-    let has_guarantors = |entry_id: usize| {
-        is_dynamic_entry(entry_id)
+    // at a top-level await while it loads. Every other entry is a root: it may
+    // be the first thing loaded (a user entry), or nothing says what precedes it.
+    let mut guaranteed = AutoBitSet::init_empty(entry_points_len)?;
+    let mut roots: Vec<usize> = Vec::new();
+    for entry_id in 0..entry_points_len {
+        if is_dynamic_entry(entry_id)
             && !required_sync.is_set(entry_id)
             && importer_bits[entry_id].find_first_set().is_some()
             && !importer_bits[entry_id].has_intersection(&awaits)
-    };
-    // The dynamic entries with guarantors that each entry `import()`s.
-    let mut dependents: Vec<Vec<u32>> = vec![Vec::new(); entry_points_len];
+        {
+            guaranteed.set(entry_id);
+        } else {
+            roots.push(entry_id);
+        }
+    }
+    // The guaranteed entries each entry `import()`s.
+    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); entry_points_len];
     for entry_id in 0..entry_points_len {
-        if !has_guarantors(entry_id) {
+        if !guaranteed.is_set(entry_id) {
             continue;
         }
         let mut iter = importer_bits[entry_id].iterator::<true, true>();
         while let Some(importer) = iter.next() {
-            dependents[importer].push(entry_id as u32);
+            dependents[importer].push(entry_id);
         }
     }
-    // `preceded(key)`: entries some member of `key` is guaranteed to have loaded
-    // before — the key itself plus, to a fixpoint, every dynamic entry all of
-    // whose importers are already in the set. An entry only reachable through a
-    // cycle of such entries never loads at all, so it counts too. `missing`
-    // counts each dependent's importers not yet in the set; `stamp` resets it
-    // per key in O(1).
-    let importer_count: Vec<u32> = importer_bits.iter().map(|b| b.count() as u32).collect();
-    let mut missing: Vec<u32> = vec![0; entry_points_len];
-    let mut stamp: Vec<u32> = vec![0; entry_points_len];
+    // `load_class(key)`: `key` minus each guaranteed entry none of whose
+    // importers a root reaches through `import()`s without passing through the
+    // key; such an importer ran after some entry of the key, so that entry's
+    // chunk was loaded first. (An importer cycle no root reaches never loads,
+    // so it does not count either.) A key whose every entry is redundant is
+    // never loaded and left alone.
+    let mut reached: Vec<u32> = vec![0; entry_points_len];
     let mut epoch: u32 = 0;
     let mut worklist: Vec<usize> = Vec::new();
-    let mut preceded = |key: &AutoBitSet| -> crate::Result<AutoBitSet> {
-        epoch += 1;
-        let mut set = key.clone()?;
-        worklist.clear();
+    let mut candidates: Vec<usize> = Vec::new();
+    let mut load_class = |key: &AutoBitSet| -> crate::Result<AutoBitSet> {
+        let mut class = key.clone()?;
+        candidates.clear();
         let mut iter = key.iterator::<true, true>();
         while let Some(entry_id) = iter.next() {
-            worklist.push(entry_id);
+            if guaranteed.is_set(entry_id) {
+                candidates.push(entry_id);
+            }
+        }
+        if candidates.is_empty() {
+            return Ok(class);
+        }
+        epoch += 1;
+        worklist.clear();
+        for &root in &roots {
+            if !key.is_set(root) {
+                reached[root] = epoch;
+                worklist.push(root);
+            }
         }
         while let Some(entry_id) = worklist.pop() {
             for &dependent in &dependents[entry_id] {
-                let dependent = dependent as usize;
-                if stamp[dependent] != epoch {
-                    stamp[dependent] = epoch;
-                    missing[dependent] = importer_count[dependent];
-                }
-                missing[dependent] -= 1;
-                if missing[dependent] == 0 && !set.is_set(dependent) {
-                    set.set(dependent);
+                if !key.is_set(dependent) && reached[dependent] != epoch {
+                    reached[dependent] = epoch;
                     worklist.push(dependent);
                 }
             }
         }
-        Ok(set)
+        for &entry_id in &candidates {
+            let mut iter = importer_bits[entry_id].iterator::<true, true>();
+            let mut preceded = true;
+            while let Some(importer) = iter.next() {
+                if reached[importer] == epoch {
+                    preceded = false;
+                    break;
+                }
+            }
+            if preceded {
+                class.unset(entry_id);
+            }
+        }
+        if class.find_first_set().is_none() {
+            return Ok(key.clone()?);
+        }
+        Ok(class)
     };
 
     // Group the live JS files by their chunk key, and the groups by their
@@ -451,18 +481,7 @@ pub(crate) fn merge_small_chunks(
                 }
             }
             MapEntry::Vacant(entry) => {
-                // Drop each dynamic entry whose every importer is preceded by
-                // the key.
-                let mut class = bits.clone()?;
-                let preceded_by_key = preceded(bits)?;
-                let mut iter = bits.iterator::<true, true>();
-                while let Some(entry_id) = iter.next() {
-                    if has_guarantors(entry_id)
-                        && importer_bits[entry_id].subset_of(&preceded_by_key)
-                    {
-                        class.unset(entry_id);
-                    }
-                }
+                let class = load_class(bits)?;
                 match classes.entry(temp.alloc_slice_copy(class.bytes(entry_points_len))) {
                     MapEntry::Occupied(e) => e.into_mut().1.push(group_index),
                     MapEntry::Vacant(e) => {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1263,6 +1263,58 @@ describe("bundler", () => {
     run: { file: "/out/b.js", stdout: "b\nd 42" },
   });
 
+  // `cmd` is import()ed from main and from `sub`, which only repl loads, so
+  // whichever way it loads, main or repl came first: the {main, repl, cmd}
+  // chunk is loaded exactly when the {main, repl} chunk is and folds into it,
+  // even though no single entry precedes `cmd` on every path.
+  itBundled("splitting/FoldsChunkWhoseImportersTheKeyCovers", {
+    files: {
+      "/main.js": /* js */ `
+        import { shared } from './shared.js'
+        import { common } from './common.js'
+        console.log('main', shared(), common())
+        import('./cmd.js').then(m => console.log('cmd', m.cmd()))
+      `,
+      "/repl.js": /* js */ `
+        import { shared } from './shared.js'
+        import { common } from './common.js'
+        console.log('repl', shared(), common())
+        import('./sub.js')
+      `,
+      "/sub.js": /* js */ `
+        console.log('sub')
+        import('./cmd.js').then(m => console.log('cmd', m.cmd()))
+      `,
+      "/cmd.js": /* js */ `
+        import { shared } from './shared.js'
+        export function cmd() { return shared() + 1 }
+      `,
+      "/shared.js": /* js */ `
+        console.log('shared evaluated')
+        export function shared() { return 41 }
+      `,
+      "/common.js": /* js */ `
+        export function common() { return 'common' }
+      `,
+    },
+    entryPoints: ["/main.js", "/repl.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      // main, repl, sub, cmd, and one {main, repl} chunk holding common.js
+      // and shared.js.
+      expect(jsFilesIn(api)).toHaveLength(5);
+      const sharedChunk = jsFilesIn(api).find(f => api.readFile("/out/" + f).includes("shared evaluated"))!;
+      api.expectFile("/out/" + sharedChunk).toContain("common");
+      expect(jsOutput(api, "cmd")).toContain(`from "./${sharedChunk}"`);
+    },
+    run: [
+      { file: "/out/main.js", stdout: "shared evaluated\nmain 41 common\ncmd 42" },
+      { file: "/out/repl.js", stdout: "shared evaluated\nrepl 41 common\nsub\ncmd 42" },
+    ],
+  });
+
   // Folding a chunk with side effects into a pure one (rule 1) makes the
   // result impure, so it may not then move into a superset chunk (rule 2).
   itBundled("splitting/MinChunkSizeFoldedImpurityBlocksSupersetFold", {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1305,7 +1305,7 @@ describe("bundler", () => {
       // main, repl, sub, cmd, and one {main, repl} chunk holding common.js
       // and shared.js.
       expect(jsFilesIn(api)).toHaveLength(5);
-      const sharedChunk = jsFilesIn(api).find(f => api.readFile("/out/" + f).includes("shared evaluated"))!;
+      const sharedChunk = chunkContaining(api, "shared evaluated");
       api.expectFile("/out/" + sharedChunk).toContain("common");
       expect(jsOutput(api, "cmd")).toContain(`from "./${sharedChunk}"`);
     },
@@ -1313,6 +1313,44 @@ describe("bundler", () => {
       { file: "/out/main.js", stdout: "shared evaluated\nmain 41 common\ncmd 42" },
       { file: "/out/repl.js", stdout: "shared evaluated\nrepl 41 common\nsub\ncmd 42" },
     ],
+  });
+
+  // Lazy modules that import() each other: `d` is only reached through `x`,
+  // which `main` or `y` loads, and `y` only through `x`, so `main` always
+  // comes first and the {main, d} chunk folds into main.js.
+  itBundled("splitting/FoldsChunkBehindDynamicImportCycle", {
+    files: {
+      "/main.js": /* js */ `
+        import { shared } from './shared.js'
+        console.log('main', shared())
+        import('./x.js')
+      `,
+      "/x.js": /* js */ `
+        console.log('x')
+        export const y = () => import('./y.js')
+        import('./d.js').then(m => console.log('d', m.d()))
+      `,
+      "/y.js": /* js */ `
+        export const x = () => import('./x.js')
+      `,
+      "/d.js": /* js */ `
+        import { shared } from './shared.js'
+        export function d() { return shared() + 1 }
+      `,
+      "/shared.js": /* js */ `
+        export function shared() { return 41 }
+      `,
+    },
+    entryPoints: ["/main.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(jsOutputs(api)).toEqual(["d.js", "main.js", "x.js", "y.js"]);
+      api.expectFile("/out/main.js").toContain("41");
+      expect(jsOutput(api, "d")).toContain('from "./main.js"');
+    },
+    run: { file: "/out/main.js", stdout: "main 41\nx\nd 42" },
   });
 
   // Folding a chunk with side effects into a pure one (rule 1) makes the


### PR DESCRIPTION
### What does this PR do?

Widens rule 1 of `mergeSmallChunks` (#40506), the always-on fold of code-splitting chunks that are loaded under the same conditions.

Rule 1 drops an `import()` entry `D` from a chunk key when `D` can never be the first thing loaded among the key's entries. #40506 required a single entry to precede `D` on every path (`guaranteed[D]`, the intersection over `D`'s importers). That never fires when the same module is `import()`ed from two places that don't have a common ancestor: with two entries `main` and `repl` that both `import("./cmd")`, the `{main, repl, cmd}` chunk is loaded exactly when the `{main, repl}` chunk is (whichever way `cmd` loads, `main` or `repl` came first), but `guaranteed[cmd] = {main} ∩ {repl} = ∅` kept the two chunks apart.

The new rule is per key: `D` is redundant when no importer of `D` can be reached from a process root through `import()`s without passing through the key. Roots are the entries nothing is known to precede: user entries, `require()` targets (#40519), entries with an importer that may be mid-evaluation at a top-level await, and entries nothing imports. `load_class` walks the `import()` graph from the roots outside the key, stopping at the key's entries, and drops each key entry none of whose importers was reached. The guarantor may differ per path, which is the only change in what is folded; importer cycles behind the key (lazy pages that `import()` each other) fold as before, and a key whose entries only `import()` each other is left alone.

The walk is a single pass per distinct chunk key over an epoch-stamped scratch array, so its cost is proportional to what the roots reach, not to the number of entries. A first cut that rescanned every entry to a fixpoint per key took 448 s on a 3000-entry `import()` chain that `main` bundles in 1.2 s; this version takes 0.85 s on it.

A self-`import()` is dropped from an entry's importers up front, so an entry that also imports itself is treated like any other.

### Measurements

A real ~2400-module CLI compiled with `--compile --splitting --bytecode` (macOS arm64, release builds; `main` is 65362b53bb):

| | main | this PR |
|---|---|---|
| chunks | 2,368 | 2,148 |
| cross-chunk `import` statements | 208,916 | 163,302 |
| chunks statically reachable from the main screen's `import()` | 692 | 530 |
| executable size | 311.5 MB | 309.1 MB |

Startup (interleaved runs, medians): the `import()` of the main screen 45.0 → 42.0 ms in the interactive path (15 runs) and 79.2 → 69.7 ms in the headless path (20 runs); time to first render 388 → 372 ms (hyperfine, 20 runs). Peak `phys_footprint` at first render 247 → 242 MB, within run-to-run noise. Bundling the CLI takes the same ~5.8 s.

Synthetic graphs (3000 `import()` entries + 3000 shared modules, `bun build --splitting --target=bun`, hyperfine 5 runs): random importers 327 → 326 ms, a chain of entries 1.16 → 0.85 s.

### How did you verify your code works?

- `test/bundler/bundler_splitting.test.ts`: new `FoldsChunkWhoseImportersTheKeyCovers` (`cmd` is `import()`ed from `main` and from a lazy module only `repl` loads; fails on `main` with 6 outputs, passes with 5) and `FoldsChunkBehindDynamicImportCycle` (`main → x ⇄ y`, `x → d`; the `{main, d}` chunk folds into `main.js` as on `main`), plus the existing 57 tests.
- `test/bundler/bundler_compile_splitting.test.ts` (19) and `test/bundler/esbuild/splitting.test.ts` (26) pass.
- Ran the compiled CLI above from both builds and compared chunk layout from the metafile and startup timings.