### PR TITLE
webcore: Blob, Body::Value and ReadableStream::Strong drop their own state

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -211,8 +211,8 @@ const _: () = {
 };
 
 impl Blob {
-    /// Heap-promote and mark as
-    /// heap-allocated so `deinit` knows to free the heap box.
+    /// Heap-promote with an intrusive count of 1; released via `Blob__deref`
+    /// (or [`Blob::destroy`] while still the sole owner).
     #[inline]
     pub fn new(mut blob: Blob) -> *mut Blob {
         blob.ref_count = bun_ptr::RawRefCount::init(1);
@@ -233,8 +233,8 @@ impl Blob {
         );
         // SAFETY: `self` is the allocation `Blob::new` produced and the JS
         // wrapper's `+1` is the count released here. `into_raw` hands the box
-        // over without dropping it; `Blob__deref` runs `deinit()` (which
-        // `drop(heap::take)`s) when the count reaches zero.
+        // over without dropping it; `Blob__deref` destroys it when the count
+        // reaches zero.
         unsafe { Blob__deref(bun_core::heap::into_raw(self)) }
     }
 
@@ -450,19 +450,15 @@ impl Blob {
         }
     }
 
-    /// Tear down owned resources; if
-    /// heap-allocated, also frees the heap box.
-    pub fn deinit(&mut self) {
-        self.detach();
-        self.name.set(bun_core::String::DEAD);
-
-        self.content_type.set(BlobContentType::default());
-
-        if self.is_heap_allocated() {
-            // SAFETY: `self` is the `*mut Blob` originally produced by
-            // `Blob::new` (`heap::alloc`).
-            unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Blob>(self))) };
-        }
+    /// Free a heap `Blob`; dropping it releases the store, name and
+    /// content type.
+    ///
+    /// # Safety
+    /// `this` must be the live allocation [`Blob::new`] produced, with no
+    /// other holder of its intrusive count.
+    pub unsafe fn destroy(this: *mut Blob) {
+        // SAFETY: caller contract.
+        unsafe { drop(bun_core::heap::take(this)) };
     }
 }
 
