### PR TITLE
bundler: propagate a whole barrel record's aliases when it is un-deferred

### DIFF
--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -864,7 +864,8 @@ pub(crate) fn schedule_barrel_deferred_imports(
         };
 
         let barrel_ir = &mut this.graph.ast.items_import_records_mut()[barrel_idx as usize];
-        if un_defer_record(barrel_ir, resolution.import_record_index as usize) {
+        let went_live = un_defer_record(barrel_ir, resolution.import_record_index as usize);
+        if went_live {
             // Resolve now: propagation below needs the source index.
             newly_scheduled +=
                 resolve_barrel_records(this, barrel_idx, &[resolution.import_record_index]);
@@ -888,6 +889,36 @@ pub(crate) fn schedule_barrel_deferred_imports(
                 alias: propagate_alias,
                 is_star: resolution.alias_is_star,
             });
+
+            // The record just went from deferred to live. Propagate every
+            // other alias this barrel imports through it, exactly as Phase 1
+            // seeding does for a record that is live when the barrel finishes
+            // parsing. Propagating only the alias that triggered the un-defer
+            // makes a downstream barrel's deferral set (and with it the
+            // symbol binding the linker produces) depend on parse completion
+            // order (#40657).
+            if went_live {
+                let named_imports = &this.graph.ast.items_named_imports()[barrel_idx as usize];
+                for ni in named_imports.values() {
+                    if ni.import_record_index != resolution.import_record_index {
+                        continue;
+                    }
+                    if ni.alias_is_star {
+                        queue.push(BarrelWorkItem {
+                            barrel_source_index: rec_si.get(),
+                            alias: b"",
+                            is_star: true,
+                        });
+                    } else if let Some(alias_ptr) = ni.alias {
+                        // Arena-backed `StoreStr`, valid for the bundler-arena lifetime.
+                        queue.push(BarrelWorkItem {
+                            barrel_source_index: rec_si.get(),
+                            alias: alias_ptr.slice(),
+                            is_star: false,
+                        });
+                    }
+                }
+            }
         }
 
         qi += 1;

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -1946,5 +1948,82 @@ describe("bundler", () => {
     onAfterBundle(api) {
       api.expectFile("/out/entry.js").toContain("a = 1");
     },
+  });
+
+  // The barrel deferral must produce the same output no matter in which order
+  // the parse tasks finish. When a request un-defers a barrel record, every
+  // alias the barrel imports through that record has to propagate to the next
+  // barrel, the same set Phase 1 seeding propagates for a record that is live
+  // when the barrel finishes parsing. Otherwise the inner barrel's records
+  // stay deferred in one order and live in another, the symbol binding flips,
+  // and minified identifier names differ between builds of an unchanged tree.
+  // https://github.com/oven-sh/bun/issues/40657
+  test("barrel deferral does not depend on parse completion order", async () => {
+    // A large comment slows down the parse of the file that carries it
+    // without changing the minified output: comments are excluded from the
+    // output and from the identifier char-frequency table, and both trees
+    // carry exactly one copy of the same comment.
+    const pad = "// " + Buffer.alloc(4_000_000, "x").toString() + "\n";
+
+    const makeFiles = (padConsumer: 1 | 2) => ({
+      "node_modules/dep/package.json": JSON.stringify({ name: "dep", sideEffects: false }),
+      "node_modules/dep/outer.js": `
+        export { other } from './impl-other.js';
+        export { used, extraA, extraB, extraC, extraD, extraE } from './inner.js';
+      `,
+      "node_modules/dep/inner.js": `
+        export { used } from './impl-used.js';
+        export { extraA, extraB, extraC, extraD, extraE } from './impl-extra.js';
+      `,
+      "node_modules/dep/impl-used.js": `export function used() { return 'used value'; }`,
+      "node_modules/dep/impl-other.js": `export function other() { return 'other value'; }`,
+      "node_modules/dep/impl-extra.js": `
+        export function extraA() { return 'A' + extraB(); }
+        export function extraB() { return 'B' + extraC(); }
+        export function extraC() { return 'C' + extraD(); }
+        export function extraD() { return 'D' + extraE(); }
+        export function extraE() { return 'E'; }
+      `,
+      "consumer1.js":
+        (padConsumer === 1 ? pad : "") +
+        `
+        import { other } from 'dep/outer.js';
+        import { extraA } from 'dep/impl-extra.js';
+        export function c1() { return other() + extraA(); }
+      `,
+      "consumer2.js":
+        (padConsumer === 2 ? pad : "") +
+        `
+        import { used } from 'dep/outer.js';
+        export function c2() { return used(); }
+      `,
+      "entry.js": `
+        import { c1 } from './consumer1.js';
+        import { c2 } from './consumer2.js';
+        console.log(c1(), c2());
+      `,
+    });
+
+    const build = async (root: string) => {
+      const out = await Bun.build({
+        entrypoints: [join(root, "entry.js")],
+        target: "browser",
+        format: "esm",
+        minify: true,
+      });
+      return await out.outputs.find(o => o.kind === "entry-point")!.text();
+    };
+
+    // Tree A: consumer2 parses slowly, so the barrels finish before anything
+    // requests "used" and outer's record to inner is deferred, then
+    // un-deferred late. Tree B: consumer1 parses slowly, so "used" is
+    // requested before outer parses and the record is live from the start.
+    using dirA = tempDir("barrel-order-a", makeFiles(2));
+    using dirB = tempDir("barrel-order-b", makeFiles(1));
+
+    const a = await build(String(dirA));
+    const b = await build(String(dirB));
+    expect(a).toContain("used value");
+    expect(a).toBe(b);
   });
 });


