### PR TITLE
bun_ptr: make assert_no_refs a debug-only check

### DIFF
--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -218,9 +218,14 @@ impl<T: RefCounted> RefCount<T> {
         self.raw_count.get()
     }
 
-    /// The count is 0 after the destructor is called.
+    /// The count is 0 after the destructor is called. Debug-only: a release
+    /// build must not abort in a destructor over a refcount slip.
     pub fn assert_no_refs(&self) {
-        assert!(self.raw_count.get() == 0);
+        debug_assert_eq!(
+            self.raw_count.get(),
+            0,
+            "destructor ran with refs outstanding"
+        );
     }
 
     fn assert_single_threaded(&self) {
@@ -380,9 +385,14 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
         self.get() == 1
     }
 
-    /// The count is 0 after the destructor is called.
+    /// The count is 0 after the destructor is called. Debug-only: a release
+    /// build must not abort in a destructor over a refcount slip.
     pub fn assert_no_refs(&self) {
-        assert!(self.raw_count.load(Ordering::SeqCst) == 0);
+        debug_assert_eq!(
+            self.raw_count.load(Ordering::SeqCst),
+            0,
+            "destructor ran with refs outstanding"
+        );
     }
 
     #[inline]
@@ -919,6 +929,29 @@ mod tests {
             drop(bun_core::heap::take(s));
         }
         assert_eq!(drops(), before + 1);
+    }
+
+    // ── assert_no_refs ────────────────────────────────────────────────────
+    //
+    // A destructor that runs with refs outstanding is a debug-build assertion
+    // only. Release builds must not abort over it.
+
+    #[test]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "destructor ran with refs outstanding")
+    )]
+    fn ref_count_assert_no_refs_is_debug_only() {
+        RefCount::<Thing>::init().assert_no_refs();
+    }
+
+    #[test]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "destructor ran with refs outstanding")
+    )]
+    fn thread_safe_ref_count_assert_no_refs_is_debug_only() {
+        ThreadSafeRefCount::<Shared>::init().assert_no_refs();
     }
 
     // ── CellRefCounted ────────────────────────────────────────────────────

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -218,8 +218,7 @@ impl<T: RefCounted> RefCount<T> {
         self.raw_count.get()
     }
 
