### PR TITLE
docs: improve phrasing in installation overview

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -5,7 +5,7 @@ description: Install Bun with npm, Homebrew, Docker, or the official script.
 
 ## Overview
 
-Bun ships as a single, dependency-free executable. Install it with the install script, a package manager, or Docker on macOS, Linux, and Windows.
+Bun ships as a single, dependency-free executable. Install it via the install script, a package manager, or Docker on macOS, Linux, and Windows.
 
 <Tip>After installation, verify with `bun --version` and `bun --revision`.</Tip>
 


### PR DESCRIPTION
docs(installation): Install it with the install script -> Install it via the install script to avoid redundancy.