@@ -487,7 +483,7 @@ unsafe impl bun_ptr::ExternalSharedDescriptor for Blob {
 /// `this` must point to a live `Blob` produced by [`Blob::new`], and the call
 /// must happen on the thread that owns it (the count is not atomic). A
 /// by-value `Blob` has a count of zero; bumping it would make a later
-/// [`Blob::deinit`] free an address that was never heap-allocated.
+/// [`Blob__deref`] free an address that was never heap-allocated.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Blob__ref(this: *mut Blob) {
     // SAFETY: caller contract above.
@@ -511,7 +507,7 @@ unsafe extern "C" fn Blob__ref(this: *mut Blob) {
 /// last count frees the `Blob`, so `this` is dangling once this returns.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Blob__deref(this: *mut Blob) {
-    // SAFETY: caller contract above. `deinit` frees the allocation, so `this`
+    // SAFETY: caller contract above. `destroy` frees the allocation, so `this`
     // is not touched after it.
     unsafe {
         debug_assert!(
@@ -519,10 +515,7 @@ unsafe extern "C" fn Blob__deref(this: *mut Blob) {
             "cannot deref: this Blob is not heap-allocated"
         );
         if (*this).ref_count.decrement() == bun_ptr::raw_ref_count::DecrementResult::ShouldDestroy {
-            // `deinit` has its own `is_heap_allocated()` guard around the
-            // `drop(heap::take)`, so re-arm so it returns true.
-            (*this).ref_count.increment();
-            (*this).deinit();
+            Blob::destroy(this);
         }
     }
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1275,7 +1275,6 @@ fn print_exception(
             colors,
             true,
         );
-        // `defer formatter.deinit()` → Drop.
     }
 
     let _ = writer.flush();
@@ -3947,7 +3946,7 @@ unsafe fn get_loader_and_virtual_source<'a>(
     specifier_str: &'a [u8],
     jsc_vm: *mut VirtualMachine,
     virtual_source_to_use: &'a mut Option<bun_ast::Source>,
-    blob_to_deinit: &mut Option<crate::webcore::Blob>,
+    resolved_blob: &mut Option<crate::webcore::Blob>,
     type_attribute_str: Option<&[u8]>,
 ) -> crate::Result<LoaderResult<'a>> {
     let (normalized_file_path_from_specifier, specifier, query) =
@@ -3988,12 +3987,12 @@ unsafe fn get_loader_and_virtual_source<'a>(
             .resolve_and_dupe(&specifier[b"blob:".len()..], unsafe { &*jsc_vm }.global())
         {
             Some(blob) => {
-                *blob_to_deinit = Some(blob);
-                // SAFETY: `blob_to_deinit` is `Some` (just written); we hold
+                *resolved_blob = Some(blob);
+                // SAFETY: `resolved_blob` is `Some` (just written); we hold
                 // `&mut` for the duration of this body, so `as_mut().unwrap()`
                 // is sound and the `&'a` reborrow points at storage owned by
                 // the *caller's* `Option<Blob>` slot (outlives `LoaderResult`).
-                let blob = blob_to_deinit.as_mut().unwrap();
+                let blob = resolved_blob.as_mut().unwrap();
                 // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
                 loader = blob.get_loader(unsafe { &*jsc_vm });
 
@@ -4002,10 +4001,10 @@ unsafe fn get_loader_and_virtual_source<'a>(
                     // Only treat it as a file if it is a `Bun.file()`.
                     if blob.needs_to_read_file() {
                         // Note: borrowck — `Fs::Path<'a>` borrows
-                        // `filename`, which borrows `*blob_to_deinit`. The
+                        // `filename`, which borrows `*resolved_blob`. The
                         // caller owns that slot for `'a`, so erase via raw ptr.
                         // SAFETY: `filename` borrows the blob's backing store,
-                        // which the caller's `blob_to_deinit` slot keeps alive
+                        // which the caller's `resolved_blob` slot keeps alive
                         // for `'a`; reconstructing the slice preserves provenance.
                         path = Fs::Path::init(unsafe {
                             core::slice::from_raw_parts(filename.as_ptr(), filename.len())
@@ -4016,7 +4015,7 @@ unsafe fn get_loader_and_virtual_source<'a>(
                 if !blob.needs_to_read_file() {
                     // SAFETY: same lifetime erasure as above — `shared_view()`
                     // borrows the blob's backing store (held in the caller's
-                    // `blob_to_deinit` slot for the synchronous transpile).
+                    // `resolved_blob` slot for the synchronous transpile).
                     // `bun_ast::Source` stores `&'static [u8]` (see
                     // logger/lib.rs §`type Str`), so erase to
                     // `'static`; sound because the blob outlives the
@@ -4183,14 +4182,14 @@ pub unsafe extern "C" fn Bun__transpileFile(
     let type_attribute_str: Option<&[u8]> = type_attribute.and_then(|s| s.as_utf8());
 
     let mut virtual_source_to_use: Option<bun_ast::Source> = None;
-    let mut blob_to_deinit: Option<crate::webcore::Blob> = None;
+    let mut resolved_blob: Option<crate::webcore::Blob> = None;
     // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
     let mut lr = match unsafe {
         get_loader_and_virtual_source(
             _specifier.slice(),
             jsc_vm,
             &mut virtual_source_to_use,
-            &mut blob_to_deinit,
+            &mut resolved_blob,
             type_attribute_str,
         )
     } {
@@ -4206,17 +4205,6 @@ pub unsafe extern "C" fn Bun__transpileFile(
             return ptr::null_mut();
         }
     };
-    // Deinit the blob (if any) on scope exit.
-    // Note: reshaped for borrowck — capture the `is_some()` flag *before*
-    // moving the option into the scopeguard so the `transpile_async` predicate
-    // can still read it without aliasing the guard's `&mut`.
-    let had_blob = blob_to_deinit.is_some();
-    let _blob_guard = scopeguard::guard(blob_to_deinit, |mut slot| {
-        if let Some(mut blob) = slot.take() {
-            blob.deinit();
-        }
-    });
-
     // ── force_loader / require.extensions override ──────────────────────────
     if let Some(loader_type) = force_loader_type {
         // Note: `@branchHint(.unlikely)` dropped (no stable Rust equiv).
@@ -4294,7 +4282,7 @@ pub unsafe extern "C" fn Bun__transpileFile(
                 (*jsc_vm).transpiler_store.enabled,
             )
         };
-        if !had_blob
+        if resolved_blob.is_none()
             && allow_promise
             && (has_loaded || is_in_preload)
             && concurrent_loader.is_java_script_like()

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -466,12 +466,6 @@ impl FileRoute {
     }
 }
 
-impl Drop for FileRoute {
-    fn drop(&mut self) {
-        self.blob.deinit();
-    }
-}
-
 /// RFC 9110 §13.2.2 precondition evaluation for a GET/HEAD file response.
 /// Order: (1) If-Match, else (2) If-Unmodified-Since; then (3) If-None-Match,
 /// else (4) If-Modified-Since. Steps 1/2 yield 412 on failure and must run

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1532,7 +1532,7 @@ where
 
         self.detach_request_body_producer();
         self.request_body_readable_stream_ref
-            .with_mut(|s| s.deinit());
+            .set(readable_stream::Strong::Empty);
 
         // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
         drop(self.cookies.replace(None));
@@ -1570,7 +1570,7 @@ where
         }
 
         self.response_body_readable_stream_ref
-            .with_mut(|s| s.deinit());
+            .set(readable_stream::Strong::Empty);
 
         self.pathname.set(BunString::EMPTY);
     }
@@ -2006,7 +2006,7 @@ where
         global_this: &JSGlobalObject,
     ) {
         stream_log!("aborted while attaching the stream");
-        let mut readable_ref = self
+        let _readable_ref = self
             .response_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
         if let Some(wrapper_ptr) = self.sink.take() {
@@ -2020,7 +2020,6 @@ where
             wrapper.sink.finalize();
             Self::destroy_sink(wrapper_ptr);
         }
-        readable_ref.deinit();
     }
 
     fn do_render_stream(pair: *mut StreamPair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>) {
@@ -2037,7 +2036,7 @@ where
         if this.is_aborted_or_ended() {
             crate::dispatch::fold(stream.cancel(global_this));
             this.response_body_readable_stream_ref
-                .with_mut(|s| s.deinit());
+                .set(readable_stream::Strong::Empty);
             return;
         }
         let resp = this.resp.get().expect("infallible: resp bound");
@@ -2116,7 +2115,7 @@ where
             Self::destroy_sink(response_stream_ptr);
             stream.done();
             this.response_body_readable_stream_ref
-                .with_mut(|s| s.deinit());
+                .set(readable_stream::Strong::Empty);
             this.end_stream(this.should_close_connection());
             return;
         }
@@ -2186,14 +2185,13 @@ where
                     }
                     jsc::PromiseResult::Fulfilled(_) => {
                         stream_log!("promise Fulfilled");
-                        let mut readable_ref = this
+                        let _readable_ref = this
                             .response_body_readable_stream_ref
                             .replace(readable_stream::Strong::default());
                         // NOTE: cleanup runs after handle_resolve_stream:
                         // body first, then the deferred cleanup.
                         this.handle_resolve_stream();
                         stream.done();
-                        readable_ref.deinit();
                     }
                     jsc::PromiseResult::Rejected(err) => {
                         stream_log!("promise Rejected");
@@ -2206,12 +2204,11 @@ where
                         {
                             server.vm().as_mut().run_error_handler(err, None);
                         }
-                        let mut readable_ref = this
+                        let _readable_ref = this
                             .response_body_readable_stream_ref
                             .replace(readable_stream::Strong::default());
                         this.handle_reject_stream(global_this, err);
                         crate::dispatch::fold(stream.cancel(global_this));
-                        readable_ref.deinit();
                     }
                 }
                 return;
@@ -2228,7 +2225,7 @@ where
             }
         }
 
