### PR TITLE
bun:ffi: name the received type in ptr() errors and throw them

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -604,9 +604,8 @@ impl<'a> Run<'a> {
                 self.log.add_error_fmt(
                     Some(self.source),
                     self.caller.loc,
-                    // `JSType` derives `Debug` (not `IntoStaticStr`).
                     format_args!(
-                        "cannot coerce {} ({:?}) to Bun's AST. Please return a simpler type",
+                        "cannot coerce {} ({}) to Bun's AST. Please return a simpler type",
                         bstr::BStr::new(name),
                         value.js_type(),
                     ),
@@ -878,9 +877,8 @@ impl<'a> Run<'a> {
         self.log.add_error_fmt(
             Some(self.source),
             self.caller.loc,
-            // `JSType` derives `Debug` (not `IntoStaticStr`).
             format_args!(
-                "cannot coerce {:?} to Bun's AST. Please return a simpler type",
+                "cannot coerce {} to Bun's AST. Please return a simpler type",
                 value.js_type(),
             ),
         );

--- a/src/jsc/JSType.rs
+++ b/src/jsc/JSType.rs
@@ -100,8 +100,6 @@ use crate::array_buffer::TypedArrayType;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, core::marker::ConstParamTy)]
 pub struct JSType(pub u8);
 
-/// Prints the tag name (`String`, `FinalObject`, ...), like a derived `Debug`
-/// on a Rust enum would. A tag without a name prints as `JSType(<u8>)`.
 impl core::fmt::Display for JSType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.name() {
@@ -570,9 +568,7 @@ impl JSType {
     pub const MIN_TYPED_ARRAY: JSType = JSType::Int8Array;
     pub const MAX_TYPED_ARRAY: JSType = JSType::DataView;
 
-    /// The tag name for diagnostics (`JSType::String` is `"String"`). `None`
-    /// for a tag this file does not name: any `u8` read from `JSCell::m_type`
-    /// is a valid `JSType`, including embedder-defined ones.
+    /// The tag name for diagnostics (`JSType::String` is `"String"`).
     pub fn name(self) -> Option<&'static str> {
         Some(match self {
             JSType::Cell => "Cell",
@@ -665,9 +661,6 @@ impl JSType {
         })
     }
 
-    /// `name()` of an `is_array_buffer_like()` tag, as bytes for the console
-    /// and `bun:test` formatters. `"TypedArray"` for any other tag, which no
-    /// real `ArrayBuffer.typed_array_type` is.
     pub fn typed_array_name(self) -> &'static [u8] {
         match self.name() {
             Some(name) if self.is_array_buffer_like() => name.as_bytes(),

--- a/src/jsc/JSType.rs
+++ b/src/jsc/JSType.rs
@@ -665,27 +665,12 @@ impl JSType {
         })
     }
 
-    /// `JSType` is a
-    /// newtype-const (not a Rust `enum`), so there is no derived stringifier.
-    /// Covers every `is_typed_array_or_array_buffer()` variant + `DataView`.
-    /// The `_ => "TypedArray"` arm is unreachable for any real
-    /// `ArrayBuffer.typed_array_type` (always one of the 14).
+    /// `name()` of an `is_array_buffer_like()` tag, as bytes for the console
+    /// and `bun:test` formatters. `"TypedArray"` for any other tag, which no
+    /// real `ArrayBuffer.typed_array_type` is.
     pub fn typed_array_name(self) -> &'static [u8] {
-        match self {
-            JSType::ArrayBuffer => b"ArrayBuffer",
-            JSType::Int8Array => b"Int8Array",
-            JSType::Uint8Array => b"Uint8Array",
-            JSType::Uint8ClampedArray => b"Uint8ClampedArray",
-            JSType::Int16Array => b"Int16Array",
-            JSType::Uint16Array => b"Uint16Array",
-            JSType::Int32Array => b"Int32Array",
-            JSType::Uint32Array => b"Uint32Array",
-            JSType::Float16Array => b"Float16Array",
-            JSType::Float32Array => b"Float32Array",
-            JSType::Float64Array => b"Float64Array",
-            JSType::BigInt64Array => b"BigInt64Array",
-            JSType::BigUint64Array => b"BigUint64Array",
-            JSType::DataView => b"DataView",
+        match self.name() {
+            Some(name) if self.is_array_buffer_like() => name.as_bytes(),
             _ => b"TypedArray",
         }
     }

--- a/src/jsc/JSType.rs
+++ b/src/jsc/JSType.rs
@@ -97,8 +97,25 @@ use crate::array_buffer::TypedArrayType;
 // be UB for unknown discriminants, so this is a transparent newtype with
 // associated consts instead.
 #[repr(transparent)]
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, core::marker::ConstParamTy)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, core::marker::ConstParamTy)]
 pub struct JSType(pub u8);
