### PR TITLE
css: recognize a98-rgb in the absolute color() form

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2352,8 +2352,7 @@ pub(crate) fn parse_predefined_relative(
         b"srgb" => PredefinedColor::Srgb(SRGB { r: a, g: b, b: c, alpha }),
         b"srgb-linear" => PredefinedColor::SrgbLinear(SRGBLinear { r: a, g: b, b: c, alpha }),
         b"display-p3" => PredefinedColor::DisplayP3(P3 { r: a, g: b, b: c, alpha }),
-        // "a99-rgb" (sic) — kept for behavioral compatibility.
-        b"a99-rgb" => PredefinedColor::A98(A98 { r: a, g: b, b: c, alpha }),
+        b"a98-rgb" => PredefinedColor::A98(A98 { r: a, g: b, b: c, alpha }),
         b"prophoto-rgb" => PredefinedColor::Prophoto(ProPhoto { r: a, g: b, b: c, alpha }),
         b"rec2020" => PredefinedColor::Rec2020(Rec2020 { r: a, g: b, b: c, alpha }),
         b"xyz-d50" => PredefinedColor::XyzD50(XYZd50 { x: a, y: b, z: c, alpha }),

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -763,4 +763,36 @@ describe("conversions between color spaces", () => {
       4,
     );
   });
