### PR TITLE
watch: close non-CLOEXEC fds across a --watch reload on macOS

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4268,9 +4268,9 @@ pub(crate) fn which<'a>(
 }
 
 // ── auto_reload_on_crash / reload_process group ───────────────────────────
-// Full body of `reloadProcess` depends on
-// `bun.spawn` (tier-4); the crash-handler only needs the flag + the
-// thread-coordination helpers + a best-effort POSIX `execve` path.
+// Lives in tier-0 because the crash handler reloads too. The platform-specific
+// exec itself is in C++ (`bun_reload_process_exec`, c-bindings.cpp), so this
+// needs no `bun_spawn_sys`.
 use core::sync::atomic::{AtomicBool, Ordering as AOrdering};
 static AUTO_RELOAD_ON_CRASH: AtomicBool = AtomicBool::new(false);
 static RELOAD_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
@@ -4355,7 +4355,9 @@ pub fn maybe_handle_panic_during_process_reload() {
 
 /// Port of `bun.reloadProcess`. `may_return == true` → returns on failure; `false` → panics.
 /// `on_before_reload_process_posix` clears CLOEXEC on stdio/IPC and resets caught signal
-/// dispositions on all POSIX; the close_range sweep is Linux/BSD only.
+/// dispositions on all POSIX; the close_range sweep is Linux/BSD only. `bun_reload_process_exec`
+/// is `execve` there and, on macOS (no close_range), `posix_spawn` with `POSIX_SPAWN_SETEXEC |
+/// POSIX_SPAWN_CLOEXEC_DEFAULT`, which closes every fd but stdio/IPC in the new image.
 pub fn reload_process(clear_terminal: bool, may_return: bool) {
     // Exactly one thread may perform the reload: the JS thread and the watcher's grace-window
     // fallback can both reach here, and concurrent execve prep crashes on musl. The swap elects a
@@ -4413,7 +4415,8 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
 
     #[cfg(unix)]
     // SAFETY: FFI calls receive only locally-built NUL-terminated argv/envp arrays; on success
-    // `execve` never returns, on failure errno is read. No borrowed Rust state observed after.
+    // the exec never returns, on failure the errno is returned. No borrowed Rust state observed
+    // after.
     unsafe {
         {
             unsafe extern "C" {
@@ -4447,9 +4450,15 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         // we must clone selfExePath in case argv[0] was not an absolute path
         let exec_path = self_exe_path().expect("unreachable").as_ptr();
 
-        libc::execve(exec_path, newargv.as_ptr().cast(), envp.as_ptr().cast());
-        // execve only returns on error.
-        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+        unsafe extern "C" {
+            fn bun_reload_process_exec(
+                path: *const core::ffi::c_char,
+                argv: *const *const core::ffi::c_char,
+                envp: *const *const core::ffi::c_char,
+            ) -> core::ffi::c_int;
+        }
+        // Returns only on failure, with the errno.
+        let errno = bun_reload_process_exec(exec_path, newargv.as_ptr(), envp.as_ptr());
         if may_return {
             crate::output::pretty_errorln(format_args!(
                 "error: Failed to reload process: errno {}",

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -18,6 +18,7 @@
 #include <sys/socket.h>
 #if OS(DARWIN)
 #include <mach-o/loader.h>
+#include <spawn.h>
 #endif
 #else
 #include <uv.h>
@@ -301,6 +302,21 @@ static void unset_cloexec(int fd)
     fcntl(fd, F_SETFD, flags);
 }
 
+// The IPC channel to the parent, or -1. NODE_CHANNEL_FD survives in environ across the
+// reload and the reloaded image re-attaches to it, so the fd it names must survive too;
+// closed, the parent stops receiving 'message' events after the first reload.
+static int node_channel_fd()
+{
+    const char* s = getenv("NODE_CHANNEL_FD");
+    if (!s)
+        return -1;
+    char* end = nullptr;
+    long fd = strtol(s, &end, 10);
+    if (end == s || *end != '\0' || fd < 3 || fd > INT_MAX)
+        return -1;
+    return static_cast<int>(fd);
+}
+
 extern "C" void on_before_reload_process_posix()
 {
     unset_cloexec(STDIN_FILENO);
@@ -314,15 +330,8 @@ extern "C" void on_before_reload_process_posix()
     bun_close_range(3, ~0U, CLOSE_RANGE_CLOEXEC);
 #endif
 
-    // Preserve the IPC channel to the parent across the execve: NODE_CHANNEL_FD survives in
-    // environ and the reloaded image re-attaches to it; CLOEXEC'd, the parent stops receiving
-    // 'message' events after the first reload.
-    if (const char* s = getenv("NODE_CHANNEL_FD")) {
-        char* end = nullptr;
-        long fd = strtol(s, &end, 10);
-        if (end != s && *end == '\0' && fd >= 3 && fd <= INT_MAX)
-            unset_cloexec(static_cast<int>(fd));
-    }
+    if (int ipc = node_channel_fd(); ipc >= 0)
+        unset_cloexec(ipc);
 
     // Reset caught dispositions so a SIGTERM arriving between here and execve isn't queued-then-
     // lost. Inherited SIG_IGN is left alone. SIGSEGV/SIGBUS/RT/sigThreadSuspendResume are left
@@ -352,6 +361,56 @@ extern "C" void on_before_reload_process_posix()
     sigset_t signal_set;
     sigemptyset(&signal_set);
     sigprocmask(SIG_SETMASK, &signal_set, nullptr);
+}
+
+// Replaces the current image with `path`, like execve(2). Returns only on failure, with the
+// errno.
+extern "C" int bun_reload_process_exec(const char* path, char* const* argv, char* const* envp)
+{
+#if OS(DARWIN)
+    // macOS has no close_range(2), and fs.openSync does not set O_CLOEXEC, so a bare execve
+    // carries every fd that user code opened into the reloaded image, one more per reload.
+    // POSIX_SPAWN_SETEXEC replaces the image without forking and POSIX_SPAWN_CLOEXEC_DEFAULT
+    // closes every fd that is not listed in the file actions, whatever its FD_CLOEXEC bit: the
+    // same result as the close_range sweep above on Linux.
+    posix_spawnattr_t attrs;
+    posix_spawn_file_actions_t actions;
+    int rc = posix_spawnattr_init(&attrs);
+    if (rc != 0)
+        return rc;
+    rc = posix_spawn_file_actions_init(&actions);
+    if (rc != 0) {
+        posix_spawnattr_destroy(&attrs);
+        return rc;
+    }
+
+    // Only the mask is reset. SETEXEC already gives execve(2) semantics for dispositions
+    // (caught handlers become SIG_DFL, SIG_IGN is preserved), the same as the Linux path.
+    sigset_t emptyMask;
+    sigemptyset(&emptyMask);
+    posix_spawnattr_setsigmask(&attrs, &emptyMask);
+    posix_spawnattr_setflags(&attrs, POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_SETEXEC | POSIX_SPAWN_SETSIGMASK);
+
+    // A closed fd in the inherit list fails the whole spawn with EBADF, so check each one.
+    auto inherit = [&](int fd) {
+        if (fcntl(fd, F_GETFD, 0) != -1)
+            posix_spawn_file_actions_addinherit_np(&actions, fd);
+    };
+    inherit(STDIN_FILENO);
+    inherit(STDOUT_FILENO);
+    inherit(STDERR_FILENO);
+    if (int ipc = node_channel_fd(); ipc >= 0)
+        inherit(ipc);
+
+    pid_t pid;
+    rc = posix_spawn(&pid, path, &actions, &attrs, argv, envp);
+    posix_spawn_file_actions_destroy(&actions);
+    posix_spawnattr_destroy(&attrs);
+    return rc;
+#else
+    execve(path, argv, envp);
+    return errno;
+#endif
 }
 
 #endif // !OS(WINDOWS)

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -373,6 +373,66 @@ it("NODE_COMPILE_CACHE persists across a --watch reload", async () => {
   expect(entries.filter(e => e.isFile()).length).toBeGreaterThan(0);
 }, 30000);
 
+// The reload must not carry fds that user code opened into the new image.
+// fs.openSync does not set O_CLOEXEC, so this relies on the pre-exec
+// close_range sweep on Linux and on POSIX_SPAWN_CLOEXEC_DEFAULT on macOS,
+// which has no close_range(2). Before the macOS path existed, every such fd
+// survived each reload and the count grew by one per restart.
+it.skipIf(isWindows)(
+  "fds opened by the script are closed across a --watch reload",
+  async () => {
+    using dir = tempDir("watch-fd-leak", {
+      "app.js": `
+        const fs = require("fs");
+        const fd = fs.openSync("leak.txt", "w");
+        fs.writeFileSync("fd.txt", String(fd));
+        console.log("iter first");
+        setInterval(() => {}, 1000);
+      `,
+    });
+
+    watchee = spawn({
+      cmd: [bunExe(), "--watch", "app.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stderr = watchee.stderr.text();
+
+    const { waitFor, release, output } = stdoutWaiter(watchee);
+
+    await waitFor("iter first");
+    // The number may be reused by the new process, so compare identities
+    // instead of checking for EBADF: a leaked fd still names leak.txt.
+    await Bun.write(
+      join(String(dir), "app.js"),
+      `
+        const fs = require("fs");
+        const fd = Number(fs.readFileSync("fd.txt", "utf8"));
+        const target = fs.statSync("leak.txt");
+        let leaked = false;
+        try {
+          const { dev, ino } = fs.fstatSync(fd);
+          leaked = dev === target.dev && ino === target.ino;
+        } catch {}
+        console.log("leaked=" + leaked);
+        console.error("stderr after reload");
+        console.log("iter second");
+      `,
+    );
+    await waitFor("iter second");
+
+    release();
+    watchee.kill("SIGKILL");
+    await watchee.exited;
+
+    expect(output()).toContain("leaked=false");
+    expect(await stderr).toContain("stderr after reload");
+  },
+  30000,
+);
+
 // NODE_CHANNEL_FD survives in environ across execve; the fd it names must
 // survive too, so the reloaded image re-attaches to a live socket instead
 // of a closed one and the parent keeps receiving 'message' events.


### PR DESCRIPTION
### Problem
- On macOS, a `--watch` reload carries every fd that user code opened into the new process. `fs.openSync` does not set `O_CLOEXEC`, so after each restart the reloaded process still holds the previous generation's files and pipes, one more per reload. Reproduced with canary 1.4.1+731aa92 on macOS 26 arm64 (`fstatSync` on the old fd number still names the old file after the reload). Stock 1.3.13 does not leak.
- `reload_process` (`src/bun_core/util.rs:4450`) did a bare `execve` on every POSIX platform. The pre-exec sweep `bun_close_range(3, ~0U, CLOSE_RANGE_CLOEXEC)` in `on_before_reload_process_posix` (`src/jsc/bindings/c-bindings.cpp:330`) is compiled only for Linux and FreeBSD. The Zig `reloadProcess` had a `posix_spawn` path for macOS, and the port dropped it.

### Fix
- The exec moves into `bun_reload_process_exec` in `c-bindings.cpp`. On macOS it is `posix_spawn` with `POSIX_SPAWN_SETEXEC | POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_SETSIGMASK`. The inherit list is stdio plus `NODE_CHANNEL_FD`. On the other platforms it stays `execve`, and `reload_process` calls it instead of `libc::execve`.
- `CLOEXEC_DEFAULT` closes every fd that is not in the inherit list, whatever its `FD_CLOEXEC` bit. That is the same result the `close_range` sweep gives on Linux. Dispositions are left to the exec (caught handlers reset, `SIG_IGN` kept), as on Linux and as `process.execve` does.
- A closed fd in the inherit list fails the whole spawn with `EBADF` and the old image keeps running, so each fd is checked with `fcntl(F_GETFD)` first. The `NODE_CHANNEL_FD` parse is shared with the Linux path (`node_channel_fd()`).
- Verified: `test/cli/watch/watch.test.ts` (new test, fails on the macOS canary, passes on Linux before and after). Also `test/cli/hot/`, `process-execve.test.ts`, `test/regression/issue/24329.test.ts`.

### Background
- `--watch` restarts by replacing the process image in place (`execve` semantics), not by spawning a child. Anything open in the old image without `FD_CLOEXEC` stays open in the new one.
- Linux closes the extras with `close_range(2)` and `CLOSE_RANGE_CLOEXEC`, which marks a whole fd range close-on-exec. macOS has no `close_range`.
- `POSIX_SPAWN_SETEXEC` and `POSIX_SPAWN_CLOEXEC_DEFAULT` are Apple extensions to `posix_spawn`. `SETEXEC` replaces the current image instead of forking. `CLOEXEC_DEFAULT` closes all fds except those named by `posix_spawn_file_actions_addinherit_np`. Bun already uses this pair for `process.execve` (`BunProcess.cpp`) and for `bun run` on macOS.
- `NODE_CHANNEL_FD` names the IPC socket to the parent. It survives in `environ` across the reload, so the fd must survive too, or the parent stops receiving messages.

<details><summary>Notes</summary>

Kernel semantics checked with a small C program on macOS 26.6.1 (darwin-arm64): with `SETEXEC | CLOEXEC_DEFAULT | SETSIGMASK` and inherit 0, 1, 2 plus one extra fd, the non-inherited fd is `EBADF` in the new image, the inherited one is open, a blocked `SIGTERM` is unblocked, and `SIG_IGN` on `SIGPIPE` is preserved. `addinherit_np` on a closed fd returns 0 but `posix_spawn` then returns `EBADF` and the old image continues, hence the `fcntl` guard. The extracted `bun_reload_process_exec` body was compiled with Apple clang and run the same way: the plain fd is closed, the `NODE_CHANNEL_FD` fd is open, and a closed stderr does not fail the spawn.

The linux-x64 debug build passes the whole `test/cli/watch/watch.test.ts` file (10 tests), including the existing IPC-survives-reload test, which exercises the `NODE_CHANNEL_FD` inherit on the macOS lanes.

The test is deliberately side-effect free: it compares `fstatSync(fd)` dev/ino with `leak.txt` instead of writing through the fd, because a correct reload may reuse the fd number for something else in the new process.

#39975 (robobun) touches the same `execve` lines for error reporting. It is a different change and will need a small rebase on whichever lands second.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->