### PR TITLE
css: print tokens as CSS in parse error messages

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5276,6 +5276,8 @@ impl Token {
         }
     }
 
+    /// Serialize the token as CSS into any byte sink. `Display` and
+    /// `to_css` both route through here.
     pub(crate) fn to_css_generic<W: WriteAll + ?Sized>(
         &self,
         writer: &mut W,
@@ -5286,11 +5288,15 @@ impl Token {
                 writer.write_all(b"@")?;
                 serializer::serialize_identifier(v, writer)
             }
-            Token::UnrestrictedHash(v) | Token::IdHash(v) => {
+            Token::UnrestrictedHash(v) => {
                 writer.write_all(b"#")?;
                 serializer::serialize_name(v, writer)
             }
-            Token::QuotedString(x) => serializer::serialize_name(x, writer),
+            Token::IdHash(v) => {
+                writer.write_all(b"#")?;
+                serializer::serialize_identifier(v, writer)
+            }
+            Token::QuotedString(x) => serializer::serialize_string(x, writer),
             Token::UnquotedUrl(x) => {
                 writer.write_all(b"url(")?;
                 serializer::serialize_unquoted_url(x, writer)?;
@@ -5365,101 +5371,26 @@ impl Token {
 
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
         match self {
-            Token::Ident(value) => dest.serialize_identifier(value),
-            Token::AtKeyword(value) => {
-                dest.write_str("@")?;
-                dest.serialize_identifier(value)
-            }
-            Token::UnrestrictedHash(value) => {
-                dest.write_str("#")?;
-                dest.serialize_name(value)
-            }
-            Token::IdHash(value) => {
-                dest.write_str("#")?;
-                dest.serialize_identifier(value)
-            }
-            Token::QuotedString(value) => dest.serialize_string(value),
-            Token::UnquotedUrl(value) => {
-                dest.write_str("url(")?;
-                serializer::serialize_unquoted_url(value, dest)
-                    .map_err(|_| dest.add_fmt_error())?;
-                dest.write_str(")")
-            }
-            Token::Delim(value) => {
-                debug_assert!(*value <= 0x7F);
-                dest.write_char(*value as u8)
-            }
-            Token::Number(num) => {
-                serializer::write_numeric(num.value, num.int_value, num.has_sign, dest)
-                    .map_err(|_| dest.add_fmt_error())
-            }
-            Token::Percentage {
-                unit_value,
-                int_value,
-                has_sign,
-            } => {
-                serializer::write_numeric(*unit_value * 100.0, *int_value, *has_sign, dest)
-                    .map_err(|_| dest.add_fmt_error())?;
-                dest.write_str("%")
-            }
-            Token::Dimension(dim) => {
-                serializer::write_numeric(dim.num.value, dim.num.int_value, dim.num.has_sign, dest)
-                    .map_err(|_| dest.add_fmt_error())?;
-                let unit = dim.unit;
-                if unit == b"e"
-                    || unit == b"E"
-                    || unit.starts_with(b"e-")
-                    || unit.starts_with(b"E-")
-                {
-                    dest.write_str("\\65 ")?;
-                    dest.serialize_name(&unit[1..])
-                } else {
-                    dest.serialize_identifier(unit)
-                }
-            }
+            // These payloads are written raw and can hold newlines.
+            // `Printer::write_bytes` tracks line/col across them; the
+            // `bun_io::Write` sink of `Printer` (`write_str`) does not.
             Token::Whitespace(content) => dest.write_bytes(content),
             Token::Comment(content) => {
                 dest.write_str("/*")?;
                 dest.write_bytes(content)?;
                 dest.write_str("*/")
             }
-            Token::Colon => dest.write_str(":"),
-            Token::Semicolon => dest.write_str(";"),
-            Token::Comma => dest.write_str(","),
-            Token::IncludeMatch => dest.write_str("~="),
-            Token::DashMatch => dest.write_str("|="),
-            Token::PrefixMatch => dest.write_str("^="),
-            Token::SuffixMatch => dest.write_str("$="),
-            Token::SubstringMatch => dest.write_str("*="),
-            Token::Cdo => dest.write_str("<!--"),
-            Token::Cdc => dest.write_str("-->"),
-            Token::Function(name) => {
-                dest.serialize_identifier(name)?;
-                dest.write_str("(")
-            }
-            Token::OpenParen => dest.write_str("("),
-            Token::OpenSquare => dest.write_str("["),
-            Token::OpenCurly => dest.write_str("{"),
             Token::BadUrl(contents) => {
                 dest.write_str("url(")?;
                 dest.write_bytes(contents)?;
                 dest.write_char(b')')
             }
-            Token::BadString(value) => {
-                dest.write_char(b'"')?;
-                let mut sw = serializer::CssStringWriter::new(dest);
-                sw.write_str(value).map_err(|_| dest.add_fmt_error())
-            }
-            Token::CloseParen => dest.write_str(")"),
-            Token::CloseSquare => dest.write_str("]"),
-            Token::CloseCurly => dest.write_str("}"),
+            _ => self
+                .to_css_generic(dest)
+                .map_err(|_| PrintErr::CSSPrintError),
         }
     }
 }
-
-// `impl Display for Token` lives at crate root (lib.rs) — minimal rendering
-// for error messages only. The CSS-serialization-correct form is
-// `Token::to_css_generic` above.
 
 /// Byte-writer trait for `serializer` and `to_css_generic`.
 /// Aliased to the canonical `bun_io::Write`; the associated

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5276,8 +5276,6 @@ impl Token {
         }
     }
 
-    /// Serialize the token as CSS into any byte sink. `Display` and
-    /// `to_css` both route through here.
     pub(crate) fn to_css_generic<W: WriteAll + ?Sized>(
         &self,
         writer: &mut W,
@@ -5371,9 +5369,7 @@ impl Token {
 
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
         match self {
-            // These payloads are written raw and can hold newlines.
-            // `Printer::write_bytes` tracks line/col across them; the
-            // `bun_io::Write` sink of `Printer` (`write_str`) does not.
+            // Raw payloads can hold newlines, which only `write_bytes` counts.
             Token::Whitespace(content) => dest.write_bytes(content),
             Token::Comment(content) => {
                 dest.write_str("/*")?;

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -390,45 +390,12 @@ pub enum Token {
     Comment(&'static [u8]),
 }
 
+/// Error messages interpolate tokens with `{}`. The output is the token as
+/// CSS (`@media`, `url(x)`, `#id`, `"str"`, `fn(`), the same bytes
+/// `Token::to_css_generic` writes.
 impl core::fmt::Display for Token {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Minimal rendering for error messages. Full CSS serialization
-        // lives in `css_parser.rs` via `serializer::*`.
-        use bstr::BStr;
-        match self {
-            Token::Ident(v)
-            | Token::Function(v)
-            | Token::AtKeyword(v)
-            | Token::UnrestrictedHash(v)
-            | Token::IdHash(v)
-            | Token::QuotedString(v)
-            | Token::BadString(v)
-            | Token::UnquotedUrl(v)
-            | Token::BadUrl(v)
-            | Token::Whitespace(v)
-            | Token::Comment(v) => {
-                write!(f, "{}", BStr::new(v))
-            }
-            Token::Delim(c) => write!(f, "{}", char::from_u32(*c).unwrap_or('\u{FFFD}')),
-            Token::Number(n) => write!(f, "{}", n.value),
-            Token::Percentage { unit_value, .. } => write!(f, "{}%", *unit_value * 100.0),
-            Token::Dimension(d) => write!(f, "{}{}", d.num.value, BStr::new(d.unit)),
-            Token::Cdo => f.write_str("<!--"),
-            Token::Cdc => f.write_str("-->"),
-            Token::IncludeMatch => f.write_str("~="),
-            Token::DashMatch => f.write_str("|="),
-            Token::PrefixMatch => f.write_str("^="),
-            Token::SuffixMatch => f.write_str("$="),
-            Token::SubstringMatch => f.write_str("*="),
-            Token::Colon => f.write_str(":"),
-            Token::Semicolon => f.write_str(";"),
-            Token::Comma => f.write_str(","),
-            Token::OpenSquare => f.write_str("["),
-            Token::CloseSquare => f.write_str("]"),
-            Token::OpenParen => f.write_str("("),
-            Token::CloseParen => f.write_str(")"),
-            Token::OpenCurly => f.write_str("{"),
-            Token::CloseCurly => f.write_str("}"),
-        }
+        self.to_css_generic(&mut bun_io::FmtAdapter::new(f))
+            .map_err(|_| core::fmt::Error)
     }
 }

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -390,9 +390,6 @@ pub enum Token {
     Comment(&'static [u8]),
 }
 
-/// Error messages interpolate tokens with `{}`. The output is the token as
-/// CSS (`@media`, `url(x)`, `#id`, `"str"`, `fn(`), the same bytes
-/// `Token::to_css_generic` writes.
 impl core::fmt::Display for Token {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.to_css_generic(&mut bun_io::FmtAdapter::new(f))

--- a/test/js/bun/css/selector-list-error-recovery.test.ts
+++ b/test/js/bun/css/selector-list-error-recovery.test.ts
@@ -52,10 +52,6 @@ function rejected(message: string) {
   return { stdout: `error: parsing failed: ${message}`, stderr: "", exitCode: 0 };
 }
 
-function minified(output: string) {
-  return { stdout: `ok: ${output}`, stderr: "", exitCode: 0 };
-}
-
 // --- :nth-child(An+B of <selectors>) ---
 
 test.concurrent("an of-list made only of a pseudo-element invalidates the rule", async () => {
@@ -103,16 +99,15 @@ test.concurrent("an empty selector before a comma invalidates the of-list", asyn
   );
 });
 
-test.concurrent("valid of-lists still parse and minify", async () => {
-  expect(await minifyInChild(":nth-child(even of li.important) {width: 20px}")).toEqual(
-    minified(":nth-child(2n of li.important){width:20px}"),
+// Valid input never reaches the empty of-list, so it does not need a child process.
+test("valid of-lists still parse and minify", () => {
+  expect(minifyTest(":nth-child(even of li.important) {width: 20px}", "")).toBe(
+    ":nth-child(2n of li.important){width:20px}",
   );
-  expect(await minifyInChild(":nth-last-child(2n of li.important, .other) {width: 20px}")).toEqual(
-    minified(":nth-last-child(2n of li.important, .other){width:20px}"),
+  expect(minifyTest(":nth-last-child(2n of li.important, .other) {width: 20px}", "")).toBe(
+    ":nth-last-child(2n of li.important, .other){width:20px}",
   );
-  expect(await minifyInChild("a:nth-child(2n of *) { color: red }")).toEqual(
-    minified("a:nth-child(2n of *){color:red}"),
-  );
+  expect(minifyTest("a:nth-child(2n of *) { color: red }", "")).toBe("a:nth-child(2n of *){color:red}");
 });
 
 // --- :has(<relative-selector-list>) ---
@@ -133,9 +128,9 @@ test.concurrent("a valid selector does not rescue a :has() list with an invalid 
   );
 });
 
-test.concurrent("valid :has() lists still parse and minify", async () => {
-  expect(await minifyInChild("a:has(.x) { color: red }")).toEqual(minified("a:has(.x){color:red}"));
-  expect(await minifyInChild("a:has(> .x, ~ .y) { color: red }")).toEqual(minified("a:has(>.x,~.y){color:red}"));
+test("valid :has() lists still parse and minify", () => {
+  expect(minifyTest("a:has(.x) { color: red }", "")).toBe("a:has(.x){color:red}");
+  expect(minifyTest("a:has(> .x, ~ .y) { color: red }", "")).toBe("a:has(>.x,~.y){color:red}");
 });
 
 // --- empty selectors ---

--- a/test/js/bun/css/selector-list-error-recovery.test.ts
+++ b/test/js/bun/css/selector-list-error-recovery.test.ts
@@ -71,8 +71,9 @@ test.concurrent("an of-list made only of a lexically invalid selector invalidate
 });
 
 test.concurrent("an of-list made only of a bad-string token invalidates the rule", async () => {
+  // A bad-string token ends at the newline, so it prints with no closing quote.
   expect(await minifyInChild('div:nth-child(2n of [q="x\n]) { color: red }')).toEqual(
-    rejected("Invalid selector. Invalid value in attribute selector: x"),
+    rejected('Invalid selector. Invalid value in attribute selector: "x'),
   );
 });
 
@@ -150,4 +151,40 @@ test("a forgiving list drops an empty selector instead of keeping it", () => {
   expect(minifyTest("a:is(, .x) { color: red }", "a.x{color:red}")).toBe("a.x{color:red}");
   // `a:is()` matches nothing; it must not be reduced to `a` (which matches everything).
   expect(minifyTest("a:is() { color: red }", "a:is(){color:red}")).toBe("a:is(){color:red}");
+});
+
+// --- tokens in error messages ---
+
+// The message interpolates the offending token. It must print as CSS, with the
+// sigil that says what kind of token it is. It used to print the payload bare,
+// so `@x`, `#x`, `"x"`, and `url(x)` all read as `x`.
+function parseErrorMessage(css: string): string {
+  try {
+    minifyTest(css, "");
+  } catch (e) {
+    return (e as Error).message;
+  }
+  throw new Error(`expected a parse error for ${css}`);
+}
+
+test.each([
+  [":nth-child(@x) {}", "Unexpected token: @x"],
+  [":nth-child(#x) {}", "Unexpected token: #x"],
+  [':nth-child("x") {}', 'Unexpected token: "x"'],
+  [':nth-child("a\\"b") {}', 'Unexpected token: "a\\"b"'],
+  [":nth-child(url(x)) {}", "Unexpected token: url(x)"],
+  ["a { background: url(a b) }", "Unexpected token: url(a b)"],
+  [":nth-child(fn(1)) {}", "Unexpected token: fn("],
+  ["[@foo] {}", "Invalid selector. Missing qualified name in attribute selector: @foo"],
+  [".a[b @c] {}", "Invalid selector. Unexpected token in attribute selector: @c"],
+  [".a[b=foo(1)] {}", "Invalid selector. Invalid value in attribute selector: foo("],
+  [".a[b=#x] {}", "Invalid selector. Invalid value in attribute selector: #x"],
+  [".a[b=#1] {}", "Invalid selector. Invalid value in attribute selector: #1"],
+  [".a[b=url(x)] {}", "Invalid selector. Invalid value in attribute selector: url(x)"],
+  [".a[b=1px] {}", "Invalid selector. Invalid value in attribute selector: 1px"],
+  [".a[b=50%] {}", "Invalid selector. Invalid value in attribute selector: 50%"],
+  [".#x {}", "Invalid selector. Expected identifier after '.' in class selector, found: #x"],
+  [".a::before@x {}", "Invalid selector. Unexpected selector after pseudo-element: @x"],
+])("a parse error prints the token as CSS: %s", (css, message) => {
+  expect(parseErrorMessage(css)).toBe(`parsing failed: ${message}`);
 });


### PR DESCRIPTION
### Problem
- CSS parse errors print the token payload bare. `:nth-child(#x)`, `:nth-child(@x)`, `:nth-child("x")`, and `:nth-child(url(x))` all report `Unexpected token: x`. `.a[b @c] {}` reports `Unexpected token in attribute selector: c`.
- `impl Display for Token` (`src/css/lib.rs:393`) was a minimal rendering that dropped the `@`, `#`, quotes, `url(` and `(`. Every `{}` site in `src/css/error.rs` uses it. The Zig `Token.format` printed the token as CSS. The port lost that.

### Fix
- `Display` forwards to `Token::to_css_generic` through `bun_io::FmtAdapter`, the same pattern `ParsedSourceMap` and `ConsoleObject` use.
- Two arms of `to_css_generic` had drifted from `Token::to_css` and from cssparser: `QuotedString` used `serialize_name` (no quotes) and `IdHash` used `serialize_name` instead of `serialize_identifier`. Both now match. No caller hit those arms before (`to_css_generic` was only used for `Dimension`, `Percentage`, and `UnquotedUrl`).
- `Token::to_css` (the `Printer` path) now delegates to `to_css_generic` too. It keeps its own arms only for `Whitespace`, `Comment`, and `BadUrl`: those payloads can hold raw newlines and need `Printer::write_bytes` for line tracking. Every other arm called the same `serializer::*` function with the same `Printer` writer, so the output is unchanged.
- Verified: `test/js/bun/css/selector-list-error-recovery.test.ts` (17 new cases, 16 fail on 1.4.1). Also `test/js/bun/css/` and `test/bundler/css/`.

### Background
- `Token` is the CSS lexer token (`src/css/lib.rs`). Its payloads are byte slices into the source.
- `to_css_generic<W: bun_io::Write>` serializes a token as CSS into any byte sink. `Printer` implements `bun_io::Write`, so the same function writes into the output CSS and, through `FmtAdapter`, into a `fmt::Formatter`.
- `Printer::write_str` asserts that its input has no newline and counts only columns. `Printer::write_bytes` also counts lines. Raw token payloads go through the second one so source maps stay right.
- #32296 is an older, stale PR with the same core change. This PR supersedes it: it also removes the duplicate serializer in `to_css`, and it updates the one existing test that encoded the bare rendering (`"x` for a bad-string token).

<details><summary>Notes</summary>

Before and after, `bun build` on each input:

```
.a[b @c] {}        Unexpected token in attribute selector: c     -> @c
.d[e=foo(1)] {}    Invalid value in attribute selector: foo      -> foo(
.f[g=#x] {}        Invalid value in attribute selector: x        -> #x
:nth-child(url(x)) Unexpected token: x                           -> url(x)
:nth-child("x")    Unexpected token: x                           -> "x"
```

Edge cases probed through the debug build with no assertion failures: bad-string (`"x` with no closing quote, as cssparser prints it), bad-url with a space, non-ASCII idents and hashes, a NUL inside a string (prints U+FFFD), `<!--`, `-->`, `~=`, `|=`, `#--`, `#-`, `#1a`, `--x`, `+1.5%`, `1e3x`.

`Token::Delim` carries only ASCII (the tokenizer routes non-ASCII bytes to `consume_ident_like`), so the `debug_assert!(*x <= 0x7F)` in `to_css_generic` holds on the error path too.

Suites run: `test/js/bun/css/` (2372 pass; the fuzz and deep-nesting files hit their 5 s and 10 s timeouts on the loaded debug+ASAN box, alone and on main too), `test/bundler/css/` (169 pass), `cargo clippy -p bun_css` clean, `cargo fmt -p bun_css --check` clean.

The `:nth-child(...)` inputs go through `cssInternals.minifyTest`. That path and the bundler log path both format `err.kind` with `{}`, so one test covers both.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/selector-list-error-recovery.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/182] cxx obj/src/jsc/bindings/highway_json.cpp.o
[2/182] cc obj/packages/bun-usockets/src/bsd.c.o
[3/182] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[4/182] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[5/182] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[6/182] cc obj/packages/bun-usockets/src/fault_inject.c.o
[7/182] cc obj/packages/bun-usockets/src/loop.c.o
[8/182] cc obj/packages/bun-usockets/src/udp.c.o
[9/182] cxx obj/src/jsc/bindings/highway_xml.cpp.o
[10/182] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[11/182] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[12/182] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[13/182] cc obj/packages/bun-usockets/src/quic.c.o
[14/182] cc obj/packages/bun-usockets/src/socket.c.o
[15/182] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[16/182] cc obj/vendor/picohttpparser/picohttpparser.c.o
[17/182] cc obj/packages/bun-usockets/src/conte
... (truncated)

release without fix: 16 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/css/selector-list-error-recovery.test.ts:
66 |   );
67 | });
68 | 
69 | test.concurrent("an of-list made only of a bad-string token invalidates the rule", async () => {
70 |   // A bad-string token ends at the newline, so it prints with no closing quote.
71 |   expect(await minifyInChild('div:nth-child(2n of [q="x\n]) { color: red }')).toEqual(
                                                                                   ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "error: parsing failed: Invalid selector. Invalid value in attribute selector: "x",
+   "stdout": "error: parsing failed: Invalid selector. Invalid value in attribute selector: x",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/css/selector-list-error-recovery.test.ts:71:79)
(fail) an of-list made only of a bad-string token invalidates the rule [22.77ms]
(pass) a valid selector does not rescue an of-list with an invalid one [22.72ms]
(pass) :nth-last-child takes the same of-list grammar [26.13ms]
(pass) an of-list made only of a lexically invalid selector in
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/selector-list-error-recovery.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/css/selector-list-error-recovery.test.ts:
(pass) an of-list made only of a pseudo-element invalidates the rule [1370.28ms]
(pass) :nth-last-child takes the same of-list grammar [1325.08ms]
(pass) an of-list made only of a bad-string token invalidates the rule [1403.92ms]
(pass) an of-list made only of a lexically invalid selector invalidates the rule [1420.63ms]
(pass) a valid selector does not rescue an of-list with an invalid one [1474.71ms]
(pass) an empty of-list invalidates the rule [1399.56ms]
(pass) an empty selector before a comma invalidates the of-list [1564.99ms]
(pass) valid of-lists still parse and minify [6.84ms]
(pass) a :has() list made only of a lexically invalid selector invalidates the rule [1337.93ms]
(pass) a lone comma in :has() invalidates the rule [1452.93ms]
(pass) a valid selector does not rescue a :has() list with an invalid one [1458.54ms]
(pass) valid :has() lists still parse and minify [4.20ms]
(pass) an empty sel
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 716ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[2/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[3/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[4/8] gen cpp.rs (cppbind)
[4/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/css_parser.rs                              | 93 +++-------------------
 src/css/lib.rs                                     | 40 +---------
 .../bun/css/selector-list-error-recovery.test.ts   | 64 +++++++++++----
 3 files changed, 60 insertions(+), 137 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/css/css_parser.rs                                     6      4      0
src/css/lib.rs                                            2      3      0
test/js/bun/css/selector-list-error-recovery.test.ts      4      9      0
```

</details>

<!-- robobun:evidence:end -->