### PR TITLE
error printer: collect nested errors into the exception list

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5955,7 +5955,7 @@ impl VirtualMachine {
     fn print_error_instance_js(
         &mut self,
         error_instance: JSValue,
-        exception_list: Option<&mut ExceptionList>,
+        mut exception_list: Option<&mut ExceptionList>,
         formatter: &mut crate::console_object::Formatter,
         writer: &mut bun_core::io::Writer,
         allow_ansi_color: bool,
@@ -6006,11 +6006,14 @@ impl VirtualMachine {
         let exception: *mut ZigException = exception_holder.zig_exception();
         let mut source_code_slice: Option<bun_core::Utf8Bytes<'static>> = None;
 
+        // `remap_zig_exception` appends this error to the list on its way out.
+        // The body then recurses into `cause` / AggregateError children with
+        // the same list, so only reborrow it here.
         self.remap_zig_exception(
             // SAFETY: `exception` points into stack-local `exception_holder`.
             unsafe { &mut *exception },
             error_instance,
-            exception_list,
+            exception_list.as_deref_mut(),
             &mut exception_holder.need_to_clear_parser_arena_on_deinit,
             &mut source_code_slice,
             formatter.error_display_level != crate::console_object::ErrorDisplayLevel::Warn,
@@ -6021,8 +6024,7 @@ impl VirtualMachine {
             // SAFETY: see above.
             unsafe { &mut *exception },
             error_instance,
-            None, // Note: `exception_list` was already
-            // consumed by `remap_zig_exception` above (only writer).
+            exception_list,
             formatter,
             writer,
             allow_ansi_color,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2113,6 +2113,91 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
   expect(exitCode).toBe(0);
 });
 
+it.concurrent("dev error page embeds the cause chain and AggregateError children of the thrown error", async () => {
+  using dir = tempDir("serve-dev-error-page-cause", {
+    "server.ts": `
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: true,
+        fetch(req) {
+          const { pathname } = new URL(req.url);
+          if (pathname === "/cause") {
+            const inner = new RangeError("inner cause");
+            const middle = new TypeError("middle cause", { cause: inner });
+            throw new Error("outer error", { cause: middle });
+          }
+          if (pathname === "/aggregate") {
+            throw new AggregateError([new Error("first child"), new RangeError("second child")], "aggregate");
+          }
+          if (pathname === "/aggregate-cause") {
+            const child = new Error("child", { cause: new TypeError("child cause") });
+            throw new AggregateError([child], "aggregate with cause");
+          }
+          return new Response("unreachable");
+        },
+      });
+      const out = {};
+      for (const path of ["/cause", "/aggregate", "/aggregate-cause"]) {
+        const res = await fetch(server.url + path.slice(1));
+        const html = await res.text();
+        const match = /<script id="__bunfallback" type="application\\/json">([^<]*)<\\/script>/.exec(html);
+        out[path] = {
+          status: res.status,
+          exceptions: JSON.parse(match[1]).problems.exceptions.map(e => ({
+            name: e.name,
+            message: e.message,
+            thrownIn: e.stack.frames[0].function_name,
+          })),
+        };
+      }
+      console.log(JSON.stringify(out));
+      server.stop(true);
+      // The thrown errors were reported through the unhandled-rejection path, which sets the exit code.
+      process.exit(0);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const out = JSON.parse(stdout.trim().split("\n").at(-1)!);
+
+  // The terminal output walks the whole chain. The page must carry the same errors, outermost first.
+  expect(out).toEqual({
+    "/cause": {
+      status: 500,
+      exceptions: [
+        { name: "Error", message: "outer error", thrownIn: "fetch" },
+        { name: "TypeError", message: "middle cause", thrownIn: "fetch" },
+        { name: "RangeError", message: "inner cause", thrownIn: "fetch" },
+      ],
+    },
+    "/aggregate": {
+      status: 500,
+      exceptions: [
+        { name: "Error", message: "first child", thrownIn: "fetch" },
+        { name: "RangeError", message: "second child", thrownIn: "fetch" },
+      ],
+    },
+    "/aggregate-cause": {
+      status: 500,
+      exceptions: [
+        { name: "Error", message: "child", thrownIn: "fetch" },
+        { name: "TypeError", message: "child cause", thrownIn: "fetch" },
+      ],
+    },
+  });
+  for (const message of ["outer error", "middle cause", "inner cause", "first child", "second child", "child cause"]) {
+    expect(stderr).toContain(message);
+  }
+  expect(exitCode).toBe(0);
+});
+
 it.concurrent("dev error page ships a bun-error bundle that evaluates and registers the renderer", async () => {
   using dir = tempDir("serve-dev-error-page-bundle", {
     "server.ts": `


### PR DESCRIPTION
### Problem
- The dev-server error page (`Bun.serve({ development: true })`) shows only the outermost error. `error.cause`, the cause's cause, and the `cause` of an AggregateError child never reach the page. The terminal output prints the whole chain.
- `print_error_instance_js` (`src/jsc/VirtualMachine.rs:6009`) moves the `Option<&mut ExceptionList>` into `remap_zig_exception`. That function's tail guard `take()`s the list to append the current error (`:5653`). The caller then passes `None` to `print_error_instance_body` (`:6024`). The body is the code that recurses into `cause` and AggregateError children (`:6540`), so the recursion has no list to append to.

### Fix
- `print_error_instance_js` reborrows the list with `as_deref_mut()` for the remap call, then hands the original `Option<&mut ExceptionList>` to the body. The reborrow ends when `remap_zig_exception` returns, so the body and its recursion see the same list.
- This is what the Zig implementation did: `exception_list` was a `?*ExceptionList` and was passed to both `remapZigException` and the recursive `printErrorInstance`. The Rust port lost the second use when the pointer became a moved `&mut`.
- The order of the list is unchanged: the outer error is appended when the remap returns, then each nested error as the body walks it. The terminal output does not change.
- Verified: `test/js/bun/http/serve.test.ts` (new test `dev error page embeds the cause chain and AggregateError children of the thrown error`, fails on the released binary with 2 of 3 routes short). Also `inspect-error.test.js`, `reportError.test.ts`, `runtime-error.test.ts`, `error-name-preservation.test.ts`, and the rest of `serve.test.ts`.

### Background
- `ExceptionList` is a `Vec<JsException>`: name, message, type codes, and a remapped stack snapshot per error. The only producer that fills one is the dev server in `src/runtime/server/RequestContext.rs` (`report_committed_body_error`, and the unhandled-rejection path that sets `vm.on_unhandled_rejection_exception_list`). `DevErrorPage` renders it as the `problems.exceptions` JSON that `packages/bun-error` shows in the browser.
- `run_error_handler` prints an error to stderr and, when it gets a list, also appends every error it prints to that list. `print_errorlike_object` handles a top-level AggregateError by calling itself per child. Everything else goes through `print_error_instance_js`, which fills a `ZigException` (`remap_zig_exception`) and then prints it and recurses into `cause` (`print_error_instance_body`).
- `remap_zig_exception` uses a drop guard (`Tail`) so that every early return still appends to the list. The guard owns the `Option<&mut ExceptionList>` it is given, which is why the caller has to reborrow instead of move.

<details><summary>Notes</summary>

Repro on the released binary (`bun 1.4.1`), `development: true`, a handler that throws `new Error("outer", { cause: new Error("inner") })`: the `__bunfallback` JSON on the 500 page has one entry in `problems.exceptions`, `outer`. stderr prints both. With this change the JSON has `outer` then `inner`, each with its own stack.

A top-level AggregateError was already complete before this change because `print_errorlike_object` iterates the children itself and each child goes through its own `remap_zig_exception`. A `cause` on one of those children was missing. The new test covers a three-deep cause chain, a plain AggregateError, and an AggregateError child with a cause.

`bun test` does not set `on_unhandled_rejection_exception_list` itself. `jest.rs` and `run_command.rs` only forward whatever pointer the VM holds, so under `bun test` the dev server is still the only producer.

Four tests in `serve.test.ts` fail in this container on the released binary and on this branch alike (`server.requestIP > v6`, `root range port (#7187)`, `#6583`, `/bun:info to loopback clients`). They need IPv6 or a non-root user and are unrelated.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->