### PR TITLE
bun init: exit quietly on Ctrl-D at a text prompt

### DIFF
--- a/src/runtime/bake/dev_server/error_report_request.rs
+++ b/src/runtime/bake/dev_server/error_report_request.rs
@@ -510,7 +510,7 @@ fn read_string32<'a>(r: &mut bun_io::FixedBufferStream<&'a [u8]>) -> crate::Resu
         .pos
         .checked_add(len)
         .filter(|&e| e <= buf.len())
-        .ok_or(crate::Error::EndOfStream)?;
+        .ok_or(bun_core::Error::EndOfStream)?;
     let s = &buf[r.pos..end];
     r.pos = end;
     Ok(s)

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -167,7 +167,7 @@ impl InitCommand {
                     // ctrl+c, ctrl+d
                     reprint_menu = false;
                     finish!(reprint_menu, selected);
-                    return Err(crate::Error::EndOfStream);
+                    return Err(crate::Error::Core(bun_core::Error::EndOfStream));
                 }
                 b'1'..=b'9' => {
                     let choice = (byte - b'1') as usize;
@@ -201,13 +201,13 @@ impl InitCommand {
                         Err(_) => {
                             reprint_menu = false;
                             finish!(reprint_menu, selected);
-                            return Err(crate::Error::EndOfStream);
+                            return Err(crate::Error::Core(bun_core::Error::EndOfStream));
                         }
                     };
                     if next != b'[' {
                         reprint_menu = false;
                         finish!(reprint_menu, selected);
-                        return Err(crate::Error::EndOfStream);
+                        return Err(crate::Error::Core(bun_core::Error::EndOfStream));
                     }
 
                     // Read arrow key
@@ -216,7 +216,7 @@ impl InitCommand {
                         Err(_) => {
                             reprint_menu = false;
                             finish!(reprint_menu, selected);
-                            return Err(crate::Error::EndOfStream);
+                            return Err(crate::Error::Core(bun_core::Error::EndOfStream));
                         }
                     };
                     match arrow {
@@ -262,7 +262,7 @@ impl InitCommand {
 
         let selection = match Self::process_radio_button::<C>(label) {
             Ok(s) => s,
-            Err(crate::Error::EndOfStream) => {
+            Err(crate::Error::Core(bun_core::Error::EndOfStream)) => {
                 Output::flush();
                 // Add an "x" cancelled
                 bun_core::prettyln!("\n<r><red>x<r> Cancelled");
@@ -577,14 +577,16 @@ impl InitCommand {
                         fields.name = match Self::prompt("<r><cyan>package name<r> ", &fields.name)
                         {
                             Ok(v) => v,
-                            Err(crate::Error::EndOfStream) => return Ok(()),
+                            Err(crate::Error::Core(bun_core::Error::EndOfStream)) => return Ok(()),
                             Err(e) => return Err(e),
                         };
                         fields.name = Self::normalize_package_name(&fields.name)?;
                         fields.entry_point =
                             match Self::prompt("<r><cyan>entry point<r> ", &fields.entry_point) {
                                 Ok(v) => v,
-                                Err(crate::Error::EndOfStream) => return Ok(()),
+                                Err(crate::Error::Core(bun_core::Error::EndOfStream)) => {
+                                    return Ok(());
+                                }
                                 Err(e) => return Err(e),
                             };
                         fields.private = false;

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -1227,10 +1227,7 @@ impl UpdateInteractiveCommand {
         let result = match Self::process_multi_select(&mut state, terminal_size) {
             Ok(r) => r,
             Err(err) => {
-                if matches!(
-                    err,
-                    crate::Error::EndOfStream | crate::Error::Core(bun_core::Error::EndOfStream)
-                ) {
+                if matches!(err, crate::Error::Core(bun_core::Error::EndOfStream)) {
                     Output::flush();
                     bun_core::prettyln!("\n<r><red>x<r> Cancelled");
                     Global::exit(0);
@@ -1942,7 +1939,7 @@ impl UpdateInteractiveCommand {
                     // ctrl+c, ctrl+d
                     reprint_menu = false;
                     cleanup_and_reprint!(reprint_menu);
-                    return Err(crate::Error::EndOfStream);
+                    return Err(crate::Error::Core(bun_core::Error::EndOfStream));
                 }
                 b' ' => {
                     state.selected[state.cursor] = !state.selected[state.cursor];

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -56,8 +56,6 @@ pub enum Error {
     IsMissingHeaderLineEnd,
     #[error("is missing header colon separator")]
     IsMissingHeaderColonSeparator,
-    #[error("EndOfStream")]
-    EndOfStream,
     #[error("TooSmall")]
     TooSmall,
     #[error("InvalidValue")]
@@ -422,7 +420,6 @@ impl Error {
             Self::IsMissingHeaderEnd => "is missing header end",
             Self::IsMissingHeaderLineEnd => "is missing header line end",
             Self::IsMissingHeaderColonSeparator => "is missing header colon separator",
-            Self::EndOfStream => "EndOfStream",
             Self::TooSmall => "TooSmall",
             Self::InvalidValue => "InvalidValue",
             Self::ConnectionFailed => "ConnectionFailed",

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -90,6 +90,53 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
   }, 30_000);
 
+  // Ctrl-D is EOF only on a POSIX tty; the Windows console has no equivalent
+  // key that ends a cooked-mode read.
+  test.skipIf(isWindows)("bun init exits quietly on Ctrl-D at a text prompt", async () => {
+    await using temp = tempDir("bun-init-ctrl-d", {});
+
+    const decoder = new TextDecoder();
+    let output = "";
+    const menu = Promise.withResolvers<void>();
+    const namePrompt = Promise.withResolvers<void>();
+    await using terminal = new Bun.Terminal({
+      cols: 80,
+      rows: 24,
+      data(_, chunk: Uint8Array) {
+        output += decoder.decode(chunk, { stream: true });
+        if (output.includes("Select a project template")) menu.resolve();
+        if (output.includes("package name")) namePrompt.resolve();
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "init"],
+      cwd: temp,
+      env: initEnv,
+      terminal,
+    });
+    // Fail with the child's output if it exits before a prompt we wait for.
+    const exitedEarly = proc.exited.then(code => {
+      throw new Error(`bun init exited before the prompt (code ${code}):\n${output}`);
+    });
+    exitedEarly.catch(() => {});
+
+    await Promise.race([menu.promise, exitedEarly]);
+    // "3" picks the third entry (Library) and submits it. Library is the
+    // template that asks text questions.
+    terminal.write("3");
+    await Promise.race([namePrompt.promise, exitedEarly]);
+    // The menu left raw mode before the text prompt printed, so Ctrl-D on the
+    // empty line is EOF.
+    terminal.write("\x04");
+
+    const exitCode = await proc.exited;
+    expect(output).not.toContain("An internal error occurred");
+    expect(output).not.toContain("EndOfStream");
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(false);
+  });
+
   test("bun init in folder", async () => {
     await using temp = tempDir("bun-init-in-folder", {
       "mydir": {


### PR DESCRIPTION
### Problem
- In an interactive `bun init`, pick `Library`, then press Ctrl-D at `package name:`. Bun prints `error: An internal error occurred (EndOfStream)` and exits with code 1. The same happens at `entry point:`. Expected: a quiet exit with code 0, the behavior before the Rust port.
- The runtime `Error` enum (`src/runtime/error.rs`) had its own `EndOfStream` variant next to the `Core(#[from] bun_core::Error)` arm. `InitCommand::prompt` reads stdin through `bun_core`, so EOF arrives as `Core(bun_core::Error::EndOfStream)`. The match arms in `exec` (`src/runtime/cli/init_command.rs:580` and `:587`) looked for `crate::Error::EndOfStream` and never fired. The error reached `handle_root_error`.

### Fix
- Remove `crate::Error::EndOfStream`. Every producer and consumer in the runtime crate now uses `Core(bun_core::Error::EndOfStream)`: the `bun init` menu and prompts, the `bun update -i` menu (which already matched both spellings), and the dev server's `read_string32`.
- With one spelling, a `?`-converted EOF from `bun_core` and an EOF raised by CLI code are the same value. The mismatch cannot come back.
- Verified: `test/cli/init/init.test.ts` (new test, runs `bun init` under `Bun.Terminal`, fails on the current release with the error above). Also the rest of `init.test.ts`, `update_interactive_install.test.ts`, and `update_interactive_formatting.test.ts`.

### Background
- `bun init` has two kinds of input. The template menu puts the tty in raw mode and reads one byte at a time (`process_radio_button`). The text prompts (`prompt`) read a line in cooked mode through the 4 KiB `BufferedStdin` in `bun_core::output`. Ctrl-D in cooked mode makes `read(2)` return 0, which `read_byte` reports as `bun_core::Error::EndOfStream`.
- Each crate has its own `thiserror` enum. Errors from a lower crate nest through a `#[from]` arm, so `bun_core::Error::EndOfStream` becomes `crate::Error::Core(EndOfStream)` at a `?`. A variant with the same name in the outer enum is a different value.
- In the Zig original `error.EndOfStream` was one error set member, so the menu code and the stdin reader could not disagree. The port split it in two.

<details><summary>Notes</summary>

- Only a real tty is affected. When stdin is not a tty, `exec` sets `auto_yes` and asks nothing.
- Ctrl-D at the template menu already worked (prints `x Cancelled`, exit 0) because `process_radio_button` raised the runtime variant and `radio` matched the same one. It now raises and matches the `Core` spelling. Checked under a PTY on the debug build: menu, `package name`, and `entry point` all exit 0 with no error line.
- The new test writes `3` to the PTY (picks Library, the template with text prompts), waits for `package name` in the output, then writes `\x04`. It asserts no error text, exit code 0, and no `package.json`. It is skipped on Windows: the console has no key that ends a cooked-mode read the way Ctrl-D does on POSIX.
- `update_interactive_command.rs:1232` had `crate::Error::EndOfStream | crate::Error::Core(bun_core::Error::EndOfStream)`, a sign the duplicate had already caused confusion once.
- `error_report_request.rs:read_string32` produced `Core(EndOfStream)` from `read_int_le` and the runtime variant from its own bounds check. Both paths now produce the same value.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/init/init.test.ts

<!-- robobun:evidence:end -->