### PR TITLE
Transpiler cache: fall back to a private per-user temp directory when HOME is unset

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -679,11 +679,8 @@ impl RuntimeTranspilerCache {
         }
     }
 
-    /// `<tmpdir>/bun-<euid>/@t@`, the last resort when there is no home
-    /// directory. A cache entry runs as code and other users can write to the
-    /// temp directory, so the root is per-user and used only when neither it
-    /// nor its parent can be replaced by another user. Returns 0 to mean
-    /// "cache disabled".
+    /// `<tmpdir>/bun-<euid>/@t@`, or 0 (disabled) when another user could
+    /// replace the root or its parent: a planted entry would run as code.
     #[cfg(unix)]
     fn tmpdir_cache_dir(top: &[u8], buf: &mut PathBuffer) -> usize {
         let euid = sys::c::geteuid();
@@ -735,9 +732,7 @@ impl RuntimeTranspilerCache {
         path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], parts).len()
     }
 
-    /// Whether another user can rename or unlink entries of this directory:
-    /// it is group/other writable and the sticky bit does not limit that to
-    /// the entry owner and a trusted directory owner (us or root).
+    /// Group/other writable, and not sticky with us or root as the owner.
     #[cfg(unix)]
     fn entries_replaceable_by_others(st: &sys::Stat, euid: libc::uid_t) -> bool {
         let mode = st.st_mode as sys::Mode;

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -669,7 +669,63 @@ impl RuntimeTranspilerCache {
             .len();
         }
 
-        0
+        #[cfg(unix)]
+        {
+            Self::tmpdir_cache_dir(top, buf)
+        }
+        #[cfg(not(unix))]
+        {
+            0
+        }
+    }
+
+    /// `<tmpdir>/bun-<euid>/@t@`: the last resort when there is no home
+    /// directory (minimal containers, some CI runners, systemd services).
+    ///
+    /// A cache entry is executed as code, and every local user can write to
+    /// the temp directory, so a shared `<tmpdir>/bun/@t@` would let another
+    /// user plant entries. The root is per-user instead: created `0700`, then
+    /// checked through an `O_NOFOLLOW` directory fd before anything is read
+    /// from it. It has to be a directory owned by the effective uid with no
+    /// group/other write bits. Anything else returns 0 ("cache disabled").
+    #[cfg(unix)]
+    fn tmpdir_cache_dir(top: &[u8], buf: &mut PathBuffer) -> usize {
+        let euid = sys::c::geteuid();
+        let mut name_buf = [0u8; 16];
+        let name = bun_core::fmt::buf_print_infallible(&mut name_buf, format_args!("bun-{}", euid));
+        let parts: &[&[u8]] = &[bun_resolver::fs::RealFS::tmpdir_path(), name];
+        let root = path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], parts);
+        let root_len = root.len();
+        const SUFFIX: &[u8] = b"/@t@";
+        if root_len + SUFFIX.len() >= MAX_PATH_BYTES {
+            return 0;
+        }
+
+        match sys::mkdir(root, 0o700) {
+            Ok(()) => {}
+            Err(err) if err.get_errno() == sys::E::EEXIST => {}
+            Err(_) => return 0,
+        }
+        let Ok(fd) = sys::open(
+            root,
+            sys::O::RDONLY | sys::O::DIRECTORY | sys::O::NOFOLLOW | sys::O::CLOEXEC,
+            0,
+        ) else {
+            return 0;
+        };
+        let _close = sys::CloseOnDrop::new(fd);
+        let Ok(st) = sys::fstat(fd) else {
+            return 0;
+        };
+        let mode = st.st_mode as sys::Mode;
+        if !sys::S::ISDIR(mode) || st.st_uid != euid || mode & (sys::S::IWGRP | sys::S::IWOTH) != 0
+        {
+            return 0;
+        }
+
+        buf[root_len..root_len + SUFFIX.len()].copy_from_slice(SUFFIX);
+        buf[root_len + SUFFIX.len()] = 0;
+        root_len + SUFFIX.len()
     }
 
     // Only do this at most once per-thread.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -684,48 +684,76 @@ impl RuntimeTranspilerCache {
     ///
     /// A cache entry is executed as code, and every local user can write to
     /// the temp directory, so a shared `<tmpdir>/bun/@t@` would let another
