### PR TITLE
bake: sort the route scan by file name, pick the most specific dynamic route in match_slow

### DIFF
--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1449,10 +1449,9 @@ pub trait InsertionHandler {
     ) -> Result<(), AllocError>;
 }
 
-/// Where a route file or directory name sorts in the scan, from the Next.js
-/// bracket syntax: a static name first, then `[param]`, `[...catchAll]`, and
-/// `[[...optionalCatchAll]]`. `match_slow` takes the first dynamic pattern
-/// that matches, so a more specific name has to be scanned first.
+/// Static names scan before `[param]`, then `[...catchAll]`, then
+/// `[[...optionalCatchAll]]`: `match_slow` takes the first dynamic route
+/// that matches, so the more specific name has to be inserted first.
 fn scan_precedence(name: &[u8]) -> u8 {
     if name.starts_with(b"[[") {
         3
@@ -1500,9 +1499,8 @@ impl FrameworkRouter {
         let fs_impl = unsafe { core::ptr::addr_of_mut!((*fs).fs) };
 
         {
-            // Snapshot the cached `DirEntry`'s entry pointers under `entries_mutex`
-            // (other threads rewrite the map in place under that lock), then drop
-            // the guard: the `read_dir_info_ignore_error` recursion below re-locks it.
+            // Snapshot under `entries_mutex` (other threads rewrite the map in place),
+            // then drop the guard: the `read_dir_info_ignore_error` recursion re-locks it.
             let mut entry_ptrs: Vec<*mut bun_resolver::fs::Entry> = {
                 let _entries_lock = fs_ref.fs.entries_mutex.lock_guard();
                 match dir_info.get_entries_const() {
@@ -1510,11 +1508,8 @@ impl FrameworkRouter {
                     None => return Ok(()),
                 }
             };
-            // The scan order is the insertion order, which `insert` turns into
-            // the sibling order of the route tree and the precedence of
-            // `dynamic_routes` in `match_slow`. Sort by precedence class, then
-            // by basename, so neither depends on the hash table layout or on
-            // the readdir order.
+            // Insertion order is the sibling order in the route tree and the match
+            // precedence, so it must not depend on the hash layout or readdir order.
             bun_collections::index_sort::sort_slice_unstable_by(&mut entry_ptrs, |&a, &b| {
                 // SAFETY: EntryStore-owned pointers, valid for the process lifetime.
                 let (a, b) = unsafe { ((*a).base(), (*b).base()) };

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -4,6 +4,7 @@
 
 use bun_alloc::ArenaVecExt as _;
 use bun_paths::strings;
+use core::cmp::Ordering;
 use core::fmt;
 use core::mem::size_of;
 
@@ -387,6 +388,37 @@ impl EncodedPattern {
             }
         }
         i == path.len()
+    }
+
+    /// Next.js precedence between two patterns that match the same path.
+    /// `Less` means `self` wins: at the first part where they differ, text
+    /// beats a param, a param beats a catch-all, and a catch-all beats an
+    /// optional catch-all. A pattern that ends first beats a longer one.
+    fn cmp_precedence(&self, other: &EncodedPattern) -> Ordering {
+        fn rank(part: &Part<'_>) -> u8 {
+            match part {
+                Part::Text(_) => 0,
+                Part::Param(_) => 1,
+                Part::CatchAll(_) => 2,
+                Part::CatchAllOptional(_) => 3,
+                // Groups are not part of the URL and are filtered out below.
+                Part::Group(_) => unreachable!(),
+            }
+        }
+        let is_segment = |part: &Part<'_>| !matches!(part, Part::Group(_));
+        let mut a = self.iterate().filter(is_segment);
+        let mut b = other.iterate().filter(is_segment);
+        loop {
+            match (a.next(), b.next()) {
+                (None, None) => return Ordering::Equal,
+                (None, Some(_)) => return Ordering::Less,
+                (Some(_), None) => return Ordering::Greater,
+                (Some(pa), Some(pb)) => match rank(&pa).cmp(&rank(&pb)) {
+                    Ordering::Equal => continue,
+                    ordering => return ordering,
+                },
+            }
+        }
     }
 }
 
@@ -1257,13 +1289,22 @@ impl FrameworkRouter {
             return Some(*static_route);
         }
 
-        for (i, pattern) in self.dynamic_routes.keys().iter().enumerate() {
-            if pattern.matches(path, params) {
-                return Some(self.dynamic_routes.values()[i]);
+        // `dynamic_routes` is in scan order, so the first match is arbitrary.
+        // Take the most specific one and run it again to fill `params`.
+        let patterns = self.dynamic_routes.keys();
+        let mut best: Option<usize> = None;
+        for (i, pattern) in patterns.iter().enumerate() {
+            if pattern.matches(path, params)
+                && best.is_none_or(|b| pattern.cmp_precedence(&patterns[b]).is_lt())
+            {
+                best = Some(i);
             }
         }
-
-        None
+        let i = best?;
+        params.params = BoundedArray::default();
+        let matched = patterns[i].matches(path, params);
+        debug_assert!(matched);
+        Some(self.dynamic_routes.values()[i])
     }
 
     pub(crate) fn route_ptr(&self, i: RouteIndex) -> &Route {
@@ -1449,21 +1490,6 @@ pub trait InsertionHandler {
     ) -> Result<(), AllocError>;
 }
 
-/// Static names scan before `[param]`, then `[...catchAll]`, then
-/// `[[...optionalCatchAll]]`: `match_slow` takes the first dynamic route
-/// that matches, so the more specific name has to be inserted first.
-fn scan_precedence(name: &[u8]) -> u8 {
-    if name.starts_with(b"[[") {
-        3
-    } else if name.starts_with(b"[...") {
-        2
-    } else if name.starts_with(b"[") {
-        1
-    } else {
-        0
-    }
-}
-
 impl FrameworkRouter {
     pub(crate) fn scan(
         &mut self,
@@ -1508,14 +1534,11 @@ impl FrameworkRouter {
                     None => return Ok(()),
                 }
             };
-            // Insertion order is the sibling order in the route tree and the match
-            // precedence, so it must not depend on the hash layout or readdir order.
+            // Insertion order is the sibling order in the route tree, so it must
+            // not depend on the hash layout or on the readdir order.
             bun_collections::index_sort::sort_slice_unstable_by(&mut entry_ptrs, |&a, &b| {
                 // SAFETY: EntryStore-owned pointers, valid for the process lifetime.
-                let (a, b) = unsafe { ((*a).base(), (*b).base()) };
-                scan_precedence(a)
-                    .cmp(&scan_precedence(b))
-                    .then_with(|| a.cmp(b))
+                unsafe { (*a).base().cmp((*b).base()) }
             });
             'outer: for file_ptr in entry_ptrs {
                 // SAFETY: EntryMap stores `*mut Entry` into the EntryStore singleton

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1449,6 +1449,22 @@ pub trait InsertionHandler {
     ) -> Result<(), AllocError>;
 }
 
+/// Where a route file or directory name sorts in the scan, from the Next.js
+/// bracket syntax: a static name first, then `[param]`, `[...catchAll]`, and
+/// `[[...optionalCatchAll]]`. `match_slow` takes the first dynamic pattern
+/// that matches, so a more specific name has to be scanned first.
+fn scan_precedence(name: &[u8]) -> u8 {
+    if name.starts_with(b"[[") {
+        3
+    } else if name.starts_with(b"[...") {
+        2
+    } else if name.starts_with(b"[") {
+        1
+    } else {
+        0
+    }
+}
+
 impl FrameworkRouter {
     pub(crate) fn scan(
         &mut self,
@@ -1496,11 +1512,15 @@ impl FrameworkRouter {
             };
             // The scan order is the insertion order, which `insert` turns into
             // the sibling order of the route tree and the precedence of
-            // `dynamic_routes` in `match_slow`. Sort by basename so neither
-            // depends on the hash table layout or on the readdir order.
+            // `dynamic_routes` in `match_slow`. Sort by precedence class, then
+            // by basename, so neither depends on the hash table layout or on
+            // the readdir order.
             bun_collections::index_sort::sort_slice_unstable_by(&mut entry_ptrs, |&a, &b| {
                 // SAFETY: EntryStore-owned pointers, valid for the process lifetime.
-                unsafe { (*a).base().cmp((*b).base()) }
+                let (a, b) = unsafe { ((*a).base(), (*b).base()) };
+                scan_precedence(a)
+                    .cmp(&scan_precedence(b))
+                    .then_with(|| a.cmp(b))
             });
             'outer: for file_ptr in entry_ptrs {
                 // SAFETY: EntryMap stores `*mut Entry` into the EntryStore singleton

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1449,29 +1449,6 @@ pub trait InsertionHandler {
     ) -> Result<(), AllocError>;
 }
 
-/// Hash context (wyhash final4, seed 0) for the `zig_hash_map` rebuild below.
-///
-/// `scan_inner` walks `DirEntry.data` to discover routes; the resulting child
-/// order is the map's iteration order, and the linear-probe bucket walk is
-/// what `test/bake/framework-router.test.ts` snapshots. `EntryMap` is a
-/// `std::collections::HashMap`, which has a different layout, so we rebuild
-/// into a `zig_hash_map` keyed/hashed deterministically before iterating.
-struct ZigStringHashContext;
-impl bun_collections::zig_hash_map::HashContext<Box<[u8]>> for ZigStringHashContext {
-    #[inline]
-    fn ctx_hash(key: &Box<[u8]>) -> u64 {
-        // `bun_wyhash::hash` is the wyhash final4 variant with seed 0.
-        // (Don't route through `auto_hash`/`OneShotHasher`
-        // here: Rust's `<[u8] as Hash>` mixes in a length prefix, which would
-        // shift the bucket layout the snapshot below depends on.)
-        bun_wyhash::hash(key)
-    }
-    #[inline]
-    fn ctx_eql(a: &Box<[u8]>, b: &Box<[u8]>) -> bool {
-        a[..] == b[..]
-    }
-}
-
 impl FrameworkRouter {
     pub(crate) fn scan(
         &mut self,
@@ -1507,33 +1484,25 @@ impl FrameworkRouter {
         let fs_impl = unsafe { core::ptr::addr_of_mut!((*fs).fs) };
 
         {
-            // Note: `entries.data` is backed by `std::collections::HashMap`,
-            // whose iteration order is unspecified. The route-tree child order
-            // is this iteration order (see `insert`), and
-            // `test/bake/framework-router.test.ts` snapshots it. Rebuild into a
-            // `zig_hash_map` (fixed wyhash/seed/probe) so the walk order is
-            // deterministic. Absent hash collisions (the common case for small
-            // dirs) the bucket order is fully determined by the hash, so
-            // re-insertion order is irrelevant.
-            let mut zig_order: bun_collections::zig_hash_map::HashMap<
-                Box<[u8]>,
-                *mut bun_resolver::fs::Entry,
-                ZigStringHashContext,
-            > = Default::default();
-            {
-                // Copy under `entries_mutex`: other threads rewrite the cached
-                // `DirEntry` map in place under that lock. Dropped before the
-                // walk so the `read_dir_info_ignore_error` recursion can re-lock.
+            // Snapshot the cached `DirEntry`'s entry pointers under `entries_mutex`
+            // (other threads rewrite the map in place under that lock), then drop
+            // the guard: the `read_dir_info_ignore_error` recursion below re-locks it.
+            let mut entry_ptrs: Vec<*mut bun_resolver::fs::Entry> = {
                 let _entries_lock = fs_ref.fs.entries_mutex.lock_guard();
-                if let Some(entries) = dir_info.get_entries_const() {
-                    for (k, &v) in entries.data.iter() {
-                        let _ = zig_order.put(Box::from(&**k), v);
-                    }
+                match dir_info.get_entries_const() {
+                    Some(entries) => entries.data.values().copied().collect(),
+                    None => return Ok(()),
                 }
-            }
-            let mut it = zig_order.iter();
-            'outer: while let Some(entry) = it.next() {
-                let file_ptr: *mut bun_resolver::fs::Entry = *entry.1;
+            };
+            // The scan order is the insertion order, which `insert` turns into
+            // the sibling order of the route tree and the precedence of
+            // `dynamic_routes` in `match_slow`. Sort by basename so neither
+            // depends on the hash table layout or on the readdir order.
+            bun_collections::index_sort::sort_slice_unstable_by(&mut entry_ptrs, |&a, &b| {
+                // SAFETY: EntryStore-owned pointers, valid for the process lifetime.
+                unsafe { (*a).base().cmp((*b).base()) }
+            });
+            'outer: for file_ptr in entry_ptrs {
                 // SAFETY: EntryMap stores `*mut Entry` into the EntryStore singleton
                 // (process lifetime); the lazy-stat rewrite in `kind()` below is
                 // serialized on the per-entry `Entry.mutex`.

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -92,12 +92,6 @@ test("discovers from filesystem paths", () => {
     layout: null,
     children: [
       {
-        part: "/:world",
-        page: path.join(dir, "[world].tsx"),
-        layout: null,
-        children: [],
-      },
-      {
         part: "/hello",
         page: path.join(dir, "hello.tsx"),
         layout: null,
@@ -130,11 +124,17 @@ test("discovers from filesystem paths", () => {
           },
         ],
       },
+      {
+        part: "/:world",
+        page: path.join(dir, "[world].tsx"),
+        layout: null,
+        children: [],
+      },
     ],
   });
 });
 
-test("route children are ordered by file name", () => {
+test("route children are ordered static first, then param, then catch-all, then by file name", () => {
   // The files are listed in an order that is neither sorted nor the order a
   // hash table walk produces, so the result only matches when the scan sorts.
   using dir = tempDir("fsr-order", {
@@ -152,6 +152,28 @@ test("route children are ordered by file name", () => {
   const router = new FrameworkRouter({ root: dir, style: "nextjs-pages" });
   const parts = (route: { children: { part: string }[] }) => route.children.map(child => child.part);
   const root = router.toJSON();
-  expect(parts(root)).toEqual(["/Beta", "/:*rest", "/:id", "/alpha", "/delta", "/epsilon", "/gamma", "/zeta"]);
-  expect(parts(root.children.find(child => child.part === "/delta"))).toEqual(["/Zed", "/:slug", "/about"]);
+  expect(parts(root)).toEqual(["/Beta", "/alpha", "/delta", "/epsilon", "/gamma", "/zeta", "/:id", "/:*rest"]);
+  expect(parts(root.children.find(child => child.part === "/delta"))).toEqual(["/Zed", "/about", "/:slug"]);
+});
+
+test("a more specific dynamic route matches before a less specific one", () => {
+  using dir = tempDir("fsr-precedence", {
+    "[...rest].tsx": "1",
+    "[id].tsx": "1",
+    "docs/[section]/[slug].tsx": "1",
+    "docs/blog/[slug].tsx": "1",
+  });
+  const router = new FrameworkRouter({ root: dir, style: "nextjs-pages" });
+  // [id] before [...rest]
+  expect(router.match("/foo")).toMatchObject({ params: { id: "foo" }, route: { part: "/:id" } });
+  // docs/blog before docs/[section]
+  expect(router.match("/docs/blog/post")).toMatchObject({
+    params: { slug: "post" },
+    route: { part: "/:slug", parent: { part: "/blog" } },
+  });
+  expect(router.match("/docs/news/post")).toMatchObject({
+    params: { section: "news", slug: "post" },
+    route: { part: "/:slug", parent: { part: "/:section" } },
+  });
+  expect(router.match("/a/b/c")).toMatchObject({ route: { part: "/:*rest" } });
 });

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -98,6 +98,12 @@ test("discovers from filesystem paths", () => {
         children: [],
       },
       {
+        part: "/hello",
+        page: path.join(dir, "hello.tsx"),
+        layout: null,
+        children: [],
+      },
+      {
         part: "/meow",
         page: null,
         layout: path.join(dir, "meow/_layout.tsx"),
@@ -124,12 +130,28 @@ test("discovers from filesystem paths", () => {
           },
         ],
       },
-      {
-        part: "/hello",
-        page: path.join(dir, "hello.tsx"),
-        layout: null,
-        children: [],
-      },
     ],
   });
+});
+
+test("route children are ordered by file name", () => {
+  // The files are listed in an order that is neither sorted nor the order a
+  // hash table walk produces, so the result only matches when the scan sorts.
+  using dir = tempDir("fsr-order", {
+    "zeta.tsx": "1",
+    "alpha.tsx": "1",
+    "[id].tsx": "1",
+    "Beta.tsx": "1",
+    "gamma/index.tsx": "1",
+    "delta/[slug].tsx": "1",
+    "delta/about.tsx": "1",
+    "delta/Zed.tsx": "1",
+    "[...rest].tsx": "1",
+    "epsilon.tsx": "1",
+  });
+  const router = new FrameworkRouter({ root: dir, style: "nextjs-pages" });
+  const parts = (route: { children: { part: string }[] }) => route.children.map(child => child.part);
+  const root = router.toJSON();
+  expect(parts(root)).toEqual(["/Beta", "/:*rest", "/:id", "/alpha", "/delta", "/epsilon", "/gamma", "/zeta"]);
+  expect(parts(root.children.find(child => child.part === "/delta"))).toEqual(["/Zed", "/:slug", "/about"]);
 });

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -92,6 +92,12 @@ test("discovers from filesystem paths", () => {
     layout: null,
     children: [
       {
+        part: "/:world",
+        page: path.join(dir, "[world].tsx"),
+        layout: null,
+        children: [],
+      },
+      {
         part: "/hello",
         page: path.join(dir, "hello.tsx"),
         layout: null,
@@ -124,17 +130,11 @@ test("discovers from filesystem paths", () => {
           },
         ],
       },
-      {
-        part: "/:world",
-        page: path.join(dir, "[world].tsx"),
-        layout: null,
-        children: [],
-      },
     ],
   });
 });
 
-test("route children are ordered static first, then param, then catch-all, then by file name", () => {
+test("route children are ordered by file name", () => {
   // The files are listed in an order that is neither sorted nor the order a
   // hash table walk produces, so the result only matches when the scan sorts.
   using dir = tempDir("fsr-order", {
@@ -152,11 +152,13 @@ test("route children are ordered static first, then param, then catch-all, then 
   const router = new FrameworkRouter({ root: dir, style: "nextjs-pages" });
   const parts = (route: { children: { part: string }[] }) => route.children.map(child => child.part);
   const root = router.toJSON();
-  expect(parts(root)).toEqual(["/Beta", "/alpha", "/delta", "/epsilon", "/gamma", "/zeta", "/:id", "/:*rest"]);
-  expect(parts(root.children.find(child => child.part === "/delta"))).toEqual(["/Zed", "/about", "/:slug"]);
+  expect(parts(root)).toEqual(["/Beta", "/:*rest", "/:id", "/alpha", "/delta", "/epsilon", "/gamma", "/zeta"]);
+  expect(parts(root.children.find(child => child.part === "/delta"))).toEqual(["/Zed", "/:slug", "/about"]);
 });
 
-test("a more specific dynamic route matches before a less specific one", () => {
+test("the most specific dynamic route matches, whatever the scan order", () => {
+  // In file name order "[...rest]" and "[section]" come before "[id]" and
+  // "blog", so a first-match walk of the dynamic routes picks the wrong one.
   using dir = tempDir("fsr-precedence", {
     "[...rest].tsx": "1",
     "[id].tsx": "1",
@@ -164,9 +166,7 @@ test("a more specific dynamic route matches before a less specific one", () => {
     "docs/blog/[slug].tsx": "1",
   });
   const router = new FrameworkRouter({ root: dir, style: "nextjs-pages" });
-  // [id] before [...rest]
   expect(router.match("/foo")).toMatchObject({ params: { id: "foo" }, route: { part: "/:id" } });
-  // docs/blog before docs/[section]
   expect(router.match("/docs/blog/post")).toMatchObject({
     params: { slug: "post" },
     route: { part: "/:slug", parent: { part: "/blog" } },
@@ -176,4 +176,14 @@ test("a more specific dynamic route matches before a less specific one", () => {
     route: { part: "/:slug", parent: { part: "/:section" } },
   });
   expect(router.match("/a/b/c")).toMatchObject({ route: { part: "/:*rest" } });
+});
+
+test("a route group does not change the precedence of the routes inside it", () => {
+  using dir = tempDir("fsr-group-precedence", {
+    "(marketing)/[...slug]/page.tsx": "1",
+    "[id]/page.tsx": "1",
+  });
+  const router = new FrameworkRouter({ root: dir, style: "nextjs-app-ui" });
+  expect(router.match("/foo")).toMatchObject({ params: { id: "foo" }, route: { part: "/:id" } });
+  expect(router.match("/foo/bar")).toMatchObject({ route: { part: "/:*slug", parent: { part: "/(marketing)" } } });
 });


### PR DESCRIPTION
### Problem
- `FrameworkRouter::scan_inner` (`src/runtime/bake/FrameworkRouter.rs`) copied every directory's entries into a fresh `zig_hash_map` on each route scan, one `Box<[u8]>` per file name, plus a hand-written wyhash `ZigStringHashContext`. The copy existed only to give the walk the bucket order that `test/bake/framework-router.test.ts` expects.
- The order was still arbitrary. It came from the hash layout, not from the files. It is the sibling order of the route tree, the route index order that `production.rs` hands to JS, and the order of `dynamic_routes`. `match_slow` returned the first dynamic pattern that matched, so with `[id].tsx` and `[...rest].tsx` in one directory, which one the dev server picked for `/foo` depended on the hash of the names.

### Fix
- Snapshot the entry pointers into a `Vec<*mut Entry>` under `entries_mutex`, the same idiom `src/router/lib.rs:556` and `src/runtime/api/filesystem_router.rs:369` use, and sort them by basename with `index_sort::sort_slice_unstable_by`. Delete the `zig_hash_map` rebuild and `ZigStringHashContext`. One `Vec` per directory, no per-name allocation, the same tree on every platform.
- `match_slow` now picks the most specific dynamic pattern among those that match, with `EncodedPattern::cmp_precedence`: at the first segment where two patterns differ, text beats a param, a param beats a catch-all, a catch-all beats an optional catch-all. Route groups `(name)` are skipped, as in `matches`. This is the Next.js rule, and it does not depend on the scan order, so a group or a nested directory cannot change it.
- Verified: `test/bake/framework-router.test.ts`. The expected child order is updated, a new test checks the order of a shuffled 10-file tree, and two new tests check `router.match()` precedence (pages router, and an app router catch-all inside a route group). Three of them fail on the unfixed build. Also `test/bake/dev/ssg-pages-router.test.ts`, `test/bake/dev/production.test.ts`, `test/bake/dev-and-prod.test.ts`.

### Background
- `FrameworkRouter` is Bake's file system router. `scan_inner` walks one directory of the resolver's cache, recurses into subdirectories, and calls `insert` for each route file.
- `DirEntry.data` is the resolver's cached directory listing, a `hashbrown` map from lowercased basename to `*mut Entry`. Other threads rewrite it in place under `entries_mutex`, so a walker snapshots it and drops the lock before it recurses.
- `insert` appends a new child route at the end of its parent's sibling list and adds a page's pattern to `dynamic_routes`, an insertion-ordered `ArrayHashMap`. `match_slow` is the dev server's matcher. It checks `static_routes` first, then the dynamic patterns.
- An `EncodedPattern` is a route pattern serialized as parts: `Text`, `Param`, `CatchAll`, `CatchAllOptional`, and `Group` (a Next.js route group, which does not appear in the URL).

<details><summary>Notes</summary>

- Probe on the unfixed build with 10 root entries: `/alpha, /:id, /gamma, /zeta, /kappa, /delta, /:*rest, /lambda, /epsilon, /Beta`. With this change: `/Beta, /:*rest, /:id, /alpha, /delta, /epsilon, /gamma, /kappa, /lambda, /zeta`.
- Two revisions of this PR tried to get the precedence from the scan order. The first sorted by name bytes only, so `[...rest]` was inserted before `[id]` and always won. The second sorted static names before `[param]` before `[...catchAll]`, which a route group defeats: `(marketing)/[...slug]/page.tsx` sorts as a static name and its catch-all was inserted before a sibling `[id]/page.tsx`. Precedence has to come from the patterns, so it moved into `match_slow`.
- `match_slow` now runs `matches` on every dynamic pattern instead of stopping at the first hit, then once more on the winner to fill `params`. The dev server has tens of dynamic routes at most.
- The sort compares `Entry::base()` (the real name), not the lowercased map key, so `Beta.tsx` sorts before `alpha.tsx` on every platform.
- `EncodedPattern::matches` has a separate bug: `/:id` matches `/` with an empty param, `/:a/:b` matches `/foo`, and a required catch-all matches zero segments. Not changed here. With `cmp_precedence` the shorter pattern wins such a tie, so the new tests hold with and without that bug.
- The production tests in `test/bake/dev/production.test.ts` each take 5 to 9 s under the debug ASAN build here and hit the 5 s default timeout. They pass with `--timeout 300000`. Unrelated to this change.
- #40261 edits the same block (it replaces `*mut Entry` with `&Entry` and keeps the `zig_hash_map` copy). Whichever lands second needs a small rebase of this region.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/framework-router.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/1285] gen bindgenv2
[2/1285] gen ErrorCode+*.h
[3/1285] fetch zlib
[zlib] up to date
[4/1285] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[5/1285] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1258] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1258] fetch tinycc
[tinycc] up to date
[8/1257] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/debug/codegen/ZigGlobalObject.lut.h from /workspace/bun/src/jsc/bindings/ZigGlobalObject.lut.txt
[9/1257] gen .bind.ts → GeneratedBindings.cpp
[10/1257] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [777.00ms]
[11/1257] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[12/1257] 
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bake/framework-router.test.ts:
(pass) pattern parse > [nextjs-pages] pass: "/index.tsx" [0.05ms]
(pass) pattern parse > [nextjs-pages] pass: "/_layout.tsx"
(pass) pattern parse > [nextjs-pages] pass: "/subdir/index.tsx" [0.05ms]
(pass) pattern parse > [nextjs-pages] pass: "/subdir/_layout.tsx"
(pass) pattern parse > [nextjs-pages] pass: "/subdir/[page].tsx" [0.02ms]
(pass) pattern parse > [nextjs-pages] pass: "/[user]/posts.tsx"
(pass) pattern parse > [nextjs-pages] pass: "/[user]/_layout.tsx"
(pass) pattern parse > [nextjs-pages] pass: "/subdir/[page]/[other].tsx"
(pass) pattern parse > [nextjs-pages] pass: "/[page]/[other]/index.js"
(pass) pattern parse > [nextjs-pages] pass: "/[...data].js"
(pass) pattern parse > [nextjs-pages] pass: "/[[...data]].js"
(pass) pattern parse > [nextjs-pages] pass: "/[...data]/index.tsx"
(pass) pattern parse > [nextjs-pages] pass: "/[[...data]]/index.jsx"
(pass) pattern parse > [nextjs-pages] pass: "/hello/[...data]/index.tsx" [0.03ms]
(pass) pattern parse > [nextjs-pages] pass: "/hello/[[...data]]/index.jsx"
(pass) pattern parse > [nextjs-pages] pass: "/[...data]/_layout.tsx"
(pass) pattern
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/framework-router.test.ts
bun test v1.4.1 (65362b53b)

test/bake/framework-router.test.ts:
(pass) pattern parse > [nextjs-pages] pass: "/index.tsx" [8.32ms]
(pass) pattern parse > [nextjs-pages] pass: "/_layout.tsx" [0.71ms]
(pass) pattern parse > [nextjs-pages] pass: "/subdir/index.tsx" [0.81ms]
(pass) pattern parse > [nextjs-pages] pass: "/subdir/_layout.tsx" [0.55ms]
(pass) pattern parse > [nextjs-pages] pass: "/subdir/[page].tsx" [0.64ms]
(pass) pattern parse > [nextjs-pages] pass: "/[user]/posts.tsx" [0.50ms]
(pass) pattern parse > [nextjs-pages] pass: "/[user]/_layout.tsx" [0.46ms]
(pass) pattern parse > [nextjs-pages] pass: "/subdir/[page]/[other].tsx" [0.51ms]
(pass) pattern parse > [nextjs-pages] pass: "/[page]/[other]/index.js" [0.51ms]
(pass) pattern parse > [nextjs-pages] pass: "/[...data].js" [0.46ms]
(pass) pattern parse > [nextjs-pages] pass: "/[[...data]].js" [0.49ms]
(pass) pattern parse > [nextjs-pages] pass: "/[...data]/index.tsx" [0.46ms]
(pass) pattern parse > [nextjs-pages] pass: "/[[...data]]/index.jsx" 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f2554bb89f
  features     baseline

23 deps, 131 codegen, 1172 objects in 1091ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [14.00ms]
[2/1244] gen .bind.ts → GeneratedBindings.cpp
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1216] fetch zlib
[zlib] up to date
[8/1216] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [48.00ms]
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [15.00ms]
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/FrameworkRouter.rs | 113 +++++++++++++++++++-----------------
 test/bake/framework-router.test.ts  |  66 +++++++++++++++++++--
 2 files changed, 120 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/bake/FrameworkRouter.rs     15     13      0
test/bake/framework-router.test.ts       3      3      0
```

</details>

<!-- robobun:evidence:end -->