### PR TITLE
install: compare the tarball origin, not the full URL, for default trusted dependencies

### DIFF
--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -52,9 +52,10 @@ A curated list of popular npm packages with lifecycle scripts is allowed by defa
   to run their lifecycle scripts, even if the package name matches an entry in the default list. This prevents malicious
   packages from spoofing trusted package names through local file paths or git repositories.
 
-  The tarball recorded in the lockfile must also come from the registry configured for the package (the same scheme,
-  host, and port). If it does not, Bun blocks the lifecycle scripts and prints a warning that names the tarball URL and
-  the registry. Add the package to `trustedDependencies` to run them anyway.
+The tarball recorded in the lockfile must also come from the registry configured for the package (the same scheme,
+host, and port). If it does not, Bun blocks the lifecycle scripts and prints a warning that names the tarball URL and
+the registry. Add the package to `trustedDependencies` to run them anyway.
+
 </Note>
 
 ### Behavior of the `trustedDependencies` field

--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -51,6 +51,10 @@ A curated list of popular npm packages with lifecycle scripts is allowed by defa
   (such as `file:`, `link:`, `git:`, or `github:` dependencies), you must explicitly add them to `trustedDependencies`
   to run their lifecycle scripts, even if the package name matches an entry in the default list. This prevents malicious
   packages from spoofing trusted package names through local file paths or git repositories.
