### PR TITLE
Bun.build: write the default compile outfile to the working directory

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -1244,6 +1244,8 @@ compile: {
 }
 ```
 
+Without `outfile`, the executable is named after the entrypoint and written to `outdir`, or to the current working directory when there is no `outdir`. This matches `bun build --compile`.
+
 ### Supported targets
 
 ```ts title="Bun.Build.CompileTarget" icon="/icons/typescript.svg"

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1275,30 +1275,8 @@ pub mod js_bundler {
                             return Err(global_this.throw_invalid_arguments(format_args!("cannot use compile with an output file named 'bun' because bun won't realize it's a standalone executable. Please choose a different name for compile.outfile")));
                         }
 
-                        // NOTE: when no `outdir`/`outfile` was given, place the
-                        // auto-derived executable next to its entry point — the
-                        // only path the caller actually supplied. Resolving the
-                        // basename against the process-wide cwd instead would
-                        // make every `Bun.build({compile: true, entrypoints:
-                        // [tmp + "/app.js"]})` from any test process write the
-                        // *same* `<cwd>/app`, so concurrently-running test files
-                        // would race on the executable (observed flake in
-                        // bun-build-compile-sourcemap.test.ts). This keeps each
-                        // build's output inside its own (temp) directory and is
-                        // also the more intuitive default for a programmatic API.
-                        // Explicit `outfile`/`outdir` are unaffected.
-                        let entry_dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
-                            entry_point,
-                        );
-                        if this.outdir.is_empty()
-                            && !entry_dir.is_empty()
-                            && bun_paths::is_absolute(entry_dir)
-                        {
-                            compile.outfile.append_slice_exact(entry_dir)?;
-                            compile
-                                .outfile
-                                .append_slice_exact(core::slice::from_ref(&bun_paths::SEP))?;
-                        }
+                        // Only the name. `do_compilation` resolves it against
+                        // `outdir`, or the working directory, like the CLI.
                         compile.outfile.append_slice_exact(outfile)?;
                     }
                 }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1275,8 +1275,6 @@ pub mod js_bundler {
                             return Err(global_this.throw_invalid_arguments(format_args!("cannot use compile with an output file named 'bun' because bun won't realize it's a standalone executable. Please choose a different name for compile.outfile")));
                         }
 
-                        // Only the name. `do_compilation` resolves it against
-                        // `outdir`, or the working directory, like the CLI.
                         compile.outfile.append_slice_exact(outfile)?;
                     }
                 }

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -21,7 +21,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       sourcemap: sourcemapValue,
     });
 
@@ -66,7 +66,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       // No sourcemap option
     });
 
@@ -99,7 +99,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       sourcemap: "external",
     });
 
@@ -134,7 +134,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "nosourcemap_entry.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "nosourcemap_entry") },
     });
 
     expect(result.success).toBe(true);
@@ -163,7 +163,7 @@ export function greet() {
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "entry.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "entry") },
       splitting: true,
       sourcemap: "external",
     });
@@ -275,7 +275,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       sourcemap: "inline",
     });
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -218,6 +218,49 @@ server.close();`,
     },
   );
 
+  test("compile without outfile writes the executable to the working directory", async () => {
+    using dir = tempDir("build-compile-default-outfile", {
+      "proj/sub/myapp.ts": `console.log("default outfile");`,
+      "cwd/build.ts": `
+        const result = await Bun.build({
+          entrypoints: [process.argv[2]],
+          compile: true,
+        });
+        console.log(JSON.stringify(result.outputs.map(output => output.path)));
+      `,
+    });
+    const cwd = join(String(dir), "cwd");
+    const entrypoint = join(String(dir), "proj", "sub", "myapp.ts");
+    const name = isWindows ? "myapp.exe" : "myapp";
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.ts", entrypoint],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // The name comes from the entrypoint. The directory is the working directory, like `bun build --compile`.
+    expect(JSON.parse(stdout)).toEqual([join(cwd, name)]);
+    expect(exitCode).toBe(0);
+
+    expect(await Bun.file(join(cwd, name)).exists()).toBe(true);
+    expect(await Bun.file(join(String(dir), "proj", "sub", name)).exists()).toBe(false);
+
+    await using app = Bun.spawn({
+      cmd: [join(cwd, name)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [appStdout, appStderr, appExitCode] = await Promise.all([app.stdout.text(), app.stderr.text(), app.exited]);
+    expect(appStdout).toBe("default outfile\n");
+    expect(appStderr).toBe("");
+    expect(appExitCode).toBe(0);
+  });
+
   test("compile with embedded resources uses correct module prefix", async () => {
     using dir = tempDir("build-compile-embedded-resources", {
       "app.js": `

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { SourceMapConsumer } from "source-map";
 
@@ -392,7 +392,7 @@ body { color: blue; }`,
 
     expect(result.success).toBe(true);
     expect(result.outputs.length).toBe(1);
-    expect(existsSync(`${dir}/app${process.platform === "win32" ? ".exe" : ""}`)).toBe(true);
+    expect(existsSync(`${dir}/app${isWindows ? ".exe" : ""}`)).toBe(true);
   });
 
   test("CLI --compile --target=browser with non-HTML falls back to normal compile", async () => {
@@ -411,7 +411,7 @@ body { color: blue; }`,
     const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // Non-HTML entrypoints with --compile --target=browser should fall back to normal bun compile
     expect(exitCode).toBe(0);
