### PR TITLE
analytics: let bunfig telemetry = true override DO_NOT_TRACK

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -107,7 +107,7 @@ Bun supports the following loaders:
 
 ### `telemetry`
 
-The `telemetry` field enables or disables analytics. By default, telemetry is enabled. This setting is equivalent to the `DO_NOT_TRACK` environment variable.
+The `telemetry` field enables or disables analytics. By default, telemetry is enabled. This setting is equivalent to the `DO_NOT_TRACK` environment variable. An explicit `telemetry` value in `bunfig.toml` takes precedence over `DO_NOT_TRACK`.
 
 We do not currently collect telemetry; this setting only controls anonymous crash reports. We plan to collect information like which Bun APIs are used most or how long `bun build` takes.
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -107,7 +107,7 @@ Bun supports the following loaders:
 
 ### `telemetry`
 
-The `telemetry` field enables or disables analytics. By default, telemetry is enabled. This setting is equivalent to the `DO_NOT_TRACK` environment variable. An explicit `telemetry` value in `bunfig.toml` takes precedence over `DO_NOT_TRACK`.
+The `telemetry` field enables or disables analytics. By default, telemetry is enabled. The `DO_NOT_TRACK=1` environment variable also disables it. If `bunfig.toml` sets `telemetry` explicitly, that value wins over `DO_NOT_TRACK`.
 
 We do not currently collect telemetry; this setting only controls anonymous crash reports. We plan to collect information like which Bun APIs are used most or how long `bun build` takes.
 

--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -44,9 +44,11 @@ pub fn set_enabled(v: TriState) {
     ENABLED.store(v as u8, Ordering::Relaxed);
 }
 
