### PR TITLE
css: scope view transition names in CSS modules

### DIFF
--- a/src/css/properties/mod.rs
+++ b/src/css/properties/mod.rs
@@ -186,6 +186,7 @@ mod generic_registrations {
         css_values::position::HorizontalPosition,
         css_values::position::VerticalPosition,
         css_values::percentage::NumberOrPercentage,
+        css_values::ident::NoneOrCustomIdentList,
     );
 
     // Length derives `css::ToCss` only (custom Calc-unwrapping `parse` is

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -291,6 +291,9 @@ pub enum PropertyIdTag {
     MaskBoxImageOutset,
     MaskBoxImageRepeat,
     ColorScheme,
+    ViewTransitionName,
+    ViewTransitionClass,
+    ViewTransitionGroup,
     All,
     Unparsed,
     Custom,
@@ -603,6 +606,9 @@ impl PropertyIdTag {
             PropertyIdTag::MaskBoxImageOutset => b"mask-box-image-outset",
             PropertyIdTag::MaskBoxImageRepeat => b"mask-box-image-repeat",
             PropertyIdTag::ColorScheme => b"color-scheme",
+            PropertyIdTag::ViewTransitionName => b"view-transition-name",
+            PropertyIdTag::ViewTransitionClass => b"view-transition-class",
+            PropertyIdTag::ViewTransitionGroup => b"view-transition-group",
             PropertyIdTag::All => b"all",
             PropertyIdTag::Unparsed => b"unparsed",
             PropertyIdTag::Custom => b"custom",
@@ -868,6 +874,9 @@ pub enum PropertyId {
     MaskBoxImageOutset(VendorPrefix),
     MaskBoxImageRepeat(VendorPrefix),
     ColorScheme,
+    ViewTransitionName,
+    ViewTransitionClass,
+    ViewTransitionGroup,
     All,
     Unparsed,
     Custom(CustomPropertyName),
@@ -1150,6 +1159,9 @@ impl PropertyId {
             PropertyId::MaskBoxImageOutset(..) => PropertyIdTag::MaskBoxImageOutset,
             PropertyId::MaskBoxImageRepeat(..) => PropertyIdTag::MaskBoxImageRepeat,
             PropertyId::ColorScheme => PropertyIdTag::ColorScheme,
+            PropertyId::ViewTransitionName => PropertyIdTag::ViewTransitionName,
+            PropertyId::ViewTransitionClass => PropertyIdTag::ViewTransitionClass,
+            PropertyId::ViewTransitionGroup => PropertyIdTag::ViewTransitionGroup,
             PropertyId::All => PropertyIdTag::All,
             PropertyId::Unparsed => PropertyIdTag::Unparsed,
             PropertyId::Custom(..) => PropertyIdTag::Custom,
@@ -1529,6 +1541,9 @@ impl PropertyId {
                 b"mask-box-image-outset" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT), PropertyId::MaskBoxImageOutset),
                 b"mask-box-image-repeat" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT), PropertyId::MaskBoxImageRepeat),
                 b"color-scheme" => (VendorPrefix::NONE, |_| PropertyId::ColorScheme),
+                b"view-transition-name" => (VendorPrefix::NONE, |_| PropertyId::ViewTransitionName),
+                b"view-transition-class" => (VendorPrefix::NONE, |_| PropertyId::ViewTransitionClass),
+                b"view-transition-group" => (VendorPrefix::NONE, |_| PropertyId::ViewTransitionGroup),
             };
         }
         let &(allowed, make) = KNOWN.get_ascii_case_insensitive(name)?;
@@ -1859,6 +1874,9 @@ pub enum Property {
     ),
     MaskBoxImageRepeat((border_image::BorderImageRepeat, VendorPrefix)),
     ColorScheme(ui::ColorScheme),
+    ViewTransitionName(transition::ViewTransitionName),
+    ViewTransitionClass(css::css_values::ident::NoneOrCustomIdentList),
+    ViewTransitionGroup(transition::ViewTransitionGroup),
     All(CSSWideKeyword),
     Unparsed(UnparsedProperty),
     Custom(CustomProperty),
