### PR TITLE
Fix Bun.generateHeapSnapshot("v8") aborting on heaps past ~15M objects (WebKit#529)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-529-d199c1f1";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -33,7 +33,10 @@ pub(crate) fn generate_and_write_profile(
     };
 
     if profile_string.is_empty() {
-        // No profile data generated
+        // The V8 builder returns an empty string when the snapshot was too
+        // large to serialize. Say so instead of silently writing nothing.
+        bun_core::pretty_errorln!("<red>error<r>: heap snapshot is too large to serialize");
+        Output::flush();
         return Ok(());
     }
 

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -35,8 +35,11 @@ pub(crate) fn generate_and_write_profile(
     if profile_string.is_empty() {
         // The V8 builder returns an empty string when the snapshot was too
         // large to serialize. Say so instead of silently writing nothing.
-        bun_core::pretty_errorln!("<red>error<r>: heap snapshot is too large to serialize");
-        Output::flush();
+        // The text profiler reports its own errors inline, so leave it alone.
+        if !config.text_format {
+            bun_core::pretty_errorln!("<red>error<r>: heap snapshot is too large to serialize");
+            Output::flush();
+        }
         return Ok(());
     }
 

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -815,6 +815,10 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
             JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
             auto bytes = builder.jsonBytes();
             RETURN_IF_EXCEPTION(throwScope, {});
+            if (builder.hasOverflowed()) {
+                throwException(globalObject, throwScope, createError(globalObject, "Heap snapshot is too large to serialize"_s));
+                return {};
+            }
             auto released = bytes.releaseBuffer();
             auto span = released.leakSpan();
             auto buffer = ArrayBuffer::createFromBytes(std::span<const uint8_t> { span.data(), span.size() }, createSharedTask<void(void*)>([](void* p) {
@@ -826,6 +830,10 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
         JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
         auto json = builder.json();
         RETURN_IF_EXCEPTION(throwScope, {});
+        if (json.isNull()) {
+            throwException(globalObject, throwScope, createError(globalObject, "Heap snapshot is too large to serialize"_s));
+            return {};
+        }
         return JSC::JSValue::encode(jsString(vm, json));
     }
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -760,9 +760,20 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
         JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
         String snapshot = builder.json();
 
+        // json() returns a null String when the snapshot was too large to
+        // serialize; reject instead of resolving with an empty string.
         ScriptExecutionContext::postTaskTo(parentId, parentLoopKind,
             [reqId, protectedProxy = WTF::move(protectedProxy), snapshot = snapshot.isolatedCopy()](ScriptExecutionContext& parentCtx) {
-                resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& vm, JSGlobalObject*) -> JSValue { return jsString(vm, snapshot); });
+                auto handle = protectedProxy->takeCrossVMRequest(reqId);
+                if (!handle || parentCtx.isJSExecutionForbidden())
+                    return;
+                auto& parentVM = parentCtx.vm();
+                auto* parentGlobalObject = parentCtx.globalObject();
+                if (snapshot.isNull()) {
+                    handle->reject(parentVM, JSC::createError(parentGlobalObject, "Heap snapshot is too large to serialize"_s));
+                    return;
+                }
+                handle->resolve(parentGlobalObject, parentVM, jsString(parentVM, snapshot));
             });
     });
     if (!accepted) {

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { join } from "node:path";
 
 const fixture = join(import.meta.dir, "v8-heap-snapshot-fixture.ts");
@@ -88,6 +88,35 @@ test("v8.writeHeapSnapshot() with path", async () => {
   const path = join(String(dir), "test.heapsnapshot");
   expect(await runFixture("write-path", { args: [path] })).toEqual({ returnedPath: path, ...structure });
 });
+
+// #40686: the builder stored one 96-byte Node per heap cell in a contiguous
+// WTF::Vector, whose single-allocation cap is ~2GiB. Past ~15M live cells the
+// vector growth tripped that cap and aborted the process (SIGABRT) inside the
+// marking walk. 16M small objects reproduce it. The walk visits every live
+// cell, so the heap has to actually be this large; ~30s and ~4GB RSS in a
+// release build, but 10-100x slower under debug/ASAN, hence the skip there.
+test.skipIf(isDebug || isASAN)(
+  "v8 heap snapshot of a 16M-object heap does not crash",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const items = Array.from({ length: 16_000_000 }, (_, i) => ({ i }));
+         const snapshot = Bun.generateHeapSnapshot("v8");
+         console.log(items.length, snapshot.length > 100_000_000);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("16000000 true\n");
+    expect(exitCode).toBe(0);
+  },
+  240_000,
+);
 
 test("v8 heap snapshot labels Web Streams internal edges", async () => {
   const edges = await runFixture("stream-edges");

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -108,10 +108,11 @@ test.skipIf(isDebug || isASAN)(
       ],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "ignore",
+      stderr: "pipe",
     });
 
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toBe("16000000 true\n");
     expect(exitCode).toBe(0);
   },


