### PR TITLE
shell: keep an empty brace expansion word in every position

### DIFF
--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -111,8 +111,7 @@ impl Assigns {
         let label = node.slice()[*idx as usize].label;
         *idx += 1;
 
-        // Join multi-word expansions with a single space. Zero words and one
-        // word are both `buf` as-is (empty for zero).
+        // Join multi-word expansions with a single space.
         let value: Vec<u8> = if out.word_count() <= 1 {
             out.buf
         } else {

--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -111,20 +111,18 @@ impl Assigns {
         let label = node.slice()[*idx as usize].label;
         *idx += 1;
 
-        // Join multi-word expansions with a single space. `ExpansionOut` stores all words contiguously in `buf`
-        // with `bounds` marking inter-word offsets, so the merged value is
-        // `buf` with a space inserted at each boundary.
-        let value: Vec<u8> = if out.bounds.is_empty() {
+        // Join multi-word expansions with a single space. Zero words and one
+        // word are both `buf` as-is (empty for zero).
+        let value: Vec<u8> = if out.word_count() <= 1 {
             out.buf
         } else {
-            let mut merged = Vec::with_capacity(out.buf.len() + out.bounds.len());
-            let mut prev = 0usize;
-            for &b in &out.bounds {
-                merged.extend_from_slice(&out.buf[prev..b as usize]);
-                merged.push(b' ');
-                prev = b as usize;
+            let mut merged = Vec::with_capacity(out.buf.len() + out.word_count());
+            for (i, word) in out.words().enumerate() {
+                if i != 0 {
+                    merged.push(b' ');
+                }
+                merged.extend_from_slice(word);
             }
-            merged.extend_from_slice(&out.buf[prev..]);
             merged
         };
 

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -364,8 +364,6 @@ impl Cmd {
                             interp.as_cmd_mut(this).exit_code = Some(out.out_exit_code);
                         }
                     }
-                    // Every word becomes an argv entry, empty words included.
-                    // `$unset` produced no word, so it adds nothing.
                     let me = interp.as_cmd_mut(this);
                     if out.word_count() == 1 {
                         me.args.push(out.buf);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -403,9 +403,10 @@ impl Cmd {
             }
         }
 
-        // Empty/null argv[0] → exit
-        // with the exit code from a sole command-substitution (stashed by
-        // `child_done` from `Expansion::out_exit_code`), else 0.
+        // No argv at all → exit with the exit code from a sole command
+        // substitution (stashed by `child_done` from
+        // `Expansion::out_exit_code`), else 0. An empty argv[0] word (`""`,
+        // or an empty brace variant) is a command name that does not exist.
         let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
             match me.args.first() {
@@ -413,7 +414,14 @@ impl Cmd {
                     // strip the trailing NUL we just added
                     a[..a.len() - 1].to_vec()
                 }
-                _ => {
+                Some(_) => {
+                    return Builtin::cmd_write_failing_error(
+                        interp,
+                        this,
+                        format_args!("bun: command not found: \n"),
+                    );
+                }
+                None => {
                     let exit = me.exit_code.unwrap_or(0);
                     let parent = me.base.parent;
                     return interp.child_done(parent, this, exit);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -364,24 +364,13 @@ impl Cmd {
                             interp.as_cmd_mut(this).exit_code = Some(out.out_exit_code);
                         }
                     }
-                    // `out.bounds` splits the expansion into multiple argv
-                    // words (glob/IFS).
+                    // Every word becomes an argv entry, empty words included.
+                    // `$unset` produced no word, so it adds nothing.
                     let me = interp.as_cmd_mut(this);
-                    if out.bounds.is_empty() {
-                        // An empty
-                        // expansion that did *not* see a `""` literal pushes
-                        // no arg at all — `$unset` vanishes, only `""` yields
-                        // an empty argv word.
-                        if !out.buf.is_empty() || out.has_quoted_empty {
-                            me.args.push(out.buf);
-                        }
+                    if out.word_count() == 1 {
+                        me.args.push(out.buf);
                     } else {
-                        let mut prev = 0usize;
-                        for &b in &out.bounds {
-                            me.args.push(out.buf[prev..b as usize].to_vec());
-                            prev = b as usize;
-                        }
-                        me.args.push(out.buf[prev..].to_vec());
+                        me.args.extend(out.words().map(<[u8]>::to_vec));
                     }
                 }
                 CmdState::ExpandingRedirect { ref mut idx } => {
@@ -389,7 +378,7 @@ impl Cmd {
                     // Zero words or >1 word (glob/brace split) leave the buffer
                     // empty so the ambiguous-redirect check in
                     // `Builtin::init_redirections` / `init_subproc_redirections` fires.
-                    let mut buf = if out.bounds.is_empty() {
+                    let mut buf = if out.word_count() == 1 {
                         out.buf
                     } else {
                         Vec::new()

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -403,10 +403,6 @@ impl Cmd {
             }
         }
 
-        // No argv at all → exit with the exit code from a sole command
-        // substitution (stashed by `child_done` from
-        // `Expansion::out_exit_code`), else 0. An empty argv[0] word (`""`,
-        // or an empty brace variant) is a command name that does not exist.
         let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
             match me.args.first() {
@@ -414,6 +410,7 @@ impl Cmd {
                     // strip the trailing NUL we just added
                     a[..a.len() - 1].to_vec()
                 }
+                // An empty argv[0] word (`""`, an empty brace variant) is a name that does not exist.
                 Some(_) => {
                     return Builtin::cmd_write_failing_error(
                         interp,
@@ -421,6 +418,7 @@ impl Cmd {
                         format_args!("bun: command not found: \n"),
                     );
                 }
+                // No argv at all runs nothing. A sole `$(...)` argv0 passes its exit code on.
                 None => {
                     let exit = me.exit_code.unwrap_or(0);
                     let parent = me.base.parent;

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -40,8 +40,7 @@ pub struct Expansion {
     /// Whether the in-flight command substitution was `"$(...)"` (no IFS
     /// splitting on its result). Only meaningful while `state == CmdSubst`.
     pub(crate) cmd_subst_quoted: bool,
-    /// Set when a `""`/`''` literal was seen. The final flush pushes an empty
-    /// `current_out` as a word only then: `""` is one empty arg, `$unset` is none.
+    /// Set when a `""`/`''` literal was seen, so the final flush keeps an empty word.
     pub(crate) has_quoted_empty: bool,
     /// Exit code of a sole-command-substitution arg — propagated to `Cmd`
     /// so `$(false)` as argv0 fails.
@@ -66,8 +65,7 @@ pub enum ExpansionState {
 #[derive(Default)]
 pub struct ExpansionOut {
     pub(crate) buf: Vec<u8>,
-    /// End offset in `buf` of each word, one entry per word, so an empty word
-    /// is representable in any position (`{,b}` is `["", "b"]`).
+    /// End offset in `buf` of each word. An empty word repeats the previous offset.
     pub(crate) word_ends: Vec<u32>,
     /// Set when the atom is a sole `$(…)`
     /// that exited non-zero, so [`Cmd::child_done`] can propagate it as the

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -489,10 +489,9 @@ impl Expansion {
         match atom {
             ast::SimpleAtom::Text(txt) => out.extend_from_slice(txt),
             ast::SimpleAtom::QuotedEmpty => {
-                // Sets `has_quoted_empty = true` so an empty word is still pushed
-                // as an arg. The flag is *required* — without it Cmd cannot
-                // tell `""` (one empty arg) from `$unset` (no arg), since
-                // both leave `out.buf` empty.
+                // The final flush in `next` pushes an empty `current_out` as a
+                // word only when this flag is set: `""` is one empty arg,
+                // `$unset` is no arg, and both leave `current_out` empty.
                 *has_quoted_empty = true;
             }
             ast::SimpleAtom::Var(label) => {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -42,9 +42,9 @@ pub struct Expansion {
     pub(crate) cmd_subst_quoted: bool,
     /// Set when a `""`/`''` literal
     /// was seen so an *empty* expansion is still pushed as an argv word.
-    /// Without this, `$unset` and `""` are indistinguishable in
-    /// [`ExpansionOut`] (both → `buf=[], bounds=[]`) and Cmd would push an
-    /// empty arg for unset vars — diverging from POSIX field-splitting.
+    /// Without this, `$unset` and `""` both leave `current_out` empty and the
+    /// final flush could not tell "no word" from "one empty word". Pushing
+    /// an empty arg for unset vars would diverge from POSIX field-splitting.
     pub(crate) has_quoted_empty: bool,
     /// Exit code of a sole-command-substitution arg — propagated to `Cmd`
     /// so `$(false)` as argv0 fails.
@@ -65,20 +65,41 @@ pub enum ExpansionState {
     Err(Box<ShellErr>),
 }
 
+/// The argv words one atom expanded to, stored contiguously in `buf`.
 #[derive(Default)]
 pub struct ExpansionOut {
     pub(crate) buf: Vec<u8>,
-    /// Word boundaries within `buf` (for IFS splitting / glob results).
-    pub(crate) bounds: Vec<u32>,
+    /// End offset in `buf` of each word, one entry per word. Words are
+    /// delimited by their end offsets rather than by non-empty spans so an
+    /// empty word is representable in any position: `{,b}` is `["", "b"]`,
+    /// `{,}` is `["", ""]`, and `$unset` (no word at all) is an empty list.
+    pub(crate) word_ends: Vec<u32>,
     /// Set when the atom is a sole `$(…)`
     /// that exited non-zero, so [`Cmd::child_done`] can propagate it as the
     /// command's exit code when that substitution was argv0 and argv is
     /// otherwise empty.
     pub(crate) out_exit_code: ExitCode,
-    /// When `buf`/`bounds` are both
-    /// empty, this distinguishes `""` (push one empty arg) from `$unset`
-    /// (push no arg). See [`Expansion::has_quoted_empty`].
-    pub(crate) has_quoted_empty: bool,
+}
+
+impl ExpansionOut {
+    fn push_word(&mut self, word: &[u8]) {
+        self.buf.extend_from_slice(word);
+        self.word_ends.push(self.buf.len() as u32);
+    }
+
+    /// Number of words, including empty ones.
+    pub(crate) fn word_count(&self) -> usize {
+        self.word_ends.len()
+    }
+
+    pub(crate) fn words(&self) -> impl Iterator<Item = &[u8]> + '_ {
+        let mut prev = 0usize;
+        self.word_ends.iter().map(move |&end| {
+            let word = &self.buf[prev..end as usize];
+            prev = end as usize;
+            word
+        })
+    }
 }
 
 impl Expansion {
@@ -256,7 +277,11 @@ impl Expansion {
             if atom.has_glob_expansion() {
                 return Self::transition_to_glob_state(interp, this);
             }
-            Self::push_current_out(me);
+            // `$unset` expands to no word at all; only an explicit `""`
+            // yields an empty one.
+            if !me.current_out.is_empty() || me.has_quoted_empty {
+                Self::push_current_out(me);
+            }
             me.state = ExpansionState::Done;
         }
         let parent = interp.as_expansion(this).base.parent;
@@ -335,13 +360,9 @@ impl Expansion {
             expanded
         };
 
-        // Push each variant as its own word; word boundaries are recorded
-        // via `bounds`.
+        // Push each variant as its own word, empty variants included.
         for s in expanded {
-            if !me.out.buf.is_empty() {
-                me.out.bounds.push(me.out.buf.len() as u32);
-            }
-            me.out.buf.extend_from_slice(&s);
+            me.out.push_word(&s);
         }
 
         let node = me.node;
@@ -526,15 +547,10 @@ impl Expansion {
         false
     }
 
-    /// Flush `current_out` into `out`
-    /// as the next argv word. The word boundary is recorded as the *previous*
-    /// end-offset so the consumer's `[prev..bound]` slicing reconstructs each
-    /// word and the trailing `[prev..]` slice yields the final one.
+    /// Flush `current_out` into `out` as the next argv word.
     fn push_current_out(me: &mut Expansion) {
-        if !me.out.buf.is_empty() {
-            me.out.bounds.push(me.out.buf.len() as u32);
-        }
         me.out.buf.append(&mut me.current_out);
+        me.out.word_ends.push(me.out.buf.len() as u32);
         me.meta_offsets.clear();
     }
 
@@ -692,10 +708,7 @@ impl Expansion {
             // Push each match as its own argv word. The
             // walker arena owns the strings, so they were `to_vec`'d already.
             for entry in result {
-                if !me.out.buf.is_empty() {
-                    me.out.bounds.push(me.out.buf.len() as u32);
-                }
-                me.out.buf.extend_from_slice(&entry);
+                me.out.push_word(&entry);
             }
             me.state = ExpansionState::Done;
         }
@@ -723,7 +736,7 @@ impl Expansion {
         }
         let me = interp.as_expansion_mut(this);
         me.out.buf.clear();
-        me.out.bounds.clear();
+        me.out.word_ends.clear();
         me.current_out.clear();
     }
 
@@ -732,7 +745,6 @@ impl Expansion {
         let me = interp.as_expansion_mut(this);
         let mut out = core::mem::take(&mut me.out);
         out.out_exit_code = me.out_exit_code;
-        out.has_quoted_empty = me.has_quoted_empty;
         out
     }
 }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -40,11 +40,8 @@ pub struct Expansion {
     /// Whether the in-flight command substitution was `"$(...)"` (no IFS
     /// splitting on its result). Only meaningful while `state == CmdSubst`.
     pub(crate) cmd_subst_quoted: bool,
-    /// Set when a `""`/`''` literal
-    /// was seen so an *empty* expansion is still pushed as an argv word.
-    /// Without this, `$unset` and `""` both leave `current_out` empty and the
-    /// final flush could not tell "no word" from "one empty word". Pushing
-    /// an empty arg for unset vars would diverge from POSIX field-splitting.
+    /// Set when a `""`/`''` literal was seen. The final flush pushes an empty
+    /// `current_out` as a word only then: `""` is one empty arg, `$unset` is none.
     pub(crate) has_quoted_empty: bool,
     /// Exit code of a sole-command-substitution arg — propagated to `Cmd`
     /// so `$(false)` as argv0 fails.
@@ -69,10 +66,8 @@ pub enum ExpansionState {
 #[derive(Default)]
 pub struct ExpansionOut {
     pub(crate) buf: Vec<u8>,
-    /// End offset in `buf` of each word, one entry per word. Words are
-    /// delimited by their end offsets rather than by non-empty spans so an
-    /// empty word is representable in any position: `{,b}` is `["", "b"]`,
-    /// `{,}` is `["", ""]`, and `$unset` (no word at all) is an empty list.
+    /// End offset in `buf` of each word, one entry per word, so an empty word
+    /// is representable in any position (`{,b}` is `["", "b"]`).
     pub(crate) word_ends: Vec<u32>,
     /// Set when the atom is a sole `$(…)`
     /// that exited non-zero, so [`Cmd::child_done`] can propagate it as the
@@ -277,8 +272,6 @@ impl Expansion {
             if atom.has_glob_expansion() {
                 return Self::transition_to_glob_state(interp, this);
             }
-            // `$unset` expands to no word at all; only an explicit `""`
-            // yields an empty one.
             if !me.current_out.is_empty() || me.has_quoted_empty {
                 Self::push_current_out(me);
             }
@@ -488,12 +481,7 @@ impl Expansion {
         use crate::shell::env_str::EnvStr;
         match atom {
             ast::SimpleAtom::Text(txt) => out.extend_from_slice(txt),
-            ast::SimpleAtom::QuotedEmpty => {
-                // The final flush in `next` pushes an empty `current_out` as a
-                // word only when this flag is set: `""` is one empty arg,
-                // `$unset` is no arg, and both leave `current_out` empty.
-                *has_quoted_empty = true;
-            }
+            ast::SimpleAtom::QuotedEmpty => *has_quoted_empty = true,
             ast::SimpleAtom::Var(label) => {
                 // Spec `expandVar`: shell_env first, then export_env, else "".
                 let key = EnvStr::init_slice(label);

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -170,6 +170,25 @@ describe("empty brace variants are argv words in every position", () => {
     expect(await $`echo {,b}`.text()).toBe(" b\n");
     expect(await $`echo {,}`.text()).toBe(" \n");
   });
+
+  // An empty word in command position is a command name that does not exist.
+  // It must not take the "no command name" exit, which ran nothing and exited 0.
+  test.concurrent.each(["{,false}", "{,echo} hi", '"" echo hi'])("%s is command not found", async cmd => {
+    const { stdout, stderr, exitCode } = await $`${{ raw: cmd }}`.nothrow().quiet();
+    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+      stdout: "",
+      stderr: "bun: command not found: \n",
+      exitCode: 1,
+    });
+  });
+
+  // Assignments join the words with a space, so an empty variant keeps its slot.
+  test("assignment keeps the empty variant", async () => {
+    expect(await $`FOO={,b}; echo "[$FOO]"`.text()).toBe("[ b]\n");
+    expect(await $`FOO={a,}; echo "[$FOO]"`.text()).toBe("[a ]\n");
+    const printFoo = "console.log(JSON.stringify(process.env.FOO))";
+    expect(await $`FOO={,b} ${bunExe()} -e ${printFoo}`.env(bunEnv).text()).toBe(`" b"\n`);
+  });
 });
 
 // A shell word combining brace + glob (`src/*.{ts,tsx}`, `{src,lib}/*.ts`) was

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -128,6 +128,44 @@ console.log(JSON.stringify(Bun.$.braces("{" + inner)));`,
   });
 });
 
+// The expansion collected its words into one buffer and recorded a word
+// boundary only when that buffer was already non-empty, so an empty variant
+// at the start of the list had no representation and was dropped: `{,b}`
+// gave ["b"] while `{b,}` gave ["b", ""]. Every variant is an argv word.
+describe("empty brace variants are argv words in every position", () => {
+  // With `-e` there is no script path, so the user args start at argv[1].
+  const printArgv = "console.log(JSON.stringify(process.argv.slice(1)))";
+  const cases: [string, string[]][] = [
+    ["{,b}", ["", "b"]],
+    ["{b,}", ["b", ""]],
+    ["{,}", ["", ""]],
+    ["{,,b}", ["", "", "b"]],
+    ["{a,,b}", ["a", "", "b"]],
+    ["{,b}{,c}", ["", "c", "b", "bc"]],
+    ["{{,a},b}", ["", "a", "b"]],
+    ["x {,b} y", ["x", "", "b", "y"]],
+    // A quoted empty prefix belongs to the same word, it is not a word of its own.
+    ['""{,b}', ["", "b"]],
+  ];
+
+  test.concurrent.each(cases)("%s", async (words, expected) => {
+    const { stdout, stderr, exitCode } = await $`${bunExe()} -e ${printArgv} ${{ raw: words }}`
+      .env(bunEnv)
+      .nothrow()
+      .quiet();
+    expect({ argv: JSON.parse(stdout.toString()), stderr: stderr.toString(), exitCode }).toEqual({
+      argv: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("builtin echo prints the empty word", async () => {
+    expect(await $`echo {,b}`.text()).toBe(" b\n");
+    expect(await $`echo {,}`.text()).toBe(" \n");
+  });
+});
+
 // A shell word combining brace + glob (`src/*.{ts,tsx}`, `{src,lib}/*.ts`) was
 // brace-expanded but the resulting `*` patterns were never globbed (the
 // brace-expand state always transitioned to Done instead of re-entering glob).

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -139,13 +139,19 @@ describe("empty brace variants are argv words in every position", () => {
     ["{,b}", ["", "b"]],
     ["{b,}", ["b", ""]],
     ["{,}", ["", ""]],
+    ["{,,,}", ["", "", "", ""]],
     ["{,,b}", ["", "", "b"]],
+    ["{,a,b}", ["", "a", "b"]],
     ["{a,,b}", ["a", "", "b"]],
+    ["{a,b,}", ["a", "b", ""]],
+    ["x{,,}", ["x", "x", "x"]],
+    ["{,}y", ["y", "y"]],
     ["{,b}{,c}", ["", "c", "b", "bc"]],
     ["{{,a},b}", ["", "a", "b"]],
     ["x {,b} y", ["x", "", "b", "y"]],
     // A quoted empty prefix belongs to the same word, it is not a word of its own.
     ['""{,b}', ["", "b"]],
+    ['""{,,}', ["", "", ""]],
   ];
 
   test.concurrent.each(cases)("%s", async (words, expected) => {


### PR DESCRIPTION
### Problem
- The shell drops an empty brace expansion word at the start of the list. `{,b}` expands to `["b"]` and `{,}` to nothing, while `{b,}` expands to `["b", ""]`. The result depends on the position of the empty variant.
- `ExpansionOut` (`src/runtime/shell/states/Expansion.rs`) stores all words in one `buf` and records a boundary in `bounds` only `if !buf.is_empty()`. A leading empty word never grows `buf`, so it has no representation. The same guard sits at the three push sites: brace variants, `push_current_out`, and glob matches.
- An empty word in command position (`"" echo hi`, or `{,echo} hi` once the empty variant survives) took the "no command name" exit in `Cmd::transition_to_exec`: it ran nothing and exited 0.

### Fix
- `ExpansionOut` records the end offset of every word in `word_ends`, one entry per word. An empty word is representable in any position and `word_count()` is explicit. All three push sites go through this encoding.
- The `$unset` (no word) versus `""` (one empty word) decision moves from `Cmd` into the Expansion's final flush, next to `has_quoted_empty`. `Cmd` and `Assigns` iterate `words()` instead of inferring words from non-empty spans.
- `transition_to_exec` takes the silent exit only with no argv at all. An empty argv[0] word fails with `bun: command not found: ` and exit 1, like any other name that does not resolve. This restores the behavior of the Zig shell, which pushed every brace variant as its own argv word, and matches `$.braces()`.
- Verified: `test/js/bun/shell/brace.test.ts` (63 pass, the new argv cases fail on 1.4.1). Also `bunshell.test.ts` and `test/js/bun/shell/commands/`.

### Background
- An `Expansion` state node turns one shell word (an `ast::Atom`) into zero or more argv words. Brace expansion, glob matches, and IFS splitting of `$(...)` output can each produce more than one word. `Cmd` collects them as argv, `Assigns` joins them with spaces.
- A word can be empty. `""` is one empty argv word, `$unset` is no word at all. The flush at the end of the walk tells them apart with `has_quoted_empty`.
- Bash 5.2 behaves differently here: it removes unquoted empty words after brace expansion, so `{,b}` and `{b,}` are both one word and `{,}` is zero. #34318 implements that. #30998 fixes the brace site alone in the same direction as this PR and no longer merges (its argv cases are ported here). This PR was requested with the keep-every-variant behavior.

<details><summary>Notes</summary>

Reproduction on bun 1.4.1 (`argv.js` prints `process.argv.slice(2)`):

```
{,b}         ["b"]          expected ["","b"]
{b,}         ["b",""]       ok
{,}          []             expected ["",""]
{,,b}        ["b"]          expected ["","","b"]
{a,,b}       ["a","","b"]   ok (the empty word is not first)
{,b}{,c}     ["c","b","bc"] expected ["","c","b","bc"]
{{,a},b}     ["a","b"]      expected ["","a","b"]
```

Bash 5.2 for the same words: `{,b}` → `b`, `{b,}` → `b`, `{,}` → zero words, `{a,,b}` → `a b`, `""{,b}` → two words (the quoted empty is kept). Bash reports `"" echo hi` as `: command not found` (exit 127). Bun uses exit 1 for every unresolved command name.

The old encoding needed a boundary count of N for N+1 words, which made "zero words" and "one empty word" the same shape (`buf=[]`, `bounds=[]`). `Cmd` resolved that with `has_quoted_empty`. With one end offset per word the shape is unambiguous: zero words is `word_ends=[]`, one empty word is `word_ends=[0]`.

`CondExpr` takes `out.buf` as a single argument and is unchanged: `buf` is still the concatenation of all words.

The Zig shell's `Cmd.transitionToExec` matched `args.items[0] orelse` (null only when argv was empty), so an empty word went through `which("")` and reported `command not found`. The Rust port's `Some(a) if a.len() > 1` guard merged the two cases.

Suites run with the debug build: `brace.test.ts` (63 pass), `bunshell.test.ts` (424 pass, 0 fail), `commands/`, `env.positionals`, `bunshell-default`, `bunshell-instance`, `shelloutput`, `assignments-in-pipeline`, `exec`. Two `ls` permission-denied tests fail as root on main too.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/29] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/29] gen cpp.rs (cppbind)
[3/29] gen JS modules (bundle-modules)
Preprocess modules (8235ms)
Bundle modules (38ms)
Postprocesss modules (216ms)
Bundle Functions (624ms)
Generate Code (50ms)

[9.18s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/14] cargo bun_runtime → libbun_runtime.a
[8/14] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_
... (truncated)

release without fix: 15 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [0.04ms]
(pass) $.braces > 2 [0.02ms]
(pass) $.braces > 3 [0.02ms]
(pass) $.braces > nested [0.04ms]
(pass) $.braces > nested 2 [0.02ms]
(pass) $.braces > nested sibling product [0.02ms]
(pass) $.braces > nested sibling product with surrounding text [0.01ms]
(pass) $.braces > nested sibling product mixed with variants [0.02ms]
(pass) $.braces > nested sibling product triple [0.05ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [0.03ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.01ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z
(pass) $.braces > nested with empty variant > {x,{,}}z
(pass) $.braces > nested with empty variant > a{b,c{d,}}e
(pass) $.braces > nested with empty variant > a{b,c{,d}}e
(pass) $.braces > nested with empty variant > {x,{a,,b}}
(pass) $.braces > nested with empty variant > {x,{a,b,}}
(pass) $.braces > nested with empty variant > {{a,},x}
(pass) $.braces > nested with empty variant > p{q,{r,}{s,}}t
(pass) $.braces > very deeply nested [0.04ms]
(pass) $.braces > literal outer group around hundreds of nested groups
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [2.14ms]
(pass) $.braces > 2 [1.89ms]
(pass) $.braces > 3 [1.51ms]
(pass) $.braces > nested [1.92ms]
(pass) $.braces > nested 2 [2.01ms]
(pass) $.braces > nested sibling product [1.38ms]
(pass) $.braces > nested sibling product with surrounding text [1.76ms]
(pass) $.braces > nested sibling product mixed with variants [1.64ms]
(pass) $.braces > nested sibling product triple [1.99ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [1.80ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.59ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z [0.47ms]
(pass) $.braces > nested with empty variant > {x,{,}}z [0.47ms]
(pass) $.braces > nested with empty variant > a{b,c{d,}}e [0.46ms]
(pass) $.braces > nested with empty variant > a{b,c{,d}}e [0.46ms]
(pass) $.braces > nested with empty variant > {x,{a,,b}} [0.46ms]
(pass) $.braces > nested with empty variant > {x,{a,b,}} [0.49ms]
(pass) $.braces > nest
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 603ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/24] gen cpp.rs (cppbind)
[3/24] gen JS modules (bundle-modules)
Preprocess modules (7617ms)
Bundle modules (44ms)
Postprocesss modules (24ms)
Bundle Functions (444ms)
Generate Code (29ms)

[8.17s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/11] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/states/Assigns.rs   | 19 ++++-----
 src/runtime/shell/states/Cmd.rs       | 35 +++++++----------
 src/runtime/shell/states/Expansion.rs | 73 +++++++++++++++++------------------
 test/js/bun/shell/brace.test.ts       | 63 ++++++++++++++++++++++++++++++
 4 files changed, 120 insertions(+), 70 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/shell/states/Assigns.rs        2      2      0
src/runtime/shell/states/Cmd.rs            3      5      0
src/runtime/shell/states/Expansion.rs      5     17      0
test/js/bun/shell/brace.test.ts            1      3      0
```

</details>

<!-- robobun:evidence:end -->