@@ -2126,6 +2144,9 @@ impl Property {
             Property::MaskBoxImageOutset(v) => PropertyId::MaskBoxImageOutset(v.1),
             Property::MaskBoxImageRepeat(v) => PropertyId::MaskBoxImageRepeat(v.1),
             Property::ColorScheme(..) => PropertyId::ColorScheme,
+            Property::ViewTransitionName(..) => PropertyId::ViewTransitionName,
+            Property::ViewTransitionClass(..) => PropertyId::ViewTransitionClass,
+            Property::ViewTransitionGroup(..) => PropertyId::ViewTransitionGroup,
             Property::All(..) => PropertyId::All,
             Property::Unparsed(u) => u.property_id,
             Property::Custom(c) => PropertyId::Custom(c.name),
@@ -2395,6 +2416,9 @@ impl Property {
             Property::MaskBoxImageOutset(v) => css::generic::to_css(&v.0, dest),
             Property::MaskBoxImageRepeat(v) => css::generic::to_css(&v.0, dest),
             Property::ColorScheme(v) => css::generic::to_css(v, dest),
+            Property::ViewTransitionName(v) => css::generic::to_css(v, dest),
+            Property::ViewTransitionClass(v) => css::generic::to_css(v, dest),
+            Property::ViewTransitionGroup(v) => css::generic::to_css(v, dest),
             Property::All(v) => css::generic::to_css(v, dest),
             Property::Unparsed(u) => u.value.to_css(dest, false),
             Property::Custom(c) => c
@@ -3833,6 +3857,23 @@ impl Property {
                     return Ok(Property::ColorScheme(c));
                 }
             }
+            PropertyId::ViewTransitionName => {
+                if let Some(c) = parse_value::<transition::ViewTransitionName>(input, options) {
+                    return Ok(Property::ViewTransitionName(c));
+                }
+            }
+            PropertyId::ViewTransitionClass => {
+                if let Some(c) =
+                    parse_value::<css::css_values::ident::NoneOrCustomIdentList>(input, options)
+                {
+                    return Ok(Property::ViewTransitionClass(c));
+                }
+            }
+            PropertyId::ViewTransitionGroup => {
+                if let Some(c) = parse_value::<transition::ViewTransitionGroup>(input, options) {
+                    return Ok(Property::ViewTransitionGroup(c));
+                }
+            }
             PropertyId::All => return CSSWideKeyword::parse(input).map(Property::All),
             PropertyId::Custom(name) => {
                 return CustomProperty::parse(name, input, options).map(Property::Custom);
@@ -4428,6 +4469,15 @@ impl Property {
                 Property::MaskBoxImageRepeat((css::generic::deep_clone(&v.0, arena), v.1))
             }
             Property::ColorScheme(v) => Property::ColorScheme(css::generic::deep_clone(v, arena)),
+            Property::ViewTransitionName(v) => {
+                Property::ViewTransitionName(css::generic::deep_clone(v, arena))
+            }
+            Property::ViewTransitionClass(v) => {
+                Property::ViewTransitionClass(css::generic::deep_clone(v, arena))
+            }
+            Property::ViewTransitionGroup(v) => {
+                Property::ViewTransitionGroup(css::generic::deep_clone(v, arena))
+            }
             Property::All(a) => Property::All(*a),
             Property::Unparsed(u) => Property::Unparsed(u.deep_clone(arena)),
             Property::Custom(c) => Property::Custom(c.deep_clone(arena)),
@@ -4952,6 +5002,15 @@ impl Property {
                 css::generic::eql(&a.0, &b.0) && a.1 == b.1
             }
             (Property::ColorScheme(a), Property::ColorScheme(b)) => css::generic::eql(a, b),
+            (Property::ViewTransitionName(a), Property::ViewTransitionName(b)) => {
+                css::generic::eql(a, b)
+            }
+            (Property::ViewTransitionClass(a), Property::ViewTransitionClass(b)) => {
+                css::generic::eql(a, b)
+            }
+            (Property::ViewTransitionGroup(a), Property::ViewTransitionGroup(b)) => {
+                css::generic::eql(a, b)
+            }
             (Property::All(_), Property::All(_)) => true,
             (Property::Unparsed(a), Property::Unparsed(b)) => a.eql(b),
             (Property::Custom(a), Property::Custom(b)) => a.eql(b),

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -12,6 +12,7 @@ use crate::css_properties::Property;
 use crate::css_properties::PropertyId;
 use crate::css_properties::masking;
 use crate::css_values::easing::EasingFunction;
+use crate::css_values::ident::CustomIdent;
 use crate::css_values::time::Time;
 
 use crate::VendorPrefix;
@@ -107,6 +108,36 @@ impl Transition {
         }
         Ok(())
     }
+}
+
+/// A value for the [view-transition-name](https://drafts.csswg.org/css-view-transitions-1/#view-transition-name-prop) property.
+///
+/// Under CSS modules the `<custom-ident>` is scoped with the same hash as the
+/// `::view-transition-*(<name>)` pseudo-element selectors, so the two keep
+/// matching after renaming.
+#[derive(Clone, Copy, crate::Parse, crate::ToCss, crate::CssEql, crate::DeepClone)]
+pub enum ViewTransitionName {
+    /// The `none` keyword.
+    None,
+    /// The `auto` keyword.
+    Auto,
+    /// The `match-element` keyword.
+    MatchElement,
+    /// A custom name.
+    Custom(CustomIdent),
+}
+
+/// A value for the [view-transition-group](https://drafts.csswg.org/css-view-transitions-2/#view-transition-group-prop) property.
+#[derive(Clone, Copy, crate::Parse, crate::ToCss, crate::CssEql, crate::DeepClone)]
+pub enum ViewTransitionGroup {
+    /// The `normal` keyword.
+    Normal,
+    /// The `contain` keyword.
+    Contain,
+    /// The `nearest` keyword.
+    Nearest,
+    /// A custom group, the `view-transition-name` of an ancestor.
+    Custom(CustomIdent),
 }
 
 #[derive(Default)]

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -4128,20 +4128,12 @@ pub enum ViewTransitionPartName {
 
 impl ViewTransitionPartName {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // `CustomIdentFns::to_css` is CSS-modules-gated via
-        // `Printer::{css_module,write_ident}`; inline the
-        // `write_ident(v, false)` body (CSS-modules custom-ident scoping is a
-        // serializer concern, not a grammar concern — the gated impl just
-        // toggles the second arg).
-        let write_ci = |name: &CustomIdent, dest: &mut Printer| -> Result<(), PrintErr> {
-            dest.serialize_identifier(name.v())
-        };
         match self {
             Self::All => dest.write_str("*"),
-            Self::Name(name) => write_ci(name, dest),
+            Self::Name(name) => name.to_css(dest),
             Self::Class(name) => {
                 dest.write_char(b'.')?;
-                write_ci(name, dest)
+                name.to_css(dest)
             }
         }
     }

--- a/src/css/values/ident.rs
+++ b/src/css/values/ident.rs
@@ -465,3 +465,43 @@ impl CustomIdent {
 
 /// A list of CSS [`<custom-ident>`](https://www.w3.org/TR/css-values-4/#custom-idents) values.
 pub type CustomIdentList = SmallList<CustomIdent, 1>;
+
+/// `none | <custom-ident>+`: the `none` keyword, or a space-separated list of
+/// [`<custom-ident>`](https://www.w3.org/TR/css-values-4/#custom-idents) values.
+#[derive(Clone, crate::CssEql, crate::DeepClone)]
+pub enum NoneOrCustomIdentList {
+    /// The `none` keyword.
+    None,
+    /// A list of idents.
+    Idents(CustomIdentList),
+}
+
+impl NoneOrCustomIdentList {
+    pub fn parse(input: &mut Parser) -> CssResult<Self> {
+        let mut idents = CustomIdentList::default();
+        while let Ok(ident) = input.try_parse(CustomIdent::parse) {
+            if strings::eql_case_insensitive_ascii_check_length(ident.v(), b"none") {
+                if idents.len() == 0 {
+                    return Ok(Self::None);
+                }
+                return Err(input.new_custom_error(css::ParserError::invalid_value));
+            }
+            idents.append(ident);
+        }
+        if idents.len() == 0 {
+            return Err(input.new_error_for_next_token());
+        }
+        Ok(Self::Idents(idents))
+    }
+
+    pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
+        match self {
+            Self::None => dest.write_str(b"none"),
+            Self::Idents(idents) => dest.write_separated(
+                idents.slice(),
+                |d| d.write_char(b' '),
+                |d, ident| ident.to_css(d),
+            ),
+        }
+    }
+}

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -181,6 +181,105 @@ describe("css", () => {
     },
   });
 
