### PR TITLE
node: render the Rust validators' ERR_OUT_OF_RANGE values like JS

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3372,8 +3372,11 @@ pub trait OutOfRangeValue {
 }
 
 impl OutOfRangeValue for f64 {
+    // Node renders the received value with `util.inspect`, which keeps `-0`.
     fn write_received(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, " Received {}", double(*self))
+        let mut buf = [0u8; 124];
+        f.write_str(" Received ")?;
+        write_bytes(f, FormatDouble::dtoa_with_negative_zero(&mut buf, *self))
     }
     fn type_name() -> &'static str {
         "f64"

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use bun_core::fmt::double;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsError, JsResult};
 
 #[cold]
@@ -43,17 +44,13 @@ pub(crate) fn throw_err_invalid_arg_type(
 }
 
 #[cold]
-fn throw_range_error(global_this: &JSGlobalObject, args: fmt::Arguments<'_>) -> JsError {
-    global_this.err(jsc::ErrorCode::OUT_OF_RANGE, args).throw()
-}
-
-#[inline]
 fn throw_range_error_msg(
     global_this: &JSGlobalObject,
     value: f64,
-    name: &str,
+    name: impl fmt::Display,
     msg: &[u8],
 ) -> JsError {
+    let name = format!("{name}");
     global_this.throw_range_error(
         value,
         jsc::RangeErrorOptions {
@@ -62,6 +59,21 @@ fn throw_range_error_msg(
             ..Default::default()
         },
     )
+}
+
+// Node's validators spell a two-sided range `>= min && <= max`
+// (lib/internal/validators.js). The shared formatter's `min`/`max` fields
+// spell it `and` (the Buffer and zlib wording), so the range goes in as `msg`.
+#[cold]
+fn throw_range_error_between(
+    global_this: &JSGlobalObject,
+    value: f64,
+    name: impl fmt::Display,
+    min: impl fmt::Display,
+    max: impl fmt::Display,
+) -> JsError {
+    let range = format!(">= {min} && <= {max}");
+    throw_range_error_msg(global_this, value, name, range.as_bytes())
 }
 
 // `Option<i64>` is not a valid const-generic type on stable, so the bounds
@@ -99,19 +111,13 @@ pub(crate) fn validate_integer(
         );
     }
 
-    let min: f64 = min_value.unwrap_or(jsc::MIN_SAFE_INTEGER) as f64;
-    let max: f64 = max_value.unwrap_or(jsc::MAX_SAFE_INTEGER) as f64;
+    let min = min_value.unwrap_or(jsc::MIN_SAFE_INTEGER);
+    let max = max_value.unwrap_or(jsc::MAX_SAFE_INTEGER);
 
     let num = value.as_number();
 
