### PR TITLE
react_compiler: import react/compiler-runtime only when a function uses memo slots

### DIFF
--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -48,6 +48,7 @@ use crate::reactive_scopes::{
     rename_variables,
 };
 
+use crate::imports::ProgramContext;
 use crate::program::{Host, JsxImportKind};
 
 /// Result of code generation for a single function.
@@ -88,7 +89,6 @@ pub struct OutlinedFunction {
 
 #[derive(Clone, Copy)]
 enum WellKnown {
-    UseMemoCache,
     MemoCache,
     NaN,
     Infinity,
@@ -98,7 +98,7 @@ enum WellKnown {
 }
 
 impl WellKnown {
-    const COUNT: usize = 7;
+    const COUNT: usize = 6;
 }
 
 /// Host-side state shared across nested function-expression codegen so the
@@ -114,18 +114,12 @@ pub(crate) struct Codegen<'h> {
 }
 
 impl<'h> Codegen<'h> {
-    pub(crate) fn new(
-        host: &'h mut dyn Host,
-        arena: &'h Arena,
-        memo_cache_import: Option<Ref>,
-    ) -> Self {
-        let mut well_known = [None; WellKnown::COUNT];
-        well_known[WellKnown::UseMemoCache as usize] = memo_cache_import;
+    pub(crate) fn new(host: &'h mut dyn Host, arena: &'h Arena) -> Self {
         Codegen {
             host,
             arena,
             id_to_ref: IdMap::new(),
-            well_known,
+            well_known: [None; WellKnown::COUNT],
             name_to_ref: HashMap::new(),
             label_to_ref: IdMap::new(),
         }
@@ -218,6 +212,7 @@ pub(crate) fn codegen_function(
     func: &ReactiveFunction,
     env: &mut Environment,
     cg: &mut Codegen<'_>,
+    context: &mut ProgramContext,
     unique_identifiers: HashSet<String>,
 ) -> Result<CodegenFunction, CompilerError> {
     let mut cx = Context::new(env, cg, unique_identifiers);
@@ -245,15 +240,14 @@ pub(crate) fn codegen_function(
         let cache_name = cx.synthesize_name("$");
         let loc = Loc::EMPTY;
 
+        // The import declaration for `useMemoCache` is emitted by
+        // `add_imports_to_program`. Register it only here, so a function that
+        // compiles to zero memo slots does not pull in `react/compiler-runtime`.
+        let use_memo_cache_ref = context.add_memo_cache_import(cx.cg.host).name_ref;
+        cx.cg.host.record_usage(use_memo_cache_ref);
         // Synthesized AST is never re-visited by the parser's `EIdentifier→EImportIdentifier`
         // promotion, so emit `EImportIdentifier` directly.
-        let use_memo_cache = Expr::init(
-            E::ImportIdentifier::new(
-                cx.cg.well_known(WellKnown::UseMemoCache, b"useMemoCache"),
-                true,
-            ),
-            loc,
-        );
+        let use_memo_cache = Expr::init(E::ImportIdentifier::new(use_memo_cache_ref, true), loc);
         let call = Expr::init(
             E::Call {
                 target: use_memo_cache,

--- a/src/react_compiler/pipeline.rs
+++ b/src/react_compiler/pipeline.rs
@@ -171,21 +171,10 @@ pub(crate) fn compile_fn(
 
     let (reactive_fn, unique_identifiers) = run_hir_passes(&mut hir, &mut env, context)?;
 
-    // Codegen emits the memo-cache call as `ident_expr("useMemoCache", ..)`;
-    // seed that name with the import's local `Ref` so the call site and the
-    // emitted `import { c as _c }` resolve to the same symbol. Opt-out
-    // functions are filtered before this call (see `maybe_compile_node`), so a
-    // spurious import is only possible when codegen itself errors below.
-    // SSR mode never allocates memo slots, so skip the import to avoid emitting
-    // an unused `react/compiler-runtime` import.
-    let memo_seed = (context.output_mode == OutputMode::Client).then(|| {
-        let memo_cache = context.add_memo_cache_import(host);
-        memo_cache.name_ref
-    });
-    let mut cg = Codegen::new(host, arena, memo_seed);
+    let mut cg = Codegen::new(host, arena);
     let codegen_result = timed!(
         "Codegen",
-        codegen::codegen_function(&reactive_fn, &mut env, &mut cg, unique_identifiers)
+        codegen::codegen_function(&reactive_fn, &mut env, &mut cg, context, unique_identifiers)
     )?;
 
     #[cfg(any(debug_assertions, bun_asan, feature = "fixtures"))]
@@ -327,13 +316,9 @@ pub(crate) fn compile_outlined_fn(
 
     let (reactive_fn, unique_identifiers) = run_hir_passes(&mut hir, &mut env, context)?;
 
-    let memo_seed = (context.output_mode == OutputMode::Client).then(|| {
-        let memo_cache = context.add_memo_cache_import(host);
-        memo_cache.name_ref
-    });
-    let mut cg = Codegen::new(host, arena, memo_seed);
+    let mut cg = Codegen::new(host, arena);
     let codegen_result =
-        codegen::codegen_function(&reactive_fn, &mut env, &mut cg, unique_identifiers)?;
+        codegen::codegen_function(&reactive_fn, &mut env, &mut cg, context, unique_identifiers)?;
 
     if env.has_errors() {
         return Err(env.take_errors());

--- a/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
+++ b/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
@@ -368,3 +368,47 @@ export {
 };
 "
 `;
+
+exports[`bundler react-compiler/ZeroMemoSlotsNoRuntimeImport 1`] = `
+"// entry.jsx
+import { useState } from "react";
+function Counter() {
+  let [count] = useState(0);
+  return count + 2;
+}
+export {
+  Counter
+};
+"
+`;
+
+exports[`bundler react-compiler/ZeroMemoSlotsBeforeMemoizedComponent 1`] = `
+"// entry.jsx
+import { useState } from "react";
+import { jsxDEV } from "react/jsx-dev-runtime";
+import { c as _c } from "react/compiler-runtime";
+function Counter() {
+  let [count] = useState(0);
+  return count + 2;
+}
+function Hello(t0) {
+  let $ = _c(2);
+  let { name } = t0;
+  let t1;
+  if ($[0] !== name)
+    t1 = /* @__PURE__ */ jsxDEV("div", {
+      children: [
+        "Hello ",
+        name
+      ]
+    }, undefined, true, undefined, this), $[0] = name, $[1] = t1;
+  else
+    t1 = $[1];
+  return t1;
+}
+export {
+  Counter,
+  Hello
+};
+"
+`;

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -753,6 +753,68 @@ describe("bundler", () => {
     },
   });
 
+  // A compiled component that needs zero memo slots must not import the
+  // runtime. The import is registered from codegen next to the `_c(N)` call,
+  // so a body with nothing to memoize leaves `react/compiler-runtime` out.
+  // `.jsx`, not `.tsx`: the TypeScript path elides unused imports and would
+  // hide a spurious one.
+  itBundled("react-compiler/ZeroMemoSlotsNoRuntimeImport", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useState } from "react";
+        export function Counter() {
+          const [count] = useState(0);
+          const step = 1;
+          const twice = step + step;
+          return count + twice;
+        }
+      `,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toMatchSnapshot();
+      // Constant propagation folded `twice` into the return, so the compiler
+      // did run on this component.
+      expect(out).toContain("return count + 2;");
+      // It found nothing to memoize: no cache, and so no runtime import.
+      expect(out).not.toMatch(/\b_c\(\d+\)/);
+      expect(out).not.toContain("react/compiler-runtime");
+    },
+  });
+
+  itBundled("react-compiler/ZeroMemoSlotsBeforeMemoizedComponent", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useState } from "react";
+        export function Counter() {
+          const [count] = useState(0);
+          const step = 1;
+          const twice = step + step;
+          return count + twice;
+        }
+        export function Hello({ name }) {
+          return <div>Hello {name}</div>;
+        }
+      `,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toMatchSnapshot();
+      expect(out).toContain("return count + 2;");
+      // `Counter` compiled first with no slots. `Hello` memoizes its JSX, so
+      // its codegen registers the runtime import: present exactly once, and
+      // `_c` resolves to it.
+      expect(out).toMatch(/\b_c\(\d+\)/);
+      expect(out.match(/from "react\/compiler-runtime"/g)).toHaveLength(1);
+    },
+  });
+
   itBundled("react-compiler/SuppressionInsideTSNamespaceDoesNotLeak", {
     files: {
       "/entry.tsx": /* tsx */ `


### PR DESCRIPTION
### Problem
- Every compiled component or hook pulled in `import { c as _c } from "react/compiler-runtime"`, even when it needs zero memo slots and never calls `_c(N)`. Repro: `Bun.build({ reactCompiler: true })` on a `.jsx` file with `export function Foo(){ const [x] = useState(0); return x; }` emits the import and no use of `_c`.
- The cause is `src/react_compiler/pipeline.rs:181-184` (and `:330-333` for outlined functions): `context.add_memo_cache_import(host)` ran before codegen for every Client-mode function. Codegen gates only the `_c(N)` call on `cache_count != 0` (`codegen.rs:242`), and `finish()` emits every registered import.

### Fix
- Codegen registers the import itself, inside the `cache_count != 0` branch, where it builds the `_c(N)` call. `codegen_function` takes `&mut ProgramContext` for this. `Codegen::new` no longer takes a seeded `useMemoCache` ref.
- This matches upstream `codegenFunction`, which calls `addMemoCacheImport()` in the same branch. `add_import_specifier` dedups, so several memoized functions still share one import.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (two new cases, `ZeroMemoSlotsNoRuntimeImport` fails on bun 1.4.1). Also `react-compiler-fixtures.test.ts` (3293 pass) and `bundler_jsx.test.ts`.

### Background
- The React Compiler memoizes values in a per-component cache array. Codegen prepends `let $ = _c(N)` to a function body that needs `N` slots. `_c` is the `c` export of `react/compiler-runtime`.
- `ProgramContext` (`imports.rs`) collects the imports the compiler needs for the whole file. `finish()` in `program.rs` turns that list into `S::Import` statements at the top of the module.
- The fixture suite loads every `.js` fixture as `tsx`, and the TypeScript path elides an unused import, so it never saw this. The new tests use `.jsx`, where an unused import stays.

<details><summary>Notes</summary>

- In a `.tsx` entry the unused `_c` import was already dropped by TypeScript import elision, so only `.js`/`.jsx` sources showed the extra import. That is why the fixture suite (1.8k upstream fixtures, all loaded as `tsx`) passed before and after this change.
- The `output_mode == Client` gate in the pipeline is gone too. Upstream has no such gate. In SSR mode `enable_memoization()` is false, so no slots are allocated and nothing registers the import. In Lint mode the compiled result is discarded and `finish()` returns `Unchanged`, so a registered import is never emitted (before this change that path minted an unused `useMemoCache` symbol instead).
- If codegen records an error after it counted slots, the import stays registered. That is the same behavior as upstream and is unchanged by this PR.
- Suites run with the debug build: `test/bundler/transpiler/react-compiler.test.ts` (39 pass), `test/bundler/transpiler/react-compiler-fixtures.test.ts` (3293 pass, 320 skip), `test/bundler/bundler_jsx.test.ts` (56 pass). `cargo clippy -p bun_react_compiler` and `cargo fmt --check` are clean.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1102.09ms]
(pass) bundler > react-compiler/ComponentWithHooks [609.01ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [601.74ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [365.29ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [148.24ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [672.47ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [205.94ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [208.03ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [166.96ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [561.19ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [745.42ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [652.45m
... (truncated)

release without fix: 1 failed, 1 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [36.88ms]
(pass) bundler > react-compiler/ComponentWithHooks [23.21ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [15.78ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [16.80ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [10.11ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [55.25ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [30.64ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [17.96ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [17.64ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [23.11ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [34.99ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [20.37ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [28.50ms]
(pass) bundler > react-compiler/ForwardRefSiblingFn [18.39ms]
(pass) bundler > react-compiler/SelfRefC
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [955.33ms]
(pass) bundler > react-compiler/ComponentWithHooks [446.19ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [445.73ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [225.29ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [131.40ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [639.50ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [152.06ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [178.98ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [137.37ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [559.56ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [466.18ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [461.35ms
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 837ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/codegen.rs                      | 28 ++++------
 src/react_compiler/pipeline.rs                     | 23 ++------
 .../__snapshots__/react-compiler.test.ts.snap      | 44 +++++++++++++++
 test/bundler/transpiler/react-compiler.test.ts     | 62 ++++++++++++++++++++++
 4 files changed, 121 insertions(+), 36 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/react_compiler/codegen.rs                                 2      5      0
src/react_compiler/pipeline.rs                                1      2      0
…er/transpiler/__snapshots__/react-compiler.test.ts.snap      0      0      0
test/bundler/transpiler/react-compiler.test.ts                2      1      0
```

</details>

<!-- robobun:evidence:end -->