### PR TITLE
Bun.serve http2: normalize req.url and give bodyless requests a null body, as HTTP/1.1 does

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -340,9 +340,15 @@ pub(super) trait RespLike {
     fn timeout(&mut self, seconds: u8);
     fn on_timeout_warn(&mut self, ud: *mut c_void);
     fn to_any_response(&mut self) -> uws::AnyResponse;
+    /// HTTP/2 only: END_STREAM on the HEADERS frame, or `content-length: 0`.
+    fn request_body_ended(&mut self) -> bool;
 }
 impl<const SSL: bool> RespLike for uws_sys::NewAppResponse<SSL> {
     const IS_MUX: bool = false;
+    #[inline]
+    fn request_body_ended(&mut self) -> bool {
+        false
+    }
     #[inline]
     fn write_status(&mut self, s: &[u8]) {
         uws_sys::NewAppResponse::<SSL>::write_status(self, s)
@@ -383,6 +389,11 @@ impl<const SSL: bool> RespLike for uws_sys::NewAppResponse<SSL> {
 }
 impl RespLike for uws_sys::h3::Response {
     const IS_MUX: bool = true;
+    /// The QUIC FIN is only seen by a read after dispatch.
+    #[inline]
+    fn request_body_ended(&mut self) -> bool {
+        false
+    }
     #[inline]
     fn write_status(&mut self, s: &[u8]) {
         uws_sys::h3::Response::write_status(self, s)
@@ -410,6 +421,10 @@ impl RespLike for uws_sys::h3::Response {
 }
 impl RespLike for uws_sys::h2::Response {
     const IS_MUX: bool = true;
+    #[inline]
+    fn request_body_ended(&mut self) -> bool {
+        uws_sys::h2::Response::request_body_ended(self)
+    }
     #[inline]
     fn write_status(&mut self, s: &[u8]) {
         uws_sys::h2::Response::write_status(self, s)
@@ -3063,7 +3078,15 @@ where
             if !path.is_empty() && path[0] == b'/' {
                 if let Some(mut s) = prefix {
                     s.extend_from_slice(path);
-                    request_object.url.set(BunString::clone_utf8(&s));
+                    // Same WHATWG pass as `Request::ensure_url` for HTTP/1.
+                    let href = bun_url::href_from_string(&BunString::from_bytes(&s));
+                    request_object.url.set(if href.is_empty() {
+                        BunString::clone_utf8(&s)
+                    } else if core::ptr::eq(href.byte_slice().as_ptr(), s.as_ptr()) {
+                        BunString::clone_latin1(&s[..href.length()])
+                    } else {
+                        href
+                    });
                 } else {
                     request_object.url.set(BunString::clone_utf8(path));
                 }
@@ -3088,11 +3111,8 @@ where
             ctx.set_request_body_content_len(req_len);
             let is_te = ReqLike::has_transfer_encoding(req);
             ctx.set_is_transfer_encoding(is_te);
-            // HTTP/2 and HTTP/3: Content-Length is optional and
-            // Transfer-Encoding is forbidden; the body is terminated by
-            // END_STREAM / the QUIC stream FIN, so always arm onData for
-            // body methods.
-            if req_len > 0 || is_te || Ctx::IS_MUX {
+            // HTTP/2 and HTTP/3 frame the body by END_STREAM or QUIC FIN, not Content-Length.
+            if req_len > 0 || is_te || (Ctx::IS_MUX && !RespLike::request_body_ended(resp)) {
                 // we defer pre-allocating the body until we receive the first chunk
                 // that way if the client is lying about how big the body is or the client aborts
                 // we don't waste memory

--- a/src/uws_sys/h2.rs
+++ b/src/uws_sys/h2.rs
@@ -128,6 +128,10 @@ impl Response {
     pub(crate) fn is_closed(&self) -> bool {
         c::uws_h2_res_is_closed(self)
     }
+    /// END_STREAM on the HEADERS frame, or `content-length: 0`.
+    pub fn request_body_ended(&self) -> bool {
+        c::uws_h2_res_request_body_ended(self)
+    }
     pub(crate) fn is_corked(&self) -> bool {
         false
     }
@@ -601,6 +605,7 @@ mod c {
         pub(super) safe fn uws_h2_res_end_stream(res: &mut Response, close: bool);
         pub(super) safe fn uws_h2_res_force_close(res: &mut Response);
         pub(super) safe fn uws_h2_res_is_closed(res: &Response) -> bool;
+        pub(super) safe fn uws_h2_res_request_body_ended(res: &Response) -> bool;
         pub(super) fn uws_h2_res_try_end(
             res: *mut Response,
             p: *const u8,

--- a/src/uws_sys/libuwsockets_h2.cpp
+++ b/src/uws_sys/libuwsockets_h2.cpp
@@ -87,6 +87,13 @@ void uws_h2_res_end_stream(uws_h2_res_t* res, bool close_connection)
 
 bool uws_h2_res_is_closed(uws_h2_res_t* res) { return ((Http2Response*)res)->dead; }
 
+/* END_STREAM on the request HEADERS, or content-length: 0 (declaredContentLength is -1 when absent). */
+bool uws_h2_res_request_body_ended(uws_h2_res_t* res)
+{
+    Http2Response* r = (Http2Response*)res;
+    return r->remoteClosed || r->declaredContentLength == 0;
+}
+
 /* Server-side failure after the response started (a body stream errored,
  * a file read failed): the peer sees INTERNAL_ERROR, not a cancel. */
 void uws_h2_res_force_close(uws_h2_res_t* res)

--- a/test/js/bun/http/serve-http2-fixture.ts
+++ b/test/js/bun/http/serve-http2-fixture.ts
@@ -100,6 +100,8 @@ async function handler(req: Request, server: Bun.Server<undefined>): Promise<Res
       for (const [k, v] of req.headers) out[k] = v;
       return Response.json({ url: req.url, method: req.method, headers: out });
     }
+    case "/body-null":
+      return new Response(String(req.body === null), { headers: { "x-method": req.method } });
     case "/set-cookies":
       return new Response("ok", {
         headers: [

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -23,6 +23,37 @@ import {
   startFixture,
 } from "./serve-http2-helpers";
 
+/** One HTTP/1.1 request on the fixture's port, written byte-exact (no
+ * client-side URL normalization), so HTTP/1.1 can serve as the oracle for what
+ * the handler must see over h2. Resolves once `content-length` bytes of body
+ * have arrived; rejects with whatever was received if the server closes first
+ * (a 400, or a response without content-length). */
+async function h1Request(port: number, secure: boolean, raw: string): Promise<{ status: number; body: string }> {
+  const socket: net.Socket = secure
+    ? tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false, ALPNProtocols: ["http/1.1"] })
+    : net.connect({ port, host: "127.0.0.1" });
+  const { promise, resolve, reject } = Promise.withResolvers<{ status: number; body: string }>();
+  let text = "";
+  socket.on("error", reject);
+  socket.on("close", () =>
+    reject(new Error("HTTP/1.1 oracle: connection closed before a complete response: " + JSON.stringify(text))),
+  );
+  socket.on("data", (chunk: Buffer) => {
+    text += chunk.toString("latin1");
+    const sep = text.indexOf("\r\n\r\n");
+    if (sep === -1) return;
+    const head = text.slice(0, sep);
+    const body = text.slice(sep + 4);
+    const length = Number(/\r\ncontent-length: (\d+)/i.exec(head)?.[1] ?? NaN);
+    if (body.length >= length) {
+      socket.destroy();
+      resolve({ status: Number(head.split(" ")[1]), body: body.slice(0, length) });
+    }
+  });
+  socket.on(secure ? "secureConnect" : "connect", () => socket.write(raw, "latin1"));
+  return promise;
+}
+
 for (const secure of [true, false]) {
   describe(`Bun.serve http2 (${secure ? "TLS + ALPN" : "cleartext prior-knowledge"})`, () => {
     let fx: Fixture;
@@ -141,6 +172,67 @@ for (const secure of [true, false]) {
       expect(json.headers["x-long"]).toHaveLength(6000);
       expect(json.headers["host"]).toBe("example.test:9");
       expect(json.headers["cookie"]).toBe("k=v");
+    });
+
+    // The HTTP/1 path builds req.url through the WHATWG parser (dot segments
+    // collapse, the path and query are percent-encoded). The h2 path used to
+    // paste :path in verbatim, so a guard or cache keyed on req.url saw a
+    // different string per transport for the same resource.
+    test("req.url is normalized the same way HTTP/1.1 normalizes it on the same port", async () => {
+      const scheme = secure ? "https" : "http";
+      const raw = await RawH2.connect(fx.port, secure);
+      let streamId = 1;
+      for (const [path, expected] of [
+        ["/a/../headers", "/headers"],
+        ["/./headers", "/headers"],
+        ["/%2e/headers", "/headers"],
+        ['/headers?q=a"b<c>', "/headers?q=a%22b%3Cc%3E"],
+      ]) {
+        raw.headers(streamId, baseHeaders(path));
+        const h2 = JSON.parse((await raw.body(streamId)).toString());
+        expect([path, h2.url]).toEqual([path, `${scheme}://localhost${expected}`]);
+        streamId += 2;
+        const h1 = await h1Request(fx.port, secure, `GET ${path} HTTP/1.1\r\nHost: localhost\r\n\r\n`);
+        expect([path, JSON.parse(h1.body).url]).toEqual([path, h2.url]);
+      }
+      raw.close();
+    });
+
+    // HTTP/1 gives req.body === null for a request that promises no body (no
+    // Content-Length, no Transfer-Encoding, or content-length: 0). The h2
+    // path used to hand every non-GET/HEAD request an empty stream instead, so
+    // `if (req.body)` and `fetch(upstream, { body: req.body })` diverged.
+    test.each(["GET", "POST", "DELETE", "OPTIONS", "PURGE"])(
+      "req.body is null for a %s whose HEADERS frame carries END_STREAM",
+      async method => {
+        const res = await request(session, { ":path": "/body-null", ":method": method }, null, { endStream: true });
+        expect([res.headers["x-method"], res.body.toString()]).toEqual([method, "true"]);
+      },
+    );
+
+    test("req.body is null for content-length: 0 and a stream otherwise, as over HTTP/1.1", async () => {
+      const withBody = await request(session, { ":path": "/body-null", ":method": "POST" }, "x");
+      expect(withBody.body.toString()).toBe("false");
+
+      const raw = await RawH2.connect(fx.port, secure);
+      // content-length: 0 without END_STREAM: no byte can follow, the empty
+      // DATA frame only completes the stream.
+      raw.headers(1, [...baseHeaders("/body-null", "POST"), ["content-length", "0"]], F.END_HEADERS);
+      raw.write(frame(T.DATA, F.END_STREAM, 1, Buffer.alloc(0)));
+      expect((await raw.body(1)).toString()).toBe("true");
+      // No content-length and no END_STREAM: bytes may still follow, so the
+      // body is a stream (an empty one here).
+      raw.headers(3, baseHeaders("/body-null", "POST"), F.END_HEADERS);
+      raw.write(frame(T.DATA, F.END_STREAM, 3, Buffer.alloc(0)));
+      expect((await raw.body(3)).toString()).toBe("false");
+      raw.close();
+
+      // The HTTP/1.1 oracle on the same port.
+      const h1 = (headers: string, body = "") =>
+        h1Request(fx.port, secure, `POST /body-null HTTP/1.1\r\nHost: localhost\r\n${headers}\r\n${body}`);
+      expect((await h1("")).body).toBe("true");
+      expect((await h1("Content-Length: 0\r\n")).body).toBe("true");
+      expect((await h1("Content-Length: 1\r\n", "x")).body).toBe("false");
     });
 
     test("split cookie fields are joined with '; '", async () => {


### PR DESCRIPTION
### Problem
- Over `http2: true`, `req.url` is `scheme://host` plus the raw `:path`. The HTTP/1.1 path on the same port runs the request target through the WHATWG parser. So `/a/../s`, `/./s` and `/%2e/s` reach the handler as sent over h2 and as `/s` over h1. Anything keyed on `req.url` (a guard, a logger, a cache) sees a different string per transport for the same resource. The cause is the eager URL build for MUX requests in `src/runtime/server/server_body.rs` (`prepare_js_request_context_for`), which skipped the `bun_url::href_from_string` pass that `Request::ensure_url` applies for h1.
- A POST, DELETE, OPTIONS or PURGE whose HEADERS frame carries END_STREAM gets an empty `ReadableStream` as `req.body`. HTTP/1.1 gives `null` for a request with no Content-Length and no Transfer-Encoding, including `content-length: 0`. The arming rule was `req_len > 0 || is_te || IS_MUX`: every body-method request over h2 or h3 got a pending body.

### Fix
- The MUX URL build now runs the same `href_from_string` normalization as `ensure_url`, with the same fallback to the raw string when the parser rejects the input.
- New `uws_h2_res_request_body_ended` (`src/uws_sys/libuwsockets_h2.cpp`): true when the stream is already half-closed by the peer or declared `content-length: 0`. `RespLike::request_body_ended` exposes it, and the arming rule becomes `req_len > 0 || is_te || (IS_MUX && !request_body_ended)`. HTTP/3 answers `false` (the QUIC FIN is only seen by a later read), so its behavior is unchanged.
- Correct because a stream that is half-closed by the peer cannot carry DATA, and `content-length: 0` with a later empty DATA frame only completes the stream. The C++ layer already rejects END_STREAM with `content-length > 0`.
- Verified: `test/js/bun/http/serve-http2.test.ts`, two new tests over TLS and cleartext (4 cases, all fail on main). Each compares h2 against an HTTP/1.1 request on the same port. Also `serve-http2-protocol`, `serve-http2-lifecycle`, `serve-http3`, `serve-protocols` (367 pass).

### Background
- `Request.url` for HTTP/1 is computed lazily from the uWS request in `Request::ensure_url` (`src/runtime/webcore/Request.rs`). HTTP/2 and HTTP/3 requests populate `url` and `headers` eagerly at dispatch because the uWS request handle does not outlive the callback.
- `req.body` starts as `BodyValue::Null`. When bytes may arrive, the server installs a `Locked` pending value and arms the transport's onData callback. The JS `Request.body` getter reports `null` only for `Null`.
- `Http2Response::remoteClosed` is set from the END_STREAM flag before the router runs, so the information is available at the point the body is armed.

<details><summary>Notes</summary>

- The uWS routers (h1 and h2) match on the raw path, so `routes["/s"]` still does not match `/a/../s` on either transport. That is unchanged here and identical across transports.
- With `content-length: 0` and no END_STREAM, the handler may answer before the empty DATA frame arrives. The stream then ends with RST_STREAM NO_ERROR after the response, the existing early-response path, and the late DATA frame is ignored.
- The fixture gained a `/body-null` route that returns `String(req.body === null)`.
- Follows #40676 (protocol-level validation). This PR is the app-layer parity part.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http2.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/http/serve-http2.test.ts:
(pass) Bun.serve http2 (TLS + ALPN) > ALPN negotiated h2 [784.52ms]
(pass) Bun.serve http2 (TLS + ALPN) > GET through fetch handler [381.37ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST body is echoed with status and request headers [94.74ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST with END_STREAM on HEADERS (no body) resolves req.text() [33.97ms]
(pass) Bun.serve http2 (TLS + ALPN) > 204 has no body [32.41ms]
(pass) Bun.serve http2 (TLS + ALPN) > HEAD returns content-length and no body [33.91ms]
(pass) Bun.serve http2 (TLS + ALPN) > unknown route is 404 from fetch [27.12ms]
(pass) Bun.serve http2 (TLS + ALPN) > routes: params, per-method, static Response, file route [382.14ms]
(pass) Bun.serve http2 (TLS + ALPN) > request url and headers reach the handler; :authority becomes host [169.53ms]
188 |         ["/%2e/headers", "/headers"],
189 |         ['/headers?q=a"b<c>', "/headers?q=a%22b%3Cc%3E"],
190 |       ]) {
191 |         
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (73795141c)

test/js/bun/http/serve-http2.test.ts:
(pass) Bun.serve http2 (TLS + ALPN) > ALPN negotiated h2 [16.94ms]
(pass) Bun.serve http2 (TLS + ALPN) > GET through fetch handler [4.70ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST body is echoed with status and request headers [1.04ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST with END_STREAM on HEADERS (no body) resolves req.text() [0.46ms]
(pass) Bun.serve http2 (TLS + ALPN) > 204 has no body [0.42ms]
(pass) Bun.serve http2 (TLS + ALPN) > HEAD returns content-length and no body [3.45ms]
(pass) Bun.serve http2 (TLS + ALPN) > unknown route is 404 from fetch [0.38ms]
(pass) Bun.serve http2 (TLS + ALPN) > routes: params, per-method, static Response, file route [29.64ms]
(pass) Bun.serve http2 (TLS + ALPN) > request url and headers reach the handler; :authority becomes host [0.79ms]
(pass) Bun.serve http2 (TLS + ALPN) > req.url is normalized the same way HTTP/1.1 normalizes it on the same port [14.05ms]
(pass) Bun.serve http2 (TLS + ALPN) > req.body is null for a GET whose HEADERS frame carries END_STREAM [0.40ms]
(pass) Bun.serve http2 (TLS + ALPN) > req.body is null for a POST whose HEADE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http2.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/http/serve-http2.test.ts:
(pass) Bun.serve http2 (TLS + ALPN) > ALPN negotiated h2 [455.26ms]
(pass) Bun.serve http2 (TLS + ALPN) > GET through fetch handler [225.53ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST body is echoed with status and request headers [54.93ms]
(pass) Bun.serve http2 (TLS + ALPN) > POST with END_STREAM on HEADERS (no body) resolves req.text() [20.66ms]
(pass) Bun.serve http2 (TLS + ALPN) > 204 has no body [18.46ms]
(pass) Bun.serve http2 (TLS + ALPN) > HEAD returns content-length and no body [19.20ms]
(pass) Bun.serve http2 (TLS + ALPN) > unknown route is 404 from fetch [15.38ms]
(pass) Bun.serve http2 (TLS + ALPN) > routes: params, per-method, static Response, file route [257.66ms]
(pass) Bun.serve http2 (TLS + ALPN) > request url and headers reach the handler; :authority becomes host [79.33ms]
(pass) Bun.serve http2 (TLS + ALPN) > req.url is normalized the same way HTTP/1.1 normalizes it on the same port [323.63ms]
(pass) Bun.serve
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     80de99f470
  features     baseline

23 deps, 131 codegen, 1172 objects in 843ms

ninja: Entering directory `/workspace/bun/build/release'
[1/143] fetch WebKit (prebuilt)
[WebKit] up to date
[2/143] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/143] gen cpp.rs (cppbind)
[4/143] gen JS modules (bundle-modules)
Preprocess modules (8418ms)
Bundle modules (198ms)
Postprocesss modules (762ms)
Bundle Functions (876ms)
Generate Code (32ms)

[10.29s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/143] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/server_body.rs       | 32 +++++++++---
 src/uws_sys/h2.rs                       |  5 ++
 src/uws_sys/libuwsockets_h2.cpp         |  7 +++
 test/js/bun/http/serve-http2-fixture.ts |  2 +
 test/js/bun/http/serve-http2.test.ts    | 92 +++++++++++++++++++++++++++++++++
 5 files changed, 132 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/server/server_body.rs            9     17      0
src/uws_sys/h2.rs                            6      6      0
src/uws_sys/libuwsockets_h2.cpp              3      3      0
test/js/bun/http/serve-http2-fixture.ts      2      2      0
test/js/bun/http/serve-http2.test.ts         6      5      0
```

</details>

<!-- robobun:evidence:end -->