### PR TITLE
Bun.serve: write 16-bit header values as latin-1 bytes, not UTF-8

### DIFF
--- a/src/jsc/bindings/HTTPLatin1String.h
+++ b/src/jsc/bindings/HTTPLatin1String.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "root.h"
+#include <span>
+#include <string_view>
+#include <wtf/Vector.h>
+#include <wtf/text/StringView.h>
+
+// SIMD kernels defined in highway_strings.cpp.
+extern "C" size_t highway_first_non_ascii16(const uint16_t* input, size_t len);
+extern "C" void highway_copy_u16_to_u8(const uint16_t* input, size_t count, uint8_t* output);
+
+namespace Bun {
+
+// The wire bytes of an HTTP header name or value: one byte per code unit (https://fetch.spec.whatwg.org/#concept-header-value).
+class HTTPLatin1String {
+    WTF_MAKE_NONCOPYABLE(HTTPLatin1String);
+
+public:
+    explicit HTTPLatin1String(const WTF::StringView& string)
+    {
+        if (string.is8Bit()) {
+            const auto span = string.span8();
+            m_view = { reinterpret_cast<const char*>(span.data()), span.size() };
+            return;
+        }
+
+        const auto span = string.span16();
+        const auto* input = reinterpret_cast<const uint16_t*>(span.data());
+        m_buffer.grow(span.size());
+        uint8_t* output = m_buffer.mutableSpan().data();
+
+        const size_t asciiPrefix = highway_first_non_ascii16(input, span.size());
+        highway_copy_u16_to_u8(input, asciiPrefix, output);
+        // Header validation rejects code units above 0xFF; '?' matches String::latin1() if one gets through.
+        for (size_t i = asciiPrefix; i < span.size(); i++)
+            output[i] = isLatin1(span[i]) ? static_cast<uint8_t>(span[i]) : '?';
+
+        m_view = { reinterpret_cast<const char*>(output), span.size() };
+    }
+
+    std::string_view view() const { return m_view; }
+
+private:
+    WTF::Vector<uint8_t, 64> m_buffer;
+    std::string_view m_view;
+};
+
+} // namespace Bun

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -369,6 +369,21 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     return JSValue::encode(returnValue);
 }
 
+// https://fetch.spec.whatwg.org/#concept-header-value
+// Header values are ByteStrings: isomorphic-encode (1 code unit = 1 byte), not
+// UTF-8, so a 16-bit string must produce the same bytes as the equal 8-bit one.
+// isValidHTTPHeaderValue and node:http's checkInvalidHeaderChar already reject
+// code units > 0xFF; like String::latin1(), anything else becomes '?'.
+static WTF::CString latin1FromUTF16(std::span<const char16_t> characters)
+{
+    std::span<char> buffer;
+    WTF::CString result = WTF::CString::newUninitialized(characters.size(), buffer);
+    size_t i = 0;
+    for (auto character : characters)
+        buffer[i++] = isLatin1(character) ? static_cast<char>(character) : '?';
+    return result;
+}
+
 template<bool isSSL>
 static void writeResponseHeader(uWS::HttpResponse<isSSL>* res, const WTF::StringView& name, const WTF::StringView& value)
 {
@@ -391,7 +406,7 @@ static void writeResponseHeader(uWS::HttpResponse<isSSL>* res, const WTF::String
         const auto valueSpan = value.span8();
         valueView = std::string_view(reinterpret_cast<const char*>(valueSpan.data()), valueSpan.size());
     } else {
-        valueStr = value.utf8();
+        valueStr = latin1FromUTF16(value.span16());
         valueView = std::string_view(valueStr.data(), valueStr.length());
     }
 
@@ -426,7 +441,7 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
             const auto valueSpan = value.span8();
             res->writeHeader(std::string_view("set-cookie", 10), std::string_view(reinterpret_cast<const char*>(valueSpan.data()), valueSpan.size()));
         } else {
-            WTF::CString valueStr = value.utf8();
+            WTF::CString valueStr = latin1FromUTF16(value.span16());
             res->writeHeader(std::string_view("set-cookie", 10), std::string_view(valueStr.data(), valueStr.length()));
         }
     }
@@ -879,7 +894,7 @@ static void writeFetchHeadersToStreamResponse(WebCore::FetchHeaders& headers, Re
             const auto s = value.span8();
             valueView = std::string_view(reinterpret_cast<const char*>(s.data()), s.size());
         } else {
-            valueStr = value.utf8();
+            valueStr = latin1FromUTF16(value.span16());
             valueView = std::string_view(valueStr.data(), valueStr.length());
         }
         res->writeHeader(nameView, valueView);
