### PR TITLE
Bun.CSRF: validate expiresIn and maxAge with the shared integer validator

### DIFF
--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -4,7 +4,7 @@
 use bun_boringssl_sys as boring;
 use bun_core::Utf8Bytes;
 use bun_csrf as csrf;
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{CallFrame, IntegerRange, JSGlobalObject, JSValue, JsResult};
 
 use crate::api::crypto::evp::Algorithm as EvpAlgorithm;
 use crate::crypto::evp;
@@ -19,6 +19,28 @@ fn algorithm_from_js_case_insensitive(
 ) -> JsResult<Option<EvpAlgorithm>> {
     let slice = input.to_utf8(global)?;
     Ok(evp::lookup_ignore_case(slice.slice()))
+}
+
+/// Reads an optional millisecond duration (`expiresIn` / `maxAge`).
+/// `validate_integer_range` maps NaN to the default. `bun_csrf` treats `0` as
+/// "no expiry", so the default here is the 24h one an absent property gets.
+fn get_optional_duration_ms(
+    target: JSValue,
+    global: &JSGlobalObject,
+    field_name: &'static [u8],
+) -> JsResult<Option<u64>> {
+    let Some(value) = target.get(global, field_name)? else {
+        return Ok(None);
+    };
+    Ok(Some(global.validate_integer_range::<u64>(
+        value,
+        csrf::DEFAULT_EXPIRATION_MS,
+        IntegerRange {
+            min: 0,
+            field_name,
+            ..Default::default()
+        },
+    )?))
 }
 
 /// Reads the optional `encoding` property. Parsed as a Buffer encoding name
@@ -78,8 +100,8 @@ pub(crate) fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsRe
         let options_value = args[1];
 
         // Extract expiresIn (optional)
-        if let Some(expires_in_js) = options_value.get_optional_int::<u64>(global, "expiresIn")? {
-            expires_in = expires_in_js;
+        if let Some(ms) = get_optional_duration_ms(options_value, global, b"expiresIn")? {
+            expires_in = ms;
         }
 
         // Extract sessionId (optional)
@@ -220,8 +242,8 @@ pub(crate) fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         }
 
         // Extract maxAge (optional)