-    /// user plant entries. The root is per-user instead: created `0700`, then
+    /// user plant entries. The root is per-user instead: created `0700` and
     /// checked through an `O_NOFOLLOW` directory fd before anything is read
     /// from it. It has to be a directory owned by the effective uid with no
-    /// group/other write bits. Anything else returns 0 ("cache disabled").
+    /// group/other write bits. Later opens go by path, so the temp directory
+    /// itself must not let another user rename or unlink that root (see
+    /// `entries_replaceable_by_others`). Anything else returns 0, which
+    /// means "cache disabled".
     #[cfg(unix)]
     fn tmpdir_cache_dir(top: &[u8], buf: &mut PathBuffer) -> usize {
         let euid = sys::c::geteuid();
-        let mut name_buf = [0u8; 16];
-        let name = bun_core::fmt::buf_print_infallible(&mut name_buf, format_args!("bun-{}", euid));
-        let parts: &[&[u8]] = &[bun_resolver::fs::RealFS::tmpdir_path(), name];
-        let root = path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], parts);
-        let root_len = root.len();
-        const SUFFIX: &[u8] = b"/@t@";
-        if root_len + SUFFIX.len() >= MAX_PATH_BYTES {
+        let tmpdir = bun_resolver::fs::RealFS::tmpdir_path();
+
+        let parent =
+            path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], &[tmpdir]);
+        let Ok(parent_fd) = sys::open(
+            parent,
+            sys::O::RDONLY | sys::O::DIRECTORY | sys::O::CLOEXEC,
+            0,
+        ) else {
+            return 0;
+        };
+        let _close_parent = sys::CloseOnDrop::new(parent_fd);
+        let Ok(parent_st) = sys::fstat(parent_fd) else {
+            return 0;
+        };
+        if Self::entries_replaceable_by_others(&parent_st, euid) {
             return 0;
         }
 
-        match sys::mkdir(root, 0o700) {
+        let mut name_buf = [0u8; 16];
+        let name =
+            bun_core::fmt::buf_print_z_infallible(&mut name_buf, format_args!("bun-{}", euid));
+        match sys::mkdirat(parent_fd, name, 0o700) {
             Ok(()) => {}
             Err(err) if err.get_errno() == sys::E::EEXIST => {}
             Err(_) => return 0,
         }
-        let Ok(fd) = sys::open(
-            root,
+        let Ok(root_fd) = sys::openat(
+            parent_fd,
+            name,
             sys::O::RDONLY | sys::O::DIRECTORY | sys::O::NOFOLLOW | sys::O::CLOEXEC,
             0,
         ) else {
             return 0;
         };
-        let _close = sys::CloseOnDrop::new(fd);
-        let Ok(st) = sys::fstat(fd) else {
+        let _close_root = sys::CloseOnDrop::new(root_fd);
+        let Ok(root_st) = sys::fstat(root_fd) else {
             return 0;
         };
-        let mode = st.st_mode as sys::Mode;
-        if !sys::S::ISDIR(mode) || st.st_uid != euid || mode & (sys::S::IWGRP | sys::S::IWOTH) != 0
-        {
+        let root_mode = root_st.st_mode as sys::Mode;
+        if root_st.st_uid != euid || root_mode & (sys::S::IWGRP | sys::S::IWOTH) != 0 {
             return 0;
         }
 
-        buf[root_len..root_len + SUFFIX.len()].copy_from_slice(SUFFIX);
-        buf[root_len + SUFFIX.len()] = 0;
-        root_len + SUFFIX.len()
+        let parts: &[&[u8]] = &[tmpdir, name.as_bytes(), b"@t@"];
+        path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], parts).len()
+    }
+
+    /// Can another user rename or unlink an entry of this directory? Write
+    /// permission on the directory is enough, unless the sticky bit limits
+    /// that to the entry owner, the directory owner and root, and the
+    /// directory owner is us or root. A standard `1777 /tmp` passes.
+    #[cfg(unix)]
+    fn entries_replaceable_by_others(st: &sys::Stat, euid: libc::uid_t) -> bool {
+        let mode = st.st_mode as sys::Mode;
+        if mode & (sys::S::IWGRP | sys::S::IWOTH) == 0 {
+            return false;
+        }
+        let sticky = mode & sys::S::ISVTX != 0;
+        !(sticky && (st.st_uid == euid || st.st_uid == 0))
     }
 
     // Only do this at most once per-thread.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -680,14 +680,17 @@ impl RuntimeTranspilerCache {
     }
 
     /// `<tmpdir>/bun-<euid>/@t@`, or 0 (disabled) when another user could
