### PR TITLE
install: fail when "overrides" or "resolutions" is not an object

### DIFF
--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -697,12 +697,7 @@ impl OverrideMap {
         expr: Expr,
     ) -> Result<(), Error> {
         if !expr.is_object() {
-            ctx.log.add_warning_fmt(
-                Some(ctx.source),
-                value_loc_of(ctx.source, expr.loc),
-                format_args!("\"overrides\" must be an object"),
-            );
-            return Ok(());
+            return Err(not_an_object(ctx, expr.loc));
         }
 
         self.map.ensure_unused_capacity(expr.property_count())?;
@@ -817,12 +812,7 @@ impl OverrideMap {
         expr: Expr,
     ) -> Result<(), Error> {
         if !expr.is_object() {
-            ctx.log.add_warning_fmt(
-                Some(ctx.source),
-                value_loc_of(ctx.source, expr.loc),
-                format_args!("\"resolutions\" must be an object with string values"),
-            );
-            return Ok(());
+            return Err(not_an_object(ctx, expr.loc));
         }
         self.map.ensure_unused_capacity(expr.property_count())?;
         expr.try_for_each_property(|k, key_loc, value_expr| {
@@ -968,6 +958,20 @@ fn clone_range(
         None,
     )
     .unwrap_or_default()
+}
+
+/// A non-object `"overrides"` / `"resolutions"` field is a typo that would otherwise install with no rules applied, so it fails the install.
+#[cold]
+fn not_an_object(ctx: &mut ParseContext<'_, '_>, loc: bun_ast::Loc) -> Error {
+    let name = ctx.field.json_name();
+    ctx.log.add_error_fmt(
+        ctx.source,
+        value_loc_of(ctx.source, loc),
+        format_args!(
+            "\"{name}\" expects a map of package names to versions, e.g.\n  \"{name}\": {{\n    \"react\": \"18.2.0\"\n  }}"
+        ),
+    );
+    Error::InvalidPackageJSON
 }
 
 fn warn_selector_error(

--- a/test/cli/install/nested-overrides.test.ts
+++ b/test/cli/install/nested-overrides.test.ts
@@ -507,18 +507,26 @@ describe.concurrent("syntax", () => {
       expect(await lock(dir)).not.toContain('"overrides"');
     });
 
+    // A non-object field is a typo that would otherwise install with no rules applied, so the install fails instead.
     describe.concurrent.each([
-      { rules: { overrides: "nope" }, warning: 'warn: "overrides" must be an object' },
-      { rules: { resolutions: ["x"] }, warning: 'warn: "resolutions" must be an object with string values' },
-    ])("a non-object field %j", ({ rules, warning }) => {
-      test("warns and installs without rules", async () => {
-        const dir = await project({ dependencies: { "one-dep": "1.0.0" }, ...rules });
+      { field: "overrides", value: "no-deps@2.0.0" },
+      { field: "overrides", value: ["no-deps@2.0.0"] },
+      { field: "resolutions", value: "no-deps@2.0.0" },
+      { field: "resolutions", value: ["no-deps@2.0.0"] },
+    ])("a non-object field %j", ({ field, value }) => {
+      test("fails the install with an error pointing at the value", async () => {
+        const dir = await project({ dependencies: { "one-dep": "1.0.0" }, [field]: value });
         const { err, exitCode } = await install(dir);
-        expect(occurrences(err, warning)).toBe(1);
-        expect(err).not.toContain("error");
-        expect(exitCode).toBe(0);
-        expect(await versionSeenBy(dir, "one-dep", "no-deps")).toBe("1.0.1");
-        expect(await lock(dir)).not.toContain('"overrides"');
+        expect(err).toContain(
+          `error: "${field}" expects a map of package names to versions, e.g.\n  "${field}": {\n    "react": "18.2.0"\n  }`,
+        );
+        expect(err).not.toContain("internal error");
+        const column = (await packageJsonText(dir)).indexOf(JSON.stringify(value)) + 1;
+        expect(column).toBeGreaterThan(0);
+        expect(err).toContain(`package.json:1:${column}`);
+        expect(exitCode).toBe(1);
+        expect(existsSync(join(dir, "node_modules"))).toBeFalse();
+        expect(existsSync(join(dir, "bun.lock"))).toBeFalse();
       });
     });
 


### PR DESCRIPTION
### Problem
- A package.json with `"overrides": "is-number@6"` (or any non-object value for `"overrides"` or `"resolutions"`) prints `warn: "overrides" must be an object` and then installs with no rules applied. `bun install` exits 0 and writes a lockfile, so the typo is easy to miss.
- `OverrideMap::parse_from_overrides` and `parse_from_resolutions` (`src/install/lockfile/OverrideMap.rs:699`, `:819`) add a warning and return `Ok(())`. The Zig version returned `error.Invalid` for overrides, which surfaced as `An internal error occurred (Invalid)`. The Rust port replaced that with `Ok(())`.

### Fix
- Both functions now call a shared `not_an_object` helper. It logs an error at the value's location and returns `Error::InvalidPackageJSON`:
  ```
  error: "overrides" expects a map of package names to versions, e.g.
    "overrides": {
      "react": "18.2.0"
    }
      at package.json:1:71
  ```
- `InvalidPackageJSON` is the existing error for a malformed package.json field (for example `"dependencies"` as an array). `bun install`, `bun add`, `bun remove` and `bun update` already handle it: they print the log and exit 1. No `internal error` line, no lockfile, no `node_modules`.
- Verified: `test/cli/install/nested-overrides.test.ts` (the "a non-object field" cases, 4 variants, all fail on bun 1.4.1). Also ran `nested-overrides.test.ts`, `overrides.test.ts`, `bun-lock.test.ts`, `migration/migrate.test.ts` and `migration/pnpm-migration.test.ts` in full.

### Background
- `OverrideMap` holds the rules from `"overrides"` (npm) or `"resolutions"` (yarn) in the root package.json. `Package::parse_with_json_impl` calls `parse_append` on it when it parses the root package.json.
- `bun_ast::Log` collects warnings and errors with source locations. `InstallCommand::handle_error` (`src/runtime/cli/install_command.rs:28`) prints the log and exits 1 when the install returns `InstallFailed` or `InvalidPackageJSON`.
- Invalid individual rules (a bad range, an empty value, a nested object that is too deep) are still warnings. Only the shape of the whole field is an error, because in that case no rule at all is applied.

<details><summary>Notes</summary>

- The message uses plain `add_error_fmt` and not `add_error_pretty!`. The pretty-format rewriter does not handle `{{` escapes and prints color tags inside them literally. That bug is tracked separately.
- With a `package-lock.json` present, the npm migration parses the root package.json for overrides too. It now fails with the same error, `bun install` reports `failed to migrate lockfile`, ignores it, parses package.json again and exits 1 with the error. The error shows twice in that case. That matches how an unparsable package.json behaves on the migration path today.
- `bun add` parses its in-memory rewrite of package.json, so the reported line and column refer to the pretty-printed text and not the file on disk. This is pre-existing for every package.json error on that path. The file is not written back.
- Requested by @dylan-conway.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/nested-overrides.test.ts
bun test v1.4.1 (65362b53b)

test/cli/install/nested-overrides.test.ts:
(pass) syntax > $ref inside a nested value that names nothing warns and is skipped [1470.92ms]
(pass) syntax > $ref inside a nested value resolves against the root's dependencies [1764.92ms]
(pass) syntax > npm object scopes the rule to the parent's edge [2269.29ms]
(pass) syntax > parent range is matched against the parent's resolved version, through an alias [2729.34ms]
(pass) syntax > "." overrides the parent itself next to its children [2815.01ms]
(pass) syntax > yarn resolutions path one-dep/no-deps > applies to one-dep's edge only [2003.92ms]
(pass) syntax > yarn resolutions path **/one-dep/no-deps > applies to one-dep's edge only [2204.96ms]
(pass) syntax > yarn resolutions path one-dep@npm:1.0.0/no-deps > applies to one-dep's edge only [1647.83ms]
(pass) syntax > yarn resolutions path **/one-dep/**/no-deps > applies to one-dep's edge only [2266.91ms]
(pass) syntax > pnpm parent>child selector [1135.64ms]
(pass) synt
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/cli/install/nested-overrides.test.ts:
(pass) syntax > $ref inside a nested value resolves against the root's dependencies [296.80ms]
(pass) syntax > pnpm parent>child selector [495.17ms]
(pass) syntax > yarn resolutions path with scoped parent and child [552.23ms]
(pass) syntax > yarn resolutions path **/one-dep/**/no-deps > applies to one-dep's edge only [618.40ms]
(pass) syntax > npm object scopes the rule to the parent's edge [620.12ms]
(pass) syntax > yarn resolutions path one-dep/no-deps > applies to one-dep's edge only [673.95ms]
(pass) syntax > yarn resolutions path **/one-dep/no-deps > applies to one-dep's edge only [673.90ms]
(pass) syntax > pnpm parent@range>child selectors, including a range containing > [686.15ms]
(pass) syntax > yarn resolutions path one-dep@npm:1.0.0/no-deps > applies to one-dep's edge only [694.75ms]
(pass) syntax > pnpm selector one-dep@<2 >=1>no-deps > applies and writes the same bun.lock as the object form [695.69ms]
(pass) syntax > the same rule spelled in two syntaxes: last one wins and one row is written [847.83ms]
(pass) syntax > a "//" comment key in overrides > is ignored without a w
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/nested-overrides.test.ts
bun test v1.4.1 (65362b53b)

test/cli/install/nested-overrides.test.ts:
(pass) syntax > $ref inside a nested value resolves against the root's dependencies [707.10ms]
(pass) syntax > $ref inside a nested value that names nothing warns and is skipped [767.78ms]
(pass) syntax > parent range is matched against the parent's resolved version, through an alias [1035.32ms]
(pass) syntax > npm object scopes the rule to the parent's edge [1137.09ms]
(pass) syntax > "." overrides the parent itself next to its children [1289.50ms]
(pass) syntax > yarn resolutions path one-dep/no-deps > applies to one-dep's edge only [1083.74ms]
(pass) syntax > yarn resolutions path **/one-dep/no-deps > applies to one-dep's edge only [1053.35ms]
(pass) syntax > yarn resolutions path **/one-dep/**/no-deps > applies to one-dep's edge only [869.06ms]
(pass) syntax > yarn resolutions path one-dep@npm:1.0.0/no-deps > applies to one-dep's edge only [1004.31ms]
(pass) syntax > yarn resolutions path with scoped parent and child [1
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 800ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/lockfile/OverrideMap.rs       | 28 ++++++++++++++++------------
 test/cli/install/nested-overrides.test.ts | 28 ++++++++++++++++++----------
 2 files changed, 34 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/install/lockfile/OverrideMap.rs            4      3      0
test/cli/install/nested-overrides.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->