### PR TITLE
macros: classify a returned Response or Blob by its MIME category

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,7 @@ dependencies = [
  "bun_collections",
  "bun_core",
  "bun_dotenv",
+ "bun_http_types",
  "bun_js_parser",
  "bun_jsc",
  "bun_parsers",

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -257,6 +257,13 @@ impl Category {
         Category::Other
     }
 
+    pub fn is_text_like(self) -> bool {
+        matches!(
+            self,
+            Category::Javascript | Category::Html | Category::Text | Category::Css | Category::Json
+        )
+    }
+
     pub fn autoset_filename(self) -> bool {
         !matches!(
             self,

--- a/src/js_parser_jsc/Cargo.toml
+++ b/src/js_parser_jsc/Cargo.toml
@@ -19,6 +19,7 @@ bun_bundler.workspace = true
 bun_parsers.workspace = true
 bun_collections.workspace = true
 bun_dotenv.workspace = true
+bun_http_types.workspace = true
 bun_js_parser.workspace = true
 bun_jsc.workspace = true
 bun_ast.workspace = true

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -1058,18 +1058,18 @@ unsafe extern "C" {
 fn expr_from_blob(
     bytes: &[u8],
     bump: &bun_alloc::Arena,
-    mime_type: &[u8],
+    content_type: &[u8],
     log: &mut Log,
     loc: bun_ast::Loc,
 ) -> crate::Result<Expr> {
     use bun_ast::{E, ExprData, StoreStr as Str};
+    use bun_http_types::MimeType::{Category, MimeType};
 
-    // MimeType::Category::Json — `application/json` or `+json`/`/json` suffix.
-    let is_json = mime_type == b"application/json"
-        || mime_type.ends_with(b"+json")
-        || mime_type.ends_with(b"/json");
+    // `Response.json()` and most servers send parameters (`;charset=utf-8`),
+    // so classify through the same parser the runtime uses for blob types.
+    let mime_type = MimeType::init(content_type, false, None);
 
-    if is_json {
+    if mime_type.category == Category::Json {
         let source = &Source::init_path_string(b"fetch.json", bytes);
         let mut out_expr: Expr = match bun_parsers::json::parse_for_macro(source, log, bump) {
             Ok(e) => e,
@@ -1084,14 +1084,7 @@ fn expr_from_blob(
         return Ok(out_expr);
     }
 
-    // MimeType::Category::isTextLike — text/*, application/javascript-ish, xml.
-    let is_text_like = mime_type.starts_with(b"text/")
-        || mime_type == b"application/javascript"
-        || mime_type == b"application/x-javascript"
-        || mime_type == b"application/ecmascript"
-        || mime_type == b"application/xml";
-
-    if is_text_like {
+    if mime_type.category.is_text_like() {
         let mut output = bun_core::MutableString::init_empty();
         bun_core::quote_for_json(bytes, &mut output, true)?;
         let owned = output.to_owned_slice();
@@ -1116,13 +1109,13 @@ fn expr_from_blob(
     let prefix = b"data:";
     let mid = b";base64,";
     let encoded_len = bun_base64::encode_len(bytes);
-    let total = prefix.len() + mime_type.len() + mid.len() + encoded_len;
+    let total = prefix.len() + content_type.len() + mid.len() + encoded_len;
     let buf: &mut [u8] = bump.alloc_slice_fill_copy(total, 0u8);
     let mut i = 0usize;
     buf[i..i + prefix.len()].copy_from_slice(prefix);
     i += prefix.len();
-    buf[i..i + mime_type.len()].copy_from_slice(mime_type);
-    i += mime_type.len();
+    buf[i..i + content_type.len()].copy_from_slice(content_type);
+    i += content_type.len();
     buf[i..i + mid.len()].copy_from_slice(mid);
     i += mid.len();
     let n = bun_base64::encode(&mut buf[i..], bytes);

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,6 +182,61 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
+// A Response or Blob returned from a macro is inlined by its content type: JSON is parsed into an object
+// literal, text becomes a string, anything else becomes a base64 data URL. The type has to be classified
+// with its parameters stripped: `Response.json()` and most servers send `application/json;charset=utf-8`.
+test("a macro that returns a JSON or text Response or Blob is inlined by its content type", async () => {
+  await using server = Bun.serve({ port: 0, fetch: () => Response.json({ from: "server" }) });
+  using dir = tempDir("macro-response-content-type", {
+    "m.ts": [
+      `export function json() {`,
+      `  return Response.json({ a: 1, b: [true, null, "x"] });`,
+      `}`,
+      `export function jsonHeader() {`,
+      `  return new Response('{"b":2}', { headers: { "content-type": "application/json" } });`,
+      `}`,
+      `export function fetched() {`,
+      `  return fetch(process.env.MACRO_TEST_URL!);`,
+      `}`,
+      `export function text() {`,
+      `  return new Response("hello", { headers: { "content-type": "text/plain; charset=utf-8" } });`,
+      `}`,
+      `export function blobJson() {`,
+      `  return new Blob(['{"c":3}'], { type: "application/json; charset=utf-8" });`,
+      `}`,
+      `export function binary() {`,
+      `  return new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "application/octet-stream" } });`,
+      `}`,
+    ].join("\n"),
+    "index.ts": [
+      `import { json, jsonHeader, fetched, text, blobJson, binary } from "./m.ts" with { type: "macro" };`,
+      `console.log(JSON.stringify([json(), jsonHeader(), fetched(), text(), blobJson(), binary()]));`,
+      ``,
+    ].join("\n"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    env: { ...bunEnv, MACRO_TEST_URL: server.url.href },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Debug builds print "[macro] call <name>" to stdout before the script's own output.
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
+    lastLine: JSON.stringify([
+      { a: 1, b: [true, null, "x"] },
+      { b: 2 },
+      { from: "server" },
+      "hello",
+      { c: 3 },
+      "data:application/octet-stream;base64,AQID",
+    ]),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 // A macro's `await` is serviced by the VM's macro event loop, so completions have to be routed by which
 // loop was current when their work started: what the macro started goes to the macro loop (or the wait
 // hangs), what the program started stays on the regular loop (or program callbacks run mid-transpile),


### PR DESCRIPTION
### Problem
- A macro that returns `Response.json(...)`, a `fetch()` of a JSON endpoint, or a `Blob` typed `application/json; charset=utf-8` is inlined as a base64 `data:` URL string (`"data:application/json;charset=utf-8;base64,eyJhIjoxfQ=="`) instead of the parsed object. Same for a plain `application/json` header, because the Response to Blob step normalizes it to `application/json;charset=utf-8`.
- `expr_from_blob` (`src/js_parser_jsc/Macro.rs:1058`) compares the raw content type with `== b"application/json"` and `starts_with(b"text/")`. Any parameter (`;charset=utf-8`) misses every branch and falls through to the data URL arm. The Zig code used `MimeType.init(...)` and `category.isTextLike()`. The Rust port replaced those with the byte compares.

### Fix
- `expr_from_blob` calls `MimeType::init(content_type, false, None)` and branches on `mime_type.category`: `Json` parses the body, `is_text_like()` inlines a string, everything else stays a data URL. `MimeType::init` strips parameters. It is what `Body.rs` and `Blob.rs` already use to classify a blob type, so the macro now agrees with the runtime.
- Adds `Category::is_text_like()` to `src/http_types/MimeType.rs`: javascript, html, text, css, json. This is the set the pre-port code used. `src/CLAUDE.md` already documents the method.
- Adds `bun_http_types` to the `bun_js_parser_jsc` dependencies (Cargo.toml and Cargo.lock).
- Verified: `test/bundler/transpiler/macro-test.test.ts` (new test, fails on 1.4.1 with the data URL output, passes with this change). Also ran the rest of that file, `transpiler.test.js`, the macro regression tests, and `test/js/web/fetch/blob.test.ts`.

### Background
- A macro result is turned into an AST node by `Run::coerce`. A `Response` or `Request` is first reduced to its body `Blob`. `expr_from_blob` then picks the node shape from the blob's content type.
- `bun_http_types::MimeType::init` parses `type/subtype;params` into a `MimeType` with a `Category`. Parameters are cut at the first `;`. `application/json` and `application/geo+json` map to `Category::Json`. `text/*` maps to `Text` (or `Css`, `Html`, `Javascript`, and `text/plain` to the `TEXT` constant).
- `Response.json()` sets `application/json;charset=utf-8` (`MimeType::JSON`). A `Response` with a `content-type` header and no blob type gets its blob type from `MimeType::init` on that header (`src/runtime/webcore/Body.rs:2146`).

<details><summary>Notes</summary>

Repro on 1.4.1:

```ts
// macro.ts
export function j() { return Response.json({ a: 1 }); }
// index.ts
import { j } from "./macro.ts" with { type: "macro" };
console.log(j());
```

`bun build index.ts` emits `console.log("data:application/json;charset=utf-8;base64,eyJhIjoxfQ==");`. With this change it emits `console.log({ a: 1 });`.

Behavior that changes besides the parameter handling, because the classification now follows `MimeType::init`:

- `application/javascript`, `application/x-javascript`, `application/ecmascript`, `application/xml` with no parameters were inlined as strings. They are `Category::Application` in `MimeType::init` and now become data URLs. With parameters they were data URLs before too. The pre-port code did the same.
- `+json` suffixes other than `geo+json` (for example `application/ld+json`) with no parameters were parsed as JSON. They are `Category::Application` and now become data URLs. `text/json` is `Category::Text` and becomes a string.
- The type is still case-sensitive, as it is everywhere else `MimeType::init` is used. A Blob built in JS is lowercased by the `Blob` constructor. A header value is used verbatim.

The data URL arm keeps the raw content type in the URL (`data:<content type>;base64,...`), unchanged.

Related: #32844 fixes the same parameter problem with string essence matching, plus a platform object error that #40059 covers. #40059 (`claude/macro-host`) also strips parameters inside `expr_from_blob` with string compares. This change conflicts with it only in the body of `expr_from_blob` and one Cargo.toml line.

The `it.todo` cases in `transpiler.test.js` ("macros can return a Response body", "pass objects to macros") stay todo. They depend on `transformSync(code, ctx)`. That call appends `ctx` after the call arguments, so a macro called with no arguments receives `ctx` as its first parameter and the fixture's second parameter is `undefined`. That is separate from this change.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[0/3] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static-Cforce-frame-pointers=yes-Zthreads=8-Cllvm-args=-addrsig-Ctarget-cpu=nehalem--check-cfg=cfg(bun_asan)-Zsanitizer=address--cfg=bun_asan--check-cfg=cfg(b
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.03ms]
(pass) latin1 string
(pass) ascii string
(pass) type coercion [0.05ms]
(pass) escaping [0.17ms]
(pass) utf16 string [0.01ms]
(pass) import aliases [0.02ms]
(pass) default import
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.08ms]
(pass) object argument with a sparse numeric key [15.56ms]
(pass) object destructuring of a macro result keeps every bound property regardless of key order or repeated keys [16.09ms]
221 |     stdout: "pipe",
222 |     stderr: "pipe",
223 |   });
224 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
225 |   // Debug builds print "[macro] call <name>" to stdout before the script's own output.
226 |   expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
                                                                      ^
error: expect(received).toEqual(expected)

  {
-   "lastLine": "[{"a":1,"b":[true,null,"x"]},{"b":2},{"from":"server"},"hello",{"c":3},"data:application/octet-stream;base64,AQID"]",
+   "lastLine": 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a7583e5272
  features     baseline

23 deps, 131 codegen, 1172 objects in 1405ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] fetch zlib
[zlib] up to date
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1216] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [50.00ms]
[6/1216] gen ErrorCode+*.h
[7/1216] gen .bind.ts → GeneratedBindings.cpp
[8/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1216] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [3.00ms]
[10/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1216] gen b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
Cargo.lock                                 |  1 +
 src/http_types/MimeType.rs                 |  7 ++++
 src/js_parser_jsc/Cargo.toml               |  1 +
 src/js_parser_jsc/Macro.rs                 | 27 ++++++---------
 test/bundler/transpiler/macro-test.test.ts | 55 ++++++++++++++++++++++++++++++
 5 files changed, 74 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
Cargo.lock                                      0      0      0
src/http_types/MimeType.rs                      1      1      0
src/js_parser_jsc/Cargo.toml                    1      2      0
src/js_parser_jsc/Macro.rs                      3      3      0
test/bundler/transpiler/macro-test.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->