### PR TITLE
async_hooks: run pending process.nextTick callbacks queued next to AsyncLocalStorage.enterWith()

### DIFF
--- a/src/jsc/bindings/JSNextTickQueue.h
+++ b/src/jsc/bindings/JSNextTickQueue.h
@@ -29,5 +29,13 @@ public:
     // Teardown: whatever was queued no longer runs (field 0 = scheduled flag, field 2 = the JS
     // drain function). The queued callbacks go with the heap.
     void discard(JSC::VM& vm);
+
+    // A queue created inside a microtask gets its first drain from the VM's onEachMicrotaskTick
+    // hook. After that GlobalObject::drainMicrotasks() drains it and the hook stays unset.
+    bool handedOff() const { return m_handedOff; }
+    void setHandedOff() { m_handedOff = true; }
+
+private:
+    bool m_handedOff { false };
 };
 }

--- a/src/jsc/bindings/JSNextTickQueue.h
+++ b/src/jsc/bindings/JSNextTickQueue.h
@@ -30,8 +30,7 @@ public:
     // drain function). The queued callbacks go with the heap.
     void discard(JSC::VM& vm);
 
-    // A queue created inside a microtask gets its first drain from the VM's onEachMicrotaskTick
-    // hook. After that GlobalObject::drainMicrotasks() drains it and the hook stays unset.
+    // Set once the onEachMicrotaskTick one-shot has drained this queue; GlobalObject::drainMicrotasks() owns it after that.
     bool handedOff() const { return m_handedOff; }
     void setHandedOff() { m_handedOff = true; }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -670,6 +670,8 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
     globalObject->isThreadLocalDefaultGlobalObject = true;
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
+    // The VM's hook slot follows the default global: this one has no nextTick queue yet.
+    globalObject->resetOnEachMicrotaskTick();
 
     // NapiEnv holds a raw Zig::GlobalObject*; deferred napi finalizers for
     // the old global's objects run on the next event-loop tick — after this

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -396,11 +396,12 @@ extern "C" JSC::EncodedJSValue BunObject__createBunStdout(JSC::JSGlobalObject*);
 static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
 {
     auto* globalObject = defaultGlobalObject();
-    if (auto queue = globalObject->m_nextTickQueue.get()) {
-        globalObject->nextTickQueueHandoffDone = true;
-        globalObject->resetOnEachMicrotaskTick();
-        queue->drain(vm, globalObject);
-    }
+    auto* queue = globalObject->m_nextTickQueue.get();
+    if (!queue || queue->handedOff())
+        return;
+    queue->setHandedOff();
+    globalObject->resetOnEachMicrotaskTick();
+    queue->drain(vm, globalObject);
 }
 
 static void cleanupAsyncHooksData(JSC::VM& vm)
@@ -408,11 +409,10 @@ static void cleanupAsyncHooksData(JSC::VM& vm)
     auto* globalObject = defaultGlobalObject();
     globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
     globalObject->asyncHooksNeedsCleanup = false;
-    // Put back the hook that jsCleanupLater displaced. A still-armed one-shot owns this
-    // microtask boundary too: the queue may have been created since it was displaced.
+    // Put back the hook that jsCleanupLater displaced and give it this microtask boundary:
+    // the queue may have been created since, with the one-shot still armed.
     globalObject->resetOnEachMicrotaskTick();
-    if (!globalObject->nextTickQueueHandoffDone)
-        checkIfNextTickWasCalledDuringMicrotask(vm);
+    checkIfNextTickWasCalledDuringMicrotask(vm);
 }
 
 GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure)