+
+  The tarball recorded in the lockfile must also come from the registry configured for the package (the same scheme,
+  host, and port). If it does not, Bun blocks the lifecycle scripts and prints a warning that names the tarball URL and
+  the registry. Add the package to `trustedDependencies` to run them anyway.
 </Note>
 
 ### Behavior of the `trustedDependencies` field

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -833,21 +833,8 @@ impl NetworkTask {
         // credentials. The empty-`tarball_url` branch builds the URL from
         // `scope.url.href()`, so its origin matches and authorized downloads
         // keep working.
-        // Compare (protocol, hostname, effective port) rather than the raw
-        // `URL.origin` slice — `origin` is a borrowed prefix of the input
-        // string and is not normalized for default ports, so a tarball URL of
-        // `https://host:443/...` would not byte-match a `.npmrc` registry of
-        // `https://host/...` even though they are the same origin. Some
-        // registries emit `dist.tarball` URLs with the default port spelled
-        // out; without normalization those installs lose the `Authorization`
-        // header and fail with 401.
-        let send_auth = matches!(authorization, Authorization::AllowAuthorization) && {
-            let tarball = URL::parse(&self.url_buf);
-            let registry = scope.url.url();
-            tarball.protocol == registry.protocol
-                && tarball.hostname == registry.hostname
-                && tarball.get_port_auto() == registry.get_port_auto()
-        };
+        let send_auth = matches!(authorization, Authorization::AllowAuthorization)
+            && URL::parse(&self.url_buf).has_same_origin(&scope.url.url());
 
         self.response_buffer = MutableString::init_empty();
 

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -2035,10 +2035,8 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            // `hasInstallScript` is not stored in bun.lock, so it reads false
-                            // on every install from a lockfile. A default-trusted package
-                            // whose grant was denied is checked regardless, so the user
-                            // learns why its scripts did not run.
+                            // `hasInstallScript` is not stored in bun.lock, so it reads
+                            // false on installs from a lockfile.
                             let default_trust_denied = if is_trusted {
                                 None
                             } else {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -2035,7 +2035,22 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            if !is_trusted && self.metas[package_id as usize].has_install_script() {
+                            // `hasInstallScript` is not stored in bun.lock, so it reads false
+                            // on every install from a lockfile. A default-trusted package
+                            // whose grant was denied is checked regardless, so the user
+                            // learns why its scripts did not run.
+                            let default_trust_denied = if is_trusted {
+                                None
+                            } else {
+                                self.lockfile().default_trust_denied_by_registry(
+                                    pkg_name.slice(string_buf!()),
+                                    resolution,
+                                )
+                            };
+                            if !is_trusted
+                                && (default_trust_denied.is_some()
+                                    || self.metas[package_id as usize].has_install_script())
+                            {
                                 // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
                                 // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
                                 let mut folder_path =
@@ -2066,10 +2081,20 @@ impl<'a> PackageInstaller<'a> {
                                         .packages_with_blocked_scripts
                                         .get_or_put(truncated_dep_name_hash)
                                         .unwrap_or_oom();
-                                    if !entry.found_existing {
+                                    let first_block = !entry.found_existing;
+                                    if first_block {
                                         *entry.value_ptr = 0;
                                     }
                                     *entry.value_ptr += count;
+                                    if let (true, Some(warning)) =
+                                        (first_block, &default_trust_denied)
+                                    {
+                                        self.manager().log_mut().add_warning_fmt(
+                                            None,
+                                            bun_ast::Loc::EMPTY,
+                                            format_args!("{warning}"),
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1578,19 +1578,6 @@ impl Task {
                         continue;
                     }
 
-                    // The eligibility check excludes any package whose
-                    // lifecycle scripts are trusted to run, so a global-store
-                    // entry should never reach script enqueueing. Guard it
-                    // anyway: `meta.hasInstallScript` can be a false negative
-                    // (yarn-migrated lockfiles force it to `.false`), and a
-                    // script running with cwd inside a shared content-
-                    // addressed directory would mutate every other project's
-                    // copy.
-                    if installer.entry_uses_global_store(self.entry_id) {
-                        step = self.next_step(current_step);
-                        continue;
-                    }
-
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
 
                     let dep = &lockfile.buffers.dependencies[dep_id as usize];
@@ -1616,6 +1603,45 @@ impl Task {
 
                     let mut pkg_cwd = AutoAbsPath::init_top_level_dir();
                     installer.append_store_path(&mut pkg_cwd, self.entry_id);
+
+                    let default_trust_denied = if is_trusted {
+                        None
+                    } else {
+                        lockfile
+                            .default_trust_denied_by_registry(pkg_name.slice(string_buf), &pkg_res)
+                    };
+                    if let Some(warning) = default_trust_denied {
+                        // A default-trusted package lost its grant. Read its
+                        // scripts so the user learns why they did not run.
+                        let mut pkg_scripts: package::scripts::Scripts =
+                            pkg_script_lists[pkg_id as usize];
+                        let mut log = Log::init();
+                        if let Ok(Some(list)) = pkg_scripts.get_list(
+                            &mut log,
+                            lockfile,
+                            &mut pkg_cwd,
+                            dep.name.slice(string_buf),
+                            &pkg_res,
+                        ) {
+                            if list.total > 0 {
+                                bun_core::warn!("{}", warning);
+                                Output::flush();
+                            }
+                        }
+                    }
+
+                    // The eligibility check excludes any package whose
+                    // lifecycle scripts are trusted to run, so a global-store
+                    // entry should never reach script enqueueing. Guard it
+                    // anyway: `meta.hasInstallScript` can be a false negative
+                    // (yarn-migrated lockfiles force it to `.false`), and a
+                    // script running with cwd inside a shared content-
+                    // addressed directory would mutate every other project's
+                    // copy.
+                    if installer.entry_uses_global_store(self.entry_id) {
+                        step = self.next_step(current_step);
+                        continue;
+                    }
 
                     'enqueue_lifecycle_scripts: {
                         if !(pkg_res.tag != ResolutionTag::Root

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1579,40 +1579,21 @@ impl Task {
                     }
 
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
-
                     let dep = &lockfile.buffers.dependencies[dep_id as usize];
-                    let truncated_dep_name_hash: TruncatedPackageNameHash =
-                        dep.name_hash as TruncatedPackageNameHash;
-
-                    let (is_trusted, is_trusted_through_update_request) = 'brk: {
-                        if installer
-                            .trusted_dependencies_from_update_requests
-                            .contains(&pkg_id)
-                        {
-                            break 'brk (true, true);
-                        }
-                        if lockfile.has_trusted_dependency(
-                            dep.name.slice(string_buf),
-                            pkg_name.slice(string_buf),
-                            &pkg_res,
-                        ) {
-                            break 'brk (true, false);
-                        }
-                        break 'brk (false, false);
-                    };
 
                     let mut pkg_cwd = AutoAbsPath::init_top_level_dir();
                     installer.append_store_path(&mut pkg_cwd, self.entry_id);
 
-                    let default_trust_denied = if is_trusted {
+                    let default_trust_denied = if installer
+                        .trusted_dependencies_from_update_requests
+                        .contains(&pkg_id)
+                    {
                         None
                     } else {
                         lockfile
                             .default_trust_denied_by_registry(pkg_name.slice(string_buf), &pkg_res)
                     };
                     if let Some(warning) = default_trust_denied {
-                        // A default-trusted package lost its grant. Read its
-                        // scripts so the user learns why they did not run.
                         let mut pkg_scripts: package::scripts::Scripts =
                             pkg_script_lists[pkg_id as usize];
                         let mut log = Log::init();
@@ -1642,6 +1623,26 @@ impl Task {
                         step = self.next_step(current_step);
                         continue;
                     }
+
+                    let truncated_dep_name_hash: TruncatedPackageNameHash =
+                        dep.name_hash as TruncatedPackageNameHash;
+
+                    let (is_trusted, is_trusted_through_update_request) = 'brk: {
+                        if installer
+                            .trusted_dependencies_from_update_requests
+                            .contains(&pkg_id)
+                        {
+                            break 'brk (true, true);
+                        }
+                        if lockfile.has_trusted_dependency(
+                            dep.name.slice(string_buf),
+                            pkg_name.slice(string_buf),
+                            &pkg_res,
+                        ) {
+                            break 'brk (true, false);
+                        }
+                        break 'brk (false, false);
+                    };
 
                     'enqueue_lifecycle_scripts: {
                         if !(pkg_res.tag != ResolutionTag::Root

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1581,8 +1581,10 @@ impl Task {
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
                     let dep = &lockfile.buffers.dependencies[dep_id as usize];
 
+                    // A global-store entry is still in its staging directory
+                    // here. `Step::Binaries` renames it into place.
                     let mut pkg_cwd = AutoAbsPath::init_top_level_dir();
-                    installer.append_store_path(&mut pkg_cwd, self.entry_id);
+                    installer.append_real_store_path(&mut pkg_cwd, self.entry_id, Which::Staging);
 
                     let default_trust_denied = if installer
                         .trusted_dependencies_from_update_requests

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -24,6 +24,7 @@ use bun_resolver::fs::{self as Fs, FileSystem};
 use bun_semver::{self as Semver, ExternalString, String as SemverString};
 use bun_sha_hmac as Crypto;
 use bun_sys::{self as sys, Fd, File};
+use bun_url::URL;
 
 use crate::config_version::ConfigVersion;
 use crate::migration;
@@ -3247,38 +3248,66 @@ impl Lockfile {
             return self.declared_by_root_or_workspace(alias, resolution);
         }
 
-        // Only allow default trusted dependencies for npm packages. Check the
-        // resolved package's real name, not the dependency alias, so an
-        // `npm:`-aliased package can't inherit trust from a default-trusted
-        // name.
-        if resolution.tag != ResolutionTag::Npm || !default_trusted_dependencies::has(pkg_name) {
-            return false;
-        }
+        self.is_default_trusted_name(pkg_name, resolution)
+            && self.npm_tarball_is_from_configured_registry(pkg_name, resolution)
+    }
 
-        let buf = self.buffers.string_bytes.as_slice();
-        let npm = resolution.npm();
-        let url = npm.url.slice(buf);
+    /// `true` when the default trusted dependencies list applies to this
+    /// package: it resolves to npm and its real name is on the list. The
+    /// dependency alias is not consulted, so an `npm:`-aliased package cannot
+    /// inherit trust from a default-trusted name.
+    fn is_default_trusted_name(&self, pkg_name: &[u8], resolution: &Resolution) -> bool {
+        resolution.tag == ResolutionTag::Npm && default_trusted_dependencies::has(pkg_name)
+    }
+
+    /// `true` when the tarball URL recorded for an npm package has the same
+    /// origin as the registry configured for its scope. Default trust is keyed
+    /// on the package name, and a lockfile can pair a default-trusted name
+    /// with a tarball on any host, so the grant only applies when the tarball
+    /// comes from the configured registry. Only the origin is compared:
+    /// registries such as Artifactory serve tarballs from a path that differs
+    /// from `<registry>/<name>/-/<name>-<version>.tgz`.
+    fn npm_tarball_is_from_configured_registry(
+        &self,
+        pkg_name: &[u8],
+        resolution: &Resolution,
+    ) -> bool {
+        let url = resolution
+            .npm()
+            .url
+            .slice(self.buffers.string_bytes.as_slice());
         if url.is_empty() {
             return true;
         }
-        let registry = PackageManager::get()
-            .scope_for_package_name(pkg_name)
-            .url
-            .href();
-        let Ok(canonical_url) = crate::extract_tarball::build_url_with_printer(
-            registry,
-            &strings::StringOrTinyString::init(pkg_name),
-            npm.version,
-            buf,
-            |args| -> Result<Vec<u8>, std::io::Error> {
-                let mut out: Vec<u8> = Vec::new();
-                out.write_fmt(args)?;
-                Ok(out)
-            },
-        ) else {
-            return false;
-        };
-        url == canonical_url.as_slice()
+        let registry = &PackageManager::get().scope_for_package_name(pkg_name).url;
+        URL::parse(url).has_same_origin(&registry.url())
+    }
+
+    /// When `has_trusted_dependency` denies `pkg_name` only because its tarball
+    /// is not on the configured registry (`package.json` has no
+    /// `trustedDependencies` list, the name is on the default trusted list, and
+    /// the lockfile tarball URL has another origin), the warning that tells the
+    /// user why the lifecycle scripts did not run.
+    pub fn default_trust_denied_by_registry<'a>(
+        &'a self,
+        pkg_name: &'a [u8],
+        resolution: &'a Resolution,
+    ) -> Option<DefaultTrustDeniedByRegistry<'a>> {
+        if self.trusted_dependencies.is_some()
+            || !self.is_default_trusted_name(pkg_name, resolution)
+            || self.npm_tarball_is_from_configured_registry(pkg_name, resolution)
+        {
+            return None;
+        }
+        Some(DefaultTrustDeniedByRegistry {
+            pkg_name,
+            resolution,
+            buf: self.buffers.string_bytes.as_slice(),
+            registry: PackageManager::get()
+                .scope_for_package_name(pkg_name)
+                .url
+                .href(),
+        })
     }
 
     fn declared_by_root_or_workspace(&self, alias: &[u8], resolution: &Resolution) -> bool {
@@ -3308,6 +3337,29 @@ impl Lockfile {
         }
 
         false
+    }
+}
+
+/// See `Lockfile::default_trust_denied_by_registry`.
+pub struct DefaultTrustDeniedByRegistry<'a> {
+    pkg_name: &'a [u8],
+    resolution: &'a Resolution,
+    buf: &'a [u8],
+    registry: &'a [u8],
+}
+
+impl fmt::Display for DefaultTrustDeniedByRegistry<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = bstr::BStr::new(self.pkg_name);
+        write!(
+            f,
+            "\"{}@{}\" is on the default trusted dependencies list, but its tarball URL \"{}\" is not on the configured registry \"{}\", so its lifecycle scripts did not run. Add \"{}\" to \"trustedDependencies\" in package.json to run them.",
+            name,
+            self.resolution.fmt(self.buf, PathSep::Posix),
+            bstr::BStr::new(self.resolution.npm().url.slice(self.buf)),
+            bstr::BStr::new(self.registry),
+            name,
+        )
     }
 }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -3252,21 +3252,16 @@ impl Lockfile {
             && self.npm_tarball_is_from_configured_registry(pkg_name, resolution)
     }
 
-    /// `true` when the default trusted dependencies list applies to this
-    /// package: it resolves to npm and its real name is on the list. The
-    /// dependency alias is not consulted, so an `npm:`-aliased package cannot
-    /// inherit trust from a default-trusted name.
+    /// The default list applies to npm resolutions only, keyed on the real
+    /// package name, never on the dependency alias.
     fn is_default_trusted_name(&self, pkg_name: &[u8], resolution: &Resolution) -> bool {
         resolution.tag == ResolutionTag::Npm && default_trusted_dependencies::has(pkg_name)
     }
 
-    /// `true` when the tarball URL recorded for an npm package has the same
-    /// origin as the registry configured for its scope. Default trust is keyed
-    /// on the package name, and a lockfile can pair a default-trusted name
-    /// with a tarball on any host, so the grant only applies when the tarball
-    /// comes from the configured registry. Only the origin is compared:
-    /// registries such as Artifactory serve tarballs from a path that differs
-    /// from `<registry>/<name>/-/<name>-<version>.tgz`.
+    /// Default trust requires the tarball to come from the registry configured
+    /// for the package's scope. Only the origin is compared: registries such as
+    /// Artifactory serve tarballs from another path than
+    /// `<registry>/<name>/-/<name>-<version>.tgz`.
     fn npm_tarball_is_from_configured_registry(
         &self,
         pkg_name: &[u8],
@@ -3283,11 +3278,8 @@ impl Lockfile {
         URL::parse(url).has_same_origin(&registry.url())
     }
 
-    /// When `has_trusted_dependency` denies `pkg_name` only because its tarball
-    /// is not on the configured registry (`package.json` has no
-    /// `trustedDependencies` list, the name is on the default trusted list, and
-    /// the lockfile tarball URL has another origin), the warning that tells the
-    /// user why the lifecycle scripts did not run.
+    /// The warning for a package that `has_trusted_dependency` denies only
+    /// because its tarball is not on the configured registry.
     pub fn default_trust_denied_by_registry<'a>(
         &'a self,
         pkg_name: &'a [u8],

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -860,13 +860,7 @@ fn registry_get(
     let mut headers = http::HeaderBuilder::default();
     headers.count(b"Accept", accept);
     // `dist.tarball` is registry-controlled; credentials only go back to the registry's own origin.
-    let same_origin = {
-        let registry = scope.url.url();
-        url.protocol == registry.protocol
-            && url.hostname == registry.hostname
-            && url.get_port_auto() == registry.get_port_auto()
-    };
-    let (token, auth): (&[u8], &[u8]) = if same_origin {
+    let (token, auth): (&[u8], &[u8]) = if url.has_same_origin(&scope.url.url()) {
         (&scope.token, &scope.auth)
     } else {
         (b"", b"")

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -484,6 +484,17 @@ impl<'a> URL<'a> {
         self.is_http() || self.is_https()
     }
 
+    /// `true` when both URLs have a host and share the scheme, the host, and
+    /// the effective port. The scheme and the host compare case-insensitively
+    /// (RFC 3986 §3.1, §3.2.2). A missing port counts as the scheme's default
+    /// port, so `https://host:443/a` and `https://host/b` have the same origin.
+    pub fn has_same_origin(&self, other: &URL<'_>) -> bool {
+        !self.hostname.is_empty()
+            && strings::eql_case_insensitive_ascii(self.protocol, other.protocol, true)
+            && strings::eql_case_insensitive_ascii(self.hostname, other.hostname, true)
+            && self.get_port_auto() == other.get_port_auto()
+    }
+
     pub fn get_port(&self) -> Option<u16> {
         bun_core::fmt::parse_int::<u16>(self.port, 10).ok()
     }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -484,10 +484,8 @@ impl<'a> URL<'a> {
         self.is_http() || self.is_https()
     }
 
-    /// `true` when both URLs have a host and share the scheme, the host, and
-    /// the effective port. The scheme and the host compare case-insensitively
-    /// (RFC 3986 §3.1, §3.2.2). A missing port counts as the scheme's default
-    /// port, so `https://host:443/a` and `https://host/b` have the same origin.
+    /// Same scheme and host (both case-insensitive) and same effective port,
+    /// where a missing port is the scheme's default. `false` without a host.
     pub fn has_same_origin(&self, other: &URL<'_>) -> bool {
         !self.hostname.is_empty()
             && strings::eql_case_insensitive_ascii(self.protocol, other.protocol, true)

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -299,124 +299,170 @@ test.concurrent("node-gyp shim directory added to lifecycle script PATH gets a r
   expect(distance > 21_600_000_000_000n).toBe(true);
 });
 
-test.concurrent("default trusted dependencies require the canonical registry tarball URL", async () => {
-  using ctx = await setupTest();
-  const { packageDir, packageJson, env } = ctx;
+for (const linker of ["hoisted", "isolated"] as const) {
+  test.concurrent(
+    `default trusted dependencies require a tarball URL on the configured registry (${linker})`,
+    async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
 
-  // No `trustedDependencies` in package.json: `electron` is on the default
-  // trusted list, so the genuine registry package's lifecycle scripts run.
-  await writeFile(
-    packageJson,
-    JSON.stringify({
-      name: "foo",
-      version: "1.0.0",
-      dependencies: {
-        "electron": "1.0.0",
-      },
-    }),
-  );
+      // No `trustedDependencies` in package.json: `electron` is on the default
+      // trusted list, so the genuine registry package's lifecycle scripts run.
+      await Promise.all([
+        verdaccio.writeBunfig(packageDir, { linker }),
+        writeFile(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            version: "1.0.0",
+            dependencies: {
+              "electron": "1.0.0",
+            },
+          }),
+        ),
+      ]);
 
-  let { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "install"],
-    cwd: packageDir,
-    stdout: "pipe",
-    stdin: "ignore",
-    stderr: "pipe",
-    env,
-  });
-
-  let err = await stderr.text();
-  let out = await stdout.text();
-  expect(err).toContain("Saved lockfile");
-  expect(err).not.toContain("error:");
-  expect(out).not.toContain("Blocked");
-  expect(await exists(join(packageDir, "node_modules", "electron", "preinstall.txt"))).toBeTrue();
-  expect(await exited).toBe(0);
-
-  // Tamper with the lockfile: keep the default-trusted name `electron` but
-  // point its tarball URL at a different package on the same registry. The
-  // install must still succeed, but the package must no longer inherit the
-  // default lifecycle-script grant because the URL is not the canonical
-  // registry tarball for `electron@1.0.0`.
-  const lockfilePath = join(packageDir, "bun.lock");
-  const lockfile = await file(lockfilePath).text();
-  expect(lockfile).toContain("/electron/-/electron-1.0.0.tgz");
-  await writeFile(
-    lockfilePath,
-    lockfile
-      .replace("/electron/-/electron-1.0.0.tgz", "/all-lifecycle-scripts/-/all-lifecycle-scripts-1.0.0.tgz")
-      .replace(/"sha512-[^"]+"/, '""'),
-  );
-
-  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-  await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
-
-  ({ stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "install"],
-    cwd: packageDir,
-    stdout: "pipe",
-    stdin: "ignore",
-    stderr: "pipe",
-    env,
-  }));
-
-  err = await stderr.text();
-  out = await stdout.text();
-  expect(err).not.toContain("error:");
-  // The redirected tarball (all-lifecycle-scripts content) installs under the
-  // recorded name, but its preinstall/install/postinstall must not run: the
-  // package no longer inherits default trust from the `electron` name because
-  // the URL is not the canonical registry tarball for `electron@1.0.0`.
-  expect(await exists(join(packageDir, "node_modules", "electron", "package.json"))).toBeTrue();
-  expect(await exists(join(packageDir, "node_modules", "electron", "install.js"))).toBeTrue();
-  expect(await exists(join(packageDir, "node_modules", "electron", "preinstall.txt"))).toBeFalse();
-  expect(await exists(join(packageDir, "node_modules", "electron", "install.txt"))).toBeFalse();
-  expect(await exists(join(packageDir, "node_modules", "electron", "postinstall.txt"))).toBeFalse();
-  expect(await exited).toBe(0);
-
-  // Tamper again: keep the canonical path for `electron@1.0.0` but point the
-  // URL at a different origin — a second local server that proxies to the
-  // real registry. The tarball still downloads and the integrity still
-  // matches, but the origin is not the configured registry, so the default
-  // lifecycle-script grant must not apply.
-  using proxy = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      return fetch(`http://localhost:${verdaccio.port}${url.pathname}${url.search}`, {
-        method: req.method,
-        headers: req.headers,
+      let { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
       });
+
+      let err = await stderr.text();
+      let out = await stdout.text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(err).not.toContain("warn:");
+      expect(out).not.toContain("Blocked");
+      expect(await exists(join(packageDir, "node_modules", "electron", "preinstall.txt"))).toBeTrue();
+      expect(await exited).toBe(0);
+
+      // Tamper with the lockfile: keep the canonical path for `electron@1.0.0` but
+      // point the URL at a different origin, a second local server that proxies to
+      // the real registry. The tarball still downloads and the integrity still
+      // matches, but the origin is not the configured registry, so the default
+      // lifecycle-script grant must not apply. The install says why.
+      using proxy = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const url = new URL(req.url);
+          return fetch(`http://localhost:${verdaccio.port}${url.pathname}${url.search}`, {
+            method: req.method,
+            headers: req.headers,
+          });
+        },
+      });
+      const lockfilePath = join(packageDir, "bun.lock");
+      const lockfile = await file(lockfilePath).text();
+      const canonicalUrl = `http://localhost:${verdaccio.port}/electron/-/electron-1.0.0.tgz`;
+      const proxiedUrl = `http://localhost:${proxy.port}/electron/-/electron-1.0.0.tgz`;
+      expect(lockfile).toContain(canonicalUrl);
+      await writeFile(lockfilePath, lockfile.replace(canonicalUrl, proxiedUrl));
+
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
+
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      }));
+
+      err = await stderr.text();
+      out = await stdout.text();
+      expect(err).not.toContain("error:");
+      expect(err).toContain(
+        `warn: "electron@1.0.0" is on the default trusted dependencies list, but its tarball URL "${proxiedUrl}" is not on the configured registry "http://localhost:${verdaccio.port}/", so its lifecycle scripts did not run. Add "electron" to "trustedDependencies" in package.json to run them.`,
+      );
+      if (linker === "hoisted") {
+        expect(out).toContain("Blocked 1 postinstall");
+      }
+      expect(await exists(join(packageDir, "node_modules", "electron", "package.json"))).toBeTrue();
+      expect(await exists(join(packageDir, "node_modules", "electron", "preinstall.txt"))).toBeFalse();
+      expect(await exists(join(packageDir, "node_modules", "electron", "install.txt"))).toBeFalse();
+      expect(await exists(join(packageDir, "node_modules", "electron", "postinstall.txt"))).toBeFalse();
+      expect(await exited).toBe(0);
     },
-  });
-  const canonicalUrl = `http://localhost:${verdaccio.port}/electron/-/electron-1.0.0.tgz`;
-  expect(lockfile).toContain(canonicalUrl);
-  await writeFile(
-    lockfilePath,
-    lockfile.replace(canonicalUrl, `http://localhost:${proxy.port}/electron/-/electron-1.0.0.tgz`),
   );
