### PR TITLE
Bun.sha: validate arguments through the SHA512_256.hash path

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -162,30 +162,10 @@ mod static_adapters {
         crate::shell::interpreter::create_shell_interpreter(g, cf)
     }
 
-    /// `Bun.sha(input, output?)` — wrapStaticMethod(Crypto.SHA512_256, "hash_", true).
-    /// Hand-roll the (BlobOrStringOrBuffer, ?StringOrBuffer) decode that
-    /// `wrapStaticMethod` would emit, with auto-protect on each argument.
+    /// `Bun.sha(input, output?)` is `Bun.SHA512_256.hash` under another name,
+    /// so it shares that method's argument decode and errors.
     pub(super) fn sha(g: &JSGlobalObject, cf: &CallFrame) -> JsResult<JSValue> {
-        use crate::node::types::{BlobOrStringOrBuffer, StringOrBuffer};
-        let [a0, a1] = cf.arguments_as_array::<2>();
-        // Protect each arg across the call (Blob materialization
-        // re-enters the VM).
-        let _a0_guard = a0.protected();
-        let _a1_guard = a1.protected();
-        let mut output = if a1.is_undefined_or_null() {
-            None
-        } else {
-            StringOrBuffer::from_js(g, a1)?
-        };
-        let Some(input) = BlobOrStringOrBuffer::from_js(g, a0)? else {
-            return Err(g.throw_invalid_arguments(format_args!(
-                "expected string, buffer, TypedArray, or Blob",
-            )));
-        };
-        if let Some(StringOrBuffer::Buffer(buffer)) = &mut output {
-            buffer.buffer = ArrayBuffer::from_typed_array(g, buffer.buffer.value);
-        }
-        Crypto::SHA512_256::hash_(g, &input, output)
+        Crypto::SHA512_256::hash(g, cf)
     }
 }
 

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -270,6 +270,47 @@ test("Bun.sha reads its buffers only after every argument has been coerced", asy
   expect(exitCode).toBe(0);
 });
 
