### PR TITLE
bun:ffi: throw the argument errors of toBuffer and toArrayBuffer

### DIFF
--- a/src/jsc/bindings/JSFFICString.cpp
+++ b/src/jsc/bindings/JSFFICString.cpp
@@ -70,10 +70,7 @@ JSC_DEFINE_HOST_FUNCTION(constructFFICString, (JSGlobalObject * globalObject, Ca
     JSValue lengthArgument = isSafeIntegerValue(byteLength) ? byteLength : jsUndefined();
     JSValue transcoded = JSValue::decode(Bun__FFI__CString__transcode(globalObject, JSValue::encode(ptrValue), JSValue::encode(offsetArgument), JSValue::encode(lengthArgument)));
     RETURN_IF_EXCEPTION(scope, {});
-    if (transcoded.isString()) [[likely]]
-        return JSValue::encode(transcoded);
-    throwException(globalObject, scope, transcoded);
-    return {};
+    return JSValue::encode(transcoded);
 }
 
 }

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -84,14 +84,10 @@ fn new_cstring(
     byte_offset: Option<JSValue>,
     length_value: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    match get_ptr_slice(global_this, value, byte_offset, length_value) {
-        ValueOrError::Err(err) => Ok(err),
-        ValueOrError::Slice(ptr, len) => {
-            // SAFETY: ptr/len point to FFI-owned memory whose lifetime the caller guarantees.
-            let bytes = unsafe { core::slice::from_raw_parts(ptr, len) };
-            bun_string_jsc::create_utf8_for_js(global_this, bytes)
-        }
-    }
+    let (ptr, len) = get_ptr_slice(global_this, value, byte_offset, length_value)?;
+    // SAFETY: ptr/len point to FFI-owned memory whose lifetime the caller guarantees.
+    let bytes = unsafe { core::slice::from_raw_parts(ptr, len) };
+    bun_string_jsc::create_utf8_for_js(global_this, bytes)
 }
 
 #[unsafe(no_mangle)]
@@ -495,36 +491,29 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
     JSValue::from_ptr_address(addr)
 }
 
-/// `Slice` carries a raw (ptr, len) pointing at caller-owned FFI memory; consumers
-/// borrow it (or delegate disposal to a supplied finalizer), never free it from Rust.
-enum ValueOrError {
-    Err(JSValue),
-    Slice(*mut u8, usize),
-}
-
+/// Resolves the `(ptr, byteOffset, byteLength)` arguments of `toBuffer`,
+/// `toArrayBuffer` and `CString` to a raw (ptr, len) over caller-owned FFI
+/// memory. Consumers borrow it (or delegate disposal to a supplied finalizer),
+/// never free it from Rust. An invalid argument throws a TypeError.
 fn get_ptr_slice(
     global_this: &JSGlobalObject,
     value: JSValue,
     byte_offset: Option<JSValue>,
     byte_length: Option<JSValue>,
-) -> ValueOrError {
+) -> JsResult<(*mut u8, usize)> {
     let num = if value.is_big_int() {
         if !value.is_big_int_in_uint64_range(0, usize::MAX as u64) {
-            return ValueOrError::Err(
-                global_this.to_invalid_arguments(format_args!("ptr is out of range.")),
-            );
+            return Err(global_this.throw_invalid_arguments(format_args!("ptr is out of range.")));
         }
         value.to_uint64_no_truncate() as usize
     } else {
         if !value.is_number() || value.as_number() < 0.0 || value.as_number() > usize::MAX as f64 {
-            return ValueOrError::Err(
-                global_this.to_invalid_arguments(format_args!("ptr must be a number.")),
-            );
+            return Err(global_this.throw_invalid_arguments(format_args!("ptr must be a number.")));
         }
         value.as_ptr_address()
     };
     if num == 0 {
-        return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+        return Err(global_this.throw_invalid_arguments(format_args!(
             "ptr cannot be zero, that would segfault Bun :("
         )));
     }
@@ -542,27 +531,24 @@ fn get_ptr_slice(
             }
 
             if addr == 0 {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+                return Err(global_this.throw_invalid_arguments(format_args!(
                     "ptr cannot be zero, that would segfault Bun :("
                 )));
             }
 
             if !byte_off.as_number().is_finite() {
-                return ValueOrError::Err(
-                    global_this.to_invalid_arguments(format_args!("ptr must be a finite number.")),
-                );
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("ptr must be a finite number.")));
             }
         } else if !byte_off.is_empty_or_undefined_or_null() {
-            // do nothing
-        } else {
-            return ValueOrError::Err(
-                global_this.to_invalid_arguments(format_args!("Expected number for byteOffset")),
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("Expected number for byteOffset"))
             );
         }
     }
 
     if addr == 0xDEADBEEF || addr == 0xaaaaaaaa || addr == 0xAAAAAAAA {
-        return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+        return Err(global_this.throw_invalid_arguments(format_args!(
             "ptr to invalid memory, that would segfault Bun :("
         )));
     }
