### PR TITLE
dotenv: skip .env entries that are not regular files

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -886,15 +886,14 @@ impl Loader {
     }
 }
 
-/// `O_NONBLOCK`: a blocking `open` of a FIFO waits for a writer. Unix only: a
-/// Windows handle opened without `FILE_SYNCHRONOUS_IO_NONALERT` cannot be read synchronously.
+/// `O_NONBLOCK`: a blocking `open` of a FIFO waits for a writer.
 #[cfg(unix)]
 const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NONBLOCK;
+/// No `O_NONBLOCK`: an overlapped Windows handle cannot be read synchronously.
 #[cfg(not(unix))]
 const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC;
 
-/// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`. The
-/// callers keep their own open-error handling and memo slot.
+/// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`.
 enum ReadEnvFile {
     /// Zero-length or not a regular file. The caller marks the slot and returns.
     Empty,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -886,25 +886,17 @@ impl Loader {
     }
 }
 
-/// `O_NONBLOCK` so the open itself cannot block on a FIFO: a blocking
-/// `open(O_RDONLY)` of a FIFO waits for a writer. It has no effect on regular
-/// files. POSIX-only: on Windows it omits `FILE_SYNCHRONOUS_IO_NONALERT`
-/// (overlapped handle) and the subsequent sync read fails. Windows has no
-/// open-blocking FIFOs in a directory; the `fstat` kind check in
-/// `read_env_file_contents` still skips pipes and devices there.
+/// `O_NONBLOCK`: a blocking `open` of a FIFO waits for a writer. Unix only: a
+/// Windows handle opened without `FILE_SYNCHRONOUS_IO_NONALERT` cannot be read synchronously.
 #[cfg(unix)]
 const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NONBLOCK;
 #[cfg(not(unix))]
 const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC;
 