-    /// replace the root or its parent: a planted entry would run as code.
+    /// replace the root or any directory above it: a planted entry would run
+    /// as code.
     #[cfg(unix)]
     fn tmpdir_cache_dir(top: &[u8], buf: &mut PathBuffer) -> usize {
         let euid = sys::c::geteuid();
-        let tmpdir = bun_resolver::fs::RealFS::tmpdir_path();
 
-        let parent =
-            path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], &[tmpdir]);
+        let parent = path_handler::join_abs_string_buf_z::<platform::Loose>(
+            top,
+            &mut buf[..],
+            &[bun_resolver::fs::RealFS::tmpdir_path()],
+        );
         let Ok(parent_fd) = sys::open(
             parent,
             sys::O::RDONLY | sys::O::DIRECTORY | sys::O::CLOEXEC,
@@ -696,10 +699,7 @@ impl RuntimeTranspilerCache {
             return 0;
         };
         let _close_parent = sys::CloseOnDrop::new(parent_fd);
-        let Ok(parent_st) = sys::fstat(parent_fd) else {
-            return 0;
-        };
-        if Self::entries_replaceable_by_others(&parent_st, euid) {
+        if !Self::dir_chain_is_stable(parent_fd, euid) {
             return 0;
         }
 
@@ -728,8 +728,63 @@ impl RuntimeTranspilerCache {
             return 0;
         }
 
-        let parts: &[&[u8]] = &[tmpdir, name.as_bytes(), b"@t@"];
-        path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], parts).len()
+        // Later opens resolve the path again, so use the real path of the
+        // directory that was checked: a symlink on the way there could live
+        // in a directory the check never saw.
+        let Ok(real_parent) = sys::get_fd_path(parent_fd, buf) else {
+            return 0;
+        };
+        let mut len = real_parent.len();
+        let tail_len = 1 + name.len() + b"/@t@".len();
+        if len + tail_len >= MAX_PATH_BYTES {
+            return 0;
+        }
+        buf[len] = SEP;
+        len += 1;
+        buf[len..len + name.len()].copy_from_slice(name.as_bytes());
+        len += name.len();
+        buf[len..len + 4].copy_from_slice(b"/@t@");
+        len += 4;
+        buf[len] = 0;
+        len
+    }
+
+    /// Whether `dir_fd` and every directory above it can only be modified by
+    /// us or root, so a path through them keeps resolving to the same inodes.
+    #[cfg(unix)]
+    fn dir_chain_is_stable(dir_fd: Fd, euid: libc::uid_t) -> bool {
+        let Ok(mut st) = sys::fstat(dir_fd) else {
+            return false;
+        };
+        if Self::entries_replaceable_by_others(&st, euid) {
+            return false;
+        }
+        // "..", "../..", ... relative to `dir_fd`: needs only search
+        // permission, and follows the directory if it was moved.
+        let mut dots = paths::path_buffer_pool::get();
+        let mut len = 0;
+        loop {
+            if len + b"/..".len() >= MAX_PATH_BYTES {
+                return false;
+            }
+            if len > 0 {
+                dots[len] = SEP;
+                len += 1;
+            }
+            dots[len..len + 2].copy_from_slice(b"..");
+            len += 2;
+            dots[len] = 0;
+            let Ok(up) = sys::fstatat(dir_fd, ZStr::from_buf(&dots[..], len)) else {
+                return false;
+            };
+            if up.st_dev == st.st_dev && up.st_ino == st.st_ino {
+                return true;
+            }
+            if Self::entries_replaceable_by_others(&up, euid) {
+                return false;
+            }
+            st = up;
+        }
     }
 
     /// Owned by a third user, or group/other writable without the sticky bit.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -679,9 +679,7 @@ impl RuntimeTranspilerCache {
         }
     }
 
