### PR TITLE
Bun.serve: add development.allowedHosts for the dev server host check

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -234,6 +234,29 @@ Bun.serve({
 
 Bun sends the logs over the existing HMR WebSocket connection.
 
+### Allowed hosts
+
+In development, HTML routes, their bundled assets under `/_bun/*`, and the HMR WebSocket only answer requests whose `Host` header is `localhost`, a `*.localhost` name, an IP address, or the `hostname` you passed to `Bun.serve()`. Any other `Host` gets a `403 Forbidden` response. This stops a DNS rebinding attack, where a web page points its own domain at `127.0.0.1` and reads your bundled source code from the dev server.
+
+If you reach the dev server through another name, such as an mDNS name (`mybox.local`), a tunnel (ngrok, cloudflared), or an entry in `/etc/hosts`, list that name in `allowedHosts`.
+
+```ts title="src/backend.ts" icon="/icons/typescript.svg"
+import homepage from "./index.html";
+
+Bun.serve({
+  development: {
+    // Hostnames without a port. A leading "." also allows every subdomain.
+    allowedHosts: ["mybox.local", ".ngrok-free.app"],
+  },
+
+  routes: {
+    "/": homepage,
+  },
+});
+```
+
+A leading `.` trusts every subdomain of that domain, so only use it for domains you control or that a tunnel provider controls. Pass `allowedHosts: true` to turn the check off. This removes the DNS rebinding protection, so prefer an explicit list.
+
 ### Development vs Production
 
 | Feature             | Development           | Production  |

--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -255,7 +255,16 @@ Bun.serve({
 });
 ```
 
+The same option is available in `bunfig.toml`, which also covers `bun ./index.html`. A value passed to `Bun.serve()` takes precedence.
+
+```toml title="bunfig.toml" icon="settings"
+[serve.static]
+allowedHosts = ["mybox.local", ".ngrok-free.app"]
+```
+
 A leading `.` trusts every subdomain of that domain, so only use it for domains you control or that a tunnel provider controls. Pass `allowedHosts: true` to turn the check off. This removes the DNS rebinding protection, so prefer an explicit list.
+
+The tunnel or proxy must pass the `Host` header through unchanged. The HMR WebSocket also checks that the browser's `Origin` matches the request's `Host`, and `allowedHosts` does not change that check. If a proxy rewrites `Host` to `localhost`, the page loads without `allowedHosts`, but the HMR WebSocket is rejected because its `Origin` is the public name.
 
 ### Development vs Production
 

--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -366,6 +366,20 @@ Bun broadcasts each `console.log` or `console.error` call to the terminal that s
 
 Internally, Bun reuses the existing WebSocket connection from hot module replacement (HMR) to send the logs.
 
+## Reach the dev server by another name
+
+The dev server only answers requests whose `Host` header is `localhost`, a `*.localhost` name, an IP address, or the `--host` you passed. Any other `Host` gets a `403 Forbidden` response. This protects your bundled source code from DNS rebinding attacks.
+
+To open the dev server through an mDNS name (`mybox.local`), a tunnel (ngrok, cloudflared), or an entry in `/etc/hosts`, list that name in `bunfig.toml`:
+
+```toml title="bunfig.toml" icon="settings"
+[serve.static]
+# Hostnames without a port. A leading "." also allows every subdomain.
+allowedHosts = ["mybox.local", ".ngrok-free.app"]
+```
+
+`allowedHosts = true` turns the check off. This removes the DNS rebinding protection, so prefer an explicit list. In a `Bun.serve()` call, the same option is `development.allowedHosts`. See [Allowed hosts](/bundler/fullstack#allowed-hosts).
+
 ## Edit files in the browser
 
 Bun's frontend dev server supports Automatic Workspace Folders in Chrome DevTools, so you can save edits to files from the browser.

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -585,6 +585,33 @@ declare module "bun" {
            * @default true
            */
           chromeDevToolsAutomaticWorkspaceFolders?: boolean;
+
+          /**
+           * Extra `Host` header values the development server answers for.
+           *
+           * In development, HTML routes, their bundled assets under `/_bun/*`
+           * and the hot-reload WebSocket only answer requests whose `Host`
+           * header is `localhost`, a `*.localhost` name, an IP address, or
+           * the configured `hostname`. Other requests get a `403`. This
+           * protects the bundled source code from DNS rebinding attacks.
+           *
+           * Add the hostnames you use to reach the server through an mDNS
+           * name, a tunnel, or an `/etc/hosts` entry. An entry with a leading
+           * `.` allows that domain and every subdomain of it. Entries are
+           * hostnames without a port. Pass `true` to answer every `Host`,
+           * which removes the DNS rebinding protection.
+           *
+           * @example
+           * ```ts
+           * Bun.serve({
+           *   routes: { "/": homepage },
+           *   development: {
+           *     allowedHosts: ["mybox.local", ".ngrok-free.app"],
+           *   },
+           * });
+           * ```
+           */
+          allowedHosts?: string[] | true;
         };
 
     type HTTPMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS";

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -599,7 +599,12 @@ declare module "bun" {
            * name, a tunnel, or an `/etc/hosts` entry. An entry with a leading
            * `.` allows that domain and every subdomain of it. Entries are
            * hostnames without a port. Pass `true` to answer every `Host`,
-           * which removes the DNS rebinding protection.
+           * which removes the DNS rebinding protection. The HMR WebSocket
+           * still requires the `Origin` header to match the request's `Host`.
+           *
+           * The same option is `allowedHosts` under `[serve.static]` in
+           * `bunfig.toml`, which also applies to `bun ./index.html`. A value
+           * passed here takes precedence.
            *
            * @example
            * ```ts

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1609,6 +1609,42 @@ impl<'a> Parser<'a> {
             }
         }
 
+        if let Some(allowed_hosts) = serve_obj.get(b"allowedHosts") {
+            if let Some(v) = allowed_hosts.as_bool() {
+                self.ctx.args.serve_allowed_hosts = if v {
+                    api::AllowedHosts::Any
+                } else {
+                    api::AllowedHosts::BuiltIn
+                };
+            } else if let ExprData::EArray(arr) = &allowed_hosts.data {
+                let raw = arr.items.slice();
+                let mut hosts: Vec<Box<[u8]>> = Vec::with_capacity(raw.len());
+                for item in raw {
+                    self.expect_string(item)?;
+                    let host = estring_to_owned(
+                        item.data
+                            .e_string()
+                            .expect("infallible: variant checked")
+                            .get(),
+                        self.bump,
+                    );
+                    if !api::AllowedHosts::is_valid_entry(&host) {
+                        self.add_error(
+                            item.loc,
+                            b"Expected allowedHosts entry to be a hostname without a scheme, port, or path (a leading \".\" allows subdomains)",
+                        )?;
+                    }
+                    hosts.push(host);
+                }
+                self.ctx.args.serve_allowed_hosts = api::AllowedHosts::List(hosts);
+            } else {
+                self.add_error(
+                    allowed_hosts.loc,
+                    b"Expected allowedHosts to be an array of hostnames or true",
+                )?;
+            }
+        }
+
         if let Some(minify) = serve_obj.get(b"minify") {
             if let Some(v) = minify.as_bool() {
                 self.ctx.args.serve_minify_syntax = Some(v);

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -47,6 +47,34 @@ pub mod api {
             __ComptimeStringMap_UNHANDLED_REJECTIONS_MAP(());
     }
 
+    /// Which `Host` header values the dev server answers for. The built-in
+    /// list (`localhost`, `*.localhost`, IP literals, the bound `hostname`)
+    /// always applies; `[serve.static] allowedHosts` in bunfig.toml and
+    /// `development.allowedHosts` in `Bun.serve()` add to it or turn the
+    /// check off.
+    #[derive(Clone, Debug, Default)]
+    pub enum AllowedHosts {
+        #[default]
+        BuiltIn,
+        /// Hostnames without a port. An entry with a leading `.` allows that
+        /// domain and every subdomain of it.
+        List(Vec<Box<[u8]>>),
+        /// `allowedHosts = true`: every `Host` header is accepted.
+        Any,
+    }
+
+    impl AllowedHosts {
+        /// Both config parsers reject the same entries. `.` alone would match
+        /// every host with a trailing dot, an empty entry would match a
+        /// malformed `Host` header, and a scheme, port, path, or glob never
+        /// matches anything.
+        pub fn is_valid_entry(entry: &[u8]) -> bool {
+            !entry.is_empty()
+                && entry != b"."
+                && bun_core::strings::index_of_any(entry, b":/?#*\t\r\n ").is_none()
+        }
+    }
+
     /// The CLI/bunfig-populated option bag that `BundleOptions::from_api`
     /// projects into bundler options.
     ///
@@ -124,6 +152,8 @@ pub mod api {
         pub serve_splitting: bool,
         pub serve_public_path: Option<Box<[u8]>>,
         pub serve_hmr: Option<bool>,
+        /// `[serve.static] allowedHosts = ["mybox.local"]` or `= true`
+        pub serve_allowed_hosts: AllowedHosts,
         pub serve_define: Option<StringMap>,
         pub serve_sourcemap: Option<SourceMapMode>,
 

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -47,27 +47,22 @@ pub mod api {
             __ComptimeStringMap_UNHANDLED_REJECTIONS_MAP(());
     }
 
-    /// Which `Host` header values the dev server answers for. The built-in
-    /// list (`localhost`, `*.localhost`, IP literals, the bound `hostname`)
-    /// always applies; `[serve.static] allowedHosts` in bunfig.toml and
-    /// `development.allowedHosts` in `Bun.serve()` add to it or turn the
-    /// check off.
+    /// `allowedHosts` for the dev server's `Host` header check, from
+    /// `[serve.static]` in bunfig.toml or `development` in `Bun.serve()`.
     #[derive(Clone, Debug, Default)]
     pub enum AllowedHosts {
+        /// Only `localhost`, `*.localhost`, IP literals, and the bound `hostname`.
         #[default]
         BuiltIn,
-        /// Hostnames without a port. An entry with a leading `.` allows that
-        /// domain and every subdomain of it.
+        /// Hostnames without a port. A leading `.` also matches every subdomain.
         List(Vec<Box<[u8]>>),
         /// `allowedHosts = true`: every `Host` header is accepted.
         Any,
     }
 
     impl AllowedHosts {
-        /// Both config parsers reject the same entries. `.` alone would match
-        /// every host with a trailing dot, an empty entry would match a
-        /// malformed `Host` header, and a scheme, port, path, or glob never
-        /// matches anything.
+        /// Rejects `""` and `"."`, which would match a malformed `Host`, and
+        /// entries with a scheme, port, path, or glob, which never match.
         pub fn is_valid_entry(entry: &[u8]) -> bool {
             !entry.is_empty()
                 && entry != b"."

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1352,8 +1352,9 @@ pub(super) enum DevHandlerId {
 /// rebound origin (`attacker.com` → 127.0.0.1) presents `Host: attacker.com`;
 /// rejecting non-loopback / non-IP / non-configured hostnames prevents the
 /// attacker's page from reading bundled source via same-origin fetch.
-/// `development.allowedHosts` extends the list for names the developer
-/// trusts (mDNS names, tunnels, `/etc/hosts` entries).
+/// `development.allowedHosts` (or `[serve.static] allowedHosts`) extends the
+/// list for names the developer trusts (mDNS names, tunnels, `/etc/hosts`
+/// entries). It does not relax `is_allowed_dev_origin`.
 pub(crate) fn is_allowed_dev_host(dev: &DevServer, req: &Request) -> bool {
     is_allowed_host_header(req, dev.server.as_ref().map(|server| server.config()))
 }
@@ -1476,7 +1477,9 @@ fn host_forbidden(resp: AnyResponse) {
         resp.write_status(b"403 Forbidden");
         resp.end(
             b"Blocked: Host header does not match the dev server.\n\
-              To allow this hostname, add it to \"development.allowedHosts\" in Bun.serve().\n",
+              To allow this hostname, add it to allowedHosts: \
+              \"development.allowedHosts\" in Bun.serve(), \
+              or \"allowedHosts\" under [serve.static] in bunfig.toml.\n",
             false,
         );
     });

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1347,37 +1347,38 @@ pub(super) enum DevHandlerId {
     Request,
 }
 
-/// DNS-rebinding guard for `/_bun/...` internal routes and the Chrome
-/// DevTools `/.well-known/...` route. A rebound origin
-/// (`attacker.com` → 127.0.0.1) presents `Host: attacker.com`; rejecting
-/// non-loopback / non-IP / non-configured hostnames prevents the attacker's
-/// page from reading bundled source via same-origin fetch.
+/// DNS-rebinding guard for `/_bun/...` internal routes, the HMR WebSocket,
+/// the HTML routes, and the Chrome DevTools `/.well-known/...` route. A
+/// rebound origin (`attacker.com` → 127.0.0.1) presents `Host: attacker.com`;
+/// rejecting non-loopback / non-IP / non-configured hostnames prevents the
+/// attacker's page from reading bundled source via same-origin fetch.
+/// `development.allowedHosts` extends the list for names the developer
+/// trusts (mDNS names, tunnels, `/etc/hosts` entries).
 pub(crate) fn is_allowed_dev_host(dev: &DevServer, req: &Request) -> bool {
-    is_allowed_host_header(
-        req,
-        dev.server.as_ref().map(|server| &server.config().address),
-    )
+    is_allowed_host_header(req, dev.server.as_ref().map(|server| server.config()))
 }
 
 pub(crate) fn is_allowed_host_header(
     req: &Request,
-    address: Option<&crate::server::server_config::Address>,
+    config: Option<&crate::server::server_config::ServerConfig>,
 ) -> bool {
+    use crate::server::server_config::{Address, AllowedHosts};
+
+    let allowed_hosts = config.map(|config| &config.allowed_hosts);
+    if matches!(allowed_hosts, Some(AllowedHosts::Any)) {
+        return true;
+    }
     let Some(host) = req.header(b"host") else {
         return false;
     };
     let host = host_without_port(host);
+    if host.is_empty() {
+        return false;
+    }
     if strings::eql_case_insensitive_ascii(host, b"localhost", true) {
         return true;
     }
-    const DOT_LOCALHOST: &[u8] = b".localhost";
-    if host.len() > DOT_LOCALHOST.len()
-        && strings::eql_case_insensitive_ascii(
-            &host[host.len() - DOT_LOCALHOST.len()..],
-            DOT_LOCALHOST,
-            true,
-        )
-    {
+    if has_domain_suffix(host, b".localhost") {
         return true;
     }
     let ip = if host.first() == Some(&b'[') && host.last() == Some(&b']') {
@@ -1388,13 +1389,33 @@ pub(crate) fn is_allowed_host_header(
     if bun_core::ip_address::is_ip_address(ip) {
         return true;
     }
-    if let Some(crate::server::server_config::Address::Tcp {
+    if let Some(Address::Tcp {
         hostname: Some(h), ..
-    }) = address
+    }) = config.map(|config| &config.address)
     {
-        return strings::eql_case_insensitive_ascii(host, h.as_bytes(), true);
+        if strings::eql_case_insensitive_ascii(host, h.as_bytes(), true) {
+            return true;
+        }
+    }
+    if let Some(AllowedHosts::List(list)) = allowed_hosts {
+        return list.iter().any(|entry| {
+            if entry.first() == Some(&b'.') {
+                strings::eql_case_insensitive_ascii(host, &entry[1..], true)
+                    || has_domain_suffix(host, entry)
+            } else {
+                strings::eql_case_insensitive_ascii(host, entry, true)
+            }
+        });
     }
     false
+}
+
+/// `host` ends with `suffix` (which starts with `.`) and has at least one
+/// label before it: `a.example.com` matches `.example.com`, `.example.com`
+/// alone does not.
+fn has_domain_suffix(host: &[u8], suffix: &[u8]) -> bool {
+    host.len() > suffix.len()
+        && strings::eql_case_insensitive_ascii(&host[host.len() - suffix.len()..], suffix, true)
 }
 
 /// `host[":" port]` / `"[" v6 "]" [":" port]` → host (brackets retained for IPv6).
@@ -1437,16 +1458,8 @@ fn is_allowed_dev_origin(req: &Request) -> bool {
         return false;
     };
     let origin_host = host_without_port(&origin[scheme_end + 3..]);
-    if strings::eql_case_insensitive_ascii(origin_host, b"localhost", true) {
-        return true;
-    }
-    const DOT_LOCALHOST: &[u8] = b".localhost";
-    if origin_host.len() > DOT_LOCALHOST.len()
-        && strings::eql_case_insensitive_ascii(
-            &origin_host[origin_host.len() - DOT_LOCALHOST.len()..],
-            DOT_LOCALHOST,
-            true,
-        )
+    if strings::eql_case_insensitive_ascii(origin_host, b"localhost", true)
+        || has_domain_suffix(origin_host, b".localhost")
     {
         return true;
     }
@@ -1461,7 +1474,11 @@ fn is_allowed_dev_origin(req: &Request) -> bool {
 fn host_forbidden(resp: AnyResponse) {
     resp.corked(move || {
         resp.write_status(b"403 Forbidden");
-        resp.end(b"Blocked: Host header does not match the dev server", false);
+        resp.end(
+            b"Blocked: Host header does not match the dev server.\n\
+              To allow this hostname, add it to \"development.allowedHosts\" in Bun.serve().\n",
+            false,
+        );
     });
 }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1352,9 +1352,7 @@ pub(super) enum DevHandlerId {
 /// rebound origin (`attacker.com` → 127.0.0.1) presents `Host: attacker.com`;
 /// rejecting non-loopback / non-IP / non-configured hostnames prevents the
 /// attacker's page from reading bundled source via same-origin fetch.
-/// `development.allowedHosts` (or `[serve.static] allowedHosts`) extends the
-/// list for names the developer trusts (mDNS names, tunnels, `/etc/hosts`
-/// entries). It does not relax `is_allowed_dev_origin`.
+/// `allowedHosts` extends the list; it does not relax `is_allowed_dev_origin`.
 pub(crate) fn is_allowed_dev_host(dev: &DevServer, req: &Request) -> bool {
     is_allowed_host_header(req, dev.server.as_ref().map(|server| server.config()))
 }
@@ -1411,9 +1409,7 @@ pub(crate) fn is_allowed_host_header(
     false
 }
 
-/// `host` ends with `suffix` (which starts with `.`) and has at least one
-/// label before it: `a.example.com` matches `.example.com`, `.example.com`
-/// alone does not.
+/// `a.example.com` matches `.example.com`; `.example.com` alone does not.
 fn has_domain_suffix(host: &[u8], suffix: &[u8]) -> bool {
     host.len() > suffix.len()
         && strings::eql_case_insensitive_ascii(&host[host.len() - suffix.len()..], suffix, true)

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -39,6 +39,9 @@ pub struct ServerConfig {
     pub(crate) max_request_body_size: usize,
     pub(crate) development: DevelopmentOption,
     pub(crate) broadcast_console_log_from_browser_to_server_for_bake: bool,
+    /// `development.allowedHosts`: extra `Host` header values the dev server
+    /// answers for. See `bake::is_allowed_host_header`.
+    pub(crate) allowed_hosts: AllowedHosts,
 
     /// Enable automatic workspace folders for Chrome DevTools
     /// https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
@@ -87,6 +90,7 @@ impl Default for ServerConfig {
             max_request_body_size: 1024 * 1024 * 128,
             development: DevelopmentOption::Development,
             broadcast_console_log_from_browser_to_server_for_bake: false,
+            allowed_hosts: AllowedHosts::BuiltIn,
             enable_chrome_devtools_automatic_workspace_folders: true,
             on_error: JSValue::ZERO,
             on_request: JSValue::ZERO,
@@ -143,6 +147,60 @@ impl DevelopmentOption {
 
     pub(crate) fn is_development(self) -> bool {
         self == DevelopmentOption::Development || self == DevelopmentOption::DevelopmentWithoutHmr
+    }
+}
+
+/// Which `Host` header values the dev server answers for. The built-in list
+/// (`localhost`, `*.localhost`, IP literals, the bound `hostname`) always
+/// applies; `development.allowedHosts` adds to it or turns the check off.
+#[derive(Default)]
+pub enum AllowedHosts {
+    #[default]
+    BuiltIn,
+    /// Hostnames without a port. An entry with a leading `.` allows that
+    /// domain and every subdomain of it.
+    List(Vec<Box<[u8]>>),
+    /// `allowedHosts: true`: every `Host` header is accepted.
+    Any,
+}
+
+impl AllowedHosts {
+    fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<AllowedHosts> {
+        const EXPECTED: &str =
+            "Bun.serve() expects 'development.allowedHosts' to be an array of hostnames or true";
+        if value.is_boolean() {
+            return Ok(if value == JSValue::TRUE {
+                AllowedHosts::Any
+            } else {
+                AllowedHosts::BuiltIn
+            });
+        }
+        if !value.is_cell() || !value.js_type().is_array() {
+            return Err(global.throw_invalid_arguments(format_args!("{EXPECTED}")));
+        }
+        let mut iter = value.array_iterator(global)?;
+        let mut hosts: Vec<Box<[u8]>> = Vec::new();
+        while let Some(item) = iter.next()? {
+            if !item.is_string() {
+                return Err(global.throw_invalid_arguments(format_args!("{EXPECTED}")));
+            }
+            let host = item.to_utf8(global)?;
+            // `.` alone would match every host with a trailing dot, and an
+            // empty entry would match a malformed `Host` header. A scheme,
+            // port, or path never matches anything, so reject those early.
+            if host.is_empty()
+                || &*host == b"."
+                || strings::index_of_any(&host, b":/?#*\t\r\n ").is_some()
+            {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "Bun.serve() expects each entry of 'development.allowedHosts' to be a hostname \
+                     without a scheme, port, or path (a leading \".\" allows subdomains), got \"{}\"",
+                    bstr::BStr::new(&*host),
+                )));
+            }
+            hosts.push(Box::<[u8]>::from(&*host));
+        }
+        Ok(AllowedHosts::List(hosts))
     }
 }
 
@@ -278,6 +336,7 @@ impl ServerConfig {
             development: self.development,
             broadcast_console_log_from_browser_to_server_for_bake: self
                 .broadcast_console_log_from_browser_to_server_for_bake,
+            allowed_hosts: core::mem::take(&mut self.allowed_hosts),
             enable_chrome_devtools_automatic_workspace_folders: self
                 .enable_chrome_devtools_automatic_workspace_folders,
             on_error: self.on_error,
@@ -710,6 +769,12 @@ impl ServerConfig {
                     dev.get_boolean_strict(global, "chromeDevToolsAutomaticWorkspaceFolders")?
                 {
                     args.enable_chrome_devtools_automatic_workspace_folders = v;
+                }
+
+                if let Some(v) = dev.get(global, "allowedHosts")? {
+                    if !v.is_undefined_or_null() {
+                        args.allowed_hosts = AllowedHosts::from_js(global, v)?;
+                    }
                 }
             } else {
                 args.development = if dev.to_boolean() {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -40,9 +40,7 @@ pub struct ServerConfig {
     pub(crate) max_request_body_size: usize,
     pub(crate) development: DevelopmentOption,
     pub(crate) broadcast_console_log_from_browser_to_server_for_bake: bool,
-    /// Extra `Host` header values the dev server answers for, from
-    /// `[serve.static] allowedHosts` or `development.allowedHosts`. See
-    /// `bake::is_allowed_host_header`.
+    /// `[serve.static] allowedHosts`, overridden by `development.allowedHosts`.
     pub(crate) allowed_hosts: AllowedHosts,
 
     /// Enable automatic workspace folders for Chrome DevTools
@@ -176,8 +174,8 @@ fn allowed_hosts_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Al
         if !AllowedHosts::is_valid_entry(&host) {
             return Err(global.throw_invalid_arguments(format_args!(
                 "Bun.serve() expects each entry of 'development.allowedHosts' to be a hostname \
-                 without a scheme, port, or path (a leading \".\" allows subdomains), got \"{}\"",
-                bstr::BStr::new(&*host),
+                 without a scheme, port, or path (a leading \".\" allows subdomains), got {}",
+                bun_fmt::quote(&host),
             )));
         }
         hosts.push(Box::<[u8]>::from(&*host));

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -17,6 +17,7 @@ use super::web_socket_server_context::WebSocketServerContext;
 use super::{AnyRoute, AnyServer};
 use crate::server::jsc::{JSGlobalObject, JSPropertyIterator, JSValue, JsResult, Strong};
 use bun_core::fmt as bun_fmt;
+pub use bun_options_types::schema::api::AllowedHosts;
 
 pub use crate::socket::ssl_config::SSLConfig;
 use crate::socket::ssl_config::SSLConfigFromJs;
@@ -39,8 +40,9 @@ pub struct ServerConfig {
     pub(crate) max_request_body_size: usize,
     pub(crate) development: DevelopmentOption,
     pub(crate) broadcast_console_log_from_browser_to_server_for_bake: bool,
-    /// `development.allowedHosts`: extra `Host` header values the dev server
-    /// answers for. See `bake::is_allowed_host_header`.
+    /// Extra `Host` header values the dev server answers for, from
+    /// `[serve.static] allowedHosts` or `development.allowedHosts`. See
+    /// `bake::is_allowed_host_header`.
     pub(crate) allowed_hosts: AllowedHosts,
 
     /// Enable automatic workspace folders for Chrome DevTools
@@ -150,58 +152,37 @@ impl DevelopmentOption {
     }
 }
 
-/// Which `Host` header values the dev server answers for. The built-in list
-/// (`localhost`, `*.localhost`, IP literals, the bound `hostname`) always
-/// applies; `development.allowedHosts` adds to it or turns the check off.
-#[derive(Default)]
-pub enum AllowedHosts {
-    #[default]
-    BuiltIn,
-    /// Hostnames without a port. An entry with a leading `.` allows that
-    /// domain and every subdomain of it.
-    List(Vec<Box<[u8]>>),
-    /// `allowedHosts: true`: every `Host` header is accepted.
-    Any,
-}
-
-impl AllowedHosts {
-    fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<AllowedHosts> {
-        const EXPECTED: &str =
-            "Bun.serve() expects 'development.allowedHosts' to be an array of hostnames or true";
-        if value.is_boolean() {
-            return Ok(if value == JSValue::TRUE {
-                AllowedHosts::Any
-            } else {
-                AllowedHosts::BuiltIn
-            });
-        }
-        if !value.is_cell() || !value.js_type().is_array() {
+/// `development.allowedHosts`: `true`, or an array of hostnames.
+fn allowed_hosts_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<AllowedHosts> {
+    const EXPECTED: &str =
+        "Bun.serve() expects 'development.allowedHosts' to be an array of hostnames or true";
+    if value.is_boolean() {
+        return Ok(if value == JSValue::TRUE {
+            AllowedHosts::Any
+        } else {
+            AllowedHosts::BuiltIn
+        });
+    }
+    if !value.is_cell() || !value.js_type().is_array() {
+        return Err(global.throw_invalid_arguments(format_args!("{EXPECTED}")));
+    }
+    let mut iter = value.array_iterator(global)?;
+    let mut hosts: Vec<Box<[u8]>> = Vec::new();
+    while let Some(item) = iter.next()? {
+        if !item.is_string() {
             return Err(global.throw_invalid_arguments(format_args!("{EXPECTED}")));
         }
-        let mut iter = value.array_iterator(global)?;
-        let mut hosts: Vec<Box<[u8]>> = Vec::new();
-        while let Some(item) = iter.next()? {
-            if !item.is_string() {
-                return Err(global.throw_invalid_arguments(format_args!("{EXPECTED}")));
-            }
-            let host = item.to_utf8(global)?;
-            // `.` alone would match every host with a trailing dot, and an
-            // empty entry would match a malformed `Host` header. A scheme,
-            // port, or path never matches anything, so reject those early.
-            if host.is_empty()
-                || &*host == b"."
-                || strings::index_of_any(&host, b":/?#*\t\r\n ").is_some()
-            {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Bun.serve() expects each entry of 'development.allowedHosts' to be a hostname \
-                     without a scheme, port, or path (a leading \".\" allows subdomains), got \"{}\"",
-                    bstr::BStr::new(&*host),
-                )));
-            }
-            hosts.push(Box::<[u8]>::from(&*host));
+        let host = item.to_utf8(global)?;
+        if !AllowedHosts::is_valid_entry(&host) {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Bun.serve() expects each entry of 'development.allowedHosts' to be a hostname \
+                 without a scheme, port, or path (a leading \".\" allows subdomains), got \"{}\"",
+                bstr::BStr::new(&*host),
+            )));
         }
-        Ok(AllowedHosts::List(hosts))
+        hosts.push(Box::<[u8]>::from(&*host));
     }
+    Ok(AllowedHosts::List(hosts))
 }
 
 impl ServerConfig {
@@ -687,6 +668,12 @@ impl ServerConfig {
             } else {
                 DevelopmentOption::Development
             },
+            allowed_hosts: vm
+                .transpiler
+                .options
+                .transform_options
+                .serve_allowed_hosts
+                .clone(),
 
             // If this is a node:cluster child, let's default to SO_REUSEPORT.
             // That way you don't have to remember to set reusePort: true in Bun.serve() when using node:cluster.
@@ -773,7 +760,7 @@ impl ServerConfig {
 
                 if let Some(v) = dev.get(global, "allowedHosts")? {
                     if !v.is_undefined_or_null() {
-                        args.allowed_hosts = AllowedHosts::from_js(global, v)?;
+                        args.allowed_hosts = allowed_hosts_from_js(global, v)?;
                     }
                 }
             } else {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2691,7 +2691,7 @@ where
     ) {
         jsc::mark_binding!();
         if !matches!(self.config.address, server_config::Address::Unix(_))
-            && (!bake::is_allowed_host_header(req, Some(&self.config.address))
+            && (!bake::is_allowed_host_header(req, Some(&self.config))
                 || !resp
                     .get_remote_socket_info()
                     .is_some_and(|address| address.is_loopback()))

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -346,11 +346,12 @@ function hmrHandshakeStatus(dev: Dev, host: string, origin = `http://${host}`): 
   socket.on("data", chunk => {
     received += chunk;
     if (received.includes("\r\n\r\n")) {
-      socket.destroy();
       resolve(received.split("\r\n")[0]);
+      socket.destroy();
     }
   });
   socket.on("error", reject);
+  socket.on("close", () => reject(new Error(`socket closed before the response ended: ${JSON.stringify(received)}`)));
   return promise;
 }
 

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -1,5 +1,6 @@
 // HTML tests are tests relating to HTML files themselves.
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import net from "node:net";
 import { type Dev, devTest, emptyHtmlFile } from "../bake-harness";
 
@@ -323,14 +324,18 @@ devTest("error report endpoint rejects requests whose origin header does not mat
   },
 });
 
