### PR TITLE
dns(macOS): pass AllowFailover so dns.lookup can fail over to scoped resolvers

### DIFF
--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -47,15 +47,25 @@ unsafe extern "C" {
     fn DNSServiceRefSockFD(sd_ref: DNSServiceRef) -> c_int;
     fn DNSServiceProcessResult(sd_ref: DNSServiceRef) -> DNSServiceErrorType;
     fn DNSServiceRefDeallocate(sd_ref: DNSServiceRef);
-    fn DNSServiceGetAddrInfo(
+    // SPI (macOS 12+): DNSServiceGetAddrInfo plus the attribute libinfo's getaddrinfo passes.
+    fn DNSServiceGetAddrInfoEx(
         sd_ref: *mut DNSServiceRef,
         flags: DNSServiceFlags,
         interface_index: u32,
         protocol: DNSServiceProtocol,
         hostname: *const c_char,
+        attr: *const DNSServiceAttribute,
         callback: GetAddrInfoReply,
         context: *mut c_void,
     ) -> DNSServiceErrorType;
+    /// Lets mDNSResponder fail a query over to other resolvers (scoped/supplemental), as getaddrinfo does.
+    #[allow(non_upper_case_globals)]
+    static kDNSServiceAttrAllowFailover: DNSServiceAttribute;
+}
+
+#[repr(C)]
+pub(crate) struct DNSServiceAttribute {
+    _opaque: [u8; 0],
 }
 
 /// Map a DNSServiceErrorType to the EAI_* code the existing error paths expect.
@@ -437,18 +447,19 @@ impl SharedConnection {
         let mut sub: DNSServiceRef = self.main_ref;
         // SAFETY: FFI; `hostname` is NUL-terminated (copied by dns_sd); `context` is only stored.
         let err = unsafe {
-            DNSServiceGetAddrInfo(
+            DNSServiceGetAddrInfoEx(
                 &raw mut sub,
                 FLAGS_SHARE_CONNECTION | FLAGS_TIMEOUT | FLAGS_RETURN_INTERMEDIATES | suppress,
                 0,
                 protocol,
                 hostname.as_ptr().cast::<c_char>(),
+                &raw const kDNSServiceAttrAllowFailover,
                 callback,
                 context,
             )
         };
         if err != ERR_NO_ERROR {
-            bun_output::scoped_log!(dns, "DNSServiceGetAddrInfo failed: {}", err);
+            bun_output::scoped_log!(dns, "DNSServiceGetAddrInfoEx failed: {}", err);
             return None;
         }
         Some(sub)


### PR DESCRIPTION
Fixes #40573

### Problem

Bun 1.4.0 moved macOS `dns.lookup` from libinfo's `getaddrinfo_async_start` to a direct `DNSServiceGetAddrInfo` call on a shared mDNSResponder connection (#36619). Names served only by a supplemental/scoped SystemConfiguration resolver (VPN split-DNS, ZeroTier/Tailscale zones, `/etc/resolver/*` drop-ins) now come back `ENOTFOUND` on the reporter's host, while 1.3.14, Node, Python, and `dig` all resolve them.

Apple's libinfo does not call `DNSServiceGetAddrInfo` under `getaddrinfo`. It issues A and AAAA `DNSServiceQueryRecordWithAttribute` queries with the `kDNSServiceAttrAllowFailover` attribute (`DNSServiceFailoverPolicyAllow`, SPI since macOS 12). Our call passed no attribute, so mDNSResponder was never allowed to fail the query over to another resolver.

### Fix

Call the exported `DNSServiceGetAddrInfoEx` SPI (same signature plus an `attr` argument) and pass `kDNSServiceAttrAllowFailover`, matching what every `getaddrinfo` caller on macOS gets. Both symbols are exported from `libsystem_dnssd` on macOS 12+; Bun's floor is 13.0.

### Verification

- A C probe built against the same SPI links and resolves with and without the attribute on macOS 26.5.
- I could **not** reproduce the reported failure locally, even after emulating the reporter's `scutil --dns` layout (catch-all supplemental resolver, `domain`-matched supplemental resolver on a utun subnet, scoped utun resolver). The failover logic lives in Apple's closed daemon code, so this is the one documented difference between our call and libinfo's, not a confirmed root cause. I'll ask the reporter to test a build from this PR.
- No new test: the behaviour depends on host SystemConfiguration state that a test cannot set up without root.