### PR TITLE
fmt: escape lone surrogates and malformed UTF-8 in the JSON string formatters

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -44,6 +44,7 @@ pub mod js_printer {
         write_pre_quoted_string(input, f, b'"', false, enc)?;
         f.write_char('"')
     }
+    /// The escaped body without the quotes, in JSON mode (`json = true`).
     pub(crate) fn write_pre_quoted_string(
         input: &[u8],
         f: &mut impl fmt::Write,
@@ -51,17 +52,36 @@ pub mod js_printer {
         ascii_only: bool,
         enc: Encoding,
     ) -> fmt::Result {
-        // Writes the escaped body WITHOUT surrounding quotes. Delegate to the
-        // canonical impl in `string::printer` (a byte-sink writer) and bridge
-        // the result into the `fmt::Write`. In JSON mode (`json = true`) every
-        // non-printable scalar (including lone surrogates) is emitted as an
-        // ASCII escape.
-        let mut buf: Vec<u8> = Vec::with_capacity(input.len() + 8);
         crate::string::printer::write_pre_quoted_string(
-            input, &mut buf, quote, ascii_only, true, enc,
+            input,
+            &mut FmtSink(f),
+            quote,
+            ascii_only,
+            true,
+            enc,
         )
-        .map_err(|_| fmt::Error)?;
-        f.write_str(&String::from_utf8_lossy(&buf))
+        .map_err(|_| fmt::Error)
+    }
+
+    /// Byte sink over a `fmt::Write` for `string::printer`, which writes escapes,
+    /// ASCII runs and whole code points, so every chunk is UTF-8 on its own.
+    struct FmtSink<'a, W: fmt::Write>(&'a mut W);
+
+    impl<W: fmt::Write> crate::io::Write for FmtSink<'_, W> {
+        fn write_all(&mut self, buf: &[u8]) -> crate::CrateResult<()> {
+            match super::strings::str_utf8(buf) {
+                Some(s) => self.0.write_str(s),
+                None => buf.utf8_chunks().try_for_each(|chunk| {
+                    self.0.write_str(chunk.valid())?;
+                    if chunk.invalid().is_empty() {
+                        Ok(())
+                    } else {
+                        self.0.write_char(char::REPLACEMENT_CHARACTER)
+                    }
+                }),
+            }
+            .map_err(|_| crate::CrateError::FmtError)
+        }
     }
 }
 use strum::IntoStaticStr;

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -38,9 +38,7 @@ pub mod js_lexer {
 pub mod js_printer {
     use super::strings::Encoding;
     use core::fmt;
-    /// Writes `input` as a `"`-quoted JSON string literal. Control characters,
-    /// lone surrogates and U+2028/U+2029 become `\u` escapes and malformed UTF-8
-    /// becomes U+FFFD, so the output is always valid JSON and valid UTF-8.
+    /// Always valid JSON and valid UTF-8: lone surrogates become `\u` escapes, malformed bytes U+FFFD.
     pub fn write_json_string(input: &[u8], f: &mut impl fmt::Write, enc: Encoding) -> fmt::Result {
         f.write_char('"')?;
         write_pre_quoted_string(input, f, b'"', false, enc)?;
@@ -3540,8 +3538,6 @@ fn splat_byte_all(w: &mut impl fmt::Write, byte: u8, count: usize) -> fmt::Resul
     Ok(())
 }
 
-/// `"`-quoted JSON string literal for UTF-8 input. Same output as
-/// [`js_printer::write_json_string`] with [`strings::Encoding::Utf8`].
 #[inline]
 pub fn encode_json_string(w: &mut impl fmt::Write, s: &[u8]) -> fmt::Result {
     js_printer::write_json_string(s, w, strings::Encoding::Utf8)

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -63,8 +63,7 @@ pub mod js_printer {
         .map_err(|_| fmt::Error)
     }
 
-    /// Byte sink over a `fmt::Write` for `string::printer`, which writes escapes,
-    /// ASCII runs and whole code points, so every chunk is UTF-8 on its own.
+    /// `string::printer` writes escapes, ASCII runs and whole code points, so each chunk is UTF-8 on its own.
     struct FmtSink<'a, W: fmt::Write>(&'a mut W);
 
     impl<W: fmt::Write> crate::io::Write for FmtSink<'_, W> {

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -38,14 +38,12 @@ pub mod js_lexer {
 pub mod js_printer {
     use super::strings::Encoding;
     use core::fmt;
-    /// Minimal escape set for fmt.rs quoting.
-    /// bun_js_printer overrides with the full (ctrl-char, \u escape, encoding-aware) impl.
+    /// Writes `input` as a `"`-quoted JSON string literal. Control characters,
+    /// lone surrogates and U+2028/U+2029 become `\u` escapes and malformed UTF-8
+    /// becomes U+FFFD, so the output is always valid JSON and valid UTF-8.
     pub fn write_json_string(input: &[u8], f: &mut impl fmt::Write, enc: Encoding) -> fmt::Result {
         f.write_char('"')?;
-        match enc {
-            Encoding::Latin1 => super::encode_json_string_chars_latin1(f, input)?,
-            _ => super::encode_json_string_chars(f, input)?,
-        }
+        write_pre_quoted_string(input, f, b'"', false, enc)?;
         f.write_char('"')
     }
     pub(crate) fn write_pre_quoted_string(
@@ -3542,107 +3540,9 @@ fn splat_byte_all(w: &mut impl fmt::Write, byte: u8, count: usize) -> fmt::Resul
     Ok(())
 }
 
-// ════════════════════════════════════════════════════════════════════════════
-// encode_json_string — single canonical impl.
-// Every duplicated copy of this JSON-string escaping logic funnels through
-// here.
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Writes the escaped body of a JSON string **without** surrounding quotes
-/// (`escape_unicode = false` semantics).
-///
-/// Escape set:
-///   - `\"` `\\` `\b` `\f` `\n` `\r` `\t`
-///   - other `0x00..=0x1F` → `\u00XX` (lowercase hex)
-///   - `0x20..=0xFF` → emitted verbatim in run-batched `write_str` calls
-///     (input is treated as UTF-8/Latin-1 bytes; no transcoding).
-pub(crate) fn encode_json_string_chars(w: &mut impl fmt::Write, s: &[u8]) -> fmt::Result {
-    let mut run = 0;
-    for (i, &b) in s.iter().enumerate() {
-        let esc: &str = match b {
-            b'"' => "\\\"",
-            b'\\' => "\\\\",
-            0x08 => "\\b",
-            0x0C => "\\f",
-            b'\n' => "\\n",
-            b'\r' => "\\r",
-            b'\t' => "\\t",
-            0x00..=0x1F => {
-                if run < i {
-                    write_bytes(w, &s[run..i])?;
-                }
-                let hex = hex_u16::<true>(b as u16);
-                w.write_str("\\u")?;
-                write_bytes(w, &hex)?;
-                run = i + 1;
-                continue;
-            }
-            _ => continue,
-        };
-        if run < i {
-            write_bytes(w, &s[run..i])?;
-        }
-        w.write_str(esc)?;
-        run = i + 1;
-    }
-    if run < s.len() {
-        write_bytes(w, &s[run..])?;
-    }
-    Ok(())
-}
-
-/// Latin-1 sibling of [`encode_json_string_chars`]: same escape table, but
-/// non-escaped bytes are widened (`b as char`) so 0x80..=0xFF are emitted as
-/// their U+0080..U+00FF UTF-8 encodings rather than passed through as raw
-/// (invalid) single bytes. ASCII runs are still batched via `write_bytes`.
-pub(crate) fn encode_json_string_chars_latin1(w: &mut impl fmt::Write, s: &[u8]) -> fmt::Result {
-    let mut run = 0;
-    for (i, &b) in s.iter().enumerate() {
-        let esc: &str = match b {
-            b'"' => "\\\"",
-            b'\\' => "\\\\",
-            0x08 => "\\b",
-            0x0C => "\\f",
-            b'\n' => "\\n",
-            b'\r' => "\\r",
-            b'\t' => "\\t",
-            0x00..=0x1F => {
-                if run < i {
-                    write_bytes(w, &s[run..i])?;
-                }
-                let hex = hex_u16::<true>(b as u16);
-                w.write_str("\\u")?;
-                write_bytes(w, &hex)?;
-                run = i + 1;
-                continue;
-            }
-            0x80..=0xFF => {
-                if run < i {
-                    write_bytes(w, &s[run..i])?;
-                }
-                // Widen Latin-1 byte → Unicode scalar → UTF-8.
-                w.write_char(b as char)?;
-                run = i + 1;
-                continue;
-            }
-            _ => continue,
-        };
-        if run < i {
-            write_bytes(w, &s[run..i])?;
-        }
-        w.write_str(esc)?;
-        run = i + 1;
-    }
-    if run < s.len() {
-        write_bytes(w, &s[run..])?;
-    }
-    Ok(())
-}
-
-/// Surrounding `"` quotes around [`encode_json_string_chars`].
+/// `"`-quoted JSON string literal for UTF-8 input. Same output as
+/// [`js_printer::write_json_string`] with [`strings::Encoding::Utf8`].
 #[inline]
 pub fn encode_json_string(w: &mut impl fmt::Write, s: &[u8]) -> fmt::Result {
-    w.write_char('"')?;
-    encode_json_string_chars(w, s)?;
-    w.write_char('"')
+    js_printer::write_json_string(s, w, strings::Encoding::Utf8)
 }

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1786,7 +1786,13 @@ pub mod printer {
         }
     }
 
-    /// Same algorithm as `bun_js_printer::write_pre_quoted_string`.
+    /// Marks a byte that does not start a well-formed WTF-8 sequence. Negative so it
+    /// cannot collide with a code unit.
+    const MALFORMED: i32 = -1;
+
+    /// Same algorithm as `bun_js_printer::write_pre_quoted_string`, except that
+    /// malformed UTF-8 input becomes U+FFFD instead of raw bytes, so the output is
+    /// always valid UTF-8.
     /// PERF: (quote_char, ascii_only, json, encoding) are runtime params —
     /// profile if it shows up on a hot path.
     pub fn write_pre_quoted_string<W: PrinterWriter + ?Sized>(
@@ -1821,9 +1827,19 @@ pub mod printer {
             let clamped_width = (width as usize).min(n.saturating_sub(i));
             let c: i32 = match encoding {
                 StrEncoding::Utf8 => {
-                    let mut buf = [0u8; 4];
-                    buf[..clamped_width].copy_from_slice(&text_in[i..i + clamped_width]);
-                    strings::decode_wtf8_rune_t::<i32>(buf, width, 0)
+                    if width == 1 {
+                        // `wtf8_byte_sequence_length_with_invalid` also returns 1 for a
+                        // stray continuation byte or a 0xF8..=0xFF lead.
+                        if text_in[i] >= 0x80 {
+                            MALFORMED
+                        } else {
+                            text_in[i] as i32
+                        }
+                    } else {
+                        let mut buf = [0u8; 4];
+                        buf[..clamped_width].copy_from_slice(&text_in[i..i + clamped_width]);
+                        strings::decode_wtf8_rune_t::<i32>(buf, width, MALFORMED)
+                    }
                 }
                 StrEncoding::Ascii => {
                     debug_assert!(text_in[i] <= 0x7F);
@@ -1832,6 +1848,18 @@ pub mod printer {
                 StrEncoding::Latin1 => text_in[i] as i32,
                 StrEncoding::Utf16 => text16[i] as i32,
             };
+
+            if c == MALFORMED {
+                // Replace only the offending byte and resync on the next one, so the
+                // bytes after a truncated sequence are not lost.
+                if ascii_only {
+                    writer.write_all(&bmp_escape(0xFFFD))?;
+                } else {
+                    writer.write_all("\u{FFFD}".as_bytes())?;
+                }
+                i += 1;
+                continue;
+            }
 
             if can_print_without_escape(c, ascii_only) {
                 match encoding {

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1786,13 +1786,9 @@ pub mod printer {
         }
     }
 
-    /// Marks a byte that does not start a well-formed WTF-8 sequence. Negative so it
-    /// cannot collide with a code unit.
     const MALFORMED: i32 = -1;
 
-    /// Same algorithm as `bun_js_printer::write_pre_quoted_string`, except that
-    /// malformed UTF-8 input becomes U+FFFD instead of raw bytes, so the output is
-    /// always valid UTF-8.
+    /// Same algorithm as `bun_js_printer::write_pre_quoted_string`, except malformed UTF-8 becomes U+FFFD.
     /// PERF: (quote_char, ascii_only, json, encoding) are runtime params —
     /// profile if it shows up on a hot path.
     pub fn write_pre_quoted_string<W: PrinterWriter + ?Sized>(
@@ -1828,8 +1824,7 @@ pub mod printer {
             let c: i32 = match encoding {
                 StrEncoding::Utf8 => {
                     if width == 1 {
-                        // `wtf8_byte_sequence_length_with_invalid` also returns 1 for a
-                        // stray continuation byte or a 0xF8..=0xFF lead.
+                        // width 1 with a byte >= 0x80 is a stray continuation byte or an invalid lead.
                         if text_in[i] >= 0x80 {
                             MALFORMED
                         } else {
@@ -1850,13 +1845,12 @@ pub mod printer {
             };
 
             if c == MALFORMED {
-                // Replace only the offending byte and resync on the next one, so the
-                // bytes after a truncated sequence are not lost.
                 if ascii_only {
                     writer.write_all(&bmp_escape(0xFFFD))?;
                 } else {
                     writer.write_all("\u{FFFD}".as_bytes())?;
                 }
+                // One byte, not `width`, so the bytes after a truncated sequence survive.
                 i += 1;
                 continue;
             }

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -381,9 +381,6 @@ impl fmt::Display for RequestCurlFormatter<'_> {
 
         if !self.body.is_empty() && Self::is_printable_body(content_type) {
             f.write_str(" --data-raw ")?;
-            // bun_core re-exports the tier-0 minimal impl as
-            // `js_printer::write_json_string`; the full encoding-aware printer
-            // in bun_js_printer overrides at link time.
             bun_core::js_printer::write_json_string(
                 self.body,
                 f,

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -800,7 +800,7 @@ describe("Bun.build metafile option variants", () => {
 });
 
 // CLI tests for --metafile-md
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 describe("bun build --metafile-md", () => {
   test("generates markdown metafile with default name", async () => {
@@ -1288,5 +1288,41 @@ describe("bun build --metafile-md", () => {
     // Should have node_modules marker in raw data
     expect(content).toContain("[NODE_MODULES:");
     expect(content).toContain("node_modules/lodash");
+  });
+});
+
+describe("bun build --metafile", () => {
+  // Bun.spawn replaces a lone surrogate in a JS string with U+FFFD before it reaches argv,
+  // so the raw bytes have to come from the shell. Windows argv is UTF-16 and cannot carry them.
+  test.skipIf(isWindows)("escapes a lone surrogate and an invalid byte in an output path", async () => {
+    using dir = tempDir("metafile-wtf8", {
+      "index.js": `console.log(1);`,
+    });
+
+    // "\355\240\200" is U+D800 in WTF-8, "\377" is not valid UTF-8 at all.
+    // No --outdir: the bundle goes to stdout and only the metafile is written.
+    await using proc = Bun.spawn({
+      cmd: [
+        "sh",
+        "-c",
+        `"$1" build index.js --metafile=meta.json --entry-naming "x$(printf '\\355\\240\\200\\377')-[name].[ext]"`,
+        "sh",
+        bunExe(),
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const bytes = await Bun.file(`${dir}/meta.json`).bytes();
+    // Throws on invalid UTF-8.
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    const metafile = JSON.parse(text) as Metafile;
+    expect(Object.keys(metafile.outputs)).toEqual(["./x\uD800\uFFFD-index.js"]);
   });
 });

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1315,7 +1315,8 @@ describe("bun build --metafile", () => {
       stdout: "pipe",
     });
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("console.log(1);");
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 


### PR DESCRIPTION
### Problem
- `bun_core::fmt::js_printer::write_json_string` (behind `quote()`, `format_json_string_utf8(quote: true)`, `format_json_string_latin1`, `encode_json_string`) escaped only `"`, `\` and C0 controls and copied every other byte raw. A path with a WTF-8 lone surrogate (`ED A0 80`) or a non-UTF-8 byte produced invalid JSON in `--metafile`, `bun audit --json`, `bun pm view --json` and the dev error page. Repro: `bun build ./index.ts --metafile=meta.json --entry-naming $'x\xed\xa0\x80\xff-[name].[ext]'`, then `json.load` fails with `UnicodeDecodeError`.
- Its comment (`src/bun_core/fmt.rs:42`) said bun_js_printer overrides it at link time. Nothing does. The full escaper, `string::printer::write_pre_quoted_string` (`src/bun_core/string/mod.rs`), is in the same crate, and the `quote: false` arm already used it.
- The full escaper had a smaller version of the bug: a stray continuation byte or a `0xF8..=0xFF` lead decoded to `0x80..=0xFF`, passed `can_print_without_escape`, and was copied raw. A truncated sequence became `\^@` and the bytes after it were skipped.

### Fix
- `write_json_string` calls the full escaper with `json = true`. The two minimal copies are deleted. The `fmt.rs` bridge no longer collects the output in a `Vec` and runs `from_utf8_lossy` over it: `FmtSink` hands each chunk to the `fmt::Write` sink, so no call allocates.
- In `string::printer::write_pre_quoted_string`, the UTF-8 arm marks a width-1 byte `>= 0x80` and a failed multi-byte decode as malformed. A malformed byte becomes U+FFFD (`\uFFFD` when `ascii_only`) and the loop continues with the next byte. Valid input produces the same bytes as before.
- Lone surrogates stay `\uD800`-style escapes. Control characters now use uppercase hex (`\^[`), the form the full escaper always used.
- Verified: `test/bundler/metafile.test.ts` (new test, fails on bun 1.4.1 with `ERR_ENCODING_INVALID_ENCODED_DATA`). Also `esbuild/metafile`, `shell/brace`, `patch`, `bun-audit`, `bun-lock`, `bun-info`, the snapshot tests, `inspect`, `console-table`.

### Background
- WTF-8 is UTF-8 plus encodings for lone surrogates (`ED A0 80` to `ED BF BF`). JS strings can hold lone surrogates, so Bun carries them through byte strings this way. JSON text must be valid UTF-8, so a JSON writer turns them into `\uD8xx` escapes.
- `wtf8_byte_sequence_length_with_invalid` returns 1 for a byte that cannot start a sequence, so a decoder can always advance. The escaper advanced, then treated the byte value as a code point and copied the raw byte.
- The escaper writes in chunks: an escape sequence, a run of printable ASCII, or one whole code point. Each chunk is valid UTF-8 on its own, so `FmtSink` can validate it with `str_utf8` and pass it to `write_str` without a buffer.

<details><summary>Notes</summary>

- Output for the repro is now `"./x\uD800\uFFFD-index.js"`. Python, `JSON.parse` and `TextDecoder("utf-8", { fatal: true })` accept it.
- A JS string cannot put a lone surrogate or an invalid byte into argv (`Bun.spawn` replaces them with U+FFFD) or into a source file (the lexer replaces them), so the test spawns `sh -c` and builds the argument with `printf`. Windows argv is UTF-16 and the test is skipped there. The test passes no `--outdir`, so no file with that name is created and the test does not depend on what the file system accepts.
- Before this PR the old bridge's `from_utf8_lossy` pass hid the stray-byte bug on the `quote: false` arm. Byte-sink callers (`quote_for_json` for source maps, `format_escapes`, which casts the escaper output with `from_utf8_unchecked`) had no such pass.
- `bun_js_printer::write_pre_quoted_string_inner` (`src/js_printer/lib.rs`) is a separate monomorphized copy of the same algorithm with the same raw-byte passthrough. Its input comes from the lexer and AST. This PR does not change it.
- #37422 (open) makes `Raw`, `write_bytes` and `String::Display` validate UTF-8. It touches other functions in the same files and does not change the JSON escaper.
- `test/js/bun/test/pretty-format-overflow.test.ts` segfaults in this container's debug ASAN build on main as well (stack overflow at the default 8 MB stack, passes with `ulimit -s unlimited`). Unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/metafile.test.ts

<!-- robobun:evidence:end -->