### PR TITLE
install: keep the copyfile fallback of a folder dependency from emptying its source

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2241,6 +2241,14 @@ impl<'a> PackageInstall<'a> {
         }
     }
 
+    /// A folder is linked from its own directory, so its failure says nothing about the cache.
+    #[cfg(not(windows))]
+    fn remember_copyfile_fallback(is_folder: bool) {
+        if !is_folder {
+            Self::set_supported_method(Method::Copyfile);
+        }
+    }
+
     pub(crate) fn package_missing_from_cache(
         &mut self,
         manager: &mut PackageManager,
@@ -2309,7 +2317,9 @@ impl<'a> PackageInstall<'a> {
 
         let mut supported_method_to_use = method_;
 
-        if resolution_tag == resolution::Tag::Folder
+        let is_folder = resolution_tag == resolution::Tag::Folder;
+
+        if is_folder
             && !self
                 .lockfile
                 .is_workspace_tree_id(self.node_modules.tree_id)
@@ -2327,7 +2337,7 @@ impl<'a> PackageInstall<'a> {
                         Ok(result) => return result,
                         Err(err) => {
                             if err == crate::Error::NotSupported {
-                                Self::set_supported_method(Method::Copyfile);
+                                Self::remember_copyfile_fallback(is_folder);
                                 supported_method_to_use = Method::Copyfile;
                             } else if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
                                 return InstallResult::fail(
@@ -2349,7 +2359,7 @@ impl<'a> PackageInstall<'a> {
                         Ok(result) => return result,
                         Err(err) => {
                             if err == crate::Error::NotSupported {
-                                Self::set_supported_method(Method::Copyfile);
+                                Self::remember_copyfile_fallback(is_folder);
                                 supported_method_to_use = Method::Copyfile;
                             } else if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
                                 return InstallResult::fail(
@@ -2372,8 +2382,12 @@ impl<'a> PackageInstall<'a> {
                         #[cfg(not(windows))]
                         {
                             if err == crate::Error::NotSameFileSystem {
-                                Self::set_supported_method(Method::Copyfile);
+                                Self::remember_copyfile_fallback(is_folder);
                                 supported_method_to_use = Method::Copyfile;
+                                // copyfile's O_TRUNC would empty the source through the files already linked.
+                                if self.destination_dir_subpath.as_bytes() != b"." {
+                                    self.uninstall_before_install(destination_dir);
+                                }
                                 break 'outer;
                             }
                         }

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -97,3 +97,118 @@ describe.skipIf(!isLinux || isMusl || !cc)("hardlink backend falls back to copyf
     }
   }
 });
+
+// A folder dependency is linked from its own directory, not from the cache.
+describe.skipIf(!isLinux || isMusl || !cc)("hardlink backend, folder dependency that cannot be hardlinked", () => {
+  // `linkat` fails with EXDEV when `fail` (a C expression over `calls`,
+  // `oldpath`, `newpath`) is true. Other calls go to the real `linkat`.
+  const shimC = (fail: string) => /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <string.h>
+
+int linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath,
+           int flags) {
+  static int calls = 0;
+  calls++;
+  if (${fail}) {
+    errno = EXDEV;
+    return -1;
+  }
+  int (*real)(int, const char *, int, const char *, int) = dlsym(RTLD_NEXT, "linkat");
+  return real(olddirfd, oldpath, newdirfd, newpath, flags);
+}
+`;
+
+  async function installWithShim(dir: string, expectedInstalled: string) {
+    {
+      await using compile = Bun.spawn({
+        cmd: [cc!, "-shared", "-fPIC", "-o", "shim.so", "shim.c", "-ldl"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [compileOut, compileErr, compileExit] = await Promise.all([
+        compile.stdout.text(),
+        compile.stderr.text(),
+        compile.exited,
+      ]);
+      if (compileExit !== 0) {
+        throw new Error(`shim compile failed: ${compileOut}${compileErr}`);
+      }
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--backend", "hardlink", "--linker", "hoisted"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(dir, "cache"),
+        LD_PRELOAD: [join(dir, "shim.so"), bunEnv.LD_PRELOAD].filter(Boolean).join(":"),
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("EXDEV");
+    expect(stdout).toContain(expectedInstalled);
+    expect(exitCode).toBe(0);
+  }
+
+  // The folder is on another file system: only this package falls back to
+  // copying. Packages from the cache keep using hardlinks.
+  test.concurrent("does not switch the remaining packages to copyfile", async () => {
+    // Packages install in name order: `aaa-local` hits EXDEV before `zzz-bar`
+    // is linked from the cache.
+    using dir = tempDir("hardlink-xdev-folder", {
+      "shim.c": shimC(`strstr(oldpath, "xdev-marker") || strstr(newpath, "xdev-marker")`),
+      "package.json": JSON.stringify({
+        name: "hardlink-xdev-folder-test",
+        dependencies: { "aaa-local": "file:./aaa-local", "zzz-bar": "file:./bar-0.0.2.tgz" },
+      }),
+      "aaa-local/package.json": JSON.stringify({ name: "aaa-local", version: "1.2.3" }),
+      "aaa-local/xdev-marker.js": "module.exports = 1;",
+    });
+    cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
+
+    await installWithShim(String(dir), "2 packages installed");
+
+    // The folder was copied: nlink === 1.
+    expect(statSync(join(String(dir), "node_modules", "aaa-local", "xdev-marker.js")).nlink).toBe(1);
+    // The package after it is still hardlinked from the cache: nlink >= 2.
+    const fromCache = join(String(dir), "node_modules", "zzz-bar", "package.json");
+    expect(await Bun.file(fromCache).json()).toMatchObject({ name: "bar", version: "0.0.2" });
+    expect(statSync(fromCache).nlink).toBeGreaterThanOrEqual(2);
+  });
+
+  // The first file of the folder is hardlinked, then `linkat` fails. The copy
+  // that follows must not truncate the source through that hardlink.
+  test.concurrent(
+    "keeps the source files intact when the fallback to copyfile starts after a partial link",
+    async () => {
+      const files = {
+        "package.json": JSON.stringify({ name: "local", version: "1.2.3" }),
+        "index.js": "module.exports = require('./other.js') + ' from index';",
+        "other.js": "module.exports = 'other';",
+      };
+      using dir = tempDir("hardlink-partial-folder", {
+        "shim.c": shimC("calls == 2"),
+        "package.json": JSON.stringify({
+          name: "hardlink-partial-folder-test",
+          dependencies: { local: "file:./local" },
+        }),
+        ...Object.fromEntries(Object.entries(files).map(([name, content]) => [`local/${name}`, content])),
+      });
+
+      await installWithShim(String(dir), "1 package installed");
+
+      for (const [name, content] of Object.entries(files)) {
+        expect(await Bun.file(join(String(dir), "local", name)).text()).toBe(content);
+        const installed = join(String(dir), "node_modules", "local", name);
+        expect(await Bun.file(installed).text()).toBe(content);
+        expect(statSync(installed).nlink).toBe(1);
+      }
+    },
+  );
+});


### PR DESCRIPTION
### Problem
- When the hardlink backend fails partway through a `file:` folder dependency (`EXDEV` from a mount point inside the folder, `EPERM` from `fs.protected_hardlinks` on a file owned by another user), `install()` falls back to copyfile over the partial destination. copyfile opens each destination with `O_TRUNC` (`src/install/PackageInstall.rs`, `install_with_copyfile`). A destination that is already a hardlink of the source shares its inode, so the open empties the user's source file and the copy writes 0 bytes. Reproduced on bun 1.4.1 with `file:./vendor/plugin` and a `linkat` shim that fails the second call: `vendor/plugin/other.js` ends up empty.
- The same fallback calls `set_supported_method(Copyfile)`, the process-wide backend. For a folder dependency the source is its own directory, not the cache, so the failure says nothing about linking from the cache. Every later package in the install was copied instead of hardlinked.

### Fix
- Before the fallback copies, `install()` renames the partial destination away with `uninstall_before_install`, the same rename-and-delete-in-background a reinstall uses. Copyfile then writes into a fresh directory and never opens a hardlink of the source.
- `remember_copyfile_fallback(is_folder)` replaces the three `set_supported_method(Copyfile)` calls. It leaves the backend alone for a folder dependency and keeps the old behavior for packages linked from the cache.
- Correct because the source files keep their content whatever the fallback does, and because the backend hint is about the cache directory, which a folder failure does not measure.
- Verified: two new tests in `test/cli/install/bun-install-hardlink-fallback.test.ts`, both fail on main. The file's existing tests and `test/cli/install/bun-install.test.ts` pass.

### Background
- `Method` is the install backend: `clonefile`, `hardlink`, `copyfile`, `symlink`. `supported_method()` is a process-global default that the fallbacks in `install()` lower when a backend fails.
- A `file:` folder dependency is installed by walking its folder (`init_install_dir`) and mirroring each file into `node_modules/<name>`; a cache package is walked the same way from the cache directory.
- The tests preload a `linkat` shim (Linux, glibc) that fails selected calls with `EXDEV` and forwards the rest, and check `nlink` to tell a hardlink (2) from a copy (1).

<details><summary>Notes</summary>

Split out of #40628 (hoisted `file:` folders outside the project), whose review found the truncation. The two changes here do not depend on that PR. They matter more once #40628 routes `file:../foo` through the hardlink backend, because a folder outside the project is more likely to cross a file system boundary.

Repro for the truncation on bun 1.4.1 (Linux):

```
cat > shim.c <<'EOF'
#define _GNU_SOURCE
#include <dlfcn.h>
#include <errno.h>
static int calls = 0;
int linkat(int a, const char *b, int c, const char *d, int e) {
  if (++calls == 2) { errno = EXDEV; return -1; }
  int (*real)(int, const char *, int, const char *, int) = dlsym(RTLD_NEXT, "linkat");
  return real(a, b, c, d, e);
}
EOF
cc -shared -fPIC -o shim.so shim.c -ldl
mkdir -p vendor/plugin && echo '{"name":"plugin","version":"1.0.0"}' > vendor/plugin/package.json
echo 'module.exports = 1;' > vendor/plugin/index.js && echo 'module.exports = 2;' > vendor/plugin/other.js
echo '{"name":"app","dependencies":{"plugin":"file:./vendor/plugin"}}' > package.json
LD_PRELOAD=$PWD/shim.so bun install && wc -c vendor/plugin/*
# one of the source files is now 0 bytes
```

The second test (`does not switch the remaining packages to copyfile`) relies on packages installing in name order within a tree: `aaa-local` (folder, hits EXDEV) is installed before `zzz-bar` (tarball, from the cache). On main `zzz-bar` is copied (nlink 1); with the fix it stays a hardlink (nlink 2).

</details>
