### PR TITLE
install: share the bun run script environment with lifecycle scripts

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -678,8 +678,8 @@ impl<'a> Transpiler<'a> {
 
 // ══════════════════════════════════════════════════════════════════════════
 // `configure_linker*` / `run_env_loader` — used by
-// `RunCommand::configure_env_for_run` (runtime/cli/run_command.rs:527),
-// `bun_install::configure_env_for_run`, `JSBundleCompletionTask`,
+// `bun_install::RunCommand::configure_env_for_run` (shared by `bun run` and
+// the package manager's lifecycle scripts), `JSBundleCompletionTask`,
 // `JSTranspiler`, and `bun.js.rs:: bun_main_shell_entry`.
 // ══════════════════════════════════════════════════════════════════════════
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1061,25 +1061,31 @@ fn configure_env_for_scripts_run(
     // to do that, we re-use the code from bun run
     // this is expensive, it traverses the entire directory tree going up to the root
     // so we really only want to do it when strictly necessary
-    // `RunCommand::configure_env_for_run` fully initializes the slot via out-param.
-    // Transpiler is NOT
-    // all-zero-valid POD, so `zeroed()` is wrong; use MaybeUninit and assume_init after fill.
+    // `RunCommand::configure_env_for_run_without_linker` fully initializes the
+    // slot via out-param. Transpiler is NOT all-zero-valid POD, so `zeroed()`
+    // is wrong; use MaybeUninit and assume_init after fill.
+    //
+    // Nothing transpiles through this `Transpiler` (lifecycle scripts are
+    // spawned through the shell), so skip the bundler-linker setup.
     let mut this_transpiler_slot =
         core::mem::MaybeUninit::<transpiler::Transpiler<'static>>::uninit();
     // `self.env` is `Option<BackRef<Loader>>`; pass the raw pointer so
-    // the shim's `Transpiler::init` reuses the manager's loader instead of
-    // allocating a fresh singleton.
+    // `Transpiler::init` reuses the manager's loader instead of allocating a
+    // fresh singleton. The `npm_*` vars land in that loader, which
+    // `spawn_package_lifecycle_scripts` clones into every script's env.
     let env_ptr: Option<*mut dot_env::Loader> = this.env.map(|p| p.as_ptr());
-    let _ = RunCommand::configure_env_for_run(
+    let _ = RunCommand::configure_env_for_run_without_linker(
+        crate::install_runner_arena(),
         ctx,
         &mut this_transpiler_slot,
         env_ptr,
-        log_level != package_manager_options::LogLevel::Silent,
-        false,
+        crate::ConfigureEnvOptions {
+            log_errors: log_level != package_manager_options::LogLevel::Silent,
+            store_root_fd: false,
+        },
     )?;
-    // SAFETY: the install-tier `RunCommand::configure_env_for_run` shim
-    // (lib.rs) `.write()`s the slot via `Transpiler::init` before returning
-    // `Ok` — same contract as the runtime impl (run_command.rs:628).
+    // SAFETY: `configure_env_for_run_without_linker` `.write()`s the slot via
+    // `Transpiler::init` before returning `Ok`.
     let this_transpiler = unsafe { this_transpiler_slot.assume_init() };
 
     let init_cwd_entry = this.env_mut().map.get_or_put_without_value(b"INIT_CWD")?;

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -206,6 +206,8 @@ pub enum Error {
     InvalidBinCount,
     #[error("InvalidBinContent")]
     InvalidBinContent,
+    #[error("CouldntReadCurrentDirectory")]
+    CouldntReadCurrentDirectory,
 
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
@@ -366,6 +368,7 @@ impl Error {
             Self::FailedToCopyFile => "FailedToCopyFile",
             Self::InvalidBinCount => "InvalidBinCount",
             Self::InvalidBinContent => "InvalidBinContent",
+            Self::CouldntReadCurrentDirectory => "CouldntReadCurrentDirectory",
             Self::Sys(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
             Self::Core(e) => e.name(),

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -754,12 +754,14 @@ impl RunCommand {
     }
 }
 
-/// Process-lifetime arena for the install-tier `Transpiler` constructed in
-/// `RunCommand::configure_env_for_run`. Mirrors `runner_arena()` in
-/// `runtime/cli/run_command.rs` — `bun_alloc::Arena` is `!Sync`, so guard a
-/// a raw `MaybeUninit` global with `Once` (PORTING.md §Forbidden bars
+/// Process-lifetime arena for the `Transpiler` that
+/// `PackageManager::configure_env_for_scripts` builds through
+/// [`RunCommand::configure_env_for_run_without_linker`]. The runtime CLI
+/// passes its own arena instead (`runner_arena()` in
+/// `runtime/cli/run_command.rs`). `bun_alloc::Arena` is `!Sync`, so guard a
+/// raw `MaybeUninit` global with `Once` (PORTING.md §Forbidden bars
 /// `Box::leak`).
-fn install_runner_arena() -> &'static bun_alloc::Arena {
+pub(crate) fn install_runner_arena() -> &'static bun_alloc::Arena {
     static ONCE: std::sync::Once = std::sync::Once::new();
     // PORTING.md §Global mutable state: `Once`-guarded init; RacyCell because
     // `Bump` is `!Sync` so `OnceLock<Arena>` can't be used.
@@ -769,61 +771,206 @@ fn install_runner_arena() -> &'static bun_alloc::Arena {
         // SAFETY: one-time init under `Once`; no concurrent writer.
         unsafe { (*ARENA.get()).write(bun_alloc::Arena::new()) };
     });
-    // SAFETY: initialized exactly once above. `configure_env_for_run` is only
-    // ever called from the single CLI dispatch thread, so the `!Sync` Bump is
-    // never observed concurrently.
+    // SAFETY: initialized exactly once above. `configure_env_for_scripts` is
+    // only ever called from the main thread, so the `!Sync` Bump is never
+    // observed concurrently.
     unsafe { (*ARENA.get()).assume_init_ref() }
 }
 
+/// Per-caller knobs for [`RunCommand::configure_env_for_run`] and
+/// [`RunCommand::configure_env_for_run_without_linker`].
+#[derive(Clone, Copy)]
+pub struct ConfigureEnvOptions {
+    /// Report a current directory that cannot be read on stderr. When `false`
+    /// it is only returned, as [`Error::CouldntReadCurrentDirectory`].
+    pub log_errors: bool,
+    /// Keep the current directory's fd open on the returned `DirInfo` (only
+    /// that one: the resolver's `store_fd` is turned back off right after),
+    /// for callers that go on to read files through it, like `bunx` resolving
+    /// a package's `bin`.
+    pub store_root_fd: bool,
+}
+
+struct NpmArgs;
+impl NpmArgs {
+    // https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md#detailed-explanation
+    const PACKAGE_NAME: &'static [u8] = b"npm_package_name";
+    const PACKAGE_VERSION: &'static [u8] = b"npm_package_version";
+}
+
 impl RunCommand {
-    /// DEP-CYCLE NOTE: the full implementation walks `bun_resolver::DirInfo`
-    /// and reads `package.json` via the resolver — T6 work that lives in
-    /// `bun_runtime::cli::RunCommand::configure_env_for_run`. The install
-    /// tier needs the *Transpiler-initialisation* half of that contract
-    /// because callers (`configure_env_for_scripts_run`) `assume_init()` the
-    /// out-param. This shim performs the init + the env-var seeding that has
-    /// no T6 dependency; the `*mut ()` return stands in for `*mut DirInfo`
-    /// (opaque to install — every caller discards it).
-    pub(crate) fn configure_env_for_run(
+    /// Builds the `Transpiler` every script runner shares (`bun run`, `bunx`,
+    /// `bun pm pack`, and the package manager's lifecycle scripts): primes its
+    /// resolver and env loader, reads the top-level `DirInfo`, configures the
+    /// bundler linker / JSX runtime, and seeds the `npm_*` env vars from the
+    /// enclosing `package.json`.
+    ///
+    /// `arena` backs the `Transpiler` for the rest of the process. Each caller
+    /// passes its own process-lifetime arena.
+    ///
+    /// Returns the `DirInfo` of the top-level directory, borrowed from the
+    /// resolver's directory cache (process-lifetime).
+    ///
+    /// Hot-path note: a caller that never transpiles through this
+    /// `Transpiler` (it shells out, or boots a fresh VM with its own
+    /// transpiler) should call
+    /// [`Self::configure_env_for_run_without_linker`] instead. That skips the
+    /// `configure_linker()` + `load_tsconfig_json` work, which is the single
+    /// largest block of bundler/linker code otherwise faulted in by `bun run`.
+    pub fn configure_env_for_run(
+        arena: &'static bun_alloc::Arena,
         ctx: &mut bun_options_types::context::ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<bun_transpiler::Transpiler<'static>>,
         env: Option<*mut bun_dotenv::Loader>,
-        _log_errors: bool,
-        store_root_fd: bool,
-    ) -> Result<*mut (), crate::Error> {
-        use bun_core::Global;
+        opts: ConfigureEnvOptions,
+    ) -> Result<bun_resolver::DirInfoRef, crate::Error> {
+        Self::configure_env_for_run_impl(arena, ctx, this_transpiler, env, opts, true)
+    }
+
+    /// Like [`Self::configure_env_for_run`] but does **not** construct the
+    /// bundler linker or enable `load_tsconfig_json` — for callers that only
+    /// use the returned `Transpiler` for module resolution / env / `$PATH`
+    /// lookup, never for transpiling.
+    pub fn configure_env_for_run_without_linker(
+        arena: &'static bun_alloc::Arena,
+        ctx: &mut bun_options_types::context::ContextData,
+        this_transpiler: &mut ::core::mem::MaybeUninit<bun_transpiler::Transpiler<'static>>,
+        env: Option<*mut bun_dotenv::Loader>,
+        opts: ConfigureEnvOptions,
+    ) -> Result<bun_resolver::DirInfoRef, crate::Error> {
+        Self::configure_env_for_run_impl(arena, ctx, this_transpiler, env, opts, false)
+    }
+
+    /// `configure_linker()` + `load_tsconfig_json` setup, factored into a
+    /// `#[cold]` callee so the bundler-linker/JSX-runtime code it pulls in does
+    /// not share `.text` pages with the hot `bun run <script>` dispatch path.
+    #[cold]
+    #[inline(never)]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
+    fn configure_run_transpiler_linker(this_transpiler: &mut bun_transpiler::Transpiler<'static>) {
+        this_transpiler.resolver.opts.load_tsconfig_json = true;
+        this_transpiler.options.load_tsconfig_json = true;
+        this_transpiler.configure_linker();
+    }
+
+    fn configure_env_for_run_impl(
+        arena: &'static bun_alloc::Arena,
+        ctx: &mut bun_options_types::context::ContextData,
+        this_transpiler: &mut ::core::mem::MaybeUninit<bun_transpiler::Transpiler<'static>>,
+        env: Option<*mut bun_dotenv::Loader>,
+        opts: ConfigureEnvOptions,
+        with_linker: bool,
+    ) -> Result<bun_resolver::DirInfoRef, crate::Error> {
+        use bun_core::{Global, Output};
 
         let args = ctx.args.clone();
-        this_transpiler.write(bun_transpiler::Transpiler::init(
-            install_runner_arena(),
-            ctx.log,
-            args,
-            env,
-        )?);
+        let env_is_none = env.is_none();
+        // Out-param constructor — `Transpiler` holds `&Arena`/`Box`/enum
+        // fields (non-null invariants), so callers MUST pass a `MaybeUninit`
+        // slot and this function writes the whole struct.
+        this_transpiler.write(bun_transpiler::Transpiler::init(arena, ctx.log, args, env)?);
         // SAFETY: fully written on the line above.
         let this_transpiler = unsafe { this_transpiler.assume_init_mut() };
         this_transpiler.options.env.behavior =
             bun_options_types::schema::api::DotEnvBehavior::load_all;
+        let env_loader = this_transpiler.env_mut();
+        env_loader.quiet = true;
+        this_transpiler.options.env.prefix = Box::default();
+
         this_transpiler.resolver.care_about_bin_folder = true;
         this_transpiler.resolver.care_about_scripts = true;
-        this_transpiler.resolver.store_fd = store_root_fd;
+        this_transpiler.resolver.store_fd = opts.store_root_fd;
 
-        // Re-derive per-use rather than holding a long-lived `&mut` (avoids
-        // Stacked-Borrows overlap with `run_env_loader`).
+        // Bundler-linker + JSX-runtime config: only callers that actually
+        // transpile through this `Transpiler` need it. `configure_linker`'s
+        // auto-JSX step reads the cwd `DirInfo` (and, with `load_tsconfig_json`
+        // on, its `tsconfig.json`) — keep it ahead of the `read_dir_info` below
+        // so that read populates/uses the same cache entry.
+        if with_linker {
+            Self::configure_run_transpiler_linker(this_transpiler);
+        }
+
+        // SAFETY: `Transpiler::init` always sets `fs` to the process singleton.
+        let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir };
+        let root_dir_info: bun_resolver::DirInfoRef =
+            match this_transpiler.resolver.read_dir_info(top_level_dir) {
+                Err(err) => {
+                    if !opts.log_errors {
+                        return Err(crate::Error::CouldntReadCurrentDirectory);
+                    }
+                    // SAFETY: `ctx.log` is set in `create_context_data`
+                    // (single-threaded CLI startup), process-lifetime.
+                    let _ = unsafe { ctx.log() }.print(std::ptr::from_mut::<bun_core::io::Writer>(
+                        Output::error_writer(),
+                    ));
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r><d>:<r> <b>{}<r> loading directory {}",
+                        bstr::BStr::new(err.name()),
+                        bun_core::fmt::QuotedFormatter {
+                            text: top_level_dir
+                        },
+                    );
+                    Output::flush();
+                    return Err(err.into());
+                }
+                Ok(None) => {
+                    // SAFETY: see `Err` arm above.
+                    let _ = unsafe { ctx.log() }.print(std::ptr::from_mut::<bun_core::io::Writer>(
+                        Output::error_writer(),
+                    ));
+                    bun_core::pretty_errorln!("error loading current directory");
+                    Output::flush();
+                    return Err(crate::Error::CouldntReadCurrentDirectory);
+                }
+                Ok(Some(info)) => info,
+            };
+
+        this_transpiler.resolver.store_fd = false;
+
+        if env_is_none {
+            // Re-derive — borrowck won't let `env_loader` straddle the
+            // `&mut this_transpiler.resolver` above. Scoped to this block so it
+            // does NOT straddle `run_env_loader` below (which itself derives
+            // `env_mut()`, popping any outstanding `&mut Loader` tag).
+            let env_loader = this_transpiler.env_mut();
+            env_loader.load_process()?;
+
+            if let Some(node_env) = env_loader.get(b"NODE_ENV") {
+                if node_env == b"production" {
+                    this_transpiler.options.production = true;
+                }
+            }
+
+            // Always skip default .env files for package.json script runner
+            // (the script's own bun instance loads .env)
+            let _ = this_transpiler.run_env_loader(true);
+        }
+
+        // Re-derive after `run_env_loader` — that call creates its own
+        // `env_mut()` borrow, which under Stacked Borrows invalidates any
+        // `&mut Loader` derived before it. Take a fresh borrow here for the
+        // remaining env-var seeding.
         let env_loader = this_transpiler.env_mut();
+
+        env_loader
+            .map
+            .put_default(b"npm_config_local_prefix", top_level_dir)?;
 
         // Propagate --no-orphans / [run] noOrphans to the script's env so any
         // Bun process the script spawns enables its own watchdog. The env
         // loader snapshots `environ` before flag parsing runs, so the
         // `setenv()` in `enable()` isn't reflected here.
-        if bun_io::parent_death_watchdog::is_enabled() {
-            let _ = env_loader.map.put(b"BUN_FEATURE_FLAG_NO_ORPHANS", b"1");
+        if bun_io::ParentDeathWatchdog::is_enabled() {
+            env_loader.map.put(b"BUN_FEATURE_FLAG_NO_ORPHANS", b"1")?;
         }
 
         // we have no way of knowing what version they're expecting without
         // running the node executable; running the node executable is too
         // slow, so we will just hardcode it to LTS
-        let _ = env_loader.map.put_default(
+        env_loader.map.put_default(
             b"npm_config_user_agent",
             // the use of npm/? is copying yarn
             // e.g.
@@ -839,21 +986,48 @@ impl RunCommand {
                 Global::arch_name,
             )
             .as_bytes(),
-        );
+        )?;
 
         if env_loader.get(b"npm_execpath").is_none() {
             // we don't care if this fails
-            if let Ok(self_exe) = bun_core::self_exe_path() {
-                let _ = env_loader
+            if let Ok(self_exe_path) = bun_core::self_exe_path() {
+                env_loader
                     .map
-                    .put_default(b"npm_execpath", self_exe.as_bytes());
+                    .put_default(b"npm_execpath", self_exe_path.as_bytes())?;
             }
         }
 
-        // DirInfo walk / npm_package_* seeding is performed by the T6 impl
-        // (`bun_runtime::cli::RunCommand::configure_env_for_run`); install
-        // callers discard the return value.
-        Ok(core::ptr::null_mut())
+        if let Some(package_json) = root_dir_info.enclosing_package_json {
+            if !package_json.name.is_empty() {
+                if env_loader.map.get(NpmArgs::PACKAGE_NAME).is_none() {
+                    env_loader
+                        .map
+                        .put(NpmArgs::PACKAGE_NAME, &package_json.name)?;
+                }
+            }
+
+            env_loader
+                .map
+                .put_default(b"npm_package_json", package_json.source.path.text)?;
+
+            if !package_json.version.is_empty() {
+                if env_loader.map.get(NpmArgs::PACKAGE_VERSION).is_none() {
+                    env_loader
+                        .map
+                        .put(NpmArgs::PACKAGE_VERSION, &package_json.version)?;
+                }
+            }
+
+            if let Some(config) = package_json.config.as_deref() {
+                env_loader.map.ensure_unused_capacity(config.count())?;
+                for (k, v) in config.keys().iter().zip(config.values().iter()) {
+                    let key = bun_core::strings::concat(&[b"npm_package_config_", &k[..]]);
+                    env_loader.map.put_assume_capacity(&key, *v);
+                }
+            }
+        }
+
+        Ok(root_dir_info)
     }
 }
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2123,7 +2123,10 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             store_root_fd: false,
         },
     ) {
-        if matches!(err, crate::Error::Alloc(_)) {
+        if matches!(
+            err,
+            crate::Error::Alloc(_) | crate::Error::Install(bun_install::Error::Alloc(_))
+        ) {
             return Err(PackError::OutOfMemory);
         }
         Output::err_generic(

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -11,7 +11,7 @@ use std::io::Write as _;
 use bun_ast::Loader;
 use bun_bundler::Transpiler;
 use bun_collections::{ArrayHashMap, StringHashMap};
-use bun_core::{self as core, Environment, Global, Output, ZStr};
+use bun_core::{self as core, Global, Output, ZStr};
 use bun_core::{pretty, pretty_errorln, prettyln};
 use bun_dotenv as DotEnv;
 use bun_jsc::js_promise::Status as PromiseStatus;
@@ -64,13 +64,6 @@ fn runner_arena() -> &'static bun_alloc::Arena {
 // the shell escaper cannot silently diverge.
 use bun_shell_parser::{escape_8bit, needs_escape_utf8_ascii_latin1};
 
-struct NpmArgs;
-impl NpmArgs {
-    // https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md#detailed-explanation
-    const PACKAGE_NAME: &'static [u8] = b"npm_package_name";
-    const PACKAGE_VERSION: &'static [u8] = b"npm_package_version";
-}
-
 /// Runtime knobs `Command::start` passes through to select the per-tag exec
 /// behavior.
 #[derive(Clone, Copy)]
@@ -81,18 +74,9 @@ pub struct ExecCfg {
 }
 
 /// Per-caller knobs for [`RunCommand::configure_env_for_run`] and
-/// [`RunCommand::configure_env_for_run_without_linker`].
-#[derive(Clone, Copy)]
-pub(crate) struct ConfigureEnvOptions {
-    /// Report a current directory that cannot be read on stderr. When `false`
-    /// it is only returned, as [`crate::Error::CouldntReadCurrentDirectory`].
-    pub(crate) log_errors: bool,
-    /// Keep the current directory's fd open on the returned `DirInfo` (only
-    /// that one: the resolver's `store_fd` is turned back off right after),
-    /// for callers that go on to read files through it, like `bunx` resolving
-    /// a package's `bin`.
-    pub(crate) store_root_fd: bool,
-}
+/// [`RunCommand::configure_env_for_run_without_linker`]. Defined next to the
+/// shared implementation in `bun_install`.
+pub(crate) use bun_install::ConfigureEnvOptions;
 
 pub(crate) struct RunCommand;
 
@@ -537,12 +521,15 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         Ok(())
     }
 
-    /// Allocates a
-    /// process-lifetime `Transpiler`, primes its resolver/env, reads the
-    /// top-level `DirInfo`, configures the bundler linker / JSX runtime, and
-    /// seeds the `npm_*` env vars.
+    /// Allocates a process-lifetime `Transpiler`, primes its resolver/env,
+    /// reads the top-level `DirInfo`, configures the bundler linker / JSX
+    /// runtime, and seeds the `npm_*` env vars.
     ///
-    /// Returns a raw `*mut DirInfo` borrowed from the resolver's directory
+    /// Implementation lives in `bun_install::RunCommand` (lower tier) so the
+    /// package manager's lifecycle scripts get the same environment as
+    /// `bun run`.
+    ///
+    /// Returns the top-level `DirInfo`, borrowed from the resolver's directory
     /// cache (process-lifetime).
     ///
     /// Hot-path note: the common `bun run <package.json script>` case never
@@ -557,7 +544,13 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         env: Option<*mut DotEnv::Loader>,
         opts: ConfigureEnvOptions,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
-        Self::configure_env_for_run_impl(ctx, this_transpiler, env, opts, true)
+        Ok(bun_install::RunCommand::configure_env_for_run(
+            runner_arena(),
+            ctx,
+            this_transpiler,
+            env,
+            opts,
+        )?)
     }
 
     /// Like [`Self::configure_env_for_run`] but does **not** construct the
@@ -570,206 +563,15 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         env: Option<*mut DotEnv::Loader>,
         opts: ConfigureEnvOptions,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
-        Self::configure_env_for_run_impl(ctx, this_transpiler, env, opts, false)
-    }
-
-    /// `configure_linker()` + `load_tsconfig_json` setup, factored into a
-    /// `#[cold]` callee so the bundler-linker/JSX-runtime code it pulls in does
-    /// not share `.text` pages with the hot `bun run <script>` dispatch path.
-    #[cold]
-    #[inline(never)]
-    #[cfg_attr(
-        any(target_os = "linux", target_os = "android"),
-        unsafe(link_section = ".text.unlikely")
-    )]
-    fn configure_run_transpiler_linker(this_transpiler: &mut Transpiler<'static>) {
-        this_transpiler.resolver.opts.load_tsconfig_json = true;
-        this_transpiler.options.load_tsconfig_json = true;
-        this_transpiler.configure_linker();
-    }
-
-    fn configure_env_for_run_impl(
-        ctx: &mut ContextData,
-        this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
-        env: Option<*mut DotEnv::Loader>,
-        opts: ConfigureEnvOptions,
-        with_linker: bool,
-    ) -> crate::Result<bun_resolver::DirInfoRef> {
-        let args = ctx.args.clone();
-        let env_is_none = env.is_none();
-        // Process-lifetime arena singleton for the runner's transpiler;
-        // threads an `&'static Arena` per PORTING.md §AST crates.
-        let arena: &'static bun_alloc::Arena = runner_arena();
-        // Out-param constructor — `configure_env_for_run` writes the whole struct.
-        // `Transpiler` holds `&Arena`/`Box`/enum fields (non-null invariants),
-        // so callers MUST pass a `MaybeUninit` slot.
-        this_transpiler.write(Transpiler::init(arena, ctx.log, args, env)?);
-        // SAFETY: fully written on the line above.
-        let this_transpiler = unsafe { this_transpiler.assume_init_mut() };
-        this_transpiler.options.env.behavior = api::DotEnvBehavior::LoadAll;
-        let env_loader = this_transpiler.env_mut();
-        env_loader.quiet = true;
-        this_transpiler.options.env.prefix = Box::default();
-
-        this_transpiler.resolver.care_about_bin_folder = true;
-        this_transpiler.resolver.care_about_scripts = true;
-        this_transpiler.resolver.store_fd = opts.store_root_fd;
-
-        // Bundler-linker + JSX-runtime config: only callers that actually
-        // transpile through this `Transpiler` need it. `configure_linker`'s
-        // auto-JSX step reads the cwd `DirInfo` (and, with `load_tsconfig_json`
-        // on, its `tsconfig.json`) — keep it ahead of the `read_dir_info` below
-        // so that read populates/uses the same cache entry.
-        if with_linker {
-            Self::configure_run_transpiler_linker(this_transpiler);
-        }
-
-        // SAFETY: `Transpiler::init` always sets `fs` to the process singleton.
-        let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir };
-        let root_dir_info: bun_resolver::DirInfoRef =
-            match this_transpiler.resolver.read_dir_info(top_level_dir) {
-                Err(err) => {
-                    if !opts.log_errors {
-                        return Err(crate::Error::CouldntReadCurrentDirectory);
-                    }
-                    // SAFETY: `ctx.log` set in `create_context_data` (single-
-                    // threaded CLI startup), process-lifetime.
-                    let _ = unsafe { ctx.log() }.print(std::ptr::from_mut::<bun_core::io::Writer>(
-                        Output::error_writer(),
-                    ));
-                    pretty_errorln!(
-                        "<r><red>error<r><d>:<r> <b>{}<r> loading directory {}",
-                        bstr::BStr::new(err.name()),
-                        bun_core::fmt::QuotedFormatter {
-                            text: top_level_dir
-                        },
-                    );
-                    Output::flush();
-                    return Err(err.into());
-                }
-                Ok(None) => {
-                    // SAFETY: see `Err` arm above.
-                    let _ = unsafe { ctx.log() }.print(std::ptr::from_mut::<bun_core::io::Writer>(
-                        Output::error_writer(),
-                    ));
-                    pretty_errorln!("error loading current directory");
-                    Output::flush();
-                    return Err(crate::Error::CouldntReadCurrentDirectory);
-                }
-                Ok(Some(info)) => info,
-            };
-
-        this_transpiler.resolver.store_fd = false;
-
-        if env_is_none {
-            // Re-derive — borrowck won't let `env_loader` straddle the
-            // `&mut this_transpiler.resolver` above. Scoped to this block so it
-            // does NOT straddle `run_env_loader` below (which itself derives
-            // `env_mut()`, popping any outstanding `&mut Loader` tag).
-            let env_loader = this_transpiler.env_mut();
-            env_loader.load_process()?;
-
-            if let Some(node_env) = env_loader.get(b"NODE_ENV") {
-                if node_env == b"production" {
-                    this_transpiler.options.production = true;
-                }
-            }
-
-            // Always skip default .env files for package.json script runner
-            // (the script's own bun instance loads .env)
-            let _ = this_transpiler.run_env_loader(true);
-        }
-
-        // Re-derive after `run_env_loader` — that call creates its own
-        // `env_mut()` borrow, which under Stacked Borrows invalidates any
-        // `&mut Loader` derived before it. Take a fresh borrow here for the
-        // remaining env-var seeding.
-        let env_loader = this_transpiler.env_mut();
-
-        env_loader
-            .map
-            .put_default(b"npm_config_local_prefix", top_level_dir)
-            .expect("unreachable");
-
-        // Propagate --no-orphans / [run] noOrphans to the script's env so any
-        // Bun process the script spawns enables its own watchdog. The env
-        // loader snapshots `environ` before flag parsing runs, so the
-        // `setenv()` in `enable()` isn't reflected here.
-        if bun_io::ParentDeathWatchdog::is_enabled() {
-            env_loader
-                .map
-                .put(b"BUN_FEATURE_FLAG_NO_ORPHANS", b"1")
-                .expect("unreachable");
-        }
-
-        // we have no way of knowing what version they're expecting without running the node executable
-        // running the node executable is too slow
-        // so we will just hardcode it to LTS
-        env_loader
-            .map
-            .put_default(
-                b"npm_config_user_agent",
-                // the use of npm/? is copying yarn
-                // e.g.
-                // > "yarn/1.22.4 npm/? node/v12.16.3 darwin x64",
-                const_format::concatcp!(
-                    "bun/",
-                    Global::package_json_version,
-                    " npm/? node/v",
-                    Environment::REPORTED_NODEJS_VERSION,
-                    " ",
-                    Global::os_name,
-                    " ",
-                    Global::arch_name
-                )
-                .as_bytes(),
-            )
-            .expect("unreachable");
-
-        if env_loader.get(b"npm_execpath").is_none() {
-            // we don't care if this fails
-            if let Ok(self_exe_path) = bun_core::self_exe_path() {
-                env_loader
-                    .map
-                    .put_default(b"npm_execpath", self_exe_path.as_bytes())
-                    .expect("unreachable");
-            }
-        }
-
-        if let Some(package_json) = root_dir_info.enclosing_package_json {
-            if !package_json.name.is_empty() {
-                if env_loader.map.get(NpmArgs::PACKAGE_NAME).is_none() {
-                    env_loader
-                        .map
-                        .put(NpmArgs::PACKAGE_NAME, &package_json.name)
-                        .expect("unreachable");
-                }
-            }
-
-            env_loader
-                .map
-                .put_default(b"npm_package_json", package_json.source.path.text)
-                .expect("unreachable");
-
-            if !package_json.version.is_empty() {
-                if env_loader.map.get(NpmArgs::PACKAGE_VERSION).is_none() {
-                    env_loader
-                        .map
-                        .put(NpmArgs::PACKAGE_VERSION, &package_json.version)
-                        .expect("unreachable");
-                }
-            }
-
-            if let Some(config) = package_json.config.as_deref() {
-                env_loader.map.ensure_unused_capacity(config.count())?;
-                for (k, v) in config.keys().iter().zip(config.values().iter()) {
-                    let key = strings::concat(&[b"npm_package_config_", &k[..]]);
-                    env_loader.map.put_assume_capacity(&key, *v);
-                }
-            }
-        }
-
-        Ok(root_dir_info)
+        Ok(
+            bun_install::RunCommand::configure_env_for_run_without_linker(
+                runner_arena(),
+                ctx,
+                this_transpiler,
+                env,
+                opts,
+            )?,
+        )
     }
 
     /// Best-effort default-loader lookup by file extension. Thin forwarder to

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -138,8 +138,6 @@ pub enum Error {
     InvalidJSXRuntime,
     #[error("ThreadSpawnFailed")]
     ThreadSpawnFailed,
-    #[error("CouldntReadCurrentDirectory")]
-    CouldntReadCurrentDirectory,
     #[error("FailedToGetTempPath")]
     FailedToGetTempPath,
     #[error("UnexpectedCreatingStdin")]
@@ -465,7 +463,6 @@ impl Error {
             Self::InvalidLoader => "InvalidLoader",
             Self::InvalidJSXRuntime => "InvalidJSXRuntime",
             Self::ThreadSpawnFailed => "ThreadSpawnFailed",
-            Self::CouldntReadCurrentDirectory => "CouldntReadCurrentDirectory",
             Self::FailedToGetTempPath => "FailedToGetTempPath",
             Self::UnexpectedCreatingStdin => "UnexpectedCreatingStdin",
             Self::UnableToEncode => "UnableToEncode",

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -299,6 +299,63 @@ test.concurrent("node-gyp shim directory added to lifecycle script PATH gets a r
   expect(distance > 21_600_000_000_000n).toBe(true);
 });
 
+test.concurrent("lifecycle scripts get the npm_package_* env vars from the root package.json", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson } = ctx;
+
+  // A test runner started through `bun run` already has npm_package_* set.
+  // Existing values are kept, so drop them to test the seeding itself.
+  const env = Object.fromEntries(Object.entries(ctx.env).filter(([key]) => !key.startsWith("npm_")));
+
+  const keys = [
+    "npm_package_name",
+    "npm_package_version",
+    "npm_package_json",
+    "npm_config_local_prefix",
+    "npm_package_config_foo",
+  ];
+  const script = `await Bun.write("env.json", JSON.stringify(Object.fromEntries(${JSON.stringify(keys)}.map(k => [k, process.env[k]]))))`;
+
+  await writeFile(
+    packageJson,
+    JSON.stringify({
+      name: "npm-env-root",
+      version: "1.2.3",
+      config: {
+        foo: "bar",
+      },
+      dependencies: {
+        "no-deps": "1.0.0",
+      },
+      scripts: {
+        postinstall: `${bunExe()} -e '${script}'`,
+      },
+    }),
+  );
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+
+  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(out).toContain("1 package installed");
+  expect(exitCode).toBe(0);
+
+  expect(await file(join(packageDir, "env.json")).json()).toEqual({
+    npm_package_name: "npm-env-root",
+    npm_package_version: "1.2.3",
+    npm_package_json: join(packageDir, "package.json"),
+    npm_config_local_prefix: packageDir,
+    npm_package_config_foo: "bar",
+  });
+});
+
 test.concurrent("default trusted dependencies require the canonical registry tarball URL", async () => {
   using ctx = await setupTest();
   const { packageDir, packageJson, env } = ctx;


### PR DESCRIPTION
### Problem
- Lifecycle scripts run by `bun install` (`preinstall`, `install`, `postinstall`) do not get `npm_package_name`, `npm_package_version`, `npm_package_json`, `npm_config_local_prefix` or `npm_package_config_*`. The repro below prints `NAME= VER= JSON= PREFIX= CFG=`. `bun run postinstall` in the same directory prints all five.
- Cause: `PackageManager::configure_env_for_scripts_run` (`src/install/PackageManager.rs:1077`) called an install-crate copy of `RunCommand::configure_env_for_run` (`src/install/lib.rs:787`). The copy only set `npm_config_user_agent`, `npm_execpath` and the node shim `PATH`. It never read the top-level `DirInfo`, so it skipped the `package.json` block that the runtime version seeds (`src/runtime/cli/run_command.rs:739-770`). Bun 1.3 shared one implementation between `bun run` and the package manager.

### Fix
- `bun_install::RunCommand::configure_env_for_run` and `configure_env_for_run_without_linker` are now the full implementation. The runtime's `RunCommand::configure_env_for_run*` forward to them, the same way `create_fake_temporary_node_executable` already lives in the install crate.
- The arena is a parameter. `bun run` keeps its `cli_arena()`, so the hot `bun run <script>` path does not gain a `Once`. The package manager passes its own arena and uses the `without_linker` variant, since nothing transpiles through that `Transpiler`.
- `ConfigureEnvOptions` and `Error::CouldntReadCurrentDirectory` move to `bun_install`. The runtime re-exports the options and wraps the error as `Error::Install(..)`. `pack_command` checks the wrapped `Alloc` too.
- Verified: `test/cli/install/bun-install-lifecycle-scripts.test.ts` (new test "lifecycle scripts get the npm_package_* env vars from the root package.json", fails on 1.4.1). Also `bun-run.test.ts`, `bun-pack.test.ts`, `bunx.test.ts`, the `npm_package_config` tests in `bun-workspaces.test.ts`, and the `bun run` env suites in `test/cli/run/`.

### Background
- `RunCommand::configure_env_for_run` builds the `Transpiler` that every script runner uses for `PATH`, `node_modules/.bin` and env lookup. It reads the top-level `DirInfo` through the resolver and copies `name`, `version`, the `package.json` path and `config` from the enclosing `package.json` into the env loader.
- `bun_runtime` depends on `bun_install`, not the other way around. That dependency direction is why the install crate had a partial copy instead of a call.
- The package manager passes its own env loader to this function. `spawn_package_lifecycle_scripts` clones that loader into the env of every script, so the values seeded here reach root and dependency scripts alike.

<details><summary>Notes</summary>

Repro:

```json
{ "name": "mypkg", "version": "1.2.3", "config": { "foo": "bar" },
  "scripts": { "postinstall": "echo NAME=$npm_package_name VER=$npm_package_version JSON=$npm_package_json PREFIX=$npm_config_local_prefix CFG=$npm_package_config_foo" } }
```

`bun install` on 1.4.1: `NAME= VER= JSON= PREFIX= CFG=`. With this branch: `NAME=mypkg VER=1.2.3 JSON=/tmp/repro-npmenv/package.json PREFIX=/tmp/repro-npmenv CFG=bar`.

Scope: this restores the 1.3 behavior. Every lifecycle script, including a dependency's, gets the values of the root `package.json`. npm gives a dependency's script its own `name`, `version`, `json` and `config`. The open #36690 and #38110 take that per-package route for some of these variables by reading the manifest at the script's cwd. That can layer on top of this change in `spawn_package_lifecycle_scripts`. #38110 is part of the fold in #39403 and touches the same shim in `src/install/lib.rs`.

Semantics kept from the runtime version: `npm_package_name` and `npm_package_version` are only set when absent, `npm_package_json`, `npm_config_local_prefix`, `npm_config_user_agent` and `npm_execpath` use `put_default`, and `npm_package_config_*` always overwrites. The new test strips inherited `npm_*` variables because a test runner started through `bun run` already carries them.

Local test notes: three existing `PATH=""` tests in `bun-install-lifecycle-scripts.test.ts` and the `npm_config_user_agent` test in `bunx.test.ts` fail under `bun bd test` in this container because `bun run` exports `NODE`, `npm_node_execpath` and `npm_config_user_agent` into the runner's env. They pass with those variables removed, on this branch and on the release build. The root-only `no-orphans.test.ts` uid/gid test fails here on the release build too.

`cargo check -p bun_install` passes for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->