-/// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`:
-/// `fstat` kind check, then `File::read_to_end` (fstat-presized) with the
-/// recoverable-errno filter. The two callers differ in their open-error
-/// handling and the memo slot they write — those stay in the callers. Only
-/// the shared read tail is factored here.
+/// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`. The
+/// callers keep their own open-error handling and memo slot.
 enum ReadEnvFile {
-    /// Zero-length, or not a regular file (a directory, FIFO, socket, or
-    /// device) — caller marks the slot and returns.
+    /// Zero-length or not a regular file. The caller marks the slot and returns.
     Empty,
     /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
     /// (unless `quiet`), marks the slot, and returns.

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -798,33 +798,33 @@ impl Loader {
 
         // `bun_sys` is errno-based; the match arms below group the recoverable
         // errnos. Any errno not listed propagates.
-        let file =
-            match bun_sys::File::openat(dir, base, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0) {
-                Ok(file) => file,
-                Err(err) => {
-                    use bun_sys::E;
-                    match err.get_errno() {
-                        E::EISDIR | E::ENOENT => {
-                            // prevent retrying
-                            self.default_files_loaded.insert(env_file);
-                            return Ok(());
-                        }
-                        E::EBUSY | E::EACCES => {
-                            if !self.quiet {
-                                bun_core::pretty_errorln!(
-                                    "<r><red>{}<r> error loading {} file",
-                                    bstr::BStr::new(err.name()),
-                                    bstr::BStr::new(base)
-                                );
-                            }
-                            // prevent retrying
-                            self.default_files_loaded.insert(env_file);
-                            return Ok(());
-                        }
-                        _ => return Err(err.into()),
+        let file = match bun_sys::File::openat(dir, base, ENV_FILE_OPEN_FLAGS, 0) {
+            Ok(file) => file,
+            Err(err) => {
+                use bun_sys::E;
+                match err.get_errno() {
+                    // ENXIO: a unix socket.
+                    E::EISDIR | E::ENOENT | E::ENXIO => {
+                        // prevent retrying
+                        self.default_files_loaded.insert(env_file);
+                        return Ok(());
                     }
+                    E::EBUSY | E::EACCES => {
+                        if !self.quiet {
+                            bun_core::pretty_errorln!(
+                                "<r><red>{}<r> error loading {} file",
+                                bstr::BStr::new(err.name()),
+                                bstr::BStr::new(base)
+                            );
+                        }
+                        // prevent retrying
+                        self.default_files_loaded.insert(env_file);
+                        return Ok(());
+                    }
+                    _ => return Err(err.into()),
                 }
-            };
+            }
+        };
 
         match read_env_file_contents(&file)? {
             ReadEnvFile::Empty => {}
@@ -855,14 +855,15 @@ impl Loader {
             return Ok(());
         }
 
-        let file = match bun_sys::open_file(file_path, bun_sys::OpenFlags::READ_ONLY) {
-            Ok(f) => f,
-            Err(_) => {
-                // prevent retrying
-                self.custom_files_loaded.insert(file_path)?;
-                return Ok(());
-            }
-        };
+        let file =
+            match bun_sys::File::openat(bun_sys::Fd::cwd(), file_path, ENV_FILE_OPEN_FLAGS, 0) {
+                Ok(f) => f,
+                Err(_) => {
+                    // prevent retrying
+                    self.custom_files_loaded.insert(file_path)?;
+                    return Ok(());
+                }
+            };
 
         match read_env_file_contents(&file)? {
             ReadEnvFile::Empty => {}
@@ -885,13 +886,25 @@ impl Loader {
     }
 }
 
+/// `O_NONBLOCK` so the open itself cannot block on a FIFO: a blocking
+/// `open(O_RDONLY)` of a FIFO waits for a writer. It has no effect on regular
+/// files. POSIX-only: on Windows it omits `FILE_SYNCHRONOUS_IO_NONALERT`
+/// (overlapped handle) and the subsequent sync read fails. Windows has no
+/// open-blocking FIFOs in a directory; the `fstat` kind check in
+/// `read_env_file_contents` still skips pipes and devices there.
+#[cfg(unix)]
+const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NONBLOCK;
+#[cfg(not(unix))]
+const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC;
+
 /// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`:
-/// `File::read_to_end` (fstat-presized) with the recoverable-errno filter.
-/// The two callers differ in their open path, open-error handling, and the
-/// memo slot they write — those stay in the callers. Only the shared read
-/// tail is factored here.
+/// `fstat` kind check, then `File::read_to_end` (fstat-presized) with the
+/// recoverable-errno filter. The two callers differ in their open-error
+/// handling and the memo slot they write — those stay in the callers. Only
+/// the shared read tail is factored here.
 enum ReadEnvFile {
-    /// Zero-length — caller marks the slot and returns.
+    /// Zero-length, or not a regular file (a directory, FIFO, socket, or
+    /// device) — caller marks the slot and returns.
     Empty,
     /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
     /// (unless `quiet`), marks the slot, and returns.
@@ -901,6 +914,10 @@ enum ReadEnvFile {
 }
 
 fn read_env_file_contents(file: &bun_sys::File) -> crate::Result<ReadEnvFile> {
+    let stat = file.stat()?;
+    if stat.st_size == 0 || !bun_sys::is_regular_file(stat.st_mode as _) {
+        return Ok(ReadEnvFile::Empty);
+    }
     match file.read_to_end() {
         Ok(buf) if buf.is_empty() => Ok(ReadEnvFile::Empty),
         Ok(buf) => Ok(ReadEnvFile::Bytes(buf)),

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -803,8 +803,8 @@ impl Loader {
             Err(err) => {
                 use bun_sys::E;
                 match err.get_errno() {
-                    // ENXIO: a unix socket.
-                    E::EISDIR | E::ENOENT | E::ENXIO => {
+                    // A unix socket: ENXIO on Linux, EOPNOTSUPP on macOS and FreeBSD.
+                    E::EISDIR | E::ENOENT | E::ENXIO | E::EOPNOTSUPP => {
                         // prevent retrying
                         self.default_files_loaded.insert(env_file);
                         return Ok(());

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -13,6 +13,7 @@ import {
   tempDir,
   tempDirWithFiles,
 } from "harness";
+import { mkfifo } from "mkfifo";
 import { parseEnv } from "node:util";
 import path from "path";
 
@@ -737,6 +738,89 @@ describe.concurrent("--env-file", () => {
   test("should ignore a file that doesn't exist", async () => {
     const res = await runEnvFile(["--env-file=.env.nonexisting"]);
     expect(res.stdout).toBe("");
+  });
+});
+
+// A `.env` entry that is a directory, a FIFO, or a unix socket is not an env
+// file. The loader skips it without a message and without blocking, and still
+// loads the sibling `.env.local`.
+describe.concurrent(".env that is not a regular file", () => {
+  const files = {
+    "package.json": JSON.stringify({ name: "dotenv-not-a-file" }),
+    ".env.local": "BUNTEST_LOCAL=1\n",
+    "index.ts": "console.log(process.env.BUNTEST_LOCAL);",
+  };
+
+  async function run(cwd: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: { ...bunEnv, NODE_ENV: undefined },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  test("directory", async () => {
+    using dir = tempDir("dotenv-dir", { ...files, ".env/keep": "" });
+
+    const install = await run(String(dir), "install");
+    expect(install.stderr).not.toContain("error loading .env file");
+    expect(install.exitCode).toBe(0);
+
+    const script = await run(String(dir), "index.ts");
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("1");
+    expect(script.exitCode).toBe(0);
+  });
+
+  // The resolver's directory listing drops a FIFO entry, so the loader only
+  // sees one through a symlink. Without O_NONBLOCK the open blocks until a
+  // writer appears.
+  test.skipIf(isWindows)("FIFO behind a symlink", async () => {
+    using dir = tempDir("dotenv-fifo", files);
+    mkfifo(path.join(String(dir), "fifo"));
+    fs.symlinkSync("fifo", path.join(String(dir), ".env"));
+
+    const install = await run(String(dir), "install");
+    expect(install.stderr).not.toContain("error loading .env file");
+    expect(install.exitCode).toBe(0);
+
+    const script = await run(String(dir), "index.ts");
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("1");
+    expect(script.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("--env-file pointing at a FIFO", async () => {
+    using dir = tempDir("dotenv-fifo-arg", files);
+    mkfifo(path.join(String(dir), "fifo"));
+
+    const script = await run(String(dir), "--env-file=fifo,.env.local", "index.ts");
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("1");
+    expect(script.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("unix socket behind a symlink", async () => {
+    using dir = tempDir("dotenv-sock", files);
+    using listener = Bun.listen({
+      unix: path.join(String(dir), "sock"),
+      socket: { data() {} },
+    });
+    fs.symlinkSync("sock", path.join(String(dir), ".env"));
+
+    const install = await run(String(dir), "install");
+    expect(install.stderr).not.toContain("ENXIO");
+    expect(install.exitCode).toBe(0);
+
+    const script = await run(String(dir), "index.ts");
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("1");
+    expect(script.exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem
- A `.env` (or `.env.local`, `.env.production`, ...) that is a directory makes every `bun install` and `bun pm` print `EISDIR error loading .env file`. The loader opens each candidate and reads it without a check of the file kind. `pread` on a directory fails with EISDIR, which the read path prints (`src/dotenv/env_loader.rs:829`).
- A `.env` that is a FIFO (through a symlink, or as `--env-file=<fifo>`) hangs bun. The hang is in `open(2)`, not in the read: a blocking `open(O_RDONLY)` of a FIFO waits in `fifo_open` for a writer.
- A `.env` that is a unix socket fails with `error: An internal error occurred (ENXIO)`.

### Fix
- `read_env_file_contents` now calls `fstat` first. A zero-length file, or anything that is not a regular file (directory, FIFO, socket, device), returns `Empty`. The caller marks the slot as loaded and moves on, the same as for an empty file. This restores the `stat.size == 0 or stat.kind != .file` check of the Zig loader, which the Rust port dropped.
- Both open paths use `O_NONBLOCK` on unix, so the open of a FIFO returns at once. `O_NONBLOCK` has no effect on regular files. Windows keeps the synchronous handle (same pattern as `Image.rs`).
- The socket open errno joins `EISDIR` and `ENOENT` in the silent skip arm of `load_env_file`: `ENXIO` on Linux, `EOPNOTSUPP` on macOS and FreeBSD.
- Verified: `test/cli/run/env.test.ts` (new block `.env that is not a regular file`, 4 tests, all 4 fail on the current build). Also the full `env.test.ts`, `no-envfile.test.ts` and `run-process-env.test.ts`, on Linux and Windows. The `EOPNOTSUPP` arm comes from the Darwin and FreeBSD `open(2)` sources and is not verified on a Mac here. CI runs the socket test on the macOS lanes.

### Background
- `Loader::load` probes the cwd listing for the default names, then `load_env_file` opens and reads each hit. `load_env_file_dynamic` does the same for `--env-file`.
- `quiet` is set for `bun run` and `bun <file>`, so only `bun install` and `bun pm` printed the message.
- The resolver drops FIFO and socket entries from its directory listing, so a plain FIFO named `.env` is never opened. A symlink to one is kept (its kind is resolved later) and blocked the open.

<details><summary>Notes</summary>

Repro before the fix:

```
mkdir -p proj/.env && cd proj && echo '{"name":"x"}' > package.json
bun install        # EISDIR error loading .env file
mkfifo f && ln -s f .env && bun install   # hangs, wchan = wait_for_partner
```

Behavior change for an explicit `--env-file` that is a pipe (`--env-file=<(cmd)`): before, `pread` failed with ESPIPE and bun exited 1 with no message. Now the pipe is skipped like any other non-regular file. Node reads the pipe. Reading pipes for explicit env files would be a separate change. #36523 reworks the error semantics of explicit `--env-file` entries and touches the same function.

A skipped entry still shows up in the `[0.05ms] ".env"` line that `bun install` prints, because the loaded set doubles as the do-not-retry memo. The Zig loader did the same.

Windows: `NtCreateFile` opens a directory handle without `FILE_NON_DIRECTORY_FILE`, and the read path reported EISDIR there too. `fstat_handle` maps `FILE_ATTRIBUTE_DIRECTORY` to `S_IFDIR`, so the new check skips it. Verified on windows-x64 with a debug build: the `directory` test passes, the FIFO and socket tests are skipped.

Suites run: `bun bd test test/cli/run/env.test.ts` (102 pass), `test/cli/run/no-envfile.test.ts`, `test/cli/run/run-process-env.test.ts`. `cargo check -p bun_dotenv` for x86_64-unknown-linux-gnu, x86_64-pc-windows-msvc and aarch64-apple-darwin. `cargo clippy -p bun_dotenv` clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->