@@ -890,7 +905,7 @@ static void writeFetchHeadersToStreamResponse(WebCore::FetchHeaders& headers, Re
             const auto s = value.span8();
             res->writeHeader(std::string_view("set-cookie", 10), std::string_view(reinterpret_cast<const char*>(s.data()), s.size()));
         } else {
-            WTF::CString v = value.utf8();
+            WTF::CString v = latin1FromUTF16(value.span16());
             res->writeHeader(std::string_view("set-cookie", 10), std::string_view(v.data(), v.length()));
         }
     }

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -369,11 +369,8 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     return JSValue::encode(returnValue);
 }
 
-// https://fetch.spec.whatwg.org/#concept-header-value
-// Header values are ByteStrings: isomorphic-encode (1 code unit = 1 byte), not
-// UTF-8, so a 16-bit string must produce the same bytes as the equal 8-bit one.
-// isValidHTTPHeaderValue and node:http's checkInvalidHeaderChar already reject
-// code units > 0xFF; like String::latin1(), anything else becomes '?'.
+// Header values are ByteStrings (https://fetch.spec.whatwg.org/#concept-header-value):
+// one byte per code unit on the wire, not UTF-8. Same '?' fallback as String::latin1().
 static WTF::CString latin1FromUTF16(std::span<const char16_t> characters)
 {
     std::span<char> buffer;

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -10,6 +10,7 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSFunction.h>
 #include "JSFetchHeaders.h"
+#include "HTTPLatin1String.h"
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Response.h>
 #include <bun-uws/src/Http2Context.h>
@@ -369,44 +370,13 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     return JSValue::encode(returnValue);
 }
 
-// Header values are ByteStrings (https://fetch.spec.whatwg.org/#concept-header-value): one byte per code unit, like String::latin1().
-static WTF::CString latin1FromUTF16(std::span<const char16_t> characters)
-{
-    std::span<char> buffer;
-    WTF::CString result = WTF::CString::newUninitialized(characters.size(), buffer);
-    size_t i = 0;
-    for (auto character : characters)
-        buffer[i++] = isLatin1(character) ? static_cast<char>(character) : '?';
-    return result;
-}
-
 template<bool isSSL>
 static void writeResponseHeader(uWS::HttpResponse<isSSL>* res, const WTF::StringView& name, const WTF::StringView& value)
 {
-    WTF::CString nameStr;
-    WTF::CString valueStr;
-
-    std::string_view nameView;
-    std::string_view valueView;
-
-    if (name.is8Bit()) {
-        const auto nameSpan = name.span8();
-        ASSERT(name.containsOnlyASCII());
-        nameView = std::string_view(reinterpret_cast<const char*>(nameSpan.data()), nameSpan.size());
-    } else {
-        nameStr = name.utf8();
-        nameView = std::string_view(nameStr.data(), nameStr.length());
-    }
-
-    if (value.is8Bit()) {
-        const auto valueSpan = value.span8();
-        valueView = std::string_view(reinterpret_cast<const char*>(valueSpan.data()), valueSpan.size());
-    } else {
-        valueStr = latin1FromUTF16(value.span16());
-        valueView = std::string_view(valueStr.data(), valueStr.length());
-    }
-
-    res->writeHeader(nameView, valueView);
+    ASSERT(name.containsOnlyASCII());
+    HTTPLatin1String nameBytes(name);
+    HTTPLatin1String valueBytes(value);
+    res->writeHeader(nameBytes.view(), valueBytes.view());
 }
 
 // Connection is `1#connection-option` (RFC 9112 §9.3): look for the "close"
@@ -432,14 +402,8 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     auto& internalHeaders = headers.internalHeaders();
 
     for (auto& value : internalHeaders.getSetCookieHeaders()) {
-
-        if (value.is8Bit()) {
-            const auto valueSpan = value.span8();
-            res->writeHeader(std::string_view("set-cookie", 10), std::string_view(reinterpret_cast<const char*>(valueSpan.data()), valueSpan.size()));
-        } else {
-            WTF::CString valueStr = latin1FromUTF16(value.span16());
-            res->writeHeader(std::string_view("set-cookie", 10), std::string_view(valueStr.data(), valueStr.length()));
-        }
+        HTTPLatin1String valueBytes(value);
+        res->writeHeader(std::string_view("set-cookie", 10), valueBytes.view());
     }
 
     auto* data = res->getHttpResponseData();