+  // The name inside `::view-transition-group(name)` (and `-old`, `-new`,
+  // `-image-pair`) is a custom ident. It must get the same module hash as the
+  // `view-transition-name` / `view-transition-class` / `view-transition-group`
+  // declarations, otherwise the selectors never match the elements.
+  itBundled("css-module/ViewTransitionNamesScoped", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(styles.card);
+      `,
+      "/styles.module.css": `
+        .card {
+          view-transition-name: hero;
+          view-transition-class: slide;
+          view-transition-group: hero;
+        }
+        .page {
+          view-transition-name: none;
+          view-transition-class: none;
+          view-transition-group: nearest;
+        }
+        ::view-transition-group(hero) { animation-duration: 1s }
+        ::view-transition-image-pair(hero) { isolation: auto }
+        ::view-transition-old(.slide) { opacity: 0 }
+        ::view-transition-new(.slide) { opacity: 1 }
+        ::view-transition-group(*) { animation-timing-function: linear }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      const css = api.readFile("/out/entry.css");
+      const card = css.match(/\.card_([A-Za-z0-9_-]+)\s*\{/);
+      expect(card, ".card should be scoped").not.toBeNull();
+      const hash = card![1];
+
+      expect(css).toEqualIgnoringWhitespace(`
+        /* styles.module.css */
+        .card_${hash} {
+          view-transition-name: hero_${hash};
+          view-transition-class: slide_${hash};
+          view-transition-group: hero_${hash};
+        }
+
+        .page_${hash} {
+          view-transition-name: none;
+          view-transition-class: none;
+          view-transition-group: nearest;
+        }
+
+        ::view-transition-group(hero_${hash}) {
+          animation-duration: 1s;
+        }
+
+        ::view-transition-image-pair(hero_${hash}) {
+          isolation: auto;
+        }
+
+        ::view-transition-old(.slide_${hash}) {
+          opacity: 0;
+        }
+
+        ::view-transition-new(.slide_${hash}) {
+          opacity: 1;
+        }
+
+        ::view-transition-group(*) {
+          animation-timing-function: linear;
+        }
+      `);
+    },
+  });
+
+  // Values the grammar rejects stay untouched, so a future keyword or a
+  // var() reference is not hashed as if it were a name.
+  itBundled("css-module/ViewTransitionUnparsedValuesNotScoped", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(styles.card);
+      `,
+      "/styles.module.css": `
+        .card {
+          view-transition-name: var(--name);
+          view-transition-class: slide none;
+          view-transition-group: 1px;
+        }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      const css = api.readFile("/out/entry.css");
+      expect(css).toContain("view-transition-name: var(--name);");
+      expect(css).toContain("view-transition-class: slide none;");
+      expect(css).toContain("view-transition-group: 1px;");
+    },
+  });
+
   itBundled("css-module/ExportsMapMultipleClassesAndComposes", {
     files: {
       "/entry.js": `

--- a/test/bundler/css/view-transition-23600.test.ts
+++ b/test/bundler/css/view-transition-23600.test.ts
@@ -70,4 +70,64 @@ describe("css", () => {
       `);
     },
   });
