### PR TITLE
install: write isolated store paths as bytes

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -123,12 +123,9 @@ struct WyhashWriter<'a> {
     hasher: &'a mut Wyhash,
 }
 
-impl<'a> std::io::Write for WyhashWriter<'a> {
-    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+impl<'a> bun_core::io::Write for WyhashWriter<'a> {
+    fn write_all(&mut self, bytes: &[u8]) -> bun_core::CrateResult<()> {
         self.hasher.update(bytes);
-        Ok(bytes.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
 }
@@ -1313,7 +1310,7 @@ pub(crate) fn install_isolated_packages(
                             let mut hw = WyhashWriter {
                                 hasher: &mut stack[top_idx].hasher,
                             };
-                            write!(hw, "{}", store::entry::fmt_store_path(id, &store, lockfile))
+                            store::entry::write_store_path(&mut hw, id, &store, lockfile)
                                 .expect("unreachable");
                         }
                         // The store path for `.npm` is just `name@version`, which
@@ -1497,14 +1494,11 @@ pub(crate) fn install_isolated_packages(
                                     let mut sub = Wyhash::init(0x9E3779B97F4A7C15);
                                     {
                                         let mut hw = WyhashWriter { hasher: &mut sub };
-                                        write!(
-                                            hw,
-                                            "{}",
-                                            store::entry::fmt_store_path(
-                                                store::entry::Id::from(m),
-                                                &store,
-                                                lockfile
-                                            )
+                                        store::entry::write_store_path(
+                                            &mut hw,
+                                            store::entry::Id::from(m),
+                                            &store,
+                                            lockfile,
                                         )
                                         .expect("unreachable");
                                     }
@@ -1553,14 +1547,11 @@ pub(crate) fn install_isolated_packages(
                                     let mut sub = Wyhash::init(0);
                                     {
                                         let mut hw = WyhashWriter { hasher: &mut sub };
-                                        write!(
-                                            hw,
-                                            "{}",
-                                            store::entry::fmt_store_path(
-                                                store::entry::Id::from(m),
-                                                &store,
-                                                lockfile
-                                            )
+                                        store::entry::write_store_path(
+                                            &mut hw,
+                                            store::entry::Id::from(m),
+                                            &store,
+                                            lockfile,
                                         )
                                         .expect("unreachable");
                                     }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -421,12 +421,17 @@ impl<'a> Installer<'a> {
             | ResolutionTag::RemoteTarball
             | ResolutionTag::Folder => {
                 let mut store_path = AutoRelPath::init();
-
-                // OOM/capacity: fire-and-forget
-                let _ = store_path.append_fmt(format_args!(
-                    "node_modules/{}",
-                    store::entry::fmt_store_path(entry_id, self.store, self.lockfile()),
-                ));
+                store_path.append(b"node_modules").assume_ok();
+                store_path
+                    .append_with(|writer| {
+                        store::entry::write_store_path(
+                            writer,
+                            entry_id,
+                            self.store,
+                            self.lockfile(),
+                        )
+                    })
+                    .assume_ok();
 
                 let _ = sys::unlink(store_path.slice_z());
             }
@@ -2149,17 +2154,17 @@ impl<'a> Installer<'a> {
 
         let mut target = AutoRelPath::init();
 
-        let _ = target.append(b".."); // OOM/capacity: fire-and-forget
+        target.append(b"..").assume_ok();
         if strings::index_of_char(pkg_name.slice(string_buf), b'/').is_some() {
-            let _ = target.append(b".."); // OOM/capacity: fire-and-forget
+            target.append(b"..").assume_ok();
         }
-
-        // OOM/capacity: fire-and-forget
-        let _ = target.append_fmt(format_args!(
-            "{}/node_modules/{}",
-            store::entry::fmt_store_path(entry_id, self.store, self.lockfile()),
-            bstr::BStr::new(pkg_name.slice(string_buf)),
-        ));
+        target
+            .append_with(|writer| {
+                store::entry::write_store_path(writer, entry_id, self.store, self.lockfile())
+            })
+            .assume_ok();
+        target.append(b"node_modules").assume_ok();
+        target.append(pkg_name.slice(string_buf)).assume_ok();
 
         #[cfg(windows)]
         let mut full_target = AutoAbsPath::init_top_level_dir();
@@ -2455,17 +2460,13 @@ impl<'a> Installer<'a> {
         debug_assert!(self.entry_uses_global_store(entry_id));
         buf.clear();
         buf.append(self.global_store_path.as_ref().unwrap().as_bytes());
-        match which {
-            Which::Final => buf.append_fmt(format_args!(
-                "{}",
-                store::entry::fmt_global_store_path(entry_id, self.store, self.lockfile()),
-            )),
-            Which::Staging => buf.append_fmt(format_args!(
-                "{}.tmp-{:x}",
-                store::entry::fmt_global_store_path(entry_id, self.store, self.lockfile()),
-                self.global_store_tmp_suffix,
-            )),
-        }
+        buf.append_with(|writer| {
+            store::entry::write_global_store_path(writer, entry_id, self.store, self.lockfile())?;
+            match which {
+                Which::Final => Ok(()),
+                Which::Staging => write!(writer, ".tmp-{:x}", self.global_store_tmp_suffix),
+            }
+        });
     }
 
     /// Atomically publish a staged global-store entry by renaming
@@ -2499,13 +2500,18 @@ impl<'a> Installer<'a> {
                 // discard ours.
                 if self.manager().options.enable.force_install() {
                     let mut old = AutoAbsPath::init();
-                    let _ = old.append(self.global_store_path.as_ref().unwrap().as_bytes()); // OOM/capacity: fire-and-forget
-                    // OOM/capacity: fire-and-forget
-                    let _ = old.append_fmt(format_args!(
-                        "{}.old-{:x}",
-                        store::entry::fmt_global_store_path(entry_id, self.store, self.lockfile()),
-                        bun_core::fast_random(),
-                    ));
+                    old.append(self.global_store_path.as_ref().unwrap().as_bytes())
+                        .assume_ok();
+                    old.append_with(|writer| {
+                        store::entry::write_global_store_path(
+                            writer,
+                            entry_id,
+                            self.store,
+                            self.lockfile(),
+                        )?;
+                        write!(writer, ".old-{:x}", bun_core::fast_random())
+                    })
+                    .assume_ok();
                     if let Some(swap_err) =
                         sys::renameat(Fd::cwd(), final_.slice_z(), Fd::cwd(), old.slice_z()).err()
                     {
@@ -2547,11 +2553,10 @@ impl<'a> Installer<'a> {
         buf: &mut impl paths::PathLike,
         entry_id: StoreEntryId,
     ) {
-        buf.append_fmt(format_args!(
-            "{}/{}",
-            NODE_MODULES_BUN,
-            store::entry::fmt_store_path(entry_id, self.store, self.lockfile()),
-        ));
+        buf.append(NODE_MODULES_BUN.as_bytes());
+        buf.append_with(|writer| {
+            store::entry::write_store_path(writer, entry_id, self.store, self.lockfile())
+        });
     }
 
     /// Create the project-level symlink `node_modules/.bun/<storepath>` →
@@ -2664,11 +2669,11 @@ impl<'a> Installer<'a> {
                 buf.append(b"node_modules");
             }
             _ => {
-                buf.append_fmt(format_args!(
-                    "{}/{}/node_modules",
-                    NODE_MODULES_BUN,
-                    store::entry::fmt_store_path(entry_id, self.store, self.lockfile()),
-                ));
+                buf.append(NODE_MODULES_BUN.as_bytes());
+                buf.append_with(|writer| {
+                    store::entry::write_store_path(writer, entry_id, self.store, self.lockfile())
+                });
+                buf.append(b"node_modules");
             }
         }
     }
@@ -2738,10 +2743,14 @@ impl<'a> Installer<'a> {
                 if dep_id != invalid_dependency_id {
                     let pkg_name = pkg_names[pkg_id as usize];
                     buf.append(NODE_MODULES_BUN.as_bytes());
-                    buf.append_fmt(format_args!(
-                        "{}",
-                        store::entry::fmt_store_path(entry_id, self.store, self.lockfile()),
-                    ));
+                    buf.append_with(|writer| {
+                        store::entry::write_store_path(
+                            writer,
+                            entry_id,
+                            self.store,
+                            self.lockfile(),
+                        )
+                    });
                     buf.append(b"node_modules");
                     if pkg_name.is_empty() {
                         buf.append(paths::basename(
@@ -2777,10 +2786,9 @@ impl<'a> Installer<'a> {
             _ => {
                 let pkg_name = pkg_names[pkg_id as usize];
                 buf.append(NODE_MODULES_BUN.as_bytes());
-                buf.append_fmt(format_args!(
-                    "{}",
-                    store::entry::fmt_store_path(entry_id, self.store, self.lockfile()),
-                ));
+                buf.append_with(|writer| {
+                    store::entry::write_store_path(writer, entry_id, self.store, self.lockfile())
+                });
                 buf.append(b"node_modules");
                 buf.append(pkg_name.slice(string_buf));
             }

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -383,11 +383,8 @@ pub mod entry {
         write!(writer, "+{:016x}", sink.hasher.final_())
     }
 
-    /// Writes `name@version` (or `name@file+path` / `name@root`) without the
-    /// `+peerhash` suffix. The resolution part is bounded by
-    /// [`MAX_RESOLUTION_LEN`]. The name is a directory name, so the bytes of
-    /// the lockfile strings are written unchanged (see
-    /// `bun_semver::string::write_store_path`).
+    /// `name@version` (or `name@file+path` / `name@root`) without the `+peerhash` suffix.
+    /// The resolution part is bounded by [`MAX_RESOLUTION_LEN`].
     pub fn write_store_key<W: Write + ?Sized>(
         writer: &mut W,
         name: SemverString,
@@ -422,8 +419,7 @@ pub mod entry {
         }
     }
 
-    /// Writes the directory name of a store entry: its store key, then
-    /// `+<peer hash>` when the entry has peers.
+    /// The entry's directory name: its store key, then `+<peer hash>` when it has peers.
     pub(crate) fn write_store_path<W: Write + ?Sized>(
         writer: &mut W,
         entry_id: Id,

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -2,10 +2,10 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::marker::PhantomData;
 
-use bstr::BStr;
-
 use bun_alloc::AllocError;
 use bun_collections::{ArrayHashMap, MultiArrayList};
+use bun_core::CrateResult;
+use bun_core::io::Write;
 use bun_semver::String as SemverString;
 use bun_wyhash::Wyhash;
 
@@ -348,9 +348,8 @@ pub mod entry {
         hasher: Wyhash,
     }
 
-    impl fmt::Write for ResolutionSink {
-        fn write_str(&mut self, s: &str) -> fmt::Result {
-            let bytes = s.as_bytes();
+    impl Write for ResolutionSink {
+        fn write_all(&mut self, bytes: &[u8]) -> CrateResult<()> {
             if let Some(room) = self.buf.get_mut(self.len..) {
                 let n = bytes.len().min(room.len());
                 room[..n].copy_from_slice(&bytes[..n]);
@@ -361,153 +360,113 @@ pub mod entry {
         }
     }
 
-    fn write_resolution(f: &mut fmt::Formatter<'_>, resolution: fmt::Arguments<'_>) -> fmt::Result {
+    fn write_resolution<W: Write + ?Sized>(
+        writer: &mut W,
+        write: impl FnOnce(&mut ResolutionSink) -> CrateResult<()>,
+    ) -> CrateResult<()> {
         let mut sink = ResolutionSink {
             buf: [0; MAX_RESOLUTION_LEN],
             len: 0,
             hasher: Wyhash::init(0),
         };
-        fmt::write(&mut sink, resolution)?;
+        write(&mut sink)?;
 
         if sink.len <= MAX_RESOLUTION_LEN {
-            return f.write_str(bun_core::str_utf8(&sink.buf[..sink.len]).ok_or(fmt::Error)?);
+            return writer.write_all(&sink.buf[..sink.len]);
         }
 
         let mut cut = CUT_RESOLUTION_LEN;
         while !bun_core::strings::is_on_char_boundary(&sink.buf, cut) {
             cut -= 1;
         }
-        f.write_str(bun_core::str_utf8(&sink.buf[..cut]).ok_or(fmt::Error)?)?;
-        write!(f, "+{:016x}", sink.hasher.final_())
+        writer.write_all(&sink.buf[..cut])?;
+        write!(writer, "+{:016x}", sink.hasher.final_())
     }
 
-    /// `name@version` (or `name@file+path` / `name@root`) without the `+peerhash` suffix.
-    /// The resolution part is bounded by [`MAX_RESOLUTION_LEN`].
-    pub struct StoreKeyFormatter<'a> {
+    /// Writes `name@version` (or `name@file+path` / `name@root`) without the
+    /// `+peerhash` suffix. The resolution part is bounded by
+    /// [`MAX_RESOLUTION_LEN`]. The name is a directory name, so the bytes of
+    /// the lockfile strings are written unchanged (see
+    /// `bun_semver::string::write_store_path`).
+    pub fn write_store_key<W: Write + ?Sized>(
+        writer: &mut W,
         name: SemverString,
-        resolution: &'a Resolution,
-        string_buf: &'a [u8],
-    }
-
-    impl<'a> fmt::Display for StoreKeyFormatter<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let string_buf = self.string_buf;
-            let pkg_name = self.name;
-            let pkg_res = self.resolution;
-
-            match pkg_res.tag {
-                crate::resolution::Tag::Root => {
-                    if pkg_name.is_empty() {
-                        write!(
-                            f,
-                            "{}",
-                            BStr::new(bun_paths::basename(
-                                crate::bun_fs::FileSystem::instance().top_level_dir()
-                            ))
-                        )
-                    } else {
-                        write!(f, "{}@root", pkg_name.fmt_store_path(string_buf))
-                    }
+        resolution: &Resolution,
+        string_buf: &[u8],
+    ) -> CrateResult<()> {
+        match resolution.tag {
+            crate::resolution::Tag::Root => {
+                if name.is_empty() {
+                    writer.write_all(bun_paths::basename(
+                        crate::bun_fs::FileSystem::instance().top_level_dir(),
+                    ))
+                } else {
+                    name.write_store_path(writer, string_buf)?;
+                    writer.write_all(b"@root")
                 }
-                crate::resolution::Tag::Folder => {
-                    let folder = *pkg_res.folder();
-                    write!(f, "{}@", pkg_name.fmt_store_path(string_buf))?;
-                    write_resolution(
-                        f,
-                        format_args!("file+{}", folder.fmt_store_path(string_buf)),
-                    )
-                }
-                _ => {
-                    write!(f, "{}@", pkg_name.fmt_store_path(string_buf))?;
-                    write_resolution(f, format_args!("{}", pkg_res.fmt_store_path(string_buf)))
-                }
+            }
+            crate::resolution::Tag::Folder => {
+                let folder = *resolution.folder();
+                name.write_store_path(writer, string_buf)?;
+                writer.write_byte(b'@')?;
+                write_resolution(writer, |sink| {
+                    sink.write_all(b"file+")?;
+                    folder.write_store_path(sink, string_buf)
+                })
+            }
+            _ => {
+                name.write_store_path(writer, string_buf)?;
+                writer.write_byte(b'@')?;
+                write_resolution(writer, |sink| resolution.write_store_path(sink, string_buf))
             }
         }
     }
 
-    pub fn fmt_store_key<'a>(
-        name: SemverString,
-        resolution: &'a Resolution,
-        string_buf: &'a [u8],
-    ) -> StoreKeyFormatter<'a> {
-        StoreKeyFormatter {
-            name,
-            resolution,
-            string_buf,
-        }
-    }
-
-    pub struct StorePathFormatter<'a> {
-        pub(crate) entry_id: Id,
-        pub(crate) store: &'a Store,
-        pub lockfile: &'a Lockfile,
-    }
-
-    impl<'a> fmt::Display for StorePathFormatter<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            use super::node::NodeColumns as _;
-            let store = self.store;
-            let entries = store.entries.slice();
-
-            let peer_hash = entries.items_peer_hash()[self.entry_id.get() as usize];
-            let node_id = entries.items_node_id()[self.entry_id.get() as usize];
-            let pkg_id = store.nodes.items_pkg_id()[node_id.get() as usize];
-
-            let pkgs = self.lockfile.packages.slice();
-            write!(
-                f,
-                "{}",
-                fmt_store_key(
-                    pkgs.items_name()[pkg_id as usize],
-                    &pkgs.items_resolution()[pkg_id as usize],
-                    self.lockfile.buffers.string_bytes.as_slice(),
-                )
-            )?;
-
-            if peer_hash != PeerHash::NONE {
-                write!(f, "+{:016x}", peer_hash.cast())?;
-            }
-
-            Ok(())
-        }
-    }
-
-    pub(crate) fn fmt_store_path<'a>(
+    /// Writes the directory name of a store entry: its store key, then
+    /// `+<peer hash>` when the entry has peers.
+    pub(crate) fn write_store_path<W: Write + ?Sized>(
+        writer: &mut W,
         entry_id: Id,
-        store: &'a Store,
-        lockfile: &'a Lockfile,
-    ) -> StorePathFormatter<'a> {
-        StorePathFormatter {
-            entry_id,
-            store,
-            lockfile,
+        store: &Store,
+        lockfile: &Lockfile,
+    ) -> CrateResult<()> {
+        use super::node::NodeColumns as _;
+        let entries = store.entries.slice();
+
+        let peer_hash = entries.items_peer_hash()[entry_id.get() as usize];
+        let node_id = entries.items_node_id()[entry_id.get() as usize];
+        let pkg_id = store.nodes.items_pkg_id()[node_id.get() as usize];
+
+        let pkgs = lockfile.packages.slice();
+        write_store_key(
+            writer,
+            pkgs.items_name()[pkg_id as usize],
+            &pkgs.items_resolution()[pkg_id as usize],
+            lockfile.buffers.string_bytes.as_slice(),
+        )?;
+
+        if peer_hash != PeerHash::NONE {
+            write!(writer, "+{:016x}", peer_hash.cast())?;
         }
+
+        Ok(())
     }
 
-    pub(crate) struct GlobalStorePathFormatter<'a> {
-        inner: StorePathFormatter<'a>,
-        entry_hash: u64,
-    }
-
-    impl<'a> fmt::Display for GlobalStorePathFormatter<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            self.inner.fmt(f)?;
-            write!(f, "-{:016x}", self.entry_hash)
-        }
-    }
-
-    /// Like `fmt_store_path` but suffixes the entry's content hash so the
+    /// Like `write_store_path` but suffixes the entry's content hash so the
     /// resulting name is safe to use as a key in the shared global virtual
     /// store (different dependency closures get different directory names).
-    pub(crate) fn fmt_global_store_path<'a>(
+    pub(crate) fn write_global_store_path<W: Write + ?Sized>(
+        writer: &mut W,
         entry_id: Id,
-        store: &'a Store,
-        lockfile: &'a Lockfile,
-    ) -> GlobalStorePathFormatter<'a> {
-        GlobalStorePathFormatter {
-            inner: fmt_store_path(entry_id, store, lockfile),
-            entry_hash: store.entries.items_entry_hash()[entry_id.get() as usize],
-        }
+        store: &Store,
+        lockfile: &Lockfile,
+    ) -> CrateResult<()> {
+        write_store_path(writer, entry_id, store, lockfile)?;
+        write!(
+            writer,
+            "-{:016x}",
+            store.entries.items_entry_hash()[entry_id.get() as usize]
+        )
     }
 
     pub(crate) fn debug_gather_all_parents(entry_id: Id, store: &Store) -> Vec<Id> {
@@ -601,7 +560,7 @@ pub mod entry {
 }
 
 pub(crate) use entry::EntryColumns;
-pub use entry::{Entry, StoreKeyFormatter, fmt_store_key};
+pub use entry::{Entry, write_store_key};
 
 // ──────────────────────────────────────────────────────────────────────────
 // Node

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -58,7 +58,6 @@ pub(crate) mod bun_bunfig {
 }
 
 use core::cell::Cell;
-use core::fmt;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Module declarations — explicit #[path] attrs for PascalCase files.
@@ -885,47 +884,6 @@ pub(crate) fn buntaghashbuf_make(buf: &mut BuntagHashBuf, patch_hash: u64) -> &m
     let digits_len = digits.len();
     buf[BUN_HASH_TAG.len() + digits_len] = 0;
     &mut buf[..BUN_HASH_TAG.len() + digits_len]
-}
-
-pub struct StorePathFormatter<'a> {
-    str: &'a [u8],
-}
-
-impl<'a> StorePathFormatter<'a> {
-    /// Emits raw bytes
-    /// verbatim (mapping `/` and `\` to `+`). This is the byte-faithful sink; callers that
-    /// need an on-disk store path (legal non-UTF-8 on Linux) must use this, not `Display`.
-    pub(crate) fn write_to<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
-        // if (!this.opts.replace_slashes) {
-        //     try writer.writeAll(this.str);
-        //     return;
-        // }
-        for &c in self.str {
-            match c {
-                b'/' | b'\\' => w.write_all(b"+")?,
-                _ => w.write_all(core::slice::from_ref(&c))?,
-            }
-        }
-        Ok(())
-    }
-}
-
-impl<'a> fmt::Display for StorePathFormatter<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // `core::fmt` cannot emit non-UTF-8 bytes, but the store path must be
-        // emitted byte-faithfully; routing through `to_str_lossy()` here was wrong
-        // (it silently expanded each invalid byte to U+FFFD = 3 bytes, changing on-disk
-        // store directory names). We now build the raw byte sequence via `write_to` and
-        // pass it through only when it is already valid UTF-8 — otherwise we surface
-        // `fmt::Error` rather than corrupt the path.
-        let mut buf = Vec::with_capacity(self.str.len());
-        self.write_to(&mut buf).map_err(|_| fmt::Error)?;
-        f.write_str(bun_core::str_utf8(&buf).ok_or(fmt::Error)?)
-    }
-}
-
-fn fmt_store_path(str: &[u8]) -> StorePathFormatter<'_> {
-    StorePathFormatter { str }
 }
 
 // these bytes are skipped

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1,6 +1,5 @@
 use core::cell::{Cell, RefCell};
 use core::ops::Range;
-use std::io::Write as _;
 
 use bstr::BStr;
 use bun_collections::{DynamicBitSet, index_sort};
@@ -184,7 +183,7 @@ fn join_alias(scope: &[u8], name: &[u8]) -> Box<[u8]> {
     out.into_boxed_slice()
 }
 
-// Store folders are named `name@version[+peers]`, scoped as `@scope+name@version` (Store.rs fmt_store_key).
+// Store folders are named `name@version[+peers]`, scoped as `@scope+name@version` (Store.rs write_store_key).
 fn split_store_key(key: &[u8]) -> (Box<[u8]>, Option<Box<[u8]>>) {
     let Some(at) = strings::index_of_char_usize(&key[key.len().min(1)..], b'@').map(|i| i + 1)
     else {
@@ -1582,10 +1581,11 @@ fn push_store_entry_names(
             continue;
         }
         name.clear();
-        write!(
-            name,
-            "{}",
-            store_entry::fmt_store_path(store_entry::Id::from(entry_idx as u32), store, lockfile)
+        store_entry::write_store_path(
+            &mut name,
+            store_entry::Id::from(entry_idx as u32),
+            store,
+            lockfile,
         )
         .expect("Vec<u8> write is infallible");
         names.push(name.as_slice().into());

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -13,7 +13,7 @@ use bun_semver::string::Buf as StringBuf;
 use crate::dependency as Dependency;
 use crate::hosted_git_info;
 use crate::install::{self as Install, ExtractData, PackageManager};
-use crate::resolution::fmt_store_url;
+use crate::resolution::write_store_url;
 
 // Thread-local scratch buffers. Callers return slices that outlive the access
 // (`try_ssh`/`try_https` hand a slice straight to `download`). `thread_local!`
@@ -328,8 +328,15 @@ pub trait RepositoryExt: Sized {
         dep: &Install::Dependency,
     ) -> Vec<u8>;
     fn format_as(&self, label: &str, buf: &[u8], writer: &mut impl fmt::Write) -> fmt::Result;
-    fn fmt_store_path<'a>(&'a self, label: &'a str, string_buf: &'a [u8])
-    -> StorePathFormatter<'a>;
+    /// Writes the repository as the resolution part of a store entry name:
+    /// `<label><owner>+<repo URL>+<commit>`, with the URL spelled by
+    /// [`write_store_url`].
+    fn write_store_path<W: bun_core::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+        label: &str,
+        string_buf: &[u8],
+    ) -> bun_core::CrateResult<()>;
     fn fmt<'a>(&'a self, label: &'a str, buf: &'a [u8]) -> Formatter<'a>;
     fn try_ssh(url: &[u8]) -> Option<&[u8]>;
     fn try_https(url: &[u8]) -> Option<&[u8]>;
@@ -591,15 +598,36 @@ impl RepositoryExt for Repository {
         write!(writer, "{}", formatter)
     }
 
-    fn fmt_store_path<'a>(
-        &'a self,
-        label: &'a str,
-        string_buf: &'a [u8],
-    ) -> StorePathFormatter<'a> {
-        StorePathFormatter {
-            repo: self,
-            label,
-            string_buf,
+    fn write_store_path<W: bun_core::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+        label: &str,
+        string_buf: &[u8],
+    ) -> bun_core::CrateResult<()> {
+        writer.write_all(label.as_bytes())?;
+
+        if !self.owner.is_empty() {
+            self.owner.write_store_path(writer, string_buf)?;
+            writer.write_byte(b'+')?;
+        } else if Dependency::is_scp_like_path(self.repo.slice(string_buf)) {
+            writer.write_all(b"ssh++")?;
+        }
+
+        write_store_url(writer, self.repo.slice(string_buf))?;
+
+        if !self.resolved.is_empty() {
+            // `#` would be the natural separator, but Windows rejects it in a filename.
+            writer.write_byte(b'+')?;
+            let mut resolved = self.resolved.slice(string_buf);
+            if let Some(i) = strings::last_index_of_char(resolved, b'-') {
+                resolved = &resolved[i + 1..];
+            }
+            bun_semver::string::write_store_path(writer, resolved)
+        } else if !self.committish.is_empty() {
+            writer.write_byte(b'+')?;
+            self.committish.write_store_path(writer, string_buf)
+        } else {
+            Ok(())
         }
     }
 
@@ -1136,54 +1164,6 @@ impl RepositoryExt for Repository {
             }),
             ..Default::default()
         })
-    }
-}
-
-pub struct StorePathFormatter<'a> {
-    repo: &'a Repository,
-    label: &'a str,
-    string_buf: &'a [u8],
-}
-
-impl<'a> fmt::Display for StorePathFormatter<'a> {
-    fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(writer, "{}", Install::fmt_store_path(self.label.as_bytes()))?;
-
-        if !self.repo.owner.is_empty() {
-            write!(
-                writer,
-                "{}",
-                self.repo.owner.fmt_store_path(self.string_buf)
-            )?;
-            // try writer.writeByte(if (this.opts.replace_slashes) '+' else '/');
-            writer.write_str("+")?;
-        } else if Dependency::is_scp_like_path(self.repo.repo.slice(self.string_buf)) {
-            // try writer.print("ssh:{s}", .{if (this.opts.replace_slashes) "++" else "//"});
-            writer.write_str("ssh++")?;
-        }
-
-        write!(
-            writer,
-            "{}",
-            fmt_store_url(self.repo.repo.slice(self.string_buf))
-        )?;
-
-        if !self.repo.resolved.is_empty() {
-            writer.write_str("+")?; // this would be '#' but it's not valid on windows
-            let mut resolved = self.repo.resolved.slice(self.string_buf);
-            if let Some(i) = strings::last_index_of_char(resolved, b'-') {
-                resolved = &resolved[i + 1..];
-            }
-            write!(writer, "{}", Install::fmt_store_path(resolved))?;
-        } else if !self.repo.committish.is_empty() {
-            writer.write_str("+")?; // this would be '#' but it's not valid on windows
-            write!(
-                writer,
-                "{}",
-                self.repo.committish.fmt_store_path(self.string_buf)
-            )?;
-        }
-        Ok(())
     }
 }
 

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -328,9 +328,7 @@ pub trait RepositoryExt: Sized {
         dep: &Install::Dependency,
     ) -> Vec<u8>;
     fn format_as(&self, label: &str, buf: &[u8], writer: &mut impl fmt::Write) -> fmt::Result;
-    /// Writes the repository as the resolution part of a store entry name:
-    /// `<label><owner>+<repo URL>+<commit>`, with the URL spelled by
-    /// [`write_store_url`].
+    /// The resolution part of a store entry name: `<label><owner>+<repo URL>+<commit>`.
     fn write_store_path<W: bun_core::io::Write + ?Sized>(
         &self,
         writer: &mut W,

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -463,9 +463,7 @@ impl<SemverInt: VersionInt> ResolutionType<SemverInt> {
         }
     }
 
-    /// Writes the resolution part of a store entry name (`<name>@<resolution>`):
-    /// the version of an npm package, or the store spelling of the path, URL
-    /// or repository of every other kind.
+    /// The resolution part of a store entry name (`<name>@<resolution>`).
     pub fn write_store_path<W: bun_core::io::Write + ?Sized>(
         &self,
         writer: &mut W,
@@ -551,12 +549,12 @@ impl<SemverInt: VersionInt> ResolutionType<SemverInt> {
 // kept so dependents that named `resolution::StringBuilderLike` still resolve.
 pub use bun_semver::StringBuilder as StringBuilderLike;
 
-/// Writes the store path of a tarball or repository URL. The store path
-/// becomes a directory name (realpaths, stack traces, `bun pm` output), so the
-/// userinfo and the query string, which is where credentials go, are left out
-/// of it; when either was present, the hash of the complete URL takes their
-/// place so that URLs differing only in those parts still get separate
-/// entries: `https://user:token@host/pkg.tgz?token=x` becomes
+/// Store path of a tarball or repository URL. The store path becomes a
+/// directory name (realpaths, stack traces, `bun pm` output), so the userinfo
+/// and the query string, which is where credentials go, are left out of it;
+/// when either was present, the hash of the complete URL takes their place so
+/// that URLs differing only in those parts still get separate entries:
+/// `https://user:token@host/pkg.tgz?token=x` becomes
 /// `https+++host+pkg.tgz+<16 hex>`. A URL without either part is spelled out
 /// unchanged.
 pub(crate) fn write_store_url<W: bun_core::io::Write + ?Sized>(

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -463,10 +463,30 @@ impl<SemverInt: VersionInt> ResolutionType<SemverInt> {
         }
     }
 
-    pub fn fmt_store_path<'a>(&'a self, string_buf: &'a [u8]) -> StorePathFormatter<'a, SemverInt> {
-        StorePathFormatter {
-            res: self,
-            string_buf,
+    /// Writes the resolution part of a store entry name (`<name>@<resolution>`):
+    /// the version of an npm package, or the store spelling of the path, URL
+    /// or repository of every other kind.
+    pub fn write_store_path<W: bun_core::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+        string_buf: &[u8],
+    ) -> bun_core::CrateResult<()> {
+        match self.tag {
+            Tag::Root => writer.write_all(b"root"),
+            Tag::Npm => write!(writer, "{}", self.npm().version.fmt(string_buf)),
+            Tag::LocalTarball => self.local_tarball().write_store_path(writer, string_buf),
+            Tag::RemoteTarball => write_store_url(writer, self.remote_tarball().slice(string_buf)),
+            Tag::Folder => self.folder().write_store_path(writer, string_buf),
+            Tag::Git => self.git().write_store_path(writer, "git+", string_buf),
+            Tag::Github => self
+                .github()
+                .write_store_path(writer, "github+", string_buf),
+            Tag::Workspace => self.workspace().write_store_path(writer, string_buf),
+            Tag::Symlink => self.symlink().write_store_path(writer, string_buf),
+            Tag::SingleFileModule => self
+                .single_file_module()
+                .write_store_path(writer, string_buf),
+            _ => Ok(()),
         }
     }
 
@@ -531,97 +551,38 @@ impl<SemverInt: VersionInt> ResolutionType<SemverInt> {
 // kept so dependents that named `resolution::StringBuilderLike` still resolve.
 pub use bun_semver::StringBuilder as StringBuilderLike;
 
-pub struct StorePathFormatter<'a, SemverInt: VersionInt> {
-    res: &'a ResolutionType<SemverInt>,
-    string_buf: &'a [u8],
-    // opts: String.StorePathFormatter.Options,
-}
-
-impl<'a, SemverInt: VersionInt> fmt::Display for StorePathFormatter<'a, SemverInt> {
-    fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let string_buf = self.string_buf;
-        let res = self.res;
-        match res.tag {
-            Tag::Root => writer.write_str("root"),
-            Tag::Npm => write!(writer, "{}", res.npm().version.fmt(string_buf)),
-            Tag::LocalTarball => {
-                write!(writer, "{}", res.local_tarball().fmt_store_path(string_buf))
-            }
-            Tag::RemoteTarball => {
-                write!(
-                    writer,
-                    "{}",
-                    fmt_store_url(res.remote_tarball().slice(string_buf))
-                )
-            }
-            Tag::Folder => write!(writer, "{}", res.folder().fmt_store_path(string_buf)),
-            Tag::Git => write!(writer, "{}", res.git().fmt_store_path("git+", string_buf)),
-            Tag::Github => {
-                write!(
-                    writer,
-                    "{}",
-                    res.github().fmt_store_path("github+", string_buf)
-                )
-            }
-            Tag::Workspace => write!(writer, "{}", res.workspace().fmt_store_path(string_buf)),
-            Tag::Symlink => write!(writer, "{}", res.symlink().fmt_store_path(string_buf)),
-            Tag::SingleFileModule => {
-                write!(
-                    writer,
-                    "{}",
-                    res.single_file_module().fmt_store_path(string_buf)
-                )
-            }
-            _ => Ok(()),
-        }
-    }
-}
-
-/// Store path of a tarball or repository URL. The store path becomes a
-/// directory name (realpaths, stack traces, `bun pm` output), so the userinfo
-/// and the query string, which is where credentials go, are left out of it;
-/// when either was present, the hash of the complete URL takes their place so
-/// that URLs differing only in those parts still get separate entries:
-/// `https://user:token@host/pkg.tgz?token=x` becomes
+/// Writes the store path of a tarball or repository URL. The store path
+/// becomes a directory name (realpaths, stack traces, `bun pm` output), so the
+/// userinfo and the query string, which is where credentials go, are left out
+/// of it; when either was present, the hash of the complete URL takes their
+/// place so that URLs differing only in those parts still get separate
+/// entries: `https://user:token@host/pkg.tgz?token=x` becomes
 /// `https+++host+pkg.tgz+<16 hex>`. A URL without either part is spelled out
 /// unchanged.
-pub(crate) struct StoreURLFormatter<'a> {
-    url: &'a [u8],
-}
+pub(crate) fn write_store_url<W: bun_core::io::Write + ?Sized>(
+    writer: &mut W,
+    url: &[u8],
+) -> bun_core::CrateResult<()> {
+    // RFC 3986: the authority follows `scheme://` (or, for an scp-like
+    // `user@host:path`, starts the string) and ends at the first `/`, `?`
+    // or `#`; the userinfo is everything in it up to the last `@`.
+    let authority_start = match strings::index_of_char_usize(url, b':') {
+        Some(colon) if url[colon + 1..].starts_with(b"//") => colon + b"://".len(),
+        _ => 0,
+    };
+    let authority_end = strings::index_of_any(&url[authority_start..], b"/?#")
+        .map_or(url.len(), |i| authority_start + i);
+    let host_start = strings::last_index_of_char(&url[authority_start..authority_end], b'@')
+        .map_or(authority_start, |at| authority_start + at + 1);
+    let query_start = strings::index_of_char_usize(&url[host_start..], b'?')
+        .map_or(url.len(), |i| host_start + i);
 
-pub(crate) fn fmt_store_url(url: &[u8]) -> StoreURLFormatter<'_> {
-    StoreURLFormatter { url }
-}
-
-impl fmt::Display for StoreURLFormatter<'_> {
-    fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let url = self.url;
-
-        // RFC 3986: the authority follows `scheme://` (or, for an scp-like
-        // `user@host:path`, starts the string) and ends at the first `/`, `?`
-        // or `#`; the userinfo is everything in it up to the last `@`.
-        let authority_start = match strings::index_of_char_usize(url, b':') {
-            Some(colon) if url[colon + 1..].starts_with(b"//") => colon + b"://".len(),
-            _ => 0,
-        };
-        let authority_end = strings::index_of_any(&url[authority_start..], b"/?#")
-            .map_or(url.len(), |i| authority_start + i);
-        let host_start = strings::last_index_of_char(&url[authority_start..authority_end], b'@')
-            .map_or(authority_start, |at| authority_start + at + 1);
-        let query_start = strings::index_of_char_usize(&url[host_start..], b'?')
-            .map_or(url.len(), |i| host_start + i);
-
-        write!(
-            writer,
-            "{}{}",
-            semver::string::fmt_store_path(&url[..authority_start]),
-            semver::string::fmt_store_path(&url[host_start..query_start]),
-        )?;
-        if host_start != authority_start || query_start != url.len() {
-            write!(writer, "+{:016x}", bun_wyhash::hash(url))?;
-        }
-        Ok(())
+    semver::string::write_store_path(writer, &url[..authority_start])?;
+    semver::string::write_store_path(writer, &url[host_start..query_start])?;
+    if host_start != authority_start || query_start != url.len() {
+        write!(writer, "+{:016x}", bun_wyhash::hash(url))?;
     }
+    Ok(())
 }
 
 pub struct URLFormatter<'a, SemverInt: VersionInt> {

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -422,8 +422,7 @@ impl<U: PathUnit, const SEP_OPT: u8> Buf<U, SEP_OPT> {
     }
 }
 
