### PR TITLE
shell: exit with the positive errno when a builtin's output write fails

### DIFF
--- a/src/runtime/shell/builtin/cd.rs
+++ b/src/runtime/shell/builtin/cd.rs
@@ -121,9 +121,13 @@ impl Cd {
         interp: &Interpreter,
         cmd: NodeId,
         _: usize,
-        _err: Option<bun_sys::SystemError>,
+        err: Option<bun_sys::SystemError>,
     ) -> Yield {
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(interp, cmd, 1)
+        Builtin::done(
+            interp,
+            cmd,
+            err.map_or(1, |e| e.get_errno() as crate::shell::ExitCode),
+        )
     }
 }

--- a/src/runtime/shell/builtin/echo.rs
+++ b/src/runtime/shell/builtin/echo.rs
@@ -113,7 +113,7 @@ impl Echo {
         Builtin::done(
             interp,
             cmd,
-            err.map(|e| e.errno as crate::shell::ExitCode).unwrap_or(0),
+            err.map_or(0, |e| e.get_errno() as crate::shell::ExitCode),
         )
     }
 }

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -82,6 +82,10 @@ impl Export {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(interp, cmd, err.map_or(0, |_| 1))
+        Builtin::done(
+            interp,
+            cmd,
+            err.map_or(0, |e| e.get_errno() as crate::shell::ExitCode),
+        )
     }
 }

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -330,7 +330,7 @@ impl Mv {
                     _ => unreachable!(),
                 };
                 // The failing rename's errno becomes the shell exit code.
-                let exit_code = e.errno as ExitCode;
+                let exit_code = e.get_errno() as ExitCode;
                 let buf = Builtin::task_error_to_string(interp, cmd, Kind::Mv, &e).to_vec();
                 Self::write_failing_error(interp, cmd, &buf, exit_code).run(interp);
                 return;

--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -179,7 +179,7 @@ impl Which {
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
         if let Some(err) = e {
-            return Builtin::done(interp, cmd, err.errno as crate::shell::ExitCode);
+            return Builtin::done(interp, cmd, err.get_errno() as crate::shell::ExitCode);
         }
         match Self::state_mut(interp, cmd).state {
             State::OneArg => Builtin::done(interp, cmd, 1),

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -8,7 +8,17 @@ import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
-import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import {
+  bunExe,
+  isLinux,
+  isPosix,
+  isWindows,
+  rss,
+  runWithErrorPromise,
+  tempDir,
+  tempDirWithFiles,
+  tmpdirSync,
+} from "harness";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -89,6 +99,19 @@ describe("bunshell", () => {
             .runAsTest(cmdstr)
         : "",
     );
+
+    // Every write to /dev/full fails with ENOSPC. The builtin reports that
+    // errno as its exit code, like the builtins that already do (cat, rm).
+    test.skipIf(!isLinux)("builtins exit with the errno of a failed output write", async () => {
+      const ENOSPC = 28;
+      const exitCodes = {
+        echo: (await $`echo hi > /dev/full`.nothrow()).exitCode,
+        which: (await $`which sh > /dev/full`.nothrow()).exitCode,
+        export: (await $`export FOO=bar; export > /dev/full`.nothrow()).exitCode,
+        cd: (await $`cd /nonexistent-dir 2> /dev/full`.nothrow()).exitCode,
+      };
+      expect(exitCodes).toEqual({ echo: ENOSPC, which: ENOSPC, export: ENOSPC, cd: ENOSPC });
+    });
   });
 
   describe("concurrency", () => {


### PR DESCRIPTION
### Problem
- A builtin whose output write fails reports a garbage exit code. `echo hi > /dev/full` and `which sh > /dev/full` exit 65508 (`ShellError: Failed with exit code 65508`). `export > /dev/full` and `cd /nonexistent 2> /dev/full` exit 1 and drop the errno.
- `echo.rs:116` and `which.rs:182` cast `SystemError.errno` to the `u16` exit code. That field holds the negated errno (`fill_system_error_common`, `src/sys/Error.rs:371`), so ENOSPC (-28) wraps to 65508. `export.rs:85` and `cd.rs:127` hard-code 1.

### Fix
- The four builtins read the errno through `SystemError::get_errno()`, which undoes the negation. `cat` and `rm` already do this, and the Zig builtins did too (`getErrno()`). `cd` keeps exit 1 when the stderr message is written without error.
- `mv` reads a failed rename's errno through `bun_sys::Error::get_errno()` instead of the raw field. That field is already positive, so the value does not change on POSIX.
- Excluded on purpose: `pwd`, `basename`, `dirname`, `seq` and `yes` keep exit 1 on a failed write. They did that before the rewrite too. #40033 proposes one status for every builtin.
- Verified: `test/js/bun/shell/bunshell.test.ts` (new test, stock bun reports 65508/65508/1/1). Also the rest of `bunshell.test.ts`, `commands/{echo,which,mv}.test.ts`, `epipe.test.ts`, `shell-pipe-read-fault.test.ts`, `shell-write-fault.test.ts`.

### Background
- A builtin that writes to a real fd (a file redirect, or the process stdout) goes through `IOWriter`, the shell's per-fd write queue. The result arrives later in the builtin's `on_io_writer_chunk` as an `Option<bun_sys::SystemError>`.
- `bun_sys::SystemError` is the JS-facing error shape. Its `errno` is stored negated to match Node's `err.errno`. `get_errno()` returns the positive `E` value.
- `bun_sys::Error` is the syscall-level error. Its `errno` is the positive `u16`.

<details><summary>Notes</summary>

Values from the repro with `/dev/full` as the redirect target (Linux, ENOSPC = 28):

| command | 1.4.1 | now |
|---|---|---|
| `echo hi > /dev/full` | 65508 | 28 |
| `which sh > /dev/full` | 65508 | 28 |
| `export FOO=bar; export > /dev/full` | 1 | 28 |
| `cd /nonexistent 2> /dev/full` | 1 | 28 |
| `cd /nonexistent` (stderr ok) | 1 | 1 |
| `mv nosuch dst` | 2 | 2 |
| `pwd > /dev/full` | 1 | 1 |
| `ls / > /dev/full` | 0 | 0 |

On Windows `SystemError.errno` is the libuv code (UV_ENOSPC = -4075), so the raw cast gave a different garbage value there. `get_errno()` canonicalizes it to the `E` discriminant, so the exit code is 28 on every platform.

The test is Linux only because `/dev/full` does not exist on macOS and Windows.

The excluded sites, with the pre-rewrite Zig behavior (commit `23427dbc12^`, `src/shell/builtin/*.zig`):

- `pwd.zig`, `basename.zig`, `dirname.zig`, `seq.zig`, `yes.zig`: `onIOWriterChunk` returned `done(1)` on a write error. The Rust port (`pwd.rs:72`, `basename.rs:62`, `dirname.rs:64`, `seq.rs:209`, `yes.rs:166`) does the same.
- `ls.zig`: `onIOWriterChunk` dropped the error. `ls.rs:182` does the same, so `ls / > /dev/full` exits 0.
- `echo.zig`, `which.zig`, `export.zig`, `cd.zig`: `onIOWriterChunk` returned `done(e.getErrno())`. The Rust port changed these four, and this PR restores them.

#40033 and #32278 are open PRs that change the same sites to exit 1 (coreutils style) for every failed write. This PR keeps the errno as the exit code, which is what the other builtins report and what the Zig implementation did.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->