### PR TITLE
bun test --parallel: send coverage and test results to the coordinator as data, not rendered LCOV/XML

### DIFF
--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -294,7 +294,7 @@ coverageThreshold = 0.8
 coverageThreshold = { lines = 0.9, functions = 0.8 }
 ```
 
-Setting a threshold makes `bun test` exit with code 1 when coverage is enabled and any file's line or function coverage is below it. Bun accepts the `statements` key but does not currently enforce it. Outside `--parallel`, the check only runs when the `text` reporter is enabled (the default); a run with only the `lcov` reporter currently exits 0 regardless of the threshold.
+Setting a threshold makes `bun test` exit with code 1 when coverage is enabled and any file's line or function coverage is below it. Bun accepts the `statements` key but does not currently enforce it. The check applies with any coverage reporter.
 
 #### Threshold Examples
 

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -681,6 +681,25 @@ impl DynamicBitSetUnmanaged {
         bun_core::cast_slice::<usize, u8>(self.masks_slice())
     }
 
+    /// Inverse of `bytes()`: `bytes` must be exactly the mask words for
+    /// `bit_length`. Padding bits past `bit_length` are cleared, so untrusted
+    /// input cannot make `count()` exceed `bit_length`.
+    pub fn from_bytes(bit_length: usize, bytes: &[u8]) -> Result<Option<Self>, AllocError> {
+        let mut set = Self::init_empty(bit_length)?;
+        let words = set.masks_slice_mut();
+        if bytes.len() != core::mem::size_of_val(words) {
+            return Ok(None);
+        }
+        bun_core::cast_slice_mut::<usize, u8>(words).copy_from_slice(bytes);
+        let n = words.len();
+        if let Some(last) = words.last_mut() {
+            let padding_bits =
+                u32::try_from(n * DYN_MASK_BITS as usize - bit_length).expect("int cast");
+            *last &= usize::MAX >> padding_bits;
+        }
+        Ok(Some(set))
+    }
+
     /// Returns the total number of set bits in this bit set.
     pub fn count(&self) -> usize {
         let mut total: usize = 0;
@@ -1259,6 +1278,23 @@ impl DynamicBitSet {
     /// The two sets must both be the same bit_length.
     pub fn set_intersection(&mut self, other: &Self) {
         self.unmanaged.set_intersection(&other.unmanaged);
+    }
+
+    /// Performs a union of two bit sets, and stores the result in the
+    /// first one. The two sets must both be the same bit_length.
+    pub fn set_union(&mut self, other: &Self) {
+        self.unmanaged.set_union(&other.unmanaged);
+    }
+
+    /// The mask words as raw bytes (native layout).
+    pub fn bytes(&self) -> &[u8] {
+        self.unmanaged.bytes()
+    }
+
+    /// See `DynamicBitSetUnmanaged::from_bytes`.
+    pub fn from_bytes(bit_length: usize, bytes: &[u8]) -> Result<Option<Self>, AllocError> {
+        Ok(DynamicBitSetUnmanaged::from_bytes(bit_length, bytes)?
+            .map(|unmanaged| Self { unmanaged }))
     }
 
     /// Iterates through the items in the set, according to the options.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1779,7 +1779,8 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
 
     if let Some(reporter) = args.option(b"--reporter") {
         if reporter == b"junit" {
-            if ctx.test_options.reporter_outfile.is_none() {
+            // A `--parallel` worker only collects for the coordinator's file.
+            if ctx.test_options.reporter_outfile.is_none() && !args.flag(b"--test-worker") {
                 Output::err_generic(
                     "--reporter=junit requires --reporter-outfile [file] to specify where to save the XML report",
                     (),

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -42,9 +42,13 @@ pub struct Coordinator<'a> {
     pub(crate) envps: Vec<bun_dotenv::NullDelimitedEnvMap>,
 
     pub(crate) workers: &'a mut [Worker],
-    pub(crate) junit_chunks: Vec<Option<Box<[u8]>>>,
-    pub(crate) junit_totals: super::aggregate::JunitTotals,
-    pub(crate) coverage_chunks: Vec<Box<[u8]>>,
+    /// Per file index, when a structured reporter (JUnit) is configured: the
+    /// `TestDone` records received for it, replayed in file order at the end
+    /// so the document matches a serial run. Empty otherwise.
+    pub(crate) test_records: Vec<FileTestRecords>,
+    /// Per source path: coverage folded across every worker that loaded it.
+    pub(crate) coverage_files:
+        bun_collections::StringArrayHashMap<bun_sourcemap_jsc::code_coverage::MergedReport>,
     /// File index whose `path:` header was most recently written. Result lines
     /// from concurrent workers interleave; whenever the source file changes the
     /// header is re-emitted so every line has visible context. None at start.
@@ -65,6 +69,13 @@ pub struct Coordinator<'a> {
     /// without running its signal handler (e.g. SIGKILL / TerminateProcess).
     #[cfg(windows)]
     pub(crate) windows_job: Option<*mut c_void>,
+}
+
+#[derive(Default)]
+pub(crate) struct FileTestRecords {
+    /// `TestDone` payloads past the formatted line; see `runner::decode_test_case`.
+    pub(crate) tests: Vec<Box<[u8]>>,
+    pub(crate) elapsed_ns: u64,
 }
 
 /// Why the run stopped dispatching files. A worker panic overrides `Bail`
@@ -174,10 +185,10 @@ impl<'a> Coordinator<'a> {
             .iter()
             .filter_map(|w| w.inflight.map(|idx| (idx, now - w.dispatched_at)))
             .collect();
-        for (idx, _) in &running {
+        for (idx, ms) in &running {
             self.reporter.summary().fail += 1;
             self.reporter.summary().files += 1;
-            self.crashed_files.push(*idx);
+            self.mark_crashed(*idx, *ms);
             self.files_done += 1;
         }
         if !running.is_empty() {
@@ -422,6 +433,9 @@ impl<'a> Coordinator<'a> {
                 if w.inflight != Some(idx) {
                     return;
                 }
+                if let Some(file) = self.test_records.get_mut(idx as usize) {
+                    file.tests.push(Box::from(rd.p));
+                }
                 self.flush_captured(w);
                 if formatted.is_empty() {
                     return; // e.g. pass under --only-failures
@@ -453,6 +467,9 @@ impl<'a> Coordinator<'a> {
                     files,
                     unhandled,
                 ] = nums;
+                if let Some(file) = self.test_records.get_mut(idx as usize) {
+                    file.elapsed_ns = rd.u64();
+                }
 
                 self.flush_captured(w);
                 if self.last_header_idx == Some(idx) {
@@ -511,20 +528,14 @@ impl<'a> Coordinator<'a> {
                     .todos_to_repeat_buf
                     .extend_from_slice(rd.str());
             }
-            frame::Kind::JunitChunk => {
-                let idx = rd.u32() as usize;
-                let chunk = rd.str();
-                if !chunk.is_empty()
-                    && let Some(slot) = self.junit_chunks.get_mut(idx)
-                {
-                    super::aggregate::add_junit_chunk_totals(&mut self.junit_totals, chunk);
-                    *slot = Some(Box::<[u8]>::from(chunk));
-                }
-            }
-            frame::Kind::CoverageChunk => {
-                let chunk = rd.str();
-                if !chunk.is_empty() {
-                    self.coverage_chunks.push(Box::<[u8]>::from(chunk));
+            frame::Kind::CoverageFile => {
+                use bun_sourcemap_jsc::code_coverage::wire;
+                // fd 3 is writable from test JS, so a frame that doesn't
+                // decode is dropped rather than trusted.
+                if let Some(report) = wire::decode(rd.str()) {
+                    let merged =
+                        bun_core::handle_oom(self.coverage_files.get_or_put(&report.source_url));
+                    bun_core::handle_oom(merged.value_ptr.add(&report));
                 }
             }
             frame::Kind::Run | frame::Kind::Shutdown => {}
@@ -598,12 +609,14 @@ impl<'a> Coordinator<'a> {
                 if w.ipc.corrupt_frame.get() && !panicked {
                     self.account_crash(
                         idx,
+                        w.dispatched_at,
                         format_args!("worker killed: corrupt IPC frame, something wrote to fd 3"),
                     );
                 } else {
                     let mut buf = [0u8; 32];
                     self.account_crash(
                         idx,
+                        w.dispatched_at,
                         format_args!(
                             "worker crashed: {}",
                             bstr::BStr::new(describe_status(&mut buf, status))
@@ -677,7 +690,19 @@ impl<'a> Coordinator<'a> {
         self.files_done += 1;
     }
 
-    fn account_crash(&mut self, file_idx: u32, detail: core::fmt::Arguments<'_>) {
+    fn mark_crashed(&mut self, file_idx: u32, elapsed_ms: i64) {
+        self.crashed_files.push(file_idx);
+        if let Some(file) = self.test_records.get_mut(file_idx as usize) {
+            file.elapsed_ns = u64::try_from(elapsed_ms).unwrap_or(0) * bun_core::time::NS_PER_MS;
+        }
+    }
+
+    fn account_crash(
+        &mut self,
+        file_idx: u32,
+        dispatched_at: i64,
+        detail: core::fmt::Arguments<'_>,
+    ) {
         self.break_dots();
         bun_core::pretty_error!(
             "<r><red>✗<r> <b>{}<r> <d>({})<r>\n",
@@ -686,7 +711,7 @@ impl<'a> Coordinator<'a> {
         );
         self.reporter.summary().fail += 1;
         self.reporter.summary().files += 1;
-        self.crashed_files.push(file_idx);
+        self.mark_crashed(file_idx, bun_core::time::milli_timestamp() - dispatched_at);
         self.files_done += 1;
         if self.bail > 0 && self.reporter.summary().fail >= self.bail {
             self.bail_out();

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -10,9 +10,14 @@ pub enum Kind {
     Ready,
     /// u32 file_idx
     FileStart,
-    /// u32 file_idx, str formatted_line (ANSI included; printed verbatim)
+    /// u32 file_idx, str formatted_line (ANSI included; printed verbatim);
+    /// then, only when the worker runs with `--reporter`, the structured
+    /// result (`runner::encode_test_case`): u32 status, u32 assertions,
+    /// u64 elapsed_ns, u32 line, str name, u32 n × {str scope_name,
+    /// u32 scope_line}, u32 has_failure [, str name, str message, str body]
     TestDone,
-    /// 9 × u32: file_idx, pass, fail, skip, todo, expectations, skipped_label, files, unhandled
+    /// 9 × u32: file_idx, pass, fail, skip, todo, expectations, skipped_label,
+    /// files, unhandled; u64 elapsed_ns
     FileDone,
     /// 3 × str: failures, skips, todos (verbatim repeat-buffer bytes)
     RepeatBufs,
@@ -21,14 +26,10 @@ pub enum Kind {
     Run,
     /// (empty)
     Shutdown,
-    /// u32 file_idx, str xml — one file's completed <testsuite> element(s).
-    /// Workers never write reports to disk; the coordinator files chunks by
-    /// index and emits them in the run's canonical file order, so the merged
-    /// document is identical regardless of which worker finishes first.
-    JunitChunk,
-    /// str lcov — this worker's coverage data, sent at exit; the coordinator
-    /// merges every worker's into the one report it writes.
-    CoverageChunk,
+    /// str report — one source file's coverage from this worker, sent at exit
+    /// as `bun_sourcemap_jsc::code_coverage::wire`. The coordinator merges
+    /// every worker's per file and writes the one report.
+    CoverageFile,
 }
 
 impl TryFrom<u8> for Kind {
@@ -43,8 +44,7 @@ impl TryFrom<u8> for Kind {
             4 => Kind::RepeatBufs,
             5 => Kind::Run,
             6 => Kind::Shutdown,
-            7 => Kind::JunitChunk,
-            8 => Kind::CoverageChunk,
+            7 => Kind::CoverageFile,
             _ => return Err(()),
         })
     }
@@ -78,32 +78,30 @@ impl Frame {
         self.buf.extend_from_slice(&v.to_le_bytes());
     }
 
+    pub(crate) fn u64(&mut self, v: u64) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+
     pub(crate) fn str(&mut self, s: &[u8]) {
         // Never let a single frame exceed `MAX_PAYLOAD` — the receiver treats that
         // as a corrupt-channel signal and closes, which would surface as a spurious
-        // worker crash. Truncate the string in place instead. Leave a small
-        // headroom so a few following u32s/short paths in the same frame still fit.
+        // worker crash. Truncate the string in place instead. Leave headroom
+        // so the fixed-size tail of the frame (u32s, short paths, and the
+        // 4-byte prefixes of any further strings, which go empty) still fits.
         const TRUNC: &[u8] = b"\n... [output truncated: would exceed --parallel IPC frame limit]\n";
-        const HEADROOM: usize = 256;
+        const HEADROOM: usize = 4096;
         let used: usize = (self.buf.len() - 5) + 4; // current payload + str-len prefix
-        let room: usize = if (MAX_PAYLOAD as usize) > used + HEADROOM {
-            (MAX_PAYLOAD as usize) - used - HEADROOM
+        let room: usize = ((MAX_PAYLOAD as usize) - HEADROOM).saturating_sub(used);
+        let (keep, marker): (usize, &[u8]) = if s.len() <= room {
+            (s.len(), b"")
+        } else if room >= TRUNC.len() {
+            (room - TRUNC.len(), TRUNC)
         } else {
-            0
+            (0, b"")
         };
-        if s.len() <= room {
-            self.u32(u32::try_from(s.len()).unwrap());
-            self.buf.extend_from_slice(s);
-            return;
-        }
-        let keep: usize = if room > TRUNC.len() {
-            room - TRUNC.len()
-        } else {
-            0
-        };
-        self.u32(u32::try_from(keep + TRUNC.len()).unwrap());
+        self.u32(u32::try_from(keep + marker.len()).unwrap());
         self.buf.extend_from_slice(&s[0..keep]);
-        self.buf.extend_from_slice(TRUNC);
+        self.buf.extend_from_slice(marker);
     }
 
     /// Finalize the header and return the encoded bytes. Caller hands them to
@@ -130,6 +128,15 @@ impl<'a> Reader<'a> {
         }
         let v = u32::from_le_bytes(self.p[0..4].try_into().unwrap());
         self.p = &self.p[4..];
+        v
+    }
+
+    pub(crate) fn u64(&mut self) -> u64 {
+        if self.p.len() < 8 {
+            return 0;
+        }
+        let v = u64::from_le_bytes(self.p[0..8].try_into().unwrap());
+        self.p = &self.p[8..];
         v
     }
 

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -355,7 +355,7 @@ impl Worker {
         f.begin(frame::Kind::Shutdown);
         self.ipc.send(f.finish());
         // Leave the channel open so the reader drains trailing
-        // repeat_bufs / junit_chunk / coverage_chunk frames; the worker exits on
+        // repeat_bufs / coverage_file frames; the worker exits on
         // `.shutdown` and its exit closes the peer end.
     }
 }

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -1,441 +1,62 @@
-//! Merges the JUnit and LCOV chunks workers stream over IPC into the
-//! single report the coordinator writes after `drive()` completes.
+//! Builds the single JUnit document and coverage report from the per-file
+//! data workers stream over IPC, once `drive()` completes.
 
-use std::io::Write as _;
+use bun_core::Output;
+use bun_options_types::code_coverage_options::CodeCoverageOptions;
+use bun_sourcemap_jsc::code_coverage::Report;
 
-use bstr::BStr;
+use super::coordinator::Coordinator;
+use super::frame::Reader;
+use super::runner;
+use crate::test_command::{TestCaseReport, TestFailure, junit_file_name, print_coverage_reports};
+use crate::test_runner::execution::Result as TestResult;
 
-use bun_collections::{ArrayHashMap, StringArrayHashMap};
-use bun_core::strings;
-use bun_core::{self, Output, ZBox};
-use bun_options_types::code_coverage_options::{CodeCoverageOptions, Fraction as CoverageFraction};
-use bun_paths::{self, PathBuffer};
-use bun_sourcemap_jsc::code_coverage::text as CoverageReportText;
-use bun_sys::{self, Fd, File, O};
-
-use crate::cli::test::parallel::coordinator::Coordinator;
-use crate::node::PathLike;
-use crate::node::fs::{NodeFS, args as fs_args};
-use crate::test_command;
-use crate::test_runner::jest::Summary;
-use bun_collections::index_sort;
-
-fn attr_value(head: &[u8], name: &'static [u8]) -> u32 {
-    let needle = [b" ", name, b"=\""].concat();
-    let Some(idx) = strings::index_of(head, &needle) else {
-        return 0;
-    };
-    let start = idx + needle.len();
-    let Some(q) = strings::index_of_char(&head[start..], b'"') else {
-        return 0;
-    };
-    let end = start + q as usize;
-    strings::parse_int::<u32>(&head[start..end], 10).unwrap_or(0)
-}
-
-#[derive(Default)]
-pub struct JunitTotals {
-    pub tests: u32,
-    pub failures: u32,
-    pub skipped: u32,
-}
-
-pub(crate) fn add_junit_chunk_totals(totals: &mut JunitTotals, chunk: &[u8]) {
-    let Some(open) = strings::index_of(chunk, b"<testsuite ") else {
+/// Feed every worker's per-test records through the coordinator's own
+/// reporters in canonical file order, so the JUnit document is the one a
+/// serial run would have written.
+pub(crate) fn replay_test_records(coord: &mut Coordinator) {
+    let files = core::mem::take(&mut coord.test_records);
+    let Some(junit) = coord.reporter.reporters.junit.as_deref_mut() else {
         return;
     };
-    let Some(gt) = strings::index_of_char(&chunk[open..], b'>') else {
-        return;
-    };
-    let head = &chunk[open..open + gt as usize];
-    totals.tests += attr_value(head, b"tests");
-    totals.failures += attr_value(head, b"failures");
-    totals.skipped += attr_value(head, b"skipped");
-}
-
-pub(crate) fn merge_junit_fragments(coord: &mut Coordinator, outfile: &[u8], summary: &Summary) {
-    let mut totals = core::mem::take(&mut coord.junit_totals);
-    let chunks = core::mem::take(&mut coord.junit_chunks);
-    let crashed = core::mem::take(&mut coord.crashed_files);
-    let mut body: Vec<u8> = Vec::new();
-    for (idx, slot) in chunks.into_iter().enumerate() {
-        if let Some(chunk) = slot {
-            body.extend_from_slice(&chunk);
-            if !strings::ends_with_char(&chunk, b'\n') {
-                body.push(b'\n');
+    for (idx, file) in files.iter().enumerate() {
+        let rel = junit_file_name(coord.files[idx].as_bytes());
+        for payload in &file.tests {
+            if let Some(test) = runner::decode_test_case(&mut Reader { p: payload }, rel) {
+                let _ = junit.record_test_case(&test);
             }
         }
-        if crashed.contains(&(idx as u32)) {
-            let rel = coord.rel_path(idx as u32);
-            body.extend_from_slice(b"  <testsuite name=\"");
-            let _ = test_command::escape_xml(rel, &mut body); // fmt::Result into Vec<u8> is infallible
-            body.extend_from_slice(b"\" file=\"");
-            let _ = test_command::escape_xml(rel, &mut body); // fmt::Result into Vec<u8> is infallible
-            body.extend_from_slice(b"\" tests=\"1\" assertions=\"0\" failures=\"1\" skipped=\"0\" time=\"0\">\n    <testcase name=\"(worker crashed)\" classname=\"");
-            let _ = test_command::escape_xml(rel, &mut body); // fmt::Result into Vec<u8> is infallible
-            body.extend_from_slice(
-                b"\">\n\
-                  \x20     <failure message=\"worker process crashed before reporting results\"></failure>\n\
-                  \x20   </testcase>\n\
-                  \x20 </testsuite>\n",
-            );
-            totals.tests += 1;
-            totals.failures += 1;
+        if coord.crashed_files.contains(&(idx as u32)) {
+            let _ = junit.record_test_case(&TestCaseReport {
+                file: rel,
+                scopes: Vec::new(),
+                name: b"(worker crashed)",
+                status: TestResult::Fail,
+                assertions: 0,
+                elapsed_ns: 0,
+                line_number: 0,
+                failure: Some(TestFailure {
+                    message: b"worker process crashed before reporting results".to_vec(),
+                    ..Default::default()
+                }),
+            });
         }
-    }
-    coord.crashed_files = crashed;
-
-    let mut contents: Vec<u8> = Vec::new();
-    let elapsed_time =
-        (bun_core::time::nano_timestamp() - bun_core::start_time()) as f64 / 1_000_000_000.0;
-    let _ = write!(
-        &mut contents,
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-         <testsuites name=\"bun test\" tests=\"{}\" assertions=\"{}\" failures=\"{}\" skipped=\"{}\" time=\"{}\">\n",
-        totals.tests, summary.expectations, totals.failures, totals.skipped, elapsed_time,
-    );
-    contents.extend_from_slice(&body);
-    contents.extend_from_slice(b"</testsuites>\n");
-
-    let out_z = ZBox::from_bytes(outfile);
-    match File::openat(Fd::cwd(), &out_z, O::WRONLY | O::CREAT | O::TRUNC, 0o664) {
-        bun_sys::Result::Err(e) => Output::err(
-            crate::Error::JUnitReportFailed,
-            "Failed to write JUnit report to {}\n{}",
-            (BStr::new(outfile), e),
-        ),
-        bun_sys::Result::Ok(fd) => match File::write_all(&fd, &contents) {
-            bun_sys::Result::Err(e) => Output::err(
-                crate::Error::JUnitReportFailed,
-                "Failed to write JUnit report to {}\n{}",
-                (BStr::new(outfile), e),
-            ),
-            bun_sys::Result::Ok(()) => {}
-        },
+        let _ = junit.end_file(Some(file.elapsed_ns));
     }
 }
 
-#[derive(Default, Clone, Copy)]
-struct LineAgg {
-    /// Summed hit count across fragments.
-    hits: u32,
-    /// Number of fragments covering this file whose DA set contains this line.
-    fragments: u32,
-}
-
-#[derive(Default)]
-struct FileCoverage {
-    path: Box<[u8]>,
-    fnf: u32,
-    fnh: u32,
-    /// Number of fragments with an SF record for this file.
-    fragments: u32,
-    /// 1-based line number → aggregate.
-    da: ArrayHashMap<u32, LineAgg>,
-}
-
-impl FileCoverage {
-    /// The `(line, hits)` pairs to report, sorted by line. A zero-hit line
-    /// counts only if every fragment that covers this file lists it. A worker
-    /// that never executes a function marks the function's whole line range
-    /// (blank lines included) as executable with zero hits, while a worker
-    /// that executed it has real per-line data and omits those lines. Keeping
-    /// a line the executed worker omits would report a fully executed
-    /// function as partially covered (#39930).
-    fn merged_lines(&self) -> Vec<(u32, u32)> {
-        let mut out: Vec<(u32, u32)> = Vec::new();
-        for (&ln, agg) in self.da.keys().iter().zip(self.da.values()) {
-            if agg.hits > 0 || agg.fragments == self.fragments {
-                out.push((ln, agg.hits));
-            }
-        }
-        index_sort::sort_slice_unstable_by(&mut out, |a, b| a.0.cmp(&b.0));
-        out
+pub(crate) fn write_coverage_report(coord: &mut Coordinator, opts: &mut CodeCoverageOptions) {
+    let mut merged = core::mem::take(&mut coord.coverage_files);
+    let mut reports: Vec<Report<'static>> = Vec::with_capacity(merged.count());
+    for m in merged.values_mut() {
+        reports.push(bun_core::handle_oom(core::mem::take(m).finish()));
     }
-}
-
-/// Merge per-worker LCOV fragments into a single report. Line-level (DA) merge
-/// sums hits, and keeps a zero-hit line only when every fragment covering the
-/// file agrees it is executable (see `FileCoverage::merged_lines`). FNF/FNH
-/// take the per-worker max since Bun's LCOV writer doesn't
-/// emit per-function FN/FNDA records yet, so disjoint per-worker function hits
-/// can't be unioned; this under-reports % Funcs when workers cover different
-/// functions of the same file. The non-parallel path has the same FN/FNDA gap.
-pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
-    chunks: &[&[u8]],
-    opts: &mut CodeCoverageOptions,
-) {
-    let mut by_file: StringArrayHashMap<FileCoverage> = StringArrayHashMap::default();
-
-    for &data in chunks {
-        let mut cur: Option<usize> = None; // index into by_file; raw &mut would alias across getOrPut
-        // reshaped for borrowck — store index instead of *mut FileCoverage
-        for raw in strings::split(data, b"\n") {
-            let line = strings::trim_right(raw, b"\r");
-            if line.starts_with(b"SF:") {
-                let name = &line[3..];
-                let gop = bun_core::handle_oom(by_file.get_or_put(name));
-                if !gop.found_existing {
-                    let owned: Box<[u8]> = Box::from(name);
-                    gop.key_ptr.clone_from(&owned);
-                    *gop.value_ptr = FileCoverage {
-                        path: owned,
-                        ..Default::default()
-                    };
-                }
-                let idx = gop.index;
-                by_file.values_mut()[idx].fragments += 1;
-                cur = Some(idx);
-            } else if line == b"end_of_record" {
-                cur = None;
-            } else if let Some(i) = cur {
-                let fc = &mut by_file.values_mut()[i];
-                if line.starts_with(b"DA:") {
-                    let mut parts = strings::split(&line[3..], b",");
-                    let Some(ln_s) = parts.next() else { continue };
-                    let Ok(ln) = strings::parse_int::<u32>(ln_s, 10) else {
-                        continue;
-                    };
-                    let Some(cnt_s) = parts.next() else { continue };
-                    let Ok(cnt) = strings::parse_int::<u32>(cnt_s, 10) else {
-                        continue;
-                    };
-                    let gop = bun_core::handle_oom(fc.da.get_or_put(ln));
-                    *gop.value_ptr = if gop.found_existing {
-                        LineAgg {
-                            hits: gop.value_ptr.hits.saturating_add(cnt),
-                            fragments: gop.value_ptr.fragments + 1,
-                        }
-                    } else {
-                        LineAgg {
-                            hits: cnt,
-                            fragments: 1,
-                        }
-                    };
-                } else if line.starts_with(b"FNF:") {
-                    fc.fnf = fc
-                        .fnf
-                        .max(strings::parse_int::<u32>(&line[4..], 10).unwrap_or(0));
-                } else if line.starts_with(b"FNH:") {
-                    fc.fnh = fc
-                        .fnh
-                        .max(strings::parse_int::<u32>(&line[4..], 10).unwrap_or(0));
-                }
-            }
-        }
-    }
-
-    if by_file.count() == 0 {
+    if reports.is_empty() {
         return;
     }
-
-    // Stable output order. ArrayHashMap has no in-place sort yet, so build a
-    // permutation and iterate via `order` everywhere below.
-    let mut order: Vec<usize> = (0..by_file.count()).collect();
-    {
-        let keys = by_file.keys();
-        index_sort::sort_slice_by(&mut order, |&a, &b| keys[a].as_ref().cmp(keys[b].as_ref()));
-    }
-
-    // Indexed like `by_file.values()`, not like `order`.
-    let merged: Vec<Vec<(u32, u32)>> = by_file
-        .values()
-        .iter()
-        .map(FileCoverage::merged_lines)
-        .collect();
-
-    if opts.reporters.lcov {
-        let mut fs = NodeFS::default();
-        let _ = fs.mkdir_recursive(&fs_args::Mkdir {
-            path: PathLike::borrowed(&opts.reports_directory),
-            always_return_none: true,
-            ..Default::default()
-        });
-        let mut path_buf = PathBuffer::uninit();
-        let out_path = bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Auto>(
-            bun_paths::fs::FileSystem::instance().top_level_dir(),
-            &mut path_buf.0,
-            &[&opts.reports_directory, b"lcov.info"],
-        );
-        match File::openat(
-            Fd::cwd(),
-            out_path,
-            O::CREAT | O::WRONLY | O::TRUNC | O::CLOEXEC,
-            0o644,
-        ) {
-            bun_sys::Result::Err(e) => Output::err(
-                crate::Error::lcovCoverageError,
-                "Failed to write merged lcov.info\n{}",
-                (e,),
-            ),
-            bun_sys::Result::Ok(f) => {
-                // Build the whole report in a Vec, then issue one write_all.
-                let mut w: Vec<u8> = Vec::with_capacity(64 * 1024);
-                for &i in &order {
-                    let fc = &by_file.values()[i];
-                    let lines = &merged[i];
-                    let _ = write!(
-                        &mut w,
-                        "TN:\nSF:{}\nFNF:{}\nFNH:{}\n",
-                        BStr::new(&fc.path),
-                        fc.fnf,
-                        fc.fnh
-                    );
-                    let mut lh: u32 = 0;
-                    for &(ln, hits) in lines {
-                        lh += (hits > 0) as u32;
-                        let _ = writeln!(&mut w, "DA:{},{}", ln, hits);
-                    }
-                    let _ = write!(&mut w, "LF:{}\nLH:{}\nend_of_record\n", lines.len(), lh);
-                }
-                let _ = File::write_all(&f, &w);
-            }
-        }
-    }
-
-    let base = opts.fractions;
-    let mut failing = false;
-    let mut avg = CoverageFraction {
-        functions: 0.0,
-        lines: 0.0,
-        stmts: 0.0,
-        ..Default::default()
-    };
-    let mut avg_n: f64 = 0.0;
-    let mut fracs: Vec<CoverageFraction> = vec![CoverageFraction::default(); by_file.count()];
-    debug_assert_eq!(order.len(), fracs.len());
-    for (&i, frac) in order.iter().zip(fracs.iter_mut()) {
-        let fc = &by_file.values()[i];
-        let lf: f64 = merged[i].len() as f64;
-        let lh_: f64 = merged[i].iter().filter(|&&(_, hits)| hits > 0).count() as f64;
-        *frac = CoverageFraction {
-            functions: if fc.fnf > 0 {
-                fc.fnh as f64 / fc.fnf as f64
-            } else {
-                1.0
-            },
-            lines: if lf > 0.0 { lh_ / lf } else { 1.0 },
-            stmts: if lf > 0.0 { lh_ / lf } else { 1.0 },
-            ..Default::default()
-        };
-        frac.failing = frac.functions < base.functions || frac.lines < base.lines;
-        if frac.failing {
-            failing = true;
-        }
-        avg.functions += frac.functions;
-        avg.lines += frac.lines;
-        avg.stmts += frac.stmts;
-        avg_n += 1.0;
-    }
-    opts.fractions.failing = failing;
-
-    if opts.reporters.text {
-        let mut max_len: usize = b"All files".len();
-        for k in by_file.keys() {
-            max_len = max_len.max(k.len());
-        }
-
-        let console = Output::error_writer();
-        fn sep<const COLORS: bool>(c: &mut bun_core::io::Writer, n: usize) {
-            let _ = c.write_all(Output::pretty_fmt::<COLORS>("<r><d>").as_ref());
-            // Repeat the byte without a heap allocation.
-            const DASHES: [u8; 64] = [b'-'; 64];
-            let mut left = n + 2;
-            while left > 0 {
-                let take = left.min(DASHES.len());
-                let _ = c.write_all(&DASHES[..take]);
-                left -= take;
-            }
-            let _ = c.write_all(
-                Output::pretty_fmt::<COLORS>("|---------|---------|-------------------<r>\n")
-                    .as_ref(),
-            );
-        }
-        sep::<ENABLE_COLORS>(console, max_len);
-        let _ = console.write_all(b"File");
-        let _ = console.write_all(&vec![b' '; max_len - b"File".len() + 1]);
-        let _ = console.write_all(
-            Output::pretty_fmt::<ENABLE_COLORS>(
-                " <d>|<r> % Funcs <d>|<r> % Lines <d>|<r> Uncovered Line #s\n",
-            )
-            .as_ref(),
-        );
-        sep::<ENABLE_COLORS>(console, max_len);
-
-        let mut body: Vec<u8> = Vec::new();
-        debug_assert_eq!(order.len(), fracs.len());
-        for (&i, frac) in order.iter().zip(fracs.iter()) {
-            let fc = &by_file.values()[i];
-            let _ = CoverageReportText::write_format_with_values::<ENABLE_COLORS>(
-                &fc.path,
-                max_len,
-                *frac,
-                base,
-                frac.failing,
-                &mut body,
-                true,
-            );
-            let _ = body.write_all(Output::pretty_fmt::<ENABLE_COLORS>("<r><d> | <r>").as_ref());
-
-            let mut first = true;
-            let mut range_start: u32 = 0;
-            let mut range_end: u32 = 0;
-            for &(ln, hits) in &merged[i] {
-                if hits != 0 {
-                    continue;
-                }
-                if range_start == 0 {
-                    range_start = ln;
-                    range_end = ln;
-                } else if ln == range_end + 1 {
-                    range_end = ln;
-                } else {
-                    write_range::<ENABLE_COLORS>(&mut body, &mut first, range_start, range_end);
-                    range_start = ln;
-                    range_end = ln;
-                }
-            }
-            if range_start != 0 {
-                write_range::<ENABLE_COLORS>(&mut body, &mut first, range_start, range_end);
-            }
-            let _ = body.write_all(b"\n");
-        }
-
-        if avg_n > 0.0 {
-            avg.functions /= avg_n;
-            avg.lines /= avg_n;
-            avg.stmts /= avg_n;
-        }
-        let _ = console.write_all(&body);
-        // bun_core::io::Writer doesn't impl bun_io::Write — buffer
-        // through a Vec then write_all once.
-        let mut all_files: Vec<u8> = Vec::new();
-        let _ = CoverageReportText::write_format_with_values::<ENABLE_COLORS>(
-            b"All files",
-            max_len,
-            avg,
-            base,
-            failing,
-            &mut all_files,
-            false,
-        );
-        let _ = console.write_all(&all_files);
-        let _ = console.write_all(Output::pretty_fmt::<ENABLE_COLORS>("<r><d> |<r>\n").as_ref());
-        sep::<ENABLE_COLORS>(console, max_len);
-
-        Output::flush();
-    }
-}
-
-fn write_range<const COLORS: bool>(w: &mut impl std::io::Write, first: &mut bool, a: u32, b: u32) {
-    if *first {
-        *first = false;
-    } else {
-        let _ = w.write_all(Output::pretty_fmt::<COLORS>("<r><d>,<r>").as_ref());
-    }
-    if a == b {
-        let _ = write!(w, "{}{}", Output::pretty_fmt::<COLORS>("<red>"), a);
-    } else {
-        let _ = write!(w, "{}{}-{}", Output::pretty_fmt::<COLORS>("<red>"), a, b);
+    reports.sort_unstable_by(|a, b| a.source_url.cmp(&b.source_url));
+    if let Err(err) = print_coverage_reports(opts, &reports) {
+        Output::err(err, "Failed to write lcov.info", ());
+        coord.aborted.get_or_insert(1);
     }
 }

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -23,11 +23,11 @@ pub(crate) fn replay_test_records(coord: &mut Coordinator) {
         let rel = junit_file_name(coord.files[idx].as_bytes());
         for payload in &file.tests {
             if let Some(test) = runner::decode_test_case(&mut Reader { p: payload }, rel) {
-                let _ = junit.record_test_case(&test);
+                junit.record_test_case(&test).expect("oom");
             }
         }
         if coord.crashed_files.contains(&(idx as u32)) {
-            let _ = junit.record_test_case(&TestCaseReport {
+            let crashed = TestCaseReport {
                 file: rel,
                 scopes: Vec::new(),
                 name: b"(worker crashed)",
@@ -39,9 +39,10 @@ pub(crate) fn replay_test_records(coord: &mut Coordinator) {
                     message: b"worker process crashed before reporting results".to_vec(),
                     ..Default::default()
                 }),
-            });
+            };
+            junit.record_test_case(&crashed).expect("oom");
         }
-        let _ = junit.end_file(Some(file.elapsed_ns));
+        junit.end_file(Some(file.elapsed_ns)).expect("oom");
     }
 }
 

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -25,6 +25,7 @@ use crate::test_command::{self, CommandLineReporter, TestCommand};
 use crate::test_runner::bun_test::FirstLast;
 use bun_collections::index_sort;
 use bun_options_types::code_coverage_options::CodeCoverageOptions;
+use bun_sourcemap_jsc::code_coverage;
 
 /// All workers are busy for at least this long before another is spawned.
 /// Overridable via BUN_TEST_PARALLEL_SCALE_MS for tests, where debug-build
@@ -63,14 +64,6 @@ pub(crate) fn run_as_coordinator(
     // rendering to a color terminal so streamed lines match serial output.
     if Output::enable_ansi_colors_stderr() {
         let _ = env.map.put(b"FORCE_COLOR", b"1");
-    }
-    if ctx.test_options.reporters.junit {
-        // Coordinator's own JunitReporter would otherwise produce an empty
-        // document and overwrite the merged one in writeJUnitReportIfNeeded.
-        if let Some(jr) = reporter.reporters.junit.take() {
-            let _ = env.map.put(b"BUN_TEST_WORKER_JUNIT", b"1");
-            drop(jr);
-        }
     }
     // Each worker gets a unique JEST_WORKER_ID / BUN_TEST_WORKER_ID (1-indexed,
     // matching Jest) so tests can pick distinct ports/databases. Serialize the
@@ -178,9 +171,12 @@ pub(crate) fn run_as_coordinator(
         },
         bail: ctx.test_options.bail,
         dots: ctx.test_options.reporters.dots,
-        junit_chunks: (0..n).map(|_| None).collect(),
-        junit_totals: Default::default(),
-        coverage_chunks: Vec::new(),
+        test_records: if ctx.test_options.reporters.junit {
+            (0..n).map(|_| Default::default()).collect()
+        } else {
+            Vec::new()
+        },
+        coverage_files: Default::default(),
         last_header_idx: None,
         frame: Frame::default(),
         files_done: 0,
@@ -218,26 +214,12 @@ pub(crate) fn run_as_coordinator(
     unsafe { &*vm_ptr }.run_with_api_lock(|| coord.drive());
     coord.end_group();
 
-    if ctx.test_options.reporters.junit {
-        if let Some(outfile) = &ctx.test_options.reporter_outfile {
-            // `coord` holds the unique &mut to `reporter`; obtain the summary
-            // through it. Raw-pointer reborrow because merge_junit_fragments
-            // also needs &mut coord (it only reads from summary).
-            let summary_ptr: *const crate::test_runner::jest::Summary = coord.reporter.summary();
-            // SAFETY: summary lives in *coord.reporter, which outlives this call
-            // and is not mutated by merge_junit_fragments.
-            aggregate::merge_junit_fragments(&mut coord, outfile, unsafe { &*summary_ptr });
-        }
-    }
+    aggregate::replay_test_records(&mut coord);
     if coverage_opts.enabled {
-        let frags: Vec<&[u8]> = coord.coverage_chunks.iter().map(|b| b.as_ref()).collect();
-        if Output::enable_ansi_colors_stderr() {
-            aggregate::merge_coverage_fragments::<true>(&frags, coverage_opts);
-        } else {
-            aggregate::merge_coverage_fragments::<false>(&frags, coverage_opts);
-        }
+        aggregate::write_coverage_report(&mut coord, coverage_opts);
     }
     if let Some(code) = coord.aborted {
+        coord.reporter.write_junit_report_if_needed();
         coord.reporter.write_timings_if_needed();
         Output::flush();
         Global::exit(code);
@@ -248,8 +230,10 @@ pub(crate) fn run_as_coordinator(
 /// Build the argv used for every worker (re)spawn. Forwards every `bun test`
 /// flag that affects how tests *execute inside* a worker, plus `--dots` and
 /// `--only-failures` since the worker formats result lines and the coordinator
-/// prints them verbatim. Coordinator-only concerns — file discovery
-/// (`--path-ignore-patterns`, `--changed`), `--reporter`/`--reporter-outfile`,
+/// prints them verbatim. `--reporter=junit` is forwarded (without the outfile)
+/// so workers attach the per-test detail the coordinator's JunitReporter
+/// needs. Coordinator-only concerns — file discovery
+/// (`--path-ignore-patterns`, `--changed`), `--reporter-outfile`,
 /// `--pass-with-no-tests`, `--parallel` itself — are intentionally not
 /// forwarded.
 fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn::CStrPtr]>> {
@@ -296,6 +280,9 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     }
     if opts.reporters.only_failures {
         argv.push(lit(b"--only-failures\0"));
+    }
+    if opts.reporters.junit {
+        argv.push(lit(b"--reporter=junit\0"));
     }
     if opts.update_snapshots {
         argv.push(lit(b"--update-snapshots\0"));
@@ -563,6 +550,8 @@ impl<'a> WorkerLoop<'a> {
 
             let before = *self.reporter.summary();
             let before_unhandled = self.reporter.jest.unhandled_errors_between_tests;
+            let started_ns =
+                bun_core::Timespec::now(bun_core::TimespecMockMode::ForceRealTime).ns();
 
             // A worker never knows which file is its last, so preload-level hooks wrap every file (with or without --isolate).
             if let Err(err) = TestCommand::run(
@@ -588,19 +577,9 @@ impl<'a> WorkerLoop<'a> {
             }
             self.reporter.jest.default_timeout_override = u32::MAX;
 
-            if let Some(junit) = &mut self.reporter.reporters.junit {
-                while !junit.suite_stack.is_empty() {
-                    let _ = junit.end_test_suite();
-                }
-                junit.current_file = Box::default();
-                if junit.contents.len() > junit.sent_upto {
-                    wf.begin(frame::Kind::JunitChunk);
-                    wf.u32(idx);
-                    wf.str(&junit.contents[junit.sent_upto..]);
-                    self.cmds.send(wf.finish());
-                    junit.sent_upto = junit.contents.len();
-                }
-            }
+            let elapsed_ns = bun_core::Timespec::now(bun_core::TimespecMockMode::ForceRealTime)
+                .ns()
+                .saturating_sub(started_ns);
 
             let after = *self.reporter.summary();
             wf.begin(frame::Kind::FileDone);
@@ -617,6 +596,7 @@ impl<'a> WorkerLoop<'a> {
             ] {
                 wf.u32(v);
             }
+            wf.u64(elapsed_ns);
             self.cmds.send(wf.finish());
         }
     }
@@ -652,15 +632,6 @@ pub(crate) fn run_as_worker(
     vm_ref.arena = Some(NonNull::from(&mut arena));
     // vm.allocator = arena.arena(); — allocator params dropped in Rust
 
-    let env = vm_ref.env_loader();
-    if let Some(junit) = reporter.reporters.junit.as_mut() {
-        junit.elements_only = true;
-    } else if env.get(b"BUN_TEST_WORKER_JUNIT").is_some() {
-        let mut junit = test_command::JunitReporter::init();
-        junit.elements_only = true;
-        reporter.reporters.junit = Some(junit);
-    }
-
     let mut wloop = WorkerLoop {
         reporter,
         vm,
@@ -675,7 +646,7 @@ pub(crate) fn run_as_worker(
 
     worker_flush_aggregates(wloop.reporter, vm_ref, ctx, &mut wloop.cmds);
     // Drain any backpressure-buffered frames before exit so the coordinator
-    // sees repeat_bufs / junit_chunk / coverage_chunk.
+    // sees repeat_bufs / coverage_file.
     while wloop.cmds.channel.has_pending_writes() && !wloop.cmds.channel.done.get() {
         // SAFETY: event_loop pointer is valid while vm lives.
         unsafe { (*vm_ref.event_loop()).tick() };
@@ -723,18 +694,15 @@ fn worker_flush_aggregates(
     wf.str(reporter.todos_to_repeat_buf.as_slice());
     cmds.send(wf.finish());
 
-    if let Some(junit) = &mut reporter.reporters.junit {
-        while !junit.suite_stack.is_empty() {
-            let _ = junit.end_test_suite();
-        }
-        junit.current_file = Box::default();
-    }
     if ctx.test_options.coverage.enabled {
-        if let Some(lcov) = reporter.render_lcov(vm, &ctx.test_options.coverage) {
-            wf.begin(frame::Kind::CoverageChunk);
-            wf.str(&lcov);
+        let mut encoded: Vec<u8> = Vec::new();
+        CommandLineReporter::for_each_coverage_report(vm, &ctx.test_options.coverage, |report| {
+            encoded.clear();
+            code_coverage::wire::encode(&report, &mut encoded);
+            wf.begin(frame::Kind::CoverageFile);
+            wf.str(&encoded);
             cmds.send(wf.finish());
-        }
+        });
     }
 }
 
@@ -752,8 +720,14 @@ static WORKER_CMDS: bun_core::RacyCell<Option<*mut WorkerCommands>> = bun_core::
 
 /// Called from `CommandLineReporter.handleTestCompleted` in the worker with the
 /// fully-formatted status line (✓/✗ + scopes + name + duration, including ANSI
-/// codes). The coordinator prints these bytes verbatim so output matches serial.
-pub(crate) fn worker_emit_test_done(file_idx: u32, formatted_line: &[u8]) {
+/// codes), which the coordinator prints verbatim so output matches serial, and,
+/// when the coordinator asked for it (`--reporter`), the structured result it
+/// replays into its own reporters.
+pub(crate) fn worker_emit_test_done(
+    file_idx: u32,
+    formatted_line: &[u8],
+    test: Option<&test_command::TestCaseReport<'_>>,
+) {
     // SAFETY: single-threaded worker; WORKER_CMDS only written/read on this thread.
     let Some(cmds_ptr) = (unsafe { WORKER_CMDS.read() }) else {
         return;
@@ -766,5 +740,68 @@ pub(crate) fn worker_emit_test_done(file_idx: u32, formatted_line: &[u8]) {
     wf.begin(frame::Kind::TestDone);
     wf.u32(file_idx);
     wf.str(formatted_line);
+    if let Some(test) = test {
+        encode_test_case(wf, test);
+    }
     cmds.send(wf.finish());
+}
+
+fn encode_test_case(wf: &mut Frame, t: &test_command::TestCaseReport<'_>) {
+    wf.u32(t.status as u32);
+    wf.u32(t.assertions);
+    wf.u64(t.elapsed_ns);
+    wf.u32(t.line_number);
+    wf.str(t.name);
+    wf.u32(u32::try_from(t.scopes.len()).expect("int cast"));
+    for &(name, line) in &t.scopes {
+        wf.str(name);
+        wf.u32(line);
+    }
+    match &t.failure {
+        None => wf.u32(0),
+        Some(f) => {
+            wf.u32(1);
+            wf.str(&f.name);
+            wf.str(&f.message);
+            wf.str(&f.body);
+        }
+    }
+}
+
+/// Inverse of `encode_test_case`; strings borrow the frame payload. The file
+/// isn't on the wire: the frame's `file_idx` names it.
+pub(crate) fn decode_test_case<'a>(
+    rd: &mut frame::Reader<'a>,
+    file: &'a [u8],
+) -> Option<test_command::TestCaseReport<'a>> {
+    use crate::test_runner::execution::Result;
+    let status =
+        Result::from_repr(u8::try_from(rd.u32()).ok()?).filter(|s| *s != Result::Pending)?;
+    let assertions = rd.u32();
+    let elapsed_ns = rd.u64();
+    let line_number = rd.u32();
+    let name = rd.str();
+    let n = rd.u32() as usize;
+    if n > 64 {
+        return None;
+    }
+    let mut scopes = Vec::with_capacity(n);
+    for _ in 0..n {
+        scopes.push((rd.str(), rd.u32()));
+    }
+    let failure = (rd.u32() != 0).then(|| test_command::TestFailure {
+        name: rd.str().to_vec(),
+        message: rd.str().to_vec(),
+        body: rd.str().to_vec(),
+    });
+    Some(test_command::TestCaseReport {
+        file,
+        scopes,
+        name,
+        status,
+        assertions,
+        elapsed_ns,
+        line_number,
+        failure,
+    })
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1527,7 +1527,6 @@ fn print_coverage_reports_<const COLORS: bool>(
     opts: &mut CodeCoverageOptions,
     reports: &[CodeCoverageReport<'_>],
 ) -> bun_sys::Result<()> {
-    use coverage::text;
     let relative_dir = FileSystem::get().top_level_dir;
     let thresholds = opts.fractions;
 
@@ -1535,13 +1534,24 @@ fn print_coverage_reports_<const COLORS: bool>(
     let failing = fractions.iter().any(|f| f.failing);
     opts.fractions.failing = failing;
 
+    if opts.reporters.text {
+        print_coverage_table::<COLORS>(relative_dir, &thresholds, reports, &fractions, failing);
+    }
     if opts.reporters.lcov {
         write_lcov_report(opts, relative_dir, reports)?;
     }
-    if !opts.reporters.text {
-        return Ok(());
-    }
+    Ok(())
+}
 
+fn print_coverage_table<const COLORS: bool>(
+    relative_dir: &[u8],
+    thresholds: &Fraction,
+    reports: &[CodeCoverageReport<'_>],
+    fractions: &[Fraction],
+    failing: bool,
+) {
+    use coverage::text;
+    let thresholds = *thresholds;
     let max_filepath_length = reports
         .iter()
         .map(|r| resolve_path::relative(relative_dir, &r.source_url).len())
@@ -1554,7 +1564,7 @@ fn print_coverage_reports_<const COLORS: bool>(
         failing: false,
     };
     let mut avg = zero;
-    for f in &fractions {
+    for f in fractions {
         avg.functions += f.functions;
         avg.lines += f.lines;
         avg.stmts += f.stmts;
@@ -1596,7 +1606,7 @@ fn print_coverage_reports_<const COLORS: bool>(
         false,
     );
     let _ = bun_core::write_pretty!(out, COLORS, "<r><d> |<r>\n");
-    for (report, fraction) in reports.iter().zip(&fractions) {
+    for (report, fraction) in reports.iter().zip(fractions) {
         let _ = text::write_format::<COLORS>(
             report,
             max_filepath_length,
@@ -1612,7 +1622,6 @@ fn print_coverage_reports_<const COLORS: bool>(
     // A closed stderr is not a reason to fail the run.
     let _ = Output::error_writer().write_all(&out);
     Output::flush();
-    Ok(())
 }
 
 /// Render to `<reports_directory>/.lcov.info.<hex>.tmp` and rename it over

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -23,15 +23,9 @@ use bun_sys::{self, Fd, File};
 // Debug log scope for test-runner entrypoint loading.
 bun_output::declare_scope!(bun_test, hidden);
 
-// ─── coverage façade ────────────────────────────────────────────────────────
-// Thin adapter over `bun_sourcemap_jsc::code_coverage` that preserves the
-// legacy call paths used in `print_code_coverage` below (the adapter
-// dispatches the runtime `enable_ansi_colors` bool to the const generic).
-// Drop once the body is normalised to call `code_coverage::{text,lcov}`
-// directly with `<ENABLE_ANSI_COLORS>`.
 mod coverage {
     pub(super) use bun_sourcemap_jsc::code_coverage::{
-        ByteRangeMapping, Fraction, Report as CodeCoverageReport, lcov as Lcov,
+        ByteRangeMapping, Fraction, Report as CodeCoverageReport, lcov, text,
     };
 
     /// Less-than predicate adapted to the `Ordering` shape `sort_by` wants.
@@ -43,68 +37,18 @@ mod coverage {
         bun_core::order(a.source_url.slice(), b.source_url.slice())
     }
 
-    #[allow(non_snake_case)]
-    pub(super) mod Text {
-        use super::*;
-        use bun_sourcemap_jsc::code_coverage::text;
-
-        /// Runtime-bool → const-generic dispatch for `text::write_format`.
-        #[inline]
-        pub(crate) fn write_format(
-            report: &CodeCoverageReport,
-            max_filename_length: usize,
-            fraction: &mut Fraction,
-            base_path: &[u8],
-            writer: &mut impl bun_io::Write,
-            enable_ansi_colors: bool,
-        ) -> bun_io::Result<()> {
-            if enable_ansi_colors {
-                text::write_format::<true>(report, max_filename_length, fraction, base_path, writer)
-            } else {
-                text::write_format::<false>(
-                    report,
-                    max_filename_length,
-                    fraction,
-                    base_path,
-                    writer,
-                )
-            }
+    pub(super) fn is_ignored(
+        opts: &bun_options_types::code_coverage_options::CodeCoverageOptions,
+        relative_dir: &[u8],
+        source_url: &[u8],
+    ) -> bool {
+        if opts.ignore_patterns.is_empty() {
+            return false;
         }
-
-        /// Runtime-bool → const-generic dispatch for `text::write_format_with_values`.
-        #[inline]
-        pub(crate) fn write_format_with_values(
-            filename: &[u8],
-            max_filename_length: usize,
-            vals: Fraction,
-            failing: Fraction,
-            failed: bool,
-            writer: &mut impl bun_io::Write,
-            indent_name: bool,
-            enable_ansi_colors: bool,
-        ) -> bun_io::Result<()> {
-            if enable_ansi_colors {
-                text::write_format_with_values::<true>(
-                    filename,
-                    max_filename_length,
-                    vals,
-                    failing,
-                    failed,
-                    writer,
-                    indent_name,
-                )
-            } else {
-                text::write_format_with_values::<false>(
-                    filename,
-                    max_filename_length,
-                    vals,
-                    failing,
-                    failed,
-                    writer,
-                    indent_name,
-                )
-            }
-        }
+        let relative_path = bun_paths::resolve_path::relative(relative_dir, source_url);
+        opts.ignore_patterns
+            .iter()
+            .any(|pattern| bun_glob::r#match(pattern, relative_path).matches())
     }
 }
 use coverage::{ByteRangeMapping, CodeCoverageReport, Fraction};
@@ -207,11 +151,39 @@ fn fmt_status_text_line(
 // `&mut io::Writer`; the previous local `err_w`/`out_w` wrappers were no-op
 // reborrows. Call sites use the `Output` accessors directly.
 
+/// Name, message and stack of the error(s) thrown by the test that is
+/// currently failing, captured as they are printed so structured reporters
+/// get them without re-running the exception formatter.
 #[derive(Default)]
-pub struct JunitFailure {
+pub struct TestFailure {
     pub name: Vec<u8>,
     pub(crate) message: Vec<u8>,
     pub(crate) body: Vec<u8>,
+}
+
+/// How a test file is named in the JUnit document: relative to the project
+/// root when inside it, else as given.
+pub(crate) fn junit_file_name(path: &[u8]) -> &[u8] {
+    let top = FileSystem::instance().top_level_dir;
+    if strings::has_prefix(path, top) {
+        without_leading_path_separator(&path[top.len()..])
+    } else {
+        path
+    }
+}
+
+/// One finished test as structured reporters see it.
+pub(crate) struct TestCaseReport<'a> {
+    /// Relative to the project root.
+    pub file: &'a [u8],
+    /// Enclosing named `describe` blocks, outermost first: (name, line).
+    pub scopes: Vec<(&'a [u8], u32)>,
+    pub name: &'a [u8],
+    pub status: bun_test::Execution::Result,
+    pub assertions: u32,
+    pub elapsed_ns: u64,
+    pub line_number: u32,
+    pub failure: Option<TestFailure>,
 }
 
 /// Append `input` to `out`, dropping CSI sequences (`ESC '[' ... final`), so a
@@ -243,18 +215,11 @@ pub struct JunitReporter {
     pub(crate) total_metrics: Metrics,
     pub(crate) offset_of_testsuites_value: usize,
     pub(crate) current_file: Box<[u8]>,
-    pub(crate) sent_upto: usize,
-    pub(crate) elements_only: bool,
     pub(crate) file_start_ns: u64,
-    pub(crate) file_end_ns: u64,
     pub(crate) properties_list_to_repeat_in_every_test_suite: Option<Box<[u8]>>,
 
     pub(crate) suite_stack: Vec<SuiteInfo>,
     pub(crate) current_depth: u32,
-
-    /// Error captured by `on_uncaught_exception` for the currently-failing
-    /// test; consumed by `write_test_case` on the next `Result::Fail`.
-    pub(crate) last_failure: Option<JunitFailure>,
 
     pub(crate) hostname_value: Option<Box<[u8]>>,
 }
@@ -327,15 +292,14 @@ impl JunitReporter {
     pub(crate) fn init() -> Box<JunitReporter> {
         Box::new(JunitReporter::default())
     }
+}
 
-    // `pub const new = bun.TrivialNew(JunitReporter);` → Box::new
-
-    /// Capture name/message/stack from the `ZigException` that
-    /// `print_error_instance_body` has already populated, so the next
-    /// `write_test_case` can emit a useful `<failure>` without re-running
-    /// the exception formatter.
-    pub(crate) fn record_failure(&mut self, exception: &jsc::ZigException) {
-        let failure = self.last_failure.get_or_insert_default();
+impl TestFailure {
+    /// Fold in a `ZigException` that `print_error_instance_body` has already
+    /// populated. A test can throw more than once (body, then `afterEach`);
+    /// the first name/message win and every stack is appended.
+    pub(crate) fn record(slot: &mut Option<TestFailure>, exception: &jsc::ZigException) {
+        let failure = slot.get_or_insert_default();
         let name = exception.name.to_utf8();
         let raw_message = exception.message.to_utf8();
         let mut message = Vec::with_capacity(raw_message.slice().len());
@@ -410,14 +374,16 @@ impl JunitReporter {
     }
 
     /// VirtualMachine::on_print_error_zig_exception thunk.
-    pub(crate) fn record_failure_cb(ctx: *mut core::ffi::c_void, exception: &jsc::ZigException) {
-        // SAFETY: `ctx` was set to `&mut JunitReporter` by `on_uncaught_exception`
-        // for the duration of a single `run_error_handler` call; single-threaded,
-        // no other borrow of the reporter is live across that call.
-        let this = unsafe { &mut *ctx.cast::<JunitReporter>() };
-        this.record_failure(exception);
+    pub(crate) fn record_cb(ctx: *mut core::ffi::c_void, exception: &jsc::ZigException) {
+        // SAFETY: `ctx` was set to `&mut CommandLineReporter.test_failure` by
+        // `on_uncaught_exception` for the duration of a single
+        // `run_error_handler` call; single-threaded, no other borrow live.
+        let slot = unsafe { &mut *ctx.cast::<Option<TestFailure>>() };
+        TestFailure::record(slot, exception);
     }
+}
 
+impl JunitReporter {
     fn generate_properties_list(&mut self) -> crate::Result<()> {
         struct PropertiesList<'a> {
             ci: &'a [u8],
@@ -517,6 +483,17 @@ impl JunitReporter {
         &SPACES[0..(total_spaces as usize).min(SPACES.len())]
     }
 
+    fn start_document(&mut self) {
+        if self.contents.is_empty() {
+            self.contents
+                .extend_from_slice(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+            self.contents
+                .extend_from_slice(b"<testsuites name=\"bun test\" ");
+            self.offset_of_testsuites_value = self.contents.len();
+            self.contents.extend_from_slice(b">\n");
+        }
+    }
+
     pub(crate) fn begin_test_suite(&mut self, name: &[u8]) -> crate::Result<()> {
         self.begin_test_suite_with_line(name, 0, true)
     }
@@ -527,14 +504,7 @@ impl JunitReporter {
         line_number: u32,
         is_file_suite: bool,
     ) -> crate::Result<()> {
-        if self.contents.is_empty() && !self.elements_only {
-            self.contents
-                .extend_from_slice(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-            self.contents
-                .extend_from_slice(b"<testsuites name=\"bun test\" ");
-            self.offset_of_testsuites_value = self.contents.len();
-            self.contents.extend_from_slice(b">\n");
-        }
+        self.start_document();
 
         let indent = Self::get_indent(self.current_depth);
         self.contents.extend_from_slice(indent);
@@ -590,7 +560,18 @@ impl JunitReporter {
         Ok(())
     }
 
-    pub(crate) fn end_test_suite(&mut self) -> crate::Result<()> {
+    /// Close every suite still open for the current file. The file suite's
+    /// `time` is `elapsed_ns` when the caller measured it (the `--parallel`
+    /// coordinator replaying a worker's file), else now − `file_start_ns`.
+    pub(crate) fn end_file(&mut self, elapsed_ns: Option<u64>) -> crate::Result<()> {
+        while !self.suite_stack.is_empty() {
+            self.end_test_suite(elapsed_ns)?;
+        }
+        self.current_file = Box::default();
+        Ok(())
+    }
+
+    fn end_test_suite(&mut self, file_elapsed_ns: Option<u64>) -> crate::Result<()> {
         if self.suite_stack.is_empty() {
             return Ok(());
         }
@@ -598,13 +579,15 @@ impl JunitReporter {
         self.current_depth -= 1;
         let suite_info = self.suite_stack.swap_remove(self.suite_stack.len() - 1);
 
-        let elapsed_time_seconds = if suite_info.is_file_suite && suite_info.started_ns > 0 {
-            let end_ns = if self.file_end_ns >= suite_info.started_ns {
-                self.file_end_ns
-            } else {
-                bun::Timespec::now(bun::TimespecMockMode::ForceRealTime).ns()
-            };
-            end_ns.saturating_sub(suite_info.started_ns) as f64 / bun::time::NS_PER_S as f64
+        let elapsed_time_seconds = if suite_info.is_file_suite
+            && let Some(ns) = file_elapsed_ns
+        {
+            ns as f64 / bun::time::NS_PER_S as f64
+        } else if suite_info.is_file_suite && suite_info.started_ns > 0 {
+            bun::Timespec::now(bun::TimespecMockMode::ForceRealTime)
+                .ns()
+                .saturating_sub(suite_info.started_ns) as f64
+                / bun::time::NS_PER_S as f64
         } else {
             suite_info.metrics.elapsed_time as f64 / bun::time::MS_PER_S as f64
         };
@@ -646,16 +629,59 @@ impl JunitReporter {
         Ok(())
     }
 
-    pub(crate) fn write_test_case(
-        &mut self,
-        status: bun_test::Execution::Result,
-        file: &[u8],
-        name: &[u8],
-        class_name: &[u8],
-        assertions: u32,
-        elapsed_ns: u64,
-        line_number: u32,
-    ) -> crate::Result<()> {
+    /// Open/close `<testsuite>` elements so the stack matches `t.file` and
+    /// `t.scopes`, then write the `<testcase>`.
+    pub(crate) fn record_test_case(&mut self, t: &TestCaseReport<'_>) -> crate::Result<()> {
+        if !strings::eql(&self.current_file, t.file) {
+            while let Some(top) = self.suite_stack.last()
+                && !top.is_file_suite
+            {
+                self.end_test_suite(None)?;
+            }
+            if !self.current_file.is_empty() {
+                self.end_test_suite(None)?;
+            }
+            self.begin_test_suite(t.file)?;
+        }
+
+        // Keep the longest prefix of open describe suites that matches
+        // `t.scopes`; close the rest, then open what is missing.
+        let open = &self.suite_stack[1..];
+        let keep = open
+            .iter()
+            .zip(&t.scopes)
+            .take_while(|(suite, (name, _))| strings::eql(&suite.name, name))
+            .count();
+        for _ in keep..open.len() {
+            self.end_test_suite(None)?;
+        }
+        for &(name, line) in &t.scopes[keep..] {
+            self.begin_test_suite_with_line(name, line, false)?;
+        }
+
+        // Innermost scope first, matching what the serial reporter always did.
+        let mut class_name: Vec<u8> = Vec::new();
+        for (i, &(name, _)) in t.scopes.iter().rev().enumerate() {
+            if i > 0 {
+                class_name.extend_from_slice(b" > ");
+            }
+            class_name.extend_from_slice(name);
+        }
+
+        self.write_test_case(t, &class_name)
+    }
+
+    fn write_test_case(&mut self, t: &TestCaseReport<'_>, class_name: &[u8]) -> crate::Result<()> {
+        let TestCaseReport {
+            file,
+            name,
+            status,
+            assertions,
+            elapsed_ns,
+            line_number,
+            ..
+        } = *t;
+        let failure = t.failure.as_ref();
         // Std::io::Write removed; bun_io::Write (top-level) provides write_fmt.
         let elapsed_ns_f64: f64 = elapsed_ns as f64;
         let elapsed_ms = elapsed_ns_f64 / bun::time::NS_PER_MS as f64;
@@ -709,7 +735,6 @@ impl JunitReporter {
                 }
                 self.contents.extend_from_slice(b">\n");
                 self.contents.extend_from_slice(indent);
-                let failure = self.last_failure.take();
                 let type_name: &[u8] = failure
                     .as_ref()
                     .map(|f| f.name.as_slice())
@@ -836,7 +861,6 @@ impl JunitReporter {
             }
             R::Pending => unreachable!(),
         }
-        self.last_failure = None;
         Ok(())
     }
 
@@ -845,9 +869,7 @@ impl JunitReporter {
             return Ok(());
         }
 
-        while !self.suite_stack.is_empty() {
-            self.end_test_suite()?;
-        }
+        self.end_file(None)?;
 
         {
             let metrics = self.total_metrics;
@@ -936,6 +958,10 @@ pub struct CommandLineReporter {
     /// is sent over the IPC pipe instead of to stderr; the coordinator owns
     /// the terminal.
     pub(crate) worker_ipc_file_idx: Option<u32>,
+    /// Errors thrown by the test now running, captured while a reporter
+    /// that attaches them to the test case (JUnit) is on. Taken by
+    /// `handle_test_completed`.
+    pub(crate) test_failure: Option<TestFailure>,
 
     pub(crate) failures_to_repeat_buf: Vec<u8>,
     pub(crate) skips_to_repeat_buf: Vec<u8>,
@@ -1175,31 +1201,18 @@ impl CommandLineReporter {
         }
     }
 
-    fn maybe_print_junit_line(
+    /// Everything a structured reporter needs about one finished test. Built
+    /// once in `handle_test_completed`; the serial runner hands it straight
+    /// to `JunitReporter::record_test_case`, a `--parallel` worker encodes it
+    /// on its `TestDone` frame and the coordinator replays it.
+    fn test_case_report<'a>(
         status: bun_test::Execution::Result,
-        buntest: &mut bun_test::BunTest,
-        sequence: &mut bun_test::Execution::ExecutionSequence,
-        test_entry: &mut bun_test::ExecutionEntry,
+        buntest: &bun_test::BunTest,
+        sequence: &bun_test::Execution::ExecutionSequence,
+        test_entry: &'a bun_test::ExecutionEntry,
         elapsed_ns: u64,
-    ) {
-        let Some(cmd_reporter) = buntest.reporter else {
-            return;
-        };
-        // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>` with write
-        // provenance from `enter_file`'s `&mut`; single-threaded test runner,
-        // exclusive access for the duration of this callback.
-        let cmd_reporter: &mut CommandLineReporter = unsafe { &mut *cmd_reporter.as_ptr() };
-        let Some(junit) = cmd_reporter.reporters.junit.as_mut() else {
-            return;
-        };
-
-        let mut scopes_stack: BoundedArray<*const bun_test::DescribeScope, 64> =
-            BoundedArray::default();
-        let mut parent_: Option<*const bun_test::DescribeScope> =
-            test_entry.base.parent.map(|p| p.cast_const());
-        let assertions = sequence.expect_call_count;
-        let line_number = test_entry.base.line_no;
-
+        failure: Option<TestFailure>,
+    ) -> TestCaseReport<'a> {
         let file: &[u8] = if let Some(runner) = jest::Jest::runner() {
             runner.files.items_source()[buntest.file_id as usize]
                 .path
@@ -1207,163 +1220,35 @@ impl CommandLineReporter {
         } else {
             b""
         };
+        let file = junit_file_name(file);
 
-        while let Some(scope) = parent_ {
-            if scopes_stack.push(scope).is_err() {
+        // Innermost first while walking up; reversed below.
+        let mut scopes: Vec<(&'a [u8], u32)> = Vec::new();
+        let mut parent = test_entry.base.parent.map(|p| p.cast_const());
+        while let Some(scope) = parent {
+            if scopes.len() == 64 {
                 break;
             }
-            // SAFETY: scope kept alive for the test run
-            parent_ = unsafe { (*scope).base.parent.map(|p| p.cast_const()) };
-        }
-
-        let scopes: &[*const bun_test::DescribeScope] = scopes_stack.as_slice();
-        let display_label: &[u8] = test_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
-
-        {
-            let filename: &[u8] = 'brk: {
-                let top = FileSystem::instance().top_level_dir;
-                if strings::has_prefix(file, top) {
-                    break 'brk without_leading_path_separator(&file[top.len()..]);
-                } else {
-                    break 'brk file;
-                }
-            };
-
-            if !strings::eql(&junit.current_file, filename) {
-                while !junit.suite_stack.is_empty()
-                    && !junit.suite_stack[junit.suite_stack.len() - 1].is_file_suite
-                {
-                    junit.end_test_suite().expect("oom");
-                }
-
-                if !junit.current_file.is_empty() {
-                    junit.end_test_suite().expect("oom");
-                }
-
-                junit.begin_test_suite(filename).expect("oom");
-            }
-
-            // To make the juint reporter generate nested suites, we need to find the needed suites and create/print them.
-            // This assumes that the scopes are in the correct order.
-            let mut needed_suites: Vec<*const bun_test::DescribeScope> = Vec::new();
-
-            for i in 0..scopes.len() {
-                let index = (scopes.len() - 1) - i;
-                let scope = scopes[index];
-                // SAFETY: scope alive for test run
-                if let Some(name) = unsafe { (*scope).base.name.as_deref() } {
-                    if !name.is_empty() {
-                        needed_suites.push(scope);
-                    }
-                }
-            }
-
-            let mut current_suite_depth: u32 = 0;
-            if !junit.suite_stack.is_empty() {
-                for suite_info in &junit.suite_stack {
-                    if !suite_info.is_file_suite {
-                        current_suite_depth += 1;
-                    }
-                }
-            }
-
-            while (current_suite_depth as usize) > needed_suites.len() {
-                if !junit.suite_stack.is_empty()
-                    && !junit.suite_stack[junit.suite_stack.len() - 1].is_file_suite
-                {
-                    junit.end_test_suite().expect("oom");
-                    current_suite_depth -= 1;
-                } else {
-                    break;
-                }
-            }
-
-            let mut suites_to_close: u32 = 0;
-            let mut suite_index: usize = 0;
-            for suite_info in &junit.suite_stack {
-                if suite_info.is_file_suite {
-                    continue;
-                }
-
-                if suite_index < needed_suites.len() {
-                    let needed_scope = needed_suites[suite_index];
-                    // SAFETY: needed_scope alive for test run
-                    let needed_name =
-                        unsafe { (*needed_scope).base.name.as_deref() }.unwrap_or(b"");
-                    if !strings::eql(&suite_info.name, needed_name) {
-                        suites_to_close = current_suite_depth - u32::try_from(suite_index).unwrap();
-                        break;
-                    }
-                } else {
-                    suites_to_close = current_suite_depth - u32::try_from(suite_index).unwrap();
-                    break;
-                }
-                suite_index += 1;
-            }
-
-            while suites_to_close > 0 {
-                if !junit.suite_stack.is_empty()
-                    && !junit.suite_stack[junit.suite_stack.len() - 1].is_file_suite
-                {
-                    junit.end_test_suite().expect("oom");
-                    suites_to_close -= 1;
-                } else {
-                    break;
-                }
-            }
-
-            let mut describe_suite_index: usize = 0;
-            for suite_info in &junit.suite_stack {
-                if !suite_info.is_file_suite {
-                    describe_suite_index += 1;
-                }
-            }
-
-            while describe_suite_index < needed_suites.len() {
-                let scope = needed_suites[describe_suite_index];
-                // SAFETY: scope alive for test run
-                let (name, line_no) = unsafe {
-                    (
-                        (*scope).base.name.as_deref().unwrap_or(b""),
-                        (*scope).base.line_no,
-                    )
-                };
-                junit
-                    .begin_test_suite_with_line(name, line_no, false)
-                    .expect("oom");
-                describe_suite_index += 1;
-            }
-
-            let mut concatenated_describe_scopes: Vec<u8> = Vec::new();
-
+            // SAFETY: describe scopes outlive the file's test run.
+            let scope: &'a bun_test::DescribeScope = unsafe { &*scope };
+            if let Some(name) = scope.base.name.as_deref()
+                && !name.is_empty()
             {
-                let initial_length = concatenated_describe_scopes.len();
-                for &scope in scopes {
-                    // SAFETY: scope alive for test run
-                    if let Some(name) = unsafe { (*scope).base.name.as_deref() } {
-                        if !name.is_empty() {
-                            if initial_length != concatenated_describe_scopes.len() {
-                                concatenated_describe_scopes.extend_from_slice(b" > ");
-                            }
-
-                            // write_test_case escapes class_name once; do not pre-escape here.
-                            concatenated_describe_scopes.extend_from_slice(name);
-                        }
-                    }
-                }
+                scopes.push((name, scope.base.line_no));
             }
+            parent = scope.base.parent.map(|p| p.cast_const());
+        }
+        scopes.reverse();
 
-            junit
-                .write_test_case(
-                    status,
-                    filename,
-                    display_label,
-                    &concatenated_describe_scopes,
-                    assertions,
-                    elapsed_ns,
-                    line_number,
-                )
-                .expect("oom");
+        TestCaseReport {
+            file,
+            scopes,
+            name: test_entry.base.name.as_deref().unwrap_or(b"(unnamed)"),
+            status,
+            assertions: sequence.expect_call_count,
+            elapsed_ns,
+            line_number: test_entry.base.line_no,
+            failure,
         }
     }
 
@@ -1388,7 +1273,7 @@ impl CommandLineReporter {
             // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>` with write
             // provenance from `enter_file`'s `&mut`; single-threaded; reporter outlives
             // every BunTest. Scoped to this block so the SharedReadOnly tag is dead
-            // before `maybe_print_junit_line` derives `&mut` from the same `NonNull`
+            // before the `&mut` derived from the same `NonNull` below
             // (stacked-borrows hygiene).
             let reporter_ref: Option<&CommandLineReporter> =
                 buntest.reporter.map(|p| unsafe { &*p.as_ptr() });
@@ -1453,30 +1338,32 @@ impl CommandLineReporter {
                 }
             }
         }
-        // always print junit if needed (creates `&mut CommandLineReporter` from
-        // the same `NonNull` — any earlier shared borrow must be dead first).
-        Self::maybe_print_junit_line(result, buntest, sequence, test_entry, elapsed_ns);
-
         let formatted_line = &output_buf[initial_length..];
-        // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>`; re-derived
-        // here (not held across `maybe_print_junit_line`'s `&mut`) per stacked
-        // borrows.
-        let worker_idx = buntest
-            .reporter
-            .and_then(|p| unsafe { (*p.as_ptr()).worker_ipc_file_idx });
-        if let Some(idx) = worker_idx {
-            ParallelRunner::worker_emit_test_done(idx, formatted_line);
-        } else {
-            let _ = Output::error_writer().write_all(formatted_line);
-        }
 
         let Some(this) = buntest.reporter else {
+            let _ = Output::error_writer().write_all(formatted_line);
             return;
-        }; // command line reporter is missing! uh oh!
+        };
         // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>` with write
         // provenance from `enter_file`'s `&mut`; single-threaded test runner,
