### PR TITLE
Bun.serve: flush the dev-mode idle timeout warning when it fires

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -647,31 +647,12 @@ pub(crate) fn wrap_handler_slot(
 }
 
 impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
-    /// Per-monomorphization static.
-    /// Rust statics cannot be const-generic; routed through a
-    /// `&'static AtomicBool` so the four (SSL,DEBUG) instantiations share one
-    /// flag — the warning is process-global by intent (printed at most once
-    /// regardless of how many servers are running).
-    fn did_send_idletimeout_warning_once() -> &'static core::sync::atomic::AtomicBool {
-        static FLAG: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
-        &FLAG
-    }
-
-    /// The body ignores both arguments so a single non-generic shim suffices.
-    fn on_timeout_for_idle_warn(_: *mut c_void, _: &mut uws_sys::NewAppResponse<SSL>) {
-        if DEBUG && !Self::did_send_idletimeout_warning_once().load(Ordering::Relaxed) {
-            if !crate::cli::Command::get().debug.silent {
-                Self::did_send_idletimeout_warning_once().store(true, Ordering::Relaxed);
-                bun_core::warn!(
-                    "Bun.serve() timed out a request after 10 seconds. Pass `idleTimeout` to configure."
-                );
-            }
-        }
-    }
-
+    /// The warning is process-global by intent (printed at most once
+    /// regardless of how many servers are running), so this reads the one
+    /// latch that `server_body::add_timeout_handler_for_warning` sets.
     fn should_add_timeout_handler_for_warning(&self) -> bool {
         if DEBUG {
-            if !Self::did_send_idletimeout_warning_once().load(Ordering::Relaxed)
+            if !server_body::did_send_idletimeout_warning_once().load(Ordering::Relaxed)
                 && !crate::cli::Command::get().debug.silent
             {
                 return !self.config.has_idle_timeout;
@@ -753,13 +734,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // Since we do timeouts by default, we should tell the user when
         // this happens - but limit it to only warn once.
         if server.should_add_timeout_handler_for_warning() {
-            // We need to pass it a pointer, any pointer should do.
-            resp_ref.on_timeout(
-                Self::on_timeout_for_idle_warn,
-                Self::did_send_idletimeout_warning_once()
-                    .as_ptr()
-                    .cast::<c_void>(),
-            );
+            server_body::add_timeout_handler_for_warning(resp_ref);
         }
 
         // SAFETY: `request_pool` points at a process-static (or

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -647,9 +647,6 @@ pub(crate) fn wrap_handler_slot(
 }
 
 impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
-    /// The warning is process-global by intent (printed at most once
-    /// regardless of how many servers are running), so this reads the one
-    /// latch that `server_body::add_timeout_handler_for_warning` sets.
     fn should_add_timeout_handler_for_warning(&self) -> bool {
         if DEBUG {
             if !server_body::did_send_idletimeout_warning_once().load(Ordering::Relaxed)

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1188,23 +1188,14 @@ fn fetch_headers_from_js(value: JSValue, global: &JSGlobalObject) -> Option<*mut
     FetchHeaders::cast_(value, global.vm()).map(|p| p.as_ptr())
 }
 
-/// Per-process latch for the dev-mode idle-timeout warning. The
-/// warning is gated on `DEBUG && !silent` and only fires once globally, so a
-/// single shared `AtomicBool` matches user-visible behavior across every
-/// `(SSL, DEBUG)` instantiation and every transport (HTTP/1, HTTP/2, HTTP/3).
+/// Per-process latch for the dev-mode idle-timeout warning, shared by every
+/// server instantiation and transport.
 #[inline]
 pub(super) fn did_send_idletimeout_warning_once() -> &'static core::sync::atomic::AtomicBool {
     static FLAG: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
     &FLAG
 }
 
-/// Emits the once-only dev-mode
-/// warning. Factored out as a free fn so the `RespLike::on_timeout_warn`
-/// closures (which cannot name `NewServer<SSL,DEBUG>`) can call it.
-///
-/// uWS runs the timeout handler from its timer sweep and closes the socket
-/// right after. Nothing else flushes stderr on that path, so the flush here
-/// is what makes the warning visible while the server is still running.
 fn on_timeout_for_idle_warn() {
     if !did_send_idletimeout_warning_once().swap(true, core::sync::atomic::Ordering::Relaxed)
         && !crate::cli::Command::get().debug.silent
@@ -1212,20 +1203,15 @@ fn on_timeout_for_idle_warn() {
         bun_core::pretty_errorln!(
             "<r><yellow>[Bun.serve]<r><d>:<r> request timed out after 10 seconds. Pass <d><cyan>`idleTimeout`<r> to configure."
         );
+        // Otherwise the line stays in the stderr buffer until the process exits.
         Output::flush();
     }
 }
 
-/// Registers `on_timeout_for_idle_warn` on `resp`. Shared by the HTTP/1
-/// (`mod.rs`) and the HTTP/2 / HTTP/3 request paths so both emit the same
-/// warning through the same latch.
+/// Registers the dev-mode idle-timeout warning on `resp` (HTTP/1, HTTP/2 and HTTP/3).
 #[inline]
 pub(super) fn add_timeout_handler_for_warning<R: RespLike + ?Sized>(resp: &mut R) {
-    // uWS skips the handler when the user-data pointer is null; any non-null
-    // pointer will do. `on_timeout_for_idle_warn` ignores it and reads the
-    // static directly. `AtomicBool::as_ptr` yields a `*mut` with
-    // interior-mutability provenance, so no `&T as *const _ as *mut _` cast
-    // is needed.
+    // uWS skips a handler whose user-data pointer is null; the handler itself ignores it.
     resp.on_timeout_warn(
         did_send_idletimeout_warning_once()
             .as_ptr()

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1188,8 +1188,6 @@ fn fetch_headers_from_js(value: JSValue, global: &JSGlobalObject) -> Option<*mut
     FetchHeaders::cast_(value, global.vm()).map(|p| p.as_ptr())
 }
 
-/// Per-process latch for the dev-mode idle-timeout warning, shared by every
-/// server instantiation and transport.
 #[inline]
 pub(super) fn did_send_idletimeout_warning_once() -> &'static core::sync::atomic::AtomicBool {
     static FLAG: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1190,9 +1190,10 @@ fn fetch_headers_from_js(value: JSValue, global: &JSGlobalObject) -> Option<*mut
 
 /// Per-process latch for the dev-mode idle-timeout warning. The
 /// warning is gated on `DEBUG && !silent` and only fires once globally, so a
-/// single shared `AtomicBool` matches user-visible behavior.
+/// single shared `AtomicBool` matches user-visible behavior across every
+/// `(SSL, DEBUG)` instantiation and every transport (HTTP/1, HTTP/2, HTTP/3).
 #[inline]
-fn did_send_idletimeout_warning_once() -> &'static core::sync::atomic::AtomicBool {
+pub(super) fn did_send_idletimeout_warning_once() -> &'static core::sync::atomic::AtomicBool {
     static FLAG: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
     &FLAG
 }
@@ -1200,6 +1201,10 @@ fn did_send_idletimeout_warning_once() -> &'static core::sync::atomic::AtomicBoo
 /// Emits the once-only dev-mode
 /// warning. Factored out as a free fn so the `RespLike::on_timeout_warn`
 /// closures (which cannot name `NewServer<SSL,DEBUG>`) can call it.
+///
+/// uWS runs the timeout handler from its timer sweep and closes the socket
+/// right after. Nothing else flushes stderr on that path, so the flush here
+/// is what makes the warning visible while the server is still running.
 fn on_timeout_for_idle_warn() {
     if !did_send_idletimeout_warning_once().swap(true, core::sync::atomic::Ordering::Relaxed)
         && !crate::cli::Command::get().debug.silent
@@ -1209,6 +1214,23 @@ fn on_timeout_for_idle_warn() {
         );
         Output::flush();
     }
+}
+
+/// Registers `on_timeout_for_idle_warn` on `resp`. Shared by the HTTP/1
+/// (`mod.rs`) and the HTTP/2 / HTTP/3 request paths so both emit the same
+/// warning through the same latch.
+#[inline]
+pub(super) fn add_timeout_handler_for_warning<R: RespLike + ?Sized>(resp: &mut R) {
+    // uWS skips the handler when the user-data pointer is null; any non-null
+    // pointer will do. `on_timeout_for_idle_warn` ignores it and reads the
+    // static directly. `AtomicBool::as_ptr` yields a `*mut` with
+    // interior-mutability provenance, so no `&T as *const _ as *mut _` cast
+    // is needed.
+    resp.on_timeout_warn(
+        did_send_idletimeout_warning_once()
+            .as_ptr()
+            .cast::<c_void>(),
+    );
 }
 
 // ─── NewServer ───────────────────────────────────────────────────────────────
@@ -2940,16 +2962,7 @@ where
         // Since we do timeouts by default, we should tell the user when
         // this happens - but limit it to only warn once.
         if server.should_add_timeout_handler_for_warning() {
-            // We need to pass it a pointer, any pointer should do.
-            // SAFETY: the user-data pointer is an opaque sentinel — `on_timeout_for_idle_warn`
-            // ignores it and reads the static directly. `AtomicBool::as_ptr` yields a `*mut`
-            // with interior-mutability provenance, so no `&T as *const _ as *mut _` cast is needed.
-            RespLike::on_timeout_warn(
-                resp,
-                did_send_idletimeout_warning_once()
-                    .as_ptr()
-                    .cast::<c_void>(),
-            );
+            add_timeout_handler_for_warning(resp);
         }
 
         let any_resp = RespLike::to_any_response(resp);

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3710,15 +3710,17 @@ describe.concurrent("handler GC tracing (heapStats wrapper-count)", () => {
 // The warning is only registered when `idleTimeout` is not passed, so the test
 // has to wait for the default 10 second timeout to fire. uWS sweeps timeouts on
 // a coarse timer, so the close lands a couple of seconds after that.
-test("development mode prints the idle timeout warning when the timeout fires, not at exit", async () => {
-  using dir = tempDir("serve-idle-timeout-warn", {});
-  const stderrPath = path.join(String(dir), "stderr.txt");
+test.concurrent(
+  "development mode prints the idle timeout warning when the timeout fires, not at exit",
+  async () => {
+    using dir = tempDir("serve-idle-timeout-warn", {});
+    const stderrPath = path.join(String(dir), "stderr.txt");
 
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         import { readFileSync } from "node:fs";
         const server = Bun.serve({
           port: 0,
@@ -3750,22 +3752,24 @@ test("development mode prints the idle timeout warning when the timeout fires, n
           },
         });
       `,
-    ],
-    env: { ...bunEnv, STDERR_PATH: stderrPath },
-    stdout: "pipe",
-    stderr: Bun.file(stderrPath),
-  });
+      ],
+      env: { ...bunEnv, STDERR_PATH: stderrPath },
+      stdout: "pipe",
+      stderr: Bun.file(stderrPath),
+    });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  const warning = "[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure.\n";
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const warning = "[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure.\n";
 
-  expect({
-    out: JSON.parse(stdout.trim() || "null"),
-    stderrAtExit: await Bun.file(stderrPath).text(),
-    exitCode,
-  }).toEqual({
-    out: { stderrAtClose: warning },
-    stderrAtExit: warning,
-    exitCode: 0,
-  });
-}, 30_000);
+    expect({
+      out: JSON.parse(stdout.trim() || "null"),
+      stderrAtExit: await Bun.file(stderrPath).text(),
+      exitCode,
+    }).toEqual({
+      out: { stderrAtClose: warning },
+      stderrAtExit: warning,
+      exitCode: 0,
+    });
+  },
+  30_000,
+);

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3706,3 +3706,66 @@ describe.concurrent("handler GC tracing (heapStats wrapper-count)", () => {
     });
   }, 30_000);
 });
+
+// The warning is only registered when `idleTimeout` is not passed, so the test
+// has to wait for the default 10 second timeout to fire. uWS sweeps timeouts on
+// a coarse timer, so the close lands a couple of seconds after that.
+test("development mode prints the idle timeout warning when the timeout fires, not at exit", async () => {
+  using dir = tempDir("serve-idle-timeout-warn", {});
+  const stderrPath = path.join(String(dir), "stderr.txt");
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { readFileSync } from "node:fs";
+        const server = Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          development: true,
+          async fetch(req) {
+            await req.text();
+            return new Response("ok");
+          },
+        });
+        await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: {
+            open(socket) {
+              // A POST whose body never completes. The server times it out
+              // after the default idleTimeout and closes the socket.
+              socket.write("POST / HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: 100\\r\\n\\r\\nabc");
+            },
+            data() {},
+            error() {},
+            close() {
+              // The server runs the timeout handler before it closes the
+              // socket. Whatever the handler wrote to stderr must already be
+              // in the file by the time the client sees the close.
+              console.log(JSON.stringify({ stderrAtClose: readFileSync(process.env.STDERR_PATH, "utf8") }));
+              server.stop(true);
+            },
+          },
+        });
+      `,
+    ],
+    env: { ...bunEnv, STDERR_PATH: stderrPath },
+    stdout: "pipe",
+    stderr: Bun.file(stderrPath),
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const warning = "[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure.\n";
+
+  expect({
+    out: JSON.parse(stdout.trim() || "null"),
+    stderrAtExit: await Bun.file(stderrPath).text(),
+    exitCode,
+  }).toEqual({
+    out: { stderrAtClose: warning },
+    stderrAtExit: warning,
+    exitCode: 0,
+  });
+}, 30_000);


### PR DESCRIPTION
### Problem
- With `development: true` and no `idleTimeout`, an HTTP/1 `Bun.serve` that times out a request prints the warning only when the process exits. On 1.4.1 the socket closes at about 12 s and `warn: Bun.serve() timed out a request after 10 seconds. Pass `idleTimeout` to configure.` appears at exit.
- The HTTP/1 path had its own copy of the handler, `NewServer::on_timeout_for_idle_warn` in `src/runtime/server/mod.rs:661`. It used `bun_core::warn!`, which writes to the buffered stderr writer and does not flush. The HTTP/2 and HTTP/3 path has a second copy in `src/runtime/server/server_body.rs:1203` with the original `[Bun.serve]:` text and a flush. The two copies also kept two separate once-only flags.

### Fix
- Delete the HTTP/1 copy. Both request paths call one new helper, `server_body::add_timeout_handler_for_warning`, which registers the single emitter `on_timeout_for_idle_warn`. That emitter prints `[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure.` and calls `Output::flush()`.
- `should_add_timeout_handler_for_warning` now reads the same latch the emitter sets. Before this change the HTTP/2 and HTTP/3 path set a flag that the registration check never read, so it registered the handler on every request after the first warning.
- Correct because uWS runs the `onTimeout` handler from its timer sweep and closes the socket right after (`packages/bun-uws/src/HttpContext.h:942`). Nothing else on that path flushes stderr, so the flush inside the handler is the only thing that makes the line visible while the server runs.
- Verified: `test/js/bun/http/bun-server.test.ts`, new case "development mode prints the idle timeout warning when the timeout fires, not at exit". It fails on 1.4.1 (`stderrAtClose: ""`, old text at exit) and passes with this build. Also ran the rest of `bun-server.test.ts`, `serve-http2.test.ts`, `serve-http2-lifecycle.test.ts`, and `serve-http3.test.ts`.

### Background
- `bun_core::pretty_errorln!` (and `warn!`, which wraps it) writes to a per-thread buffered stderr writer. The bytes reach the fd on `Output::flush()`, or at exit. A message that must be seen at a point in time needs an explicit flush.
- `NewServer<SSL, DEBUG>` is monomorphized four times. `development: true` selects `DEBUG = true`. The warning handler is only registered when `DEBUG` is set, the user passed no `idleTimeout`, and the process is not `--silent`.
- `RespLike` (`server_body.rs:336`) is the small trait over the HTTP/1, HTTP/2, and HTTP/3 response types. `on_timeout_warn` is the arm that registers the uWS timeout callback. The new helper is generic over it, so both paths share one call.

<details><summary>Notes</summary>

- The test spawns a child with `stderr: Bun.file(path)`. The child opens a POST with `Content-Length: 100`, sends 3 bytes, and stalls. When the server closes the socket, the client `close()` callback reads the stderr file and prints its contents as JSON. The server runs the timeout handler before the close, so whatever the handler flushed is in the file by then. No sleeps: the assertion is on ordering, not time.
- The test waits for the default 10 s idle timeout because the warning is only registered when `idleTimeout` is absent. uWS sweeps timeouts on a coarse timer, so the close lands at about 12 s. The test has a 30 s budget for that reason.
- The old HTTP/1 copy also checked `DEBUG` inside the handler. The check is redundant: the handler is only registered when `should_add_timeout_handler_for_warning` already required `DEBUG`.
- Four other tests in `bun-server.test.ts` fail in this container with and without the change (IPv6 and `localhost` egress in the sandbox): "allows listen on IPV6", "rejected promise handled by error method should not be logged", "should be able to parse source map and fetch small stream", "should be able to abrubtly close a upload request".
- `cargo check -p bun_runtime` and `cargo clippy -p bun_runtime --no-deps` report nothing for the changed files.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-server.test.ts

<!-- robobun:evidence:end -->