-    /// `<tmpdir>/bun-<euid>/@t@`, or 0 (disabled) when another user could
-    /// replace the root or any directory above it: a planted entry would run
-    /// as code.
+    /// `<tmpdir>/bun-<euid>/@t@`, or 0 when another user could swap a directory on that path.
     #[cfg(unix)]
     fn tmpdir_cache_dir(top: &[u8], buf: &mut PathBuffer) -> usize {
         let euid = sys::c::geteuid();
@@ -728,9 +726,7 @@ impl RuntimeTranspilerCache {
             return 0;
         }
 
-        // Later opens resolve the path again, so use the real path of the
-        // directory that was checked: a symlink on the way there could live
-        // in a directory the check never saw.
+        // Real path: later opens must not resolve a symlink the check never saw.
         let Ok(real_parent) = sys::get_fd_path(parent_fd, buf) else {
             return 0;
         };
@@ -749,8 +745,7 @@ impl RuntimeTranspilerCache {
         len
     }
 
-    /// Whether `dir_fd` and every directory above it can only be modified by
-    /// us or root, so a path through them keeps resolving to the same inodes.
+    /// Whether only us or root can modify `dir_fd` and every directory above it.
     #[cfg(unix)]
     fn dir_chain_is_stable(dir_fd: Fd, euid: libc::uid_t) -> bool {
         let Ok(mut st) = sys::fstat(dir_fd) else {
@@ -759,8 +754,7 @@ impl RuntimeTranspilerCache {
         if Self::entries_replaceable_by_others(&st, euid) {
             return false;
         }
-        // "..", "../..", ... relative to `dir_fd`: needs only search
-        // permission, and follows the directory if it was moved.
+        // "..", "../..", ... from `dir_fd`: only needs search permission.
         let mut dots = paths::path_buffer_pool::get();
         let mut len = 0;
         loop {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -732,15 +732,14 @@ impl RuntimeTranspilerCache {
         path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], parts).len()
     }
 
-    /// Group/other writable, and not sticky with us or root as the owner.
+    /// Owned by a third user, or group/other writable without the sticky bit.
     #[cfg(unix)]
     fn entries_replaceable_by_others(st: &sys::Stat, euid: libc::uid_t) -> bool {
-        let mode = st.st_mode as sys::Mode;
-        if mode & (sys::S::IWGRP | sys::S::IWOTH) == 0 {
-            return false;
+        if st.st_uid != euid && st.st_uid != 0 {
+            return true;
         }
-        let sticky = mode & sys::S::ISVTX != 0;
-        !(sticky && (st.st_uid == euid || st.st_uid == 0))
+        let mode = st.st_mode as sys::Mode;
+        mode & (sys::S::IWGRP | sys::S::IWOTH) != 0 && mode & sys::S::ISVTX == 0
     }
 
     // Only do this at most once per-thread.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -679,18 +679,11 @@ impl RuntimeTranspilerCache {
         }
     }
 
-    /// `<tmpdir>/bun-<euid>/@t@`: the last resort when there is no home
-    /// directory (minimal containers, some CI runners, systemd services).
-    ///
-    /// A cache entry is executed as code, and every local user can write to
-    /// the temp directory, so a shared `<tmpdir>/bun/@t@` would let another
-    /// user plant entries. The root is per-user instead: created `0700` and
-    /// checked through an `O_NOFOLLOW` directory fd before anything is read
-    /// from it. It has to be a directory owned by the effective uid with no
-    /// group/other write bits. Later opens go by path, so the temp directory
-    /// itself must not let another user rename or unlink that root (see
-    /// `entries_replaceable_by_others`). Anything else returns 0, which
-    /// means "cache disabled".
+    /// `<tmpdir>/bun-<euid>/@t@`, the last resort when there is no home
+    /// directory. A cache entry runs as code and other users can write to the
+    /// temp directory, so the root is per-user and used only when neither it
+    /// nor its parent can be replaced by another user. Returns 0 to mean
+    /// "cache disabled".
     #[cfg(unix)]
     fn tmpdir_cache_dir(top: &[u8], buf: &mut PathBuffer) -> usize {
         let euid = sys::c::geteuid();
@@ -742,10 +735,9 @@ impl RuntimeTranspilerCache {
         path_handler::join_abs_string_buf_z::<platform::Loose>(top, &mut buf[..], parts).len()
     }
 
-    /// Can another user rename or unlink an entry of this directory? Write
-    /// permission on the directory is enough, unless the sticky bit limits
-    /// that to the entry owner, the directory owner and root, and the
-    /// directory owner is us or root. A standard `1777 /tmp` passes.
+    /// Whether another user can rename or unlink entries of this directory:
+    /// it is group/other writable and the sticky bit does not limit that to
+    /// the entry owner and a trusted directory owner (us or root).
     #[cfg(unix)]
     fn entries_replaceable_by_others(st: &sys::Stat, euid: libc::uid_t) -> bool {
         let mode = st.st_mode as sys::Mode;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4935,13 +4935,14 @@ pub mod c {
     use core::ffi::{c_char, c_void};
     #[cfg(unix)]
     pub use libc::fchmod;
-    // `getuid`/`getgid` take no args and read kernel
+    // `getuid`/`geteuid`/`getgid` take no args and read kernel
     // process state — no preconditions, never fail. Declared locally as
     // `safe fn` (instead of re-exporting the `libc` crate's raw decls) so
     // callers need no per-site proof.
     #[cfg(unix)]
     unsafe extern "C" {
         pub safe fn getuid() -> libc::uid_t;
+        pub safe fn geteuid() -> libc::uid_t;
         pub safe fn getgid() -> libc::gid_t;
     }
     #[cfg(unix)]

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -239,6 +239,14 @@ describe("transpiler cache", () => {
       chmodSync(private_tmp, 0o755);
       expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(private_tmp))).toSpawn("tmpdir-cache");
       expect(readdirSync(join(private_tmp, `bun-${process.geteuid!()}`, "@t@"))).toHaveLength(1);
+
+      // A temp dir reached through a symlink is used by its real path, so the
+      // entry lands in the directory that was checked.
+      const linked_tmp = join(temp_dir, "linked-tmp");
+      symlinkSync(private_tmp, linked_tmp);
+      writeFileSync(join(temp_dir, "b.js"), dummyFile((50 * 1024 * 1.5) | 0, "2", "linked-tmpdir-cache"));
+      expect(await bunRun(join(temp_dir, "b.js"), noHomeEnv(linked_tmp))).toSpawn("linked-tmpdir-cache");
+      expect(readdirSync(join(private_tmp, `bun-${process.geteuid!()}`, "@t@"))).toHaveLength(2);
     },
   );
 
@@ -254,6 +262,16 @@ describe("transpiler cache", () => {
     expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("untrusted-root");
     expect(readdirSync(shared_tmp)).toEqual([]);
     chmodSync(shared_tmp, 0o1777);
+
+    // The same for a directory above the temp dir: another user could rename
+    // the whole temp dir away.
+    const outer = join(temp_dir, "outer");
+    const inner_tmp = join(outer, "tmp");
+    mkdirSync(inner_tmp, { recursive: true });
+    chmodSync(outer, 0o777);
+    chmodSync(inner_tmp, 0o755);
+    expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(inner_tmp))).toSpawn("untrusted-root");
+    expect(readdirSync(inner_tmp)).toEqual([]);
 
     // Another local user pre-created the root as a world-writable directory.
     mkdirSync(user_root, { recursive: true });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -216,8 +216,10 @@ describe("transpiler cache", () => {
     "falls back to a private per-user directory in the temp dir when there is no home",
     async () => {
       writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "tmpdir-cache"));
+      // Shaped like a standard /tmp: world-writable with the sticky bit.
       const shared_tmp = join(temp_dir, "shared-tmp");
       mkdirSync(shared_tmp, { recursive: true });
+      chmodSync(shared_tmp, 0o1777);
 
       const user_root = join(shared_tmp, `bun-${process.geteuid!()}`);
       const user_cache = join(user_root, "@t@");
@@ -230,6 +232,13 @@ describe("transpiler cache", () => {
       // The second run is served from the cache and writes no new entry.
       expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("tmpdir-cache");
       expect(readdirSync(user_cache)).toHaveLength(1);
+
+      // A private temp dir (no write bits for others) works as well.
+      const private_tmp = join(temp_dir, "private-tmp");
+      mkdirSync(private_tmp, { recursive: true });
+      chmodSync(private_tmp, 0o755);
+      expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(private_tmp))).toSpawn("tmpdir-cache");
+      expect(readdirSync(join(private_tmp, `bun-${process.geteuid!()}`, "@t@"))).toHaveLength(1);
     },
   );
 
@@ -237,6 +246,14 @@ describe("transpiler cache", () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "untrusted-root"));
     const shared_tmp = join(temp_dir, "shared-tmp");
     const user_root = join(shared_tmp, `bun-${process.geteuid!()}`);
+
+    // The temp dir is world-writable without the sticky bit: another user
+    // could rename our root away after the check, so nothing is created.
+    mkdirSync(shared_tmp, { recursive: true });
+    chmodSync(shared_tmp, 0o777);
+    expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("untrusted-root");
+    expect(readdirSync(shared_tmp)).toEqual([]);
+    chmodSync(shared_tmp, 0o1777);
 
     // Another local user pre-created the root as a world-writable directory.
     mkdirSync(user_root, { recursive: true });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -1,7 +1,18 @@
 import { Subprocess } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, tmpdirSync } from "harness";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
