### PR TITLE
bun_alloc: size BSS overflow blocks per store instead of a shared 2048

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -1288,19 +1288,30 @@ macro_rules! bss_list {
     };
 }
 
-/// Declare a `BSSStringList<COUNT, ITEM_LENGTH>` singleton accessor.
+/// Declare a `BSSStringList<COUNT, ITEM_LENGTH, OVERFLOW_BLOCK_SIZE>` singleton
+/// accessor. The overflow block size is derived from `$count`.
 #[macro_export]
 macro_rules! bss_string_list {
     ($(#[$m:meta])* $vis:vis $name:ident : $count:expr, $item_len:expr) => {
-        $crate::bss_singleton!($(#[$m])* $vis fn $name() -> $crate::BSSStringList<{ $count }, { $item_len }>);
+        $crate::bss_singleton!($(#[$m])* $vis fn $name() -> $crate::BSSStringList<
+            { $count },
+            { $item_len },
+            { $crate::bss_overflow_block_size($count) },
+        >);
     };
 }
 
-/// Declare a `BSSMapInner<T, COUNT, RM_SLASH>` singleton accessor.
+/// Declare a `BSSMapInner<T, COUNT, OVERFLOW_BLOCK_SIZE, RM_SLASH>` singleton
+/// accessor. The overflow block size is derived from `$count`.
 #[macro_export]
 macro_rules! bss_map_inner {
     ($(#[$m:meta])* $vis:vis $name:ident : $value_ty:ty, $count:expr, $rm_slash:expr) => {
-        $crate::bss_singleton!($(#[$m])* $vis fn $name() -> $crate::BSSMapInner<$value_ty, { $count }, { $rm_slash }>);
+        $crate::bss_singleton!($(#[$m])* $vis fn $name() -> $crate::BSSMapInner<
+            $value_ty,
+            { $count },
+            { $crate::bss_overflow_block_size($count) },
+            { $rm_slash },
+        >);
     };
 }
 
@@ -1599,9 +1610,16 @@ unsafe impl<ValueType: Send, const COUNT: usize> Sync for BSSList<ValueType, COU
 
 const BSS_LIST_CHUNK_SIZE: usize = 256;
 
-/// The per-store overflow-block size is `count / 4`; this shared constant must
-/// be >= the largest store's, i.e. the filename store's `8192 / 4`.
-const BSS_OVERFLOW_BLOCK_SIZE: usize = 2048;
+/// Capacity of one heap-allocated overflow block for a `BSSStringList` or
+/// `BSSMapInner` that holds `count` entries inline.
+///
+/// Stable Rust cannot write `COUNT / 4` in a field type, so each store takes
+/// the result as its own `OVERFLOW_BLOCK_SIZE` const generic. The `bss_*!`
+/// macros pass it from `$count`; a hand-written type alias must pass the same
+/// value.
+pub const fn bss_overflow_block_size(count: usize) -> usize {
+    count / 4
+}
 
 /// `#[repr(C)]` with `prev` before `data` so the inline `BSSList::tail` block's
 /// scalar fields cluster at the front of the singleton mapping (see the layout
@@ -1799,8 +1817,9 @@ impl<ValueType, const COUNT: usize> Drop for BSSList<ValueType, COUNT> {
 ///
 /// Same const-generic-arithmetic and per-type-static caveats as `BSSList`.
 pub struct BSSStringList<
-    const COUNT: usize,       /* = _COUNT * 2 */
-    const ITEM_LENGTH: usize, /* = _ITEM_LENGTH + 1 */
+    const COUNT: usize,               /* = _COUNT * 2 */
+    const ITEM_LENGTH: usize,         /* = _ITEM_LENGTH + 1 */
+    const OVERFLOW_BLOCK_SIZE: usize, /* = bss_overflow_block_size(COUNT) */
 > {
     // Inline arrays would live in the same demand-faulted allocation
     // as the rest of the singleton with `init()` writing only the four scalar
@@ -1814,7 +1833,7 @@ pub struct BSSStringList<
     // `[..backing_buf_used]` / `[..slice_buf_used]` are ever read.
     pub(crate) backing_buf: NonNull<[MaybeUninit<u8>]>, // len == COUNT * ITEM_LENGTH
     pub(crate) backing_buf_used: u64,
-    pub(crate) overflow_list: OverflowList<&'static [u8], BSS_OVERFLOW_BLOCK_SIZE>,
+    pub(crate) overflow_list: OverflowList<&'static [u8], OVERFLOW_BLOCK_SIZE>,
     pub(crate) slice_buf: NonNull<[MaybeUninit<&'static [u8]>]>, // len == COUNT
     pub(crate) slice_buf_used: u16,
     pub(crate) mutex: Mutex,
@@ -1872,7 +1891,9 @@ impl BSSAppendable for &[&[u8]] {
     }
 }
 
-impl<const COUNT: usize, const ITEM_LENGTH: usize> BSSStringList<COUNT, ITEM_LENGTH> {
+impl<const COUNT: usize, const ITEM_LENGTH: usize, const OVERFLOW_BLOCK_SIZE: usize>
+    BSSStringList<COUNT, ITEM_LENGTH, OVERFLOW_BLOCK_SIZE>
+{
     const MAX_INDEX: usize = COUNT - 1;
 
     /// In-place field initialization into uninitialized storage.
@@ -2178,20 +2199,29 @@ impl<const COUNT: usize, const ITEM_LENGTH: usize> BSSStringList<COUNT, ITEM_LEN
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// BSSMapInner<ValueType, COUNT, REMOVE_TRAILING_SLASHES>
+// BSSMapInner<ValueType, COUNT, OVERFLOW_BLOCK_SIZE, REMOVE_TRAILING_SLASHES>
 // ──────────────────────────────────────────────────────────────────────────
 
-pub struct BSSMapInner<ValueType, const COUNT: usize, const REMOVE_TRAILING_SLASHES: bool> {
+pub struct BSSMapInner<
+    ValueType,
+    const COUNT: usize,
+    const OVERFLOW_BLOCK_SIZE: usize, /* = bss_overflow_block_size(COUNT) */
+    const REMOVE_TRAILING_SLASHES: bool,
+> {
     pub(crate) index: IndexMap,
-    pub overflow_list: OverflowList<ValueType, BSS_OVERFLOW_BLOCK_SIZE>,
+    pub overflow_list: OverflowList<ValueType, OVERFLOW_BLOCK_SIZE>,
     pub(crate) mutex: Mutex,
     // Only `[0..backing_buf_used]` is initialized.
     pub backing_buf: [MaybeUninit<ValueType>; COUNT],
     pub backing_buf_used: u16,
 }
 
-impl<ValueType, const COUNT: usize, const REMOVE_TRAILING_SLASHES: bool>
-    BSSMapInner<ValueType, COUNT, REMOVE_TRAILING_SLASHES>
+impl<
+    ValueType,
+    const COUNT: usize,
+    const OVERFLOW_BLOCK_SIZE: usize,
+    const REMOVE_TRAILING_SLASHES: bool,
+> BSSMapInner<ValueType, COUNT, OVERFLOW_BLOCK_SIZE, REMOVE_TRAILING_SLASHES>
 {
     const MAX_INDEX: usize = COUNT - 1;
 

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -1019,16 +1019,14 @@ pub mod allocators {
 // ──────────────────────────────────────────────────────────────────────────
 // Per-monomorphization singleton macros
 //
-// Each instantiation needs its own singleton. Rust forbids
-// generic statics, so the storage is emitted at the *declare site* instead:
+// Rust forbids generic statics, so each instantiation's storage is emitted at
+// the declare site:
 //
 //   bss_string_list! { pub dirname_store: 4096, 129 }
-//   // → static STORAGE: AtomicPtr<BSSStringList<4096, 129, 1024>>
-//   //   pub fn dirname_store() -> *mut BSSStringList<4096, 129, 1024>
+//   // → pub fn dirname_store() -> *mut BSSStringList<4096, 129, 1024>
 //
-// The accessor heap-allocates and field-initializes via `init_at` on first
-// call. It returns a raw `*mut`; callers must not hold overlapping unique
-// borrows.
+// The accessor runs `init_at` on first call and returns a raw `*mut`; callers
+// must not hold overlapping unique borrows.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Emit a process-lifetime singleton accessor for any type with an
@@ -1288,8 +1286,7 @@ macro_rules! bss_list {
     };
 }
 
-/// Declare a `BSSStringList<COUNT, ITEM_LENGTH, OVERFLOW_BLOCK_SIZE>` singleton
-/// accessor. The overflow block size is derived from `$count`.
+/// Declare a `BSSStringList` singleton accessor; the block size comes from `$count`.
 #[macro_export]
 macro_rules! bss_string_list {
     ($(#[$m:meta])* $vis:vis $name:ident : $count:expr, $item_len:expr) => {
@@ -1301,8 +1298,7 @@ macro_rules! bss_string_list {
     };
 }
 
-/// Declare a `BSSMapInner<T, COUNT, OVERFLOW_BLOCK_SIZE, RM_SLASH>` singleton
-/// accessor. The overflow block size is derived from `$count`.
+/// Declare a `BSSMapInner` singleton accessor; the block size comes from `$count`.
 #[macro_export]
 macro_rules! bss_map_inner {
     ($(#[$m:meta])* $vis:vis $name:ident : $value_ty:ty, $count:expr, $rm_slash:expr) => {
@@ -1517,6 +1513,7 @@ impl<ValueType, const COUNT: usize> OverflowList<ValueType, COUNT> {
     /// `bss_heap_init`/`bss_lazy_bytes`, NOT `mi_malloc`/stack `MaybeUninit`).
     #[inline]
     pub(crate) unsafe fn init_counters_at(slot: *mut Self) {
+        const { assert!(COUNT > 0, "an overflow block must hold at least one item") };
         // SAFETY: caller contract.
         unsafe {
             addr_of_mut!((*slot).list.used).write(0);
@@ -1610,13 +1607,10 @@ unsafe impl<ValueType: Send, const COUNT: usize> Sync for BSSList<ValueType, COU
 
 const BSS_LIST_CHUNK_SIZE: usize = 256;
 
-/// Capacity of one heap-allocated overflow block for a `BSSStringList` or
-/// `BSSMapInner` that holds `count` entries inline.
-///
-/// Stable Rust cannot write `COUNT / 4` in a field type, so each store takes
-/// the result as its own `OVERFLOW_BLOCK_SIZE` const generic. The `bss_*!`
-/// macros pass it from `$count`; a hand-written type alias must pass the same
-/// value.
+/// Overflow block capacity for a store with `count` inline entries. Each store
+/// takes it as its `OVERFLOW_BLOCK_SIZE` const generic because a field type
+/// cannot spell `COUNT / 4` (see the note above `OverflowListBlock`). A store
+/// needs `count >= 4`; a zero-capacity block fails to compile.
 pub const fn bss_overflow_block_size(count: usize) -> usize {
     count / 4
 }

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -1023,11 +1023,11 @@ pub mod allocators {
 // generic statics, so the storage is emitted at the *declare site* instead:
 //
 //   bss_string_list! { pub dirname_store: 4096, 129 }
-//   // → static STORAGE: SyncUnsafeCell<MaybeUninit<BSSStringList<4096,129>>>
-//   //   pub fn dirname_store() -> *mut BSSStringList<4096,129>
+//   // → static STORAGE: AtomicPtr<BSSStringList<4096, 129, 1024>>
+//   //   pub fn dirname_store() -> *mut BSSStringList<4096, 129, 1024>
 //
-// The accessor lazily field-initializes via `init_at` under `std::sync::Once`.
-// Returning `&'static mut` means callers must not hold overlapping unique
+// The accessor heap-allocates and field-initializes via `init_at` on first
+// call. It returns a raw `*mut`; callers must not hold overlapping unique
 // borrows.
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -1808,7 +1808,7 @@ impl<ValueType, const COUNT: usize> Drop for BSSList<ValueType, COUNT> {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// BSSStringList<_COUNT, _ITEM_LENGTH>
+// BSSStringList<COUNT, ITEM_LENGTH, OVERFLOW_BLOCK_SIZE>
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Append-only list.

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -200,9 +200,6 @@ impl Linker {
         resolve_results: *mut ResolveResults,
         fs: *mut Fs::FileSystem,
     ) -> Self {
-        // The `LazyLock` accessor initializes `relative_paths_list` lazily on
-        // first `intern_path()` / `relative_paths_list()` call, so no eager
-        // poke is needed (it would be startup overhead for non-bundling code paths).
         Self {
             options,
             fs,

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -42,15 +42,20 @@ pub struct Linker {
 const RUNTIME_SOURCE_PATH: &[u8] = b"bun:wrap";
 
 // ── relative_paths_list singleton ────────────────────────────────────────
-// `bun_alloc::BSSStringList<COUNT, ITEM_LENGTH>` encodes the parameters as
-// `COUNT = _COUNT * 2`, `ITEM_LENGTH = _ITEM_LENGTH + 1` (see `bun_alloc/lib.rs`).
+// `bun_alloc::BSSStringList<COUNT, ITEM_LENGTH, OVERFLOW_BLOCK_SIZE>` encodes the
+// parameters as `COUNT = _COUNT * 2`, `ITEM_LENGTH = _ITEM_LENGTH + 1`,
+// `OVERFLOW_BLOCK_SIZE = bss_overflow_block_size(COUNT)` (see `bun_alloc/lib.rs`).
 // `bss_string_list!` would be the canonical declare-site macro but
 // expands to `core::cell::SyncUnsafeCell`, and `bun_bundler` does not (yet)
 // enable `#![feature(sync_unsafe_cell)]`. Use the heap-allocating `init()`
 // fallback under a `LazyLock` instead — same lifetime semantics
 // (process-static, never freed), just not BSS-backed. Swap to the macro once
 // the crate-level feature flag lands.
-type ImportPathsList = bun_alloc::BSSStringList<{ 512 * 2 }, { 128 + 1 }>;
+type ImportPathsList = bun_alloc::BSSStringList<
+    { 512 * 2 },
+    { 128 + 1 },
+    { bun_alloc::bss_overflow_block_size(512 * 2) },
+>;
 
 /// `Send + Sync` newtype around the leaked `BSSStringList` heap allocation so
 /// it can sit inside a `LazyLock`. The underlying list serializes its own

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -41,43 +41,8 @@ pub struct Linker {
 
 const RUNTIME_SOURCE_PATH: &[u8] = b"bun:wrap";
 
-// ── relative_paths_list singleton ────────────────────────────────────────
-// `bun_alloc::BSSStringList<COUNT, ITEM_LENGTH, OVERFLOW_BLOCK_SIZE>` encodes the
-// parameters as `COUNT = _COUNT * 2`, `ITEM_LENGTH = _ITEM_LENGTH + 1`,
-// `OVERFLOW_BLOCK_SIZE = bss_overflow_block_size(COUNT)` (see `bun_alloc/lib.rs`).
-// `bss_string_list!` would be the canonical declare-site macro but
-// expands to `core::cell::SyncUnsafeCell`, and `bun_bundler` does not (yet)
-// enable `#![feature(sync_unsafe_cell)]`. Use the heap-allocating `init()`
-// fallback under a `LazyLock` instead — same lifetime semantics
-// (process-static, never freed), just not BSS-backed. Swap to the macro once
-// the crate-level feature flag lands.
-type ImportPathsList = bun_alloc::BSSStringList<
-    { 512 * 2 },
-    { 128 + 1 },
-    { bun_alloc::bss_overflow_block_size(512 * 2) },
->;
-
-/// `Send + Sync` newtype around the leaked `BSSStringList` heap allocation so
-/// it can sit inside a `LazyLock`. The underlying list serializes its own
-/// mutation through an internal `Mutex` (see `BSSStringList::append`), so
-/// sharing the raw pointer across threads is sound; the `&mut self` receiver
-/// on `append` is not an exclusivity requirement.
-struct ImportPathsListPtr(core::ptr::NonNull<ImportPathsList>);
-// SAFETY: `BSSStringList` guards every mutating method with `self.mutex`, and
-// the allocation is process-lifetime (never freed). The pointer is therefore
-// safe to publish and dereference from any thread.
-unsafe impl Send for ImportPathsListPtr {}
-// SAFETY: same invariant as `Send` — internal mutex serializes mutation and the
-// allocation is process-lifetime, so shared `&` access from any thread is sound.
-unsafe impl Sync for ImportPathsListPtr {}
-
-static RELATIVE_PATHS_LIST: std::sync::LazyLock<ImportPathsListPtr> =
-    std::sync::LazyLock::new(|| ImportPathsListPtr(ImportPathsList::init()));
-
-#[inline]
-fn relative_paths_list_ptr() -> *mut ImportPathsList {
-    RELATIVE_PATHS_LIST.0.as_ptr()
-}
+// `relative_paths_list: BSSStringList(512, 128)` → `<{512*2}, {128+1}>`
+bun_alloc::bss_string_list! { relative_paths_list_ptr : 512 * 2, 128 + 1 }
 
 // ── HardcodedModule alias lookup ────────────────────────────────────────
 // Thin adapter over `bun_resolve_builtins::Alias::get` so the call site keeps
@@ -121,12 +86,11 @@ mod hardcoded_module {
 /// singleton (the `OnceLock`-style exception PORTING.md carves out).
 #[inline]
 pub(crate) fn dupe(src: &[u8]) -> &'static [u8] {
-    // SAFETY: `relative_paths_list_ptr()` is Once-initialized and never freed
-    // (process-lifetime singleton). `append` takes `*mut Self`, serializes on
-    // the inner mutex, copies `src` into its owned backing buffer and returns
-    // a slice borrowing that storage; the returned borrow is `'static`-valid
-    // by construction.
-    unsafe { ImportPathsList::append(relative_paths_list_ptr(), &src).expect("OOM") }
+    // SAFETY: `relative_paths_list_ptr()` is the process-lifetime `bss_string_list!`
+    // singleton. `append` takes `*mut Self`, serializes on the inner mutex,
+    // copies `src` into its owned backing buffer and returns a slice borrowing
+    // that storage; the returned borrow is `'static`-valid by construction.
+    unsafe { bun_alloc::BSSStringList::append(relative_paths_list_ptr(), &src).expect("OOM") }
 }
 #[inline]
 fn intern(buf: Vec<u8>) -> &'static [u8] {

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -395,7 +395,8 @@ pub use Flags as Flag;
 // 4. Allocate onto the https://en.wikipedia.org/wiki/.bss#BSS_in_C instead of the heap, so we can avoid memory leaks
 //
 // COUNT mirrors `fs::preallocate::counts::DIR_ENTRY`.
-pub type HashMap = allocators::BSSMapInner<DirInfo, 2048, true>;
+pub type HashMap =
+    allocators::BSSMapInner<DirInfo, 2048, { allocators::bss_overflow_block_size(2048) }, true>;
 
 /// Insert `value` at `result`'s slot and return a retag-durable slot pointer
 /// (see [`slot_ptr_at`]). Takes a raw map pointer, not `&mut self`: a

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -28,8 +28,11 @@ mod preallocate {
     }
 }
 
-pub(crate) type FilenameStoreBacking =
-    allocators::BSSStringList<{ preallocate::counts::FILES * 2 }, { 64 + 1 }>;
+pub(crate) type FilenameStoreBacking = allocators::BSSStringList<
+    { preallocate::counts::FILES * 2 },
+    { 64 + 1 },
+    { allocators::bss_overflow_block_size(preallocate::counts::FILES * 2) },
+>;
 pub(crate) type EntryStoreBacking = allocators::BSSList<Entry, { preallocate::counts::FILES * 2 }>;
 
 // Per-monomorphization singleton storage, emitted at the declare site via

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -959,7 +959,12 @@ pub mod fs {
     /// Fixed-capacity (2048-entry) BSS-backed hash map for the directory-entry
     /// cache. Keys are not stored — only their hashes — so lookups cannot
     /// recover key bytes (`BSSMapInner` is the keyless inner shape).
-    type EntriesOptionMap = bun_alloc::BSSMapInner<EntriesOption, 2048, true>;
+    type EntriesOptionMap = bun_alloc::BSSMapInner<
+        EntriesOption,
+        2048,
+        { bun_alloc::bss_overflow_block_size(2048) },
+        true,
+    >;
 
     // Per-monomorphization singleton storage for `EntriesOption.Map`.
     bun_alloc::bss_map_inner! { pub entries_option_map : EntriesOption, 2048, true }

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1145,6 +1145,53 @@ it("resolves through many directories without corrupting the dir cache", async (
   expect(exitCode).toBe(0);
 }, 20_000);
 
+// The resolver's directory-entry cache keeps 2048 entries inline and then
+// spills into heap blocks of 512 entries each. A readdir that fails with
+// ENOTDIR occupies a cache slot like a real directory does, so paths below a
+// regular file fill the inline storage and several overflow blocks without
+// creating any directories. The real directories resolved after that land in
+// an overflow block; the second pass reads them back through the block index.
+it("resolves correctly once the dir cache spills into overflow blocks", async () => {
+  const FILLER = 2700;
+  const REAL = 40;
+  const files: Record<string, string> = { "f.js": "" };
+  for (let i = 0; i < REAL; i++) {
+    files[`r${i}/index.js`] = `module.exports = ${i};`;
+  }
+  files["index.js"] = `
+    const root = import.meta.dir.replaceAll("\\\\", "/");
+    let thrown = 0;
+    let ok = 0;
+    for (let pass = 0; pass < 2; pass++) {
+      for (let i = 0; i < ${FILLER}; i++) {
+        try {
+          Bun.resolveSync("./f.js/d" + i + "/x", import.meta.dir);
+        } catch {
+          thrown++;
+        }
+      }
+      for (let i = 0; i < ${REAL}; i++) {
+        const resolved = Bun.resolveSync("./r" + i, import.meta.dir).replaceAll("\\\\", "/");
+        if (resolved === root + "/r" + i + "/index.js") ok++;
+      }
+    }
+    console.log(thrown, ok);
+  `;
+
+  await using dir = tempDir("dir-cache-overflow", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(`${2 * FILLER} ${2 * REAL}\n`);
+  expect(exitCode).toBe(0);
+});
+
 // ASAN builds print a warning on stderr that has nothing to do with resolution.
 function stripAsanWarning(stderr: string): string {
   return stderr


### PR DESCRIPTION
### Problem
- `BSSStringList` and `BSSMapInner` allocate their overflow blocks from one shared constant, `BSS_OVERFLOW_BLOCK_SIZE = 2048` (`src/bun_alloc/lib.rs:1604`), whose own comment says the per-store value is `count / 4`.
- Every store that overflows allocates 2048-entry blocks. The resolver's `DirInfo` and directory-entry maps (2048 inline) need 512, the dirname store (4096) needs 1024, the bundler's relative path list (1024) needs 256.

### Fix
- `BSSStringList` and `BSSMapInner` take the block capacity as a new const generic, `OVERFLOW_BLOCK_SIZE`. `bss_overflow_block_size(count)` returns `count / 4`.
- `bss_string_list!` and `bss_map_inner!` pass it from `$count`. The resolver's type aliases pass the same value. The linker declares its relative path list with `bss_string_list!` instead of a `LazyLock` around `init()`.
- Stable Rust cannot spell `COUNT / 4` in a field type, so each store pins the value at its use site, like `COUNT = _COUNT * 2` today. A zero block size (`count < 4`) is a compile error.
- Verified: `test/js/bun/resolve/resolve.test.ts` (new test fills the directory-entry cache past the inline 2048 entries and several 512-entry blocks). Also `require.test.ts`, `bundler_edgecase.test.ts`, clippy, rustfmt.

### Background
- A BSS store is a process-lifetime singleton with an inline array of `COUNT` slots. When it is full, `OverflowList` appends to heap blocks, allocated one at a time, up to 4096 of them.
- The block capacity was already a type parameter of `OverflowList`. Only the two stores hard-coded it to the shared constant.
- The maximum overflow capacity of a store is `4096 * block size`: from 8M entries to `1024 * COUNT`, the limit the Zig original had.

<details><summary>Notes</summary>

- Review changes: `OverflowList::init_counters_at` asserts `COUNT > 0` in an inline const. Every store's `init_at` calls it, and a temporary `count = 2` store was rejected at build time while instantiating `OverflowList::<u32, 0>::init_counters_at`. The linker's `LazyLock` plus `Send`/`Sync` newtype worked around a `SyncUnsafeCell` macro expansion that no longer exists; the macro emits an `AtomicPtr` accessor and needs no feature flag.

- Slots are never reclaimed, so the test can fill the cache without directories: `Bun.resolveSync("./f.js/d<i>/x", root)` makes `load_as_file` call `read_directory("root/f.js/d<i>")`, which fails with `ENOTDIR`. `read_directory_error` stores that error in a slot (only `ENOENT` skips the slot). The runtime busts the entry after the failed resolve and retries once, so each filler consumes two slots. With 2700 fillers and two passes that is about 10,800 slots, or the inline array plus 17 blocks of 512. Verified with `BUN_DEBUG_Resolver=1`: 10,800 `Failed to load DirEntry` lines, one per cached read.
- The 40 real directories resolve after the fillers, so their entries sit in an overflow block. The second pass reads them back through `at_index_mut` and checks the resolved path.
- On Windows a path below a regular file probably fails with `ENOENT` instead, so the filler paths take no slot there and the test is a plain resolution test.
- Debug build: the test takes about 2 s. Release: about 80 ms.
- Singleton sizes do not change. `OverflowGroup::ptrs` stays `[Option<Box<_>>; 4096]` (32 KiB) per store. Only the lazily allocated heap blocks shrink.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->