@@ -877,33 +841,15 @@ static void writeFetchHeadersToStreamResponse(WebCore::FetchHeaders& headers, Re
     auto* data = res->getHttpResponseData();
 
     auto writeOne = [&](const WTF::StringView& name, const WTF::StringView& value) {
-        WTF::CString nameStr, valueStr;
-        std::string_view nameView, valueView;
-        if (name.is8Bit()) {
-            const auto s = name.span8();
-            nameView = std::string_view(reinterpret_cast<const char*>(s.data()), s.size());
-        } else {
-            nameStr = name.utf8();
-            nameView = std::string_view(nameStr.data(), nameStr.length());
-        }
-        if (value.is8Bit()) {
-            const auto s = value.span8();
-            valueView = std::string_view(reinterpret_cast<const char*>(s.data()), s.size());
-        } else {
-            valueStr = latin1FromUTF16(value.span16());
-            valueView = std::string_view(valueStr.data(), valueStr.length());
-        }
-        res->writeHeader(nameView, valueView);
+        ASSERT(name.containsOnlyASCII());
+        HTTPLatin1String nameBytes(name);
+        HTTPLatin1String valueBytes(value);
+        res->writeHeader(nameBytes.view(), valueBytes.view());
     };
 
     for (auto& value : internalHeaders.getSetCookieHeaders()) {
-        if (value.is8Bit()) {
-            const auto s = value.span8();
-            res->writeHeader(std::string_view("set-cookie", 10), std::string_view(reinterpret_cast<const char*>(s.data()), s.size()));
-        } else {
-            WTF::CString v = latin1FromUTF16(value.span16());
-            res->writeHeader(std::string_view("set-cookie", 10), std::string_view(v.data(), v.length()));
-        }
+        HTTPLatin1String valueBytes(value);
+        res->writeHeader(std::string_view("set-cookie", 10), valueBytes.view());
     }
 
     for (const auto& header : internalHeaders.commonHeaders()) {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -369,8 +369,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     return JSValue::encode(returnValue);
 }
 
-// Header values are ByteStrings (https://fetch.spec.whatwg.org/#concept-header-value):
-// one byte per code unit on the wire, not UTF-8. Same '?' fallback as String::latin1().
+// Header values are ByteStrings (https://fetch.spec.whatwg.org/#concept-header-value): one byte per code unit, like String::latin1().
 static WTF::CString latin1FromUTF16(std::span<const char16_t> characters)
 {
     std::span<char> buffer;

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -110,6 +110,36 @@ describe("response header values are isomorphic-encoded on the wire", () => {
     expect(headerHex(await rawResponse(server.port, "/8"), "set-cookie")).toEqual(expected);
     expect(headerHex(await rawResponse(server.port, "/16"), "set-cookie")).toEqual(expected);
   });
+
+  test("long values and values that start with a non-ASCII char", async () => {
+    // 300 ASCII code units, then latin-1, then digits: longer than the writer's inline buffer.
+    const units = Array.from({ length: 300 }, (_, i) => 0x41 + (i % 26));
+    units.push(0xe9, 0x80, 0xff, ...Array.from({ length: 100 }, (_, i) => 0x30 + (i % 10)));
+    const values: Record<string, Uint16Array> = {
+      long: new Uint16Array(units),
+      lead: new Uint16Array([0xe9, 0x61]),
+      ascii: new Uint16Array([0x61, 0x62, 0x63]),
+    };
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch(req) {
+        const url = new URL(req.url);
+        const codeUnits = values[url.pathname.slice(1)];
+        const value =
+          url.searchParams.get("bits") === "16"
+            ? new TextDecoder("utf-16le").decode(codeUnits)
+            : String.fromCharCode(...codeUnits);
+        return new Response("ok", { headers: { "x-t": value } });
+      },
+    });
+
+    for (const [name, codeUnits] of Object.entries(values)) {
+      const expected = [[...codeUnits].map(c => c.toString(16).padStart(2, "0")).join(" ")];
+      expect(headerHex(await rawResponse(server.port, `/${name}?bits=8`), "x-t")).toEqual(expected);
+      expect(headerHex(await rawResponse(server.port, `/${name}?bits=16`), "x-t")).toEqual(expected);
+    }
+  });
 });
 
 // RFC 9112 §9.6: a server that sends "Connection: close" MUST close the

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -37,6 +37,81 @@ test("weird headers", async () => {
   }
 });
 