+
+/// Prints the tag name (`String`, `FinalObject`, ...), like a derived `Debug`
+/// on a Rust enum would. A tag without a name prints as `JSType(<u8>)`.
+impl core::fmt::Display for JSType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self.name() {
+            Some(name) => f.write_str(name),
+            None => write!(f, "JSType({})", self.0),
+        }
+    }
+}
+
+impl core::fmt::Debug for JSType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
+    }
+}
 
 #[allow(non_upper_case_globals)]
 impl JSType {
@@ -552,6 +569,101 @@ impl JSType {
 impl JSType {
     pub const MIN_TYPED_ARRAY: JSType = JSType::Int8Array;
     pub const MAX_TYPED_ARRAY: JSType = JSType::DataView;
+
+    /// The tag name for diagnostics (`JSType::String` is `"String"`). `None`
+    /// for a tag this file does not name: any `u8` read from `JSCell::m_type`
+    /// is a valid `JSType`, including embedder-defined ones.
+    pub fn name(self) -> Option<&'static str> {
+        Some(match self {
+            JSType::Cell => "Cell",
+            JSType::String => "String",
+            JSType::HeapBigInt => "HeapBigInt",
+            JSType::Symbol => "Symbol",
+            JSType::GetterSetter => "GetterSetter",
+            JSType::CustomGetterSetter => "CustomGetterSetter",
+            JSType::APIValueWrapper => "APIValueWrapper",
+            JSType::NativeExecutable => "NativeExecutable",
+            JSType::ProgramExecutable => "ProgramExecutable",
+            JSType::ModuleProgramExecutable => "ModuleProgramExecutable",
+            JSType::EvalExecutable => "EvalExecutable",
+            JSType::FunctionExecutable => "FunctionExecutable",
+            JSType::UnlinkedFunctionExecutable => "UnlinkedFunctionExecutable",
+            JSType::UnlinkedProgramCodeBlock => "UnlinkedProgramCodeBlock",
+            JSType::UnlinkedModuleProgramCodeBlock => "UnlinkedModuleProgramCodeBlock",
+            JSType::UnlinkedEvalCodeBlock => "UnlinkedEvalCodeBlock",
+            JSType::UnlinkedFunctionCodeBlock => "UnlinkedFunctionCodeBlock",
+            JSType::CodeBlock => "CodeBlock",
+            JSType::JSCellButterfly => "JSCellButterfly",
+            JSType::JSSourceCode => "JSSourceCode",
+            JSType::SlimPromiseReaction => "SlimPromiseReaction",
+            JSType::FullPromiseReaction => "FullPromiseReaction",
+            JSType::PromiseAllContext => "PromiseAllContext",
+            JSType::PromiseAllGlobalContext => "PromiseAllGlobalContext",
+            JSType::Object => "Object",
+            JSType::FinalObject => "FinalObject",
+            JSType::JSCallee => "JSCallee",
+            JSType::JSFunction => "JSFunction",
+            JSType::InternalFunction => "InternalFunction",
+            JSType::BooleanObject => "BooleanObject",
+            JSType::NumberObject => "NumberObject",
+            JSType::ErrorInstance => "ErrorInstance",
+            JSType::GlobalProxy => "GlobalProxy",
+            JSType::DirectArguments => "DirectArguments",
+            JSType::ScopedArguments => "ScopedArguments",
+            JSType::ClonedArguments => "ClonedArguments",
+            JSType::Array => "Array",
+            JSType::DerivedArray => "DerivedArray",
+            JSType::ArrayBuffer => "ArrayBuffer",
+            JSType::Int8Array => "Int8Array",
+            JSType::Uint8Array => "Uint8Array",
+            JSType::Uint8ClampedArray => "Uint8ClampedArray",
+            JSType::Int16Array => "Int16Array",
+            JSType::Uint16Array => "Uint16Array",
+            JSType::Int32Array => "Int32Array",
+            JSType::Uint32Array => "Uint32Array",
+            JSType::Float16Array => "Float16Array",
+            JSType::Float32Array => "Float32Array",
+            JSType::Float64Array => "Float64Array",
+            JSType::BigInt64Array => "BigInt64Array",
+            JSType::BigUint64Array => "BigUint64Array",
+            JSType::DataView => "DataView",
+            JSType::GlobalObject => "GlobalObject",
+            JSType::GlobalLexicalEnvironment => "GlobalLexicalEnvironment",
+            JSType::LexicalEnvironment => "LexicalEnvironment",
+            JSType::ModuleEnvironment => "ModuleEnvironment",
+            JSType::StrictEvalActivation => "StrictEvalActivation",
+            JSType::WithScope => "WithScope",
+            JSType::ModuleNamespaceObject => "ModuleNamespaceObject",
+            JSType::ShadowRealm => "ShadowRealm",
+            JSType::RegExpObject => "RegExpObject",
+            JSType::JSDate => "JSDate",
+            JSType::ProxyObject => "ProxyObject",
+            JSType::Generator => "Generator",
+            JSType::AsyncGenerator => "AsyncGenerator",
+            JSType::JSArrayIterator => "JSArrayIterator",
+            JSType::Iterator => "Iterator",
+            JSType::IteratorHelper => "IteratorHelper",
+            JSType::MapIterator => "MapIterator",
+            JSType::SetIterator => "SetIterator",
+            JSType::StringIterator => "StringIterator",
+            JSType::WrapForValidIterator => "WrapForValidIterator",
+            JSType::RegExpStringIterator => "RegExpStringIterator",
+            JSType::JSPromise => "JSPromise",
+            JSType::Map => "Map",
+            JSType::Set => "Set",
+            JSType::WeakMap => "WeakMap",
+            JSType::WeakSet => "WeakSet",
+            JSType::WebAssemblyModule => "WebAssemblyModule",
+            JSType::WebAssemblyInstance => "WebAssemblyInstance",
+            JSType::WebAssemblyGCObject => "WebAssemblyGCObject",
+            JSType::StringObject => "StringObject",
+            JSType::DerivedStringObject => "DerivedStringObject",
+            JSType::Event => "Event",
+            JSType::DOMWrapper => "DOMWrapper",
+            JSType::JSAsJSONType => "JSAsJSONType",
+            _ => return None,
+        })
+    }
 
     /// `JSType` is a
     /// newtype-const (not a Rust `enum`), so there is no derived stringifier.

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -422,7 +422,11 @@ pub mod reader {
     }
 }
 
-pub(crate) fn ptr(global_this: &JSGlobalObject, _: JSValue, arguments: &[JSValue]) -> JSValue {
+pub(crate) fn ptr(
+    global_this: &JSGlobalObject,
+    _: JSValue,
+    arguments: &[JSValue],
+) -> JsResult<JSValue> {
     match arguments.len() {
         0 => ptr_(global_this, JSValue::ZERO, None),
         1 => ptr_(global_this, arguments[0], None),
@@ -430,30 +434,34 @@ pub(crate) fn ptr(global_this: &JSGlobalObject, _: JSValue, arguments: &[JSValue
     }
 }
 
-fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValue>) -> JSValue {
+fn ptr_(
+    global_this: &JSGlobalObject,
+    value: JSValue,
+    byte_offset: Option<JSValue>,
+) -> JsResult<JSValue> {
     if value.is_empty() {
-        return JSValue::NULL;
+        return Ok(JSValue::NULL);
     }
 
     let Some(array_buffer) = value.as_array_buffer(global_this) else {
-        return global_this.to_invalid_arguments(format_args!(
-            "Expected ArrayBufferView but received {:?}",
+        return Err(global_this.throw_invalid_arguments(format_args!(
+            "Expected ArrayBufferView but received {}",
             value.js_type()
-        ));
+        )));
     };
 
     if array_buffer.len == 0 {
-        return global_this.to_invalid_arguments(format_args!(
+        return Err(global_this.throw_invalid_arguments(format_args!(
             "ArrayBufferView must have a length > 0. A pointer to empty memory doesn't work"
-        ));
+        )));
     }
 
     let mut addr: usize = array_buffer.ptr as usize;
     if let Some(off) = byte_offset {
         if !off.is_empty_or_undefined_or_null() {
             if !off.is_number() {
-                return global_this
-                    .to_invalid_arguments(format_args!("Expected number for byteOffset"));
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("Expected number for byteOffset")));
             }
         }
 
@@ -466,29 +474,31 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
         }
 
         if addr > array_buffer.ptr as usize + array_buffer.byte_len as usize {
-            return global_this.to_invalid_arguments(format_args!("byteOffset out of bounds"));
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("byteOffset out of bounds"))
+            );
         }
     }
 
     if addr > MAX_ADDRESSABLE_MEMORY {
-        return global_this.to_invalid_arguments(format_args!(
+        return Err(global_this.throw_invalid_arguments(format_args!(
             "Pointer is outside max addressible memory, which usually means a bug in your program."
-        ));
+        )));
     }
 
     if addr == 0 {
-        return global_this.to_invalid_arguments(format_args!("Pointer must not be 0"));
+        return Err(global_this.throw_invalid_arguments(format_args!("Pointer must not be 0")));
     }
 
     if addr == 0xDEADBEEF || addr == 0xaaaaaaaa || addr == 0xAAAAAAAA {
-        return global_this.to_invalid_arguments(format_args!(
+        return Err(global_this.throw_invalid_arguments(format_args!(
             "ptr to invalid memory, that would segfault Bun :("
-        ));
+        )));
     }
 
     debug_assert!(JSValue::from_ptr_address(addr).as_ptr_address() == addr);
 
