### PR TITLE
darwin-ci: leave the checkout's .git out of the guest sync

### DIFF
--- a/scripts/darwin-ci/README.md
+++ b/scripts/darwin-ci/README.md
@@ -54,6 +54,21 @@ ssh <admin>@<host> 'darwin-ci/host.sh <hostname> tart --tags <tailscale tags>'
 Approve the Tailscale login it prints, reboot when it asks, run the same
 command again, and check the agent appears under `queue=test-darwin`.
 
+## Updating the scripts on a host
+
+The agent runs the hooks from the copy in `/usr/local/share/darwin-ci`, not
+from the job's checkout, so a change under `scripts/darwin-ci` reaches a host
+only once that copy is refreshed. No agent restart is needed: every job starts
+a fresh `hooks/command.ts`.
+
+```sh
+rsync -a --delete scripts/darwin-ci/ <admin>@<host>:darwin-ci/
+ssh <admin>@<host> '/usr/local/bin/bun darwin-ci/main.ts install-self'
+```
+
+A change to `lib/agent.ts` needs `install-agent` too, and a change to what the
+guest image contains needs `bake`.
+
 ## Removing a host
 
 Unload the agent (`launchctl bootout` the `com.buildkite.buildkite-agent`

--- a/scripts/darwin-ci/lib/guest.ts
+++ b/scripts/darwin-ci/lib/guest.ts
@@ -22,6 +22,11 @@ const sshOptions = [
   "ServerAliveInterval=30",
 ];
 
+// The guest gets the working tree only. Nothing in it reads the checkout's .git (the runner takes the commit from
+// the forwarded BUILDKITE_* env), and the `git gc --auto` the agent's fetch leaves running rewrites .git while
+// rsync reads it: a vanished .git/gc.pid fails the sync with exit 23. Anchored, so a nested repo still copies whole.
+export const checkoutExcludes = ["--exclude=/.git"];
+
 export async function ensureHostKey(): Promise<string> {
   if (!(await Bun.file(hostKey).exists())) {
     await $`ssh-keygen -q -t ed25519 -N "" -C ${`${process.env.USER}@darwin-ci`} -f ${hostKey}`;
@@ -50,7 +55,7 @@ export function guest(ip: string) {
     push: (local: string, remote: string) => $`scp ${sshOptions} -q ${local} ${target}:${remote}`.quiet(),
 
     syncTo: (localDir: string, remoteDir: string) =>
-      $`rsync -a --delete -e ${rsh} ${localDir}/ ${target}:${remoteDir}/`.quiet(),
+      $`rsync -a --delete ${checkoutExcludes} -e ${rsh} ${localDir}/ ${target}:${remoteDir}/`.quiet(),
 
     collectReports: (remoteDir: string, localDir: string) =>
       $`rsync -a -e ${rsh} --include=*/ --include=*.xml --include=*.junit --exclude=* --prune-empty-dirs ${target}:${remoteDir}/ ${localDir}/`

--- a/scripts/darwin-ci/main.ts
+++ b/scripts/darwin-ci/main.ts
@@ -23,8 +23,9 @@ const usage = `usage:
   main.ts setup-user                                                    create the auto-login ${config.ciUser} user
   main.ts bake [--base <image>] [--ref <bun ref>]                       build ${config.tart.image} (run as ${config.ciUser})
   main.ts install-agent [--release N] [--spawn N]                       write agent config and launchd jobs
+  main.ts install-self                                                  refresh ${config.installDir} from this checkout
 
-provision, setup-user and install-agent need passwordless sudo.`;
+provision, setup-user, install-agent and install-self need passwordless sudo.`;
 
 const { positionals, values } = parseArgs({
   allowPositionals: true,
@@ -52,6 +53,9 @@ switch (subcommand) {
     break;
   case "install-agent":
     await installTartAgent(agentOptions);
+    break;
+  case "install-self":
+    await installSelf();
     break;
   default:
     fail(usage);

--- a/test/internal/darwin-ci-guest-sync.test.ts
+++ b/test/internal/darwin-ci-guest-sync.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The darwin tart command hook (scripts/darwin-ci/hooks/command.ts) rsyncs the agent's checkout into a fresh
+ * macOS guest with guest().syncTo() from scripts/darwin-ci/lib/guest.ts. The checkout's own .git must stay out
+ * of that copy: the `git gc --auto` the agent's fetch leaves running rewrites .git while rsync reads it, and a
+ * file that vanishes mid-transfer (.git/gc.pid) fails the sync, and the job with it, before any test runs.
+ *
+ * syncTo runs the real rsync over `-e ssh`. A fake `ssh` on PATH drops the ssh options and runs the rsync server
+ * side in a local "guest home" instead, so the command under test is the one the hook runs.
+ */
+import { expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { guest } from "../../scripts/darwin-ci/lib/guest.ts";
+
+const rsync = Bun.which("rsync");
+
+test.skipIf(isWindows || !rsync)("syncTo sends the working tree, not the checkout's .git", async () => {
+  using dir = tempDir("darwin-ci-sync", {
+    "checkout/package.json": `{ "name": "bun" }`,
+    "checkout/.gitignore": "node_modules\n",
+    "checkout/src/index.ts": "export {};\n",
+    "checkout/.git/HEAD": "ref: refs/heads/main\n",
+    "checkout/.git/gc.pid": "12345 host\n",
+    "checkout/.git/objects/pack/pack-a.pack": "PACK",
+    // a vendor clone is its own repository; only the checkout root's .git stays behind
+    "checkout/vendor/elysia/.git/HEAD": "ref: refs/heads/main\n",
+    "checkout/vendor/elysia/package.json": `{ "name": "elysia" }`,
+    // the baked image has an empty ~/work; a leftover must still be mirrored away
+    "guest/work/stale.txt": "from a previous sync\n",
+  });
+  const root = String(dir);
+  const guestHome = join(root, "guest");
+
+  mkdirSync(join(root, "bin"));
+  writeFileSync(
+    join(root, "bin", "ssh"),
+    [
+      "#!/bin/bash",
+      "# stands in for ssh: drop the options (rsync passes the user as -l) and the host, then run the rsync server",
+      "while [[ $1 == -* ]]; do case $1 in -i | -o | -l) shift 2 ;; *) shift ;; esac; done",
+      "shift",
+      `cd ${JSON.stringify(guestHome)} && exec "$@"`,
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  const path = process.env.PATH;
+  process.env.PATH = `${join(root, "bin")}:${path}`;
+  try {
+    await guest("192.0.2.1").syncTo(join(root, "checkout"), "work");
+  } finally {
+    process.env.PATH = path;
+  }
+
+  const work = join(guestHome, "work");
+  expect(existsSync(join(work, ".git"))).toBe(false);
+  expect(existsSync(join(work, "stale.txt"))).toBe(false);
+  expect(readFileSync(join(work, "package.json"), "utf8")).toBe(`{ "name": "bun" }`);
+  expect(readFileSync(join(work, "src", "index.ts"), "utf8")).toBe("export {};\n");
+  expect(readFileSync(join(work, ".gitignore"), "utf8")).toBe("node_modules\n");
+  expect(readFileSync(join(work, "vendor", "elysia", ".git", "HEAD"), "utf8")).toBe("ref: refs/heads/main\n");
+});


### PR DESCRIPTION
### Problem
- A darwin-aarch64 test job on a Tart host fails with `step failed outside runner` before any test runs. The sync step prints `ShellError: Failed with exit code 23` and `rsync(45694): error: .../.git/gc.pid: open (2) ...: No such file or directory` (build 107284, agent `darwin-arm64-baguette-tart-26-1`).
- The command hook rsyncs the whole checkout into the guest, `.git` included (`scripts/darwin-ci/lib/guest.ts:53`). The agent's `git fetch` leaves a detached `git gc --auto` running. It removes `.git/gc.pid` and rewrites packs while rsync reads them. A vanished file is exit 23, fatal to the hook.

### Fix
- `syncTo` passes `--exclude=/.git`. The pattern is anchored to the checkout root, so a nested repository still copies whole.
- Correct because nothing in the guest reads the checkout's `.git`. The runner takes commit, branch, and repository from the forwarded `BUILDKITE_*` env (`scripts/utils.mjs`). Vendor tests clone their own repositories, and tests that need one create it in a temp dir. Nothing else writes to the checkout during the sync.
- `main.ts install-self` exposes the existing `installSelf()`, and the README gets an "Updating the scripts on a host" section. See Rollout.
- Verified: `test/internal/darwin-ci-guest-sync.test.ts` runs the real `syncTo` through a fake `ssh` that runs the rsync server side locally. It fails on main and passes here. Also `test/internal/runner-junit.test.ts`.

### Rollout
- The hosts run the hooks from the copy installed in `/usr/local/share/darwin-ci` at provision time. This PR's own darwin lanes ran that old copy, so a green tart lane here is not evidence the new sync ran. The unit test is.
- After the merge, the five tart hosts (challah, baguette, ciabatta, focaccia, sourdough) need the refresh from the README: `rsync` the directory over, then `main.ts install-self`. No agent restart. cc @alii

### Background
- A `test-darwin` Tart job boots a fresh macOS guest, rsyncs the checkout to `~/work`, and runs `guest/job.sh` over ssh.
- `git gc --auto` runs after a fetch when a repository has too many packs or loose objects. It detaches by default, so it outlives the checkout step.
- rsync exit 23 is "partial transfer due to error". The macOS rsync reports a vanished source file this way. Upstream rsync uses exit 24.

<details><summary>Notes</summary>

- The guest also receives about 1 GB less per job, the size of a full bun `.git`.
- The Tart agent config (`lib/agent.ts`) sets no `git-clone-flags` and no `git-mirrors-path`, so the checkout is a full clone that is fetched on every job and wiped nightly. Each fetch adds a pack or loose objects. Once the count crosses `gc.autoPackLimit` (50) or `gc.auto` (6700), the next fetch triggers the background repack. On a multi-GB repository that takes minutes, so the race window covers the whole sync.
- Excluding only `gc.pid` is not enough. The repack also writes `objects/pack/tmp_pack_*`, then renames them and deletes the old packs, so other files vanish too.
- A retry on exit 23 or 24 was the other option. A repack that is still running can fail the retry the same way, and each attempt copies the whole `.git` again. Leaving `.git` out removes the only concurrent writer to the checkout.
- `--delete` is kept. An excluded path is not deleted on the receiver without `--delete-excluded`, and the baked image ships an empty `~/work` anyway.
- Local check of the failure class: rsync 3.4.1 copying a tree whose `.git/gc.pid` is removed mid-copy exits 24 ("some files vanished") without the exclude and 0 with it.
- Possible follow-ups, each its own PR: let `hooks/command` run the checkout's `scripts/darwin-ci/hooks/command.ts` when present, so a hook fix ships with its commit and a PR's own darwin lane exercises it. Give the Tart agent a `git-mirrors-path` like `scripts/agent.mjs` does.
- #37771 rewrites the same `syncTo` call to an argv array. Whichever lands second needs a one-line rebase.
- The test skips when `rsync` is not on PATH (Windows). The fake `ssh` handles the `-l user` form that rsync uses for `user@host`.
- Also ran `test/internal/build-download-retry.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/internal/darwin-ci-guest-sync.test.ts

<!-- robobun:evidence:end -->