### PR TITLE
Forward --inspect and --dns-result-order to the VM in compiled executables

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3287,10 +3287,9 @@ pub struct Options {
     // forward-dep crate; callers pass it as the resolver's trait object so
     // both VM and resolver can hold it without the cycle.
     pub graph: Option<&'static dyn bun_resolver::StandaloneModuleGraph>,
-    // Note: debugger
-    // configuration is plumbed through `RuntimeHooks::ensure_debugger` (the
-    // CLI option struct lives in `bun_cli`, a forward dep). See
-    // `runtime/jsc_hooks.rs` for the `configureDebugger` call site.
+    /// The `--inspect*` CLI flag. Forwarded to `InitOptions::debugger` so
+    /// `RuntimeHooks::init_runtime_state` → `configureDebugger` sees it.
+    pub debugger: bun_options_types::context::Debugger,
     pub is_main_thread: bool,
 }
 
@@ -4051,6 +4050,7 @@ impl VirtualMachine {
         let graph = opts.graph.expect("init_with_module_graph requires graph");
         let init_opts = InitOptions {
             transform_options: opts.args,
+            debugger: opts.debugger,
             graph: Some(graph),
             log: opts.log,
             env_loader: opts.env_loader,
@@ -4063,6 +4063,7 @@ impl VirtualMachine {
         let vm = Self::init(init_opts)?;
         // SAFETY: `vm` is the unique live VM on this thread.
         let vm_ref = unsafe { &mut *vm };
+        vm_ref.dns_result_order = opts.dns_result_order;
         vm_ref.transpiler.resolver.standalone_module_graph = Some(graph);
         vm_ref.install_bytecode_string_table(graph);
         // Avoid reading from tsconfig.json & package.json when in standalone mode

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3287,8 +3287,6 @@ pub struct Options {
     // forward-dep crate; callers pass it as the resolver's trait object so
     // both VM and resolver can hold it without the cycle.
     pub graph: Option<&'static dyn bun_resolver::StandaloneModuleGraph>,
-    /// The `--inspect*` CLI flag. Forwarded to `InitOptions::debugger` so
-    /// `RuntimeHooks::init_runtime_state` → `configureDebugger` sees it.
     pub debugger: bun_options_types::context::Debugger,
     pub is_main_thread: bool,
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -99,6 +99,8 @@ pub struct InitOptions {
     /// `top_level_dir`, so it threads through `init_runtime_state`.
     pub store_fd: bool,
     pub smol: bool,
+    /// `bun_dns::Order` as its `u8` repr, like `VirtualMachine::dns_result_order`.
+    pub dns_result_order: u8,
     pub eval_mode: bool,
     pub is_main_thread: bool,
     /// Forwarded to `Zig__GlobalObject__create` so the C++ ZigGlobalObject is
@@ -124,6 +126,7 @@ impl Default for InitOptions {
             graph: None,
             store_fd: false,
             smol: false,
+            dns_result_order: 0,
             eval_mode: false,
             is_main_thread: false,
             worker_ptr: core::ptr::null_mut(),
@@ -2610,6 +2613,7 @@ impl VirtualMachine {
             addr_of_mut!((*vm).origin_timer).write(std::time::Instant::now());
             addr_of_mut!((*vm).origin_timestamp).write(get_origin_timestamp());
             addr_of_mut!((*vm).smol).write(opts.smol);
+            addr_of_mut!((*vm).dns_result_order).write(opts.dns_result_order);
             // `Option<{CPU,Heap}ProfilerConfig>` are NOT zero-valid: each
             // payload contains a `bool`, and rustc picks that field's invalid
             // range (not the `&[u8]` null-ptr) as the enum niche, so all-zero
@@ -4054,6 +4058,7 @@ impl VirtualMachine {
             env_loader: opts.env_loader,
             smol: opts.smol,
             mini_mode: opts.smol,
+            dns_result_order: opts.dns_result_order,
             eval_mode: false,
             is_main_thread: opts.is_main_thread,
             ..Default::default()
@@ -4061,7 +4066,6 @@ impl VirtualMachine {
         let vm = Self::init(init_opts)?;
         // SAFETY: `vm` is the unique live VM on this thread.
         let vm_ref = unsafe { &mut *vm };
-        vm_ref.dns_result_order = opts.dns_result_order;
         vm_ref.transpiler.resolver.standalone_module_graph = Some(graph);
         vm_ref.install_bytecode_string_table(graph);
         // Avoid reading from tsconfig.json & package.json when in standalone mode

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -65,8 +65,6 @@ impl ReplCommand {
         // is `MimallocArena` (a per-heap mimalloc wrapper).
         let arena = Arena::new();
 
-        // Validate DNS result order before VM init; wired onto the VM
-        // post-init below, like run_command.rs.
         let dns_order = DnsOrder::from_string(&ctx.runtime_options.dns_result_order)
             .unwrap_or_else(|| {
                 bun_core::pretty_errorln!("<r><red>error<r><d>:<r> Invalid DNS result order.");
@@ -81,6 +79,7 @@ impl ReplCommand {
             debugger: core::mem::take(&mut ctx.runtime_options.debugger),
             log: core::ptr::NonNull::new(ctx.log),
             smol: ctx.runtime_options.smol,
+            dns_result_order: dns_order as u8,
             eval_mode: true,
             is_main_thread: true,
             ..Default::default()
@@ -92,9 +91,6 @@ impl ReplCommand {
         unsafe {
             (*vm).preload = core::mem::take(&mut ctx.preloads);
             (*vm).argv = core::mem::take(&mut ctx.passthrough);
-            // `vm.dns_result_order` is a `u8` (see VirtualMachine.rs); set
-            // post-init like run_command.rs since InitOptions doesn't carry it.
-            (*vm).dns_result_order = dns_order as u8;
         }
         // There is no per-VM allocator handle; the `vm.arena` assignment itself happens below
         // ReplRunner construction to avoid a move-after-borrow.

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -961,6 +961,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             debugger: ::core::mem::take(&mut ctx.runtime_options.debugger),
             smol: ctx.runtime_options.smol,
             mini_mode: ctx.runtime_options.smol,
+            // `Order` is `#[repr(u8)]`, so `as u8` is exact.
+            dns_result_order: bun_dns::Order::from_string_or_die(
+                &ctx.runtime_options.dns_result_order,
+            ) as u8,
             eval_mode: ctx.runtime_options.eval.eval_and_print,
             is_main_thread: true,
             ..Default::default()
@@ -974,10 +978,6 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         vm.argv = std::mem::take(&mut ctx.passthrough);
         // `InitOptions` has no `store_fd` field, so set it on the resolver directly.
         vm.transpiler.resolver.store_fd = ctx.debug.hot_reload != cli::command::HotReload::None;
-        // `vm.dns_result_order` is a `u8` until the b2-cycle widens
-        // it to `bun_dns::Order`; the enum is `#[repr(u8)]` so `as u8` is exact.
-        vm.dns_result_order =
-            bun_dns::Order::from_string_or_die(&ctx.runtime_options.dns_result_order) as u8;
         // `vm.main` is a BACKREF into these bytes and the runner never returns,
         // so the allocation is process-lifetime by construction.
         let entry: &'static [u8] = Box::leak(entry_path);
@@ -1158,9 +1158,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             is_main_thread: true,
             smol: ctx.runtime_options.smol,
             debugger: ::core::mem::take(&mut ctx.runtime_options.debugger),
-            // `Options::dns_result_order` is `u8` until the
-            // b2-cycle widens it to `bun_dns::Order`; the enum is
-            // `#[repr(u8)]` so `as u8` is exact.
+            // `Order` is `#[repr(u8)]`, so `as u8` is exact.
             dns_result_order: bun_dns::Order::from_string_or_die(
                 &ctx.runtime_options.dns_result_order,
             ) as u8,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1157,6 +1157,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             graph: Some(graph_dyn),
             is_main_thread: true,
             smol: ctx.runtime_options.smol,
+            debugger: ::core::mem::take(&mut ctx.runtime_options.debugger),
             // `Options::dns_result_order` is `u8` until the
             // b2-cycle widens it to `bun_dns::Order`; the enum is
             // `#[repr(u8)]` so `as u8` is exact.

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
 import { itBundled } from "./expectBundled";
 
 // `BUN_JSC_dumpOptions=2` prints every JSC option as `   name=value` on stderr
@@ -451,4 +453,96 @@ describe("bundler", () => {
       validate: expectFullJSCConfiguration,
     },
   });
+});
+
+// The standalone boot path parses exec argv into the CLI context and then
+// builds the VM through `init_with_module_graph`. Flags that only the VM acts
+// on (the inspector, the DNS result order) must survive that hand-off, not
+// just show up in `process.execArgv`.
+describe("compile-exec-argv runtime flags reach the VM", () => {
+  // `--inspect-wait` blocks the program until a client sends
+  // `Inspector.initialized`, so the shape is deterministic either way: the
+  // fixed binary prints the listening URL and waits, a binary that drops the
+  // flag runs to completion and its stderr ends without a URL.
+  const flags = ["--inspect-wait=127.0.0.1:0", "--dns-result-order=ipv4first"];
+
+  async function waitForInspectorUrl(stderr: ReadableStream<Uint8Array>): Promise<URL> {
+    const reader = stderr.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      const match = text.match(/^\s*(ws:\/\/\S+)\n/m);
+      if (match) {
+        // Keep draining so the child never blocks on a full stderr pipe.
+        void (async () => {
+          while (!(await reader.read()).done) {}
+        })();
+        return new URL(match[1]);
+      }
+    }
+    throw new Error(`inspector did not start. stderr:\n${text}`);
+  }
+
+  for (const [source, execArgv, env] of [
+    ["--compile-exec-argv", flags, {}],
+    ["BUN_OPTIONS", [], { BUN_OPTIONS: flags.join(" ") }],
+  ] as const) {
+    test.concurrent(`--inspect-wait and --dns-result-order from ${source}`, async () => {
+      using dir = tempDir("compile-exec-argv-vm-flags", {
+        "entry.js": /* js */ `
+          const dns = require("node:dns");
+          console.log(JSON.stringify({ execArgv: process.execArgv, dnsOrder: dns.getDefaultResultOrder() }));
+        `,
+      });
+      const exe = join(String(dir), isWindows ? "app.exe" : "app");
+      await using build = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "--compile",
+          ...(execArgv.length ? [`--compile-exec-argv=${execArgv.join(" ")}`] : []),
+          "--outfile",
+          exe,
+          "entry.js",
+        ],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      expect(buildStderr).not.toContain("error");
+      expect(buildExit).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [exe],
+        env: { ...bunEnv, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const url = await waitForInspectorUrl(proc.stderr);
+      expect(url.hostname).toBe("127.0.0.1");
+
+      const ws = new WebSocket(url.href);
+      const opened = Promise.withResolvers<void>();
+      ws.onopen = () => opened.resolve();
+      ws.onerror = event => opened.reject(new Error("WebSocket error", { cause: event }));
+      await opened.promise;
+
+      // Releases the wait. A connected client keeps the process alive, so
+      // close once the inspector has acknowledged the message.
+      const reply = Promise.withResolvers<unknown>();
+      ws.onmessage = event => reply.resolve(JSON.parse(String(event.data)));
+      ws.send(JSON.stringify({ id: 1, method: "Inspector.initialized", params: {} }));
+      expect(await reply.promise).toEqual({ id: 1, result: {} });
+      ws.close();
+
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(JSON.parse(stdout)).toEqual({ execArgv: flags, dnsOrder: "ipv4first" });
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -1,3 +1,4 @@
+import type { Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
@@ -460,11 +461,11 @@ describe("bundler", () => {
 // on (the inspector, the DNS result order) must survive that hand-off, not
 // just show up in `process.execArgv`.
 describe("compile-exec-argv runtime flags reach the VM", () => {
-  // `--inspect-wait` blocks the program until a client sends
-  // `Inspector.initialized`, so the shape is deterministic either way: the
-  // fixed binary prints the listening URL and waits, a binary that drops the
-  // flag runs to completion and its stderr ends without a URL.
-  const flags = ["--inspect-wait=127.0.0.1:0", "--dns-result-order=ipv4first"];
+  // Where the flags come from: baked into the executable, or the environment.
+  const sources = [
+    ["--compile-exec-argv", (flags: readonly string[]) => ({ execArgv: flags, env: {} })],
+    ["BUN_OPTIONS", (flags: readonly string[]) => ({ execArgv: [], env: { BUN_OPTIONS: flags.join(" ") } })],
+  ] as const;
 
   async function waitForInspectorUrl(stderr: ReadableStream<Uint8Array>): Promise<URL> {
     const reader = stderr.getReader();
@@ -486,36 +487,89 @@ describe("compile-exec-argv runtime flags reach the VM", () => {
     throw new Error(`inspector did not start. stderr:\n${text}`);
   }
 
-  for (const [source, execArgv, env] of [
-    ["--compile-exec-argv", flags, {}],
-    ["BUN_OPTIONS", [], { BUN_OPTIONS: flags.join(" ") }],
-  ] as const) {
+  async function readLine(stdout: ReadableStream<Uint8Array>): Promise<string> {
+    const reader = stdout.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    while (!text.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    return text;
+  }
+
+  async function compile(dir: string, execArgv: readonly string[]): Promise<string> {
+    const exe = join(dir, isWindows ? "app.exe" : "app");
+    await using build = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        ...(execArgv.length ? [`--compile-exec-argv=${execArgv.join(" ")}`] : []),
+        "--outfile",
+        exe,
+        "entry.js",
+      ],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).not.toContain("error");
+    expect(buildExit).toBe(0);
+    return exe;
+  }
+
+  // Opens a session on the inspectee. A dropped socket or a dead inspectee
+  // rejects whatever is awaited instead of leaving it to the test timeout.
+  async function connectInspector(proc: Subprocess, url: URL) {
+    const ws = new WebSocket(url.href);
+    const failed = Promise.withResolvers<never>();
+    failed.promise.catch(() => {});
+    ws.onerror = event => failed.reject(new Error("WebSocket error", { cause: event }));
+    ws.onclose = event => failed.reject(new Error(`WebSocket closed (${event.code})`));
+    proc.exited.then(code => failed.reject(new Error(`inspectee exited (${code}) before the inspector answered`)));
+
+    const opened = Promise.withResolvers<void>();
+    ws.onopen = () => opened.resolve();
+    await Promise.race([opened.promise, failed.promise]);
+
+    const pending = new Map<number, (reply: unknown) => void>();
+    ws.onmessage = event => {
+      const message = JSON.parse(String(event.data));
+      pending.get(message.id)?.(message);
+    };
+    let nextId = 1;
+    return {
+      request(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+        const id = nextId++;
+        const reply = Promise.withResolvers<unknown>();
+        pending.set(id, reply.resolve);
+        ws.send(JSON.stringify({ id, method, params }));
+        return Promise.race([reply.promise, failed.promise]);
+      },
+      close: () => ws.close(),
+    };
+  }
+
+  for (const [source, via] of sources) {
+    // `--inspect-wait` blocks the program until a client sends
+    // `Inspector.initialized`, so the shape is deterministic either way: the
+    // fixed binary prints the listening URL and waits, a binary that drops the
+    // flag runs to completion and its stderr ends without a URL.
     test.concurrent(`--inspect-wait and --dns-result-order from ${source}`, async () => {
+      const flags = ["--inspect-wait=127.0.0.1:0", "--dns-result-order=ipv4first"];
+      const { execArgv, env } = via(flags);
       using dir = tempDir("compile-exec-argv-vm-flags", {
         "entry.js": /* js */ `
           const dns = require("node:dns");
           console.log(JSON.stringify({ execArgv: process.execArgv, dnsOrder: dns.getDefaultResultOrder() }));
         `,
       });
-      const exe = join(String(dir), isWindows ? "app.exe" : "app");
-      await using build = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "build",
-          "--compile",
-          ...(execArgv.length ? [`--compile-exec-argv=${execArgv.join(" ")}`] : []),
-          "--outfile",
-          exe,
-          "entry.js",
-        ],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-      expect(buildStderr).not.toContain("error");
-      expect(buildExit).toBe(0);
+      const exe = await compile(String(dir), execArgv);
 
       await using proc = Bun.spawn({
         cmd: [exe],
@@ -526,30 +580,51 @@ describe("compile-exec-argv runtime flags reach the VM", () => {
       const url = await waitForInspectorUrl(proc.stderr);
       expect(url.hostname).toBe("127.0.0.1");
 
-      const ws = new WebSocket(url.href);
-      // A dropped socket or a dead inspectee rejects whatever is awaited
-      // instead of leaving it to the test timeout.
-      const failed = Promise.withResolvers<never>();
-      failed.promise.catch(() => {});
-      ws.onerror = event => failed.reject(new Error("WebSocket error", { cause: event }));
-      ws.onclose = event => failed.reject(new Error(`WebSocket closed (${event.code})`));
-      proc.exited.then(code => failed.reject(new Error(`inspectee exited (${code}) before the inspector answered`)));
-
-      const opened = Promise.withResolvers<void>();
-      ws.onopen = () => opened.resolve();
-      await Promise.race([opened.promise, failed.promise]);
-
-      // Releases the wait. A connected client keeps the process alive, so
-      // close once the inspector has acknowledged the message.
-      const reply = Promise.withResolvers<unknown>();
-      ws.onmessage = event => reply.resolve(JSON.parse(String(event.data)));
-      ws.send(JSON.stringify({ id: 1, method: "Inspector.initialized", params: {} }));
-      expect(await Promise.race([reply.promise, failed.promise])).toEqual({ id: 1, result: {} });
-      ws.close();
+      const inspector = await connectInspector(proc, url);
+      // Releases the wait. The program runs to its end, and the connected
+      // client keeps the process alive for the evaluation.
+      expect(await inspector.request("Inspector.initialized")).toEqual({ id: 1, result: {} });
+      expect(await inspector.request("Runtime.evaluate", { expression: "1 + 1" })).toMatchObject({
+        id: 2,
+        result: { result: { type: "number", value: 2 } },
+      });
+      inspector.close();
 
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       expect(JSON.parse(stdout)).toEqual({ execArgv: flags, dnsOrder: "ipv4first" });
       expect(exitCode).toBe(0);
+    });
+
+    // Plain `--inspect` must not block the program. The inspectee holds itself
+    // open for the client the way `test/cli/inspect/inspectee.js` does. When
+    // the flag is dropped that timer is all that is pending, so the process
+    // exits on its own and stderr ends without a URL.
+    test.concurrent(`--inspect from ${source} starts the inspector without blocking the program`, async () => {
+      const { execArgv, env } = via(["--inspect=127.0.0.1:0"]);
+      using dir = tempDir("compile-exec-argv-inspect", {
+        "entry.js": /* js */ `
+          console.log("started");
+          setTimeout(() => {}, 30_000);
+        `,
+      });
+      const exe = await compile(String(dir), execArgv);
+
+      await using proc = Bun.spawn({
+        cmd: [exe],
+        env: { ...bunEnv, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      // The program runs before any client connects.
+      expect(await readLine(proc.stdout)).toBe("started\n");
+
+      const url = await waitForInspectorUrl(proc.stderr);
+      const inspector = await connectInspector(proc, url);
+      expect(await inspector.request("Runtime.evaluate", { expression: "1 + 1" })).toMatchObject({
+        id: 1,
+        result: { result: { type: "number", value: 2 } },
+      });
+      inspector.close();
     });
   }
 });

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isCI, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -461,6 +461,10 @@ describe("bundler", () => {
 // on (the inspector, the DNS result order) must survive that hand-off, not
 // just show up in `process.execArgv`.
 describe("compile-exec-argv runtime flags reach the VM", () => {
+  // Each test rewrites a whole executable (the debug binary is ~800 MB), so
+  // give them the budget `itBundled` gives its compile tests.
+  const compileTest = (name: string, fn: () => Promise<void>) => test.concurrent(name, fn, isCI ? undefined : 30_000);
+
   // Where the flags come from: baked into the executable, or the environment.
   const sources = [
     ["--compile-exec-argv", (flags: readonly string[]) => ({ execArgv: flags, env: {} })],
@@ -560,7 +564,7 @@ describe("compile-exec-argv runtime flags reach the VM", () => {
     // `Inspector.initialized`, so the shape is deterministic either way: the
     // fixed binary prints the listening URL and waits, a binary that drops the
     // flag runs to completion and its stderr ends without a URL.
-    test.concurrent(`--inspect-wait and --dns-result-order from ${source}`, async () => {
+    compileTest(`--inspect-wait and --dns-result-order from ${source}`, async () => {
       const flags = ["--inspect-wait=127.0.0.1:0", "--dns-result-order=ipv4first"];
       const { execArgv, env } = via(flags);
       using dir = tempDir("compile-exec-argv-vm-flags", {
@@ -596,15 +600,15 @@ describe("compile-exec-argv runtime flags reach the VM", () => {
     });
 
     // Plain `--inspect` must not block the program. The inspectee holds itself
-    // open for the client the way `test/cli/inspect/inspectee.js` does. When
-    // the flag is dropped that timer is all that is pending, so the process
-    // exits on its own and stderr ends without a URL.
-    test.concurrent(`--inspect from ${source} starts the inspector without blocking the program`, async () => {
+    // open long enough for the client to connect; a connected client then keeps
+    // the process alive. When the flag is dropped that timer is all that is
+    // pending, so the process exits on its own and stderr ends without a URL.
+    compileTest(`--inspect from ${source} starts the inspector without blocking the program`, async () => {
       const { execArgv, env } = via(["--inspect=127.0.0.1:0"]);
       using dir = tempDir("compile-exec-argv-inspect", {
         "entry.js": /* js */ `
           console.log("started");
-          setTimeout(() => {}, 30_000);
+          setTimeout(() => {}, 10_000);
         `,
       });
       const exe = await compile(String(dir), execArgv);

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -527,17 +527,24 @@ describe("compile-exec-argv runtime flags reach the VM", () => {
       expect(url.hostname).toBe("127.0.0.1");
 
       const ws = new WebSocket(url.href);
+      // A dropped socket or a dead inspectee rejects whatever is awaited
+      // instead of leaving it to the test timeout.
+      const failed = Promise.withResolvers<never>();
+      failed.promise.catch(() => {});
+      ws.onerror = event => failed.reject(new Error("WebSocket error", { cause: event }));
+      ws.onclose = event => failed.reject(new Error(`WebSocket closed (${event.code})`));
+      proc.exited.then(code => failed.reject(new Error(`inspectee exited (${code}) before the inspector answered`)));
+
       const opened = Promise.withResolvers<void>();
       ws.onopen = () => opened.resolve();
-      ws.onerror = event => opened.reject(new Error("WebSocket error", { cause: event }));
-      await opened.promise;
+      await Promise.race([opened.promise, failed.promise]);
 
       // Releases the wait. A connected client keeps the process alive, so
       // close once the inspector has acknowledged the message.
       const reply = Promise.withResolvers<unknown>();
       ws.onmessage = event => reply.resolve(JSON.parse(String(event.data)));
       ws.send(JSON.stringify({ id: 1, method: "Inspector.initialized", params: {} }));
-      expect(await reply.promise).toEqual({ id: 1, result: {} });
+      expect(await Promise.race([reply.promise, failed.promise])).toEqual({ id: 1, result: {} });
       ws.close();
 
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isCI, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isCI, isDebug, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -461,15 +461,24 @@ describe("bundler", () => {
 // on (the inspector, the DNS result order) must survive that hand-off, not
 // just show up in `process.execArgv`.
 describe("compile-exec-argv runtime flags reach the VM", () => {
-  // Each test rewrites a whole executable (the debug binary is ~800 MB), so
-  // give them the budget `itBundled` gives its compile tests.
-  const compileTest = (name: string, fn: () => Promise<void>) => test.concurrent(name, fn, isCI ? undefined : 30_000);
+  // Serial, like the other compile tests: each `bun build --compile` rewrites
+  // the whole runtime binary (~800 MB for a debug build), and overlapping
+  // builds starve CI (see bundler_compile.test.ts). Same local budget as the
+  // `itBundled` compile tests.
+  const compileTest = (name: string, fn: () => Promise<void>) =>
+    test(name, fn, isCI ? undefined : isDebug ? Infinity : 30_000);
 
-  // Where the flags come from: baked into the executable, or the environment.
-  const sources = [
-    ["--compile-exec-argv", (flags: readonly string[]) => ({ execArgv: flags, env: {} })],
-    ["BUN_OPTIONS", (flags: readonly string[]) => ({ execArgv: [], env: { BUN_OPTIONS: flags.join(" ") } })],
-  ] as const;
+  // One program for every case. It reports what reached the VM and exits, or
+  // stays up for an inspector client when run with `hold` (a connected client
+  // then keeps it alive). A binary that dropped `--inspect` and runs without
+  // `hold` exits at once, so its stderr ends without a URL.
+  const entry = /* js */ `
+    const dns = require("node:dns");
+    console.log(JSON.stringify({ execArgv: process.execArgv, dnsOrder: dns.getDefaultResultOrder() }));
+    if (process.argv.includes("hold")) setTimeout(() => {}, 10_000);
+  `;
+  const waitFlags = ["--inspect-wait=127.0.0.1:0", "--dns-result-order=ipv4first"];
+  const inspectFlag = "--inspect=127.0.0.1:0";
 
   async function waitForInspectorUrl(stderr: ReadableStream<Uint8Array>): Promise<URL> {
     const reader = stderr.getReader();
@@ -559,76 +568,67 @@ describe("compile-exec-argv runtime flags reach the VM", () => {
     };
   }
 
-  for (const [source, via] of sources) {
-    // `--inspect-wait` blocks the program until a client sends
-    // `Inspector.initialized`, so the shape is deterministic either way: the
-    // fixed binary prints the listening URL and waits, a binary that drops the
-    // flag runs to completion and its stderr ends without a URL.
-    compileTest(`--inspect-wait and --dns-result-order from ${source}`, async () => {
-      const flags = ["--inspect-wait=127.0.0.1:0", "--dns-result-order=ipv4first"];
-      const { execArgv, env } = via(flags);
-      using dir = tempDir("compile-exec-argv-vm-flags", {
-        "entry.js": /* js */ `
-          const dns = require("node:dns");
-          console.log(JSON.stringify({ execArgv: process.execArgv, dnsOrder: dns.getDefaultResultOrder() }));
-        `,
-      });
-      const exe = await compile(String(dir), execArgv);
-
-      await using proc = Bun.spawn({
-        cmd: [exe],
-        env: { ...bunEnv, ...env },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const url = await waitForInspectorUrl(proc.stderr);
-      expect(url.hostname).toBe("127.0.0.1");
-
-      const inspector = await connectInspector(proc, url);
-      // Releases the wait. The program runs to its end, and the connected
-      // client keeps the process alive for the evaluation.
-      expect(await inspector.request("Inspector.initialized")).toEqual({ id: 1, result: {} });
-      expect(await inspector.request("Runtime.evaluate", { expression: "1 + 1" })).toMatchObject({
-        id: 2,
-        result: { result: { type: "number", value: 2 } },
-      });
-      inspector.close();
-
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(JSON.parse(stdout)).toEqual({ execArgv: flags, dnsOrder: "ipv4first" });
-      expect(exitCode).toBe(0);
+  // `--inspect-wait` blocks the program until a client sends
+  // `Inspector.initialized`: the binary prints the listening URL and waits,
+  // then runs and reports the flags once the client releases it.
+  async function expectWaitThenRun(exe: string, env: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [exe],
+      env: { ...bunEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
     });
+    const url = await waitForInspectorUrl(proc.stderr);
+    expect(url.hostname).toBe("127.0.0.1");
 
-    // Plain `--inspect` must not block the program. The inspectee holds itself
-    // open long enough for the client to connect; a connected client then keeps
-    // the process alive. When the flag is dropped that timer is all that is
-    // pending, so the process exits on its own and stderr ends without a URL.
-    compileTest(`--inspect from ${source} starts the inspector without blocking the program`, async () => {
-      const { execArgv, env } = via(["--inspect=127.0.0.1:0"]);
-      using dir = tempDir("compile-exec-argv-inspect", {
-        "entry.js": /* js */ `
-          console.log("started");
-          setTimeout(() => {}, 10_000);
-        `,
-      });
-      const exe = await compile(String(dir), execArgv);
-
-      await using proc = Bun.spawn({
-        cmd: [exe],
-        env: { ...bunEnv, ...env },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      // The program runs before any client connects.
-      expect(await readLine(proc.stdout)).toBe("started\n");
-
-      const url = await waitForInspectorUrl(proc.stderr);
-      const inspector = await connectInspector(proc, url);
-      expect(await inspector.request("Runtime.evaluate", { expression: "1 + 1" })).toMatchObject({
-        id: 1,
-        result: { result: { type: "number", value: 2 } },
-      });
-      inspector.close();
+    const inspector = await connectInspector(proc, url);
+    expect(await inspector.request("Inspector.initialized")).toEqual({ id: 1, result: {} });
+    expect(await inspector.request("Runtime.evaluate", { expression: "1 + 1" })).toMatchObject({
+      id: 2,
+      result: { result: { type: "number", value: 2 } },
     });
+    inspector.close();
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ execArgv: waitFlags, dnsOrder: "ipv4first" });
+    expect(exitCode).toBe(0);
   }
+
+  // Plain `--inspect` must not block the program: it reports before any client
+  // connects, and the inspector answers while it runs.
+  async function expectRunWithInspector(exe: string, env: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [exe, "hold"],
+      env: { ...bunEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(JSON.parse(await readLine(proc.stdout))).toEqual({ execArgv: [inspectFlag], dnsOrder: "verbatim" });
+
+    const url = await waitForInspectorUrl(proc.stderr);
+    const inspector = await connectInspector(proc, url);
+    expect(await inspector.request("Runtime.evaluate", { expression: "1 + 1" })).toMatchObject({
+      id: 1,
+      result: { result: { type: "number", value: 2 } },
+    });
+    inspector.close();
+  }
+
+  compileTest("--inspect-wait and --dns-result-order from --compile-exec-argv", async () => {
+    using dir = tempDir("compile-exec-argv-wait", { "entry.js": entry });
+    await expectWaitThenRun(await compile(String(dir), waitFlags), {});
+  });
+
+  compileTest("--inspect from --compile-exec-argv does not block the program", async () => {
+    using dir = tempDir("compile-exec-argv-inspect", { "entry.js": entry });
+    await expectRunWithInspector(await compile(String(dir), [inspectFlag]), {});
+  });
+
+  // The environment is read at run time, so one binary serves both cases.
+  compileTest("--inspect-wait, --dns-result-order and --inspect from BUN_OPTIONS", async () => {
+    using dir = tempDir("compile-exec-argv-bun-options", { "entry.js": entry });
+    const exe = await compile(String(dir), []);
+    await expectWaitThenRun(exe, { BUN_OPTIONS: waitFlags.join(" ") });
+    await expectRunWithInspector(exe, { BUN_OPTIONS: inspectFlag });
+  });
 });

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -473,8 +473,8 @@ describe("compile-exec-argv runtime flags reach the VM", () => {
   // then keeps it alive). A binary that dropped `--inspect` and runs without
   // `hold` exits at once, so its stderr ends without a URL.
   const entry = /* js */ `
-    const dns = require("node:dns");
-    console.log(JSON.stringify({ execArgv: process.execArgv, dnsOrder: dns.getDefaultResultOrder() }));
+    import { getDefaultResultOrder } from "node:dns";
+    console.log(JSON.stringify({ execArgv: process.execArgv, dnsOrder: getDefaultResultOrder() }));
     if (process.argv.includes("hold")) setTimeout(() => {}, 10_000);
   `;
   const waitFlags = ["--inspect-wait=127.0.0.1:0", "--dns-result-order=ipv4first"];


### PR DESCRIPTION
### Problem
- On a `bun build --compile` executable, `--inspect`, `--inspect-brk`, `--inspect-wait` and `--dns-result-order` from `--compile-exec-argv` or `BUN_OPTIONS` do nothing. The flag shows up in `process.execArgv`, but no inspector starts and `dns.getDefaultResultOrder()` stays `verbatim`.
- `RunCommand::boot_standalone` (`src/runtime/cli/run_command.rs:1154`) builds the VM with `init_with_module_graph`. `virtual_machine::Options` had no `debugger` field, so `configure_debugger` (`src/runtime/jsc_hooks.rs:579`) always saw `Debugger::Unspecified`. `Options::dns_result_order` existed, but `init_with_module_graph` never applied it.

### Fix
- Add `debugger: bun_options_types::context::Debugger` to `virtual_machine::Options`. `init_with_module_graph` forwards it to `InitOptions::debugger`. `boot_standalone` passes `ctx.runtime_options.debugger`, as `boot` (`run_command.rs:961`) already does.
- Add `dns_result_order` to `InitOptions`, and let `init()` write `vm.dns_result_order` next to `smol`, as the Zig `init` did. `boot`, the repl, and `init_with_module_graph` pass it in their init options instead of writing the VM field after init. No behavior change for `bun run` and `bun repl`.
- Verified: `test/bundler/compile-argv.test.ts`, three serial tests: `--inspect-wait` plus `--dns-result-order` with a `Runtime.evaluate` round trip, and plain `--inspect` (program not blocked), each from `--compile-exec-argv` and from `BUN_OPTIONS`. All three fail on the release build. Also ran that whole file, `repl.test.ts`, and the `test-dns-default-order-*` node tests.

### Background
- A compiled executable boots through `cli/mod.rs::boot_standalone`. It splices the baked `compile_exec_argv` and `BUN_OPTIONS` into argv, runs the normal CLI parser (so `process.execArgv` is right), then calls `RunCommand::boot_standalone`.
- `configure_debugger` turns the CLI flag or the `BUN_INSPECT*` env vars into `vm.debugger`. `ensure_debugger` starts the inspector from `load_entry_point` when `vm.debugger` is set. Only the env var path worked for compiled executables, because it is read inside `configure_debugger`.

Related to #20253. The issue's own report (`BUN_INSPECT=host:port/prefix?wait=1` serving `/prefix%3Fwait=1`, no banner) is a separate defect in `parseUrl` (`src/js/internal/debugger.ts`) and is not changed here.

Supersedes #35128, an earlier PR with the same change. Its test coverage is ported here.

<details><summary>Notes</summary>

Repro with the release build:

```sh
echo 'console.log(JSON.stringify(process.execArgv)); setTimeout(() => {}, 200);' > insp.js
bun build --compile --compile-exec-argv="--inspect=127.0.0.1:0" insp.js --outfile insp
./insp
# ["--inspect=127.0.0.1:0"], no "Bun Inspector" banner, no listener
```

```sh
echo 'console.log(require("node:dns").getDefaultResultOrder())' > dnso.js
bun build --compile --compile-exec-argv="--dns-result-order=ipv4first" dnso.js --outfile dnso
./dnso       # verbatim
bun --dns-result-order=ipv4first dnso.js   # ipv4first
```

`init_worker` and `init_bake` use `..Default::default()` and are unchanged. Workers still never configure a debugger: `configure_debugger` is gated on `worker_ptr`, and `init_worker` leaves `Options::debugger` at its default. Worker VMs also keep `dns_result_order` at its default, as before.

The Zig `initWithModuleGraph` called `vm.configureDebugger(opts.debugger)` and `bootStandalone` passed `.debugger = ctx.runtime_options.debugger`, so the debugger part is a port regression. Zig's `init` applied `dns_result_order` (`VirtualMachine.zig`, `vm.dns_result_order = opts.dns_result_order`), but `initWithModuleGraph` never did, so the dns half of the standalone bug is older than the port. The Rust port had moved the write out of `init` into the callers (`boot`, the repl), which is how `init_with_module_graph` could miss it.

`--inspect-wait` blocks the program until a client sends `Inspector.initialized`, so a binary that drops the flag runs to completion and its stderr ends without a URL. That makes the fail-before run explicit instead of a timeout. With this PR, `BUN_OPTIONS=--inspect-wait=host:port/prefix` gives a compiled executable the banner and a clean prefix, which is what the reporter of #20253 was after.

Probe of the `--inspect-wait` protocol used by the test (release build, `bun run`): after the client sends `Inspector.initialized` the program runs (stdout appears about 5 ms later), and the process exits 0 once the client closes the WebSocket. A connected client keeps the process alive.

The plain `--inspect` case runs the program with a `hold` argument. It then keeps itself alive with a 10 s timer, the same way `test/cli/inspect/inspectee.js` does. A listening inspector with no client does not keep the process alive, so without the timer the program would exit before the test can connect. When the flag is dropped, that timer is the only pending work, and the test ends with "inspector did not start" once the process exits.

Each `bun build --compile` rewrites the whole runtime binary (about 800 MB for a debug build), so the tests run serially and share one binary for the two `BUN_OPTIONS` cases, following `bundler_compile.test.ts`. They use the same local time budget as the `itBundled` compile tests.

Tests ported from #35128: plain `--inspect` from `BUN_OPTIONS` and from `--compile-exec-argv` with a `Runtime.evaluate` round trip, `--inspect-wait` from `BUN_OPTIONS`, and `--dns-result-order` from `BUN_OPTIONS` on a compiled executable. All of them pass against this branch's build.

`bun test` does not pass `--dns-result-order` to its VM (`test_command.rs`, `InitOptions` literal without the field). That is a separate gap and is not changed here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/compile-argv.test.ts

<!-- robobun:evidence:end -->
