### PR TITLE
Build URL join and lockfile depth scratch buffers from MaybeUninit

### DIFF
--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -51,6 +51,7 @@ const MIRI_CRATES = [
   "bun_resolve_builtins",
   "bun_shell_parser",
   "bun_threading",
+  "bun_url",
   "bun_wyhash",
 ];
 

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -734,7 +734,7 @@ impl<'a> PackageInstaller<'a> {
     }
 
     pub(crate) fn link_remaining_bins(&mut self, log_level: Options::LogLevel) {
-        let mut depth_buf: lockfile::tree::DepthBuf = [0u32; lockfile::tree::MAX_DEPTH];
+        let mut depth_buf = lockfile::tree::depth_buf_uninit();
         let mut node_modules_rel_path_buf = PathBuffer::uninit();
         node_modules_rel_path_buf[..b"node_modules".len()].copy_from_slice(b"node_modules");
 

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1,4 +1,5 @@
 use core::marker::ConstParamTy;
+use core::mem::MaybeUninit;
 
 use bun_alloc::AllocError;
 use bun_collections::{ArrayHashMap, DynamicBitSet, MultiArrayList, index_sort};
@@ -69,21 +70,14 @@ impl Tree {
 // max number of node_modules folders
 pub(crate) const MAX_DEPTH: usize = (MAX_PATH_BYTES / b"node_modules".len()) + 1;
 
-pub(crate) type DepthBuf = [Id; MAX_DEPTH];
+/// Scratch for [`relative_path_and_depth`]: the parent walk writes
+/// `1..=depth` before the path loop reads them back, so the array (~1.4 KB,
+/// 32 KB on Windows) is never zeroed.
+pub(crate) type DepthBuf = [MaybeUninit<Id>; MAX_DEPTH];
 
-/// Write-only scratch buffer
-/// for [`relative_path_and_depth`]. Every slot is written before it is read
-/// (index 0 unconditionally, indices `1..depth_buf_len` in the parent-walk
-/// loop), so leaving the ~1.4 KB array uninitialised is sound and
-/// avoids a `memset` per tree in the `--frozen-lockfile` no-change path.
-/// Same shape/contract as [`bun_core::PathBuffer::uninit`].
 #[inline]
-#[allow(invalid_value, clippy::uninit_assumed_init)]
 pub(crate) fn depth_buf_uninit() -> DepthBuf {
-    // SAFETY: `DepthBuf` is `[u32; N]`; every bit pattern is a valid `u32`.
-    // Callers treat this as a write-only scratch buffer — no element is read
-    // before being assigned by `relative_path_and_depth`.
-    unsafe { core::mem::MaybeUninit::uninit().assume_init() }
+    [const { MaybeUninit::uninit() }; MAX_DEPTH]
 }
 
 impl Tree {
@@ -329,8 +323,6 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
         bun_core::Global::crash();
     };
 
-    depth_buf[0] = 0;
-
     if tree.id > 0 {
         let buf = string_buf;
         let mut depth_buf_len: usize = 1;
@@ -340,7 +332,7 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
                 path_buf[path_written] = 0;
                 return (ZStr::from_buf(path_buf, path_written), 0);
             }
-            depth_buf[depth_buf_len] = parent_id;
+            depth_buf[depth_buf_len].write(parent_id);
             parent_id = trees[parent_id as usize].parent;
             depth_buf_len += 1;
         }
@@ -365,7 +357,9 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
                 path_written += 1;
             }
 
