### PR TITLE
verify-baseline-static: restart the x64 decoder at every symbol start

### DIFF
--- a/scripts/verify-baseline-static/CLAUDE.md
+++ b/scripts/verify-baseline-static/CLAUDE.md
@@ -31,10 +31,11 @@ check — together they catch most things; neither alone is bulletproof.
 **In scope but may miss:**
 
 - x64 linear-sweep may desync on data-in-`.text` and skip real instructions
-  that follow. Variable-length x86 encoding makes perfect code/data
-  separation undecidable (`README.md:53-59`). aarch64 is more reliable
-  (fixed-width words, `$d` mapping symbols mark data), but a missing mapping
-  symbol can still hide a hit.
+  that follow, up to the next symbol start (the decoder restarts there, so a
+  desync never crosses into the next function). Variable-length x86 encoding
+  makes perfect code/data separation undecidable (`README.md:53-69`). aarch64
+  is more reliable (fixed-width words, `$d` mapping symbols mark data), but a
+  missing mapping symbol can still hide a hit.
 - Instructions deliberately ignored (TZCNT/XGETBV on x64, hint-space PAC/BTI
   on aarch64) could theoretically be misused; we assume the compiler's idiom
   is the only one.
@@ -43,7 +44,7 @@ check — together they catch most things; neither alone is bulletproof.
 
 - Data bytes in `.text` that happen to form a valid post-baseline encoding.
   Rare on ELF (LLVM puts tables in `.rodata`), common on Windows PE (MSVC
-  inlines jump tables). See `README.md:61-74`.
+  inlines jump tables). See `README.md:71-86`.
 
 When in doubt, the emulator is ground truth: `qemu -cpu Nehalem` and hit the
 code path. SIGILL = real bug. No SIGILL = either gated or a data-in-text

--- a/scripts/verify-baseline-static/CLAUDE.md
+++ b/scripts/verify-baseline-static/CLAUDE.md
@@ -33,7 +33,7 @@ check — together they catch most things; neither alone is bulletproof.
 - x64 linear-sweep may desync on data-in-`.text` and skip real instructions
   that follow, up to the next symbol start (the decoder restarts there, so a
   desync never crosses into the next function). Variable-length x86 encoding
-  makes perfect code/data separation undecidable (`README.md:53-69`). aarch64
+  makes perfect code/data separation undecidable (`README.md:53-70`). aarch64
   is more reliable (fixed-width words, `$d` mapping symbols mark data), but a
   missing mapping symbol can still hide a hit.
 - Instructions deliberately ignored (TZCNT/XGETBV on x64, hint-space PAC/BTI
@@ -44,7 +44,7 @@ check — together they catch most things; neither alone is bulletproof.
 
 - Data bytes in `.text` that happen to form a valid post-baseline encoding.
   Rare on ELF (LLVM puts tables in `.rodata`), common on Windows PE (MSVC
-  inlines jump tables). See `README.md:71-86`.
+  inlines jump tables). See `README.md:72-87`.
 
 When in doubt, the emulator is ground truth: `qemu -cpu Nehalem` and hit the
 code path. SIGILL = real bug. No SIGILL = either gated or a data-in-text

--- a/scripts/verify-baseline-static/README.md
+++ b/scripts/verify-baseline-static/README.md
@@ -64,8 +64,10 @@ symbol can only produce garbage up to that symbol, never into the function
 after it. JSC's LLInt is the case that matters. `ENABLE(LLINT_EMBEDDED_OPCODE_ID)`
 puts a raw 4-byte `.int <opcode id>` in front of every opcode handler. On ELF
 each handler has its own `llint_op_*` symbol, so the id bytes decode on their
