### PR TITLE
test(websocket): assert the blob's own reported size, not a heap-wide delta

### DIFF
--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,6 +1,6 @@
 import type { Server, ServerWebSocket, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
-import { heapStats } from "bun:jsc";
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { afterEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, forceGuardMalloc, isWindows, tempDir } from "harness";
 import net, { isIP } from "node:net";
@@ -942,25 +942,15 @@ describe("ServerWebSocket", () => {
           },
         },
       });
-      // Stays alive until the end, so it is part of both measurements.
       const payload = new Uint8Array(2 * 1024 * 1024);
-      let before = 0;
       const client = new WebSocket(`ws://${server.hostname}:${server.port}`);
       client.onerror = () => reject(new Error("client error"));
-      client.onopen = () => {
-        // Both sockets exist at this point, so only the transfer separates the two measurements.
-        Bun.gc(true);
-        before = heapStats().extraMemorySize;
-        client.send(payload);
-      };
+      client.onopen = () => client.send(payload);
       try {
         const blob = await promise;
-        Bun.gc(true);
-        const reported = heapStats().extraMemorySize - before;
         expect(blob.size).toBe(payload.byteLength);
-        // Without the report this is close to 0. Memory that earlier tests release in the
-        // meantime lowers the number a little, so half the payload is the bound.
-        expect(reported).toBeGreaterThanOrEqual(payload.byteLength / 2);
+        // The size the Blob's visitChildren reports; close to 0 when the bytes are not reported.
+        expect(estimateShallowMemoryUsageOf(blob)).toBeGreaterThanOrEqual(payload.byteLength);
       } finally {
         client.close();
       }


### PR DESCRIPTION
### What does this PR do?

The "blob frames report their bytes to the garbage collector" test took `heapStats().extraMemorySize` before sending a 2 MiB frame and after receiving it as a Blob, and asserted the difference was at least half the payload. That counter is recomputed for the whole heap on every full GC, so anything else that becomes collectable between the two snapshots is subtracted from the result.

Under `bun test --parallel`, a worker runs many files in one process with `--isolate`. The previous file's global object is often still held by an in-flight handle (a subprocess exit, a socket close) when the first snapshot is taken, and is released a few event-loop turns later — right inside the measurement window. Freeing an entire global drops several MiB of reported string/source/buffer memory, so the delta comes out like `-2462488` and the test fails in the parallel batch while passing alone.

The test now asserts `estimateShallowMemoryUsageOf(blob) >= payload.byteLength`. That is the same per-object size the Blob's `visitChildren` reports to the GC, so it checks the property directly with no GC calls and no dependence on what else is in the heap.

### How did you verify your code works?

With a current main build: `bun test websocket-server.test.ts -t "blob frames report"` passes, and `bun test --parallel=1 websocket.test.js websocket-blob.test.ts websocket-server-backpressure-buffer.test.ts websocket-server.test.ts` (one worker, this file last) passes — that same batch failed the old assertion with a delta of 910075. The ws blob reports 2097480 bytes for a 2097152-byte payload.
