### PR TITLE
install: remove the store package directory when an isolated install task fails

### DIFF
--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -398,18 +398,14 @@ impl<'a> Installer<'a> {
 
         // Clean up the staging directory so a half-built global-store entry
         // doesn't leak in the cache (it would never be reused — the suffix is
-        // random — but it's wasted disk). The published entry was never
-        // touched, so there is nothing else to remove.
+        // random — but it's wasted disk).
         if self.entry_uses_global_store(entry_id) {
             let mut staging = AutoAbsPath::init();
             self.append_global_store_entry_path(&mut staging, entry_id, Which::Staging);
             let _ = Fd::cwd().delete_tree(staging.slice());
         } else {
-            // Remove the project-local package directory
-            // (`node_modules/.bun/<storepath>/node_modules/<pkg>`), whatever
-            // state the failed steps left it in. Its absence is what makes the
-            // next install build this entry again, from scratch, instead of
-            // skipping it as installed.
+            // Remove the package directory so the next install builds this
+            // entry again instead of skipping it as installed.
             match pkg_res.tag {
                 ResolutionTag::Uninitialized
                 | ResolutionTag::SingleFileModule

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -398,40 +398,39 @@ impl<'a> Installer<'a> {
 
         // Clean up the staging directory so a half-built global-store entry
         // doesn't leak in the cache (it would never be reused — the suffix is
-        // random — but it's wasted disk).
+        // random — but it's wasted disk). The published entry was never
+        // touched, so there is nothing else to remove.
         if self.entry_uses_global_store(entry_id) {
             let mut staging = AutoAbsPath::init();
             self.append_global_store_entry_path(&mut staging, entry_id, Which::Staging);
             let _ = Fd::cwd().delete_tree(staging.slice());
-        }
+        } else {
+            // Remove the project-local package directory
+            // (`node_modules/.bun/<storepath>/node_modules/<pkg>`), whatever
+            // state the failed steps left it in. Its absence is what makes the
+            // next install build this entry again, from scratch, instead of
+            // skipping it as installed.
+            match pkg_res.tag {
+                ResolutionTag::Uninitialized
+                | ResolutionTag::SingleFileModule
+                | ResolutionTag::Root
+                | ResolutionTag::Workspace
+                | ResolutionTag::Symlink => {}
 
-        // attempt deleting the package so the next install will install it again
-        match pkg_res.tag {
-            ResolutionTag::Uninitialized
-            | ResolutionTag::SingleFileModule
-            | ResolutionTag::Root
-            | ResolutionTag::Workspace
-            | ResolutionTag::Symlink => {}
+                // to be safe make sure we only delete packages in the store
+                ResolutionTag::Npm
+                | ResolutionTag::Git
+                | ResolutionTag::Github
+                | ResolutionTag::LocalTarball
+                | ResolutionTag::RemoteTarball
+                | ResolutionTag::Folder => {
+                    let mut store_path = AutoPath::init_top_level_dir();
+                    self.append_real_store_path(&mut store_path, entry_id, Which::Final);
+                    let _ = Fd::cwd().delete_tree(store_path.slice());
+                }
 
-            // to be safe make sure we only delete packages in the store
-            ResolutionTag::Npm
-            | ResolutionTag::Git
-            | ResolutionTag::Github
-            | ResolutionTag::LocalTarball
-            | ResolutionTag::RemoteTarball
-            | ResolutionTag::Folder => {
-                let mut store_path = AutoRelPath::init();
-
-                // OOM/capacity: fire-and-forget
-                let _ = store_path.append_fmt(format_args!(
-                    "node_modules/{}",
-                    store::entry::fmt_store_path(entry_id, self.store, self.lockfile()),
-                ));
-
-                let _ = sys::unlink(store_path.slice_z());
+                _ => {}
             }
-
-            _ => {}
         }
 
         if self.manager().options.enable.fail_early() {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -404,8 +404,6 @@ impl<'a> Installer<'a> {
             self.append_global_store_entry_path(&mut staging, entry_id, Which::Staging);
             let _ = Fd::cwd().delete_tree(staging.slice());
         } else {
-            // Remove the package directory so the next install builds this
-            // entry again instead of skipping it as installed.
             match pkg_res.tag {
                 ResolutionTag::Uninitialized
                 | ResolutionTag::SingleFileModule

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -520,7 +520,10 @@ test("a failed install removes the store entry's package so the next install bui
   const storePackage = join(packageDir, "node_modules", ".bun", "folder-dep@file+pkg-1", "node_modules", "folder-dep");
 
   await Promise.all([
-    write(packageJson, JSON.stringify({ name: "test-pkg-failed-link", dependencies: { "folder-dep": "file:./pkg-1" } })),
+    write(
+      packageJson,
+      JSON.stringify({ name: "test-pkg-failed-link", dependencies: { "folder-dep": "file:./pkg-1" } }),
+    ),
     write(join(packageDir, "pkg-1", "package.json"), JSON.stringify({ name: "folder-dep", version: "1.0.0" })),
     write(join(packageDir, "pkg-1", "lib"), "module.exports = 'file';"),
   ]);

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -514,6 +514,42 @@ test("can install folder dependencies", async () => {
   ).toBe("module.exports = 'hello from pkg-1';");
 });
 
+test("a failed install removes the store entry's package so the next install builds it again", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  const storePackage = join(packageDir, "node_modules", ".bun", "folder-dep@file+pkg-1", "node_modules", "folder-dep");
+
+  await Promise.all([
+    write(packageJson, JSON.stringify({ name: "test-pkg-failed-link", dependencies: { "folder-dep": "file:./pkg-1" } })),
+    write(join(packageDir, "pkg-1", "package.json"), JSON.stringify({ name: "folder-dep", version: "1.0.0" })),
+    write(join(packageDir, "pkg-1", "lib"), "module.exports = 'file';"),
+  ]);
+
+  await runBunInstall(bunEnv, packageDir);
+  expect(statSync(join(storePackage, "lib")).isFile()).toBe(true);
+
+  // `lib` becomes a directory. The relink keeps the old `lib` file in the store
+  // entry, so linking `lib/index.js` into it fails with ENOTDIR.
+  await rm(join(packageDir, "pkg-1", "lib"));
+  await write(join(packageDir, "pkg-1", "lib", "index.js"), "module.exports = 'dir';");
+
+  const { err } = await runBunInstall(bunEnv, packageDir, {
+    allowErrors: true,
+    expectedExitCode: 1,
+    savesLockfile: false,
+  });
+  expect(err).toContain("failed to link package: folder-dep@pkg-1");
+
+  // The failed entry is gone from the store, so nothing stale is left for the next install to trip on.
+  expect(existsSync(storePackage)).toBe(false);
+
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+  expect(readlinkSync(join(packageDir, "node_modules", "folder-dep"))).toBe(
+    join(".bun", "folder-dep@file+pkg-1", "node_modules", "folder-dep"),
+  );
+  expect(await file(join(storePackage, "lib", "index.js")).text()).toBe("module.exports = 'dir';");
+});
+
 test("can install folder dependencies on root package", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 


### PR DESCRIPTION
### Problem
- When a store entry fails to install with `--linker=isolated`, the cleanup in `Installer::on_task_fail` (`src/install/isolated_install/Installer.rs:408`) is a no-op. It builds `node_modules/<store entry>` and calls `sys::unlink` on it. The entry lives at `node_modules/.bun/<store entry>/`, and the package inside it is a directory, so the call fails with ENOENT every time and the result is discarded. The Zig original had the same path, so this has never run.
- The half-linked package stays in the store. A later `bun install` either skips it as installed (the skip check only looks for `node_modules/.bun/<entry>/node_modules/<pkg>/package.json`) or fails again on the same stale files. Repro on 1.4.1: a `file:` dependency whose `lib` changes from a file to a directory fails to link with `ENOTDIR: failed to link package: dep@dep (link)`, and so does every install after it, until the user deletes `node_modules`.

### Fix
- For a project-local entry, `on_task_fail` now runs `delete_tree` on `node_modules/.bun/<store entry>/node_modules/<pkg>` (via `append_real_store_path`). The tag guard that keeps root, workspace and `link:` resolutions out of the delete is unchanged.
- This is the path the skip check reads and the path `Step::LinkPackage` wipes before it links, so after a failure the entry is in the same state as one that was never installed: the next install builds it again from scratch.
- Global-store entries are untouched. They only write to a staging directory, which `on_task_fail` already removes, and the published entry is shared with other projects.
- Verified: new test in `test/cli/install/isolated-install.test.ts` (fails on stock bun at the `existsSync` check). Also the full `isolated-install.test.ts`, `isolated-relink.test.ts`, `bun-install-patch.test.ts`, `bun-install-hardlink-fallback.test.ts`.

### Background
- A store entry is one directory `node_modules/.bun/<name>@<version>[+<peers>]/`. Its `node_modules/<pkg>` holds the package files (hardlinked from the cache or from a `file:` folder). Its other `node_modules/*` entries are symlinks to the entries of its dependencies.
- The install loop decides per entry whether to build it. For npm packages it checks that `<entry>/node_modules/<pkg>/package.json` exists. For `file:` folders it always relinks, by overlaying the source folder onto the existing package directory.
- The global store (`BUN_INSTALL_GLOBAL_STORE`) builds eligible entries under `<cache>/links/<entry>.tmp-<suffix>` and renames them into place when complete. `node_modules/.bun/<entry>` is then a symlink into the cache.

<details><summary>Notes</summary>

- Both problems with the old call: the path has no `.bun/` component, and `unlink` cannot remove a directory (EISDIR) even with the right path.
- `delete_tree` never follows symlinks (`unlinkat` on the top path, `O_NOFOLLOW` on subdirectories), so a stale `node_modules/.bun/<entry>` symlink into the global store from a previous configuration is removed as a link, not followed.
- The failure kinds that reach `on_task_fail` before the link step (download, patch) delete the package directory too. Such an entry was about to be rebuilt (the skip check failed, or `--force`), so leaving the old copy would make the next install skip the package the user asked to reinstall.
- The test uses a `file:` dependency because it is the one deterministic way to make the link step fail midway without permission tricks (which root ignores in CI): the isolated relink overlays the folder onto the previous build, so a path that turns from a file into a directory fails with ENOTDIR when `lib/index.js` is linked into the old `lib` file. With the fix the failed install removes the package directory and the next install succeeds.
- Lifecycle-script tests (`bun-install-lifecycle-scripts.test.ts`) fail in my container for the debug build only because `node` and `bun` are not next to `bun-debug` on the scripts' PATH; they pass with the release build and are unrelated.
- Related open work: #38783 moves the isolated link into a staging directory and replaces this block; #37138 wipes a `file:` dependency's package directory before every relink. Both are independent of this fix.
</details>
