### PR TITLE
WebSocket client: share one libdeflate decompressor and inflate buffer per VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "bun_js_parser",
  "bun_js_printer",
  "bun_jsc_macros",
+ "bun_libdeflate_sys",
  "bun_opaque",
  "bun_options_types",
  "bun_patch",

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -344,29 +344,31 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     fn dispatch_compressed_data(&self, data: &[u8], kind: Opcode) {
-        let mut deflate_slot = self.deflate.borrow_mut();
-        let Some(deflate) = deflate_slot.as_mut() else {
-            drop(deflate_slot);
-            self.terminate(ErrorCode::CompressionUnsupported);
-            return;
+        let rare = self.global_this.bun_vm().as_mut().rare_data();
+        let mut decompressed = rare.take_websocket_inflate_scratch();
+        let result = match self.deflate.borrow_mut().as_mut() {
+            None => Err(ErrorCode::CompressionUnsupported),
+            Some(deflate) => deflate
+                .decompress(rare.libdeflate_decompressor(), data, &mut decompressed)
+                .map_err(|err| match err {
+                    websocket_deflate::Error::InflateFailed => ErrorCode::InvalidCompressedData,
+                    websocket_deflate::Error::TooLarge => ErrorCode::MessageTooBig,
+                    websocket_deflate::Error::OutOfMemory => ErrorCode::FailedToAllocateMemory,
+                }),
         };
 
-        let mut decompressed = deflate.rare_data.array_list();
-        if let Err(err) = deflate.decompress(data, &mut decompressed) {
-            let error_code = match err {
-                websocket_deflate::Error::InflateFailed => ErrorCode::InvalidCompressedData,
-                websocket_deflate::Error::TooLarge => ErrorCode::MessageTooBig,
-                websocket_deflate::Error::OutOfMemory => ErrorCode::FailedToAllocateMemory,
-            };
-            drop(deflate_slot);
-            self.terminate(error_code);
-            return;
+        // The deflate borrow is released: both arms can re-enter `clear_data`.
+        match result {
+            Ok(()) => self.dispatch_data(&decompressed, kind),
+            Err(code) => self.terminate(code),
         }
 
-        // Drop the deflate borrow: `dispatch_data` can re-enter `clear_data`.
-        drop(deflate_slot);
-        let items = decompressed.as_slice();
-        self.dispatch_data(items, kind);
+        // Both arms run JS, so reach for `RareData` again instead of holding `rare` across them.
+        self.global_this
+            .bun_vm()
+            .as_mut()
+            .rare_data()
+            .put_back_websocket_inflate_scratch(decompressed);
     }
 
     /// Data will be cloned in C++.

--- a/src/http_jsc/websocket_client/WebSocketDeflate.rs
+++ b/src/http_jsc/websocket_client/WebSocketDeflate.rs
@@ -31,45 +31,20 @@ impl Params {
     pub(crate) const MIN_WINDOW_BITS: u8 = 8;
 }
 
-#[derive(Default)]
-pub struct RareData {
-    libdeflate_decompressor: Option<libdeflate_sys::OwnedDecompressor>,
-    // PERF: a 128KB inline buffer reused as scratch for (de)compression
-    // output could avoid per-call allocation — profile if hot.
-}
-
-impl RareData {
-    pub(crate) const STACK_BUFFER_SIZE: usize = 128 * 1024;
-
-    pub(crate) fn array_list(&self) -> Vec<u8> {
-        // PERF: allocates a fresh heap Vec per call — profile if hot.
-        Vec::with_capacity(Self::STACK_BUFFER_SIZE)
-    }
-
-    pub(crate) fn decompressor(&mut self) -> Option<&mut libdeflate_sys::Decompressor> {
-        if self.libdeflate_decompressor.is_none() {
-            self.libdeflate_decompressor = libdeflate_sys::OwnedDecompressor::new();
-        }
-        self.libdeflate_decompressor.as_deref_mut()
-    }
-}
-
 /// Parent module references this type as `WebSocketDeflate`.
 pub type WebSocketDeflate = PerMessageDeflate;
 /// Parent module matches `websocket_deflate::Error::*` against `decompress()`'s
 /// error type.
 pub(crate) type Error = DecompressError;
 
+/// The zlib streams are per connection: with context takeover (the default)
+/// each message's back-references reach into the previous message's window.
+/// The libdeflate fast path is stateless and lives in the VM's
+/// `bun_jsc::RareData`, shared by every client on the thread.
 pub struct PerMessageDeflate {
     pub(crate) compress_stream: zlib::DeflateEncoder,
     pub(crate) decompress_stream: zlib::InflateDecoder,
     pub(crate) params: Params,
-    // VM `bun_jsc::RareData` would be the natural owner (pooled libdeflate
-    // handles, shared across connections), but the concrete type is *this*
-    // `RareData`, which `bun_jsc` cannot name without a dep cycle, so each
-    // connection owns a fresh instance instead: a per-connection libdeflate
-    // allocation, not a correctness divergence.
-    pub(crate) rare_data: RareData,
 }
 
 // Constants from zlib.h
@@ -79,6 +54,11 @@ const Z_DEFAULT_MEM_LEVEL: c_int = 8;
 
 // Buffer size for compression/decompression operations
 const COMPRESSION_BUFFER_SIZE: usize = 4096;
+
+/// Output space reserved up front for one message. The one-shot libdeflate
+/// path gets exactly that space, so it is skipped for compressed inputs at
+/// least this large: their output would not fit either.
+const INFLATE_BUFFER_SIZE: usize = 128 * 1024;
 
 // Maximum decompressed message size (128 MB)
 const MAX_DECOMPRESSED_SIZE: usize = 128 * 1024 * 1024;
@@ -125,8 +105,6 @@ impl PerMessageDeflate {
             params,
             compress_stream,
             decompress_stream,
-            // Fresh per-connection instance; see the `rare_data` field note.
-            rare_data: RareData::default(),
         }))
     }
 
