### PR TITLE
node:fs: stop the async recursive readdir walk at the first error

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2132,6 +2132,13 @@ mod _async_tasks {
 
         pub(crate) subtask_count: AtomicUsize,
 
+        /// Set once `pending_err` is. From then on `enqueue` schedules nothing
+        /// and a subtask that starts skips its directory, so the scan settles as
+        /// soon as the subtasks already in flight return instead of draining the
+        /// whole frontier. Two directory symlinks back to the same tree make
+        /// that frontier 2^41 paths deep before the kernel reports ELOOP.
+        pub(crate) has_error: AtomicBool,
+
         /// The final result list
         pub(crate) result_list: ResultListEntryValue,
 
@@ -2292,6 +2299,9 @@ mod _async_tasks {
 
     impl AsyncReaddirRecursiveTask {
         pub(crate) fn enqueue(&mut self, basename: &ZStr) {
+            if self.has_error.load(Ordering::Relaxed) {
+                return;
+            }
             // The subtask runs on another thread after the caller's `name_to_copy_z`
             // (which points into a per-iteration buffer) has been overwritten, so we
             // must heap-own the bytes here. Freed in ReaddirSubtask::call's cleanup.
@@ -2351,6 +2361,7 @@ mod _async_tasks {
                     done: None,
                     has_result: AtomicBool::new(false),
                     subtask_count: AtomicUsize::new(1),
+                    has_error: AtomicBool::new(false),
                     root_path,
                     result_list,
                     result_list_count: AtomicUsize::new(0),
@@ -2370,6 +2381,10 @@ mod _async_tasks {
             buf: &mut PathBuffer,
             is_root: bool,
         ) {
+            if self.has_error.load(Ordering::Relaxed) {
+                self.on_subtask_done();
+                return;
+            }
             macro_rules! impl_tag {
                 ($T:ty, $variant:ident) => {{
                     // A bare `Vec::new()` here
@@ -2401,9 +2416,8 @@ mod _async_tasks {
                                     self.pending_err = Some(err.with_path(err_path));
                                 }
                             }
-                            if self.subtask_count.fetch_sub(1, Ordering::Relaxed) == 1 {
-                                self.finish_concurrently();
-                            }
+                            self.has_error.store(true, Ordering::Relaxed);
+                            self.on_subtask_done();
                         }
                         Ok(()) => {
                             self.write_results::<$T>(&mut entries);
@@ -2439,7 +2453,14 @@ mod _async_tasks {
                 };
             }
 
-            if self.subtask_count.fetch_sub(1, Ordering::Relaxed) == 1 {
+            self.on_subtask_done();
+        }
+
+        /// Drops this subtask's `subtask_count` reference. The last one finishes
+        /// the scan; `AcqRel` publishes every subtask's `pending_err` and queued
+        /// results to it.
+        fn on_subtask_done(&mut self) {
+            if self.subtask_count.fetch_sub(1, Ordering::AcqRel) == 1 {
                 self.finish_concurrently();
             }
         }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1834,6 +1834,55 @@ it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple 
   });
 });
 
+// After the first subtask failed, the walker kept scheduling a subtask for every
+// directory it found and only settled once that frontier drained. Two symlinks
+// back to the root make the frontier 2^41 directories (the kernel follows 40
+// symlinks before ELOOP), so the promise and the callback never settled.
+it.skipIf(isWindows)(
+  "readdir({recursive: true}) settles with the first error while symlink loops are still being walked",
+  async () => {
+    using dir = tempDir("readdir-recursive-loop", {
+      "a/b/keep.txt": "x",
+    });
+    const root = String(dir);
+    // Opening this one with O_DIRECTORY fails with ELOOP at once.
+    fs.symlinkSync(join(root, "bad"), join(root, "bad"));
+    fs.symlinkSync(".", join(root, "loop1"));
+    fs.symlinkSync(".", join(root, "loop2"));
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("fs");
+          const root = ${JSON.stringify(root)};
+          const viaPromise = await fs.promises.readdir(root, { recursive: true }).then(
+            r => "resolved " + r.length,
+            e => "rejected " + e.code,
+          );
+          console.log("promise", viaPromise);
+          const { promise, resolve } = Promise.withResolvers();
+          fs.readdir(root, { recursive: true }, (e, r) => resolve(e ? "rejected " + e.code : "resolved " + r.length));
+          console.log("callback", await promise);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      timeout: 10_000,
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "promise rejected ELOOP\ncallback rejected ELOOP",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+);
+
 describe("readSync", () => {
   it("rejects the read when the length argument detaches the destination buffer during coercion", () => {
     const fd = openSync(import.meta.dir + "/readFileSync.txt", "r");


### PR DESCRIPTION
### Problem
- `fs.promises.readdir(dir, { recursive: true })` and the callback form never settle on a tree with two directory symlink loops and one entry that fails to open (`ln -s . loop1; ln -s . loop2; ln -s bad bad`). Every pool thread spins and the caller cannot catch anything. `readdirSync` rejects the same tree with `ELOOP` in milliseconds. Both async forms share `AsyncReaddirRecursiveTask` (`node_fs_binding.rs:204`).
- Cause: a failing subtask records its error in `pending_err` and releases its reference (`node_fs.rs:2404`), but every other subtask keeps calling `enqueue` (`node_fs.rs:2294`), which schedules one new subtask per directory found. Nothing reads `pending_err` until `subtask_count` reaches zero, so the promise waits for the whole frontier. The kernel follows 40 symlinks before `ELOOP`, so two loops make that frontier 2^41 directories.

### Fix
- `AsyncReaddirRecursiveTask` gets a `has_error` flag, set right after the first error is recorded. `enqueue` then schedules nothing, and a subtask that starts after the flag is set releases its reference without opening its directory. The scan settles once the few subtasks already in flight return.
- The rejection is the same error as before (the first one recorded). On success nothing changes: the flag is never set, so the only new cost is one relaxed atomic load per directory.
- The `subtask_count` decrements are now `AcqRel`, so the last subtask sees the other subtasks' `pending_err` and queued results. The cp task already uses this ordering.
- Verified: `test/js/node/fs/fs.test.ts` (`readdir({recursive: true}) settles with the first error while symlink loops are still being walked`, promise and callback form; on the stock binary the test times out with the child still spinning, the fixed one settles in 0.6 s under ASAN). Also ran all of `fs.test.ts`, `readdirSync-recursive-error-leak.test.ts`, `dir.test.ts`, `fs-path-length.test.ts` and node's `test-fs-readdir*.js`.

### Background
- The async recursive readdir is one `Job` whose off-thread part is shared by pool subtasks. The root directory runs in `run`. Each directory or symlink entry becomes a `ReaddirSubtask` on the work pool. `subtask_count` is a refcount: it starts at 1 for the root, `enqueue` adds one, and every subtask subtracts one when it is done. The subtask that brings it to zero calls `finish_concurrently`, which joins the results or keeps the error and hands the job back to the JS thread.
- `readdir_skips_subdir` lists the errors that skip one entry (`ENOENT`, `ENOTDIR`, `EPERM`). Any other error, `ELOOP` included, fails the whole listing, as in the sync walker.
- This change does not bound a tree that has only the two loops and no entry that fails early. On a stock kernel the first `ELOOP` appears at depth 41, so that tree is a 2^41 directory walk for `readdirSync`, and for node's sync and async walkers too (node v26 did not finish it here either). Only cycle detection (the dev/ino of the ancestors) would bound it. That is a semantics change, and it interacts with #33432 and #31418, which make `ELOOP` a skipped error. It is not part of this PR.

<details><summary>Notes</summary>

Repro on the released build (Linux 6.17, overlayfs):

```
mkdir -p /tmp/t/a/b && cd /tmp/t && ln -s bad bad && ln -s . s1 && ln -s . s2
timeout -s KILL 20 bun -e 'require("fs").promises.readdir(".",{recursive:true}).then(a=>console.log("ok",a.length),e=>console.log("rej",e.code))'
# never prints, rc=137. Same with fs.readdir(".", {recursive:true}, cb).
bun -e 'try{require("fs").readdirSync(".",{recursive:true})}catch(e){console.log(e.code)}'
# ELOOP in 9 ms
```

With this change both async forms print `rej ELOOP` in about 10 ms (0.5 s for the debug build, most of it startup).

The bare two-loop tree without `bad`: `readdirSync` did not finish in 30 s on this machine. The fuzz report that saw it finish in 11 s ran on a box where the kernel returns `ELOOP` after 8 to 11 components, so the sync walker got its first error early there. The async walker was the only one that did not stop at that error.

`USE_SYSTEM_BUN=1 bun test` on the new test: the test hits the 5 s runner timeout and the runner kills the spinning child ("killed 1 dangling process"). `bun bd test` with this change: pass in 583 ms.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->