+test("Bun.sha validates its arguments like Bun.SHA512_256.hash", () => {
+  const hex = "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23";
+  expect(Bun.sha("abc", "hex")).toBe(hex);
+  expect(Bun.SHA512_256.hash("abc", "hex")).toBe(hex);
+  const out = new Uint8Array(32);
+  expect(Bun.sha("abc", out)).toBe(out);
+  expect(Buffer.from(out).toString("hex")).toBe(hex);
+  expect(Bun.sha("abc")).toEqual(out);
+  expect(Bun.sha("abc", undefined)).toEqual(out);
+
+  // An output argument that is neither an encoding nor a TypedArray throws
+  // instead of being ignored.
+  const badOutput = expect.objectContaining({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: "expected string or buffer",
+  });
+  for (const output of [123, {}, null, true, [], () => {}, Symbol("x")]) {
+    const label = `output ${typeof output}`;
+    // @ts-expect-error
+    expect(() => Bun.sha("abc", output), label).toThrow(badOutput);
+    // @ts-expect-error
+    expect(() => Bun.SHA512_256.hash("abc", output), label).toThrow(badOutput);
+  }
+
+  const badInput = expect.objectContaining({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: "expected blob, string or buffer",
+  });
+  for (const input of [undefined, 123, null, {}]) {
+    const label = `input ${typeof input}`;
+    // @ts-expect-error
+    expect(() => Bun.sha(input), label).toThrow(badInput);
+    // @ts-expect-error
+    expect(() => Bun.SHA512_256.hash(input), label).toThrow(badInput);
+  }
+  // @ts-expect-error
+  expect(() => Bun.sha()).toThrow(badInput);
+});
+
 describe("HMAC", () => {
   const hashes = {
     "sha1": "e2e1f7f597941d9b0021978618218a9e08731426",


### PR DESCRIPTION
### Problem
- `Bun.sha(input, output)` ignores an `output` argument that is neither a string encoding nor a TypedArray. `Bun.sha("abc", 123)` returns a `Uint8Array` digest. `Bun.SHA512_256.hash("abc", 123)` throws `TypeError: expected string or buffer`. The same applies to `{}`, `null`, `true`, and other non-string non-buffer values.
- The cause is the hand-rolled adapter in `src/runtime/api/BunObject.rs:168`. It maps a failed `StringOrBuffer::from_js` to "no output" instead of an error. Its missing-input message ("expected string, buffer, TypedArray, or Blob") also differs from the static hasher message.

### Fix
- `Bun.sha` now calls `Crypto::SHA512_256::hash(g, cf)`, the same host function that backs `Bun.SHA512_256.hash`. The adapter body is gone.
- Both entry points now share one argument decode: `undefined` or a missing second argument means no output, any other non-string non-buffer value throws `expected string or buffer`, and a missing or invalid input throws `expected blob, string or buffer`.
- The argument order is unchanged. The output argument is coerced before the input buffer is read, so the existing coercion-order test for `Bun.sha` still passes.
- Verified: `test/js/bun/util/bun-cryptohasher.test.ts` (new test `Bun.sha validates its arguments like Bun.SHA512_256.hash`, fails on the released bun). Also ran the full file (404 tests) and `test/js/bun/util/hash.test.js`.

### Background
- `Bun.sha` is SHA-512/256 under a short name. `Bun.SHA512_256` is the class with the same algorithm, and its static `hash` method is `StaticCryptoHasher::hash` in `src/runtime/crypto/CryptoHasher.rs:1205`.
- `StringOrBuffer::from_js` returns `Ok(None)` when the value is not a string, a String object, or an ArrayBuffer view. The caller decides whether `None` is an error.
- The old adapter also protected both arguments against GC. Call frame arguments are already GC roots for the duration of a host call, and `StaticCryptoHasher::hash` does not protect them, so nothing is lost.

<details><summary>Notes</summary>

Behavior on the released bun 1.4.1 (left) versus this branch (right), for `Bun.sha`:

| call | before | after |
| --- | --- | --- |
| `Bun.sha("abc", 123)` | `Uint8Array(32)` | `TypeError: expected string or buffer` |
| `Bun.sha("abc", {})` | `Uint8Array(32)` | `TypeError: expected string or buffer` |
| `Bun.sha("abc", null)` | `Uint8Array(32)` | `TypeError: expected string or buffer` |
| `Bun.sha("abc", true)` | `Uint8Array(32)` | `TypeError: expected string or buffer` |
| `Bun.sha("abc", undefined)` | `Uint8Array(32)` | `Uint8Array(32)` |
| `Bun.sha()` | `expected string, buffer, TypedArray, or Blob` | `expected blob, string or buffer` |
| `Bun.sha("abc", "hex")` | hex string | hex string |
| `Bun.sha("abc", new Uint8Array(1))` | `TypedArray must be at least 32 bytes` | same |
| `Bun.sha(Bun.file(p))` | `File blob cannot be used here` | same |

The "after" column matches `Bun.SHA512_256.hash` for every row, on both the released bun and this branch.

The original Zig `wrapStaticMethod(Crypto.SHA512_256, "hash_", true)` decode treated only `undefined` as "no output" and threw `expected string or buffer` for anything else that was not a string or buffer. The Rust port of `Bun.sha` lost that, while the port of the static `hash` kept it.

`Bun.sha.length` stays 1 (set in `BunObject.cpp`). This PR does not change it.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [15.06ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [6.46ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [37.34ms]
(pass) update(str, 'hex') decodes two-byte strings from the low byte of each code unit like node [17.44ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [10.41ms]
(pass) static hash requires the algorithm to be a string primitive [12.98ms]
(pass) update rejects a hasher that was digested while its input was being converted [393.03ms]
(pass) static hash reads the input buffer only after every argument has been coerced [390.02ms]
(pass) Bun.sha reads its buffers only after every argument has been coerced [448.29ms]
288 |     message: "expected string or buffer",
289 |   });
290 |   for (const output of [123, {}, null, true, [], () => {}, Symbol("x")]) {
29
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [0.20ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [0.05ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [0.41ms]
(pass) update(str, 'hex') decodes two-byte strings from the low byte of each code unit like node [0.20ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [0.12ms]
(pass) static hash requires the algorithm to be a string primitive [0.12ms]
(pass) update rejects a hasher that was digested while its input was being converted [8.11ms]
(pass) static hash reads the input buffer only after every argument has been coerced [10.92ms]
(pass) Bun.sha reads its buffers only after every argument has been coerced [9.56ms]
288 |     message: "expected string or buffer",
289 |   });
290 |   for (const output of [123, {}, null, true, [], () => {}, Symbol("x")]) {
291 |     const label = `output ${typeof output}`;
292 |     // @ts-expect-error
293 |     expect(() => Bun.sha("abc", output), label).toThrow(badOutput);
                       
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [12.21ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [5.63ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [35.82ms]
(pass) update(str, 'hex') decodes two-byte strings from the low byte of each code unit like node [16.38ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [9.69ms]
(pass) static hash requires the algorithm to be a string primitive [13.22ms]
(pass) update rejects a hasher that was digested while its input was being converted [433.54ms]
(pass) static hash reads the input buffer only after every argument has been coerced [417.31ms]
(pass) Bun.sha reads its buffers only after every argument has been coerced [381.56ms]
(pass) Bun.sha validates its arguments like Bun.SHA512_256.hash [25.01ms]
(pass) HMAC > sha1 (key: String) [12.66ms]
(pass) HMAC > sha256 (key: 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 613ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 50s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+cc1fc3cdc
[build] done
bun test v1.4.1-canary.1 (cc1fc3cdc)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [0.17ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [0.05ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [0.45ms]
(pass) update(str, 'hex') decodes two-byte strings from the low byte of each code unit like node [0.19ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [0.13ms]
(pass) static hash requires the algorithm to be a 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/BunObject.rs              | 26 +++-----------------
 test/js/bun/util/bun-cryptohasher.test.ts | 41 +++++++++++++++++++++++++++++++
 2 files changed, 44 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/BunObject.rs                   2      1      0
test/js/bun/util/bun-cryptohasher.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->