+/// An explicit bunfig `telemetry = true|false` sets `Yes`/`No` and wins over
+/// the environment. `DO_NOT_TRACK` only decides the `Unknown` state.
 pub fn is_enabled() -> bool {
     match enabled() {
-        TriState::Yes => !env_var::DO_NOT_TRACK.get().unwrap_or(false),
+        TriState::Yes => true,
         TriState::No => false,
         TriState::Unknown => {
             let detected = 'detect: {

--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -44,8 +44,7 @@ pub fn set_enabled(v: TriState) {
     ENABLED.store(v as u8, Ordering::Relaxed);
 }
 
-/// An explicit bunfig `telemetry = true|false` sets `Yes`/`No` and wins over
-/// the environment. `DO_NOT_TRACK` only decides the `Unknown` state.
+/// An explicit bunfig `telemetry` value wins over `DO_NOT_TRACK`.
 pub fn is_enabled() -> bool {
     match enabled() {
         TriState::Yes => true,

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -120,6 +120,7 @@ export const cssInternals = {
 
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
+  isAnalyticsEnabled: () => boolean;
   segfault: () => void;
   panic: () => void;
   rootError: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -229,8 +229,6 @@ pub(crate) mod js_bindings {
         BunString::clone_latin1(buf.slice()).into_js(global)
     }
 
-    /// The value the crash reporter consults before an upload: bunfig
-    /// `telemetry`, else `DO_NOT_TRACK`.
     #[bun_jsc::host_fn]
     fn js_is_analytics_enabled(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         Ok(JSValue::js_boolean(analytics::is_enabled()))

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -21,6 +21,7 @@ pub(crate) mod js_bindings {
             ),
             ("getFeaturesAsVLQ", __jsc_host_js_get_features_as_vlq),
             ("getFeatureData", __jsc_host_js_get_feature_data),
+            ("isAnalyticsEnabled", __jsc_host_js_is_analytics_enabled),
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
             ("panic", __jsc_host_js_panic),
@@ -226,6 +227,13 @@ pub(crate) mod js_bindings {
             // there is definitely enough space in the bounded array
             .expect("unreachable");
         BunString::clone_latin1(buf.slice()).into_js(global)
+    }
+
+    /// The value the crash reporter consults before an upload: bunfig
+    /// `telemetry`, else `DO_NOT_TRACK`.
+    #[bun_jsc::host_fn]
+    fn js_is_analytics_enabled(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        Ok(JSValue::js_boolean(analytics::is_enabled()))
     }
 
     #[bun_jsc::host_fn]

--- a/test/config/bunfig/telemetry.test.ts
+++ b/test/config/bunfig/telemetry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// The only consumer of this value is the crash reporter, which debug builds
+// never reach. Read it through the test binding instead.
+const script = `console.log(require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled());`;
+
+// bunEnv inherits the agent's environment, which may carry either variable.
+const cleanEnv = { ...bunEnv };
+delete cleanEnv.DO_NOT_TRACK;
+delete cleanEnv.HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET;
+
+async function isAnalyticsEnabled(bunfig: string | null, env: Record<string, string>): Promise<boolean> {
+  using dir = tempDir("bunfig-telemetry", bunfig === null ? {} : { "bunfig.toml": bunfig });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...cleanEnv, ...env },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  expect(["true\n", "false\n"]).toContain(stdout);
+  return stdout === "true\n";
+}
+
+describe("bunfig telemetry", () => {
+  test.concurrent("telemetry = true overrides DO_NOT_TRACK=1", async () => {
+    expect(await isAnalyticsEnabled("telemetry = true\n", { DO_NOT_TRACK: "1" })).toBe(true);
+  });
+
+  test.concurrent("telemetry = false disables analytics", async () => {
+    expect(await isAnalyticsEnabled("telemetry = false\n", {})).toBe(false);
+  });
+
+  test.concurrent("without a telemetry setting, DO_NOT_TRACK=1 disables analytics", async () => {
+    expect(await isAnalyticsEnabled(null, { DO_NOT_TRACK: "1" })).toBe(false);
+  });
+
+  test.concurrent("without a telemetry setting, analytics is enabled by default", async () => {
+    expect(await isAnalyticsEnabled(null, {})).toBe(true);
+  });
+});


### PR DESCRIPTION
### Problem
- `telemetry = true` in `bunfig.toml` no longer enables crash reports when `DO_NOT_TRACK=1` is set. The explicit opt-in is ignored.
- `is_enabled()` in `src/analytics/lib.rs:49` returns `!DO_NOT_TRACK` for `TriState::Yes`. Only the bunfig setter (`src/bunfig/bunfig.rs:394`) sets `Yes`. The `Unknown` arm already consults `DO_NOT_TRACK`, so `Yes` does not need to.
- #36165 changed the arm from `true` to `!DO_NOT_TRACK` without a note in the PR body and without a test. The Zig source had `.yes => true`.

### Fix
- `TriState::Yes => true`. An explicit bunfig value wins over the environment. `DO_NOT_TRACK` decides only the `Unknown` state. The bunfig docs now state this order.
- Debug and ASAN builds return from `is_reporting_enabled()` before they reach `is_enabled()`. So a test cannot observe the value through a crash. This PR adds `crash_handler.isAnalyticsEnabled()` to `bun:internal-for-testing`, next to `getFeatureData()`.
- Verified: `test/config/bunfig/telemetry.test.ts` (4 cases). With the binding but without the one-line fix, the `telemetry = true` plus `DO_NOT_TRACK=1` case prints `false`. Also ran `test/config/bunfig/bunfig-errors.test.ts`, `test/cli/run/run-crash-handler.test.ts`, `test/internal/macos-cross-config.test.ts`, and `test/internal/source-lints/`.

### Background
- `bun_analytics::ENABLED` is a process-global `TriState` (`Yes`, `No`, `Unknown`). It starts as `Unknown`. The bunfig loader sets `Yes` or `No` from the `telemetry` key.
- `is_enabled()` resolves `Unknown` once from the environment (`DO_NOT_TRACK`, `HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET`) and caches the result.
- The crash handler (`src/crash_handler/lib.rs:2729`) is the only reader. It checks `BUN_CRASH_REPORT_URL`, `BUN_ENABLE_CRASH_REPORTING`, debug, and ASAN first, then `is_enabled()`.

<details><summary>Notes</summary>

- Regressing commit: ff512eaa5f (#36165), hunk in `src/analytics/lib.rs`. The PR body lists no telemetry change. Rust unit tests for the workspace do not run in CI, and no JS test covered this path.
- The test deletes `DO_NOT_TRACK` and `HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET` from the inherited env before it sets its own values, because `bunEnv` spreads the agent environment.
- `bun -e` runs as the auto command and loads `bunfig.toml` from the cwd, so the test uses `-e` with a `tempDir` that holds the bunfig.
- `cargo clippy -p bun_analytics --no-deps` is clean. `cargo fmt --check` and prettier are clean for the changed files.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/config/bunfig/telemetry.test.ts
bun test v1.4.1 (65362b53b)

test/config/bunfig/telemetry.test.ts:
18 |     cwd: String(dir),
19 |     stdout: "pipe",
20 |     stderr: "pipe",
21 |   });
22 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
23 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "1 | console.log(require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled());
+                                                                   ^
+ TypeError: require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled is not a function. (In 'require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled()', 'require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled' is undefined)
+       at /tmp/bunfig-telemetry_q8hJI1/[eval]:1:63
+ 
+ Bun v1.4.1-debug+65362b53b (Linux x64)
+ "

- Expected  - 1
+ Received  + 7

      at isAnalyticsEnabled (/workspace/bun/test/config/bunfig/telemetry.test.ts:2
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/config/bunfig/telemetry.test.ts:
18 |     cwd: String(dir),
19 |     stdout: "pipe",
20 |     stderr: "pipe",
21 |   });
22 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
23 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "1 | console.log(require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled());
+                                                                   ^
+ TypeError: require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled is not a function. (In 'require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled()', 'require("bun:internal-for-testing").crash_handler.isAnalyticsEnabled' is undefined)
+       at /tmp/bunfig-telemetry_mcFex5/[eval]:1:63
+ 
+ Bun v1.4.1-canary.1+65362b53b (Linux x64)
+ "

- Expected  - 1
+ Received  + 7

      at isAnalyticsEnabled (/workspace/bun/test/config/bunfig/telemetry.test.ts:23:18)
      at async <anonymous> (/workspace/bun/test/config/bunfig/telemetry.test.ts:39:18)
(fail) bunfig telemetry > without a telemetry setting, DO_NOT_TRA
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/config/bunfig/telemetry.test.ts
bun test v1.4.1 (65362b53b)

test/config/bunfig/telemetry.test.ts:
(pass) bunfig telemetry > telemetry = true overrides DO_NOT_TRACK=1 [1444.92ms]
(pass) bunfig telemetry > without a telemetry setting, DO_NOT_TRACK=1 disables analytics [1360.62ms]
(pass) bunfig telemetry > without a telemetry setting, analytics is enabled by default [1364.74ms]
(pass) bunfig telemetry > telemetry = false disables analytics [1425.68ms]

 4 pass
 0 fail
 16 expect() calls
Ran 4 tests across 1 file. [3.78s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 791ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9627ms)
Bundle modules (138ms)
Postprocesss modules (930ms)
Bundle Functions (1017ms)
Generate Code (91ms)

[11.81s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_analytics v0.0.0 (/workspace/bun/src/analytics)
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn_sys)
[1m[92m   Compiling[0m bun_io v0.0.0 (/workspace/bun/src/io)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/bunfig.mdx              |  2 +-
 src/analytics/lib.rs                 |  3 ++-
 src/js/internal-for-testing.ts       |  1 +
 src/runtime/api/crash_handler_jsc.rs |  6 +++++
 test/config/bunfig/telemetry.test.ts | 45 ++++++++++++++++++++++++++++++++++++
 5 files changed, 55 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
docs/runtime/bunfig.mdx                   1      2      0
src/analytics/lib.rs                      2      4      0
src/js/internal-for-testing.ts            1      1      0
src/runtime/api/crash_handler_jsc.rs      2      3      0
test/config/bunfig/telemetry.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->