### PR TITLE
WTFTimer: decide "no event loop on this thread" by checking for the VirtualMachine, not a bundler-thread flag

### DIFF
--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -168,7 +168,6 @@ pub(crate) fn __bun_jsc_generate_cached_bytecode(
     depth: u32,
     external_strings: Option<NonNull<EncoderStringTable>>,
 ) -> Option<Box<[u8]>> {
-    crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
     let (bytes, handle) =
         CachedBytecode::generate(format, source, source_provider_url, depth, external_strings)?;
@@ -199,7 +198,6 @@ pub(crate) fn __bun_jsc_encoder_string_table_take(table: NonNull<EncoderStringTa
 
 #[unsafe(no_mangle)]
 pub(crate) fn __bun_jsc_encoder_string_table_new() -> NonNull<EncoderStringTable> {
-    crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
     EncoderStringTable::new()
 }
@@ -240,7 +238,6 @@ pub(crate) fn __bun_jsc_generate_internal_module_bytecode(
     depth: u32,
     external_strings: Option<NonNull<EncoderStringTable>>,
 ) -> Option<Box<[u8]>> {
-    crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
     let mut bytes: Option<NonNull<u8>> = None;
     let mut size: usize = 0;
@@ -270,7 +267,6 @@ pub(crate) fn __bun_jsc_generate_internal_module_bytecode_from_source(
     depth: u32,
     external_strings: Option<NonNull<EncoderStringTable>>,
 ) -> Option<Box<[u8]>> {
-    crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
     let mut bytes: Option<NonNull<u8>> = None;
     let mut size: usize = 0;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -562,8 +562,6 @@ impl VMHolder {
 }
 
 #[thread_local]
-pub static IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE: Cell<bool> = Cell::new(false);
-#[thread_local]
 pub static IS_MAIN_THREAD_VM: Cell<bool> = Cell::new(false);
 
 static IS_SMOL_MODE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -12,7 +12,7 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 
 use bun_core::{Timespec, TimespecMockMode};
 
-use crate::jsc::virtual_machine::{IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE, VirtualMachine};
+use crate::jsc::virtual_machine::VirtualMachine;
 use crate::webcore::script_execution_context::Identifier as ScriptExecutionContextIdentifier;
 
 use super::{
@@ -236,16 +236,18 @@ impl WTFTimer {
     }
 }
 
+/// A `WTF::RunLoop` timer on this thread, backed by this thread's event loop. Null when the thread has no Bun
+/// `VirtualMachine` (a `JSC::VM` on a bundler thread generating bytecode, say): the timer then never fires, which
+/// `RunLoop::TimerBase` accepts.
+///
 /// # Safety
 /// `run_loop_timer` must be a non-null, live `WTF::RunLoop::TimerBase` owned
 /// by the caller for the lifetime of the returned `WTFTimer`.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn WTFTimer__create(run_loop_timer: *mut RunLoopTimer) -> *mut c_void {
-    if IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.get() {
+    let Some(vm) = VirtualMachine::get_or_null() else {
         return ptr::null_mut();
-    }
-
-    let vm = VirtualMachine::get_mut_ptr();
+    };
 
     // SAFETY: `vm` is the thread-local VirtualMachine; `run_loop_timer` is
     // non-null per caller contract; `event_loop().imminent_gc_timer` lives as


### PR DESCRIPTION
## What

`WTFTimer__create` backs every `WTF::RunLoop` timer (JSC's GC / promise / deferred-work timers, created per `JSC::VM`) with a timer on the *current thread's* Bun event loop. A thread that has no `VirtualMachine` — today, the bundler thread when it creates a `JSC::VM` to generate `--bytecode` output — has no event loop to put them on, and `RunLoopBun.cpp` already accepts a null timer for that case.

How that case was detected: a thread-local `IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE` flag that each bytecode entry point in `CachedBytecode.rs` had to set before touching JSC; `WTFTimer__create` otherwise called `VirtualMachine::get_mut_ptr()` unconditionally, so any other VM-less thread that ever constructed a `JSC::VM` (or any `RunLoop::Timer`) would dereference null.

Now `WTFTimer__create` checks `VirtualMachine::get_or_null()` itself and returns null when there is none; the flag and its four setters are gone. Behaviour on threads that do have a VM is unchanged (including a second `JSC::VM` created on a JS thread, whose timers correctly run on that thread's loop and are freed with the VM).

## Test

No new test — behaviour-preserving. Exercised: `bun build --compile --bytecode` (bundler thread, no VM in the process), `Bun.build({ compile, bytecode })` from a script (bundler thread while the main thread has a VM), and `bundler_bytecode_portable.test.ts` "encoder output does not depend on the encoding process" (≈200 bytecode-cache VMs created and destroyed on the JS thread).