+
+  // Outside CSS modules the view transition names are printed as written.
+  itBundled("css/view-transition-declarations", {
+    files: {
+      "index.css": /* css */ `
+        .card {
+          view-transition-name: hero;
+          view-transition-class: slide fade;
+          view-transition-group: hero;
+        }
+
+        .page {
+          view-transition-name: NONE;
+          view-transition-class: none;
+          view-transition-group: NEAREST;
+        }
+
+        .root {
+          view-transition-name: match-element;
+          view-transition-group: contain;
+        }
+
+        .invalid {
+          view-transition-name: 1px;
+          view-transition-class: slide none;
+          view-transition-group: var(--group);
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        .card {
+          view-transition-name: hero;
+          view-transition-class: slide fade;
+          view-transition-group: hero;
+        }
+
+        .page {
+          view-transition-name: none;
+          view-transition-class: none;
+          view-transition-group: nearest;
+        }
+
+        .root {
+          view-transition-name: match-element;
+          view-transition-group: contain;
+        }
+
+        .invalid {
+          view-transition-name: 1px;
+          view-transition-class: slide none;
+          view-transition-group: var(--group);
+        }
+        "
+      `);
+    },
+  });
 });


### PR DESCRIPTION
### Problem
- In a `.module.css` file, `::view-transition-group(hero)` (and `-old`, `-new`, `-image-pair`) keeps the bare name `hero` while class names in the same file are hashed. `ViewTransitionPartName::to_css` (`src/css/selectors/parser.rs`) wrote the name with `serialize_identifier`, which skips the module hash. The Zig version used `CustomIdentFns.toCss`, so this is a regression from the Rust rewrite.
- `view-transition-name: hero` was not a known property. The value was printed raw, so no side of the pair was scoped.

