### PR TITLE
compile: pre-register embedded modules without allocating loader promises

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "86e19b8edd7c2309b4eb41fcd73df96664d6a2d1";
+export const WEBKIT_VERSION = "f5deafe090cfda095a6f54a00f24a3c2d7784986";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "0bb01ed52617cb9a0530cf8aa07c73c0e8e09510";
+export const WEBKIT_VERSION = "86e19b8edd7c2309b4eb41fcd73df96664d6a2d1";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3853,7 +3853,7 @@ static void collectStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleLo
 }
 
 // Register the collected modules as fetched. When the closure is complete, every module any of them can reach is in it,
-// so they are marked loaded outright — [[LoadedModules]] filled and loadPromise settled — and JSC's graph walk finishes
+// so they are marked loaded outright — [[LoadedModules]] filled and the entry marked loaded — and JSC's graph walk finishes
 // without a HostLoadImportedModule call or microtask per edge. Otherwise they are left the way JSC's own
 // fetch -> makeModule chain leaves them and JSC runs one load step per module to finish the job.
 static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleLoader* loader, StandaloneClosure& closure)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3865,7 +3865,7 @@ static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleL
         auto* entry = loader->ensureRegistered(globalObject, m.key, ScriptFetchParameters::Type::JavaScript);
         RETURN_IF_EXCEPTION(scope, void());
         RELEASE_ASSERT(!entry->record()); // nothing between collect and register can register one of these keys
-        entry->provideModule(vm, m.source, m.record);
+        entry->provideModule(vm, m.record);
         releaseModuleInfo(globalObject, m.source);
     }
     if (!closure.complete)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3801,7 +3801,7 @@ static void collectStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleLo
                 continue;
             if (auto* entry = loader->registryEntry(key)) {
                 // Usable as a loaded dependency only if the loader already finished loading that module's own subgraph.
-                if (entry->record() && entry->loadPromise() && entry->loadPromise()->status() == JSPromise::Status::Fulfilled)
+                if (entry->record() && entry->isLoaded())
                     closure.records.add(key.impl(), entry->record());
                 else
                     closure.complete = false;
@@ -3865,8 +3865,7 @@ static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleL
         auto* entry = loader->ensureRegistered(globalObject, m.key, ScriptFetchParameters::Type::JavaScript);
         RETURN_IF_EXCEPTION(scope, void());
         RELEASE_ASSERT(!entry->record()); // nothing between collect and register can register one of these keys
-        entry->provideModule(globalObject, m.source, m.record);
-        RETURN_IF_EXCEPTION(scope, void());
+        entry->provideModule(vm, m.source, m.record);
         releaseModuleInfo(globalObject, m.source);
     }
     if (!closure.complete)
@@ -3880,14 +3879,8 @@ static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleL
             RETURN_IF_EXCEPTION(scope, void());
         }
     }
-    for (auto& m : closure.modules) {
-        auto* entry = loader->registryEntry(m.key);
-        if (!entry->loadPromise()) {
-            JSPromise* loaded = JSPromise::create(vm, globalObject->promiseStructure());
-            loaded->fulfill(vm, m.record);
-            entry->setLoadPromise(vm, loaded);
-        }
-    }
+    for (auto& m : closure.modules)
+        loader->registryEntry(m.key)->markLoaded();
 }
 
 JSC::JSPromise* StandaloneGlobalObject::moduleLoaderFetch(JSGlobalObject* jsGlobalObject, JSModuleLoader* loader, JSValue key, RefPtr<JSC::ScriptFetchParameters> parameters, RefPtr<JSC::ScriptFetcher> fetcher)


### PR DESCRIPTION
### What does this PR do?

Follow-up to #40643. When a compiled executable pre-registers its embedded module graph, each module got a fetch promise, a module promise and a resolved load promise that nothing ever awaits (the graph walk reads `[[LoadedModules]]` / `record()` directly). With oven-sh/WebKit@f5deafe090cf:

- `ModuleRegistryEntry::provideModule(vm, record)` stores the record without allocating any promise or reaction (and no extra GC field); `ensureFetchPromise()` / `ensureModulePromise()` hand back ones already settled with the record if a later top-level load asks, and `moduleLoadTopSettled` treats a record result as already provided.
- `AbstractModuleRecord::evaluateModuleSync` evaluates a `SyntheticModuleRecord` (Bun's `node:*` / `bun:*` builtins) directly instead of wrapping `undefined` in a fresh promise — InnerModuleEvaluation hits that once per import edge to a builtin.
- `markLoaded()` states that the record's `[[LoadedModules]]` is complete; `hostLoadImportedModule` treats such an entry as loaded and only materializes a load promise (`loadedPromise()`) for the edge that actually needs one (in practice: each root).

Bun's `registerStandaloneClosure` now calls those two instead of building promises itself.

| `claude --help` (2.1.250, `--compile --bytecode --splitting`) | before | after |
|---|---|---|
| `JSPromise::create` calls | 2,986 | 630 |
| loader microtasks | 603 | 603 |
| host resolve / fetch calls | unchanged | |

The remaining promise allocations are ~10 per *root* (JSC's top-level `loadModule` / evaluate chain × 61 roots here); nothing is per module or per import edge anymore.

### How did you verify your code works?

`test/bundler/bundler_compile_splitting.test.ts` (incl. the host-hook-count assertions added in #40643), `bun-build-compile.test.ts`, `bundler_compile.test.ts`; drove compiled apps by hand (static/dynamic imports, cycles through the entry, builtins, Worker, `import.meta.resolve`, missing embedded path, CJS + bytecode); built the Claude Code CLI with this branch and compared `BUN_JSC_dumpModuleLoadingState` / promise / microtask counts against `main`.