@@ -570,32 +556,32 @@ fn get_ptr_slice(
     if let Some(value_length) = byte_length {
         if !value_length.is_empty_or_undefined_or_null() {
             if !value_length.is_number() {
-                return ValueOrError::Err(
-                    global_this.to_invalid_arguments(format_args!("length must be a number.")),
+                return Err(
+                    global_this.throw_invalid_arguments(format_args!("length must be a number."))
                 );
             }
 
             if value_length.as_number() == 0.0 {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+                return Err(global_this.throw_invalid_arguments(format_args!(
                     "length must be > 0. This usually means a bug in your code."
                 )));
             }
 
             let length_i = value_length.to_int64();
             if length_i < 0 {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+                return Err(global_this.throw_invalid_arguments(format_args!(
                     "length must be > 0. This usually means a bug in your code."
                 )));
             }
 
             if length_i > i64::try_from(MAX_ADDRESSABLE_MEMORY).expect("int cast") {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+                return Err(global_this.throw_invalid_arguments(format_args!(
                     "length exceeds max addressable memory. This usually means a bug in your code."
                 )));
             }
 
             let length = usize::try_from(length_i).expect("int cast");
-            return ValueOrError::Slice(addr as *mut u8, length);
+            return Ok((addr as *mut u8, length));
         }
     }
 
@@ -604,7 +590,7 @@ fn get_ptr_slice(
     let len = unsafe { bun_core::ffi::cstr(addr as *const core::ffi::c_char) }
         .to_bytes()
         .len();
-    ValueOrError::Slice(addr as *mut u8, len)
+    Ok((addr as *mut u8, len))
 }
 
 fn get_cptr(value: JSValue) -> Option<usize> {
@@ -631,55 +617,51 @@ fn to_array_buffer(
     finalization_ctx_or_ptr: Option<JSValue>,
     finalization_callback: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    match get_ptr_slice(global_this, value, byte_offset, value_length) {
-        ValueOrError::Err(erro) => Ok(erro),
-        ValueOrError::Slice(ptr, len) => {
-            let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
-            let mut ctx: Option<*mut c_void> = None;
-            if let Some(callback_value) = finalization_callback {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
+    let (ptr, len) = get_ptr_slice(global_this, value, byte_offset, value_length)?;
+    let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
+    let mut ctx: Option<*mut c_void> = None;
+    if let Some(callback_value) = finalization_callback {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
 
-                    if let Some(ctx_value) = finalization_ctx_or_ptr {
-                        if let Some(ctx_ptr) = get_cptr(ctx_value) {
-                            ctx = Some(ctx_ptr as *mut c_void);
-                        } else if !ctx_value.is_undefined_or_null() {
-                            return Ok(global_this.to_invalid_arguments(format_args!(
-                                "Expected user data to be a C pointer (number or BigInt)"
-                            )));
-                        }
-                    }
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
-                    )));
-                }
-            } else if let Some(callback_value) = finalization_ctx_or_ptr {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
+            if let Some(ctx_value) = finalization_ctx_or_ptr {
+                if let Some(ctx_ptr) = get_cptr(ctx_value) {
+                    ctx = Some(ctx_ptr as *mut c_void);
+                } else if !ctx_value.is_undefined_or_null() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected user data to be a C pointer (number or BigInt)"
                     )));
                 }
             }
-
-            // SAFETY: ptr/len came from get_ptr_slice; FFI-owned memory. The
-            // `bun:ffi` user asserts the pointer stays valid for the object's
-            // lifetime and that their finalization callback/ctx pair, if
-            // provided, is sound to invoke once at GC — `toArrayBuffer(ptr,
-            // ...)` is an inherently trusting FFI API.
-            unsafe {
-                let slice = core::slice::from_raw_parts_mut(ptr, len);
-                ArrayBuffer::from_bytes(slice, jsc::JSType::ArrayBuffer).to_js_with_context(
-                    global_this,
-                    ctx.unwrap_or(core::ptr::null_mut()),
-                    callback,
-                )
-            }
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
         }