### Fix
- `ViewTransitionPartName::to_css` prints the name through `CustomIdent::to_css`. That is the path every other custom ident takes, and it applies the module hash.
- `view-transition-name`, `view-transition-class` and `view-transition-group` are now known properties (`ViewTransitionName`, `NoneOrCustomIdentList`, `ViewTransitionGroup`). Their `<custom-ident>` values print through `CustomIdent::to_css` too, so `.card { view-transition-name: hero }` and `::view-transition-group(hero)` get the same `hero_<hash>`. This matches current lightningcss.
- Keywords (`none`, `auto`, `match-element`, `normal`, `contain`, `nearest`) are not hashed. A value the grammar rejects (`1px`, `var()`, `slide none`) falls back to the unparsed path and is printed as written.
- Verified: `test/bundler/css/css-modules.test.ts` (`ViewTransitionNamesScoped` fails on bun 1.4.1) and `test/bundler/css/view-transition-23600.test.ts`. Also ran `test/bundler/css/`, `test/bundler/esbuild/css.test.ts`, `test/bundler/bundler_loader.test.ts` and `test/js/bun/css/css.test.ts`.

### Background
- CSS modules rename local names to `<name>_<hash>`. The hash comes from the file path. `Printer::write_ident(ident, true)` does the renaming. `CustomIdent::to_css` calls it when `css_module.config.custom_idents` is set, which is the default in the bundler.
- A `<custom-ident>` is an author defined name, for example an animation name or a view transition name. The view transition pseudo-elements select by that name, so the declaration and the selector must rename the same way.
- `properties_generated.rs` is the hand maintained table of known properties. A known property is parsed into a typed value and printed from it. An unknown property is kept as a token list.

<details><summary>Notes</summary>

Repro on bun 1.4.1:

```css
/* a.module.css */
.card { view-transition-name: hero }
::view-transition-group(hero) { animation-duration: 1s }
```

`bun build c.ts --outdir=out` prints `.card_BLNoTg { view-transition-name: hero }` and `::view-transition-group(hero)`. With this change both print `hero_BLNoTg`.

Keyword case is normalized for the new known properties (`NONE` prints as `none`), the same as for other keyword properties. Custom idents keep their case.

The JS export object of a CSS module lists class and id names only (`local_scope` in the bundler). View transition names are not added to it, the same as `@keyframes` names today. This change does not alter that.