-    if num < min || num > max {
-        return Err(throw_range_error(
-            global_this,
-            format_args!(
-                "The value of \"{}\" is out of range. It must be >= {} && <= {}. Received {}",
-                name, min, max, num
-            ),
-        ));
+    if num < min as f64 || num > max as f64 {
+        return Err(throw_range_error_between(global_this, num, name, min, max));
     }
 
     Ok(num as i64)
@@ -139,29 +145,11 @@ pub(crate) fn validate_int32(
     // Number.isInteger semantics like Node's validateInt32: -0 and integral doubles
     // outside the int52 range are integers; the range check below rejects out-of-range.
     if !num.is_finite() || num.fract() != 0.0 {
-        let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
-        return Err(throw_range_error(
-            global_this,
-            format_args!(
-                "The value of \"{}\" is out of range. It must be an integer. Received {}",
-                name,
-                value.to_fmt(&mut formatter)
-            ),
-        ));
+        return Err(throw_range_error_msg(global_this, num, name, b"an integer"));
     }
     // Use floating point comparison here to ensure values out of i32 range get caught instead of clamp/truncated.
-    if num < (min as f64) || num > (max as f64) {
-        let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
-        return Err(throw_range_error(
-            global_this,
-            format_args!(
-                "The value of \"{}\" is out of range. It must be >= {} && <= {}. Received {}",
-                name,
-                min,
-                max,
-                value.to_fmt(&mut formatter)
-            ),
-        ));
+    if num < f64::from(min) || num > f64::from(max) {
+        return Err(throw_range_error_between(global_this, num, name, min, max));
     }
     Ok(num as i32)
 }
@@ -182,30 +170,12 @@ pub(crate) fn validate_uint32(
     }
     let num = value.as_number();
     if !num.is_finite() || num.fract() != 0.0 {
-        let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
-        return Err(throw_range_error(
-            global_this,
-            format_args!(
-                "The value of \"{}\" is out of range. It must be an integer. Received {}",
-                name,
-                value.to_fmt(&mut formatter)
-            ),
-        ));
+        return Err(throw_range_error_msg(global_this, num, name, b"an integer"));
     }
-    let min: f64 = if greater_than_zero { 1.0 } else { 0.0 };
-    let max: f64 = f64::from(u32::MAX);
-    if num < min || num > max {
-        let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
-        return Err(throw_range_error(
-            global_this,
-            format_args!(
-                "The value of \"{}\" is out of range. It must be >= {} && <= {}. Received {}",
-                name,
-                min,
-                max,
-                value.to_fmt(&mut formatter)
-            ),
-        ));
+    let min: u32 = if greater_than_zero { 1 } else { 0 };
+    let max = u32::MAX;
+    if num < f64::from(min) || num > f64::from(max) {
+        return Err(throw_range_error_between(global_this, num, name, min, max));
     }
     Ok(num as u32)
 }
@@ -254,28 +224,28 @@ pub(crate) fn validate_number(
     }
     if !valid {
         if let (Some(min), Some(max)) = (maybe_min, maybe_max) {
-            return Err(throw_range_error(
+            return Err(throw_range_error_between(
                 global_this,
-                format_args!(
-                    "The value of \"{}\" is out of range. It must be >= {} && <= {}. Received {}",
-                    name, min, max, num
-                ),
+                num,
+                name,
+                double(min),
+                double(max),
             ));
         } else if let Some(min) = maybe_min {
-            return Err(throw_range_error(
+            let range = format!(">= {}", double(min));
+            return Err(throw_range_error_msg(
                 global_this,
-                format_args!(
-                    "The value of \"{}\" is out of range. It must be >= {}. Received {}",
-                    name, min, num
-                ),
+                num,
+                name,
+                range.as_bytes(),
             ));
         } else if let Some(max) = maybe_max {
-            return Err(throw_range_error(
+            let range = format!("<= {}", double(max));
+            return Err(throw_range_error_msg(
                 global_this,
-                format_args!(
-                    "The value of \"{}\" is out of range. It must be <= {}. Received {}",
-                    name, max, num
-                ),
+                num,
+                name,
+                range.as_bytes(),
             ));
         }
     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5975,6 +5975,52 @@ it("open mode verification", async () => {
   );
 });
 
+// The received value of an ERR_OUT_OF_RANGE message is rendered the way JS
+// renders a number (1e+21, -0), not the way Rust renders an f64
+// (1000000000000000000000, 0). The range keeps Node's validator wording (&&).
+it("integer validators render the received value like JS", () => {
+  using dir = tempDir("fs-validators-out-of-range", { "file.txt": "x" });
+  const file = join(String(dir), "file.txt");
+  const fd = fs.openSync(file, "r+");
+  try {
+    // validateInteger with caller bounds
+    expect(() => fs.ftruncateSync(fd, 1e21)).toThrow(
+      RangeError(
+        `The value of "len" is out of range. It must be >= -2251799813685248 && <= 4503599627370495. Received 1e+21`,
+      ),
+    );
+    expect(() => fs.fchownSync(fd, 1e21, 0)).toThrow(
+      RangeError(`The value of "uid" is out of range. It must be >= -1 && <= 4294967295. Received 1e+21`),
+    );
+    // validateInteger with the default safe-integer bounds
+    expect(() => fs.truncateSync(file, -1e21)).toThrow(
+      RangeError(
+        `The value of "len" is out of range. It must be >= -9007199254740991 && <= 9007199254740991. Received -1e+21`,
+      ),
+    );
+    expect(() => fs.truncateSync(file, 2 ** 53)).toThrow(
+      RangeError(
+        `The value of "len" is out of range. It must be >= -9007199254740991 && <= 9007199254740991. Received 9007199254740992`,
+      ),
+    );
+    // validateUint32 (mode) and validateInt32 (flags)
+    expect(() => fs.fchmodSync(fd, 1e21)).toThrow(
+      RangeError(`The value of "mode" is out of range. It must be >= 0 && <= 4294967295. Received 1e+21`),
+    );
+    expect(() => fs.fchmodSync(fd, -1)).toThrow(
+      RangeError(`The value of "mode" is out of range. It must be >= 0 && <= 4294967295. Received -1`),
+    );
+    expect(() => fs.openSync(file, 1e21)).toThrow(
+      RangeError(`The value of "flags" is out of range. It must be >= -2147483648 && <= 2147483647. Received 1e+21`),
+    );
+    expect(() => fs.openSync(file, -Infinity)).toThrow(
+      RangeError(`The value of "flags" is out of range. It must be an integer. Received -Infinity`),
+    );
+  } finally {
+    fs.closeSync(fd);
+  }
+});
+
 it("fs.mkdirSync recursive should not error when the directory already exists, but should error when its a file", () => {
   expect(() => mkdirSync(import.meta.dir, { recursive: true })).not.toThrowError();
   expect(() => mkdirSync(import.meta.path, { recursive: true })).toThrowError();

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -14,6 +14,7 @@ import {
   isIPv4,
   isIPv6,
   Server,
+  setDefaultAutoSelectFamilyAttemptTimeout,
   Socket,
   Stream,
 } from "node:net";
@@ -48,6 +49,20 @@ it("should support net.isIPv6()", () => {
   expect(isIPv6("127.0.0.1")).toBe(false);
   expect(isIPv6("127.0.0.1/24")).toBe(false);
   expect(isIPv6("127.000.000.001")).toBe(false);
+});
+
+// Node renders the received value of ERR_OUT_OF_RANGE with util.inspect, so
+// -0 stays -0 and 1e21 reads 1e+21.
+it("setDefaultAutoSelectFamilyAttemptTimeout renders an out-of-range value like JS", () => {
+  expect(() => setDefaultAutoSelectFamilyAttemptTimeout(-0)).toThrow(
+    RangeError(`The value of "value" is out of range. It must be >= 1 && <= 2147483647. Received -0`),
+  );
+  expect(() => setDefaultAutoSelectFamilyAttemptTimeout(1e21)).toThrow(
+    RangeError(`The value of "value" is out of range. It must be >= 1 && <= 2147483647. Received 1e+21`),
+  );
+  expect(() => setDefaultAutoSelectFamilyAttemptTimeout(1.5)).toThrow(
+    RangeError(`The value of "value" is out of range. It must be an integer. Received 1.5`),
+  );
 });
 
 describe("net.BlockList subnet rules", () => {


### PR DESCRIPTION
### Problem
- `fs.ftruncateSync(fd, 1e21)` throws `The value of "len" is out of range. It must be >= -2251799813685248 && <= 4503599627370495. Received 1000000000000000000000`. Node and every other `ERR_OUT_OF_RANGE` in Bun render the number the JS way: `Received 1e+21`.
- `validate_integer` and `validate_number` in `src/runtime/node/util/validators.rs` build the message by hand with `format_args!` and Rust's `f64` `Display`, which never uses exponent notation. `validate_int32` and `validate_uint32` also build the message by hand, with the console formatter for the value.

### Fix
- All four validators now throw through `JSGlobalObject::throw_range_error`, the shared `ERR_OUT_OF_RANGE` formatter. The range goes in as `msg` (`>= a && <= b`), the same way `fd_jsc.rs` and `node_crypto_binding.rs` already pass Node's validator ranges. The bounds print as integers, the value prints as a JS number.
- The wording stays `&&`. Node's `validateInteger`, `validateInt32`, `validateUint32` and `validateNumber` spell the range `>= ${min} && <= ${max}` (lib/internal/validators.js). The `and` form in the shared formatter is Node's Buffer and zlib wording. The C++ twin `NodeValidator.cpp` made the same choice in #32623, and the vendored tests `test-fs-fchmod.js`, `test-fs-fchown.js`, `test-fs-utimes.js` and `test-fs-promises.js` pin `&&`.
- The shared formatter's `f64` path now prints `-0` as `-0` (`dtoa_with_negative_zero`). Node renders the received value with `util.inspect`, which keeps the sign. Without this, `validate_int32` would lose `Received -0` in the move.
- Verified: `test/js/node/fs/fs.test.ts` (new test fails on the released bun with `Received 1000000000000000000000`), `test/js/node/net/node-net.test.ts` (new `-0` test). Also the vendored node tests above plus `test-crypto-random.js`, `test-crypto-keygen.js`, `test-crypto-scrypt.js`, `test-zlib-deflate-constructors.js`, `test-dgram-createSocket-type.js`, and `argon2.test.ts`, `pbkdf2.test.ts`, `csrf.test.ts`, `spawnSync.test.ts`.

### Background
- `bun_core::fmt::out_of_range` is the Rust `ERR_OUT_OF_RANGE` formatter. It takes `OutOfRangeOptions { field_name, min, max, msg }`. With `min`/`max` set it writes `>= min and <= max.`, otherwise it writes `msg` and a period. Then it appends ` Received <value>`. `JSGlobalObject::throw_range_error(value, options)` wraps it in an `ERR_OUT_OF_RANGE` RangeError.
- For an `f64` value the formatter calls `WTF::numberToString`, the algorithm behind `Number.prototype.toString`. That is where `1e+21` comes from.
- The Rust validators in `validators.rs` back `node:fs` (fd, mode, uid, gid, position, len), `node:crypto` (scrypt and argon2 parameters), `node:zlib` (windowBits, level), `node:dgram` and `net.BlockList`.

<details><summary>Notes</summary>

- Node adds numeric separators to an integer above 2**32 in this message (`Received 9_007_199_254_740_992`, and the quirky `1e_+21`). The C++ `Bun::ERR::OUT_OF_RANGE` does this. The Rust shared formatter does not, and `csrf.test.ts` pins the plain form. This PR does not change that.
- `fs.ftruncate` validates `len` against `i52::MIN .. BLOB_SIZE_MAX`, so its bounds differ from Node's safe-integer bounds. Out of scope here.
- `validate_number` is only called with no bounds today (`assert_size` in `node_crypto_binding.rs`), so its range branch has no JS-reachable test. It was changed for consistency and compiles through the same helpers.
- `node-net.test.ts` has connect-related failures in this container (`ECONNREFUSED`) that also happen on the released bun. They are environmental.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts, test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->