-/// The sink behind `Path::append_with`: a cursor over a pooled path buffer
-/// that fails with `NoSpaceLeft` instead of growing.
+/// The sink behind `Path::append_with`: a cursor that fails with `NoSpaceLeft` instead of growing.
 struct ScratchWriter<'a> {
     buf: &'a mut [u8],
     len: usize,
@@ -1020,10 +1019,8 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         self.append_with(|writer| writer.write_fmt(args))
     }
 
-    /// Appends the bytes that `write` produces, trimmed and separated like
-    /// `append`. Use this instead of `append_fmt` for a path component that is
-    /// not text: `core::fmt` only carries `&str`, and a filesystem name can
-    /// hold any bytes.
+    /// Appends the bytes that `write` produces, trimmed and separated like `append`.
+    /// Unlike `append_fmt`, the bytes do not have to be UTF-8.
     pub fn append_with(
         &mut self,
         write: impl FnOnce(&mut dyn bun_core::io::Write) -> bun_core::CrateResult<()>,

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -422,6 +422,30 @@ impl<U: PathUnit, const SEP_OPT: u8> Buf<U, SEP_OPT> {
     }
 }
 
+/// The sink behind `Path::append_with`: a cursor over a pooled path buffer
+/// that fails with `NoSpaceLeft` instead of growing.
+struct ScratchWriter<'a> {
+    buf: &'a mut [u8],
+    len: usize,
+}
+
+impl bun_core::io::Write for ScratchWriter<'_> {
+    fn write_all(&mut self, bytes: &[u8]) -> bun_core::CrateResult<()> {
+        let end = self.len + bytes.len();
+        let room = self
+            .buf
+            .get_mut(self.len..end)
+            .ok_or(bun_core::CrateError::NoSpaceLeft)?;
+        room.copy_from_slice(bytes);
+        self.len = end;
+        Ok(())
+    }
+
+    fn written_len(&self) -> usize {
+        self.len
+    }
+}
+
 /// Width-generic `bun.strings.basename`.
 /// Platform-split: POSIX recognizes only `/`; Windows recognizes `/`, `\`, and
 /// the `X:` drive designator at index 1.