+// https://fetch.spec.whatwg.org/#concept-header-value
+// Header values are ByteStrings: U+00E9 goes out as the single byte 0xE9, not as
+// UTF-8 0xC3 0xA9. The bytes must not depend on whether JSC stores the string as
+// 8-bit (a literal) or 16-bit (TextDecoder, normalize(), JSON.parse output).
+describe("response header values are isomorphic-encoded on the wire", () => {
+  const eightBit = "caf\u00e9-\u0080\u00ff";
+  // A utf-16le decode always yields a 16-bit string, even for latin-1 content.
+  const sixteenBit = new TextDecoder("utf-16le").decode(new Uint16Array([0x63, 0x61, 0x66, 0xe9, 0x2d, 0x80, 0xff]));
+  const expectedHex = "63 61 66 e9 2d 80 ff";
+
+  async function rawResponse(port: number, path: string): Promise<string> {
+    const socket = net.connect(port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+      let raw = "";
+      await new Promise<void>(resolve => {
+        socket.on("data", chunk => (raw += chunk.toString("latin1")));
+        socket.on("close", resolve);
+      });
+      return raw;
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  function headerHex(raw: string, name: string): string[] {
+    const head = raw.split("\r\n\r\n")[0];
+    return head
+      .split("\r\n")
+      .filter(line => line.toLowerCase().startsWith(name + ":"))
+      .map(line =>
+        [...Buffer.from(line.slice(name.length + 2), "latin1")].map(c => c.toString(16).padStart(2, "0")).join(" "),
+      );
+  }
+
+  test("Response headers", async () => {
+    expect(sixteenBit).toBe(eightBit);
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch(req) {
+        const value = new URL(req.url).pathname === "/16" ? sixteenBit : eightBit;
+        return new Response("ok", { headers: { "x-t": value } });
+      },
+    });
+
+    expect(headerHex(await rawResponse(server.port, "/8"), "x-t")).toEqual([expectedHex]);
+    expect(headerHex(await rawResponse(server.port, "/16"), "x-t")).toEqual([expectedHex]);
+
+    // A fetch() client reads the same value back, not mojibake.
+    const res = await fetch(`http://127.0.0.1:${server.port}/16`);
+    expect(res.headers.get("x-t")).toBe(eightBit);
+  });
+
+  test("Set-Cookie headers", async () => {
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch(req) {
+        const value = new URL(req.url).pathname === "/16" ? sixteenBit : eightBit;
+        const headers = new Headers();
+        headers.append("set-cookie", `a=${value}`);
+        headers.append("set-cookie", `b=${value}`);
+        return new Response("ok", { headers });
+      },
+    });
+
+    const expected = ["61 3d " + expectedHex, "62 3d " + expectedHex];
+    expect(headerHex(await rawResponse(server.port, "/8"), "set-cookie")).toEqual(expected);
+    expect(headerHex(await rawResponse(server.port, "/16"), "set-cookie")).toEqual(expected);
+  });
+});
+
 // RFC 9112 §9.6: a server that sends "Connection: close" MUST close the
 // connection after that response. Bun was emitting the header but leaving the
 // socket in the keep-alive pool, servicing further requests on the "closed"

--- a/test/js/bun/http/serve-http2-fixture.ts
+++ b/test/js/bun/http/serve-http2-fixture.ts
@@ -109,6 +109,19 @@ async function handler(req: Request, server: Bun.Server<undefined>): Promise<Res
           ["x-multi", "2"],
         ],
       });
+    case "/latin1-headers": {
+      // ?bits=16 serves the same value from a 16-bit string (utf-16le decode).
+      const value =
+        url.searchParams.get("bits") === "16"
+          ? new TextDecoder("utf-16le").decode(new Uint16Array([0x63, 0x61, 0x66, 0xe9, 0x2d, 0x80, 0xff]))
+          : "caf\u00e9-\u0080\u00ff";
+      return new Response("ok", {
+        headers: [
+          ["content-disposition", value],
+          ["set-cookie", `a=${value}`],
+        ],
+      });
+    }
     case "/many-headers": {
       const h = new Headers();
       for (let i = 0; i < 3000; i++) h.set("x-header-" + i, "x-value-" + i);

--- a/test/js/bun/http/serve-http2-helpers.ts
+++ b/test/js/bun/http/serve-http2-helpers.ts
@@ -335,6 +335,55 @@ export const baseHeaders = (path: string, method = "GET"): [string, string][] =>
   [":authority", "localhost"],
 ];
 
