### PR TITLE
shell: finish a pipeline whose pipe setup fails instead of throwing

### DIFF
--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -86,6 +86,7 @@ pub enum WriterTag {
     Builtin,
     Cmd,
     CondExpr,
+    Pipeline,
     /// `subproc::PipeReader::CapturedWriter` — heap-allocated, addressed via
     /// `ChildPtr::raw` rather than `node`.
     Subproc,
@@ -1225,12 +1226,15 @@ pub(crate) fn on_io_writer_chunk(
     err: Option<sys::SystemError>,
 ) -> Yield {
     use crate::shell::builtin::Builtin;
-    use crate::shell::states::{cmd, cond_expr};
+    use crate::shell::states::{cmd, cond_expr, pipeline};
     match child.tag {
         WriterTag::Builtin => Builtin::on_io_writer_chunk(interp, child.node, written, err),
         WriterTag::Cmd => cmd::Cmd::on_io_writer_chunk(interp, child.node, written, err),
         WriterTag::CondExpr => {
             cond_expr::CondExpr::on_io_writer_chunk(interp, child.node, written, err)
+        }
+        WriterTag::Pipeline => {
+            pipeline::Pipeline::on_io_writer_chunk(interp, child.node, written, err)
         }
         // The target is the subprocess PipeReader's `CapturedWriter`; it
         // lives outside the NodeId arena (heap-allocated PipeReader), so it

--- a/src/runtime/shell/states/Pipeline.rs
+++ b/src/runtime/shell/states/Pipeline.rs
@@ -1,3 +1,4 @@
+use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::interpreter::{
     Interpreter, Node, NodeId, Pipe, ShellExecEnv, ShellExecEnvKind, StateKind, closefd, log,
@@ -11,7 +12,6 @@ use crate::shell::states::cond_expr::CondExpr;
 use crate::shell::states::r#if::If;
 use crate::shell::states::subshell::Subshell;
 use crate::shell::yield_::Yield;
-use crate::shell::{ExitCode, ShellErr};
 
 pub struct Pipeline {
     pub(crate) base: Base,
@@ -114,12 +114,7 @@ impl Pipeline {
 
         if cmd_count == 0 {
             // An empty pipeline finishes with 0.
-            // Return `Next(this)` so the trampoline sees `is_done`, removes us
-            // from the pipeline stack, and `next()` bubbles to the parent.
-            // Calling `child_done(parent, ..)` directly here would free this
-            // node while it's still on `pipeline_stack`.
-            interp.as_pipeline_mut(this).state = PipelineState::Done { exit_code: 0 };
-            return Yield::Next(this);
+            return Self::finish(interp, this, 0);
         }
 
         // First entry: allocate pipes + cmd slots.
@@ -143,13 +138,12 @@ impl Pipeline {
                             closefd(p[0]);
                             closefd(p[1]);
                         }
-                        // Leave `StartingCmds` so `drain_pipelines` doesn't
-                        // re-enter `next_starting` and retry the failing
-                        // syscall in a loop; stay suspended until the error
-                        // write completes.
-                        interp.as_pipeline_mut(this).state = PipelineState::WaitingWriteErr;
-                        interp.throw(ShellErr::new_sys(&e));
-                        return Yield::failed();
+                        let sys_err = e.to_shell_system_error();
+                        return Self::write_failing_error(
+                            interp,
+                            this,
+                            format_args!("bun: {}\n", sys_err.message),
+                        );
                     }
                 }
             }
@@ -226,12 +220,8 @@ impl Pipeline {
         } {
             Ok(d) => d,
             Err(e) => {
-                // On dupe failure,
-                // close the pipe ends not yet wrapped in an IOReader/IOWriter,
-                // deref `cmd_io`, transition to `.waiting_write_err`, and
-                // suspend. Without the state transition `drain_pipelines`
-                // would re-enter at the same `idx`, re-wrapping the same fds
-                // in fresh IOReader/IOWriter each iteration.
+                // Drop `child_io` (its IOReader/IOWriter own two of the pipe
+                // ends) and close the pipe ends no child has claimed yet.
                 drop(child_io);
                 {
                     let me = interp.as_pipeline_mut(this);
@@ -244,10 +234,13 @@ impl Pipeline {
                             closefd(p[1]);
                         }
                     }
-                    me.state = PipelineState::WaitingWriteErr;
                 }
-                interp.throw(ShellErr::new_sys(&e));
-                return Yield::failed();
+                let sys_err = e.to_shell_system_error();
+                return Self::write_failing_error(
+                    interp,
+                    this,
+                    format_args!("bun: {}\n", sys_err.message),
+                );
             }
         };
 
@@ -266,6 +259,69 @@ impl Pipeline {
         // Spawn exactly this one child. The trampoline will re-enter us via
         // `drain_pipelines` to spawn the next after this one yields.
         interp.start_node(child)
+    }
+
+    /// Mark the pipeline done with `exit_code`. Returns `Next(this)` so the
+    /// trampoline sees `is_done`, removes us from `pipeline_stack`, and
+    /// `next()` reports to the parent. Calling `child_done(parent, ..)`
+    /// directly would free this node while it is still on `pipeline_stack`.
+    fn finish(interp: &Interpreter, this: NodeId, exit_code: ExitCode) -> Yield {
+        interp.as_pipeline_mut(this).state = PipelineState::Done { exit_code };
+        Yield::Next(this)
+    }
+
+    /// Same shape as `Builtin::cmd_write_failing_error`: `.fd` stderr
+    /// enqueues an async write and parks in `WaitingWriteErr` (resumed by
+    /// `on_io_writer_chunk`); otherwise append to the captured stderr buffer
+    /// and finish with exit 1.
+    fn write_failing_error(
+        interp: &Interpreter,
+        this: NodeId,
+        args: core::fmt::Arguments<'_>,
+    ) -> Yield {
+        use std::io::Write as _;
+        let mut buf = Vec::new();
+        let _ = buf.write_fmt(args);
+        if interp.as_pipeline(this).io.stderr.needs_io().is_some() {
+            // Only the fd arm transitions state.
+            interp.as_pipeline_mut(this).state = PipelineState::WaitingWriteErr;
+            let child = io_writer::ChildPtr::new(this, io_writer::WriterTag::Pipeline);
+            // `OutKind::Fd` guaranteed by `needs_io()`.
+            if let OutKind::Fd(fd) = &interp.as_pipeline(this).io.stderr {
+                return fd.writer.enqueue(child, fd.captured, &buf);
+            }
+            unreachable!()
+        }
+        if let OutKind::Pipe = &interp.as_pipeline(this).io.stderr {
+            // SAFETY: single trampoline frame; no other borrow of the env's
+            // (or its parent's) stderr buffer is live.
+            let stderr = unsafe {
+                interp
+                    .as_pipeline_mut(this)
+                    .base
+                    .shell_mut()
+                    .buffered_stderr_mut()
+            };
+            stderr.extend_from_slice(&buf);
+        }
+        Self::finish(interp, this, 1)
+    }
+
+    /// IOWriter completion callback for the error message written in
+    /// `WaitingWriteErr`. The pipeline finishes with exit code 1 whether or
+    /// not the write succeeded: the parent always needs a completion, and a
+    /// failed stderr write has nowhere else to be reported.
+    pub(crate) fn on_io_writer_chunk(
+        interp: &Interpreter,
+        this: NodeId,
+        _written: usize,
+        _err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        debug_assert!(matches!(
+            interp.as_pipeline(this).state,
+            PipelineState::WaitingWriteErr
+        ));
+        Self::finish(interp, this, 1)
     }
 
     pub(crate) fn child_done(

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -574,6 +574,81 @@ describe("bunshell", () => {
     expect(exitCode).toBe(0);
   });
 
+  // `ulimit -n` caps the fd table of the child so the pipeline cannot create
+  // its pipes (EMFILE). The pipeline must print the error on its stderr and
+  // finish with exit code 1 so the `$` promise settles and the script goes on,
+  // instead of throwing from inside the interpreter and never completing.
+  describe.skipIf(isWindows)("pipeline that fails to create its pipes", () => {
+    const runWithFdLimit = (limit: number, script: string, env = bunEnv) =>
+      Bun.spawn({
+        cmd: ["/bin/sh", "-c", `ulimit -n ${limit} && exec "$1" -e "$2"`, "sh", bunExe(), script],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+    test("reports EMFILE on stderr and finishes with exit code 1", async () => {
+      // 24 pipes need 48 fds; the whole process gets 32.
+      const pipeline = ["echo hi", ...Array(24).fill("cat")].join(" | ");
+      const script = /* ts */ `
+        import { $ } from "bun";
+        const results = {};
+        const record = (name, r) => {
+          results[name] = { stdout: r.stdout.toString(), stderr: r.stderr.toString(), exitCode: r.exitCode };
+        };
+        record("stderr captured", await $\`${pipeline}\`.nothrow().quiet());
+        record("stderr on a fd", await $\`${pipeline}\`.nothrow());
+        record("script continues", await $\`${pipeline}; echo after\`.nothrow().quiet());
+        try {
+          await $\`${pipeline}\`.quiet();
+          results["throws"] = "did not throw";
+        } catch (e) {
+          record("throws", e);
+        }
+        console.log(JSON.stringify(results));
+      `;
+      await using proc = runWithFdLimit(32, script);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("bun: Too many open files\n");
+      expect(JSON.parse(stdout)).toEqual({
+        "stderr captured": { stdout: "", stderr: "bun: Too many open files\n", exitCode: 1 },
+        "stderr on a fd": { stdout: "", stderr: "bun: Too many open files\n", exitCode: 1 },
+        "script continues": { stdout: "after\n", stderr: "bun: Too many open files\n", exitCode: 0 },
+        "throws": { stdout: "", stderr: "bun: Too many open files\n", exitCode: 1 },
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    // Pipelines of growing length against a fixed fd budget. The short ones
+    // fit. Past some length the pipes still fit but the per-command `dup` of
+    // the cwd fd fails. Past that the pipes themselves fail. Every pipeline
+    // must finish, either with its output or with the EMFILE message.
+    test("reports EMFILE from the per-command env dup and finishes", async () => {
+      const script = /* ts */ `
+        import { $ } from "bun";
+        const results = [];
+        for (let n = 2; n <= 16; n++) {
+          const pipeline = ["echo hi", ...Array(n - 1).fill("cat")].join(" | ");
+          const r = await $\`\${{ raw: pipeline }}\`.nothrow().quiet();
+          results.push({ stdout: r.stdout.toString(), stderr: r.stderr.toString(), exitCode: r.exitCode });
+        }
+        console.log(JSON.stringify(results));
+      `;
+      // The builtin cat keeps this to pipes and dups: no subprocess, so no
+      // spawn-time fds change the accounting.
+      await using proc = runWithFdLimit(32, script, { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const results = JSON.parse(stdout);
+      const ok = { stdout: "hi\n", stderr: "", exitCode: 0 };
+      const emfile = { stdout: "", stderr: "bun: Too many open files\n", exitCode: 1 };
+      const firstFailure = results.findIndex(r => r.exitCode !== 0);
+      expect(firstFailure).toBeGreaterThan(0);
+      expect(results).toEqual([...Array(firstFailure).fill(ok), ...Array(results.length - firstFailure).fill(emfile)]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("operators no spaces", async () => {
     TestBuilder.command`echo LMAO|cat`.stdout("LMAO\n").runAsTest("pipeline");
     TestBuilder.command`echo foo&&echo hi`.stdout("foo\nhi\n").runAsTest("&&");


### PR DESCRIPTION
### Problem
- When a shell pipeline cannot create its pipes, the `$` promise never settles and the process never exits. Repro: `ulimit -n 16; bun -e 'await Bun.$\`echo a; echo hi | cat | cat | cat | cat | cat | cat | cat | cat\`'` prints `a`, reports `EMFILE: Too many open files (socketpair)`, then hangs.
- The cause is the two pipe setup error paths in `Pipeline::next_starting` (`src/runtime/shell/states/Pipeline.rs`, the `socketpair()` loop and the `dupe_for_subshell` call). They set the state to `WaitingWriteErr`, call `interp.throw(..)` and return `Yield::failed()`. No writer is enqueued for that state and no `child_done` reaches the parent, so the interpreter never calls `finish()`. The pending-activity count is never dropped either, so the process stays alive.

### Fix
- Both error paths now call a new `Pipeline::write_failing_error`, which writes `bun: <message>\n` to the pipeline's stderr and finishes with exit code 1. This is the shape `Builtin::cmd_write_failing_error` and `CondExpr::write_failing_error` already use.
- A stderr fd enqueues the message on the IOWriter with a new `WriterTag::Pipeline` and parks in `WaitingWriteErr`. `Pipeline::on_io_writer_chunk` finishes the pipeline when the write completes. A captured stderr is appended to synchronously.
- Both completions go through `Pipeline::finish`, which sets `Done { exit_code }` and returns `Next(this)`. The trampoline then removes the pipeline from `pipeline_stack` before `next()` reports to the parent, which frees the node. The empty-pipeline path uses the same helper.
- Verified: `test/js/bun/shell/bunshell.test.ts`, two new tests under `pipeline that fails to create its pipes` (both fail on the released bun with an uncaught EMFILE error). Also `bunshell.test.ts`, `pipeline_stack.test.ts`, `yield.test.ts`, `shell-hang.test.ts`, `epipe.test.ts`, `assignments-in-pipeline.test.ts`, `throw.test.ts`, `exec.test.ts`, `shell-write-fault.test.ts`, `shell-pipe-read-fault.test.ts`.

### Background
- The shell interpreter is a state machine over an arena of nodes (`Script`, `Stmt`, `Pipeline`, `Cmd`, ...). Each step returns a `Yield`. `Yield::run` is the trampoline that drives it. A node reports completion to its parent with `interp.child_done(parent, this, exit_code)`, and the root completion calls `Interpreter::finish`, which settles the JS promise.
- `Yield::failed()` only means "a JS exception was raised". It does not complete the node. Outside `run_from_js`, nothing catches that exception, so the parent waits forever.
- The trampoline keeps a `pipeline_stack` of pipelines that are still starting children. A pipeline must not call `child_done` on its parent while it is on that stack: the parent frees the node and the stack then points at a freed slot. Returning `Next(this)` in the `Done` state lets the trampoline pop it first.
- `IOWriter` is the shared async writer for an fd. A state enqueues bytes with a `ChildPtr` (node id plus `WriterTag`) and gets `on_io_writer_chunk` when the chunk is written. The tag selects which state's callback runs.

<details><summary>Notes</summary>

- The Zig shell had this behavior (`writeFailingError("bun: {f}\n", system_err.message)` then `childDone(this, 1)` from `onIOWriterChunk`). The Rust port replaced it with `throw` + `failed()`.
- The message uses `to_shell_system_error().message` with no path, so it reads `bun: Too many open files`. The `ShellErr` `Display` impl would add a trailing `: ` because `socketpair` and `dup` carry no path.
- `on_io_writer_chunk` finishes with exit 1 even when the stderr write itself failed. Throwing there would hang the same way, and the parent always needs a completion.
- In the `dupe_for_subshell` path at `cmd_idx > 0`, earlier children are already running. Finishing the pipeline makes the parent free it, and `Pipeline::deinit` tears down those children (`Cmd::deinit` kills a live subprocess, drops a builtin). `ProcessHandle` detaches the exit handler before the subprocess box is freed. The second test reaches this path with live builtin children at several `cmd_idx` values under the ASAN debug build.
- `bun exec` (mini event loop) used to abort the whole script with `error: Failed due to error: bunsh: Too many open files: ` and exit 1. It now prints `bun: Too many open files` and continues, like bash does after `pipe error`.
- Test design: `/bin/sh -c 'ulimit -n N && exec bun -e <script>'` lowers both the soft and hard fd limits so bun cannot raise them at startup. The first test uses 24 `cat`s under a limit of 32, so the pipes can never fit, and covers captured stderr, stderr on an fd, a script that continues after the failed pipeline, and the thrown `ShellError`. The second test grows the pipeline from 2 to 16 commands under a limit of 32 with the builtin `cat`, so the runs cross from success into the `dup` failure and then into the `socketpair` failure without any subprocess fds in the accounting.
- Related open PR #32302 is an earlier attempt at the same bug. It conflicts with main and leaves the `cmd_idx > 0` path throwing.
- Out of scope, already tracked: with subprocess children under fd exhaustion, a successful `posix_spawn` followed by `pidfd_open` failing with EMFILE makes `spawn_process.rs` block in `wait4` on a live child (the pipeline hangs at the first `cat` spawn for some `ulimit` values). That is a separate bug in `src/spawn_sys/spawn_process.rs` with its own PRs.
- `leak.test.ts` was also run. Its `memleak_*` and `#11816 > external` cases time out in this debug build environment for tests that do not involve pipelines too (`memleak_redirect_file`, `memleak_change_cwd`), so that is the environment, not this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->