-        let mut readable_ref = this
+        let _readable_ref = this
             .response_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
 
@@ -2250,7 +2247,6 @@ where
                     response_stream.sink.finalize();
                     this.sink.set(None);
                     Self::destroy_sink(response_stream_ptr);
-                    readable_ref.deinit();
                     this.render_missing();
                     return;
                 }
@@ -2266,7 +2262,6 @@ where
         response_stream.sink.finalize();
         this.sink.set(None);
         Self::destroy_sink(response_stream_ptr);
-        readable_ref.deinit();
         this.render_missing();
     }
 
@@ -3131,7 +3126,7 @@ where
                     match stream.ptr {
                         readable_stream::Source::Invalid => {
                             this.response_body_readable_stream_ref
-                                .with_mut(|s| s.deinit());
+                                .set(readable_stream::Strong::Empty);
                             // Stream is invalid, render empty body
                             this.do_render_blob();
                             return;
@@ -3162,7 +3157,7 @@ where
                                 // we don't have a response, so we can discard the stream
                                 stream.done();
                                 this.response_body_readable_stream_ref
-                                    .with_mut(|s| s.deinit());
+                                    .set(readable_stream::Strong::Empty);
                                 return;
                             }
                             let resp = this.resp.get().expect("infallible: resp bound");
@@ -3174,7 +3169,7 @@ where
                                     byte_list.move_to_list_managed(),
                                 ));
                                 this.response_body_readable_stream_ref
-                                    .with_mut(|s| s.deinit());
+                                    .set(readable_stream::Strong::Empty);
                                 this.do_render_blob();
                                 return;
                             }
@@ -3188,10 +3183,6 @@ where
                             ));
                             stream.lock_native(global_this);
                             byte_stream.signal_consumer_attached();
-                            // Deinit the old Strong reference before creating a new one
-                            // to avoid leaking the Strong.Impl memory
-                            this.response_body_readable_stream_ref
-                                .with_mut(|s| s.deinit());
                             this.response_body_readable_stream_ref
                                 .set(readable_stream::Strong::init(stream, global_this));
 
@@ -3320,7 +3311,7 @@ where
                 let global_this = this.server().global_this();
                 let js_err = err.to_js(global_this);
                 this.response_body_readable_stream_ref
