### PR TITLE
Bun.file(Uint8Array): stop keeping the path buffer alive forever

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -127,7 +127,7 @@ async call; `StringOrBuffer`: borrowed for a sync call) and
 `StringOrBuffer::PinnedBuffer` (pinned and GC-rooted, parsed for an async
 call). Values parsed from JS for an async call, stored, or sent to another thread (the
 `from_js_async` parsers, which return `ThreadIsolated<T>`;
-`PathLike::thread_isolated_copy` for a `Blob` store) is `'static`.
+`PathLike::thread_isolated_copy` for a `Blob` store, which always owns its bytes) are `'static`.
 
 `EncodedSlice<'a>` is the `{ptr, len}` + encoding-bits (Latin-1/UTF-8/UTF-16)
 borrowed view handed to C++. Constructors name the encoding of the bytes:

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -645,9 +645,8 @@ impl ArrayBuffer {
 
 /// A JS ArrayBuffer/view whose backing store is pinned (cannot be detached or
 /// moved) for as long as this value lives; [`root`](Self::root) additionally
-/// GC-roots the cell. `Drop` releases what was taken. Constructed on the JS
-/// thread; a `root()`ed value is dropped there too, while a `pin()`-only value
-/// held by a `Blob` store drops wherever the store's last ref goes.
+/// GC-roots the cell. `Drop` releases what was taken. Constructed and
+/// dropped on the JS thread.
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
@@ -742,8 +741,7 @@ impl Drop for PinnedArrayBuffer {
     }
 }
 
-// SAFETY: a pin and GC protection on a heap cell; constructed on the JS thread,
-// and a rooted value is dropped there (a pin-only one may drop with its `Blob` store).
+// SAFETY: a pin and GC protection on a heap cell; constructed and dropped on the JS thread.
 unsafe impl crate::job::JsAffine for PinnedArrayBuffer {}
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -83,17 +83,14 @@ impl<'a> PathLike<'a> {
 
 impl PathLike<'static> {
     /// For a path a `Blob` store keeps (dropped on any thread): a JS-backed
-    /// string becomes a private copy never handed to JS; a buffer stays
-    /// pinned and is GC-protected for good.
+    /// string becomes a private copy never handed to JS, a buffer's bytes are
+    /// copied and its pin released here.
     pub fn thread_isolated_copy(self) -> Self {
         match self {
             Self::String(s) | Self::ThreadIsolatedString(s) => {
                 Self::ThreadIsolatedString(s.thread_isolated_copy())
             }
-            Self::Buffer(b) => {
-                b.value.protect();
-                Self::Buffer(b)
-            }
+            Self::Buffer(b) => Self::Utf8(Utf8Bytes::Owned(b.slice().to_vec())),
             Self::Utf8(s) => Self::Utf8(s),
         }
     }

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -155,3 +155,31 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
   });
   expect(exitCode).toBe(0);
 });
