### PR TITLE
macros: create the build-time macro VM from the build's transform options

### DIFF
--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -251,6 +251,8 @@ pub mod options {
     /// `options.Format` — many ported call-sites spell this `OutputFormat`.
     pub use bun_options_types::Format as OutputFormat;
     pub use bun_options_types::schema::api::DotEnvBehavior as EnvBehavior;
+    /// The type behind `BundleOptions::transform_options`.
+    pub use bun_options_types::schema::api::TransformOptions;
 
     /// Output kind of a build artifact (`OutputFile.output_kind`).
     ///

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -51,8 +51,6 @@ fn is_macro_path(str: &[u8]) -> bool {
 pub(crate) struct MacroContext {
     pub(crate) resolver: *mut Resolver<'static>,
     pub(crate) env: *mut DotEnvLoader,
-    /// The build's options. `Macro::init` creates the macro VM from these
-    /// when the thread has no VM yet.
     pub(crate) transform_options: Arc<TransformOptions>,
     pub(crate) macros: MacroMap,
     pub(crate) remap: bun_ptr::BackRef<MacroRemap>,
@@ -425,8 +423,6 @@ impl Macro {
         let (vm, is_new_vm): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
             (VirtualMachine::get_mut_ptr(), false)
         } else {
-            // The build's options, so the macro module sees the same
-            // `--define`s, loaders and tsconfig as the rest of the build.
             let mut transform_options = transform_options.clone();
             // Build-only flags about the output bundle. The macro module's own
             // imports must still resolve.

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -51,10 +51,8 @@ fn is_macro_path(str: &[u8]) -> bool {
 pub(crate) struct MacroContext {
     pub(crate) resolver: *mut Resolver<'static>,
     pub(crate) env: *mut DotEnvLoader,
-    /// The owning build's `TransformOptions` (`--define`, `--loader`,
-    /// `--tsconfig-override`, ...). When no VM is loaded on this thread,
-    /// `Macro::init` creates the macro VM from these so the macro module is
-    /// transpiled with the same options as the rest of the build.
+    /// The build's options. `Macro::init` creates the macro VM from these
+    /// when the thread has no VM yet.
     pub(crate) transform_options: Arc<TransformOptions>,
     pub(crate) macros: MacroMap,
     pub(crate) remap: bun_ptr::BackRef<MacroRemap>,
@@ -427,14 +425,10 @@ impl Macro {
         let (vm, is_new_vm): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
             (VirtualMachine::get_mut_ptr(), false)
         } else {
-            // No VM on this thread (CLI build or bundler worker thread): create
-            // one for the macros from the build's own options, so the macro
-            // module is transpiled with the same `--define`s, loaders and
-            // tsconfig as the rest of the build. `InitOptions` owns its
-            // `TransformOptions`, hence the clone.
+            // The build's options, so the macro module sees the same
+            // `--define`s, loaders and tsconfig as the rest of the build.
             let mut transform_options = transform_options.clone();
-            // `--external` and `--packages=external` describe the output
-            // bundle. The macro module runs here, at build time, so its own
+            // Build-only flags about the output bundle. The macro module's own
             // imports must still resolve.
             transform_options.external = Vec::new();
             transform_options.packages = None;

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -2,10 +2,12 @@ use bun_collections::VecExt;
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr::NonNull;
+use std::sync::Arc;
 
 use bun_ast::DisableStoreReset;
 use bun_ast::{E, Expr, ExprData, ExprNodeList, G, ToJSError};
 use bun_ast::{Log, Range, Source};
+use bun_bundler::options::TransformOptions;
 use bun_bundler::{Transpiler, entry_points::MacroEntryPoint};
 use bun_collections::{ArrayHashMap, HashMap};
 use bun_core::Output;
@@ -49,6 +51,11 @@ fn is_macro_path(str: &[u8]) -> bool {
 pub(crate) struct MacroContext {
     pub(crate) resolver: *mut Resolver<'static>,
     pub(crate) env: *mut DotEnvLoader,
+    /// The owning build's `TransformOptions` (`--define`, `--loader`,
+    /// `--tsconfig-override`, ...). When no VM is loaded on this thread,
+    /// `Macro::init` creates the macro VM from these so the macro module is
+    /// transpiled with the same options as the rest of the build.
+    pub(crate) transform_options: Arc<TransformOptions>,
     pub(crate) macros: MacroMap,
     pub(crate) remap: bun_ptr::BackRef<MacroRemap>,
     pub(crate) javascript_object: JSValue,
@@ -89,6 +96,7 @@ impl MacroContext {
             macros: MacroMap::new(),
             resolver: &raw mut transpiler.resolver,
             env: transpiler.env,
+            transform_options: Arc::clone(&transpiler.options.transform_options),
             remap: bun_ptr::BackRef::new(&transpiler.options.macro_remap),
             javascript_object: JSValue::ZERO,
             // Deferred until `call()` — see field doc.
@@ -183,6 +191,7 @@ impl MacroContext {
                 input_specifier,
                 log,
                 self.env,
+                &self.transform_options,
                 function_name,
                 &specifier_buf[0..specifier_buf_len as usize],
                 hash,
@@ -410,6 +419,7 @@ impl Macro {
         input_specifier: &[u8],
         log: &mut Log,
         env: *mut DotEnvLoader,
+        transform_options: &TransformOptions,
         function_name: &[u8],
         specifier: &[u8],
         hash: i32,
@@ -417,19 +427,23 @@ impl Macro {
         let (vm, is_new_vm): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
             (VirtualMachine::get_mut_ptr(), false)
         } else {
-            // The resolver's forward-decl `BundleOptions` does not carry
-            // `transform_options` (the canonical owner is the bundler's
-            // `BundleOptions<'a>`), and
-            // `RuntimeHooks::init_runtime_state` builds the macro VM's
-            // transpiler from a fresh `TransformOptions` value rather than
-            // borrowing the caller's, so there is nothing to mutate-and-restore
-            // on `resolver.opts` here. `log`/`env_loader` *are* threaded so the
-            // CLI-path macro VM uses the caller's log sink and env loader.
+            // No VM on this thread (CLI build or bundler worker thread): create
+            // one for the macros from the build's own options, so the macro
+            // module is transpiled with the same `--define`s, loaders and
+            // tsconfig as the rest of the build. `InitOptions` owns its
+            // `TransformOptions`, hence the clone.
+            let mut transform_options = transform_options.clone();
+            // `--external` and `--packages=external` describe the output
+            // bundle. The macro module runs here, at build time, so its own
+            // imports must still resolve.
+            transform_options.external = Vec::new();
+            transform_options.packages = None;
 
             // JSC needs to be initialized if building from CLI
             jsc::initialize(jsc::InitializeOptions::default());
 
             let _vm = VirtualMachine::init(VirtualMachineInitOptions {
+                transform_options,
                 log: Some(NonNull::from(&mut *log)),
                 env_loader: NonNull::new(env),
                 is_main_thread: false,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1182,6 +1182,9 @@ impl CompletionStruct for JSBundleCompletionTask {
             },
             inject: Vec::new(),
             external: config.external.keys().to_vec(),
+            // `configure_bundler` sets `options.loaders` too; the copy here is
+            // what the macro VM is created from (`Macro::init`).
+            loaders: config.loaders.clone(),
             main_fields: Vec::new(),
             extension_order: Vec::new(),
             env_files: Vec::new(),

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1182,8 +1182,7 @@ impl CompletionStruct for JSBundleCompletionTask {
             },
             inject: Vec::new(),
             external: config.external.keys().to_vec(),
-            // `configure_bundler` sets `options.loaders` too; the copy here is
-            // what the macro VM is created from (`Macro::init`).
+            // Also read by `Macro::init`, which creates the macro VM from these.
             loaders: config.loaders.clone(),
             main_fields: Vec::new(),
             extension_order: Vec::new(),

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2653,6 +2653,65 @@ describe("bundler", () => {
     target: "bun",
     run: { stdout: '[true,true,null,"{\\"__proto__\\":{\\"x\\":1},\\"a\\":2}"]' },
   });
+  // The macro module is transpiled by the macro VM, not by the bundler. That
+  // VM has to be created from the build's transform options, or the macro
+  // module does not see `--define` and `--loader`.
+  const macroSeesBuildOptionsFiles = {
+    "/entry.ts": /* js */ `
+      import { mode, banner } from "./macro.ts" with { type: "macro" };
+      console.log(mode(), banner());
+    `,
+    "/macro.ts": /* js */ `
+      import banner_ from "./banner.dat";
+      export function mode() {
+        return process.env.MODE ?? "none";
+      }
+      export function banner() {
+        return banner_;
+      }
+    `,
+    "/banner.dat": "hello from a text loader",
+  };
+  itBundled("edgecase/MacroSeesBuildDefinesAndLoadersCLI", {
+    files: macroSeesBuildOptionsFiles,
+    backend: "cli",
+    define: { "process.env.MODE": '"prod"' },
+    loader: { ".dat": "text" },
+    target: "bun",
+    run: { stdout: "prod hello from a text loader" },
+  });
+  itBundled("edgecase/MacroSeesBuildDefinesAndLoadersAPI", {
+    files: macroSeesBuildOptionsFiles,
+    backend: "api",
+    define: { "process.env.MODE": '"prod"' },
+    loader: { ".dat": "text" },
+    target: "bun",
+    run: { stdout: "prod hello from a text loader" },
+  });
+  // `--external` and `--packages=external` describe the output bundle, not the
+  // macro VM. A package the macro module imports has to resolve at build time.
+  itBundled("edgecase/MacroImportsPackageMarkedExternal", {
+    files: {
+      "/entry.ts": /* js */ `
+        import { fooAtBuildTime } from "./macro.ts" with { type: "macro" };
+        import foo from "foo";
+        console.log(fooAtBuildTime(), foo);
+      `,
+      "/macro.ts": /* js */ `
+        import foo from "foo";
+        export function fooAtBuildTime() {
+          return foo;
+        }
+      `,
+      "/node_modules/foo/package.json": `{ "name": "foo", "version": "1.0.0", "main": "index.js" }`,
+      "/node_modules/foo/index.js": `module.exports = "foo-value";`,
+    },
+    backend: "cli",
+    external: ["foo"],
+    packages: "external",
+    target: "bun",
+    run: { stdout: "foo-value foo-value" },
+  });
   itBundled("edgecase/NodeBuiltinWithoutPrefix", {
     files: {
       "/entry.ts": `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2655,34 +2655,27 @@ describe("bundler", () => {
   });
   // The macro module is transpiled by the macro VM, not by the bundler. That
   // VM has to be created from the build's transform options, or the macro
-  // module does not see `--define` and `--loader`.
-  const macroSeesBuildOptionsFiles = {
-    "/entry.ts": /* js */ `
-      import { mode, banner } from "./macro.ts" with { type: "macro" };
-      console.log(mode(), banner());
-    `,
-    "/macro.ts": /* js */ `
-      import banner_ from "./banner.dat";
-      export function mode() {
-        return process.env.MODE ?? "none";
-      }
-      export function banner() {
-        return banner_;
-      }
-    `,
-    "/banner.dat": "hello from a text loader",
-  };
-  itBundled("edgecase/MacroSeesBuildDefinesAndLoadersCLI", {
-    files: macroSeesBuildOptionsFiles,
+  // module does not see `--define` and `--loader`. The `Bun.build()` variant
+  // lives in transpiler/macro-test.test.ts: the macro VM of a worker thread
+  // outlives the build that created it, so that test needs its own process.
+  itBundled("edgecase/MacroSeesBuildDefinesAndLoaders", {
+    files: {
+      "/entry.ts": /* js */ `
+        import { mode, banner } from "./macro.ts" with { type: "macro" };
+        console.log(mode(), banner());
+      `,
+      "/macro.ts": /* js */ `
+        import banner_ from "./banner.dat";
+        export function mode() {
+          return process.env.MODE ?? "none";
+        }
+        export function banner() {
+          return banner_;
+        }
+      `,
+      "/banner.dat": "hello from a text loader",
+    },
     backend: "cli",
-    define: { "process.env.MODE": '"prod"' },
-    loader: { ".dat": "text" },
-    target: "bun",
-    run: { stdout: "prod hello from a text loader" },
-  });
-  itBundled("edgecase/MacroSeesBuildDefinesAndLoadersAPI", {
-    files: macroSeesBuildOptionsFiles,
-    backend: "api",
     define: { "process.env.MODE": '"prod"' },
     loader: { ".dat": "text" },
     target: "bun",

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -402,6 +402,44 @@ test("a macro in a module transpiled off the main thread sees --define", async (
   expect(exitCode).toBe(0);
 });
 
+// `Bun.build()` parses on the process-wide worker pool. The macro VM a worker creates takes the
+// options of the build that creates it and lives on after that build, so this runs in its own
+// process: an earlier build in the same process would otherwise decide what the macro sees.
+test("Bun.build() passes define and loader to the macro VM", async () => {
+  using dir = tempDir("macro-build-api-options", {
+    "entry.ts": `import { mode, banner } from "./macro.ts" with { type: "macro" };\nconsole.log(mode(), banner());\n`,
+    "macro.ts": [
+      `import banner_ from "./banner.dat";`,
+      `export function mode() {\n  return process.env.MODE ?? "none";\n}`,
+      `export function banner() {\n  return banner_;\n}`,
+      ``,
+    ].join("\n"),
+    "banner.dat": "hello from a text loader",
+    "build.ts": `
+      const result = await Bun.build({
+        entrypoints: ["./entry.ts"],
+        target: "bun",
+        define: { "process.env.MODE": '"prod"' },
+        loader: { ".dat": "text" },
+      });
+      console.log(await result.outputs[0].text());
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "build.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
+    lastLine: `console.log("prod", "hello from a text loader");`,
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -381,6 +381,27 @@ describe("event loop routing around macros", () => {
   });
 });
 
+// A module that is not the entry point is transpiled on a worker thread, where no VM exists yet. The
+// macro VM created there has to take the CLI's transform options, or the macro module never sees
+// `--define`.
+test("a macro in a module transpiled off the main thread sees --define", async () => {
+  using dir = tempDir("macro-off-thread-define", {
+    "m.ts": `export function mode() {\n  return process.env.MODE ?? "none";\n}\n`,
+    "lib.ts": `import { mode } from "./m.ts" with { type: "macro" };\nexport const x = mode();\n`,
+    "index.ts": `import { x } from "./lib.ts";\nconsole.log(x);\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--define", 'process.env.MODE:"prod"', "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({ lastLine: "prod", stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `


### PR DESCRIPTION
### Problem
- `bun build --define process.env.MODE:'"prod"' app.ts`, where `app.ts` imports a macro that reads `process.env.MODE`, inlines `"none"` (the macro's fallback). A file the macro module imports through `--loader .dat:text` is parsed as JavaScript instead (`Expected ";" but found "from"`). `Bun.build({ define, loader })` and a `bun --define` run whose macro sits in a module transpiled off the main thread behave the same way.
- When no VM is loaded on the current thread (a bundler parse worker, the `Bun.build()` bundle thread, a runtime transpiler-store worker), `Macro::init` (`src/js_parser_jsc/Macro.rs`) creates the macro VM with `InitOptions { log, env_loader, is_main_thread, ..Default::default() }`. `transform_options` stays at its default, so the VM's transpiler has no defines, no loaders, no tsconfig override. The Zig version passed `.args = resolver.opts.transform_options` here.

### Fix
- `MacroContext` keeps an `Arc` clone of `transpiler.options.transform_options` (the field already is an `Arc`). `Macro::init` copies it into `InitOptions::transform_options` when it creates the VM, so the macro module is transpiled with the same `--define`, `--loader`, `--tsconfig-override`, JSX and resolution settings as the build.
- `--external` and `--packages=external` are cleared on that copy. They are build-only flags that describe the output bundle. The macro module runs at build time, so its own `import foo from "foo"` must still resolve. Without this, `bun build -e foo` broke a macro that imports `foo`.
- `Bun.build()` now includes its `loader` map in the `TransformOptions` it builds (`js_bundle_completion_task.rs`). `configure_bundler` already applied the map to the build's own transpiler, but the macro VM is created from the `TransformOptions`.
- Verified: `test/bundler/bundler_edgecase.test.ts` (`MacroSeesBuildDefinesAndLoadersCLI`, `MacroSeesBuildDefinesAndLoadersAPI`, `MacroImportsPackageMarkedExternal`) and `test/bundler/transpiler/macro-test.test.ts` ("a macro in a module transpiled off the main thread sees --define"). Also ran `bundler_edgecase.test.ts`, `bun-build-api.test.ts`, `transpiler.test.js`, `bundler_env.test.ts`, `bundler_loader.test.ts` and the macro regression tests.

### Background
- A macro import (`with { type: "macro" }`) runs the imported module in a JSC VM at build time and splices the call result into the AST. In `bun run` the current VM is used. In `bun build` the parse happens on worker threads that have no VM, so `Macro::init` creates one per thread.
- `api::TransformOptions` is the CLI/bunfig option bag. `BundleOptions::from_api` projects it into the transpiler's options (defines, loaders, externals, conditions) and keeps the original in `BundleOptions::transform_options`. `VirtualMachine::init` takes a `TransformOptions` by value and builds the VM's transpiler from it.
- The resolver treats a specifier that matches `--external` or `--packages=external` as external and returns it unresolved. The bundler leaves such an import in the output. A runtime VM has no such concept and fails to load the module.

<details><summary>Notes</summary>

- Repro, released 1.4.1: `app.ts` has `import { mode } from "./m.ts" with { type: "macro" }; console.log(mode());` and `m.ts` has `export function mode() { return process.env.MODE ?? "none"; }`. `bun build --define 'process.env.MODE:"prod"' app.ts` prints `console.log("none")`. `bun --define 'process.env.MODE:"prod"' app.ts` prints `prod` (the entry point is transpiled on the main thread). With `app.ts` importing `lib.ts` that uses the macro, the run prints `none` too: `lib.ts` goes through the runtime transpiler store on a worker thread.
- `Bun.build()` with `define` and a macro printed `none` as well, and neither the runtime's own `--define` nor the build's reached the macro: the bundle thread and its workers have no VM.
- `TransformOptions` is exposed through `bun_bundler::options` next to the existing `EnvBehavior` re-export, so `bun_js_parser_jsc` does not need a new Cargo dependency.
- The macro VM runs `configure_defines` after init, which loads `.env` files into the shared env loader again. The build's transpiler loaded the same files into the same loader first, so this is a repeat of the same work, unchanged from before.
- `--drop`, `--feature`, `--conditions`, `--main-fields`, `--extension-order`, `--preserve-symlinks`, `--env-file` and the JSX flags are accepted by `bun run` too and now reach the macro VM the same way they reach a runtime VM. `--external` and `--packages` are build-only and are cleared.
- The two bytecode tests in `bun-build-api.test.ts` (`function record on an encoder page boundary`, `repeated builds don't retain the generated code`) hit the 5 s timeout on an unmodified main debug build in this container as well. Unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->