+export type HpackField = {
+  /** Static or dynamic table index when the whole field, or only its name, is indexed. */
+  index?: number;
+  /** Literal name and value as sent, with their Huffman flags. Absent on a fully indexed field. */
+  name?: { huffman: boolean; bytes: Buffer };
+  value?: { huffman: boolean; bytes: Buffer };
+};
+
+/** Split a header block into its fields (RFC 7541 §6) without decoding them:
+ * indexed fields keep their index, literals keep their raw bytes and Huffman
+ * flag. Enough to check what bytes the server put on the wire for one header. */
+export function hpackFields(block: Buffer): HpackField[] {
+  let pos = 0;
+  const int = (prefixBits: number) => {
+    const max = (1 << prefixBits) - 1;
+    let value = block[pos++] & max;
+    if (value < max) return value;
+    for (let shift = 0; ; shift += 7) {
+      const byte = block[pos++];
+      value += (byte & 0x7f) << shift;
+      if ((byte & 0x80) === 0) return value;
+    }
+  };
+  const str = () => {
+    const huffman = (block[pos] & 0x80) !== 0;
+    const length = int(7);
+    const bytes = block.subarray(pos, pos + length);
+    pos += length;
+    return { huffman, bytes };
+  };
+  const fields: HpackField[] = [];
+  while (pos < block.length) {
+    const first = block[pos];
+    if (first & 0x80) {
+      fields.push({ index: int(7) });
+      continue;
+    }
+    if ((first & 0xe0) === 0x20) {
+      int(5); // dynamic table size update
+      continue;
+    }
+    const index = int(first & 0x40 ? 6 : 4);
+    const field: HpackField = index ? { index } : { name: str() };
+    field.value = str();
+    fields.push(field);
+  }
+  return fields;
+}
+
 /** Just enough HPACK to read the `:status` the server always encodes first:
  * either an indexed static-table entry (200/204/206/304/400/404/500) or a
  * literal with indexed name whose 3-digit value may be Huffman-coded. */

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -16,6 +16,7 @@ import {
   connectH2,
   decodeStatus,
   frame,
+  hpackFields,
   hpackLiteral,
   request,
   sha256,
@@ -157,6 +158,40 @@ for (const secure of [true, false]) {
       expect(res.headers["x-multi"]).toBe("1, 2");
       const viaCookieMap = await request(session, { ":path": "/cookies", cookie: "seen=xx" });
       expect(viaCookieMap.headers["set-cookie"]).toEqual(["seen=xxx; Path=/; SameSite=Lax"]);
+    });
+
+    test("latin-1 header values are one byte per code unit for 8-bit and 16-bit strings", async () => {
+      // https://fetch.spec.whatwg.org/#concept-header-value
+      // U+00E9 is the single byte 0xE9 on the wire, not UTF-8 0xC3 0xA9, whether JSC
+      // stores the string as 8-bit or 16-bit. Both names are in the HPACK static table
+      // (content-disposition = 25, set-cookie = 55), so the fields arrive as literals
+      // with an indexed name. A fresh connection per request keeps the dynamic table
+      // out of the picture.
+      const expected = "63 61 66 e9 2d 80 ff";
+      const hex = (b: Buffer) => [...b].map(c => c.toString(16).padStart(2, "0")).join(" ");
+      for (const bits of ["8", "16"]) {
+        const raw = await RawH2.connect(fx.port, secure);
+        try {
+          await raw.waitFor(f => f.type === T.SETTINGS);
+          raw.headers(1, baseHeaders(`/latin1-headers?bits=${bits}`));
+          const headers = await raw.waitFor(f => f.type === T.HEADERS && f.streamId === 1);
+          const fields = hpackFields(headers.payload);
+          const literal = (index: number) => {
+            const field = fields.find(f => f.index === index && f.value);
+            if (!field?.value) throw new Error(`no literal for static name ${index} in ${JSON.stringify(fields)}`);
+            // These bytes cost more Huffman-coded than raw, so the encoder sends them as is.
+            expect(field.value.huffman).toBe(false);
+            return hex(field.value.bytes);
+          };
+          expect({ bits, "content-disposition": literal(25), "set-cookie": literal(55) }).toEqual({
+            bits,
+            "content-disposition": expected,
+            "set-cookie": "61 3d " + expected,
+          });
+        } finally {
+          raw.close();
+        }
+      }
     });
 
     test("5 MB response body (flow control + socket backpressure)", async () => {

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,14 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  // Bind and connect on the same concrete address. "localhost" can resolve to
+  // ::1 for listen and 127.0.0.1 for connect on a dual-stack host.
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4293,3 +4293,76 @@ test("https 'clientError' for a connection whose handshake completes after close
     raw.destroy();
   }
 });
