### PR TITLE
node:domain: follow domains across async boundaries

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -113,7 +113,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:domain`](https://nodejs.org/api/domain.html)
 
-🟡 Missing `Domain` `members`. A domain only catches errors thrown synchronously inside `run()`/`bind()` or emitted by emitters passed to `add()`. Bun does not route errors from timers, `process.nextTick`, promises and other async callbacks to the domain.
+🟢 Implemented on top of `AsyncLocalStorage`, like Node.js's current implementation. Errors thrown in timers, `process.nextTick`, promises and I/O callbacks created inside a domain reach its `'error'` handler, and emitters created inside a domain are bound to it. A domain without an `'error'` listener leaves unhandled rejections to `process.on('unhandledRejection')` instead of turning them into uncaught exceptions.
 
 ### [`node:http2`](https://nodejs.org/api/http2.html)
 

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -100,8 +100,11 @@ function handleError(er, type) {
     // node: promiseInfo.domain.emit('error', reason), outside every domain.
     if (active.listenerCount("error") === 0) return false;
     setStack([]);
-    active.emit("error", er);
-    setStack(stack);
+    try {
+      active.emit("error", er);
+    } finally {
+      setStack(stack);
+    }
     return true;
   }
 
@@ -213,7 +216,7 @@ Domain.prototype.add = function (ee) {
 
   // A Domain->Domain cycle would make emit('error') recurse forever.
   if (ee instanceof Domain) {
-    for (let d = this.domain; d; d = d.domain) {
+    for (let d = this; d; d = d.domain) {
       if (ee === d) return;
     }
   }

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -125,7 +125,11 @@ function handleError(er, type) {
     return false;
   }
 
-  return active._errorHandler(er);
+  // Like node's capture callback, the result of _errorHandler is not consulted:
+  // with a listener on the stack it delivers the error or throws. emit() returns
+  // false when it routed the error to the domain's own parent domain.
+  active._errorHandler(er);
+  return true;
 }
 
 setDomainErrorHandler(handleError);

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -60,9 +60,8 @@ function activeDomain(): Domain | undefined {
 }
 
 // The stack array the innermost enter() still in effect installed. A context
-// restored for an async callback holds the array that was current when the
-// callback was created, never this one, which tells a throw inside run() from
-// a throw in a callback that only inherited its stack.
+// restored for an async callback never holds this array, which tells a throw
+// inside run() from a throw in a callback that only inherited its stack.
 let syncStack: Domain[] | undefined;
 // One record per enter() still in effect: what exit() puts back.
 const syncEntries: { domain: Domain; stack: Domain[] | undefined; syncStack: Domain[] | undefined }[] = [];

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -21,6 +21,12 @@ const { AsyncLocalStorage } = require("node:async_hooks");
 const setDomainErrorHandler = $newCppFunction("BunProcess.cpp", "jsFunctionSetDomainErrorHandler", 1);
 
 const ObjectDefineProperty = Object.defineProperty;
+const ObjectHasOwn = Object.hasOwn;
+const ArrayPrototypeIndexOf = Array.prototype.indexOf;
+const ArrayPrototypeLastIndexOf = Array.prototype.lastIndexOf;
+const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeSlice = Array.prototype.slice;
+const ArrayPrototypeSplice = Array.prototype.splice;
 
 // The domains entered and not yet exited, innermost last, or undefined when
 // there is none. Never mutated in place: enter()/exit() install a new array so
@@ -45,15 +51,15 @@ function setStack(stack: Domain[]) {
   const { length } = context;
   let i = 0;
   while (i < length && context[i] !== domainStack) i += 2;
-  const next = context.slice();
+  const next = ArrayPrototypeSlice.$call(context);
   if (i < length) {
     if (value === undefined) {
-      next.splice(i, 2);
+      ArrayPrototypeSplice.$call(next, i, 2);
     } else {
       next[i + 1] = value;
     }
   } else if (value !== undefined) {
-    next.push(domainStack, value);
+    ArrayPrototypePush.$call(next, domainStack, value);
   } else {
     return;
   }
@@ -65,10 +71,11 @@ function activeDomain(): Domain | undefined {
   return stack === undefined ? undefined : stack[stack.length - 1];
 }
 
-// The domain entered last by enter() in the current synchronous run, or null.
-// handleError uses it to tell a throw inside run()/bind()/intercept() from a
-// throw in an async callback that only inherited the stack.
-let syncDomain: Domain | null = null;
+// The domains entered by enter() and not yet exited in synchronous code, in
+// order. Only enter() adds to it, a restored async context never does, so
+// handleError can tell a throw inside run()/bind()/intercept() from a throw in
+// an async callback that only inherited its stack.
+const syncEntries: Domain[] = [];
 
 function setActiveDomain(domain) {
   if (domain === null || domain === undefined) {
@@ -77,8 +84,8 @@ function setActiveDomain(domain) {
   }
   if (activeDomain() !== domain) {
     const stack = currentStack();
-    const next = stack === undefined ? [] : stack.slice();
-    next.push(domain);
+    const next = stack === undefined ? [] : ArrayPrototypeSlice.$call(stack);
+    ArrayPrototypePush.$call(next, domain);
     setStack(next);
   }
 }
@@ -93,7 +100,7 @@ ObjectDefineProperty(process, "domain", {
 
 function domainUncaughtExceptionClear() {
   setStack([]);
-  syncDomain = null;
+  syncEntries.length = 0;
 }
 
 // Called from BunProcess.cpp for every uncaught exception and unhandled
@@ -123,7 +130,7 @@ function handleError(er, type) {
   // normal path with the stack cleared first (node prepends
   // domainUncaughtExceptionClear to the 'uncaughtException' listeners).
   let hasErrorListener = active.listenerCount("error") > 0;
-  if (!hasErrorListener && syncDomain === active) {
+  if (!hasErrorListener && syncEntries[syncEntries.length - 1] === active) {
     for (let i = stack.length - 2; i >= 0; i--) {
       if (stack[i].listenerCount("error") > 0) {
         hasErrorListener = true;
@@ -218,22 +225,23 @@ Domain.prototype.enter = function () {
   // Note that this might be a no-op, but we still need to push it onto the
   // stack so that we can pop it later.
   const stack = currentStack();
-  const next = stack === undefined ? [] : stack.slice();
-  next.push(this);
+  const next = stack === undefined ? [] : ArrayPrototypeSlice.$call(stack);
+  ArrayPrototypePush.$call(next, this);
   setStack(next);
-  syncDomain = this;
+  ArrayPrototypePush.$call(syncEntries, this);
 };
 
 Domain.prototype.exit = function () {
   // Don't do anything if this domain is not on the stack.
   const stack = currentStack();
   if (stack === undefined) return;
-  const index = stack.lastIndexOf(this);
+  const index = ArrayPrototypeLastIndexOf.$call(stack, this);
   if (index === -1) return;
 
   // Exit all domains until this one.
-  setStack(stack.slice(0, index));
-  syncDomain = index === 0 ? null : stack[index - 1];
+  setStack(ArrayPrototypeSlice.$call(stack, 0, index));
+  const syncIndex = ArrayPrototypeLastIndexOf.$call(syncEntries, this);
+  if (syncIndex !== -1) syncEntries.length = syncIndex;
 };
 
 // note: this works for timers as well.
@@ -267,13 +275,13 @@ Domain.prototype.add = function (ee) {
     value: this,
     writable: true,
   });
-  this.members.push(ee);
+  ArrayPrototypePush.$call(this.members, ee);
 };
 
 Domain.prototype.remove = function (ee) {
   ee.domain = null;
-  const index = this.members.indexOf(ee);
-  if (index !== -1) this.members.splice(index, 1);
+  const index = ArrayPrototypeIndexOf.$call(this.members, ee);
+  if (index !== -1) ArrayPrototypeSplice.$call(this.members, index, 1);
 };
 
 Domain.prototype.run = function (fn, ...args) {
@@ -301,7 +309,7 @@ function intercepted(_this, self, cb, fnargs) {
   }
 
   self.enter();
-  const ret = cb.$apply(_this, Array.prototype.slice.$call(fnargs, 1));
+  const ret = cb.$apply(_this, ArrayPrototypeSlice.$call(fnargs, 1));
   self.exit();
 
   return ret;
@@ -360,27 +368,42 @@ EventEmitter.init = function (opts) {
     this.domain = active;
   }
 
-  return eventInit.$call(this, opts);
+  const ret = eventInit.$call(this, opts);
+
+  // events.ts gives a captureRejections emitter its own `emit`, which would
+  // shadow the domain-aware prototype emit below. Wrap that one as well.
+  if (ObjectHasOwn(this, "emit")) {
+    const ownEmit = this.emit;
+    this.emit = function emit(...args) {
+      return emitWithDomain(this, ownEmit, args);
+    };
+  }
+
+  return ret;
 };
 
 const eventEmit = EventEmitter.prototype.emit;
 EventEmitter.prototype.emit = function emit(...args) {
-  const domain = this.domain;
+  return emitWithDomain(this, eventEmit, args);
+};
+
+function emitWithDomain(emitter, originalEmit, args) {
+  const domain = emitter.domain;
 
   const type = args[0];
-  const shouldEmitError = type === "error" && this.listenerCount(type) > 0;
+  const shouldEmitError = type === "error" && emitter.listenerCount(type) > 0;
 
   // Just call original `emit` if current EE instance has `error`
   // handler, there's no active domain or this is process
-  if (shouldEmitError || domain === null || domain === undefined || this === process) {
-    return eventEmit.$apply(this, args);
+  if (shouldEmitError || domain === null || domain === undefined || emitter === process) {
+    return originalEmit.$apply(emitter, args);
   }
 
   if (type === "error") {
     const er = args.length > 1 && args[1] ? args[1] : $ERR_UNHANDLED_ERROR();
 
     if (typeof er === "object") {
-      er.domainEmitter = this;
+      er.domainEmitter = emitter;
       ObjectDefineProperty(er, "domain", {
         __proto__: null,
         configurable: true,
@@ -402,7 +425,7 @@ EventEmitter.prototype.emit = function emit(...args) {
       while (idx > -1 && origStack[idx] === origActive) {
         --idx;
       }
-      setStack(idx < 0 ? [] : origStack.slice(0, idx + 1));
+      setStack(idx < 0 ? [] : ArrayPrototypeSlice.$call(origStack, 0, idx + 1));
     }
 
     domain.emit("error", er);
@@ -417,11 +440,11 @@ EventEmitter.prototype.emit = function emit(...args) {
   }
 
   domain.enter();
-  const ret = eventEmit.$apply(this, args);
+  const ret = originalEmit.$apply(emitter, args);
   domain.exit();
 
   return ret;
-};
+}
 
 export default {
   Domain,

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -1,96 +1,442 @@
-// Import Events
-let EventEmitter;
+// Hardcoded module "node:domain"
+//
+// Port of node's lib/domain.js. Node releases follow a domain across async
+// boundaries with async_hooks: `init` pairs a new resource with process.domain,
+// `before` and `after` enter and exit that domain around each callback. Bun
+// has no before/after hooks, so the stack of entered domains lives in the
+// async context instead (the store AsyncLocalStorage rides), the way node's
+// main branch now does it too. Every callback that snapshots the async context
+// (timers, process.nextTick, promise reactions, I/O callbacks) then runs with
+// the stack it was created under.
+//
+// Errors reach `handleError` below through jsFunctionSetDomainErrorHandler
+// (BunProcess.cpp). The uncaught-exception and unhandled-rejection paths call
+// it with the async context of the throw (or rejection) still active and skip
+// the 'uncaughtException' / 'unhandledRejection' listeners when it returns
+// true, like node's domain-owned uncaughtExceptionCaptureCallback.
+
+const EventEmitter = require("node:events");
+const { AsyncLocalStorage } = require("node:async_hooks");
+
+const setDomainErrorHandler = $newCppFunction("BunProcess.cpp", "jsFunctionSetDomainErrorHandler", 1);
 
 const ObjectDefineProperty = Object.defineProperty;
 
-// Export Domain
-var domain: any = {};
-domain.createDomain = domain.create = function () {
-  if (!EventEmitter) {
-    EventEmitter = require("node:events");
-  }
-  var d = new EventEmitter();
+// The domains entered and not yet exited, innermost last, or undefined when
+// there is none. Never mutated in place: enter()/exit() install a new array so
+// a callback that snapshotted the old context keeps its own stack.
+const domainStack = new AsyncLocalStorage();
 
-  function emitError(e) {
-    e ||= $ERR_UNHANDLED_ERROR();
-    if (typeof e === "object") {
-      e.domainEmitter = this;
-      ObjectDefineProperty(e, "domain", {
+function currentStack(): Domain[] | undefined {
+  return domainStack.getStore();
+}
+
+// Writes the [AsyncLocalStorage, value, ...] context array node/async_hooks.ts
+// keeps, instead of going through enterWith(): enterWith() schedules a reset
+// of the context at the next microtask checkpoint, and a domain entered by
+// run() has to outlive the throw it did not catch until handleError runs.
+function setStack(stack: Domain[]) {
+  const value = stack.length === 0 ? undefined : stack;
+  const context = $getInternalField($asyncContext, 0);
+  if (context === undefined) {
+    if (value !== undefined) $putInternalField($asyncContext, 0, [domainStack, value]);
+    return;
+  }
+  const { length } = context;
+  let i = 0;
+  while (i < length && context[i] !== domainStack) i += 2;
+  const next = context.slice();
+  if (i < length) {
+    if (value === undefined) {
+      next.splice(i, 2);
+    } else {
+      next[i + 1] = value;
+    }
+  } else if (value !== undefined) {
+    next.push(domainStack, value);
+  } else {
+    return;
+  }
+  $putInternalField($asyncContext, 0, next.length === 0 ? undefined : next);
+}
+
+function activeDomain(): Domain | undefined {
+  const stack = currentStack();
+  return stack === undefined ? undefined : stack[stack.length - 1];
+}
+
+// The domain entered last by enter() in the current synchronous run, or null.
+// handleError uses it to tell a throw inside run()/bind()/intercept() from a
+// throw in an async callback that only inherited the stack.
+let syncDomain: Domain | null = null;
+
+function setActiveDomain(domain) {
+  if (domain === null || domain === undefined) {
+    setStack([]);
+    return;
+  }
+  if (activeDomain() !== domain) {
+    const stack = currentStack();
+    const next = stack === undefined ? [] : stack.slice();
+    next.push(domain);
+    setStack(next);
+  }
+}
+
+ObjectDefineProperty(process, "domain", {
+  __proto__: null,
+  enumerable: true,
+  configurable: true,
+  get: activeDomain,
+  set: setActiveDomain,
+});
+
+function domainUncaughtExceptionClear() {
+  setStack([]);
+  syncDomain = null;
+}
+
+// Called from BunProcess.cpp for every uncaught exception and unhandled
+// rejection, before the process listeners, with the async context of the
+// failure still active. Returns true when a domain took the error.
+function handleError(er, type) {
+  const stack = currentStack();
+  if (stack === undefined) return false;
+  const active = stack[stack.length - 1];
+
+  if (type === "unhandledRejection") {
+    // node: promiseInfo.domain.emit('error', reason). The handler runs from
+    // the tick queue in node, outside every domain.
+    if (active.listenerCount("error") === 0) return false;
+    setStack([]);
+    active.emit("error", er);
+    setStack(stack);
+    return true;
+  }
+
+  // node hands the error to the active domain only while a domain on the
+  // stack has an 'error' listener. Inside a synchronous run() any domain on
+  // the stack counts: when the inner one has no listener its emit() throws and
+  // _errorHandler passes the error to the parent. In an async callback only
+  // the active domain counts, as in node: the parents were on the stack when
+  // the callback was created, not when it ran. Otherwise the error takes the
+  // normal path with the stack cleared first (node prepends
+  // domainUncaughtExceptionClear to the 'uncaughtException' listeners).
+  let hasErrorListener = active.listenerCount("error") > 0;
+  if (!hasErrorListener && syncDomain === active) {
+    for (let i = stack.length - 2; i >= 0; i--) {
+      if (stack[i].listenerCount("error") > 0) {
+        hasErrorListener = true;
+        break;
+      }
+    }
+  }
+  if (!hasErrorListener) {
+    domainUncaughtExceptionClear();
+    return false;
+  }
+
+  return active._errorHandler(er);
+}
+
+setDomainErrorHandler(handleError);
+
+class Domain extends EventEmitter {
+  members: any[];
+
+  constructor() {
+    super();
+    this.members = [];
+  }
+}
+
+function createDomain() {
+  return new Domain();
+}
+
+Domain.prototype.members = undefined;
+
+// Called for an error thrown while this domain was active.
+Domain.prototype._errorHandler = function (er) {
+  let caught = false;
+
+  if ((typeof er === "object" && er !== null) || typeof er === "function") {
+    ObjectDefineProperty(er, "domain", {
+      __proto__: null,
+      configurable: true,
+      enumerable: false,
+      value: this,
+      writable: true,
+    });
+    er.domainThrown = true;
+  }
+  // Pop all adjacent duplicates of this domain from the stack so its error
+  // handler does not run inside the domain itself and re-enter recursively.
+  while (activeDomain() === this) {
+    this.exit();
+  }
+
+  if (currentStack() === undefined) {
+    // Top-level domain handler. An exception it throws is not caught here so it
+    // stays fatal, as in node.
+    //
+    // Without an 'error' listener, do not emit: the throw from emit() would
+    // end the process before the 'uncaughtException' listeners get the error.
+    if (this.listenerCount("error") > 0) {
+      caught = this.emit("error", er);
+    }
+  } else {
+    // Wrap this in a try/catch so we don't get infinite throwing
+    try {
+      // One of three things will happen here.
+      //
+      // 1. There is a handler, caught = true
+      // 2. There is no handler, caught = false
+      // 3. It throws, caught = false
+      caught = this.emit("error", er);
+    } catch (er2) {
+      // The domain error handler threw. See if another domain can catch THIS
+      // error, or else crash on the original one.
+      const stack = currentStack();
+      if (stack !== undefined) {
+        caught = stack[stack.length - 1]._errorHandler(er2);
+      } else {
+        // Pass on to the next exception handler.
+        throw er2;
+      }
+    }
+  }
+
+  // Exit all domains on the stack. Uncaught exceptions end the current tick
+  // and no domains should be left on the stack between ticks.
+  domainUncaughtExceptionClear();
+
+  return caught;
+};
+
+Domain.prototype.enter = function () {
+  // Note that this might be a no-op, but we still need to push it onto the
+  // stack so that we can pop it later.
+  const stack = currentStack();
+  const next = stack === undefined ? [] : stack.slice();
+  next.push(this);
+  setStack(next);
+  syncDomain = this;
+};
+
+Domain.prototype.exit = function () {
+  // Don't do anything if this domain is not on the stack.
+  const stack = currentStack();
+  if (stack === undefined) return;
+  const index = stack.lastIndexOf(this);
+  if (index === -1) return;
+
+  // Exit all domains until this one.
+  setStack(stack.slice(0, index));
+  syncDomain = index === 0 ? null : stack[index - 1];
+};
+
+// note: this works for timers as well.
+Domain.prototype.add = function (ee) {
+  const { domain: previous } = ee;
+  // If the domain is already added, then nothing left to do.
+  if (previous === this) return;
+
+  // Has a domain already - remove it first.
+  if (previous) previous.remove(ee);
+
+  // Check for circular Domain->Domain links.
+  // They cause big issues.
+  //
+  // For example:
+  // var d = domain.create();
+  // var e = domain.create();
+  // d.add(e);
+  // e.add(d);
+  // e.emit('error', er); // RangeError, stack overflow!
+  if (ee instanceof Domain) {
+    for (let d = this.domain; d; d = d.domain) {
+      if (ee === d) return;
+    }
+  }
+
+  ObjectDefineProperty(ee, "domain", {
+    __proto__: null,
+    configurable: true,
+    enumerable: false,
+    value: this,
+    writable: true,
+  });
+  this.members.push(ee);
+};
+
+Domain.prototype.remove = function (ee) {
+  ee.domain = null;
+  const index = this.members.indexOf(ee);
+  if (index !== -1) this.members.splice(index, 1);
+};
+
+Domain.prototype.run = function (fn, ...args) {
+  this.enter();
+  const ret = fn.$apply(this, args);
+  this.exit();
+
+  return ret;
+};
+
+function intercepted(_this, self, cb, fnargs) {
+  if (fnargs[0] && fnargs[0] instanceof Error) {
+    const er = fnargs[0];
+    er.domainBound = cb;
+    er.domainThrown = false;
+    ObjectDefineProperty(er, "domain", {
+      __proto__: null,
+      configurable: true,
+      enumerable: false,
+      value: self,
+      writable: true,
+    });
+    self.emit("error", er);
+    return;
+  }
+
+  self.enter();
+  const ret = cb.$apply(_this, Array.prototype.slice.$call(fnargs, 1));
+  self.exit();
+
+  return ret;
+}
+
+Domain.prototype.intercept = function (cb) {
+  const self = this;
+
+  function runIntercepted() {
+    return intercepted(this, self, cb, arguments);
+  }
+
+  return runIntercepted;
+};
+
+function bound(_this, self, cb, fnargs) {
+  self.enter();
+  const ret = cb.$apply(_this, fnargs);
+  self.exit();
+
+  return ret;
+}
+
+Domain.prototype.bind = function (cb) {
+  const self = this;
+
+  function runBound() {
+    return bound(this, self, cb, arguments);
+  }
+
+  ObjectDefineProperty(runBound, "domain", {
+    __proto__: null,
+    configurable: true,
+    enumerable: false,
+    value: this,
+    writable: true,
+  });
+
+  return runBound;
+};
+
+// Override EventEmitter methods to make it domain-aware.
+EventEmitter.usingDomains = true;
+
+const eventInit = EventEmitter.init;
+EventEmitter.init = function (opts) {
+  ObjectDefineProperty(this, "domain", {
+    __proto__: null,
+    configurable: true,
+    enumerable: false,
+    value: null,
+    writable: true,
+  });
+  const active = activeDomain();
+  if (active !== undefined && !(this instanceof Domain)) {
+    this.domain = active;
+  }
+
+  return eventInit.$call(this, opts);
+};
+
+const eventEmit = EventEmitter.prototype.emit;
+EventEmitter.prototype.emit = function emit(...args) {
+  const domain = this.domain;
+
+  const type = args[0];
+  const shouldEmitError = type === "error" && this.listenerCount(type) > 0;
+
+  // Just call original `emit` if current EE instance has `error`
+  // handler, there's no active domain or this is process
+  if (shouldEmitError || domain === null || domain === undefined || this === process) {
+    return eventEmit.$apply(this, args);
+  }
+
+  if (type === "error") {
+    const er = args.length > 1 && args[1] ? args[1] : $ERR_UNHANDLED_ERROR();
+
+    if (typeof er === "object") {
+      er.domainEmitter = this;
+      ObjectDefineProperty(er, "domain", {
         __proto__: null,
         configurable: true,
         enumerable: false,
-        value: d,
+        value: domain,
         writable: true,
       });
-      e.domainThrown = false;
+      er.domainThrown = false;
     }
-    d.emit("error", e);
+
+    // Remove the active domain (and its duplicates) from the stack so the
+    // domain's error handler does not run in its own context. Otherwise an
+    // event emitter created or an exception thrown in that handler would
+    // recursively execute that handler.
+    const origStack = currentStack();
+    if (origStack !== undefined) {
+      const origActive = origStack[origStack.length - 1];
+      let idx = origStack.length - 1;
+      while (idx > -1 && origStack[idx] === origActive) {
+        --idx;
+      }
+      setStack(idx < 0 ? [] : origStack.slice(0, idx + 1));
+    }
+
+    domain.emit("error", er);
+
+    // Now that the domain's error handler has completed, restore the domains
+    // stack and the active domain to their original values.
+    if (origStack !== undefined) {
+      setStack(origStack);
+    }
+
+    return false;
   }
 
-  d.add = function (emitter) {
-    emitter.on("error", emitError);
-  };
-  d.remove = function (emitter) {
-    emitter.removeListener("error", emitError);
-  };
-  d.bind = function (fn) {
-    return function () {
-      var args = Array.prototype.slice.$call(arguments);
-      try {
-        fn.$apply(null, args);
-      } catch (err) {
-        emitError(err);
-      }
-    };
-  };
-  d.intercept = function (fn) {
-    return function (err) {
-      if (err) {
-        emitError(err);
-      } else {
-        var args = Array.prototype.slice.$call(arguments, 1);
-        try {
-          fn.$apply(null, args);
-        } catch (err) {
-          emitError(err);
-        }
-      }
-    };
-  };
-  d.run = function (fn, ...args) {
-    this.enter();
-    try {
-      return fn.$apply(this, args);
-    } catch (err) {
-      emitError(err);
-    } finally {
-      this.exit();
-    }
-  };
-  d.dispose = function () {
-    this.removeAllListeners();
-    return this;
-  };
-  d.enter = function () {
-    stack.push(this);
-    domain.active = process.domain = this;
-    return this;
-  };
-  d.exit = function () {
-    const index = stack.lastIndexOf(this);
-    if (index === -1) return this;
-    stack.splice(index, stack.length);
-    domain.active = process.domain = stack.length ? stack[stack.length - 1] : null;
-    return this;
-  };
-  return d;
+  domain.enter();
+  const ret = eventEmit.$apply(this, args);
+  domain.exit();
+
+  return ret;
 };
 
-// Domains entered via enter()/run() and not yet exited, innermost last.
-// process.domain mirrors the top of the stack like in node so other modules
-// can observe the currently active domain.
-const stack: any[] = [];
-domain._stack = stack;
-domain.active = null;
-
-export default domain;
+export default {
+  Domain,
+  create: createDomain,
+  createDomain,
+  // The active domain is always the one that we're currently in.
+  get active() {
+    return activeDomain() ?? null;
+  },
+  set active(domain) {
+    setActiveDomain(domain);
+  },
+  // The stack of entered domains, innermost last.
+  get _stack() {
+    const stack = currentStack();
+    return stack === undefined ? [] : stack;
+  },
+};

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -59,10 +59,13 @@ function activeDomain(): Domain | undefined {
   return stack === undefined ? undefined : stack[stack.length - 1];
 }
 
-// Domains entered by enter() in synchronous code and not yet exited. A restored
-// async context never adds to it, which tells a throw inside run() from a throw
-// in a callback that only inherited its stack.
-const syncEntries: Domain[] = [];
+// The stack array the innermost enter() still in effect installed. A context
+// restored for an async callback holds the array that was current when the
+// callback was created, never this one, which tells a throw inside run() from
+// a throw in a callback that only inherited its stack.
+let syncStack: Domain[] | undefined;
+// One record per enter() still in effect: what exit() puts back.
+const syncEntries: { domain: Domain; stack: Domain[] | undefined; syncStack: Domain[] | undefined }[] = [];
 
 function setActiveDomain(domain) {
   if (domain === null || domain === undefined) {
@@ -88,6 +91,7 @@ ObjectDefineProperty(process, "domain", {
 function domainUncaughtExceptionClear() {
   setStack([]);
   syncEntries.length = 0;
+  syncStack = undefined;
 }
 
 // Returns true when a domain took the error.
@@ -112,7 +116,7 @@ function handleError(er, type) {
   // inside a synchronous run(). An async callback had only the active domain
   // entered for it, so without a listener there the error takes the normal path.
   let hasErrorListener = active.listenerCount("error") > 0;
-  if (!hasErrorListener && syncEntries[syncEntries.length - 1] === active) {
+  if (!hasErrorListener && stack === syncStack) {
     for (let i = stack.length - 2; i >= 0; i--) {
       if (stack[i].listenerCount("error") > 0) {
         hasErrorListener = true;
@@ -195,10 +199,14 @@ Domain.prototype._errorHandler = function (er) {
 
 Domain.prototype.enter = function () {
   const stack = currentStack();
+  // Records left by an enter() whose exit() a caught throw skipped belong to
+  // an earlier synchronous run once the current stack is no longer theirs.
+  if (stack !== syncStack) syncEntries.length = 0;
   const next = stack === undefined ? [] : ArrayPrototypeSlice.$call(stack);
   ArrayPrototypePush.$call(next, this);
   setStack(next);
-  ArrayPrototypePush.$call(syncEntries, this);
+  ArrayPrototypePush.$call(syncEntries, { domain: this, stack, syncStack });
+  syncStack = next;
 };
 
 Domain.prototype.exit = function () {
@@ -208,9 +216,16 @@ Domain.prototype.exit = function () {
   if (index === -1) return;
 
   // Exit all domains until this one.
-  setStack(ArrayPrototypeSlice.$call(stack, 0, index));
-  const syncIndex = ArrayPrototypeLastIndexOf.$call(syncEntries, this);
-  if (syncIndex !== -1) syncEntries.length = syncIndex;
+  let i = syncEntries.length - 1;
+  while (i >= 0 && syncEntries[i].domain !== this) i--;
+  if (i === -1) {
+    setStack(ArrayPrototypeSlice.$call(stack, 0, index));
+    return;
+  }
+  const entry = syncEntries[i];
+  syncEntries.length = i;
+  setStack(entry.stack === undefined ? [] : entry.stack);
+  syncStack = entry.syncStack;
 };
 
 Domain.prototype.add = function (ee) {
@@ -371,6 +386,7 @@ function emitWithDomain(emitter, originalEmit, args) {
     // The handler runs outside the active domain (and its duplicates) so it
     // cannot re-enter itself through an emitter created or a throw inside it.
     const origStack = currentStack();
+    const origSyncStack = syncStack;
     if (origStack !== undefined) {
       const origActive = origStack[origStack.length - 1];
       let idx = origStack.length - 1;
@@ -378,12 +394,14 @@ function emitWithDomain(emitter, originalEmit, args) {
         --idx;
       }
       setStack(idx < 0 ? [] : ArrayPrototypeSlice.$call(origStack, 0, idx + 1));
+      syncStack = currentStack();
     }
 
     domain.emit("error", er);
 
     if (origStack !== undefined) {
       setStack(origStack);
+      syncStack = origSyncStack;
     }
 
     return false;

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -1,19 +1,10 @@
 // Hardcoded module "node:domain"
 //
-// Port of node's lib/domain.js. Node releases follow a domain across async
-// boundaries with async_hooks: `init` pairs a new resource with process.domain,
-// `before` and `after` enter and exit that domain around each callback. Bun
-// has no before/after hooks, so the stack of entered domains lives in the
-// async context instead (the store AsyncLocalStorage rides), the way node's
-// main branch now does it too. Every callback that snapshots the async context
-// (timers, process.nextTick, promise reactions, I/O callbacks) then runs with
-// the stack it was created under.
-//
-// Errors reach `handleError` below through jsFunctionSetDomainErrorHandler
-// (BunProcess.cpp). The uncaught-exception and unhandled-rejection paths call
-// it with the async context of the throw (or rejection) still active and skip
-// the 'uncaughtException' / 'unhandledRejection' listeners when it returns
-// true, like node's domain-owned uncaughtExceptionCaptureCallback.
+// Port of node's lib/domain.js (the AsyncLocalStorage-based version on node's
+// main branch). The stack of entered domains lives in the async context, so a
+// callback runs with the stack it was created under. BunProcess.cpp calls
+// `handleError` for every uncaught exception and unhandled rejection before
+// the process listeners, with the async context of the failure still active.
 
 const EventEmitter = require("node:events");
 const { AsyncLocalStorage } = require("node:async_hooks");
@@ -28,19 +19,16 @@ const ArrayPrototypePush = Array.prototype.push;
 const ArrayPrototypeSlice = Array.prototype.slice;
 const ArrayPrototypeSplice = Array.prototype.splice;
 
-// The domains entered and not yet exited, innermost last, or undefined when
-// there is none. Never mutated in place: enter()/exit() install a new array so
-// a callback that snapshotted the old context keeps its own stack.
+// The domains entered and not yet exited, innermost last, or undefined. Never
+// mutated in place: a callback that snapshotted the old context keeps its stack.
 const domainStack = new AsyncLocalStorage();
 
 function currentStack(): Domain[] | undefined {
   return domainStack.getStore();
 }
 
-// Writes the [AsyncLocalStorage, value, ...] context array node/async_hooks.ts
-// keeps, instead of going through enterWith(): enterWith() schedules a reset
-// of the context at the next microtask checkpoint, and a domain entered by
-// run() has to outlive the throw it did not catch until handleError runs.
+// Not enterWith(): that schedules a context reset at the next microtask
+// checkpoint, before a throw out of run() reaches handleError.
 function setStack(stack: Domain[]) {
   const value = stack.length === 0 ? undefined : stack;
   const context = $getInternalField($asyncContext, 0);
@@ -71,10 +59,9 @@ function activeDomain(): Domain | undefined {
   return stack === undefined ? undefined : stack[stack.length - 1];
 }
 
-// The domains entered by enter() and not yet exited in synchronous code, in
-// order. Only enter() adds to it, a restored async context never does, so
-// handleError can tell a throw inside run()/bind()/intercept() from a throw in
-// an async callback that only inherited its stack.
+// Domains entered by enter() in synchronous code and not yet exited. A restored
+// async context never adds to it, which tells a throw inside run() from a throw
+// in a callback that only inherited its stack.
 const syncEntries: Domain[] = [];
 
 function setActiveDomain(domain) {
@@ -103,17 +90,14 @@ function domainUncaughtExceptionClear() {
   syncEntries.length = 0;
 }
 
-// Called from BunProcess.cpp for every uncaught exception and unhandled
-// rejection, before the process listeners, with the async context of the
-// failure still active. Returns true when a domain took the error.
+// Returns true when a domain took the error.
 function handleError(er, type) {
   const stack = currentStack();
   if (stack === undefined) return false;
   const active = stack[stack.length - 1];
 
   if (type === "unhandledRejection") {
-    // node: promiseInfo.domain.emit('error', reason). The handler runs from
-    // the tick queue in node, outside every domain.
+    // node: promiseInfo.domain.emit('error', reason), outside every domain.
     if (active.listenerCount("error") === 0) return false;
     setStack([]);
     active.emit("error", er);
@@ -121,14 +105,9 @@ function handleError(er, type) {
     return true;
   }
 
-  // node hands the error to the active domain only while a domain on the
-  // stack has an 'error' listener. Inside a synchronous run() any domain on
-  // the stack counts: when the inner one has no listener its emit() throws and
-  // _errorHandler passes the error to the parent. In an async callback only
-  // the active domain counts, as in node: the parents were on the stack when
-  // the callback was created, not when it ran. Otherwise the error takes the
-  // normal path with the stack cleared first (node prepends
-  // domainUncaughtExceptionClear to the 'uncaughtException' listeners).
+  // Like node, a parent domain's 'error' listener only counts for a throw
+  // inside a synchronous run(). An async callback had only the active domain
+  // entered for it, so without a listener there the error takes the normal path.
   let hasErrorListener = active.listenerCount("error") > 0;
   if (!hasErrorListener && syncEntries[syncEntries.length - 1] === active) {
     for (let i = stack.length - 2; i >= 0; i--) {
@@ -163,7 +142,6 @@ function createDomain() {
 
 Domain.prototype.members = undefined;
 
-// Called for an error thrown while this domain was active.
 Domain.prototype._errorHandler = function (er) {
   let caught = false;
 
@@ -177,53 +155,38 @@ Domain.prototype._errorHandler = function (er) {
     });
     er.domainThrown = true;
   }
-  // Pop all adjacent duplicates of this domain from the stack so its error
-  // handler does not run inside the domain itself and re-enter recursively.
+  // The handler must not run inside the domain it handles errors for.
   while (activeDomain() === this) {
     this.exit();
   }
 
   if (currentStack() === undefined) {
-    // Top-level domain handler. An exception it throws is not caught here so it
-    // stays fatal, as in node.
-    //
-    // Without an 'error' listener, do not emit: the throw from emit() would
-    // end the process before the 'uncaughtException' listeners get the error.
+    // Top-level handler: a throw from it stays fatal. Without a listener emit()
+    // would throw before the 'uncaughtException' listeners see the error.
     if (this.listenerCount("error") > 0) {
       caught = this.emit("error", er);
     }
   } else {
-    // Wrap this in a try/catch so we don't get infinite throwing
     try {
-      // One of three things will happen here.
-      //
-      // 1. There is a handler, caught = true
-      // 2. There is no handler, caught = false
-      // 3. It throws, caught = false
       caught = this.emit("error", er);
     } catch (er2) {
-      // The domain error handler threw. See if another domain can catch THIS
-      // error, or else crash on the original one.
+      // The handler threw: the next domain on the stack gets that error.
       const stack = currentStack();
       if (stack !== undefined) {
         caught = stack[stack.length - 1]._errorHandler(er2);
       } else {
-        // Pass on to the next exception handler.
         throw er2;
       }
     }
   }
 
-  // Exit all domains on the stack. Uncaught exceptions end the current tick
-  // and no domains should be left on the stack between ticks.
+  // An uncaught exception ends the tick: no domain stays entered after it.
   domainUncaughtExceptionClear();
 
   return caught;
 };
 
 Domain.prototype.enter = function () {
-  // Note that this might be a no-op, but we still need to push it onto the
-  // stack so that we can pop it later.
   const stack = currentStack();
   const next = stack === undefined ? [] : ArrayPrototypeSlice.$call(stack);
   ArrayPrototypePush.$call(next, this);
@@ -232,7 +195,6 @@ Domain.prototype.enter = function () {
 };
 
 Domain.prototype.exit = function () {
-  // Don't do anything if this domain is not on the stack.
   const stack = currentStack();
   if (stack === undefined) return;
   const index = ArrayPrototypeLastIndexOf.$call(stack, this);
@@ -244,24 +206,12 @@ Domain.prototype.exit = function () {
   if (syncIndex !== -1) syncEntries.length = syncIndex;
 };
 
-// note: this works for timers as well.
 Domain.prototype.add = function (ee) {
   const { domain: previous } = ee;
-  // If the domain is already added, then nothing left to do.
   if (previous === this) return;
-
-  // Has a domain already - remove it first.
   if (previous) previous.remove(ee);
 
-  // Check for circular Domain->Domain links.
-  // They cause big issues.
-  //
-  // For example:
-  // var d = domain.create();
-  // var e = domain.create();
-  // d.add(e);
-  // e.add(d);
-  // e.emit('error', er); // RangeError, stack overflow!
+  // A Domain->Domain cycle would make emit('error') recurse forever.
   if (ee instanceof Domain) {
     for (let d = this.domain; d; d = d.domain) {
       if (ee === d) return;
@@ -370,8 +320,7 @@ EventEmitter.init = function (opts) {
 
   const ret = eventInit.$call(this, opts);
 
-  // events.ts gives a captureRejections emitter its own `emit`, which would
-  // shadow the domain-aware prototype emit below. Wrap that one as well.
+  // A captureRejections emitter gets its own `emit` from events.ts.
   if (ObjectHasOwn(this, "emit")) {
     const ownEmit = this.emit;
     this.emit = function emit(...args) {
@@ -393,8 +342,6 @@ function emitWithDomain(emitter, originalEmit, args) {
   const type = args[0];
   const shouldEmitError = type === "error" && emitter.listenerCount(type) > 0;
 
-  // Just call original `emit` if current EE instance has `error`
-  // handler, there's no active domain or this is process
   if (shouldEmitError || domain === null || domain === undefined || emitter === process) {
     return originalEmit.$apply(emitter, args);
   }
@@ -414,10 +361,8 @@ function emitWithDomain(emitter, originalEmit, args) {
       er.domainThrown = false;
     }
 
-    // Remove the active domain (and its duplicates) from the stack so the
-    // domain's error handler does not run in its own context. Otherwise an
-    // event emitter created or an exception thrown in that handler would
-    // recursively execute that handler.
+    // The handler runs outside the active domain (and its duplicates) so it
+    // cannot re-enter itself through an emitter created or a throw inside it.
     const origStack = currentStack();
     if (origStack !== undefined) {
       const origActive = origStack[origStack.length - 1];
@@ -430,8 +375,6 @@ function emitWithDomain(emitter, originalEmit, args) {
 
     domain.emit("error", er);
 
-    // Now that the domain's error handler has completed, restore the domains
-    // stack and the active domain to their original values.
     if (origStack !== undefined) {
       setStack(origStack);
     }

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -67,8 +67,7 @@ function EventEmitter(opts) {
 Object.defineProperty(EventEmitter, "name", { value: "EventEmitter", configurable: true });
 const EventEmitterPrototype = (EventEmitter.prototype = {});
 
-// Looked up through `EventEmitter.init` on every construction, like node, so
-// node:domain can replace it to stamp the active domain on new emitters.
+// Reached through `EventEmitter.init` like node, so node:domain can replace it.
 function init(opts) {
   if (this._events === undefined || this._events === this.__proto__._events) {
     this._events = Object.create(null);

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -62,6 +62,14 @@ var defaultMaxListeners = 10;
 
 // EventEmitter must be a standard function because some old code will do weird tricks like `EventEmitter.$apply(this)`.
 function EventEmitter(opts) {
+  EventEmitter.init.$call(this, opts);
+}
+Object.defineProperty(EventEmitter, "name", { value: "EventEmitter", configurable: true });
+const EventEmitterPrototype = (EventEmitter.prototype = {});
+
+// Looked up through `EventEmitter.init` on every construction, like node, so
+// node:domain can replace it to stamp the active domain on new emitters.
+function init(opts) {
   if (this._events === undefined || this._events === this.__proto__._events) {
     this._events = Object.create(null);
     this._eventsCount = 0;
@@ -87,8 +95,6 @@ function EventEmitter(opts) {
     }
   }
 }
-Object.defineProperty(EventEmitter, "name", { value: "EventEmitter", configurable: true });
-const EventEmitterPrototype = (EventEmitter.prototype = {});
 
 EventEmitterPrototype.setMaxListeners = function setMaxListeners(n) {
   validateNumber(n, "setMaxListeners", 0);
@@ -992,7 +998,7 @@ Object.assign(EventEmitter, {
   EventEmitterAsyncResource,
   errorMonitor: kErrorMonitor,
   addAbortListener,
-  init: EventEmitter,
+  init,
   listenerCount,
 });
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1331,12 +1331,8 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
         RETURN_IF_EXCEPTION(monitorScope, true);
     }
 
-    // node:domain gets the error before the capture callback and the
-    // 'uncaughtException' listeners, like node's domain-owned captureFn. The
-    // async context of the throw is still active here, so the router sees the
-    // domain the failing callback was created in. A rejection that reaches this
-    // path (--unhandled-rejections=strict or throw) is routed like a throw, as
-    // node's _fatalException does.
+    // node:domain gets the error first, like node's domain-owned captureFn. The
+    // async context of the throw is still active here.
     if (auto* domainHandler = process->domainErrorHandler()) {
         auto domainScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         MarkedArgumentBuffer domainArgs;
@@ -1347,9 +1343,7 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
             (void)domainScope.tryClearException();
             if (vm.hasPendingTerminationException()) [[unlikely]]
                 return true;
-            // A throw from a domain 'error' handler is fatal, like a throw from an
-            // 'uncaughtException' listener: the re-entrant report exits with code 7
-            // and prints the handler's error, not the one it was handling.
+            // Fatal like a throw from an 'uncaughtException' listener (exit code 7).
             Bun__reportUnhandledError(lexicalGlobalObject, JSValue::encode(JSValue(ex)));
             return true;
         }
@@ -1478,8 +1472,7 @@ extern "C" int Bun__handleUnhandledRejection(JSC::JSGlobalObject* lexicalGlobalO
         return true;
     auto* process = globalObject->processObject();
 
-    // handleRejectedPromises() restored the async context of the rejection, so
-    // node:domain's router sees the domain the promise was rejected under.
+    // handleRejectedPromises() restored the async context of the rejection.
     if (auto* domainHandler = process->domainErrorHandler()) {
         auto domainScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         MarkedArgumentBuffer args;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1331,6 +1331,32 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
         RETURN_IF_EXCEPTION(monitorScope, true);
     }
 
+    // node:domain gets the error before the capture callback and the
+    // 'uncaughtException' listeners, like node's domain-owned captureFn. The
+    // async context of the throw is still active here, so the router sees the
+    // domain the failing callback was created in. A rejection that reaches this
+    // path (--unhandled-rejections=strict or throw) is routed like a throw, as
+    // node's _fatalException does.
+    if (auto* domainHandler = process->domainErrorHandler()) {
+        auto domainScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        MarkedArgumentBuffer domainArgs;
+        domainArgs.append(exception);
+        domainArgs.append(jsString(vm, String("uncaughtException"_s)));
+        JSValue handled = call(lexicalGlobalObject, domainHandler, domainArgs, "domain error handler"_s);
+        if (auto* ex = domainScope.exception()) [[unlikely]] {
+            (void)domainScope.tryClearException();
+            if (vm.hasPendingTerminationException()) [[unlikely]]
+                return true;
+            // A throw from a domain 'error' handler is fatal, like a throw from an
+            // 'uncaughtException' listener: the re-entrant report exits with code 7
+            // and prints the handler's error, not the one it was handling.
+            Bun__reportUnhandledError(lexicalGlobalObject, JSValue::encode(JSValue(ex)));
+            return true;
+        }
+        if (handled.isTrue())
+            return true;
+    }
+
     auto uncaughtExceptionIdent = Identifier::fromString(JSC::getVM(globalObject), "uncaughtException"_s);
 
     // if there is an uncaughtExceptionCaptureCallback, call it and consider the exception handled
@@ -1451,6 +1477,20 @@ extern "C" int Bun__handleUnhandledRejection(JSC::JSGlobalObject* lexicalGlobalO
     if (vm.hasPendingTerminationException()) [[unlikely]]
         return true;
     auto* process = globalObject->processObject();
+
+    // handleRejectedPromises() restored the async context of the rejection, so
+    // node:domain's router sees the domain the promise was rejected under.
+    if (auto* domainHandler = process->domainErrorHandler()) {
+        auto domainScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        MarkedArgumentBuffer args;
+        args.append(reason);
+        args.append(jsString(vm, String("unhandledRejection"_s)));
+        args.append(promise);
+        JSValue handled = call(lexicalGlobalObject, domainHandler, args, "domain error handler"_s);
+        RETURN_IF_EXCEPTION(domainScope, true);
+        if (handled.isTrue())
+            return true;
+    }
 
     auto eventType = Identifier::fromString(vm, "unhandledRejection"_s);
     auto& wrapped = process->wrapped();
@@ -3725,6 +3765,7 @@ void Process::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_uncaughtExceptionCaptureCallback);
+    visitor.append(thisObject->m_domainErrorHandler);
     visitor.append(thisObject->m_nextTickFunction);
     visitor.append(thisObject->m_cachedCwd);
     visitor.append(thisObject->m_argv);
@@ -4348,6 +4389,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionReportUncaughtException, (JSC::JSGlobalObject
 {
     JSValue arg0 = callFrame->argument(0);
     Bun__reportUnhandledError(globalObject, JSValue::encode(arg0));
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionSetDomainErrorHandler, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    JSValue handler = callFrame->argument(0);
+    ASSERT(handler.isCallable());
+    defaultGlobalObject(globalObject)->processObject()->setDomainErrorHandler(handler.getObject());
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -27,6 +27,10 @@ class Process : public WebCore::JSEventEmitter {
     // Only used by internal code via passing to queueNextTick
     LazyProperty<Process, JSFunction> m_emitHelperFunction;
     WriteBarrier<Unknown> m_uncaughtExceptionCaptureCallback;
+    // node:domain's error router (jsFunctionSetDomainErrorHandler). It gets
+    // every uncaught exception and unhandled rejection before the listeners do
+    // and returns true when the active domain took the error.
+    WriteBarrier<JSObject> m_domainErrorHandler;
     WriteBarrier<JSObject> m_nextTickFunction;
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/bootstrap/switches/does_own_process_state.js#L113-L116
     WriteBarrier<JSString> m_cachedCwd;
@@ -131,6 +135,16 @@ public:
         return m_uncaughtExceptionCaptureCallback.get();
     }
 
+    inline void setDomainErrorHandler(JSC::JSObject* handler)
+    {
+        m_domainErrorHandler.set(vm(), this, handler);
+    }
+
+    inline JSC::JSObject* domainErrorHandler()
+    {
+        return m_domainErrorHandler.get();
+    }
+
     inline Structure* cpuUsageStructure() { return m_cpuUsageStructure.getInitializedOnMainThread(this); }
     inline Structure* resourceUsageStructure() { return m_resourceUsageStructure.getInitializedOnMainThread(this); }
     inline Structure* memoryUsageStructure() { return m_memoryUsageStructure.getInitializedOnMainThread(this); }
@@ -144,5 +158,8 @@ JSC_DECLARE_HOST_FUNCTION(Process_functionDlopen);
 // process.nextTick drain and, via $newCppFunction, by the node-style
 // callback shims in src/js.
 JSC_DECLARE_HOST_FUNCTION(jsFunctionReportUncaughtException);
+
+// Installs node:domain's error router (see Process::m_domainErrorHandler).
+JSC_DECLARE_HOST_FUNCTION(jsFunctionSetDomainErrorHandler);
 
 } // namespace Bun

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -27,9 +27,8 @@ class Process : public WebCore::JSEventEmitter {
     // Only used by internal code via passing to queueNextTick
     LazyProperty<Process, JSFunction> m_emitHelperFunction;
     WriteBarrier<Unknown> m_uncaughtExceptionCaptureCallback;
-    // node:domain's error router (jsFunctionSetDomainErrorHandler). It gets
-    // every uncaught exception and unhandled rejection before the listeners do
-    // and returns true when the active domain took the error.
+    // node:domain's router, set by jsFunctionSetDomainErrorHandler. Returns
+    // true when the active domain took the error.
     WriteBarrier<JSObject> m_domainErrorHandler;
     WriteBarrier<JSObject> m_nextTickFunction;
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/bootstrap/switches/does_own_process_state.js#L113-L116

--- a/src/jsc/bindings/PendingRejectionList.h
+++ b/src/jsc/bindings/PendingRejectionList.h
@@ -7,14 +7,9 @@
 
 namespace Bun {
 
-// Promises rejected with no handler attached yet, each paired with the async
-// context that was active when it was rejected. handleRejectedPromises()
-// restores that context while it reports the rejection, so 'unhandledRejection'
-// listeners and node:domain observe the AsyncLocalStorage state of the
-// rejection rather than the event loop's (node: promiseInfo.contextFrame).
-//
-// Same cellLock discipline as WriteBarrierList: every mutation and the GC
-// visit take the owner's cellLock.
+// Promises rejected with no handler yet, each with the async context active at
+// the rejection (node: promiseInfo.contextFrame). Same cellLock discipline as
+// WriteBarrierList.
 class PendingRejectionList {
 public:
     void append(JSC::VM& vm, JSC::JSCell* owner, JSC::JSPromise* promise, JSC::JSValue asyncContext)
@@ -34,8 +29,7 @@ public:
         });
     }
 
-    // Move every entry out under one cellLock. promises[i] and asyncContexts[i]
-    // describe the same rejection.
+    // promises[i] and asyncContexts[i] describe the same rejection.
     void drainTo(JSC::JSCell* owner, JSC::MarkedArgumentBuffer& promises, JSC::MarkedArgumentBuffer& asyncContexts)
     {
         WTF::Locker locker { owner->cellLock() };

--- a/src/jsc/bindings/PendingRejectionList.h
+++ b/src/jsc/bindings/PendingRejectionList.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <wtf/Vector.h>
+#include <JavaScriptCore/ArgList.h>
+#include <JavaScriptCore/JSPromise.h>
+#include <JavaScriptCore/WriteBarrier.h>
+
+namespace Bun {
+
+// Promises rejected with no handler attached yet, each paired with the async
+// context that was active when it was rejected. handleRejectedPromises()
+// restores that context while it reports the rejection, so 'unhandledRejection'
+// listeners and node:domain observe the AsyncLocalStorage state of the
+// rejection rather than the event loop's (node: promiseInfo.contextFrame).
+//
+// Same cellLock discipline as WriteBarrierList: every mutation and the GC
+// visit take the owner's cellLock.
+class PendingRejectionList {
+public:
+    void append(JSC::VM& vm, JSC::JSCell* owner, JSC::JSPromise* promise, JSC::JSValue asyncContext)
+    {
+        WTF::Locker locker { owner->cellLock() };
+        m_entries.append(Entry {
+            JSC::WriteBarrier<JSC::JSPromise>(vm, owner, promise),
+            JSC::WriteBarrier<JSC::Unknown>(vm, owner, asyncContext),
+        });
+    }
+
+    bool remove(JSC::JSCell* owner, JSC::JSPromise* promise)
+    {
+        WTF::Locker locker { owner->cellLock() };
+        return m_entries.removeFirstMatching([&](const Entry& entry) {
+            return entry.promise.get() == promise;
+        });
+    }
+
+    // Move every entry out under one cellLock. promises[i] and asyncContexts[i]
+    // describe the same rejection.
+    void drainTo(JSC::JSCell* owner, JSC::MarkedArgumentBuffer& promises, JSC::MarkedArgumentBuffer& asyncContexts)
+    {
+        WTF::Locker locker { owner->cellLock() };
+        promises.ensureCapacity(promises.size() + m_entries.size());
+        asyncContexts.ensureCapacity(asyncContexts.size() + m_entries.size());
+        for (Entry& entry : m_entries) {
+            if (auto* promise = entry.promise.get()) {
+                promises.append(promise);
+                asyncContexts.append(entry.asyncContext.get());
+            }
+        }
+        m_entries.clear();
+    }
+
+    template<typename Visitor>
+    void visit(JSC::JSCell* owner, Visitor& visitor)
+    {
+        WTF::Locker locker { owner->cellLock() };
+        for (auto& entry : m_entries) {
+            visitor.append(entry.promise);
+            visitor.append(entry.asyncContext);
+        }
+    }
+
+    bool isEmpty() const
+    {
+        return m_entries.isEmpty();
+    }
+
+private:
+    struct Entry {
+        JSC::WriteBarrier<JSC::JSPromise> promise;
+        JSC::WriteBarrier<JSC::Unknown> asyncContext;
+    };
+
+    WTF::Vector<Entry> m_entries;
+};
+
+}

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1066,13 +1066,10 @@ void GlobalObject::promiseRejectionTracker(JSGlobalObject* obj, JSC::JSPromise* 
 
     switch (operation) {
     case JSPromiseRejectionOperation::Reject:
-        globalObj->m_aboutToBeNotifiedRejectedPromises.append(obj->vm(), globalObj, promise);
+        globalObj->m_aboutToBeNotifiedRejectedPromises.append(obj->vm(), globalObj, promise, obj->m_asyncContextData.get()->getInternalField(0));
         break;
     case JSPromiseRejectionOperation::Handle:
-        bool removed = globalObj->m_aboutToBeNotifiedRejectedPromises.removeFirstMatching(globalObj, [&](JSC::WriteBarrier<JSC::JSPromise>& unhandledPromise) {
-            return unhandledPromise.get() == promise;
-        });
-        if (removed) break;
+        if (globalObj->m_aboutToBeNotifiedRejectedPromises.remove(globalObj, promise)) break;
         // handleRejectedPromises() drains the list into a local buffer before
         // running any handler. A handler may .catch() a later still-queued
         // promise; that promise is no longer in m_aboutToBeNotifiedRejectedPromises
@@ -3245,21 +3242,29 @@ void GlobalObject::handleRejectedPromises()
         // the same pattern JSC's VM::didExhaustMicrotaskQueue and WebCore's
         // RejectedPromiseTracker use.
         JSC::MarkedArgumentBuffer promises;
-        m_aboutToBeNotifiedRejectedPromises.drainTo(this, promises);
+        JSC::MarkedArgumentBuffer asyncContexts;
+        m_aboutToBeNotifiedRejectedPromises.drainTo(this, promises, asyncContexts);
         RELEASE_ASSERT(!promises.hasOverflowed());
+        RELEASE_ASSERT(!asyncContexts.hasOverflowed());
         // Expose the not-yet-processed tail so promiseRejectionTracker(Handle)
         // can tell "still pending" apart from "already notified". Linked as a
         // stack so a re-entrant handleRejectedPromises() (a handler that ticks
         // the event loop) restores the outer frame instead of nulling it.
         InFlightRejections inflight { &promises, 0, m_rejectedPromisesBeingProcessed };
         WTF::SetForScope inflightScope(m_rejectedPromisesBeingProcessed, &inflight);
+        auto* asyncContextData = m_asyncContextData.get();
         for (size_t i = 0, size = promises.size(); i < size; ++i) {
             auto* promise = static_cast<JSC::JSPromise*>(promises.at(i).asCell());
             if (promise->isHandled())
                 continue;
             inflight.index = i + 1;
 
+            // Report under the async context that was active when the promise
+            // rejected, the way node restores promiseInfo.contextFrame.
+            JSValue previousAsyncContext = asyncContextData->getInternalField(0);
+            asyncContextData->putInternalField(virtual_machine, 0, asyncContexts.at(i));
             Bun__handleRejectedPromise(this, promise);
+            asyncContextData->putInternalField(virtual_machine, 0, previousAsyncContext);
             if (auto ex = scope.exception()) {
                 if (virtual_machine.isTerminationException(ex)) [[unlikely]]
                     return;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3259,8 +3259,7 @@ void GlobalObject::handleRejectedPromises()
                 continue;
             inflight.index = i + 1;
 
-            // Report under the async context that was active when the promise
-            // rejected, the way node restores promiseInfo.contextFrame.
+            // Report under the async context of the rejection (node: promiseInfo.contextFrame).
             JSValue previousAsyncContext = asyncContextData->getInternalField(0);
             asyncContextData->putInternalField(virtual_machine, 0, asyncContexts.at(i));
             Bun__handleRejectedPromise(this, promise);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -70,6 +70,7 @@ struct node_module;
 #include <node_api.h>
 #include "BakeAdditionsToGlobalObject.h"
 #include "WriteBarrierList.h"
+#include "PendingRejectionList.h"
 #include "NativeModuleList.h"
 #include "streams/JSStreamsRuntime.h"
 
@@ -810,7 +811,7 @@ private:
     DOMGuardedObjectSet m_guardedObjects WTF_GUARDED_BY_LOCK(m_gcLock);
     WebCore::SubtleCrypto* m_subtleCrypto = nullptr;
 
-    Bun::WriteBarrierList<JSC::JSPromise> m_aboutToBeNotifiedRejectedPromises;
+    Bun::PendingRejectionList m_aboutToBeNotifiedRejectedPromises;
 
 public:
     // While handleRejectedPromises() is iterating its drained snapshot, this

--- a/test/js/node/async_hooks/async-context/async-context-process-unhandledRejection.js
+++ b/test/js/node/async_hooks/async-context/async-context-process-unhandledRejection.js
@@ -1,0 +1,31 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+// 'unhandledRejection' runs under the async context that was active when the
+// promise rejected, not the event loop's.
+const expected = ["sync reject", "reaction throw"];
+const seen = [];
+
+process.on("unhandledRejection", reason => {
+  const store = asyncLocalStorage.getStore()?.test;
+  if (store !== reason.message) {
+    console.error(`FAIL: unhandledRejection for "${reason.message}" ran with store ${JSON.stringify(store)}`);
+    process.exit(1);
+  }
+  seen.push(reason.message);
+  if (seen.length === expected.length) {
+    process.exit(0);
+  }
+});
+
+asyncLocalStorage.run({ test: "sync reject" }, () => {
+  Promise.reject(new Error("sync reject"));
+});
+
+asyncLocalStorage.run({ test: "reaction throw" }, () => {
+  Promise.resolve().then(() => {
+    throw new Error("reaction throw");
+  });
+});

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -341,6 +341,26 @@ describe.concurrent("node:domain without a handler and with nested domains", () 
     expect(exitCode).toBe(1);
   });
 
+  test("a listener throw caught in one callback does not make a later async throw synchronous", async () => {
+    // the caught throw skips the exit() that emit() would have run after the listener
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const inner = domain.create();
+        d.run(() => inner.run(() => {
+          process.nextTick(() => {
+            const ee = new EventEmitter();
+            ee.on("x", () => { throw new Error("caught"); });
+            try { ee.emit("x"); } catch {}
+            console.log("caught", process.domain === inner);
+          });
+          setTimeout(() => { throw new Error("boom"); }, 1);
+        }));`,
+    );
+    expect(stdout).toBe("caught true\nuncaughtException:boom active=undefined\n");
+    expect(exitCode).toBe(1);
+  });
+
   test("an inner domain with a listener handles its own async errors", async () => {
     const { stdout, exitCode } = await run(
       prelude +

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -170,9 +170,17 @@ describe.concurrent("node:domain EventEmitter integration", () => {
         d.add(other);
         d.remove(other);
         console.log(ee.domain === d, other.domain, d.members.length, Object.keys(ee).includes("domain"));
+        // a domain cannot be added to itself or to one of its own members
+        const child = domain.create();
+        d.add(child);
+        d.add(d);
+        child.add(d);
+        console.log(d.domain, child.domain === d, d.members.length);
         setTimeout(() => ee.emit("error", new Error("boom")), 1);`,
     );
-    expect(stdout).toBe("true null 1 false\ndomain:boom thrown=false d=true emitter=EventEmitter active=undefined\n");
+    expect(stdout).toBe(
+      "true null 1 false\nnull true 2\ndomain:boom thrown=false d=true emitter=EventEmitter active=undefined\n",
+    );
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -365,6 +365,26 @@ describe.concurrent("node:domain without a handler and with nested domains", () 
     expect(exitCode).toBe(0);
   });
 
+  test("a throw in a child domain added to its parent reaches the parent's handler once", async () => {
+    const { stdout, exitCode } = await run(
+      `
+      const domain = require("node:domain");
+      const parent = domain.create();
+      const child = domain.create();
+      parent.add(child);
+      let calls = 0;
+      parent.on("error", e => {
+        calls++;
+        console.log("parent:" + e.message, "emitter=" + (e.domainEmitter === child), "d=" + (e.domain === parent));
+      });
+      process.on("uncaughtException", e => { console.log("uncaughtException:" + e.message); process.exit(1); });
+      setTimeout(() => { console.log("calls", calls); process.exit(0); }, 1);
+      parent.run(() => child.run(() => { throw new Error("boom"); }));`,
+    );
+    expect(stdout).toBe("parent:boom emitter=true d=true\ncalls 1\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("a top-level 'error' handler that throws is fatal with exit code 7", async () => {
     const { stdout, stderr, exitCode } = await run(
       `

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -176,6 +176,36 @@ describe.concurrent("node:domain EventEmitter integration", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("an emitter with captureRejections keeps its own emit and still enters the domain", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        let ee;
+        d.run(() => {
+          ee = new EventEmitter({ captureRejections: true });
+          ee.on("x", () => { console.log("listener", process.domain === d); throw new Error("boom"); });
+        });
+        console.log(Object.hasOwn(ee, "emit"));
+        setTimeout(() => ee.emit("x"), 1);`,
+    );
+    expect(stdout).toBe(`true\nlistener true\ndomain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("an emitter with captureRejections routes 'error' without listeners to its domain", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        let ee;
+        d.run(() => {
+          ee = new EventEmitter({ captureRejections: true });
+        });
+        setTimeout(() => ee.emit("error", new Error("boom")), 1);`,
+    );
+    expect(stdout).toBe("domain:boom thrown=false d=true emitter=EventEmitter active=undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("EventEmitter.usingDomains and EventEmitter.init", async () => {
     // `bun -e` preloads a builtin for every identifier named like one, so the
     // module is bound to `dom` to keep the first line before the load.
@@ -284,6 +314,20 @@ describe.concurrent("node:domain without a handler and with nested domains", () 
         `
         const inner = domain.create();
         d.run(() => inner.run(() => setTimeout(() => { throw new Error("boom"); }, 1)));`,
+    );
+    expect(stdout).toBe("uncaughtException:boom active=undefined\n");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a run() that completed in an earlier callback does not make a later async throw synchronous", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const inner = domain.create();
+        d.run(() => inner.run(() => setTimeout(() => {
+          inner.run(() => {});
+          setTimeout(() => { throw new Error("boom"); }, 1);
+        }, 1)));`,
     );
     expect(stdout).toBe("uncaughtException:boom active=undefined\n");
     expect(exitCode).toBe(1);

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function run(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// One domain with an 'error' listener plus process-level fallbacks. Every
+// route prints one line and exits with a distinct code, so a test can tell the
+// domain handler (0) from 'uncaughtException' (1) and 'unhandledRejection' (2).
+const prelude = `
+  const domain = require("node:domain");
+  const EventEmitter = require("node:events");
+  const d = domain.create();
+  d.on("error", e => {
+    console.log("domain:" + e.message, "thrown=" + e.domainThrown, "d=" + (e.domain === d),
+      "emitter=" + (e.domainEmitter ? e.domainEmitter.constructor.name : "none"),
+      "active=" + String(process.domain));
+    process.exit(0);
+  });
+  process.on("uncaughtException", e => { console.log("uncaughtException:" + e.message, "active=" + String(process.domain)); process.exit(1); });
+  process.on("unhandledRejection", e => { console.log("unhandledRejection:" + e.message); process.exit(2); });
+`;
+
+const thrown = "thrown=true d=true emitter=none active=undefined";
+
+describe.concurrent("node:domain routes errors from async callbacks created inside the domain", () => {
+  test("setTimeout", async () => {
+    const { stdout, exitCode } = await run(prelude + `d.run(() => setTimeout(() => { throw new Error("boom"); }, 1));`);
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("setImmediate", async () => {
+    const { stdout, exitCode } = await run(prelude + `d.run(() => setImmediate(() => { throw new Error("boom"); }));`);
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("process.nextTick", async () => {
+    const { stdout, exitCode } = await run(
+      prelude + `d.run(() => process.nextTick(() => { throw new Error("boom"); }));`,
+    );
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a timer created by a timer", async () => {
+    const { stdout, exitCode } = await run(
+      prelude + `d.run(() => setTimeout(() => setTimeout(() => { throw new Error("boom"); }, 1), 1));`,
+    );
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("fs callback", async () => {
+    const { stdout, exitCode } = await run(
+      prelude + `d.run(() => require("fs").stat(".", () => { throw new Error("boom"); }));`,
+    );
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("net socket event", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const net = require("net");
+        const server = net.createServer(s => s.end()).listen(0, () => {
+          d.run(() => {
+            const c = net.connect(server.address().port);
+            c.on("connect", () => { throw new Error("boom"); });
+          });
+        });`,
+    );
+    expect(stdout).toStartWith("domain:boom ");
+    expect(exitCode).toBe(0);
+  });
+
+  test("process.domain and domain.active inside the callback", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        console.log("before", process.domain === undefined, domain.active === null, domain._stack.length);
+        d.run(() => {
+          console.log("inside", process.domain === d, domain.active === d, domain._stack.length);
+          setTimeout(() => {
+            console.log("timer", process.domain === d, domain.active === d, domain._stack.length);
+            process.exit(0);
+          }, 1);
+        });
+        console.log("after", process.domain === undefined, domain.active === null, domain._stack.length);`,
+    );
+    expect(stdout).toBe("before true true 0\ninside true true 1\nafter true true 0\ntimer true true 1\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("node:domain routes unhandled rejections", () => {
+  test("Promise.reject inside run()", async () => {
+    const { stdout, exitCode } = await run(prelude + `d.run(() => { Promise.reject(new Error("boom")); });`);
+    // node hands the reason to the domain without the thrown-error decoration
+    expect(stdout).toBe("domain:boom thrown=undefined d=false emitter=none active=undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a throw after await", async () => {
+    const { stdout, exitCode } = await run(
+      prelude + `d.run(async () => { await new Promise(r => setTimeout(r, 1)); throw new Error("boom"); });`,
+    );
+    expect(stdout).toBe("domain:boom thrown=undefined d=false emitter=none active=undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a domain without an 'error' listener leaves the rejection to the process", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const quiet = domain.create();
+        quiet.run(() => { Promise.reject(new Error("boom")); });`,
+    );
+    expect(stdout).toBe("unhandledRejection:boom\n");
+    expect(exitCode).toBe(2);
+  });
+});
+
+describe.concurrent("node:domain EventEmitter integration", () => {
+  test("an emitter created inside the domain routes 'error' without listeners to it", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        d.run(() => {
+          const ee = new EventEmitter();
+          setTimeout(() => ee.emit("error", new Error("boom")), 1);
+        });`,
+    );
+    expect(stdout).toBe("domain:boom thrown=false d=true emitter=EventEmitter active=undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("an emitter created inside the domain enters it for every emit", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        let ee;
+        d.run(() => {
+          ee = new EventEmitter();
+          ee.on("x", () => { throw new Error("boom"); });
+        });
+        setTimeout(() => ee.emit("x"), 1);`,
+    );
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("d.add(ee) and d.remove(ee)", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const ee = new EventEmitter();
+        const other = new EventEmitter();
+        d.add(ee);
+        d.add(other);
+        d.remove(other);
+        console.log(ee.domain === d, other.domain, d.members.length, Object.keys(ee).includes("domain"));
+        setTimeout(() => ee.emit("error", new Error("boom")), 1);`,
+    );
+    expect(stdout).toBe("true null 1 false\ndomain:boom thrown=false d=true emitter=EventEmitter active=undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("EventEmitter.usingDomains and EventEmitter.init", async () => {
+    // `bun -e` preloads a builtin for every identifier named like one, so the
+    // module is bound to `dom` to keep the first line before the load.
+    const { stdout, exitCode } = await run(
+      `
+      const EventEmitter = require("node:events");
+      const init = EventEmitter.init;
+      console.log(EventEmitter.usingDomains, "domain" in new EventEmitter());
+      const dom = process.getBuiltinModule("node:domain");
+      console.log(EventEmitter.usingDomains, EventEmitter.init !== init, "domain" in new EventEmitter(), new EventEmitter().domain);
+      class Sub extends EventEmitter {}
+      const d = dom.create();
+      const sub = d.run(() => new Sub());
+      console.log(sub.domain === d, d.domain, new EventEmitter().domain, sub instanceof Sub, sub.listenerCount("x"));`,
+    );
+    expect(stdout).toBe("false false\ntrue true true null\ntrue null null true 0\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("node:domain run, bind and intercept", () => {
+  test("a synchronous throw inside run() is handled and does not return to the caller", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        d.run(() => { throw new Error("boom"); });
+        console.log("unreachable");`,
+    );
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("run() returns the callback's result and passes arguments", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const result = d.run(function (a, b) { return [this === d, a, b, process.domain === d]; }, 1, 2);
+        console.log(JSON.stringify(result), process.domain);`,
+    );
+    expect(stdout).toBe("[true,1,2,true] undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bind()", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const fn = d.bind(function (a) { console.log("bound", a, this.tag, process.domain === d); throw new Error("boom"); });
+        console.log(fn.domain === d);
+        setTimeout(() => fn.call({ tag: "t" }, 42), 1);`,
+    );
+    expect(stdout).toBe(`true\nbound 42 t true\ndomain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("intercept() with an error argument", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        d.prependListener("error", e => console.log("bound=" + (e.domainBound === cb)));
+        const cb = () => { throw new Error("not called"); };
+        setTimeout(d.intercept(cb), 1, new Error("boom"));`,
+    );
+    expect(stdout).toBe("bound=true\ndomain:boom thrown=false d=true emitter=none active=undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("intercept() without an error argument drops the first argument", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        setTimeout(d.intercept((a, b) => { console.log("intercepted", a, b, process.domain === d); throw new Error("boom"); }), 1, null, 1, 2);`,
+    );
+    expect(stdout).toBe(`intercepted 1 2 true\ndomain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("node:domain without a handler and with nested domains", () => {
+  test("a domain without an 'error' listener leaves the error to 'uncaughtException' with the stack cleared", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const quiet = domain.create();
+        quiet.run(() => setTimeout(() => { throw new Error("boom"); }, 1));`,
+    );
+    expect(stdout).toBe("uncaughtException:boom active=undefined\n");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a synchronous throw in an inner domain without a listener goes to the outer domain", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const inner = domain.create();
+        d.run(() => inner.run(() => { throw new Error("boom"); }));`,
+    );
+    expect(stdout).toBe(`domain:boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("an async throw in an inner domain without a listener is not handed to the outer domain", async () => {
+    // node: the timer callback runs with only the inner domain active
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const inner = domain.create();
+        d.run(() => inner.run(() => setTimeout(() => { throw new Error("boom"); }, 1)));`,
+    );
+    expect(stdout).toBe("uncaughtException:boom active=undefined\n");
+    expect(exitCode).toBe(1);
+  });
+
+  test("an inner domain with a listener handles its own async errors", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const inner = domain.create();
+        inner.on("error", e => { console.log("inner:" + e.message, process.domain === d, domain._stack.length); process.exit(3); });
+        d.run(() => inner.run(() => setTimeout(() => { throw new Error("boom"); }, 1)));`,
+    );
+    expect(stdout).toBe("inner:boom true 1\n");
+    expect(exitCode).toBe(3);
+  });
+
+  test("an 'error' handler that throws hands its error to the outer domain", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const inner = domain.create();
+        inner.on("error", e => { throw new Error("from handler: " + e.message); });
+        d.run(() => inner.run(() => { throw new Error("boom"); }));`,
+    );
+    expect(stdout).toBe(`domain:from handler: boom ${thrown}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a top-level 'error' handler that throws is fatal with exit code 7", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `
+      const domain = require("node:domain");
+      const d = domain.create();
+      d.on("error", () => { throw new Error("exception from domain error handler"); });
+      d.run(() => process.nextTick(() => { throw new Error("You should NOT see me"); }));`,
+    );
+    expect(stdout).toBe("");
+    expect(stderr).toContain("exception from domain error handler");
+    expect(stderr).not.toContain("You should NOT see me");
+    expect(exitCode).toBe(7);
+  });
+});
+
+describe.concurrent("node:domain per-request error handling", () => {
+  test("an http server answers 500 instead of dying when a request's timer throws", async () => {
+    const { stdout, exitCode } = await run(
+      `
+      const domain = require("node:domain");
+      const http = require("http");
+      process.on("uncaughtException", e => { console.log("uncaughtException:" + e.message); process.exit(1); });
+      const server = http.createServer((req, res) => {
+        const d = domain.create();
+        d.on("error", e => {
+          res.statusCode = 500;
+          res.end("handled: " + e.message);
+        });
+        d.run(() => setTimeout(() => { throw new Error("boom"); }, 1));
+      }).listen(0, async () => {
+        const res = await fetch("http://localhost:" + server.address().port);
+        console.log(res.status, await res.text());
+        server.close();
+      });`,
+    );
+    expect(stdout).toBe("500 handled: boom\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/test/parallel/test-domain-add-remove.js
+++ b/test/js/node/test/parallel/test-domain-add-remove.js
@@ -1,0 +1,30 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const EventEmitter = require('events');
+const isEnumerable = Function.call.bind(Object.prototype.propertyIsEnumerable);
+
+const d = new domain.Domain();
+const e = new EventEmitter();
+const e2 = new EventEmitter();
+
+d.add(e);
+assert.strictEqual(e.domain, d);
+assert.strictEqual(isEnumerable(e, 'domain'), false);
+
+// Adding the same event to a domain should not change the member count
+let previousMemberCount = d.members.length;
+d.add(e);
+assert.strictEqual(previousMemberCount, d.members.length);
+
+d.add(e2);
+assert.strictEqual(e2.domain, d);
+assert.strictEqual(isEnumerable(e2, 'domain'), false);
+
+previousMemberCount = d.members.length;
+d.remove(e2);
+assert.notStrictEqual(e2.domain, d);
+assert.strictEqual(isEnumerable(e2, 'domain'), false);
+assert.strictEqual(previousMemberCount - 1, d.members.length);

--- a/test/js/node/test/parallel/test-domain-bind-timeout.js
+++ b/test/js/node/test/parallel/test-domain-bind-timeout.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+const d = new domain.Domain();
+
+d.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'foobar');
+  assert.strictEqual(err.domain, d);
+  assert.strictEqual(err.domainEmitter, undefined);
+  assert.strictEqual(err.domainBound, undefined);
+  assert.strictEqual(err.domainThrown, true);
+}));
+
+setTimeout(d.bind(() => { throw new Error('foobar'); }), 1);

--- a/test/js/node/test/parallel/test-domain-ee-implicit.js
+++ b/test/js/node/test/parallel/test-domain-ee-implicit.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const EventEmitter = require('events');
+
+const d = new domain.Domain();
+let implicit;
+
+d.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'foobar');
+  assert.strictEqual(err.domain, d);
+  assert.strictEqual(err.domainEmitter, implicit);
+  assert.strictEqual(err.domainBound, undefined);
+  assert.strictEqual(err.domainThrown, false);
+}));
+
+// Implicit addition of the EventEmitter by being created within a domain-bound
+// context.
+d.run(common.mustCall(() => {
+  implicit = new EventEmitter();
+}));
+
+setTimeout(common.mustCall(() => {
+  // Escape from the domain, but implicit is still bound to it.
+  implicit.emit('error', new Error('foobar'));
+}), 1);

--- a/test/js/node/test/parallel/test-domain-ee.js
+++ b/test/js/node/test/parallel/test-domain-ee.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const EventEmitter = require('events');
+
+const d = new domain.Domain();
+const e = new EventEmitter();
+
+d.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'foobar');
+  assert.strictEqual(err.domain, d);
+  assert.strictEqual(err.domainEmitter, e);
+  assert.strictEqual(err.domainBound, undefined);
+  assert.strictEqual(err.domainThrown, false);
+}));
+
+d.add(e);
+e.emit('error', new Error('foobar'));
+
+{
+  // Ensure initial params pass to origin `EventEmitter.init` function
+  const e = new EventEmitter({ captureRejections: true });
+  const kCapture = Object.getOwnPropertySymbols(e)
+    .find((it) => it.description === 'kCapture');
+  assert.strictEqual(e[kCapture], true);
+}

--- a/test/js/node/test/parallel/test-domain-emit-error-handler-stack.js
+++ b/test/js/node/test/parallel/test-domain-emit-error-handler-stack.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const EventEmitter = require('events');
+
+// Make sure that the domains stack and the active domain is setup properly when
+// a domain's error handler is called due to an error event being emitted.
+// More specifically, we want to test that:
+// - the active domain in the domain's error handler is//not* that domain,//but*
+//   the active domain is a any direct parent domain at the time the error was
+//   emitted.
+// - the domains stack in the domain's error handler does//not* include that
+//   domain, *but* it includes all parents of that domain when the error was
+//   emitted.
+const d1 = domain.create();
+const d2 = domain.create();
+const d3 = domain.create();
+
+function checkExpectedDomains(err) {
+  // First, check that domains stack and active domain is as expected when the
+  // event handler is called synchronously via ee.emit('error').
+  if (domain._stack.length !== err.expectedStackLength) {
+    console.error('expected domains stack length of %d, but instead is %d',
+                  err.expectedStackLength, domain._stack.length);
+    process.exit(1);
+  }
+
+  if (process.domain !== err.expectedActiveDomain) {
+    console.error('expected active domain to be %j, but instead is %j',
+                  err.expectedActiveDomain, process.domain);
+    process.exit(1);
+  }
+
+  // Then make sure that the domains stack and active domain is setup as
+  // expected when executing a callback scheduled via nextTick from the error
+  // handler.
+  // Note: With AsyncLocalStorage-based domains, async callbacks inherit the
+  // full stack from when they were scheduled, so stack length matches the
+  // sync context.
+  process.nextTick(() => {
+    const expectedStackLengthInNextTickCb = err.expectedStackLength;
+    if (domain._stack.length !== expectedStackLengthInNextTickCb) {
+      console.error('expected stack length in nextTick cb to be %d, ' +
+                'but instead is %d', expectedStackLengthInNextTickCb,
+                    domain._stack.length);
+      process.exit(1);
+    }
+
+    const expectedActiveDomainInNextTickCb =
+            expectedStackLengthInNextTickCb === 0 ? undefined :
+              err.expectedActiveDomain;
+    if (process.domain !== expectedActiveDomainInNextTickCb) {
+      console.error('expected active domain in nextTick cb to be %j, ' +
+                'but instead is %j', expectedActiveDomainInNextTickCb,
+                    process.domain);
+      process.exit(1);
+    }
+  });
+}
+
+d1.on('error', common.mustCall((err) => {
+  checkExpectedDomains(err);
+}, 2));
+
+d2.on('error', common.mustCall((err) => {
+  checkExpectedDomains(err);
+}, 2));
+
+d3.on('error', common.mustCall((err) => {
+  checkExpectedDomains(err);
+}, 1));
+
+d1.run(common.mustCall(() => {
+  const ee = new EventEmitter();
+  assert.strictEqual(process.domain, d1);
+  assert.strictEqual(domain._stack.length, 1);
+
+  const err = new Error('oops');
+  err.expectedStackLength = 0;
+  err.expectedActiveDomain = undefined;
+  ee.emit('error', err);
+
+  assert.strictEqual(process.domain, d1);
+  assert.strictEqual(domain._stack.length, 1);
+}));
+
+d1.run(common.mustCall(() => {
+  d1.run(common.mustCall(() => {
+    const ee = new EventEmitter();
+
+    assert.strictEqual(process.domain, d1);
+    assert.strictEqual(domain._stack.length, 2);
+
+    const err = new Error('oops');
+    err.expectedStackLength = 0;
+    err.expectedActiveDomain = undefined;
+    ee.emit('error', err);
+
+    assert.strictEqual(process.domain, d1);
+    assert.strictEqual(domain._stack.length, 2);
+  }));
+}));
+
+d1.run(common.mustCall(() => {
+  d2.run(common.mustCall(() => {
+    const ee = new EventEmitter();
+
+    assert.strictEqual(process.domain, d2);
+    assert.strictEqual(domain._stack.length, 2);
+
+    const err = new Error('oops');
+    err.expectedStackLength = 1;
+    err.expectedActiveDomain = d1;
+    ee.emit('error', err);
+
+    assert.strictEqual(process.domain, d2);
+    assert.strictEqual(domain._stack.length, 2);
+  }));
+}));
+
+d1.run(common.mustCall(() => {
+  d2.run(common.mustCall(() => {
+    d2.run(common.mustCall(() => {
+      const ee = new EventEmitter();
+
+      assert.strictEqual(process.domain, d2);
+      assert.strictEqual(domain._stack.length, 3);
+
+      const err = new Error('oops');
+      err.expectedStackLength = 1;
+      err.expectedActiveDomain = d1;
+      ee.emit('error', err);
+
+      assert.strictEqual(process.domain, d2);
+      assert.strictEqual(domain._stack.length, 3);
+    }));
+  }));
+}));
+
+d3.run(common.mustCall(() => {
+  d1.run(common.mustCall(() => {
+    d3.run(common.mustCall(() => {
+      d3.run(common.mustCall(() => {
+        const ee = new EventEmitter();
+
+        assert.strictEqual(process.domain, d3);
+        assert.strictEqual(domain._stack.length, 4);
+
+        const err = new Error('oops');
+        err.expectedStackLength = 2;
+        err.expectedActiveDomain = d1;
+        ee.emit('error', err);
+
+        assert.strictEqual(process.domain, d3);
+        assert.strictEqual(domain._stack.length, 4);
+      }));
+    }));
+  }));
+}));

--- a/test/js/node/test/parallel/test-domain-enter-exit.js
+++ b/test/js/node/test/parallel/test-domain-enter-exit.js
@@ -1,0 +1,60 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+// Make sure the domain stack is a stack
+
+require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+function names(array) {
+  return array.map(function(d) {
+    return d.name;
+  }).join(', ');
+}
+
+const a = domain.create();
+a.name = 'a';
+const b = domain.create();
+b.name = 'b';
+const c = domain.create();
+c.name = 'c';
+
+a.enter(); // push
+assert.deepStrictEqual(domain._stack, [a],
+                       `a not pushed: ${names(domain._stack)}`);
+
+b.enter(); // push
+assert.deepStrictEqual(domain._stack, [a, b],
+                       `b not pushed: ${names(domain._stack)}`);
+
+c.enter(); // push
+assert.deepStrictEqual(domain._stack, [a, b, c],
+                       `c not pushed: ${names(domain._stack)}`);
+
+b.exit(); // pop
+assert.deepStrictEqual(domain._stack, [a],
+                       `b and c not popped: ${names(domain._stack)}`);
+
+b.enter(); // push
+assert.deepStrictEqual(domain._stack, [a, b],
+                       `b not pushed: ${names(domain._stack)}`);

--- a/test/js/node/test/parallel/test-domain-error-handler-throw-no-recursion.js
+++ b/test/js/node/test/parallel/test-domain-error-handler-throw-no-recursion.js
@@ -1,0 +1,45 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+// Test that when a domain's error handler throws, the exception does NOT
+// recursively call the same domain's error handler. Instead, it should
+// propagate to the parent domain or crash the process.
+
+let d1ErrorCount = 0;
+let d2ErrorCount = 0;
+
+const d1 = domain.create();
+const d2 = domain.create();
+
+d1.on('error', common.mustCall((err) => {
+  d1ErrorCount++;
+  assert.strictEqual(err.message, 'from d2 error handler');
+  // d1 should only be called once - when d2's error handler throws
+  assert.strictEqual(d1ErrorCount, 1);
+}));
+
+d2.on('error', common.mustCall((err) => {
+  d2ErrorCount++;
+  // d2's error handler should only be called once for the original error
+  assert.strictEqual(d2ErrorCount, 1);
+  assert.strictEqual(err.message, 'original error');
+  // Throwing here should go to d1, NOT back to d2
+  throw new Error('from d2 error handler');
+}));
+
+d1.run(() => {
+  d2.run(() => {
+    // Emit an error on an EventEmitter bound to d2
+    const EventEmitter = require('events');
+    const ee = new EventEmitter();
+    d2.add(ee);
+
+    // This should:
+    // 1. Call d2's error handler with 'original error'
+    // 2. d2's error handler throws 'from d2 error handler'
+    // 3. That exception should go to d1's error handler, NOT d2 again
+    ee.emit('error', new Error('original error'));
+  });
+});

--- a/test/js/node/test/parallel/test-domain-error-types.js
+++ b/test/js/node/test/parallel/test-domain-error-types.js
@@ -1,0 +1,26 @@
+// Flags: --gc-interval=100 --stress-compaction
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+// This test is similar to test-domain-multiple-errors, but uses a new domain
+// for each errors.
+// The test flags are not essential, but serve as a way to verify that
+// https://github.com/nodejs/node/issues/28275 is fixed in debug mode.
+
+for (const something of [
+  42, null, undefined, false, () => {}, 'string', Symbol('foo'),
+]) {
+  const d = new domain.Domain();
+  d.run(common.mustCall(() => {
+    process.nextTick(common.mustCall(() => {
+      throw something;
+    }));
+  }));
+
+  d.on('error', common.mustCall((err) => {
+    assert.strictEqual(something, err);
+  }));
+}

--- a/test/js/node/test/parallel/test-domain-from-timer.js
+++ b/test/js/node/test/parallel/test-domain-from-timer.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+// Simple tests of most basic domain functionality.
+
+require('../common');
+const assert = require('assert');
+
+// Timeouts call the callback directly from cc, so need to make sure the
+// domain will be used regardless
+setTimeout(() => {
+  const domain = require('domain');
+  const d = domain.create();
+  d.run(() => {
+    process.nextTick(() => {
+      console.trace('in nexttick', process.domain === d);
+      assert.strictEqual(process.domain, d);
+    });
+  });
+}, 1);

--- a/test/js/node/test/parallel/test-domain-fs-enoent-stream.js
+++ b/test/js/node/test/parallel/test-domain-fs-enoent-stream.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const fs = require('fs');
+
+const d = new domain.Domain();
+
+const fst = fs.createReadStream('stream for nonexistent file');
+
+d.on('error', common.mustCall((err) => {
+  assert.ok(err.message.match(/^ENOENT: no such file or directory, open '/));
+  assert.strictEqual(err.domain, d);
+  assert.strictEqual(err.domainEmitter, fst);
+  assert.strictEqual(err.domainBound, undefined);
+  assert.strictEqual(err.domainThrown, false);
+}));
+
+d.add(fst);

--- a/test/js/node/test/parallel/test-domain-http-server.js
+++ b/test/js/node/test/parallel/test-domain-http-server.js
@@ -1,0 +1,118 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const domain = require('domain');
+const http = require('http');
+const assert = require('assert');
+const debug = require('util').debuglog('test');
+
+process.on('warning', common.mustNotCall());
+
+const objects = { foo: 'bar', baz: {}, num: 42, arr: [1, 2, 3] };
+objects.baz.asdf = objects;
+
+let serverCaught = 0;
+let clientCaught = 0;
+
+const server = http.createServer(common.mustCallAtLeast(function(req, res) {
+  const dom = domain.create();
+  req.resume();
+  dom.add(req);
+  dom.add(res);
+
+  dom.on('error', function(er) {
+    serverCaught++;
+    debug('horray! got a server error', er);
+    // Try to send a 500.  If that fails, oh well.
+    res.writeHead(500, { 'content-type': 'text/plain' });
+    res.end(er.stack || er.message || 'Unknown error');
+  });
+
+  dom.run(common.mustCall(() => {
+    // Now, an action that has the potential to fail!
+    // if you request 'baz', then it'll throw a JSON circular ref error.
+    const data = JSON.stringify(objects[req.url.replace(/[^a-z]/g, '')]);
+
+    // This line will throw if you pick an unknown key
+    assert.notStrictEqual(data, undefined);
+
+    res.writeHead(200);
+    res.end(data);
+  }));
+}));
+
+server.listen(0, next);
+
+function next() {
+  const port = this.address().port;
+  debug(`listening on localhost:${port}`);
+
+  let requests = 0;
+  let responses = 0;
+
+  makeReq('/');
+  makeReq('/foo');
+  makeReq('/arr');
+  makeReq('/baz');
+  makeReq('/num');
+
+  function makeReq(p) {
+    requests++;
+
+    const dom = domain.create();
+    dom.on('error', function(er) {
+      clientCaught++;
+      debug('client error', er);
+      req.socket.destroy();
+    });
+
+    const req = http.get({ host: 'localhost', port: port, path: p });
+    dom.add(req);
+    req.on('response', function(res) {
+      responses++;
+      debug(`requests=${requests} responses=${responses}`);
+      if (responses === requests) {
+        debug('done, closing server');
+        // no more coming.
+        server.close();
+      }
+
+      dom.add(res);
+      let d = '';
+      res.on('data', function(c) {
+        d += c;
+      });
+      res.on('end', function() {
+        debug('trying to parse json', d);
+        d = JSON.parse(d);
+        debug('json!', d);
+      });
+    });
+  }
+}
+
+process.on('exit', function() {
+  assert.strictEqual(serverCaught, 2);
+  assert.strictEqual(clientCaught, 2);
+  debug('ok');
+});

--- a/test/js/node/test/parallel/test-domain-implicit-binding.js
+++ b/test/js/node/test/parallel/test-domain-implicit-binding.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const fs = require('fs');
+const isEnumerable = Function.call.bind(Object.prototype.propertyIsEnumerable);
+
+process.on('warning', common.mustNotCall());
+
+{
+  const d = new domain.Domain();
+
+  d.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'foobar');
+    assert.strictEqual(err.domain, d);
+    assert.strictEqual(isEnumerable(err, 'domain'), false);
+    assert.strictEqual(err.domainEmitter, undefined);
+    assert.strictEqual(err.domainBound, undefined);
+    assert.strictEqual(err.domainThrown, true);
+  }));
+
+  d.run(common.mustCall(() => {
+    process.nextTick(common.mustCall(() => {
+      const i = setInterval(common.mustCall(() => {
+        clearInterval(i);
+        setTimeout(common.mustCall(() => {
+          fs.stat('this file does not exist', common.mustCall((er, stat) => {
+            throw new Error('foobar');
+          }));
+        }), 1);
+      }), 1);
+    }));
+  }));
+}

--- a/test/js/node/test/parallel/test-domain-implicit-fs.js
+++ b/test/js/node/test/parallel/test-domain-implicit-fs.js
@@ -1,0 +1,63 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+// Simple tests of most basic domain functionality.
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+process.on('warning', common.mustNotCall());
+
+const d = new domain.Domain();
+
+d.on('error', common.mustCall(function(er) {
+  console.error('caught', er);
+
+  assert.strictEqual(er.domain, d);
+  assert.strictEqual(er.domainThrown, true);
+  assert.ok(!er.domainEmitter);
+  assert.strictEqual(er.actual.code, 'ENOENT');
+  assert.match(er.actual.path, /\bthis file does not exist\b/i);
+  assert.strictEqual(typeof er.actual.errno, 'number');
+}));
+
+
+// Implicit handling of thrown errors while in a domain, via the
+// single entry points of ReqWrap and MakeCallback.  Even if
+// we try very hard to escape, there should be no way to, even if
+// we go many levels deep through timeouts and multiple IO calls.
+// Everything that happens between the domain.enter() and domain.exit()
+// calls will be bound to the domain, even if multiple levels of
+// handles are created.
+d.run(common.mustCall(() => {
+  setTimeout(common.mustCall(() => {
+    const fs = require('fs');
+    fs.readdir(__dirname, common.mustCall(() => {
+      // eslint-disable-next-line node-core/prefer-common-mustsucceed
+      fs.open('this file does not exist', 'r', common.mustCall((er) => {
+        assert.ifError(er);
+        throw new Error('should not get here!');
+      }));
+    }));
+  }), 100);
+}));

--- a/test/js/node/test/parallel/test-domain-intercept.js
+++ b/test/js/node/test/parallel/test-domain-intercept.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+{
+  const d = new domain.Domain();
+
+  const mustNotCall = common.mustNotCall();
+
+  d.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'foobar');
+    assert.strictEqual(err.domain, d);
+    assert.strictEqual(err.domainEmitter, undefined);
+    assert.strictEqual(err.domainBound, mustNotCall);
+    assert.strictEqual(err.domainThrown, false);
+  }));
+
+  const bound = d.intercept(mustNotCall);
+  bound(new Error('foobar'));
+}
+
+{
+  const d = new domain.Domain();
+
+  const bound = d.intercept(common.mustCall((data) => {
+    assert.strictEqual(data, 'data');
+  }));
+
+  bound(null, 'data');
+}
+
+{
+  const d = new domain.Domain();
+
+  const bound = d.intercept(common.mustCall((data, data2) => {
+    assert.strictEqual(data, 'data');
+    assert.strictEqual(data2, 'data2');
+  }));
+
+  bound(null, 'data', 'data2');
+}

--- a/test/js/node/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
+++ b/test/js/node/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
@@ -1,0 +1,22 @@
+'use strict';
+// Tests that domain can be loaded after setUncaughtExceptionCaptureCallback
+// has been called. This verifies that the mutual exclusivity has been removed.
+const common = require('../common');
+
+// Set up a capture callback first
+process.setUncaughtExceptionCaptureCallback(common.mustNotCall());
+
+// Loading domain should not throw (coexistence is now supported)
+const domain = require('domain');
+
+// Verify domain module loaded successfully
+const assert = require('assert');
+assert.ok(domain);
+assert.ok(domain.create);
+
+// Clean up
+process.setUncaughtExceptionCaptureCallback(null);
+
+// Domain should still be usable
+const d = domain.create();
+assert.ok(d);

--- a/test/js/node/test/parallel/test-domain-multiple-errors.js
+++ b/test/js/node/test/parallel/test-domain-multiple-errors.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+// This test is similar to test-domain-error-types, but uses a single domain
+// to emit all errors.
+
+const d = new domain.Domain();
+
+const values = [
+  42, null, undefined, false, () => {}, 'string', Symbol('foo'),
+];
+
+d.on('error', common.mustCall((err) => {
+  assert(values.includes(err));
+}, values.length));
+
+for (const something of values) {
+  d.run(common.mustCall(() => {
+    process.nextTick(common.mustCall(() => {
+      throw something;
+    }));
+  }));
+}

--- a/test/js/node/test/parallel/test-domain-nested.js
+++ b/test/js/node/test/parallel/test-domain-nested.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+// Make sure that the nested domains don't cause the domain stack to grow
+
+require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+process.on('exit', function(c) {
+  assert.strictEqual(domain._stack.length, 0);
+});
+
+domain.create().run(function() {
+  domain.create().run(function() {
+    domain.create().run(function() {
+      domain.create().on('error', function(e) {
+        // Don't need to do anything here
+      }).run(function() {
+        throw new Error('died');
+      });
+    });
+  });
+});

--- a/test/js/node/test/parallel/test-domain-nexttick.js
+++ b/test/js/node/test/parallel/test-domain-nexttick.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+const d = new domain.Domain();
+
+d.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'foobar');
+  assert.strictEqual(err.domain, d);
+  assert.strictEqual(err.domainEmitter, undefined);
+  assert.strictEqual(err.domainBound, undefined);
+  assert.strictEqual(err.domainThrown, true);
+}));
+
+d.run(common.mustCall(() => {
+  process.nextTick(common.mustCall(() => {
+    throw new Error('foobar');
+  }));
+}));

--- a/test/js/node/test/parallel/test-domain-promise.js
+++ b/test/js/node/test/parallel/test-domain-promise.js
@@ -1,0 +1,138 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const fs = require('fs');
+const vm = require('vm');
+
+process.on('warning', common.mustNotCall());
+
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(common.mustCall(() => {
+      assert.strictEqual(process.domain, d);
+    }));
+  }));
+}
+
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(() => {}).then(() => {}).then(common.mustCall(() => {
+      assert.strictEqual(process.domain, d);
+    }));
+  }));
+}
+
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    vm.runInNewContext(`
+      const promise = Promise.resolve();
+      assert.strictEqual(promise.domain, undefined);
+      promise.then(common.mustCall(() => {
+        assert.strictEqual(process.domain, d);
+      }));
+    `, { common, assert, process, d });
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.resolve(42);
+  }));
+
+  d2.run(common.mustCall(() => {
+    p.then(common.mustCall((v) => {
+      assert.strictEqual(process.domain, d2);
+    }));
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.resolve(42);
+  }));
+
+  d2.run(common.mustCall(() => {
+    p.then(d1.bind(common.mustCall((v) => {
+      assert.strictEqual(process.domain, d1);
+    }))).then(common.mustCall());
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.resolve(42);
+  }));
+
+  d1.run(common.mustCall(() => {
+    d2.run(common.mustCall(() => {
+      p.then(common.mustCall((v) => {
+        assert.strictEqual(process.domain, d2);
+      }));
+    }));
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.reject(new Error('foobar'));
+  }));
+
+  d2.run(common.mustCall(() => {
+    p.catch(common.mustCall((v) => {
+      assert.strictEqual(process.domain, d2);
+    }));
+  }));
+}
+
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(common.mustCall(() => {
+      setTimeout(common.mustCall(() => {
+        assert.strictEqual(process.domain, d);
+      }), 0);
+    }));
+  }));
+}
+
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(common.mustCall(() => {
+      fs.readFile(__filename, common.mustCall(() => {
+        assert.strictEqual(process.domain, d);
+      }));
+    }));
+  }));
+}
+{
+  // Unhandled rejections become errors on the domain
+  const d = domain.create();
+  d.on('error', common.mustCall((e) => {
+    assert.strictEqual(e.message, 'foo');
+  }));
+  d.run(common.mustCall(() => {
+    Promise.reject(new Error('foo'));
+  }));
+}

--- a/test/js/node/test/parallel/test-domain-run.js
+++ b/test/js/node/test/parallel/test-domain-run.js
@@ -1,0 +1,13 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+const d = new domain.Domain();
+
+assert.strictEqual(d.run(() => 'return value'),
+                   'return value');
+
+assert.strictEqual(d.run((a, b) => `${a} ${b}`, 'return', 'value'),
+                   'return value');

--- a/test/js/node/test/parallel/test-domain-safe-exit.js
+++ b/test/js/node/test/parallel/test-domain-safe-exit.js
@@ -1,0 +1,40 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+require('../common');
+// Make sure the domain stack doesn't get clobbered by un-matched .exit()
+
+const assert = require('assert');
+const domain = require('domain');
+const util = require('util');
+
+const a = domain.create();
+const b = domain.create();
+
+a.enter(); // push
+b.enter(); // push
+assert.deepStrictEqual(domain._stack, [a, b], 'Unexpected stack shape ' +
+                       `(domain._stack = ${util.inspect(domain._stack)})`);
+
+domain.create().exit(); // no-op
+assert.deepStrictEqual(domain._stack, [a, b], 'Unexpected stack shape ' +
+                       `(domain._stack = ${util.inspect(domain._stack)})`);

--- a/test/js/node/test/parallel/test-domain-set-uncaught-exception-capture-after-load.js
+++ b/test/js/node/test/parallel/test-domain-set-uncaught-exception-capture-after-load.js
@@ -1,0 +1,23 @@
+'use strict';
+// Tests that setUncaughtExceptionCaptureCallback can be called after domain
+// is loaded. This verifies that the mutual exclusivity has been removed.
+const common = require('../common');
+const assert = require('assert');
+
+// Load domain first
+const domain = require('domain');
+assert.ok(domain);
+
+// Setting callback should not throw (coexistence is now supported)
+process.setUncaughtExceptionCaptureCallback(common.mustNotCall());
+
+// Verify callback is registered
+assert.ok(process.hasUncaughtExceptionCaptureCallback());
+
+// Clean up
+process.setUncaughtExceptionCaptureCallback(null);
+assert.ok(!process.hasUncaughtExceptionCaptureCallback());
+
+// Domain should still be usable after callback operations
+const d = domain.create();
+assert.ok(d);

--- a/test/js/node/test/parallel/test-domain-stack-empty-in-process-uncaughtexception.js
+++ b/test/js/node/test/parallel/test-domain-stack-empty-in-process-uncaughtexception.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const domain = require('domain');
+const assert = require('assert');
+
+const d = domain.create();
+
+process.once('uncaughtException', common.mustCall(function onUncaught() {
+  assert.strictEqual(
+    process.domain, undefined,
+    'Domains stack should be empty in uncaughtException handler ' +
+    `but the value of process.domain is ${JSON.stringify(process.domain)}`);
+}));
+
+process.on('beforeExit', common.mustCall(function onBeforeExit() {
+  assert.strictEqual(
+    process.domain, undefined,
+    'Domains stack should be empty in beforeExit handler ' +
+    `but the value of process.domain is ${JSON.stringify(process.domain)}`);
+}));
+
+d.run(function() {
+  throw new Error('boom');
+});

--- a/test/js/node/test/parallel/test-domain-stack.js
+++ b/test/js/node/test/parallel/test-domain-stack.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+// Make sure that the domain stack doesn't get out of hand.
+
+require('../common');
+const domain = require('domain');
+
+const a = domain.create();
+a.name = 'a';
+
+a.on('error', function() {
+  if (domain._stack.length > 5) {
+    console.error('leaking!', domain._stack);
+    process.exit(1);
+  }
+});
+
+const foo = a.bind(function() {
+  throw new Error('error from foo');
+});
+
+for (let i = 0; i < 1000; i++) {
+  process.nextTick(foo);
+}
+
+process.on('exit', function(c) {
+  if (!c) console.log('ok');
+});

--- a/test/js/node/test/parallel/test-domain-thrown-error-handler-stack.js
+++ b/test/js/node/test/parallel/test-domain-thrown-error-handler-stack.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const common = require('../common');
+const domain = require('domain');
+
+// Make sure that when an error is thrown from a nested domain, its error
+// handler runs outside of that domain, but within the context of any parent
+// domain.
+
+const d = domain.create();
+const d2 = domain.create();
+
+d2.on('error', common.mustCall((err) => {
+  if (domain._stack.length !== 1) {
+    console.error('domains stack length should be 1 but is %d',
+                  domain._stack.length);
+    process.exit(1);
+  }
+
+  if (process.domain !== d) {
+    console.error('active domain should be %j but is %j', d, process.domain);
+    process.exit(1);
+  }
+
+  process.nextTick(() => {
+    if (domain._stack.length !== 1) {
+      console.error('domains stack length should be 1 but is %d',
+                    domain._stack.length);
+      process.exit(1);
+    }
+
+    if (process.domain !== d) {
+      console.error('active domain should be %j but is %j', d,
+                    process.domain);
+      process.exit(1);
+    }
+  });
+}));
+
+d.run(() => {
+  d2.run(() => {
+    throw new Error('oops');
+  });
+});

--- a/test/js/node/test/parallel/test-domain-timer.js
+++ b/test/js/node/test/parallel/test-domain-timer.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const isEnumerable = Function.call.bind(Object.prototype.propertyIsEnumerable);
+
+const d = new domain.Domain();
+
+d.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'foobar');
+  assert.strictEqual(err.domain, d);
+  assert.strictEqual(isEnumerable(err, 'domain'), false);
+  assert.strictEqual(err.domainEmitter, undefined);
+  assert.strictEqual(err.domainBound, undefined);
+  assert.strictEqual(err.domainThrown, true);
+}));
+
+d.run(common.mustCall(() => {
+  setTimeout(common.mustCall(() => {
+    throw new Error('foobar');
+  }), 1);
+}));

--- a/test/js/node/test/parallel/test-domain-timers-uncaught-exception.js
+++ b/test/js/node/test/parallel/test-domain-timers-uncaught-exception.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that the timer callbacks are called in the order in which
+// they were created in the event of an unhandled exception in the domain.
+
+const domain = require('domain').create();
+const assert = require('assert');
+
+let first = false;
+
+domain.run(common.mustCall(() => {
+  setTimeout(() => { throw new Error('FAIL'); }, 1);
+  setTimeout(() => { first = true; }, 1);
+  setTimeout(common.mustCall(() => { assert.strictEqual(first, true); }), 2);
+
+  // Ensure that 2 ms have really passed
+  let i = 1e6;
+  while (i--);
+}));
+
+domain.once('error', common.mustCall((err) => {
+  assert(err);
+  assert.strictEqual(err.message, 'FAIL');
+}));

--- a/test/js/node/test/parallel/test-domain-timers.js
+++ b/test/js/node/test/parallel/test-domain-timers.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const domain = require('domain');
+const assert = require('assert');
+
+const timeoutd = domain.create();
+
+timeoutd.on('error', common.mustCall(function(e) {
+  assert.strictEqual(e.message, 'Timeout UNREFd');
+}, 2));
+
+let t;
+timeoutd.run(function() {
+  setTimeout(function() {
+    throw new Error('Timeout UNREFd');
+  }, 0).unref();
+
+  t = setTimeout(function() {
+    clearTimeout(timeout);
+    throw new Error('Timeout UNREFd');
+  }, 0);
+});
+t.unref();
+
+const immediated = domain.create();
+
+immediated.on('error', common.mustCall(function(e) {
+  assert.strictEqual(e.message, 'Immediate Error');
+}));
+
+immediated.run(function() {
+  setImmediate(function() {
+    throw new Error('Immediate Error');
+  });
+});
+
+const timeout = setTimeout(common.mustNotCall(), 10 * 1000);

--- a/test/js/node/test/parallel/test-domain-top-level-error-handler-clears-stack.js
+++ b/test/js/node/test/parallel/test-domain-top-level-error-handler-clears-stack.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const domain = require('domain');
+
+// Make sure that the domains stack is cleared after a top-level domain
+// error handler exited gracefully.
+const d = domain.create();
+
+d.on('error', common.mustCall(() => {
+  // Scheduling a callback with process.nextTick _could_ enter a _new_ domain,
+  // but domain's error handlers are called outside of their domain's context.
+  // So there should _no_ domain on the domains stack if the domains stack was
+  // cleared properly when the domain error handler was called.
+  process.nextTick(() => {
+    if (domain._stack.length !== 0) {
+      // Do not use assert to perform this test: this callback runs in a
+      // different callstack as the original process._fatalException that
+      // handled the original error, thus throwing here would trigger another
+      // call to process._fatalException, and so on recursively and
+      // indefinitely.
+      console.error('domains stack length should be 0, but instead is:',
+                    domain._stack.length);
+      process.exit(1);
+    }
+  });
+}));
+
+d.run(() => {
+  throw new Error('Error from domain');
+});

--- a/test/js/node/test/parallel/test-domain-top-level-error-handler-throw.js
+++ b/test/js/node/test/parallel/test-domain-top-level-error-handler-throw.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// The goal of this test is to make sure that when a top-level error
+// handler throws an error following the handling of a previous error,
+// the process reports the error message from the error thrown in the
+// top-level error handler, not the one from the previous error.
+
+const common = require('../common');
+
+const domainErrHandlerExMessage = 'exception from domain error handler';
+const internalExMessage = 'You should NOT see me';
+
+if (process.argv[2] === 'child') {
+  const domain = require('domain');
+  const d = domain.create();
+
+  d.on('error', function() {
+    throw new Error(domainErrHandlerExMessage);
+  });
+
+  d.run(function doStuff() {
+    process.nextTick(function() {
+      throw new Error(internalExMessage);
+    });
+  });
+} else {
+  const fork = require('child_process').fork;
+  const assert = require('assert');
+
+  const child = fork(process.argv[1], ['child'], { silent: true });
+  let stderrOutput = '';
+  if (child) {
+    child.stderr.on('data', function onStderrData(data) {
+      stderrOutput += data.toString();
+    });
+
+    child.on('close', common.mustCall(function onChildClosed() {
+      assert(stderrOutput.includes(domainErrHandlerExMessage));
+      assert.strictEqual(stderrOutput.includes(internalExMessage), false);
+    }));
+
+    child.on('exit', common.mustCall(function onChildExited(exitCode, signal) {
+      const expectedExitCode = 7;
+      const expectedSignal = null;
+
+      assert.strictEqual(exitCode, expectedExitCode);
+      assert.strictEqual(signal, expectedSignal);
+    }));
+  }
+}

--- a/test/js/node/test/parallel/test-domain-uncaught-exception.js
+++ b/test/js/node/test/parallel/test-domain-uncaught-exception.js
@@ -1,0 +1,189 @@
+'use strict';
+
+// The goal of this test is to make sure that errors thrown within domains
+// are handled correctly. It checks that the process' 'uncaughtException' event
+// is emitted when appropriate, and not emitted when it shouldn't. It also
+// checks that the proper domain error handlers are called when they should
+// be called, and not called when they shouldn't.
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const child_process = require('child_process');
+
+const tests = [];
+
+function test1() {
+  // Throwing from an async callback from within a domain that doesn't have
+  // an error handler must result in emitting the process' uncaughtException
+  // event.
+  const d = domain.create();
+  d.run(function() {
+    setTimeout(function onTimeout() {
+      throw new Error('boom!');
+    }, 1);
+  });
+}
+
+tests.push({
+  fn: test1,
+  expectedMessages: ['uncaughtException']
+});
+
+function test2() {
+  // Throwing from within a domain that doesn't have an error handler must
+  // result in emitting the process' uncaughtException event.
+  const d2 = domain.create();
+  d2.run(function() {
+    throw new Error('boom!');
+  });
+}
+
+tests.push({
+  fn: test2,
+  expectedMessages: ['uncaughtException']
+});
+
+function test3() {
+  // This test creates two nested domains: d3 and d4. d4 doesn't register an
+  // error handler, but d3 does. The error is handled by the d3 domain and thus
+  // an 'uncaughtException' event should _not_ be emitted.
+  const d3 = domain.create();
+  const d4 = domain.create();
+
+  d3.on('error', function onErrorInD3Domain() {
+    process.send('errorHandledByDomain');
+  });
+
+  d3.run(function() {
+    d4.run(function() {
+      throw new Error('boom!');
+    });
+  });
+}
+
+tests.push({
+  fn: test3,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+function test4() {
+  // This test creates two nested domains: d5 and d6. d6 doesn't register an
+  // error handler. When the timer's callback is called, because async
+  // operations like timer callbacks are bound to the domain that was active
+  // at the time of their creation, and because both d5 and d6 domains have
+  // exited by the time the timer's callback is called, its callback runs with
+  // only d6 on the domains stack. Since d6 doesn't register an error handler,
+  // the process' uncaughtException event should be emitted.
+  const d5 = domain.create();
+  const d6 = domain.create();
+
+  d5.on('error', function onErrorInD2Domain() {
+    process.send('errorHandledByDomain');
+  });
+
+  d5.run(function() {
+    d6.run(function() {
+      setTimeout(function onTimeout() {
+        throw new Error('boom!');
+      }, 1);
+    });
+  });
+}
+
+tests.push({
+  fn: test4,
+  expectedMessages: ['uncaughtException']
+});
+
+function test5() {
+  // This test creates two nested domains: d7 and d8. d8 _does_ register an
+  // error handler, so throwing within that domain should not emit an uncaught
+  // exception.
+  const d7 = domain.create();
+  const d8 = domain.create();
+
+  d8.on('error', function onErrorInD3Domain() {
+    process.send('errorHandledByDomain');
+  });
+
+  d7.run(function() {
+    d8.run(function() {
+      throw new Error('boom!');
+    });
+  });
+}
+tests.push({
+  fn: test5,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+function test6() {
+  // This test creates two nested domains: d9 and d10. d10 _does_ register an
+  // error handler, so throwing within that domain in an async callback should
+  // _not_ emit an uncaught exception.
+  //
+  const d9 = domain.create();
+  const d10 = domain.create();
+
+  d10.on('error', function onErrorInD2Domain() {
+    process.send('errorHandledByDomain');
+  });
+
+  d9.run(function() {
+    d10.run(function() {
+      setTimeout(function onTimeout() {
+        throw new Error('boom!');
+      }, 1);
+    });
+  });
+}
+
+tests.push({
+  fn: test6,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+if (process.argv[2] === 'child') {
+  const testIndex = process.argv[3];
+  process.on('uncaughtException', function onUncaughtException() {
+    process.send('uncaughtException');
+  });
+
+  tests[testIndex].fn();
+} else {
+  // Run each test's function in a child process. Listen on
+  // messages sent by each child process and compare expected
+  // messages defined for each test with the actual received messages.
+  tests.forEach(function doTest(test, testIndex) {
+    const testProcess = child_process.fork(__filename, ['child', testIndex]);
+
+    testProcess.on('message', function onMsg(msg) {
+      if (test.messagesReceived === undefined)
+        test.messagesReceived = [];
+
+      test.messagesReceived.push(msg);
+    });
+
+    testProcess.on('disconnect', common.mustCall(function onExit() {
+      // Make sure that all expected messages were sent from the
+      // child process
+      test.expectedMessages.forEach(function(expectedMessage) {
+        const msgs = test.messagesReceived;
+        if (msgs === undefined || !msgs.includes(expectedMessage)) {
+          assert.fail(`test ${test.fn.name} should have sent message: ${
+            expectedMessage} but didn't`);
+        }
+      });
+
+      if (test.messagesReceived) {
+        test.messagesReceived.forEach(function(receivedMessage) {
+          if (!test.expectedMessages.includes(receivedMessage)) {
+            assert.fail(`test ${test.fn.name} should not have sent message: ${
+              receivedMessage} but did`);
+          }
+        });
+      }
+    }));
+  });
+}

--- a/test/js/node/test/parallel/test-domain-vm-promise-isolation.js
+++ b/test/js/node/test/parallel/test-domain-vm-promise-isolation.js
@@ -18,8 +18,7 @@ function run(code) {
     const p = vm.runInContext(code, context)();
     assert.strictEqual(p.domain, undefined);
     p.then(common.mustCall(() => {
-      // FIXME: Bun does not yet support process.domain propagation
-      // assert.strictEqual(process.domain, d);
+      assert.strictEqual(process.domain, d);
     }));
   }));
 }

--- a/test/js/node/test/parallel/test-timers-immediate-queue-throw.js
+++ b/test/js/node/test/parallel/test-timers-immediate-queue-throw.js
@@ -29,13 +29,9 @@ process.once('uncaughtException', common.mustCall((err, errorOrigin) => {
   common.expectsError(errObj)(err);
 }));
 
-// The domain part of this test is commented out because it's not planned to be
-// supported in Bun. The rest of this test is untouched and still tests the behavior
-// of throwing errors in setImmediate callbacks exactly like Node.js.
-
-// const d1 = domain.create();
-// d1.once('error', common.expectsError(errObj));
-// d1.once('error', () => assert.strictEqual(stage, 0));
+const d1 = domain.create();
+d1.once('error', common.expectsError(errObj));
+d1.once('error', common.mustCall(() => assert.strictEqual(stage, 0)));
 
 const run = common.mustCall((callStage) => {
   assert(callStage >= stage);
@@ -50,11 +46,11 @@ for (let i = 0; i < QUEUE; i++)
   setImmediate(run, 0);
 setImmediate(() => {
   threw = true;
-  process.nextTick(common.mustCall(() => assert.strictEqual(stage, 1)));
+  process.nextTick(() => assert.strictEqual(stage, 1));
   throw new Error('setImmediate Err');
 });
-// d1.run(() => setImmediate(() => {
-//   throw new Error('setImmediate Err');
-// }));
+d1.run(() => setImmediate(() => {
+  throw new Error('setImmediate Err');
+}));
 for (let i = 0; i < QUEUE; i++)
   setImmediate(run, 1);


### PR DESCRIPTION
### Problem
- `node:domain` only caught synchronous throws. An error in a timer, `process.nextTick`, promise or I/O callback created inside `d.run()` killed the process through `uncaughtException` or `unhandledRejection`. Node routes it to the domain's `'error'` handler, so express-era per-request error handling dies in Bun.
- `process.domain` was `null` in every async callback, and new emitters were not bound to the active domain.

### Fix
- `domain.ts` is a port of node's `lib/domain.js`. The stack of entered domains lives in the async context, the store `AsyncLocalStorage` rides, so a callback runs with the domain it was created under.
- `BunProcess.cpp`: the module installs one router. The uncaught-exception and unhandled-rejection paths call it before the process listeners and stop when it returns true.
- `ZigGlobalObject.cpp`: the rejection tracker saves the async context at rejection time and restores it while the rejection is reported, like node's `promiseInfo.contextFrame`.
- Verified: `test/js/node/domain/domain.test.ts` (25 of 26 cases fail on main), 32 vendored `test-domain-*.js` (25 fail on main), plus the events, async_hooks, process and stream suites.

### Background
- A domain is an `EventEmitter`. `d.run(fn)` pushes `d` on a stack, `process.domain` is the top, and an error raised while `d` is active goes to `d.emit('error')`. Node tracks this with `async_hooks`, which Bun lacks.
- The async context is the value in `globalObject->m_asyncContextData`, snapshotted when native code stores a callback and restored around the call. `AsyncLocalStorage` keeps `[storage, value, ...]` pairs in it.
- `events.ts` now calls `EventEmitter.init` from the constructor, as node does, so the domain module can override it and stamp `ee.domain`.

<details><summary>Notes</summary>

Routing table, node v26.3.0 versus Bun before and after, from a domain `d` with an `'error'` listener plus `uncaughtException` and `unhandledRejection` listeners:

| cell | node | bun before | bun after |
|---|---|---|---|
| `d.run(() => setTimeout(() => { throw }))` | domain | uncaughtException | domain |
| `setImmediate`, `process.nextTick`, timer in timer | domain | uncaughtException | domain |
| `fs.stat` callback, `net` socket event | domain | uncaughtException | domain |
| `d.run(() => Promise.reject(err))` | domain | unhandledRejection | domain |
| `d.run(async () => { await ...; throw })` | domain | unhandledRejection | domain |
| emitter created in `d`, `emit('error')` later | domain | uncaughtException | domain |
| emitter created in `d`, listener throws on an emit from outside | domain | uncaughtException | domain |
| `d.run(() => { throw })` at top level | domain, `domainThrown` true | domain, `domainThrown` false, code after `run()` continues | domain, `domainThrown` true |
| `process.domain` / `domain.active` inside a timer | `d` | `null` | `d` |
| outer domain with handler, inner without, async throw | uncaughtException | uncaughtException | uncaughtException |
| outer domain with handler, inner without, sync throw | outer domain | outer domain | outer domain |
| top-level domain handler throws | exit 7 | exit 1 | exit 7 |
| http server, per-request domain, timer throws | 500 | process dies | 500 |

Node's `main` branch moved `lib/domain.js` onto `AsyncLocalStorage` the same way; the vendored tests come from that suite.

A throw from a domain `'error'` handler is reported re-entrantly (`Bun__reportUnhandledError`) and exits with code 7, the path a throwing `uncaughtException` listener already takes. Node exits 7 too and prints the handler's error, not the original one (`test-domain-top-level-error-handler-throw.js`).

`Bun__handleUncaughtException` is the common path for every uncaught error (`uncaughtExceptionMonitor`, the capture callback, then the `uncaughtException` listeners). Node gives its domain the same priority through a domain-owned capture callback. Bun's capture callback cannot decline an error, and the decision here depends on the error's async context, so the module registers a dedicated router instead. Bun reports timer, `nextTick`, fs and socket exceptions before it restores the previous async context (`NodeTimerObject.cpp`, `processTicksAndRejections`, the socket handlers), which is what makes the router see the domain.

The rejection-time context restore is node parity on its own: `process.on('unhandledRejection')` now sees the `AsyncLocalStorage` store of the code that rejected (`async-context-process-unhandledRejection.js` runs against both bun and node).

Known differences from node v26:
- The whole stack of entered domains propagates to callbacks, not only the innermost domain. This matches node's `main` branch and the vendored `test-domain-emit-error-handler-stack.js`. It is observable as `domain._stack.length` inside callbacks and when an inner domain's handler throws (the outer domain gets the error here, node v26 exits 7).
- A domain without an `'error'` listener leaves an unhandled rejection on the `unhandledRejection` path. Node's `domain.emit('error', reason)` throws in that case and turns the rejection into an `uncaughtException`.
- `queueMicrotask` callbacks inherit the domain in Bun (the async context propagates there). Node does not track them.

Follow-up, not in this PR: an `EventEmitterAsyncResource` with `captureRejections` still bypasses the domain-aware `emit`. Its constructor deletes the own `emit` that the domain module wrapped, and its prototype `emit` picks the capture variant directly instead of `super.emit`. Covering it needs a hook in `events.ts` for that class.

Why the module writes the context array directly instead of `AsyncLocalStorage.enterWith()`: `enterWith()` schedules `cleanupAsyncHooksData`, which wipes the context at the next microtask checkpoint. A sync throw out of `d.run()` at top level reaches `Bun__handleUncaughtException` only after that checkpoint, so the domain would be gone. Node's `main` keeps module-level `currentDomain` state next to its storage for the same reason.

Two pre-existing `AsyncLocalStorage` bugs found on the way were handed off separately: `enterWith()` at top level drops pending `process.nextTick` callbacks at exit (`cleanupAsyncHooksData` skips the drain), and `enterWith(array)` spreads the array into the context through `Array.prototype.concat`.

Vendored node tests left out: the `test-domain-no-error-handler-abort-on-uncaught-*`, `test-domain-abort-on-uncaught`, `test-domain-with-abort-on-uncaught-exception` and `test-domain-throw-error-then-throw-from-uncaught-exception-handler` tests need `--abort-on-uncaught-exception`; `test-domain-multi` needs node's http client parser to reject a stray byte written to the socket; `test-domain-async-resource-domain-removed` checks a node-main-only `ERR_ASYNC_RESOURCE_DOMAIN_REMOVED`. `test-domain-vm-promise-isolation.js` and `test-timers-immediate-queue-throw.js` are restored to their upstream versions (their domain assertions were commented out).

Related open PRs with narrower scope: #30675 (timers only), #35444 (`bind()`/`intercept()` return values, covered here), #39731 (adds `domain.Domain` and `process.domain` to the sync shim among other modules).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 43 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 29 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domain/domain.test.ts
bun test v1.4.1 (731aa92da)

test/js/node/domain/domain.test.ts:
32 | const thrown = "thrown=true d=true emitter=none active=undefined";
33 | 
34 | describe.concurrent("node:domain routes errors from async callbacks created inside the domain", () => {
35 |   test("setTimeout", async () => {
36 |     const { stdout, exitCode } = await run(prelude + `d.run(() => setTimeout(() => { throw new Error("boom"); }, 1));`);
37 |     expect(stdout).toBe(`domain:boom ${thrown}\n`);
                        ^
error: expect(received).toBe(expected)

- "domain:boom thrown=true d=true emitter=none active=undefined
+ "uncaughtException:boom active=null
  "

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/domain/domain.test.ts:37:20)
(fail) node:domain routes errors from async callbacks created inside the domain > setTimeout [460.04ms]
54 | 
55 |   test("a timer created by a timer", async () => {
56 |     const { stdout, exitCode } = await run(
57 |       prelude + `d.run(() => setTime
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (b2f62eac7)

test/js/node/domain/domain.test.ts:
(pass) node:domain routes errors from async callbacks created inside the domain > process.nextTick [10.05ms]
(pass) node:domain routes errors from async callbacks created inside the domain > setImmediate [11.67ms]
(pass) node:domain routes unhandled rejections > Promise.reject inside run() [9.29ms]
(pass) node:domain routes unhandled rejections > a domain without an 'error' listener leaves the rejection to the process [8.85ms]
(pass) node:domain routes errors from async callbacks created inside the domain > process.domain and domain.active inside the callback [12.07ms]
(pass) node:domain routes errors from async callbacks created inside the domain > setTimeout [15.29ms]
(pass) node:domain routes errors from async callbacks created inside the domain > a timer created by a timer [13.95ms]
(pass) node:domain routes errors from async callbacks created inside the domain > fs callback [15.40ms]
(pass) node:domain routes unhandled rejections > a throw after await [15.95ms]
(pass) node:domain EventEmitter integration > an emitter created inside the domain routes 'error' without listeners to it [15.41m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domain/domain.test.ts
bun test v1.4.1 (731aa92da)

test/js/node/domain/domain.test.ts:
(pass) node:domain routes errors from async callbacks created inside the domain > setTimeout [583.27ms]
(pass) node:domain routes errors from async callbacks created inside the domain > process.nextTick [540.61ms]
(pass) node:domain routes errors from async callbacks created inside the domain > setImmediate [608.94ms]
(pass) node:domain routes errors from async callbacks created inside the domain > fs callback [599.20ms]
(pass) node:domain routes errors from async callbacks created inside the domain > a timer created by a timer [618.75ms]
(pass) node:domain routes unhandled rejections > a domain without an 'error' listener leaves the rejection to the process [478.01ms]
(pass) node:domain routes errors from async callbacks created inside the domain > process.domain and domain.active inside the callback [590.89ms]
(pass) node:domain routes unhandled rejections > Promise.reject inside run() [563.41ms]
(pass) node:domain routes unhandled rej
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 613ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen cpp.rs (cppbind)
[2/125] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/125] gen JS modules (bundle-modules)
Preprocess modules (7856ms)
Bundle modules (87ms)
Postprocesss modules (248ms)
Bundle Functions (514ms)
Generate Code (42ms)

[8.76s] Bundled "src/js" for production
  2601 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/125] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/sa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/nodejs-compat.mdx                     |   2 +-
 src/js/node/domain.ts                              | 498 +++++++++++++++++----
 src/js/node/events.ts                              |  11 +-
 src/jsc/bindings/BunProcess.cpp                    |  42 ++
 src/jsc/bindings/BunProcess.h                      |  16 +
 src/jsc/bindings/PendingRejectionList.h            |  71 +++
 src/jsc/bindings/ZigGlobalObject.cpp               |  16 +-
 src/jsc/bindings/ZigGlobalObject.h                 |   3 +-
 .../async-context-process-unhandledRejection.js    |  31 ++
 test/js/node/domain/domain.test.ts                 | 446 ++++++++++++++++++
 .../node/test/parallel/test-domain-add-remove.js   |  30 ++
 .../node/test/parallel/test-domain-bind-timeout.js |  17 +
 .../node/test/parallel/test-domain-ee-implicit.js  |  28 ++
 test/js/node/test/parallel/test-domain-ee.js       |  28 ++
 .../test-domain-emit-error-handler-stack.js        | 161 +++++++
 .../node/test/parallel/test-domain-enter-exit.js   |  60 +++
 ...test-domain-error-handler-throw-no-recursion.js |  45 ++
 .../node/test/parallel/test-domain-error-types.js  |  26 ++
 .../node/test/parallel/test-domain-from-timer.js   |  39 ++
 .../test/parallel/test-domain-fs-enoent-stream.js  |  20 +
 .../node/test/parallel/test-domain-http-server.js  | 118 +++++
 .../test/parallel/test-domain-implicit-binding.js  |  35 ++
 .../node/test/parallel/test-domain-implicit-fs.js  |  63 +++
 .../js/node/test/parallel/test-domain-intercept.js |  43 ++
 ...in-load-after-set-uncaught-exception-capture.js |  22 +
 .../test/parallel/test-domain-multiple-errors.js   |  26 ++
 test/js/node/test/parallel/test-domain-nested.js   |  43 ++
 test/js/node/test/parallel/test-domain-nexttick.js |  21 +
 test/js/node/test/parallel/test-domain-promise.js  | 138 ++++++
 test/js/node/test/parallel/test-domain-run.js      |  13 +
 .../js/node/test/parallel/test-domain-safe-exit.js |  40 ++
 ...in-set-uncaught-exception-capture-after-load.j
... (truncated)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
docs/runtime/nodejs-compat.mdx                                1      1      0
src/js/node/domain.ts                                        21     35      0
src/js/node/events.ts                                         4      4      0
src/jsc/bindings/BunProcess.cpp                               4      8      0
src/jsc/bindings/BunProcess.h                                 1      4      0
src/jsc/bindings/PendingRejectionList.h                       0      3      0
src/jsc/bindings/ZigGlobalObject.cpp                          3      3      0
src/jsc/bindings/ZigGlobalObject.h                            2      3      0
…ync-context/async-context-process-unhandledRejection.js      0      1      0
test/js/node/domain/domain.test.ts                            6     11      0
test/js/node/test/parallel/test-domain-add-remove.js          0      0      0
test/js/node/test/parallel/test-domain-bind-timeout.js        0      0      0
test/js/node/test/parallel/test-domain-ee-implicit.js         0      0      0
test/js/node/test/parallel/test-domain-ee.js                  0      0      0
…e/test/parallel/test-domain-emit-error-handler-stack.js      0      0      0
test/js/node/test/parallel/test-domain-enter-exit.js          0      0      0
(+ 27 more files)
```

</details>

<!-- robobun:evidence:end -->