### PR TITLE
node:http2: read inbound header values as latin-1, not UTF-8

### DIFF
--- a/src/jsc/bindings/H2HeadersMaterializer.cpp
+++ b/src/jsc/bindings/H2HeadersMaterializer.cpp
@@ -49,8 +49,7 @@ static bool h2IsSingleValueHeader(WTF::StringView name)
         || name == "x-content-type-options"_s;
 }
 
-// One latin-1 code unit per wire byte, as node does (node_http2.cc builds
-// header values as one-byte strings). UTF-8 decoding would lose obs-text.
+// Latin-1, one code unit per wire byte, like node (node_http2.cc). Not UTF-8.
 static JSString* h2ValueToJS(VM& vm, const uint8_t* ptr, size_t length)
 {
     if (length == 0)

--- a/src/jsc/bindings/H2HeadersMaterializer.cpp
+++ b/src/jsc/bindings/H2HeadersMaterializer.cpp
@@ -18,7 +18,6 @@
 #include <wtf/text/StringView.h>
 #include "HTTPHeaderIdentifiers.h"
 #include "HTTPHeaderNames.h"
-#include "wtf/SIMDUTF.h"
 
 using namespace JSC;
 using namespace WebCore;
@@ -50,17 +49,15 @@ static bool h2IsSingleValueHeader(WTF::StringView name)
         || name == "x-content-type-options"_s;
 }
 
-// Mirrors BunString__createUTF8ForJS: ASCII fast path, lossy UTF-8 otherwise.
+// Header values are byte strings. Node hands nghttp2's value bytes to JS as a
+// one-byte string (node_http2.cc, ExternOneByteString), so each wire byte is
+// one latin-1 code unit and obs-text (0x80-0xFF) survives. Decoding as UTF-8
+// would turn those bytes into U+FFFD.
 static JSString* h2ValueToJS(VM& vm, const uint8_t* ptr, size_t length)
 {
     if (length == 0)
         return jsEmptyString(vm);
-    if (simdutf::validate_ascii(reinterpret_cast<const char*>(ptr), length))
-        return jsString(vm, WTF::String(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(ptr), length)));
-    auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const Latin1Character*>(ptr), length });
-    if (str.isNull()) [[unlikely]]
-        return nullptr;
-    return jsString(vm, WTF::move(str));
+    return jsString(vm, WTF::String(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(ptr), length)));
 }
 
 // meta layout: per field, two u32s: [nameLen | (sensitive << 31), valueLen].
@@ -122,10 +119,6 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__h2__materializ
         }
 
         JSString* valueStr = h2ValueToJS(vm, valueBytes, valueLen);
-        if (!valueStr) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return {};
-        }
 
         raw->putDirectIndex(globalObject, rawIndex++, nameStr);
         RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/H2HeadersMaterializer.cpp
+++ b/src/jsc/bindings/H2HeadersMaterializer.cpp
@@ -49,10 +49,8 @@ static bool h2IsSingleValueHeader(WTF::StringView name)
         || name == "x-content-type-options"_s;
 }
 