+    } else if let Some(callback_value) = finalization_ctx_or_ptr {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
+        }
+    }
+
+    // SAFETY: ptr/len came from get_ptr_slice; FFI-owned memory. The
+    // `bun:ffi` user asserts the pointer stays valid for the object's
+    // lifetime and that their finalization callback/ctx pair, if
+    // provided, is sound to invoke once at GC — `toArrayBuffer(ptr,
+    // ...)` is an inherently trusting FFI API.
+    unsafe {
+        let slice = core::slice::from_raw_parts_mut(ptr, len);
+        ArrayBuffer::from_bytes(slice, jsc::JSType::ArrayBuffer).to_js_with_context(
+            global_this,
+            ctx.unwrap_or(core::ptr::null_mut()),
+            callback,
+        )
     }
 }
 
@@ -691,53 +673,49 @@ fn to_buffer(
     finalization_ctx_or_ptr: Option<JSValue>,
     finalization_callback: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    match get_ptr_slice(global_this, value, byte_offset, value_length) {
-        ValueOrError::Err(err) => Ok(err),
-        ValueOrError::Slice(ptr, len) => {
-            let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
-            let mut ctx: Option<*mut c_void> = None;
-            if let Some(callback_value) = finalization_callback {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
+    let (ptr, len) = get_ptr_slice(global_this, value, byte_offset, value_length)?;
+    let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
+    let mut ctx: Option<*mut c_void> = None;
+    if let Some(callback_value) = finalization_callback {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
 
-                    if let Some(ctx_value) = finalization_ctx_or_ptr {
-                        if let Some(ctx_ptr) = get_cptr(ctx_value) {
-                            ctx = Some(ctx_ptr as *mut c_void);
-                        } else if !ctx_value.is_empty_or_undefined_or_null() {
-                            return Ok(global_this.to_invalid_arguments(format_args!(
-                                "Expected user data to be a C pointer (number or BigInt)"
-                            )));
-                        }
-                    }
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
-                    )));
-                }
-            } else if let Some(callback_value) = finalization_ctx_or_ptr {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
+            if let Some(ctx_value) = finalization_ctx_or_ptr {
+                if let Some(ctx_ptr) = get_cptr(ctx_value) {
+                    ctx = Some(ctx_ptr as *mut c_void);
+                } else if !ctx_value.is_empty_or_undefined_or_null() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected user data to be a C pointer (number or BigInt)"
                     )));
                 }
             }
-
-            // SAFETY: ptr/len came from get_ptr_slice; caller-owned FFI memory.
-            let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
-            // No finalizer means borrow: the noop deallocator keeps GC from freeing
-            // caller-owned storage (oven-sh/bun#35405).
-            create_buffer_with_ctx(
-                global_this,
-                slice,
-                ctx.unwrap_or(core::ptr::null_mut()),
-                callback.or(Some(noop_bytes_deallocator)),
-            )
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
+        }
+    } else if let Some(callback_value) = finalization_ctx_or_ptr {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
         }
     }
+
+    // SAFETY: ptr/len came from get_ptr_slice; caller-owned FFI memory.
+    let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
+    // No finalizer means borrow: the noop deallocator keeps GC from freeing
+    // caller-owned storage (oven-sh/bun#35405).
+    create_buffer_with_ctx(
+        global_this,
+        slice,
+        ctx.unwrap_or(core::ptr::null_mut()),
+        callback.or(Some(noop_bytes_deallocator)),
+    )
 }
 
 pub(crate) fn getter(global_object: &JSGlobalObject, _: &JSObject) -> JSValue {

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -561,14 +561,10 @@ fn get_ptr_slice(
                 );
             }
 
-            if value_length.as_number() == 0.0 {
-                return Err(global_this.throw_invalid_arguments(format_args!(
-                    "length must be > 0. This usually means a bug in your code."
-                )));
-            }
-
+            // `to_int64` maps NaN and every value in (-1, 1) to 0, so this also
+            // rejects a length that would truncate to an empty view.
             let length_i = value_length.to_int64();
-            if length_i < 0 {
+            if length_i <= 0 {
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "length must be > 0. This usually means a bug in your code."
                 )));

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -491,10 +491,8 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
     JSValue::from_ptr_address(addr)
 }
 
-/// Resolves the `(ptr, byteOffset, byteLength)` arguments of `toBuffer`,
-/// `toArrayBuffer` and `CString` to a raw (ptr, len) over caller-owned FFI
-/// memory. Consumers borrow it (or delegate disposal to a supplied finalizer),
-/// never free it from Rust. An invalid argument throws a TypeError.
+/// Resolves `(ptr, byteOffset, byteLength)` to a raw (ptr, len) over caller-owned FFI
+/// memory. Consumers borrow it or hand it to a supplied finalizer, never free it from Rust.
 fn get_ptr_slice(
     global_this: &JSGlobalObject,
     value: JSValue,
@@ -561,8 +559,7 @@ fn get_ptr_slice(
                 );
             }
 