### PR DESCRIPTION
### Problem

- `Bun.generateHeapSnapshot("v8")` and `node:v8.writeHeapSnapshot()` abort the process (SIGABRT, `EXC_BREAKPOINT` on macOS) once the heap passes about 15M live cells. The crash is in `BunV8HeapSnapshotBuilder::Node` vector growth. Issue #40686, reproduced with 16M small objects.
- The builder stores one 96-byte `Node` per heap cell in a contiguous `WTF::Vector`. A `WTF::Vector` caps one allocation at about 2GiB and `CRASH()`es past it. The 16M-object heap needs a 23M-node growth step, which is 2.2GiB.

### Fix

- oven-sh/WebKit#529, pinned here: shrink `Node` to 40 bytes (the removed fields were written but never read), store nodes in a `SegmentedVector` (no contiguous allocation, so no cap), and record overflow from the still-contiguous containers (edges, strings, serialized output) instead of crashing.
- Bun side consumes the new overflow signal: `Bun.generateHeapSnapshot("v8")` throws, `worker.getHeapSnapshot()` rejects, and the `--heap-prof` writer prints an error instead of silently writing nothing.
- Verified: the 16M repro completes on a debug ASAN build of this branch and aborts bun 1.4.1 in seconds. New test in `test/js/bun/util/v8-heap-snapshot.test.ts` runs the repro on release lanes. It is skipped under debug/ASAN, where the heap walk takes over an hour. Existing v8 snapshot, worker snapshot, and node:v8 suites pass.

### Background

- `BunV8HeapSnapshotBuilder` is a JSC `HeapAnalyzer` in the oven-sh/WebKit fork. A full GC walks the heap and calls it back for every live cell and edge. The builder records them, then serializes the V8 `.heapsnapshot` JSON.
- Snapshot storage is proportional to the heap. Node storage was the first structure to hit the Vector cap. Edge storage and the serialized output can pass 2GiB on still larger heaps. Those cases now raise a catchable "Heap snapshot is too large to serialize" error instead of crashing.
- Do not merge before oven-sh/WebKit#529 merges. `WEBKIT_VERSION` must then be swapped from the preview tag to the merged sha.

<details><summary>Notes</summary>