@@ -993,30 +1017,30 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
     }
 
     pub fn append_fmt(&mut self, args: core::fmt::Arguments<'_>) -> options::Result<()> {
-        // TODO: there's probably a better way to do this. needed for trimming slashes
-        let mut temp: Path<u8, { Kind::ANY }, { PathSeparators::ANY }> = Path::init();
+        self.append_with(|writer| writer.write_fmt(args))
+    }
 
-        // match BufType::Pool
-        let input = {
-            use std::io::Write;
-            let buf = u8::buffer_as_mut_slice(&mut temp._buf.pooled);
-            let mut cursor: &mut [u8] = buf;
-            let total = cursor.len();
-            match cursor.write_fmt(args) {
-                Ok(()) => {
-                    let written = total - cursor.len();
-                    &u8::buffer_as_slice(&temp._buf.pooled)[..written]
-                }
-                Err(_) => {
-                    if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath {
-                        return Err(PathError::MaxPathExceeded);
-                    }
-                    unreachable!();
-                }
-            }
+    /// Appends the bytes that `write` produces, trimmed and separated like
+    /// `append`. Use this instead of `append_fmt` for a path component that is
+    /// not text: `core::fmt` only carries `&str`, and a filesystem name can
+    /// hold any bytes.
+    pub fn append_with(
+        &mut self,
+        write: impl FnOnce(&mut dyn bun_core::io::Write) -> bun_core::CrateResult<()>,
+    ) -> options::Result<()> {
+        let mut scratch = crate::path_buffer_pool::get();
+        let mut writer = ScratchWriter {
+            buf: &mut scratch[..],
+            len: 0,
         };
-
-        self.append(input)
+        if write(&mut writer).is_err() {
+            if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath {
+                return Err(PathError::MaxPathExceeded);
+            }
+            unreachable!();
+        }
+        let len = writer.len;
+        self.append(&scratch[..len])
     }
 
     fn assert_joinable(&self) {

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -1019,8 +1019,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         self.append_with(|writer| writer.write_fmt(args))
     }
 
-    /// Appends the bytes that `write` produces, trimmed and separated like `append`.
-    /// Unlike `append_fmt`, the bytes do not have to be UTF-8.
+    /// Like `append_fmt`, for a producer of bytes that need not be UTF-8.
     pub fn append_with(
         &mut self,
         write: impl FnOnce(&mut dyn bun_core::io::Write) -> bun_core::CrateResult<()>,

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -422,29 +422,6 @@ impl<U: PathUnit, const SEP_OPT: u8> Buf<U, SEP_OPT> {
     }
 }
 
-/// The sink behind `Path::append_with`: a cursor that fails with `NoSpaceLeft` instead of growing.
-struct ScratchWriter<'a> {
-    buf: &'a mut [u8],
-    len: usize,
-}
-
-impl bun_core::io::Write for ScratchWriter<'_> {
-    fn write_all(&mut self, bytes: &[u8]) -> bun_core::CrateResult<()> {
-        let end = self.len + bytes.len();
-        let room = self
-            .buf
-            .get_mut(self.len..end)
-            .ok_or(bun_core::CrateError::NoSpaceLeft)?;
-        room.copy_from_slice(bytes);
-        self.len = end;
-        Ok(())
-    }
-
-    fn written_len(&self) -> usize {
-        self.len
-    }
-}
-
 /// Width-generic `bun.strings.basename`.
 /// Platform-split: POSIX recognizes only `/`; Windows recognizes `/`, `\`, and
 /// the `X:` drive designator at index 1.