+
+test("Bun.file(Uint8Array) does not keep the Uint8Array alive", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { heapStats } = require("bun:jsc");
+        const path = new TextEncoder().encode(process.execPath);
+        const files = [];
+        for (let i = 0; i < 200; i++) files.push(Bun.file(new Uint8Array(path)));
+        Bun.gc(true);
+        // The Blobs are still alive; only the path buffers they were created from should be collectable.
+        console.log(heapStats().objectTypeCounts.Uint8Array ?? 0, files.length, await files[199].exists());
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const [count, files, exists] = stdout.trim().split(" ");
+  expect({ files, exists }).toEqual({ files: "200", exists: "true" });
+  expect(Number(count)).toBeLessThan(100);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -183,3 +183,17 @@ test("Bun.file(Uint8Array) does not keep the Uint8Array alive", async () => {
   expect(Number(count)).toBeLessThan(100);
   expect(exitCode).toBe(0);
 });
+
+test("a file created from a buffer path owns a copy of the path", async () => {
+  // Writing to the buffer after the call must not change which file the Blob refers to.
+  const path = new TextEncoder().encode(process.execPath);
+  const file = Bun.file(path);
+  path.fill(0);
+  expect(file.name).toBe(process.execPath);
+  expect(await file.exists()).toBe(true);
+
+  const s3Path = Buffer.from("s3://bucket/key.txt");
+  const s3File = Bun.s3.file(s3Path);
+  s3Path.fill(0x41);
+  expect(s3File.name).toBe("bucket/key.txt");
+});


### PR DESCRIPTION
### What does this PR do?

`Bun.file(path)` / `Bun.s3(path)` with a `Uint8Array`/`Buffer` path called `JSValue::protect()` on the buffer when the path moved into the `Blob`'s store, and nothing ever unprotected it — a store is refcounted, shared across threads, and its last ref can drop inside a GC finalizer, where `unprotect()` isn't allowed. So every such call leaked the typed array for the life of the process (`Bun.file(new Uint8Array(p))` ×500 → 501 live `Uint8Array`s after GC on 1.4), and the file's path kept aliasing the caller's buffer, so mutating the buffer afterwards changed which file the `Blob` referred to.

A store-held path now always owns its bytes: `PathLike::thread_isolated_copy` copies a buffer path (paths are short; a string path already paid the same one copy via `thread_isolated_copy`) and releases the pin right there on the JS thread. With that, `PinnedArrayBuffer` is only ever dropped on the JS thread, which its docs now say.

### How did you verify your code works?

New test in `test/js/bun/util/bun-file.test.ts`: 200 `Bun.file(new Uint8Array(path))` with the Blobs kept alive, GC, then `heapStats().objectTypeCounts.Uint8Array` must be < 100 (201 with `USE_SYSTEM_BUN=1` on 1.4.0, 1 with this change) and the last file still `exists()`. Also checked that zero-filling the buffer after `Bun.file()` no longer affects `file.name`/`exists()`.

Added in 4869b39 (adopted by @robobun): a second test in the same file for the aliasing. It fills the buffer after `Bun.file(buf)` and after `Bun.s3.file(buf)`, then checks `file.name` and `exists()`. On the current release `file.name` reads the zeroed bytes and `exists()` is false. With this change the path is an independent copy. Both `thread_isolated_copy` callers are covered: the file store (`find_or_create_file_from_path`) and the S3 store (`Store::init_s3`). The rooted variant (`Bun.write(new Uint8Array(path), data)` on the async path) also no longer leaks: 50 calls leave 2 live `Uint8Array`s after GC on a debug build.

The two CI failures on build 107188 (`url.test.ts` on macOS x64, `require-cache.test.ts` on Windows x64 and Linux x64-asan) are pre-existing on main and do not touch this diff.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [73.99ms]
(pass) writer.end() should not close the fd if it does not own the fd [112.03ms]
(pass) Bun.file() read errors include async stack frames [14.55ms]
(pass) Bun.write() errors include async stack frames [25.62ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [10.50ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [356.83ms]
178 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
179 | 
180 |   expect(stderr).toBe("");
181 |   const [count, files, exists] = stdout.trim().split(" ");
182 |   expect({ files, exists }).toEqual({ files: "200", exists: "true" });
183 |   expect(Number(count)).toBeLessThan(100);
                              ^
error: expect(received).toBeLessThan(expected)

Expected: < 100
Received: 201

      at <anonymous> (/workspace/bun/test/js/bun/util/
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [1.68ms]
(pass) writer.end() should not close the fd if it does not own the fd [2.45ms]
(pass) Bun.file() read errors include async stack frames [0.24ms]
(pass) Bun.write() errors include async stack frames [1.02ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [0.15ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [9.43ms]
178 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
179 | 
180 |   expect(stderr).toBe("");
181 |   const [count, files, exists] = stdout.trim().split(" ");
182 |   expect({ files, exists }).toEqual({ files: "200", exists: "true" });
183 |   expect(Number(count)).toBeLessThan(100);
                              ^
error: expect(received).toBeLessThan(expected)

Expected: < 100
Received: 201

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-file.test.ts:183:25)
(fail) Bun.file(Uint8Array) does not keep the Uint8Array alive [6.98ms]
187 | test("a file created from a buffer path owns a copy of the path
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [90.61ms]
(pass) writer.end() should not close the fd if it does not own the fd [107.46ms]
(pass) Bun.file() read errors include async stack frames [14.85ms]
(pass) Bun.write() errors include async stack frames [25.49ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [11.52ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [366.97ms]
(pass) Bun.file(Uint8Array) does not keep the Uint8Array alive [489.07ms]
(pass) a file created from a buffer path owns a copy of the path [11.29ms]

 8 pass
 0 fail
 56 expect() calls
Ran 8 tests across 1 file. [3.24s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4869b39455
  features     baseline

23 deps, 131 codegen, 1172 objects in 879ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [6.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1244] gen bindgenv2
[4/1244] gen ErrorCode+*.h
[5/1244] fetch zlib
[zlib] up to date
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[7/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[8/1244] gen .bind.ts → GeneratedBindings.cpp
[9/1244] fetch tinycc
[tinycc] up to date
[10/1243] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSB
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/CLAUDE.md                     |  2 +-
 src/jsc/array_buffer.rs           |  8 +++-----
 src/jsc/node_path.rs              |  9 +++------
 test/js/bun/util/bun-file.test.ts | 42 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 49 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/CLAUDE.md                          0      0      0
src/jsc/array_buffer.rs                1      0      0
src/jsc/node_path.rs                   1      0      0
test/js/bun/util/bun-file.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->