### PR TITLE
streams: deliver the source error to native sinks on controller.close(error)

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -394,9 +394,12 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
     ${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
     controller->m_sinkPtr = nullptr;
 
-    // close(reason): the pump (rsisAbrupt) passes the source's error, a clean
-    // close passes nothing. The sink tells the two apart.
-    ${name}__close(lexicalGlobalObject, ptr, JSC::JSValue::encode(callFrame->argument(0)));
+    // close(reason): the pump's abrupt path passes the source's error, which
+    // can itself be undefined (controller.error() with no argument); a clean
+    // close passes no argument. "No argument" is encoded as the empty value so
+    // the sink can tell the two apart.
+    ${name}__close(lexicalGlobalObject, ptr,
+        callFrame->argumentCount() > 0 ? JSC::JSValue::encode(callFrame->argument(0)) : JSC::JSValue::encode(JSC::JSValue()));
 
     // detach() must still fire onClose (it transitions the direct
     // ReadableStream to closed/errored and calls underlyingSource.cancel())
@@ -507,7 +510,7 @@ JSC_DEFINE_HOST_FUNCTION(${name}__doClose, (JSC::JSGlobalObject * lexicalGlobalO
     }
 
     sink->detach();
-    ${name}__close(lexicalGlobalObject, ptr, JSC::JSValue::encode(JSC::jsUndefined()));
+    ${name}__close(lexicalGlobalObject, ptr, JSC::JSValue::encode(JSC::JSValue()));
     // detach() nulled m_sinkPtr so ~${className} won't finalize ptr; do the
     // destructor's teardown (onDestroy first so Subprocess clears its weak
     // back-pointer, then __finalize) here instead, even if __close threw.

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -394,10 +394,8 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
     ${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
     controller->m_sinkPtr = nullptr;
 
-    // close(reason): the pump's abrupt path passes the source's error, which
-    // can itself be undefined (controller.error() with no argument); a clean
-    // close passes no argument. "No argument" is encoded as the empty value so
-    // the sink can tell the two apart.
+    // A failed source closes with its error (possibly undefined); a clean
+    // close passes no argument, encoded as the empty value.
     ${name}__close(lexicalGlobalObject, ptr,
         callFrame->argumentCount() > 0 ? JSC::JSValue::encode(callFrame->argument(0)) : JSC::JSValue::encode(JSC::JSValue()));
 
@@ -1159,9 +1157,8 @@ pub extern "C" fn ${name}__controllerDetached(this: &mut ${name}, controller: JS
 `;
 
     // ZIG_DECL JSC::EncodedJSValue ${name}__close(JSC::JSGlobalObject*, void* sinkPtr, JSC::EncodedJSValue reason)
-    // C++ caller null-checks `ptr` before calling. `*mut`, not `&mut`: a
-    // failing close can re-enter the sink through its owner (see
-    // `JsSinkType::close_with_error`).
+    // C++ caller null-checks `ptr` before calling. `*mut`: a failing close can
+    // re-enter the sink (see `JsSinkType::close_with_error`).
     symbols.push(`${name}__close`);
     templ += `#[allow(dead_code, unreachable_pub, unused)]
 #[unsafe(no_mangle)]

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -394,7 +394,9 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
     ${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
     controller->m_sinkPtr = nullptr;
 
-    ${name}__close(lexicalGlobalObject, ptr);
+    // close(reason): the pump (rsisAbrupt) passes the source's error, a clean
+    // close passes nothing. The sink tells the two apart.
+    ${name}__close(lexicalGlobalObject, ptr, JSC::JSValue::encode(callFrame->argument(0)));
 
     // detach() must still fire onClose (it transitions the direct
     // ReadableStream to closed/errored and calls underlyingSource.cancel())
@@ -505,7 +507,7 @@ JSC_DEFINE_HOST_FUNCTION(${name}__doClose, (JSC::JSGlobalObject * lexicalGlobalO
     }
 
     sink->detach();
-    ${name}__close(lexicalGlobalObject, ptr);
+    ${name}__close(lexicalGlobalObject, ptr, JSC::JSValue::encode(JSC::jsUndefined()));
     // detach() nulled m_sinkPtr so ~${className} won't finalize ptr; do the
     // destructor's teardown (onDestroy first so Subprocess clears its weak
     // back-pointer, then __finalize) here instead, even if __close threw.
@@ -1153,13 +1155,16 @@ pub extern "C" fn ${name}__controllerDetached(this: &mut ${name}, controller: JS
 
 `;
 
-    // ZIG_DECL JSC::EncodedJSValue ${name}__close(JSC::JSGlobalObject*, void* sinkPtr)
-    // C++ caller null-checks `ptr` before calling.
+    // ZIG_DECL JSC::EncodedJSValue ${name}__close(JSC::JSGlobalObject*, void* sinkPtr, JSC::EncodedJSValue reason)
+    // C++ caller null-checks `ptr` before calling. `*mut`, not `&mut`: a
+    // failing close can re-enter the sink through its owner (see
+    // `JsSinkType::close_with_error`).
     symbols.push(`${name}__close`);
     templ += `#[allow(dead_code, unreachable_pub, unused)]
 #[unsafe(no_mangle)]
-pub extern "C" fn ${name}__close(global: &JSGlobalObject, this: &mut ${name}) -> JSValue {
-    ${JSSinkT}::js_close(global, this)
+pub unsafe extern "C" fn ${name}__close(global: &JSGlobalObject, this: *mut ${name}, reason: JSValue) -> JSValue {
+    // SAFETY: C++ passes its live, null-checked \`m_sinkPtr\`.
+    unsafe { ${JSSinkT}::js_close(global, this, reason) }
 }
 
 `;

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -436,7 +436,7 @@ CPP_DECL JSC::EncodedJSValue ArrayBufferSink__createObject(JSC::JSGlobalObject* 
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue ArrayBufferSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue ArrayBufferSink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(ArrayBufferSink__construct);
 BUN_DECLARE_HOST_FUNCTION(ArrayBufferSink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI ArrayBufferSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
@@ -451,7 +451,7 @@ CPP_DECL JSC::EncodedJSValue HTTPSResponseSink__createObject(JSC::JSGlobalObject
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue HTTPSResponseSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue HTTPSResponseSink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(HTTPSResponseSink__construct);
 BUN_DECLARE_HOST_FUNCTION(HTTPSResponseSink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI HTTPSResponseSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
@@ -466,7 +466,7 @@ CPP_DECL JSC::EncodedJSValue HTTPResponseSink__createObject(JSC::JSGlobalObject*
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue HTTPResponseSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue HTTPResponseSink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(HTTPResponseSink__construct);
 BUN_DECLARE_HOST_FUNCTION(HTTPResponseSink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI SYSV_ABI HTTPResponseSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
@@ -481,7 +481,7 @@ CPP_DECL JSC::EncodedJSValue FileSink__createObject(JSC::JSGlobalObject* arg0, v
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue FileSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue FileSink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(FileSink__construct);
 BUN_DECLARE_HOST_FUNCTION(FileSink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI FileSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
@@ -497,7 +497,7 @@ CPP_DECL JSC::EncodedJSValue FileSink__createObject(JSC::JSGlobalObject* arg0, v
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue FileSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue FileSink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(FileSink__construct);
 BUN_DECLARE_HOST_FUNCTION(FileSink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI FileSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
@@ -513,7 +513,7 @@ CPP_DECL void* NetworkSink__fromJS(JSC::EncodedJSValue JSValue1);
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue NetworkSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue NetworkSink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(NetworkSink__construct);
 BUN_DECLARE_HOST_FUNCTION(NetworkSink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI SYSV_ABI NetworkSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
@@ -529,7 +529,7 @@ CPP_DECL void* FetchRequestBodySink__fromJS(JSC::EncodedJSValue JSValue1);
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue FetchRequestBodySink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue FetchRequestBodySink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__construct);
 BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI SYSV_ABI FetchRequestBodySink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
@@ -545,7 +545,7 @@ CPP_DECL void* HTMLRewriterSink__fromJS(JSC::EncodedJSValue JSValue1);
 
 #ifdef __cplusplus
 
-ZIG_DECL JSC::EncodedJSValue HTMLRewriterSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+ZIG_DECL JSC::EncodedJSValue HTMLRewriterSink__close(JSC::JSGlobalObject* arg0, void* arg1, JSC::EncodedJSValue arg2);
 BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__construct);
 BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__end);
 ZIG_DECL JSC::EncodedJSValue SYSV_ABI HTMLRewriterSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -729,9 +729,9 @@ pub struct RewriterPipe {
     /// from calling `end_rewrite()`; run it once unblocked.
     input_ended: Cell<bool>,
     /// `true` while a JS-pump `.then()` reaction (attached in
-    /// [`Self::wire_input`]) is still owed. The generated `${controller}__close`
-    /// drops its error argument, so `end_from_stream` defers terminal work to
-    /// the reaction (which carries the real error) while this is set.
+    /// [`Self::wire_input`]) is still owed. The pump closes the sink before
+    /// its promise settles, so `end_from_stream` defers terminal work to the
+    /// reaction while this is set.
     js_pump_reaction_pending: Cell<bool>,
     /// Bytes accepted from the input while suspended or output-backpressured.
     pending_input: JsCell<Vec<u8>>,

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1478,11 +1478,10 @@ impl RewriterPipe {
 
         if self.js_pump_reaction_pending.get() {
             // The pump-promise `.then()` reaction is the single terminal
-            // authority on the JS-pump path: `rsisAbrupt` calls
-            // `controller.close(error)` synchronously (the generated `__close`
-            // drops the argument) before rejecting the pump promise, so running
-            // `end_rewrite` here would resolve the body with truncated output
-            // and pre-empt the reject reaction.
+            // authority on the JS-pump path: the pump calls
+            // `controller.close(...)` synchronously before the promise settles,
+            // so running `end_rewrite` here would resolve the body before the
+            // reaction has had its say.
             return;
         }
 
@@ -1888,6 +1887,17 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
     }
     fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
         self.end_from_stream(err.map(StreamError::Error));
+        bun_sys::Result::Ok(())
+    }
+    unsafe fn close_with_error(
+        this: *mut Self,
+        global: &JSGlobalObject,
+        reason: JSValue,
+    ) -> bun_sys::Result<()> {
+        // SAFETY: caller contract; `end_from_stream` pins the pipe itself.
+        unsafe { &*this }.end_from_stream(Some(StreamError::JSValue(
+            jsc::strong::Optional::create(reason, global),
+        )));
         bun_sys::Result::Ok(())
     }
     fn end_from_js(&mut self, _global: &JSGlobalObject) -> bun_sys::Result<JSValue> {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1477,11 +1477,8 @@ impl RewriterPipe {
         let src = self.detach_input_source(false);
 
         if self.js_pump_reaction_pending.get() {
-            // The pump-promise `.then()` reaction is the single terminal
-            // authority on the JS-pump path: the pump calls
-            // `controller.close(...)` synchronously before the promise settles,
-            // so running `end_rewrite` here would resolve the body before the
-            // reaction has had its say.
+            // The pump closes the sink before its promise settles; the `.then()`
+            // reaction is the terminal step on this path.
             return;
         }
 

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -313,18 +313,13 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue>;
     fn flush(&mut self) -> sys::Result<()>;
     fn start(&mut self, config: streams::Start) -> sys::Result<()>;
-    /// `controller.close(reason)` called with an argument: the JS pump's
-    /// source failed (`rsisAbrupt`), so the bytes written so far are a
-    /// truncated body, not a complete one. `reason` is the source's stored
-    /// error and can be `undefined` or `null` (`controller.error()` with no
-    /// argument). A sink whose output is observable (a file, an upload, a
-    /// transformed body) must fail instead of ending as if the source had
-    /// closed. The default keeps the clean end for sinks whose owner learns
-    /// of the failure from the pump promise rejection.
+    /// `controller.close(reason)` with an argument: the pump's source failed,
+    /// so the bytes written so far are a truncated body. `reason` is the
+    /// source's error and may be nullish. The default keeps the clean end for
+    /// sinks whose owner handles the pump promise rejection.
     ///
-    /// Raw pointer, not `&mut self`: failing can re-enter the sink through its
-    /// owner (the S3 upload task's completion callback borrows the sink) and
-    /// may free it.
+    /// Raw pointer: failing can re-enter the sink through its owner and may
+    /// free it.
     ///
     /// # Safety
     /// `this` is the cell's live sink.
@@ -642,9 +637,8 @@ impl<T: JsSinkType> JSSink<T> {
     /// `${abi_name}__close` body — called from
     /// `${controller}__close` and `${name}__doClose` in JSSink.cpp with a raw
     /// `m_sinkPtr` (not a host-fn callframe), so exceptions become `.zero`.
-    /// `reason` is the `close(reason)` argument: the source's error from the
-    /// pump's abrupt path (possibly `undefined`), or the empty value when
-    /// `close()` was called with no argument (a clean close).
+    /// `reason` is the `close(reason)` argument, or the empty value when
+    /// `close()` had no argument.
     ///
     /// # Safety
     /// `this` is the cell's live sink.

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -313,12 +313,14 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue>;
     fn flush(&mut self) -> sys::Result<()>;
     fn start(&mut self, config: streams::Start) -> sys::Result<()>;
-    /// `controller.close(reason)` with a non-empty `reason`: the JS pump's
+    /// `controller.close(reason)` called with an argument: the JS pump's
     /// source failed (`rsisAbrupt`), so the bytes written so far are a
-    /// truncated body, not a complete one. A sink whose output is observable
-    /// (a file, an upload, a transformed body) must fail instead of ending as
-    /// if the source had closed. The default keeps the clean end for sinks
-    /// whose owner learns of the failure from the pump promise rejection.
+    /// truncated body, not a complete one. `reason` is the source's stored
+    /// error and can be `undefined` or `null` (`controller.error()` with no
+    /// argument). A sink whose output is observable (a file, an upload, a
+    /// transformed body) must fail instead of ending as if the source had
+    /// closed. The default keeps the clean end for sinks whose owner learns
+    /// of the failure from the pump promise rejection.
     ///
     /// Raw pointer, not `&mut self`: failing can re-enter the sink through its
     /// owner (the S3 upload task's completion callback borrows the sink) and
@@ -641,7 +643,8 @@ impl<T: JsSinkType> JSSink<T> {
     /// `${controller}__close` and `${name}__doClose` in JSSink.cpp with a raw
     /// `m_sinkPtr` (not a host-fn callframe), so exceptions become `.zero`.
     /// `reason` is the `close(reason)` argument: the source's error from the
-    /// pump's abrupt path, `undefined` for a clean close.
+    /// pump's abrupt path (possibly `undefined`), or the empty value when
+    /// `close()` was called with no argument (a clean close).
     ///
     /// # Safety
     /// `this` is the cell's live sink.
@@ -664,7 +667,7 @@ impl<T: JsSinkType> JSSink<T> {
             return JSValue::ZERO;
         }
 
-        let result = if reason.is_empty_or_undefined_or_null() {
+        let result = if reason.is_empty() {
             // SAFETY: as above; `end` does not free the sink.
             unsafe { (*this).end(None) }
         } else {

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -313,6 +313,27 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue>;
     fn flush(&mut self) -> sys::Result<()>;
     fn start(&mut self, config: streams::Start) -> sys::Result<()>;
+    /// `controller.close(reason)` with a non-empty `reason`: the JS pump's
+    /// source failed (`rsisAbrupt`), so the bytes written so far are a
+    /// truncated body, not a complete one. A sink whose output is observable
+    /// (a file, an upload, a transformed body) must fail instead of ending as
+    /// if the source had closed. The default keeps the clean end for sinks
+    /// whose owner learns of the failure from the pump promise rejection.
+    ///
+    /// Raw pointer, not `&mut self`: failing can re-enter the sink through its
+    /// owner (the S3 upload task's completion callback borrows the sink) and
+    /// may free it.
+    ///
+    /// # Safety
+    /// `this` is the cell's live sink.
+    unsafe fn close_with_error(
+        this: *mut Self,
+        _global: &JSGlobalObject,
+        _reason: JSValue,
+    ) -> sys::Result<()> {
+        // SAFETY: caller contract; `end` does not free the sink.
+        unsafe { (*this).end(None) }
+    }
 
     fn construct(_this: &mut core::mem::MaybeUninit<Self>) {
         // Only reached when `HAS_CONSTRUCT = false` callers misroute; the
@@ -619,15 +640,23 @@ impl<T: JsSinkType> JSSink<T> {
     /// `${abi_name}__close` body — called from
     /// `${controller}__close` and `${name}__doClose` in JSSink.cpp with a raw
     /// `m_sinkPtr` (not a host-fn callframe), so exceptions become `.zero`.
-    pub(crate) fn js_close(
+    /// `reason` is the `close(reason)` argument: the source's error from the
+    /// pump's abrupt path, `undefined` for a clean close.
+    ///
+    /// # Safety
+    /// `this` is the cell's live sink.
+    pub(crate) unsafe fn js_close(
         global: &crate::webcore::jsc::JSGlobalObject,
-        this: &mut T,
+        this: *mut T,
+        reason: crate::webcore::jsc::JSValue,
     ) -> crate::webcore::jsc::JSValue {
         use crate::webcore::jsc::JSValue;
         use bun_sys_jsc::ErrorJsc;
         bun_core::mark_binding!();
 
-        if let Some(err) = this.get_pending_error() {
+        // SAFETY: caller contract; the borrow ends before `close_with_error`,
+        // which may re-enter or free the sink.
+        if let Some(err) = unsafe { (*this).get_pending_error() } {
             // `throw_error` sets the pending JS exception and returns the
             // `JsError` for `?`-propagation; this host fn returns bare
             // `JSValue`, so report and return ZERO (caller checks exception).
@@ -635,8 +664,16 @@ impl<T: JsSinkType> JSSink<T> {
             return JSValue::ZERO;
         }
 
+        let result = if reason.is_empty_or_undefined_or_null() {
+            // SAFETY: as above; `end` does not free the sink.
+            unsafe { (*this).end(None) }
+        } else {
+            // SAFETY: caller contract.
+            unsafe { T::close_with_error(this, global, reason) }
+        };
+
         // TODO: properly propagate exception upwards
-        match this.end(None) {
+        match result {
             sys::Result::Ok(()) => JSValue::UNDEFINED,
             sys::Result::Err(err) => match err.to_js(global) {
                 Ok(v) => {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2387,13 +2387,10 @@ impl NetworkSink {
         bun_sys::Result::Ok(())
     }
 
-    /// JS-pump terminator for a source that failed (`controller.close(error)`
-    /// from the pump's abrupt path). Unlike `end()`, the upload is not
-    /// committed: `task.fail` aborts it, and the stashed error makes the
-    /// caller's promise reject with the source's own error (a nullish reason
-    /// falls back to the generic S3 error). The pump promise's reject reaction
-    /// (`S3UploadStreamWrapper::handle_reject_stream`) still runs afterwards
-    /// and releases the pump ref, so no wrapper deref here.
+    /// JS-pump terminator for a source that failed. Unlike `end()`, the upload
+    /// is aborted, not committed; the stashed reason becomes the caller's
+    /// rejection. The pump's reject reaction still releases the pump ref, so
+    /// no wrapper deref here.
     ///
     /// Raw `*mut Self`: `task.fail()` synchronously fires
     /// `S3UploadStreamWrapper::resolve`, which re-borrows this sink.

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2390,9 +2390,10 @@ impl NetworkSink {
     /// JS-pump terminator for a source that failed (`controller.close(error)`
     /// from the pump's abrupt path). Unlike `end()`, the upload is not
     /// committed: `task.fail` aborts it, and the stashed error makes the
-    /// caller's promise reject with the source's own error. The pump promise's
-    /// reject reaction (`S3UploadStreamWrapper::handle_reject_stream`) still
-    /// runs afterwards and releases the pump ref, so no wrapper deref here.
+    /// caller's promise reject with the source's own error (a nullish reason
+    /// falls back to the generic S3 error). The pump promise's reject reaction
+    /// (`S3UploadStreamWrapper::handle_reject_stream`) still runs afterwards
+    /// and releases the pump ref, so no wrapper deref here.
     ///
     /// Raw `*mut Self`: `task.fail()` synchronously fires
     /// `S3UploadStreamWrapper::resolve`, which re-borrows this sink.
@@ -2408,7 +2409,9 @@ impl NetworkSink {
             (*this).done = true;
             (*this).pending.result = Writable::Done;
             (*this).pending.run();
-            (*this).upstream_error.set(global, reason);
+            if !reason.is_empty_or_undefined_or_null() {
+                (*this).upstream_error.set(global, reason);
+            }
             (*this).task
         };
         let Some(task_ref) = task_ref else {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2387,6 +2387,39 @@ impl NetworkSink {
         bun_sys::Result::Ok(())
     }
 
+    /// JS-pump terminator for a source that failed (`controller.close(error)`
+    /// from the pump's abrupt path). Unlike `end()`, the upload is not
+    /// committed: `task.fail` aborts it, and the stashed error makes the
+    /// caller's promise reject with the source's own error. The pump promise's
+    /// reject reaction (`S3UploadStreamWrapper::handle_reject_stream`) still
+    /// runs afterwards and releases the pump ref, so no wrapper deref here.
+    ///
+    /// Raw `*mut Self`: `task.fail()` synchronously fires
+    /// `S3UploadStreamWrapper::resolve`, which re-borrows this sink.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub(crate) fn fail_from_js_pump(this: *mut Self, global: &JSGlobalObject, reason: JSValue) {
+        // SAFETY: `this` is the live Box<NetworkSink> the wrapper owns; the
+        // borrow ends before `fail` re-enters.
+        let task_ref = unsafe {
+            if (*this).ended {
+                return;
+            }
+            (*this).ended = true;
+            (*this).done = true;
+            (*this).pending.result = Writable::Done;
+            (*this).pending.run();
+            (*this).upstream_error.set(global, reason);
+            (*this).task
+        };
+        let Some(task_ref) = task_ref else {
+            return;
+        };
+        let _ = task_ref.get().fail(bun_s3_signing::error::S3Error {
+            code: b"UnknownError",
+            message: b"ReadableStream ended with an error",
+        });
+    }
+
     /// Native-path terminator called from `SinkHandle::end`. Unlike `end()`
     /// (clean EOF / commit), an upstream error on the ByteStream fast-path must
     /// abort the upload and surface the original JS error to the caller.
@@ -2502,6 +2535,14 @@ impl crate::webcore::sink::JsSinkType for NetworkSink {
             (*this).finalize();
             Self::release_writer_holder(this);
         }
+    }
+    unsafe fn close_with_error(
+        this: *mut Self,
+        global: &JSGlobalObject,
+        reason: JSValue,
+    ) -> bun_sys::Result<()> {
+        Self::fail_from_js_pump(this, global, reason);
+        bun_sys::Result::Ok(())
     }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         Self::end_from_js(self, global)

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1866,9 +1866,21 @@ describe("s3 upload stream body error", () => {
     [
       "async pull",
       "await Bun.sleep(1); if (n++ < 2) controller.enqueue(new Uint8Array(1024)); else controller.error(new Error('boom'));",
+      "rejected boom",
     ],
-    ["sync pull", "if (n++ < 2) controller.enqueue(new Uint8Array(1024)); else controller.error(new Error('boom'));"],
-  ])("does not commit a PUT when a ReadableStream body errors after enqueue (%s)", async (_, pullBody) => {
+    [
+      "sync pull",
+      "if (n++ < 2) controller.enqueue(new Uint8Array(1024)); else controller.error(new Error('boom'));",
+      "rejected boom",
+    ],
+    // error() with no reason still errors the stream; the sink must not read
+    // the undefined reason as a clean close.
+    [
+      "error() without a reason",
+      "if (n++ < 2) controller.enqueue(new Uint8Array(1024)); else controller.error();",
+      "rejected ReadableStream ended with an error",
+    ],
+  ])("does not commit a PUT when a ReadableStream body errors after enqueue (%s)", async (_, pullBody, expected) => {
     const fixture = `
       const puts = {};
       const server = Bun.serve({
@@ -1911,7 +1923,7 @@ describe("s3 upload stream body error", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({
-      outcome: "rejected boom",
+      outcome: expected,
       after: 1,
       puts: { "/my_bucket/ok": 1 },
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1856,6 +1856,68 @@ describe("s3 upload stream body error", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A JS ReadableStream body that errors after some chunks. The pump closes the
+  // sink with the error before the write() promise rejects; that close used to
+  // be a clean end, which committed the buffered chunks as a complete
+  // single-file PUT while the caller saw the rejection. The upload must be
+  // aborted instead: no PUT for the object, and the promise rejects with the
+  // source's own error.
+  it.each([
+    [
+      "async pull",
+      "await Bun.sleep(1); if (n++ < 2) controller.enqueue(new Uint8Array(1024)); else controller.error(new Error('boom'));",
+    ],
+    ["sync pull", "if (n++ < 2) controller.enqueue(new Uint8Array(1024)); else controller.error(new Error('boom'));"],
+  ])("does not commit a PUT when a ReadableStream body errors after enqueue (%s)", async (_, pullBody) => {
+    const fixture = `
+      const puts = {};
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const key = new URL(req.url).pathname;
+          puts[key] = (puts[key] ?? 0) + (await req.arrayBuffer()).byteLength;
+          return new Response(undefined, { status: 200, headers: { ETag: '"etag"' } });
+        },
+      });
+      const client = new Bun.S3Client({
+        accessKeyId: "test",
+        secretAccessKey: "test",
+        region: "eu-west-3",
+        bucket: "my_bucket",
+        endpoint: \`http://127.0.0.1:\${server.port}\`,
+        virtualHostedStyle: false,
+      });
+      let n = 0;
+      const rs = new ReadableStream({
+        async pull(controller) { ${pullBody} },
+      });
+      const outcome = await client.write("obj", rs).then(
+        bytes => "resolved " + bytes,
+        e => "rejected " + e.message,
+      );
+      // A healthy upload afterwards proves the client still works and, having
+      // round-tripped through the same server, that no earlier PUT is pending.
+      const after = await client.write("ok", "x");
+      server.stop(true);
+      console.log(JSON.stringify({ outcome, after, puts }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      // The S3 client honors the proxy environment; the stub is on loopback.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      outcome: "rejected boom",
+      after: 1,
+      puts: { "/my_bucket/ok": 1 },
+    });
+    expect(exitCode).toBe(0);
+  });
+
   // A native ByteStream source (fetch response body) that errors mid-stream must
   // reject the s3.write() promise with the original JS error, not commit a
   // truncated PUT or reject with a generic UnknownError.

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -504,16 +504,25 @@ describe("HTMLRewriter", () => {
     // read throws, so `controller.close(error)` and the pump rejection both
     // happen inside transform(), before any reject reaction is attached. The
     // close must carry the error to the pipe, or the body resolves to "".
-    it("a JS ReadableStream input that is already errored rejects the body", async () => {
+    // `error()` with no reason errors the stream with `undefined`; that must
+    // not read as a clean close either.
+    it.each([
+      ["an Error", new Error("upstream boom")],
+      ["undefined", undefined],
+    ])("a JS ReadableStream input that is already errored (%s) rejects the body", async (_, reason) => {
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
           controller.enqueue(encoder.encode("<p>partial"));
-          controller.error(new Error("upstream boom"));
+          controller.error(reason);
         },
       });
       const res = new HTMLRewriter().on("p", { element() {} }).transform(new Response(stream));
-      await expect(res.text()).rejects.toThrow("upstream boom");
+      const settled = await res.text().then(
+        text => ({ resolved: text }),
+        err => ({ rejected: err }),
+      );
+      expect(settled).toEqual({ rejected: reason });
     });
 
     // A `type: 'direct'` source whose `pull()` throws synchronously leaves the

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -471,10 +471,9 @@ describe("HTMLRewriter", () => {
     });
 
     // `rsisAbrupt` calls `controller.close(error)` synchronously before
-    // rejecting the pump promise, and the generated `__close` drops its error
-    // argument. The pipe must defer its terminal step to the reject reaction
-    // so the real error reaches the output body instead of resolving with
-    // truncated HTML.
+    // rejecting the pump promise. The pipe must defer its terminal step to the
+    // reject reaction so the real error reaches the output body instead of
+    // resolving with truncated HTML.
     it.each(["default", "pull"])(
       "a JS ReadableStream (%s) input that errors mid-stream rejects the body",
       async kind => {
@@ -500,6 +499,22 @@ describe("HTMLRewriter", () => {
         await expect(res.text()).rejects.toThrow("upstream boom");
       },
     );
+
+    // The input is already errored when transform() runs: the pump's first
+    // read throws, so `controller.close(error)` and the pump rejection both
+    // happen inside transform(), before any reject reaction is attached. The
+    // close must carry the error to the pipe, or the body resolves to "".
+    it("a JS ReadableStream input that is already errored rejects the body", async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode("<p>partial"));
+          controller.error(new Error("upstream boom"));
+        },
+      });
+      const res = new HTMLRewriter().on("p", { element() {} }).transform(new Response(stream));
+      await expect(res.text()).rejects.toThrow("upstream boom");
+    });
 
     // A `type: 'direct'` source whose `pull()` throws synchronously leaves the
     // JS controller's `m_sinkPtr` set after `readDirectStream` returns with an


### PR DESCRIPTION
### Problem
- A `ReadableStream` pumped into a native sink fails, and the sink treats it as a clean end. `S3Client.write(key, stream)` commits the buffered bytes as a complete single-file PUT (the object exists, truncated) while the returned promise rejects with the source error. `new HTMLRewriter().transform(new Response(stream)).text()` resolves to `""` when the stream is already errored at `transform()` time.
- Cause: `readStreamIntoSink` calls `controller.close(error)` on the sink controller before it rejects the pump promise (`BunStreamSource.cpp`, `rsisAbrupt` → `rsisSinkClose`). The generated `${controller}__close` (`src/codegen/generate-jssink.ts`) never read the argument, and `JSSink::js_close` (`src/runtime/webcore/Sink.rs`) always called `end(None)`. Every native sink saw EOF.

### Fix
- `close(reason)` now reaches the sink: the generated controller method passes `callFrame->argument(0)` to `${name}__close`, and `js_close` routes a non-empty reason to a new `JsSinkType::close_with_error(this, global, reason)`. Its default is the old clean end, so `ArrayBufferSink`, `FetchRequestBodySink`, the HTTP response sinks and `FileSink` behave as before (their owners already handle the pump rejection).
- `NetworkSink` (S3) fails the upload instead of committing: `task.fail` before any PUT is scheduled, with the source error stashed so the caller's promise rejects with it. `RewriterPipe` fails the rewrite with the error, so the output body rejects.
- Correct because the pump has already decided the body is incomplete when it closes with an error; the sink is the only party that did not know. The pump rejection reactions still run afterwards and still release their refs, so the ownership protocol of each sink is unchanged.
- Verified: `test/js/bun/s3/s3.test.ts` (two new rows, stock bun commits a 2048 byte PUT) and `test/js/workerd/html-rewriter.test.js` (one new test, stock bun resolves `""`). Also `filesink.test.ts`, the `spawn-stdin-*` files, `streams.test.js`, `serve-stream-body-error.test.ts`, `serve-direct-readable-stream.test.ts`, `body.test.ts`, `body-stream.test.ts`, `fetch.stream.test.ts`, `fetch-backpressure.test.ts`, `html-rewriter-doctype.test.ts`.

### Background
- A native sink (`JsSinkType` in `Sink.rs`) is a Rust writer behind a JS controller object. `JSSink::assign_to_stream` starts `readStreamIntoSink`, the JS pump: it reads the stream and calls the controller's `write`, `end`, or `close(error)`. The pump also returns a promise the sink's owner reacts to.
- `close_with_error` takes `*mut Self`, like `finalize`: `NetworkSink::fail` fires the S3 task's completion callback synchronously, and that callback borrows the sink again.
- The sink's own JS `close()` method (`${name}__doClose`) still passes no reason.

<details><summary>Notes</summary>

Wire before the fix, S3 stub on loopback, stream enqueues two 1 KB chunks then `controller.error(new Error("boom"))`: the stub receives `PUT /my_bucket/obj` with `Content-Length: 2048` and a complete body; `client.write` rejects with `boom`. After: no PUT, the same rejection. A stream that closes cleanly still produces the PUT.

HTMLRewriter before the fix: a stream that errors after the first chunk already rejected (the pump's reject reaction is the terminal step on the Pending arm). Only the already-errored input resolved to `""`: `readMany` throws synchronously, so `close(error)` and the rejection both happen inside `transform()`, the pipe had already run `end_rewrite` from the clean close, and the Rejected arm's `end_from_stream(Some(err))` found it done.

FileSink (spawn stdin, `Bun.write(path, stream)`) keeps the default. Its pump reactions already handle the failure (`Bun.write` rejects; the spawn path aborts the stream). Closing without flushing would drop the bytes the source produced before it failed depending on whether the auto-flusher had run yet, and `spawn-stdin-readable-stream-edge-cases.test.ts` ("ReadableStream with exception in pull") pins that those bytes reach the child. A pipe has no incomplete-message signal beyond EOF, so there is nothing else for the sink to do there; what a JS observer for a failed spawn stdin stream should look like is a separate question.

Related: #40596 fixes the same family on the `Bun.serve` response side.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js

<!-- robobun:evidence:end -->