### PR TITLE
shell: export rejects invalid identifiers

### DIFF
--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -2,7 +2,7 @@ use crate::shell::builtin::{Builtin, BuiltinState, IoKind};
 use crate::shell::interpreter::{Interpreter, NodeId};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
-use crate::shell::{EnvStr, is_valid_var_name};
+use crate::shell::{EnvStr, ExitCode, is_valid_var_name};
 use bun_collections::index_sort;
 
 #[derive(Default)]
@@ -92,8 +92,15 @@ impl Export {
         _: usize,
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        let failed = err.is_some() || matches!(Self::state_mut(interp, cmd).state, State::Err);
+        let failed = matches!(Self::state_mut(interp, cmd).state, State::Err);
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(interp, cmd, if failed { 1 } else { 0 })
+        Builtin::done(
+            interp,
+            cmd,
+            match err {
+                Some(_err) => 1,
+                None => ExitCode::from(failed),
+            },
+        )
     }
 }

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -22,12 +22,14 @@ enum State {
 impl Export {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let argc = Builtin::of(interp, cmd).args_slice().len();
-        if argc == 0 {
+        // POSIX end-of-options marker: `export -- NAME=value`.
+        let start = usize::from(argc > 0 && Builtin::of(interp, cmd).arg_bytes(0) == b"--");
+        if start >= argc {
             // No args: print all exported vars.
             return Self::print_all(interp, cmd);
         }
         let mut errors = Vec::new();
-        for i in 0..argc {
+        for i in start..argc {
             let s = Builtin::of(interp, cmd).arg_bytes(i);
             let (name, value) = match bun_core::strings::index_of_char_usize(s, b'=') {
                 Some(eq) => (&s[..eq], &s[eq + 1..]),

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -31,9 +31,6 @@ impl Export {
         let mut errors = Vec::new();
         for i in 0..argc {
             let s = Builtin::of(interp, cmd).arg_bytes(i);
-            if s.is_empty() {
-                continue;
-            }
             let (name, value) = match bun_core::strings::index_of_char_usize(s, b'=') {
                 Some(eq) => (&s[..eq], &s[eq + 1..]),
                 None => (s, &b""[..]),

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -1,8 +1,8 @@
-use crate::shell::EnvStr;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind};
 use crate::shell::interpreter::{Interpreter, NodeId};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
+use crate::shell::{EnvStr, is_valid_var_name};
 use bun_collections::index_sort;
 
 #[derive(Default)]
@@ -15,6 +15,7 @@ enum State {
     #[default]
     Idle,
     WaitingIo,
+    Err,
     Done,
 }
 
@@ -25,6 +26,9 @@ impl Export {
             // No args: print all exported vars.
             return Self::print_all(interp, cmd);
         }
+        // Like bash: every invalid word is reported, the valid ones are still
+        // exported, and the exit code is 1 if any word was rejected.
+        let mut errors = Vec::new();
         for i in 0..argc {
             let s = Builtin::of(interp, cmd).arg_bytes(i);
             if s.is_empty() {
@@ -34,6 +38,12 @@ impl Export {
                 Some(eq) => (&s[..eq], &s[eq + 1..]),
                 None => (s, &b""[..]),
             };
+            if !is_valid_var_name(name) {
+                errors.extend_from_slice(b"export: `");
+                errors.extend_from_slice(s);
+                errors.extend_from_slice(b"`: not a valid identifier\n");
+                continue;
+            }
             // The argv backing is freed when the Cmd retires,
             // so the key/value MUST be duplicated into ref-counted storage —
             // `init_slice` here would leave dangling EnvStr in `export_env`.
@@ -45,7 +55,11 @@ impl Export {
             label.deref();
             val.deref();
         }
-        Builtin::done(interp, cmd, 0)
+        if errors.is_empty() {
+            return Builtin::done(interp, cmd, 0);
+        }
+        Self::state_mut(interp, cmd).state = State::Err;
+        Builtin::write_failing_error(interp, cmd, &errors, 1)
     }
 
     fn print_all(interp: &Interpreter, cmd: NodeId) -> Yield {
@@ -81,7 +95,8 @@ impl Export {
         _: usize,
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
+        let failed = err.is_some() || matches!(Self::state_mut(interp, cmd).state, State::Err);
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(interp, cmd, err.map_or(0, |_| 1))
+        Builtin::done(interp, cmd, if failed { 1 } else { 0 })
     }
 }

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -26,8 +26,6 @@ impl Export {
             // No args: print all exported vars.
             return Self::print_all(interp, cmd);
         }
-        // Like bash: every invalid word is reported, the valid ones are still
-        // exported, and the exit code is 1 if any word was rejected.
         let mut errors = Vec::new();
         for i in 0..argc {
             let s = Builtin::of(interp, cmd).arg_bytes(i);

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -132,7 +132,7 @@ pub mod subproc;
 
 // ─── shell escaping (canonical impl lives in bun_shell_parser) ───────────────
 // Re-export so `crate::shell::*` callers resolve without duplicating the table.
-pub use bun_shell_parser::{escape_8bit, needs_escape_utf8_ascii_latin1};
+pub use bun_shell_parser::{escape_8bit, is_valid_var_name, needs_escape_utf8_ascii_latin1};
 
 // ─── AST surface (lifetime-erased aliases over `bun_shell_parser::ast`) ──────
 // State nodes hold `*const ast::*` raw pointers into the bumpalo-allocated AST

--- a/src/shell_parser/lib.rs
+++ b/src/shell_parser/lib.rs
@@ -20,5 +20,5 @@ pub mod json_fmt;
 
 pub use parse::{
     JSValueRaw, LexResult, LexerError, ParseError, Parser, ast, escape_8bit, escape_bun_str,
-    needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
+    is_valid_var_name, needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
 };

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -3785,7 +3785,7 @@ impl<'a, const ENCODING: StringEncoding> ShellCharIter<'a, ENCODING> {
 /// - a-zA-Z
 /// - _
 /// - 0-9 (but can't be first char)
-pub(crate) fn is_valid_var_name(var_name: &[u8]) -> bool {
+pub fn is_valid_var_name(var_name: &[u8]) -> bool {
     if is_all_ascii(var_name) {
         return is_valid_var_name_ascii(var_name);
     }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1399,12 +1399,13 @@ describe("deno_task", () => {
       .stdout("1 testing test this out\n")
       .runAsTest("exported vars 2");
 
-    TestBuilder.command`export 1abc a-b=5 =x ok=1; ${BUN} -e ${"console.log(JSON.stringify([process.env['1abc'], process.env['a-b'], process.env.ok]))"}`
+    TestBuilder.command`export 1abc a-b=5 =x "" ok=1; ${BUN} -e ${"console.log(JSON.stringify([process.env['1abc'], process.env['a-b'], process.env.ok]))"}`
       .stdout('[null,null,"1"]\n')
       .stderr(
         "export: `1abc`: not a valid identifier\n" +
           "export: `a-b=5`: not a valid identifier\n" +
-          "export: `=x`: not a valid identifier\n",
+          "export: `=x`: not a valid identifier\n" +
+          "export: ``: not a valid identifier\n",
       )
       .testMini()
       .runAsTest("export rejects invalid identifiers and keeps the valid ones");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1398,6 +1398,24 @@ describe("deno_task", () => {
     TestBuilder.command`export VAR=1 VAR2=testing VAR3="test this out" && echo $VAR $VAR2 $VAR3`
       .stdout("1 testing test this out\n")
       .runAsTest("exported vars 2");
+
+    TestBuilder.command`export 1abc a-b=5 =x ok=1; ${BUN} -e ${"console.log(JSON.stringify([process.env['1abc'], process.env['a-b'], process.env.ok]))"}`
+      .stdout('[null,null,"1"]\n')
+      .stderr(
+        "export: `1abc`: not a valid identifier\n" +
+          "export: `a-b=5`: not a valid identifier\n" +
+          "export: `=x`: not a valid identifier\n",
+      )
+      .testMini()
+      .runAsTest("export rejects invalid identifiers and keeps the valid ones");
+
+    TestBuilder.command`export 1abc`
+      .stderr("export: `1abc`: not a valid identifier\n")
+      .exitCode(1)
+      .testMini()
+      .runAsTest("export exits 1 on an invalid identifier");
+
+    TestBuilder.command`export _ok OK2=1 && echo done`.stdout("done\n").runAsTest("export accepts valid identifiers");
   });
 
   describe("pipeline", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1426,6 +1426,21 @@ describe("deno_task", () => {
         expect(stdout).toEndWith("done\n");
       })
       .runAsTest("export treats a leading -- as the end of options");
+
+    TestBuilder.command`export ""`
+      .stderr("export: ``: not a valid identifier\n")
+      .exitCode(1)
+      .runAsTest("export exits 1 on an empty word");
+
+    TestBuilder.command`export A=1 2B C=3 3D || echo "failed A=$A C=$C"`
+      .stdout("failed A=1 C=3\n")
+      .stderr("export: `2B`: not a valid identifier\nexport: `3D`: not a valid identifier\n")
+      .runAsTest("export exits 1 when a bare name is invalid and still exports the valid ones");
+
+    TestBuilder.command`export a-b=5 1FOO=bar OK=1 || echo "failed OK=$OK"`
+      .stdout("failed OK=1\n")
+      .stderr("export: `a-b=5`: not a valid identifier\nexport: `1FOO=bar`: not a valid identifier\n")
+      .runAsTest("export exits 1 when an assignment name is invalid and still exports the valid ones");
   });
 
   describe("pipeline", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1416,6 +1416,14 @@ describe("deno_task", () => {
       .testMini()
       .runAsTest("export exits 1 on an invalid identifier");
 
+    // `.quiet()` keeps stderr as an in-memory buffer, so the builtin takes the
+    // synchronous write path instead of the async fd write the other runs use.
+    TestBuilder.command`export 1abc`
+      .stderr("export: `1abc`: not a valid identifier\n")
+      .exitCode(1)
+      .quiet()
+      .runAsTest("export exits 1 on an invalid identifier with quiet output");
+
     TestBuilder.command`export _ok OK2=1 && echo done`.stdout("done\n").runAsTest("export accepts valid identifiers");
 
     TestBuilder.command`export -- FOO=bar && echo $FOO && export -- && echo done`

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1417,6 +1417,15 @@ describe("deno_task", () => {
       .runAsTest("export exits 1 on an invalid identifier");
 
     TestBuilder.command`export _ok OK2=1 && echo done`.stdout("done\n").runAsTest("export accepts valid identifiers");
+
+    TestBuilder.command`export -- FOO=bar && echo $FOO && export -- && echo done`
+      .stdout(stdout => {
+        expect(stdout).toStartWith("bar\n");
+        expect(stdout).toContain("FOO=bar\n");
+        expect(stdout).not.toContain("--=");
+        expect(stdout).toEndWith("done\n");
+      })
+      .runAsTest("export treats a leading -- as the end of options");
   });
 
   describe("pipeline", async () => {


### PR DESCRIPTION
### Problem
- The Bun shell `export` builtin accepts any name. `export 1abc a-b=5` puts `1abc=` and `a-b=5` into every child environment, prints nothing, and exits 0. Found by comparison with bash, no user report.
- `src/runtime/shell/builtin/export.rs:33-44` splits each word at the first `=` and inserts the pair into `export_env` without calling `is_valid_var_name` (`src/shell_parser/parse.rs:3788`).

### Fix
- `Export::start` checks each name with `is_valid_var_name` (now `pub` in `bun_shell_parser`). An invalid word is not exported and stderr gets ``export: `1abc`: not a valid identifier``. Valid words in the same command are still exported. The exit code is 1, as in bash.
- Errors go through `Builtin::write_failing_error`. A new `State::Err` variant makes `on_io_writer_chunk` report exit 1 after an async write (a write error still wins). A leading `--` is skipped.
- Land #40764 first or together. It stops the field split of `export NAME=$(cmd)`. Without it, a split word such as `28` now fails the command (Notes).
- Verified: `test/js/bun/shell/bunshell.test.ts`, eight new tests in `env variables` (two also via `bun run script.bun.sh`, one with `.quiet()`). The released bun fails nine of ten runs. Other shell tests and `cargo clippy -p bun_runtime` pass.

### Background
- When stderr is an fd, a builtin's write is asynchronous: it enqueues bytes on an `IOWriter` and yields. `on_io_writer_chunk` fires when the write completes and passes the exit code to `Builtin::done`. `$` uses this path by default.
- With `$.quiet()`, stderr is a buffer: `write_no_io` appends and `done` runs at once.
- `is_valid_var_name` accepts `[A-Za-z_][A-Za-z0-9_]*`, as bash does.

<details><summary>Notes</summary>

- bash output for the same command:
  ```
  $ bash -c 'export 1abc a-b=5 ok=1; echo "exit=$?"; env | grep -E "^(1abc|a-b|ok)="'
  bash: line 1: export: `1abc': not a valid identifier
  bash: line 1: export: `a-b=5': not a valid identifier
  exit=1
  ok=1
  ```
- The Zig implementation (before the Rust port) checked the name only when the word had no `=`, returned on the first bad word, and exited 0. The port dropped the check. This change validates both forms, processes every word, and exits 1.
- Interaction with a pre-existing bug, #40763, fixed by #40764: the Bun shell field-splits the output of `$(cmd)` in `export NAME=$(cmd)`. bash does not. With `export DATE=$(date)`, the old code set `DATE` to the first word only and silently exported `Aug=`, `28=`, `12:37:27=` and so on, exit 0. With this change alone, `DATE` is still the first word and the split words that are not identifiers (`28`, `12:37:27`, `2026`) are reported, exit 1. On Windows, package.json scripts run in the Bun shell, so such a script would start to fail. The value of `DATE` is wrong either way. The workaround is `export DATE="$(date)"`. #40764 removes the split, so the two changes compose. Both insert tests after `exported vars 2` in `bunshell.test.ts`, so whichever lands second needs a small rebase.
- Exit code of `on_io_writer_chunk`: a write error gives 1, then `State::Err` gives 1, else 0. #40702 (open) changes the write error arm to the errno. The two changes are independent. Whichever lands second rebases one arm.
- #32298 is an older open PR with the same fix (same files, same check, same message, exit 1). Its five test cases pass on this branch. The three cases this PR lacked (`export ""` exits 1, and the exit code when valid and invalid words are mixed, for bare names and for assignments) are now in this PR. #32298 is closed as a duplicate.
- #33549 and #33550 (open, conflicting) change what `export NAME` does when the variable already exists and how a reassignment reaches the child environment. Those are separate behaviors and are not part of this change.
- An empty argument (`export ""`) is rejected too, like bash. The old code skipped it.
- The bash options `-p`, `-n` and `-f` are not supported by the Bun shell, before or after this change. Before, `export -p` put `-p=` into the environment. Now it is reported as an invalid word. #33995 (open) adds `--` handling to every builtin with a shared helper. It will need a rebase on this change.
- A script run with `bun run x.bun.sh` (stderr is a real fd) exits 1 for each bad name with stderr redirected to `/dev/null`, to a file, and through a pipe.
- The three tests in `test/js/bun/shell/shell-load.test.ts` and `commands/ls.test.ts` that fail locally also fail on main in this container (root user, timing). They are unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->