Reproduction (bun 1.4.1, linux x64 and the reporter's macOS arm64):

```ts
const items = Array.from({ length: 16_000_000 }, (_, i) => ({ i }));
const snapshot = Bun.generateHeapSnapshot("v8");
console.log(items.length, snapshot.length);
```

`bun repro.ts` exits 134 (SIGABRT) after ~14s at ~3.9GB peak RSS. The trap fires in `Vector::allocateBuffer` via `isValidCapacityForVector<Node>`: capacity growth 15,354,379 -> 23,031,568 at 96 bytes per node exceeds `(UINT_MAX >> 1)` bytes, matching the registers in the report.

Fail-before note for the mechanical gate: the fix lives in prebuilt WebKit, which `git stash push -- src/ packages/` does not revert, and the crash threshold (about 15M live cells) makes the walk take over an hour under a debug ASAN build. The new test therefore proves the fix on release builds only: with `USE_SYSTEM_BUN=1` (1.4.1) it fails in ~10s, with this branch it passes.

Local verification against WebKit#529 (debug ASAN, local WebKit build):

- 16M repro prints `16000000 825993840` (an 826M-char snapshot) and exits cleanly.
- `test/js/bun/util/v8-heap-snapshot.test.ts`: 7 pass.
- `test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts`: pass.
- `test/js/node/test/parallel/test-v8-getheapsnapshot-twice.js`, `test-worker-heap-snapshot.js`: pass.
- String, arraybuffer, and `writeHeapSnapshot` outputs agree on node/edge counts at 200k objects.
- `test/js/bun/util/heap-snapshot.test.ts` has two pre-existing 5s timeouts on debug builds (URL, Headers), identical on an unmodified build; tracked by #37835.

The removed `Node` fields (`edges`, `traceLocation`, `parentNodeId`, `childrenVectorIndex`) were write-only. `trace_function_infos` is always serialized empty, so dropping `traceLocation` changes no output.

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/util/v8-heap-snapshot.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/util/v8-heap-snapshot.test.ts:
(pass) v8 heap snapshot [2694.04ms]
(pass) v8 heap snapshot arraybuffer [2169.53ms]
(pass) v8 heap snapshot arraybuffer matches string output [1221.69ms]
(pass) v8.getHeapSnapshot() [2954.60ms]
(pass) v8.writeHeapSnapshot() [2792.66ms]
(pass) v8.writeHeapSnapshot() with path [1841.81ms]
(skip) v8 heap snapshot of a 16M-object heap does not crash
(pass) v8 heap snapshot labels Web Streams internal edges [1131.49ms]

 7 pass
 1 skip
 0 fail
 18 expect() calls
Ran 8 tests across 1 file. [16.75s]
__F:0:S:1

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/util/v8-heap-snapshot.test.ts:
(pass) v8 heap snapshot [41.11ms]
(pass) v8 heap snapshot arraybuffer [44.21ms]
(pass) v8 heap snapshot arraybuffer matches string output [22.16ms]
(pass) v8.getHeapSnapshot() [40.35ms]
(pass) v8.writeHeapSnapshot() [41.30ms]
(pass) v8.writeHeapSnapshot() with path [24.52ms]
110 |       stdout: "pipe",
111 |       stderr: "pipe",
112 |     });
113 | 
114 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
115 |     expect(stderr).toBe("");
                         ^
error: expect(received).toBe(expected)

- ""
+ "============================================================
+ Bun Canary v1.4.1-canary.1 (65362b53b) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "-e" "const items = Array.from({ length: 16_000_000 }, (_, i) => ({ i }));\n         const snapshot = Bun.generateHeapSnapshot(\"v8\");\n         console.log(items.length, "...
+ Features: bunfig jsc tsconfig heap_snapshot 
+ Builtins: "bun:main" 
+ 
+ Elapsed: 8756ms | User: 5672ms | Sys: 34
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/util/v8-heap-snapshot.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/util/v8-heap-snapshot.test.ts:
(pass) v8 heap snapshot [2754.89ms]
(pass) v8 heap snapshot arraybuffer [2166.30ms]
(pass) v8 heap snapshot arraybuffer matches string output [1149.58ms]
(pass) v8.getHeapSnapshot() [2935.39ms]
(pass) v8.writeHeapSnapshot() [2794.55ms]
(pass) v8.writeHeapSnapshot() with path [1863.41ms]
(skip) v8 heap snapshot of a 16M-object heap does not crash
(pass) v8 heap snapshot labels Web Streams internal edges [1123.54ms]

 7 pass
 1 skip
 0 fail
 18 expect() calls
Ran 8 tests across 1 file. [16.78s]
__F:0:S:1

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4245901227
  features     baseline

23 deps, 131 codegen, 1172 objects in 677ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[2/1244] gen bindgenv2
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] gen ErrorCode+*.h
[5/1243] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[6/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1216] fetch zlib
[zlib] up to date
[8/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts              |  2 +-
 src/jsc/BunHeapProfiler.rs                |  8 +++++++-
 src/jsc/bindings/BunObject.cpp            |  8 ++++++++
 src/jsc/bindings/webcore/JSWorker.cpp     | 13 ++++++++++++-
 test/js/bun/util/v8-heap-snapshot.test.ts | 32 ++++++++++++++++++++++++++++++-
 5 files changed, 59 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
scripts/build/deps/webkit.ts                   6      8      0
src/jsc/BunHeapProfiler.rs                     2      3      0
src/jsc/bindings/BunObject.cpp                 1      2      0
src/jsc/bindings/webcore/JSWorker.cpp          1      2      0
test/js/bun/util/v8-heap-snapshot.test.ts      1      6      0
```

</details>

<!-- robobun:evidence:end -->