### PR TITLE
streams: treat a falsy controller.close(reason) as a clean close

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -218,6 +218,10 @@ protected:
 JSObject* createJSSinkPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WebCore::SinkID sinkID);
 JSObject* createJSSinkControllerPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WebCore::SinkID sinkID);
 Structure* createJSSinkControllerStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WebCore::SinkID sinkID);
+// readStreamIntoSink's close for a failed source: \`error\` reaches the sink
+// whatever its value. The controller's JS close(error) reads a falsy argument
+// as a clean close instead.
+void closeSinkControllerWithError(JSC::JSGlobalObject*, JSReadableSinkControllerBase*, JSC::JSValue error);
 } // namespace WebCore
 `;
   var templ = outer;
@@ -368,18 +372,13 @@ size_t ${controller}::estimatedSize(JSCell* cell, JSC::VM& vm) {
     return Base::estimatedSize(cell, vm) + ${controller}::memoryCost(uncheckedDowncast<${controller}>(cell)->wrapped());
 }
 
-JSC_DECLARE_HOST_FUNCTION(${controller}__close);
-JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame *callFrame))
+// The body of the controller's close(). \`reason\` is the empty value for a
+// clean close; any other value, undefined included, tells the sink its
+// source failed with that reason.
+static JSC::EncodedJSValue ${controller}__closeWithReason(JSC::JSGlobalObject* lexicalGlobalObject, WebCore::${controller}* controller, JSC::EncodedJSValue reason)
 {
-    
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
-    WebCore::${controller}* controller = dynamicDowncast<WebCore::${controller}>(callFrame->thisValue());
-    if (!controller) {
-        scope.throwException(globalObject, JSC::createTypeError(globalObject, "Expected ${controller}"_s));
-        return JSC::JSValue::encode(JSC::jsUndefined());
-    }
 
     void *ptr = controller->wrapped();
     if (ptr == nullptr) {
@@ -394,10 +393,7 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
     ${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
     controller->m_sinkPtr = nullptr;
 
-    // A failed source closes with its error (possibly undefined); a clean
-    // close passes no argument, encoded as the empty value.
-    ${name}__close(lexicalGlobalObject, ptr,
-        callFrame->argumentCount() > 0 ? JSC::JSValue::encode(callFrame->argument(0)) : JSC::JSValue::encode(JSC::JSValue()));
+    ${name}__close(lexicalGlobalObject, ptr, reason);
 
     // detach() must still fire onClose (it transitions the direct
     // ReadableStream to closed/errored and calls underlyingSource.cancel())
@@ -417,6 +413,26 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
     controller->detach();
     RETURN_IF_EXCEPTION(scope, {});
     return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+JSC_DECLARE_HOST_FUNCTION(${controller}__close);
+JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame *callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
+    WebCore::${controller}* controller = dynamicDowncast<WebCore::${controller}>(callFrame->thisValue());
+    if (!controller) {
+        scope.throwException(globalObject, JSC::createTypeError(globalObject, "Expected ${controller}"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    // close(error?): a falsy argument is the same clean close as close(),
+    // the truthiness rule readDirectStreamCloseImpl uses for its reason. The
+    // pump reports a failed source through closeSinkControllerWithError.
+    JSC::JSValue error = callFrame->argument(0);
+    JSC::EncodedJSValue reason = error.toBoolean(lexicalGlobalObject) ? JSC::JSValue::encode(error) : JSC::JSValue::encode(JSC::JSValue());
+    RELEASE_AND_RETURN(scope, ${controller}__closeWithReason(lexicalGlobalObject, controller, reason));
 }
 
 JSC_DECLARE_HOST_FUNCTION(${controller}__end);
@@ -1022,6 +1038,21 @@ ${classes
   )
   .join("\n")}
 }
+
+namespace WebCore {
+
+void closeSinkControllerWithError(JSC::JSGlobalObject* globalObject, JSReadableSinkControllerBase* controller, JSC::JSValue error)
+{
+    JSC::EncodedJSValue reason = JSC::JSValue::encode(error);
+${classes
+  .map(
+    name =>
+      `    if (auto* typed = dynamicDowncast<${names(name).controller}>(controller)) { ${names(name).controller}__closeWithReason(globalObject, typed, reason); return; }`,
+  )
+  .join("\n")}
+}
+
+} // namespace WebCore
 `;
   return templ;
 }

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -915,8 +915,14 @@ static JSValue rsisSinkEnd(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStre
     return invokeMethod(vm, globalObject, op->m_sink.get(), builtinNames(vm).endPublicName(), noArgs);
 }
 