-own (no id below 3599 spells a post-Nehalem instruction; real ids stay under 1000) and the next handler starts clean. On Windows the PDB has no per-handler
-record, so the whole interpreter is one symbol and stays allowlisted.
+own and the next handler starts clean. No value an id can hold decodes to a
+flagged instruction (a unit test checks all 65536 of them against the filters
+in `main.rs`). On Windows the PDB has no per-handler record, so the whole
+interpreter is one symbol and stays allowlisted.
 
 MSVC inlines jump tables and small `static const` arrays into `.text` right
 after the function that uses them (LLVM puts them in `.rodata`, so ELF builds

--- a/scripts/verify-baseline-static/README.md
+++ b/scripts/verify-baseline-static/README.md
@@ -52,11 +52,21 @@ If you're not sure which: run the binary under `qemu-x86_64 -cpu Nehalem`
 
 ### Data-in-`.text` false positives
 
-The tool linear-sweeps every byte in `.text`. There's no general way to do
-better for x86: toolchains don't emit "this byte is data" markers the way
-ARM EABI's `$d` mapping symbols do, and code/data separation in x86 binaries
-is undecidable in general
+The tool linear-sweeps every byte in `.text`, restarting the decoder at every
+symbol start (the same resync rule `objdump -d` uses). There's no general way
+to do better for x86: toolchains don't emit "this byte is data" markers the
+way ARM EABI's `$d` mapping symbols do, and code/data separation in x86
+binaries is undecidable in general
 ([Schwarz & Debray 2002](https://www2.cs.arizona.edu/~debray/Publications/disasm.pdf)).
+
+The restart bounds how far a desync can travel: data that sits right before a
+symbol can only produce garbage up to that symbol, never into the function
+after it. JSC's LLInt is the case that matters. `ENABLE(LLINT_EMBEDDED_OPCODE_ID)`
+puts a raw 4-byte `.int <opcode id>` in front of every opcode handler. On ELF
+each handler has its own `llint_op_*` symbol, so the id bytes decode on their
+own (no id below 3599 spells a post-Nehalem instruction; real ids stay under
+1000) and the next handler starts clean. On Windows the PDB has no per-handler
+record, so the whole interpreter is one symbol and stays allowlisted.
 
 MSVC inlines jump tables and small `static const` arrays into `.text` right
 after the function that uses them (LLVM puts them in `.rodata`, so ELF builds

--- a/scripts/verify-baseline-static/README.md
+++ b/scripts/verify-baseline-static/README.md
@@ -64,8 +64,7 @@ symbol can only produce garbage up to that symbol, never into the function
 after it. JSC's LLInt is the case that matters. `ENABLE(LLINT_EMBEDDED_OPCODE_ID)`
 puts a raw 4-byte `.int <opcode id>` in front of every opcode handler. On ELF
 each handler has its own `llint_op_*` symbol, so the id bytes decode on their
-own (no id below 3599 spells a post-Nehalem instruction; real ids stay under
-1000) and the next handler starts clean. On Windows the PDB has no per-handler
+own (no id below 3599 spells a post-Nehalem instruction; real ids stay under 1000) and the next handler starts clean. On Windows the PDB has no per-handler
 record, so the whole interpreter is one symbol and stays allowlisted.
 
 MSVC inlines jump tables and small `static const` arrays into `.text` right

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -976,15 +976,23 @@ strspn
 # ENABLE(LLINT_EMBEDDED_OPCODE_ID) is on for x86_64 (WTF/wtf/PlatformEnable.h),
 # so every LLInt opcode handler inside llint_entry starts with a raw 4-byte
 # ".int <opcode_id>" (LowLevelInterpreter.cpp: EMBED_OPCODE_ID_IF_NEEDED). The
-# linear-sweep decoder desyncs on those ~900 embedded ints and, depending on
-# how preceding .text code aligns, can decode a stray VEX-encoded instruction
-# out of the garbage. offlineasm's x86 backend emits SSE2 cvttsd2si (not VEX),
-# and the Intel SDE Nehalem emulation step in this same job exercises the LLInt
-# and passes, so any single-digit hit here is decode noise. Ceiling [AVX] so a
-# multi-feature leak still fails.
+# decoder desyncs on those ~900 embedded ints and reads garbage for a few
+# instructions into the handler that follows. The garbage includes rel32 and
+# RIP-relative displacements, so what it spells changes with the link layout:
+# VEX prefixes in one build, a bare `0f 33` RDPMC in another. A feature ceiling
+# has nothing to bound here and re-flakes on the next layout, so this is a
+# blanket pass (the guide's rule for confirmed data-in-.text misdecodes).
+#
+# The decoder restarts at every symbol start, which fixes this on ELF: there
+# each handler has its own llint_op_* symbol, so a desync ends at the next
+# handler. The PDB has no per-handler record (the opcode labels are assembler
+# locals), so on Windows the whole interpreter is one symbol and the entry
+# stays. offlineasm's x86 backend emits SSE2 (not VEX), and the Intel SDE
+# Nehalem emulation step in this same job exercises the LLInt, so a real
+# post-baseline instruction in it would still fail the job.
 # (1 symbol)
 # ----------------------------------------------------------------------------
-llint_entry  [AVX]
+llint_entry
 
 
 # ----------------------------------------------------------------------------

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1334,22 +1334,3 @@ jsimd_ycc_rgb_convert_avx2.column_st7                [AVX, AVX2]
 jsimd_ycc_rgb_convert_avx2.columnloop                [AVX, AVX2]
 jsimd_ycc_rgb_convert_avx2.out1                      [AVX, AVX2]
 jsimd_ycc_rgb_convert_avx2.return                    [AVX, AVX2]
-
-
-# ----------------------------------------------------------------------------
-# JSC LLInt. Data-in-.text false positive, NOT a gate.
-#
-# ENABLE(LLINT_EMBEDDED_OPCODE_ID) is on for x86_64 (WTF/wtf/PlatformEnable.h),
-# so every LLInt opcode handler starts with a raw 4-byte ".int <opcode_id>"
-# (LowLevelInterpreter.cpp: EMBED_OPCODE_ID_IF_NEEDED). The linear-sweep
-# decoder desyncs on those embedded ints and, depending on how preceding .text
-# code aligns, can decode a stray VEX-encoded instruction out of the garbage.
-# offlineasm's x86 backend emits SSE2 (not VEX), and the Intel SDE Nehalem
-# emulation step in this same job exercises the LLInt and passes, so any
-# single-digit hit here is decode noise. Ceiling [AVX] so a multi-feature leak
-# still fails. On ELF each opcode handler has its own symbol, so layout shifts
-# can move the desync between llint_op_* siblings; add them here as they trip.
-# (2 symbols)
-# ----------------------------------------------------------------------------
-llint_op_enter_wide32  [AVX]
-llint_op_wide16_wide16  [AVX]

--- a/scripts/verify-baseline-static/src/main.rs
+++ b/scripts/verify-baseline-static/src/main.rs
@@ -739,57 +739,90 @@ fn record(
     });
 }
 
+/// Split a text section into decode units: one per symbol start, so the
+/// x64 decoder is re-aligned at every address the symbol table vouches for
+/// as an instruction boundary. The first unit starts at the section start
+/// (covers a section with no symbol at its first byte), the last ends at
+/// the section end. Gaps between sized symbols stay inside the unit of the
+/// symbol before them, so inter-function padding is still decoded and still
+/// attributed to `<no-symbol@...>` by `symbol_for`.
+///
+/// `syms` is sorted by address (both table builders guarantee it).
+fn decode_units(sec_addr: u64, sec_len: usize, syms: &[Sym]) -> Vec<(u64, u64)> {
+    let sec_end = sec_addr + sec_len as u64;
+    let lo = syms.partition_point(|s| s.addr < sec_addr);
+    let hi = syms.partition_point(|s| s.addr < sec_end);
+    let mut starts: Vec<u64> = Vec::with_capacity(hi - lo + 2);
+    starts.push(sec_addr);
+    starts.extend(syms[lo..hi].iter().map(|s| s.addr));
+    starts.dedup();
+    starts.push(sec_end);
+    starts.windows(2).map(|w| (w[0], w[1])).collect()
+}
+
 /// x64 decode + classify. iced provides exact per-instruction CpuidFeature.
 fn scan_x86_64(bytes: &[u8], sec_addr: u64, syms: &[Sym], allowlist: &Allowlist) -> ScanResult {
     let mut violations = Buckets::new();
     let mut allowlisted = Buckets::new();
     let mut total_insns = 0u64;
 
-    // Linear sweep. iced handles variable-length encoding; on undecodable
-    // bytes (data-in-text) it returns Code::INVALID and we skip. False
-    // positives from data-in-text are rare in practice — LLVM puts jump
-    // tables in .rodata, not inline.
-    let mut decoder = Decoder::with_ip(64, bytes, sec_addr, DecoderOptions::NONE);
+    // Linear sweep, restarted at every symbol start (objdump's resync rule).
+    // iced handles variable-length encoding; on undecodable bytes
+    // (data-in-text) it returns Code::INVALID and we skip.
+    //
+    // The restart bounds a desync to the symbol it starts in. JSC's LLInt
+    // puts a raw 4-byte `.int <opcode id>` in front of every opcode handler
+    // (LowLevelInterpreter.cpp: EMBED_OPCODE_ID_IF_NEEDED); one sweep over
+    // the whole section reads those bytes as an instruction that runs INTO
+    // the next handler and stays desynced for several more, through rel32
+    // displacements that change with link layout. That is how an RDPMC
+    // appeared in llint_op_jmp_wide32 on a PR that did not touch JSC.
+    // No real instruction straddles a symbol start, so a straddler is
+    // always garbage; truncating it (it decodes as INVALID) loses nothing.
     let mut insn = Instruction::default();
-    while decoder.can_decode() {
-        decoder.decode_out(&mut insn);
-        if insn.is_invalid() {
-            continue;
-        }
-        total_insns += 1;
-
-        let feats = insn.cpuid_features();
-        // Fast path: no post-baseline features at all (the common case).
-        if feats.iter().copied().all(is_allowed) {
-            continue;
-        }
-        if is_harmless_on_nehalem(&insn) {
-            continue;
-        }
-
-        // iced's Mnemonic and CpuidFeature are repr'd via tables with static
-        // &str names behind their Debug impls, but there's no public stable
-        // accessor. Leak the Debug repr once per hit — tiny volume (tens of
-        // thousands of hits max, each a few bytes; a KB or so for a full scan).
-        let mnem: &'static str = Box::leak(format!("{:?}", insn.mnemonic()).into_boxed_str());
-        // Record EVERY post-baseline feature, not just the first one found.
-        // Multi-feature instructions (e.g. VPCLMULQDQ requires AVX+PCLMULQDQ)
-        // must check each feature against the ceiling independently — if the
-        // ceiling says [AVX] but PCLMULQDQ is also required, that's a violation.
-        for bad_feat in feats.iter().copied().filter(|f| !is_allowed(*f)) {
-            if is_impossible_feature(bad_feat) {
+    for (from, to) in decode_units(sec_addr, bytes.len(), syms) {
+        let unit = &bytes[(from - sec_addr) as usize..(to - sec_addr) as usize];
+        let mut decoder = Decoder::with_ip(64, unit, from, DecoderOptions::NONE);
+        while decoder.can_decode() {
+            decoder.decode_out(&mut insn);
+            if insn.is_invalid() {
                 continue;
             }
-            let feat: &'static str = Box::leak(format!("{:?}", bad_feat).into_boxed_str());
-            record(
-                insn.ip(),
-                mnem,
-                feat,
-                syms,
-                allowlist,
-                &mut violations,
-                &mut allowlisted,
-            );
+            total_insns += 1;
+
+            let feats = insn.cpuid_features();
+            // Fast path: no post-baseline features at all (the common case).
+            if feats.iter().copied().all(is_allowed) {
+                continue;
+            }
+            if is_harmless_on_nehalem(&insn) {
+                continue;
+            }
+
+            // iced's Mnemonic and CpuidFeature are repr'd via tables with static
+            // &str names behind their Debug impls, but there's no public stable
+            // accessor. Leak the Debug repr once per hit — tiny volume (tens of
+            // thousands of hits max, each a few bytes; a KB or so for a full scan).
+            let mnem: &'static str = Box::leak(format!("{:?}", insn.mnemonic()).into_boxed_str());
+            // Record EVERY post-baseline feature, not just the first one found.
+            // Multi-feature instructions (e.g. VPCLMULQDQ requires AVX+PCLMULQDQ)
+            // must check each feature against the ceiling independently — if the
+            // ceiling says [AVX] but PCLMULQDQ is also required, that's a violation.
+            for bad_feat in feats.iter().copied().filter(|f| !is_allowed(*f)) {
+                if is_impossible_feature(bad_feat) {
+                    continue;
+                }
+                let feat: &'static str = Box::leak(format!("{:?}", bad_feat).into_boxed_str());
+                record(
+                    insn.ip(),
+                    mnem,
+                    feat,
+                    syms,
+                    allowlist,
+                    &mut violations,
+                    &mut allowlisted,
+                );
+            }
         }
     }
 
@@ -1186,5 +1219,107 @@ fn main() -> ExitCode {
             eprintln!("error: {e}");
             ExitCode::from(2)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bytes 0x3590cc4..0x3590d1c of the bun-linux-x64-musl `bun-profile`
+    /// from CI build 107029: the tail of `llint_op_jmp_wide16`, the embedded
+    /// opcode id `.int 0x2c6` of the next handler, all of `llint_op_jmp_wide32`,
+    /// and the embedded id `.int 0x47` of `llint_op_jtrue` after it.
+    #[rustfmt::skip]
+    const LLINT_JMP_WIDE32: &[u8] = &[
+        // llint_op_jmp_wide16 tail: movzx / lea rsi,[rip+disp32] / jmp [rsi+rax*8]
+        0x43, 0x0f, 0xb6, 0x44, 0x05, 0x00, 0x48, 0x8d, 0x35, 0x2f, 0x33, 0x21, 0x01, 0xff, 0x24, 0xc6,
+        // .int 710 (op_jmp_wide32), then llint_op_jmp_wide32 at +0x14
+        0xc6, 0x02, 0x00, 0x00, 0x4b, 0x63, 0x44, 0x05, 0x02, 0x85, 0xc0, 0x74, 0x13, 0x49, 0x01, 0xc0,
+        // lea rsi,[rip+0x121330f]: the displacement bytes 0f 33 spell RDPMC
+        0x43, 0x0f, 0xb6, 0x44, 0x05, 0x00, 0x48, 0x8d, 0x35, 0x0f, 0x33, 0x21, 0x01, 0xff, 0x24, 0xc6,
+        0x4d, 0x01, 0xe8, 0x48, 0x89, 0xef, 0x4c, 0x89, 0xc6, 0xe8, 0x52, 0x4d, 0x7f, 0x00, 0x49, 0x89,
+        0xc0, 0x4d, 0x29, 0xe8, 0x43, 0x0f, 0xb6, 0x44, 0x05, 0x00, 0x48, 0x8d, 0x35, 0xeb, 0x32, 0x21,
+        // jmp [rsi+rax*8], then .int 71 (op_jtrue)
+        0x01, 0xff, 0x24, 0xc6, 0x47, 0x00, 0x00, 0x00,
+    ];
+    const BASE: u64 = 0x3590cc4;
+    const WIDE32: u64 = 0x3590cd8;
+    const JTRUE: u64 = 0x3590d1c;
+
+    fn sym(addr: u64, end: u64, name: &str) -> Sym {
+        Sym {
+            addr,
+            end,
+            name: name.to_owned(),
+        }
+    }
+
+    fn llint_syms() -> Vec<Sym> {
+        vec![
+            sym(BASE, WIDE32, "llint_op_jmp_wide16"),
+            sym(WIDE32, JTRUE, "llint_op_jmp_wide32"),
+        ]
+    }
+
+    fn violation_names(res: &ScanResult) -> Vec<String> {
+        res.violations
+            .iter()
+            .map(|(sym, rep)| {
+                let mut feats: Vec<_> = rep.features.iter().copied().collect();
+                feats.sort();
+                format!("{sym} [{}]", feats.join(", "))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn without_symbol_starts_the_sweep_desyncs_into_the_next_handler() {
+        // No symbols: a single decode unit, i.e. the plain linear sweep. The
+        // `.int 0x2c6` desyncs it into the next handler and it reads `0f 33`
+        // out of the lea displacement. This is the false positive CI saw.
+        let res = scan_x86_64(LLINT_JMP_WIDE32, BASE, &[], &Allowlist::new());
+        assert_eq!(
+            violation_names(&res),
+            vec![format!("<no-symbol@{:#x}> [RDPMC]", 0x3590ced_u64)]
+        );
+    }
+
+    #[test]
+    fn sweep_restarts_at_each_symbol_start() {
+        let res = scan_x86_64(LLINT_JMP_WIDE32, BASE, &llint_syms(), &Allowlist::new());
+        assert!(res.violations.is_empty(), "{:?}", violation_names(&res));
+        assert!(res.allowlisted.is_empty());
+        // 3 real instructions in the wide16 tail, the `mov byte ptr [rdx],0`
+        // that the first three id bytes spell (the fourth is truncated at the
+        // symbol start and dropped), 16 in llint_op_jmp_wide32, and the
+        // `.int 0x47` tail that decodes as `add [r8],r8b` plus a truncated byte.
+        assert_eq!(res.total_insns, 3 + 1 + 16 + 1);
+    }
+
+    #[test]
+    fn decode_units_cover_the_section_exactly_once() {
+        let len = LLINT_JMP_WIDE32.len();
+        let sec_end = BASE + len as u64;
+        // A symbol at the section start does not produce an empty unit, and
+        // symbols outside the section are ignored.
+        let with_neighbors = vec![
+            sym(BASE - 0x100, BASE - 0x80, "before"),
+            sym(BASE, WIDE32, "llint_op_jmp_wide16"),
+            sym(WIDE32, JTRUE, "llint_op_jmp_wide32"),
+            sym(JTRUE + 0x40, JTRUE + 0x80, "after"),
+        ];
+        assert_eq!(
+            decode_units(BASE, len, &with_neighbors),
+            vec![(BASE, WIDE32), (WIDE32, sec_end)]
+        );
+        // A section whose first symbol starts after the section start gets a
+        // leading unit for the bytes before it.
+        assert_eq!(
+            decode_units(BASE - 8, len + 8, &llint_syms()),
+            vec![(BASE - 8, BASE), (BASE, WIDE32), (WIDE32, sec_end)]
+        );
+        // No symbols: one unit, the whole section.
+        assert_eq!(decode_units(BASE, len, &[]), vec![(BASE, sec_end)]);
     }
 }

--- a/scripts/verify-baseline-static/src/main.rs
+++ b/scripts/verify-baseline-static/src/main.rs
@@ -53,6 +53,7 @@ const NEHALEM_ALLOWED: &[CpuidFeature] = &[
     CpuidFeature::FXSR,  // FXSAVE/FXRSTOR
     CpuidFeature::SYSCALL,
     CpuidFeature::RDTSCP, // Nehalem has this (K8 introduced it, Intel added in Nehalem)
+    CpuidFeature::RDPMC,  // P6 (1995); on every x86-64 CPU
     // LAHF/SAHF in 64-bit: iced doesn't tag these with a distinct feature
     // (they're just INTEL8086 or X64). If it ever does, we'd add it here.
     CpuidFeature::CMPXCHG16B, // Nehalem has it, required by x86-64-v2
@@ -1236,7 +1237,8 @@ mod tests {
         0x43, 0x0f, 0xb6, 0x44, 0x05, 0x00, 0x48, 0x8d, 0x35, 0x2f, 0x33, 0x21, 0x01, 0xff, 0x24, 0xc6,
         // .int 710 (op_jmp_wide32), then llint_op_jmp_wide32 at +0x14
         0xc6, 0x02, 0x00, 0x00, 0x4b, 0x63, 0x44, 0x05, 0x02, 0x85, 0xc0, 0x74, 0x13, 0x49, 0x01, 0xc0,
-        // lea rsi,[rip+0x121330f]: the displacement bytes 0f 33 spell RDPMC
+        // lea rsi,[rip+0x121330f] at +0x26; the desynced sweep lands on its
+        // displacement at +0x29, where `0f 33` spelled RDPMC in build 107029
         0x43, 0x0f, 0xb6, 0x44, 0x05, 0x00, 0x48, 0x8d, 0x35, 0x0f, 0x33, 0x21, 0x01, 0xff, 0x24, 0xc6,
         0x4d, 0x01, 0xe8, 0x48, 0x89, 0xef, 0x4c, 0x89, 0xc6, 0xe8, 0x52, 0x4d, 0x7f, 0x00, 0x49, 0x89,
         0xc0, 0x4d, 0x29, 0xe8, 0x43, 0x0f, 0xb6, 0x44, 0x05, 0x00, 0x48, 0x8d, 0x35, 0xeb, 0x32, 0x21,
@@ -1246,6 +1248,11 @@ mod tests {
     const BASE: u64 = 0x3590cc4;
     const WIDE32: u64 = 0x3590cd8;
     const JTRUE: u64 = 0x3590d1c;
+    /// Offset of the lea displacement the desynced sweep reads as an opcode.
+    const LEA_DISP: usize = 0x29;
+    /// `vmovdqa xmm0,xmm1`: a 4-byte VEX instruction, the cheapest real
+    /// post-Nehalem encoding to splice into the fixture.
+    const VMOVDQA: [u8; 4] = [0xc5, 0xf9, 0x6f, 0xc1];
 
     fn sym(addr: u64, end: u64, name: &str) -> Sym {
         Sym {
@@ -1262,13 +1269,22 @@ mod tests {
         ]
     }
 
-    fn violation_names(res: &ScanResult) -> Vec<String> {
+    /// The fixture with `patch` written over the bytes at `offset`.
+    fn patched(offset: usize, patch: &[u8]) -> Vec<u8> {
+        let mut bytes = LLINT_JMP_WIDE32.to_vec();
+        bytes[offset..offset + patch.len()].copy_from_slice(patch);
+        bytes
+    }
+
+    /// Every violating instruction as (symbol, ip, mnemonic, feature), in
+    /// report order.
+    fn violation_hits(res: &ScanResult) -> Vec<(&str, u64, &str, &str)> {
         res.violations
             .iter()
-            .map(|(sym, rep)| {
-                let mut feats: Vec<_> = rep.features.iter().copied().collect();
-                feats.sort();
-                format!("{sym} [{}]", feats.join(", "))
+            .flat_map(|(sym, rep)| {
+                rep.hits
+                    .iter()
+                    .map(move |h| (sym.as_str(), h.ip, h.mnemonic, h.feature))
             })
             .collect()
     }
@@ -1276,25 +1292,106 @@ mod tests {
     #[test]
     fn without_symbol_starts_the_sweep_desyncs_into_the_next_handler() {
         // No symbols: a single decode unit, i.e. the plain linear sweep. The
-        // `.int 0x2c6` desyncs it into the next handler and it reads `0f 33`
-        // out of the lea displacement. This is the false positive CI saw.
-        let res = scan_x86_64(LLINT_JMP_WIDE32, BASE, &[], &Allowlist::new());
+        // `.int 0x2c6` desyncs it into the next handler, where it reads the
+        // lea displacement as an opcode. The displacement is link-layout
+        // dependent; here it is set to spell an AVX instruction, the shape
+        // #32744 and #39597 saw (build 107029 got RDPMC out of the same slot,
+        // which Nehalem decodes, so it is not a violation on its own).
+        let bytes = patched(LEA_DISP, &VMOVDQA);
+        let res = scan_x86_64(&bytes, BASE, &[], &Allowlist::new());
         assert_eq!(
-            violation_names(&res),
-            vec![format!("<no-symbol@{:#x}> [RDPMC]", 0x3590ced_u64)]
+            violation_hits(&res),
+            vec![(
+                "<no-symbol@0x3590ced>",
+                BASE + LEA_DISP as u64,
+                "Vmovdqa",
+                "AVX"
+            )]
         );
+        // The same bytes, decoded per symbol: the lea is one instruction and
+        // its displacement is never looked at.
+        let res = scan_x86_64(&bytes, BASE, &llint_syms(), &Allowlist::new());
+        assert_eq!(violation_hits(&res), vec![]);
     }
 
     #[test]
     fn sweep_restarts_at_each_symbol_start() {
         let res = scan_x86_64(LLINT_JMP_WIDE32, BASE, &llint_syms(), &Allowlist::new());
-        assert!(res.violations.is_empty(), "{:?}", violation_names(&res));
+        assert_eq!(violation_hits(&res), vec![]);
         assert!(res.allowlisted.is_empty());
         // 3 real instructions in the wide16 tail, the `mov byte ptr [rdx],0`
         // that the first three id bytes spell (the fourth is truncated at the
         // symbol start and dropped), 16 in llint_op_jmp_wide32, and the
         // `.int 0x47` tail that decodes as `add [r8],r8b` plus a truncated byte.
         assert_eq!(res.total_insns, 3 + 1 + 16 + 1);
+        // The whole-section sweep decodes one more: the straddler and its
+        // garbage successors replace the handler's first six instructions.
+        let res = scan_x86_64(LLINT_JMP_WIDE32, BASE, &[], &Allowlist::new());
+        assert_eq!(res.total_insns, 22);
+    }
+
+    #[test]
+    fn a_real_violation_is_reported_from_every_position_in_a_unit() {
+        // Positive controls: the restart must not lose or misattribute a real
+        // post-Nehalem instruction, wherever it sits relative to the unit
+        // boundaries. Each variant replaces whole instructions of the fixture
+        // with vmovdqa (plus nop padding) so the decoder stays in sync around
+        // the splice; `insns` is the resulting instruction count (21 for the
+        // unpatched fixture).
+        let cases: [(&str, usize, &[u8], &str, u64); 3] = [
+            // Middle of llint_op_jmp_wide32: over `mov r8,rax / sub r8,r13`
+            // (two instructions, replaced by two).
+            (
+                "mid-unit",
+                0x3e,
+                &[0xc5, 0xf9, 0x6f, 0xc1, 0x66, 0x90],
+                "llint_op_jmp_wide32",
+                21,
+            ),
+            // Last instruction of the wide16 unit, ending exactly at the next
+            // symbol start: over the `.int 0x2c6` bytes (one instruction plus
+            // a truncated byte, replaced by one). Pins that a unit's tail is
+            // decoded in full and not truncated early.
+            (
+                "last-before-boundary",
+                0x10,
+                &VMOVDQA,
+                "llint_op_jmp_wide16",
+                21,
+            ),
+            // First instruction of the wide32 unit: over `movsxd rax,[r13+r8+2]`
+            // (one instruction, replaced by two). Pins the ip base of a
+            // non-first unit and its attribution.
+            (
+                "first-of-unit",
+                0x14,
+                &[0xc5, 0xf9, 0x6f, 0xc1, 0x90],
+                "llint_op_jmp_wide32",
+                22,
+            ),
+        ];
+        for (name, offset, patch, expect_sym, insns) in cases {
+            let bytes = patched(offset, patch);
+            let res = scan_x86_64(&bytes, BASE, &llint_syms(), &Allowlist::new());
+            assert_eq!(
+                violation_hits(&res),
+                vec![(expect_sym, BASE + offset as u64, "Vmovdqa", "AVX")],
+                "{name}"
+            );
+            assert_eq!(res.total_insns, insns, "{name}");
+        }
+    }
+
+    #[test]
+    fn an_embedded_opcode_id_decoded_on_its_own_is_never_a_violation() {
+        // With the restart, the 4 id bytes before each handler are the tail
+        // of the previous unit and decode in isolation. Check every value the
+        // `.int` could hold (real ids are below 1000; 2^16 covers any opcode
+        // count) so no layout can turn an id into a false positive.
+        for id in 0..=u16::MAX as u32 {
+            let res = scan_x86_64(&id.to_le_bytes(), 0x1000, &[], &Allowlist::new());
+            assert_eq!(violation_hits(&res), vec![], "opcode id {id}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Problem
- The x64-musl `verify-baseline` lane fails on PRs that do not touch JSC. Build 107029: `llint_op_jmp_wide32 [RDPMC] (1 insns) 0x0003590ced Rdpmc`.
- `scan_x86_64` (`scripts/verify-baseline-static/src/main.rs`) decodes a text section in one linear sweep. The LLInt stores a 4-byte `.int <opcode id>` before every handler. The sweep reads it as an instruction that runs into the next handler and stays desynced there. Here `0f 33` is inside a `lea rsi,[rip+disp32]` displacement, which changes with link layout, so the hit moves between siblings (#32744, #39597 allowlisted earlier ones).

### Fix
- Decode one unit per symbol start (`decode_units`), as `objdump -d` does. A symbol start is an instruction boundary, so a straddling instruction is garbage and gets truncated as INVALID.
- Correct because on ELF every LLInt handler has its own symbol. The id bytes decode alone, and no value an id can hold decodes to a flagged instruction (a test checks all 65536).
- Allow `RDPMC` (P6, decodable on every x86-64 CPU, same hunk as #40404). Drop the two `llint_op_*` allowlist entries. Windows keeps `llint_entry` (no per-handler PDB record) as a blanket pass: a misdecode can spell any feature.
- Verified: `cargo test` in the crate (five new tests, with positive controls for a real AVX hit at each position in a unit). The 107029 x64-musl artifact goes FAIL to PASS. The x64 glibc and windows-x64 reports are byte-identical.

### Background
- `verify-baseline-static` disassembles `.text` of the `-profile` binary, flags instructions Nehalem cannot decode, and attributes hits to symbols.
- `EMBED_OPCODE_ID_IF_NEEDED` (`LowLevelInterpreter.cpp`) stores each handler's opcode id as data before its label, for `getOpcodeID`.
- x86 decoding self-synchronizes: a decoder that starts mid-instruction emits garbage for a few instructions, then realigns.

<details><summary>Notes</summary>

The old sweep through the failing region, with the `.int 0x2c6` of `op_jmp_wide32` at `0x3590cd4`:

```
0x3590cd1  ff 24 c6                 jmp qword ptr [rsi+rax*8]     ; end of llint_op_jmp_wide16
0x3590cd4  c6 02 00                 mov byte ptr [rdx],0          ; embedded id 0x2c6
0x3590cd7  00 4b 63                 add [rbx+63h],cl              ; straddles into llint_op_jmp_wide32 (0x3590cd8)
0x3590cda  44 05 02 85 c0 74        add eax,74C08502h
0x3590ce0  13 49 01                 adc ecx,[rcx+1]
0x3590ce3  c0 43 0f b6              rol byte ptr [rbx+0Fh],0B6h
0x3590ce7  44 05 00 48 8d 35        add eax,358D4800h
0x3590ced  0f 33                    rdpmc                         ; bytes 3..4 of lea rsi,[rip+0x121330f]
0x3590cef  21 01                    and [rcx],eax
0x3590cf1  ff 24 c6                 jmp qword ptr [rsi+rax*8]     ; back in sync
```

The displacement `0f 33 21 01` is the distance to the opcode map, so it depends on everything linked between the LLInt and that table. The PRs that tripped it (106976, 107029) changed unrelated code. Main's own build (107018) passed with the same WebKit.

Audit of old sweep vs new sweep over the full binaries (a throwaway tool that diffs the two instruction sets):

- x64-musl: 937 instructions only in the old sweep, 674 only in the new one, all inside the LLInt (`llint_*`, `js_trampoline_*`, `op_*_return_location`). The other 12.47M instructions are identical. The new-only instructions are the handlers' real prologues (plain X64/INTEL386 decodes).
- x64 glibc: report byte-identical (1086 allowlisted symbols, same counts).
- windows-x64: report byte-identical (894 allowlisted symbols). 10 old-only and 5 new-only instructions, all at the MSVC CRT `strcspn`/`strspn`/`_powf_special` inline jump tables, where the old sweep ran into the prologues of `fallbackMethod` and `_realloc_base`.

Brute force over all 65536 possible `.int` values decoded as a 4-byte unit: 5 decode to an instruction iced tags as post-Nehalem (ids 3599 FEMMS, 7183 CLDEMOTE, 13071 RDPMC, 43535 RSM, 63686 XABORT). FEMMS, RSM and XABORT are filtered by `is_impossible_feature`, CLDEMOTE by `is_harmless_on_nehalem`. RDPMC was not filtered before this PR, which is why build 107029 failed on it; it is now in `NEHALEM_ALLOWED`. All five are far above the real id range (0..833 in this build) anyway. The test `an_embedded_opcode_id_decoded_on_its_own_is_never_a_violation` runs the same check through the real filter chain.

The new tests use the exact bytes of the failing region. The desync test sets the lea displacement to spell `vmovdqa` (the AVX shape #32744 and #39597 saw) so it does not depend on the RDPMC taxonomy. The positive controls splice `vmovdqa` into the middle of a unit, as the last instruction before a symbol start, and as the first instruction of a unit, and assert the exact (symbol, ip, mnemonic, feature) hit. Mutations that drop a unit's last byte, skip its first byte, or decode with the wrong ip base each fail at least one of them. CI does not run `cargo test` for this crate (it only builds it). Run it by hand: `cargo test --release --manifest-path scripts/verify-baseline-static/Cargo.toml`.

Reproduce with the steps in `scripts/verify-baseline-static/CLAUDE.md` against the build 107029 `bun-linux-x64-musl-profile.zip` artifact.

Open PRs that carry a workaround for the same failure: #38128 and #40658 add a `llint_op_jmp_wide32` blanket-pass entry, #40404 adds the same `RDPMC` line to `NEHALEM_ALLOWED`. With this change the allowlist entries are unnecessary, and the `RDPMC` hunk is identical so it merges either way.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->