@@ -453,9 +453,10 @@ JSC::Structure* GlobalObject::createStructure(JSC::VM& vm)
 void Zig::GlobalObject::resetOnEachMicrotaskTick()
 {
     auto& vm = this->vm();
+    auto* queue = this->m_nextTickQueue.get();
     if (this->asyncHooksNeedsCleanup) {
         vm.setOnEachMicrotaskTick(&cleanupAsyncHooksData);
-    } else if (this->nextTickQueueHandoffDone) {
+    } else if (queue && queue->handedOff()) {
         vm.setOnEachMicrotaskTick(nullptr);
     } else {
         vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -391,10 +391,13 @@ extern "C" JSC::EncodedJSValue BunObject__createBunStdin(JSC::JSGlobalObject*);
 extern "C" JSC::EncodedJSValue BunObject__createBunStderr(JSC::JSGlobalObject*);
 extern "C" JSC::EncodedJSValue BunObject__createBunStdout(JSC::JSGlobalObject*);
 
+// One-shot: a process.nextTick queued inside a microtask creates m_nextTickQueue after
+// GlobalObject::drainMicrotasks() has already checked for it, so the first drain happens here.
 static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
 {
     auto* globalObject = defaultGlobalObject();
     if (auto queue = globalObject->m_nextTickQueue.get()) {
+        globalObject->nextTickQueueHandoffDone = true;
         globalObject->resetOnEachMicrotaskTick();
         queue->drain(vm, globalObject);
     }
@@ -405,12 +408,11 @@ static void cleanupAsyncHooksData(JSC::VM& vm)
     auto* globalObject = defaultGlobalObject();
     globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
     globalObject->asyncHooksNeedsCleanup = false;
-    if (!globalObject->m_nextTickQueue) {
-        vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
+    // Put back the hook that jsCleanupLater displaced. A still-armed one-shot owns this
+    // microtask boundary too: the queue may have been created since it was displaced.
+    globalObject->resetOnEachMicrotaskTick();
+    if (!globalObject->nextTickQueueHandoffDone)
         checkIfNextTickWasCalledDuringMicrotask(vm);
-    } else {
-        vm.setOnEachMicrotaskTick(nullptr);
-    }
 }
 
 GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure)
@@ -453,12 +455,10 @@ void Zig::GlobalObject::resetOnEachMicrotaskTick()
     auto& vm = this->vm();
     if (this->asyncHooksNeedsCleanup) {
         vm.setOnEachMicrotaskTick(&cleanupAsyncHooksData);
+    } else if (this->nextTickQueueHandoffDone) {
+        vm.setOnEachMicrotaskTick(nullptr);
     } else {
-        if (this->m_nextTickQueue) {
-            vm.setOnEachMicrotaskTick(nullptr);
-        } else {
-            vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
-        }
+        vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
     }
 }
 
@@ -560,15 +560,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.setOnComputeErrorInfo(computeErrorInfoWrapperToString);
     vm.setOnComputeErrorInfoJSValue(computeErrorInfoWrapperToJSValue);
     vm.setComputeLineColumnWithSourcemap(computeLineColumnWithSourcemap);
-    vm.setOnEachMicrotaskTick([](JSC::VM& vm) -> void {
-        // if you process.nextTick on a microtask we need this
-        auto* globalObject = defaultGlobalObject();
-        if (auto queue = globalObject->m_nextTickQueue.get()) {
-            globalObject->resetOnEachMicrotaskTick();
-            queue->drain(vm, globalObject);
-            return;
-        }
-    });
+    vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
 
     if (executionContextId > -1) {
         const auto initializeWorker = [&](WebCore::WorkerMessagingProxy& worker) -> void {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -391,8 +391,7 @@ extern "C" JSC::EncodedJSValue BunObject__createBunStdin(JSC::JSGlobalObject*);
 extern "C" JSC::EncodedJSValue BunObject__createBunStderr(JSC::JSGlobalObject*);
 extern "C" JSC::EncodedJSValue BunObject__createBunStdout(JSC::JSGlobalObject*);
 
-// One-shot: a process.nextTick queued inside a microtask creates m_nextTickQueue after
-// GlobalObject::drainMicrotasks() has already checked for it, so the first drain happens here.
+// A queue created inside a microtask missed the drain at the top of GlobalObject::drainMicrotasks().
 static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
 {
     auto* globalObject = defaultGlobalObject();
@@ -409,8 +408,7 @@ static void cleanupAsyncHooksData(JSC::VM& vm)
     auto* globalObject = defaultGlobalObject();
     globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
     globalObject->asyncHooksNeedsCleanup = false;
-    // Put back the hook that jsCleanupLater displaced and give it this microtask boundary:
-    // the queue may have been created since, with the one-shot still armed.
+    // The one-shot this cleanup displaced still owns this microtask boundary.
     globalObject->resetOnEachMicrotaskTick();
     checkIfNextTickWasCalledDuringMicrotask(vm);
 }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -426,6 +426,9 @@ public:
     }
 
     bool asyncHooksNeedsCleanup = false;
+    // Set once the onEachMicrotaskTick hook has drained a freshly created m_nextTickQueue.
+    // From then on GlobalObject::drainMicrotasks() owns the queue and the hook stays unset.
+    bool nextTickQueueHandoffDone = false;
     double INSPECT_MAX_BYTES = 50;
     bool isInsideErrorPrepareStackTraceCallback = false;
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -426,9 +426,6 @@ public:
     }
 
     bool asyncHooksNeedsCleanup = false;
