### PR TITLE
bake: throw ERR_INVALID_ARG_TYPE for wrong-typed app options

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1528,7 +1528,8 @@ impl JSValue {
 
     /// `JSValue.getOptional` — loose, coercing property fetch.
     /// Absent / `undefined` / `null` → `None`; anything else is run through
-    /// [`coerce`](Self::coerce) (ToNumber for integer `T`). Distinct from
+    /// [`coerce`](Self::coerce) (ToNumber for integer `T`, the value itself
+    /// for `JSValue`). Distinct from
     /// [`get_optional_int`], which validates the property is already an
     /// in-range integer and throws otherwise.
     pub fn get_optional<T: CoerceTo>(
@@ -1920,6 +1921,12 @@ impl CoerceTo for i64 {
         // ToNumber here so string inputs above 2^31 round-trip to i64.
         let num = v.to_number(global)?;
         Ok(if num.is_nan() { 0 } else { num as i64 })
+    }
+}
+/// No coercion: `get_optional::<JSValue>` is `get` with `null` filtered out.
+impl CoerceTo for JSValue {
+    fn coerce_from(v: JSValue, _global: &JSGlobalObject) -> JsResult<JSValue> {
+        Ok(v)
     }
 }
 

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -32,67 +32,6 @@ use super::{dev_server, framework_router};
 // FrameworkRouter` are already provided by the parent `mod.rs` (lines 349/369);
 // re-exporting here triggers E0365 because `bake_body` is a private module.
 
-/// Local shim until `bun_jsc` grows a typed `get_optional`.
-/// Returns `None` for missing/null/undefined.
-fn get_optional_slice(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &[u8],
-) -> JsResult<Option<Utf8Bytes<'static>>> {
-    match target.get(global, property)? {
-        Some(v) if !v.is_undefined_or_null() => Ok(Some(v.to_utf8(global)?)),
-        _ => Ok(None),
-    }
-}
-
-/// `JSValue.getBooleanStrict` — local shim.
-fn get_boolean_strict(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &[u8],
-) -> JsResult<Option<bool>> {
-    match target.get(global, property)? {
-        Some(v) if v.is_boolean() => Ok(Some(v.as_boolean())),
-        _ => Ok(None),
-    }
-}
-
-/// `JSValue.getBooleanLoose` — local shim until `bun_jsc` grows it.
-fn get_boolean_loose(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &[u8],
-) -> JsResult<Option<bool>> {
-    match target.get(global, property)? {
-        Some(v) if !v.is_undefined_or_null() => Ok(Some(v.to_boolean())),
-        _ => Ok(None),
-    }
-}
-
-/// `JSValue.getOptional(JSValue, ..)` — local shim: filters undefined/null.
-fn get_optional_value(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &[u8],
-) -> JsResult<Option<JSValue>> {
-    match target.get(global, property)? {
-        Some(v) if !v.is_undefined_or_null() => Ok(Some(v)),
-        _ => Ok(None),
-    }
-}
-
-/// `JSValue.getFunction` — local shim until `bun_jsc` grows it.
-fn get_function(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &[u8],
-) -> JsResult<Option<JSValue>> {
-    match target.get(global, property)? {
-        Some(v) if v.is_callable() => Ok(Some(v)),
-        _ => Ok(None),
-    }
-}
-
 use bun_bundler_jsc::source_map_mode_jsc::source_map_mode_from_js;
 
 /// Convert a `crate::Error` into a thrown JS exception in a `JsResult`
@@ -205,14 +144,14 @@ impl UserOptions {
             );
         }
 
