### PR TITLE
test: fix crash when spyOn targets a non-function indexed property

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1549,8 +1549,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
             } else if (auto index = parseIndex(propertyKey)) {
-                // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
+                object->putDirectIndex(globalObject, *index, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1210,6 +1210,12 @@ describe("spyOn", () => {
     test("spyOn works with a missing indexed property", () => {
       const obj = {};
       const fn = spyOn(obj, 7);
+      expect(Object.getOwnPropertyDescriptor(obj, 7)).toEqual({
+        get: fn,
+        set: fn,
+        enumerable: true,
+        configurable: true,
+      });
       expect(obj[7]).toBeUndefined();
       expect(fn).toHaveBeenCalledTimes(1);
 
@@ -1218,7 +1224,15 @@ describe("spyOn", () => {
       expect(fn.mock.calls[1]).toEqual([1]);
 
       fn.mockRestore();
+      // Same as a missing named key: restore writes the original `undefined` back as a data property.
+      expect(Object.getOwnPropertyDescriptor(obj, 7)).toEqual({
+        value: undefined,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
       expect(obj[7]).toBeUndefined();
+      expect(fn).not.toHaveBeenCalled();
     });
 
     // The engine serves a function's `prototype` property specially, so it cannot be

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1157,6 +1157,70 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    test("spyOn works with indexed properties that are not functions", () => {
+      const obj = { 0: 5 };
+      const fn = spyOn(obj, 0);
+      expect(Object.getOwnPropertyDescriptor(obj, 0)).toEqual({
+        get: fn,
+        set: fn,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(obj[0]).toBe(5);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      obj[0] = 6;
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls[1]).toEqual([6]);
+      expect(obj[0]).toBe(5);
+
+      fn.mockRestore();
+      expect(Object.getOwnPropertyDescriptor(obj, 0)).toEqual({
+        value: 5,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(obj[0]).toBe(5);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("spyOn works with array elements that are not functions", () => {
+      const arr = [1, 2, 3];
+      const fn = spyOn(arr, 1);
+      expect(arr[1]).toBe(2);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      arr[1] = 20;
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls[1]).toEqual([20]);
+      expect(arr[1]).toBe(2);
+      expect(arr.length).toBe(3);
+
+      fn.mockRestore();
+      expect(arr).toEqual([1, 2, 3]);
+      expect(Object.getOwnPropertyDescriptor(arr, 1)).toEqual({
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    });
+
+    test("spyOn works with a missing indexed property", () => {
+      const obj = {};
+      const fn = spyOn(obj, 7);
+      expect(obj[7]).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      obj[7] = 1;
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls[1]).toEqual([1]);
+
+      fn.mockRestore();
+      expect(obj[7]).toBeUndefined();
+    });
+
     // The engine serves a function's `prototype` property specially, so it cannot be
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {


### PR DESCRIPTION
### What does this PR do?

`spyOn(obj, 0)` on a property whose value is not a function left the object in a broken state. The non-callable branch in `JSMock__jsSpyOn` sets the `Accessor` attribute, but for an index key it stored the raw mock function with `putDirectIndex` instead of a `GetterSetter`. The sparse array entry then had the `Accessor` bit with a plain function as its value.

JSC treats such an entry as an accessor:

- A read (`obj[0]`) hits `ASSERTION FAILED: attributes == attributesForStructure(attributes) && !(attributes & PropertyAttribute::Accessor)` in `PropertySlot::setValue` (PropertySlot.h:226) in debug builds. This is the fingerprint Fuzzilli reported.
- An assignment (`obj[0] = 6`) calls `GetterSetter::callSetter` on the mock function and segfaults in release builds.

The fix wraps the mock in a `GetterSetter` for the indexed path, the same as the non-indexed path already does. `putDirectIndex` stores a `GetterSetter` with the `Accessor` attribute in the sparse map the same way `defineOwnIndexedProperty` does. The spy now behaves like a spy on a named non-function property: the read returns the original value and records a call, the assignment records a call, and `mockRestore` puts the data property back.

Minimal repro on the current release:

```js
const { spyOn } = Bun.jest();
const obj = { 0: 5 };
spyOn(obj, 0);
obj[0]; // returns the mock function instead of 5
obj[0] = 6; // segfault
```

### How did you verify your code works?

- Ran the repro with the debug build: no assertion, the read returns 5, and the assignment records a call.
- Added three tests to `test/js/bun/test/mock-fn.test.js`: a plain object index, an array element, and a missing index. They fail on the current release (the read returns the mock function) and pass with the debug build.
- `bun bd test test/js/bun/test/mock-fn.test.js`: 89 pass.
- `bun bd test test/js/bun/test/mock-disposable.test.ts test/js/bun/test/spyMatchers.test.ts test/js/bun/test/mock/`: 175 pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.1 (65362b53b)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.69ms]
(pass) mock() > mock [6.60ms]
(pass) mock() > checks the this value > mock [6.86ms]
(pass) mock() > checks the this value > _protoImpl [0.78ms]
(pass) mock() > checks the this value > getMockImplementation [1.09ms]
(pass) mock() > checks the this value > getMockName [0.73ms]
(pass) mock() > checks the this value > mockClear [1.20ms]
(pass) mock() > checks the this value > mockReset [0.59ms]
(pass) mock() > checks the this value > mockRestore [0.61ms]
(pass) mock() > checks the this value > mockImplementation [0.59ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.82ms]
(pass) mock() > checks the this value > withImplementation [0.58ms]
(pass) mock() > checks the this value > mockName [0.60ms]
(pass) mock() > checks the this value > mockReturnThis [0.50ms]
(pass) mock() > checks the this value > mockReturnValue [0.50ms]
(pass) mock() > checks the this value
... (truncated)

release without fix: 3 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.02ms]
(pass) mock() > mock [0.09ms]
(pass) mock() > checks the this value > mock [0.11ms]
(pass) mock() > checks the this value > _protoImpl [0.02ms]
(pass) mock() > checks the this value > getMockImplementation [0.02ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce [0.01ms]
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the this value
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.1 (65362b53b)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [2.88ms]
(pass) mock() > mock [8.02ms]
(pass) mock() > checks the this value > mock [10.65ms]
(pass) mock() > checks the this value > _protoImpl [1.05ms]
(pass) mock() > checks the this value > getMockImplementation [1.60ms]
(pass) mock() > checks the this value > getMockName [0.89ms]
(pass) mock() > checks the this value > mockClear [1.62ms]
(pass) mock() > checks the this value > mockReset [0.86ms]
(pass) mock() > checks the this value > mockRestore [0.82ms]
(pass) mock() > checks the this value > mockImplementation [0.71ms]
(pass) mock() > checks the this value > mockImplementationOnce [1.16ms]
(pass) mock() > checks the this value > withImplementation [0.60ms]
(pass) mock() > checks the this value > mockName [0.83ms]
(pass) mock() > checks the this value > mockReturnThis [0.66ms]
(pass) mock() > checks the this value > mockReturnValue [0.83ms]
(pass) mock() > checks the this valu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 867ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp |  3 +-
 test/js/bun/test/mock-fn.test.js    | 78 +++++++++++++++++++++++++++++++++++++
 2 files changed, 79 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp      4      1      0
test/js/bun/test/mock-fn.test.js         2      3      0
```

</details>

<!-- robobun:evidence:end -->