-/** Status line of a raw `/_bun/hmr` WebSocket handshake sent with the given `Host`. */
-function hmrHandshakeStatus(dev: Dev, host: string): Promise<string> {
+/**
+ * Status line of a raw `/_bun/hmr` WebSocket handshake sent with the given
+ * `Host`. `Origin` defaults to the same host, the way a browser sends it for a
+ * page served by this dev server.
+ */
+function hmrHandshakeStatus(dev: Dev, host: string, origin = `http://${host}`): Promise<string> {
   const { promise, resolve, reject } = Promise.withResolvers<string>();
   const socket = net.connect(dev.port, "127.0.0.1", () => {
     socket.write(
       `GET /_bun/hmr HTTP/1.1\r\n` +
         `Host: ${host}\r\n` +
-        `Origin: http://${host}\r\n` +
+        `Origin: ${origin}\r\n` +
         `Upgrade: websocket\r\n` +
         `Connection: Upgrade\r\n` +
         `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n` +
@@ -405,7 +410,13 @@ devTest("development.allowedHosts lets the dev server answer for extra hostnames
       const res = await dev.fetch("/", { headers: { Host: host } });
       expect(await res.text()).toContain("<h1>Allowed Hosts</h1>");
       expect(res.status).toBe(200);
+      expect(await hmrHandshakeStatus(dev, host)).toBe("HTTP/1.1 101 Switching Protocols");
     }
+
+    // The Origin check is separate: a page on another origin cannot open the
+    // HMR socket through an allowed host, not even one that the list allows.
+    expect(await hmrHandshakeStatus(dev, "mybox.local", "http://other-page.example")).toBe("HTTP/1.1 403 Forbidden");
+    expect(await hmrHandshakeStatus(dev, "mybox.local", "http://evil.tunnel.example")).toBe("HTTP/1.1 403 Forbidden");
 
     // Every other hostname is still blocked, and the response says how to allow it.
     for (const host of ["nottunnel.example", "mybox.local.example", "rebound-host.example"]) {
@@ -461,7 +472,71 @@ devTest("development.allowedHosts: true turns the host check off", {
     const script = await dev.fetch(scriptUrl, { headers: { Host: "any-host.example" } });
     expect(script.status).toBe(200);
     expect(await hmrHandshakeStatus(dev, "any-host.example")).toBe("HTTP/1.1 101 Switching Protocols");
+
+    // `true` only turns the Host check off. The Origin check still applies.
+    expect(await hmrHandshakeStatus(dev, "any-host.example", "http://other-page.example")).toBe(
+      "HTTP/1.1 403 Forbidden",
+    );
   },
+});
+
+devTest("[serve.static] allowedHosts in bunfig.toml configures the dev server host check", {
+  files: {
+    "bunfig.toml": `
+      [serve.static]
+      allowedHosts = ["mybox.local", ".tunnel.example"]
+    `,
+    "index.html": emptyHtmlFile({
+      scripts: ["/script.ts"],
+      body: "<h1>Bunfig Hosts</h1>",
+    }),
+    "script.ts": `
+      console.log("hello");
+    `,
+  },
+  async test(dev) {
+    // The harness-generated bun.app.ts has no `development` object, so the
+    // bunfig value is what the server uses.
+    for (const host of ["mybox.local", "a.tunnel.example"]) {
+      const page = await dev.fetch("/", { headers: { Host: host } });
+      const pageText = await page.text();
+      expect(pageText).toContain("<h1>Bunfig Hosts</h1>");
+      expect(page.status).toBe(200);
+      const [, scriptUrl] = pageText.match(/src="(\/_bun\/client\/[^"]+)"/)!;
+      const script = await dev.fetch(scriptUrl, { headers: { Host: host } });
+      expect(script.status).toBe(200);
+      expect(await hmrHandshakeStatus(dev, host)).toBe("HTTP/1.1 101 Switching Protocols");
+    }
+
+    const blocked = await dev.fetch("/", { headers: { Host: "rebound-host.example" } });
+    expect(await blocked.text()).toContain("bunfig.toml");
+    expect(blocked.status).toBe(403);
+  },
+});
+
+test("[serve.static] allowedHosts rejects values that are not hostnames", async () => {
+  using dir = tempDir("allowed-hosts-bunfig", {
+    "bunfig.toml": `
+      [serve.static]
+      allowedHosts = ["http://mybox.local"]
+    `,
+    "index.ts": `
+      console.log("unreachable");
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain(
+    'Expected allowedHosts entry to be a hostname without a scheme, port, or path (a leading "." allows subdomains)',
+  );
+  expect(exitCode).toBe(1);
 });
 
 test("development.allowedHosts rejects values that are not hostnames", () => {

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -1,5 +1,7 @@
 // HTML tests are tests relating to HTML files themselves.
-import { devTest, emptyHtmlFile } from "../bake-harness";
+import { expect, test } from "bun:test";
+import net from "node:net";
+import { type Dev, devTest, emptyHtmlFile } from "../bake-harness";
 
 devTest("html file is watched", {
   files: {
@@ -319,6 +321,172 @@ devTest("error report endpoint rejects requests whose origin header does not mat
 
     await dev.fetch("/").expect.toInclude("<h1>Origin Check</h1>");
   },
+});
+
+/** Status line of a raw `/_bun/hmr` WebSocket handshake sent with the given `Host`. */
+function hmrHandshakeStatus(dev: Dev, host: string): Promise<string> {
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const socket = net.connect(dev.port, "127.0.0.1", () => {
+    socket.write(
+      `GET /_bun/hmr HTTP/1.1\r\n` +
+        `Host: ${host}\r\n` +
+        `Origin: http://${host}\r\n` +
+        `Upgrade: websocket\r\n` +
+        `Connection: Upgrade\r\n` +
+        `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n` +
+        `Sec-WebSocket-Version: 13\r\n\r\n`,
+    );
+  });
+  let received = "";
+  socket.on("data", chunk => {
+    received += chunk;
+    if (received.includes("\r\n\r\n")) {
+      socket.destroy();
+      resolve(received.split("\r\n")[0]);
+    }
+  });
+  socket.on("error", reject);
+  return promise;
+}
+
+devTest("development.allowedHosts lets the dev server answer for extra hostnames", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["/style.css"],
+      scripts: ["/script.ts"],
+      body: "<h1>Allowed Hosts</h1>",
+    }),
+    "style.css": `
+      h1 { color: red; }
+    `,
+    "script.ts": `
+      console.log("hello");
+    `,
+    // The harness-generated bun.app.ts has no `development` object, so
+    // provide one directly. `htmlFiles: []` tells the harness not to
+    // generate its own config from index.html.
+    "bun.app.ts": `
+      import html from "./index.html";
+      export default {
+        static: {
+          "/": html,
+        },
+        development: {
+          allowedHosts: ["mybox.local", ".tunnel.example"],
+        },
+        fetch(req) {
+          return new Response("Not Found", { status: 404 });
+        },
+      };
+    `,
+  },
+  htmlFiles: [],
+  async test(dev) {
+    // Hostnames match case-insensitively and without the port.
+    const page = await dev.fetch("/", { headers: { Host: "MYBOX.local:3000" } });
+    const pageText = await page.text();
+    expect(pageText).toContain("<h1>Allowed Hosts</h1>");
+    expect(page.status).toBe(200);
+
+    // The script and stylesheet the page references load under that host too,
+    // as does the HMR WebSocket.
+    const [, scriptUrl] = pageText.match(/src="(\/_bun\/client\/[^"]+)"/)!;
+    const [, styleUrl] = pageText.match(/href="(\/_bun\/asset\/[^"]+)"/)!;
+    const script = await dev.fetch(scriptUrl, { headers: { Host: "mybox.local" } });
+    expect(await script.text()).toContain('console.log("hello")');
+    expect(script.status).toBe(200);
+    const style = await dev.fetch(styleUrl, { headers: { Host: "mybox.local" } });
+    expect(await style.text()).toContain("color: red");
+    expect(style.status).toBe(200);
+    expect(await hmrHandshakeStatus(dev, "mybox.local")).toBe("HTTP/1.1 101 Switching Protocols");
+
+    // A leading "." allows the domain itself and every subdomain.
+    for (const host of ["tunnel.example", "a.b.tunnel.example"]) {
+      const res = await dev.fetch("/", { headers: { Host: host } });
+      expect(await res.text()).toContain("<h1>Allowed Hosts</h1>");
+      expect(res.status).toBe(200);
+    }
+
+    // Every other hostname is still blocked, and the response says how to allow it.
+    for (const host of ["nottunnel.example", "mybox.local.example", "rebound-host.example"]) {
+      const res = await dev.fetch("/", { headers: { Host: host } });
+      const text = await res.text();
+      expect(text).not.toContain("/_bun/client/");
+      expect(text).toContain("development.allowedHosts");
+      expect(res.status).toBe(403);
+      const blockedScript = await dev.fetch(scriptUrl, { headers: { Host: host } });
+      expect(blockedScript.status).toBe(403);
+    }
+    expect(await hmrHandshakeStatus(dev, "rebound-host.example")).toBe("HTTP/1.1 403 Forbidden");
+
+    // The built-in list still applies.
+    const local = await dev.fetch("/", { headers: { Host: "app.localhost" } });
+    expect(await local.text()).toContain("<h1>Allowed Hosts</h1>");
+    expect(local.status).toBe(200);
+  },
+});
+
+devTest("development.allowedHosts: true turns the host check off", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["/script.ts"],
+      body: "<h1>Any Host</h1>",
+    }),
+    "script.ts": `
+      console.log("hello");
+    `,
+    "bun.app.ts": `
+      import html from "./index.html";
+      export default {
+        static: {
+          "/": html,
+        },
+        development: {
+          allowedHosts: true,
+        },
+        fetch(req) {
+          return new Response("Not Found", { status: 404 });
+        },
+      };
+    `,
+  },
+  htmlFiles: [],
+  async test(dev) {
+    const page = await dev.fetch("/", { headers: { Host: "any-host.example" } });
+    const pageText = await page.text();
+    expect(pageText).toContain("<h1>Any Host</h1>");
+    expect(page.status).toBe(200);
+
+    const [, scriptUrl] = pageText.match(/src="(\/_bun\/client\/[^"]+)"/)!;
+    const script = await dev.fetch(scriptUrl, { headers: { Host: "any-host.example" } });
+    expect(script.status).toBe(200);
+    expect(await hmrHandshakeStatus(dev, "any-host.example")).toBe("HTTP/1.1 101 Switching Protocols");
+  },
+});
+
+test("development.allowedHosts rejects values that are not hostnames", () => {
+  const serve = (allowedHosts: unknown) => {
+    const server = Bun.serve({
+      port: 0,
+      development: { allowedHosts } as any,
+      fetch() {
+        return new Response("unreachable");
+      },
+    });
+    // Only reached when the option was accepted, which fails the assertion below.
+    server.stop(true);
+  };
+  expect(() => serve("mybox.local")).toThrow(
+    "Bun.serve() expects 'development.allowedHosts' to be an array of hostnames or true",
+  );
+  expect(() => serve([42])).toThrow(
+    "Bun.serve() expects 'development.allowedHosts' to be an array of hostnames or true",
+  );
+  for (const entry of ["", ".", "http://mybox.local", "mybox.local:3000", "mybox.local/app", "*.tunnel.example"]) {
+    expect(() => serve([entry])).toThrow(
+      `Bun.serve() expects each entry of 'development.allowedHosts' to be a hostname without a scheme, port, or path (a leading "." allows subdomains), got "${entry}"`,
+    );
+  }
 });
 
 devTest("error report endpoint blanks stray non-text bytes in reported frames", {


### PR DESCRIPTION
### Problem
- In development, `Bun.serve({ routes: { "/": html } })` and `bun ./index.html` answer `403 Blocked: Host header does not match the dev server` for any `Host` that is not `localhost`, `*.localhost`, an IP literal, or the configured `hostname`. mDNS names (`mybox.local`), tunnels, and `/etc/hosts` names cannot reach the app, and there is no way to allow one.
- The check (`is_allowed_host_header`, `src/runtime/bake/DevServer.rs:1362`) guards the HTML route, `/_bun/*`, the HMR WebSocket, and the DevTools json route against DNS rebinding. Dropping it from the HTML route alone does not help: the page's `/_bun/client/*.js` and `/_bun/asset/*.css` tags still get 403, so the user sees a blank page.

### Fix
- Add an `allowedHosts` option: an array of hostnames, or `true` to turn the check off. An entry with a leading `.` allows that domain and every subdomain. Entries with a scheme, port, path, or `*` are rejected. It is set as `development.allowedHosts` in `Bun.serve()`, or as `[serve.static] allowedHosts` in `bunfig.toml` (which also covers `bun ./index.html`). The `Bun.serve()` value takes precedence, the same way `hmr` works today.
- `AllowedHosts` lives in `bun_options_types` so bunfig and `Bun.serve()` share the type and the entry validation. The bunfig value seeds `ServerConfig.allowed_hosts`, and the one shared check reads it, so the list applies to every guarded route at once. The built-in list and the `Origin` check are unchanged, so the default behavior is the same as before.
- The 403 body now names both places to set the option. It does not echo request data.
- Verified: `test/bake/dev/html.test.ts` (five new tests, all fail on the released bun). Also the rest of `html.test.ts`, the host and origin tests in `test/bake/dev/esm.test.ts`, and `test/integration/bun-types/bun-types.test.ts`.

### Background
- DNS rebinding: a page on `attacker.com` points its own DNS record at `127.0.0.1` after it loads. Its `fetch("/_bun/client/...")` is same-origin for the browser, reaches the local dev server, and carries `Host: attacker.com`. Refusing unknown `Host` values is the standard defense (Vite `server.allowedHosts`, webpack-dev-server `allowedHosts`).
- The check cannot be made host-agnostic without config: a rebound name resolves to the loopback address on the server side too, and the request comes from the loopback address like a legitimate one.
- The `Origin` check (`is_allowed_dev_origin`) is a separate guard for the WebSocket and `POST /_bun/*` routes. `allowedHosts` does not extend it, on purpose: a page hosted on any allowed origin (for example another tenant of a tunnel domain listed with a leading `.`) could otherwise open the HMR socket and read hot-update payloads. The tests pin this for both a list and `true`.

<details><summary>Notes</summary>

Repro on the released bun (1.4.1) with `routes: { "/": html, "/api": handler }` and `development: true`:

```
Host: mybox.local  GET /                        403
Host: mybox.local  GET /api                     200  (user routes were never checked)
Host: mybox.local  GET /_bun/client/index-*.js  403
Host: mybox.local  GET /_bun/asset/*.css        403
```

With `allowedHosts: ["mybox.local", ".tunnel.example"]` on this branch: `mybox.local`, `MYBOX.LOCAL:3000`, `tunnel.example`, `a.b.tunnel.example` get 200 on the page, the script, the stylesheet, and the `/_bun/hmr` upgrade (`101`). `nottunnel.example`, `attacker.example` stay 403. A handshake for an allowed host with a foreign `Origin` stays 403.

Matching is case-insensitive ASCII on the `Host` value without its port. A malformed `Host` yields an empty host, which fails before the list is consulted. Entries that are empty or `.` are rejected at config time so they cannot match that case.

`bunfig.toml` precedence, checked by hand: bunfig `["bunfig.example"]` alone allows that name. With `development: { allowedHosts: ["js.example"] }` in the same process, only `js.example` is allowed. bunfig `allowedHosts = true` allows every name. A bad bunfig value prints the usual bunfig error with the file location and exits.

`server.reload()` does not change `development` options today, and `allowedHosts` follows the same rule.

A proxy that rewrites `Host` to `localhost` serves the page without `allowedHosts`, but the HMR WebSocket is rejected by the `Origin` check because its `Origin` is the public name. That is pre-existing and documented now.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/html.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/11] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/11] gen cpp.rs (cppbind)
[2/11] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static-C
... (truncated)

