### PR TITLE
docs: improve phrasing in feedback guide

### DIFF
--- a/docs/feedback.mdx
+++ b/docs/feedback.mdx
@@ -30,7 +30,7 @@ Here's how to open a helpful issue for a bug, a performance problem, or a featur
     	If the issue persists after upgrading, continue to the next step.
     </Step>
     <Step title="Review Existing Issues">
-    	Check whether the issue has already been reported before opening a new one. Checking first saves time for everyone and helps us focus on fixing things.
+    	Check whether the issue has already been reported. Doing so saves time for everyone and helps us focus on fixing things.
 
     	- 🔍 [**Search existing issues**](https://github.com/oven-sh/bun/issues)
     	- 💬 [**Check discussions**](https://github.com/oven-sh/bun/discussions)


### PR DESCRIPTION
docs(feedback): efore opening a new one. Checking first saves time -> Doing so saves time for concision.