### PR DESCRIPTION
### Problem

- `Bun.build({ minify: true })` is not deterministic. The same tree produces two outputs of identical byte length whose generated identifier names differ. Reproduced with the issue's repo: under CPU load, 2 to 4 of 60 in-process builds flip between the two reported hashes (`706328dd39c9a25` and `b667ca6974bb6b5d`).
- The cause is in the barrel optimization (`src/bundler/barrel_imports.rs`). When a request un-defers a deferred barrel import record, the BFS propagates only the one alias that triggered it (`schedule_barrel_deferred_imports`). A record that is live when the barrel finishes parsing instead gets every alias seeded by Phase 1. So the alias set that reaches a downstream barrel depends on parse completion order.
- In the slow order the downstream barrel keeps records deferred (`IS_UNUSED`). `advance_import_tracker` (`src/bundler/LinkerContext.rs:3380`) then treats the re-export as external, the symbol merge is skipped, and the minify renamer sorts a different symbol set into the name slots.

### Fix

- When `un_defer_record` flips a record from deferred to live, push a BFS item for every alias the barrel imports through that record, not just the requested one. This is the same set Phase 1 seeds for a live record, so both orders converge to one deferral state.
- The emitted module set does not change. The propagated aliases go through the existing dedup in the BFS.
- Verified: `test/bundler/bundler_barrel.test.ts` (new test, stock bun fails it on every run). All 58 tests in the file pass. The issue's repro repo is byte-stable for 100 builds under CPU contention with the fix, and flips 2 to 4 times in 60 without it.

### Background

- The barrel optimization defers the import records of a pure re-export file (`sideEffects: false`) until some file requests one of its exports. `requested_exports` records requests eagerly, and a BFS un-defers records through chains of barrels as requests arrive.
- Deferral state is decided on the bundle thread in parse completion order, which varies with load. The compensation logic must therefore converge to one final state for every order. The single-alias propagation was the one path that did not.
- The test pins the order with a 4 MB comment: it slows the parse of one consumer without changing minified output, and builds the same graph in both orders. The outputs must be byte-identical.

<details><summary>Notes</summary>