-    expect(existsSync(`${dir}/app${process.platform === "win32" ? ".exe" : ""}`)).toBe(true);
+    expect(existsSync(`${dir}/app${isWindows ? ".exe" : ""}`)).toBe(true);
   });
 
   test("fails with splitting", async () => {

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -382,15 +382,17 @@ body { color: blue; }`,
       "app.js": `console.log("no html");`,
     });
 
-    // compile: true + target: "browser" with non-HTML entrypoints should
+    // compile + target: "browser" with non-HTML entrypoints should
     // fall back to normal bun executable compile (not standalone HTML)
     const result = await Bun.build({
       entrypoints: [`${dir}/app.js`],
-      compile: true,
+      compile: { outfile: `${dir}/app` },
       target: "browser",
     });
 
     expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+    expect(existsSync(`${dir}/app${process.platform === "win32" ? ".exe" : ""}`)).toBe(true);
   });
 
   test("CLI --compile --target=browser with non-HTML falls back to normal compile", async () => {
@@ -401,6 +403,7 @@ body { color: blue; }`,
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", "--compile", "--target=browser", `${dir}/app.js`],
       env: bunEnv,
+      cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",
     });
@@ -408,6 +411,7 @@ body { color: blue; }`,
     const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // Non-HTML entrypoints with --compile --target=browser should fall back to normal bun compile
     expect(exitCode).toBe(0);
+    expect(existsSync(`${dir}/app${process.platform === "win32" ? ".exe" : ""}`)).toBe(true);
   });
 
   test("fails with splitting", async () => {


### PR DESCRIPTION
### Problem
- `Bun.build({ compile: true, entrypoints: ["/abs/dir/app.ts"] })` with no `outfile` and no `outdir` writes the executable to `/abs/dir/app`, next to the source file. `bun build --compile` writes `<cwd>/app`. The API did the same before the Rust port.
- The cause is in `Config::from_js` (`src/runtime/api/JSBundler.rs:1278-1301`). It prefixes the entrypoint's directory to the derived name. The comment there cites a test race, not intended behavior.

### Fix
- Store only the derived name. `do_compilation` (`src/runtime/api/js_bundle_completion_task.rs:300-318`) already resolves a bare name against `outdir`, or the working directory. So `compile: true` now behaves like `compile: { outfile: "<name>" }`, the same as the CLI.
- The tests that relied on the old placement (`bun-build-compile-sourcemap.test.ts`, two cases in `standalone.test.ts`) now pass an explicit `outfile` inside their temp directory. That also removes the race the old comment described: several test files no longer write the same `<cwd>/app`.
- The docs state the rule in one sentence under the `compile` usage forms.
- Verified: `test/bundler/bun-build-compile.test.ts` (new case, fails on 1.4.1 with `proj/sub/myapp` instead of `cwd/myapp`). Also `bun-build-compile-sourcemap.test.ts` and `standalone.test.ts`.

### Background
- `Config::from_js` parses the `Bun.build` options on the JS thread. For `compile` without `outfile` it derives a name from the first entrypoint: the file name without extension, or the directory name for `index`.
- `do_compilation` runs after the bundle. It turns the bundled entry point into an executable at `outdir/<name>`, or `<name>` resolved against `top_level_dir` (the process working directory) when there is no `outdir`.
- #37493 removes the same prefix as part of a larger change (a shared name helper, an `index` fallback, types). This PR is the narrow fix only.

<details><summary>Notes</summary>

Repro on bun 1.4.1, run from `/tmp/repro-compile/elsewhere`:

```js
await Bun.build({ entrypoints: ["/tmp/repro-compile/proj/sub/myapp.ts"], compile: true });
// writes /tmp/repro-compile/proj/sub/myapp
```

`bun build --compile /tmp/repro-compile/proj/sub/myapp.ts` from the same directory writes `/tmp/repro-compile/elsewhere/myapp`.

The removed block was added in the Rust port (#30412). The Zig version of `JSBundler` stored only the name.

The new test spawns bun from a `cwd/` subdirectory of the temp dir, builds `proj/sub/myapp.ts` with `compile: true`, and asserts the reported output path is `cwd/myapp`, that `proj/sub/myapp` does not exist, and that the executable runs.

`standalone.test.ts` "CLI --compile --target=browser with non-HTML falls back to normal compile" spawned `bun build --compile` without a `cwd`, so it wrote `<repo>/app` on every run. It now runs inside its temp dir and asserts the executable exists.

Other results from `bun-build-compile.test.ts` under debug+ASAN in this container: "--compile --bytecode for ..." (two cases) pass with `--timeout 120000` and time out at the 5 s default with or without this change. "bytecode from a compiled executable is not copied into private memory" times out at its 60 s limit here. All three pass an explicit `outfile` and do not reach the changed code.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/standalone.test.ts, test/bundler/bun-build-compile.test.ts, test/bundler/bun-build-compile-sourcemap.test.ts

<!-- robobun:evidence:end -->