### PR TITLE
Bun.serve http2: reject the request bytes the HTTP/1 parser rejects

### DIFF
--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -152,14 +152,25 @@ static inline unsigned char *hpackEncodeInteger(unsigned char *dst, uint8_t pref
     return dst;
 }
 
-/* RFC 9113 §8.2.1 field validity, beyond what HPACK decoding guarantees. */
+/* RFC 9113 §8.2.1 field validity, beyond what HPACK decoding guarantees: a
+ * name is an RFC 9110 token with no uppercase letter, optionally behind the
+ * single ':' of a pseudo-header. The token set is the one the HTTP/1 parser
+ * (isFieldNameByte) and the HTTP/3 header-set interface accept. */
 static inline bool validFieldName(const char *p, unsigned n) {
-    if (n == 0) return false;
-    for (unsigned i = 0; i < n; i++) {
+    unsigned i = n && p[0] == ':';
+    if (i == n) return false;
+    for (; i < n; i++) {
         unsigned char c = (unsigned char) p[i];
-        if (c <= 0x20 || c >= 0x7f || (c >= 'A' && c <= 'Z') || (c == ':' && i != 0)) return false;
+        if (!isTokenByte(c) || (c >= 'A' && c <= 'Z')) return false;
     }
     return true;
+}
+
+/* The methods Bun.serve can represent: the HTTP/1 parser's strict set, in
+ * their RFC 9110 case-sensitive wire form. */
+static inline bool isKnownMethod(std::string_view method) {
+    for (unsigned char c : method) if (!((c >= 'A' && c <= 'Z') || c == '-')) return false;
+    return Bun__HTTPMethod__from(method.data(), method.size()) != -1;
 }
 
 /* The request fields validation cares about. lshpack reports the HPACK
@@ -193,11 +204,14 @@ static inline Field classify(int hpackIndex, std::string_view name) {
     return Field::Other;
 }
 
+/* RFC 9113 §8.2.1: field-content (RFC 9110 §5.5) with no leading or trailing
+ * whitespace. HTAB is the only control byte allowed; DEL and obs-text pass,
+ * as they do through the HTTP/1 parser. */
 static inline bool validFieldValue(const char *p, unsigned n) {
     if (n && (p[0] == ' ' || p[0] == '\t' || p[n - 1] == ' ' || p[n - 1] == '\t')) return false;
     for (unsigned i = 0; i < n; i++) {
         unsigned char c = (unsigned char) p[i];
-        if (c == '\r' || c == '\n' || c == 0) return false;
+        if (c < 0x20 && c != '\t') return false;
     }
     return true;
 }
@@ -1700,6 +1714,12 @@ inline bool Http2Connection::handleHeaderBlock(uint32_t streamId, uint8_t flags,
     stream->remoteClosed = endStream;
     streams.push_back(stream);
     progressed = true;
+    if (!http2::isKnownMethod(method)) {
+        /* RFC 9110 §15.6.2. The router would dispatch it to the "any" handler,
+         * which cannot represent the method and would report GET. */
+        stream->writeStatus("501 Not Implemented")->end();
+        return !closed;
+    }
     return dispatchRequest(stream, list.data(), (unsigned) list.size());
 }
 

--- a/packages/bun-uws/src/Utilities.h
+++ b/packages/bun-uws/src/Utilities.h
@@ -34,13 +34,30 @@ static inline bool asciiIEquals(std::string_view a, const char *lower) {
     for (size_t i = 0; i < a.size(); i++) if ((a[i] | 0x20) != lower[i]) return false;
     return true;
 }
+/* RFC 9110 §5.6.2 tchar. */
+static inline bool isTokenByte(unsigned char c) {
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) return true;
+    switch (c) {
+    case '!': case '#': case '$': case '%': case '&': case '\'': case '*':
+    case '+': case '-': case '.': case '^': case '_': case '`': case '|': case '~':
+        return true;
+    }
+    return false;
+}
+
 /* RFC 9113 §8.3.1 / RFC 9114 §4.3.1 request-target rules shared by the h2
- * and h3 request validators: :path is origin-form (or "*" for OPTIONS);
- * CONNECT carries no :path; there is an authority, Host doesn't contradict
- * :authority, and :authority has no userinfo. */
+ * and h3 request validators: :method is a token; :path is origin-form (or
+ * "*" for OPTIONS) and carries no byte the HTTP/1 request line could not
+ * (controls, SP); CONNECT carries no :path; there is an authority, Host
+ * doesn't contradict :authority, and :authority has no userinfo. */
 static inline bool validPseudoHeaderTarget(std::string_view method, std::string_view path, std::string_view authority, std::string_view host) {
+    if (method.empty()) return false;
+    for (unsigned char c : method) if (!isTokenByte(c)) return false;
     bool isConnect = method == "CONNECT";
-    if (!isConnect && !(path.size() && path[0] == '/') && !(path == "*" && method == "OPTIONS")) return false;
+    if (!isConnect) {
+        if (!(path.size() && path[0] == '/') && !(path == "*" && method == "OPTIONS")) return false;
+        for (unsigned char c : path) if (c <= 0x20) return false;
+    }
     if (authority.empty() && host.empty()) return false;
     if (!authority.empty() && !host.empty() && authority != host) return false;
     if (authority.find('@') != std::string_view::npos) return false;

--- a/patches/lshpack/no-name-trim.patch
+++ b/patches/lshpack/no-name-trim.patch
@@ -1,0 +1,16 @@
+--- a/lshpack.c	2026-08-28 00:15:39.411868808 +0000
++++ b/lshpack.c	2026-08-28 00:15:39.429205515 +0000
+@@ -1890,8 +1890,11 @@
+         }
+         if (len > UINT16_MAX)
+             return LSHPACK_ERR_TOO_LARGE;
+-        while(len > 0 && isspace(*(name + len - 1)))
+-            --len;
++        /* Bun: hand the literal name to the caller byte-exact. Upstream trims
++         * trailing whitespace here, which (a) lets a name such as "x-a " reach
++         * the application as "x-a" instead of being rejected as malformed
++         * (RFC 9113 8.2.1) and (b) enters the shortened name into the dynamic
++         * table, so the decoder's table size no longer matches the encoder's. */
+         if (len == 0)
+             return LSHPACK_ERR_BAD_DATA;
+ 