- Instrumented the minify renamer inputs and diffed a flapped run against a normal one: char frequency and use counts were identical, but symbols such as `isErrorRetry` and `SCHEMA_ERROR_CODE_TITLES` resolved to the re-exporting barrel's import items in the flapped run instead of the defining files. The `symbols.merge` calls for the barrel's items were missing entirely.
- A link-time dump of `IS_UNUSED` records showed exactly two records of `packages/core/src/exports/error-contract.ts` left deferred and unresolved in flapped runs. Both target modules were in the bundle through direct imports elsewhere, which is why the output length and string literals stay identical and only names move.
- Event logs of the barrel BFS showed the divergence: when `core/src/index.ts` parsed before its first consumer, its own record to `error-contract` was deferred, and the later un-defer propagated only the handful of aliases consumers had requested by then. When it parsed after a consumer, Phase 1 seeded all 40 aliases of the record.
- The issue's repro depends on a `sideEffects` array being read as `false` (#40650, fix in #40651). That fix would hide this repro but not the order dependence for real `sideEffects: false` packages, which this PR fixes.
- Ran the new test 5 times under the fixed debug build (5 of 5 pass) and 4 times under stock bun 1.4.1 (4 of 4 fail), so the order pinning is stable in both directions.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_barrel.test.ts
bun test v1.4.1 (731aa92da)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [573.27ms]
(pass) bundler > barrel/AllExportsNeeded [118.46ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [105.32ms]
(pass) bundler > barrel/NoOptimizationWithoutSideEffects [120.59ms]
(pass) bundler > barrel/ExportStarLoadsAll [85.68ms]
(pass) bundler > barrel/NonBarrelWithLocalExports [95.90ms]
(pass) bundler > barrel/NamespaceImportLoadsAll [99.78ms]
(pass) bundler > barrel/OutputEquivalence [98.89ms]
(pass) bundler > barrel/DefaultReExport [111.83ms]
(pass) bundler > barrel/ImportThenExport [93.75ms]
(pass) bundler > barrel/ReExportChain [103.64ms]
(pass) bundler > barrel/StarWithNamedFromSameSource [117.43ms]
(pass) bundler > barrel/SideEffectOnlyImport [123.39ms]
(pass) bundler > barrel/MultipleImporters [172.56ms]
(pass) bundler > barrel/CircularExports [382.28ms]
(pass) bundler > barrel/CircularStarExports [370.30ms]
(pass) bundler > barrel/NamespaceReExportCycle
... (truncated)

release without fix: 3 FAILED
bun test v1.4.1-canary.1 (731aa92da)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [12.85ms]
(pass) bundler > barrel/AllExportsNeeded [3.43ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [2.87ms]
(pass) bundler > barrel/NoOptimizationWithoutSideEffects [2.73ms]
(pass) bundler > barrel/ExportStarLoadsAll [2.37ms]
(pass) bundler > barrel/NonBarrelWithLocalExports [2.18ms]
(pass) bundler > barrel/NamespaceImportLoadsAll [2.18ms]
(pass) bundler > barrel/OutputEquivalence [3.20ms]
(pass) bundler > barrel/DefaultReExport [2.80ms]
(pass) bundler > barrel/ImportThenExport [2.70ms]
(pass) bundler > barrel/ReExportChain [3.14ms]
(pass) bundler > barrel/StarWithNamedFromSameSource [2.29ms]
(pass) bundler > barrel/SideEffectOnlyImport [3.22ms]
(pass) bundler > barrel/MultipleImporters [3.39ms]
(pass) bundler > barrel/CircularExports [10.07ms]
(pass) bundler > barrel/CircularStarExports [9.04ms]
(pass) bundler > barrel/NamespaceReExportCycleThroughStarTarget [9.91ms]
(pass) bundler > barrel/SelfReExport [4.12ms]
(pass) bundler > barrel/DynamicImportInSubmodule [4.08ms]
(pass) bundler > barrel/DynamicImportWithStaticImportS
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_barrel.test.ts
bun test v1.4.1 (731aa92da)

test/bundler/bundler_barrel.test.ts:
(pass) bundler > barrel/SkipUnusedWithOptimizeImports [554.95ms]
(pass) bundler > barrel/AllExportsNeeded [113.28ms]
(pass) bundler > barrel/SkipUnusedWithSideEffectsFalse [103.53ms]
(pass) bundler > barrel/NoOptimizationWithoutSideEffects [114.07ms]
(pass) bundler > barrel/ExportStarLoadsAll [101.98ms]
(pass) bundler > barrel/NonBarrelWithLocalExports [101.90ms]
(pass) bundler > barrel/NamespaceImportLoadsAll [102.32ms]
(pass) bundler > barrel/OutputEquivalence [111.37ms]
(pass) bundler > barrel/DefaultReExport [120.43ms]
(pass) bundler > barrel/ImportThenExport [104.06ms]
(pass) bundler > barrel/ReExportChain [113.12ms]
(pass) bundler > barrel/StarWithNamedFromSameSource [110.32ms]
(pass) bundler > barrel/SideEffectOnlyImport [103.36ms]
(pass) bundler > barrel/MultipleImporters [120.47ms]
(pass) bundler > barrel/CircularExports [362.79ms]
(pass) bundler > barrel/CircularStarExports [355.58ms]
(pass) bundler > barrel/NamespaceReExport
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     842a7df1a3
  features     baseline

23 deps, 129 codegen, 1172 objects in 678ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (731aa92da)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (731aa92da)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (731aa92da)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[8/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/barrel_imports.rs       | 33 ++++++++++++++-
 test/bundler/bundler_barrel.test.ts | 81 ++++++++++++++++++++++++++++++++++++-
 2 files changed, 112 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/bundler/barrel_imports.rs            1      4      0
test/bundler/bundler_barrel.test.ts      2      2      0
```

</details>

**root cause** · written by the author bot

The bundler's barrel-file optimization deferred re-export records in parse-completion order, and when a deferred record was later revived by a downstream request, only the single requested alias was propagated instead of all aliases the barrel imported through that record. Under load, a different parse-completion order could leave the remaining aliases permanently marked unused, causing advance_import_tracker to treat them as external and sever symbol merges, which shuffled minified identifier names between otherwise identical builds. The fix propagates every alias through a record when it …

<!-- robobun:evidence:end -->