-            // `to_int64` maps NaN and every value in (-1, 1) to 0, so this also
-            // rejects a length that would truncate to an empty view.
+            // NaN and every value in (-1, 1) truncate to 0 and fail this check too.
             let length_i = value_length.to_int64();
             if length_i <= 0 {
                 return Err(global_this.throw_invalid_arguments(format_args!(

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -1,6 +1,83 @@
-import { dlopen, linkSymbols } from "bun:ffi";
+import { CString, dlopen, linkSymbols, ptr, toArrayBuffer, toBuffer } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import { isMusl } from "harness";
+
+// Not `toThrow()`: it also accepts an Error that the function returns, which is
+// what `toBuffer()` and `toArrayBuffer()` did with their TypeError before they
+// threw it.
+function thrownBy(fn: () => unknown): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  return undefined;
+}
+
+describe.each([
+  ["toBuffer", toBuffer],
+  ["toArrayBuffer", toArrayBuffer],
+] as const)("%s argument errors", (name, view) => {
+  const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+  const address = ptr(bytes);
+  const asArray = (result: Buffer | ArrayBuffer) => Array.from(new Uint8Array(result));
+
+  test.each([
+    ["a string ptr", () => view("x" as any), "ptr must be a number."],
+    ["a negative ptr", () => view(-1 as any), "ptr must be a number."],
+    ["a zero ptr", () => view(0 as any), "ptr cannot be zero, that would segfault Bun :("],
+    ["a BigInt ptr past usize", () => view((2n ** 64n) as any), "ptr is out of range."],
+    ["a sentinel ptr", () => view(0xdeadbeef as any), "ptr to invalid memory, that would segfault Bun :("],
+    ["a string byteOffset", () => view(address, "garbage" as any, 8), "Expected number for byteOffset"],
+    ["an object byteOffset", () => view(address, {} as any, 8), "Expected number for byteOffset"],
+    ["an infinite byteOffset", () => view(address, Infinity, 8), "ptr must be a finite number."],
+    ["a string byteLength", () => view(address, 0, "x" as any), "length must be a number."],
+    ["a zero byteLength", () => view(address, 0, 0), "length must be > 0. This usually means a bug in your code."],
+    ["a negative byteLength", () => view(address, 0, -1), "length must be > 0. This usually means a bug in your code."],
+    [
+      "a string finalization callback",
+      () => (view as any)(address, 0, 8, "x"),
+      "Expected callback to be a C pointer (number or BigInt)",
+    ],
+    [
+      "a string finalization callback after user data",
+      () => (view as any)(address, 0, 8, 1, "x"),
+      "Expected callback to be a C pointer (number or BigInt)",
+    ],
+    [
+      "string user data",
+      () => (view as any)(address, 0, 8, "x", 1),
+      "Expected user data to be a C pointer (number or BigInt)",
+    ],
+  ])(`${name} throws a TypeError for %s`, (_, call, message) => {
+    const err = thrownBy(call);
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message).toBe(message);
+  });
+
+  test(`${name} accepts an undefined or null byteOffset`, () => {
+    // `bytes` stays referenced here so its storage outlives every test above.
+    expect(asArray(view(address, undefined, 8))).toEqual(Array.from(bytes));
+    expect(asArray(view(address, null as any, 8))).toEqual(Array.from(bytes));
+    expect(asArray(view(address, 2, 4))).toEqual(Array.from(bytes.subarray(2, 6)));
+  });
+});
+
+describe("CString argument errors", () => {
+  test("CString throws a TypeError for a negative ptr", () => {
+    const err = thrownBy(() => new CString(-1 as any));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message).toBe("ptr must be a number.");
+  });
+
+  test("CString reads the bytes at ptr + byteOffset", () => {
+    const bytes = new TextEncoder().encode("hello\0");
+    expect(`${new CString(ptr(bytes), 1, 4)}`).toBe("ello");
+    expect(`${new CString(ptr(bytes))}`).toBe("hello");
+  });
+});
 
 describe("FFI error messages", () => {
   test("dlopen shows library name when library cannot be opened", () => {

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -34,6 +34,12 @@ describe.each([
     ["a string byteLength", () => view(address, 0, "x" as any), "length must be a number."],
     ["a zero byteLength", () => view(address, 0, 0), "length must be > 0. This usually means a bug in your code."],
     ["a negative byteLength", () => view(address, 0, -1), "length must be > 0. This usually means a bug in your code."],
+    ["a NaN byteLength", () => view(address, 0, NaN), "length must be > 0. This usually means a bug in your code."],
+    [
+      "a byteLength that truncates to zero",
+      () => view(address, 0, 0.5),
+      "length must be > 0. This usually means a bug in your code.",
+    ],
     [
       "a string finalization callback",
       () => (view as any)(address, 0, 8, "x"),


### PR DESCRIPTION
### Problem
- `toBuffer(-1)` and `toArrayBuffer("x")` from `bun:ffi` do not throw. They return the `TypeError: ptr must be a number.` object as the call's result, so `try { toBuffer(-1) } catch {}` catches nothing. All 12 argument checks in the two functions fail this way.
- `get_ptr_slice` (`src/runtime/ffi/FFIObject.rs:505`) returned the error as a `ValueOrError::Err` value. `to_buffer` and `to_array_buffer` turned it into `Ok(err)`, and their finalizer checks returned `Ok(to_invalid_arguments(..))`.

### Fix
- `get_ptr_slice` returns `JsResult<(*mut u8, usize)>` and throws through `throw_invalid_arguments`. The three callers use `?`. The `CString` constructor drops its rethrow of a returned error value.
- The byteOffset arms of `get_ptr_slice` were inverted: `undefined` or `null` was the error, a string was ignored. Thrown, that error would fail the valid call `toBuffer(ptr, undefined, len)`. The arms now match `ptr()`: nullish means no offset, a non-number throws.
- Correct because both functions are host functions behind `wrap_host_fn!`, which maps `Err` to a pending exception. Every other `bun:ffi` entry point reports a bad argument with a thrown `TypeError`. #40732 makes the same change for `ptr()`.
- A `NaN` or fractional byteLength below 1 truncated to 0 and returned an empty view. The length check now tests the truncated integer with `<= 0`.
- Verified: `test/js/bun/ffi/ffi-error-messages.test.ts` (34 new cases, all fail on 1.4.1). Also `ffi.test.js`, `addr32.test.ts`, `cc.test.ts`.

### Background
- `to_invalid_arguments` creates an `ERR_INVALID_ARG_TYPE` TypeError and returns it as a value. `throw_invalid_arguments` creates the same error and sets it as the pending exception. A host function that wants JS to see a throw uses the second one and returns `Err`.
- `wrap_host_fn!` is the trampoline between JSC and a Rust `JsResult` body. `Err` becomes the empty `JSValue` that JSC expects from a throwing host function.

<details><summary>Notes</summary>

- Bun's `expect(fn).toThrow()` also accepts a function that returns an Error, so it passes on the unfixed binary. The tests use a try/catch helper instead.
- The Zig version had the same two defects (returned errors, inverted arms), so this is not a regression and the test lives next to the other FFI error tests.
- #33353 converts the same errors inside a larger change (a `RangeError` for a byteLength past 4 GiB) and swaps the same arms. It has conflicted with main since July. This PR carries only the throw conversion so it can land on its own. #33353 can rebase onto it.
- `returns: "cstring"` symbols go through `new CString(v)` in `src/js/bun/ffi.ts` with no byteOffset, and the C++ constructor already turned a returned error into a throw, so that path does not change.
- Correction after the merge: a direct `new CString(ptr, byteOffset)` call with a truthy non-number byteOffset (`"garbage"`, `true`, `1n`, `{}`) now throws `Expected number for byteOffset`. Before, the offset was silently ignored: `new CString(ptr, 1n, 4)` read from `ptr`, not `ptr + 1`. The constructor maps a falsy byteOffset (`undefined`, `null`, `false`, `""`, `NaN`) to 0 before the call, so those still work. The earlier text here said `CString` behavior does not change. That was wrong.
- User-visible changes beyond the throw: `toBuffer(ptr, undefined, len)` and `toBuffer(ptr, null, len)` now return a view (before: a TypeError object). `toBuffer(ptr, "garbage", len)` now throws (before: the offset was ignored). Same for `toArrayBuffer` and for `new CString(ptr, "garbage")`.
- Debug build: `ffi-error-messages.test.ts` 41 pass. `ffi.test.js` 147 pass, 1 fail: "ptr argument: ArrayBuffer cells through an FTL-compiled call site" times out at 5 s in the debug+ASAN build. It uses only `dlopen` and `read.u8`, and #40732 reports the same timeout without its change. `addr32.test.ts`, `cc.test.ts` and the FFI regression tests (#21677, #25231, #29181) pass.
</details>