-            let id = depth_buf[depth_buf_len];
+            // SAFETY: the parent walk above wrote `depth_buf[1..=depth]` and
+            // `1 <= depth_buf_len <= depth`.
+            let id = unsafe { depth_buf[depth_buf_len].assume_init() };
             let name = trees[id as usize].folder_name(dependencies, buf);
             if !folder_name_is_safe(name) {
                 Output::err_generic(

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -70,9 +70,7 @@ impl Tree {
 // max number of node_modules folders
 pub(crate) const MAX_DEPTH: usize = (MAX_PATH_BYTES / b"node_modules".len()) + 1;
 
-/// Scratch for [`relative_path_and_depth`]: the parent walk writes
-/// `1..=depth` before the path loop reads them back, so the array (~1.4 KB,
-/// 32 KB on Windows) is never zeroed.
+/// Parent-id stack for [`relative_path_and_depth`] (32 KB on Windows, so not zeroed).
 pub(crate) type DepthBuf = [MaybeUninit<Id>; MAX_DEPTH];
 
 #[inline]

--- a/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
+++ b/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
@@ -12,7 +12,7 @@ use crate::repository::Repository;
 use crate::{Dependency, DependencyID, Npm, Origin, PackageID, invalid_package_id};
 
 use super::package::scripts::Scripts as PackageScripts;
-use super::tree::{DepthBuf, IteratorPathStyle, MAX_DEPTH};
+use super::tree::IteratorPathStyle;
 use super::{FormatVersion, Lockfile, Package, package_index, tree};
 
 // Since this output is debug-only and an error mid-stream already yields malformed JSON,
@@ -229,7 +229,7 @@ where
         let dependencies = this.buffers.dependencies.as_slice();
         let hoisted_deps = this.buffers.hoisted_dependencies.as_slice();
         let resolutions = this.buffers.resolutions.as_slice();
-        let mut depth_buf: DepthBuf = [0; MAX_DEPTH];
+        let mut depth_buf = tree::depth_buf_uninit();
         let mut path_buf = PathBuffer::uninit();
         path_buf[..b"node_modules".len()].copy_from_slice(b"node_modules");
 

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -516,10 +516,9 @@ impl<'a> URL<'a> {
     /// Stack scratch for `join_normalize`. Longer joins go to the heap.
     const JOIN_STACK_BUF_LEN: usize = 2048;
 
-    /// Upper bound on the unnormalized path `join_normalize` builds: the
-    /// leading `/`, the four parts, and the `/` between `dirname` and `basename`.
+    /// Length bound of the unnormalized path `join_normalize` builds.
     fn join_needed(prefix: &[u8], dirname: &[u8], basename: &[u8], extname: &[u8]) -> usize {
-        2 + prefix.len() + dirname.len() + basename.len() + extname.len()
+        b"/".len() + prefix.len() + dirname.len() + b"/".len() + basename.len() + extname.len()
     }
 
     pub(crate) fn join_normalize<'b>(
@@ -591,8 +590,6 @@ impl<'a> URL<'a> {
         extname: &[u8],
     ) -> crate::Result<()> {
         let needed = Self::join_needed(prefix, dirname, basename, extname);
-        // The pooled buffer is not re-zeroed: `normalize_string_buf` reads only
-        // the bytes it wrote.
         let mut out_pooled: bun_paths::path_buffer_pool::Guard;
         let mut out_heap: Vec<u8>;
         let out: &mut [u8] = if needed <= bun_paths::MAX_PATH_BYTES {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub use error::{Error, Result};
 
 use core::cell::RefCell;
+use core::mem::MaybeUninit;
 
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
 use bun_core::{self, fmt as bun_fmt};
@@ -512,14 +513,13 @@ impl<'a> URL<'a> {
         !self.hostname.is_empty() && !self.pathname.is_empty()
     }
 
-    #[inline]
-    #[allow(
-        invalid_value,
-        clippy::uninit_assumed_init,
-        clippy::undocumented_unsafe_blocks
-    )]
-    fn join_buf_uninit() -> [u8; 2048] {
-        unsafe { core::mem::MaybeUninit::uninit().assume_init() }
+    /// Stack scratch for `join_normalize`. Longer joins go to the heap.
+    const JOIN_STACK_BUF_LEN: usize = 2048;
+
+    /// Upper bound on the unnormalized path `join_normalize` builds: the
+    /// leading `/`, the four parts, and the `/` between `dirname` and `basename`.
+    fn join_needed(prefix: &[u8], dirname: &[u8], basename: &[u8], extname: &[u8]) -> usize {
+        2 + prefix.len() + dirname.len() + basename.len() + extname.len()
     }
 
     pub(crate) fn join_normalize<'b>(
@@ -564,20 +564,22 @@ impl<'a> URL<'a> {
         for part in &path_parts[0..path_end] {
             total += part.len();
         }
-        let mut buf_stack = Self::join_buf_uninit();
-        let mut buf_heap: Vec<u8>;
-        let buf: &mut [u8] = if total <= buf_stack.len() {
+        let mut buf_stack = [const { MaybeUninit::<u8>::uninit() }; Self::JOIN_STACK_BUF_LEN];
+        let mut buf_heap: Vec<u8> = Vec::new();
+        let buf: &mut [MaybeUninit<u8>] = if total <= Self::JOIN_STACK_BUF_LEN {
             &mut buf_stack
         } else {
-            buf_heap = vec![0u8; total];
-            &mut buf_heap
+            buf_heap.reserve_exact(total);
+            buf_heap.spare_capacity_mut()
         };
         let mut buf_i: usize = 0;
         for part in &path_parts[0..path_end] {
-            buf[buf_i..buf_i + part.len()].copy_from_slice(part);
+            buf[buf_i..buf_i + part.len()].write_copy_of_slice(part);
             buf_i += part.len();
         }
-        resolve_path::normalize_string_buf::<false, platform::Loose, false>(&buf[0..buf_i], out)
+        // SAFETY: the loop above wrote every byte of `buf[..buf_i]`.
+        let joined = unsafe { buf[..buf_i].assume_init_ref() };
+        resolve_path::normalize_string_buf::<false, platform::Loose, false>(joined, out)
     }
 
     pub fn join_write(
@@ -588,11 +590,14 @@ impl<'a> URL<'a> {
         basename: &[u8],
         extname: &[u8],
     ) -> crate::Result<()> {
-        let needed = 2 + prefix.len() + dirname.len() + basename.len() + extname.len();
-        let mut out_stack = Self::join_buf_uninit();
+        let needed = Self::join_needed(prefix, dirname, basename, extname);
+        // The pooled buffer is not re-zeroed: `normalize_string_buf` reads only
+        // the bytes it wrote.
+        let mut out_pooled: bun_paths::path_buffer_pool::Guard;
         let mut out_heap: Vec<u8>;
-        let out: &mut [u8] = if needed <= out_stack.len() {
-            &mut out_stack
+        let out: &mut [u8] = if needed <= bun_paths::MAX_PATH_BYTES {
+            out_pooled = bun_paths::path_buffer_pool::get();
+            &mut out_pooled[..]
         } else {
             out_heap = vec![0u8; needed];
             &mut out_heap
@@ -622,20 +627,9 @@ impl<'a> URL<'a> {
             v.extend_from_slice(absolute_path);
             Ok(v.into_boxed_slice())
         } else {
-            let needed = 2 + prefix.len() + dirname.len() + basename.len() + extname.len();
-            let mut out_stack = Self::join_buf_uninit();
-            let mut out_heap: Vec<u8>;
-            let out: &mut [u8] = if needed <= out_stack.len() {
-                &mut out_stack
-            } else {
-                out_heap = vec![0u8; needed];
-                &mut out_heap
-            };
-            let normalized_path = Self::join_normalize(out, prefix, dirname, basename, extname);
-            let mut v = Vec::with_capacity(self.origin.len() + 1 + normalized_path.len());
-            v.extend_from_slice(self.origin);
-            v.extend_from_slice(b"/");
-            v.extend_from_slice(normalized_path);
+            let needed = Self::join_needed(prefix, dirname, basename, extname);
+            let mut v = Vec::with_capacity(self.origin.len() + 1 + needed);
+            self.join_write(&mut v, prefix, dirname, basename, extname)?;
             Ok(v.into_boxed_slice())
         }
     }
@@ -1762,5 +1756,68 @@ impl<'a> Scanner<'a> {
                 value_needs_decoding: false,
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::URL;
+
+    const ORIGIN: &[u8] = b"http://localhost:3000";
+
+    fn join(prefix: &[u8], dirname: &[u8], basename: &[u8], extname: &[u8]) -> Vec<u8> {
+        let url = URL::parse(b"http://localhost:3000/");
+        assert_eq!(url.origin, ORIGIN);
+        let mut out = Vec::new();
+        url.join_write(&mut out, prefix, dirname, basename, extname)
+            .expect("Vec<u8> writes cannot fail");
+        let boxed = url
+            .join_alloc(prefix, dirname, basename, extname, b"/abs/unused")
+            .expect("Vec<u8> writes cannot fail");
+        assert_eq!(&*boxed, &*out, "join_alloc and join_write must agree");
+        out
+    }
+
+    #[test]
+    fn join_normalizes_the_path() {
+        assert_eq!(
+            join(b"_next/", b"/pages//", b"index", b".js"),
+            b"http://localhost:3000/_next/pages/index.js"
+        );
+        assert_eq!(
+            join(b"", b"a/./b/..", b"d", b""),
+            b"http://localhost:3000/a/d"
+        );
+        assert_eq!(join(b"", b"", b"", b""), b"http://localhost:3000/");
+    }
+
+    #[test]
+    fn join_alloc_uplevel_dirname_uses_the_absolute_path() {
+        let url = URL::parse(b"http://localhost:3000/");
+        let boxed = url
+            .join_alloc(b"", b"../pages", b"index", b".js", b"/srv/pages/index.js")
+            .expect("Vec<u8> writes cannot fail");
+        assert_eq!(&*boxed, b"http://localhost:3000/abs:/srv/pages/index.js");
+    }
+
+    #[test]
+    fn join_at_the_stack_buffer_limit() {
+        // `/` plus the basename fills the scratch buffer exactly.
+        let basename = vec![b'a'; URL::JOIN_STACK_BUF_LEN - 1];
+        let mut expected = ORIGIN.to_vec();
+        expected.push(b'/');
+        expected.extend_from_slice(&basename);
+        assert_eq!(join(b"", b"", &basename, b""), expected);
+    }
+
+    #[test]
+    fn join_longer_than_every_stack_buffer() {
+        let len = URL::JOIN_STACK_BUF_LEN.max(bun_paths::MAX_PATH_BYTES) + 1;
+        let basename = vec![b'a'; len];
+        let mut expected = ORIGIN.to_vec();
+        expected.extend_from_slice(b"/dir/");
+        expected.extend_from_slice(&basename);
+        expected.extend_from_slice(b".js");
+        assert_eq!(join(b"", b"dir", &basename, b".js"), expected);
     }
 }

--- a/test/internal/source-lints/uninit-assumed-init.test.ts
+++ b/test/internal/source-lints/uninit-assumed-init.test.ts
@@ -1,0 +1,76 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `MaybeUninit::uninit().assume_init()` on an integer array produces a value
+// whose bytes are uninitialized. The Rust reference lists that as undefined
+// behavior no matter what the code does with the bytes afterwards, and Miri
+// stops at the constructor:
+//
+//   constructing invalid value of type [u8; 2048]: at [0], encountered
+//   uninitialized memory, but expected an integer
+//
+// rustc's `invalid_value` lint (an error under the workspace `warnings = deny`)
+// and clippy's `uninit_assumed_init` both catch the pattern, so such code only
+// compiles under an `#[allow(..)]` for them. A scratch buffer is
+// `[MaybeUninit<T>; N]` instead, written with `write_copy_of_slice` / `write`
+// and read back through `assume_init_ref` on the written prefix. See
+// `bun_url::URL::join_normalize` and `bun_paths::resolve_path::join_string_buf_t`.
+//
+// `PathBuffer::uninit` and `WPathBuffer::uninit` in `src/bun_core/util.rs`
+// still use the pattern. Their ~400 call sites need an initialized-prefix API
+// (or the path buffer pool) before they can change. This lint keeps that set
+// from growing; remove the entry when those two are fixed.
+const KNOWN_SITES = ["src/bun_core/util.rs"];
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const sources = new Map<string, string>();
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions don't count.
+  sources.set(source, content.replace(/^\s*\/\/.*$/gm, ""));
+}
+
+function scan(pattern: RegExp): string[] {
+  const offenders: string[] = [];
+  for (const [source, stripped] of sources) {
+    if (pattern.test(stripped)) {
+      offenders.push(source);
+    }
+  }
+  return offenders.sort();
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the assertion below pass vacuously.
+  expect(sources.size).toBeGreaterThan(0);
+});
+
+test("no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)]", () => {
+  // `[^)]*` spans the multi-line form of the attribute; lint paths never
+  // contain `)`.
+  expect(scan(/#!?\[(?:allow|expect)\([^)]*\b(?:invalid_value|clippy::uninit_assumed_init)\b/)).toEqual(KNOWN_SITES);
+});


### PR DESCRIPTION
### Problem
- `URL::join_normalize`, `join_write` and `join_alloc` (`src/url/lib.rs:521`) built their 2 KB scratch buffers with `MaybeUninit::<[u8; 2048]>::uninit().assume_init()` under a lint allow. An integer array from uninitialized memory is undefined behavior even when every byte is written before it is read. Miri: `constructing invalid value of type [u8; 2048]: at [0], encountered uninitialized memory, but expected an integer`.
- `lockfile::tree::depth_buf_uninit` (`src/install/lockfile/Tree.rs:82`) did the same for a `[u32; MAX_DEPTH]`.

### Fix
- The concatenation scratch in `join_normalize` is `[MaybeUninit<u8>; 2048]`, filled with `write_copy_of_slice`. Only the written prefix becomes a `&[u8]`, the idiom `bun_paths::resolve_path::join_string_buf_t` uses for the same step.
- The normalize output in `join_write` comes from `bun_paths::path_buffer_pool`, so there is no per-call memset. Joins longer than `MAX_PATH_BYTES` keep the zeroed heap fallback. `join_alloc` now writes through `join_write` into its `Vec`.
- `DepthBuf` is `[MaybeUninit<Id>; MAX_DEPTH]`. `relative_path_and_depth` writes slots `1..=depth`, then reads them back with `assume_init`. The never-read `depth_buf[0] = 0` is gone.
- Verified: `bun run rust:miri -p bun_url` (4 new unit tests, `bun_url` joins the Miri crate set). `test/internal/source-lints/uninit-assumed-init.test.ts` pins the `#[allow(invalid_value)]` sites to `src/bun_core/util.rs`. Also `test/js/bun/util/filesystem_router.test.ts` and four `test/cli/install` files.

### Background
- `MaybeUninit<T>` is the std wrapper for memory that may not be initialized. `write_copy_of_slice` fills a `[MaybeUninit<u8>]`, and `assume_init_ref` views a filled range as `&[u8]`.
- `path_buffer_pool` is a thread-local cache of up to 4 `PathBuffer`s (4 KB Linux, 1 KB macOS, 98 KB Windows). `get()` pops one or allocates it zeroed. The guard returns it on drop.
- `normalize_string_buf` writes its output from index 0 and reads only indices it already wrote. Stale bytes in a pooled buffer are never observed.

<details><summary>Notes</summary>

Fail-before: with the tests from this PR appended to the unfixed `src/url/lib.rs`, `MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -p bun_url` stops at `join_buf_uninit` with the error quoted above. With the fix all 4 tests pass. `cargo test -p bun_url` without Miri does not link (the Highway SIMD symbols come from C++), which is why the Miri lane is where these tests run, same as `bun_paths`.

`join_alloc` used to size its `Vec` exactly from the normalized length. It now reserves the upper bound (`origin + 1 + needed`) and `into_boxed_slice` shrinks it. The callers are the legacy linker (`src/bundler/linker.rs`) and `FileSystemRouter`/dev-server `src` generation, not hot paths.

Install tests run: `test/cli/install/bun-dedupe.test.ts`, `bun-prune.test.ts`, `bun-lock.test.ts`, `bun-install-native-binlink.test.ts`.

Not in this PR: `PathBuffer::uninit()` and `WPathBuffer::uninit()` in `src/bun_core/util.rs:727,774` have the same `assume_init` pattern. They have 348 + 24 call sites in 118 files (plus 34 `PathBuffer::default()`), and the `uninit` body exists because zeroing the 98 KB Windows buffer at every site caused test timeouts. A sound version needs either a `MaybeUninit`-backed buffer type with an initialized-prefix API or moving the sites to `path_buffer_pool`. That is a separate change. #31258 (open, external) proposes to zero them, which brings the Windows memset back.

Also ran: `cargo clippy -p bun_url -p bun_install --tests --no-deps` (clean), `cargo fmt --check`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/uninit-assumed-init.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/25] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/25] gen JS modules (bundle-modules)
Preprocess modules (8034ms)
Bundle modules (54ms)
Postprocesss modules (218ms)
Bundle Functions (527ms)
Generate Code (47ms)

[8.89s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/7] cargo bun_runtime → libbun_runtime.a
[4/7] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/internal/source-lints/uninit-assumed-init.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.11ms]
70 | });
71 | 
72 | test("no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)]", () => {
73 |   // `[^)]*` spans the multi-line form of the attribute; lint paths never
74 |   // contain `)`.
75 |   expect(scan(/#!?\[(?:allow|expect)\([^)]*\b(?:invalid_value|clippy::uninit_assumed_init)\b/)).toEqual(KNOWN_SITES);
                                                                                                     ^
error: expect(received).toEqual(expected)

  [
    "src/bun_core/util.rs",
+   "src/install/lockfile/Tree.rs",
+   "src/url/lib.rs",
  ]

- Expected  - 0
+ Received  + 2

      at <anonymous> (/workspace/bun/test/internal/source-lints/uninit-assumed-init.test.ts:75:97)
(fail) no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)] [13.02ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [1.89s]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/uninit-assumed-init.test.ts
bun test v1.4.1 (65362b53b)

test/internal/source-lints/uninit-assumed-init.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.38ms]
(pass) no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)] [173.11ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [27.20s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 737ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9162ms)
Bundle modules (87ms)
Postprocesss modules (392ms)
Bundle Functions (653ms)
Generate Code (44ms)

[10.35s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_url v0.0.0 (/workspace/bun/src/url)
[1m[92m   Compiling[0m bun_http_types v0.0.0 (/workspace/bun/src/http_types)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_which
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/rust-miri.ts                               |   1 +
 src/install/PackageInstaller.rs                    |   2 +-
 src/install/lockfile/Tree.rs                       |  24 ++---
 .../lockfile_json_stringify_for_debugging.rs       |   4 +-
 src/url/lib.rs                                     | 120 +++++++++++++++------
 .../source-lints/uninit-assumed-init.test.ts       |  76 +++++++++++++
 6 files changed, 175 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/rust-miri.ts                                          1      1      0
src/install/PackageInstaller.rs                               1      2      0
src/install/lockfile/Tree.rs                                  4      5      0
…stall/lockfile/lockfile_json_stringify_for_debugging.rs      2      2      0
src/url/lib.rs                                                4     10      0
test/internal/source-lints/uninit-assumed-init.test.ts        0      1      0
```

</details>

<!-- robobun:evidence:end -->