@@ -1025,17 +1002,14 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         write: impl FnOnce(&mut dyn bun_core::io::Write) -> bun_core::CrateResult<()>,
     ) -> options::Result<()> {
         let mut scratch = crate::path_buffer_pool::get();
-        let mut writer = ScratchWriter {
-            buf: &mut scratch[..],
-            len: 0,
-        };
-        if write(&mut writer).is_err() {
+        let mut cursor = bun_core::fmt::SliceCursor::new(&mut scratch[..]);
+        if write(&mut cursor).is_err() {
             if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath {
                 return Err(PathError::MaxPathExceeded);
             }
             unreachable!();
         }
-        let len = writer.len;
+        let len = cursor.at;
         self.append(&scratch[..len])
     }
 

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -369,6 +369,10 @@ pub trait PathLike {
     fn clear(&mut self);
     fn append(&mut self, bytes: &[u8]);
     fn append_fmt(&mut self, args: core::fmt::Arguments<'_>);
+    fn append_with(
+        &mut self,
+        write: impl FnOnce(&mut dyn bun_core::io::Write) -> bun_core::CrateResult<()>,
+    );
 }
 // Bound to `CheckLength::ASSUME` only. This prevents check-mode callers from
 // silently swallowing `MaxPathExceeded` through the duck-typed surface; they
@@ -389,6 +393,14 @@ impl<U: PathUnit, const KIND: u8, const SEP: u8> PathLike
     fn append_fmt(&mut self, args: core::fmt::Arguments<'_>) {
         use path::options::AssumeOk as _;
         path::Path::append_fmt(self, args).assume_ok()
+    }
+    #[inline]
+    fn append_with(
+        &mut self,
+        write: impl FnOnce(&mut dyn bun_core::io::Write) -> bun_core::CrateResult<()>,
+    ) {
+        use path::options::AssumeOk as _;
+        path::Path::append_with(self, write).assume_ok()
     }
 }
 

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -7,7 +7,7 @@ use bun_ast::{Expr, Log, Source};
 use bun_collections::{DynamicBitSet, StringHashMap, index_sort};
 use bun_core::fmt::PathSep;
 use bun_core::{FileKind, Global, Output, strings};
-use bun_install::isolated_install::store::entry::fmt_store_key;
+use bun_install::isolated_install::store::entry::write_store_key;
 use bun_install::lockfile::{Lockfile, package::PackageColumns as _, reachable, tree};
 use bun_install::package_manager::{LogLevel, workspace_selection};
 use bun_install::{PackageID, PackageManager, Resolution, ResolutionTag};
@@ -574,7 +574,7 @@ impl BunStore {
         }
 
         let mut key: Vec<u8> = Vec::new();
-        let _ = write!(&mut key, "{}", fmt_store_key(pkg_name, resolution, buf));
+        write_store_key(&mut key, pkg_name, resolution, buf).expect("Vec<u8> write is infallible");
 
         let i = entries.partition_point(|e| e[..] < key[..]);
         let entry = entries.get(i)?;

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -300,9 +300,14 @@ pub mod semver_string {
             }
         }
 
