### PR TITLE
sys: attach the fd to errors from fd-based POSIX syscall wrappers

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -34,7 +34,6 @@ use bun_threading::work_pool::{IntrusiveWorkTask as _, Task as WorkPoolTask, Wor
 pub trait MaybeSysResultExt<R>: Sized {
     fn get_errno(&self) -> E;
     fn init_err_with_p(e: SystemErrno, syscall: sys::Tag, path: impl AsRef<[u8]>) -> Self;
-    fn errno_sys<Rc: sys::GetErrno>(rc: Rc, syscall: sys::Tag) -> Option<Self>;
     fn errno_sys_fd<Rc: sys::GetErrno>(rc: Rc, syscall: sys::Tag, fd: FD) -> Option<Self>;
     fn errno_sys_p<Rc: sys::GetErrno>(
         rc: Rc,
@@ -64,17 +63,6 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
             path: path.as_ref().into(),
             ..Default::default()
         })
-    }
-    #[inline]
-    fn errno_sys<Rc: sys::GetErrno>(rc: Rc, syscall: sys::Tag) -> Option<Self> {
-        match sys::get_errno(rc) {
-            E::SUCCESS => None,
-            e => Some(Err(sys::Error {
-                errno: (e as u16),
-                syscall,
-                ..Default::default()
-            })),
-        }
     }
     #[inline]
     fn errno_sys_fd<Rc: sys::GetErrno>(rc: Rc, syscall: sys::Tag, fd: FD) -> Option<Self> {
@@ -5262,7 +5250,7 @@ impl NodeFS {
             unsafe extern "C" {
                 safe fn fsync(fd: libc::c_int) -> libc::c_int;
             }
-            Maybe::<ret::Fsync>::errno_sys(fsync(args.fd.native()), sys::Tag::fsync)
+            Maybe::<ret::Fsync>::errno_sys_fd(fsync(args.fd.native()), sys::Tag::fsync, args.fd)
                 .unwrap_or(Ok(()))
         }
     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1822,8 +1822,8 @@ mod posix_impl {
     // EINTR-retry: most wrappers loop on EINTR. NOT all — the macOS
     // `$NOCANCEL` arms for open/openat/read/write/recv/send issue exactly one
     // call and surface EINTR to the caller without looping. `check!` keeps the
-    // retry for the common path; `check_once!` is the single-shot variant for
-    // the Darwin arms.
+    // retry for the common path; the `check_once_*!` macros are the
+    // single-shot variants for the Darwin arms.
     macro_rules! check {
         ($rc:expr, $tag:expr) => {{
             loop {
@@ -1854,6 +1854,22 @@ mod posix_impl {
             }
         }};
     }
+    // Attaches `.fd`.
+    macro_rules! check_fd {
+        ($rc:expr, $tag:expr, $fd:expr) => {{
+            loop {
+                let rc = $rc;
+                if rc < 0 {
+                    let e = last_errno();
+                    if e == libc::EINTR {
+                        continue;
+                    }
+                    return Err(Error::from_code_int(e, $tag).with_fd($fd));
+                }
+                break rc;
+            }
+        }};
+    }
     // Attaches BOTH `.fd` and `.path`.
     macro_rules! check_fp {
         ($rc:expr, $tag:expr, $fd:expr, $path:expr) => {{
@@ -1874,21 +1890,21 @@ mod posix_impl {
     }
     // Single-shot: no EINTR retry (Darwin `$NOCANCEL` arms).
     #[cfg(target_os = "macos")]
-    macro_rules! check_once {
-        ($rc:expr, $tag:expr) => {{
-            let rc = $rc;
-            if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), $tag));
-            }
-            rc
-        }};
-    }
-    #[cfg(target_os = "macos")]
     macro_rules! check_once_p {
         ($rc:expr, $tag:expr, $path:expr) => {{
             let rc = $rc;
             if rc < 0 {
                 return Err(Error::from_code_int(last_errno(), $tag).with_path($path.as_bytes()));
+            }
+            rc
+        }};
+    }
+    #[cfg(target_os = "macos")]
+    macro_rules! check_once_fd {
+        ($rc:expr, $tag:expr, $fd:expr) => {{
+            let rc = $rc;
+            if rc < 0 {
+                return Err(Error::from_code_int(last_errno(), $tag).with_fd($fd));
             }
             rc
         }};
@@ -2006,23 +2022,25 @@ mod posix_impl {
         // macOS: single `read$NOCANCEL`, no EINTR retry.
         #[cfg(target_os = "macos")]
         {
-            let n = check_once!(
+            let n = check_once_fd!(
                 // SAFETY: `fd` is a live descriptor; `buf` is valid for `len` writes.
                 unsafe { sys_read(fd.native(), buf.as_mut_ptr().cast(), len) },
-                Tag::read
+                Tag::read,
+                fd
             );
             Ok(n as usize)
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             super::linux_syscall::read(fd, &mut buf[..len])
-                .map_err(|e| Error::from_code_int(e, Tag::read))
+                .map_err(|e| Error::from_code_int(e, Tag::read).with_fd(fd))
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         {
-            let n = check!(
+            let n = check_fd!(
                 unsafe { sys_read(fd.native(), buf.as_mut_ptr().cast(), len) },
-                Tag::read
+                Tag::read,
+                fd
             );
             Ok(n as usize)
         }
@@ -2032,23 +2050,25 @@ mod posix_impl {
         // macOS: single `write$NOCANCEL`, no EINTR retry.
         #[cfg(target_os = "macos")]
         {
-            let n = check_once!(
+            let n = check_once_fd!(
                 // SAFETY: `fd` is a live descriptor; `buf` is valid for `len` reads.
                 unsafe { sys_write(fd.native(), buf.as_ptr().cast(), len) },
-                Tag::write
+                Tag::write,
+                fd
             );
             Ok(n as usize)
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             super::linux_syscall::write(fd, &buf[..len])
-                .map_err(|e| Error::from_code_int(e, Tag::write))
+                .map_err(|e| Error::from_code_int(e, Tag::write).with_fd(fd))
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         {
-            let n = check!(
+            let n = check_fd!(
                 unsafe { sys_write(fd.native(), buf.as_ptr().cast(), len) },
-                Tag::write
+                Tag::write,
+                fd
             );
             Ok(n as usize)
         }
@@ -2058,14 +2078,15 @@ mod posix_impl {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::pread(fd, &mut buf[..len], off)
-                .map_err(|e| Error::from_code_int(e, Tag::pread));
+                .map_err(|e| Error::from_code_int(e, Tag::pread).with_fd(fd));
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
-            let n = check!(
+            let n = check_fd!(
                 // SAFETY: `fd` is a live descriptor; `buf` is valid for `len` writes.
                 unsafe { sys_pread(fd.native(), buf.as_mut_ptr().cast(), len, off) },
-                Tag::pread
+                Tag::pread,
+                fd
             );
             Ok(n as usize)
         }
@@ -2075,14 +2096,15 @@ mod posix_impl {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::pwrite(fd, &buf[..len], off)
-                .map_err(|e| Error::from_code_int(e, Tag::pwrite));
+                .map_err(|e| Error::from_code_int(e, Tag::pwrite).with_fd(fd));
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
-            let n = check!(
+            let n = check_fd!(
                 // SAFETY: `fd` is a live descriptor; `buf` is valid for `len` reads.
                 unsafe { sys_pwrite(fd.native(), buf.as_ptr().cast(), len, off) },
-                Tag::pwrite
+                Tag::pwrite,
+                fd
             );
             Ok(n as usize)
         }
@@ -2110,15 +2132,16 @@ mod posix_impl {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::fstat(fd)
-                .map_err(|e| Error::from_code_int(e, Tag::fstat));
+                .map_err(|e| Error::from_code_int(e, Tag::fstat).with_fd(fd));
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let mut st = core::mem::MaybeUninit::<Stat>::uninit();
-            check!(
+            check_fd!(
                 // SAFETY: `fd` is a live descriptor; `st` is a valid out-param.
                 unsafe { libc::fstat(fd.native(), st.as_mut_ptr()) },
-                Tag::fstat
+                Tag::fstat,
+                fd
             );
             // SAFETY: rc == 0 ⇒ kernel populated `st`.
             Ok(unsafe { st.assume_init() })
@@ -2344,11 +2367,10 @@ mod posix_impl {
                     SUPPORTS_STATX_ON_LINUX.store(false, Ordering::Relaxed);
                     return statx_fallback(fd, path, flags);
                 }
-                return Err(Error {
-                    errno: raw_errno as _,
-                    syscall,
-                    ..Default::default()
-                });
+                let err = Error::from_code_int(raw_errno, syscall);
+                // `fstatx` names the file by `fd`; `statx`/`lstatx` pass
+                // `AT_FDCWD` plus a path, and the caller attaches the path.
+                return Err(if path.is_none() { err.with_fd(fd) } else { err });
             }
 
             // SAFETY: rc == 0 ⇒ kernel populated the buffer.
@@ -2628,18 +2650,19 @@ mod posix_impl {
         }
     }
     pub fn fchmod(fd: Fd, mode: Mode) -> Maybe<()> {
-        check!(
+        check_fd!(
             safe_libc::fchmod(fd.native(), mode as libc::mode_t),
-            Tag::fchmod
+            Tag::fchmod,
+            fd
         );
         Ok(())
     }
     pub fn fchown(fd: Fd, uid: u32, gid: u32) -> Maybe<()> {
-        check!(safe_libc::fchown(fd.native(), uid, gid), Tag::fchown);
+        check_fd!(safe_libc::fchown(fd.native(), uid, gid), Tag::fchown, fd);
         Ok(())
     }
     pub fn ftruncate(fd: Fd, len: i64) -> Maybe<()> {
-        check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
+        check_fd!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate, fd);
         Ok(())
     }
     pub fn getcwd(buf: &mut [u8]) -> Maybe<usize> {
@@ -2901,11 +2924,12 @@ mod posix_impl {
     }
     pub fn futimens(fd: Fd, atime: TimeLike, mtime: TimeLike) -> Maybe<()> {
         let ts = [atime.to_timespec(), mtime.to_timespec()];
-        check!(
+        check_fd!(
             // SAFETY: `fd` is a live descriptor; `ts` is a 2-element stack
             // array and `futimens` reads exactly two `timespec`s.
             unsafe { libc::futimens(fd.native(), ts.as_ptr()) },
-            Tag::futimens
+            Tag::futimens,
+            fd
         );
         Ok(())
     }
@@ -3020,11 +3044,15 @@ mod posix_impl {
         safe_libc::isatty(fd.native()) == 1
     }
     pub fn fsync(fd: Fd) -> Maybe<()> {
-        check!(safe_libc::fsync(fd.native()), Tag::fsync);
+        check_fd!(safe_libc::fsync(fd.native()), Tag::fsync, fd);
         Ok(())
     }
     pub fn lseek(fd: Fd, offset: i64, whence: i32) -> Maybe<i64> {
-        let rc = check!(safe_libc::lseek(fd.native(), offset, whence), Tag::lseek);
+        let rc = check_fd!(
+            safe_libc::lseek(fd.native(), offset, whence),
+            Tag::lseek,
+            fd
+        );
         Ok(rc)
     }
     pub fn chdir(path: &ZStr) -> Maybe<()> {
@@ -3049,17 +3077,19 @@ mod posix_impl {
         let len = buf.len().min(MAX_COUNT);
         // macOS: single `recvfrom$NOCANCEL`, no EINTR retry.
         #[cfg(target_os = "macos")]
-        let n = check_once!(
+        let n = check_once_fd!(
             // SAFETY: `fd` is a live socket; `buf` is valid for `len` writes.
             unsafe { sys_recv(fd.native(), buf.as_mut_ptr().cast(), len, flags) },
-            Tag::recv
+            Tag::recv,
+            fd
         );
         #[cfg(not(target_os = "macos"))]
-        let n = check!(
+        let n = check_fd!(
             // SAFETY: `fd` is a live socket; `buf[..len]` is a valid exclusive
             // slice and `len <= buf.len()` (clamped above).
             unsafe { sys_recv(fd.native(), buf.as_mut_ptr().cast(), len, flags) },
-            Tag::recv
+            Tag::recv,
+            fd
         );
         Ok(n as usize)
     }
@@ -3068,17 +3098,19 @@ mod posix_impl {
         // forward the full length and let the kernel decide.
         // macOS: single `sendto$NOCANCEL`, no EINTR retry.
         #[cfg(target_os = "macos")]
-        let n = check_once!(
+        let n = check_once_fd!(
             // SAFETY: `fd` is a live socket; `buf` is valid for `buf.len()` reads.
             unsafe { sys_send(fd.native(), buf.as_ptr().cast(), buf.len(), flags) },
-            Tag::send
+            Tag::send,
+            fd
         );
         #[cfg(not(target_os = "macos"))]
-        let n = check!(
+        let n = check_fd!(
             // SAFETY: `fd` is a live socket; `buf` is a valid shared slice of
             // `buf.len()` readable bytes.
             unsafe { sys_send(fd.native(), buf.as_ptr().cast(), buf.len(), flags) },
-            Tag::send
+            Tag::send,
+            fd
         );
         Ok(n as usize)
     }
@@ -4492,7 +4524,7 @@ pub fn pwritev(fd: Fd, vecs: &[PlatformIoVecConst], offset: i64) -> Maybe<usize>
                 )
             };
             if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), Tag::pwritev));
+                return Err(Error::from_code_int(last_errno(), Tag::pwritev).with_fd(fd));
             }
             return Ok(rc as usize);
         }
@@ -4502,7 +4534,7 @@ pub fn pwritev(fd: Fd, vecs: &[PlatformIoVecConst], offset: i64) -> Maybe<usize>
             return unsafe {
                 linux_syscall::pwritev(fd, vecs.as_ptr().cast::<libc::iovec>(), vecs.len(), offset)
             }
-            .map_err(|e| Error::from_code_int(e, Tag::pwritev));
+            .map_err(|e| Error::from_code_int(e, Tag::pwritev).with_fd(fd));
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         loop {
@@ -4519,7 +4551,7 @@ pub fn pwritev(fd: Fd, vecs: &[PlatformIoVecConst], offset: i64) -> Maybe<usize>
                 if e == libc::EINTR {
                     continue;
                 }
-                return Err(Error::from_code_int(e, Tag::pwritev));
+                return Err(Error::from_code_int(e, Tag::pwritev).with_fd(fd));
             }
             return Ok(rc as usize);
         }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1819,11 +1819,8 @@ mod posix_impl {
             unsafe { libc::send(fd, buf, n, flags) }
         }
     }
-    // EINTR-retry: most wrappers loop on EINTR. NOT all — the macOS
-    // `$NOCANCEL` arms for open/openat/read/write/recv/send issue exactly one
-    // call and surface EINTR to the caller without looping. `check!` keeps the
-    // retry for the common path; the `check_once_*!` macros are the
-    // single-shot variants for the Darwin arms.
+    // `check*!` retries on EINTR. The macOS `$NOCANCEL` arms use the
+    // single-shot `check_once_*!` variants and surface EINTR to the caller.
     macro_rules! check {
         ($rc:expr, $tag:expr) => {{
             loop {
@@ -2367,10 +2364,7 @@ mod posix_impl {
                     SUPPORTS_STATX_ON_LINUX.store(false, Ordering::Relaxed);
                     return statx_fallback(fd, path, flags);
                 }
-                let err = Error::from_code_int(raw_errno, syscall);
-                // `fstatx` names the file by `fd`; `statx`/`lstatx` pass
-                // `AT_FDCWD` plus a path, and the caller attaches the path.
-                return Err(if path.is_none() { err.with_fd(fd) } else { err });
+                return Err(Error::from_code_int(raw_errno, syscall));
             }
 
             // SAFETY: rc == 0 ⇒ kernel populated the buffer.
@@ -2412,7 +2406,7 @@ mod posix_impl {
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn fstatx(fd: Fd, mask: u32) -> Maybe<PosixStat> {
-        statx_impl(fd, None, libc::AT_EMPTY_PATH, mask, Tag::fstat)
+        statx_impl(fd, None, libc::AT_EMPTY_PATH, mask, Tag::fstat).map_err(|e| e.with_fd(fd))
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn statx(path: &ZStr, mask: u32) -> Maybe<PosixStat> {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1819,8 +1819,6 @@ mod posix_impl {
             unsafe { libc::send(fd, buf, n, flags) }
         }
     }
-    // `check*!` retries on EINTR. The macOS `$NOCANCEL` arms use the
-    // single-shot `check_once_*!` variants and surface EINTR to the caller.
     macro_rules! check {
         ($rc:expr, $tag:expr) => {{
             loop {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5880,8 +5880,9 @@ describe("fd-based fs errors carry err.fd", () => {
   const cases: { name: string; syscall: string; op: () => unknown; skip?: boolean }[] = [
     { name: "readSync", syscall: "read", op: () => fs.readSync(BAD_FD, buf) },
     { name: "writeSync", syscall: "write", op: () => fs.writeSync(BAD_FD, buf) },
-    { name: "readvSync", syscall: "readv", op: () => fs.readvSync(BAD_FD, [buf]) },
-    { name: "writevSync", syscall: "writev", op: () => fs.writevSync(BAD_FD, [buf]) },
+    // libuv has no readv/writev, so Windows reports the underlying read/write.
+    { name: "readvSync", syscall: isWindows ? "read" : "readv", op: () => fs.readvSync(BAD_FD, [buf]) },
+    { name: "writevSync", syscall: isWindows ? "write" : "writev", op: () => fs.writevSync(BAD_FD, [buf]) },
     { name: "fstatSync", syscall: "fstat", op: () => fs.fstatSync(BAD_FD) },
     { name: "ftruncateSync", syscall: "ftruncate", op: () => fs.ftruncateSync(BAD_FD, 0) },
     { name: "fchmodSync", syscall: "fchmod", op: () => fs.fchmodSync(BAD_FD, 0o644) },

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5874,6 +5874,54 @@ it("promises.fdatasync with a bad fd should include that in the error thrown", a
   expect.unreachable();
 });
 
+describe("fd-based fs errors carry err.fd", () => {
+  const BAD_FD = 50001;
+  const buf = Buffer.alloc(1);
+  const cases: { name: string; syscall: string; op: () => unknown; skip?: boolean }[] = [
+    { name: "readSync", syscall: "read", op: () => fs.readSync(BAD_FD, buf) },
+    { name: "writeSync", syscall: "write", op: () => fs.writeSync(BAD_FD, buf) },
+    { name: "readvSync", syscall: "readv", op: () => fs.readvSync(BAD_FD, [buf]) },
+    { name: "writevSync", syscall: "writev", op: () => fs.writevSync(BAD_FD, [buf]) },
+    { name: "fstatSync", syscall: "fstat", op: () => fs.fstatSync(BAD_FD) },
+    { name: "ftruncateSync", syscall: "ftruncate", op: () => fs.ftruncateSync(BAD_FD, 0) },
+    { name: "fchmodSync", syscall: "fchmod", op: () => fs.fchmodSync(BAD_FD, 0o644) },
+    // libuv implements fchown as a no-op on Windows, so it never fails there.
+    { name: "fchownSync", syscall: "fchown", op: () => fs.fchownSync(BAD_FD, 0, 0), skip: isWindows },
+    { name: "futimesSync", syscall: "futime", op: () => fs.futimesSync(BAD_FD, 0, 0) },
+    { name: "fsyncSync", syscall: "fsync", op: () => fs.fsyncSync(BAD_FD) },
+    { name: "fdatasyncSync", syscall: "fdatasync", op: () => fs.fdatasyncSync(BAD_FD) },
+    { name: "closeSync", syscall: "close", op: () => fs.closeSync(BAD_FD) },
+  ];
+
+  for (const { name, syscall, op, skip } of cases) {
+    it.skipIf(!!skip)(`${name} on a bad fd`, () => {
+      expect(op).toThrow(
+        expect.objectContaining({
+          code: "EBADF",
+          syscall,
+          fd: BAD_FD,
+        }),
+      );
+    });
+  }
+
+  it("writeSync on a read-only fd", () => {
+    using dir = tempDir("fs-err-fd", { "file.txt": "read only" });
+    const fd = fs.openSync(join(String(dir), "file.txt"), "r");
+    try {
+      expect(() => fs.writeSync(fd, "x")).toThrow(
+        expect.objectContaining({
+          code: "EBADF",
+          syscall: "write",
+          fd,
+        }),
+      );
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+});
+
 it("promises.cp should work even if dest does not exist", async () => {
   const x_dir = tmpdirSync();
   const text_expected = "A".repeat(131073);


### PR DESCRIPTION
### Problem
- Errors from fd-based `node:fs` calls (`readSync`, `writeSync`, `fstatSync`, `ftruncateSync`, `fchmodSync`, `fchownSync`, `futimesSync`, `fsyncSync`, and their async forms) have `fd: undefined`. Bun 1.3.0 set `err.fd` on all of them. `readvSync`, `writevSync`, `fdatasyncSync` and `closeSync` still do.
- The POSIX wrappers in `src/sys/lib.rs` build the error with only the errno and the syscall tag: `Error::from_code_int(e, Tag::read)` at `src/sys/lib.rs:2019`, and the same shape for `write`, `pread`, `pwrite`, `fstat`, `fstatx`, `fchmod`, `fchown`, `ftruncate`, `futimens`, `fsync`, `lseek`, `recv`, `send` and `pwritev`. Nothing calls `.with_fd(fd)`. The Windows wrappers in `src/sys/sys_uv.rs` do call it.

### Fix
- Add `check_fd!` and `check_once_fd!` next to the existing `check_p!` and `check_once_p!` macros in `posix_impl`. They attach the fd the same way the path variants attach the path.
- Use them in every wrapper above. The Linux `map_err` arms and the top-level `pwritev` get `.with_fd(fd)` directly, like `readv` and `writev` already do.
- `statx_impl` attaches the fd only for `fstatx`. `statx` and `lstatx` pass `AT_FDCWD` plus a path, and `node_fs.rs` attaches the path for those.
- `node_fs.rs` `fsync` now uses `errno_sys_fd`, like `fdatasync` and the Windows path. The unused `errno_sys` helper is removed.
- Verified: `test/js/node/fs/fs.test.ts` (13 new cases, 9 fail on bun 1.4.1). Also `test/js/node/fs/promises.test.js`, `fs-stat-seccomp-linux.test.ts`, `fs-write-offset-bound.test.ts`, `test/js/bun/io/bun-write.test.js`, `test/js/bun/util/bun-file.test.ts`, `error-name-preservation.test.ts`.

### Background
- `bun_sys::Error` (`src/sys/Error.rs`) is the syscall error. It carries `errno`, `syscall`, `path`, `dest` and `fd`. `to_system_error` copies each field that is set onto the JS `SystemError`, so `err.fd` in JS exists only when the wrapper sets `fd`.
- `with_fd` and `with_path` are the two builders for that context. The path-based wrappers use `check_p!`, which calls `with_path`. Before this change there was no fd equivalent, so the fd wrappers used plain `check!`.
- The macOS arms call the `$NOCANCEL` syscalls once and do not retry on `EINTR`. `check_once_fd!` is the single-shot form for those arms. The old `check_once!` had no other users and is removed.

<details><summary>Notes</summary>

Repro on bun 1.4.1:

```js
const fs = require("fs");
const fd = fs.openSync("/etc/hostname", "r");
try { fs.writeSync(fd, "x"); } catch (e) { console.log(e.code, "fd" in e, e.fd); }
// EBADF false undefined
```

bun 1.3.0 prints `EBADF true <fd>`. Node does not set `err.fd` on these errors at all, so this restores Bun's own behavior rather than matching Node.

`node_fs.rs` `pread_inner` and `pwrite_inner` rebuild the error with `fd` themselves, which is why `readSync` and `writeSync` with a `position` kept `err.fd`. They are unchanged.

`with_fd` has a `debug_assert!(fd != Fd::INVALID)`. Every wrapper changed here receives a validated fd: `node:fs` rejects negative fds with `ERR_OUT_OF_RANGE` before the syscall, and the internal callers (`Blob`, `FileSink`, `copy_file`, the resolver) check for `Fd::INVALID` before they read or write. The Windows wrappers have used `with_fd` on these same paths all along. #31165 proposes to drop that assertion and is independent of this change.

The `fchownSync` case is skipped on Windows because libuv implements `uv_fs_fchown` as a no-op there.

`cargo check -p bun_sys` passes for `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin` and `x86_64-unknown-freebsd`.

`test/js/bun/io/bun-write.test.js` "on large files" timed out at 5 s once under the debug ASAN build (a 256 MB copy with `copy_file_range` disabled). It exercises a success path only and is unrelated to this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->