### PR TITLE
output: build PrettyBuf only from UTF-8 input

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1691,10 +1691,11 @@ pub fn prettyln(payload: impl PrettyFmtInput) {
 /// tested against it).
 pub use bun_core_macros::pretty_fmt;
 
-/// Input accepted by [`pretty_fmt`]: either a `&str`/`&[u8]` template or a
+/// Input accepted by [`pretty_fmt`]: either a `&str` template or a
 /// pre-formatted `&fmt::Arguments<'_>` (which is first rendered to a string
 /// then `<tag>`-rewritten — used by `Custom Inspect`-style call sites that
-/// build the template via `format_args!`).
+/// build the template via `format_args!`). Every input is UTF-8, which is what
+/// lets [`PrettyBuf`] hand out a `&str`.
 pub trait PrettyFmtInput {
     fn into_pretty_buf(self, is_enabled: bool) -> PrettyBuf;
 }
@@ -1702,12 +1703,6 @@ impl PrettyFmtInput for &str {
     #[inline]
     fn into_pretty_buf(self, is_enabled: bool) -> PrettyBuf {
         PrettyBuf(pretty_fmt_runtime(self.as_bytes(), is_enabled))
-    }
-}
-impl PrettyFmtInput for &[u8] {
-    #[inline]
-    fn into_pretty_buf(self, is_enabled: bool) -> PrettyBuf {
-        PrettyBuf(pretty_fmt_runtime(self, is_enabled))
     }
 }
 impl PrettyFmtInput for &fmt::Arguments<'_> {
@@ -1746,8 +1741,12 @@ pub fn pretty_fmt_rt(input: impl PrettyFmtInput, is_enabled: bool) -> PrettyBuf 
 /// Owned ANSI-rewritten buffer; derefs to `[u8]` so it can be passed to
 /// `write_all(&buf)` directly, and implements `Display` so it can be used in
 /// `write!(w, "{}", pretty_fmt::<true>("…"))`.
+///
+/// Only [`PrettyFmtInput`] builds one, from UTF-8 input. `pretty_fmt_runtime`
+/// copies that input byte for byte and only drops `<tag>` spans and inserts
+/// ASCII escapes, so the buffer stays UTF-8.
 #[repr(transparent)]
-pub struct PrettyBuf(pub Vec<u8>);
+pub struct PrettyBuf(Vec<u8>);
 impl core::ops::Deref for PrettyBuf {
     type Target = [u8];
     #[inline]
@@ -1764,9 +1763,8 @@ impl AsRef<[u8]> for PrettyBuf {
 impl AsRef<str> for PrettyBuf {
     #[inline]
     fn as_ref(&self) -> &str {
-        // SAFETY: contents are ANSI escape bytes (pure ASCII) interleaved with
-        // verbatim runs of a `&'static str` template — both UTF-8 by
-        // construction.
+        // SAFETY: UTF-8 by construction, see the type docs. The field is
+        // private, so no other constructor exists.
         unsafe { core::str::from_utf8_unchecked(&self.0) }
     }
 }

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1694,8 +1694,7 @@ pub use bun_core_macros::pretty_fmt;
 /// Input accepted by [`pretty_fmt`]: either a `&str` template or a
 /// pre-formatted `&fmt::Arguments<'_>` (which is first rendered to a string
 /// then `<tag>`-rewritten — used by `Custom Inspect`-style call sites that
-/// build the template via `format_args!`). Every input is UTF-8, which is what
-/// lets [`PrettyBuf`] hand out a `&str`.
+/// build the template via `format_args!`). Both are UTF-8; [`PrettyBuf`] relies on that.
 pub trait PrettyFmtInput {
     fn into_pretty_buf(self, is_enabled: bool) -> PrettyBuf;
 }
@@ -1740,11 +1739,7 @@ pub fn pretty_fmt_rt(input: impl PrettyFmtInput, is_enabled: bool) -> PrettyBuf 
 
 /// Owned ANSI-rewritten buffer; derefs to `[u8]` so it can be passed to
 /// `write_all(&buf)` directly, and implements `Display` so it can be used in
-/// `write!(w, "{}", pretty_fmt::<true>("…"))`.
-///
-/// Only [`PrettyFmtInput`] builds one, from UTF-8 input. `pretty_fmt_runtime`
-/// copies that input byte for byte and only drops `<tag>` spans and inserts
-/// ASCII escapes, so the buffer stays UTF-8.
+/// `write!(w, "{}", pretty_fmt::<true>("…"))`. UTF-8 by construction: see [`PrettyFmtInput`].
 #[repr(transparent)]
 pub struct PrettyBuf(Vec<u8>);
 impl core::ops::Deref for PrettyBuf {
@@ -1763,8 +1758,7 @@ impl AsRef<[u8]> for PrettyBuf {
 impl AsRef<str> for PrettyBuf {
     #[inline]
     fn as_ref(&self) -> &str {
-        // SAFETY: UTF-8 by construction, see the type docs. The field is
-        // private, so no other constructor exists.
+        // SAFETY: the field is private and every `PrettyFmtInput` is UTF-8.
         unsafe { core::str::from_utf8_unchecked(&self.0) }
     }
 }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -241,7 +241,7 @@ impl Expect {
         }
         let render = |enabled: bool| -> Box<str> {
             #[allow(clippy::disallowed_methods)] // `args` is a `'static` template literal
-            let params = Output::pretty_fmt_rt(args.as_bytes(), enabled);
+            let params = Output::pretty_fmt_rt(args, enabled);
             if enabled {
                 if not {
                     format!(

--- a/test/internal/source-lints/unchecked-str-over-pub-field.test.ts
+++ b/test/internal/source-lints/unchecked-str-over-pub-field.test.ts
@@ -1,0 +1,188 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A `&str` built with `core::str::from_utf8_unchecked` over a struct's own
+// bytes (`from_utf8_unchecked(&self.buf)`, `from_utf8_unchecked(self.0)`) is
+// sound only while nothing outside the defining module can choose those bytes.
+// A `pub` field breaks that: a struct literal in safe code, in any crate, puts
+// arbitrary bytes behind the cast, and the SAFETY comment on it no longer
+// describes the program. A `&str` that is not UTF-8 is undefined behavior.
+//
+// Motivating instances, both in bun_core. `PrettyBuf(pub Vec<u8>)` in
+// src/bun_core/output.rs backed `AsRef<str>` and `Display` with that cast, and
+// also accepted a `&[u8]` template through `PrettyFmtInput`. `Raw<'a>(pub &'a
+// [u8])` in src/bun_core/fmt.rs (the `fmt::s()` adapter) did the same in
+// `Display`, over argv, paths and package.json strings.
+//
+// Scope: the cast and the struct definition have to be in the same file. A
+// public constructor that accepts bytes defeats the invariant the same way and
+// is not something this scan can see; review those by hand.
+//
+// Sibling guards: unsound-erased-box.test.ts, unsafe-refcount-exports.test.ts.
+
+// Known offenders that a PR in flight removes. Keyed by source path, listing
+// the struct names. Drop an entry once the fix lands.
+const ALLOWED: Record<string, string[]> = {
+  // `Raw::fmt` validates and substitutes U+FFFD in #37422.
+  "src/bun_core/fmt.rs": ["Raw"],
+};
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `from_utf8_unchecked(&self.buf)`, `(&mut self.buf[..n])`, `(self.0)`. The
+// `\b(?!\s*\()` keeps `self.as_bytes()` (a method, not a field) out.
+const CAST = /\bfrom_utf8_unchecked(?:_mut)?\(\s*&?\s*(?:mut\s+)?self\.(\w+)\b(?!\s*\()/g;
+
+// An `impl` header, possibly spanning lines, up to its opening brace.
+const IMPL_HEADER = /^impl\b[^{]*\{/gm;
+
+function lineOf(text: string, index: number): number {
+  return text.slice(0, index).split("\n").length;
+}
+
+// Skip a balanced `<...>` group at the start of `s`.
+function skipGenerics(s: string): string {
+  if (!s.startsWith("<")) return s;
+  let depth = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "<") depth++;
+    else if (s[i] === ">" && --depth === 0) return s.slice(i + 1);
+  }
+  return "";
+}
+
+// `impl<..> Trait<..> for Type<..> {` -> `Type`; `impl<..> Type<..> {` -> `Type`.
+function implTarget(header: string): string | null {
+  const rest = skipGenerics(header.replace(/^impl\b/, "").trimStart());
+  const forIndex = rest.lastIndexOf(" for ");
+  const target = forIndex >= 0 ? rest.slice(forIndex + " for ".length) : rest;
+  const m = target.match(/^\s*&?(?:'\w+\s+)?(?:mut\s+)?(?:[\w]+::)*(\w+)/);
+  return m ? m[1] : null;
+}
+
+// Index of the delimiter that closes the one at `open` (`(`/`)` or `{`/`}`).
+function closing(text: string, open: number): number {
+  const openCh = text[open];
+  const closeCh = openCh === "(" ? ")" : "}";
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === openCh) depth++;
+    else if (text[i] === closeCh && --depth === 0) return i;
+  }
+  return -1;
+}
+
+// Split on commas that are not nested in `<>`, `()` or `[]`.
+function splitTopLevel(s: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "<" || c === "(" || c === "[") depth++;
+    else if (c === ">" || c === ")" || c === "]") depth--;
+    else if (c === "," && depth === 0) {
+      out.push(s.slice(start, i));
+      start = i + 1;
+    }
+  }
+  out.push(s.slice(start));
+  return out;
+}
+
+// The `pub` qualifier (any form) on `field` of `struct name` in `text`, null if
+// the field is private, undefined if the struct or field is not in `text`.
+function fieldVisibility(text: string, name: string, field: string): string | null | undefined {
+  const def = new RegExp(`\\bstruct\\s+${name}\\b[^;{(]*([({;])`).exec(text);
+  if (def === null) return undefined;
+  const open = def.index + def[0].length - 1;
+  if (def[1] === ";") return undefined;
+  const end = closing(text, open);
+  if (end < 0) return undefined;
+  const body = text.slice(open + 1, end);
+  if (def[1] === "(") {
+    const item = splitTopLevel(body)[Number(field)];
+    if (item === undefined) return undefined;
+    const vis = /^\s*(?:#\[[^\]]*\]\s*)*(pub(?:\([^)]*\))?)\s/.exec(item);
+    return vis ? vis[1] : null;
+  }
+  const m = new RegExp(`(?:^|[{,])\\s*(?:#\\[[^\\]]*\\]\\s*)*(?:(pub(?:\\([^)]*\\))?)\\s+)?${field}\\s*:`).exec(body);
+  if (m === null) return undefined;
+  return m[1] ?? null;
+}
+
+const found: string[] = [];
+const unresolved: string[] = [];
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments (including `///` docs) so prose mentions don't
+  // count. `[ \t]*`, not `\s*`, so blank lines survive and line numbers stay
+  // right.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  const headers = [...stripped.matchAll(IMPL_HEADER)];
+  for (const cast of stripped.matchAll(CAST)) {
+    const line = lineOf(stripped, cast.index);
+    const header = headers.filter(h => h.index < cast.index).at(-1);
+    const type = header ? implTarget(header[0]) : null;
+    if (type === null) {
+      unresolved.push(`${source}:${line}: self.${cast[1]} outside an impl block`);
+      continue;
+    }
+    const vis = fieldVisibility(stripped, type, cast[1]);
+    if (vis === undefined) {
+      unresolved.push(`${source}:${line}: struct ${type} or its field ${cast[1]} is not in this file`);
+      continue;
+    }
+    found.push(`${source}:${line}: ${type}.${cast[1]}`);
+    if (vis !== null && !ALLOWED[source]?.includes(type)) {
+      offenders.push(`${source}:${line}: ${type}.${cast[1]} is ${vis}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the assertions below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the pattern still recognizes the tree's own-bytes casts", () => {
+  // If this goes empty, the casts moved into helpers this scan cannot follow
+  // and the regex above needs updating, not the assertion below.
+  expect(found).not.toBeEmpty();
+});
+
+test("every cast resolves to a struct in the same file", () => {
+  // A cast whose struct lives elsewhere is outside what this lint can check.
+  // Move the cast next to the struct, or extend the scan.
+  expect(unresolved).toEqual([]);
+});
+
+test("a struct that casts its own bytes to str keeps that field private", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `Output::PrettyBuf` returns a `&str` from `AsRef<str>` and `Display` with `core::str::from_utf8_unchecked(&self.0)` (`src/bun_core/output.rs:1765`). The SAFETY comment says the buffer is UTF-8 by construction.
- That was not enforced. The field was `pub`, and `PrettyFmtInput` was implemented for `&[u8]`, so `Output::pretty_fmt_rt(b"\xff", false).as_ref()` built an invalid `&str` from safe code. This is the same pattern as the `fmt::Raw` / `fmt::s()` sink that #37422 fixes.

### Fix
- Remove `impl PrettyFmtInput for &[u8]`. Every input is now a `&str` or a `fmt::Arguments`, both UTF-8. `pretty_fmt_runtime` copies its input byte for byte and only drops `<tag>` spans (ASCII delimited) and inserts ASCII escapes, so the output stays UTF-8.
- Make the `PrettyBuf` field private, so `PrettyFmtInput` is the only constructor. Nothing outside `output.rs` constructed one directly.
- The one `&[u8]` caller, `Expect::get_signature` (`src/runtime/test_runner/expect.rs:244`), passed `args.as_bytes()` where `args: &'static str`. It now passes `args`.
- Test: `test/internal/source-lints/unchecked-str-over-pub-field.test.ts`. It finds every `from_utf8_unchecked` over a struct's own field inside an `impl`, resolves the struct in the same file, and fails when the field is `pub`. On main it reports `src/bun_core/output.rs: PrettyBuf.0 is pub`. `Raw` in `fmt.rs` is allowlisted until #37422 lands. There is no runtime behavior to test: every existing caller already passed UTF-8.
- Verified: `bun bd` links (no other `&[u8]` caller), `test/internal/source-lints/`, `test/js/bun/test/expect.test.js`, `expect-failure-message-angle-brackets.test.ts`, `expect-label.test.ts`, `test/cli/init/init.test.ts`.

### Background
- `pretty_fmt_rt` / `pretty_fmt::<COLORS>` rewrite a template with `<red>`, `<d>`, `<r>` markup into ANSI escapes at runtime and return the result as a `PrettyBuf`. The compile-time `pretty_fmt!` proc macro is the common path. The runtime path is for templates picked at runtime (expect matcher headers, the `bun init` prompts, the crash handler).
- A `&str` that holds invalid UTF-8 is undefined behavior in Rust. The sinks in use today copy bytes through, so nothing misbehaves yet. A `str`-inspecting sink (padding, `String`) would.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/unchecked-str-over-pub-field.test.ts
bun test v1.4.1 (65362b53b)

test/internal/source-lints/unchecked-str-over-pub-field.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.26ms]
(pass) the pattern still recognizes the tree's own-bytes casts [1.45ms]
(pass) every cast resolves to a struct in the same file [1.10ms]
182 |   // Move the cast next to the struct, or extend the scan.
183 |   expect(unresolved).toEqual([]);
184 | });
185 | 
186 | test("a struct that casts its own bytes to str keeps that field private", () => {
187 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/bun_core/output.rs:1770: PrettyBuf.0 is pub",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/unchecked-str-over-pub-field.test.ts:187:21)
(fail) a struct that casts its own bytes to str keeps that field private [4.05ms]

 3 pass
 1 fail
 4 expect() calls
Ran 4 tests across 1 file. [25.69s]
error: scr
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/internal/source-lints/unchecked-str-over-pub-field.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.12ms]
(pass) the pattern still recognizes the tree's own-bytes casts [0.02ms]
(pass) every cast resolves to a struct in the same file [0.03ms]
182 |   // Move the cast next to the struct, or extend the scan.
183 |   expect(unresolved).toEqual([]);
184 | });
185 | 
186 | test("a struct that casts its own bytes to str keeps that field private", () => {
187 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/bun_core/output.rs:1770: PrettyBuf.0 is pub",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/unchecked-str-over-pub-field.test.ts:187:21)
(fail) a struct that casts its own bytes to str keeps that field private [0.21ms]

 3 pass
 1 fail
 4 expect() calls
Ran 4 tests across 1 file. [701.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/unchecked-str-over-pub-field.test.ts
bun test v1.4.1 (65362b53b)

test/internal/source-lints/unchecked-str-over-pub-field.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.22ms]
(pass) the pattern still recognizes the tree's own-bytes casts [1.48ms]
(pass) every cast resolves to a struct in the same file [1.10ms]
(pass) a struct that casts its own bytes to str keeps that field private [1.35ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [24.97s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b2a15a2525
  features     baseline

23 deps, 131 codegen, 1172 objects in 824ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 K
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/output.rs                             |  18 +-
 src/runtime/test_runner/expect.rs                  |   2 +-
 .../unchecked-str-over-pub-field.test.ts           | 188 +++++++++++++++++++++
 3 files changed, 194 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bun_core/output.rs                                       10      8      0
src/runtime/test_runner/expect.rs                             1      1      0
…ernal/source-lints/unchecked-str-over-pub-field.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->