+}
 
-  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-  await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
+for (const linker of ["hoisted", "isolated"] as const) {
+  test.concurrent(
+    `default trusted dependencies accept a tarball URL from the configured registry with a different path (${linker})`,
+    async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
 
-  ({ stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "install"],
-    cwd: packageDir,
-    stdout: "pipe",
-    stdin: "ignore",
-    stderr: "pipe",
-    env,
-  }));
+      // A registry front like an Artifactory virtual repository: manifests are
+      // served under `/npm/virtual/`, and every `dist.tarball` in them points
+      // at `/npm/remote/` on the same origin. The URL bun records in the
+      // lockfile is then not `<registry>/<name>/-/<name>-<version>.tgz`.
+      const upstream = `http://localhost:${verdaccio.port}`;
+      using registry = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname.startsWith("/npm/virtual/")) {
+            const res = await fetch(`${upstream}/${url.pathname.slice("/npm/virtual/".length)}${url.search}`, {
+              headers: { accept: req.headers.get("accept") ?? "*/*" },
+            });
+            const body = (await res.text()).replaceAll(`${upstream}/`, `${url.origin}/npm/remote/`);
+            return new Response(body, {
+              status: res.status,
+              headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+            });
+          }
+          if (url.pathname.startsWith("/npm/remote/")) {
+            return fetch(`${upstream}/${url.pathname.slice("/npm/remote/".length)}${url.search}`);
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
 
-  err = await stderr.text();
-  out = await stdout.text();
-  expect(err).not.toContain("error:");
-  expect(await exists(join(packageDir, "node_modules", "electron", "package.json"))).toBeTrue();
-  expect(await exists(join(packageDir, "node_modules", "electron", "preinstall.txt"))).toBeFalse();
-  expect(await exists(join(packageDir, "node_modules", "electron", "install.txt"))).toBeFalse();
-  expect(await exists(join(packageDir, "node_modules", "electron", "postinstall.txt"))).toBeFalse();
-  expect(await exited).toBe(0);
-});
+      await Promise.all([
+        write(
+          join(packageDir, "bunfig.toml"),
+          Bun.TOML.stringify({
+            install: {
+              cache: join(packageDir, ".bun-cache"),
+              registry: `http://localhost:${registry.port}/npm/virtual/`,
+              linker,
+            },
+          }),
+        ),
+        // No `trustedDependencies` in package.json: `electron` is on the
+        // default trusted list.
+        write(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { "electron": "1.0.0" } })),
+      ]);
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(err).not.toContain("warn:");
+      expect(out).not.toContain("Blocked");
+      expect(await file(join(packageDir, "bun.lock")).text()).toContain(
+        `http://localhost:${registry.port}/npm/remote/electron/-/electron-1.0.0.tgz`,
+      );
+      expect(await exists(join(packageDir, "node_modules", "electron", "preinstall.txt"))).toBeTrue();
+      expect(exitCode).toBe(0);
+    },
+  );
+}
 
 test.concurrent("binary lockfile trusted dependency entries require an exact name match", async () => {
   using ctx = await setupTest();

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -299,9 +299,13 @@ test.concurrent("node-gyp shim directory added to lifecycle script PATH gets a r
   expect(distance > 21_600_000_000_000n).toBe(true);
 });
 
-for (const linker of ["hoisted", "isolated"] as const) {
+for (const [linker, globalStore] of [
+  ["hoisted", false],
+  ["isolated", false],
+  ["isolated", true],
+] as const) {
   test.concurrent(
-    `default trusted dependencies require a tarball URL on the configured registry (${linker})`,
+    `default trusted dependencies require a tarball URL on the configured registry (${linker}${globalStore ? ", global store" : ""})`,
     async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
@@ -309,7 +313,7 @@ for (const linker of ["hoisted", "isolated"] as const) {
       // No `trustedDependencies` in package.json: `electron` is on the default
       // trusted list, so the genuine registry package's lifecycle scripts run.
       await Promise.all([
-        verdaccio.writeBunfig(packageDir, { linker }),
+        verdaccio.writeBunfig(packageDir, { linker, globalStore }),
         writeFile(
           packageJson,
           JSON.stringify({


### PR DESCRIPTION
### Problem
- A default-trusted package (esbuild, sharp) keeps its lifecycle-script grant only when the lockfile tarball URL equals `<registry>/<name>/-/<name>-<version>.tgz` byte for byte. Artifactory and similar registries serve tarballs from another path on the same host. Their scripts are skipped with no diagnostic.
- The check is `Lockfile::has_trusted_dependency` (`src/install/lockfile.rs:3258`), added in #31339.

### Fix
- The grant now requires the tarball URL to have the same scheme, host, and effective port as the registry configured for the package's scope. The new `URL::has_same_origin` also replaces the inline checks in `NetworkTask::for_tarball` and `bun pm diff`, so the trust gate and the credential gates share one predicate.
- Correct because the check is about provenance: the tarball must come from the configured registry. A URL on another host still loses the grant. A same-origin URL to another package is now trusted (see Notes).
- Both installers warn with the package, the tarball URL, the registry, and the `trustedDependencies` fix. The hoisted installer now counts these blocked scripts on lockfile installs too, where `hasInstallScript` reads false.
- Verified: `test/cli/install/bun-install-lifecycle-scripts.test.ts` (5 new or changed tests, all fail on the released bun). Other install suites: see Notes.

### Background
- `trustedDependencies` in package.json replaces the default list. Without it, bun trusts the names in `src/install/default-trusted-dependencies.txt` (npm resolutions only).
- The lockfile stores the `dist.tarball` URL the registry advertised, and `bun install` downloads from it. A lockfile edit can pair a trusted name with any tarball. That is why the URL is checked.
- A `Scope` (`src/install/npm.rs`) is the registry config for the default registry or for one `@scope`.

<details><summary>Notes</summary>

- Trade-off. A same-origin swap (pointing `esbuild` at `https://registry.npmjs.org/@evil/x/-/x-1.0.0.tgz` with a matching integrity) now runs that tarball's scripts. With the same lockfile access, an attacker can already point any dependency at any tarball, and that code runs on the first import. A stricter rule that still fixes Artifactory: also require the path to end with `/<name>/-/<name>-<version>.tgz`, with the segment before `<name>` not starting with `@`. That breaks GitLab's scoped layout (`/@scope/name/-/@scope/name-1.0.0.tgz`). I can switch to it if preferred. The old test for the same-origin swap is removed.
- #38795 fixed one instance of the same problem (yarn.lock `#sha1` fragments) by stripping the fragment before the exact compare. The origin comparison covers that case too.
- Real-world layouts checked against the new rule: npmjs, Artifactory virtual/remote, Verdaccio `url_prefix`, Nexus, Azure Artifacts, Google Artifact Registry, AWS CodeArtifact, GitLab: all same origin. GitHub Packages proxies unscoped names to registry.npmjs.org: cross origin, still blocked (as before).
- `URL::has_same_origin` compares scheme and host case-insensitively and treats a missing port as the scheme's default, like the credentials check.
- Repro used in the test: a local `Bun.serve` front that serves manifests under `/npm/virtual/` and rewrites every `dist.tarball` to `/npm/remote/` on the same origin. On the released bun: hoisted prints `Blocked 1 postinstall`, isolated prints nothing, `preinstall.txt` is missing in both.
- Isolated linker: the warning reads the scripts from the global-store staging path (`Which::Staging`) because a cold global-store entry is renamed into place only in `Step::Binaries`. A probe with the project path printed no warning on a cold global store. The test variant "(isolated, global store)" covers it.
- The isolated linker has no `Blocked N postinstall` summary at all. Pre-existing, not changed here.
- Docs: one paragraph added to `docs/pm/lifecycle.mdx`.
- Suites run: the whole `bun-install-lifecycle-scripts.test.ts` (the 4 failures left are `node -p`/node-gyp PATH and CPU-time tests that fail under the debug build without this change too), `isolated-install.test.ts`, `bun-pm.test.ts`, `bun-lock.test.ts`, `bun-install-native-binlink.test.ts`, trust-related tests in `bun-install.test.ts` and `bun-install-registry.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->