### PR TITLE
Bump WebKit (oven-sh/WebKit#526 preview): honor a deferred GC request at the next VM entry

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f5deafe090cfda095a6f54a00f24a3c2d7784986";
+export const WEBKIT_VERSION = "autobuild-preview-pr-526-6473271a";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "86e19b8edd7c2309b4eb41fcd73df96664d6a2d1";
+export const WEBKIT_VERSION = "f5deafe090cfda095a6f54a00f24a3c2d7784986";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "0bb01ed52617cb9a0530cf8aa07c73c0e8e09510";
+export const WEBKIT_VERSION = "86e19b8edd7c2309b4eb41fcd73df96664d6a2d1";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3853,7 +3853,7 @@ static void collectStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleLo
 }
 
 // Register the collected modules as fetched. When the closure is complete, every module any of them can reach is in it,
-// so they are marked loaded outright — [[LoadedModules]] filled and loadPromise settled — and JSC's graph walk finishes
+// so they are marked loaded outright — [[LoadedModules]] filled and the entry marked loaded — and JSC's graph walk finishes
 // without a HostLoadImportedModule call or microtask per edge. Otherwise they are left the way JSC's own
 // fetch -> makeModule chain leaves them and JSC runs one load step per module to finish the job.
 static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleLoader* loader, StandaloneClosure& closure)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3865,7 +3865,7 @@ static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleL
         auto* entry = loader->ensureRegistered(globalObject, m.key, ScriptFetchParameters::Type::JavaScript);
         RETURN_IF_EXCEPTION(scope, void());
         RELEASE_ASSERT(!entry->record()); // nothing between collect and register can register one of these keys
-        entry->provideModule(vm, m.source, m.record);
+        entry->provideModule(vm, m.record);
         releaseModuleInfo(globalObject, m.source);
     }
     if (!closure.complete)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3801,7 +3801,7 @@ static void collectStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleLo
                 continue;
             if (auto* entry = loader->registryEntry(key)) {
                 // Usable as a loaded dependency only if the loader already finished loading that module's own subgraph.
-                if (entry->record() && entry->loadPromise() && entry->loadPromise()->status() == JSPromise::Status::Fulfilled)
+                if (entry->record() && entry->isLoaded())
                     closure.records.add(key.impl(), entry->record());
                 else
                     closure.complete = false;
@@ -3865,8 +3865,7 @@ static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleL
         auto* entry = loader->ensureRegistered(globalObject, m.key, ScriptFetchParameters::Type::JavaScript);
         RETURN_IF_EXCEPTION(scope, void());
         RELEASE_ASSERT(!entry->record()); // nothing between collect and register can register one of these keys
-        entry->provideModule(globalObject, m.source, m.record);
-        RETURN_IF_EXCEPTION(scope, void());
+        entry->provideModule(vm, m.source, m.record);
         releaseModuleInfo(globalObject, m.source);
     }
     if (!closure.complete)
@@ -3880,14 +3879,8 @@ static void registerStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleL
             RETURN_IF_EXCEPTION(scope, void());
         }
     }
-    for (auto& m : closure.modules) {
-        auto* entry = loader->registryEntry(m.key);
-        if (!entry->loadPromise()) {
-            JSPromise* loaded = JSPromise::create(vm, globalObject->promiseStructure());
-            loaded->fulfill(vm, m.record);
-            entry->setLoadPromise(vm, loaded);
-        }
-    }
+    for (auto& m : closure.modules)
+        loader->registryEntry(m.key)->markLoaded();
 }
 
 JSC::JSPromise* StandaloneGlobalObject::moduleLoaderFetch(JSGlobalObject* jsGlobalObject, JSModuleLoader* loader, JSValue key, RefPtr<JSC::ScriptFetchParameters> parameters, RefPtr<JSC::ScriptFetcher> fetcher)


### PR DESCRIPTION
### What

Points `WEBKIT_VERSION` at the preview build of oven-sh/WebKit#526 (`autobuild-preview-pr-526-6473271a`) so the full test matrix runs against it — in particular `test/cli/run/require-cache.test.ts` on Windows x64, which has failed on `main` since the 8c4fd56347 WebKit upgrade (#40276).

Stacked on #40674 because the preview is built on oven-sh/WebKit `main`, which already contains the module-loader changes that PR adapts to. The only change on top of #40674 is the version string. Draft: for CI validation of the WebKit change; the real bump lands once oven-sh/WebKit#526 is merged.

### Why

`require-cache.test.ts › via require() with a lot of function calls` re-requires a 100 KB module 500 times, does `Bun.gc(true)`, and reads RSS. What it trips over is not a leak: JSC leaves a GC request pending (`m_didDeferGCWork`) when it is raised under `DeferGCForAWhile` — which is where the ~4 MB/iteration of CodeBlock metadata and baseline JIT code is reported — and nothing on this path picks it up for 30–90 iterations, so 100–280 MB of dead CodeBlocks pile into MarkedBlocks that are never swept again until the final synchronous GC, whose freed pages libpas returns ~100–250 ms after the test has read RSS. The WebKit PR honors the pending request at the next VM entry; details and measurements (perf/RSS/CPU across 17 workloads, GC counts unchanged) are in oven-sh/WebKit#526.