--- a/scripts/build/deps/lshpack.ts
+++ b/scripts/build/deps/lshpack.ts
@@ -25,7 +25,11 @@ export const lshpack: Dependency = {
   // hencs[65536]/hdecs[65536] (768 KB of .rodata) are pure functions of the
   // 257-entry encode_table. Declare them in .bss and fill on first init
   // (~250 us once); the hot-path lookup is unchanged.
-  patches: ["patches/lshpack/bss-huff-tables.patch"],
+  //
+  // no-name-trim: upstream strips trailing whitespace from a decoded literal
+  // field name, so "x-a " reached the request validators as "x-a" instead of
+  // being rejected, and the shortened name went into the dynamic table.
+  patches: ["patches/lshpack/bss-huff-tables.patch", "patches/lshpack/no-name-trim.patch"],
 
   build: cfg => {
     // <sys/queue.h> ships with glibc and BSD libc but not musl or win32.

--- a/test/js/bun/http/serve-http2-protocol.test.ts
+++ b/test/js/bun/http/serve-http2-protocol.test.ts
@@ -285,6 +285,29 @@ describe.concurrent("Bun.serve http2 protocol", () => {
       ],
     ],
     ["response pseudo-header", [...baseHeaders("/hello"), [":status", "200"]]],
+    // Bytes the HTTP/1.1 parser on the same port answers 400 or 505 for. The
+    // handler must never see a method, path, or field name other than the one
+    // on the wire (a stripped HTAB would alias /sta\ttic to /static).
+    [":method with SP", baseHeaders("/hello", "GET /x HTTP/1.1")],
+    [":method with a control byte", baseHeaders("/hello", "\x01")],
+    [":method with non-token bytes", baseHeaders("/hello", "GET{}")],
+    [":path with HTAB", baseHeaders("/sta\ttic")],
+    [":path with SP", baseHeaders("/a b")],
+    [":path with a control byte", baseHeaders("/hello\x01")],
+    ["field name with trailing SP", [...baseHeaders("/hello"), ["x-a ", "1"]]],
+    ["field name with trailing HTAB", [...baseHeaders("/hello"), ["x-a\t", "1"]]],
+    ["field name with trailing LF", [...baseHeaders("/hello"), ["x-a\n", "1"]]],
+    ["field name with parentheses", [...baseHeaders("/hello"), ["x-(a)", "1"]]],
+    ["field name with comma", [...baseHeaders("/hello"), ["x-a,b", "1"]]],
+    ["field name with semicolon and equals", [...baseHeaders("/hello"), ["x-a;b=c", "1"]]],
+    ["field name with braces", [...baseHeaders("/hello"), ["x-{a}", "1"]]],
+    ["field name with DQUOTE", [...baseHeaders("/hello"), ['x-"a"', "1"]]],
+    ["field name with slash", [...baseHeaders("/hello"), ["x-a/b", "1"]]],
+    ["field name with @ [ ] ?", [...baseHeaders("/hello"), ["x-a@[b]?", "1"]]],
+    ["field name with DEL", [...baseHeaders("/hello"), ["x-a\x7f", "1"]]],
+    ["field name with a byte above 0x7f", [...baseHeaders("/hello"), ["x-a\xe9", "1"]]],
+    ["field value with a control byte", [...baseHeaders("/hello"), ["x-v", "a\x01b"]]],
+    ["field value with ESC", [...baseHeaders("/hello"), ["x-v", "a\x1bb"]]],
   ] as [string, [string, string][]][]) {
     test(`malformed request (${name}) → RST_STREAM PROTOCOL_ERROR, connection survives`, async () => {
       const raw = await RawH2.connect(fx.port, secure);
@@ -1087,6 +1110,36 @@ describe.concurrent("Bun.serve http2 protocol", () => {
     ]);
     const f = await raw.waitFor(f => f.streamId === 1 && (f.type === T.HEADERS || f.type === T.RST_STREAM));
     expect(f.type).toBe(T.HEADERS);
+    raw.close();
+  });
+
+  // A token Bun.serve has no Method for. The "any" route used to take it and
+  // the handler saw req.method === "GET"; HTTP/1.1 on the same port never
+  // dispatches it.
+  for (const method of ["BREW", "GETX", "get", "Get", "M_SEARCH"]) {
+    test(`unknown :method ${method} → 501 without reaching the handler, connection survives`, async () => {
+      const raw = await RawH2.connect(fx.port, secure);
+      raw.headers(1, baseHeaders("/headers", method));
+      const h = await raw.waitFor(f => f.streamId === 1 && (f.type === T.HEADERS || f.type === T.RST_STREAM));
+      expect(h.type).toBe(T.HEADERS);
+      expect(decodeStatus(h.payload)).toBe(501);
+      // /headers always answers with a JSON body; END_STREAM on the HEADERS
+      // frame means no handler ran.
+      expect(h.flags & F.END_STREAM).toBe(F.END_STREAM);
+      raw.headers(3, baseHeaders("/hello"));
+      expect((await raw.body(3)).toString()).toBe("hello");
+      raw.close();
+    });
+  }
+
+  test("a known method with a hyphen, every tchar in a field name, and HTAB inside a value reach the handler byte-exact", async () => {
+    const raw = await RawH2.connect(fx.port, secure);
+    const name = "x-a!#$%&'*+.^_`|~0";
+    raw.headers(1, [...baseHeaders("/headers", "M-SEARCH"), [name, "1"], ["x-tab", "a\tb"]]);
+    const body = JSON.parse((await raw.body(1)).toString());
+    expect(body.method).toBe("M-SEARCH");
+    expect(body.headers[name]).toBe("1");
+    expect(body.headers["x-tab"]).toBe("a\tb");
     raw.close();
   });
 


### PR DESCRIPTION
### Problem
- Over `http2: true`, an unknown `:method` (`BREW`, lowercase `get`) reaches the handler as `req.method === "GET"`: the any-method route takes it and `RequestContext::create` maps an unknown method to GET (`src/runtime/server/RequestContext.rs:1346`).
- `:path` accepts HTAB, SP and control bytes, so `/sta\ttic` reaches the handler and `new URL(req.url).pathname` is `/static`. lshpack trims trailing whitespace from field names before validation (`lshpack.c:1893`), so `x-a ` arrives as `x-a`. Names with `(),;={}"` and values with control bytes pass.
- The HTTP/1.1 parser on the same port rejects all of these.

### Fix
- `validPseudoHeaderTarget` (`packages/bun-uws/src/Utilities.h`): `:method` must be a token, `:path` has no byte at or below 0x20. `validFieldName` accepts lowercase token bytes only. `validFieldValue` rejects control bytes other than HTAB. Each is RST_STREAM PROTOCOL_ERROR, the connection survives.
- A well-formed method Bun has no `Method` for gets `501 Not Implemented` on its stream before the router runs (`Http2Context.h`, `handleHeaderBlock`). The known set is the HTTP/1 parser's strict set, case-sensitive.
- `patches/lshpack/no-name-trim.patch` removes the trim. node:http2 and the fetch h2 client already validate names, so they now reject `x-a ` instead of seeing `x-a`.
- Verified: `test/js/bun/http/serve-http2-protocol.test.ts` (26 new cases, 21 fail on main). Also the other h2, h3, node:http2 and fetch h2 suites.

### Background
- The h2 server decodes HPACK with lshpack, validates the list per RFC 9113 §8.3 in `Http2Connection::handleHeaderBlock`, then routes through the uWS router. The `fetch` handler sits on the any-method node.
- The HTTP/1 router registers that handler once per known method, so an unknown method matches nothing and the socket closes. Over h2 the any-method node matched everything.
- `Request.method` is a fixed enum. No arbitrary token can reach JS, so an unknown method must be rejected at the protocol layer.
- The WHATWG URL parser strips HTAB and trims trailing control bytes, which is how `/sta\ttic` becomes `/static`.

<details><summary>Notes</summary>

- HTTP/1.1 on the same build, same bytes, over loopback: `BREW / HTTP/1.1` closes the socket with no response (no route for the method); `\x01` as the method: 400; HTAB, SP or a control byte in the target: 505; trailing SP or a non-token byte in a field name: 400; a control byte in a value: 400. DEL and bytes at or above 0x80 in the target or a value: accepted. h2 accepts those two as well after this change.
- Not changed here: `req.url` over h2 is the raw `:path`, over h1 it is WHATWG-normalized (`"` becomes `%22`). Bytes at or above 0x80 in the path fold to U+FFFD on both. `OPTIONS *` reaches the handler with `req.url === "*"`. HTTP/3 (`packages/bun-usockets/src/quic.c`) validates field names as tokens but has no pseudo-header validation.
- The lshpack trim also pushed the shortened name into the dynamic table, so for such a block the decoder's table size accounting no longer matched the encoder's.
- `isKnownMethod` is `[A-Z-]` plus `Bun__HTTPMethod__from`, which is the HTTP/1 parser's strict method check. `Method::which` alone accepts `get` (for `new Request("get")`), so a lowercase wire method would still have been reported as `GET`.
- 30-row probe (each row sent over h2 and as an HTTP/1.1 request line on the same port) is what the test matrix distills. Every row now agrees on accept or reject.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 20 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http2-protocol.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/http/serve-http2-protocol.test.ts:
(pass) Bun.serve http2 protocol > first frame not SETTINGS → GOAWAY PROTOCOL_ERROR [328.24ms]
(pass) Bun.serve http2 protocol > SETTINGS with bad length → GOAWAY FRAME_SIZE_ERROR [341.53ms]
(pass) Bun.serve http2 protocol > oversized frame → GOAWAY FRAME_SIZE_ERROR [350.87ms]
(pass) Bun.serve http2 protocol > WINDOW_UPDATE of 0 on the connection → GOAWAY PROTOCOL_ERROR [361.85ms]
(pass) Bun.serve http2 protocol > connection WINDOW_UPDATE overflow → GOAWAY FLOW_CONTROL_ERROR [252.45ms]
(pass) Bun.serve http2 protocol > even stream id → GOAWAY PROTOCOL_ERROR [249.08ms]
(pass) Bun.serve http2 protocol > HEADERS interleaved before CONTINUATION → GOAWAY PROTOCOL_ERROR [250.14ms]
(pass) Bun.serve http2 protocol > PUSH_PROMISE from client → GOAWAY PROTOCOL_ERROR [244.23ms]
(pass) Bun.serve http2 protocol > bad preface closes the connection [848.58ms]
(pass) Bun.serve http2 protocol > invalid HPACK → GOA
... (truncated)

release without fix: 192 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/http/serve-http2-protocol.test.ts:
error: The session has been destroyed
 code: "ERR_HTTP2_INVALID_SESSION"

      at unknown:1:1
      at destroyWithInvalidSessionNT (node:http2:2399:38)
      at processTicksAndRejections (native:7:39)
278 |   /** Resolve with the first frame matching `pred`, waiting for more data as needed. */
279 |   async waitFor(pred: (f: RawFrame) => boolean): Promise<RawFrame> {
280 |     for (;;) {
281 |       const found = this.frames.find(pred);
282 |       if (found) return found;
283 |       if (this.closed) throw new Error("connection closed before expected frame; got " + this.describe());
                                       ^
error: connection closed before expected frame; got []
      at waitFor (/workspace/bun/test/js/bun/http/serve-http2-helpers.ts:283:34)
278 |   /** Resolve with the first frame matching `pred`, waiting for more data as needed. */
279 |   async waitFor(pred: (f: RawFrame) => boolean): Promise<RawFrame> {
280 |     for (;;) {
281 |       const found = this.frames.find(pred);
282 |       if (found) return found;
283 |       if (this.closed) throw new Error("connect
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http2-protocol.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/http/serve-http2-protocol.test.ts:
(pass) Bun.serve http2 protocol > first frame not SETTINGS → GOAWAY PROTOCOL_ERROR [469.07ms]
(pass) Bun.serve http2 protocol > SETTINGS with bad length → GOAWAY FRAME_SIZE_ERROR [490.94ms]
(pass) Bun.serve http2 protocol > oversized frame → GOAWAY FRAME_SIZE_ERROR [505.45ms]
(pass) Bun.serve http2 protocol > WINDOW_UPDATE of 0 on the connection → GOAWAY PROTOCOL_ERROR [523.79ms]
(pass) Bun.serve http2 protocol > connection WINDOW_UPDATE overflow → GOAWAY FLOW_CONTROL_ERROR [384.05ms]
(pass) Bun.serve http2 protocol > even stream id → GOAWAY PROTOCOL_ERROR [379.25ms]
(pass) Bun.serve http2 protocol > HEADERS interleaved before CONTINUATION → GOAWAY PROTOCOL_ERROR [382.84ms]
(pass) Bun.serve http2 protocol > PUSH_PROMISE from client → GOAWAY PROTOCOL_ERROR [373.02ms]
(pass) Bun.serve http2 protocol > bad preface closes the connection [1243.89ms]
(pass) Bun.serve http2 protocol > invalid HPACK → GO
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f5b2098b0c
  features     baseline

23 deps, 131 codegen, 1172 objects in 970ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [22.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] gen .bind.ts → GeneratedBindings.cpp
[5/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[6/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch zlib
[zlib] up to date
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [31.00ms]
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Pro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/Http2Context.h           | 30 ++++++++++++---
 packages/bun-uws/src/Utilities.h              | 25 +++++++++++--
 patches/lshpack/no-name-trim.patch            | 16 ++++++++
 scripts/build/deps/lshpack.ts                 |  6 ++-
 test/js/bun/http/serve-http2-protocol.test.ts | 53 +++++++++++++++++++++++++++
 5 files changed, 120 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-uws/src/Http2Context.h                3      7      0
packages/bun-uws/src/Utilities.h                   2      2      0
patches/lshpack/no-name-trim.patch                 0      0      0
scripts/build/deps/lshpack.ts                      2      4      0
test/js/bun/http/serve-http2-protocol.test.ts      4      2      0
```

</details>

<!-- robobun:evidence:end -->