-        if let Some(max_age_js) = options_value.get_optional_int::<u64>(global, "maxAge")? {
-            max_age = max_age_js;
+        if let Some(ms) = get_optional_duration_ms(options_value, global, b"maxAge")? {
+            max_age = ms;
         }
 
         // Extract encoding (optional)

--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -21,9 +21,7 @@ fn algorithm_from_js_case_insensitive(
     Ok(evp::lookup_ignore_case(slice.slice()))
 }
 
-/// Reads an optional millisecond duration (`expiresIn` / `maxAge`).
-/// `validate_integer_range` maps NaN to the default. `bun_csrf` treats `0` as
-/// "no expiry", so the default here is the 24h one an absent property gets.
+/// `expiresIn` / `maxAge`. NaN maps to the default, and `0` would mean "no expiry".
 fn get_optional_duration_ms(
     target: JSValue,
     global: &JSGlobalObject,

--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -21,33 +21,6 @@ fn algorithm_from_js_case_insensitive(
     Ok(evp::lookup_ignore_case(slice.slice()))
 }
 
-/// Validates an optional integer property in `[0, MAX_SAFE_INTEGER]`.
-/// Differs from `JSValue::get_optional_int::<u64>` in rejecting NaN and in
-/// the error message wording expected by existing tests.
-fn get_optional_int_u64(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &'static str,
-) -> JsResult<Option<u64>> {
-    let Some(value) = target.get(global, property)? else {
-        return Ok(None);
-    };
-    if value.is_undefined() || value.is_empty() {
-        return Ok(Some(0));
-    }
-    if !value.is_number() {
-        return Err(global.throw_invalid_argument_type_value(property, "number", value));
-    }
-    let num: f64 = value.as_number();
-    const MAX_SAFE_INTEGER: f64 = 9007199254740991.0;
-    if num.fract() != 0.0 || num < 0.0 || num > MAX_SAFE_INTEGER {
-        return Err(global.throw_invalid_arguments(format_args!(
-            "{property} must be an integer between 0 and {MAX_SAFE_INTEGER}"
-        )));
-    }
-    Ok(Some(num as u64))
-}
-
 /// Reads the optional `encoding` property. Parsed as a Buffer encoding name
 /// ("" selects base64url), of which only the three token formats are accepted.
 fn get_optional_token_format(
@@ -105,7 +78,7 @@ pub(crate) fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsRe
         let options_value = args[1];
 
         // Extract expiresIn (optional)
-        if let Some(expires_in_js) = get_optional_int_u64(options_value, global, "expiresIn")? {
+        if let Some(expires_in_js) = options_value.get_optional_int::<u64>(global, "expiresIn")? {
             expires_in = expires_in_js;
         }
 
@@ -247,7 +220,7 @@ pub(crate) fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         }
 
         // Extract maxAge (optional)
-        if let Some(max_age_js) = get_optional_int_u64(options_value, global, "maxAge")? {
+        if let Some(max_age_js) = options_value.get_optional_int::<u64>(global, "maxAge")? {
             max_age = max_age_js;
         }
 

--- a/test/js/bun/util/csrf.test.ts
+++ b/test/js/bun/util/csrf.test.ts
@@ -197,9 +197,17 @@ describe("Bun.CSRF", () => {
       throw new Error(`expected ${field}: ${String(value)} to throw`);
     }
 
-    test("NaN is treated as 0", () => {
+    test("NaN is treated as an absent option", () => {
       expect(() => call(NaN)).not.toThrow();
       expect(CSRF.verify(CSRF.generate(secret, { expiresIn: NaN }), { secret, maxAge: NaN })).toBe(true);
+
+      // The token embeds expiresIn as a big-endian u64 at bytes 24..32, after
+      // the timestamp and the nonce. 0 there means the token never expires.
+      const embeddedExpiresIn = (options?: { expiresIn: number }) =>
+        Buffer.from(CSRF.generate(secret, options), "base64url").readBigUInt64BE(24);
+      expect(embeddedExpiresIn({ expiresIn: 0 })).toBe(0n);
+      expect(embeddedExpiresIn({ expiresIn: NaN })).toBe(embeddedExpiresIn());
+      expect(embeddedExpiresIn({ expiresIn: NaN })).toBe(BigInt(24 * 60 * 60 * 1000));
     });
 
     test("out-of-range values throw RangeError [ERR_OUT_OF_RANGE]", () => {

--- a/test/js/bun/util/csrf.test.ts
+++ b/test/js/bun/util/csrf.test.ts
@@ -184,6 +184,57 @@ describe("Bun.CSRF", () => {
     expect(() => CSRF.verify(token, { secret, sessionId: 123 })).toThrow();
   });
 
+  describe.each([
+    ["expiresIn", (value: unknown) => CSRF.generate(secret, { expiresIn: value as number })],
+    ["maxAge", (value: unknown) => CSRF.verify(CSRF.generate(secret), { secret, maxAge: value as number })],
+  ])("%s option validation", (field, call) => {
+    function thrown(value: unknown) {
+      try {
+        call(value);
+      } catch (error: any) {
+        return { constructor: error.constructor, code: error.code, message: error.message };
+      }
+      throw new Error(`expected ${field}: ${String(value)} to throw`);
+    }
+
+    test("NaN is treated as 0", () => {
+      expect(() => call(NaN)).not.toThrow();
+      expect(CSRF.verify(CSRF.generate(secret, { expiresIn: NaN }), { secret, maxAge: NaN })).toBe(true);
+    });
+
+    test("out-of-range values throw RangeError [ERR_OUT_OF_RANGE]", () => {
+      const prefix = `The value of "${field}" is out of range. It must be >= 0 and <= 9007199254740991.`;
+      expect(thrown(-1)).toEqual({
+        constructor: RangeError,
+        code: "ERR_OUT_OF_RANGE",
+        message: `${prefix} Received -1`,
+      });
+      expect(thrown(2 ** 53)).toEqual({
+        constructor: RangeError,
+        code: "ERR_OUT_OF_RANGE",
+        message: `${prefix} Received 9007199254740992`,
+      });
+      expect(thrown(Infinity)).toEqual({
+        constructor: RangeError,
+        code: "ERR_OUT_OF_RANGE",
+        message: `${prefix} Received Infinity`,
+      });
+    });
+
+    test("non-integer and non-number values throw TypeError [ERR_INVALID_ARG_TYPE]", () => {
+      expect(thrown(1.5)).toEqual({
+        constructor: TypeError,
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "${field}" property must be of type integer. Received number`,
+      });
+      expect(thrown("100")).toEqual({
+        constructor: TypeError,
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "${field}" property must be of type number. Received string`,
+      });
+    });
+  });
+
   test("rejects encodings that are not token formats", () => {
     const token = CSRF.generate(secret);
     const message = "Invalid format: must be 'base64', 'base64url', or 'hex'";


### PR DESCRIPTION
### Problem
- `Bun.CSRF.generate({ expiresIn })` and `Bun.CSRF.verify({ maxAge })` throw `TypeError [ERR_INVALID_ARG_TYPE]` for every bad value. Out-of-range values such as `-1` and `2 ** 53` must throw `RangeError [ERR_OUT_OF_RANGE]`. `NaN` throws where the option should be treated as absent.
- The cause is the local `get_optional_int_u64` helper in `src/runtime/api/csrf_jsc.rs:27`. The Rust port added it. The Zig version called the shared `getOptionalInt`, which routes through `validateIntegerRange`. The helper's doc comment cites tests that do not exist.

### Fix
- Delete `get_optional_int_u64`. Both options now go through `JSGlobalObject::validate_integer_range::<u64>` (`src/jsc/JSGlobalObject.rs:1241`), with `default = DEFAULT_EXPIRATION_MS` and `min = 0`.
- Out-of-range values (`-1`, `2 ** 53`, `Infinity`) throw `RangeError [ERR_OUT_OF_RANGE]`. Non-integers (`1.5`) and non-numbers (`"100"`) throw `TypeError [ERR_INVALID_ARG_TYPE]`. `NaN` gives the 24h default, the same as an absent property.
- The default is not `0` on purpose. `JSValue::get_optional_int` passes `0` as the validator default, and `bun_csrf` treats `0` as "no expiry". A `NaN` from a bad computation would then issue a token that never expires.
- Verified: `test/js/bun/util/csrf.test.ts` (6 new tests fail on 1.4.0, pass with this change). The whole file passes (31 tests).

### Background
- `validate_integer_range` is Bun's port of node's integer option validators. It returns the default for `undefined` and `NaN`, throws `ERR_INVALID_ARG_TYPE` when the value is not a number or not an integer, and `ERR_OUT_OF_RANGE` when the value is outside `[min, max]`, with min and max clamped to the safe integer range. For `u64` that is `[0, 9007199254740991]`.
- `JSValue::get` returns `None` for a missing property and for `undefined`. So `{ expiresIn: undefined }` and no option both keep the 24h default. Only `NaN` reaches the validator's default path.
- A token is `timestamp (8) | nonce (16) | expiresIn (8, big-endian u64) | HMAC`. `bun_csrf::verify` skips the expiry check when that field is `0`, and skips the `maxAge` check when `max_age_ms` is `0`. The test reads bytes 24..32 to check which default `NaN` selects.

Supersedes #32288, which mapped `NaN` to `0` and is stale.

<details><summary>Notes</summary>

Repro on 1.4.0 and 1.4.1:

```js
for (const v of [NaN, -1, 1.5, 2 ** 53]) {
  try { Bun.CSRF.generate("secret", { expiresIn: v }); console.log(String(v), "ok"); }
  catch (e) { console.log(String(v), e.code, e.constructor.name); }
}
// NaN   ERR_INVALID_ARG_TYPE TypeError   (expected: ok)
// -1    ERR_INVALID_ARG_TYPE TypeError   (expected: ERR_OUT_OF_RANGE RangeError)
// 1.5   ERR_INVALID_ARG_TYPE TypeError
// 2**53 ERR_INVALID_ARG_TYPE TypeError   (expected: ERR_OUT_OF_RANGE RangeError)
```

With this change:

```
NaN   ok (embedded expiresIn = 86400000, the same as with no option)
-1    ERR_OUT_OF_RANGE RangeError   The value of "expiresIn" is out of range. It must be >= 0 and <= 9007199254740991. Received -1
1.5   ERR_INVALID_ARG_TYPE TypeError   The "expiresIn" property must be of type integer. Received number
2**53 ERR_OUT_OF_RANGE RangeError   The value of "expiresIn" is out of range. It must be >= 0 and <= 9007199254740991. Received 9007199254740992
```

The same applies to `verify({ maxAge })`.

The Zig source before the port (`src/runtime/api/csrf_jsc.zig` at b8ecc78b03) read both options with `options_value.getOptionalInt(globalObject, "expiresIn", u64)`. That mapped `NaN` to `0` too. The first revision of this PR did the same through `get_optional_int::<u64>`. Review pointed out that `0` disables expiry, so the second revision passes `DEFAULT_EXPIRATION_MS` as the default instead. The new `NaN` test fails against the first revision, which shows it tells the two defaults apart.

Other call sites in the tree handle the same hazard explicitly: `js_bun_spawn_bindings.rs` rejects a `NaN` `timeout` before the validator because `0` would mean no timeout, and `socket_body.rs` rejects a `NaN` `tos`.

The test does not assert the `null` case. The shared validator reports `Received object` for `null` (from `jsTypeStringForValue`). That wording is owned by the shared helper, not by this file.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/csrf.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/util/csrf.test.ts:
(pass) Bun.CSRF > CSRF exists [4.98ms]
(pass) Bun.CSRF > generates a token with default options [3.91ms]
(pass) Bun.CSRF > generates a token with different formats [6.12ms]
(pass) Bun.CSRF > verifies a valid token [2.26ms]
(pass) Bun.CSRF > rejects an invalid token [2.18ms]
(pass) Bun.CSRF > token verification is sensitive to the secret [2.20ms]
(pass) Bun.CSRF > tokens expire after the specified time [17.05ms]
(pass) Bun.CSRF > verification respects maxAge parameter [16.48ms]
(pass) Bun.CSRF > token with expiresIn parameter works [118.95ms]
(pass) Bun.CSRF > token format doesn't affect verification [5.37ms]
(pass) Bun.CSRF > test with default algorithm [2.80ms]
(pass) Bun.CSRF > test with algorithm blake2b256 [2.91ms]
(pass) Bun.CSRF > test with algorithm blake2b512 [0.62ms]
(pass) Bun.CSRF > test with algorithm sha256 [0.44ms]
(pass) Bun.CSRF > test with algorithm sha384 [0.45ms]
(pass) Bun.CSRF > test with algorithm sha512 [0.42ms]
(pass) Bun.C
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (662c5f3cf)

test/js/bun/util/csrf.test.ts:
(pass) Bun.CSRF > CSRF exists [0.04ms]
(pass) Bun.CSRF > generates a token with default options [0.12ms]
(pass) Bun.CSRF > generates a token with different formats [0.10ms]
(pass) Bun.CSRF > verifies a valid token [0.03ms]
(pass) Bun.CSRF > rejects an invalid token [0.06ms]
(pass) Bun.CSRF > token verification is sensitive to the secret [0.02ms]
(pass) Bun.CSRF > tokens expire after the specified time [10.22ms]
(pass) Bun.CSRF > verification respects maxAge parameter [10.30ms]
(pass) Bun.CSRF > token with expiresIn parameter works [110.53ms]
(pass) Bun.CSRF > token format doesn't affect verification [0.15ms]
(pass) Bun.CSRF > test with default algorithm [0.05ms]
(pass) Bun.CSRF > test with algorithm blake2b256 [0.06ms]
(pass) Bun.CSRF > test with algorithm blake2b512 [0.01ms]
(pass) Bun.CSRF > test with algorithm sha256
(pass) Bun.CSRF > test with algorithm sha384
(pass) Bun.CSRF > test with algorithm sha512
(pass) Bun.CSRF > test with algorithm sha512-256
(pass) Bun.CSRF > default secret [0.04ms]
(pass) Bun.CSRF > token bound to a sessionId verifies for the same sessionId [0.02ms]
(pass) Bun.CSRF 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/csrf.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/util/csrf.test.ts:
(pass) Bun.CSRF > CSRF exists [13.43ms]
(pass) Bun.CSRF > generates a token with default options [5.02ms]
(pass) Bun.CSRF > generates a token with different formats [5.55ms]
(pass) Bun.CSRF > verifies a valid token [2.00ms]
(pass) Bun.CSRF > rejects an invalid token [1.96ms]
(pass) Bun.CSRF > token verification is sensitive to the secret [1.94ms]
(pass) Bun.CSRF > tokens expire after the specified time [16.47ms]
(pass) Bun.CSRF > verification respects maxAge parameter [15.16ms]
(pass) Bun.CSRF > token with expiresIn parameter works [118.70ms]
(pass) Bun.CSRF > token format doesn't affect verification [5.97ms]
(pass) Bun.CSRF > test with default algorithm [2.80ms]
(pass) Bun.CSRF > test with algorithm blake2b256 [2.97ms]
(pass) Bun.CSRF > test with algorithm blake2b512 [0.66ms]
(pass) Bun.CSRF > test with algorithm sha256 [0.41ms]
(pass) Bun.CSRF > test with algorithm sha384 [0.46ms]
(pass) Bun.CSRF > test with algorithm sha512 [0.43ms]
(pass) Bun.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 675ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/csrf_jsc.rs   | 43 +++++++++++++------------------
 test/js/bun/util/csrf.test.ts | 59 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 77 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/runtime/api/csrf_jsc.rs        3      6      0
test/js/bun/util/csrf.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->