### PR TITLE
napi: finalize an aborted threadsafe function without waiting for the other threads' references

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2438,9 +2438,10 @@ extern "C" fn napi_internal_enqueue_finalizer(
 // ThreadSafeFunction
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Ownership: the JS thread owns this allocation while the env lives and frees
-/// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
-/// `thread_count` references, and whoever drops the last one frees it.
+/// Ownership: the JS thread owns this allocation until it has finalized the
+/// function (`finalize`, or `env_teardown` when the env dies first); from
+/// `resources_released` on it belongs to the remaining `thread_count`
+/// references, and whoever drops the last one frees it.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2492,11 +2493,11 @@ pub(crate) struct ThreadSafeFunction {
     /// that would reach `event_loop` from another thread reads it under the
     /// same lock, so teardown cannot land between the check and the enqueue.
     pub(crate) env_dead: AtomicBool,
-    /// Also written under `lock`, once `env_teardown` has released every
-    /// JS-thread-owned resource. Until then teardown still owns this object,
-    /// so a thread that drops the last `thread_count` reference must not free
-    /// it (Node's `kClosed`).
-    pub(crate) env_teardown_done: AtomicBool,
+    /// Also written under `lock` on the JS thread, once `finalize` or
+    /// `env_teardown` has released every JS-thread-owned resource. Until then
+    /// the JS thread still owns this object, so a thread that drops the last
+    /// `thread_count` reference must not free it (Node's `kClosed`).
+    pub(crate) resources_released: AtomicBool,
 }
 
 pub(crate) enum TsfnCallback {
@@ -2593,9 +2594,9 @@ impl ThreadSafeFunction {
         }
         // SAFETY: as above.
         if unsafe { (*this).closing.load(Ordering::SeqCst) } == ClosingState::Closed as u8 {
-            // Finalize the ThreadSafeFunction.
-            // SAFETY: `this` is the live heap allocation we own; closed state guarantees no other thread will touch it.
-            unsafe { ThreadSafeFunction::destroy(this) };
+            // SAFETY: `this` is the live heap allocation `maybe_queue_finalizer`
+            // queued this task for.
+            unsafe { ThreadSafeFunction::finalize(this) };
             return;
         }
 
@@ -2714,15 +2715,16 @@ impl ThreadSafeFunction {
                 // Closing (napi_tsfn_abort, or the last call already ran):
                 // nothing still queued runs any more, as in Node's DispatchOne.
                 // An abort's leftovers go back to the addon, with no lock held
-                // since that re-enters it; the function finalizes once the last
-                // thread reference is gone.
+                // since that re-enters it. Then the function finalizes, whether
+                // or not other threads still hold references: after an abort
+                // they are told to make no further calls, so they may never
+                // release (Node's CloseHandlesAndMaybeDelete). They only decide
+                // who frees the allocation (`finalize`).
                 let leftovers = self.take_queue();
                 drop(_g);
                 self.hand_back(leftovers);
                 let _g = self.lock.lock_guard();
-                if self.thread_count.load(Ordering::SeqCst) == 0 {
-                    self.maybe_queue_finalizer();
-                }
+                self.maybe_queue_finalizer();
                 return Ok(false);
             }
             let was_blocked = self.queue.is_blocked();
@@ -2943,34 +2945,64 @@ impl ThreadSafeFunction {
         }
     }
 