+
+// Header values are byte strings: Node writes U+00E9 as the single byte 0xE9, never as
+// UTF-8 0xC3 0xA9, whatever the engine's internal representation of the string is. A
+// 16-bit string (TextDecoder, normalize(), JSON.parse output) must produce the same
+// bytes as the equal 8-bit literal. The body is a Buffer so that Node does not glue the
+// header block onto a utf8 string chunk.
+describe("response header values are written as latin-1 bytes", () => {
+  const eightBit = "caf\u00e9-\u0080\u00ff";
+  const sixteenBit = new TextDecoder("utf-16le").decode(new Uint16Array([0x63, 0x61, 0x66, 0xe9, 0x2d, 0x80, 0xff]));
+  const expectedHex = "63 61 66 e9 2d 80 ff";
+
+  async function headerHex(port: number, path: string, name: string): Promise<string[]> {
+    const socket = connect(port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+      let raw = "";
+      await new Promise<void>(resolve => {
+        socket.on("data", chunk => (raw += chunk.toString("latin1")));
+        socket.on("close", resolve);
+      });
+      return raw
+        .split("\r\n\r\n")[0]
+        .split("\r\n")
+        .filter(line => line.toLowerCase().startsWith(name + ":"))
+        .map(line =>
+          [...Buffer.from(line.slice(name.length + 2), "latin1")].map(c => c.toString(16).padStart(2, "0")).join(" "),
+        );
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  async function check(
+    write: (res: ServerResponse, value: string) => void,
+    name: string,
+    expected: string[],
+  ): Promise<void> {
+    expect(sixteenBit).toBe(eightBit);
+    const server = createServer((req, res) => {
+      write(res, req.url === "/16" ? sixteenBit : eightBit);
+      res.end(Buffer.from("ok"));
+    });
+    try {
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { port } = server.address() as AddressInfo;
+      expect(await headerHex(port, "/8", name)).toEqual(expected);
+      expect(await headerHex(port, "/16", name)).toEqual(expected);
+    } finally {
+      server.close();
+    }
+  }
+
+  it("setHeader", async () => {
+    await check((res, value) => res.setHeader("x-t", value), "x-t", [expectedHex]);
+  });
+
+  it("writeHead with an object", async () => {
+    await check((res, value) => res.writeHead(200, { "x-t": value }), "x-t", [expectedHex]);
+  });
+
+  it("writeHead with a flat array", async () => {
+    await check((res, value) => res.writeHead(200, ["x-t", value]), "x-t", [expectedHex]);
+  });
+
+  it("setHeader with a Set-Cookie array", async () => {
+    await check((res, value) => res.setHeader("set-cookie", [`a=${value}`, `b=${value}`]), "set-cookie", [
+      "61 3d " + expectedHex,
+      "62 3d " + expectedHex,
+    ]);
+  });
+});


### PR DESCRIPTION
### Problem
- `Bun.serve` writes the same response header value as different bytes depending on how JSC stores the string. `"caf\xe9"` from a literal (8-bit) goes out as `63 61 66 e9`. The `===`-equal string from `TextDecoder`, `normalize()` or `JSON.parse` (16-bit) goes out as `63 61 66 c3 a9`, and a `fetch()` client reads back `cafÃ©`.
- `writeResponseHeader` in `src/jsc/bindings/NodeHTTP.cpp:394` copies 8-bit values byte for byte but calls `WTF::String::utf8()` on 16-bit values. The Set-Cookie loop (line 429) and the HTTP/2 and HTTP/3 writer (lines 882, 893) do the same.
- Reachable for `Bun.serve` since #40589 let the validator accept 16-bit latin-1 values. node:http (`setHeader`, `writeHead`) uses the same writer with its own validator, so it was affected before that.

### Fix
- Add `HTTPLatin1String` (`src/jsc/bindings/HTTPLatin1String.h`): the wire bytes of one header name or value. An 8-bit string is borrowed. A 16-bit string is narrowed into a 64 byte inline buffer (heap above that): `highway_first_non_ascii16` finds the ASCII prefix, `highway_copy_u16_to_u8` narrows it with SIMD, a scalar loop does the rest with the `?` fallback of `String::latin1()`.
- The four writer sites build one for the name and one for the value instead of branching on `is8Bit()`. `WebCore__FetchHeaders__copyTo` (fetch requests, static routes) already narrows with `String::latin1()`.
- Correct because header values are ByteStrings (Fetch spec). Node and undici write them as latin-1. Every path into these writers rejects code units above 0xFF and non-token names, so nothing is lost.
- Verified: `bun-serve-headers.test.ts` (raw TCP, incl. values past the inline buffer), `serve-http2.test.ts` (HPACK literals on a raw HTTP/2 connection), `node-http.test.ts` (setHeader, writeHead, Set-Cookie). All fail on the unfixed build. Also ran the fetch headers, cookie, HTTP/2, HTTP/3 and serve suites.

### Background
- A WTF::String is 8-bit (one latin-1 byte per code unit) or 16-bit (UTF-16). JSC picks the representation by how the string was produced, so two equal strings can differ.
- A header value is a ByteString: one byte per code unit on the wire. UTF-8 is wrong for 0x80 to 0xFF, which are legal obs-text.
- `writeResponseHeader` is the last step before uWS `writeHeader`, which copies bytes as is. node:http `writeHead` and `Response` objects both end there. `writeFetchHeadersToStreamResponse` is the HTTP/2 and HTTP/3 equivalent.
- `highway_strings.cpp` holds Bun's runtime-dispatched SIMD kernels. Both kernels used here already existed.

<details><summary>Notes</summary>

Repro on main (the 16-bit string throws `Header 'x' has invalid value` on 1.4.0 and 1.4.1, so this is new since #40589):

```js
import net from "node:net";
const lat8 = "caf\xe9", lat16 = new TextDecoder("utf-16le").decode(new Uint16Array([0x63, 0x61, 0x66, 0xe9]));
const srv = Bun.serve({ port: 0, fetch(req) { return new Response("b", { headers: { x: req.url.endsWith("/16") ? lat16 : lat8 } }); } });
for (const p of ["/8", "/16"]) {
  const raw = await new Promise(res => { const s = net.connect(srv.port, "127.0.0.1", () => s.write(`GET ${p} HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n`)); let b = Buffer.alloc(0); s.on("data", d => b = Buffer.concat([b, d])); s.on("close", () => res(b)); });
  console.log(p, raw.toString("latin1").match(/\r\nx: ([^\r\n]*)/)[1].split("").map(c => c.charCodeAt(0).toString(16)).join(" "));
}
// before: /8 -> 63 61 66 e9   /16 -> 63 61 66 c3 a9
// after:  /8 -> 63 61 66 e9   /16 -> 63 61 66 e9
```

Tests: `test/js/bun/http/bun-serve-headers.test.ts` (Response headers, Set-Cookie, a 403 code unit value that leaves the 64 byte inline buffer, a value that starts with a non-ASCII code unit, an all-ASCII 16-bit value), `test/js/bun/http/serve-http2.test.ts` (TLS and cleartext), `test/js/node/http/node-http.test.ts` (setHeader, writeHead object, writeHead flat array, Set-Cookie array). Suites run on the final build: fetch_headers, headers, bun-serve-cookies, serve-http2-protocol, serve-http2-lifecycle, serve-http3, serve, bun-server.

node:http on main, with `res.end(Buffer.from("ok"))`: `setHeader`, `writeHead(200, {...})`, `writeHead(200, [...])` and a Set-Cookie array all show the same 8-bit/16-bit split. Node 26 writes `63 61 66 e9 2d 80 ff` for every one of these. Node does glue the header block onto a utf8 string body chunk when `res.end("string")` is used, so the new node:http test ends with a Buffer to keep the assertion valid in Node too.

HTTP/2 test design: Bun's node:http2 client decodes header bytes as UTF-8 (Node uses latin-1), so it cannot observe the wire bytes. The test uses the existing raw-frame client and a small `hpackFields` walker that splits the header block into fields without decoding them. The two header names are static table entries (content-disposition 25, set-cookie 55), so the fields arrive as literals with an indexed name, and the test reads the raw value bytes. These values cost more Huffman-coded than raw, so lshpack sends them as is (it uses Huffman only when the coded form is not longer). The http2 client decoding is a separate issue and was reported separately.

History of the fix shape: the first version was a `latin1FromUTF16` helper that returned a `WTF::CString` (one heap allocation per 16-bit value, scalar loop). The class with the inline buffer and the SIMD prefix copy replaced it after review. Names go through the same class: they are validated as RFC 7230 tokens (ASCII) on every path, so the narrowing is exact for them, and the 8-bit `ASSERT(name.containsOnlyASCII())` now covers 16-bit names too.

`CookieMap__write` (`request.cookies`) also calls `utf8()` but `Cookie::toString` percent-encodes the value and validates name, path and domain, so its output is ASCII. Not changed.

`test/js/node/http/node-http-proxy.js` listened on `localhost` and connected to `localhost`. On a dual-stack host the first resolves to `::1` and the second to `127.0.0.1`, so the request was refused before it reached the proxy (also under Node 26). It now uses `127.0.0.1` for both.

Pre-existing failures in this container, identical with and without the change: 8 tests in `serve.test.ts`/`bun-server.test.ts` that need IPv6 or a root port.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts "test/js/bun/http/serve-http2.test.ts" test/js/node/http/node-http.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [377.58ms]
84 |         return new Response("ok", { headers: { "x-t": value } });
85 |       },
86 |     });
87 | 
88 |     expect(headerHex(await rawResponse(server.port, "/8"), "x-t")).toEqual([expectedHex]);
89 |     expect(headerHex(await rawResponse(server.port, "/16"), "x-t")).toEqual([expectedHex]);
                                                                         ^
