### PR TITLE
node:async_hooks: do not spread an array store in AsyncLocalStorage.enterWith()

### DIFF
--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -173,8 +173,7 @@ class AsyncLocalStorage {
         return;
       }
     }
-    // Not concat(): it spreads an array (or isConcatSpreadable) store into
-    // the [key, value, ...] frame.
+    // Not concat(): it would spread an array store.
     const appended = context.slice();
     appended.push(this, store);
     set(appended);

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -173,7 +173,11 @@ class AsyncLocalStorage {
         return;
       }
     }
-    set(context.concat(this, store));
+    // Not concat(): it spreads an array (or isConcatSpreadable) store into
+    // the [key, value, ...] frame.
+    const appended = context.slice();
+    appended.push(this, store);
+    set(appended);
     $assert(sameValue(this.getStore(), store));
   }
 

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -103,18 +103,41 @@ describe("AsyncLocalStorage", () => {
         expect(arrayStore.getStore()).toBe(arr);
         expect(spreadableStore.getStore()).toBe(spreadable);
         expect(emptyArrayStore.getStore()).toBe(empty);
+      });
+      // enterWith() is not scoped: the entries survive the enclosing run()
+      expect(stores()).toEqual([undefined, arr, obj, spreadable, empty]);
 
-        // replacing an existing entry with an array
+      // replacing an existing entry with an array
+      outer.run("outer", () => {
         outer.enterWith([3, 4]);
         expect(stores()).toEqual([[3, 4], arr, obj, spreadable, empty]);
       });
-      // enterWith() is not scoped: the entries survive the enclosing run()
       expect(stores()).toEqual([undefined, arr, obj, spreadable, empty]);
     } finally {
       arrayStore.disable();
       objectStore.disable();
       spreadableStore.disable();
       emptyArrayStore.disable();
+    }
+  });
+
+  // The frame is immutable: enterWith() must append to a copy. A snapshot that
+  // captured the old frame by reference must not see the new entry, and run()
+  // must still restore from a frame it did not hand out. Verified against Node
+  // v26.3.0.
+  test("enterWith() appends to a copy of the frame", () => {
+    const a = new AsyncLocalStorage();
+    const b = new AsyncLocalStorage();
+    try {
+      a.run("A", () => {
+        const snap = AsyncLocalStorage.snapshot();
+        b.enterWith("B");
+        expect(snap(() => [a.getStore(), b.getStore()])).toEqual(["A", undefined]);
+        expect([a.getStore(), b.getStore()]).toEqual(["A", "B"]);
+      });
+      expect([a.getStore(), b.getStore()]).toEqual([undefined, "B"]);
+    } finally {
+      b.disable();
     }
   });
 

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -118,17 +118,6 @@ describe("AsyncLocalStorage", () => {
     }
   });
 