-        if let Some(js_options) = get_optional_value(config, global, b"bundlerOptions")? {
-            if let Some(server_options) = get_optional_value(js_options, global, b"server")? {
+        if let Some(js_options) = config.get_optional::<JSValue>(global, "bundlerOptions")? {
+            if let Some(server_options) = js_options.get_optional::<JSValue>(global, "server")? {
                 bundler_options.server = BuildConfigSubset::from_js(global, server_options)?;
             }
-            if let Some(client_options) = get_optional_value(js_options, global, b"client")? {
+            if let Some(client_options) = js_options.get_optional::<JSValue>(global, "client")? {
                 bundler_options.client = BuildConfigSubset::from_js(global, client_options)?;
             }
-            if let Some(ssr_options) = get_optional_value(js_options, global, b"ssr")? {
+            if let Some(ssr_options) = js_options.get_optional::<JSValue>(global, "ssr")? {
                 bundler_options.ssr = BuildConfigSubset::from_js(global, ssr_options)?;
             }
         }
@@ -233,7 +172,7 @@ impl UserOptions {
             &arena,
         )?;
 
-        let root: &[u8] = if let Some(slice) = get_optional_slice(config, global, b"root")? {
+        let root: &[u8] = if let Some(slice) = config.get_optional_slice(global, "root")? {
             allocations.track(slice)
         } else {
             match bun_sys::getcwd_alloc() {
@@ -335,20 +274,19 @@ impl SplitBundlerOptions {
                 );
             }
 
-            if let Some(slice) = get_optional_slice(plugin_config, global, b"name")? {
+            if let Some(slice) = plugin_config.get_optional_slice(global, "name")? {
                 if slice.slice().is_empty() {
                     return Err(global.throw_invalid_arguments(format_args!(
                         "Expected plugin to have a non-empty name"
                     )));
                 }
-                // slice dropped here (defer slice.deinit())
             } else {
                 return Err(
                     global.throw_invalid_arguments(format_args!("Expected plugin to have a name"))
                 );
             }
 
-            let function = match get_function(plugin_config, global, b"setup")? {
+            let function = match plugin_config.get_function(global, "setup")? {
                 Some(f) => f,
                 None => {
                     return Err(global.throw_invalid_arguments(format_args!(
@@ -410,7 +348,7 @@ impl BuildConfigSubset {
         let mut options = BuildConfigSubset::default();
 
         'brk: {
-            let Some(val) = get_optional_value(js_options, global, b"sourcemap")? else {
+            let Some(val) = js_options.get_optional::<JSValue>(global, "sourcemap")? else {
                 break 'brk;
             };
             if let Some(sourcemap) = source_map_mode_from_js(global, val)? {
@@ -427,7 +365,7 @@ impl BuildConfigSubset {
         }
 
         'brk: {
-            let Some(minify_options) = get_optional_value(js_options, global, b"minify")? else {
+            let Some(minify_options) = js_options.get_optional::<JSValue>(global, "minify")? else {
                 break 'brk;
             };
             if minify_options.is_boolean() && minify_options.as_boolean() {
@@ -437,13 +375,13 @@ impl BuildConfigSubset {
                 break 'brk;
             }
 
-            if let Some(value) = get_boolean_loose(minify_options, global, b"whitespace")? {
+            if let Some(value) = minify_options.get_boolean_loose(global, "whitespace")? {
                 options.minify_whitespace = Some(value);
             }
-            if let Some(value) = get_boolean_loose(minify_options, global, b"syntax")? {
+            if let Some(value) = minify_options.get_boolean_loose(global, "syntax")? {
                 options.minify_syntax = Some(value);
             }
-            if let Some(value) = get_boolean_loose(minify_options, global, b"identifiers")? {
+            if let Some(value) = minify_options.get_boolean_loose(global, "identifiers")? {
                 options.minify_identifiers = Some(value);
             }
         }
@@ -837,7 +775,7 @@ impl Framework {
             Some(ServerComponents {
                 separate_ssr_graph: 'brk: {
                     // Intentionally not using a truthiness check
-                    let prop = match get_optional_value(sc, global, b"separateSSRGraph")? {
+                    let prop = match sc.get_optional::<JSValue>(global, "separateSSRGraph")? {
                         Some(p) => p,
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -856,7 +794,7 @@ impl Framework {
                     )));
                 },
                 server_runtime_import: refs.track(
-                    match get_optional_slice(sc, global, b"serverRuntimeImportSource")? {
+                    match sc.get_optional_slice(global, "serverRuntimeImportSource")? {
                         Some(s) => s,
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -866,7 +804,7 @@ impl Framework {
                     },
                 ),
                 server_register_client_reference: if let Some(slice) =
-                    get_optional_slice(sc, global, b"serverRegisterClientReferenceExport")?
+                    sc.get_optional_slice(global, "serverRegisterClientReferenceExport")?
                 {
                     refs.track(slice)
                 } else {
@@ -969,9 +907,12 @@ impl Framework {
                     get_optional_string(fsr_opts, global, b"clientEntryPoint", refs)?;
                 let prefix =
                     get_optional_string(fsr_opts, global, b"prefix", refs)?.unwrap_or(b"/");
-                let ignore_underscores =
-                    get_boolean_strict(fsr_opts, global, b"ignoreUnderscores")?.unwrap_or(false);
-                let layouts = get_boolean_strict(fsr_opts, global, b"layouts")?.unwrap_or(false);
+                let ignore_underscores = fsr_opts
+                    .get_boolean_strict(global, "ignoreUnderscores")?
+                    .unwrap_or(false);
+                let layouts = fsr_opts
+                    .get_boolean_strict(global, "layouts")?
+                    .unwrap_or(false);
 
                 let style = style_from_js(
                     match fsr_opts.get(global, "style")? {
@@ -1094,7 +1035,7 @@ impl Framework {
             built_in_modules,
         };
 
-        if let Some(plugin_array) = get_optional_value(opts, global, b"plugins")? {
+        if let Some(plugin_array) = opts.get_optional::<JSValue>(global, "plugins")? {
             bundler_options.parse_plugin_array(plugin_array, global)?;
         }
 
@@ -1379,13 +1320,9 @@ fn get_optional_string(
     property: &[u8],
     allocations: &mut StringRefList,
 ) -> JsResult<Option<&'static [u8]>> {
-    let Some(value) = target.get(global, property)? else {
-        return Ok(None);
-    };
-    if value.is_undefined_or_null() {
-        return Ok(None);
-    }
-    Ok(Some(allocations.track(value.to_utf8(global)?)))
+    Ok(target
+        .get_optional_slice(global, property)?
+        .map(|slice| allocations.track(slice)))
 }
 
 // Note: `HmrRuntime` is defined canonically in the parent `bake/mod.rs`

--- a/test/bake/app-options.test.ts
+++ b/test/bake/app-options.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Every option here is declared as `string` or `boolean` in bake.d.ts. A value
+// of another type must throw ERR_INVALID_ARG_TYPE from Bun.serve, before any
+// dev server starts.
+test("Bun.serve({ app }) rejects wrong-typed framework options", async () => {
+  using dir = tempDir("bake-app-options", {
+    "fixture.ts": `
+      const fsr = { root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" };
+      const framework = { fileSystemRouterTypes: [fsr] };
+      const cases = {
+        "root": { framework, root: 123 },
+        "fileSystemRouterTypes[].root": { framework: { fileSystemRouterTypes: [{ ...fsr, root: 123 }] } },
+        "fileSystemRouterTypes[].ignoreUnderscores": {
+          framework: { fileSystemRouterTypes: [{ ...fsr, ignoreUnderscores: "yes" }] },
+        },
+        "fileSystemRouterTypes[].layouts": { framework: { fileSystemRouterTypes: [{ ...fsr, layouts: 1 }] } },
+        "serverComponents.serverRuntimeImportSource": {
+          framework: { ...framework, serverComponents: { separateSSRGraph: false, serverRuntimeImportSource: 5 } },
+        },
+        "plugins[].name": { framework, plugins: [{ name: 42, setup() {} }] },
+        "plugins[].setup": { framework, plugins: [{ name: "p", setup: "nope" }] },
+      };
+      for (const [name, app] of Object.entries(cases)) {
+        let result;
+        try {
+          Bun.serve({ port: 0, development: true, app, fetch: () => new Response() }).stop(true);
+          result = "no error";
+        } catch (e) {
+          result = e.code + ": " + e.message;
+        }
+        console.log(name + " -> " + result);
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toMatchInlineSnapshot(`
+    "root -> ERR_INVALID_ARG_TYPE: The "root" property must be of type string, got number
+    fileSystemRouterTypes[].root -> ERR_INVALID_ARG_TYPE: The "root" property must be of type string, got number
+    fileSystemRouterTypes[].ignoreUnderscores -> ERR_INVALID_ARG_TYPE: The "ignoreUnderscores" property must be of type boolean, got string
+    fileSystemRouterTypes[].layouts -> ERR_INVALID_ARG_TYPE: The "layouts" property must be of type boolean, got number
+    serverComponents.serverRuntimeImportSource -> ERR_INVALID_ARG_TYPE: The "serverRuntimeImportSource" property must be of type string, got number
+    plugins[].name -> ERR_INVALID_ARG_TYPE: The "name" property must be of type string, got number
+    plugins[].setup -> ERR_INVALID_ARG_TYPE: setup must be a function
+    "
+  `);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `Bun.serve({ app })` and `bun build --app` accept wrong-typed framework options without an error. `root: 123` becomes the string `"123"`, `ignoreUnderscores: "yes"` is ignored, a plugin `name: 42` passes, and `setup: "nope"` reports `Expected plugin to have a setup() function` as if it were missing.
- `src/runtime/bake/bake_body.rs` kept local copies of `get_optional_slice`, `get_boolean_strict`, `get_boolean_loose`, `get_optional_value` and `get_function` ("until `bun_jsc` grows them"). `bun_jsc::JSValue` has all of them (`src/jsc/JSValue.rs:1171-1263`), and the local copies skip the type checks.

### Fix
- Delete the five local copies. The 27 call sites now call the `bun_jsc::JSValue` methods, which throw `ERR_INVALID_ARG_TYPE` with the property name (`The "root" property must be of type string, got number`, `setup must be a function`).
- Route `get_optional_string` (used for `fileSystemRouterTypes[].root`, `serverEntryPoint`, `clientEntryPoint`, `prefix`, `builtInModules[].*`) through `get_optional_slice` too. These are all typed `string` in `bake.d.ts`. The previous version coerced with `toString`.
- Add `impl CoerceTo for JSValue` in `bun_jsc` so `get_optional::<JSValue>` exists. It returns the property value with `undefined` and `null` filtered out. The Zig `coerceOptional` had this arm and the port did not.
- Verified: `test/bake/app-options.test.ts` (new, fails on the current canary). Also `test/bake/framework-router.test.ts`, `test/bake/serve-plugins-dev-server.test.ts`, `test/bake/dev/plugins.test.ts`, `test/bake/dev/production.test.ts`, and `test/internal/source-lints/`.

### Background
- `UserOptions::from_js` in `bake_body.rs` parses the `app` object for both entry points: `Bun.serve({ app })` (`ServerConfig.rs:1160`) and the `bun build --app` config file (`production.rs:395`).
- `get_boolean_loose` behavior for `null` also changes with the swap: the `bun_jsc` version returns `Some(false)` where the local one returned `None`. This is what the Zig `getBooleanLoose` did. It only affects `bundlerOptions.*.minify.{whitespace,syntax,identifiers}: null`.

<details><summary>Notes</summary>

Reproduction on `1.4.1-canary.1+65362b53b`, each case through `Bun.serve({ port: 0, development: true, app, fetch })`:

```
root:123                    -> no throw
fsr.root:123                -> no throw
ignoreUnderscores:'yes'     -> no throw
layouts:1                   -> no throw
plugin name:42              -> no throw
plugin setup:'nope'         -> ERR_INVALID_ARG_TYPE "Expected plugin to have a setup() function"
sc.serverRuntimeImportSource:5 -> "Framework is missing required files!" (async, after the server started)
```

With this change every case throws synchronously from `Bun.serve`.

`test/bake/dev/production.test.ts` hits the 5 s default timeout on the local debug+ASAN build for tests that run a full React production build (6 to 10 s each here). The same tests pass with `--timeout 180000`. Those tests use `framework: "react"`, which does not go through `Framework::from_js`.

`src/runtime/api/bun/Terminal.rs:219-236` has the same `get_optional_value` / `get_optional_i32` shims. They have the same semantics as `bun_jsc` (no behavior difference), so this PR leaves them alone.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/app-options.test.ts
bun test v1.4.1 (65362b53b)

test/bake/app-options.test.ts:
42 |     stdout: "pipe",
43 |     stderr: "pipe",
44 |   });
45 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
46 | 
47 |   expect(stdout).toMatchInlineSnapshot(`
                      ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "root -> ERR_INVALID_ARG_TYPE: The "root" property must be of type string, got number
- fileSystemRouterTypes[].root -> ERR_INVALID_ARG_TYPE: The "root" property must be of type string, got number
- fileSystemRouterTypes[].ignoreUnderscores -> ERR_INVALID_ARG_TYPE: The "ignoreUnderscores" property must be of type boolean, got string
- fileSystemRouterTypes[].layouts -> ERR_INVALID_ARG_TYPE: The "layouts" property must be of type boolean, got number
- serverComponents.serverRuntimeImportSource -> ERR_INVALID_ARG_TYPE: The "serverRuntimeImportSource" property must be of type string, got number
- plugins[].name -> ERR_INVALID_ARG_TYPE: The "
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bake/app-options.test.ts:
42 |     stdout: "pipe",
43 |     stderr: "pipe",
44 |   });
45 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
46 | 
47 |   expect(stdout).toMatchInlineSnapshot(`
                      ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "root -> ERR_INVALID_ARG_TYPE: The "root" property must be of type string, got number
- fileSystemRouterTypes[].root -> ERR_INVALID_ARG_TYPE: The "root" property must be of type string, got number
- fileSystemRouterTypes[].ignoreUnderscores -> ERR_INVALID_ARG_TYPE: The "ignoreUnderscores" property must be of type boolean, got string
- fileSystemRouterTypes[].layouts -> ERR_INVALID_ARG_TYPE: The "layouts" property must be of type boolean, got number
- serverComponents.serverRuntimeImportSource -> ERR_INVALID_ARG_TYPE: The "serverRuntimeImportSource" property must be of type string, got number
- plugins[].name -> ERR_INVALID_ARG_TYPE: The "name" property must be of type string, got number
- plugins[].setup -> ERR_INVALID_ARG_TYPE: setup must be a function
+ "root -> undefined: Framework is m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/app-options.test.ts
bun test v1.4.1 (65362b53b)

test/bake/app-options.test.ts:
(pass) Bun.serve({ app }) rejects wrong-typed framework options [529.94ms]

 1 pass
 0 fail
 1 snapshots, 3 expect() calls
Ran 1 test across 1 file. [2.83s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b4700127d7
  features     baseline

23 deps, 131 codegen, 1172 objects in 948ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] gen .bind.ts → GeneratedBindings.cpp
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] gen ErrorCode+*.h
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [13.00ms]
[10/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1216] gen bake.{client,server,error}.js
->
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSValue.rs            |   9 +++-
 src/runtime/bake/bake_body.rs | 113 ++++++++++--------------------------------
 test/bake/app-options.test.ts |  59 ++++++++++++++++++++++
 3 files changed, 92 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/jsc/JSValue.rs                 3      2      0
src/runtime/bake/bake_body.rs      4     11      0
test/bake/app-options.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->