+
+  test("a98-rgb to xyz applies the 563/256 gamma before the matrix", () => {
+    // XYZ of the a98-rgb primaries, i.e. the columns of the matrix in
+    // https://www.w3.org/TR/css-color-4/#color-conversion-code.
+    const red = [0.576669, 0.297345, 0.027031];
+    const green = [0.185558, 0.627364, 0.070689];
+    const blue = [0.188229, 0.075291, 0.991338];
+    const g = 0.5 ** (563 / 256);
+    const b = 0.002 ** (563 / 256);
+    const out = same("xyz", "color(a98-rgb 1 0.5 0.002)");
+    expect(out).toStartWith("color(xyz ");
+    expectChannels(
+      out,
+      [0, 1, 2].map(i => red[i] + g * green[i] + b * blue[i]),
+      4,
+    );
+  });
+});
+
+describe("color(a98-rgb)", () => {
+  test.each([
+    ["color(a98-rgb 0 1 0 / 50%)", "color(a98-rgb 0 1 0 / .5)"],
+    ["color(A98-RGB 100% 50% 0%)", "color(a98-rgb 1 .5 0)"],
+    ["color(from #c86432 a98-rgb r g b)", "color(a98-rgb .695066 .391898 .220089)"],
+    ["rgb(from color(a98-rgb .5 .25 .125) r g b)", "#923e17"],
+  ])("%s is %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test("a99-rgb is not a color space", () => {
+    expect(color("color(a99-rgb 1 0 0)", "css")).toBeNull();
+  });
 });

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7701,6 +7701,56 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  describe("color(a98-rgb)", () => {
+    // A color() that fails to parse is kept as an unparsed token stream, so the
+    // alpha percentage, the channel percentages and the uppercase ident would
+    // be printed verbatim instead of being folded.
+    minify_test(".foo { color: color(a98-rgb 0 1 0 / 50%) }", ".foo{color:color(a98-rgb 0 1 0/.5)}");
+    minify_test(".foo { color: color(A98-RGB 100% 50% 0%) }", ".foo{color:color(a98-rgb 1 .5 0)}");
+    minify_test(
+      ".foo { color: color(from #c86432 a98-rgb r g b) }",
+      ".foo{color:color(a98-rgb .695066 .391898 .220089)}",
+    );
+    minify_test(
+      ".foo { color: color(from #c86432 a98-rgb r g b / 50%) }",
+      ".foo{color:color(a98-rgb .695066 .391898 .220089/.5)}",
+    );
+    minify_test(".foo { color: rgb(from color(a98-rgb .5 .25 .125) r g b) }", ".foo{color:#923e17}");
+    // "a99-rgb" is not a color space.
+    minify_test(".foo { color: color(a99-rgb 1 0 0) }", ".foo{color:color(a99-rgb 1 0 0)}");
+
+    prefix_test(
+      ".foo { color: color(a98-rgb 1 0 0) }",
+      indoc`
+        .foo {
+          color: #ff6251;
+          color: color(a98-rgb 1 0 0);
+        }
+      `,
+      { chrome: 90 << 16 },
+    );
+    prefix_test(
+      ".foo { color: color(a98-rgb 1 0 0) }",
+      indoc`
+        .foo {
+          color: #ff6251;
+          color: color(display-p3 1.0633 .238564 .167582);
+          color: color(a98-rgb 1 0 0);
+        }
+      `,
+      { chrome: 87 << 16, safari: 14 << 16 },
+    );
+    prefix_test(
+      ".foo { color: color(a98-rgb 1 0 0) }",
+      indoc`
+        .foo {
+          color: color(a98-rgb 1 0 0);
+        }
+      `,
+      { chrome: 111 << 16 },
+    );
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(


### PR DESCRIPTION
### Problem
- `color(a98-rgb 1 0 0)` is not recognized as a predefined color space. The declaration is kept as an unparsed token stream: no minification, no sRGB or `display-p3` fallback for older targets, and `Bun.color("color(a98-rgb 1 0 0)", "css")` returns `null`. `display-p3`, `rec2020` and the other spaces work.
- Cause: the second color space match in `parse_predefined_relative` (`src/css/values/color.rs:2355`) spells the keyword `a99-rgb`. The first match, which resolves the `from` origin color, spells it `a98-rgb`. So the relative form `color(from red a98-rgb r g b)` fails too, and the misspelling `color(a99-rgb ...)` is accepted and printed as `a98-rgb`.
- The typo dates from the original CSS parser (#14122). The Rust port kept it with a "(sic)" comment.

### Fix
- `a99-rgb` becomes `a98-rgb` in that match. The comment goes away.
- Correct because this is the CSS Color 4 keyword, it is what the `from` branch and the serializer already use, and it is what lightningcss (which this parser ports) matches. The A98 conversion, serialization and fallback code already existed and are unchanged.
- Verified: `test/js/bun/css/css.test.ts` (new `color(a98-rgb)` block: minify, relative form, fallbacks per target, `a99-rgb` stays unparsed) and `test/js/bun/css/color.test.ts` (`Bun.color()` and an a98-rgb to xyz conversion). 14 of the new cases fail on bun 1.4.1. Also ran `test/bundler/css/wpt/`, `css-loader.test.ts` and `doesnt_crash.test.ts`.

### Background
- `color()` (CSS Color 4) takes a predefined color space ident (`srgb`, `srgb-linear`, `display-p3`, `a98-rgb`, `prophoto-rgb`, `rec2020`, `xyz-d50`, `xyz`, `xyz-d65`) and three channels. `parse_predefined_relative` matches that ident twice: once to convert an optional `from` origin color into the target space, once to build the `PredefinedColor`.
- When a declaration value fails to parse, the CSS parser keeps it as an unparsed token list and prints it back. That is why the bug shows up as a missing fallback and not as an error.
- Fallbacks: for a target that lacks `color()` support (Chrome < 111), the bundler emits an sRGB hex fallback, and a `display-p3` fallback when some target supports P3 but not `color()`.

<details><summary>Notes</summary>

Repro on bun 1.4.1:

```
$ printf '.a { color: color(a98-rgb 1 0 0) }\n.b { color: color(display-p3 1 0 0) }\n' > x.css
$ bun build x.css --target=browser
.a {
  color: color(a98-rgb 1 0 0);
}
.b {
  color: #ff0f0e;
  color: color(display-p3 1 0 0);
}
```

With the fix, `.a` gets `color: #ff6251;` and `color: color(display-p3 1.0633 .238564 .167582);` before the original declaration.

Cross-check of the expected test values against `@csstools/css-color-parser` 3.0.7: `color(a98-rgb .5 .25 .125)` converts to `rgb(146, 62, 23)` (`#923e17`), and `color(from #c86432 a98-rgb r g b)` yields channels `.695066 .391898 .220089`. Both match.

#38487 contains the same one line change together with two other color fixes (the `r` channel of `srgb-linear` relative colors and `color-mix(in xyz-d50)`). This PR is only the a98-rgb part. If this lands first, #38487 needs a rebase.

Suites run with the debug build: `test/js/bun/css/css.test.ts` (1190 pass, 67 skip), `test/js/bun/css/color.test.ts` (1028 pass), `test/bundler/css/wpt/` (159 pass), `test/js/bun/css/css-loader.test.ts` and `test/js/bun/css/doesnt_crash.test.ts` (63 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.97ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.64ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.14ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.82ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [13.59ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.19ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.53ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.31ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.63ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.23ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.50ms]
(pass) color({"r":0,"g":25
... (truncated)

release without fix: 14 failed, 67 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.10ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.04ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.02ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.05ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.79ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.05ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.03ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.01ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.01ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ans
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [7.58ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [4.92ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [2.81ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [5.89ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [25.10ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [4.21ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [3.91ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.70ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.46ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.46ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.94ms]
(pass) color({"r":0,"g":25
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1041ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/values/color.rs       |  3 +--
 test/js/bun/css/color.test.ts | 32 +++++++++++++++++++++++++++
 test/js/bun/css/css.test.ts   | 50 +++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 83 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css/values/color.rs            3      1      0
test/js/bun/css/color.test.ts      3      2      0
test/js/bun/css/css.test.ts        3      1      0
```

</details>

<!-- robobun:evidence:end -->