-    JSValue::from_ptr_address(addr)
+    Ok(JSValue::from_ptr_address(addr))
 }
 
 /// Resolves `(ptr, byteOffset, byteLength)` to a raw (ptr, len) over caller-owned FFI

--- a/src/runtime/ffi/mod.rs
+++ b/src/runtime/ffi/mod.rs
@@ -58,6 +58,7 @@ mod dom_call_slowpath {
     }
 
     dom_call_slowpath! {
+        FFI__ptr__slowpath       => ffi_object::ptr,
         Reader__u8__slowpath     => ffi_object::reader::u8,
         Reader__u16__slowpath    => ffi_object::reader::u16,
         Reader__u32__slowpath    => ffi_object::reader::u32,
@@ -70,26 +71,6 @@ mod dom_call_slowpath {
         Reader__intptr__slowpath => ffi_object::reader::intptr,
         Reader__f32__slowpath    => ffi_object::reader::f32,
         Reader__f64__slowpath    => ffi_object::reader::f64,
-    }
-
-    // `FFI.ptr` slowpath — body returns bare `JSValue` (errors are values, not
-    // exceptions), so no `to_js_host_call` mapping.
-    #[unsafe(no_mangle)]
-    #[bun_jsc::host_call]
-    fn FFI__ptr__slowpath(
-        global: *mut JSGlobalObject,
-        this_value: JSValue,
-        arguments_ptr: *const JSValue,
-        arguments_len: usize,
-    ) -> JSValue {
-        // SAFETY: see `dom_call_slowpath!` above.
-        let (global, arguments) = unsafe {
-            (
-                &*global,
-                core::slice::from_raw_parts(arguments_ptr, arguments_len),
-            )
-        };
-        ffi_object::ptr(global, this_value, arguments)
     }
 }
 

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from "bun:test";
 import { isMusl } from "harness";
 
 // Not `toThrow()`: it also accepts an Error that the function returns, which is
