### PR TITLE
errno: map a kernel errno outside the table to EUNKNOWN instead of transmuting

### DIFF
--- a/src/errno/darwin_errno.rs
+++ b/src/errno/darwin_errno.rs
@@ -4,7 +4,16 @@ pub use crate::posix::S;
 
 #[repr(u16)]
 #[derive(
-    Copy, Clone, Eq, PartialEq, Hash, Debug, strum::IntoStaticStr, strum::EnumString, enum_map::Enum,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Debug,
+    strum::IntoStaticStr,
+    strum::EnumString,
+    strum::FromRepr,
+    enum_map::Enum,
 )]
 pub enum SystemErrno {
     SUCCESS = 0,
@@ -114,10 +123,13 @@ pub enum SystemErrno {
     ENOTRECOVERABLE = 104,
     EOWNERDEAD = 105,
     EQFULL = 106,
+    /// Not a kernel errno. `from_raw` maps every code the enum does not
+    /// declare here.
+    EUNKNOWN = 107,
 }
 
 impl SystemErrno {
-    pub const MAX: u16 = 107;
+    pub const MAX: u16 = 108;
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/errno/darwin_errno.rs
+++ b/src/errno/darwin_errno.rs
@@ -123,8 +123,7 @@ pub enum SystemErrno {
     ENOTRECOVERABLE = 104,
     EOWNERDEAD = 105,
     EQFULL = 106,
-    /// Not a kernel errno. `from_raw` maps every code the enum does not
-    /// declare here.
+    /// Not a kernel errno: the `from_raw` result for an undeclared code.
     EUNKNOWN = 107,
 }
 

--- a/src/errno/freebsd_errno.rs
+++ b/src/errno/freebsd_errno.rs
@@ -4,7 +4,16 @@ pub use crate::posix::S;
 
 #[repr(u16)]
 #[derive(
-    Copy, Clone, Eq, PartialEq, Hash, Debug, strum::IntoStaticStr, strum::EnumString, enum_map::Enum,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Debug,
+    strum::IntoStaticStr,
+    strum::EnumString,
+    strum::FromRepr,
+    enum_map::Enum,
 )]
 pub enum SystemErrno {
     SUCCESS = 0,
@@ -105,10 +114,13 @@ pub enum SystemErrno {
     ENOTRECOVERABLE = 95,
     EOWNERDEAD = 96,
     EINTEGRITY = 97,
+    /// Not a kernel errno. `from_raw` maps every code the enum does not
+    /// declare here.
+    EUNKNOWN = 98,
 }
 
 impl SystemErrno {
-    pub const MAX: u16 = 98;
+    pub const MAX: u16 = 99;
 
     /// On FreeBSD `ENOTSUP` is not a distinct errno; libc aliases it to
     /// `EOPNOTSUPP` (45). Provide the alias so cross-platform call sites that

--- a/src/errno/freebsd_errno.rs
+++ b/src/errno/freebsd_errno.rs
@@ -114,8 +114,7 @@ pub enum SystemErrno {
     ENOTRECOVERABLE = 95,
     EOWNERDEAD = 96,
     EINTEGRITY = 97,
-    /// Not a kernel errno. `from_raw` maps every code the enum does not
-    /// declare here.
+    /// Not a kernel errno: the `from_raw` result for an undeclared code.
     EUNKNOWN = 98,
 }
 

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -275,8 +275,7 @@ pub fn e_from_negated(errno: core::ffi::c_int) -> E {
 }
 
 impl SystemErrno {
-    /// A code the enum does not declare (the kernel is not bound to the
-    /// table: FUSE, `ENOTSUPP` 524) maps to `EUNKNOWN`.
+    /// The kernel is not bound to this table (FUSE, `ENOTSUPP` 524): an undeclared code is `EUNKNOWN`.
     #[inline]
     pub const fn from_raw(n: u16) -> SystemErrno {
         match Self::from_repr(n) {

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -17,8 +17,6 @@ macro_rules! impl_get_errno_libc {
                 // against the type's own all-ones value instead (== -1 for
                 // signed, == MAX for unsigned — both are libc's failure rc).
                 if self == !(0 as $t) {
-                    // A code that does not fit the table is `EUNKNOWN`, never
-                    // a truncated cast that lands on another variant.
                     u16::try_from($crate::posix::errno())
                         .map_or($crate::E::EUNKNOWN, $crate::E::from_raw)
                 } else {
@@ -277,10 +275,8 @@ pub fn e_from_negated(errno: core::ffi::c_int) -> E {
 }
 
 impl SystemErrno {
-    /// Map a raw errno to its variant. A code the enum does not declare
-    /// becomes `EUNKNOWN`: the kernel is not bound to the table (Linux FUSE
-    /// and driver-internal codes such as `ENOTSUPP` 524 reach userspace), so
-    /// the result is defined for every `u16`.
+    /// A code the enum does not declare (the kernel is not bound to the
+    /// table: FUSE, `ENOTSUPP` 524) maps to `EUNKNOWN`.
     #[inline]
     pub const fn from_raw(n: u16) -> SystemErrno {
         match Self::from_repr(n) {
@@ -301,9 +297,7 @@ pub fn from_errno(errno: i32) -> SystemErrno {
 
 #[cfg(not(windows))]
 impl SystemErrno {
-    // `i64` covers every concrete call site (errno-range values). The sign is
-    // ignored: Node-style negated codes decode the same as positive ones.
-    // `None` for a code the enum does not declare.
+    // `i64` covers every concrete call site (errno-range values).
     //
     // Windows defines its own `init<C: SystemErrnoInit>` (typed dispatch over
     // DWORD/c_int/Win32Error) in windows_errno.rs, so this impl is POSIX-only.
@@ -453,8 +447,7 @@ mod errno_name_tests {
         #[cfg(not(windows))]
         assert_eq!(system_errno_name(max as i32), None);
 
-        // Spot-check the last kernel entry on each platform; `EUNKNOWN` sits
-        // one past it.
+        // Spot-check the last entry on each platform.
         #[cfg(any(target_os = "linux", target_os = "android", target_family = "wasm"))]
         {
             assert_eq!(system_errno_name(133), Some("EHWPOISON"));
@@ -482,8 +475,6 @@ mod errno_name_tests {
         }
     }
 
-    /// A code the enum does not declare is not UB: `from_raw` is total and
-    /// lands on `EUNKNOWN`, the checked decoders report `None`.
     #[test]
     fn unknown_errno_is_defined() {
         // Linux `ENOTSUPP`, `ERESTARTSYS`, and the largest possible code.

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -17,7 +17,10 @@ macro_rules! impl_get_errno_libc {
                 // against the type's own all-ones value instead (== -1 for
                 // signed, == MAX for unsigned — both are libc's failure rc).
                 if self == !(0 as $t) {
-                    $crate::E::from_raw($crate::posix::errno() as u16)
+                    // A code that does not fit the table is `EUNKNOWN`, never
+                    // a truncated cast that lands on another variant.
+                    u16::try_from($crate::posix::errno())
+                        .map_or($crate::E::EUNKNOWN, $crate::E::from_raw)
                 } else {
                     $crate::E::SUCCESS
                 }
@@ -256,9 +259,7 @@ pub fn get_errno<T: GetErrno>(rc: T) -> E {
 /// Decode a Node-style **negated** errno (`c_int`, as written by
 /// `Error::to_system_error`) back into an `E`. The input crosses FFI
 /// (BunObject.cpp `SystemError__*`) and is NOT trusted to be a declared
-/// discriminant: an out-of-range `#[repr(u16)]` enum value is immediate UB.
-/// Validate via the checked
-/// constructor and fall back to `SUCCESS` for unmapped values.
+/// discriminant. `0` is `SUCCESS`; an unmapped value is `EUNKNOWN`.
 #[inline]
 pub fn e_from_negated(errno: core::ffi::c_int) -> E {
     let n = errno.wrapping_neg();
@@ -267,31 +268,25 @@ pub fn e_from_negated(errno: core::ffi::c_int) -> E {
         u16::try_from(n)
             .ok()
             .and_then(E::try_from_raw)
-            .unwrap_or(E::SUCCESS)
+            .unwrap_or(E::EUNKNOWN)
     }
     #[cfg(not(windows))]
     {
-        SystemErrno::init(i64::from(n)).unwrap_or(SystemErrno::SUCCESS)
+        SystemErrno::init(i64::from(n)).unwrap_or(SystemErrno::EUNKNOWN)
     }
 }
 
 impl SystemErrno {
-    /// Unchecked discriminant cast.
-    ///
-    /// On POSIX the enum is dense `0..MAX`, so we debug-assert `n < MAX`.
-    /// On Windows the enum is **sparse** (dense `0..=137` plus isolated `UV_E*`
-    /// discriminants in the ~3000-4095 range — see windows_errno.rs), so the
-    /// `< MAX` bound does not hold for valid tags and the assert is skipped.
+    /// Map a raw errno to its variant. A code the enum does not declare
+    /// becomes `EUNKNOWN`: the kernel is not bound to the table (Linux FUSE
+    /// and driver-internal codes such as `ENOTSUPP` 524 reach userspace), so
+    /// the result is defined for every `u16`.
     #[inline]
     pub const fn from_raw(n: u16) -> SystemErrno {
-        // `as usize` on both sides papers over per-OS `MAX` typing (POSIX `u16`
-        // vs Windows `usize`) without normalizing the constant itself.
-        #[cfg(not(windows))]
-        debug_assert!((n as usize) < (Self::MAX as usize));
-        // SAFETY: caller guarantees `n` is a declared `#[repr(u16)]` discriminant
-        // of `SystemErrno`. The enum is NOT
-        // contiguous on Windows; do not assume `n < MAX` implies validity there.
-        unsafe { core::mem::transmute::<u16, SystemErrno>(n) }
+        match Self::from_repr(n) {
+            Some(e) => e,
+            None => Self::EUNKNOWN,
+        }
     }
 }
 
@@ -306,21 +301,16 @@ pub fn from_errno(errno: i32) -> SystemErrno {
 
 #[cfg(not(windows))]
 impl SystemErrno {
-    // `i64` covers every concrete call site (errno-range values).
+    // `i64` covers every concrete call site (errno-range values). The sign is
+    // ignored: Node-style negated codes decode the same as positive ones.
+    // `None` for a code the enum does not declare.
     //
     // Windows defines its own `init<C: SystemErrnoInit>` (typed dispatch over
     // DWORD/c_int/Win32Error) in windows_errno.rs, so this impl is POSIX-only.
     pub fn init(code: i64) -> Option<SystemErrno> {
-        if code < 0 {
-            if code <= -(Self::MAX as i64) {
-                return None;
-            }
-            return Some(Self::from_raw((-code) as u16));
-        }
-        if code >= Self::MAX as i64 {
-            return None;
-        }
-        Some(Self::from_raw(code as u16))
+        u16::try_from(code.unsigned_abs())
+            .ok()
+            .and_then(Self::from_repr)
     }
 }
 
@@ -463,9 +453,13 @@ mod errno_name_tests {
         #[cfg(not(windows))]
         assert_eq!(system_errno_name(max as i32), None);
 
-        // Spot-check the last entry on each platform.
+        // Spot-check the last kernel entry on each platform; `EUNKNOWN` sits
+        // one past it.
         #[cfg(any(target_os = "linux", target_os = "android", target_family = "wasm"))]
-        assert_eq!(system_errno_name(133), Some("EHWPOISON"));
+        {
+            assert_eq!(system_errno_name(133), Some("EHWPOISON"));
+            assert_eq!(system_errno_name(134), Some("EUNKNOWN"));
+        }
         #[cfg(windows)]
         {
             assert_eq!(system_errno_name(137), Some("EFTYPE"));
@@ -477,9 +471,55 @@ mod errno_name_tests {
             assert_eq!(system_errno_name(-5000), None);
         }
         #[cfg(target_os = "macos")]
-        assert_eq!(system_errno_name(106), Some("EQFULL"));
+        {
+            assert_eq!(system_errno_name(106), Some("EQFULL"));
+            assert_eq!(system_errno_name(107), Some("EUNKNOWN"));
+        }
         #[cfg(target_os = "freebsd")]
-        assert_eq!(system_errno_name(97), Some("EINTEGRITY"));
+        {
+            assert_eq!(system_errno_name(97), Some("EINTEGRITY"));
+            assert_eq!(system_errno_name(98), Some("EUNKNOWN"));
+        }
+    }
+
+    /// A code the enum does not declare is not UB: `from_raw` is total and
+    /// lands on `EUNKNOWN`, the checked decoders report `None`.
+    #[test]
+    fn unknown_errno_is_defined() {
+        // Linux `ENOTSUPP`, `ERESTARTSYS`, and the largest possible code.
+        for raw in [524u16, 512, u16::MAX] {
+            assert_eq!(SystemErrno::from_raw(raw), SystemErrno::EUNKNOWN);
+            #[cfg(not(windows))]
+            {
+                assert_eq!(SystemErrno::init(i64::from(raw)), None);
+                assert_eq!(SystemErrno::init(-i64::from(raw)), None);
+            }
+            assert_eq!(system_errno_name(i32::from(raw)), None);
+        }
+        assert_eq!(SystemErrno::from_raw(0), SystemErrno::SUCCESS);
+        assert_eq!(SystemErrno::from_raw(2), SystemErrno::ENOENT);
+        assert_eq!(
+            SystemErrno::from_raw(SystemErrno::EUNKNOWN as u16),
+            SystemErrno::EUNKNOWN
+        );
+
+        // Round trip: a stored `EUNKNOWN` decodes as itself, not as `SUCCESS`.
+        #[cfg(not(windows))]
+        assert_eq!(
+            SystemErrno::init(i64::from(SystemErrno::EUNKNOWN as u16)),
+            Some(SystemErrno::EUNKNOWN)
+        );
+        assert_eq!(e_from_negated(0), E::SUCCESS);
+        assert_eq!(e_from_negated(-524), E::EUNKNOWN);
+        assert_eq!(e_from_negated(-(E::EUNKNOWN as i32)), E::EUNKNOWN);
+
+        // Linux raw syscalls hand back `-errno` in the return register.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            assert_eq!((-524isize as usize).get_errno(), E::EUNKNOWN);
+            assert_eq!((-2isize as usize).get_errno(), E::ENOENT);
+            assert_eq!(7usize.get_errno(), E::SUCCESS);
+        }
     }
 
     /// `win32_errno_name` translation contract: known `GetLastError()` codes

--- a/src/errno/linux_errno.rs
+++ b/src/errno/linux_errno.rs
@@ -153,9 +153,7 @@ pub enum SystemErrno {
     ENOTRECOVERABLE = 131,
     ERFKILL = 132,
     EHWPOISON = 133,
-    /// Not a kernel errno. `from_raw` maps every code the enum does not
-    /// declare here: FUSE and driver-internal codes such as `ENOTSUPP` (524)
-    /// do reach userspace.
+    /// Not a kernel errno: the `from_raw` result for an undeclared code.
     EUNKNOWN = 134,
 }
 

--- a/src/errno/linux_errno.rs
+++ b/src/errno/linux_errno.rs
@@ -4,7 +4,16 @@ pub use crate::posix::S;
 
 #[repr(u16)]
 #[derive(
-    Copy, Clone, Eq, PartialEq, Hash, Debug, strum::IntoStaticStr, strum::EnumString, enum_map::Enum,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Debug,
+    strum::IntoStaticStr,
+    strum::EnumString,
+    strum::FromRepr,
+    enum_map::Enum,
 )]
 pub enum SystemErrno {
     SUCCESS = 0,
@@ -144,10 +153,14 @@ pub enum SystemErrno {
     ENOTRECOVERABLE = 131,
     ERFKILL = 132,
     EHWPOISON = 133,
+    /// Not a kernel errno. `from_raw` maps every code the enum does not
+    /// declare here: FUSE and driver-internal codes such as `ENOTSUPP` (524)
+    /// do reach userspace.
+    EUNKNOWN = 134,
 }
 
 impl SystemErrno {
-    pub const MAX: u16 = 134;
+    pub const MAX: u16 = 135;
 
     /// On Linux `EOPNOTSUPP` and `ENOTSUP` share value 95; the enum defines
     /// only `ENOTSUP`. Provide this alias so cross-platform call sites
@@ -187,8 +200,7 @@ impl GetErrno for usize {
         } else {
             0
         };
-        // SAFETY: int is in [0, 4096); E is #[repr] over the kernel errno range
-        unsafe { core::mem::transmute::<u16, E>(int as u16) }
+        E::from_raw(int as u16)
     }
 }
 

--- a/src/errno/windows_errno.rs
+++ b/src/errno/windows_errno.rs
@@ -25,7 +25,7 @@ use bun_libuv_sys as uv;
 //   [UV_X]         — no counterpart (EAI_* resolver codes, UNKNOWN, ERRNO_MAX)
 //
 // ORDER IS LOAD-BEARING: `enum_map::Enum` derives ordinals from declaration
-// order, and `SystemErrno::to_e` transmutes by discriminant, so the two enums
+// order, and `SystemErrno::to_e` maps by discriminant, so the two enums
 // MUST stay in lockstep. Editing this list updates both atomically.
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -242,16 +242,16 @@ pub enum E {
 }} // ← UV_* tail appended by `for_each_uv_errno!`
 
 impl E {
+    /// Map a raw discriminant to its variant; an undeclared value becomes
+    /// `UNKNOWN`. `E` is sparse (dense 0..=137 plus isolated UV_* tags
+    /// ~3000–4095), so the lookup goes through the `strum::FromRepr` match
+    /// and not a range check.
     #[inline]
     pub(crate) const fn from_raw(n: u16) -> Self {
-        // `E` is sparse (dense 0..=137 plus isolated UV_* tags ~3000–4095), so
-        // `n < MAX` is NOT a sufficient validity check. `strum::FromRepr`
-        // generates a `const fn from_repr` matching every declared variant.
-        debug_assert!(Self::from_repr(n).is_some(), "invalid E discriminant");
-        // SAFETY: caller guarantees `n` is a declared `#[repr(u16)]` discriminant
-        // of `E`. Debug-asserted above; for
-        // untrusted input use `try_from_raw` instead.
-        unsafe { core::mem::transmute::<u16, E>(n) }
+        match Self::from_repr(n) {
+            Some(e) => e,
+            None => Self::UNKNOWN,
+        }
     }
 
     /// Checked discriminant lookup —

--- a/src/errno/windows_errno.rs
+++ b/src/errno/windows_errno.rs
@@ -242,10 +242,7 @@ pub enum E {
 }} // ← UV_* tail appended by `for_each_uv_errno!`
 
 impl E {
-    /// Map a raw discriminant to its variant; an undeclared value becomes
-    /// `UNKNOWN`. `E` is sparse (dense 0..=137 plus isolated UV_* tags
-    /// ~3000–4095), so the lookup goes through the `strum::FromRepr` match
-    /// and not a range check.
+    /// An undeclared discriminant maps to `UNKNOWN`.
     #[inline]
     pub(crate) const fn from_raw(n: u16) -> Self {
         match Self::from_repr(n) {

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -726,8 +726,7 @@ mod _impl {
             if ret != 0 {
                 return Err(global.throw_value(
                     bun_sys::Error::from_code(
-                        // `ret` is a libc errno; `E::from_raw` is the centralized
-                        // `@enumFromInt` (debug-asserts the discriminant).
+                        // `ret` is a libc errno; a code outside the table is `EUNKNOWN`.
                         bun_sys::E::from_raw(ret as u16),
                         bun_sys::Tag::uv_os_homedir,
                     )

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -163,9 +163,9 @@ impl Error {
 
     #[inline]
     pub fn get_errno(&self) -> E {
-        // Transmuting an out-of-range discriminant
-        // (e.g. TODO_ERRNO = u16::MAX-1) into a #[repr(u16)] enum is immediate UB. Use the checked
-        // discriminant constructor and fall back to SUCCESS for unmapped values.
+        // `self.errno` is a raw u16 and may hold a code the enum does not
+        // declare (a kernel errno above the table, or TODO_ERRNO). Such an
+        // `Error` is still a failure, so it reads as `EUNKNOWN`, not `SUCCESS`.
         #[cfg(windows)]
         {
             // `self.errno` already stores an E/SystemErrno *discriminant* (set via `E as Int`),
@@ -173,11 +173,11 @@ impl Error {
             // route through `SystemErrno::init`: on Windows its u16/i32 entry points are the
             // Win32/WSA/uv-error→errno *mapper*, not a discriminant validator, and would
             // corrupt the value (e.g. EPERM=1 → Win32 INVALID_FUNCTION → EISDIR).
-            E::try_from_raw(self.errno).unwrap_or(E::SUCCESS)
+            E::try_from_raw(self.errno).unwrap_or(E::EUNKNOWN)
         }
         #[cfg(not(windows))]
         {
-            SystemErrno::init(self.errno as i64).unwrap_or(SystemErrno::SUCCESS)
+            SystemErrno::init(i64::from(self.errno)).unwrap_or(SystemErrno::EUNKNOWN)
         }
     }
 

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -163,10 +163,7 @@ impl Error {
 
     #[inline]
     pub fn get_errno(&self) -> E {
-        // `self.errno` is a raw u16 and may hold a code the enum does not
-        // declare (a kernel errno above the table, or the placeholder from
-        // `Error::default()`). Such an `Error` is still a failure, so it reads
-        // as `EUNKNOWN`, not `SUCCESS`.
+        // An errno the enum does not declare is still a failure: `EUNKNOWN`, not `SUCCESS`.
         #[cfg(windows)]
         {
             // `self.errno` already stores an E/SystemErrno *discriminant* (set via `E as Int`),

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -164,8 +164,9 @@ impl Error {
     #[inline]
     pub fn get_errno(&self) -> E {
         // `self.errno` is a raw u16 and may hold a code the enum does not
-        // declare (a kernel errno above the table, or TODO_ERRNO). Such an
-        // `Error` is still a failure, so it reads as `EUNKNOWN`, not `SUCCESS`.
+        // declare (a kernel errno above the table, or the placeholder from
+        // `Error::default()`). Such an `Error` is still a failure, so it reads
+        // as `EUNKNOWN`, not `SUCCESS`.
         #[cfg(windows)]
         {
             // `self.errno` already stores an E/SystemErrno *discriminant* (set via `E as Int`),

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -4,18 +4,10 @@ import { spawnSync } from "node:child_process";
 import { existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
-// Reproduces the seccomp class of failures documented in libuv's
-// deps/uv/src/unix/fs.c: statx under a seccomp filter that does not
-// whitelist it returns EPERM (libseccomp < 2.3.3, docker < 18.04, various
-// CI sandboxes). Before the fix, fs.stat would throw EPERM here.
-// After the fix, statxImpl falls back to fstat/lstat/stat.
-//
-// Each stat variant runs in its OWN subprocess so the per-process
-// `supports_statx_on_linux` flag is still `true` on entry — otherwise the
-// first call would flip the flag and subsequent calls would bypass
-// statxImpl/statxFallback entirely and go straight to Syscall.lstat/fstat.
-describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
-  const helperSrc = `
+// Seccomp helper: installs a filter that makes one syscall (`BLOCK_SYSCALL`,
+// a `-D` define) fail with the errno given in argv[1], then execs argv[2..].
+// Shared by the describe blocks below.
+const helperSrc = `
 #define _GNU_SOURCE
 #include <errno.h>
 #include <linux/audit.h>
@@ -36,9 +28,11 @@ describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
   #define MY_AUDIT_ARCH 0
 #endif
 
+/* usage: block <errno> <cmd> [args...] */
 int main(int argc, char **argv) {
-  if (argc < 2) return 2;
+  if (argc < 3) return 2;
   if (MY_AUDIT_ARCH == 0) return 77; /* unsupported arch, skip */
+  unsigned int err = (unsigned int)atoi(argv[1]);
 
   struct sock_filter filter[] = {
     /* arch check */
@@ -47,9 +41,9 @@ int main(int argc, char **argv) {
     BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
     /* load syscall nr */
     BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
-    /* if nr == __NR_statx → return EPERM */
-    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_statx, 0, 1),
-    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA)),
+    /* if nr == BLOCK_SYSCALL → return the requested errno */
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, BLOCK_SYSCALL, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (err & SECCOMP_RET_DATA)),
     /* else → allow */
     BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
   };
@@ -67,55 +61,74 @@ int main(int argc, char **argv) {
     return 77; /* cannot install filter, skip */
   }
 
-  execvp(argv[1], &argv[1]);
+  execvp(argv[2], &argv[2]);
   perror("execvp");
   return 127;
 }
 `;
 
-  // Compile the seccomp helper once. Returns the binary path, or null if
-  // the host genuinely can't build it (no cc, missing kernel headers).
-  // Any other compile failure throws so a source regression isn't silently
-  // hidden as a skip.
-  const tryBuild = (): string | null => {
-    const dir = tempDirWithFiles("stat-seccomp", {
-      "block_statx.c": helperSrc,
-    });
-    const src = join(dir, "block_statx.c");
-    const bin = join(dir, "block_statx");
-    const compile = spawnSync("cc", ["-O0", "-o", bin, src], { stdio: "pipe" });
+// Linux errno values (identical on x86_64 and aarch64).
+const EPERM = 1;
+const EACCES = 13;
+// Driver-internal code that leaks to userspace; above EHWPOISON (133), the
+// last errno bun's SystemErrno table declares.
+const ENOTSUPP = 524;
 
-    // compiler not on PATH — expected skip
-    if ((compile.error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return null;
+// Compile the seccomp helper for one syscall. Returns the binary path, or
+// null if the host genuinely can't build it (no cc, missing kernel headers).
+// Any other compile failure throws so a source regression isn't silently
+// hidden as a skip.
+function tryBuildHelper(syscall: string): string | null {
+  const dir = tempDirWithFiles("seccomp-helper", {
+    "block.c": helperSrc,
+  });
+  const src = join(dir, "block.c");
+  const bin = join(dir, "block");
+  const compile = spawnSync("cc", ["-O0", `-DBLOCK_SYSCALL=${syscall}`, "-o", bin, src], { stdio: "pipe" });
 
-    if (compile.status !== 0) {
-      const stderr = compile.stderr?.toString() ?? "";
-      // missing linux/*.h on the host — expected skip
-      if (/linux\/(seccomp|filter|audit)\.h|sys\/prctl\.h/.test(stderr)) return null;
-      throw new Error(`failed to compile seccomp helper:\n${stderr}`);
-    }
-    if (!existsSync(bin)) {
-      throw new Error("seccomp helper compiled successfully but output binary is missing");
-    }
-    return bin;
-  };
+  // compiler not on PATH — expected skip
+  if ((compile.error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return null;
 
-  const helperBin = tryBuild();
-
-  // Run `snippet` in a bun subprocess guarded by the seccomp helper.
-  // Returns { stdout, stderr, exitCode } on success, or null if the
-  // environment refused to install the seccomp filter (skip).
-  async function runUnderSeccomp(bin: string, snippet: string) {
-    await using proc = Bun.spawn({
-      cmd: [bin, bunExe(), "-e", snippet],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    if (exitCode === 77) return null;
-    return { stdout, stderr, exitCode };
+  if (compile.status !== 0) {
+    const stderr = compile.stderr?.toString() ?? "";
+    // missing linux/*.h on the host — expected skip
+    if (/linux\/(seccomp|filter|audit)\.h|sys\/prctl\.h/.test(stderr)) return null;
+    throw new Error(`failed to compile seccomp helper:\n${stderr}`);
   }
+  if (!existsSync(bin)) {
+    throw new Error("seccomp helper compiled successfully but output binary is missing");
+  }
+  return bin;
+}
+
+// Run `bun -e snippet args...` under the seccomp helper, with the blocked
+// syscall failing with `errno`. Returns { stdout, stderr, exitCode } on
+// success, or null if the environment refused to install the seccomp filter
+// (skip).
+async function runUnderSeccomp(bin: string, errno: number, snippet: string, args: string[] = []) {
+  await using proc = Bun.spawn({
+    cmd: [bin, String(errno), bunExe(), "-e", snippet, ...args],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode === 77) return null;
+  return { stdout, stderr, exitCode };
+}
+
+// Reproduces the seccomp class of failures documented in libuv's
+// deps/uv/src/unix/fs.c: statx under a seccomp filter that does not
+// whitelist it returns EPERM (libseccomp < 2.3.3, docker < 18.04, various
+// CI sandboxes). Before the fix, fs.stat would throw EPERM here.
+// After the fix, statxImpl falls back to fstat/lstat/stat.
+//
+// Each stat variant runs in its OWN subprocess so the per-process
+// `supports_statx_on_linux` flag is still `true` on entry — otherwise the
+// first call would flip the flag and subsequent calls would bypass
+// statxImpl/statxFallback entirely and go straight to Syscall.lstat/fstat.
+describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
+  const helperBin = tryBuildHelper("__NR_statx");
 
   // `lstatSync` targets a symlink so the SYMLINK_NOFOLLOW branch of
   // statxFallback is actually distinguishable from the stat() branch: if
@@ -178,7 +191,7 @@ int main(int argc, char **argv) {
       // supports regular files).
       symlinkSync("file.txt", join(targetDir, "link.txt"));
 
-      const out = await runUnderSeccomp(helperBin, c.snippet(c.target(targetDir)));
+      const out = await runUnderSeccomp(helperBin, EPERM, c.snippet(c.target(targetDir)));
       if (out == null) {
         console.warn(`SKIP fs.${c.name} seccomp: seccomp not permitted in this environment`);
         return;
@@ -190,4 +203,70 @@ int main(int argc, char **argv) {
       expect(out.exitCode).toBe(0);
     });
   }
+});
+
+// The kernel is not bound to the errno table bun knows: FUSE filesystems and
+// some drivers return codes above EHWPOISON (133). fs.fsyncSync decodes the
+// errno through SystemErrno::from_raw; a code outside the table must report
+// as EUNKNOWN instead of becoming an invalid enum value (a debug build used
+// to die on an assertion there).
+describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
+  const helperBin = tryBuildHelper("__NR_fsync");
+
+  const snippet = `
+    const fs = require("node:fs");
+    const fd = fs.openSync(process.argv[1], "r");
+    try {
+      fs.fsyncSync(fd);
+      console.log(JSON.stringify({ threw: false }));
+    } catch (e) {
+      console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }));
+    }
+  `;
+
+  // fs.fsyncSync in a bun subprocess whose fsync(2) fails with `errno`.
+  // Returns the parsed result line, or null on an environment skip.
+  async function fsyncWithErrno(errno: number) {
+    if (helperBin == null) {
+      console.warn("SKIP fsync seccomp: cc or seccomp headers not available");
+      return null;
+    }
+    using dir = tempDir("fsync-seccomp-target", { "file.txt": "hello" });
+    const out = await runUnderSeccomp(helperBin, errno, snippet, [join(String(dir), "file.txt")]);
+    if (out == null) {
+      console.warn("SKIP fsync seccomp: seccomp not permitted in this environment");
+      return null;
+    }
+    // Don't assert empty stderr — ASAN builds emit a startup warning there.
+    expect({ stdout: out.stdout.trim(), exitCode: out.exitCode }).toEqual({
+      stdout: expect.stringContaining('{"threw":true'),
+      exitCode: 0,
+    });
+    return JSON.parse(out.stdout.trim());
+  }
+
+  test.concurrent("a code above the table reports EUNKNOWN", async () => {
+    const result = await fsyncWithErrno(ENOTSUPP);
+    if (result == null) return;
+    expect(result).toEqual({
+      threw: true,
+      errno: expect.any(Number),
+      code: "EUNKNOWN",
+      syscall: "fsync",
+      message: "EUNKNOWN: unknown error, fsync",
+    });
+    expect(result.errno).toBeLessThan(0);
+  });
+
+  test.concurrent("a code in the table keeps its name", async () => {
+    const result = await fsyncWithErrno(EACCES);
+    if (result == null) return;
+    expect(result).toEqual({
+      threw: true,
+      errno: -EACCES,
+      code: "EACCES",
+      syscall: "fsync",
+      message: "EACCES: permission denied, fsync",
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `SystemErrno::from_raw` (`src/errno/lib.rs`) and the Linux raw-syscall `impl GetErrno for usize` (`src/errno/linux_errno.rs`) built the `#[repr(u16)]` enum with `transmute::<u16, E>`. The only guard was a `debug_assert!(n < MAX)` or an `n < 4096` range check. Linux declares 134 variants, so any larger code is an invalid enum value in a release build (a `match` on it can jump anywhere). A debug build dies with `panic: assertion failed: (n as usize) < (Self::MAX as usize)`.
- Such codes reach userspace. FUSE filesystems pass through any errno below 512. Driver-internal codes such as `ENOTSUPP` (524) and `ERESTARTSYS` (512) leak out. Every libc `get_errno(rc)` path (`impl_get_errno_libc!`) and `E::from_raw` caller decoded them this way.

### Fix
- Add an `EUNKNOWN` variant to the Linux (134), Darwin (107) and FreeBSD (98) enums, one past the last kernel errno. The Windows enum already has `EUNKNOWN = 134`. Derive `strum::FromRepr` on the POSIX enums.
- `from_raw` is now a total function: `from_repr(n)` for a declared discriminant, `EUNKNOWN` for anything else. `init` decodes through `from_repr` too. The errno crate has no transmute left. The Windows `E::from_raw` gets the same shape, with `UNKNOWN` as the fallback.
- `Error::get_errno` and `e_from_negated` fell back to `SUCCESS` for a code they could not decode. An `Error` is a failure, and the shell builtins turn that `SUCCESS` into exit code 0. They fall back to `EUNKNOWN` now. `from_errno` and `to_zig_err` keep their `EIO` fallback.
- Verified: `test/js/node/fs/fs-stat-seccomp-linux.test.ts`, new block "node:fs errno outside the SystemErrno table" (a seccomp filter makes `fsync(2)` fail with 524, `fs.fsyncSync` must report `code: "EUNKNOWN"`). Also `cargo test -p bun_errno`, `cargo check --workspace` for the linux, darwin, windows, freebsd and android targets, `test/js/node/fs/fs.test.ts`, `test/js/node/test/parallel/test-uv-errno.js`.

### Background
- `SystemErrno` (alias `E` on POSIX) is the per-OS errno enum. Rust requires a `#[repr(u16)]` enum to hold a declared discriminant at all times. A value that is not one is undefined behaviour at the point of construction, whether or not a `match` ever runs.
- `strum::FromRepr` generates `const fn from_repr(u16) -> Option<Self>`, an exhaustive match over the declared variants. It is the checked constructor the Windows enums already used.
- `get_errno(rc)` turns a syscall return value into an `E`. On libc targets it reads the thread-local errno after a `-1`. On Linux raw syscalls the kernel returns `-errno` in the result register, and any value in `-4095..=-1` is an error, a range wider than the table.
- `bun_sys::Error` stores the errno as a plain `u16` and decodes it on read. A code outside the table already reported as name `UNKNOWN` with the real negative number on that path. `get_errno(rc)` has no room for the raw number because `E` is an exhaustive enum, so the new variant is what it reports. JS sees `code: "EUNKNOWN"` and `errno: -134` on Linux.

<details><summary>Notes</summary>

Reproduction, both on the release binary and on a debug build. The seccomp helper from the test makes `fsync(2)` return 524, then runs `fs.fsyncSync(fd)`:

```
release (1.4.1-canary.1): {"errno":-524,"syscall":"fsync","message":"Unknown Error, fsync"}
                          (the invalid enum value happened to survive as its bit pattern; no `code`)
debug:                    panic: assertion failed: (n as usize) < (Self::MAX as usize)
                          <bun_errno::linux_errno::SystemErrno>::from_raw  src/errno/lib.rs:290
                          <i32 as bun_errno::GetErrno>::get_errno           src/errno/lib.rs:20
                          ...::MaybeSysResultExt<()>>::errno_sys::<i32>     src/runtime/node/node_fs.rs:70
                          <bun_runtime::node::fs::NodeFS>::fsync            src/runtime/node/node_fs.rs:5244
with this change:         {"errno":-134,"code":"EUNKNOWN","syscall":"fsync","message":"EUNKNOWN: unknown error, fsync"}
```

Design choice: the fallback is a variant, not `EIO`. Windows already models unmapped errors this way, the result round-trips through `init` (`init(134)` is `Some(EUNKNOWN)`, so a stored `EUNKNOWN` never reads back as `SUCCESS`), and it keeps the user-visible name honest. Node on Linux reports `errno: -524, code: "Unknown system error -524"` for the same call. The raw number is not preserved here because `get_errno(rc)` returns the enum. The `check!`-style wrappers in `bun_sys` (`Error::from_code_int`) store the raw number and are unchanged.

Placement: `EUNKNOWN` sits at the old `MAX`, and `MAX` grows by one, so the enums stay dense and `enum_map::Enum`, `LIBUV_ERROR_MAP`, `COREUTILS_ERROR_MAP` and `system_errno_max_dense()` keep working without changes. Both maps fill the new slot with "unknown error". `os.constants.errno` and `util.getSystemErrorMap()` are built from other tables and do not change.

`impl_get_errno_libc!` now converts the `c_int` errno with `u16::try_from` instead of `as u16`, so a value that does not fit cannot wrap onto another variant.

Related open PRs. #38914 fixes the same transmute as half of a larger change (release-mode `assert!` in the `ZStr`/`WStr` constructors). It makes `from_raw` panic on an undeclared code and routes OS codes to `EIO`. This PR takes the variant approach and touches only the errno path. The two conflict in `src/errno`. #30924 makes `from_raw` panic on OS input. #39340 renames the Windows `EUNKNOWN` strum name to `UNKNOWN`. If it lands, the three POSIX variants added here want the same `#[strum(serialize = "UNKNOWN")]`.

Other suites run: `test/js/bun/shell/commands/rm.test.ts` (its "replaced by a symlink during deletion" case runs 4.7 to 5.1 s against the 5 s default in this ASAN container and times out on some runs, with and without the change), `test/js/bun/sys/error-name-from-libuv.test.ts`, `cargo clippy -p bun_errno -p bun_sys`, `cargo fmt --check`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs-stat-seccomp-linux.test.ts

<!-- robobun:evidence:end -->