-    /// Consumes and frees a heap-allocated ThreadSafeFunction (allocated by `new`).
-    /// SAFETY: `this` must be a live `*mut ThreadSafeFunction` returned from `heap::alloc`
-    /// and not aliased; caller transfers ownership.
-    pub(crate) unsafe fn destroy(this: *mut ThreadSafeFunction) {
-        // SAFETY: caller contract — `this` is a live heap allocation and we are
-        // the sole owner; reclaim the Box up front so the body works on owned
-        // state and the drop at scope end frees it.
-        let mut self_ = unsafe { bun_core::heap::take(this) };
-        self_.unref();
+    /// Runs on the JS thread once the function has closed
+    /// (`maybe_queue_finalizer`). Runs the addon's finalizer and releases what
+    /// only this thread may release, then hands the allocation over to the
+    /// remaining `thread_count` references (Node's Finalize + MaybeDelete):
+    /// with none left it is freed here, else by whoever drops the last one
+    /// (`release_locked`).
+    ///
+    /// SAFETY: `this` is a live allocation from `new` that no other event-loop
+    /// task will reach again.
+    unsafe fn finalize(this: *mut ThreadSafeFunction) {
+        // SAFETY: caller contract. The borrow ends before the addon's finalizer
+        // runs, since that may still use the handle
+        // (napi_get_threadsafe_function_context).
+        let finalizer = unsafe {
+            let self_ = &mut *this;
+            if let Some(env) = self_.env.as_ref() {
+                // SAFETY: env is live (we hold a ref); drops our registry entry
+                // so teardown cannot hand this pointer out after it is freed.
+                // `this` is passed as an opaque registry key only, never
+                // dereferenced.
+                NapiEnv__unregisterThreadSafeFunction(env.get(), this.cast());
+            }
+            self_
+                .finalizer_fun
+                .take()
+                .zip(self_.env.as_ref())
+                .map(|(fun, env)| Finalizer {
+                    env: env.clone(),
+                    fun,
+                    data: self_.finalizer_data,
+                    hint: self_.ctx,
+                })
+        };
 
-        if let Some(env) = self_.env.as_ref() {
-            // SAFETY: env is live (we hold a ref); drops our registry entry so
-            // teardown cannot hand this pointer out after we free it. `this` is
-            // passed as an opaque registry key only, never dereferenced.
-            unsafe { NapiEnv__unregisterThreadSafeFunction(env.get(), this.cast()) };
+        // Before anything is released, as in Node and `env_teardown`. This
+        // dispatch is the finalizer's landing frame.
+        if let Some(mut finalizer) = finalizer {
+            crate::dispatch::fold(finalizer.run());
         }
 
-        if let (Some(fun), Some(env)) = (self_.finalizer_fun, self_.env.as_ref()) {
-            // Note: ownership transfer of `env` into the Finalizer. We clone (bumps the
-            // external refcount) and let the original drop with the Box below — net refcount
-            // delta is zero.
-            let finalizer = Finalizer {
-                env: env.clone(),
-                fun,
-                data: self_.finalizer_data,
-                hint: self_.ctx,
-            };
-            finalizer.enqueue();
+        // SAFETY: caller contract; the finalizer has returned and the borrow
+        // ends before the free below.
+        let free = unsafe {
+            let self_ = &mut *this;
+            // Published in the same critical section that reads thread_count,
+            // as in `env_teardown`: a thread that drops the last reference
+            // frees the allocation only if it sees this store.
+            let _g = self_.lock.lock_guard();
+            self_.event_loop = None;
+            drop(self_.env.take());
+            self_.resources_released.store(true, Ordering::SeqCst);
+            self_.thread_count.load(Ordering::SeqCst) <= 0
+        };
+
+        if free {
+            // SAFETY: no thread reference is left, the lock is dropped, and
+            // nothing else can reach this allocation.
+            unsafe { ThreadSafeFunction::free_orphaned(this) };
         }
     }
 
@@ -3056,15 +3088,15 @@ impl ThreadSafeFunction {
         }
 
         // Phase 3: release what only the JS thread may release, then hand the
-        // allocation over: `env_teardown_done` is what lets another thread free
-        // it, so it is published in the same critical section that reads
+        // allocation over: `resources_released` is what lets another thread
+        // free it, so it is published in the same critical section that reads
         // thread_count (Node's ReleaseResources + MaybeDelete).
         let _g = self.lock.lock_guard();
         self.callback = TsfnCallback::Js(StrongOptional::empty());
         self.poll_ref.disable();
         self.event_loop = None;
         drop(self.env.take());
-        self.env_teardown_done.store(true, Ordering::SeqCst);
+        self.resources_released.store(true, Ordering::SeqCst);
         // Cleanup hooks are the loop's last tick: a task still queued for this
         // TSFN will never run (and its `release_unrun` does not dereference it).
         // With no thread_count reference left, nobody else can reach this, so
@@ -3130,34 +3162,35 @@ impl ThreadSafeFunction {
 
         let prev_remaining = self.thread_count.fetch_sub(1, Ordering::SeqCst);
 
-        if self.env_dead.load(Ordering::SeqCst) {
-            // The event loop we were created on is gone (`env_teardown` set
-            // this under the lock we hold). Never schedule onto it. Whoever
-            // drops the last reference frees us -- but only once teardown has
-            // released the JS-thread-owned resources; until then it owns us
-            // and will free us itself if we are the last to let go.
-            let orphaned = prev_remaining == 1 && self.env_teardown_done.load(Ordering::SeqCst);
+        if self.env_dead.load(Ordering::SeqCst)
+            || self.closing.load(Ordering::SeqCst) == ClosingState::Closed as u8
+        {
+            // The JS thread owns the finalization: `finalize` is queued or
+            // done, or the event loop we were created on is gone
+            // (`env_teardown`; both set their state under the lock we hold).
+            // Never schedule onto the loop again. Whoever drops the last
+            // reference frees us -- but only once the JS thread has released
+            // the resources only it may release; until then it owns us and
+            // will free us itself if we are the last to let go.
+            let orphaned = prev_remaining == 1 && self.resources_released.load(Ordering::SeqCst);
             return (NapiStatus::ok as napi_status, orphaned);
         }
 
-        if mode == napi_threadsafe_function_release_mode::abort || prev_remaining == 1 {
-            if !self.is_closing() {
-                if mode == napi_threadsafe_function_release_mode::abort {
-                    self.closing
-                        .store(ClosingState::Closing as u8, Ordering::SeqCst);
-                    if self.queue.max_queue_size > 0 {
-                        // Wake all producers blocked in enqueue()'s bounded
-                        // queue wait so they observe is_closing and release.
-                        self.blocking_condvar.broadcast();
-                    }
+        // Already closing: the abort's dispatch is pending or running and
+        // finalizes whatever thread_count is by then.
+        if (mode == napi_threadsafe_function_release_mode::abort || prev_remaining == 1)
+            && !self.is_closing()
+        {
+            if mode == napi_threadsafe_function_release_mode::abort {
+                self.closing
+                    .store(ClosingState::Closing as u8, Ordering::SeqCst);
+                if self.queue.max_queue_size > 0 {
+                    // Wake all producers blocked in enqueue()'s bounded
+                    // queue wait so they observe is_closing and release.
+                    self.blocking_condvar.broadcast();
                 }
-                self.schedule_dispatch();
-            } else if prev_remaining == 1 {
-                // Already closing from an earlier abort. The last release must
-                // still reach dispatch_one's thread_count==0 path so the
-                // finalizer runs and the event-loop keepalive is dropped.
-                self.schedule_dispatch();
             }
+            self.schedule_dispatch();
         }
 
         (NapiStatus::ok as napi_status, false)
@@ -3245,7 +3278,7 @@ extern "C" fn napi_create_threadsafe_function(
         blocking_condvar: Condvar::default(),
         closing: AtomicU8::new(ClosingState::NotClosing as u8),
         env_dead: AtomicBool::new(false),
-        env_teardown_done: AtomicBool::new(false),
+        resources_released: AtomicBool::new(false),
     });
 
     // Register with the env so that VM/worker teardown neutralizes this TSFN

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2868,7 +2868,8 @@ impl ThreadSafeFunction {
 
         if orphaned {
             // SAFETY: the lock is dropped, we dropped the last thread reference
-            // and `env_teardown` already released everything it owned.
+            // and the JS thread (`finalize` or `env_teardown`) already released
+            // everything it owned.
             unsafe { ThreadSafeFunction::free_orphaned(this) };
         }
         status
@@ -3008,7 +3009,8 @@ impl ThreadSafeFunction {
 
     /// Frees the allocation and nothing else: no finalizer, no registry entry,
     /// no event loop. Every JS-thread-owned resource must already be released
-    /// (`env_teardown`) or be safe to drop here (a creation that failed).
+    /// (`finalize`, `env_teardown`) or be safe to drop here (a creation that
+    /// failed).
     ///
     /// SAFETY: `this` is a live allocation from `new`, the caller holds no
     /// lock on it, and no other thread holds a reference.
@@ -3144,7 +3146,8 @@ impl ThreadSafeFunction {
 
         if orphaned {
             // SAFETY: the lock is dropped, we dropped the last thread reference
-            // and `env_teardown` already released everything it owned.
+            // and the JS thread (`finalize` or `env_teardown`) already released
+            // everything it owned.
             unsafe { ThreadSafeFunction::free_orphaned(this) };
         }
         status
@@ -3202,7 +3205,7 @@ impl ThreadSafeFunction {
 #[unsafe(no_mangle)]
 extern "C" fn napi_internal_threadsafe_function_env_teardown(tsfn: *mut c_void) {
     let this = tsfn.cast::<ThreadSafeFunction>();
-    // SAFETY: the registry only holds live TSFN pointers — `destroy` and
+    // SAFETY: the registry only holds live TSFN pointers — `finalize` and
     // `env_teardown` both remove the entry before freeing. Exclusive borrow
     // scoped to this call.
     if unsafe { (*this).env_teardown() } {

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2438,10 +2438,9 @@ extern "C" fn napi_internal_enqueue_finalizer(
 // ThreadSafeFunction
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Ownership: the JS thread owns this allocation until it has finalized the
-/// function (`finalize`, or `env_teardown` when the env dies first); from
-/// `resources_released` on it belongs to the remaining `thread_count`
-/// references, and whoever drops the last one frees it.
+/// Ownership: the JS thread owns this allocation until `finalize` (or
+/// `env_teardown`) sets `resources_released`; then the remaining
+/// `thread_count` references own it and the last one dropped frees it.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2493,10 +2492,10 @@ pub(crate) struct ThreadSafeFunction {
     /// that would reach `event_loop` from another thread reads it under the
     /// same lock, so teardown cannot land between the check and the enqueue.
     pub(crate) env_dead: AtomicBool,
-    /// Also written under `lock` on the JS thread, once `finalize` or
-    /// `env_teardown` has released every JS-thread-owned resource. Until then
-    /// the JS thread still owns this object, so a thread that drops the last
-    /// `thread_count` reference must not free it (Node's `kClosed`).
+    /// Also written under `lock`, once `finalize` or `env_teardown` has
+    /// released every JS-thread-owned resource. Until then the thread that
+    /// drops the last `thread_count` reference must not free this (Node's
+    /// `kClosed`).
     pub(crate) resources_released: AtomicBool,
 }
 
@@ -2715,11 +2714,9 @@ impl ThreadSafeFunction {
                 // Closing (napi_tsfn_abort, or the last call already ran):
                 // nothing still queued runs any more, as in Node's DispatchOne.
                 // An abort's leftovers go back to the addon, with no lock held
-                // since that re-enters it. Then the function finalizes, whether
-                // or not other threads still hold references: after an abort
-                // they are told to make no further calls, so they may never
-                // release (Node's CloseHandlesAndMaybeDelete). They only decide
-                // who frees the allocation (`finalize`).
+                // since that re-enters it. Then the function finalizes whatever
+                // thread_count is: after an abort the other threads may never
+                // release (Node's CloseHandlesAndMaybeDelete).
                 let leftovers = self.take_queue();
                 drop(_g);
                 self.hand_back(leftovers);
@@ -2867,9 +2864,8 @@ impl ThreadSafeFunction {
         let (status, orphaned) = unsafe { (*this).enqueue(ctx, block) };
 
         if orphaned {
-            // SAFETY: the lock is dropped, we dropped the last thread reference
-            // and the JS thread (`finalize` or `env_teardown`) already released
-            // everything it owned.
+            // SAFETY: the lock is dropped, this was the last thread reference,
+            // and the JS thread already released what only it may release.
             unsafe { ThreadSafeFunction::free_orphaned(this) };
         }
         status
@@ -2946,26 +2942,21 @@ impl ThreadSafeFunction {
         }
     }
 
-    /// Runs on the JS thread once the function has closed
-    /// (`maybe_queue_finalizer`). Runs the addon's finalizer and releases what
-    /// only this thread may release, then hands the allocation over to the
-    /// remaining `thread_count` references (Node's Finalize + MaybeDelete):
-    /// with none left it is freed here, else by whoever drops the last one
-    /// (`release_locked`).
+    /// Runs on the JS thread once the function has closed. Runs the addon's
+    /// finalizer, releases what only this thread may release, and frees the
+    /// allocation unless another thread still holds a reference; then the last
+    /// release frees it (Node's Finalize + MaybeDelete).
     ///
     /// SAFETY: `this` is a live allocation from `new` that no other event-loop
     /// task will reach again.
     unsafe fn finalize(this: *mut ThreadSafeFunction) {
         // SAFETY: caller contract. The borrow ends before the addon's finalizer
-        // runs, since that may still use the handle
-        // (napi_get_threadsafe_function_context).
+        // runs; it may still use the handle (napi_get_threadsafe_function_context).
         let finalizer = unsafe {
             let self_ = &mut *this;
             if let Some(env) = self_.env.as_ref() {
-                // SAFETY: env is live (we hold a ref); drops our registry entry
-                // so teardown cannot hand this pointer out after it is freed.
-                // `this` is passed as an opaque registry key only, never
-                // dereferenced.
+                // SAFETY: env is live (we hold a ref). `this` is an opaque
+                // registry key here, never dereferenced.
                 NapiEnv__unregisterThreadSafeFunction(env.get(), this.cast());
             }
             self_
@@ -2980,8 +2971,7 @@ impl ThreadSafeFunction {
                 })
         };
 
-        // Before anything is released, as in Node and `env_teardown`. This
-        // dispatch is the finalizer's landing frame.
+        // Before anything is released, as in Node and `env_teardown`.
         if let Some(mut finalizer) = finalizer {
             crate::dispatch::fold(finalizer.run());
         }
@@ -2990,9 +2980,8 @@ impl ThreadSafeFunction {
         // ends before the free below.
         let free = unsafe {
             let self_ = &mut *this;
-            // Published in the same critical section that reads thread_count,
-            // as in `env_teardown`: a thread that drops the last reference
-            // frees the allocation only if it sees this store.
+            // The same critical section reads thread_count, so a thread that
+            // drops the last reference frees only if it sees this store.
             let _g = self_.lock.lock_guard();
             self_.event_loop = None;
             drop(self_.env.take());
@@ -3090,9 +3079,8 @@ impl ThreadSafeFunction {
         }
 
         // Phase 3: release what only the JS thread may release, then hand the
-        // allocation over: `resources_released` is what lets another thread
-        // free it, so it is published in the same critical section that reads
-        // thread_count (Node's ReleaseResources + MaybeDelete).
+        // allocation over. `resources_released` is published in the critical
+        // section that reads thread_count (Node's ReleaseResources + MaybeDelete).
         let _g = self.lock.lock_guard();
         self.callback = TsfnCallback::Js(StrongOptional::empty());
         self.poll_ref.disable();
@@ -3145,9 +3133,8 @@ impl ThreadSafeFunction {
         };
 
         if orphaned {
-            // SAFETY: the lock is dropped, we dropped the last thread reference
-            // and the JS thread (`finalize` or `env_teardown`) already released
-            // everything it owned.
+            // SAFETY: the lock is dropped, this was the last thread reference,
+            // and the JS thread already released what only it may release.
             unsafe { ThreadSafeFunction::free_orphaned(this) };
         }
         status
@@ -3168,13 +3155,10 @@ impl ThreadSafeFunction {
         if self.env_dead.load(Ordering::SeqCst)
             || self.closing.load(Ordering::SeqCst) == ClosingState::Closed as u8
         {
-            // The JS thread owns the finalization: `finalize` is queued or
-            // done, or the event loop we were created on is gone
-            // (`env_teardown`; both set their state under the lock we hold).
-            // Never schedule onto the loop again. Whoever drops the last
-            // reference frees us -- but only once the JS thread has released
-            // the resources only it may release; until then it owns us and
-            // will free us itself if we are the last to let go.
+            // The JS thread owns the finalization (`finalize` is queued or
+            // done, or `env_teardown` ran): never schedule onto the loop again.
+            // The last reference frees us once the JS thread has released what
+            // only it may release; before that, it frees us itself.
             let orphaned = prev_remaining == 1 && self.resources_released.load(Ordering::SeqCst);
             return (NapiStatus::ok as napi_status, orphaned);
         }

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -138,9 +138,10 @@ nativeTests.test_threadsafe_function_abort_with_outstanding_ref = async () => {
     await new Promise(resolve => setImmediate(resolve));
   }
   console.log("finalized:", nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_finalized());
-  // the other thread releases once it has seen the finalizer run; that is the
-  // one step here that depends on OS scheduling, so wait for it by deadline
-  const deadline = Date.now() + 10_000;
+  // the other thread releases once it has seen the finalizer run (or gives up
+  // after 2s and says so); that is the one step here that depends on OS
+  // scheduling, so wait for it by deadline, under the test runner's 5s
+  const deadline = Date.now() + 4_000;
   while (
     nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_release_status() === -1 &&
     Date.now() < deadline
@@ -148,7 +149,9 @@ nativeTests.test_threadsafe_function_abort_with_outstanding_ref = async () => {
     await new Promise(resolve => setTimeout(resolve, 1));
   }
   console.log(
-    "release after finalize:",
+    "released after finalize:",
+    nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_released_after_finalize(),
+    "status:",
     nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_release_status(),
   );
 };

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -127,6 +127,32 @@ nativeTests.test_threadsafe_function_abort_blocked_producers = async () => {
   console.log("finalized:", nativeTests.test_napi_threadsafe_function_abort_blocked_producers_finalized());
 };
 
+nativeTests.test_threadsafe_function_abort_with_outstanding_ref = async () => {
+  // create (thread_count=2) with the second reference held by a thread that
+  // makes no calls, then abort from this thread
+  nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref();
+  // the finalizer runs from the abort's dispatch on this thread, so a bounded
+  // number of turns is enough; it must not wait for the other thread
+  for (let i = 0; i < 1000; i++) {
+    if (nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_finalized()) break;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  console.log("finalized:", nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_finalized());
+  // the other thread releases once it has seen the finalizer run; that is the
+  // one step here that depends on OS scheduling, so wait for it by deadline
+  const deadline = Date.now() + 10_000;
+  while (
+    nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_release_status() === -1 &&
+    Date.now() < deadline
+  ) {
+    await new Promise(resolve => setTimeout(resolve, 1));
+  }
+  console.log(
+    "release after finalize:",
+    nativeTests.test_napi_threadsafe_function_abort_with_outstanding_ref_release_status(),
+  );
+};
+
 nativeTests.test_get_exception = (_, value) => {
   function thrower() {
     throw value;

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -200,6 +200,7 @@ test_napi_threadsafe_function_abort_blocked_producers_finalized(
 
 static napi_threadsafe_function tsfn_abort_outstanding = nullptr;
 static std::atomic<bool> tsfn_abort_outstanding_finalized{false};
+static std::atomic<bool> tsfn_abort_outstanding_released_after_finalize{false};
 static std::atomic<int> tsfn_abort_outstanding_release_status{-1};
 
 static void tsfn_abort_outstanding_finalize(napi_env env, void *finalize_data,
@@ -210,13 +211,17 @@ static void tsfn_abort_outstanding_finalize(napi_env env, void *finalize_data,
 // Holds the second thread reference without making any call. It learns of the
 // abort from the finalizer (it could as well never release: after an abort no
 // other thread is to make further calls) and only then releases, which frees
-// the function.
+// the function. If the finalizer has not run after 2 seconds it releases
+// anyway, and records that it did not see the finalizer, so the process exits
+// and the test fails on the output instead of hanging.
 static void tsfn_abort_outstanding_holder() {
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
   while (!tsfn_abort_outstanding_finalized.load() &&
          std::chrono::steady_clock::now() < deadline) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+  tsfn_abort_outstanding_released_after_finalize.store(
+      tsfn_abort_outstanding_finalized.load());
   tsfn_abort_outstanding_release_status.store(napi_release_threadsafe_function(
       tsfn_abort_outstanding, napi_tsfn_release));
 }
@@ -231,6 +236,7 @@ static napi_value test_napi_threadsafe_function_abort_with_outstanding_ref(
   napi_value resource_name =
       Napi::String::New(env, "abort_with_outstanding_ref");
   tsfn_abort_outstanding_finalized.store(false);
+  tsfn_abort_outstanding_released_after_finalize.store(false);
   tsfn_abort_outstanding_release_status.store(-1);
   NODE_API_CALL(env,
                 napi_create_threadsafe_function(
@@ -258,6 +264,13 @@ test_napi_threadsafe_function_abort_with_outstanding_ref_release_status(
     const Napi::CallbackInfo &info) {
   return Napi::Number::New(info.Env(),
                            tsfn_abort_outstanding_release_status.load());
+}
+
+static napi_value
+test_napi_threadsafe_function_abort_with_outstanding_ref_released_after_finalize(
+    const Napi::CallbackInfo &info) {
+  return Napi::Boolean::New(
+      info.Env(), tsfn_abort_outstanding_released_after_finalize.load());
 }
 
 static napi_threadsafe_function tsfn_abort_full = nullptr;
@@ -4528,6 +4541,9 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(
       env, exports,
       test_napi_threadsafe_function_abort_with_outstanding_ref_release_status);
+  REGISTER_FUNCTION(
+      env, exports,
+      test_napi_threadsafe_function_abort_with_outstanding_ref_released_after_finalize);
   REGISTER_FUNCTION(env, exports, test_napi_threadsafe_function_abort_full_queue);
   REGISTER_FUNCTION(
       env, exports, test_napi_threadsafe_function_abort_full_queue_finalized);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -198,6 +198,68 @@ test_napi_threadsafe_function_abort_blocked_producers_finalized(
   return Napi::Boolean::New(info.Env(), tsfn_abort_blocked_finalized);
 }
 
+static napi_threadsafe_function tsfn_abort_outstanding = nullptr;
+static std::atomic<bool> tsfn_abort_outstanding_finalized{false};
+static std::atomic<int> tsfn_abort_outstanding_release_status{-1};
+
+static void tsfn_abort_outstanding_finalize(napi_env env, void *finalize_data,
+                                            void *finalize_hint) {
+  tsfn_abort_outstanding_finalized.store(true);
+}
+
+// Holds the second thread reference without making any call. It learns of the
+// abort from the finalizer (it could as well never release: after an abort no
+// other thread is to make further calls) and only then releases, which frees
+// the function.
+static void tsfn_abort_outstanding_holder() {
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (!tsfn_abort_outstanding_finalized.load() &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  tsfn_abort_outstanding_release_status.store(napi_release_threadsafe_function(
+      tsfn_abort_outstanding, napi_tsfn_release));
+}
+
+// Create a tsfn with initial_thread_count=2, the second reference held by a
+// thread that makes no calls, then abort from this thread. The finalizer runs
+// from the abort's dispatch, on this thread, and the event-loop keepalive is
+// dropped with it: neither waits for the other thread's reference.
+static napi_value test_napi_threadsafe_function_abort_with_outstanding_ref(
+    const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  napi_value resource_name =
+      Napi::String::New(env, "abort_with_outstanding_ref");
+  tsfn_abort_outstanding_finalized.store(false);
+  tsfn_abort_outstanding_release_status.store(-1);
+  NODE_API_CALL(env,
+                napi_create_threadsafe_function(
+                    env, /* JavaScript function */ nullptr,
+                    /* async resource */ nullptr, resource_name,
+                    /* max queue size (unlimited) */ 0,
+                    /* initial thread count */ 2, /* finalize data */ nullptr,
+                    tsfn_abort_outstanding_finalize, /* context */ nullptr,
+                    &noop_callback, &tsfn_abort_outstanding));
+  std::thread(tsfn_abort_outstanding_holder).detach();
+  NODE_API_CALL(env, napi_release_threadsafe_function(tsfn_abort_outstanding,
+                                                      napi_tsfn_abort));
+  return env.Undefined();
+}
+
+static napi_value
+test_napi_threadsafe_function_abort_with_outstanding_ref_finalized(
+    const Napi::CallbackInfo &info) {
+  return Napi::Boolean::New(info.Env(),
+                            tsfn_abort_outstanding_finalized.load());
+}
+
+static napi_value
+test_napi_threadsafe_function_abort_with_outstanding_ref_release_status(
+    const Napi::CallbackInfo &info) {
+  return Napi::Number::New(info.Env(),
+                           tsfn_abort_outstanding_release_status.load());
+}
+
 static napi_threadsafe_function tsfn_abort_full = nullptr;
 static bool tsfn_abort_full_finalized = false;
 
@@ -4458,6 +4520,14 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(
       env, exports,
       test_napi_threadsafe_function_abort_blocked_producers_finalized);
+  REGISTER_FUNCTION(env, exports,
+                    test_napi_threadsafe_function_abort_with_outstanding_ref);
+  REGISTER_FUNCTION(
+      env, exports,
+      test_napi_threadsafe_function_abort_with_outstanding_ref_finalized);
+  REGISTER_FUNCTION(
+      env, exports,
+      test_napi_threadsafe_function_abort_with_outstanding_ref_release_status);
   REGISTER_FUNCTION(env, exports, test_napi_threadsafe_function_abort_full_queue);
   REGISTER_FUNCTION(
       env, exports, test_napi_threadsafe_function_abort_full_queue_finalized);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -714,6 +714,15 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("finalized: true");
     });
 
+    // An abort finalizes from its own dispatch, like Node: it does not wait for
+    // the references other threads still hold (they are told to make no further
+    // calls, so they may never release). The late release of such a reference
+    // reports napi_ok (0) and frees the function.
+    it("runs the finalizer on abort while another thread still holds a reference", async () => {
+      const result = await checkSameOutput("test_threadsafe_function_abort_with_outstanding_ref", []);
+      expect(result).toContain("finalized: true\nrelease after finalize: 0");
+    });
+
     // A full bounded queue must not hide that the function is closing: the call
     // reports napi_closing (16) and consumes the caller's thread reference, so
     // the finalizer still runs. napi_queue_full (17) would strand it forever.

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -720,7 +720,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     // reports napi_ok (0) and frees the function.
     it("runs the finalizer on abort while another thread still holds a reference", async () => {
       const result = await checkSameOutput("test_threadsafe_function_abort_with_outstanding_ref", []);
-      expect(result).toContain("finalized: true\nrelease after finalize: 0");
+      expect(result).toContain("finalized: true\nreleased after finalize: true status: 0");
     });
 
     // A full bounded queue must not hide that the function is closing: the call


### PR DESCRIPTION
### Problem
- `test/napi/napi.test.ts` "wakes blocked producers, runs the finalizer and exits when aborted with a bounded queue" is the most frequent retry-passed failure of that file in CI (30 builds in the last 24 hours, every Linux lane): `- "finalized: true` / `+ "finalized: false`.
- `napi_release_threadsafe_function(tsfn, napi_tsfn_abort)` in bun ran the finalizer and dropped the event-loop keepalive only once `thread_count` reached zero (`dispatch_one`, `src/runtime/napi/napi_body.rs:2713`). Node finalizes from the abort's own dispatch (`DispatchOne` -> `CloseHandlesAndMaybeDelete` -> `Finalize`) and keeps only the allocation alive for the threads that still hold a reference. In the test, the finalizer waited for two producer threads to be scheduled, and the fixture's 1000 `setImmediate` turns (about 3 ms) do not cover that under load.
- With a thread that holds a reference and never releases it (allowed after an abort: "no other thread should make any further calls"), bun never ran the finalizer and the process did not exit. Node finalizes and exits.

### Fix
- The closing dispatch now finalizes whatever `thread_count` is. `finalize` (replaces `destroy`) runs the addon's finalizer while the handle is still valid, then releases the JS-thread resources under the lock, and frees the allocation only if no thread reference is left. Otherwise the last `napi_release_threadsafe_function` or `napi_closing` call frees it, through the same path `env_teardown` already used (`env_teardown_done`, renamed `resources_released`).
- `release_locked` never schedules a dispatch once the function is `Closed`: the JS thread owns the finalization, so no task can reach the allocation after it is freed.
- Verified: `test/napi/napi.test.ts` (new test "runs the finalizer on abort while another thread still holds a reference" fails on main with `finalized: false`, passes with the fix; all 189 tests pass). The blocked-producers fixture: 1 of 60 runs printed `finalized: false` under CPU load with the release build, 0 of 160 with the fix.

### Background
- A threadsafe function (tsfn) lets addon threads queue calls that run on the JS thread. `thread_count` is the number of threads that hold a reference; `napi_tsfn_abort` marks it closing so that further calls report `napi_closing`.
- The function's event-loop keepalive (`poll_ref`) keeps the process alive until the function finalizes. The finalizer is the addon callback that frees the context.
- Node's lifecycle: `Finalize` runs the finalizer, then `MaybeDelete` releases the JS resources (`ReleaseResources`, state `kClosed`) and deletes the object only when `thread_count == 0`; a later `Release` or `Push` from a remaining thread deletes it otherwise. Bun's `resources_released` is Node's `kClosed`.

<details><summary>Notes</summary>

- CI scan: 400 builds (106331..107004). `napi.test.ts` appeared in the retry-passed list of 131 builds; the tsfn signature above is 30 of them (Debian 13 x64 16, Debian 13 aarch64 8, Ubuntu 25.04 x64 5, Alpine x64 1). The other two signatures in that file are `napi_wrap has the right lifetime` (Windows only, GC observation) and `napi_get_value_string_*` timeouts under ASAN.
- Local repro: `test/napi/napi-app/main.js test_threadsafe_function_abort_blocked_producers` in a loop with 32 busy-loop processes, release bun 1.4.1-canary: 1 of 60 runs `finalized: false`. Without load 1000 `setImmediate` turns take 3.4 ms in bun.
- Node's `Release(abort)` uses `cond->Signal`, so only one blocked producer wakes there; bun keeps its `broadcast`. Node's own `test_threadsafe_function` joins the producer threads inside the finalizer, which requires the finalizer to run while they are still blocked, as this change does.
- The `else if prev_remaining == 1 { schedule_dispatch() }` branch of `release_locked` is gone: a `Closing` function always has the abort's dispatch pending or running, and that dispatch now finalizes on its own.
- Also ran `test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts` (same result as main: `test.js` is todo because of `uv_thread_create`).
- Open PR #39848 changes `destroy` too (run the finalizer before the free). This change keeps that ordering in `finalize`; the two will need a manual merge in `napi_body.rs`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->