-  test("enterWith() an array store with no active context", () => {
-    const als = new AsyncLocalStorage();
-    const arr = [1, 2];
-    try {
-      als.enterWith(arr);
-      expect(als.getStore()).toBe(arr);
-    } finally {
-      als.disable();
-    }
-  });
-
   // withScope() enters and restores through enterWith().
   test("withScope() with an array store nested under another storage", () => {
     const outer = new AsyncLocalStorage();

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -74,6 +74,84 @@ describe("AsyncLocalStorage", () => {
     }
   });
 
+  // Appending to a non-empty frame must not spread an array store: a store is
+  // one value slot, whatever its shape. Verified against Node v26.3.0.
+  test("enterWith() keeps an array store intact when another storage is active", () => {
+    const outer = new AsyncLocalStorage();
+    const arrayStore = new AsyncLocalStorage();
+    const objectStore = new AsyncLocalStorage();
+    const spreadableStore = new AsyncLocalStorage();
+    const emptyArrayStore = new AsyncLocalStorage();
+    const arr = [1, 2];
+    const obj = { x: 1 };
+    const spreadable = { length: 1, 0: "zero", [Symbol.isConcatSpreadable]: true };
+    const empty: unknown[] = [];
+    const stores = () => [
+      outer.getStore(),
+      arrayStore.getStore(),
+      objectStore.getStore(),
+      spreadableStore.getStore(),
+      emptyArrayStore.getStore(),
+    ];
+    try {
+      outer.run("outer", () => {
+        arrayStore.enterWith(arr);
+        objectStore.enterWith(obj);
+        spreadableStore.enterWith(spreadable);
+        emptyArrayStore.enterWith(empty);
+        expect(stores()).toEqual(["outer", arr, obj, spreadable, empty]);
+        expect(arrayStore.getStore()).toBe(arr);
+        expect(spreadableStore.getStore()).toBe(spreadable);
+        expect(emptyArrayStore.getStore()).toBe(empty);
+
+        // replacing an existing entry with an array
+        outer.enterWith([3, 4]);
+        expect(stores()).toEqual([[3, 4], arr, obj, spreadable, empty]);
+      });
+      // enterWith() is not scoped: the entries survive the enclosing run()
+      expect(stores()).toEqual([undefined, arr, obj, spreadable, empty]);
+    } finally {
+      arrayStore.disable();
+      objectStore.disable();
+      spreadableStore.disable();
+      emptyArrayStore.disable();
+    }
+  });
+
+  test("enterWith() an array store with no active context", () => {
+    const als = new AsyncLocalStorage();
+    const arr = [1, 2];
+    try {
+      als.enterWith(arr);
+      expect(als.getStore()).toBe(arr);
+    } finally {
+      als.disable();
+    }
+  });
+
+  // withScope() enters and restores through enterWith().
+  test("withScope() with an array store nested under another storage", () => {
+    const outer = new AsyncLocalStorage();
+    // @types/node does not declare withScope() yet.
+    const inner = new AsyncLocalStorage() as any;
+    const prev = ["prev"];
+    const arr = [1, 2];
+    try {
+      outer.run("outer", () => {
+        inner.enterWith(prev);
+        {
+          using _scope = inner.withScope(arr);
+          expect([outer.getStore(), inner.getStore()]).toEqual(["outer", arr]);
+          expect(inner.getStore()).toBe(arr);
+        }
+        expect([outer.getStore(), inner.getStore()]).toEqual(["outer", prev]);
+        expect(inner.getStore()).toBe(prev);
+      });
+    } finally {
+      inner.disable();
+    }
+  });
+
   // Node compares stores with the primordial ObjectIs, which userland cannot
   // reach. Subprocess: patches a global. Verified against Node v26.3.0.
   test("run() is unaffected by a userland Object.is patch", async () => {


### PR DESCRIPTION
### Problem
- `als.enterWith(store)` with an array store corrupts the async context when another `AsyncLocalStorage` already has a value. `b.enterWith([1, 2])` inside `a.run("A", ...)` makes `b.getStore()` return `1`. Node returns `[1, 2]`. A debug build throws `AssertionError: array.length % 2 === 0` from `set()`.
- The cause is `set(context.concat(this, store))` in `enterWith` (`src/js/node/async_hooks.ts:176`). `Array.prototype.concat` spreads an array argument (and any `Symbol.isConcatSpreadable` object). The frame becomes `[a, "A", b, 1, 2]` and loses its `[key, value, key, value]` layout. Later storages land on odd slots and read as `undefined`.

### Fix
- Build the new frame with `slice()` and `push()`. `push` writes the store as one slot whatever its shape. `run()` already appends its pair this way.
- Correct because a store is one value. Node keeps the store object itself in its frame. `getStore()` now returns the reference that `enterWith()` received, for arrays, empty arrays, and `isConcatSpreadable` objects.
- Only the append path changes. The first-storage path and the replace path never spread.
- Verified: `test/js/node/async_hooks/AsyncLocalStorage.test.ts`. Two new tests pass an array store to `enterWith()` and `withScope()` under an active storage. Each fails on stock bun. A third new test fails if the append path pushes into the frame in place. Also the rest of `test/js/node/async_hooks/` and the upstream `test-async-local-storage-*.js` tests.

### Background
- The async context is one immutable array in a JSC internal field: `[storage, store, storage, store, ...]`. `getStore()` scans the even slots for its storage and returns the next slot.
- `enterWith()` replaces the array instead of mutating it, so a callback that captured the old array keeps its own values.
- `withScope()` enters and restores through `enterWith()`, so it hit the same bug.

<details><summary>Notes</summary>

Repro (bun 1.4.1 and main at 65362b53bb):

```js
const { AsyncLocalStorage } = require("node:async_hooks");
const a = new AsyncLocalStorage();
const b = new AsyncLocalStorage();
a.run("A", () => {
  b.enterWith([1, 2]);
  console.log("a =", a.getStore(), "b =", JSON.stringify(b.getStore()));
});
```

Node v26.3.0: `a = A b = [1,2]`. Bun: `a = A b = 1`.

A one-element array store keeps the frame even-length, so the even-length assertion in `set()` does not fire. The identity assertion after the append does: `AssertionError: sameValue(this.getStore(), store)`. In a release build both shapes are silent and `inner.enterWith(["prev"])` makes `inner.getStore()` return `"prev"`. The `withScope()` test covers this shape.

An empty array store was the worst case: `concat(this, [])` appends only the key, so the storage has no value slot and every later storage shifts by one.

Before this PR no test under `test/` passed an array to `enterWith()` or `withScope()` while another storage was active. The debug assertions catch every shape once the path runs, so the new tests close a coverage hole rather than an assertion gap.

Expected values in the new tests were checked against Node v26.3.0 with and without `--async-context-frame`.

The copy test (`enterWith() appends to a copy of the frame`) takes an `AsyncLocalStorage.snapshot()` inside `a.run()`, then calls `b.enterWith("B")`. The snapshot must not see `"B"`, and `b.getStore()` must still be `"B"` after `run()` returns. Fault injection (`const appended = context as any[]`, which pushes in place) fails this test and the array-store test. With `concat()` the test passes, since `concat()` also copies. The array-store test does its replace step (`outer.enterWith([3, 4])`) in a second `run()`, so the "entries survive the enclosing run()" check is not neutralized by the fresh array the replace path installs.

Review dropped a test that covered the unchanged first-storage path (`set([this, store])`). It failed on the base branch only through contamination from the test before it.

Suites run with the debug build: `test/js/node/async_hooks/AsyncLocalStorage.test.ts` (50 pass, 2 todo), `async_hooks.node.test.ts`, `AsyncLocalStorage-tracking.test.ts`, `async-local-storage-thenable.test.ts`, `EventEmitterAsyncResource.test.ts` (88 pass, 1 todo), and `test/js/node/test/parallel/test-async-local-storage-{bind,contexts,deep-stack,enter-with,exit-does-not-leak,isolation,run-scope,snapshot}.js` (all exit 0).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/AsyncLocalStorage.test.ts
bun test v1.4.1 (731aa92da)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [93.21ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [30.66ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [18.34ms]
[async_hooks] ASSERTION FAILED: array.length % 2 === 0
AsyncContextData should be even-length, got [
  AsyncLocalStorage { [debug id]: "rhy8rw@hooks" }, "outer", AsyncLocalStorage { [debug id]: "b63wbe@hooks" }, 1, 2
]
  at assertValidAsyncContextArray (node:async_hooks:47:10)

93 |       spreadableStore.getStore(),
94 |       emptyArrayStore.getStore(),
95 |     ];
96 |     try {
97 |       outer.run("outer", () => {
98 |         arrayStore.enterWith(arr);
                        ^
AssertionError: array.length % 2 === 0
      at $assert (node:async_hooks:30:12)
      at assertValidAsyncContextArray (node:async_hooks:47:10)
      at set 
... (truncated)

release without fix: 2 failed, 2 skipped
bun test v1.4.1-canary.1 (731aa92da)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [0.32ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [0.21ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [0.14ms]
 97 |       outer.run("outer", () => {
 98 |         arrayStore.enterWith(arr);
 99 |         objectStore.enterWith(obj);
100 |         spreadableStore.enterWith(spreadable);
101 |         emptyArrayStore.enterWith(empty);
102 |         expect(stores()).toEqual(["outer", arr, obj, spreadable, empty]);
                               ^
error: expect(received).toEqual(expected)

  [
    "outer",
-   [
-     1,
-     2,
-   ],
-   {
-     "x": 1,
-   },
-   {
-     "0": "zero",
-     [Symbol(Symbol.isConcatSpreadable)]: true,
-     "length": 1,
-   },
-   [],
+   1,
+   undefined,
+   undefined,
+   undefined,
  ]

- Expected  - 13
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/node/async_hooks/AsyncLocalStorage.test.ts:102:26)
      at run (node:async_hooks:99:29)
      at <anonymous> (/workspace/bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/AsyncLocalStorage.test.ts
bun test v1.4.1 (731aa92da)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [92.51ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [31.84ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [19.26ms]
(pass) AsyncLocalStorage > enterWith() keeps an array store intact when another storage is active [71.06ms]
(pass) AsyncLocalStorage > enterWith() appends to a copy of the frame [20.49ms]
(pass) AsyncLocalStorage > withScope() with an array store nested under another storage [25.48ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [771.74ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [14.93ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [23.61ms]
(pass) AsyncLocalStorage > run(undefined)/exit() on a 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     16680db29a
  features     baseline

23 deps, 129 codegen, 1172 objects in 610ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (731aa92da)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (731aa92da)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] gen .bind.ts → GeneratedBindings.cpp
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (731aa92da)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[10/1243] fetch zlib
[zlib] up to date
[11/1243] fetch libjpeg-turbo
[libjpeg-
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/async_hooks.ts                         |  5 +-
 test/js/node/async_hooks/AsyncLocalStorage.test.ts | 90 ++++++++++++++++++++++
 2 files changed, 94 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/async_hooks.ts                              4      2      0
test/js/node/async_hooks/AsyncLocalStorage.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->