### PR TITLE
crash_handler: report Rust panics through crash_handler() so --watch restarts and other threads wait

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -614,9 +614,6 @@ mod draft {
     static SUPPRESS_REPORTING: AtomicBool = AtomicBool::new(false);
 
     /// This structure and formatter must be kept in sync with `bun.report`'s decoder implementation.
-    ///
-    /// Borrows the message from the crashing frame: a reason is only ever
-    /// formatted and then passed to `crash_handler`/`crash`, never stored.
     #[derive(Clone, Copy)]
     pub enum CrashReason<'a> {
         /// From @panic()
@@ -1711,33 +1708,17 @@ mod draft {
         std::panic::set_hook(Box::new(rust_panic_hook));
     }
 
-    /// `std::panic` hook. A Rust `panic!` (`unwrap()` on `None`/`Err`, a failed
-    /// `assert!`, `unreachable!()`, …) is a bug in Bun, so it is reported through
-    /// the same `crash_handler()` every other crash goes through: same header,
-    /// same `panic(main thread): <message>` line, same trace string and upload,
-    /// same multi-thread/re-entrancy bookkeeping, same SIGABRT at the end.
-    /// `crash_handler` never returns, so nothing unwinds past this hook.
-    ///
-    /// Only the message is reported, not `info.location()`: the call site is in
-    /// the captured trace, and release builds compile with
-    /// `-Zlocation-detail=none` so the location would read `<redacted>:0:0`.
+    /// Omits `info.location()`: release builds use `-Zlocation-detail=none`; the trace has the site.
     #[cold]
     #[inline(never)]
     fn rust_panic_hook(info: &std::panic::PanicHookInfo<'_>) {
-        /// A panic payload can be arbitrarily long (`assert_eq!` on two large
-        /// values), but `encode_trace_string` has to fit the compressed message
-        /// into the fixed-size trace string buffer. Cut on a char boundary so
-        /// the report stays valid UTF-8.
+        /// The trace string must fit the compressed message in a fixed buffer (`encode_trace_string`).
         const MAX_MESSAGE_BYTES: usize = 1024;
 
-        // `panic!` in Rust 2021 always carries a `&'static str` or `String`
-        // payload; only `std::panic::panic_any` can produce anything else.
         let msg = info
             .payload_as_str()
             .unwrap_or("<non-string panic payload>");
         let msg = &msg[..msg.floor_char_boundary(MAX_MESSAGE_BYTES)];
-        // Read in this frame (not inside a closure) so the trim anchor is a
-        // frame that is still on the stack when the trace is captured.
         crash_handler(
             CrashReason::Panic(msg.as_bytes()),
             TraceSeed::BeginAddr(debug::return_address()),

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1709,144 +1709,38 @@ mod draft {
         std::panic::set_hook(Box::new(rust_panic_hook));
     }
 
-    /// `std::panic` hook: emit the same trace-string + auto-report as the fatal
-    /// `crash_handler()` path, then **abort**.
-    /// With `panic = "abort"` no unwind starts after this hook returns, so there
-    /// are no `catch_unwind` boundaries to reach.
+    /// `std::panic` hook. A Rust `panic!` (`unwrap()` on `None`/`Err`, a failed
+    /// `assert!`, `unreachable!()`, …) is a bug in Bun, so it is reported through
+    /// the same `crash_handler()` every other crash goes through: same header,
+    /// same `panic(main thread): <message>` line, same trace string and upload,
+    /// same multi-thread/re-entrancy bookkeeping, same SIGABRT at the end.
+    /// `crash_handler` never returns, so nothing unwinds past this hook.
+    ///
+    /// Only the message is reported, not `info.location()`: the call site is in
+    /// the captured trace, and release builds compile with
+    /// `-Zlocation-detail=none` so the location would read `<redacted>:0:0`.
     #[cold]
     #[inline(never)]
     fn rust_panic_hook(info: &std::panic::PanicHookInfo<'_>) {
-        // Re-entry guard: if the hook itself panics (formatter, write, …), the
-        // recursive entry sees stage>0, prints a one-liner, and returns so the
-        // inner unwind tears the process down rather than looping.
-        let stage = PANIC_STAGE.with(|s| s.get());
-        if stage != 0 {
-            PANIC_STAGE.with(|s| s.set(stage + 1));
-            let stderr = &mut stderr_writer();
-            let _ = write!(
-                stderr,
-                "\npanic: {info}\npanicked during a panic. Aborting.\n"
-            );
-            return;
-        }
-        PANIC_STAGE.with(|s| s.set(1));
-
-        // Just the panic message — no `(file:line:col)` suffix. The call site is
-        // captured in the backtrace and symbolized there. With `-Zlocation-detail=none`
-        // in release the location would be `<redacted>:0:0` anyway.
-        let mut msg_buf = BoundedArray::<u8, 1024>::default();
-        {
-            let payload = info.payload();
-            let msg: &str = if let Some(s) = payload.downcast_ref::<&'static str>() {
-                s
-            } else if let Some(s) = payload.downcast_ref::<std::string::String>() {
-                s.as_str()
-            } else {
-                "<non-string panic payload>"
-            };
-            let _ = write!(msg_buf.writer(), "{msg}");
-        }
-        // SAFETY: `CrashReason::Panic` stores `&'static [u8]` (it was designed for
-        // the `-> !` path). `msg_buf` outlives every read of `reason` below — the
-        // borrow is fully consumed by the `Display`/`TraceString` writes inside
-        // this frame and never escapes.
+        // `panic!` in Rust 2021 always carries a `&'static str` or `String`
+        // payload; only `std::panic::panic_any` can produce anything else.
+        let msg = info
+            .payload_as_str()
+            .unwrap_or("<non-string panic payload>");
+        // `encode_trace_string` has to fit the compressed message into the
+        // fixed-size trace string buffer; cap it so a huge assertion dump still
+        // yields a usable report.
+        let msg = &msg[..msg.floor_char_boundary(1024)];
+        // SAFETY: `CrashReason::Panic` holds a `&'static [u8]` because every
+        // path that builds one ends in `crash_handler`, which never returns.
+        // The payload is owned by the std panic machinery's frames below this
+        // one (or is a string literal), so it stays live for as long as the
+        // process does, and nothing takes a `&mut` to it while the hook runs.
         let reason =
-            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg_buf.const_slice()) });
-
-        let mut trace_str_buf = BoundedArray::<u8, 1024>::default();
-        {
-            let _panic_guard = PANIC_MUTEX.lock();
-            let writer = &mut stderr_writer();
-
-            let debug_trace = Environment::SHOW_CRASH_TRACE
-                && 'check_flag: {
-                    for arg in bun_core::argv() {
-                        if arg == &b"--debug-crash-handler-use-trace-string"[..] {
-                            break 'check_flag false;
-                        }
-                    }
-                    if is_reporting_enabled() {
-                        break 'check_flag false;
-                    }
-                    true
-                };
-
-            Output::flush();
-            let _ =
-                writer.write_all(b"============================================================\n");
-            let _ = print_metadata(writer);
-
-            if enable_ansi_colors_stderr() {
-                let _ = writer.write_all(&Output::pretty_fmt::<true>("<red>"));
-            }
-            let _ = writer.write_all(b"panic");
-            if enable_ansi_colors_stderr() {
-                let _ = writer.write_all(&Output::pretty_fmt::<true>("<r>"));
-            }
-            let _ = writeln!(writer, ": {}", reason);
-
-            if let Some(action) = CURRENT_ACTION.with(|c| c.get()) {
-                let _ = writeln!(writer, "Crashed while {}", action);
-            }
-
-            let mut addr_buf: [usize; 20] = [0; 20];
-            let idx = debug::capture_stack_trace(debug::return_address(), &mut addr_buf);
-            let trace = StackTrace {
-                index: idx,
-                instruction_addresses: &addr_buf,
-            };
-
-            if debug_trace {
-                dump_stack_trace(&trace, WriteStackTraceLimits::default());
-                let _ = write!(
-                    trace_str_buf.writer(),
-                    "{}",
-                    TraceString {
-                        trace: &trace,
-                        reason,
-                        action: TraceStringAction::ViewTrace,
-                    }
-                );
-            } else {
-                let _ = writer.write_all(b"oh no");
-                if enable_ansi_colors_stderr() {
-                    let _ = writer.write_all(&Output::pretty_fmt::<true>("<r><d>:<r> "));
-                } else {
-                    let _ = writer.write_all(b": ");
-                }
-                let _ = writer.write_all(
-                    b"Bun has crashed. This indicates a bug in Bun, not your code.\n\n\
-                  To send a redacted crash report to Bun's team,\n\
-                  please file a GitHub issue using the link below:\n\n ",
-                );
-                if enable_ansi_colors_stderr() {
-                    let _ = writer.write_all(&Output::pretty_fmt::<true>("<cyan>"));
-                }
-                let _ = write!(
-                    trace_str_buf.writer(),
-                    "{}",
-                    TraceString {
-                        trace: &trace,
-                        reason,
-                        action: TraceStringAction::OpenIssue,
-                    }
-                );
-                let _ = writer.write_all(trace_str_buf.const_slice());
-                let _ = writer.write_all(b"\n");
-            }
-            if enable_ansi_colors_stderr() {
-                let _ = writer.write_all(&Output::pretty_fmt::<true>("<r>\n"));
-            } else {
-                let _ = writer.write_all(b"\n");
-            }
-        }
-
-        report(trace_str_buf.const_slice());
-
-        // A Rust `panic!` is a bug. The process must not continue — with
-        // `panic = "abort"` no unwind starts, so `catch_unwind` boundaries are
-        // unreachable for Rust panics.
-        crash(reason);
+            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg.as_bytes()) });
+        // Read in this frame (not inside a closure) so the trim anchor is a
+        // frame that is still on the stack when the trace is captured.
+        crash_handler(reason, TraceSeed::BeginAddr(debug::return_address()));
     }
 
     /// Adapter for non-fatal `bun_core::dump_current_stack_trace` callers

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -614,10 +614,13 @@ mod draft {
     static SUPPRESS_REPORTING: AtomicBool = AtomicBool::new(false);
 
     /// This structure and formatter must be kept in sync with `bun.report`'s decoder implementation.
+    ///
+    /// Borrows the message from the crashing frame: a reason is only ever
+    /// formatted and then passed to `crash_handler`/`crash`, never stored.
     #[derive(Clone, Copy)]
-    pub enum CrashReason {
+    pub enum CrashReason<'a> {
         /// From @panic()
-        Panic(&'static [u8]),
+        Panic(&'a [u8]),
         /// "reached unreachable code"
         Unreachable,
 
@@ -638,12 +641,12 @@ mod draft {
         StackOverflow,
 
         /// Either `main` returned an error, or somewhere else in the code a trace string is printed.
-        ZigError(&'static [u8]),
+        ZigError(&'a [u8]),
 
         OutOfMemory,
     }
 
-    impl CrashReason {
+    impl CrashReason<'_> {
         /// Signal to terminate the process with after the crash report has
         /// been printed. Signal-originated crashes re-raise the original
         /// fault so the parent process (and core-dump analyzers) see the
@@ -668,7 +671,7 @@ mod draft {
         }
     }
 
-    impl fmt::Display for CrashReason {
+    impl fmt::Display for CrashReason<'_> {
         fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
                 CrashReason::Panic(message) => write!(writer, "{}", bstr::BStr::new(message)),
@@ -785,7 +788,7 @@ mod draft {
 
     /// This function is invoked when a crash happens. A crash is classified in `CrashReason`.
     #[cold]
-    pub fn crash_handler(reason: CrashReason, seed: TraceSeed) -> ! {
+    pub fn crash_handler(reason: CrashReason<'_>, seed: TraceSeed) -> ! {
         if cfg!(debug_assertions) {
             Output::disable_scoped_debug_writer();
         }
@@ -1449,8 +1452,7 @@ mod draft {
             if msg == b"reached unreachable code" {
                 CrashReason::Unreachable
             } else {
-                // SAFETY: process is about to abort; the borrow is never invalidated.
-                CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg) })
+                CrashReason::Panic(msg)
             },
             TraceSeed::BeginAddr(begin_addr),
         );
@@ -1722,25 +1724,24 @@ mod draft {
     #[cold]
     #[inline(never)]
     fn rust_panic_hook(info: &std::panic::PanicHookInfo<'_>) {
+        /// A panic payload can be arbitrarily long (`assert_eq!` on two large
+        /// values), but `encode_trace_string` has to fit the compressed message
+        /// into the fixed-size trace string buffer. Cut on a char boundary so
+        /// the report stays valid UTF-8.
+        const MAX_MESSAGE_BYTES: usize = 1024;
+
         // `panic!` in Rust 2021 always carries a `&'static str` or `String`
         // payload; only `std::panic::panic_any` can produce anything else.
         let msg = info
             .payload_as_str()
             .unwrap_or("<non-string panic payload>");
-        // `encode_trace_string` has to fit the compressed message into the
-        // fixed-size trace string buffer; cap it so a huge assertion dump still
-        // yields a usable report.
-        let msg = &msg[..msg.floor_char_boundary(1024)];
-        // SAFETY: `CrashReason::Panic` holds a `&'static [u8]` because every
-        // path that builds one ends in `crash_handler`, which never returns.
-        // The payload is owned by the std panic machinery's frames below this
-        // one (or is a string literal), so it stays live for as long as the
-        // process does, and nothing takes a `&mut` to it while the hook runs.
-        let reason =
-            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg.as_bytes()) });
+        let msg = &msg[..msg.floor_char_boundary(MAX_MESSAGE_BYTES)];
         // Read in this frame (not inside a closure) so the trim anchor is a
         // frame that is still on the stack when the trace is captured.
-        crash_handler(reason, TraceSeed::BeginAddr(debug::return_address()));
+        crash_handler(
+            CrashReason::Panic(msg.as_bytes()),
+            TraceSeed::BeginAddr(debug::return_address()),
+        );
     }
 
     /// Adapter for non-fatal `bun_core::dump_current_stack_trace` callers
@@ -1841,7 +1842,7 @@ mod draft {
     #[cfg(windows)]
     fn classify_exception_windows(
         record: &bun_sys::windows::EXCEPTION_RECORD,
-    ) -> Option<CrashReason> {
+    ) -> Option<CrashReason<'static>> {
         Some(match record.ExceptionCode {
             bun_sys::windows::EXCEPTION_DATATYPE_MISALIGNMENT => CrashReason::DatatypeMisalignment,
             bun_sys::windows::EXCEPTION_ACCESS_VIOLATION => {
@@ -2455,7 +2456,7 @@ mod draft {
 
     struct TraceString<'a> {
         trace: &'a StackTrace<'a>,
-        reason: CrashReason,
+        reason: CrashReason<'a>,
         action: TraceStringAction,
     }
 
@@ -2818,7 +2819,7 @@ mod draft {
     /// On POSIX this re-raises the signal that caused the crash (or SIGABRT
     /// for panics) so the parent sees the real fault and core dumps are
     /// attributed correctly.
-    fn crash(reason: CrashReason) -> ! {
+    fn crash(reason: CrashReason<'_>) -> ! {
         #[cfg(not(windows))]
         {
             let sig = reason.terminal_signal();
@@ -3518,7 +3519,7 @@ mod draft {
         // SAFETY: per the caller contract above, `name` is a valid NUL-terminated C string (non-null).
         let name_bytes = unsafe { bun_core::ffi::cstr(name) }.to_bytes();
         // PORTING.md §Forbidden: no Box::leak. We're on the noreturn path, so a stack
-        // buffer suffices — `panic_impl` erases to &'static for the abort path.
+        // buffer suffices.
         let mut msg = BoundedArray::<u8, 256>::default();
         let _ = write!(
             msg.writer(),
@@ -3535,8 +3536,7 @@ mod draft {
         // SAFETY: caller passes a valid (ptr, len) byte slice
         let msg = unsafe { core::slice::from_raw_parts(message_ptr, message_len) };
         crash_handler(
-            // SAFETY: noreturn — see panic_impl note
-            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg) }),
+            CrashReason::Panic(msg),
             TraceSeed::BeginAddr(debug::return_address()),
         );
     }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -122,8 +122,11 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
-  /** A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler directly). */
-  rustPanic: () => void;
+  /**
+   * A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler
+   * directly). Panics with a fixed literal, or with `message` when one is given.
+   */
+  rustPanic: (message?: string) => void;
   /** A real `Result::unwrap()` on an `Err`, also reported through the `std::panic` hook. */
   rustUnwrap: () => void;
   rootError: () => void;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -122,10 +122,7 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
-  /**
-   * A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler
-   * directly). Panics with a fixed literal, or with `message` when one is given.
-   */
+  /** A real Rust `panic!` (goes through the `std::panic` hook, unlike `panic()` above), with `message` if given. */
   rustPanic: (message?: string) => void;
   /** A real `Result::unwrap()` on an `Err`, also reported through the `std::panic` hook. */
   rustUnwrap: () => void;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -122,6 +122,10 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
+  /** A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler directly). */
+  rustPanic: () => void;
+  /** A real `Result::unwrap()` on an `Err`, also reported through the `std::panic` hook. */
+  rustUnwrap: () => void;
   rootError: () => void;
   outOfMemory: () => void;
   abort: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -136,11 +136,19 @@ pub(crate) mod js_bindings {
 
     /// Unlike `js_panic`, which calls `panic_impl` directly, this is a real
     /// `panic!`, so it goes through the `std::panic` hook the crash handler
-    /// installs. A literal message reaches the hook as a `&'static str` payload.
+    /// installs. Without an argument the literal reaches the hook as a
+    /// `&'static str` payload; `rustPanic(message)` panics with that message
+    /// (a `String` payload), which is how the tests exercise the hook's
+    /// message cap.
     #[bun_jsc::host_fn]
-    fn js_rust_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    fn js_rust_panic(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
-        panic!("invoked crashByRustPanic() handler");
+        let message = frame.argument(0);
+        if message.is_undefined() {
+            panic!("invoked crashByRustPanic() handler");
+        }
+        let message = message.to_utf8(global)?;
+        panic!("{}", bstr::BStr::new(&message));
     }
 
     /// `Result::unwrap()` on an `Err`, the shape of the `.unwrap()` sites that

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -24,6 +24,8 @@ pub(crate) mod js_bindings {
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
             ("panic", __jsc_host_js_panic),
+            ("rustPanic", __jsc_host_js_rust_panic),
+            ("rustUnwrap", __jsc_host_js_rust_unwrap),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
             ("abort", __jsc_host_js_abort),
@@ -130,6 +132,27 @@ pub(crate) mod js_bindings {
     fn js_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None);
+    }
+
+    /// Unlike `js_panic`, which calls `panic_impl` directly, this is a real
+    /// `panic!`, so it goes through the `std::panic` hook the crash handler
+    /// installs. A literal message reaches the hook as a `&'static str` payload.
+    #[bun_jsc::host_fn]
+    fn js_rust_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        panic!("invoked crashByRustPanic() handler");
+    }
+
+    /// `Result::unwrap()` on an `Err`, the shape of the `.unwrap()` sites that
+    /// reach the panic hook in production. std formats the `Err` into the
+    /// message, so this one reaches the hook as a `String` payload.
+    #[bun_jsc::host_fn]
+    fn js_rust_unwrap(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        let result: Result<(), &str> =
+            core::hint::black_box(Err("invoked crashByRustUnwrap() handler"));
+        result.unwrap();
+        Ok(JSValue::UNDEFINED)
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -134,12 +134,7 @@ pub(crate) mod js_bindings {
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None);
     }
 
-    /// Unlike `js_panic`, which calls `panic_impl` directly, this is a real
-    /// `panic!`, so it goes through the `std::panic` hook the crash handler
-    /// installs. Without an argument the literal reaches the hook as a
-    /// `&'static str` payload; `rustPanic(message)` panics with that message
-    /// (a `String` payload), which is how the tests exercise the hook's
-    /// message cap.
+    /// A real `panic!` (reaches the crash handler through the std panic hook, unlike `js_panic`).
     #[bun_jsc::host_fn]
     fn js_rust_panic(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
@@ -151,9 +146,7 @@ pub(crate) mod js_bindings {
         panic!("{}", bstr::BStr::new(&message));
     }
 
-    /// `Result::unwrap()` on an `Err`, the shape of the `.unwrap()` sites that
-    /// reach the panic hook in production. std formats the `Err` into the
-    /// message, so this one reaches the hook as a `String` payload.
+    /// A real `Result::unwrap()` on an `Err`; std formats the message, so the hook sees a `String` payload.
     #[bun_jsc::host_fn]
     fn js_rust_unwrap(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();

--- a/test/cli/run/crash-report-command-char.test.ts
+++ b/test/cli/run/crash-report-command-char.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, mergeWindowEnvs, tempDir } from "harness";
 import path from "path";
 
-// NOTE: kept separate from run-crash-handler.test.ts on purpose — that file
-// is skip-listed in test/expectations.txt (its segfault-reporter test is
-// broken), so anything added there never runs in CI.
+// The rest of the crash handler's coverage lives in run-crash-handler.test.ts.
 describe.concurrent("crash report command character", () => {
   // Crash while a given subcommand is running and return the command
   // character from the trace string printed to stderr:

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -12,6 +12,7 @@ if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
   console.error(
-    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
+    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rustPanic|rustUnwrap|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
   );
+  process.exit(1);
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -30,13 +30,23 @@ const panicApproaches = [
   ["rustUnwrap", 'called `Result::unwrap()` on an `Err` value: "invoked crashByRustUnwrap() handler"'],
 ] as const;
 
+// In trace-string mode (release builds, or --debug-crash-handler-use-trace-string)
+// the report ends with the trace string on its own line after "please file a
+// GitHub issue using the link below:". With noReportEnv's empty base URL it is
+// printed as just the path, `/{version}/...`.
+function traceStringFromReport(stderr: string): string {
+  const traceString = (stderr.split("using the link below:")[1] ?? "").trim().split(/\s+/)[0];
+  expect(traceString).toBeTruthy();
+  return traceString;
+}
+
 // A trace string is `{base}/{version}/{header}{frames...}{VLQ 0}{reason}`. For
 // a panic the reason is the tag `0` followed by the zlib-compressed, base64
 // message (see `encode_trace_string` in src/crash_handler/lib.rs). The frames
 // are variable-length, so find the terminator by trying each `A0` (`A` is the
 // VLQ encoding of 0) until the remainder inflates.
 function panicMessageFromTraceString(traceString: string): string | undefined {
-  const pathname = new URL(traceString).pathname;
+  const pathname = new URL(traceString, "http://trace.invalid").pathname;
   const payload = pathname.slice(pathname.indexOf("/", 1) + 1);
   for (let i = payload.indexOf("A0"); i !== -1; i = payload.indexOf("A0", i + 1)) {
     try {
@@ -115,6 +125,39 @@ describe("panics through panic_impl and through the std panic hook print the sam
     // The message is reported on its own, with no `file:line:col` suffix.
     expect(stderr).toContain(`panic(main thread): ${message}\n`);
     expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.");
+    expect(panicMessageFromTraceString(traceStringFromReport(stderr))).toBe(message);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
+// The one thing the panic hook does besides calling the crash handler: a panic
+// payload can be arbitrarily long (an `assert_eq!` dump), so it reports at most
+// MAX_MESSAGE_BYTES (1024) of it, cut on a char boundary (see `rust_panic_hook`
+// in src/crash_handler/lib.rs). `rustPanic(message)` panics with the given
+// message, which reaches the hook as a `String` payload.
+describe("the panic hook caps the reported message at 1024 bytes", () => {
+  const a = (n: number) => Buffer.alloc(n, "a").toString();
+  // [name, JS expression the child panics with, what the report must contain]
+  test.concurrent.each([
+    ["a 1024-byte message is reported whole", `Buffer.alloc(1019, "a") + ":tail"`, `${a(1019)}:tail`],
+    ["a longer message is cut after 1024 bytes", `Buffer.alloc(1024, "a") + ":tail"`, a(1024)],
+    // Bytes 1023-1024 are one two-byte char; cutting at byte 1024 would split it.
+    ["the cut does not split a multi-byte char", `Buffer.alloc(1023, "a") + "\\u00e9"`, a(1023)],
+  ])("%s", async (_name, messageExpr, reported) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("bun:internal-for-testing").crash_handler.rustPanic(${messageExpr})`,
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr.match(/^panic\(main thread\): (.*)$/m)?.[1]).toBe(reported);
+    expect(panicMessageFromTraceString(traceStringFromReport(stderr))).toBe(reported);
     expect(exitCode).not.toBe(0);
   });
 });
@@ -656,8 +699,8 @@ describe("automatic crash reporter", () => {
 
       // Assert on the report before waiting for the upload, so a crash that
       // never reports fails here instead of timing out on the promise below.
-      const traceString = stderr.split(/\s+/).find(word => word.startsWith(server.url.toString()));
-      expect(traceString).toBeDefined();
+      const traceString = traceStringFromReport(stderr);
+      expect(traceString).toStartWith(server.url.toString());
       if (approach !== "outOfMemory") {
         expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
       } else {
@@ -668,7 +711,7 @@ describe("automatic crash reporter", () => {
       // so a real Rust panic must encode its message exactly like panic_impl.
       const panicMessage = panicMessages.get(approach);
       if (panicMessage !== undefined) {
-        expect(panicMessageFromTraceString(traceString!)).toBe(panicMessage);
+        expect(panicMessageFromTraceString(traceString)).toBe(panicMessage);
       }
       expect(exitCode).not.toBe(0);
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -116,7 +116,7 @@ describe("panics through panic_impl and through the std panic hook print the sam
     await using proc = Bun.spawn({
       cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
       env: noReportEnv,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", "ignore", "pipe"],
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
@@ -183,7 +183,7 @@ describe("the panic hook caps the reported message at 1024 bytes", () => {
         "--debug-crash-handler-use-trace-string",
       ],
       env: noReportEnv,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", "ignore", "pipe"],
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
@@ -257,7 +257,7 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
       env: noReportEnv,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", "ignore", "pipe"],
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -130,6 +130,37 @@ describe("panics through panic_impl and through the std panic hook print the sam
   });
 });
 
+// `--watch` sets `auto_reload_on_crash`, and `crash_handler()` restarts the
+// process after it has printed the report. The hook used to end the process
+// without checking the flag, so a Rust panic under `--watch` stayed dead while
+// a segfault or a `panic_impl` crash restarted.
+describe.if(isPosix)("--watch restarts the process after a panic", () => {
+  test.concurrent.each(panicApproaches)("%s", async (approach, message) => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "--watch", fixture, approach, "--debug-crash-handler-use-trace-string"],
+      env: noReportEnv,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    try {
+      // The restarted process crashes and restarts again, so stop at the first
+      // restart notice instead of waiting for the process to exit.
+      const restartNotice = "Bun is auto-restarting due to crash";
+      const decoder = new TextDecoder();
+      let stderr = "";
+      for await (const chunk of proc.stderr) {
+        stderr += decoder.decode(chunk, { stream: true });
+        if (stderr.includes(restartNotice)) break;
+      }
+
+      expect(stderr).toContain(`panic(main thread): ${message}\n`);
+      expect(stderr).toContain(restartNotice);
+    } finally {
+      proc.kill("SIGKILL");
+      await proc.exited;
+    }
+  });
+});
+
 // The one thing the panic hook does besides calling the crash handler: a panic
 // payload can be arbitrarily long (an `assert_eq!` dump), so it reports at most
 // MAX_MESSAGE_BYTES (1024) of it, cut on a char boundary (see `rust_panic_hook`

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
+import { inflateSync } from "node:zlib";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -15,11 +16,41 @@ const noReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPO
 // without it the fallback printer has no Rust symbol names to assert on.
 const hasSymbolizer = !!(Bun.which("llvm-symbolizer") || Bun.which("llvm-symbolizer-21"));
 
+const fixture = path.join(import.meta.dir, "fixture-crash.js");
+
+// `panic` calls the crash handler's `panic_impl` directly. `rustPanic` and
+// `rustUnwrap` are a real `panic!` and a real `Result::unwrap()` on an `Err`,
+// which is how every `.unwrap()` / `assert!` / `unreachable!()` in Bun crashes:
+// they reach the crash handler through the `std::panic` hook it installs. The
+// literal `panic!` arrives there as a `&'static str` payload; std formats the
+// unwrapped `Err` into a `String` payload. All three must print the same report.
+const panicApproaches = [
+  ["panic", "invoked crashByPanic() handler"],
+  ["rustPanic", "invoked crashByRustPanic() handler"],
+  ["rustUnwrap", 'called `Result::unwrap()` on an `Err` value: "invoked crashByRustUnwrap() handler"'],
+] as const;
+
+// A trace string is `{base}/{version}/{header}{frames...}{VLQ 0}{reason}`. For
+// a panic the reason is the tag `0` followed by the zlib-compressed, base64
+// message (see `encode_trace_string` in src/crash_handler/lib.rs). The frames
+// are variable-length, so find the terminator by trying each `A0` (`A` is the
+// VLQ encoding of 0) until the remainder inflates.
+function panicMessageFromTraceString(traceString: string): string | undefined {
+  const pathname = new URL(traceString).pathname;
+  const payload = pathname.slice(pathname.indexOf("/", 1) + 1);
+  for (let i = payload.indexOf("A0"); i !== -1; i = payload.indexOf("A0", i + 1)) {
+    try {
+      return inflateSync(Buffer.from(payload.slice(i + 2), "base64")).toString();
+    } catch {}
+  }
+  return undefined;
+}
+
 test.if(isDebug && isLinux && hasSymbolizer)(
   "crash trace starts at the crash site, not inside the crash handler",
   async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic"],
+      cmd: [bunExe(), fixture, "panic"],
       env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -43,6 +74,50 @@ test.if(isDebug && isLinux && hasSymbolizer)(
   },
   60_000, // symbolizing the debug binary takes several seconds
 );
+
+// For a real Rust panic the innermost frames are std's panic machinery, so the
+// crash site is not frame 0, but it must be in the trace and the crash
+// handler's own frames must not be.
+describe.if(isDebug && isLinux && hasSymbolizer)("Rust panic trace includes the panic site", () => {
+  test.each([
+    ["rustPanic", "js_rust_panic"],
+    ["rustUnwrap", "js_rust_unwrap"],
+  ] as const)(
+    "%s",
+    async (approach, crashSite) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture, approach],
+        env: noReportEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("panic(main thread): ");
+      expect(stdout).toContain(crashSite);
+      expect(stdout).not.toContain("capture_stack_trace");
+      expect(exitCode).not.toBe(0);
+    },
+    60_000, // symbolizing the debug binary takes several seconds
+  );
+});
+
+describe("panics through panic_impl and through the std panic hook print the same report", () => {
+  test.concurrent.each(panicApproaches)("%s", async (approach, message) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Metadata header, e.g. "Bun Debug v1.4.0 (eabb96de7) Linux x64".
+    expect(stderr).toMatch(/^Bun (Debug |Canary )?v\d+\.\d+\.\d+/m);
+    // The message is reported on its own, with no `file:line:col` suffix.
+    expect(stderr).toContain(`panic(main thread): ${message}\n`);
+    expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.");
+    expect(exitCode).not.toBe(0);
+  });
+});
 
 // `crash()` resets fatal-signal dispositions to SIG_DFL before re-raising so
 // that JS-registered listeners (`process.on("SIGABRT")` etc., installed by
@@ -96,37 +171,25 @@ test.if(isPosix)(
 // reported "illegal hardware instruction" for every crash and parent
 // processes could not distinguish a panic from a CPU/codegen fault.
 describe.if(isPosix)("terminal signal reflects the crash cause", () => {
-  test.each([
-    ["panic", "SIGABRT"],
-    ["outOfMemory", "SIGABRT"],
-    ["segfault", "SIGSEGV"],
-    ["abort", "SIGABRT"],
-    ["trap", "SIGTRAP"],
-  ] as const)("%s terminates with %s", async (approach, expectedSignal) => {
+  test.concurrent.each([
+    ["panic", "SIGABRT", "invoked crashByPanic() handler"],
+    ["rustPanic", "SIGABRT", "invoked crashByRustPanic() handler"],
+    ["rustUnwrap", "SIGABRT", "called `Result::unwrap()` on an `Err` value"],
+    ["outOfMemory", "SIGABRT", "Bun has run out of memory"],
+    ["segfault", "SIGSEGV", "Segmentation fault at address"],
+    ["abort", "SIGABRT", "abort() called"],
+    ["trap", "SIGTRAP", "Trap instruction"],
+  ] as const)("%s terminates with %s", async (approach, expectedSignal, expectedMessage) => {
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        path.join(import.meta.dir, "fixture-crash.js"),
-        approach,
-        "--debug-crash-handler-use-trace-string",
-      ],
+      cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
       env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    if (approach === "segfault") {
-      expect(stderr).toContain("Segmentation fault at address");
-    } else if (approach === "panic") {
-      expect(stderr).toContain("invoked crashByPanic() handler");
-    } else if (approach === "abort") {
-      expect(stderr).toContain("abort() called");
-    } else if (approach === "trap") {
-      expect(stderr).toContain("Trap instruction");
-    }
+    expect(stderr).toContain(expectedMessage);
     expect(proc.signalCode).toBe(expectedSignal);
     expect(exitCode).not.toBe(0);
-    void stdout;
   });
 });
 
@@ -177,7 +240,7 @@ describe.if(isPosix)("cwd deleted before startup", () => {
 // handler's own frames in the trace and none of the bun callers.
 test.if(isWindows && isDebug)("Windows: segfault inside a system DLL captures the bun callers", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "segfaultInDll"],
+    cmd: [bunExe(), fixture, "segfaultInDll"],
     env: noReportEnv,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -367,7 +430,7 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
   });
 
   const proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "raiseIgnoringPanicHandler"],
+    cmd: [bunExe(), fixture, "raiseIgnoringPanicHandler"],
     env: mergeWindowEnvs([
       bunEnv,
       {
@@ -416,12 +479,7 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
     });
 
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        path.join(import.meta.dir, "fixture-crash.js"),
-        approach,
-        "--debug-crash-handler-use-trace-string",
-      ],
+      cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
       env: mergeWindowEnvs([
         bunEnv,
         {
@@ -562,7 +620,8 @@ describe.if(isPosix)("process.kill() aimed at the process itself is not reported
 });
 
 describe("automatic crash reporter", () => {
-  for (const approach of ["panic", "segfault", "outOfMemory"]) {
+  const panicMessages = new Map<string, string>(panicApproaches);
+  for (const approach of ["panic", "rustPanic", "rustUnwrap", "segfault", "outOfMemory"]) {
     test(`${approach} should report`, async () => {
       let sent = false;
       const resolve_handler = Promise.withResolvers();
@@ -579,7 +638,7 @@ describe("automatic crash reporter", () => {
       });
 
       const proc = Bun.spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), approach],
+        cmd: [bunExe(), fixture, approach],
         env: mergeWindowEnvs([
           bunEnv,
           {
@@ -595,16 +654,25 @@ describe("automatic crash reporter", () => {
       const stderr = await proc.stderr.text();
       console.log(stderr);
 
-      await resolve_handler.promise;
-
-      expect(exitCode).not.toBe(0);
-      expect(stderr).toContain(server.url.toString());
+      // Assert on the report before waiting for the upload, so a crash that
+      // never reports fails here instead of timing out on the promise below.
+      const traceString = stderr.split(/\s+/).find(word => word.startsWith(server.url.toString()));
+      expect(traceString).toBeDefined();
       if (approach !== "outOfMemory") {
         expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
       } else {
         expect(stderr.toLowerCase()).toContain("out of memory");
         expect(stderr.toLowerCase()).not.toContain("panic");
       }
+      // bun.report shows the panic message it decodes from the trace string,
+      // so a real Rust panic must encode its message exactly like panic_impl.
+      const panicMessage = panicMessages.get(approach);
+      if (panicMessage !== undefined) {
+        expect(panicMessageFromTraceString(traceString!)).toBe(panicMessage);
+      }
+      expect(exitCode).not.toBe(0);
+
+      await resolve_handler.promise;
       expect(sent).toBe(true);
     });
   }
@@ -633,7 +701,7 @@ test.if(isWindows)(
       await Bun.write(path.join(String(dir), "powershell.exe"), Bun.file(bunExe()));
 
       await using proc = Bun.spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic"],
+        cmd: [bunExe(), fixture, "panic"],
         cwd: String(dir),
         env: mergeWindowEnvs([
           bunEnv,


### PR DESCRIPTION
### Problem
- A Rust `panic!` (`unwrap()` on `None`/`Err`, a failed `assert!`, an out-of-bounds index) is reported by `rust_panic_hook` in `src/crash_handler/lib.rs`. The hook was a hand-copied subset of `crash_handler()`. It printed a report and called `crash()`, and skipped the rest.
- It skipped `PANICKING.fetch_add`, so `Global::exit()` on another thread did not wait (`sleep_forever_if_another_thread_is_crashing`, `src/bun_core/Global.rs:228`) and could end the process in the middle of the report. It skipped `maybe_handle_panic_during_process_reload`, `wait_for_other_thread_to_finish_panicking`, `reset_segfault_handler` and the `auto_reload_on_crash` branch, so `bun --watch` did not restart after a panic. It also printed `panic: <msg>` without the `(main thread)` tag that `scripts/runner.node.mjs` extracts.
- Nothing tested the hook: the `crash_handler.panic()` test helper calls `panic_impl` directly.

### Fix
- `rust_panic_hook` takes the payload string (`PanicHookInfo::payload_as_str`), cuts it at 1024 bytes on a char boundary, and calls `crash_handler(CrashReason::Panic(msg), TraceSeed::BeginAddr(return_address()))`. There is one crash path. The copied report code is deleted.
- `CrashReason` gets a lifetime (`CrashReason<'a>`). A reason is only formatted and passed down to `crash_handler()` and `crash()`, never stored, so the three sites that laundered a message to `&'static` with `unsafe { detach_lifetime(..) }` become plain constructors.
- New test helpers `crash_handler.rustPanic(message?)` (a real `panic!`) and `rustUnwrap()` (a real `Result::unwrap()` on an `Err`). `test/cli/run/run-crash-handler.test.ts` holds `panic`, `rustPanic` and `rustUnwrap` to the same report, trace string, upload and SIGABRT, tests the 1024-byte cap, and tests that `bun --watch` prints `Bun is auto-restarting due to crash` after each of them.
- Verified: `bun bd test test/cli/run/run-crash-handler.test.ts` (42 pass, 7 platform skips), `crash-report-command-char.test.ts`, `test/cli/watch/watch.test.ts`, `cargo check` of `bun_crash_handler` and `bun_runtime` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, `cargo clippy`, `cargo fmt`.

Supersedes #38927 (the same change, rebased onto main, plus the `--watch` test).

### Background
- `crash_handler()` is the one function that prints a crash report. Every other entry point calls it: the signal handlers, the Windows VEH, OOM, and `panic_impl`. Bun builds with `panic = "abort"`, so the `std::panic` hook is all that runs for a Rust panic.
- `PANICKING` is a process-wide count of threads inside `crash_handler()`. `Global::exit()` parks forever while it is non-zero, so a crash report from a worker thread can finish.
- `auto_reload_on_crash` is set by `--watch` (`src/runtime/cli/Arguments.rs:1050`). `crash_handler()` checks it after the report and calls `reload_process`, which `execve`s bun again.
- A trace string is the bun.report URL in the report. For a panic it carries the zlib-compressed message, which the tests inflate.

<details><summary>Notes</summary>

Fail-before with the released bun (1.4.1-canary.1). The `toBeWithin` panic itself is fixed separately in #40694.

```
$ bun --watch test a.test.ts     # a.test.ts: expect(1).toBeWithin(0)
panic: index out of bounds: the len is 1 but the index is 1
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
...
exit: 134
```

With this change:

```
panic(main thread): index out of bounds: the len is 1 but the index is 1
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
--- Bun is auto-restarting due to crash [time: 1787894053618] ---
panic(main thread): index out of bounds: the len is 1 but the index is 1
...
```

Re-entrancy: std aborts a panic raised inside the hook itself (`PanicInHook`), so the hook's own `PANIC_STAGE` guard was only reachable for a panic raised while `crash_handler()` was already printing a signal or OOM report. `crash_handler()`'s stage 1 to 3 branches handle that case, the same way they do for `panic_impl`.

The trim anchor `return_address()` is read in the hook's own frame, so the trace starts at the hook's caller in std and reaches the panicking function. The debug-build trace test asserts `js_rust_panic` / `js_rust_unwrap` is in the trace and `capture_stack_trace` is not.

The `--watch` test is POSIX only. On Windows, `--watch` runs a watcher-manager parent and only the child gets `auto_reload_on_crash`, a different mechanism that this change does not touch.

The 1024-byte cap is the bound the old `BoundedArray<u8, 1024>` already imposed. Over it, the old hook reported an empty message (the append was all-or-nothing). `encode_trace_string` still drops a message whose compressed form does not fit the trace string buffer. That affects `panic_impl` the same way and is not changed here.

Rebase from #38927: two conflicts, both from code deleted on main (`TraceSeed` lost its lifetime, `cold_handle_error_return_trace` was removed) and `JSValue::to_slice` became `to_utf8`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->