-// Header values are byte strings. Node hands nghttp2's value bytes to JS as a
-// one-byte string (node_http2.cc, ExternOneByteString), so each wire byte is
-// one latin-1 code unit and obs-text (0x80-0xFF) survives. Decoding as UTF-8
-// would turn those bytes into U+FFFD.
+// One latin-1 code unit per wire byte, as node does (node_http2.cc builds
+// header values as one-byte strings). UTF-8 decoding would lose obs-text.
 static JSString* h2ValueToJS(VM& vm, const uint8_t* ptr, size_t length)
 {
     if (length == 0)

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3138,11 +3138,17 @@ describe("http2 header values are latin-1 byte strings", () => {
     try {
       const response = Promise.withResolvers();
       const trailers = Promise.withResolvers();
-      client.on("error", response.reject);
+      const fail = err => {
+        response.reject(err);
+        trailers.reject(err);
+      };
+      client.on("error", fail);
       const req = client.request({ ":path": "/" }, { endStream: true });
-      req.on("error", response.reject);
+      req.on("error", fail);
       req.on("response", (headers, _flags, rawHeaders) => response.resolve({ headers, rawHeaders }));
       req.on("trailers", headers => trailers.resolve(headers));
+      // A settled promise ignores this, so it only fires when trailers never arrived.
+      req.on("close", () => fail(new Error(`stream closed without trailers (rstCode ${req.rstCode})`)));
       req.resume();
 
       const { headers, rawHeaders } = await response.promise;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3081,6 +3081,133 @@ it("http2 server resets streams whose request headers contain CR, LF, or NUL oct
   }
 });
 
+// node:http2 hands header values to JS as one-byte strings (node_http2.cc):
+// each wire byte is one latin-1 code unit. Bytes 0x80-0xFF are legal obs-text
+// in a field value and are not UTF-8 decoded, so a peer that sends UTF-8 is
+// read as mojibake and a peer that sends latin-1 is read as is. Decoding as
+// UTF-8 instead would turn the latin-1 bytes into U+FFFD and lose them.
+describe("http2 header values are latin-1 byte strings", () => {
+  const codeUnits = str => [...str].map(c => c.charCodeAt(0));
+  // HPACK string literal: 7-bit length prefix, no Huffman coding.
+  const literal = bytes => Buffer.concat([Buffer.from([bytes.length]), Buffer.from(bytes)]);
+  // Literal header field without indexing, new name.
+  const field = (name, valueBytes) => Buffer.concat([Buffer.from([0x00]), literal(name), literal(valueBytes)]);
+  const obsText = [0x63, 0x61, 0x66, 0xe9, 0x2d, 0x80, 0xff]; // "caf\xe9-\x80\xff"
+  const utf8Bytes = [0x63, 0x61, 0x66, 0xc3, 0xa9]; // "caf\xc3\xa9", stays two code units
+
+  it("client reads response headers and trailers as latin-1", async () => {
+    const responseBlock = Buffer.concat([
+      Buffer.from([0x88]), // :status: 200 (static table index 8)
+      field("x-latin1", obsText),
+      field("x-utf8", utf8Bytes),
+    ]);
+    const trailerBlock = field("x-trailer", obsText);
+
+    // Raw-socket h2 server: preface handshake, then answer the first HEADERS
+    // with a response header block and a trailer block.
+    const server = net.createServer(socket => {
+      let buf = Buffer.alloc(0);
+      let sawPreface = false;
+      socket.on("error", () => {});
+      socket.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        if (!sawPreface) {
+          if (buf.length < http2utils.kClientMagic.length) return;
+          buf = buf.subarray(http2utils.kClientMagic.length);
+          sawPreface = true;
+          socket.write(new http2utils.SettingsFrame(false).data);
+        }
+        while (buf.length >= 9) {
+          const length = buf.readUIntBE(0, 3);
+          if (buf.length < 9 + length) break;
+          const type = buf[3];
+          const flags = buf[4];
+          const streamId = buf.readUInt32BE(5) & 0x7fffffff;
+          buf = buf.subarray(9 + length);
+          if (type === 4 && (flags & 1) === 0) {
+            socket.write(new http2utils.SettingsFrame(true).data);
+          } else if (type === 1) {
+            socket.write(new http2utils.HeadersFrame(streamId, responseBlock, 0, true, false).data);
+            socket.write(new http2utils.HeadersFrame(streamId, trailerBlock, 0, true, true).data);
+          }
+        }
+      });
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      const response = Promise.withResolvers();
+      const trailers = Promise.withResolvers();
+      client.on("error", response.reject);
+      const req = client.request({ ":path": "/" }, { endStream: true });
+      req.on("error", response.reject);
+      req.on("response", (headers, _flags, rawHeaders) => response.resolve({ headers, rawHeaders }));
+      req.on("trailers", headers => trailers.resolve(headers));
+      req.resume();
+
+      const { headers, rawHeaders } = await response.promise;
+      expect(headers[":status"]).toBe(200);
+      expect(codeUnits(headers["x-latin1"])).toEqual(obsText);
+      expect(codeUnits(headers["x-utf8"])).toEqual(utf8Bytes);
+      expect(rawHeaders.map(codeUnits)).toEqual([
+        codeUnits(":status"),
+        codeUnits("200"),
+        codeUnits("x-latin1"),
+        obsText,
+        codeUnits("x-utf8"),
+        utf8Bytes,
+      ]);
+      expect(codeUnits((await trailers.promise)["x-trailer"])).toEqual(obsText);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("server reads request headers as latin-1", async () => {
+    const requestBlock = Buffer.concat([
+      Buffer.from([0x82]), // :method: GET   (static table index 2)
+      Buffer.from([0x86]), // :scheme: http  (static table index 6)
+      Buffer.from([0x84]), // :path: /       (static table index 4)
+      Buffer.from([0x01]), // :authority     (literal without indexing, name index 1)
+      literal(Buffer.from("localhost")),
+      field("x-latin1", obsText),
+      field("x-utf8", utf8Bytes),
+    ]);
+
+    const delivered = Promise.withResolvers();
+    const server = http2.createServer();
+    server.on("error", delivered.reject);
+    server.on("stream", (stream, headers, _flags, rawHeaders) => {
+      delivered.resolve({ headers, rawHeaders });
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+    const socket = net.connect(server.address().port, "127.0.0.1", () => {
+      socket.write(http2utils.kClientMagic);
+      socket.write(new http2utils.SettingsFrame(false).data);
+      socket.write(new http2utils.HeadersFrame(1, requestBlock, 0, true, true).data);
+    });
+    socket.on("error", delivered.reject);
+    try {
+      const { headers, rawHeaders } = await delivered.promise;
+      expect(codeUnits(headers["x-latin1"])).toEqual(obsText);
+      expect(codeUnits(headers["x-utf8"])).toEqual(utf8Bytes);
+      expect(rawHeaders.slice(-4).map(codeUnits)).toEqual([
+        codeUnits("x-latin1"),
+        obsText,
+        codeUnits("x-utf8"),
+        utf8Bytes,
+      ]);
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+});
+
 it("http2 server rejects requests carrying connection-specific or repeated pseudo-headers", async () => {
   // RFC 9113 Section 8.2.2: connection-specific fields (transfer-encoding,
   // connection, keep-alive, ...) make an HTTP/2 request malformed, and


### PR DESCRIPTION
### Problem
- node:http2 in Bun reads the header value bytes `63 61 66 e9 2d 80 ff` as `caf\uFFFD-\uFFFD\uFFFD`. Node reads them as `café-\x80\xff`, one code unit per byte. Client and server are both affected.
- The cause is `h2ValueToJS` in `src/jsc/bindings/H2HeadersMaterializer.cpp:53`. It runs non-ASCII values through `WTF::String::fromUTF8ReplacingInvalidSequences`. Node creates the value as a one-byte string (`node_http2.cc`, `ExternOneByteString`) and never decodes.

### Fix
- Build the value as a latin-1 string, as every other inbound header path in Bun does (`NodeHTTPParser.h`, `FetchHeaders__createFromUWS`, `createFromH3`, `quic/session.rs`). The helper covers response headers, request headers, trailers and push promises.
- Correct because a header value is a byte string: one wire byte is one code unit. Latin-1 is lossless. UTF-8 decoding destroys every byte it cannot parse. This matches Node on every input.
- Verified: `test/js/node/http2/node-http2.test.js`, two new tests with raw HPACK blocks (both directions, `rawHeaders`, trailers). Both fail on stock bun. Node 26.3.0 gives the same code units. Also ran the http2 test directory and 68 `test-http2-*` tests from `test/js/node/test/parallel/`.

### Background
- obs-text is bytes 0x80 to 0xFF. RFC 9110 allows them in a field value. The HTTP/2 engine only rejects NUL, CR and LF, so they reach the materializer.
- `Bun__h2__materializeHeaders` is the one native call per header block. It builds the `rawHeaders` array, the headers object and the sensitive-names array from the block bytes.
- A WTF::String built from a `Latin1Character` span stores one byte per code unit, with no decoding. The Fetch spec calls this a ByteString.

<details><summary>Notes</summary>

Repro on main against a Node 26 http2 server that sets `x-t` to the string `caf\xe9-\x80\xff`:

```
node client: 63 61 66 e9 2d 80 ff
bun client:  63 61 66 fffd 2d fffd fffd
```

The server direction has the same fault on main: a Node client sending that header to a Bun node:http2 server produces `63 61 66 fffd 2d fffd fffd` in `req.headers["x-t"]`. Same helper, same fix.

Other inbound header paths were checked and already produce latin-1: Bun.serve HTTP/1 (`WebCore__FetchHeaders__createFromUWS`), Bun.serve HTTP/2 and HTTP/3 (`WebCore__FetchHeaders__createFromH3`), fetch() and the node:http client (`createFromPicoHeaders_`, `NodeHTTPParser.h`), node:http server over Bun.serve (`Bun__NodeHTTP__buildRawHeadersArray`), and node:quic h3 (`session.rs`, `clone_latin1`). `Bun__h2__materializeHeaders` has one caller, `on_headers_complete` in `src/runtime/api/bun/h2_frame_parser.rs`. Names are validated lowercase ASCII tokens before the materializer and were already built as latin-1.

The OOM branch in the caller goes away: the latin-1 `WTF::String` constructor never returns a null string, unlike `fromUTF8ReplacingInvalidSequences`.

A peer that sends UTF-8 bytes is now read as two code units per non-ASCII character, which is what Node does too. User code recovers the bytes with `Buffer.from(value, "latin1")`. The new tests assert this for `63 61 66 c3 a9`.

Not changed here: the node:http2 outbound side (`request`, `respond`, trailers, push) encodes JS string values with `to_utf8()`. Node writes them with `WriteOneByte`. So a Bun client sending `café` to a Node server is still read there as `cafÃ©`. That is a separate change with its own question (Node truncates code units above 0xFF to their low byte). The Bun.serve response writer has the same outbound issue and is fixed in #40685. The ALTSVC and ORIGIN frame payloads also still decode as UTF-8. They are ASCII in practice.

Suites run with the debug build: `node-http2.test.js` (364 pass, 6 skip), `h2-conformance.test.ts`, `node-http2-invalid-padding.test.ts`, `node-http2-continuation.test.ts`, `node-http2-streams-rehash.test.ts`, `node-http2-upgrade.test.mts` (103 pass), and 68 `test-http2-*` files from `test/js/node/test/parallel/` that cover headers, trailers, cookies, push, compat request and response, sensitive headers, status and date (all exit 0).

</details>