`view-transition-group: none` is a valid `<custom-ident>` per css-view-transitions-2 (`none` is not a keyword of that property), so it is hashed. lightningcss does the same.

`cargo clippy -p bun_css` and `cargo fmt --check` are clean.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts "test/bundler/css/view-transition-23600.test.ts"
bun test v1.4.1 (65362b53b)

test/bundler/css/view-transition-23600.test.ts:
(pass) css > css/view-transition-class-selector-23600 [547.30ms]
100 |       `,
101 |     },
102 |     outdir: "/out",
103 |     entryPoints: ["/index.css"],
104 |     onAfterBundle(api) {
105 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                             ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
  .card {
    view-transition-name: hero;
    view-transition-class: slide fade;
    view-transition-group: hero;
  }
  
  .page {
-   view-transition-name: none;
+   view-transition-name: NONE;
    view-transition-class: none;
-   view-transition-group: nearest;
+   view-transition-group: NEAREST;
  }
  
  .root {
    view-transition-name: match-element;
    view-transition-group: contain;
  }
  
  .invalid {
    view-transition-name: 1px;
    view-transition-class: slide none;
    view-transition-
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/css/view-transition-23600.test.ts:
(pass) css > css/view-transition-class-selector-23600 [14.87ms]
100 |       `,
101 |     },
102 |     outdir: "/out",
103 |     entryPoints: ["/index.css"],
104 |     onAfterBundle(api) {
105 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                             ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
  .card {
    view-transition-name: hero;
    view-transition-class: slide fade;
    view-transition-group: hero;
  }
  
  .page {
-   view-transition-name: none;
+   view-transition-name: NONE;
    view-transition-class: none;
-   view-transition-group: nearest;
+   view-transition-group: NEAREST;
  }
  
  .root {
    view-transition-name: match-element;
    view-transition-group: contain;
  }
  
  .invalid {
    view-transition-name: 1px;
    view-transition-class: slide none;
    view-transition-group: var(--group);
  }
  "
  

- Expected  - 2
+ Received  + 2

      at onAfterBundle (/workspace/bun/test/bundler/css/view-transition-23600.test.ts:105:40)
      at <anonymous> (/workspace/bun/test/bundler/e
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts "test/bundler/css/view-transition-23600.test.ts"
bun test v1.4.1 (65362b53b)

test/bundler/css/view-transition-23600.test.ts:
(pass) css > css/view-transition-class-selector-23600 [541.80ms]
(pass) css > css/view-transition-declarations [97.60ms]

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [88.65ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [95.91ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [99.70ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [104.60ms]
(pass) css > css-module/RepeatedClassAndIdReferences [169.62ms]
(pass) css > css-module/ViewTransitionNamesScoped [113.61ms]
(pass) css > css-module/ViewTransitionUnparsedValuesNotScoped [97.42ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [104.66ms]

 10 pass
 0 fail
 6 snapshots, 32 expect() calls
Ran 10 tests across 2 files. [4.27s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a3a13628b4
  features     baseline

23 deps, 131 codegen, 1172 objects in 666ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [10.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] gen .bind.ts → GeneratedBindings.cpp
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [19.00ms]
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 23ms

  react-refresh.js  4.8
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/mod.rs                      |  1 +
 src/css/properties/properties_generated.rs     | 59 +++++++++++++++
 src/css/properties/transition.rs               | 31 ++++++++
 src/css/selectors/parser.rs                    | 12 +---
 src/css/values/ident.rs                        | 40 +++++++++++
 test/bundler/css/css-modules.test.ts           | 99 ++++++++++++++++++++++++++
 test/bundler/css/view-transition-23600.test.ts | 60 ++++++++++++++++
 7 files changed, 292 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/css/properties/mod.rs                           2      1      0
src/css/properties/properties_generated.rs          6     11      0
src/css/properties/transition.rs                    1      2      0
src/css/selectors/parser.rs                         2      1      0
src/css/values/ident.rs                             3      1      0
test/bundler/css/css-modules.test.ts                2      1      0
test/bundler/css/view-transition-23600.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->