### PR TITLE
fetch, node:fs: take PathBuffer scratch from the pool in fetch_impl and NodeFS

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1331,7 +1331,7 @@ unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
         None
     };
     bun_core::heap::into_raw(Box::new(NodeFS {
-        sync_error_buf: bun_paths::PathBuffer::uninit(),
+        sync_error_buf: bun_paths::path_buffer_pool::get(),
         vm: vm_field,
     }))
     .cast::<c_void>()

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4433,9 +4433,7 @@ impl Default for NodeFS {
 }
 
 impl NodeFS {
-    /// A fresh `NodeFS` on the heap. `sync_error_buf` makes the struct
-    /// `MAX_PATH_BYTES` large (96 KB on Windows), so a stack local of it costs
-    /// that much frame in every caller, taken or not.
+    /// Heap allocated: `sync_error_buf` makes this struct 96 KB on Windows.
     pub(crate) fn new_boxed() -> Box<Self> {
         // SAFETY: all-zero bytes are a valid `NodeFS`: `sync_error_buf` is a
         // `u8` array and a null `Option<NonNull<_>>` is `None`.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4432,6 +4432,17 @@ impl Default for NodeFS {
     }
 }
 
+impl NodeFS {
+    /// A fresh `NodeFS` on the heap. `sync_error_buf` makes the struct
+    /// `MAX_PATH_BYTES` large (96 KB on Windows), so a stack local of it costs
+    /// that much frame in every caller, taken or not.
+    pub(crate) fn new_boxed() -> Box<Self> {
+        // SAFETY: all-zero bytes are a valid `NodeFS`: `sync_error_buf` is a
+        // `u8` array and a null `Option<NonNull<_>>` is `None`.
+        unsafe { Box::<Self>::new_zeroed().assume_init() }
+    }
+}
+
 /// Encode a path returned by the OS (`mkdtemp`/`readlink`/`realpath`) using the
 /// caller's `encoding` option, matching Node.js: `"buffer"` yields a `Buffer`
 /// of the raw bytes, any other encoding is `Buffer.from(bytes).toString(enc)`.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4408,7 +4408,6 @@ pub mod ret {
 
 pub struct NodeFS {
     /// Scratch for a temporary file path that might appear in a returned error message.
-    /// Pooled on the heap: a `PathBuffer` is 96 KB on Windows and a `NodeFS` is often a stack local.
     pub(crate) sync_error_buf: paths::path_buffer_pool::Guard,
     pub(crate) vm: Option<NonNull<VirtualMachine>>,
 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4406,38 +4406,19 @@ pub mod ret {
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/fs.d.ts
 // ──────────────────────────────────────────────────────────────────────────
 
-// `#[repr(C)]` pins `sync_error_buf` (a `[u8; N]`, nominal align = 1) at
-// offset 0. The struct's overall alignment is ≥ `align_of::<*const ()>()`
-// (from the `vm` field), so the buffer's address inherits that alignment.
-// This is load-bearing on Windows where `sync_error_buf` is reinterpreted as
-// `&mut [u16]` / `&mut WPathBuffer` (see `mkdir_recursive_os_path_impl` and
-// the `os_path_kernel32` callers); a misaligned `&mut [u16]` is instant UB.
-#[repr(C)]
 pub struct NodeFS {
-    /// Buffer to store a temporary file path that might appear in a returned error message.
-    ///
-    /// We want to avoid allocating a new path buffer for every error message so that jsc can clone + GC it.
-    /// That means a stack-allocated buffer won't suffice. Instead, we re-use
-    /// the heap allocated buffer on the NodeFS struct
-    pub(crate) sync_error_buf: PathBuffer, // must be align_of::<u16>()-aligned — enforced via #[repr(C)] + field order, see above
+    /// Scratch for a temporary file path that might appear in a returned error message.
+    /// Pooled on the heap: a `PathBuffer` is 96 KB on Windows and a `NodeFS` is often a stack local.
+    pub(crate) sync_error_buf: paths::path_buffer_pool::Guard,
     pub(crate) vm: Option<NonNull<VirtualMachine>>,
 }
 
 impl Default for NodeFS {
     fn default() -> Self {
         Self {
-            sync_error_buf: PathBuffer::uninit(),
+            sync_error_buf: paths::path_buffer_pool::get(),
             vm: None,
         }
-    }
-}
-
-impl NodeFS {
-    /// Heap allocated: `sync_error_buf` makes this struct 96 KB on Windows.
-    pub(crate) fn new_boxed() -> Box<Self> {
-        // SAFETY: all-zero bytes are a valid `NodeFS`: `sync_error_buf` is a
-        // `u8` array and a null `Option<NonNull<_>>` is `None`.
-        unsafe { Box::<Self>::new_zeroed().assume_init() }
     }
 }
 
@@ -5550,8 +5531,8 @@ impl NodeFS {
             }
         }
 
-        // SAFETY: `NodeFS` is `#[repr(C)]` with `sync_error_buf` at offset 0 and
-        // struct alignment ≥ pointer-align (from `vm`), so this address is
+        // SAFETY: `sync_error_buf` is a pooled heap allocation, and every
+        // supported allocator aligns it to at least 8 bytes, so this address is
         // ≥ `align_of::<OSPathChar>()`-aligned. On Windows
         // `OSPathBuffer = [u16; PATH_MAX_WIDE]` (65 534 B) which fits inside
         // `PathBuffer` (`MAX_PATH_BYTES` = 98 302 B); on POSIX it is the same
@@ -5560,7 +5541,7 @@ impl NodeFS {
         // `&mut PathBuffer` without reborrowing `&mut self` (which would alias
         // `working_mem` under stacked borrows). On every such path `working_mem` is
         // not used afterward, so the re-derive is sound.
-        let sync_error_buf_ptr: *mut PathBuffer = &raw mut self.sync_error_buf;
+        let sync_error_buf_ptr: *mut PathBuffer = &raw mut *self.sync_error_buf;
         assert!(
             sync_error_buf_ptr.cast::<OSPathChar>().is_aligned(),
             "NodeFS.sync_error_buf misaligned for OSPathChar",

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -47,7 +47,6 @@ use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
 use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _, URLJsc as _};
-use bun_paths::{self, PathBuffer};
 use bun_sys::FdExt as _;
 // `FromJsEnum for FetchRedirect` lives in bun_http_jsc; importing the impl crate
 // brings the trait impl into scope for `JSValue::get_optional_enum::<FetchRedirect>`.
@@ -1267,8 +1266,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // We don't pass along headers, we ignore method, we ignore status code...
     // But it's better than status quo.
     if url_type != URLType::Remote {
-        let mut path_buf = PathBuffer::uninit();
-        let mut path_buf2 = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
+        let mut path_buf2 = bun_paths::path_buffer_pool::get();
         let decoded_len = match PercentEncoding::decode_into(
             &mut path_buf2[..],
             match url_type {
@@ -1347,11 +1346,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 }
 
                 #[cfg(windows)]
-                let mut cwd_buf = PathBuffer::uninit();
+                let mut cwd_buf = bun_paths::path_buffer_pool::get();
                 #[cfg(windows)]
                 // `bun_sys::getcwd` returns the byte length written into
                 // `cwd_buf`; slice it here.
-                let cwd: &[u8] = match bun_sys::getcwd(&mut cwd_buf) {
+                let cwd: &[u8] = match bun_sys::getcwd(&mut cwd_buf[..]) {
                     Ok(len) => &cwd_buf[..len],
                     Err(err) => {
                         return Err(global_this.throw_error(err, "Failed to resolve file url"));
@@ -1517,10 +1516,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     }
     if body.needs_to_read_file() {
         'prepare_body: {
-            // A local `PathBuffer` serves as NUL-termination scratch for
-            // `path.slice_z()` (the `vm.node_fs()` accessor is gated behind a
-            // jsc↔runtime cycle).
-            let mut open_path_buf = PathBuffer::uninit();
+            let mut open_path_buf = bun_paths::path_buffer_pool::get();
             let opened_fd_res: bun_sys::Result<bun_sys::Fd> = {
                 let store = body.store().expect("needs_to_read_file implies store");
                 match &store.data.as_file().pathlike {
@@ -1617,10 +1613,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // TODO: make this async + lazy
             let blob_offset = body.any_blob().blob().offset.get();
             let blob_size = body.any_blob().blob().size.get();
-            // The `vm.node_fs()` accessor is a jsc↔runtime cycle. `read_file`
-            // with an `Fd` path only touches `self.sync_error_buf` for
-            // path-variant inputs, so a fresh `NodeFS` is sufficient here.
-            let mut node_fs = node::fs::NodeFS::default();
+            // `read_file` with an `Fd` path only touches `self.sync_error_buf`
+            // for path-variant inputs, so a fresh `NodeFS` is sufficient here.
+            let mut node_fs = node::fs::NodeFS::new_boxed();
             // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
             let mut rf_args = node::fs::args::ReadFile::default();
             rf_args.encoding = Encoding::Buffer;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1614,7 +1614,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             let blob_offset = body.any_blob().blob().offset.get();
             let blob_size = body.any_blob().blob().size.get();
             // A fresh `NodeFS` suffices: `read_file` on an `Fd` never touches `sync_error_buf`.
-            let mut node_fs = node::fs::NodeFS::new_boxed();
+            let mut node_fs = node::fs::NodeFS::default();
             // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
             let mut rf_args = node::fs::args::ReadFile::default();
             rf_args.encoding = Encoding::Buffer;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1613,8 +1613,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // TODO: make this async + lazy
             let blob_offset = body.any_blob().blob().offset.get();
             let blob_size = body.any_blob().blob().size.get();
-            // `read_file` with an `Fd` path only touches `self.sync_error_buf`
-            // for path-variant inputs, so a fresh `NodeFS` is sufficient here.
+            // A fresh `NodeFS` suffices: `read_file` on an `Fd` never touches `sync_error_buf`.
             let mut node_fs = node::fs::NodeFS::new_boxed();
             // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
             let mut rf_args = node::fs::args::ReadFile::default();

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -27,6 +27,41 @@ test("Response.bytes() with async iterable body does not crash with null deref",
   expect(exitCode).toBe(0);
 });
 
+// Each level of this recursion holds one native fetch() frame on the stack.
+// Windows used to reach 16 levels before the RangeError because that frame
+// carried three 96 KB path buffers (Linux: 387 levels with the same script).
+// A debug build of the fix reaches 96 on Windows; stock 1.4.1 reaches 16.
+test("fetch() called from a body's Symbol.asyncIterator getter recurses deeply before the stack limit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      let depth = 0;
+      const signal = AbortSignal.abort();
+      const body = {
+        get [Symbol.asyncIterator]() {
+          depth++;
+          fetch("http://localhost/", { method: "POST", body, signal }).catch(() => {});
+          return undefined;
+        },
+      };
+      fetch("http://localhost/", { method: "POST", body, signal }).catch(() => {});
+      console.log(depth);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(Number(stdout.trim())).toBeGreaterThanOrEqual(32);
+  expect(exitCode).toBe(0);
+});
+
 test("Response.arrayBuffer() with async iterable body does not crash with null deref", async () => {
   await using proc = Bun.spawn({
     cmd: [


### PR DESCRIPTION
### Problem
- Every `fetch()` on Windows x64 reserves about 297 KB of native stack (the `fetch_impl<false>` prologue in 1.4.0: `movl $0x48bb8, %eax; callq __chkstk`). Linux: 11 KB.
- `fetch_impl` (`src/runtime/webcore/fetch.rs`) holds five `PathBuffer`-sized locals, three live at once, and a `PathBuffer` is 98 302 bytes on Windows. One of the five is a `NodeFS`, which embeds a `PathBuffer` by value, so every `NodeFS::default()` stack local in the tree (15 sites) is 96 KB too.
- A body whose `Symbol.asyncIterator` getter calls `fetch()` again recurses 16 levels on Windows before the RangeError, 387 on Linux.

### Fix
- The four `PathBuffer` locals come from `bun_paths::path_buffer_pool::get()`: a 16-byte guard on the stack, the buffer on the heap.
- `NodeFS::sync_error_buf` becomes a `path_buffer_pool::Guard`. `NodeFS` shrinks to two words and every `NodeFS::default()` site with it. `#[repr(C)]` goes: the `u16` reinterpretation now relies on the heap allocation's alignment, which the existing `assert!` checks.
- Correct because each buffer is write-only scratch that does not outlive its owner, and the pool hands out the same `PathBuffer` type. A probe over file:, blob: and `Bun.file()` bodies (Notes) gives identical output before and after.
- Verified: `test/js/web/fetch/body-async-iterator.test.ts`, which stock 1.4.1 fails on Windows (16 < 32). Windows debug build: 9 levels before, 96 after. Windows-host clippy `large_stack_frames` (128 KB threshold): 45 functions before, 38 after.

### Background
- `PathBuffer` is `[u8; MAX_PATH_BYTES]`: 4096 bytes on Linux, 1024 on macOS, 98 302 on Windows.
- `bun_paths::path_buffer_pool` caches up to four heap `PathBuffer`s per thread behind an RAII guard, for exactly this problem.
- A function reserves the stack slots of all its locals in its prologue, taken branch or not. On Windows `__chkstk` then probes every page of the frame: 73 pages per `fetch()` call here.
- JSC checks its 5 MB stack budget in JS prologues. Bun's main and worker threads reserve 18 MB on Windows, so the big frame costs per-call work and shallow re-entrant recursion, not an overflow.

<details><summary>Notes</summary>

- The five locals: `path_buf`, `path_buf2`, `cwd_buf` (Windows only) in the file:/blob: branch, `open_path_buf` and `NodeFS::sync_error_buf` in the `Bun.file()` body branch. The two branches never run together, so the compiler shares their slots and the frame holds three buffers. On Linux `cwd_buf` does not exist: 2 x 4 KB plus 3 KB of other locals matches the 11 KB prologue.
- The test cannot fail on Linux on the unfixed build: `PathBuffer` is 4 KB there, so the recursion already reaches 387 levels (release) or 57 (debug, ASAN). It fails on Windows only. Measured on windows-x64 with stock `1.4.1-canary`: `Expected: >= 32, Received: 16`. With this branch, the Windows debug build reaches 96 and the Linux debug build 71. The test passed on every CI lane, including both Windows release lanes.
- Threshold: 32 is twice the unfixed Windows number and a third of the fixed Windows debug number. Release builds have smaller frames and reach more levels.
- The test uses a pre-aborted `AbortSignal`, so the recursion happens in body extraction and no socket is opened (`strace -e connect` shows zero calls).
- clippy numbers: `cargo clippy -p bun_runtime --no-deps` on a Windows host (`large_stack_frames` is `deny` in `Cargo.toml` with `stack-size-threshold = 131072`, but CI runs clippy on Linux only; #37605 adds the Windows target). Functions that leave the list: `fetch.rs:385` `fetch_impl` (539 424 bytes estimated, clippy does not model slot sharing), `node_fs.rs:4427` `NodeFS::default`, `node_fs_binding.rs:126` `Binding::new`, `jsc_hooks.rs:1323` `create_node_fs`, `Blob.rs:4285`, `test_command.rs:1668`, `aggregate.rs:164`. The 38 that remain are mostly CLI commands; the JS-facing ones are `Listener.rs:176` (`Bun.listen`, 206 KB), `path.rs:1355` (`path.resolve`, 197 KB), `node_fs.rs:8258` (297 KB), `copy_file.rs:1475` (199 KB), `glob.rs:33` (296 KB) and `filesystem_router.rs:109` (203 KB). Those are follow-ups.
- Why not the per-VM `NodeFS` (`VirtualMachine::node_fs()`) for the fetch read: when `NodeFS.vm` is set (standalone executables), `read_file` claims the VM pipe-read scratch and returns a `MarkedArrayBuffer` created in the JSC heap. The fetch caller copies `result.slice()` and calls `destroy()`, which is a no-op for that buffer, so it would work but leave a dead ArrayBuffer per `Bun.file()` body. A fresh `NodeFS` with `vm: None` is what the code did before, and it is now cheap.
- Pre-existing and unchanged by this PR: on a Windows debug build, `fetch("file:rel.txt")` panics at `debug_assert!(crate::is_absolute_windows(maybe_posix_path))` in `resolve_cwd_with_external_buf_z`. The URL parser turns the input into the path `/rel.txt`, `is_absolute` accepts the leading slash, then the Windows branch strips it and passes the relative `rel.txt` to the normalizer. Release builds skip the assertion and open the file relative to cwd. Reproduced on main.
- Suites run: `fetch.test.ts` (same 25 release / 41 debug environment failures before and after, all `Unable to connect` to a `localhost` listener or debug timeouts), `fetch-file-upload.test.ts`, `blob.test.ts`, `fetch-compress.test.ts`, `body.test.ts`, `fetch-args.test.ts`, `regression/issue/29787.test.ts`, `node/fs/{fs,fs-mkdir,fs-path-length,cp,promises}.test`, `bun-write.test.js`, `bun-file.test.ts`, `shell/commands/mkdir.test.ts`, `blob-write.test.ts`, `test/internal/source-lints`. On Windows: `body-async-iterator`, `fs`, `fs-mkdir`, `fs-path-length`, `readdir-windows-ntstatus`, `rm-windows-ntstatus`, `bun-file-windows`, `bun-write`. The one failure seen (`readSync > works on large files`, 5 s timeout) also times out with the stock canary on that machine.
- Probe script (run with both builds, output diffed on Linux and Windows):

```js
await fetch(pathToFileURL(dir + "/rel.txt").href);            // abs
await fetch(href.replace("rel.txt", "rel%2Etxt"));            // percent-decoded
await fetch(pathToFileURL(dir).href);                         // EISDIR
await fetch(URL.createObjectURL(new Blob(["blob-body"])));    // blob:
await fetch(url, { method: "POST", body: Bun.file(small) });  // read_file path
await fetch(url, { method: "POST", body: Bun.file(big64k) }); // sendfile path
await fetch(url, { method: "POST", body: Bun.file(big64k).slice(100, 1100) });
await fetch(url, { method: "POST", body: Bun.file(missing) }); // ENOENT
await fetch(url, { method: "POST", body: Bun.file(openSync(small, "r")) }); // fd
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body-async-iterator.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/167] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/167] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 7 sinks, 84 exported symbols
Generating /workspace/bun/build/debug/codegen/JSSink.lut.h from /workspace/bun/build/debug/codegen/JSSink.lut.txt
[3/167] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (d699f46e0)

test/js/web/fetch/body-async-iterator.test.ts:
(pass) Response.bytes() with async iterable body does not crash with null deref [8.22ms]
(pass) fetch() called from a body's Symbol.asyncIterator getter recurses deeply before the stack limit [14.42ms]
(pass) Response.arrayBuffer() with async iterable body does not crash with null deref [8.96ms]

 3 pass
 0 fail
 7 expect() calls
Ran 3 tests across 1 file. [142.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body-async-iterator.test.ts
bun test v1.4.1 (65362b53b)

test/js/web/fetch/body-async-iterator.test.ts:
(pass) Response.bytes() with async iterable body does not crash with null deref [429.16ms]
(pass) fetch() called from a body's Symbol.asyncIterator getter recurses deeply before the stack limit [510.71ms]
(pass) Response.arrayBuffer() with async iterable body does not crash with null deref [446.47ms]

 3 pass
 0 fail
 7 expect() calls
Ran 3 tests across 1 file. [4.33s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 877ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/127] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/127] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/jsc_hooks.rs                      |  2 +-
 src/runtime/node/node_fs.rs                   | 23 +++++-------------
 src/runtime/webcore/fetch.rs                  | 18 +++++---------
 test/js/web/fetch/body-async-iterator.test.ts | 35 +++++++++++++++++++++++++++
 4 files changed, 48 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/jsc_hooks.rs                           1      2      0
src/runtime/node/node_fs.rs                       10      7      0
src/runtime/webcore/fetch.rs                       9      9      0
test/js/web/fetch/body-async-iterator.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->