-// what `toBuffer()` and `toArrayBuffer()` did with their TypeError before they
-// threw it.
+// what `ptr()`, `toBuffer()` and `toArrayBuffer()` did with their TypeError
+// before they threw it.
 function thrownBy(fn: () => unknown): any {
   try {
     fn();
@@ -86,6 +86,26 @@ describe("CString argument errors", () => {
 });
 
 describe("FFI error messages", () => {
+  test.each([
+    ["hello", "String"],
+    [{}, "FinalObject"],
+    [[1, 2, 3], "Array"],
+    [() => {}, "JSFunction"],
+    [10n, "HeapBigInt"],
+    [new Date(0), "JSDate"],
+  ])("ptr(%p) throws a TypeError that names the received type", (value, typeName) => {
+    const err = thrownBy(() => ptr(value as any));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message).toBe(`Expected ArrayBufferView but received ${typeName}`);
+  });
+
+  test("ptr() throws for an empty ArrayBufferView", () => {
+    const err = thrownBy(() => ptr(new Uint8Array(0)));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.message).toBe("ArrayBufferView must have a length > 0. A pointer to empty memory doesn't work");
+  });
+
   test("dlopen shows library name when library cannot be opened", () => {
     // Try to open a non-existent library
     try {


### PR DESCRIPTION
### Problem
- `ptr("hello")` from `bun:ffi` reports `Expected ArrayBufferView but received JSType(2)`. The message formats `value.js_type()` with `{:?}`, and `JSType` (`src/jsc/JSType.rs`) is a `u8` newtype that only derives `Debug`. The Zig version printed `@tagName`, so the message read `received String`. The two macro coercion errors in `src/js_parser_jsc/Macro.rs:609` and `:882` have the same defect (`cannot coerce JSType(74) to Bun's AST`).
- `ptr()` did not throw that TypeError. It returned it as the call's value, so `try { ptr("hello") } catch {}` caught nothing. `FFI__ptr__slowpath` (`src/runtime/ffi/mod.rs`) returned the bare `JSValue` from `ptr_` without the `to_js_host_call` wrapper the `read.*` functions use.

### Fix
- `JSType::name()` maps every named tag to its name (`String`, `FinalObject`, `JSDate`, ...). `Display` and `Debug` print that name, and fall back to `JSType(<u8>)` for a tag the table does not know. The three messages use `{}`, and `typed_array_name()` reads from the same table instead of its own copy.
- `ptr_` returns `JsResult<JSValue>` and throws through `throw_invalid_arguments`. `FFI__ptr__slowpath` joins the `dom_call_slowpath!` list, so it goes through `to_js_host_call` like `Reader__*__slowpath`.
- Correct because `ptr()` is a plain host function (the `put` helper in `ZigGeneratedCode.cpp` installs `FFI__ptr__slowpathWrapper`, there is no DOMJIT fast path), so a pending exception is the normal way for it to fail. The types declare `ptr(): Pointer`, never an `Error`.
- Verified: `test/js/bun/ffi/ffi-error-messages.test.ts` (7 new tests, all fail on the current release). Also `test/js/bun/ffi/ffi.test.js`.

### Background
- `JSType` is the type byte in every JSC cell header. Rust reads it raw over FFI, so any `u8` must be a valid value. That is why it is a newtype with associated consts and not a Rust `enum`, and why it has no derived variant names.
- `to_invalid_arguments` creates an `ERR_INVALID_ARG_TYPE` TypeError and returns it as a value. `throw_invalid_arguments` creates the same error and sets it as the pending exception. A host function that wants JS to see a throw must use the second one and return empty.
- `to_js_host_call` runs a `JsResult` body inside an exception validation scope and turns `Err` into the empty `JSValue` that JSC expects from a throwing host function.

<details><summary>Notes</summary>

- `ptr(42)`, `ptr(true)`, `ptr(null)` and `ptr(undefined)` still say `received Cell`. `js_type()` returns `Cell` for a non-cell value, as the Zig `jsType()` did. This PR only restores the names the Zig version printed.
- `toBuffer()` and `toArrayBuffer()` had the same return-instead-of-throw quirk. #40751 fixed them on main. This branch is rebased on it; the only conflict was the shared `thrownBy` helper and the imports in `ffi-error-messages.test.ts`.
- Test helper: the new tests use a `try`/`catch` helper instead of `expect().toThrow()`. Bun's `toThrow()` also accepts a function that returns an Error, so it passed against the unfixed binary.
- Ran with the debug build: `ffi-error-messages.test.ts` 12 pass. `ffi.test.js` 143 pass, 5 timeouts in the `integer identities` and FTL subprocess tests at 5 s in the debug+ASAN build (they also time out there without this change).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/ffi/ffi-error-messages.test.ts

<!-- robobun:evidence:end -->