release without fix: 6 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-qz8WsL
[0;30mdev|[0m Started development server: http://localhost:42517
[0;30mdev|[0m [32mBundled page in 3ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 2ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 2ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 2ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 1ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:html-1: html file is watched [733.29ms]
[0;30mdev|[0m Started development server: http://localhost:41673
[0;30mdev|[0m [32mBundled page in 2ms[0m[2m:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/html.test.ts
bun test v1.4.1 (65362b53b)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-1cWtIo
[0;30mdev|[0m Started development server: http://localhost:36111
[0;30mdev|[0m [32mBundled page in 106ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 44ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 66ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 74ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 29ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     253d4f54ca
  features     baseline

23 deps, 131 codegen, 1172 objects in 727ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [5.00ms]
[4/1244] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1244] gen ErrorCode+*.h
[6/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1244] gen .bind.ts → GeneratedBindings.cpp
[8/1244] fetch zlib
[zlib] up to date
[9/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[10/1244]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/fullstack.mdx         |  32 +++++
 docs/bundler/html-static.mdx       |  14 +++
 packages/bun-types/serve.d.ts      |  32 +++++
 src/bunfig/bunfig.rs               |  36 ++++++
 src/options_types/schema.rs        |  25 ++++
 src/runtime/bake/DevServer.rs      |  80 +++++++-----
 src/runtime/server/ServerConfig.rs |  50 ++++++++
 src/runtime/server/server_body.rs  |   2 +-
 test/bake/dev/html.test.ts         | 246 ++++++++++++++++++++++++++++++++++++-
 9 files changed, 483 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
docs/bundler/fullstack.mdx              2      3      0
docs/bundler/html-static.mdx            2      1      0
packages/bun-types/serve.d.ts           1      4      0
src/bunfig/bunfig.rs                    1      2      0
src/options_types/schema.rs             1      4      0
src/runtime/bake/DevServer.rs           5      9      0
src/runtime/server/ServerConfig.rs      5     15      0
src/runtime/server/server_body.rs       1      1      0
test/bake/dev/html.test.ts              1      9      0
```

</details>

<!-- robobun:evidence:end -->