-    // Set once the onEachMicrotaskTick hook has drained a freshly created m_nextTickQueue.
-    // From then on GlobalObject::drainMicrotasks() owns the queue and the hook stays unset.
-    bool nextTickQueueHandoffDone = false;
     double INSPECT_MAX_BYTES = 50;
     bool isInsideErrorPrepareStackTraceCallback = false;
 

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import http2 from "http2";
 
 describe("AsyncLocalStorage", () => {
@@ -1247,5 +1247,127 @@ describe("async generators", () => {
       }
     });
     expect(caughtStore).toBe("STORE_X");
+  });
+});
+
+// enterWith() swaps the VM's onEachMicrotaskTick hook for its own cleanup. The
+// default hook is the one-shot that drains a process.nextTick queue created
+// inside a microtask (the entry script's top-level code runs in one). The
+// cleanup used to hand back nothing when the queue already existed, so ticks
+// queued next to an enterWith() were never drained and the process exited
+// without running them. Every case spawns a fresh process because that hook
+// is per-process state.
+describe("enterWith() and process.nextTick() in the same microtask", () => {
+  async function run(args: string[], cwd?: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const cjsImport = `const { AsyncLocalStorage } = require("node:async_hooks");`;
+  const esmImport = `import { AsyncLocalStorage } from "node:async_hooks";`;
+  const entryScript = (importLine: string) => `
+    ${importLine}
+    const als = new AsyncLocalStorage();
+    als.enterWith("x");
+    process.nextTick(() => console.log("tick", als.getStore()));
+    console.log("end");
+  `;
+
+  test.concurrent("CommonJS entry: the tick runs before exit", async () => {
+    using dir = tempDir("als-enterwith-tick", { "entry.cjs": entryScript(cjsImport) });
+    expect(await run(["entry.cjs"], String(dir))).toEqual({ stdout: "end\ntick x\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("ES module entry: the tick runs before exit", async () => {
+    using dir = tempDir("als-enterwith-tick", { "entry.mjs": entryScript(esmImport) });
+    expect(await run(["entry.mjs"], String(dir))).toEqual({ stdout: "end\ntick x\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("bun -e: the tick runs before exit", async () => {
+    expect(await run(["-e", entryScript(cjsImport)])).toEqual({ stdout: "end\ntick x\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("a tick queued before enterWith() runs too, with the store it captured", async () => {
+    const script = `
+      ${cjsImport}
+      const als = new AsyncLocalStorage();
+      process.nextTick(() => console.log("tick1", als.getStore()));
+      als.enterWith("x");
+      process.nextTick(() => console.log("tick2", als.getStore()));
+      console.log("end");
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "end\ntick1 undefined\ntick2 x\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("ticks run before the promise jobs the script queued after them", async () => {
+    const script = `
+      ${cjsImport}
+      const als = new AsyncLocalStorage();
+      als.enterWith("x");
+      process.nextTick(() => console.log("tick", als.getStore()));
+      Promise.resolve().then(() => console.log("then", als.getStore()));
+      queueMicrotask(() => console.log("microtask", als.getStore()));
+      console.log("end");
+    `;
+    expect(await run(["-e", script])).toEqual({
+      stdout: "end\ntick x\nthen x\nmicrotask x\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("enterWith() in the microtask that first touches process.nextTick", async () => {
+    const script = `
+      ${cjsImport}
+      const als = new AsyncLocalStorage();
+      Promise.resolve().then(() => {
+        als.enterWith("y");
+        process.nextTick(() => console.log("tick", als.getStore()));
+      });
+      console.log("end");
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "end\ntick y\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("a second enterWith() in a promise job keeps its own tick", async () => {
+    const script = `
+      ${cjsImport}
+      const als = new AsyncLocalStorage();
+      als.enterWith("a");
+      Promise.resolve().then(() => {
+        als.enterWith("b");
+        process.nextTick(() => console.log("tick-b", als.getStore()));
+      });
+      process.nextTick(() => console.log("tick-a", als.getStore()));
+      console.log("end");
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "end\ntick-a a\ntick-b b\n", stderr: "", exitCode: 0 });
+  });
+
+  // Once the queue has had its first drain, a tick queued from a microtask
+  // waits for the sibling microtasks, as in node. enterWith() in that
+  // microtask must not pull the drain forward.
+  test.concurrent("enterWith() after the first drain does not run ticks ahead of sibling microtasks", async () => {
+    const script = `
+      ${cjsImport}
+      const als = new AsyncLocalStorage();
+      process.nextTick(() => console.log("tick0"));
+      setTimeout(() => {
+        Promise.resolve().then(() => {
+          als.enterWith("y");
+          process.nextTick(() => console.log("tick", als.getStore()));
+        });
+        Promise.resolve().then(() => console.log("then"));
+      }, 1);
+      console.log("end");
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "end\ntick0\nthen\ntick y\n", stderr: "", exitCode: 0 });
   });
 });

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1370,4 +1370,42 @@ describe("enterWith() and process.nextTick() in the same microtask", () => {
     `;
     expect(await run(["-e", script])).toEqual({ stdout: "end\ntick0\nthen\ntick y\n", stderr: "", exitCode: 0 });
   });
+
+  // The cleanup's other job: the store enterWith() set outside any microtask
+  // is gone once the next microtask ends.
+  test.concurrent("enterWith() in a timer callback does not leak into the next timer", async () => {
+    const script = `
+      ${cjsImport}
+      const als = new AsyncLocalStorage();
+      setTimeout(() => {
+        als.enterWith("x");
+        Promise.resolve().then(() => console.log("then", als.getStore()));
+      }, 1);
+      setTimeout(() => console.log("timer", als.getStore()), 5);
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "then x\ntimer undefined\n", stderr: "", exitCode: 0 });
+  });
+
+  // bun test --isolate gives the second file a new global with no nextTick
+  // queue. The hook slot has to follow it, or the file's top-level ticks wait
+  // for the sibling microtasks instead of running first like in a fresh process.
+  test.concurrent("bun test --isolate arms the nextTick drain for each new global", async () => {
+    using dir = tempDir("als-isolate-tick", {
+      "a.test.js": `
+        import { test, expect } from "bun:test";
+        process.nextTick(() => {});
+        test("a", () => expect(1).toBe(1));
+      `,
+      "b.test.js": `
+        import { test, expect } from "bun:test";
+        const ran = [];
+        process.nextTick(() => ran.push("tick"));
+        Promise.resolve().then(() => ran.push("then"));
+        test("b", () => expect(ran).toEqual(["tick", "then"]));
+      `,
+    });
+    const result = await run(["test", "--isolate", "a.test.js", "b.test.js"], String(dir));
+    expect(result.stderr).toContain(" 2 pass");
+    expect(result.exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- After `als.enterWith(x)` in a script's top-level code, a `process.nextTick(cb)` queued in the same code never runs when nothing else keeps the event loop alive. The process exits 0 without running `cb`. Node runs `cb`.
- `AsyncLocalStorage.enterWith` calls `jsCleanupLater` (`src/jsc/bindings/NodeAsyncHooks.cpp:17`). It puts `cleanupAsyncHooksData` into the VM's single `onEachMicrotaskTick` slot, in place of the one-shot hook that drains a nextTick queue created inside a microtask. When the cleanup ran, it restored the one-shot only if `m_nextTickQueue` did not exist yet (`src/jsc/bindings/ZigGlobalObject.cpp:408` on main). A queue created in the same microtask as the `enterWith()` was treated as already drained, so its first drain never happened.

### Fix
- `JSNextTickQueue` records whether the one-shot has drained it (`handedOff()`). `checkIfNextTickWasCalledDuringMicrotask` sets it on the first drain and is a no-op after that. `resetOnEachMicrotaskTick` picks the hook from that bit instead of from the queue's existence.
- `cleanupAsyncHooksData` restores the hook it displaced and runs the one-shot for the current microtask boundary. The VM creation path installs the same function instead of an identical lambda. `bun test --isolate` resets the slot for each fresh global, which has no queue yet.
- Correct because the hook slot now always mirrors the default global's queue state. The cleanup only borrows the slot for one microtask, and the one-shot it displaced would have fired at that same boundary. Once handed off, the slot stays empty as before, so a tick queued from a later microtask still waits for its sibling microtasks as in node.
- Verified: `test/js/node/async_hooks/AsyncLocalStorage.test.ts` (new block, 10 cases, 8 fail on the current build). Also `test/js/node/async_hooks/`, `test/cli/test/{isolation,parallel,test-shard,bun-test}.test.ts`, `process-nexttick.test.js`, `microtask.test.js`, and the vendored `test-next-tick*`, `test-microtask-queue-*`, `test-async-local-storage-*` node tests.

### Background
- `process.nextTick` is drained in two places. `GlobalObject::drainMicrotasks()` drains the queue before each microtask checkpoint, but only if the queue already exists. A queue created inside a microtask (the entry script's top-level code runs in one) misses that check, so the one-shot `onEachMicrotaskTick` hook drains it at the end of that microtask and then unsets itself. From then on the first path owns the queue.
- `onEachMicrotaskTick` is a JSC hook called after every microtask. The VM has one slot for it. `enterWith()` needs the same slot to clear the async context it set once the current microtask ends.
- `JSNextTickQueue::drain` calls the JS `processTicksAndRejections`, which runs ticks and microtasks in a loop until both queues are empty.

<details><summary>Notes</summary>

Repro (bun 1.4.1 prints only `end`, node 26 prints both lines):

```js
const { AsyncLocalStorage } = require("node:async_hooks");
const als = new AsyncLocalStorage();
als.enterWith("x");
process.nextTick(() => console.log("tick ran, store =", als.getStore()));
console.log("end");
```

Also affected, same cause: `bun -e`, ES module entries, `process.nextTick` before `enterWith()` in the same microtask, and `enterWith()` inside the promise job that first touches `process.nextTick`. Not affected: `enterWith()` in a timer callback, and `enterWith()` in a later microtask once the queue has had its first drain. Workers are not affected because the implicit `node:worker_threads` preload already creates the queue before the worker's entry runs.

Relationship to other open PRs on the same lines. #33088 (nextTick order relative to pending microtasks) contains this hand-off change as its first half, with the bit on `Zig::GlobalObject`. With this PR as the base, #33088 shrinks to the module-boundary checkpoint and can read `queue->handedOff()`. #32628 and #31828 each carry a smaller hunk in `cleanupAsyncHooksData` for the same symptom (drain the queue when it exists); both can drop that hunk and #32628 its duplicate test once this lands. Those hunks also pull the drain forward in the steady state, which the last ordering test here rules out. #34121 keeps the hook permanently armed, which contradicts the same node order.

The bit lives on the queue rather than on the global object. Before the queue exists the one-shot is armed by definition, so the null case needs no separate state. The first revision kept a `nextTickQueueHandoffDone` field on `Zig::GlobalObject`; the review pointed at the no-new-global-fields rule and it moved.

The alternative of always re-arming and running the one-shot from the cleanup (without the bit) also fixes the exit case, but it would pull the drain forward in the steady state: a tick queued next to an `enterWith()` inside a promise job would run before that job's sibling microtasks. Node runs it after them, and stock Bun already matches node there. The ordering test in the new block pins that.

Separate pre-existing bug seen while probing, not addressed here: a `test()` registered while an `AsyncLocalStorage` context is active (for example `als.enterWith("x")` at the top of a test file) times out after 5 s with "before its done callback was called" even when the body passes synchronously. `parse_arguments` wraps the callback in an `AsyncContextFrame` before `callback_length` is read, the wrapper has no `length` property, `JSC__JSValue__getLengthIfPropertyExistsInternal` returns infinity for that case, and `JSValue::get_length` only maps `f64::MAX` to 0. The released bun has the same behavior.

Other suites run: `test/js/node/stream/`, `test/js/web/timers/`, `test/js/node/events/`, `test/js/node/worker_threads/`, `test/js/node/process/`. The only failures were timing or RSS-threshold tests that also fail on a main debug build (`stdin-fixtures.test.ts` 1 s kill timer, `setTimeout` leak fixture's 10 MB non-ASAN threshold under `bun-debug`, `worker_destruction` 5 s default timeout).
</details>