+        /// See [`write_store_path`].
         #[inline]
-        pub fn fmt_store_path<'a>(&'a self, buf: &'a [u8]) -> StorePathFormatter<'a> {
-            fmt_store_path(self.slice(buf))
+        pub fn write_store_path<W: bun_core::io::Write + ?Sized>(
+            self,
+            writer: &mut W,
+            buf: &[u8],
+        ) -> bun_core::CrateResult<()> {
+            write_store_path(writer, self.slice(buf))
         }
 
         #[inline]
@@ -694,33 +699,24 @@ pub mod semver_string {
     }
 
     // ── String.StorePathFormatter ─────────────────────────────────────────
-    pub struct StorePathFormatter<'a> {
-        bytes: &'a [u8],
-    }
 
-    /// Spells `bytes` as a single path component of the isolated store.
-    pub fn fmt_store_path(bytes: &[u8]) -> StorePathFormatter<'_> {
-        StorePathFormatter { bytes }
-    }
-
-    impl<'a> fmt::Display for StorePathFormatter<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            for &c in self.bytes {
-                let n = match c {
-                    b'/' => b'+',
-                    b'\\' => b'+',
-                    b':' => b'+',
-                    b'#' => b'+',
-                    // `?` would be parsed as a query-string delimiter during
-                    // module resolution (and is invalid in Windows filenames).
-                    b'?' => b'+',
-                    _ => c,
-                };
-                use core::fmt::Write;
-                f.write_char(n as char)?;
-            }
-            Ok(())
+    /// Writes `bytes` as a single path component of the isolated store.
+    /// `/`, `\`, `:` and `#` become `+`, and so does `?` (module resolution
+    /// would parse it as a query-string delimiter, and Windows rejects it in
+    /// a filename). Every other byte is written unchanged: the component is
+    /// a filesystem name, not text, so a non-ASCII or non-UTF-8 path spells
+    /// the same bytes on disk as in the lockfile.
+    pub fn write_store_path<W: bun_core::io::Write + ?Sized>(
+        writer: &mut W,
+        bytes: &[u8],
+    ) -> bun_core::CrateResult<()> {
+        let mut rest = bytes;
+        while let Some(i) = strings::index_of_any(rest, b"/\\:#?") {
+            writer.write_all(&rest[..i])?;
+            writer.write_byte(b'+')?;
+            rest = &rest[i + 1..];
         }
+        writer.write_all(rest)
     }
 
     // ── HashContext / ArrayHashContext ────────────────────────────────────

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -700,15 +700,13 @@ pub mod semver_string {
 
     // ── String.StorePathFormatter ─────────────────────────────────────────
 
-    /// Writes `bytes` as a single path component of the isolated store:
-    /// `/`, `\`, `:`, `#` and `?` become `+`, every other byte is written unchanged.
+    /// `bytes` as one path component of the isolated store: `/`, `\`, `:`, `#` and `?` become `+`.
     pub fn write_store_path<W: bun_core::io::Write + ?Sized>(
         writer: &mut W,
         bytes: &[u8],
     ) -> bun_core::CrateResult<()> {
         let mut rest = bytes;
-        // `?` would be parsed as a query-string delimiter during module
-        // resolution (and is invalid in Windows filenames).
+        // `?` is a query-string delimiter in module resolution and invalid in Windows filenames.
         while let Some(i) = strings::index_of_any(rest, b"/\\:#?") {
             writer.write_all(&rest[..i])?;
             writer.write_byte(b'+')?;

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -700,17 +700,15 @@ pub mod semver_string {
 
     // ── String.StorePathFormatter ─────────────────────────────────────────
 
-    /// Writes `bytes` as a single path component of the isolated store.
-    /// `/`, `\`, `:` and `#` become `+`, and so does `?` (module resolution
-    /// would parse it as a query-string delimiter, and Windows rejects it in
-    /// a filename). Every other byte is written unchanged: the component is
-    /// a filesystem name, not text, so a non-ASCII or non-UTF-8 path spells
-    /// the same bytes on disk as in the lockfile.
+    /// Writes `bytes` as a single path component of the isolated store:
+    /// `/`, `\`, `:`, `#` and `?` become `+`, every other byte is written unchanged.
     pub fn write_store_path<W: bun_core::io::Write + ?Sized>(
         writer: &mut W,
         bytes: &[u8],
     ) -> bun_core::CrateResult<()> {
         let mut rest = bytes;
+        // `?` would be parsed as a query-string delimiter during module
+        // resolution (and is invalid in Windows filenames).
         while let Some(i) = strings::index_of_any(rest, b"/\\:#?") {
             writer.write_all(&rest[..i])?;
             writer.write_byte(b'+')?;

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, readFileSync, readlinkSync, statSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, statSync, writeFileSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, isLinux, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
 import { basename, dirname, join } from "path";
 import { pathToFileURL } from "url";
@@ -2439,8 +2439,8 @@ describe("long store entry names", () => {
   test("a cut that would split a multi-byte character backs up to the character boundary", async () => {
     // `file+x` is 6 bytes and every character after it is 2 bytes wide, so
     // byte 63 of the resolution falls inside a character and the cut ends at
-    // byte 62. Only the shape is asserted: how non-ASCII bytes are spelled in
-    // the name is a separate matter (#32304), the boundary handling is not.
+    // byte 62: 28 characters after `file+x`. The hash covers the full
+    // resolution.
     const folder = `x${Buffer.alloc(40 * 2, "\u00e9").toString()}`;
     const { packageJson, packageDir } = await registry.createTestDir({
       bunfigOpts: { linker: "isolated" },
@@ -2453,11 +2453,11 @@ describe("long store entry names", () => {
 
     await runBunInstall(bunEnv, packageDir);
 
-    const entries = await storeEntries(packageDir);
-    expect(entries).toEqual([expect.stringMatching(/^non-ascii@file\+x.*\+[0-9a-f]{16}$/)]);
-    const [entry] = entries;
-    const cutResolution = entry.slice("non-ascii@".length, -"+0123456789abcdef".length);
-    expect(Buffer.byteLength(cutResolution)).toBe(CUT_RESOLUTION_LEN - 1);
+    const entry = `non-ascii@file+x${Buffer.alloc(28 * 2, "\u00e9").toString()}+${urlHash(`file+${folder}`)}`;
+    expect(Buffer.byteLength(entry.slice("non-ascii@".length, -"+0123456789abcdef".length))).toBe(
+      CUT_RESOLUTION_LEN - 1,
+    );
+    expect(await storeEntries(packageDir)).toEqual([entry]);
     expect(readlinkSync(join(packageDir, "node_modules", "non-ascii"))).toBe(
       join(".bun", entry, "node_modules", "non-ascii"),
     );
@@ -2629,6 +2629,85 @@ describe("long store entry names", () => {
     expect(entry).toMatch(/^git-dep@git\+file\+\+\+\+.*\+[0-9a-f]{16}$/);
     expect(await storeEntries(packageDir)).toEqual([entry]);
     expect(await file(join(packageDir, "node_modules", "git-dep", "postinstall-ran.txt")).text()).toBe("ran");
+  });
+});
+
+// A store entry is named after lockfile strings: the package name and, for a
+// folder, tarball, workspace or git dependency, its path or URL. The name is a
+// directory name, so those bytes go into it unchanged (apart from `/`, `\`,
+// `:`, `#` and `?`, which become `+`). Spelling each byte as a character
+// instead turned the UTF-8 `ñ` (c3 b1) of a folder path into `Ã±` (c3 83 c2 b1).
+describe("store entry names with non-ASCII bytes", () => {
+  async function storeEntries(packageDir: string): Promise<string[]> {
+    return (await readdirSorted(join(packageDir, "node_modules", ".bun"))).filter(entry => entry !== "node_modules");
+  }
+
+  test("a folder dependency under a non-ASCII directory keeps its UTF-8 bytes", async () => {
+    const folder = "paquetes/a\u00f1adir";
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+      files: {
+        [`${folder}/package.json`]: JSON.stringify({ name: "anadir", version: "1.0.0" }),
+        [`${folder}/index.js`]: "module.exports = 'hola';",
+      },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({ name: "test-non-ascii-folder", dependencies: { anadir: `file:./${folder}` } }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const entry = "anadir@file+paquetes+a\u00f1adir";
+    expect(await storeEntries(packageDir)).toEqual([entry]);
+    expect(readlinkSync(join(packageDir, "node_modules", "anadir"))).toBe(
+      join(".bun", entry, "node_modules", "anadir"),
+    );
+    expect(await file(join(packageDir, "node_modules", "anadir", "package.json")).json()).toEqual({
+      name: "anadir",
+      version: "1.0.0",
+    });
+
+    // The next install derives the same name from the lockfile.
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    expect(await storeEntries(packageDir)).toEqual([entry]);
+  });
+
+  // Only Linux accepts a directory name that is not UTF-8. package.json is
+  // written as raw bytes because it has to spell the directory as the
+  // filesystem does.
+  test.skipIf(!isLinux)("a folder dependency under a directory that is not UTF-8 keeps its bytes", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const latin1 = Buffer.from([0x63, 0x61, 0x66, 0xe9]); // "café" in Latin-1
+    const folder = Buffer.concat([Buffer.from(`${join(packageDir, "vendor")}/`), latin1]);
+    mkdirSync(folder, { recursive: true });
+    writeFileSync(
+      Buffer.concat([folder, Buffer.from("/package.json")]),
+      JSON.stringify({ name: "dep", version: "1.0.0" }),
+    );
+    writeFileSync(
+      packageJson,
+      Buffer.concat([
+        Buffer.from('{"name":"test-latin1-folder","dependencies":{"dep":"file:./vendor/'),
+        latin1,
+        Buffer.from('"}}'),
+      ]),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const entry = Buffer.concat([Buffer.from("dep@file+vendor+"), latin1]);
+    const entries = readdirSync(join(packageDir, "node_modules", ".bun"), { encoding: "buffer" }).filter(
+      name => !name.equals(Buffer.from("node_modules")),
+    );
+    expect(entries).toEqual([entry]);
+    expect(readlinkSync(join(packageDir, "node_modules", "dep"), { encoding: "buffer" })).toEqual(
+      Buffer.concat([Buffer.from(".bun/"), entry, Buffer.from("/node_modules/dep")]),
+    );
+    expect(await file(join(packageDir, "node_modules", "dep", "package.json")).json()).toEqual({
+      name: "dep",
+      version: "1.0.0",
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- With `--linker=isolated`, a dependency whose path holds non-ASCII bytes gets a mojibake store directory. `file:./paquetes/añadir` is installed into `node_modules/.bun/anadir@file+paquetes+aÃ±adir` (`c3 b1` becomes `c3 83 c2 b1`). The cause is `bun_semver`'s `StorePathFormatter` (`src/semver/lib.rs:706`): it spells each byte with `f.write_char(n as char)`, which treats the byte as a Latin-1 code point and re-encodes it.
- A second formatter for the same job, `bun_install::StorePathFormatter` (`src/install/lib.rs:913`), returns `fmt::Error` for a path that is not UTF-8. Its callers in `Installer.rs` dropped the `Result` with `let _ = buf.append_fmt(..)`.

### Fix
- One byte-oriented writer replaces both: `bun_semver::string::write_store_path` over `bun_core::io::Write`. It writes the bytes unchanged, apart from `/`, `\`, `:`, `#` and `?`, which become `+` as before. The formatters that compose an entry name (`Repository`, `Resolution`, the store key, the entry path, the global entry path) are now `write_*` functions over the same sink, so no `&str` sits between the lockfile bytes and the directory name.
- `Path` gets `append_with(|writer| ..)`: the producer writes bytes into a pooled scratch buffer, and the result is appended with the same trimming and separator rules as `append`. `append_fmt` is now built on it. `Installer.rs` appends store paths through it and keeps the `Result` (`.assume_ok()` on the `ASSUME` path types, as the type documents).
- Correct because a store entry name is a filesystem name, not text. The same bytes that the lockfile holds now name the directory, which is what the Zig `writeByte` loop did. For a valid UTF-8 path the name is the UTF-8 spelling of the path, so macOS and Windows see a valid name. For a path that is not UTF-8 (legal on Linux) the name holds the same bytes as the source directory.
- Verified: `test/cli/install/isolated-install.test.ts` (new `store entry names with non-ASCII bytes` block: UTF-8 folder, Latin-1 folder on Linux, plus the multi-byte cut test now asserts the exact name). Stock bun fails all three. Also ran the whole file (87 tests), `bun-prune`, `bun-pm-licenses`, `isolated-relink`, `bun-install-git-deps`, clippy, and a `cargo check` for `x86_64-pc-windows-msvc`.

### Background
- The isolated linker installs each package once under `node_modules/.bun/<entry>/node_modules/<name>` and symlinks dependents to it. `<entry>` is `<name>@<resolution>[+<peer hash>]`, and the resolution part embeds a folder path, a tarball URL or a git URL for non-npm packages. The same name is computed in several places (install, prune, hashing for the global store, `bun pm licenses`), so they all have to spell it identically.
- `core::fmt` only transports `&str`. A `Display` impl cannot emit a byte that is not part of valid UTF-8, so any `fmt`-based chain either re-encodes or errors on such input. `bun_core::io::Write` is the crate's byte sink trait (`write_all(&[u8])`), already used by the lockfile writers for the same reason.
- `bun_paths::Path` is a pooled, fixed-capacity path buffer. `append` trims leading and trailing separators from its input and inserts the platform separator. The `Auto*` aliases skip the length check (`CheckLength::ASSUME`), so their `Result` is always `Ok` and `.assume_ok()` is the documented way to consume it.

<details><summary>Notes</summary>

- Supersedes #32304, which kept `fmt::Display`, fixed only the UTF-8 case and made non-UTF-8 input a `fmt::Error`.
- Repro on bun 1.4.1 (Linux): `{"dependencies":{"anadir":"file:./paquetes/añadir"}}` with `bun install --linker=isolated` creates `node_modules/.bun/anadir@file+paquetes+aÃ±adir`. With a Latin-1 byte in the path (`caf\xe9`, package.json written as raw bytes) stock bun creates `caf\xc3\xa9`. After this change: `caf\xe9`.
- Behavior for every ASCII input is unchanged: the git/github `label` and `resolved` values only ever went through the `/` and `\` mapping of the deleted formatter, and both are validated ASCII (`is_safe_resolved_tag`). The existing exact-name tests for tarball and git entries pass unchanged.
- An existing install with a mojibake entry self-heals: the next install computes the new name, creates it, and prune removes the old directory.
- `bun.lock` writes the resolution of such a dependency with a JSON escape for code point 0 in place of the invalid byte: the JSON string printer decodes an invalid byte as 0 (same as the Zig printer). Pre-existing, not touched here.
- `Installer.rs` (the package failure handler) unlinks `node_modules/<entry>` to force a reinstall next time, but the entry lives at `node_modules/.bun/<entry>`, so the cleanup has never run. This PR rewrites that block for the byte writer and keeps its target path. The path fix (prefix with `NODE_MODULES_BUN`, delete the tree instead of `unlink`) needs a test that injects a failure mid-install and is handled as a separate change.
- Suites run: `isolated-install.test.ts` (87 pass), `bun-pm-licenses.test.ts`, `bun-prune.test.ts`, `isolated-relink.test.ts`, `bun-install-git-deps.test.ts` (203 pass, 2 skip), `test/internal/source-lints` (165 pass), `cargo clippy -p bun_semver -p bun_paths -p bun_install`, `cargo check -p bun_install -p bun_paths --target x86_64-pc-windows-msvc`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->
