### PR TITLE
bun:test: fail instead of crash when toBeWithin() gets one argument

### DIFF
--- a/src/runtime/test_runner/expect/toBeWithin.rs
+++ b/src/runtime/test_runner/expect/toBeWithin.rs
@@ -18,7 +18,7 @@ impl Expect {
 
         let arguments = frame.arguments();
 
-        if arguments.len() < 1 {
+        if arguments.len() < 2 {
             return Err(global.throw_invalid_arguments(format_args!(
                 "toBeWithin() requires 2 arguments"
             )));

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("Bun.version", () => {
   expect(process.versions.bun).toBe(Bun.version);
@@ -40,4 +40,46 @@ console.log("OK");`,
 
   expect(stdout).toBe("OK\n");
   expect(exitCode).toBe(0);
+});
+
+// toBeWithin() with one argument used to index past the argument slice and
+// abort the process instead of failing the test.
+test("toBeWithin() with missing or non-number arguments fails the test without crashing", async () => {
+  using dir = tempDir("to-be-within-args", {
+    "within.test.ts": `
+      import { test, expect } from "bun:test";
+
+      test("one argument", () => {
+        expect(1).toBeWithin(0);
+      });
+
+      test("no arguments", () => {
+        expect(1).toBeWithin();
+      });
+
+      test("start is not a number", () => {
+        expect(1).toBeWithin("0", 2);
+      });
+
+      test("end is not a number", () => {
+        expect(1).toBeWithin(0, "2");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "within.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("toBeWithin() requires 2 arguments");
+  expect(stderr).toContain("toBeWithin() requires the first argument to be a number");
+  expect(stderr).toContain("toBeWithin() requires the second argument to be a number");
+  expect(stderr).toContain("4 fail");
+  expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
### Problem
- `expect(1).toBeWithin(0)` aborts the `bun test` process with `panic: index out of bounds: the len is 1 but the index is 1` (exit code 134) instead of failing the test.
- `to_be_within` in `src/runtime/test_runner/expect/toBeWithin.rs:21` only rejects a call with zero arguments. It then reads `arguments[1]`. `frame.arguments()` is the raw argument slice, so a one-argument call indexes past its end.

### Fix
- The guard now requires two arguments (`arguments.len() < 2`) before the matcher reads either one. A one-argument call throws the existing `toBeWithin() requires 2 arguments` error, which the test runner reports as a normal test failure.
- `toIncludeRepeated.rs` is the other matcher with two required arguments. It already uses this guard.
- Verified: `test/js/bun/test/bun-test.test.ts` (the new test spawns `bun test` on a fixture with one, zero, and non-number arguments, and asserts four normal failures and exit code 1). Also ran the `toBeWithin()` tests in `test/js/bun/test/expect.test.js` and `test/js/bun/test/jest-extended.test.js`.

### Background
- `CallFrame::arguments()` (`src/jsc/CallFrame.rs`) returns a slice over the JSC register file with exactly `argumentsCount()` entries. An index at or past that count is out of bounds and panics.
- `CallFrame::arguments_as_array::<N>()` is the padded accessor. It fills missing slots with `undefined`. The Zig version of this matcher used a padded array, so the missing second argument read as a non-number and hit the type check. The Rust port switched to the raw slice without changing the guard.

<details><summary>Notes</summary>

- Repro with the released build (1.4.1-canary.1):

  ```ts
  import { test, expect } from "bun:test";
  test("x", () => { expect(1).toBeWithin(0); });
  ```

  `bun test` prints `panic: index out of bounds: the len is 1 but the index is 1` and exits 134. With the fix, the debug build prints `TypeError: toBeWithin() requires 2 arguments` and exits 1.
- Audit of the other matchers under `src/runtime/test_runner/expect/` that read `arguments[1]` or later: `toBeCloseTo`, `toHaveProperty`, `toIncludeRepeated`, `toMatchInlineSnapshot`, `toMatchSnapshot`, and the helpers in `expect.rs` all check the length first. `toBeWithin` was the only unguarded read.
- #32311 also touches `toBeWithin.rs`, but for the expect-call counter order. It does not change this guard.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/bun-test.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/test/bun-test.test.ts:
(pass) Bun.version [9.19ms]
(pass) expect().not.not [1.45ms]
(pass) Bun.jest() expect statics do not crash on misuse [326.57ms]
75 |     stderr: "pipe",
76 |   });
77 | 
78 |   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
79 | 
80 |   expect(stderr).toContain("toBeWithin() requires 2 arguments");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "toBeWithin() requires 2 arguments"
Received: "\nwithin.test.ts:\n============================================================\nBun Debug v1.4.1 (65362b53b) Linux x64\nLinux Kernel v6.17.0 | glibc v2.41\nCPU: sse42 popcnt avx avx2 avx512\nArgs: \"/workspace/bun/build/debug/bun-debug\" \"test\" \"within.test.ts\"\nFeatures: jsc \nBuiltins: \"bun:test\" \n\n\npanic: index out of bounds: the len is 1 but the index is 1\n\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/bun-test.test.ts:80:18)
(fa
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/test/bun-test.test.ts:
(pass) Bun.version [0.05ms]
(pass) expect().not.not [0.02ms]
(pass) Bun.jest() expect statics do not crash on misuse [8.80ms]
75 |     stderr: "pipe",
76 |   });
77 | 
78 |   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
79 | 
80 |   expect(stderr).toContain("toBeWithin() requires 2 arguments");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "toBeWithin() requires 2 arguments"
Received: "\nwithin.test.ts:\n============================================================\nBun Canary v1.4.1-canary.1 (65362b53b) Linux x64\nLinux Kernel v6.17.0 | glibc v2.41\nCPU: sse42 popcnt avx avx2 avx512\nArgs: \"/workspace/bun/build/release/bun\" \"test\" \"within.test.ts\"\nFeatures: jsc \nBuiltins: \"bun:test\" \n\nElapsed: 9ms | User: 1ms | Sys: 4ms\nRSS: 30.57 MB | Peak: 47.60 MB | Commit: 41.29 MB | Faults: 0 | Machine: 34.36 GB\n\npanic: index out of bounds: the len is 1 but the index is 1\noh no: Bun has crashed. This indicates a bug in Bun, not your code.\n\nTo send a redacted crash report to Bun's team,\np
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/bun-test.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/test/bun-test.test.ts:
(pass) Bun.version [11.62ms]
(pass) expect().not.not [1.78ms]
(pass) Bun.jest() expect statics do not crash on misuse [337.46ms]
(pass) toBeWithin() with missing or non-number arguments fails the test without crashing [325.20ms]

 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [2.79s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 702ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 58s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+68d854af9
[build] done
bun test v1.4.1-canary.1 (68d854af9)

test/js/bun/test/bun-test.test.ts:
(pass) Bun.version [0.06ms]
(pass) expect().not.not [0.02ms]
(pass) Bun.jest() expect statics do not crash on misuse [7.53ms]
(pass) toBeWithin() with missing or non-number arguments fails the test without crashing [7.49ms]

 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [511.00ms]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect/toBeWithin.rs |  2 +-
 test/js/bun/test/bun-test.test.ts            | 44 +++++++++++++++++++++++++++-
 2 files changed, 44 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/runtime/test_runner/expect/toBeWithin.rs      1      1      0
test/js/bun/test/bun-test.test.ts                 1      2      0
```

</details>

<!-- robobun:evidence:end -->