@@ -135,19 +113,24 @@ impl PerMessageDeflate {
             return false;
         }
 
-        len < RareData::STACK_BUFFER_SIZE
+        len < INFLATE_BUFFER_SIZE
     }
 
+    /// Inflate one message onto `out`. `decompressor` is the thread's shared
+    /// libdeflate handle (`None` when it could not be allocated).
     pub(crate) fn decompress(
         &mut self,
+        decompressor: Option<&mut libdeflate_sys::Decompressor>,
         in_buf: &[u8],
         out: &mut Vec<u8>,
     ) -> Result<(), DecompressError> {
         let initial_len = out.len();
+        out.try_reserve_exact(INFLATE_BUFFER_SIZE)
+            .map_err(|_| DecompressError::OutOfMemory)?;
 
         // First we try with libdeflate, which is both faster and doesn't need the trailing deflate bytes
         if Self::can_use_libdeflate(in_buf.len()) {
-            if let Some(decompressor) = self.rare_data.decompressor() {
+            if let Some(decompressor) = decompressor {
                 let result =
                     decompressor.decompress_to_vec(in_buf, out, libdeflate_sys::Encoding::Deflate);
                 if result.status == libdeflate_sys::Status::Success {

--- a/src/jsc/Cargo.toml
+++ b/src/jsc/Cargo.toml
@@ -38,6 +38,7 @@ bun_install.workspace = true
 bun_io.workspace = true
 bun_js_parser.workspace = true
 bun_js_printer.workspace = true
+bun_libdeflate_sys.workspace = true
 bun_ast.workspace = true
 bun_options_types.workspace = true
 bun_paths.workspace = true

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -12,6 +12,7 @@ use bun_core::strings;
 use bun_core::{Mutex, Output};
 use bun_event_loop::MiniEventLoop::__bun_stdio_blob_store_new;
 use bun_io::{self as Async};
+use bun_libdeflate_sys::libdeflate;
 use bun_paths::MAX_PATH_BYTES;
 use bun_sys::{self as syscall, Fd, Mode};
 use bun_uws::{self as uws, SocketGroup};
@@ -268,6 +269,10 @@ pub struct RareData {
     h2_padded_frame_buffer: Option<Box<H2PaddedFrameBuffer>>,
     /// Output scratch for one JS-thread `CompressionStream` step; see [`Self::take_compression_scratch`].
     compression_scratch: Option<Vec<u8>>,
+    /// Inflated payload of one `new WebSocket()` client message; see [`Self::take_websocket_inflate_scratch`].
+    websocket_inflate_scratch: Option<Vec<u8>>,
+    /// One libdeflate handle for every JS-thread one-shot inflate; see [`Self::libdeflate_decompressor`].
+    libdeflate_decompressor: Option<libdeflate::OwnedDecompressor>,
 
     // There is intentionally no `aws_signature_cache` field — storage lives in
     // `bun_s3_signing::credentials::AWS_SIGNATURE_CACHE` (process static; it
@@ -327,6 +332,8 @@ impl Default for RareData {
             pipe_read_scratch: Box::new(bun_event_loop::PipeReadScratch::new()),
             h2_padded_frame_buffer: None,
             compression_scratch: None,
+            websocket_inflate_scratch: None,
+            libdeflate_decompressor: None,
             s3_default_client: Strong::empty(),
             node_quic_callbacks: Strong::empty(),
             default_csrf_secret: Box::default(),
@@ -678,6 +685,31 @@ impl RareData {
             buffer.clear();
             self.compression_scratch = Some(buffer);
         }
+    }
+
+    /// Empty `Vec` with whatever capacity the last WebSocket client inflate left behind. By value,
+    /// like [`Self::take_h2_padded_frame_buffer`]: delivering the payload runs JS, which can reach
+    /// this path again before the buffer comes back.
+    pub fn take_websocket_inflate_scratch(&mut self) -> Vec<u8> {
+        self.websocket_inflate_scratch.take().unwrap_or_default()
+    }
+
+    /// Hand a taken buffer back; the slot keeps the first one returned and lets an oversized one go.
+    pub fn put_back_websocket_inflate_scratch(&mut self, mut buffer: Vec<u8>) {
+        const KEEP: usize = 256 * 1024;
+        if self.websocket_inflate_scratch.is_none() && buffer.capacity() <= KEEP {
+            buffer.clear();
+            self.websocket_inflate_scratch = Some(buffer);
+        }
+    }
+
+    /// libdeflate keeps no state between calls, so one handle serves every one-shot inflate on
+    /// this thread. `None` when libdeflate cannot allocate it; callers fall back to zlib.
+    pub fn libdeflate_decompressor(&mut self) -> Option<&mut libdeflate::Decompressor> {
+        if self.libdeflate_decompressor.is_none() {
+            self.libdeflate_decompressor = libdeflate::OwnedDecompressor::new();
+        }
+        self.libdeflate_decompressor.as_deref_mut()
     }
 
     pub fn boring_engine(&mut self) -> *mut boring::ENGINE {

--- a/test/js/web/websocket/websocket-permessage-deflate.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate.test.ts
@@ -1,4 +1,4 @@
-import { serve } from "bun";
+import { serve, type ServerWebSocket } from "bun";
 import { expect, test } from "bun:test";
 
 test("WebSocket client negotiates permessage-deflate", async () => {
@@ -247,6 +247,155 @@ test("WebSocket client handles context takeover options", async () => {
 test.skip("WebSocket client rejects compressed control frames", async () => {
   // This test would require a custom server that sends invalid compressed control frames
   // Skip for now as it requires low-level WebSocket frame manipulation
+});
+
+// Every WebSocket client on a thread inflates through one shared libdeflate
+// handle and one shared output buffer. Interleaving compressed messages across
+// clients must not let one client's payload leak into another's.
+test("clients on one thread share the inflater without mixing up their messages", async () => {
+  const clientCount = 6;
+  const messagesPerClient = 5;
+  const bodyFor = (client: number, index: number) =>
+    `client ${client} message ${index}: ` + Buffer.alloc(900 + 37 * index, String.fromCharCode(65 + client)).toString();
+
+  const serverSockets: ServerWebSocket<{ id: number }>[] = [];
+  const allOpen = Promise.withResolvers<void>();
+  using server = serve<{ id: number }>({
+    port: 0,
+    fetch(req, server) {
+      const id = Number(new URL(req.url).searchParams.get("id"));
+      if (server.upgrade(req, { data: { id } })) {
+        return;
+      }
+      return new Response("Not found", { status: 404 });
+    },
+    websocket: {
+      perMessageDeflate: true,
+      open(ws) {
+        serverSockets[ws.data.id] = ws;
+        if (serverSockets.filter(Boolean).length === clientCount) allOpen.resolve();
+      },
+      message() {},
+    },
+  });
+
+  const received: string[][] = Array.from({ length: clientCount }, () => []);
+  const allReceived = Promise.withResolvers<void>();
+  let remaining = clientCount * messagesPerClient;
+  const clients = Array.from({ length: clientCount }, (_, id) => {
+    const client = new WebSocket(`ws://localhost:${server.port}/?id=${id}`);
+    client.onmessage = event => {
+      received[id].push(event.data);
+      if (--remaining === 0) allReceived.resolve();
+    };
+    client.onclose = event =>
+      allReceived.reject(new Error(`client ${id} closed: code=${event.code} reason=${event.reason}`));
+    return client;
+  });
+  await Promise.all(
+    clients.map(
+      client =>
+        new Promise<void>((resolve, reject) => {
+          client.onopen = () => resolve();
+          client.onerror = () => reject(new Error("client errored"));
+        }),
+    ),
+  );
+  await allOpen.promise;
+  for (const client of clients) expect(client.extensions).toContain("permessage-deflate");
+
+  // Round-robin so consecutive inflates on the client side alternate between connections.
+  for (let index = 0; index < messagesPerClient; index++) {
+    for (let id = 0; id < clientCount; id++) {
+      serverSockets[id].send(bodyFor(id, index), true);
+    }
+  }
+  await allReceived.promise;
+
+  expect(received).toEqual(
+    Array.from({ length: clientCount }, (_, id) =>
+      Array.from({ length: messagesPerClient }, (_, index) => bodyFor(id, index)),
+    ),
+  );
+
+  for (const client of clients) {
+    client.onclose = null;
+    client.close();
+  }
+});
+
+// A payload too large for the one-shot libdeflate path is inflated by the
+// connection's zlib stream into the same shared buffer, growing it. Messages
+// after it, on this and on another connection, must still arrive intact.
+test("a message that outgrows the libdeflate buffer does not disturb later messages", async () => {
+  const large = Buffer.alloc(200 * 1024, "0123456789abcdef").toString();
+  const small = (tag: string) => `${tag}: ${Buffer.alloc(1000, tag).toString()}`;
+  const expected = {
+    first: [small("a"), large, small("b"), small("c")],
+    second: [small("x"), small("y")],
+  };
+
+  const serverSockets: Record<string, ServerWebSocket<{ name: string }>> = {};
+  const allOpen = Promise.withResolvers<void>();
+  using server = serve<{ name: string }>({
+    port: 0,
+    fetch(req, server) {
+      const name = new URL(req.url).searchParams.get("name")!;
+      if (server.upgrade(req, { data: { name } })) {
+        return;
+      }
+      return new Response("Not found", { status: 404 });
+    },
+    websocket: {
+      perMessageDeflate: true,
+      open(ws) {
+        serverSockets[ws.data.name] = ws;
+        if (Object.keys(serverSockets).length === 2) allOpen.resolve();
+      },
+      message() {},
+    },
+  });
+
+  const received: Record<string, string[]> = { first: [], second: [] };
+  const allReceived = Promise.withResolvers<void>();
+  let remaining = expected.first.length + expected.second.length;
+  const clients = Object.fromEntries(
+    ["first", "second"].map(name => {
+      const client = new WebSocket(`ws://localhost:${server.port}/?name=${name}`);
+      client.onmessage = event => {
+        received[name].push(event.data);
+        if (--remaining === 0) allReceived.resolve();
+      };
+      client.onclose = event =>
+        allReceived.reject(new Error(`client ${name} closed: code=${event.code} reason=${event.reason}`));
+      return [name, client];
+    }),
+  );
+  await Promise.all(
+    Object.values(clients).map(
+      client =>
+        new Promise<void>((resolve, reject) => {
+          client.onopen = () => resolve();
+          client.onerror = () => reject(new Error("client errored"));
+        }),
+    ),
+  );
+  await allOpen.promise;
+
+  serverSockets.first.send(expected.first[0], true);
+  serverSockets.first.send(expected.first[1], true);
+  serverSockets.second.send(expected.second[0], true);
+  serverSockets.first.send(expected.first[2], true);
+  serverSockets.second.send(expected.second[1], true);
+  serverSockets.first.send(expected.first[3], true);
+  await allReceived.promise;
+
+  expect(received).toEqual(expected);
+
+  for (const client of Object.values(clients)) {
+    client.onclose = null;
+    client.close();
+  }
 });
 
 // The "dedicated" decompressor is the only server mode whose handshake response


### PR DESCRIPTION
### Problem
- Every `new WebSocket()` connection that negotiates `permessage-deflate` owns a private `RareData` with its own libdeflate decompressor (about 12 KB each, `src/http_jsc/websocket_client/WebSocketDeflate.rs`). N connections cost N decompressor states for a handle that keeps no state between calls.
- Every compressed inbound message allocates a fresh 128 KB `Vec` in `RareData::array_list()` and frees it after dispatch. The allocation is infallible, so an OOM aborts the process.
- The VM-wide slot in `bun_jsc::RareData` meant for this was deleted in #31977 because nothing used it.

### Fix
- `bun_jsc::RareData` gains `libdeflate_decompressor()` (one lazily allocated `OwnedDecompressor` per VM) and a `take_websocket_inflate_scratch()` / `put_back_websocket_inflate_scratch()` pair, the same idiom as `compression_scratch`. `bun_jsc` now depends on the leaf crate `bun_libdeflate_sys`.
- `dispatch_compressed_data` takes the scratch by value, inflates with the shared handle, dispatches, and puts the buffer back. A nested inflate (JS re-entry during dispatch) finds the slot empty and allocates its own. The slot keeps buffers up to 256 KB.
- The per-connection zlib streams stay: with context takeover a message's back-references reach into the previous message's window. `PerMessageDeflate::decompress` now receives the decompressor as a parameter and reserves the 128 KB with `try_reserve_exact`, so OOM is `FailedToAllocateMemory` instead of an abort.
- Verified: `test/js/web/websocket/websocket-permessage-deflate.test.ts` (two new tests: six clients with interleaved compressed messages, and a 200 KB message that overflows the libdeflate buffer), plus `websocket-permessage-deflate-simple`, `-edge-cases`, and `test/js/web/websocket/`.

### Background
- RFC 7692 permessage-deflate sends each message as a raw DEFLATE stream. Bun's client first tries libdeflate, a one-shot decoder that succeeds only on a complete stream (BFINAL set, as Bun's server emits). Otherwise it falls back to the connection's zlib inflate stream, which carries the sliding window across messages.
- `RareData` is the per-VM bag of lazily created subsystems. The JS thread is the only user, so "per VM" is also "per thread".

<details><summary>Notes</summary>

Release build, client receiving from a node raw-frame server (one complete DEFLATE stream per frame, 200-byte payloads), 3 runs each:

| scenario | before | after |
| --- | --- | --- |
| 50 connections x 20k messages | 1.13 to 1.24 M msg/s, 115 MB RSS | 1.02 to 1.34 M msg/s, 113 MB RSS |
| 1 connection x 300k messages | 1.21 to 1.26 M msg/s | 1.23 to 1.29 M msg/s |
| 2000 connections x 1 message | 494 MB RSS | 470 MB RSS |
| 2000 connections x 5 messages | 500 MB RSS | 475 MB RSS |

Throughput is unchanged within noise in release: mimalloc recycles the 128 KB block quickly. The measurable win is about 12 KB per connection (the decompressor), 24 MB across 2000 connections. Against a Bun server (`ws.send(msg, true)`) both builds are server-bound at about 180k msg/s.

Debug (ASAN) build, 20 connections x 5000 messages against a Bun server: 9.9k msg/s before, 15.2k msg/s after. Allocation is expensive under ASAN, which is why the old per-message `Vec` shows up there.

Most of the remaining per-connection memory is the eagerly created zlib deflate stream (`deflateInit2` with memLevel 8 and 15 window bits), which exists even on a client that never sends a compressed message. Making it lazy is a separate change.

The two new tests fail if `put_back_websocket_inflate_scratch` does not `clear()` the buffer (checked by temporarily removing it): later messages arrive with the previous payload prepended. The failing tests in `test/js/web/websocket/websocket.test.js` need `ws.postman-echo.com` and fail the same way on main in this environment.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/4] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/4] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static
... (truncated)

release without fix: 1 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/js/web/websocket/websocket-permessage-deflate.test.ts:
(pass) WebSocket client negotiates permessage-deflate [3.37ms]
(pass) WebSocket client handles compressed text messages [101.25ms]
(pass) WebSocket client handles compressed binary messages [101.98ms]
(pass) WebSocket client handles fragmented compressed messages [1.87ms]
(pass) WebSocket client handles context takeover options [101.13ms]
(skip) WebSocket client rejects compressed control frames
(pass) clients on one thread share the inflater without mixing up their messages [5.96ms]
(pass) a message that outgrows the libdeflate buffer does not disturb later messages [4.14ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (every message fits the fast-path buffer) [1.78ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (message 1 overflows the fast-path buffer) [1.06ms]
(pass) server enforces maxPayloadLength on compressed messages inflated through the fast path [1.67ms]

 10 pass
 1 skip
 0 fail
 37 expect() calls
Ran 11 tests across 1 file. [417.00ms]
__F:0:S:1
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate.test.ts
bun test v1.4.1 (65362b53b)

test/js/web/websocket/websocket-permessage-deflate.test.ts:
(pass) WebSocket client negotiates permessage-deflate [62.76ms]
(pass) WebSocket client handles compressed text messages [129.16ms]
(pass) WebSocket client handles compressed binary messages [138.87ms]
(pass) WebSocket client handles fragmented compressed messages [29.87ms]
(pass) WebSocket client handles context takeover options [129.44ms]
(skip) WebSocket client rejects compressed control frames
(pass) clients on one thread share the inflater without mixing up their messages [94.66ms]
(pass) a message that outgrows the libdeflate buffer does not disturb later messages [59.75ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (every message fits the fast-path buffer) [36.18ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (message 1 overflows the fast-path buffer) [16.00ms]
(pass) server enforces maxPayloadLength o
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     384498cbce
  features     baseline

23 deps, 131 codegen, 1172 objects in 692ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [6.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] fetch zlib
[zlib] up to date
[5/1244] gen ErrorCode+*.h
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Proc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
Cargo.lock                                         |   1 +
 src/http_jsc/websocket_client.rs                   |  40 +++---
 src/http_jsc/websocket_client/WebSocketDeflate.rs  |  49 +++----
 src/jsc/Cargo.toml                                 |   1 +
 src/jsc/rare_data.rs                               |  32 +++++
 .../websocket/websocket-permessage-deflate.test.ts | 151 ++++++++++++++++++++-
 6 files changed, 221 insertions(+), 53 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
Cargo.lock                                                    0      0      0
src/http_jsc/websocket_client.rs                              4      1      0
src/http_jsc/websocket_client/WebSocketDeflate.rs             2      5      0
src/jsc/Cargo.toml                                            1      2      0
src/jsc/rare_data.rs                                          1      4      0
…t/js/web/websocket/websocket-permessage-deflate.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->