-    /// The count is 0 after the destructor is called. Debug-only: a release
-    /// build must not abort in a destructor over a refcount slip.
+    /// The count is 0 after the destructor is called.
     pub fn assert_no_refs(&self) {
         debug_assert_eq!(
             self.raw_count.get(),
@@ -385,8 +384,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
         self.get() == 1
     }
 
-    /// The count is 0 after the destructor is called. Debug-only: a release
-    /// build must not abort in a destructor over a refcount slip.
+    /// The count is 0 after the destructor is called.
     pub fn assert_no_refs(&self) {
         debug_assert_eq!(
             self.raw_count.load(Ordering::SeqCst),
@@ -932,9 +930,6 @@ mod tests {
     }
 
     // ── assert_no_refs ────────────────────────────────────────────────────
-    //
-    // A destructor that runs with refs outstanding is a debug-build assertion
-    // only. Release builds must not abort over it.
 
     #[test]
     #[cfg_attr(

--- a/test/internal/source-lints/ptr-debug-only-asserts.test.ts
+++ b/test/internal/source-lints/ptr-debug-only-asserts.test.ts
@@ -1,0 +1,104 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `bun_ptr` (src/ptr/) is the intrusive refcount and smart-pointer layer under
+// `RefPtr` and every refcounted host (`FetchTasklet`, `JSValkeyClient`, ...).
+// Its sanity checks compile out of release builds by design: `DebugData` and
+// `ThreadLock` are `#[cfg(debug_assertions)]` state, and the count checks are
+// `debug_assert!`. A bare `assert!` in this crate is a release-build abort
+// ("Bun has crashed"), usually inside a destructor, for a refcount accounting
+// slip that a debug or ASAN build already reports.
+//
+// Motivating instance: `RefCount::assert_no_refs` and
+// `ThreadSafeRefCount::assert_no_refs` (src/ptr/ref_count.rs) were plain
+// `assert!(count == 0)`, called from `FetchTasklet::drop` and
+// `JSValkeyClient::drop`. They are `debug_assert_eq!` now.
+//
+// Spelling: `debug_assert!` / `debug_assert_eq!` / `debug_assert_ne!`. A bare
+// `assert!` inside a `#[cfg(debug_assertions)]` block is flagged too; write it
+// as `debug_assert!`. Compile-time `const { assert!(..) }` blocks and the
+// `#[cfg(test)]` module at the tail of each file are out of scope.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+const rustSources = globAllSources().rust.filter(abs => {
+  if (!abs.endsWith(".rs")) return false;
+  return path.relative(root, abs).replaceAll(path.sep, "/").startsWith("src/ptr/");
+});
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout).
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `assert!`, `assert_eq!`, `assert_ne!`. The lookbehind rejects the `debug_`
+// prefix; the `!` rejects `assert_no_refs(` and friends.
+const RUNTIME_ASSERT = /(?<!\w)assert(?:_eq|_ne)?!\s*\(/;
+
+// Every file in the crate keeps its test module at the tail.
+const TEST_CFG = /^#\[cfg\((?:all\()?test\b/;
+
+// A compile-time const item: inline `const { .. }` or `const _: () = { .. };`.
+// `const fn` bodies run at runtime and do not match.
+const CONST_ITEM = /^\s*(?:pub(?:\([^)]*\))?\s+)?const\s+(?!(?:unsafe\s+)?fn\b)/;
+
+function braceDelta(line: string): number {
+  let depth = 0;
+  for (const ch of line) {
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+  }
+  return depth;
+}
+
+const scanned: string[] = [];
+const offenders: string[] = [];
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned.push(source);
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions do not count. `[ \t]*`, not
+  // `\s*`, so blank lines survive and line numbers hold.
+  const lines = content.replace(/^[ \t]*\/\/.*$/gm, "").split("\n");
+  let constDepth = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (TEST_CFG.test(line)) break;
+    if (constDepth > 0) {
+      constDepth += braceDelta(line);
+      continue;
+    }
+    if (CONST_ITEM.test(line)) {
+      constDepth = Math.max(0, braceDelta(line));
+      continue;
+    }
+    if (RUNTIME_ASSERT.test(line)) offenders.push(`${source}:${i + 1}: ${line.trim()}`);
+  }
+}
+
+test("scans the tracked bun_ptr sources", () => {
+  expect(scanned).toContain("src/ptr/ref_count.rs");
+});
+
+test("the pattern matches a bare assert and not a debug one", () => {
+  expect(RUNTIME_ASSERT.test("        assert!(self.raw_count.get() == 0);")).toBe(true);
+  expect(RUNTIME_ASSERT.test("        assert_eq!(self.raw_count.get(), 0);")).toBe(true);
+  expect(RUNTIME_ASSERT.test("        debug_assert_eq!(self.raw_count.get(), 0);")).toBe(false);
+  expect(RUNTIME_ASSERT.test("        self.ref_count.assert_no_refs();")).toBe(false);
+});
+
+test("bun_ptr has no runtime assert outside its test modules", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `RefCount::assert_no_refs` and `ThreadSafeRefCount::assert_no_refs` (`src/ptr/ref_count.rs:222`, `:384`) are plain `assert!(count == 0)`. Both run from destructors: `FetchTasklet::drop` (`src/runtime/webcore/fetch/FetchTasklet.rs:283`) and `JSValkeyClient::drop` (`src/runtime/valkey_jsc/js_valkey.rs:423`).
- A refcount slip in either (a pending callback that still holds a ref when the object is finalized) aborts a release build with "Bun has crashed". The Zig original gated this check on `ci_assert`. #30918 made it unconditional as an audit instrument, with the plan to downgrade the survivors later.

### Fix
- Replace both `assert!` with `debug_assert_eq!(count, 0, "destructor ran with refs outstanding")`. Debug, ASAN and release-assertions builds still check it. Release builds compile it out.
- `debug_assert_eq!` prints the outstanding count when it fires, so the debug failure carries more than the old bare `assert!`.
- These two were the only runtime `assert!` left in `bun_ptr`. Every other invariant check in the crate is already a `debug_assert!`.
- Verified: `test/internal/source-lints/ptr-debug-only-asserts.test.ts` scans `src/ptr/` for a bare `assert!` outside test modules and const blocks. It reports the two old lines on main and passes here. Two unit tests in `src/ptr/ref_count.rs` run under `cargo miri test -p bun_ptr`: `should_panic` under `debug_assertions`, no panic without it. Also `cargo check`, `cargo clippy` and `cargo fmt` on `bun_ptr`.

### Background
- `bun_ptr::RefCount<T>` / `ThreadSafeRefCount<T>` are the intrusive refcounts that `RefPtr<T>` manages. `deref` runs `T::destructor` when the count hits 0. `assert_no_refs` is a sanity check a `Drop` impl calls to confirm it was reached through that path.
- `debug_assertions` is on in the `dev` profile and in release-asan / release-assertions builds (`scripts/build/rust.ts` sets `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS`). It is off in the shipped release build.

<details><summary>Notes</summary>

- Before the change, the new tests fail under `cargo miri test -p bun_ptr --release` with `assertion left == right failed: destructor ran with refs outstanding` (both tests). After the change they pass in both profiles.
- The test attribute is `#[cfg_attr(debug_assertions, should_panic(expected = "..."))]`, so the same test body checks both behaviors.
- `cargo test -p bun_ptr` without Miri does not link (missing highway / dispatch C symbols). That is pre-existing; `bun run rust:miri -p bun_ptr` is the way to run this crate's tests.
- `cargo clippy -p bun_ptr --all-targets` reports two pre-existing errors in the test module (`std::thread::spawn` disallowed, `deref_addrof`). They are on main too and CI's `rust:clippy` does not lint test targets.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/ptr-debug-only-asserts.test.ts
bun test v1.4.1 (65362b53b)

test/internal/source-lints/ptr-debug-only-asserts.test.ts:
(pass) scans the tracked bun_ptr sources [8.66ms]
(pass) the pattern matches a bare assert and not a debug one [4.46ms]
 98 |   expect(RUNTIME_ASSERT.test("        debug_assert_eq!(self.raw_count.get(), 0);")).toBe(false);
 99 |   expect(RUNTIME_ASSERT.test("        self.ref_count.assert_no_refs();")).toBe(false);
100 | });
101 | 
102 | test("bun_ptr has no runtime assert outside its test modules", () => {
103 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/ptr/ref_count.rs:223: assert!(self.raw_count.get() == 0);",
+   "src/ptr/ref_count.rs:385: assert!(self.raw_count.load(Ordering::SeqCst) == 0);",
+ ]

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/internal/source-lints/ptr-debug-only-asserts.test.ts:103:21)
(fail) bun_ptr has no runtime assert outside its test modules [5.99ms]

 2 pass

... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/internal/source-lints/ptr-debug-only-asserts.test.ts:
(pass) scans the tracked bun_ptr sources [0.07ms]
(pass) the pattern matches a bare assert and not a debug one [0.05ms]
 98 |   expect(RUNTIME_ASSERT.test("        debug_assert_eq!(self.raw_count.get(), 0);")).toBe(false);
 99 |   expect(RUNTIME_ASSERT.test("        self.ref_count.assert_no_refs();")).toBe(false);
100 | });
101 | 
102 | test("bun_ptr has no runtime assert outside its test modules", () => {
103 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/ptr/ref_count.rs:223: assert!(self.raw_count.get() == 0);",
+   "src/ptr/ref_count.rs:385: assert!(self.raw_count.load(Ordering::SeqCst) == 0);",
+ ]

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/internal/source-lints/ptr-debug-only-asserts.test.ts:103:21)
(fail) bun_ptr has no runtime assert outside its test modules [0.35ms]

 2 pass
 1 fail
 6 expect() calls
Ran 3 tests across 1 file. [365.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/ptr-debug-only-asserts.test.ts
bun test v1.4.1 (65362b53b)

test/internal/source-lints/ptr-debug-only-asserts.test.ts:
(pass) scans the tracked bun_ptr sources [4.88ms]
(pass) the pattern matches a bare assert and not a debug one [2.51ms]
(pass) bun_ptr has no runtime assert outside its test modules [1.46ms]

 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [21.44s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6bc3e9538d
  features     baseline

23 deps, 131 codegen, 1172 objects in 715ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/buil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ptr/ref_count.rs                               |  32 ++++++-
 .../source-lints/ptr-debug-only-asserts.test.ts    | 104 +++++++++++++++++++++
 2 files changed, 134 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/ptr/ref_count.rs                                          3      7      0
…st/internal/source-lints/ptr-debug-only-asserts.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->