-                    .with_mut(|s| s.deinit());
+                    .set(readable_stream::Strong::Empty);
                 this.run_error_handler(js_err);
                 return;
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -571,7 +571,6 @@ impl BlobExt for Blob {
             impl<H: ReadBytesHandler> Task<H> {
                 fn done(mut self: Box<Self>, r: ReadBytesResult) -> JsResult<()> {
                     self.poll.unref(bun_io::js_vm_ctx());
-                    self.blob.deinit();
                     let ctx = self.ctx;
                     drop(self);
                     // SAFETY: `ctx` is the pointer handed to `read_bytes_to_handler`;
@@ -1724,7 +1723,6 @@ impl BlobExt for Blob {
 
                 let credentials_with_options =
                     s3.get_credentials_with_options(Some(options), global_this)?;
-                // `defer credentialsWithOptions.deinit()` → Drop handles slices.
                 // `writable_stream` adopts the dup'd ref by value; the
                 // MultiPartUpload derefs on done.
                 return crate::webcore::s3::client::writable_stream(
@@ -3903,11 +3901,8 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
             let bytes_len = reader.read_int_le::<u32>()?;
             let bytes = read_slice(reader, bytes_len as usize)?;
 
+            // Owns `bytes` (via its Store when non-empty); an early `?` drops it.
             let blob = Blob::init(bytes, global_this);
-            // `blob` now owns `bytes` (via its Store when non-empty). If any
-            // of the remaining reads fail before we heap-promote it, Drop on
-            // `blob` releases the store so the payload bytes don't leak.
-            let guard = scopeguard::guard(blob, |mut b| b.deinit());
 
             'versions: {
                 if version == 1 {
@@ -3917,8 +3912,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 let name_len = reader.read_int_le::<u32>()?;
                 let name = read_slice(reader, name_len as usize)?;
 
-                // ScopeGuard derefs to its inner Blob.
-                if let Some(store) = (*guard).store() {
+                if let Some(store) = blob.store() {
                     if let store::Data::Bytes(bytes_store) = &mut Store::data_mut(store) {
                         // Transfer ownership of the local `name: Vec<u8>` into
                         // `stored_name` (a `Box<[u8]>`); freed by `Bytes::Drop`.
@@ -3932,7 +3926,6 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 }
             }
 
-            let blob = scopeguard::ScopeGuard::into_inner(guard);
             break 'bytes Blob::new(blob);
         }
         store::SerializeTag::File => 'file: {
@@ -3985,8 +3978,8 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
     // (truncated trailer fields) tear down both the heap object and its
     // store. `content_type` is handled by its own Drop above since it
     // hasn't been attached to `blob` yet.
-    // SAFETY: blob is a freshly-allocated heap pointer from Blob::new.
-    let blob_guard = scopeguard::guard(blob, |b| unsafe { (*b).deinit() });
+    // SAFETY: blob is a freshly-allocated heap pointer from Blob::new; sole owner.
+    let blob_guard = scopeguard::guard(blob, |b| unsafe { Blob::destroy(b) });
     // SAFETY: `blob_guard` holds the sole pointer to the fresh heap allocation.
     // Shared access only — Blob state is Cell/JsCell-based.
     let blob = unsafe { &**blob_guard };
@@ -5755,9 +5748,7 @@ impl S3BlobDownloadTask {
 
 impl Drop for S3BlobDownloadTask {
     fn drop(&mut self) {
-        Blob::deinit(&mut self.blob);
         self.poll_ref.unref(bun_io::js_vm_ctx());
-        // promise: Drop handles deinit.
     }
 }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -242,7 +242,6 @@ pub struct PendingValue {
     pub producer: streams::SourceHandle,
     pub(crate) size_hint: blob::SizeType,
 
-    pub(crate) deinit: bool,
     pub(crate) action: Action,
 }
 
@@ -270,7 +269,6 @@ impl Default for PendingValue {
             on_readable_stream_available: None,
             producer: streams::SourceHandle::None,
             size_hint: 0,
-            deinit: false,
             action: Action::None,
         }
     }
@@ -363,7 +361,7 @@ impl PendingValue {
         let mut stream = self.readable.get()?;
 
         if let Some(blob) = stream.to_any_blob(global) {
-            self.readable.deinit();
+            self.readable = webcore::readable_stream::Strong::Empty;
             return Some(blob);
         }
 
@@ -407,7 +405,7 @@ impl PendingValue {
                         }
                         _ => unreachable!(),
                     };
-                    self.readable.deinit();
+                    self.readable = webcore::readable_stream::Strong::Empty;
                     // The ReadableStream within is expected to keep this Promise alive.
                     // If you try to protect() this, it will leak memory because the other end of the ReadableStream won't call it.
                     // See https://github.com/oven-sh/bun/issues/13678
@@ -754,8 +752,7 @@ impl Value {
             Value::Empty => ReadableStream::empty(global_this),
             Value::Null => Ok(JSValue::NULL),
             Value::InternalBlob(_) | Value::Blob(_) | Value::WTFStringImpl(_) => {
-                // `deinit` must run on every exit incl. `?` paths.
-                let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
+                let blob = self.use_();
                 blob.resolve_size();
                 let blob_size = blob.size.get();
                 let value = ReadableStream::from_blob_copy_ref(global_this, &blob, blob_size)?;
@@ -813,7 +810,7 @@ impl Value {
             }
             Value::Blob(_) => {
                 let stream = {
-                    let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
+                    let blob = self.use_();
                     blob.resolve_size();
                     if blob.needs_to_read_file() || blob.is_s3() {
                         let blob_size = blob.size.get();
@@ -1069,7 +1066,7 @@ impl Value {
                 } else {
                     readable.done();
                 }
-                locked.readable.deinit();
+                locked.readable = webcore::readable_stream::Strong::Empty;
             }
 
             if let Some(callback) = locked.on_receive_value.take() {
@@ -1169,8 +1166,7 @@ impl Value {
         match self {
             Value::Blob(b) => {
                 // `Value` has `Drop`, so we cannot move the `Blob` out by
-                // value (E0509). `mem::take` leaves a default `Blob` whose `deinit()`
-                // (run by `Value::drop` on the assignment below) is a no-op.
+                // value (E0509); `mem::take` leaves a default `Blob`.
                 let new_blob = core::mem::take(b);
                 *self = Value::Used;
                 debug_assert!(!new_blob.is_heap_allocated()); // owned by Body
@@ -1299,9 +1295,8 @@ impl Value {
         global: &JSGlobalObject,
     ) -> jsc::JsResult<()> {
         if let Value::Locked(_) = self {
-            // reshaped for borrowck + E0509 (`Value` has `Drop`) — `mem::take`
-            // the `PendingValue` out (leaves `Locked(default)`, whose Drop is a no-op on
-            // an empty readable), then overwrite with `Error`.
+            // `Value` has `Drop` (E0509): `mem::take` the `PendingValue` out, then
+            // overwrite with `Error`.
             let mut locked = match self {
                 Value::Locked(l) => core::mem::take(l),
                 _ => unreachable!(),
@@ -1313,10 +1308,6 @@ impl Value {
             let Value::Error(err_ref) = self else {
                 unreachable!()
             };
-
-            // `deinit` must run on every exit incl. `?` paths.
-            let strong_readable =
-                scopeguard::guard(core::mem::take(&mut locked.readable), |mut r| r.deinit());
 
             if let Some(promise_value) = locked.promise.take() {
                 // `unprotect` + `ensure_still_alive` are non-Drop side effects
@@ -1335,7 +1326,7 @@ impl Value {
 
             // The Promise version goes before the ReadableStream version incase the Promise version is used too.
             // Avoid creating unnecessary duplicate JSValue.
-            if let Some(readable) = strong_readable.get() {
+            if let Some(readable) = locked.readable.get() {
                 // BACKREF: see `Source::bytes()` — payload live for the
                 // lifetime of the ReadableStream JS wrapper.
                 if let Some(bytes) = readable.ptr.bytes() {
@@ -1361,51 +1352,24 @@ impl Value {
         Ok(())
     }
 
-    // mutates self to Null and is called explicitly at specific protocol points.
-    // Renamed from `deinit` per PORTING.md (never expose `pub fn deinit(&mut self)`). Now
-    // delegates the actual resource release to `Drop` (below) via assignment, so a later
-    // `HiveArray::put()` → `drop_in_place` on the resulting `Null` is a guaranteed no-op
-    // (idempotent — no double-free).
+    /// Release the payload now, at an explicit protocol point: `Locked` stays
+    /// `Locked` with its GC root released (callers may still inspect the
+    /// variant); everything else becomes `Null`.
     pub fn reset(&mut self) {
         if let Value::Locked(locked) = self {
-            // Locked stays Locked (callers may still inspect the variant after
-            // reset()); flip the `deinit` latch so Drop is a no-op afterwards.
-            if !locked.deinit {
-                locked.deinit = true;
-                locked.readable.deinit();
-                locked.readable = Default::default();
-            }
+            locked.readable = webcore::readable_stream::Strong::Empty;
             return;
         }
-        // Assignment runs `Drop` on the old variant: deref WTFStringImpl, deinit
-        // Blob, free InternalBlob's Vec, reset Error. Null/Used/Empty are no-ops.
         *self = Value::Null;
     }
 }
 
-/// Runs when a `HiveRef<Value>` slot is recycled
-/// (`HiveArray::Fallback::put` → `drop_in_place`; see
-/// `bun_collections::HiveRef::unref`). Without this impl `Request`/`Response`
-/// GC finalization leaked `WTFStringImpl` refs / `Blob` stores /
-/// `InternalBlob` buffers (H3 elysia rss).
-///
-/// Unlike `reset()` this never reassigns `*self` (it's already being torn
-/// down), so calling `reset()` first then dropping (or dropping a `Null`
-/// produced by `reset()`) is a no-op second pass — no double-free.
+/// `WTFStringImpl` is the one payload held as a raw ref; every other variant's
+/// payload releases itself.
 impl Drop for Value {
     fn drop(&mut self) {
-        match self {
-            Value::Locked(locked) => {
-                if !locked.deinit {
-                    locked.deinit = true;
-                    locked.readable.deinit();
-                }
-            }
-            Value::WTFStringImpl(s) => wtf_impl(s).deref(),
-            Value::Blob(b) => b.deinit(),
-            Value::Error(e) => e.reset(),
-            // `InternalBlob`'s `Vec<u8>` is freed by the compiler's drop glue.
-            Value::InternalBlob(_) | Value::Used | Value::Empty | Value::Null => {}
+        if let Value::WTFStringImpl(s) = self {
+            wtf_impl(s).deref();
         }
     }
 }
@@ -2059,7 +2023,6 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 webcore::form_data::Encoding::Multipart(b)
             }
         };
-        // encoder dropped at end of scope (replaces defer encoder.deinit())
 
         let js_value =
             match webcore::form_data::FormData::to_js(global_object, blob.slice(), &encoding) {

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -52,9 +52,6 @@ impl readable_stream::SourceContext for ByteBlobLoader {
     fn on_cancel(&mut self) {
         Self::on_cancel(self);
     }
-    fn deinit_fn(&mut self) {
-        Self::deinit(self)
-    }
     fn drain_internal_buffer(&mut self) -> Vec<u8> {
         Self::drain(self)
     }
@@ -180,14 +177,6 @@ impl ByteBlobLoader {
     }
 
     pub(crate) fn on_cancel(&mut self) {
-        self.clear_data();
-    }
-
-    // Kept as inherent method (not `Drop`) — invoked via `SourceContext::deinit_fn`.
-    // Only side-effect teardown lives here; the enclosing `Box<Source>` is freed by
-    // the caller (`NewSource::decrement_count`) *after* this returns. Freeing the
-    // parent here would deallocate the storage backing `&mut self` (dangling UAF).
-    pub(crate) fn deinit(&mut self) {
         self.clear_data();
     }
 

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -47,13 +47,6 @@ impl Entry {
     }
 }
 
-impl Drop for Entry {
-    fn drop(&mut self) {
-        self.blob.deinit();
-        // The allocation itself is freed by the `Box<Entry>` drop.
-    }
-}
-
 impl ObjectURLRegistry {
     pub(crate) fn register(&self, vm: &mut VirtualMachine, blob: &Blob) -> UUID {
         let uuid = vm.rare_data().next_uuid();

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -83,10 +83,6 @@ impl Strong {
         }
     }
 
-    pub(crate) fn deinit(&mut self) {
-        *self = Self::Empty;
-    }
-
     /// The held stream, re-tagged. Pure: no script, no exception, no trap poll (unlike
     /// [`ReadableStream::from_js`], which converts arbitrary values).
     pub(crate) fn get(&self) -> Option<ReadableStream> {
@@ -760,12 +756,12 @@ pub trait SourceContext: Sized {
     fn on_start(&mut self) -> streams::Start;
     fn on_pull(&mut self, buf: &mut [u8], view: JSValue) -> streams::Result;
     fn on_cancel(&mut self);
-    /// Per-context teardown side-effects (unref pollers, flush pending callbacks,
-    /// release handles). **Must NOT free the enclosing `NewSource<Self>` allocation** —
+    /// Per-context teardown side-effects beyond field `Drop` (unref pollers, flush
+    /// pending callbacks). **Must NOT free the enclosing `NewSource<Self>` allocation** —
     /// that is done by the caller ([`NewSource::decrement_count`]) *after* this
     /// returns, via `Box::from_raw`, which then runs `Drop` on every field. Freeing
     /// here would deallocate the storage backing the live `&mut self` borrow (UAF).
-    fn deinit_fn(&mut self);
+    fn deinit_fn(&mut self) {}
 
     fn finalize_detach(&mut self) -> bool {
         false

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -593,6 +593,18 @@ mod windows_impl {
 
     bun_io::intrusive_uv_fs!(WriteFileWindows, io_request);
 
+    impl Drop for WriteFileWindows {
+        fn drop(&mut self) {
+            if self.fd > 0 && self.owned_fd {
+                aio::Closer::close(Fd::from_uv(self.fd), self.io_request.loop_);
+            }
+            self.poll_ref.disable();
+            // SAFETY: `io_request` is a valid `uv_fs_t`; `uv_fs_req_cleanup` is
+            // safe on a zeroed or previously-used req.
+            unsafe { uv::uv_fs_req_cleanup(&mut self.io_request) };
+        }
+    }
+
     #[derive(thiserror::Error, Debug)]
     pub(crate) enum WriteFileWindowsError {
         #[error("WriteFileWindowsDeinitialized")]
@@ -649,7 +661,7 @@ mod windows_impl {
             // `open`/`do_write_loop` may free `*write_file` on the `Err` path,
             // so we operate through the raw `write_file` pointer rather than
             // holding a `&mut` across those calls (Stacked Borrows: a `&mut`
-            // local would dangle once `deinit` reclaims the Box).
+            // local would dangle once `run_from_js_thread` reclaims the Box).
             unsafe {
                 (*write_file).io_request.loop_ = (*event_loop).uv_loop();
                 (*write_file).io_request.data = write_file.cast::<c_void>();
@@ -724,7 +736,7 @@ mod windows_impl {
 
         /// # Safety
         /// `this` must point to a live `WriteFileWindows` allocated via [`Self::new`].
-        /// On `Err` return, `*this` has been freed (via [`Self::throw`] → [`Self::deinit`])
+        /// On `Err` return, `*this` has been freed (via [`Self::throw`])
         /// and must not be accessed again.
         pub(crate) unsafe fn open(this: *mut Self) -> Result<(), WriteFileWindowsError> {
             // SAFETY: caller contract — `this` is live.
@@ -802,7 +814,7 @@ mod windows_impl {
         pub(crate) extern "C" fn on_open(req: *mut uv::fs_t) {
             // SAFETY: req points to WriteFileWindows.io_request. Kept as a raw
             // pointer (NOT `&mut`) because the paths below may free `*this`
-            // (`throw`/`do_write_loop` → `deinit`), and a `&mut` argument/local
+            // (`throw`/`do_write_loop`), and a `&mut` argument/local
             // would be invalidated by that deallocation (Stacked Borrows).
             let this: *mut WriteFileWindows = unsafe { WriteFileWindows::from_uv_fs(req) };
             debug_assert!(core::ptr::eq(
@@ -913,7 +925,7 @@ mod windows_impl {
                 completion_ctx: ctx,
                 // BORROW: AsyncMkdirp.path is `*const [u8]` (not owned); `path`
                 // points into `self.file_blob.store`, which outlives the mkdirp
-                // task (it's released only in `deinit()`).
+                // task (it's released only when `self` drops).
                 path: bun_core::dirname(path)
                     // this shouldn't happen
                     .unwrap_or(path) as *const [u8],
@@ -924,7 +936,7 @@ mod windows_impl {
 
         /// # Safety
         /// `this` must point to a live `WriteFileWindows` allocated via [`Self::new`].
-        /// `*this` may be freed by the time this returns (via `throw`/`open` → `deinit`).
+        /// `*this` may be freed by the time this returns (via `throw`/`open`).
         unsafe fn on_mkdirp_complete(this: *mut Self) {
             // SAFETY: caller contract — `this` is live.
             let err = unsafe { (*this).err.take() };
@@ -982,7 +994,7 @@ mod windows_impl {
         extern "C" fn on_write_complete(req: *mut uv::fs_t) {
             // SAFETY: req points to WriteFileWindows.io_request. Kept as a raw
             // pointer (NOT `&mut`) because the paths below may free `*this`
-            // (`throw`/`do_write_loop` → `deinit`), and a `&mut` would be
+            // (`throw`/`do_write_loop`), and a `&mut` would be
             // invalidated by that deallocation (Stacked Borrows).
             let this: *mut WriteFileWindows = unsafe { WriteFileWindows::from_uv_fs(req) };
             debug_assert!(core::ptr::eq(
@@ -1039,22 +1051,19 @@ mod windows_impl {
         /// `this` must point to a live `WriteFileWindows` allocated via [`Self::new`].
         /// On return, `*this` has been freed and must not be accessed again.
         pub(crate) unsafe fn run_from_js_thread(this: *mut Self) -> WriteFileWindowsError {
-            // SAFETY: caller contract — `this` is live; copy out everything we
-            // need before `deinit` frees the allocation.
-            let (cb, cb_ctx) = unsafe { ((*this).on_complete_callback, (*this).on_complete_ctx) };
+            // SAFETY: caller contract — `this` is the live allocation from
+            // `Self::new`; reclaimed here and dropped before the callback runs.
+            let this = unsafe { bun_core::heap::take(this) };
+            let (cb, cb_ctx) = (this.on_complete_callback, this.on_complete_ctx);
 
-            // SAFETY: caller contract — `this` is live.
-            if let Some(err) = unsafe { (*this).to_system_error() } {
-                // SAFETY: caller contract — `this` is live; consumed here.
-                unsafe { Self::deinit(this) };
+            if let Some(err) = this.to_system_error() {
+                drop(this);
                 if let Err(e) = cb(cb_ctx, WriteFileResultType::Err(Box::new(err))) {
                     return e.into();
                 }
             } else {
-                // SAFETY: caller contract — `this` is live.
-                let wrote = unsafe { (*this).total_written };
-                // SAFETY: caller contract — `this` is live; consumed here.
-                unsafe { Self::deinit(this) };
+                let wrote = this.total_written;
+                drop(this);
                 if let Err(e) = cb(cb_ctx, WriteFileResultType::Result(wrote as SizeType)) {
                     return e.into();
                 }
@@ -1099,7 +1108,7 @@ mod windows_impl {
 
         /// # Safety
         /// `this` must point to a live `WriteFileWindows` allocated via [`Self::new`].
-        /// On `Err` return, `*this` has been freed (via `on_finish`/`throw` → `deinit`)
+        /// On `Err` return, `*this` has been freed (via `on_finish`/`throw`)
         /// and must not be accessed again. On `Ok`, `*this` remains live.
         pub(crate) unsafe fn do_write_loop(
             this: *mut Self,
@@ -1171,31 +1180,6 @@ mod windows_impl {
 
         pub(crate) fn new(init: WriteFileWindows) -> *mut WriteFileWindows {
             bun_core::heap::into_raw(Box::new(init))
-        }
-
-        /// # Safety
-        /// `this` must be the unique live pointer to a `WriteFileWindows`
-        /// allocated via [`Self::new`]. Consumes the allocation; `*this` is
-        /// freed and must not be accessed after this returns.
-        ///
-        /// Takes a raw pointer (not `&mut self`) because reclaiming the `Box`
-        /// while a `&mut self` argument is on the stack is a Stacked Borrows
-        /// protector violation (deallocating memory a protected reference
-        /// points into is UB even if the reference is never used again).
-        pub(crate) unsafe fn deinit(this: *mut Self) {
-            // SAFETY: caller contract — `this` is live.
-            unsafe {
-                let fd = (*this).fd;
-                if fd > 0 && (*this).owned_fd {
-                    aio::Closer::close(Fd::from_uv(fd), (*this).io_request.loop_);
-                }
-                (*this).poll_ref.disable();
-                // (*this).io_request is a valid uv_fs_t embedded in this struct; uv_fs_req_cleanup
-                // is safe on a zeroed or previously-used req.
-                uv::uv_fs_req_cleanup(&mut (*this).io_request);
-                // `this` was allocated via Self::new (heap::into_raw); reclaim and drop here.
-                drop(bun_core::heap::take(this));
-            }
         }
 
         pub(crate) fn create<C>(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -188,9 +188,7 @@ impl HTTPRequestBody {
     pub(crate) fn detach(&mut self) {
         match self {
             HTTPRequestBody::AnyBlob(blob) => blob.detach(),
-            HTTPRequestBody::ReadableStream(stream) => {
-                stream.deinit();
-            }
+            HTTPRequestBody::ReadableStream(stream) => *stream = ReadableStreamStrong::Empty,
             HTTPRequestBody::Sendfile(sendfile) => {
                 if sendfile.offset.max(sendfile.remain) > 0 {
                     sendfile.fd.close();
@@ -215,10 +213,8 @@ impl HTTPRequestBody {
         }
         if let BodyValue::Locked(locked) = &mut body_value {
             if locked.readable.has() {
-                // `BodyValue` now has `Drop` (H3), so we cannot move
-                // `l.readable` out by value (E0509). `mem::take` leaves a default
-                // readable; `Value::drop` on the residual `Locked` then runs
-                // `readable.deinit()` on that default — a no-op.
+                // `BodyValue` has `Drop`, so `locked.readable` cannot move out by
+                // value (E0509); `mem::take` leaves an empty one.
                 return Ok(HTTPRequestBody::ReadableStream(core::mem::take(
                     &mut locked.readable,
                 )));
@@ -2614,14 +2610,11 @@ impl FetchTaskletPromiseSettle {
         let prom = self.promise.value_or_empty().as_any_promise().unwrap();
         let res = self.held.swap();
         res.ensure_still_alive();
-        let r = if self.success {
+        if self.success {
             prom.resolve(&self.global_object, res)
         } else {
             prom.reject_with_async_stack(&self.global_object, res)
-        };
-        self.held.deinit();
-        self.promise = jsc::JSPromiseStrong::empty();
-        r
+        }
     }
 }
 

--- a/test/internal/source-lints/self-receiver-reclaim.test.ts
+++ b/test/internal/source-lints/self-receiver-reclaim.test.ts
@@ -75,12 +75,7 @@ const BANNED = new RegExp(`${RECLAIM}(?:${SELF_AS_POINTER})`, "g");
 
 // Documented, ratcheted exceptions: files allowed to keep exactly N of the
 // shape. Prefer converting over adding an entry here.
-const ALLOW: Record<string, number> = {
-  // `Blob::deinit(&mut self)` frees heap-allocated blobs through its receiver.
-  // It is being converted separately (#37672); delete this entry when that
-  // lands.
-  "src/jsc/webcore_types.rs": 1,
-};
+const ALLOW: Record<string, number> = {};
 
 const counts: Record<string, number> = {};
 const offenders: string[] = [];


### PR DESCRIPTION
### What does this PR do?

Continues the RAII cleanup (#40478, #40516) in `src/runtime/webcore`: types whose `deinit()` only released what their fields already release on `Drop` lose the method, and their owners stop calling it.

- `Blob::deinit()` is gone. A by-value `Blob` (stack value or struct field, count 0) releases its `Store` ref, `name` and content type through field `Drop`, so the `scopeguard::guard(blob, |b| b.deinit())` guards in `Body`, `Blob`, `jsc_hooks` and the explicit calls in `S3BlobDownloadTask`/`ObjectURLRegistry`/`FileRoute` `Drop` impls disappear. The heap case that `deinit()` also handled (free the box when `is_heap_allocated()`) is now `unsafe fn Blob::destroy(this)`, called from `Blob__deref` at count 0 and one construction error path — no more "re-arm the count so deinit's guard fires".
- `ReadableStream::Strong::deinit()` (`*self = Empty`) is gone; early releases write `Strong::Empty`, end-of-life ones just drop. `Body::PendingValue`'s `deinit` latch field goes with it, and `Drop for Body::Value` shrinks to the one payload held as a raw ref (`WTFStringImpl`).
- `WriteFileWindows::deinit(*mut Self)` → `impl Drop` (close fd, `poll_ref.disable()`, `uv_fs_req_cleanup`); `ByteBlobLoader::deinit` (pure field drops) removed.
- The `self-receiver-reclaim` source lint's one allowlist entry (for `Blob::deinit`) is removed.

No behaviour change intended; same releases at the same points (two store releases now happen after an adjacent `poll.unref` instead of before). Left as-is: the `uv fs_t` cleanups in read_file/copy_file (the request is reused between calls, so cleanup is not end-of-life) and the `strong::Optional::deinit()` early-release calls (that type's API is untouched here).

### How did you verify your code works?

`cargo check`/clippy (linux + windows), source lints; debug build + body, blob, fetch.stream, streams, serve-body-leak, bun-serve-file, bun-write suites.