-        // sole writer for the duration of this completion callback.
+        // sole writer for the duration of this completion callback, and the
+        // shared borrow above is dead.
         let this: &mut CommandLineReporter = unsafe { &mut *this.as_ptr() };
+
+        // Under `--parallel` the flag is forwarded to workers, whose records
+        // the coordinator replays into its own `JunitReporter`.
+        let report = this.jest.test_options.reporters.junit.then(|| {
+            let failure = this.test_failure.take();
+            Self::test_case_report(result, buntest, sequence, test_entry, elapsed_ns, failure)
+        });
+        if let Some(idx) = this.worker_ipc_file_idx {
+            ParallelRunner::worker_emit_test_done(idx, formatted_line, report.as_ref());
+        } else {
+            let _ = Output::error_writer().write_all(formatted_line);
+            if let (Some(junit), Some(report)) = (this.reporters.junit.as_mut(), &report) {
+                junit.record_test_case(report).expect("oom");
+            }
+        }
 
         if !this.reporters.dots && !this.reporters.only_failures {
             match sequence.result.basic_result() {
@@ -1564,10 +1451,38 @@ impl CommandLineReporter {
     pub(crate) fn write_junit_report_if_needed(&mut self) {
         if let Some(junit) = self.reporters.junit.as_mut() {
             if let Some(outfile) = self.jest.test_options.reporter_outfile.as_deref() {
-                if !junit.current_file.is_empty() {
-                    let _ = junit.end_test_suite();
-                }
                 let _ = junit.write_to_file(outfile);
+            }
+        }
+    }
+
+    /// This process's coverage, one `Report` per instrumented file, sorted by
+    /// path, with `coveragePathIgnorePatterns` applied.
+    pub(crate) fn for_each_coverage_report(
+        vm: &mut VirtualMachine,
+        opts: &CodeCoverageOptions,
+        mut each: impl FnMut(CodeCoverageReport<'_>),
+    ) {
+        let Some(map) = ByteRangeMapping::map() else {
+            return;
+        };
+        // SAFETY: thread-local Box pinned for the thread; sole `&mut` for the
+        // collection loop below (single-threaded CLI report path).
+        let map = unsafe { &mut *map.as_ptr() };
+        let relative_dir = FileSystem::get().top_level_dir;
+        let mut byte_ranges: Vec<&mut ByteRangeMapping> = Vec::with_capacity(map.len());
+        for entry in map.values_mut() {
+            if !coverage::is_ignored(opts, relative_dir, entry.source_url.slice()) {
+                byte_ranges.push(entry);
+            }
+        }
+        index_sort::sort_slice_by(&mut byte_ranges, coverage::is_less_than_cmp);
+
+        for entry in byte_ranges {
+            if let Some(report) =
+                CodeCoverageReport::generate(vm.global(), entry, opts.ignore_sourcemap)
+            {
+                each(report);
             }
         }
     }
@@ -1576,464 +1491,189 @@ impl CommandLineReporter {
         &mut self,
         vm: &mut VirtualMachine,
         opts: &mut CodeCoverageOptions,
-        reporters_text: bool,
-        reporters_lcov: bool,
-        enable_ansi_colors: bool,
-    ) -> crate::Result<()> {
-        if !reporters_text && !reporters_lcov {
-            return Ok(());
+    ) {
+        let _trace = bun::perf::trace("TestCommand.printCodeCoverage");
+        if ByteRangeMapping::map().is_none_or(|m| {
+            // SAFETY: see `for_each_coverage_report`.
+            unsafe { m.as_ref() }.is_empty()
+        }) {
+            return;
         }
-
-        let Some(map) = ByteRangeMapping::map() else {
-            return Ok(());
-        };
-        // SAFETY: thread-local Box pinned for the thread; sole `&mut` for the
-        // collection loop below (single-threaded CLI report path).
-        let map = unsafe { &mut *map.as_ptr() };
-        // `ByteRangeMapping` owns a `MultiArrayList` and is not `Copy`, so
-        // collect mutable borrows into the thread-local map instead — no
-        // double-free risk.
-        let mut byte_ranges: Vec<&mut ByteRangeMapping> = Vec::with_capacity(map.len());
-        for entry in map.values_mut() {
-            byte_ranges.push(entry);
+        let mut reports: Vec<CodeCoverageReport<'static>> = Vec::new();
+        Self::for_each_coverage_report(vm, opts, |report| reports.push(report.into_owned()));
+        if let Err(err) = print_coverage_reports(opts, &reports) {
+            Output::err(err, "Failed to write lcov.info", ());
+            Global::exit(1);
         }
+    }
+}
 
-        if byte_ranges.is_empty() {
-            return Ok(());
-        }
+/// Write the `--coverage` text table to stderr and/or `lcov.info` for
+/// `reports` (sorted by path), and set `opts.fractions.failing`. The serial
+/// runner passes this process's reports; the `--parallel` coordinator passes
+/// reports merged from every worker. Errors only from writing `lcov.info`.
+pub(crate) fn print_coverage_reports(
+    opts: &mut CodeCoverageOptions,
+    reports: &[CodeCoverageReport<'_>],
+) -> bun_sys::Result<()> {
+    if Output::enable_ansi_colors_stderr() {
+        print_coverage_reports_::<true>(opts, reports)
+    } else {
+        print_coverage_reports_::<false>(opts, reports)
+    }
+}
 
-        index_sort::sort_slice_by(&mut byte_ranges, coverage::is_less_than_cmp);
+fn print_coverage_reports_<const COLORS: bool>(
+    opts: &mut CodeCoverageOptions,
+    reports: &[CodeCoverageReport<'_>],
+) -> bun_sys::Result<()> {
+    use coverage::text;
+    let relative_dir = FileSystem::get().top_level_dir;
+    let thresholds = opts.fractions;
 
-        self.print_code_coverage(
-            vm,
-            opts,
-            &mut byte_ranges,
-            reporters_text,
-            reporters_lcov,
-            enable_ansi_colors,
-        )
+    let fractions: Vec<Fraction> = reports.iter().map(|r| r.fraction(&thresholds)).collect();
+    let failing = fractions.iter().any(|f| f.failing);
+    opts.fractions.failing = failing;
+
+    if opts.reporters.lcov {
+        write_lcov_report(opts, relative_dir, reports)?;
+    }
+    if !opts.reporters.text {
+        return Ok(());
     }
 
-    pub(crate) fn render_lcov(
-        &mut self,
-        vm: &mut VirtualMachine,
-        opts: &CodeCoverageOptions,
-    ) -> Option<Vec<u8>> {
-        let map = ByteRangeMapping::map()?;
-        // SAFETY: thread-local Box pinned for the thread; sole `&mut` for the
-        // collection loop below (single-threaded CLI report path).
-        let map = unsafe { &mut *map.as_ptr() };
-        // See `generate_code_coverage` — collect borrows, not bitwise copies.
-        let mut byte_ranges: Vec<&mut ByteRangeMapping> = Vec::with_capacity(map.len());
-        for entry in map.values_mut() {
-            byte_ranges.push(entry);
-        }
-        if byte_ranges.is_empty() {
-            return None;
-        }
-        index_sort::sort_slice_by(&mut byte_ranges, coverage::is_less_than_cmp);
+    let max_filepath_length = reports
+        .iter()
+        .map(|r| resolve_path::relative(relative_dir, &r.source_url).len())
+        .fold(b"All files".len(), usize::max);
 
-        let relative_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-        let mut buffered: Vec<u8> = Vec::with_capacity(64 * 1024);
-        let writer = &mut buffered;
-
-        for entry in byte_ranges.iter_mut() {
-            if !opts.ignore_patterns.is_empty() {
-                let rel = resolve_path::relative(relative_dir, entry.source_url.slice());
-                let mut skip = false;
-                for p in &opts.ignore_patterns {
-                    if bun_glob::r#match(p, rel).matches() {
-                        skip = true;
-                        break;
-                    }
-                }
-                if skip {
-                    continue;
-                }
-            }
-            let Some(report) =
-                CodeCoverageReport::generate(vm.global(), entry, opts.ignore_sourcemap)
-            else {
-                continue;
-            };
-            // report dropped at end of iteration
-            if coverage::Lcov::write_format(&report, relative_dir, writer).is_err() {
-                continue;
-            }
-            drop(report);
-        }
-        Some(buffered)
+    let zero = Fraction {
+        functions: 0.0,
+        lines: 0.0,
+        stmts: 0.0,
+        failing: false,
+    };
+    let mut avg = zero;
+    for f in &fractions {
+        avg.functions += f.functions;
+        avg.lines += f.lines;
+        avg.stmts += f.stmts;
     }
+    let avg_thresholds = if fractions.is_empty() {
+        zero
+    } else {
+        let n = fractions.len() as f64;
+        avg.functions /= n;
+        avg.lines /= n;
+        avg.stmts /= n;
+        thresholds
+    };
 
-    pub(crate) fn print_code_coverage(
-        &mut self,
-        vm: &mut VirtualMachine,
-        opts: &mut CodeCoverageOptions,
-        byte_ranges: &mut [&mut ByteRangeMapping],
-        reporters_text: bool,
-        reporters_lcov: bool,
-        enable_ansi_colors: bool,
-    ) -> crate::Result<()> {
-        // Both spellings are compile-time constants; pick one by the runtime flag.
-        macro_rules! pretty_lit {
-            ($fmt:literal) => {
-                if enable_ansi_colors {
-                    bun_core::pretty_fmt!($fmt, true).as_bytes()
-                } else {
-                    bun_core::pretty_fmt!($fmt, false).as_bytes()
-                }
-            };
-        }
-        // `perf::Ctx` ends its span on Drop.
-        let _trace = if reporters_text && reporters_lcov {
-            bun::perf::trace("TestCommand.printCodeCoverageLCovAndText")
-        } else if reporters_text {
-            bun::perf::trace("TestCommand.printCodeCoverageText")
-        } else if reporters_lcov {
-            bun::perf::trace("TestCommand.printCodeCoverageLCov")
-        } else {
-            // Unreachable by construction.
-            unreachable!("No reporters enabled")
-        };
-
-        if !reporters_text && !reporters_lcov {
-            unreachable!("No reporters enabled");
-        }
-
-        let relative_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-
-        // --- Text ---
-        let max_filepath_length: usize = if reporters_text {
-            'brk: {
-                let mut len = b"All files".len();
-                for entry in byte_ranges.iter() {
-                    let utf8 = entry.source_url.slice();
-                    let relative_path = resolve_path::relative(relative_dir, utf8);
-
-                    // Check if this file should be ignored based on coveragePathIgnorePatterns
-                    if !opts.ignore_patterns.is_empty() {
-                        let mut should_ignore = false;
-                        for pattern in &opts.ignore_patterns {
-                            if bun_glob::r#match(pattern, relative_path).matches() {
-                                should_ignore = true;
-                                break;
-                            }
-                        }
-
-                        if should_ignore {
-                            continue;
-                        }
-                    }
-
-                    len = relative_path.len().max(len);
-                }
-
-                break 'brk len;
-            }
-        } else {
-            0
-        };
-
-        // `&mut bun_core::io::Writer: bun_io::Write` (impl in `bun_core::io`);
-        // `splat_byte_all` / `write_all` resolve via the trait import at top.
-        let mut console = Output::error_writer();
-        let base_fraction = opts.fractions;
-        let mut failing = false;
-
-        if reporters_text {
-            if console.write_all(pretty_lit!("<r><d>")).is_err() {
-                return Ok(());
-            }
-            if console
-                .splat_byte_all(b'-', max_filepath_length + 2)
-                .is_err()
-            {
-                return Ok(());
-            }
-            if console
-                .write_all(pretty_lit!("|---------|---------|-------------------<r>\n"))
-                .is_err()
-            {
-                return Ok(());
-            }
-            if console.write_all(b"File").is_err() {
-                return Ok(());
-            }
-            if console
-                .splat_byte_all(b' ', max_filepath_length - b"File".len() + 1)
-                .is_err()
-            {
-                return Ok(());
-            }
-            if console
-                .write_all(pretty_lit!(
-                    " <d>|<r> % Funcs <d>|<r> % Lines <d>|<r> Uncovered Line #s\n"
-                ))
-                .is_err()
-            {
-                return Ok(());
-            }
-            if console.write_all(pretty_lit!("<d>")).is_err() {
-                return Ok(());
-            }
-            if console
-                .splat_byte_all(b'-', max_filepath_length + 2)
-                .is_err()
-            {
-                return Ok(());
-            }
-            if console
-                .write_all(pretty_lit!("|---------|---------|-------------------<r>\n"))
-                .is_err()
-            {
-                return Ok(());
-            }
-        }
-
-        let mut console_buffer: Vec<u8> = Vec::new();
-        let console_writer = &mut console_buffer;
-
-        let mut avg = Fraction {
-            functions: 0.0,
-            lines: 0.0,
-            stmts: 0.0,
-            ..Default::default()
-        };
-        let mut avg_count: f64 = 0.0;
-        // --- Text ---
-
-        // --- LCOV ---
-        let mut lcov_name_buf = PathBuffer::uninit();
-        let mut lcov_state: Option<(File, &bun_core::ZStr, /*buffered*/ Vec<u8>)> =
-            if reporters_lcov {
-                'brk: {
-                    // Ensure the directory exists
-                    let mut fs = crate::node::fs::NodeFS::default();
-                    let _ = fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
-                        path: crate::node::PathLike::borrowed(&opts.reports_directory),
-                        always_return_none: true,
-                        recursive: true,
-                        ..Default::default()
-                    });
-
-                    // Write the lcov.info file to a temporary file we atomically rename to the final name after it succeeds
-                    let mut base64_bytes = [0u8; 8];
-                    let mut shortname_buf = [0u8; 512];
-                    bun_boringssl_sys::rand_bytes(&mut base64_bytes);
-                    // Temp name: `.lcov.info.<lowercase hex of 8 random bytes>.tmp`.
-                    let tmpname = {
-                        use std::io::Write as _;
-                        let mut cursor = &mut shortname_buf[..];
-                        let _ = cursor.write_all(b".lcov.info.");
-                        let _ = write!(cursor, "{}", bun_core::fmt::hex_lower(&base64_bytes));
-                        let _ = cursor.write_all(b".tmp\0");
-                        let s = bun_core::slice_to_nul(&shortname_buf);
-                        // NUL written above; `slice_to_nul` returns the prefix before it.
-                        bun_core::ZStr::from_buf(&shortname_buf[..], s.len())
-                    };
-                    let path = resolve_path::join_abs_string_buf_z::<bun_path::platform::Auto>(
-                        relative_dir,
-                        &mut lcov_name_buf,
-                        &[&opts.reports_directory, tmpname.as_bytes()],
-                    );
-                    let file = File::openat(
-                        Fd::cwd(),
-                        path,
-                        bun_sys::O::CREAT
-                            | bun_sys::O::WRONLY
-                            | bun_sys::O::TRUNC
-                            | bun_sys::O::CLOEXEC,
-                        0o644,
-                    );
-
-                    match file {
-                        bun_sys::Result::Err(err) => {
-                            Output::err(
-                                crate::Error::lcovCoverageError,
-                                "Failed to create lcov file",
-                                (),
-                            );
-                            Output::print_error(format_args!("\n{}", err));
-                            Global::exit(1);
-                        }
-                        bun_sys::Result::Ok(f) => {
-                            // Accumulate in a `Vec<u8>` (impl `bun_io::Write`)
-                            // and flush to the fd via `write_all` on success
-                            // below.
-                            let buffered: Vec<u8> = Vec::with_capacity(64 * 1024);
-                            break 'brk Some((f, path, buffered));
-                        }
-                    }
-                }
-            } else {
-                None
-            };
-        let mut lcov_guard = scopeguard::guard(
-            &mut lcov_state,
-            |s: &mut Option<(File, &bun_core::ZStr, Vec<u8>)>| {
-                if reporters_lcov {
-                    if let Some((file, name, _)) = s.take() {
-                        let _ = file.close(); // close error is non-actionable
-                        let _ = bun_sys::unlink(name);
-                    }
-                }
-            },
+    // Writes below target a Vec and cannot fail.
+    let mut out: Vec<u8> = Vec::new();
+    let separator = |out: &mut Vec<u8>| {
+        let _ = bun_core::write_pretty!(out, COLORS, "<r><d>");
+        out.resize(out.len() + max_filepath_length + 2, b'-');
+        let _ =
+            bun_core::write_pretty!(out, COLORS, "|---------|---------|-------------------<r>\n");
+    };
+    separator(&mut out);
+    out.extend_from_slice(b"File");
+    out.resize(out.len() + max_filepath_length - b"File".len() + 1, b' ');
+    let _ = bun_core::write_pretty!(
+        out,
+        COLORS,
+        " <d>|<r> % Funcs <d>|<r> % Lines <d>|<r> Uncovered Line #s\n"
+    );
+    separator(&mut out);
+    let _ = text::write_format_with_values::<COLORS>(
+        b"All files",
+        max_filepath_length,
+        avg,
+        avg_thresholds,
+        failing,
+        &mut out,
+        false,
+    );
+    let _ = bun_core::write_pretty!(out, COLORS, "<r><d> |<r>\n");
+    for (report, fraction) in reports.iter().zip(&fractions) {
+        let _ = text::write_format::<COLORS>(
+            report,
+            max_filepath_length,
+            fraction,
+            &thresholds,
+            relative_dir,
+            &mut out,
         );
-        // --- LCOV ---
-
-        for entry in byte_ranges.iter_mut() {
-            // Check if this file should be ignored based on coveragePathIgnorePatterns
-            if !opts.ignore_patterns.is_empty() {
-                let utf8 = entry.source_url.slice();
-                let relative_path = resolve_path::relative(relative_dir, utf8);
-
-                let mut should_ignore = false;
-                for pattern in &opts.ignore_patterns {
-                    if bun_glob::r#match(pattern, relative_path).matches() {
-                        should_ignore = true;
-                        break;
-                    }
-                }
-
-                if should_ignore {
-                    continue;
-                }
-            }
-
-            let Some(report) =
-                CodeCoverageReport::generate(vm.global(), entry, opts.ignore_sourcemap)
-            else {
-                continue;
-            };
-
-            if reporters_text {
-                let mut fraction = base_fraction;
-                if coverage::Text::write_format(
-                    &report,
-                    max_filepath_length,
-                    &mut fraction,
-                    relative_dir,
-                    console_writer,
-                    enable_ansi_colors,
-                )
-                .is_err()
-                {
-                    continue;
-                }
-                avg.functions += fraction.functions;
-                avg.lines += fraction.lines;
-                avg.stmts += fraction.stmts;
-                avg_count += 1.0;
-                if fraction.failing {
-                    failing = true;
-                }
-
-                console_writer.extend_from_slice(b"\n");
-            }
-
-            if reporters_lcov {
-                if let Some((_, _, buffered)) = lcov_guard.as_mut() {
-                    if coverage::Lcov::write_format(&report, relative_dir, buffered).is_err() {
-                        continue;
-                    }
-                }
-            }
-
-            drop(report);
-        }
-
-        if reporters_text {
-            {
-                if avg_count == 0.0 {
-                    avg.functions = 0.0;
-                    avg.lines = 0.0;
-                    avg.stmts = 0.0;
-                } else {
-                    avg.functions /= avg_count;
-                    avg.lines /= avg_count;
-                    avg.stmts /= avg_count;
-                }
-
-                let failed = if avg_count > 0.0 {
-                    base_fraction
-                } else {
-                    Fraction {
-                        functions: 0.0,
-                        lines: 0.0,
-                        stmts: 0.0,
-                        ..Default::default()
-                    }
-                };
-
-                coverage::Text::write_format_with_values(
-                    b"All files",
-                    max_filepath_length,
-                    avg,
-                    failed,
-                    failing,
-                    &mut console,
-                    false,
-                    enable_ansi_colors,
-                )?;
-
-                console.write_all(pretty_lit!("<r><d> |<r>\n"))?;
-            }
-
-            console.write_all(&console_buffer)?;
-            console.write_all(pretty_lit!("<r><d>"))?;
-            // Disarm the lcov cleanup guard before the early `Ok(())`; the
-            // temp file is left for the OS.
-            if console
-                .splat_byte_all(b'-', max_filepath_length + 2)
-                .is_err()
-            {
-                let _ = scopeguard::ScopeGuard::into_inner(lcov_guard);
-                return Ok(());
-            }
-            if console
-                .write_all(pretty_lit!("|---------|---------|-------------------<r>\n"))
-                .is_err()
-            {
-                let _ = scopeguard::ScopeGuard::into_inner(lcov_guard);
-                return Ok(());
-            }
-
-            opts.fractions.failing = failing;
-            Output::flush();
-        }
-
-        if reporters_lcov {
-            // `try lcov_writer.flush()` — keep the errdefer guard armed across the
-            // write so an error here still closes + unlinks the temp file.
-            if let Some((lcov_file, _, buffered)) = &mut **lcov_guard {
-                if let bun_sys::Result::Err(e) = lcov_file.write_all(buffered) {
-                    // `lcov_guard` drops on this early return → close + unlink.
-                    return Err(crate::Error::from(e));
-                }
-            }
-            // Flush succeeded — disarm the errdefer cleanup.
-            let state = scopeguard::ScopeGuard::into_inner(lcov_guard);
-            if let Some((lcov_file, lcov_name, _)) = state.take() {
-                let _ = lcov_file.close();
-                let cwd = Fd::cwd();
-                if let Err(err) = bun_sys::move_file_z(
-                    cwd,
-                    lcov_name,
-                    cwd,
-                    resolve_path::join_abs_string_z::<bun_path::platform::Auto>(
-                        relative_dir,
-                        &[&opts.reports_directory, b"lcov.info"],
-                    ),
-                ) {
-                    Output::err(err, "Failed to save lcov.info file", ());
-                    Global::exit(1);
-                }
-            }
-        } else {
-            let _ = scopeguard::ScopeGuard::into_inner(lcov_guard);
-        }
-        Ok(())
+        out.push(b'\n');
     }
+    separator(&mut out);
+
+    // A closed stderr is not a reason to fail the run.
+    let _ = Output::error_writer().write_all(&out);
+    Output::flush();
+    Ok(())
+}
+
+/// Render to `<reports_directory>/.lcov.info.<hex>.tmp` and rename it over
+/// `lcov.info`, so an interrupted run never leaves a truncated report.
+fn write_lcov_report(
+    opts: &CodeCoverageOptions,
+    relative_dir: &[u8],
+    reports: &[CodeCoverageReport<'_>],
+) -> bun_sys::Result<()> {
+    let mut contents: Vec<u8> = Vec::with_capacity(64 * 1024);
+    for report in reports {
+        // Writing into a Vec cannot fail.
+        let _ = coverage::lcov::write_format(report, relative_dir, &mut contents);
+    }
+
+    let mut fs = crate::node::fs::NodeFS::default();
+    let _ = fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
+        path: crate::node::PathLike::borrowed(&opts.reports_directory),
+        always_return_none: true,
+        recursive: true,
+        ..Default::default()
+    });
+
+    let mut rand = [0u8; 8];
+    bun_boringssl_sys::rand_bytes(&mut rand);
+    let mut tmpname: Vec<u8> = Vec::new();
+    let _ = write!(
+        &mut tmpname,
+        ".lcov.info.{}.tmp",
+        bun_core::fmt::hex_lower(&rand)
+    );
+    let mut buf = PathBuffer::uninit();
+    let tmp_path = resolve_path::join_abs_string_buf_z::<bun_path::platform::Auto>(
+        relative_dir,
+        &mut buf,
+        &[&opts.reports_directory, &tmpname],
+    );
+    let file = File::openat(
+        Fd::cwd(),
+        tmp_path,
+        bun_sys::O::CREAT | bun_sys::O::WRONLY | bun_sys::O::TRUNC | bun_sys::O::CLOEXEC,
+        0o644,
+    )?;
+    let written = file.write_all(&contents);
+    drop(file);
+    let moved = match written {
+        Ok(()) => bun_sys::move_file_z(
+            Fd::cwd(),
+            tmp_path,
+            Fd::cwd(),
+            resolve_path::join_abs_string_z::<bun_path::platform::Auto>(
+                relative_dir,
+                &[&opts.reports_directory, b"lcov.info"],
+            ),
+        ),
+        err => err,
+    };
+    if moved.is_err() {
+        let _ = bun_sys::unlink(tmp_path);
+    }
+    moved
 }
 
 #[unsafe(no_mangle)]
@@ -2223,6 +1863,7 @@ impl TestCommand {
             repeat_count: 1,
             last_printed_dot: core::cell::Cell::new(false),
             worker_ipc_file_idx: None,
+            test_failure: None,
             failures_to_repeat_buf: Vec::new(),
             skips_to_repeat_buf: Vec::new(),
             todos_to_repeat_buf: Vec::new(),
@@ -2244,7 +1885,7 @@ impl TestCommand {
         // `reporter.jest.test_options` is initialised in the struct
         // literal above (lifetime-erased); the post-init assignment is dropped.
 
-        if ctx.test_options.reporters.junit {
+        if ctx.test_options.reporters.junit && !ctx.test_options.test_worker {
             reporter.reporters.junit = Some(JunitReporter::init());
         }
         if ctx.test_options.reporters.dots {
@@ -2836,17 +2477,7 @@ impl TestCommand {
             pretty_error!("\n");
 
             if coverage_options.enabled && !ran_parallel {
-                let (text, lcov) = (
-                    coverage_options.reporters.text,
-                    coverage_options.reporters.lcov,
-                );
-                reporter.generate_code_coverage(
-                    vm,
-                    &mut coverage_options,
-                    text,
-                    lcov,
-                    Output::enable_ansi_colors_stderr(),
-                )?;
+                reporter.generate_code_coverage(vm, &mut coverage_options);
             }
 
             // `Summary` is `Copy`; take a value snapshot so the `&mut` from
@@ -3381,11 +3012,7 @@ impl TestCommand {
             repeat_index += 1;
         }
         if let Some(junit) = reporter.reporters.junit.as_mut() {
-            junit.file_end_ns = bun::Timespec::now(bun::TimespecMockMode::ForceRealTime).ns();
-            while !junit.suite_stack.is_empty() {
-                let _ = junit.end_test_suite();
-            }
-            junit.current_file = Box::default();
+            let _ = junit.end_file(None);
         }
         Ok(())
     }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -201,7 +201,7 @@ impl ExecutionSequence {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Default, strum::IntoStaticStr)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, strum::IntoStaticStr, strum::FromRepr)]
 #[repr(u8)]
 pub enum Result {
     #[default]
@@ -707,7 +707,7 @@ impl Execution {
         }
     }
 
-    /// Drop any captured junit failure so the next retry/repeat starts fresh.
+    /// Drop any captured failure so the next retry/repeat starts fresh.
     /// Kept out of `reset_sequence` so within-attempt errors (e.g. a throwing
     /// afterEach after the test body already threw) accumulate instead of
     /// clobbering the primary failure.
@@ -717,9 +717,7 @@ impl Execution {
         if let Some(reporter) = unsafe { (*buntest.as_ptr()).reporter } {
             // SAFETY: `reporter` is a `NonNull<CommandLineReporter>` with write
             // provenance (see BunTest docs); single-threaded, no other borrow.
-            if let Some(junit) = unsafe { (*reporter.as_ptr()).reporters.junit.as_deref_mut() } {
-                junit.last_failure = None;
-            }
+            unsafe { (*reporter.as_ptr()).test_failure = None };
         }
     }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1294,7 +1294,7 @@ impl BunTest {
             return; // the exception should not be visible (eg m_terminationException)
         };
 
-        let junit_ctx: *mut core::ffi::c_void = 'ctx: {
+        let failure_ctx: *mut core::ffi::c_void = 'ctx: {
             if handle_status != HandleUncaughtExceptionResult::ShowHandledError {
                 break 'ctx core::ptr::null_mut();
             }
@@ -1303,9 +1303,11 @@ impl BunTest {
             };
             // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
             // `&mut`; single-threaded test runner, no other borrow live here.
-            match unsafe { (*reporter.as_ptr()).reporters.junit.as_deref_mut() } {
-                Some(junit) => core::ptr::from_mut(junit).cast(),
-                None => core::ptr::null_mut(),
+            let reporter = unsafe { &mut *reporter.as_ptr() };
+            if reporter.jest.test_options.reporters.junit {
+                core::ptr::from_mut(&mut reporter.test_failure).cast()
+            } else {
+                core::ptr::null_mut()
             }
         };
 
@@ -1328,13 +1330,13 @@ impl BunTest {
         }
 
         let vm = global_this.bun_vm().as_mut();
-        if !junit_ctx.is_null() {
+        if !failure_ctx.is_null() {
             vm.on_print_error_zig_exception =
-                Some(crate::cli::test_command::JunitReporter::record_failure_cb);
-            vm.on_print_error_zig_exception_ctx = junit_ctx;
+                Some(crate::cli::test_command::TestFailure::record_cb);
+            vm.on_print_error_zig_exception_ctx = failure_ctx;
         }
         vm.run_error_handler(exception, None);
-        if !junit_ctx.is_null() {
+        if !failure_ctx.is_null() {
             vm.on_print_error_zig_exception = None;
             vm.on_print_error_zig_exception_ctx = core::ptr::null_mut();
         }

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -1,6 +1,7 @@
 use core::cell::UnsafeCell;
 use core::ffi::{c_int, c_void};
 use core::ptr::NonNull;
+use std::borrow::Cow;
 
 use bun_ast::Loc;
 use bun_collections::VecExt;
@@ -29,18 +30,20 @@ type Bitset = DynamicBitSet;
 /// We use two bitsets since the typical size will be decently small,
 /// bitsets are simple and bitsets are relatively fast to construct and query
 pub struct Report<'a> {
-    pub(crate) source_url: &'a [u8],
+    pub source_url: Cow<'a, [u8]>,
     pub(crate) executable_lines: Bitset,
     pub(crate) lines_which_have_executed: Bitset,
     pub(crate) line_hits: LinesHits,
-    pub(crate) functions: Vec<Block>,
+    /// Indexed in step with `functions_which_have_executed`.
+    pub(crate) functions: Vec<ByteRange>,
     pub(crate) functions_which_have_executed: Bitset,
+    /// Indexed in step with `stmts_which_have_executed`.
+    pub(crate) stmts: Vec<ByteRange>,
     pub(crate) stmts_which_have_executed: Bitset,
-    pub(crate) stmts: Vec<Block>,
 }
 
 impl<'a> Report<'a> {
-    pub(crate) fn lines_coverage_fraction(&self) -> f64 {
+    pub fn lines_coverage_fraction(&self) -> f64 {
         let mut intersected = self
             .executable_lines
             .clone()
@@ -57,7 +60,7 @@ impl<'a> Report<'a> {
         intersected_count / total_count
     }
 
-    pub(crate) fn stmts_coverage_fraction(&self) -> f64 {
+    pub fn stmts_coverage_fraction(&self) -> f64 {
         let total_count: f64 = self.stmts.len() as f64;
 
         if total_count == 0.0 {
@@ -67,12 +70,32 @@ impl<'a> Report<'a> {
         (self.stmts_which_have_executed.count() as f64) / total_count
     }
 
-    pub(crate) fn function_coverage_fraction(&self) -> f64 {
+    pub fn function_coverage_fraction(&self) -> f64 {
         let total_count: f64 = self.functions.len() as f64;
         if total_count == 0.0 {
             return 1.0;
         }
         (self.functions_which_have_executed.count() as f64) / total_count
+    }
+
+    /// This file's fractions, with `failing` judged against `thresholds`.
+    pub fn fraction(&self, thresholds: &Fraction) -> Fraction {
+        let functions = self.function_coverage_fraction();
+        let lines = self.lines_coverage_fraction();
+        Fraction {
+            functions,
+            lines,
+            stmts: self.stmts_coverage_fraction(),
+            failing: functions < thresholds.functions || lines < thresholds.lines,
+        }
+    }
+
+    /// Detach from the `ByteRangeMapping` this was generated from.
+    pub fn into_owned(self) -> Report<'static> {
+        Report {
+            source_url: Cow::Owned(self.source_url.into_owned()),
+            ..self
+        }
     }
 
     pub fn generate(
@@ -110,6 +133,220 @@ impl<'a> Report<'a> {
         }
 
         result
+    }
+}
+
+/// Byte encoding of a `Report` for handing one process's coverage of a file to
+/// another (`bun test --parallel` workers → coordinator). Both ends are the
+/// same executable on the same host, so integers and bitset words are written
+/// in native layout.
+///
+///   str  source_url
+///   u32  line_count, then executable_lines words, lines_which_have_executed
+///        words, line_count × u32 hits
+///   u32  n_functions, then n × {u32 start, u32 end}, executed words
+///   u32  n_stmts, same shape
+pub mod wire {
+    use super::*;
+
+    fn put_u32(out: &mut Vec<u8>, v: u32) {
+        out.extend_from_slice(&v.to_ne_bytes());
+    }
+
+    fn put_ranges(out: &mut Vec<u8>, ranges: &[ByteRange], executed: &Bitset) {
+        debug_assert_eq!(executed.bit_length(), ranges.len());
+        put_u32(out, u32::try_from(ranges.len()).expect("int cast"));
+        for r in ranges {
+            put_u32(out, r.start);
+            put_u32(out, r.end);
+        }
+        out.extend_from_slice(executed.bytes());
+    }
+
+    pub fn encode(report: &Report<'_>, out: &mut Vec<u8>) {
+        let line_count = report.line_hits.len();
+        debug_assert_eq!(report.executable_lines.bit_length(), line_count);
+        debug_assert_eq!(report.lines_which_have_executed.bit_length(), line_count);
+
+        put_u32(
+            out,
+            u32::try_from(report.source_url.len()).expect("int cast"),
+        );
+        out.extend_from_slice(&report.source_url);
+        put_u32(out, u32::try_from(line_count).expect("int cast"));
+        out.extend_from_slice(report.executable_lines.bytes());
+        out.extend_from_slice(report.lines_which_have_executed.bytes());
+        out.extend_from_slice(bun_core::cast_slice::<u32, u8>(&report.line_hits));
+        put_ranges(
+            out,
+            &report.functions,
+            &report.functions_which_have_executed,
+        );
+        put_ranges(out, &report.stmts, &report.stmts_which_have_executed);
+    }
+
+    struct Reader<'a>(&'a [u8]);
+
+    impl<'a> Reader<'a> {
+        fn bytes(&mut self, n: usize) -> Option<&'a [u8]> {
+            let (head, tail) = self.0.split_at_checked(n)?;
+            self.0 = tail;
+            Some(head)
+        }
+        fn u32(&mut self) -> Option<u32> {
+            Some(u32::from_ne_bytes(self.bytes(4)?.try_into().unwrap()))
+        }
+        fn len(&mut self) -> Option<usize> {
+            self.u32().map(|n| n as usize)
+        }
+        fn bitset(&mut self, bit_length: usize) -> Option<Bitset> {
+            let words = bit_length.div_ceil(usize::BITS as usize) * core::mem::size_of::<usize>();
+            Bitset::from_bytes(bit_length, self.bytes(words)?).ok()?
+        }
+        fn ranges(&mut self) -> Option<(Vec<ByteRange>, Bitset)> {
+            let n = self.len()?;
+            let mut ranges = Vec::with_capacity(n.min(self.0.len() / 8));
+            for _ in 0..n {
+                ranges.push(ByteRange {
+                    start: self.u32()?,
+                    end: self.u32()?,
+                });
+            }
+            Some((ranges, self.bitset(n)?))
+        }
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Report<'static>> {
+        let mut r = Reader(bytes);
+        let url_len = r.len()?;
+        let source_url = Cow::Owned(r.bytes(url_len)?.to_vec());
+        let line_count = r.len()?;
+        // Bound the allocations below by the input size, not by a length
+        // field read from it.
+        if line_count.checked_mul(4)? > r.0.len() {
+            return None;
+        }
+        let executable_lines = r.bitset(line_count)?;
+        let lines_which_have_executed = r.bitset(line_count)?;
+        let mut line_hits = vec![0u32; line_count];
+        bun_core::cast_slice_mut::<u32, u8>(&mut line_hits)
+            .copy_from_slice(r.bytes(line_count * 4)?);
+        let (functions, functions_which_have_executed) = r.ranges()?;
+        let (stmts, stmts_which_have_executed) = r.ranges()?;
+        if !r.0.is_empty() {
+            return None;
+        }
+        Some(Report {
+            source_url,
+            executable_lines,
+            lines_which_have_executed,
+            line_hits,
+            functions,
+            functions_which_have_executed,
+            stmts,
+            stmts_which_have_executed,
+        })
+    }
+}
+
+/// Folds several processes' `Report`s for one source file into one, for
+/// `bun test --parallel` where each worker that loaded the file reports it.
+///
+/// Hits and executed lines/functions/blocks union across reports. Executable
+/// lines do not: a process that never ran a function marks the function's
+/// whole line span (blank lines included) executable, while one that ran it
+/// knows the real lines. So a line counts as executable only if it executed
+/// somewhere or every report agrees it is executable; otherwise the coarse
+/// span from an import-only worker would show a fully executed function as
+/// partially covered (#39930).
+#[derive(Default)]
+pub struct MergedReport {
+    source_url: Vec<u8>,
+    reports: u32,
+    executable_in_all: Bitset,
+    executed_in_any: Bitset,
+    line_hits: LinesHits,
+    /// Every report's ranges with their executed bit; deduplicated in `finish`.
+    functions: Vec<(ByteRange, bool)>,
+    stmts: Vec<(ByteRange, bool)>,
+}
+
+impl MergedReport {
+    pub fn add(&mut self, report: &Report<'_>) -> Result<(), bun_alloc::AllocError> {
+        let n = report.line_hits.len();
+        self.reports += 1;
+        if self.reports == 1 {
+            self.source_url = report.source_url.to_vec();
+            self.executable_in_all = report.executable_lines.clone()?;
+            self.executed_in_any = report.lines_which_have_executed.clone()?;
+            self.line_hits.clone_from(&report.line_hits);
+        } else {
+            if n != self.line_hits.len() {
+                // Same path, different contents between workers. Keep the
+                // longer view; lines past the shorter one's end count only
+                // if executed.
+                let len = n.max(self.line_hits.len());
+                self.executable_in_all.resize(len, false)?;
+                self.executed_in_any.resize(len, false)?;
+                self.line_hits.resize(len, 0);
+            }
+            let mut executable = report.executable_lines.clone()?;
+            let mut executed = report.lines_which_have_executed.clone()?;
+            executable.resize(self.line_hits.len(), false)?;
+            executed.resize(self.line_hits.len(), false)?;
+            self.executable_in_all.set_intersection(&executable);
+            self.executed_in_any.set_union(&executed);
+            for (sum, &hits) in self.line_hits.iter_mut().zip(&report.line_hits) {
+                *sum = sum.saturating_add(hits);
+            }
+        }
+        for (i, &r) in report.functions.iter().enumerate() {
+            self.functions
+                .push((r, report.functions_which_have_executed.is_set(i)));
+        }
+        for (i, &r) in report.stmts.iter().enumerate() {
+            self.stmts
+                .push((r, report.stmts_which_have_executed.is_set(i)));
+        }
+        Ok(())
+    }
+
+    fn dedupe(
+        mut all: Vec<(ByteRange, bool)>,
+    ) -> Result<(Vec<ByteRange>, Bitset), bun_alloc::AllocError> {
+        all.sort_unstable_by_key(|e| e.0);
+        all.dedup_by(|next, kept| {
+            next.0 == kept.0 && {
+                kept.1 |= next.1;
+                true
+            }
+        });
+        let mut executed = Bitset::init_empty(all.len())?;
+        let mut ranges = Vec::with_capacity(all.len());
+        for (i, (r, hit)) in all.into_iter().enumerate() {
+            if hit {
+                executed.set(i);
+            }
+            ranges.push(r);
+        }
+        Ok((ranges, executed))
+    }
+
+    pub fn finish(self) -> Result<Report<'static>, bun_alloc::AllocError> {
+        let mut executable_lines = self.executable_in_all;
+        executable_lines.set_union(&self.executed_in_any);
+        let (functions, functions_which_have_executed) = Self::dedupe(self.functions)?;
+        let (stmts, stmts_which_have_executed) = Self::dedupe(self.stmts)?;
+        Ok(Report {
+            source_url: Cow::Owned(self.source_url),
+            executable_lines,
+            lines_which_have_executed: self.executed_in_any,
+            line_hits: self.line_hits,
+            functions,
+            functions_which_have_executed,
+            stmts,
+            stmts_which_have_executed,
+        })
     }
 }
 
@@ -181,25 +418,17 @@ pub mod text {
         Ok(())
     }
 
+    /// One table row: name, the two percentages from `fraction` (coloured
+    /// against `thresholds`), and the uncovered line ranges.
     pub fn write_format<const ENABLE_COLORS: bool>(
         report: &Report,
         max_filename_length: usize,
-        fraction: &mut Fraction,
+        fraction: &Fraction,
+        thresholds: &Fraction,
         base_path: &[u8],
         writer: &mut impl bun_io::Write,
     ) -> bun_io::Result<()> {
-        let failing = *fraction;
-        let fns = report.function_coverage_fraction();
-        let lines = report.lines_coverage_fraction();
-        let stmts = report.stmts_coverage_fraction();
-        fraction.functions = fns;
-        fraction.lines = lines;
-        fraction.stmts = stmts;
-
-        let failed = fns < failing.functions || lines < failing.lines; // || stmts < failing.stmts;
-        fraction.failing = failed;
-
-        let mut filename = report.source_url;
+        let mut filename: &[u8] = &report.source_url;
         if !base_path.is_empty() {
             filename = bun_paths::resolve_path::relative(base_path, filename);
         }
@@ -208,8 +437,8 @@ pub mod text {
             filename,
             max_filename_length,
             *fraction,
-            failing,
-            failed,
+            *thresholds,
+            fraction.failing,
             writer,
             true,
         )?;
@@ -226,9 +455,6 @@ pub mod text {
         executable_lines_that_havent_been_executed.set_intersection(&report.executable_lines);
 
         let mut iter = executable_lines_that_havent_been_executed.iterator::<true, true>();
-        let mut start_of_line_range: usize = 0;
-        let mut prev_line: usize = 0;
-        let mut is_first = true;
 
         // `concat!(pretty_fmt!(..), "{}")` requires a literal; split into a
         // prefix `write_all` + plain `write!` so the const-generic `ENABLE_COLORS` can
@@ -236,47 +462,32 @@ pub mod text {
         let red = pretty_fmt::<ENABLE_COLORS>("<red>");
         let comma = pretty_fmt::<ENABLE_COLORS>("<r><d>,<r>");
 
-        while let Some(next_line) = iter.next() {
-            if next_line == (prev_line + 1) {
-                prev_line = next_line;
-                continue;
-            } else if is_first && start_of_line_range == 0 && prev_line == 0 {
-                start_of_line_range = next_line;
-                prev_line = next_line;
-                continue;
-            }
-
-            if is_first {
-                is_first = false;
-            } else {
-                writer.write_all(&comma)?;
-            }
-
-            if start_of_line_range == prev_line {
+        let mut is_first = true;
+        let mut emit =
+            |writer: &mut dyn bun_io::Write, start: usize, end: usize| -> bun_io::Result<()> {
+                if !core::mem::take(&mut is_first) {
+                    writer.write_all(&comma)?;
+                }
                 writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
-            } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
-            }
-
-            prev_line = next_line;
-            start_of_line_range = next_line;
+                if start == end {
+                    write!(writer, "{}", start + 1)
+                } else {
+                    write!(writer, "{}-{}", start + 1, end + 1)
+                }
+            };
+        let mut range: Option<(usize, usize)> = None;
+        while let Some(line) = iter.next() {
+            range = match range {
+                Some((start, end)) if line == end + 1 => Some((start, line)),
+                Some((start, end)) => {
+                    emit(writer, start, end)?;
+                    Some((line, line))
+                }
+                None => Some((line, line)),
+            };
         }
-
-        if prev_line != start_of_line_range {
-            if is_first {
-            } else {
-                writer.write_all(&comma)?;
-            }
-
-            if start_of_line_range == prev_line {
-                writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
-            } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
-            }
+        if let Some((start, end)) = range {
+            emit(writer, start, end)?;
         }
         Ok(())
     }
@@ -290,7 +501,7 @@ pub mod lcov {
         base_path: &[u8],
         writer: &mut impl bun_io::Write,
     ) -> bun_io::Result<()> {
-        let mut filename = report.source_url;
+        let mut filename: &[u8] = &report.source_url;
         if !base_path.is_empty() {
             filename = bun_paths::resolve_path::relative(base_path, filename);
         }
@@ -490,13 +701,13 @@ impl ByteRangeMapping {
                 .get(source_url);
         let mut line_hits: LinesHits;
 
-        let mut functions: Vec<Block> = Vec::new();
+        let mut functions: Vec<ByteRange> = Vec::new();
         functions.reserve_exact(function_blocks.len());
         let mut functions_which_have_executed: Bitset = Bitset::init_empty(function_blocks.len())?;
         let mut stmts_which_have_executed: Bitset = Bitset::init_empty(blocks.len())?;
 
-        let mut stmts: Vec<Block> = Vec::new();
-        stmts.reserve_exact(function_blocks.len());
+        let mut stmts: Vec<ByteRange> = Vec::new();
+        stmts.reserve_exact(blocks.len());
 
         let line_count: u32;
 
@@ -507,7 +718,7 @@ impl ByteRangeMapping {
             line_hits = vec![0u32; line_count as usize];
             let line_hits_slice = line_hits.as_mut_slice();
 
-            for (i, block) in blocks.iter().enumerate() {
+            for block in blocks {
                 if block.end_offset < 0 || block.start_offset < 0 {
                     continue; // does not map to anything
                 }
@@ -548,14 +759,14 @@ impl ByteRangeMapping {
 
                 if min_line != u32::MAX {
                     if has_executed {
-                        stmts_which_have_executed.set(i);
+                        stmts_which_have_executed.set(stmts.len());
                     }
 
-                    stmts.push(Block {});
+                    stmts.push(ByteRange::of(min, max));
                 }
             }
 
-            for (i, function) in function_blocks.iter().enumerate() {
+            for function in function_blocks {
                 if function.end_offset < 0 || function.start_offset < 0 {
                     continue; // does not map to anything
                 }
@@ -599,11 +810,10 @@ impl ByteRangeMapping {
                     }
                 }
 
-                functions.push(Block {});
-
                 if did_fn_execute {
-                    functions_which_have_executed.set(i);
+                    functions_which_have_executed.set(functions.len());
                 }
+                functions.push(ByteRange::of(min, max));
             }
         } else if let Some(parsed_mapping) = parsed_mappings_.as_deref() {
             line_count = (parsed_mapping.input_line_count as u32) + 1;
@@ -614,7 +824,7 @@ impl ByteRangeMapping {
 
             let mut cur_: Option<internal_source_map::Cursor> = parsed_mapping.internal_cursor();
 
-            for (i, block) in blocks.iter().enumerate() {
+            for block in blocks {
                 if block.end_offset < 0 || block.start_offset < 0 {
                     continue; // does not map to anything
                 }
@@ -685,15 +895,14 @@ impl ByteRangeMapping {
                 }
 
                 if min_line != u32::MAX {
-                    stmts.push(Block {});
-
                     if has_executed {
-                        stmts_which_have_executed.set(i);
+                        stmts_which_have_executed.set(stmts.len());
                     }
+                    stmts.push(ByteRange::of(min, max));
                 }
             }
 
-            for (i, function) in function_blocks.iter().enumerate() {
+            for function in function_blocks {
                 if function.end_offset < 0 || function.start_offset < 0 {
                     continue; // does not map to anything
                 }
@@ -774,17 +983,20 @@ impl ByteRangeMapping {
                     }
                 }
 
-                functions.push(Block {});
                 if did_fn_execute {
-                    functions_which_have_executed.set(i);
+                    functions_which_have_executed.set(functions.len());
                 }
+                functions.push(ByteRange::of(min, max));
             }
         } else {
             unreachable!();
         }
 
+        functions_which_have_executed.resize(functions.len(), false)?;
+        stmts_which_have_executed.resize(stmts.len(), false)?;
+
         Ok(Report {
-            source_url,
+            source_url: Cow::Borrowed(source_url),
             functions,
             executable_lines,
             lines_which_have_executed,
@@ -872,7 +1084,7 @@ extern "C" fn ByteRangeMapping__findExecutedLines(
         Err(_) => return global_this.throw_out_of_memory_value(),
     };
 
-    let mut coverage_fraction = Fraction::default();
+    let thresholds = Fraction::default();
 
     // std.Io.Writer.Allocating → Vec<u8> byte buffer (bun_io::Write target).
     let mut buf: Vec<u8> = Vec::new();
@@ -880,7 +1092,8 @@ extern "C" fn ByteRangeMapping__findExecutedLines(
     if text::write_format::<false>(
         &report,
         source_url.utf8_byte_length(),
-        &mut coverage_fraction,
+        &report.fraction(&thresholds),
+        &thresholds,
         b"",
         &mut buf,
     )
@@ -903,5 +1116,20 @@ extern "C" fn ByteRangeMapping__findExecutedLines(
 // writers and the test runner share one definition.
 pub use bun_options_types::code_coverage_options::Fraction;
 
-#[derive(Clone, Copy, Default)]
-pub struct Block {}
+/// A basic block or function body as `[start, end)` byte offsets into the
+/// generated source. Offsets are what JSC reports, so they identify the same
+/// block across processes that loaded the same file.
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ByteRange {
+    pub start: u32,
+    pub end: u32,
+}
+
+impl ByteRange {
+    fn of(min: usize, max: usize) -> ByteRange {
+        ByteRange {
+            start: u32::try_from(min).expect("int cast"),
+            end: u32::try_from(max).expect("int cast"),
+        }
+    }
+}

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -690,10 +690,10 @@ test("calls second", () => {
   });
   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toMatch(/ subject\.ts +\| +100\.00 +\| +100\.00 +\| +\n/);
   const lcov = readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8");
   const record = lcov.split("end_of_record").find(r => r.includes("SF:subject.ts"));
   expect(record).toMatch(/FNF:2\nFNH:2\n/);
-  expect(stderr).toMatch(/ subject\.ts +\| +100\.00 +\| +100\.00 +\| +\n/);
-  expect(stderr).toContain("2 pass");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -193,7 +193,7 @@ test("should call only some functions", () => {
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |   75.00 |   83.33 |
- include-me.ts |   50.00 |   66.67 | 
+ include-me.ts |   50.00 |   66.67 | 6
  test.test.ts  |  100.00 |  100.00 | 
 ---------------|---------|---------|-------------------
 
@@ -639,5 +639,61 @@ test("only imports the function", () => {
   expect(record).toMatch(/LF:4\nLH:4\n/);
 
   expect(stderr).toMatch(/ subject\.ts +\| +100\.00 +\| +100\.00 +\| +\n/);
+  expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/40586
+// Each worker executes a different function of the same module; the merged
+// report must count a function as covered if any worker ran it.
+test("--parallel merges function coverage across workers", async () => {
+  // Each test file waits at import time until the other has started, so the
+  // two can only make progress in two different workers.
+  const rendezvous = (me: string, other: string) => `
+await Bun.write("${me}.started", "");
+for (const deadline = Date.now() + 60_000; !(await Bun.file("${other}.started").exists()); ) {
+  if (Date.now() > deadline) throw new Error("${other} never started in another worker");
+  await Bun.sleep(5);
+}
+`;
+  using dir = tempDir("cov-parallel-fn-merge", {
+    "bunfig.toml": `[test]\ncoverageSkipTestFiles = true\ncoverageThreshold = { lines = 1.0, functions = 1.0 }\n`,
+    "subject.ts": `export function first() {
+  return 1;
+}
+export function second() {
+  return 2;
+}
+`,
+    "first.test.ts": `${rendezvous("first", "second")}
+import { expect, test } from "bun:test";
+import { first } from "./subject.ts";
+
+test("calls first", () => {
+  expect(first()).toBe(1);
+});
+`,
+    "second.test.ts": `${rendezvous("second", "first")}
+import { expect, test } from "bun:test";
+import { second } from "./subject.ts";
+
+test("calls second", () => {
+  expect(second()).toBe(2);
+});
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=text", "--coverage-reporter=lcov", "--parallel=2"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lcov = readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8");
+  const record = lcov.split("end_of_record").find(r => r.includes("SF:subject.ts"));
+  expect(record).toMatch(/FNF:2\nFNH:2\n/);
+  expect(stderr).toMatch(/ subject\.ts +\| +100\.00 +\| +100\.00 +\| +\n/);
+  expect(stderr).toContain("2 pass");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -523,16 +523,19 @@ test("--parallel --reporter=junit writes the same document as a serial run", asy
     "b.test.js": `import {test,expect} from "bun:test"; test("tb <needs> & 'escaping'", () => expect(1).toBe(1));`,
   };
   using dir = tempDir("parallel-junit-parity", files);
-  const run = async (...extra: string[]) => {
+  const run = async (name: string, ...extra: string[]) => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", ...extra, "--reporter=junit", "--reporter-outfile=out.xml"],
+      cmd: [bunExe(), "test", ...extra, "--reporter=junit", `--reporter-outfile=${name}.xml`],
       env: bunEnv,
       cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const xml = await Bun.file(String(dir) + "/out.xml").text();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("3 pass");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+    const xml = await Bun.file(`${dir}/${name}.xml`).text();
     // Per-file <testsuite> blocks keyed by file, with timings and hostname masked.
     const suites: Record<string, string> = {};
     for (const m of xml
@@ -543,8 +546,8 @@ test("--parallel --reporter=junit writes the same document as a serial run", asy
     const header = xml.match(/<testsuites [^>]*>/)![0].replace(/ time="[^"]*"/, "");
     return { stdout, exitCode, suites, header };
   };
-  const serial = await run();
-  const parallel = await run("--parallel=2");
+  const serial = await run("serial");
+  const parallel = await run("parallel", "--parallel=2");
   expect(serial.stdout).not.toContain("PARALLEL");
   expect(parallel.stdout).toContain("PARALLEL");
   expect(Object.keys(serial.suites).sort()).toEqual(["a.test.js", "b.test.js"]);
@@ -555,7 +558,6 @@ test("--parallel --reporter=junit writes the same document as a serial run", asy
     '<failure type="AssertionError" message="expect(received).toBe(expected)',
   );
   expect(parallel.suites["a.test.js"]).toMatch(/<testsuite name="inner"[^>]* line="\d+"/);
-  expect([serial.exitCode, parallel.exitCode]).toEqual([1, 1]);
 });
 
 test("--parallel --reporter=junit keeps the suites of files a worker finished before it crashed", async () => {
@@ -671,28 +673,37 @@ test("--parallel --coverage prints merged text table", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("--coverage enforces coverageThreshold with either reporter, serial and --parallel", async () => {
+test.each([
+  ["lcov", "--parallel=2"],
+  ["text", "--parallel=2"],
+  ["lcov", ""],
+  ["text", ""],
+])("--coverage --coverage-reporter=%s %s enforces coverageThreshold", async (reporter, mode) => {
   using dir = tempDir("parallel-coverage-threshold", {
     "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,
     "lib.js": `export function used() { return 1; }\nexport function unused() { return 2; }\nexport function alsoUnused() { return 3; }\n`,
     "a.test.js": `import {test,expect} from "bun:test"; import {used} from "./lib.js"; test("a",()=>expect(used()).toBe(1));`,
     "b.test.js": `import {test,expect} from "bun:test"; import {used} from "./lib.js"; test("b",()=>expect(used()).toBe(1));`,
   });
-
-  for (const [reporter, ...mode] of [["lcov", "--parallel=2"], ["text", "--parallel=2"], ["lcov"], ["text"]]) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", ...mode, "--coverage", `--coverage-reporter=${reporter}`, "--coverage-dir=./cov"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.includes("PARALLEL")).toBe(mode.length > 0);
-    expect(stderr).toContain("2 pass");
-    // lib.js has 1/3 functions covered → below 0.9 threshold → must fail.
-    expect({ reporter, mode, exitCode }).toEqual({ reporter, mode, exitCode: 1 });
-  }
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "test",
+      ...(mode ? [mode] : []),
+      "--coverage",
+      `--coverage-reporter=${reporter}`,
+      "--coverage-dir=./cov",
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.includes("PARALLEL")).toBe(mode !== "");
+  expect(stderr).toContain("2 pass");
+  // lib.js has 1/3 functions covered → below 0.9 threshold → must fail.
+  expect(exitCode).toBe(1);
 });
 
 test("--parallel --dots prints one status character per test", async () => {

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -508,6 +508,56 @@ test("--parallel --reporter=junit produces a merged report covering all files", 
   expect(exitCode).toBe(1);
 });
 
+test("--parallel --reporter=junit writes the same document as a serial run", async () => {
+  const files = {
+    "a.test.js": `import {test,expect,describe} from "bun:test";
+      describe("outer", () => {
+        describe("inner", () => {
+          test("passes", () => expect(1).toBe(1));
+          test("fails", () => expect(1).toBe(2));
+        });
+        test.skip("skipped", () => {});
+        test.todo("todo");
+      });
+      test("top level", () => expect(1).toBe(1));`,
+    "b.test.js": `import {test,expect} from "bun:test"; test("tb <needs> & 'escaping'", () => expect(1).toBe(1));`,
+  };
+  using dir = tempDir("parallel-junit-parity", files);
+  const run = async (...extra: string[]) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...extra, "--reporter=junit", "--reporter-outfile=out.xml"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const xml = await Bun.file(String(dir) + "/out.xml").text();
+    // Per-file <testsuite> blocks keyed by file, with timings and hostname masked.
+    const suites: Record<string, string> = {};
+    for (const m of xml
+      .replace(/ (time|hostname)="[^"]*"/g, "")
+      .matchAll(/^  <testsuite name="([^"]+)"[^]*?^  <\/testsuite>\n/gm)) {
+      suites[m[1]] = m[0];
+    }
+    const header = xml.match(/<testsuites [^>]*>/)![0].replace(/ time="[^"]*"/, "");
+    return { stdout, exitCode, suites, header };
+  };
+  const serial = await run();
+  const parallel = await run("--parallel=2");
+  expect(serial.stdout).not.toContain("PARALLEL");
+  expect(parallel.stdout).toContain("PARALLEL");
+  expect(Object.keys(serial.suites).sort()).toEqual(["a.test.js", "b.test.js"]);
+  expect(parallel.suites).toEqual(serial.suites);
+  expect(parallel.header).toEqual(serial.header);
+  // The failure detail captured in the worker made it across.
+  expect(parallel.suites["a.test.js"]).toContain(
+    '<failure type="AssertionError" message="expect(received).toBe(expected)',
+  );
+  expect(parallel.suites["a.test.js"]).toMatch(/<testsuite name="inner"[^>]* line="\d+"/);
+  expect([serial.exitCode, parallel.exitCode]).toEqual([1, 1]);
+});
+
 test("--parallel --reporter=junit keeps the suites of files a worker finished before it crashed", async () => {
   using dir = tempDir("parallel-junit-crash", {
     "aslow.test.js": `import {test,expect} from "bun:test"; test("slow", async () => { await Bun.sleep(400); expect(1).toBe(1); });`,
@@ -621,7 +671,7 @@ test("--parallel --coverage prints merged text table", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("--parallel --coverage enforces coverageThreshold with lcov-only reporter", async () => {
+test("--coverage enforces coverageThreshold with either reporter, serial and --parallel", async () => {
   using dir = tempDir("parallel-coverage-threshold", {
     "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,
     "lib.js": `export function used() { return 1; }\nexport function unused() { return 2; }\nexport function alsoUnused() { return 3; }\n`,
@@ -629,19 +679,19 @@ test("--parallel --coverage enforces coverageThreshold with lcov-only reporter",
     "b.test.js": `import {test,expect} from "bun:test"; import {used} from "./lib.js"; test("b",()=>expect(used()).toBe(1));`,
   });
 
-  for (const reporter of ["lcov", "text"] as const) {
+  for (const [reporter, ...mode] of [["lcov", "--parallel=2"], ["text", "--parallel=2"], ["lcov"], ["text"]]) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--parallel=2", "--coverage", `--coverage-reporter=${reporter}`, "--coverage-dir=./cov"],
+      cmd: [bunExe(), "test", ...mode, "--coverage", `--coverage-reporter=${reporter}`, "--coverage-dir=./cov"],
       env: bunEnv,
       cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toContain("PARALLEL");
+    expect(stdout.includes("PARALLEL")).toBe(mode.length > 0);
     expect(stderr).toContain("2 pass");
     // lib.js has 1/3 functions covered → below 0.9 threshold → must fail.
-    expect({ reporter, exitCode }).toEqual({ reporter, exitCode: 1 });
+    expect({ reporter, mode, exitCode }).toEqual({ reporter, mode, exitCode: 1 });
   }
 });
 

--- a/test/internal/runner-junit.test.ts
+++ b/test/internal/runner-junit.test.ts
@@ -73,17 +73,23 @@ describe("parseJunitFileSuites", () => {
   });
 
   test("reports the suite bun test --parallel writes for a file whose worker crashed", () => {
-    // Written by the coordinator instead of the worker's reporter; its testcase has no
-    // file attribute, so the file counts as failed without a case to show.
+    // The coordinator records a synthetic failing case for the file, after any
+    // cases the worker reported before it died.
     const xml = `<testsuites name="bun test" tests="1" assertions="0" failures="1" skipped="0" time="0.3">
-  <testsuite name="test/crash.test.ts" file="test/crash.test.ts" tests="1" assertions="0" failures="1" skipped="0" time="0">
-    <testcase name="(worker crashed)" classname="test/crash.test.ts">
-      <failure message="worker process crashed before reporting results"></failure>
+  <testsuite name="test/crash.test.ts" file="test/crash.test.ts" tests="1" assertions="0" failures="1" skipped="0" time="0.12" hostname="h">
+    <testcase name="(worker crashed)" classname="" time="0" file="test/crash.test.ts" assertions="0">
+      <failure type="Error" message="worker process crashed before reporting results" />
     </testcase>
   </testsuite>
 </testsuites>
 `;
-    expect(parse(xml)).toEqual({ "test/crash.test.ts": { failures: 1, seconds: 0, cases: [] } });
+    expect(parse(xml)).toEqual({
+      "test/crash.test.ts": {
+        failures: 1,
+        seconds: 0.12,
+        cases: [{ name: "(worker crashed)", message: "worker process crashed before reporting results" }],
+      },
+    });
   });
 
   test("reports nothing for a report without file suites", () => {
@@ -142,7 +148,11 @@ test("parseJunitFileSuites reads the report bun test --parallel --reporter=junit
       ],
     },
     "test/plain.test.ts": { failures: 0, seconds: expect.any(Number), cases: [] },
-    "test/crash.test.ts": { failures: 1, seconds: 0, cases: [] },
+    "test/crash.test.ts": {
+      failures: 1,
+      seconds: expect.any(Number),
+      cases: [{ name: "(worker crashed)", message: "worker process crashed before reporting results" }],
+    },
   });
   expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
### What

`bun test --parallel` workers used to render their own LCOV text and JUnit XML fragments, and the coordinator re-parsed them to merge (line-splitting LCOV and summing `DA:`/max-ing `FNH:`, scraping `tests=`/`failures=` attributes out of XML). This replaces that with: the child sends the underlying data as binary frames, the parent merges it and runs the one set of writers the serial path already uses.

- **Coverage** — the unit is `code_coverage::Report` (per file: executable/executed line bitsets, line hits, function and basic-block byte ranges + executed bits). Workers encode it with `code_coverage::wire` (one `CoverageFile` frame per file). The coordinator folds them per path with `MergedReport` (hits summed, executed unioned, functions/blocks unioned by byte range, executable lines by the #39930 rule) and prints through `print_coverage_reports()` — the same function the serial `--coverage` path now calls. No text/lcov writer in aggregate.rs any more.
- **JUnit** — the unit is `TestCaseReport` (file, describe path, name, status, assertions, duration, line, captured `TestFailure`). Serial hands it to `JunitReporter::record_test_case`; a worker appends it to its `TestDone` frame; the coordinator buffers per file and replays them in file order into its own `JunitReporter`. Workers never construct a `JunitReporter` and no XML crosses IPC.

`aggregate.rs` goes from 441 lines to ~60. Net −200 lines overall.

### Behaviour changes

- Fixes #40586: function coverage is unioned across workers by byte range, so `% Funcs`/`FNH` no longer under-report when different workers execute different functions of a file (supersedes #40590 without synthesising `FN:`/`FNDA:` names).
- `--parallel --reporter=junit` now includes `line=` attributes and nested `describe` suites exactly as a serial run does (previously workers had no line numbers). New test asserts the parallel document equals the serial one modulo `time`/`hostname`.
- A file whose worker crashed keeps the test cases it reported before the crash in the JUnit document, plus the synthetic `(worker crashed)` failure.
- Text reporter: the last uncovered line range of a file was never printed in `Uncovered Line #s` (serial and parallel-after-this-change shared that writer); fixed, one snapshot updated.
- `coverageThreshold` is now enforced with the lcov-only reporter outside `--parallel` too (docs previously called this out as unenforced; `--parallel` already enforced it). Docs updated.
- `--parallel --reporter=junit` with zero recorded tests writes no file, matching serial (previously wrote an empty `<testsuites>`).

### Tests

- `test/cli/test/coverage.test.ts`: new `--parallel merges function coverage across workers` (two files rendezvous at import so they must run in different workers; fails on 1.4.0 with `FNH:1`).
- `test/cli/test/parallel.test.ts`: new `--parallel --reporter=junit writes the same document as a serial run`; threshold test now covers serial + parallel × text + lcov.
- Existing `coverage.test.ts`, `parallel.test.ts`, `test/js/junit-reporter/junit.test.js`, `regression/issue/26851` pass on the debug build.
