### PR TITLE
cli: name --target and echo the rejected value when it is invalid

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1508,7 +1508,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     ctx.bundler_options.ignore_dce_annotations = args.flag(b"--ignore-dce-annotations");
 
     if cmd == CommandTag::BuildCommand {
-        parse_build_command_options(cmd, &args, &mut opts, ctx, &mut diag);
+        parse_build_command_options(cmd, &args, &mut opts, ctx);
     }
 
     if opts.entry_points.is_empty() {
@@ -2030,7 +2030,6 @@ fn parse_build_command_options(
     args: &clap::Args<clap::Help>,
     opts: &mut api::TransformOptions,
     ctx: Context<'_>,
-    diag: &mut clap::Diagnostic,
 ) {
     ctx.bundler_options.transform_only = args.flag(b"--no-bundle");
     ctx.bundler_options.bytecode = args.flag(b"--bytecode");
@@ -2183,7 +2182,13 @@ fn parse_build_command_options(
                     }
                 }
                 b"bun" => api::Target::Bun,
-                _ => cli::invalid_target(diag, target),
+                _ => {
+                    Output::err_generic(
+                        "Invalid value for --target: {}. Must be 'browser', 'bun', or 'node'.",
+                        (bun_core::fmt::quote(target),),
+                    );
+                    Global::exit(1);
+                }
             }));
 
             if opts.target.unwrap() == api::Target::Bun {
@@ -2192,12 +2197,7 @@ fn parse_build_command_options(
                 if ctx.bundler_options.bytecode {
                     Output::err_generic(
                         "target must be 'bun' when bytecode is true. Received: {}",
-                        format_args!(
-                            "{:?}",
-                            <bun_ast::Target as bun_options_types::TargetExt>::from_api(
-                                opts.target
-                            )
-                        ),
+                        format_args!("{}", BStr::new(target)),
                     );
                     Global::exit(1);
                 }
@@ -2205,12 +2205,7 @@ fn parse_build_command_options(
                 if ctx.bundler_options.bake {
                     Output::err_generic(
                         "target must be 'bun' when using --app. Received: {}",
-                        format_args!(
-                            "{:?}",
-                            <bun_ast::Target as bun_options_types::TargetExt>::from_api(
-                                opts.target
-                            )
-                        ),
+                        format_args!("{}", BStr::new(target)),
                     );
                 }
             }
@@ -2600,15 +2595,11 @@ fn parse_build_command_options(
     if args.flag(b"--server-components") {
         ctx.bundler_options.server_components = true;
         if let Some(target) = opts.target {
-            if !<bun_ast::Target as bun_options_types::TargetExt>::from_api(Some(target))
-                .is_server_side()
-            {
+            let target = <bun_ast::Target as bun_options_types::TargetExt>::from_api(Some(target));
+            if !target.is_server_side() {
                 Output::err_generic(
                     "Cannot use client-side --target={} with --server-components",
-                    format_args!(
-                        "{:?}",
-                        <bun_ast::Target as bun_options_types::TargetExt>::from_api(Some(target))
-                    ),
+                    format_args!("{}", BStr::new(target.naming_placeholder())),
                 );
                 Global::crash();
             } else {

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -522,12 +522,6 @@ impl colon_list_type::ColonListValue for &'static [u8] {
     }
 }
 
-#[cold]
-fn invalid_target(diag: &mut bun_clap::Diagnostic, _target: &[u8]) -> ! {
-    let _ = diag.report(Output::error_writer(), bun_clap::Error::InvalidArgument);
-    Global::exit(1);
-}
-
 // ─── Cli (entry point) ───────────────────────────────────────────────────────
 pub mod cli {
     use super::*;

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -849,6 +849,60 @@ describe("CLI argument error messages", () => {
     expect(stderr).toContain("key=value");
     expect(exitCode).toBe(1);
   });
+
+  test.each(["nope", "deno", ""])(
+    "--target with an unrecognized value names the flag and echoes %j back",
+    async value => {
+      using dir = tempDir("build-target-err", { "in.js": "console.log(1)" });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", `--target=${value}`, "in.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: normalizeBunSnapshot(stderr) }).toEqual({
+        stdout: "",
+        stderr: `error: Invalid value for --target: "${value}". Must be 'browser', 'bun', or 'node'.`,
+      });
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  test("--bytecode with a non-bun --target echoes the value as the user wrote it", async () => {
+    using dir = tempDir("build-bytecode-target-err", { "in.js": "console.log(1)" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--bytecode", "--target=browser", "in.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr: normalizeBunSnapshot(stderr) }).toEqual({
+      stdout: "",
+      stderr: "error: target must be 'bun' when bytecode is true. Received: browser",
+    });
+    expect(exitCode).toBe(1);
+  });
+
+  test("--server-components with a client-side --target echoes the value as the user wrote it", async () => {
+    using dir = tempDir("build-server-components-target-err", { "in.js": "console.log(1)" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--server-components", "--target=browser", "in.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr: normalizeBunSnapshot(stderr) }).toEqual({
+      stdout: "",
+      stderr: "error: Cannot use client-side --target=browser with --server-components",
+    });
+    expect(exitCode).toBe(1);
+  });
 });
 
 describe.concurrent("modules that fail to print", () => {


### PR DESCRIPTION
### Problem
- `bun build --target=nope ./index.ts` prints `error: Invalid Argument ''`. The message has neither the flag name nor the rejected value.
- The cause is `invalid_target` in `src/runtime/cli/mod.rs:526`. It ignored its `_target` parameter and reported `bun_clap::Error::InvalidArgument` through the clap `Diagnostic`. The parser had accepted `--target` itself, so the `Diagnostic` carried no flag name and no value, and the renderer printed an empty `''`.
- The `--bytecode`, `--app`, and `--server-components` target conflict errors in `Arguments.rs` formatted `bun_ast::Target` with `{:?}`, so they printed `Received: Browser` instead of the spelling the user typed.

### Fix
- Report the error at the match arm in `parse_build_command_options` (`src/runtime/cli/Arguments.rs`), in the same shape as the `--format` error next to it: `Invalid value for --target: "nope". Must be 'browser', 'bun', or 'node'.` The listed values match the `--target` help text.
- Remove the `invalid_target` helper and the `diag` parameter of `parse_build_command_options`. The helper was its only user.
- The three conflict errors print the target as the user spells it: the raw `--target` bytes where they are in scope, and `Target::naming_placeholder()` (the `[target]` spelling) in the `--server-components` check.
- Verified: `test/bundler/cli.test.ts` (five new tests in `CLI argument error messages`, all five fail on the current release). Also the rest of `test/bundler/cli.test.ts`.

### Background
- `bun_clap::Diagnostic` is the error-path record the argument parser fills in when it rejects a token. It only knows the flag the parser choked on. When the parser accepts a flag and the command later rejects the flag's value, the `Diagnostic` is empty, so the command has to print its own message.
- `Output::err_generic` prints `error: ` plus a formatted message to stderr. `bun_core::fmt::quote` wraps a byte slice in double quotes with escaping.

Supersedes #34315, which is the same fix but no longer merges.

<details><summary>Notes</summary>

- The Zig original set `diag.name.long = "target"` and `diag.arg = target` and reported `error.InvalidTarget`, which rendered as `InvalidTarget while parsing argument '--target'`. The port collapsed that into `InvalidArgument` with no name, which is how the value and the flag name both got lost.
- The Zig original printed the conflict errors with `@tagName(opts.target.?)`, the snake_case `api::Target` tag (`browser`). The port switched to `{:?}` on `bun_ast::Target`, which is PascalCase.
- `opts.target` is `None` on entry to `parse_build_command_options` for the build command (the only other writers are the run and standalone paths), so after the `--target` block it always equals the `--target` value. That is why echoing the raw bytes is accurate for the `--bytecode` and `--app` errors.
- Two pre-existing issues noticed nearby and left alone: the `--app` conflict error prints and continues without exiting (the Zig original did the same), and `--format=cjs` writes `ctx.args.target = Node`, which `parse` overwrites with `opts` on return, so it never takes effect.
- `test/bundler/bun-build-api.test.ts -t bytecode`: the two page-boundary and retention tests time out at 5 s in this debug build and pass with a longer timeout (32 s). They use `Bun.build`, not the CLI parser.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->