### PR TITLE
build --compile: resolve the cross-compile cache like bun install

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -242,8 +242,7 @@ impl Loader {
         None
     }
 
-    /// Bun's install cache directory, shared by `bun install` and the `bun build --compile` download
-    /// of another platform's executable. `cache_directory` is the `--cache-dir` / bunfig setting.
+    /// `cache_directory` is the `--cache-dir` / bunfig `install.cache.dir` setting, if any.
     pub fn install_cache_directory_path<'b>(
         &self,
         cache_directory: Option<&[u8]>,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -242,6 +242,35 @@ impl Loader {
         None
     }
 
+    /// Bun's install cache: where `bun install` extracts packages and where `bun build --compile`
+    /// keeps the downloaded executables of other targets. The first one set wins:
+    /// `$BUN_INSTALL_CACHE_DIR`, `cache_directory` (`--cache-dir` or bunfig `install.cache.dir`),
+    /// `$BUN_INSTALL/install/cache`, `$XDG_CACHE_HOME/.bun/install/cache`, `$HOME/.bun/install/cache`,
+    /// and last `node_modules/.bun-cache`. A relative path resolves against the top-level directory.
+    pub fn install_cache_directory_path(&self, cache_directory: Option<&[u8]>) -> Vec<u8> {
+        use bun_paths::resolve_path::{join_abs_string, platform};
+        let top_level_dir = bun_paths::fs::FileSystem::instance().top_level_dir();
+        let abs =
+            |parts: &[&[u8]]| join_abs_string::<platform::Loose>(top_level_dir, parts).to_vec();
+
+        if let Some(dir) = self.get(b"BUN_INSTALL_CACHE_DIR") {
+            return abs(&[dir]);
+        }
+        if let Some(dir) = cache_directory.filter(|dir| !dir.is_empty()) {
+            return abs(&[dir]);
+        }
+        if let Some(dir) = self.get(b"BUN_INSTALL") {
+            return abs(&[dir, b"install/", b"cache/"]);
+        }
+        if let Some(dir) = bun_core::env_var::XDG_CACHE_HOME.get() {
+            return abs(&[dir, b".bun/", b"install/", b"cache/"]);
+        }
+        if let Some(dir) = bun_core::env_var::HOME.get() {
+            return abs(&[dir, b".bun/", b"install/", b"cache/"]);
+        }
+        abs(&[b"node_modules/.bun-cache"])
+    }
+
     pub fn is_ci(&self) -> bool {
         self.get(b"CI")
             .or_else(|| self.get(b"TDDIUM"))

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -246,29 +246,32 @@ impl Loader {
     /// keeps the downloaded executables of other targets. The first one set wins:
     /// `$BUN_INSTALL_CACHE_DIR`, `cache_directory` (`--cache-dir` or bunfig `install.cache.dir`),
     /// `$BUN_INSTALL/install/cache`, `$XDG_CACHE_HOME/.bun/install/cache`, `$HOME/.bun/install/cache`,
-    /// and last `node_modules/.bun-cache`. A relative path resolves against the top-level directory.
-    pub fn install_cache_directory_path(&self, cache_directory: Option<&[u8]>) -> Vec<u8> {
-        use bun_paths::resolve_path::{join_abs_string, platform};
-        let top_level_dir = bun_paths::fs::FileSystem::instance().top_level_dir();
-        let abs =
-            |parts: &[&[u8]]| join_abs_string::<platform::Loose>(top_level_dir, parts).to_vec();
-
-        if let Some(dir) = self.get(b"BUN_INSTALL_CACHE_DIR") {
-            return abs(&[dir]);
-        }
-        if let Some(dir) = cache_directory.filter(|dir| !dir.is_empty()) {
-            return abs(&[dir]);
-        }
-        if let Some(dir) = self.get(b"BUN_INSTALL") {
-            return abs(&[dir, b"install/", b"cache/"]);
-        }
-        if let Some(dir) = bun_core::env_var::XDG_CACHE_HOME.get() {
-            return abs(&[dir, b".bun/", b"install/", b"cache/"]);
-        }
-        if let Some(dir) = bun_core::env_var::HOME.get() {
-            return abs(&[dir, b".bun/", b"install/", b"cache/"]);
-        }
-        abs(&[b"node_modules/.bun-cache"])
+    /// and last `node_modules/.bun-cache`. Writes the absolute path into `buf` (a relative setting
+    /// resolves against the top-level directory) and returns it.
+    pub fn install_cache_directory_path<'b>(
+        &self,
+        cache_directory: Option<&[u8]>,
+        buf: &'b mut [u8],
+    ) -> &'b [u8] {
+        use bun_paths::resolve_path::{join_abs_string_buf, platform};
+        let parts: &[&[u8]] = if let Some(dir) = self.get(b"BUN_INSTALL_CACHE_DIR") {
+            &[dir]
+        } else if let Some(dir) = cache_directory.filter(|dir| !dir.is_empty()) {
+            &[dir]
+        } else if let Some(dir) = self.get(b"BUN_INSTALL") {
+            &[dir, b"install/", b"cache/"]
+        } else if let Some(dir) = bun_core::env_var::XDG_CACHE_HOME.get() {
+            &[dir, b".bun/", b"install/", b"cache/"]
+        } else if let Some(dir) = bun_core::env_var::HOME.get() {
+            &[dir, b".bun/", b"install/", b"cache/"]
+        } else {
+            &[b"node_modules/.bun-cache"]
+        };
+        join_abs_string_buf::<platform::Loose>(
+            bun_paths::fs::FileSystem::instance().top_level_dir(),
+            buf,
+            parts,
+        )
     }
 
     pub fn is_ci(&self) -> bool {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -242,12 +242,8 @@ impl Loader {
         None
     }
 
-    /// Bun's install cache: where `bun install` extracts packages and where `bun build --compile`
-    /// keeps the downloaded executables of other targets. The first one set wins:
-    /// `$BUN_INSTALL_CACHE_DIR`, `cache_directory` (`--cache-dir` or bunfig `install.cache.dir`),
-    /// `$BUN_INSTALL/install/cache`, `$XDG_CACHE_HOME/.bun/install/cache`, `$HOME/.bun/install/cache`,
-    /// and last `node_modules/.bun-cache`. Writes the absolute path into `buf` (a relative setting
-    /// resolves against the top-level directory) and returns it.
+    /// Bun's install cache directory, shared by `bun install` and the `bun build --compile` download
+    /// of another platform's executable. `cache_directory` is the `--cache-dir` / bunfig setting.
     pub fn install_cache_directory_path<'b>(
         &self,
         cache_directory: Option<&[u8]>,

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -7,7 +7,7 @@ use crate::bun_fs::FileSystem;
 use crate::lockfile_real::package::PackageColumns;
 use crate::repository::Repository;
 use bun_core::ZStr;
-use bun_core::{Global, Output, ZBox, env_var, fmt as bun_fmt};
+use bun_core::{Global, Output, ZBox, fmt as bun_fmt};
 use bun_dotenv::Loader as DotEnvLoader;
 use bun_install::lockfile::{Format as LockfileFormat, LoadResult, Lockfile};
 use bun_install::resolution::Tag as ResolutionTag;
@@ -377,44 +377,8 @@ pub struct CacheDir {
 }
 
 pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
-    if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
-        return CacheDir {
-            path: FileSystem::instance().abs(&[dir]).to_vec(),
-        };
-    }
-
-    if let Some(opts) = options {
-        if !opts.cache_directory.is_empty() {
-            return CacheDir {
-                path: FileSystem::instance().abs(&[opts.cache_directory]).to_vec(),
-            };
-        }
-    }
-
-    if let Some(dir) = env.get(b"BUN_INSTALL") {
-        let parts: [&[u8]; 3] = [dir, b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
-        let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    if let Some(dir) = env_var::HOME.get() {
-        let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    let fallback_parts: [&[u8]; 1] = [b"node_modules/.bun-cache"];
     CacheDir {
-        path: FileSystem::instance().abs(&fallback_parts).to_vec(),
+        path: env.install_cache_directory_path(options.map(|opts| opts.cache_directory)),
     }
 }
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -332,12 +332,14 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
             // SAFETY: caller-provided provenance root; `env_mut()` itself
             // encapsulates the BackRef deref + singleton-liveness invariant.
             let env = unsafe { &*this }.env_mut();
+            let mut buf = path::path_buffer_pool::get();
             // SAFETY: shared read of `options`; disjoint from `cache_directory_path`.
-            let cache_dir = fetch_cache_directory_path(env, Some(unsafe { &(*this).options }));
+            let cache_dir =
+                fetch_cache_directory_path(env, Some(unsafe { &(*this).options }), &mut buf[..]);
             // SAFETY: see fn safety contract.
-            unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
+            unsafe { (*this).cache_directory_path = ZBox::from_bytes(cache_dir) };
 
-            match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
+            match Dir::cwd().make_open_path(cache_dir, Default::default()) {
                 Ok(d) => return d,
                 Err(_) => {
                     // SAFETY: narrow `&mut enable` projection; disjoint from
@@ -372,14 +374,12 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
     }
 }
 
-pub struct CacheDir {
-    pub path: Vec<u8>,
-}
-
-pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
-    CacheDir {
-        path: env.install_cache_directory_path(options.map(|opts| opts.cache_directory)),
-    }
+pub fn fetch_cache_directory_path<'b>(
+    env: &DotEnvLoader,
+    options: Option<&Options>,
+    buf: &'b mut [u8],
+) -> &'b [u8] {
+    env.install_cache_directory_path(options.map(|opts| opts.cache_directory), buf)
 }
 
 // ─────────────────────── cached folder name printers ──────────────────────────

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -212,11 +212,12 @@ impl CompileTarget {
             return version_str;
         }
 
-        let cache_dir = env.install_cache_directory_path(None);
+        let mut cache_dir_buf = path::path_buffer_pool::get();
+        let cache_dir = env.install_cache_directory_path(None, &mut cache_dir_buf[..]);
         let dest = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
             path::fs::FileSystem::instance().top_level_dir(),
             &mut buf[..],
-            &[cache_dir.as_slice(), version_str.as_bytes()],
+            &[cache_dir, version_str.as_bytes()],
         );
 
         if bun_sys::exists_at(Fd::cwd(), dest) {

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -191,7 +191,7 @@ impl CompileTarget {
         &self,
         buf: &'a mut PathBuffer,
         version_str: &'a ZStr,
-        _env: &mut bun_dotenv::Loader,
+        env: &bun_dotenv::Loader,
         needs_download: &mut bool,
     ) -> &'a ZStr {
         if self.is_default() {
@@ -212,8 +212,7 @@ impl CompileTarget {
             return version_str;
         }
 
-        // T1 fallback ignores `_env` (full env-override chain lives in bun_install).
-        let cache_dir = bun_sys::fetch_cache_directory_path();
+        let cache_dir = env.install_cache_directory_path(None);
         let dest = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
             path::fs::FileSystem::instance().top_level_dir(),
             &mut buf[..],

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -439,9 +439,11 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
 
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
-                let cache_dir = fetch_cache_directory_path(&mut process_env, None);
+                let mut cache_dir_buf = Path::path_buffer_pool::get();
+                let cache_dir =
+                    fetch_cache_directory_path(&process_env, None, &mut cache_dir_buf[..]);
                 let mut rm_buf = PathBuffer::uninit();
-                let rm_dir = match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
+                let rm_dir = match Dir::cwd().make_open_path(cache_dir, Default::default()) {
                     Ok(d) => d,
                     Err(err) => {
                         bun_core::pretty_errorln!(

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2329,28 +2329,36 @@ pub(crate) fn download_to_path(
                     return Err(crate::Error::ExtractionFailed);
                 }
 
+                let src_name: &ZStr = if target.os == CompileTargetOs::Windows {
+                    bun_core::zstr!("bun.exe")
+                } else {
+                    bun_core::zstr!("bun")
+                };
+                if !bun_sys::exists_at(tmpdir.fd(), src_name) {
+                    refresher.root.end();
+                    return Err(crate::Error::ExtractionFailed);
+                }
+
                 let mut did_retry = false;
                 loop {
-                    let src_name: &ZStr = if target.os == CompileTargetOs::Windows {
-                        bun_core::zstr!("bun.exe")
-                    } else {
-                        bun_core::zstr!("bun")
-                    };
-                    let mv = bun_sys::move_file_z(tmpdir.fd(), src_name, Fd::INVALID, dest_z);
-                    if mv.is_err() {
+                    if let Err(mv_err) =
+                        bun_sys::move_file_z(tmpdir.fd(), src_name, Fd::INVALID, dest_z)
+                    {
                         if !did_retry {
                             did_retry = true;
                             let dirname = path::dirname_simple(dest_z.as_bytes());
                             if !dirname.is_empty() {
-                                let _ = bun_sys::Dir::cwd().make_path(dirname);
+                                if let Err(mk_err) = bun_sys::Dir::cwd().make_path(dirname) {
+                                    refresher.root.end();
+                                    return Err(crate::Error::CacheWriteFailed(mk_err.into()));
+                                }
                                 continue;
                             }
 
                             // fallthrough, failed for another reason
                         }
                         refresher.root.end();
-                        // Return error without printing - let caller handle the messaging
-                        return Err(crate::Error::ExtractionFailed);
+                        return Err(crate::Error::CacheWriteFailed(mv_err.into()));
                     }
                     break;
                 }
@@ -2411,6 +2419,12 @@ pub fn target_executable(
                     crate::Error::ExtractionFailed => CompileError::fmt(format_args!(
                         "Failed to extract executable for '{}'. The download may be incomplete.",
                         target
+                    )),
+                    crate::Error::CacheWriteFailed(errno) => CompileError::fmt(format_args!(
+                        "Failed to write cached executable for '{}' to {}: {}",
+                        target,
+                        bun_core::fmt::quote(dest_z.as_bytes()),
+                        <&'static str>::from(errno),
                     )),
                     _ => CompileError::fmt(format_args!(
                         "Failed to download '{}': {}",

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     InvalidResponse,
     #[error("ExtractionFailed")]
     ExtractionFailed,
+    #[error("CacheWriteFailed")]
+    CacheWriteFailed(bun_errno::SystemErrno),
     #[error("InvalidSourceMap")]
     InvalidSourceMap,
     #[error("SourceMapTooLarge")]
@@ -43,6 +45,7 @@ impl Error {
             Self::NetworkError => "NetworkError",
             Self::InvalidResponse => "InvalidResponse",
             Self::ExtractionFailed => "ExtractionFailed",
+            Self::CacheWriteFailed(e) => <&'static str>::from(e),
             Self::InvalidSourceMap => "InvalidSourceMap",
             Self::SourceMapTooLarge => "SourceMapTooLarge",
             Self::Sys(e) => <&'static str>::from(e),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9193,22 +9193,6 @@ pub fn write_file_with_path_buffer(
     r.map(|_| buffer.len())
 }
 
-/// `bun.fetchCacheDirectoryPath` — resolve `$BUN_INSTALL_CACHE_DIR` /
-/// `$XDG_CACHE_HOME/.bun/install/cache` / `$HOME/.bun/install/cache`.
-/// full env-override chain lives in `bun_install`; this is the
-/// fallback so the symbol resolves at T1. Returns an owned path (caller frees).
-pub fn fetch_cache_directory_path() -> Vec<u8> {
-    if let Some(v) = bun_core::getenv_z(bun_core::zstr!("BUN_INSTALL_CACHE_DIR")) {
-        return v.to_vec();
-    }
-    if let Some(home) = bun_core::getenv_z(bun_core::zstr!("HOME")) {
-        let mut p = home.to_vec();
-        p.extend_from_slice(b"/.bun/install/cache");
-        return p;
-    }
-    b".bun-cache".to_vec()
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // OUTPUT_SINK — bun_core's stderr vtable, installed by us at init (B-0 hook).
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
+import {
+  chmodSync,
+  closeSync,
+  cpSync,
+  existsSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  writeFileSync,
+} from "node:fs";
+import { gzipSync } from "node:zlib";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -953,6 +964,118 @@ describe("compiled binary in a deleted cwd", () => {
     },
     60_000,
   );
+});
+
+// `--compile --target=<another platform>` downloads that platform's bun from npm and keeps it in
+// bun's install cache, the same directory `bun install` uses. `BUN_COMPILE_TARGET_TARBALL_URL`
+// points the download at a local server, so nothing here touches the network. The served "bun" is
+// a placeholder, not an executable, so the build fails after the download. The tests only check
+// where the download is cached.
+describe("cross-compile executable cache", () => {
+  // Another CPU than the host, so the executable is never this bun and always comes from the cache.
+  const target = isArm64 ? "bun-linux-x64" : "bun-linux-arm64";
+  const placeholder = `placeholder for ${target}\n`;
+
+  function octal(n: number, width: number): string {
+    return n.toString(8).padStart(width - 1, "0") + "\0";
+  }
+
+  // A gzipped ustar archive with one entry, `package/bin/bun`, like the npm tarballs.
+  function tarball(): Buffer {
+    const body = Buffer.from(placeholder);
+    const header = Buffer.alloc(512, 0);
+    header.write("package/bin/bun", 0, 100, "utf8");
+    header.write(octal(0o755, 8), 100); // mode
+    header.write(octal(0, 8), 108); // uid
+    header.write(octal(0, 8), 116); // gid
+    header.write(octal(body.length, 12), 124); // size
+    header.write(octal(0, 12), 136); // mtime
+    header.fill(" ", 148, 156); // checksum placeholder
+    header.write("0", 156); // regular file
+    header.write("ustar\0", 257);
+    header.write("00", 263);
+    let sum = 0;
+    for (let i = 0; i < 512; i++) sum += header[i];
+    header.write(octal(sum, 8), 148);
+    const pad = Buffer.alloc((512 - (body.length % 512)) % 512, 0);
+    return gzipSync(Buffer.concat([header, body, pad, Buffer.alloc(1024, 0)]));
+  }
+
+  // Runs the cross-compile of `<dir>/project/app.js`. `env` sets the variables the cache directory
+  // comes from; `null` unsets one. HOME points into `dir`, so a wrongly placed download shows up
+  // there and not in the real home directory.
+  async function crossCompile(dir: string, env: Record<string, string | null>, args: string[] = []) {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response(tarball(), { headers: { "Content-Type": "application/octet-stream" } }),
+    });
+    const childEnv: Record<string, string | undefined> = {
+      ...bunEnv,
+      HOME: join(dir, "home"),
+      USERPROFILE: join(dir, "home"),
+      BUN_INSTALL_CACHE_DIR: undefined,
+      BUN_INSTALL: undefined,
+      XDG_CACHE_HOME: undefined,
+      BUN_COMPILE_TARGET_TARBALL_URL: `http://127.0.0.1:${server.port}/bun.tgz`,
+    };
+    for (const [key, value] of Object.entries(env)) {
+      childEnv[key] = value ?? undefined;
+    }
+    for (const key of Object.keys(childEnv)) {
+      if (childEnv[key] === undefined) delete childEnv[key];
+    }
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", `--target=${target}`, ...args, "app.js", "--outfile", "app"],
+      env: childEnv,
+      cwd: join(dir, "project"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The download worked and the build failed on the placeholder, not earlier.
+    expect(stderr).toContain("failed to write compiled executable");
+    expect(existsSync(join(dir, "home", ".bun"))).toBe(false);
+    expect(existsSync(join(dir, "project", ".bun-cache"))).toBe(false);
+  }
+
+  // The cache directory holds the download and nothing else.
+  function cachedDownload(cacheDir: string): string {
+    const entries = readdirSync(cacheDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toStartWith("bun-linux-");
+    return readFileSync(join(cacheDir, entries[0]), "utf8");
+  }
+
+  const files = { "project/app.js": `console.log("hi");`, "home/.keep": "" };
+
+  test.concurrent("caches the download under $XDG_CACHE_HOME/.bun/install/cache", async () => {
+    using dir = tempDir("compile-cache-xdg", files);
+    await crossCompile(String(dir), { XDG_CACHE_HOME: join(String(dir), "xdg") });
+    expect(cachedDownload(join(String(dir), "xdg", ".bun", "install", "cache"))).toBe(placeholder);
+  });
+
+  test.concurrent("caches the download under $BUN_INSTALL/install/cache", async () => {
+    using dir = tempDir("compile-cache-bun-install", files);
+    await crossCompile(String(dir), { BUN_INSTALL: join(String(dir), "bun-install") });
+    expect(cachedDownload(join(String(dir), "bun-install", "install", "cache"))).toBe(placeholder);
+  });
+
+  // `--env=disable` makes `bun build` load .env files without inlining them into the bundle.
+  test.concurrent("caches the download under BUN_INSTALL_CACHE_DIR from a .env file", async () => {
+    using dir = tempDir("compile-cache-dotenv", files);
+    const cacheDir = join(String(dir), "dotenv-cache");
+    writeFileSync(join(String(dir), "project", ".env"), `BUN_INSTALL_CACHE_DIR=${cacheDir.replaceAll("\\", "/")}\n`);
+    await crossCompile(String(dir), {}, ["--env=disable"]);
+    expect(cachedDownload(cacheDir)).toBe(placeholder);
+  });
+
+  // Without a home directory the cache goes under the project's node_modules, like `bun install`.
+  test.concurrent.skipIf(isWindows)("caches the download under node_modules/.bun-cache without HOME", async () => {
+    using dir = tempDir("compile-cache-no-home", files);
+    await crossCompile(String(dir), { HOME: null });
+    expect(cachedDownload(join(String(dir), "project", "node_modules", ".bun-cache"))).toBe(placeholder);
+  });
 });
 
 // file command test works well

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1001,10 +1001,10 @@ describe("cross-compile executable cache", () => {
     return gzipSync(Buffer.concat([header, body, pad, Buffer.alloc(1024, 0)]));
   })();
 
-  // Runs the cross-compile of `<dir>/project/app.js`. `env` sets the variables the cache directory
-  // comes from; `null` unsets one. HOME points into `dir`, so a wrongly placed download shows up
-  // there and not in the real home directory.
-  async function crossCompile(dir: string, env: Record<string, string | null>, args: string[] = []) {
+  // Runs the cross-compile of `<dir>/project/app.js` and returns its stderr. `env` sets the variables
+  // the cache directory comes from; `null` unsets one. HOME points into `dir`, so a wrongly placed
+  // download shows up there and not in the real home directory.
+  async function crossCompile(dir: string, env: Record<string, string | null>, args: string[] = []): Promise<string> {
     await using server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
@@ -1033,14 +1033,15 @@ describe("cross-compile executable cache", () => {
       stderr: "pipe",
     });
     const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // The download worked and the build failed on the placeholder, not earlier.
-    expect(stderr).toContain("failed to write compiled executable");
     expect(existsSync(join(dir, "home", ".bun"))).toBe(false);
     expect(existsSync(join(dir, "project", ".bun-cache"))).toBe(false);
+    return stderr;
   }
 
   // The cache directory holds the download and nothing else.
-  function cachedDownload(cacheDir: string): string {
+  function cachedDownload(stderr: string, cacheDir: string): string {
+    // The download worked and the build failed on the placeholder, not earlier.
+    expect(stderr).toContain("failed to write compiled executable");
     const entries = readdirSync(cacheDir);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toStartWith("bun-linux-");
@@ -1051,14 +1052,14 @@ describe("cross-compile executable cache", () => {
 
   test.concurrent("caches the download under $XDG_CACHE_HOME/.bun/install/cache", async () => {
     using dir = tempDir("compile-cache-xdg", files);
-    await crossCompile(String(dir), { XDG_CACHE_HOME: join(String(dir), "xdg") });
-    expect(cachedDownload(join(String(dir), "xdg", ".bun", "install", "cache"))).toBe(placeholder);
+    const stderr = await crossCompile(String(dir), { XDG_CACHE_HOME: join(String(dir), "xdg") });
+    expect(cachedDownload(stderr, join(String(dir), "xdg", ".bun", "install", "cache"))).toBe(placeholder);
   });
 
   test.concurrent("caches the download under $BUN_INSTALL/install/cache", async () => {
     using dir = tempDir("compile-cache-bun-install", files);
-    await crossCompile(String(dir), { BUN_INSTALL: join(String(dir), "bun-install") });
-    expect(cachedDownload(join(String(dir), "bun-install", "install", "cache"))).toBe(placeholder);
+    const stderr = await crossCompile(String(dir), { BUN_INSTALL: join(String(dir), "bun-install") });
+    expect(cachedDownload(stderr, join(String(dir), "bun-install", "install", "cache"))).toBe(placeholder);
   });
 
   // `--env=disable` makes `bun build` load .env files without inlining them into the bundle.
@@ -1066,15 +1067,27 @@ describe("cross-compile executable cache", () => {
     using dir = tempDir("compile-cache-dotenv", files);
     const cacheDir = join(String(dir), "dotenv-cache");
     writeFileSync(join(String(dir), "project", ".env"), `BUN_INSTALL_CACHE_DIR=${cacheDir.replaceAll("\\", "/")}\n`);
-    await crossCompile(String(dir), {}, ["--env=disable"]);
-    expect(cachedDownload(cacheDir)).toBe(placeholder);
+    const stderr = await crossCompile(String(dir), {}, ["--env=disable"]);
+    expect(cachedDownload(stderr, cacheDir)).toBe(placeholder);
   });
 
   // Without a home directory the cache goes under the project's node_modules, like `bun install`.
   test.concurrent.skipIf(isWindows)("caches the download under node_modules/.bun-cache without HOME", async () => {
     using dir = tempDir("compile-cache-no-home", files);
-    await crossCompile(String(dir), { HOME: null });
-    expect(cachedDownload(join(String(dir), "project", "node_modules", ".bun-cache"))).toBe(placeholder);
+    const stderr = await crossCompile(String(dir), { HOME: null });
+    expect(cachedDownload(stderr, join(String(dir), "project", "node_modules", ".bun-cache"))).toBe(placeholder);
+  });
+
+  // The configured cache directory is a regular file, so nothing can be written under it. The error
+  // names the path bun tried to write and the errno, so the user knows which directory to fix.
+  test.concurrent("names the cache path and the errno when the download cannot be cached", async () => {
+    using dir = tempDir("compile-cache-unwritable", { ...files, "not-a-directory": "" });
+    const cacheDir = join(String(dir), "not-a-directory");
+    const stderr = await crossCompile(String(dir), { BUN_INSTALL_CACHE_DIR: cacheDir });
+    const line = stderr.split("\n").find(line => line.startsWith("Failed to write cached executable")) ?? stderr;
+    expect(line.replaceAll("\\", "/")).toContain(`' to "${cacheDir.replaceAll("\\", "/")}/bun-linux-`);
+    expect(line).toMatch(isWindows ? /": E[A-Z]+$/ : /": ENOTDIR$/);
+    expect(stderr).not.toContain("The download may be incomplete");
   });
 });
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -981,7 +981,7 @@ describe("cross-compile executable cache", () => {
   }
 
   // A gzipped ustar archive with one entry, `package/bin/bun`, like the npm tarballs.
-  function tarball(): Buffer {
+  const tarball: Buffer = (() => {
     const body = Buffer.from(placeholder);
     const header = Buffer.alloc(512, 0);
     header.write("package/bin/bun", 0, 100, "utf8");
@@ -999,7 +999,7 @@ describe("cross-compile executable cache", () => {
     header.write(octal(sum, 8), 148);
     const pad = Buffer.alloc((512 - (body.length % 512)) % 512, 0);
     return gzipSync(Buffer.concat([header, body, pad, Buffer.alloc(1024, 0)]));
-  }
+  })();
 
   // Runs the cross-compile of `<dir>/project/app.js`. `env` sets the variables the cache directory
   // comes from; `null` unsets one. HOME points into `dir`, so a wrongly placed download shows up
@@ -1008,7 +1008,7 @@ describe("cross-compile executable cache", () => {
     await using server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
-      fetch: () => new Response(tarball(), { headers: { "Content-Type": "application/octet-stream" } }),
+      fetch: () => new Response(tarball, { headers: { "Content-Type": "application/octet-stream" } }),
     });
     const childEnv: Record<string, string | undefined> = {
       ...bunEnv,


### PR DESCRIPTION
### Problem
- `bun build --compile --target=<other platform>` ignores `BUN_INSTALL`, `XDG_CACHE_HOME`, and `.env` values when it looks for the cached base executable. `CompileTarget::exe_path` (`src/options_types/compile_target.rs:190`) ignored its `_env` argument and called `bun_sys::fetch_cache_directory_path`, a stub that read only `BUN_INSTALL_CACHE_DIR` and `HOME`. The Zig version called `PackageManager.fetchCacheDirectoryPath(env, null)`.
- When the move into the cache fails, the error says `Failed to extract executable for '<target>'. The download may be incomplete.` The download is complete. The cache directory cannot be written (#13513, #25346, #28327).

### Fix
- Move the resolution chain into `bun_dotenv::Loader::install_cache_directory_path(cache_directory, buf)`. It writes into the caller's buffer. The order is unchanged: `BUN_INSTALL_CACHE_DIR`, the explicit `cache_directory`, `BUN_INSTALL/install/cache`, `XDG_CACHE_HOME/.bun/install/cache`, `HOME/.bun/install/cache`, `node_modules/.bun-cache`.
- `bun_install::fetch_cache_directory_path` and `CompileTarget::exe_path` both call it, so the cache directory has one definition. The `bun_sys` stub and the `CacheDir` struct are removed.
- A failed move into the cache returns `Error::CacheWriteFailed(errno)`. The message is `Failed to write cached executable for '<target>' to "<path>": ENOTDIR`. A tarball without `bin/bun` still reports `ExtractionFailed`, checked before the move.
- Verified: `test/bundler/bun-build-compile.test.ts`, block `cross-compile executable cache` (5 tests, all fail on 1.4.1). Also `test/cli/install/bun-pm.test.ts`.

### Background
- `target_executable` (`src/standalone_graph/StandaloneModuleGraph.rs`) asks `exe_path` for the cache location and downloads the npm tarball `@oven/bun-<os>-<arch>` there when the file is missing.
- `bun_options_types` cannot call `bun_install` because `bun_install` depends on it. `bun_dotenv` sits below both, which is why the shared function lives on the env loader.
- The tests point `BUN_COMPILE_TARGET_TARBALL_URL` at a local `Bun.serve` that returns a tarball with a placeholder `package/bin/bun`, so they never touch the network.

<details><summary>Notes</summary>

- #34330 fixed the same cache directory bug through a new `bun_options_types::install_cache` module that returned a `Vec`. This PR shares the implementation with the package manager through the env loader and writes into the caller's buffer. The error message change here is adapted from #34330.
- `XDG_CACHE_HOME` and `HOME` keep coming from the process environment (`bun_core::env_var`), as in the package manager before this change. `BUN_INSTALL_CACHE_DIR` and `BUN_INSTALL` come from the loader, so `.env` files apply when `bun build` loads them (`--env=disable` or `--env=inline`).
- `bun pm cache rm` still resolves through a process-only loader (`package_manager_command.rs`), so its behavior does not change.
- The cache file name uses the npm arch name, for example `bun-linux-aarch64-v1.4.1`, so the tests match the `bun-linux-` prefix and read the file back.
- The `no HOME` case is skipped on Windows, where `HOME` maps to `USERPROFILE`.
- The error test points `BUN_INSTALL_CACHE_DIR` at a regular file, not at a path below one. `bun_paths::make_path_with` loops forever when a path component is a regular file on Windows or a dangling symlink on POSIX (`mkdir` of the child returns `ENOENT`, `mkdir` of the parent returns `EEXIST`, and the walk never checks that the parent is a directory). `bun build --outdir <file>/sub` hangs on Windows 1.4.1 for the same reason. That is a separate bug in `make_path_with` and is not changed here.
- The first revision returned a `Vec` copied from the thread-local join buffer. Review asked for no extra copy, so the function now writes into the caller's buffer.
- Three pre-existing tests in `bun-build-compile.test.ts` hit their 5 s and 60 s timeouts in my debug ASAN container (each copies the 800 MB debug binary). They use `--compile-executable-path` and never reach the download path.
- Suites run on the debug build after the rebase: `test/bundler/bun-build-compile.test.ts` (22 pass, the 3 timeouts above), `test/cli/install/bun-pm.test.ts` (22 pass), `test/cli/install/bun-install-offline.test.ts` and `test/cli/install/bun-install-hardlink-fallback.test.ts` (14 pass). These cover the `bun install` and `bun pm cache rm` callers of the shared function.

</details>
