### PR TITLE
s3: share the client's credentials with files that do not override them

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -873,10 +873,10 @@ pub mod store {
         pub fn init(
             pathlike: PathLike<'static>,
             mime_type: Option<MimeType>,
-            credentials: bun_s3_signing::S3Credentials,
+            credentials: RefPtr<bun_s3_signing::S3Credentials>,
         ) -> S3 {
             S3 {
-                credentials: Some(RefPtr::new(credentials)),
+                credentials: Some(credentials),
                 pathlike,
                 mime_type: mime_type.unwrap_or(bun_http_types::MimeType::OTHER),
                 options: bun_s3_signing::MultiPartUploadOptions::default(),

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1782,8 +1782,9 @@ fn get_s3_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JsResult
     // here at the high-tier call site (dotenv ≤T2 may not name s3_signing T5).
     // SAFETY: `transpiler.env` is the process-lifetime dotenv loader; disjoint
     // from `rare_data` storage.
-    let env_creds =
-        crate::webcore::fetch::s3_credentials_from_env(unsafe { (*env_ptr).get_s3_credentials() });
+    let env_creds = bun_ptr::RefPtr::new(crate::webcore::fetch::s3_credentials_from_env(unsafe {
+        (*env_ptr).get_s3_credentials()
+    }));
     let aws_options = match crate::webcore::s3::credentials_jsc::get_credentials_with_options(
         &env_creds,
         Default::default(),
@@ -1799,7 +1800,7 @@ fn get_s3_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JsResult
         Err(err) => return Err(err),
     };
     let client = S3Client {
-        credentials: aws_options.credentials.dupe(),
+        credentials: aws_options.credentials,
         options: aws_options.options,
         acl: aws_options.acl,
         storage_class: aws_options.storage_class,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1403,14 +1403,8 @@ impl BlobExt for Blob {
             };
             let proxy_url = proxy.map(|p| p.href);
 
-            // When no JS overrides were supplied, hand the store's *base*
-            // credentials to the upload.
             return crate::webcore::__s3_client::upload_stream(
-                if extra_options.is_some() {
-                    aws_options.credentials.dupe()
-                } else {
-                    s3.get_credentials().clone()
-                },
+                aws_options.credentials.clone(),
                 path,
                 readable_stream,
                 global_this,
@@ -1725,10 +1719,10 @@ impl BlobExt for Blob {
                 let credentials_with_options =
                     s3.get_credentials_with_options(Some(options), global_this)?;
                 // `defer credentialsWithOptions.deinit()` → Drop handles slices.
-                // `writable_stream` adopts the dup'd ref by value; the
+                // `writable_stream` adopts the ref by value; the
                 // MultiPartUpload derefs on done.
                 return crate::webcore::s3::client::writable_stream(
-                    credentials_with_options.credentials.dupe(),
+                    credentials_with_options.credentials.clone(),
                     path,
                     global_this,
                     credentials_with_options.options,
@@ -3474,7 +3468,8 @@ impl BlobExt for Blob {
                     // `bun_s3_signing::S3Credentials` here at the T6 call site
                     // (dotenv cannot name the s3_signing type — upward dep).
                     let env_creds = vm.transpiler.env_mut().get_s3_credentials();
-                    let credentials = crate::webcore::fetch::s3_credentials_from_env(env_creds);
+                    let credentials =
+                        RefPtr::new(crate::webcore::fetch::s3_credentials_from_env(env_creds));
                     let copy = core::mem::replace(
                         path_or_fd,
                         PathOrFileDescriptor::Path(PathLike::default()),
@@ -4589,11 +4584,7 @@ pub(crate) fn write_file_with_source_destination(
                         ctx,
                     )? {
                         return s3_client::upload_stream(
-                            if options.extra_options.is_some() {
-                                aws_options.credentials.dupe()
-                            } else {
-                                s3.get_credentials().clone()
-                            },
+                            aws_options.credentials.clone(),
                             s3.path(),
                             stream,
                             ctx,
@@ -4685,11 +4676,7 @@ pub(crate) fn write_file_with_source_destination(
                     ctx,
                 )? {
                     return s3_client::upload_stream(
-                        if options.extra_options.is_some() {
-                            aws_options.credentials.dupe()
-                        } else {
-                            s3.get_credentials().clone()
-                        },
+                        aws_options.credentials.clone(),
                         s3.path(),
                         stream,
                         ctx,
@@ -4972,11 +4959,7 @@ pub(crate) fn write_file_internal(
                             let proxy_owned = http_proxy_href(global_this);
                             let proxy_url = proxy_owned.as_deref();
                             return Ok(ControlFlow::Break(s3_client::upload_stream(
-                                if options.extra_options.is_some() {
-                                    aws_options.credentials.dupe()
-                                } else {
-                                    s3.get_credentials().clone()
-                                },
+                                aws_options.credentials.clone(),
                                 s3.path(),
                                 readable,
                                 global_this,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1718,9 +1718,6 @@ impl BlobExt for Blob {
 
                 let credentials_with_options =
                     s3.get_credentials_with_options(Some(options), global_this)?;
-                // `defer credentialsWithOptions.deinit()` → Drop handles slices.
-                // `writable_stream` adopts the ref by value; the
-                // MultiPartUpload derefs on done.
                 return crate::webcore::s3::client::writable_stream(
                     credentials_with_options.credentials.clone(),
                     path,

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -7,6 +7,7 @@ use crate::webcore::blob::store::S3Ext as _;
 use crate::webcore::s3::MultiPartUploadOptions;
 use crate::webcore::s3::client::{ACL, S3Credentials, StorageClass};
 use bun_jsc::{CallFrame, ConsoleFormatter, ErrorCode, JSGlobalObject, JSValue, JsResult};
+use bun_ptr::RefPtr;
 
 use super::s3_file as S3File;
 
@@ -37,11 +38,7 @@ pub(crate) trait S3CredentialsExt {
     fn guess_bucket(endpoint: &[u8]) -> Option<&[u8]>;
     #[allow(clippy::too_many_arguments)]
     fn get_credentials_with_options(
-        // Takes `&S3Credentials` (not by-value) — `bun_s3_signing::S3Credentials`
-        // has a private `ref_count` field and no `Clone`, so callers holding a borrow
-        // (e.g. `&RefPtr<S3Credentials>` deref) cannot produce an owned copy. The
-        // real impl in `s3/credentials_jsc.rs` deep-copies internally.
-        this: &S3Credentials,
+        this: &RefPtr<S3Credentials>,
         default_options: MultiPartUploadOptions,
         options: Option<JSValue>,
         default_acl: Option<ACL>,
@@ -61,7 +58,7 @@ impl S3CredentialsExt for S3Credentials {
     }
     #[inline]
     fn get_credentials_with_options(
-        this: &S3Credentials,
+        this: &RefPtr<S3Credentials>,
         default_options: MultiPartUploadOptions,
         options: Option<JSValue>,
         default_acl: Option<ACL>,
@@ -248,7 +245,7 @@ where
 
 #[bun_jsc::JsClass]
 pub struct S3Client {
-    pub(crate) credentials: bun_ptr::RefPtr<S3Credentials>,
+    pub(crate) credentials: RefPtr<S3Credentials>,
     pub(crate) options: MultiPartUploadOptions,
     pub(crate) acl: Option<ACL>,
     pub(crate) storage_class: Option<StorageClass>,
@@ -269,14 +266,14 @@ impl S3Client {
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (set during init). `get_s3_credentials` takes `&mut self`
         // only to lazily memoize — single-threaded JS event-loop discipline applies.
-        let env_creds = crate::webcore::fetch::s3_credentials_from_env(
+        let env_creds = RefPtr::new(crate::webcore::fetch::s3_credentials_from_env(
             global
                 .bun_vm()
                 .as_mut()
                 .transpiler
                 .env_mut()
                 .get_s3_credentials(),
-        );
+        ));
         let aws_options = <S3Credentials as S3CredentialsExt>::get_credentials_with_options(
             &env_creds,
             MultiPartUploadOptions::default(),
@@ -287,7 +284,7 @@ impl S3Client {
             global,
         )?;
         Ok(Box::new(S3Client {
-            credentials: aws_options.credentials.dupe(),
+            credentials: aws_options.credentials,
             options: aws_options.options,
             acl: aws_options.acl,
             storage_class: aws_options.storage_class,
@@ -637,14 +634,14 @@ impl S3Client {
 
         // get credentials from env — `Transpiler::env_mut` is the safe accessor
         // for the process-singleton dotenv loader (set during init).
-        let existing_credentials = crate::webcore::fetch::s3_credentials_from_env(
+        let existing_credentials = RefPtr::new(crate::webcore::fetch::s3_credentials_from_env(
             global
                 .bun_vm()
                 .as_mut()
                 .transpiler
                 .env_mut()
                 .get_s3_credentials(),
-        );
+        ));
 
         let blob = S3File::construct_s3_file_with_s3_credentials(
             global,

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -244,29 +244,30 @@ fn construct_s3_file_internal_store(
 ) -> JsResult<Blob> {
     // get credentials from env — `Transpiler::env_mut` is the safe accessor
     // for the process-singleton dotenv loader (set during init).
-    let existing_credentials = crate::webcore::fetch::s3_credentials_from_env(
+    let existing_credentials = RefPtr::new(crate::webcore::fetch::s3_credentials_from_env(
         global
             .bun_vm()
             .as_mut()
             .transpiler
             .env_mut()
             .get_s3_credentials(),
-    );
+    ));
     construct_s3_file_with_s3_credentials(global, path, options, &existing_credentials)
 }
 
-/// if the credentials have changed, we need to clone it, if not we can just ref/deref it
+/// The store shares `default_credentials` unless `options` overrides a
+/// credential field. Then it gets its own copy with the overrides applied.
 pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
     global: &JSGlobalObject,
     path: PathLike<'static>,
     options: Option<JSValue>,
-    default_credentials: &s3::S3Credentials,
+    default_credentials: &RefPtr<s3::S3Credentials>,
     default_options: s3::MultiPartUploadOptions,
     default_acl: Option<s3::ACL>,
     default_storage_class: Option<s3::StorageClass>,
     default_request_payer: bool,
 ) -> JsResult<Blob> {
-    let mut aws_options = <s3::S3Credentials>::get_credentials_with_options(
+    let aws_options = <s3::S3Credentials>::get_credentials_with_options(
         default_credentials,
         default_options,
         options,
@@ -275,13 +276,7 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
         default_request_payer,
         global,
     )?;
-
-    let credentials = if aws_options.changed_credentials {
-        std::mem::take(&mut aws_options.credentials)
-    } else {
-        default_credentials.clone()
-    };
-    let store = blob::Store::init_s3(path, None, credentials).expect("oom");
+    let store = blob::Store::init_s3(path, None, aws_options.credentials.clone()).expect("oom");
     finish_s3_blob(global, store, &aws_options, options)
 }
 
@@ -289,9 +284,9 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
     global: &JSGlobalObject,
     path: PathLike<'static>,
     options: Option<JSValue>,
-    existing_credentials: &s3::S3Credentials,
+    existing_credentials: &RefPtr<s3::S3Credentials>,
 ) -> JsResult<Blob> {
-    let mut aws_options = <s3::S3Credentials>::get_credentials_with_options(
+    let aws_options = <s3::S3Credentials>::get_credentials_with_options(
         existing_credentials,
         Default::default(),
         options,
@@ -300,8 +295,7 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
         false,
         global,
     )?;
-    let credentials = std::mem::take(&mut aws_options.credentials);
-    let store = blob::Store::init_s3(path, None, credentials).expect("oom");
+    let store = blob::Store::init_s3(path, None, aws_options.credentials.clone()).expect("oom");
     finish_s3_blob(global, store, &aws_options, options)
 }
 
@@ -572,9 +566,8 @@ pub(crate) fn get_presign_url_from(
     // defaults here — they are only seeded from the store when extra_options
     // is provided (via `getCredentialsWithOptions` below).
     let mut credentials_with_options = s3::S3CredentialsWithOptions {
-        credentials: (**s3.get_credentials()).clone(),
         request_payer: s3.request_payer,
-        ..Default::default()
+        ..s3::S3CredentialsWithOptions::new(s3.get_credentials().clone())
     };
 
     if let Some(options) = extra_options {

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -255,8 +255,6 @@ fn construct_s3_file_internal_store(
     construct_s3_file_with_s3_credentials(global, path, options, &existing_credentials)
 }
 
-/// The store shares `default_credentials` unless `options` overrides a
-/// credential field. Then it gets its own copy with the overrides applied.
 pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
     global: &JSGlobalObject,
     path: PathLike<'static>,

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -45,7 +45,7 @@ pub trait StoreExt {
     fn init_s3(
         pathlike: PathLike<'static>,
         mime_type: Option<MimeType>,
-        credentials: S3Credentials,
+        credentials: RefPtr<S3Credentials>,
     ) -> Result<RefPtr<Store>, crate::Error>
     where
         Self: Sized;
@@ -124,7 +124,7 @@ impl StoreExt for Store {
     fn init_s3(
         pathlike: PathLike<'static>,
         mime_type: Option<MimeType>,
-        credentials: S3Credentials,
+        credentials: RefPtr<S3Credentials>,
     ) -> Result<RefPtr<Store>, crate::Error> {
         let path = pathlike.thread_isolated_copy();
 
@@ -252,10 +252,6 @@ impl S3Ext for S3 {
         options: Option<JSValue>,
         global_object: &JSGlobalObject,
     ) -> JsResult<S3CredentialsWithOptions> {
-        // The associated fn (surfaced via `S3CredentialsExt` in `webcore/S3Client.rs`)
-        // takes `&S3Credentials` instead of by-value because `S3Credentials` carries a
-        // private intrusive ref-count and cannot be struct-copied; the impl deep-copies
-        // internally.
         use crate::webcore::s3_client::S3CredentialsExt as _;
         S3Credentials::get_credentials_with_options(
             self.get_credentials(),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -69,6 +69,7 @@ use bun_jsc::AbortSignalRef;
 #[cfg(windows)]
 use bun_paths::resolve_path::PosixToWinNormalizer;
 use bun_picohttp as picohttp;
+use bun_ptr::RefPtr;
 use bun_resolver::data_url::DataURL;
 use bun_s3_signing::{SignOptions, SignResult};
 use bun_url::PercentEncoding;
@@ -1644,13 +1645,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 .env_mut()
                 .get_s3_credentials(),
         );
-        let mut credentials_with_options = s3::S3CredentialsWithOptions {
-            credentials: env_creds,
-            options: Default::default(),
-            acl: None,
-            storage_class: None,
-            ..Default::default()
-        };
+        let mut credentials_with_options =
+            s3::S3CredentialsWithOptions::new(RefPtr::new(env_creds));
         // `defer credentialsWithOptions.deinit()` → Drop.
 
         if let Some(options) = options_object {
@@ -1722,11 +1718,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 // lifetime is managed by the resolve callback itself).
                 let _ = S3StreamWrapper::resolve(result, ctx.cast::<S3StreamWrapper<'static>>());
             }
-            // `dupe()` heap-allocates a fresh intrusive-refcounted copy.
-            // `upload_stream` adopts the ref by value (no extra bump) and the
-            // MultiPartUpload derefs on completion.
+            // `upload_stream` adopts the ref by value and the MultiPartUpload
+            // derefs on completion.
             let _ = s3::upload_stream(
-                credentials_with_options.credentials.dupe(),
+                credentials_with_options.credentials.clone(),
                 s3_path,
                 readable_stream.get().unwrap(),
                 global_this,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1718,8 +1718,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 // lifetime is managed by the resolve callback itself).
                 let _ = S3StreamWrapper::resolve(result, ctx.cast::<S3StreamWrapper<'static>>());
             }
-            // `upload_stream` adopts the ref by value and the MultiPartUpload
-            // derefs on completion.
             let _ = s3::upload_stream(
                 credentials_with_options.credentials.clone(),
                 s3_path,

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -6,6 +6,7 @@ use core::sync::atomic::Ordering;
 
 use bun_core::{String as BunString, Tag as BunStringTag, strings};
 use bun_jsc::{JSGlobalObject, JSValue, JsResult, RangeErrorOptions, StringJsc as _};
+use bun_ptr::RefPtr;
 
 use bun_s3_signing::{
     ACL, MultiPartUploadOptions, S3Credentials, S3CredentialsWithOptions, StorageClass,
@@ -54,9 +55,19 @@ const ACL_ONE_OF: &str = "\"private\", \"public-read\", \"public-read-write\", \
 const STORAGE_CLASS_ONE_OF: &str = "\"STANDARD\", \"STANDARD_IA\", \"INTELLIGENT_TIERING\", \"EXPRESS_ONEZONE\", \
 \"ONEZONE_IA\", \"GLACIER\", \"GLACIER_IR\", \"REDUCED_REDUNDANCY\", \"OUTPOSTS\", \"DEEP_ARCHIVE\", \"SNOW\"";
 
+/// The credential overrides from the options object apply to a copy of `base`.
+/// The copy is made on the first override only, so a call with no credential
+/// override never copies.
+fn copy_on_override<'a>(
+    copy: &'a mut Option<S3Credentials>,
+    base: &S3Credentials,
+) -> &'a mut S3Credentials {
+    copy.get_or_insert_with(|| base.clone())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn get_credentials_with_options(
-    this: &S3Credentials,
+    this: &RefPtr<S3Credentials>,
     default_options: MultiPartUploadOptions,
     options: Option<JSValue>,
     default_acl: Option<ACL>,
@@ -65,34 +76,29 @@ pub(crate) fn get_credentials_with_options(
     global_object: &JSGlobalObject,
 ) -> JsResult<S3CredentialsWithOptions> {
     bun_analytics::features::s3.fetch_add(1, Ordering::Relaxed);
-    // get ENV config
-    // `S3Credentials`
-    // carries an intrusive ref-count and is not `Copy`; `Clone` performs a
-    // deep field copy with a fresh ref-count.
     let mut new_credentials = S3CredentialsWithOptions {
-        credentials: this.clone(),
         options: default_options,
         acl: default_acl,
         storage_class: default_storage_class,
         request_payer: default_request_payer,
-        ..Default::default()
+        ..S3CredentialsWithOptions::new(this.clone())
     };
+    let mut copy: Option<S3Credentials> = None;
 
     if let Some(opts) = options {
         if opts.is_object() {
             if let Some(utf8) = get_truthy_string_utf8(opts, global_object, b"accessKeyId", true)? {
-                new_credentials.credentials.access_key_id = utf8.into_vec().into_boxed_slice();
-                new_credentials.changed_credentials = true;
+                copy_on_override(&mut copy, this).access_key_id =
+                    utf8.into_vec().into_boxed_slice();
             }
             if let Some(utf8) =
                 get_truthy_string_utf8(opts, global_object, b"secretAccessKey", true)?
             {
-                new_credentials.credentials.secret_access_key = utf8.into_vec().into_boxed_slice();
-                new_credentials.changed_credentials = true;
+                copy_on_override(&mut copy, this).secret_access_key =
+                    utf8.into_vec().into_boxed_slice();
             }
             if let Some(utf8) = get_truthy_string_utf8(opts, global_object, b"region", true)? {
-                new_credentials.credentials.region = utf8.into_vec().into_boxed_slice();
-                new_credentials.changed_credentials = true;
+                copy_on_override(&mut copy, this).region = utf8.into_vec().into_boxed_slice();
             }
             if let Some(js_value) = opts.get_truthy(global_object, "endpoint")? {
                 if !js_value.is_empty_or_undefined_or_null() {
@@ -102,13 +108,12 @@ pub(crate) fn get_credentials_with_options(
                             let utf8 = str.into_utf8();
                             let endpoint = utf8.slice();
                             if let Some(parsed) = URL::parse_s3_endpoint(endpoint) {
-                                new_credentials.credentials.endpoint = parsed.host_with_path;
+                                let credentials = copy_on_override(&mut copy, this);
+                                credentials.endpoint = parsed.host_with_path;
 
                                 // Default to https://
                                 // Only use http:// if the endpoint specifically starts with 'http://'
-                                new_credentials.credentials.insecure_http = parsed.is_http;
-
-                                new_credentials.changed_credentials = true;
+                                credentials.insecure_http = parsed.is_http;
                             } else if !endpoint.is_empty() {
                                 // endpoint is not a valid URL
                                 return Err(global_object.throw_invalid_argument_type_value(
@@ -128,21 +133,19 @@ pub(crate) fn get_credentials_with_options(
                 }
             }
             if let Some(utf8) = get_truthy_string_utf8(opts, global_object, b"bucket", true)? {
-                new_credentials.credentials.bucket = utf8.into_vec().into_boxed_slice();
-                new_credentials.changed_credentials = true;
+                copy_on_override(&mut copy, this).bucket = utf8.into_vec().into_boxed_slice();
             }
 
             if let Some(virtual_hosted_style) =
                 opts.get_boolean_strict(global_object, "virtualHostedStyle")?
             {
-                new_credentials.credentials.virtual_hosted_style = virtual_hosted_style;
-                new_credentials.changed_credentials = true;
+                copy_on_override(&mut copy, this).virtual_hosted_style = virtual_hosted_style;
             }
 
             if let Some(utf8) = get_truthy_string_utf8(opts, global_object, b"sessionToken", true)?
             {
-                new_credentials.credentials.session_token = utf8.into_vec().into_boxed_slice();
-                new_credentials.changed_credentials = true;
+                copy_on_override(&mut copy, this).session_token =
+                    utf8.into_vec().into_boxed_slice();
             }
 
             if let Some(page_size) = opts.get_optional::<i64>(global_object, "pageSize")? {
@@ -260,6 +263,9 @@ pub(crate) fn get_credentials_with_options(
                 new_credentials.request_payer = request_payer;
             }
         }
+    }
+    if let Some(copy) = copy {
+        new_credentials.credentials = RefPtr::new(copy);
     }
     Ok(new_credentials)
 }

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -55,9 +55,7 @@ const ACL_ONE_OF: &str = "\"private\", \"public-read\", \"public-read-write\", \
 const STORAGE_CLASS_ONE_OF: &str = "\"STANDARD\", \"STANDARD_IA\", \"INTELLIGENT_TIERING\", \"EXPRESS_ONEZONE\", \
 \"ONEZONE_IA\", \"GLACIER\", \"GLACIER_IR\", \"REDUCED_REDUNDANCY\", \"OUTPOSTS\", \"DEEP_ARCHIVE\", \"SNOW\"";
 
-/// The credential overrides from the options object apply to a copy of `base`.
-/// The copy is made on the first override only, so a call with no credential
-/// override never copies.
+/// Copies `base` on the first override. Later overrides write to that copy.
 fn copy_on_override<'a>(
     copy: &'a mut Option<S3Credentials>,
     base: &S3Credentials,

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -1205,9 +1205,8 @@ impl<'a> Default for SignOptions<'a> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct S3CredentialsWithOptions {
-    /// The credentials the request signs with. When the options object
-    /// overrides no credential field this is another ref on the caller's
-    /// credentials, otherwise a fresh copy with the overrides applied.
+    /// A new ref on the caller's credentials, or a fresh copy when the
+    /// options object overrides a credential field.
     pub credentials: RefPtr<S3Credentials>,
     pub options: MultiPartUploadOptions,
     pub acl: Option<ACL>,

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -200,23 +200,6 @@ impl Clone for S3Credentials {
     }
 }
 
-impl Default for S3Credentials {
-    fn default() -> Self {
-        Self {
-            ref_count: RefCount::init(),
-            access_key_id: Box::default(),
-            secret_access_key: Box::default(),
-            region: Box::default(),
-            endpoint: Box::default(),
-            bucket: Box::default(),
-            session_token: Box::default(),
-            storage_class: None,
-            insecure_http: false,
-            virtual_hosted_style: false,
-        }
-    }
-}
-
 impl S3Credentials {
     /// Construct a value (refcount = 1) from owned field data. Exists so
     /// higher-tier callers (e.g. `bun_runtime`) can build the refcounted
@@ -253,21 +236,6 @@ impl S3Credentials {
             + self.secret_access_key.len()
             + self.endpoint.len()
             + self.bucket.len()
-    }
-
-    pub fn dupe(&self) -> RefPtr<S3Credentials> {
-        RefPtr::new(S3Credentials {
-            ref_count: RefCount::init(),
-            access_key_id: self.access_key_id.clone(),
-            secret_access_key: self.secret_access_key.clone(),
-            region: self.region.clone(),
-            endpoint: self.endpoint.clone(),
-            bucket: self.bucket.clone(),
-            session_token: self.session_token.clone(),
-            storage_class: None,
-            insecure_http: self.insecure_http,
-            virtual_hosted_style: self.virtual_hosted_style,
-        })
     }
 
     pub fn sign_request<const ALLOW_EMPTY_PATH: bool>(
@@ -1236,9 +1204,11 @@ impl<'a> Default for SignOptions<'a> {
 // S3CredentialsWithOptions
 // ──────────────────────────────────────────────────────────────────────────
 
-#[derive(Default)]
 pub struct S3CredentialsWithOptions {
-    pub credentials: S3Credentials,
+    /// The credentials the request signs with. When the options object
+    /// overrides no credential field this is another ref on the caller's
+    /// credentials, otherwise a fresh copy with the overrides applied.
+    pub credentials: RefPtr<S3Credentials>,
     pub options: MultiPartUploadOptions,
     pub acl: Option<ACL>,
     pub storage_class: Option<StorageClass>,
@@ -1247,10 +1217,22 @@ pub struct S3CredentialsWithOptions {
     pub content_encoding: Option<bun_core::Utf8Bytes<'static>>,
     /// indicates if requester pays for the request (for requester pays buckets)
     pub request_payer: bool,
-    /// indicates if the credentials have changed
-    pub changed_credentials: bool,
-    /// indicates if the virtual hosted style is used
-    pub virtual_hosted_style: bool,
+}
+
+impl S3CredentialsWithOptions {
+    /// `credentials` with the default options and nothing overridden.
+    pub fn new(credentials: RefPtr<S3Credentials>) -> Self {
+        Self {
+            credentials,
+            options: MultiPartUploadOptions::default(),
+            acl: None,
+            storage_class: None,
+            content_disposition: None,
+            content_type: None,
+            content_encoding: None,
+            request_payer: false,
+        }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -1205,8 +1205,7 @@ impl<'a> Default for SignOptions<'a> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct S3CredentialsWithOptions {
-    /// A new ref on the caller's credentials, or a fresh copy when the
-    /// options object overrides a credential field.
+    /// The caller's credentials, or a copy when the options object overrides a field.
     pub credentials: RefPtr<S3Credentials>,
     pub options: MultiPartUploadOptions,
     pub acl: Option<ACL>,

--- a/test/js/bun/s3/s3-client-credentials.test.ts
+++ b/test/js/bun/s3/s3-client-credentials.test.ts
@@ -1,6 +1,6 @@
-import { S3Client, type S3File, type S3Options } from "bun";
+import { S3Client, type S3Options } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, expectRssDeltaBelow } from "harness";
 
 // `S3Client.file()` and the other per-key methods share the client's
 // credentials with the returned S3 file when the call passes no credential
@@ -36,21 +36,25 @@ describe("S3Client credentials", () => {
     expect(signer(client.presign("dir/file.txt"))).toEqual(clientSigner);
   });
 
-  test("file() without overrides does not copy the client's credentials", () => {
-    // Two 64 KiB strings make one copy of the credentials cost 128 KiB.
-    const big = Buffer.alloc(64 * 1024, "s").toString();
-    const client = new S3Client({ ...clientOptions, secretAccessKey: big, sessionToken: big });
-    const count = 500;
-    const copyCost = count * 128 * 1024;
-
-    const files: S3File[] = [];
-    Bun.gc(true);
-    const rssBefore = process.memoryUsage.rss();
-    for (let i = 0; i < count; i++) files.push(client.file(`dir/file-${i}.txt`));
-    const rssGrowth = process.memoryUsage.rss() - rssBefore;
-
-    expect(files).toHaveLength(count);
-    expect(rssGrowth).toBeLessThan(copyCost / 4);
+  test("file() without overrides does not copy the client's credentials", async () => {
+    // Two 64 KiB strings make one copy of the credentials cost 128 KiB, so 500
+    // copies are 64 MiB.
+    await expectRssDeltaBelow(
+      [
+        "-e",
+        `
+          const big = Buffer.alloc(64 * 1024, "s").toString();
+          const client = new Bun.S3Client({ ...${JSON.stringify(clientOptions)}, secretAccessKey: big, sessionToken: big });
+          const files = [];
+          Bun.gc(true);
+          const rssBefore = process.memoryUsage.rss();
+          for (let i = 0; i < 500; i++) files.push(client.file("dir/file-" + i + ".txt"));
+          const deltaMiB = (process.memoryUsage.rss() - rssBefore) / 1024 / 1024;
+          console.log(JSON.stringify({ deltaMiB, count: files.length }));
+        `,
+      ],
+      { release: 16, debug: 32 },
+    );
   });
 
   test("non-credential options keep the client's credentials", () => {

--- a/test/js/bun/s3/s3-client-credentials.test.ts
+++ b/test/js/bun/s3/s3-client-credentials.test.ts
@@ -1,12 +1,12 @@
-import { S3Client, type S3Options } from "bun";
+import { S3Client, type S3File, type S3Options } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // `S3Client.file()` and the other per-key methods share the client's
 // credentials with the returned S3 file when the call passes no credential
 // override. These tests check that the shared credentials sign correctly,
-// that an override only applies to its own file, and that a file outlives
-// the client it came from.
+// that a file() call does not copy them, that an override only applies to
+// its own file, and that a file outlives the client it came from.
 describe("S3Client credentials", () => {
   const clientOptions: S3Options = {
     accessKeyId: "client-key",
@@ -34,6 +34,23 @@ describe("S3Client credentials", () => {
       expect(signer(client.file("dir/file.txt").presign())).toEqual(clientSigner);
     }
     expect(signer(client.presign("dir/file.txt"))).toEqual(clientSigner);
+  });
+
+  test("file() without overrides does not copy the client's credentials", () => {
+    // Two 64 KiB strings make one copy of the credentials cost 128 KiB.
+    const big = Buffer.alloc(64 * 1024, "s").toString();
+    const client = new S3Client({ ...clientOptions, secretAccessKey: big, sessionToken: big });
+    const count = 500;
+    const copyCost = count * 128 * 1024;
+
+    const files: S3File[] = [];
+    Bun.gc(true);
+    const rssBefore = process.memoryUsage.rss();
+    for (let i = 0; i < count; i++) files.push(client.file(`dir/file-${i}.txt`));
+    const rssGrowth = process.memoryUsage.rss() - rssBefore;
+
+    expect(files).toHaveLength(count);
+    expect(rssGrowth).toBeLessThan(copyCost / 4);
   });
 
   test("non-credential options keep the client's credentials", () => {

--- a/test/js/bun/s3/s3-client-credentials.test.ts
+++ b/test/js/bun/s3/s3-client-credentials.test.ts
@@ -1,0 +1,121 @@
+import { S3Client, type S3Options } from "bun";
+import { describe, expect, test } from "bun:test";
+
+// `S3Client.file()` and the other per-key methods share the client's
+// credentials with the returned S3 file when the call passes no credential
+// override. These tests check that the shared credentials sign correctly,
+// that an override only applies to its own file, and that a file outlives
+// the client it came from.
+describe("S3Client credentials", () => {
+  const clientOptions: S3Options = {
+    accessKeyId: "client-key",
+    secretAccessKey: "client-secret",
+    region: "eu-west-3",
+    bucket: "client-bucket",
+  };
+
+  function signer(presigned: string) {
+    const url = new URL(presigned);
+    const [accessKeyId, , region] = url.searchParams.get("X-Amz-Credential")!.split("/");
+    return { host: url.host, pathname: url.pathname, accessKeyId, region };
+  }
+
+  const clientSigner = {
+    host: "s3.eu-west-3.amazonaws.com",
+    pathname: "/client-bucket/dir/file.txt",
+    accessKeyId: "client-key",
+    region: "eu-west-3",
+  };
+
+  test("file() without overrides signs with the client's credentials", () => {
+    const client = new S3Client(clientOptions);
+    for (let i = 0; i < 50; i++) {
+      expect(signer(client.file("dir/file.txt").presign())).toEqual(clientSigner);
+    }
+    expect(signer(client.presign("dir/file.txt"))).toEqual(clientSigner);
+  });
+
+  test("non-credential options keep the client's credentials", () => {
+    const client = new S3Client(clientOptions);
+    const file = client.file("dir/file.txt", { type: "text/plain", acl: "public-read", partSize: 10 * 1024 * 1024 });
+    expect(signer(file.presign())).toEqual(clientSigner);
+    expect(file.type).toBe("text/plain;charset=utf-8");
+  });
+
+  test("credential overrides apply to that file only", () => {
+    const client = new S3Client(clientOptions);
+    const before = client.file("dir/file.txt");
+
+    const overridden = client.file("dir/file.txt", {
+      accessKeyId: "other-key",
+      region: "us-east-1",
+      bucket: "other-bucket",
+    });
+    expect(signer(overridden.presign())).toEqual({
+      host: "s3.us-east-1.amazonaws.com",
+      pathname: "/other-bucket/dir/file.txt",
+      accessKeyId: "other-key",
+      region: "us-east-1",
+    });
+    expect(overridden.bucket).toBe("other-bucket");
+
+    const endpointOverridden = client.file("dir/file.txt", { endpoint: "http://localhost:9000" });
+    expect(signer(endpointOverridden.presign())).toEqual({ ...clientSigner, host: "localhost:9000" });
+
+    // Neither the client nor the files created before or after changed.
+    expect(signer(before.presign())).toEqual(clientSigner);
+    expect(signer(client.file("dir/file.txt").presign())).toEqual(clientSigner);
+    expect(signer(client.presign("dir/file.txt"))).toEqual(clientSigner);
+    expect(before.bucket).toBe("client-bucket");
+  });
+
+  test("a file keeps its credentials after the client is collected", () => {
+    const file = (() => {
+      const client = new S3Client(clientOptions);
+      return client.file("dir/file.txt");
+    })();
+    Bun.gc(true);
+    expect(signer(file.presign())).toEqual(clientSigner);
+    expect(file.bucket).toBe("client-bucket");
+  });
+
+  test("requests sign with the shared or the overridden credentials", async () => {
+    const requests: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const accessKeyId = req.headers.get("authorization")!.match(/Credential=([^/]+)\//)![1];
+        requests.push(`${req.method} ${new URL(req.url).pathname} ${accessKeyId}`);
+        return new Response("", {
+          status: 200,
+          headers: {
+            "Content-Type": "text/plain",
+            "Content-Length": "5",
+            "Last-Modified": "Thu, 01 Jan 2026 00:00:00 GMT",
+            "ETag": '"etag"',
+          },
+        });
+      },
+    });
+    const client = new S3Client({ ...clientOptions, endpoint: server.url.href });
+    const override = { accessKeyId: "other-key", secretAccessKey: "other-secret", bucket: "other-bucket" };
+
+    expect(await client.file("dir/file.txt").exists()).toBe(true);
+    expect(await client.file("dir/file.txt", override).exists()).toBe(true);
+    expect(await client.exists("dir/file.txt")).toBe(true);
+    expect(await client.size("dir/file.txt", override)).toBe(5);
+    expect(await client.file("dir/file.txt").write("hello")).toBe(5);
+    expect(await client.unlink("dir/file.txt")).toBe(true);
+    expect((await client.file("dir/file.txt").stat()).size).toBe(5);
+
+    expect(requests).toEqual([
+      "HEAD /client-bucket/dir/file.txt client-key",
+      "HEAD /other-bucket/dir/file.txt other-key",
+      "HEAD /client-bucket/dir/file.txt client-key",
+      "HEAD /other-bucket/dir/file.txt other-key",
+      "PUT /client-bucket/dir/file.txt client-key",
+      "DELETE /client-bucket/dir/file.txt client-key",
+      "HEAD /client-bucket/dir/file.txt client-key",
+    ]);
+  });
+});

--- a/test/js/bun/s3/s3-client-credentials.test.ts
+++ b/test/js/bun/s3/s3-client-credentials.test.ts
@@ -81,8 +81,7 @@ describe("S3Client credentials", () => {
   });
 
   test("requests sign with the shared or the overridden credentials", async () => {
-    // The fake S3 endpoint is a server in the child process. The child runs
-    // without the proxy variables of this environment so the requests reach it.
+    // Run without the proxy variables of this environment so the requests reach the fake endpoint.
     const env = { ...bunEnv };
     for (const name of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]) delete env[name];
     await using proc = Bun.spawn({

--- a/test/js/bun/s3/s3-client-credentials.test.ts
+++ b/test/js/bun/s3/s3-client-credentials.test.ts
@@ -1,5 +1,6 @@
 import { S3Client, type S3Options } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // `S3Client.file()` and the other per-key methods share the client's
 // credentials with the returned S3 file when the call passes no credential
@@ -80,42 +81,66 @@ describe("S3Client credentials", () => {
   });
 
   test("requests sign with the shared or the overridden credentials", async () => {
-    const requests: string[] = [];
-    using server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        const accessKeyId = req.headers.get("authorization")!.match(/Credential=([^/]+)\//)![1];
-        requests.push(`${req.method} ${new URL(req.url).pathname} ${accessKeyId}`);
-        return new Response("", {
-          status: 200,
-          headers: {
-            "Content-Type": "text/plain",
-            "Content-Length": "5",
-            "Last-Modified": "Thu, 01 Jan 2026 00:00:00 GMT",
-            "ETag": '"etag"',
-          },
-        });
-      },
+    // The fake S3 endpoint is a server in the child process. The child runs
+    // without the proxy variables of this environment so the requests reach it.
+    const env = { ...bunEnv };
+    for (const name of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]) delete env[name];
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const requests = [];
+          const server = Bun.serve({
+            port: 0,
+            fetch(req) {
+              const accessKeyId = req.headers.get("authorization").match(/Credential=([^/]+)\\//)[1];
+              requests.push(req.method + " " + new URL(req.url).pathname + " " + accessKeyId);
+              return new Response("", {
+                status: 200,
+                headers: {
+                  "Content-Type": "text/plain",
+                  "Content-Length": "5",
+                  "Last-Modified": "Thu, 01 Jan 2026 00:00:00 GMT",
+                  "ETag": '"etag"',
+                },
+              });
+            },
+          });
+          const client = new Bun.S3Client({ ...${JSON.stringify(clientOptions)}, endpoint: server.url.href });
+          const override = { accessKeyId: "other-key", secretAccessKey: "other-secret", bucket: "other-bucket" };
+          const results = [
+            await client.file("dir/file.txt").exists(),
+            await client.file("dir/file.txt", override).exists(),
+            await client.exists("dir/file.txt"),
+            await client.size("dir/file.txt", override),
+            await client.file("dir/file.txt").write("hello"),
+            await client.unlink("dir/file.txt"),
+            (await client.file("dir/file.txt").stat()).size,
+          ];
+          server.stop(true);
+          console.log(JSON.stringify({ results, requests }));
+        `,
+      ],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-    const client = new S3Client({ ...clientOptions, endpoint: server.url.href });
-    const override = { accessKeyId: "other-key", secretAccessKey: "other-secret", bucket: "other-bucket" };
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(await client.file("dir/file.txt").exists()).toBe(true);
-    expect(await client.file("dir/file.txt", override).exists()).toBe(true);
-    expect(await client.exists("dir/file.txt")).toBe(true);
-    expect(await client.size("dir/file.txt", override)).toBe(5);
-    expect(await client.file("dir/file.txt").write("hello")).toBe(5);
-    expect(await client.unlink("dir/file.txt")).toBe(true);
-    expect((await client.file("dir/file.txt").stat()).size).toBe(5);
-
-    expect(requests).toEqual([
-      "HEAD /client-bucket/dir/file.txt client-key",
-      "HEAD /other-bucket/dir/file.txt other-key",
-      "HEAD /client-bucket/dir/file.txt client-key",
-      "HEAD /other-bucket/dir/file.txt other-key",
-      "PUT /client-bucket/dir/file.txt client-key",
-      "DELETE /client-bucket/dir/file.txt client-key",
-      "HEAD /client-bucket/dir/file.txt client-key",
-    ]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      results: [true, true, true, 5, 5, true, 5],
+      requests: [
+        "HEAD /client-bucket/dir/file.txt client-key",
+        "HEAD /other-bucket/dir/file.txt other-key",
+        "HEAD /client-bucket/dir/file.txt client-key",
+        "HEAD /other-bucket/dir/file.txt other-key",
+        "PUT /client-bucket/dir/file.txt client-key",
+        "DELETE /client-bucket/dir/file.txt client-key",
+        "HEAD /client-bucket/dir/file.txt client-key",
+      ],
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- Every `s3.file(key)`, `.exists()`, `.stat()`, `.unlink()`, `.write()` and `.presign()` on an `S3Client` deep-copied the client's `S3Credentials` (six `Box<[u8]>` plus a fresh `RefPtr`), even with no credential override. Twice: `credentials_jsc.rs:73` cloned before it read the options, then `S3File.rs:282` cloned again and dropped the first copy.
- The Zig version shared the client's credentials by reference (`initS3WithReferencedCredentials`). The Rust port lost that path and kept the comment that described it.

### Fix
- `S3CredentialsWithOptions.credentials` is now a `RefPtr<S3Credentials>`. With no credential override it is a new ref on the caller's credentials. With an override, `get_credentials_with_options` copies once, on the first override.
- `Store::init_s3` and `S3::init` take the `RefPtr`, so a store built from a client shares the client's allocation. The upload, write, presign and constructor paths reuse the ref instead of `dupe()`. `dupe()`, `Default for S3Credentials` and `changed_credentials` are removed.
- Correct because `RefPtr` gives no `&mut` access: an override never mutates the shared allocation, and a store keeps its credentials alive after the client is collected through its own ref.
- Verified: `test/js/bun/s3/s3-client-credentials.test.ts` (new). Also `test/js/bun/s3/`, the S3 regression tests and `test/js/bun/http/proxy.test.ts`.

### Background
- `S3Credentials` (`src/s3_signing/credentials.rs`) owns six byte boxes (key, secret, region, endpoint, bucket, session token) and an intrusive non-atomic `RefCount`. `RefPtr<T>` is one ref on such a value: `Clone` bumps the count, `Drop` releases it.
- `get_credentials_with_options` (`src/runtime/webcore/s3/credentials_jsc.rs`) merges a JS options object into a base set of credentials. Every S3 entry point calls it.
- An S3 blob is a `Blob` whose `Store` holds `Data::S3`. The store owns the `RefPtr<S3Credentials>` that signs its requests.

<details><summary>Notes</summary>

- #37503 goes the other way: it keeps the copies and removes the refcount because nothing shared it. This change makes the refcount the sharing mechanism, so the two are exclusive.
- The sharing does not change the threading model. `RefPtr<S3Credentials>` is `!Send` and every ref is taken and released on the JS thread (`S3Client`, the blob store and `MultiPartUpload` are JS-thread objects). The Zig code shared the same non-atomic count the same way.
- `S3::estimated_size` still adds the credentials' size for every store. With sharing that over-reports by a few hundred bytes per blob, which the Zig version also did.
- Also removed: the `virtual_hosted_style` field on `S3CredentialsWithOptions`. Nothing wrote or read it.
- The new test covers presign and request signing with and without overrides, a file that outlives its client (a missing ref would be a use after free under the ASAN debug build), and the copy itself: 500 files from a client with two 64 KiB credential strings (64 MiB if copied) must grow RSS by less than 16 MiB on release and 32 MiB on ASAN or debug builds (`expectRssDeltaBelow`). Measured: 0 to 1 MiB and 4 MiB with the fix, 81 MiB on an ASAN debug build without it. The request test runs in a child without the proxy variables because the S3 client does not apply NO_PROXY (see below).
- `cargo check` and `cargo clippy` are clean for `bun_s3_signing`, `bun_jsc` and `bun_runtime`.
- `test/js/bun/s3/s3-list-objects.test.ts` times out under `describe.concurrent` in the debug ASAN build on this machine (5 s per test, 37 concurrent tests). The same tests pass in isolation with the debug build and all pass with the release build. This change does not touch the list path beyond the credential handoff.
- While testing I found that S3 requests ignore `NO_PROXY` and always use `HTTP_PROXY` (`get_http_proxy(true, None, None)` at every S3 call site). That is a separate bug, tracked on its own.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-client-credentials.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/1285] gen bindgenv2
[2/1285] gen ErrorCode+*.h
[3/1285] fetch tinycc
[tinycc] up to date
[4/1284] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1257] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[6/1257] fetch zlib
[zlib] up to date
[7/1257] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1257] gen .bind.ts → GeneratedBindings.cpp
[9/1257] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1257] subst deps/zlib/zlib.h
[11/1257] fetch picohttpparser
[picohttpparser] up to date
[12/1257] subst deps/zlib/zconf.h
[13/1208] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [210.00ms]
[14/1208] gen ProcessBindingHTTPParse
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/s3/s3-client-credentials.test.ts:
(pass) S3Client credentials > file() without overrides signs with the client's credentials [1.01ms]
360 |     stderr: "pipe",
361 |   });
362 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
363 |   expect(stderr.trim()).toBe("");
364 |   const { deltaMiB } = JSON.parse(stdout.trim().split("\n").at(-1)!);
365 |   expect(deltaMiB).toBeLessThan(isASAN || isDebug ? bounds.debug : bounds.release);
                         ^
error: expect(received).toBeLessThan(expected)

Expected: < 16
Received: 65

      at expectRssDeltaBelow (/workspace/bun/test/harness.ts:365:20)
      at async <anonymous> (/workspace/bun/test/js/bun/s3/s3-client-credentials.test.ts:42:11)
(fail) S3Client credentials > file() without overrides does not copy the client's credentials [44.56ms]
(pass) S3Client credentials > non-credential options keep the client's credentials [0.19ms]
(pass) S3Client credentials > credential overrides apply to that file only [0.17ms]
(pass) S3Client credentials > a file keeps its credentials after the client is collected [2
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-client-credentials.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/s3/s3-client-credentials.test.ts:
(pass) S3Client credentials > file() without overrides signs with the client's credentials [113.79ms]
(pass) S3Client credentials > file() without overrides does not copy the client's credentials [569.80ms]
(pass) S3Client credentials > non-credential options keep the client's credentials [9.34ms]
(pass) S3Client credentials > credential overrides apply to that file only [24.14ms]
(pass) S3Client credentials > a file keeps its credentials after the client is collected [72.01ms]
(pass) S3Client credentials > requests sign with the shared or the overridden credentials [375.87ms]

 6 pass
 0 fail
 68 expect() calls
Ran 6 tests across 1 file. [4.70s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ea4875f57a
  features     baseline

23 deps, 131 codegen, 1172 objects in 797ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[5/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[6/1244] gen ErrorCode+*.h
[7/1244] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1244] fetch zlib
[zlib] up to date
[9/1244] gen .bind.ts → GeneratedBindings.cpp
[10/1244] 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/webcore_types.rs                     |   4 +-
 src/runtime/api/BunObject.rs                 |   7 +-
 src/runtime/webcore/Blob.rs                  |  34 ++----
 src/runtime/webcore/S3Client.rs              |  21 ++--
 src/runtime/webcore/S3File.rs                |  27 ++---
 src/runtime/webcore/blob/Store.rs            |   8 +-
 src/runtime/webcore/fetch.rs                 |  15 +--
 src/runtime/webcore/s3/credentials_jsc.rs    |  50 ++++----
 src/s3_signing/credentials.rs                |  56 +++------
 test/js/bun/s3/s3-client-credentials.test.ts | 166 +++++++++++++++++++++++++++
 10 files changed, 248 insertions(+), 140 deletions(-)
```

</details>

**gate history** · 3 passed · 2 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/webcore_types.rs                          2      1      0
src/runtime/api/BunObject.rs                      1      2      0
src/runtime/webcore/Blob.rs                       1      2      0
src/runtime/webcore/S3Client.rs                   2      3      0
src/runtime/webcore/S3File.rs                     2      2      0
src/runtime/webcore/blob/Store.rs                 2      0      0
src/runtime/webcore/fetch.rs                      1      3      0
src/runtime/webcore/s3/credentials_jsc.rs         3      4      0
src/s3_signing/credentials.rs                     5      3      0
test/js/bun/s3/s3-client-credentials.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->