### PR TITLE
output: keep a bare `>` in pretty templates instead of dropping it

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1965,9 +1965,6 @@ pub fn pretty_fmt_runtime(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                     }
                 }
             }
-            b'>' => {
-                i += 1;
-            }
             b'{' => {
                 while i < fmt.len() && fmt[i] != b'}' {
                     out.push(fmt[i]);
@@ -1985,6 +1982,10 @@ pub fn pretty_fmt_runtime(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                     i += 1;
                 }
                 let color_name = &fmt[start..i];
+                // Skip the tag's closing `>`. Any other `>` is text.
+                if i < fmt.len() {
+                    i += 1;
+                }
                 let color_str: &str = 'picker: {
                     if let Some(lit) = color_map::get(color_name) {
                         break 'picker lit;
@@ -2957,6 +2958,23 @@ mod pretty_fmt_tests {
     }
 
     #[test]
+    fn bare_closing_bracket_is_literal() {
+        // Only the `>` that closes a tag is markup.
+        assert_eq!(pretty_fmt!("-> {}", true), "-> {}");
+        assert_eq!(pretty_fmt!("-> {}", false), "-> {}");
+        assert_eq!(pretty_fmt!("<cyan>><r>", true), "\x1b[36m>\x1b[0m");
+        assert_eq!(pretty_fmt!("<cyan>><r>", false), ">");
+        assert_eq!(
+            pretty_fmt!("<cyan>echo x >> /etc/sysctl.conf<r>", false),
+            "echo x >> /etc/sysctl.conf"
+        );
+        assert_eq!(
+            pretty_fmt_runtime(b"<cyan>><r> a -> b", false),
+            b"> a -> b".as_slice()
+        );
+    }
+
+    #[test]
     fn format_specs_with_angle_brackets_pass_through() {
         // `{:<16}` / `{:>.2}` contain `<`/`>` *inside* a format spec — the
         // brace scanner must shield them from the tag parser.
@@ -3038,6 +3056,9 @@ mod pretty_fmt_tests {
         check!("<b>Usage<r>: <b><green>bun init<r> <cyan>[flags]<r> <blue>[\\<folder\\>]<r>\n");
         check!("<r><d>[<b>{d:>.2}ms<r><d>]<r>");
         check!("<r><red>error<r><d>:<r> ");
+        check!("<r><cyan>><r>   ");
+        check!("-> {}");
+        check!("  <cyan>sudo echo x >> /etc/sysctl.conf<r>\n");
         check!(
             "  <b><blue>link<r>      <d>[\\<package\\>]<r>          Register or link a local npm package\n"
         );

--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -109,10 +109,6 @@ fn rewrite(fmt: &str, is_enabled: bool) -> Result<String, String> {
                     }
                 }
             }
-            b'>' => {
-                // stray closer — dropped
-                i += 1;
-            }
             b'{' => {
                 // copy `{ ... }` verbatim, optionally rewriting legacy specs
                 let start = i;
@@ -139,6 +135,10 @@ fn rewrite(fmt: &str, is_enabled: bool) -> Result<String, String> {
                     i += 1;
                 }
                 let name = &fmt[start..i];
+                // Skip the tag's closing `>`. Any other `>` is text.
+                if i < bytes.len() {
+                    i += 1;
+                }
                 let seq: &str = if let Some(c) = color_for(name) {
                     c
                 } else if name == "r" {
@@ -152,7 +152,6 @@ fn rewrite(fmt: &str, is_enabled: bool) -> Result<String, String> {
                 if is_enabled {
                     out.push_str(if is_reset { RESET } else { seq });
                 }
-                // trailing `>` consumed by the `'>'` arm next iteration
             }
             _ => {
                 // Preserve full UTF-8: push the char at this byte position.

--- a/src/clap_macros/lib.rs
+++ b/src/clap_macros/lib.rs
@@ -294,9 +294,6 @@ fn pretty_rewrite(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                     }
                 }
             }
-            b'>' => {
-                i += 1;
-            }
             b'{' => {
                 while i < fmt.len() && fmt[i] != b'}' {
                     out.push(fmt[i]);
@@ -314,6 +311,10 @@ fn pretty_rewrite(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                     i += 1;
                 }
                 let name = &fmt[start..i];
+                // Skip the tag's closing `>`. Any other `>` is text.
+                if i < fmt.len() {
+                    i += 1;
+                }
                 let seq: &str = if let Some(c) = color_for_bytes(name) {
                     c
                 } else if name == b"r" {

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -133,13 +133,10 @@ impl InitCommand {
                 if i == selected.to_index() {
                     if colors {
                         bun_core::pretty!("<r><cyan>❯<r>   ");
-                    } else {
-                        bun_core::pretty!("<r><cyan>><r>   ");
-                    }
-                    if colors {
                         Output::print(format_args!("\x1B[4m{}\x1B[24m\x1B[0K\n", option));
                     } else {
-                        Output::print(format_args!("    {}\x1B[0K\n", option));
+                        bun_core::pretty!("<r><cyan>><r>   ");
+                        Output::print(format_args!("{}\x1B[0K\n", option));
                     }
                 } else {
                     Output::print(format_args!("    {}\x1B[0K\n", option));

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isMusl, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isMusl, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -175,6 +175,28 @@ describe("bun", () => {
       );
     });
   });
+
+  // `bun discord` runs the platform opener (`xdg-open` on Linux) and prints the
+  // URL when that fails. Linux only: an empty PATH makes `xdg-open` fail to
+  // resolve, while macOS spawns `/usr/bin/open` by absolute path and would
+  // open a browser.
+  describe.skipIf(!isLinux)("discord", () => {
+    test("prints the URL when the opener is not on PATH", async () => {
+      using emptyPath = tempDir("bun-discord-empty-path", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "discord"],
+        env: { ...bunEnv, PATH: String(emptyPath) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toBe("-> https://bun.com/discord\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("getcompletes", () => {
     test("getcompletes should not panic and should not be empty", () => {
       const { stdout, exitCode } = spawnSync({

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -228,8 +228,9 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     // Ctrl-C cancels the menu without creating a project.
     terminal.write("\x03");
     await waitFor(all => all.includes("Cancelled"));
-    expect(await proc.exited).toBe(0);
+    const exitCode = await proc.exited;
     expect(fs.existsSync(path.join(temp, "package.json"))).toBe(false);
+    expect(exitCode).toBe(0);
   });
 
   test("bun init in folder", async () => {

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -137,6 +137,101 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, "package.json"))).toBe(false);
   });
 
+  // Windows is skipped: ConPTY rewrites the child's output into its own escape
+  // sequences, so the raw rows cannot be compared.
+  test.skipIf(isWindows)("bun init template menu marks the selected row when colors are off", async () => {
+    await using temp = tempDir("bun-init-menu-no-color", {});
+
+    const received: string[] = [];
+    let eof = false;
+    let wake: (() => void) | null = null;
+    const decoder = new TextDecoder();
+    // bunEnv sets NO_COLOR=1, so the menu takes its no-color branch: an ASCII
+    // `>` in place of the colored `❯` and no underline on the selected row.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "init"],
+      cwd: temp,
+      env: initEnv,
+      // An inline terminal is owned by the subprocess: when the child exits, the
+      // remaining output is drained and then `exit` fires. So `eof` means that
+      // no more output can arrive.
+      terminal: {
+        cols: 80,
+        rows: 24,
+        data(_term, chunk) {
+          received.push(decoder.decode(chunk, { stream: true }));
+          wake?.();
+        },
+        exit() {
+          eof = true;
+          wake?.();
+        },
+      },
+    });
+    await using terminal = proc.terminal!;
+
+    // Resolves with everything received so far, once `ready` accepts it.
+    // Fails at once, with that output, if the process exits first.
+    const waitFor = async (ready: (all: string) => boolean): Promise<string> => {
+      const deadline = Date.now() + 10_000;
+      while (true) {
+        const all = received.join("");
+        if (ready(all)) return all;
+        if (eof) {
+          throw new Error(`bun init exited before the expected output. Received:\n${JSON.stringify(all)}`);
+        }
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          throw new Error(`Timed out waiting for the menu. Received so far:\n${JSON.stringify(all)}`);
+        }
+        await new Promise<void>(resolve => {
+          const timer = setTimeout(resolve, remaining);
+          wake = () => {
+            clearTimeout(timer);
+            resolve();
+          };
+        });
+        wake = null;
+      }
+    };
+    // Every draw of the menu ends with "clear to end of screen", then the
+    // process blocks on stdin. So once the `count`-th one has arrived, the
+    // output is complete and stable.
+    const drawn = (count: number) => (all: string) => all.split("\x1b[0J").length > count;
+    // The menu is redrawn in place on every keypress (cursor up, then the three
+    // rows again). The last three non-empty lines are the current state.
+    const currentMenu = (all: string) =>
+      all
+        .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "")
+        .split("\r\n")
+        .filter(Boolean)
+        .slice(-3);
+
+    expect(currentMenu(await waitFor(drawn(1)))).toMatchInlineSnapshot(`
+      [
+        ">   Blank",
+        "    React",
+        "    Library",
+      ]
+    `);
+
+    // Down arrow: the marker follows the selection.
+    terminal.write("\x1b[B");
+    expect(currentMenu(await waitFor(drawn(2)))).toMatchInlineSnapshot(`
+      [
+        "    Blank",
+        ">   React",
+        "    Library",
+      ]
+    `);
+
+    // Ctrl-C cancels the menu without creating a project.
+    terminal.write("\x03");
+    await waitFor(all => all.includes("Cancelled"));
+    expect(await proc.exited).toBe(0);
+    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(false);
+  });
+
   test("bun init in folder", async () => {
     await using temp = tempDir("bun-init-in-folder", {
       "mydir": {


### PR DESCRIPTION
### Problem
- With colors off (`NO_COLOR=1`, or stdout is not a color terminal), the `bun init` template menu draws the selected row with no marker: `"       Blank"` (7 spaces, no `>`).
- Cause: the pretty-format rewriter drops every `>` outside a `{}` spec, as if it closed a tag. Only `\>` survives. The marker template `pretty!("<r><cyan>><r>   ")` (`src/runtime/cli/init_command.rs:137`) loses its `>`.
- 17 other templates lose a `>` the same way, for example the `-> url` fallback of `bun discord` and the `>> /etc/sysctl.conf` redirect in the crash handler's fd-limit hint.

### Fix
- In all three rewriter copies (proc-macro, runtime, clap help), the `<` arm consumes the `>` that closes its own tag, and the separate `>` arm is removed. Any other `>` falls through as text. `\>` still works.
- Correct because a `>` only has meaning in this markup as the closer of `<name>`. Every bare `>` in the tree wants a literal character. No test pinned the broken output.
- The no-color `bun init` menu also drops 4 extra spaces on the selected row, so labels line up: `>   Blank` over `    React`, like the color mode.
- Verified: new PTY test in `test/cli/init/init.test.ts` and new `bun discord` test in `test/cli/bun.test.ts`, both fail on the released bun. Also new `pretty_fmt_tests` cases, and the `--help` output of 11 subcommands is unchanged.

### Background
- Pretty templates are the `<red>...<r>` markup that `pretty!`, `prettyln!`, `warn!` and friends accept. `pretty_fmt!` rewrites them at compile time into ANSI escapes, or strips the tags when colors are off. `pretty_fmt_runtime` and `clap_macros` hold copies for runtime templates and `--help` text.
- The rewriter is a byte-level state machine. Its `<` arm stopped before the closing `>` and left it to a separate `>` arm, which skipped every unrelated `>` too.

<details><summary>Notes</summary>

The three rewriter copies: `src/bun_core_macros/lib.rs:112` (`rewrite`), `src/bun_core/output.rs:1984` (`pretty_fmt_runtime`), `src/clap_macros/lib.rs:297` (`pretty_rewrite`), line numbers before this change.

Repro under a `Bun.Terminal` PTY with `NO_COLOR=1` before the fix:

```
"\r\n? Select a project template - Press return to submit.\r\n       Blank\^[[0K\r\n    React\^[[0K\r\n    Library\^[[0K\r\n\^[[0J"
```

After the fix:

```
"\r\n? Select a project template - Press return to submit.\r\n>   Blank\^[[0K\r\n    React\^[[0K\r\n    Library\^[[0K\r\n\^[[0J"
```

The Zig original had the same template and the same rewriter rule, so the marker has never rendered.

An earlier revision of this PR escaped the two templates as `\>`. A self-review traced the defect to the rewriter rule and counted the other affected templates, so the fix moved to the rewriter. #38691 adds `\>` escapes to the three verbose-fetch templates in `src/http/lib.rs` for the same reason. Those become unnecessary after this change but stay harmless.

Bare `>` templates that this change fixes without an edit (scan of every pretty-family string literal under `src/`): `src/runtime/cli/mod.rs:236` (the `bun discord` fallback), `src/crash_handler/lib.rs:1299,1342`, `src/http/lib.rs:1396,1409,1415`, `src/install/PackageInstaller.rs:699`, `src/install/isolated_install/Installer.rs:1842,2415`, `src/install/lockfile.rs:1194`, `src/install/PackageManager/PackageManagerEnqueue.rs:1033,1590`, `src/install/PackageInstall.rs:647,1860`, `src/libarchive/lib.rs:1108,1643`, `src/sys/windows/mod.rs:1903`. All of them want a literal `>` (`->`, `>>`, `->>`). The ~49 templates that already write `\<` or `\>` need no edit. `{:>5}` style specs inside `{}` were never affected: the `{` arm copies them verbatim.

Open PRs #37855 and #34313 edit the same three functions for other reasons and will need a small conflict resolution.

The `bun discord` test is Linux only. It puts an empty directory on `PATH` so `xdg-open` cannot resolve and the fallback runs. macOS spawns `/usr/bin/open` by absolute path, which ignores `PATH` and would open a browser.

The PTY test is skipped on Windows. ConPTY rewrites the child's output into its own escape sequences, so the raw rows cannot be compared. It uses an inline terminal (`terminal: {...}` in `Bun.spawn`), which the subprocess owns: the `exit` callback fires after the last output chunk, so the test fails at once with the output so far if `bun init` exits early. It checks the marker on the default row, that the marker follows the down arrow, and that Ctrl-C cancels without creating a project.

Flake check: the PTY test passed 25 of 25 consecutive runs with the debug build across both revisions.

`cargo test -p bun_core` cannot link on its own (the crate needs C++ symbols), so the new `pretty_fmt_tests` cases were checked by reading, and the behavior by the two end-to-end tests and the help-text comparison.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/init/init.test.ts, test/cli/bun.test.ts

<!-- robobun:evidence:end -->