error: expect(received).toEqual(expected)

  [
-   "63 61 66 e9 2d 80 ff",
+   "63 61 66 c3 a9 2d c2 80 c3 bf",
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-headers.test.ts:89:69)
(fail) response header values are isomorphic-encoded on the wire > Response headers [484.35ms]
106 |       },
107 |     });
108 | 
109 |     const expected = ["61 3d " + expectedHex, "62 3d " + expectedHex];
110 |     e
... (truncated)

release without fix: 1 skipped
bun test v1.4.1-canary.1 (538b79d45)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [11.41ms]
(pass) response header values are isomorphic-encoded on the wire > Response headers [11.72ms]
(pass) response header values are isomorphic-encoded on the wire > Set-Cookie headers [2.96ms]
(pass) response Connection: close closes the socket > string body [2.18ms]
(pass) response Connection: close closes the socket > case-insensitive value [1.77ms]
(pass) response Connection: close closes the socket > token list [1.53ms]
(pass) response Connection: close closes the socket > streaming body [2.03ms]
(pass) response Connection: close closes the socket > keep-alive still the default [1.96ms]

test/js/bun/http/serve-http2.test.ts:
(pass) Bun.serve http2 (TLS + ALPN) > ALPN negotiated h2 [22.53ms]
(pass) Bun.serve http2 (TLS + ALPN) > GET through fetch handler [4.86ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST body is echoed with status and request headers [1.14ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST with END_STREAM on HEADERS (no body) resolves req.text() [0.53ms]
(pass) Bun.serve http2 (TLS + ALPN) > 204 has no body [0.40ms]
(pass) Bun.serve http2 (TLS
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts "test/js/bun/http/serve-http2.test.ts" test/js/node/http/node-http.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [533.09ms]
(pass) response header values are isomorphic-encoded on the wire > Response headers [649.07ms]
(pass) response header values are isomorphic-encoded on the wire > Set-Cookie headers [125.90ms]
(pass) response Connection: close closes the socket > string body [98.11ms]
(pass) response Connection: close closes the socket > case-insensitive value [63.41ms]
(pass) response Connection: close closes the socket > token list [61.41ms]
(pass) response Connection: close closes the socket > streaming body [72.16ms]
(pass) response Connection: close closes the socket > keep-alive still the default [75.41ms]

test/js/bun/http/serve-http2.test.ts:
(pass) Bun.serve http2 (TLS + ALPN) > ALPN negotiated h2 [460.22ms]
(pass) Bun.serve http2 (TLS + ALPN) > GET through fetch handler [321.54ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST b
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1010ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/36] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/36] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 7 sinks, 84 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[3/36] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeHTTP.cpp              | 19 ++++++--
 test/js/bun/http/bun-serve-headers.test.ts | 75 ++++++++++++++++++++++++++++++
 test/js/bun/http/serve-http2-fixture.ts    | 13 ++++++
 test/js/bun/http/serve-http2-helpers.ts    | 49 +++++++++++++++++++
 test/js/bun/http/serve-http2.test.ts       | 35 ++++++++++++++
 test/js/node/http/node-http-proxy.js       |  6 ++-
 test/js/node/http/node-http.test.ts        | 73 +++++++++++++++++++++++++++++
 7 files changed, 264 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/NodeHTTP.cpp                   4      7      0
test/js/bun/http/bun-serve-headers.test.ts      1      1      0
test/js/bun/http/serve-http2-fixture.ts         1      3      0
test/js/bun/http/serve-http2-helpers.ts         1      1      0
test/js/bun/http/serve-http2.test.ts            1      4      0
test/js/node/http/node-http-proxy.js            1      1      0
test/js/node/http/node-http.test.ts             1      0      0
```

</details>

<!-- robobun:evidence:end -->