+import { bunEnv, bunExe, bunRun, isWindows, tmpdirSync } from "harness";
 import { join } from "path";
 
 function dummyFile(size: number, cache_bust: string, value: string | { code: string }) {
@@ -164,7 +175,24 @@ describe("transpiler cache", () => {
       expect(await proc.stdout.text()).toBe("b\n");
     }
   }, 99999999);
-  test("disables the cache instead of falling back to the shared temp directory", async () => {
+  // No per-user cache location is available (no BUN_RUNTIME_TRANSPILER_CACHE_PATH,
+  // no XDG_CACHE_HOME, no HOME). The only remaining candidate is the temp dir,
+  // which every other local user can write to as well.
+  function noHomeEnv(shared_tmp: string) {
+    return {
+      ...env,
+      BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined,
+      XDG_CACHE_HOME: undefined,
+      HOME: undefined,
+      USERPROFILE: undefined,
+      BUN_TMPDIR: undefined,
+      TMPDIR: shared_tmp,
+      TMP: shared_tmp,
+      TEMP: shared_tmp,
+    };
+  }
+
+  test("never uses a shared temp directory that another user could have pre-populated", async () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "no-tmpdir-cache"));
 
     // Stand-in for the shared, world-writable system temp dir. Pre-create
@@ -173,22 +201,7 @@ describe("transpiler cache", () => {
     const shared_cache = join(shared_tmp, "bun", "@t@");
     mkdirSync(shared_cache, { recursive: true });
 
-    // No per-user cache location is available (no BUN_RUNTIME_TRANSPILER_CACHE_PATH,
-    // no XDG_CACHE_HOME, no HOME) — the only remaining candidate is the shared
-    // temp dir, so the cache must be disabled instead of using it.
-    expect(
-      await bunRun(join(temp_dir, "a.js"), {
-        ...env,
-        BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined,
-        XDG_CACHE_HOME: undefined,
-        HOME: undefined,
-        USERPROFILE: undefined,
-        BUN_TMPDIR: undefined,
-        TMPDIR: shared_tmp,
-        TMP: shared_tmp,
-        TEMP: shared_tmp,
-      }),
-    ).toSpawn("no-tmpdir-cache");
+    expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("no-tmpdir-cache");
 
     // No cache entry may be written into (or read back from) a directory that
     // another local user could own and pre-populate.
@@ -197,6 +210,53 @@ describe("transpiler cache", () => {
     // A per-user cache location still works.
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("no-tmpdir-cache");
     expect(newCacheCount()).toBe(1);
+  });
+
+  test.skipIf(isWindows)(
+    "falls back to a private per-user directory in the temp dir when there is no home",
+    async () => {
+      writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "tmpdir-cache"));
+      const shared_tmp = join(temp_dir, "shared-tmp");
+      mkdirSync(shared_tmp, { recursive: true });
+
+      const user_root = join(shared_tmp, `bun-${process.geteuid!()}`);
+      const user_cache = join(user_root, "@t@");
+
+      expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("tmpdir-cache");
+      expect(readdirSync(user_cache)).toHaveLength(1);
+      // The root is ours alone: no group/other bits.
+      expect(statSync(user_root).mode & 0o077).toBe(0);
+
+      // The second run is served from the cache and writes no new entry.
+      expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("tmpdir-cache");
+      expect(readdirSync(user_cache)).toHaveLength(1);
+    },
+  );
+
+  test.skipIf(isWindows)("disables the cache when the per-user temp dir root cannot be trusted", async () => {
+    writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "untrusted-root"));
+    const shared_tmp = join(temp_dir, "shared-tmp");
+    const user_root = join(shared_tmp, `bun-${process.geteuid!()}`);
+
+    // Another local user pre-created the root as a world-writable directory.
+    mkdirSync(user_root, { recursive: true });
+    chmodSync(user_root, 0o777);
+    expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("untrusted-root");
+    expect(readdirSync(user_root)).toEqual([]);
+
+    // The root is a symlink into a directory another user controls.
+    rmSync(user_root, { recursive: true, force: true });
+    const elsewhere = join(temp_dir, "elsewhere");
+    mkdirSync(elsewhere, { recursive: true });
+    symlinkSync(elsewhere, user_root);
+    expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("untrusted-root");
+    expect(readdirSync(elsewhere)).toEqual([]);
+
+    // The root is not a directory at all.
+    rmSync(user_root, { force: true });
+    writeFileSync(user_root, "not a directory");
+    expect(await bunRun(join(temp_dir, "a.js"), noHomeEnv(shared_tmp))).toSpawn("untrusted-root");
+    expect(readFileSync(user_root, "utf8")).toBe("not a directory");
   });
   test("works if the cache is not user-readable", async () => {
     mkdirSync(cache_dir, { recursive: true });


### PR DESCRIPTION
### Problem
- When neither `HOME` nor `XDG_CACHE_HOME` is set (minimal containers, some CI runners, systemd services) the on-disk runtime transpiler cache is silently disabled. Every run transpiles large files again.
- `really_get_cache_dir` (`src/jsc/RuntimeTranspilerCache.rs:609`) returns 0 after the `HOME` arm, which sets `IS_DISABLED`. #31339 removed the `<tmpdir>/bun/@t@` fallback on purpose: another local user can pre-create that directory and plant cache entries, and a cache entry is executed as code.

### Fix
- On POSIX, fall back to `<tmpdir>/bun-<euid>/@t@`. The temp directory and every directory above it are checked first (`dir_chain_is_stable`, a `..` walk from the opened temp dir to the root): each must be owned by us or root, and either have no group/other write bits or have the sticky bit. Otherwise another user could rename a directory on the path after the check. A standard `1777 /tmp` passes.
- The root is then created `0700` with `mkdirat` and opened with `openat(O_DIRECTORY | O_NOFOLLOW)`, both relative to the verified temp dir fd, and checked with `fstat`: owned by the effective uid, no group/other write bits. The stored cache path is the real path of the verified temp dir, so later opens never resolve a symlink the check did not see.
- A root that another user created, a symlink, a plain file, or a temp dir (or ancestor) that other users can modify fails the check and keeps the cache disabled, as today. Windows keeps the current behavior (disabled) since `stat` there carries no owner.
- Verified: `test/cli/run/transpiler-cache.test.ts` (3 tests: the planted `bun/@t@` stays unused, the fallback is written and hit under a sticky, a private and a symlinked temp dir, each untrusted shape disables the cache). The fallback test fails on the released bun. Also ran `test/regression/issue/28159.test.ts` and `30887.test.ts`.

### Background
- The runtime transpiler cache stores transpiled output for source files of 4 KiB or more as `<hash>.pile` files. On a hit, bun runs the stored output instead of transpiling. The integrity hashes live inside the file, so whoever can write the directory controls what runs.
- `RealFS::tmpdir_path()` is `BUN_TMPDIR`, then `TMPDIR`/`TMP`/`TEMP`, then the platform default (`/tmp`).
- The sticky bit on a directory limits rename and unlink of an entry to the entry owner, the directory owner, and root. That is what makes a world-writable `/tmp` usable.
- `bun_sys::c::geteuid` is new, next to the existing `getuid`. The file owner that `open(2)` records is the effective uid.

<details><summary>Notes</summary>

- The same pattern (create `0700`, refuse a pre-existing entry that is not a directory we own with no group/other write bits) already guards `/tmp/bun-node-<sha>` in `src/install/lib.rs` and the embedded `.node` extraction in `src/runtime/jsc_hooks.rs`. The ancestor walk follows OpenSSH's `safe_path` (StrictModes), with the sticky bit accepted so `/tmp` qualifies.
- The walk uses `fstatat(fd, "..")`, `fstatat(fd, "../..")`, and so on from the opened temp dir, so it needs only search permission on the ancestors and follows the directory if it was moved. It stops when `..` resolves to the same inode (the root of the mount namespace).
- The original Zig code fell back to `<tmpdir>/bun/@t@` with no check. #31339 replaced the fallback with `0` and added the test "disables the cache instead of falling back to the shared temp directory". That test is kept with a new name. It still asserts that the pre-created `bun/@t@` is never used.
- #35747 (open) hardens the `HOME`-based locations (per-uid leaf, ownership check) and keeps the temp directory disabled. The two changes are independent. They overlap only in the `geteuid` declaration and in the test file.
- Repro with the released bun 1.4.1:
  ```
  printf '// %s\nconsole.log(1)' "$(head -c 150000 /dev/zero | tr '\0' x)" > big.ts
  env -i PATH=/usr/bin TMPDIR=$PWD/t1 bun big.ts; find t1 -type f | wc -l   # 0
  ```
  With this change: `t1/bun-<euid>/@t@/<hash>.pile`, root mode `drwx------`, and the second run restores from it.
- Manual checks as an unprivileged user (`setpriv --reuid=65534`) against a root-owned `1777 /tmp`: the entry is written to `/tmp/bun-65534/@t@`, also when `TMPDIR` is a symlink to `/tmp`. A root-owned `0777 /tmp/bun-65534` planted in advance, a `0777` non-sticky `TMPDIR`, and a `0755 TMPDIR` owned by a third uid that already holds a victim-owned `bun-65534`, all log `CacheDisabled` and write nothing.
- Cross-target `cargo check -p bun_jsc -p bun_sys` passes for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->