+// The source failed with `error`, which can be falsy (`controller.error()` with no reason). A native
+// sink gets the failure directly: its JS close(error) reads a falsy argument as a clean close.
 static void rsisSinkClose(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* sink, JSValue error)
 {
+    if (auto* controller = dynamicDowncast<WebCore::JSReadableSinkControllerBase>(sink)) {
+        WebCore::closeSinkControllerWithError(globalObject, controller, error);
+        return;
+    }
     MarkedArgumentBuffer args;
     args.append(error);
     ASSERT(!args.hasOverflowed());

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -313,10 +313,10 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue>;
     fn flush(&mut self) -> sys::Result<()>;
     fn start(&mut self, config: streams::Start) -> sys::Result<()>;
-    /// `controller.close(reason)` with an argument: the pump's source failed,
-    /// so the bytes written so far are a truncated body. `reason` is the
-    /// source's error and may be nullish. The default keeps the clean end for
-    /// sinks whose owner handles the pump promise rejection.
+    /// The source failed, so the bytes written so far are a truncated body:
+    /// `controller.close(error)` with a truthy argument, or the pump's close
+    /// for an errored stream, whose `reason` may be nullish. The default keeps
+    /// the clean end for sinks whose owner handles the pump promise rejection.
     ///
     /// Raw pointer: failing can re-enter the sink through its owner and may
     /// free it.
@@ -635,10 +635,11 @@ impl<T: JsSinkType> JSSink<T> {
     }
 
     /// `${abi_name}__close` body — called from
-    /// `${controller}__close` and `${name}__doClose` in JSSink.cpp with a raw
-    /// `m_sinkPtr` (not a host-fn callframe), so exceptions become `.zero`.
-    /// `reason` is the `close(reason)` argument, or the empty value when
-    /// `close()` had no argument.
+    /// `${controller}__closeWithReason` and `${name}__doClose` in JSSink.cpp
+    /// with a raw `m_sinkPtr` (not a host-fn callframe), so exceptions become
+    /// `.zero`. `reason` is the empty value for a clean close (`close()`, a
+    /// falsy `close(reason)` argument, or the sink's own `close()`), otherwise
+    /// the failed source's reason, which the pump may pass as `undefined`.
     ///
     /// # Safety
     /// `this` is the cell's live sink.

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1930,6 +1930,68 @@ describe("s3 upload stream body error", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A `type: "direct"` pull() ends the body through the sink controller's own
+  // `close(error?)`. The argument is optional, so a falsy one is the same clean
+  // close as `close()`: the bytes written so far are the object and the PUT
+  // goes out. Only a truthy error aborts the upload.
+  it.each([
+    ["", "resolved 12", { "/my_bucket/obj": 12, "/my_bucket/ok": 1 }],
+    ["undefined", "resolved 12", { "/my_bucket/obj": 12, "/my_bucket/ok": 1 }],
+    ["null", "resolved 12", { "/my_bucket/obj": 12, "/my_bucket/ok": 1 }],
+    ["false", "resolved 12", { "/my_bucket/obj": 12, "/my_bucket/ok": 1 }],
+    ['""', "resolved 12", { "/my_bucket/obj": 12, "/my_bucket/ok": 1 }],
+    ["new Error('boom')", "rejected boom", { "/my_bucket/ok": 1 }],
+  ])("a direct stream body that calls controller.close(%s)", async (closeArg, expectedOutcome, expectedPuts) => {
+    const fixture = `
+      const puts = {};
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const key = new URL(req.url).pathname;
+          puts[key] = (puts[key] ?? 0) + (await req.arrayBuffer()).byteLength;
+          return new Response(undefined, { status: 200, headers: { ETag: '"etag"' } });
+        },
+      });
+      const client = new Bun.S3Client({
+        accessKeyId: "test",
+        secretAccessKey: "test",
+        region: "eu-west-3",
+        bucket: "my_bucket",
+        endpoint: \`http://127.0.0.1:\${server.port}\`,
+        virtualHostedStyle: false,
+      });
+      const rs = new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          controller.write("<b>hello</b>");
+          controller.close(${closeArg});
+        },
+      });
+      const outcome = await client.write("obj", new Response(rs)).then(
+        bytes => "resolved " + bytes,
+        e => "rejected " + e.message,
+      );
+      const after = await client.write("ok", "x");
+      server.stop(true);
+      console.log(JSON.stringify({ outcome, after, puts }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      // The S3 client honors the proxy environment; the stub is on loopback.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      outcome: expectedOutcome,
+      after: 1,
+      puts: expectedPuts,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   // A native ByteStream source (fetch response body) that errors mid-stream must
   // reject the s3.write() promise with the original JS error, not commit a
   // truncated PUT or reject with a generic UnknownError.

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -525,6 +525,33 @@ describe("HTMLRewriter", () => {
       expect(settled).toEqual({ rejected: reason });
     });
 
+    // A `type: 'direct'` pull() ends the input through the sink controller's
+    // own `close(error?)`. The argument is optional: a falsy one is the same
+    // clean close as `close()` and the body resolves with the rewritten HTML.
+    // Only a truthy error fails the rewrite.
+    it.each([
+      ["close()", c => c.close(), { resolved: "<p>hello</p>" }],
+      ["close(undefined)", c => c.close(undefined), { resolved: "<p>hello</p>" }],
+      ["close(null)", c => c.close(null), { resolved: "<p>hello</p>" }],
+      ["close(false)", c => c.close(false), { resolved: "<p>hello</p>" }],
+      ['close("")', c => c.close(""), { resolved: "<p>hello</p>" }],
+      ["close(error)", c => c.close(new Error("source boom")), { rejected: "source boom" }],
+    ])("a direct ReadableStream input whose pull() ends with %s", async (_, close, expected) => {
+      const stream = new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          controller.write("<p>hello</p>");
+          close(controller);
+        },
+      });
+      const res = new HTMLRewriter().on("p", { element() {} }).transform(new Response(stream));
+      const settled = await res.text().then(
+        text => ({ resolved: text }),
+        err => ({ rejected: err instanceof Error ? err.message : err }),
+      );
+      expect(settled).toEqual(expected);
+    });
+
     // A `type: 'direct'` source whose `pull()` throws synchronously leaves the
     // JS controller's `m_sinkPtr` set after `readDirectStream` returns with an
     // exception; `end_from_stream` must null it (via `JSSink::detach`) before


### PR DESCRIPTION
### Problem
- A `type: "direct"` ReadableStream whose `pull()` ends with `controller.close(undefined)` (or `null`, `false`, `""`) is treated as a failed source. `S3Client.write` sends no PutObject and rejects with `ReadableStream ended with an error`. `HTMLRewriter.transform(...).text()` rejects with `undefined`. 1.4.0 commits the PUT and resolves the text. `close()` is unaffected.
- Cause: #40669 made the generated `${controller}__close` (`src/codegen/generate-jssink.ts`) forward `argument(0)` whenever `argumentCount() > 0`, so `JSSink::js_close` (`src/runtime/webcore/Sink.rs`) routed `undefined` to `close_with_error`. The pump (`rsisAbrupt`, `BunStreamSource.cpp`) reports a failed source through the same JS method, and its error can itself be `undefined`.

### Fix
- The JS-facing `close(error?)` treats a falsy argument as a clean close, the truthiness rule `readDirectStreamCloseImpl` already uses for the same value. The host function body moves to a shared `${controller}__closeWithReason`, where an empty `reason` is a clean close.
- The pump gets its own entry, `WebCore::closeSinkControllerWithError`, which dispatches on the controller class and always delivers the failure, `undefined` included. `rsisSinkClose` uses it for native sink controllers.
- Correct because the two callers mean different things by the same value: user code passes an optional error, the pump passes "the source failed, with this reason". The Rust contract in `js_close` is unchanged: empty means clean, anything else means failed.
- Verified: `test/js/bun/s3/s3.test.ts` and `test/js/workerd/html-rewriter.test.js` (six new rows each, four per file fail on main). Also the serve direct stream, streams, spawn stdin, fetch body and backpressure suites.

### Background
- A native sink (`JsSinkType` in `Sink.rs`) is a Rust writer behind a JS controller object. For a `type: "direct"` stream, `pull(controller)` receives that sink controller, so the user's `controller.close()` is the generated host function.
- `readStreamIntoSink` is the pump for non-direct streams. When the source errors, `rsisAbrupt` closes the sink with the error, then rejects the pump promise.
- `JsSinkType::close_with_error` is the #40669 hook: `NetworkSink` (S3) aborts the upload, `RewriterPipe` fails the rewrite, every other sink keeps the clean end.

<details><summary>Notes</summary>

Repro on main (debug build, same results with `null`, `false`, `""`):

```js
const mk = () => new ReadableStream({ type: "direct", pull(c) { c.write("<b>hello</b>"); c.close(undefined); } });
await new HTMLRewriter().transform(new Response(mk())).text(); // rejects with undefined
await s3.write("k", new Response(mk()));                       // rejects, no PUT on the wire
```

`close(new Error("boom"))` on a direct stream keeps the #40669 behavior: no PUT, the promise rejects with `boom`, the HTMLRewriter body rejects with the error. Both test files pin that row too.

The `error() without a reason` rows from #40669 still pass: that path is the pump, which now calls `closeSinkControllerWithError(controller, undefined)` and reaches `close_with_error` as before.

`readableStreamCancel` on a stream bound to a native sink also calls the JS `close(reason)`. `cancel()` with no reason is a clean close again (as in 1.4.0), `cancel(error)` fails the sink.

Suites run: `serve-direct-readable-stream.test.ts`, `serve-stream-body-error.test.ts`, `streams.test.js`, `spawn-stdin-readable-stream*.test.ts`, `body.test.ts`, `body-stream.test.ts`, `fetch.stream.test.ts`, `fetch-backpressure.test.ts`. In the last one, the four `h3 receive backpressure` tests time out in this container when the whole file runs and pass in isolation. They fail the same way on an unmodified build of main here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js

<!-- robobun:evidence:end -->