### PR TITLE
bundler: hand native plugin asset buffers to the output file without a copy

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -256,6 +256,9 @@ pub mod default_alloc {
 pub use max_heap_allocator::MaxHeapAllocator;
 pub use stack_fallback::ArenaPtr;
 
+mod owned_bytes;
+pub use owned_bytes::OwnedBytes;
+
 #[path = "MimallocArena.rs"]
 pub mod mimalloc_arena;
 

--- a/src/bun_alloc/owned_bytes.rs
+++ b/src/bun_alloc/owned_bytes.rs
@@ -1,0 +1,114 @@
+use core::ptr::NonNull;
+
+use crate::{Alignment, StdAllocator, basic};
+
+/// A heap byte buffer paired with the [`StdAllocator`] that frees it.
+///
+/// `Box<[u8]>` in the common case (global allocator), but the buffer can also
+/// belong to a foreign owner with its own free callback (a native bundler
+/// plugin's `free_plugin_source_code_context`), so a consumer such as the
+/// bundler's `OutputFile` can adopt such bytes without a copy.
+pub struct OwnedBytes {
+    /// `None` ⇒ empty; nothing is freed on drop.
+    ptr: Option<NonNull<u8>>,
+    len: usize,
+    allocator: StdAllocator,
+}
+
+// SAFETY: the buffer is uniquely owned through `ptr` and `StdAllocator` is
+// `Send + Sync`; the free callback's thread-safety is the allocator's contract
+// (same as `StdAllocator` itself).
+unsafe impl Send for OwnedBytes {}
+// SAFETY: `&OwnedBytes` only reads the uniquely owned slice.
+unsafe impl Sync for OwnedBytes {}
+
+impl OwnedBytes {
+    pub const fn new() -> Self {
+        Self {
+            ptr: None,
+            len: 0,
+            allocator: basic::C_ALLOCATOR,
+        }
+    }
+
+    /// Adopt `ptr[..len]`, to be released with `allocator.free`.
+    ///
+    /// # Safety
+    /// `ptr[..len]` must be a live, initialized allocation owned by `allocator`
+    /// and nothing else may free it afterwards.
+    pub unsafe fn from_raw_parts(ptr: NonNull<u8>, len: usize, allocator: StdAllocator) -> Self {
+        Self {
+            ptr: Some(ptr),
+            len,
+            allocator,
+        }
+    }
+
+    /// Give up ownership: `(ptr, len, allocator)`, or `None` when empty. The
+    /// caller must free `ptr[..len]` through `allocator`.
+    pub fn into_raw_parts(self) -> Option<(NonNull<u8>, usize, StdAllocator)> {
+        let this = core::mem::ManuallyDrop::new(self);
+        this.ptr.map(|ptr| (ptr, this.len, this.allocator))
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        match self.ptr {
+            // SAFETY: `ptr[..len]` is live and initialized (`from_raw_parts` contract).
+            Some(ptr) => unsafe { core::slice::from_raw_parts(ptr.as_ptr(), self.len) },
+            None => &[],
+        }
+    }
+}
+
+impl Default for OwnedBytes {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl core::ops::Deref for OwnedBytes {
+    type Target = [u8];
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl From<Box<[u8]>> for OwnedBytes {
+    fn from(bytes: Box<[u8]>) -> Self {
+        if bytes.is_empty() {
+            return Self::new();
+        }
+        let len = bytes.len();
+        // SAFETY: `Box::into_raw` of a non-empty slice is non-null.
+        let ptr = unsafe { NonNull::new_unchecked(Box::into_raw(bytes).cast::<u8>()) };
+        Self {
+            ptr: Some(ptr),
+            len,
+            allocator: basic::C_ALLOCATOR,
+        }
+    }
+}
+
+impl From<Vec<u8>> for OwnedBytes {
+    #[inline]
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::from(bytes.into_boxed_slice())
+    }
+}
+
+impl Drop for OwnedBytes {
+    fn drop(&mut self) {
+        if let Some(ptr) = self.ptr {
+            // Not `StdAllocator::free`: that skips empty slices, but a foreign
+            // owner's callback must run even for a zero-length buffer.
+            // SAFETY: `ptr[..len]` is the allocation handed over in
+            // `from_raw_parts`/`From<Box<[u8]>>`, owned by `allocator`.
+            let buf = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), self.len) };
+            self.allocator
+                .raw_free(buf, Alignment::from_byte_units(1), 0);
+        }
+    }
+}

--- a/src/bun_alloc/owned_bytes.rs
+++ b/src/bun_alloc/owned_bytes.rs
@@ -2,12 +2,9 @@ use core::ptr::NonNull;
 
 use crate::{Alignment, StdAllocator, basic};
 
-/// A heap byte buffer paired with the [`StdAllocator`] that frees it.
-///
-/// `Box<[u8]>` in the common case (global allocator), but the buffer can also
-/// belong to a foreign owner with its own free callback (a native bundler
-/// plugin's `free_plugin_source_code_context`), so a consumer such as the
-/// bundler's `OutputFile` can adopt such bytes without a copy.
+/// `Box<[u8]>` whose deallocator is a [`StdAllocator`]: the global allocator,
+/// or a foreign free callback (a native bundler plugin's) when the bytes were
+/// adopted from it instead of copied.
 pub struct OwnedBytes {
     /// `None` ⇒ empty; nothing is freed on drop.
     ptr: Option<NonNull<u8>>,
@@ -15,9 +12,7 @@ pub struct OwnedBytes {
     allocator: StdAllocator,
 }
 
-// SAFETY: the buffer is uniquely owned through `ptr` and `StdAllocator` is
-// `Send + Sync`; the free callback's thread-safety is the allocator's contract
-// (same as `StdAllocator` itself).
+// SAFETY: `ptr` is the sole alias of the buffer; `StdAllocator` is `Send + Sync`.
 unsafe impl Send for OwnedBytes {}
 // SAFETY: `&OwnedBytes` only reads the uniquely owned slice.
 unsafe impl Sync for OwnedBytes {}
@@ -31,11 +26,8 @@ impl OwnedBytes {
         }
     }
 
-    /// Adopt `ptr[..len]`, to be released with `allocator.free`.
-    ///
     /// # Safety
-    /// `ptr[..len]` must be a live, initialized allocation owned by `allocator`
-    /// and nothing else may free it afterwards.
+    /// `ptr[..len]` is a live allocation owned by `allocator`; ownership moves here.
     pub unsafe fn from_raw_parts(ptr: NonNull<u8>, len: usize, allocator: StdAllocator) -> Self {
         Self {
             ptr: Some(ptr),
@@ -44,8 +36,7 @@ impl OwnedBytes {
         }
     }
 
-    /// Give up ownership: `(ptr, len, allocator)`, or `None` when empty. The
-    /// caller must free `ptr[..len]` through `allocator`.
+    /// `(ptr, len, allocator)` for the caller to free, or `None` when empty.
     pub fn into_raw_parts(self) -> Option<(NonNull<u8>, usize, StdAllocator)> {
         let this = core::mem::ManuallyDrop::new(self);
         this.ptr.map(|ptr| (ptr, this.len, this.allocator))
@@ -102,10 +93,8 @@ impl From<Vec<u8>> for OwnedBytes {
 impl Drop for OwnedBytes {
     fn drop(&mut self) {
         if let Some(ptr) = self.ptr {
-            // Not `StdAllocator::free`: that skips empty slices, but a foreign
-            // owner's callback must run even for a zero-length buffer.
-            // SAFETY: `ptr[..len]` is the allocation handed over in
-            // `from_raw_parts`/`From<Box<[u8]>>`, owned by `allocator`.
+            // `raw_free`, not `free`: a foreign callback must run for a zero-length buffer too.
+            // SAFETY: `ptr[..len]` is the allocation adopted by `from_raw_parts`/`From`.
             let buf = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), self.len) };
             self.allocator
                 .raw_free(buf, Alignment::from_byte_units(1), 0);

--- a/src/bun_alloc/owned_bytes.rs
+++ b/src/bun_alloc/owned_bytes.rs
@@ -2,9 +2,7 @@ use core::ptr::NonNull;
 
 use crate::{Alignment, StdAllocator, basic};
 
-/// `Box<[u8]>` whose deallocator is a [`StdAllocator`]: the global allocator,
-/// or a foreign free callback (a native bundler plugin's) when the bytes were
-/// adopted from it instead of copied.
+/// `Box<[u8]>` freed through a [`StdAllocator`]: the global allocator or a foreign free callback.
 pub struct OwnedBytes {
     /// `None` ⇒ empty; nothing is freed on drop.
     ptr: Option<NonNull<u8>>,

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -106,11 +106,7 @@ pub struct FileOperation {
 pub enum Value {
     Copy(FileOperation),
     Noop,
-    /// `bytes` carries its own allocator: the global one for bundler output, a
-    /// native plugin's free callback for an asset the plugin provided.
-    Buffer {
-        bytes: OwnedBytes,
-    },
+    Buffer { bytes: OwnedBytes },
     Saved(SavedFile),
 }
 

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -5,6 +5,7 @@ use crate::options::Loader;
 // the `options` module already defines them locally.
 use crate::Error;
 use crate::options::{OutputKind, Side};
+use bun_alloc::OwnedBytes;
 use bun_core::String as BunString;
 use bun_paths::PathBuffer;
 use bun_paths::fs;
@@ -102,11 +103,14 @@ pub struct FileOperation {
     pub pathname: Box<[u8]>,
 }
 
-#[derive(Clone)]
 pub enum Value {
     Copy(FileOperation),
     Noop,
-    Buffer { bytes: Box<[u8]> },
+    /// `bytes` carries its own allocator: the global one for bundler output, a
+    /// native plugin's free callback for an asset the plugin provided.
+    Buffer {
+        bytes: OwnedBytes,
+    },
     Saved(SavedFile),
 }
 
@@ -153,10 +157,7 @@ impl Value {
 pub struct SavedFile {}
 
 pub enum OptionsData {
-    Buffer {
-        // arena dropped — global mimalloc.
-        data: Box<[u8]>,
-    },
+    Buffer { data: OwnedBytes },
     Saved(usize),
 }
 

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2177,10 +2177,7 @@ pub mod parse_worker {
                                 len: wrapper.result.source_len,
                             }
                         };
-                    // The plugin buffer has exactly one owner:
-                    // `self.task.external_free_function` (set above),
-                    // released via `BundleV2.finalizers` or, for an emitted
-                    // asset, by the `OutputFile` that adopts the buffer.
+                    // `self.task.external_free_function` (set above) is the plugin buffer's only owner.
                     return Ok(CacheEntry {
                         contents,
                         fd: wrapper.original_source_fd,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -92,6 +92,8 @@ pub struct ParseTask {
     pub(crate) secondary_path_for_commonjs_interop: Option<Fs::Path<'static>>,
     pub(crate) contents_or_fd: ContentsOrFd,
     pub(crate) external_free_function: ExternalFreeFunction,
+    /// A native `onBeforeParse` plugin replaced the source with its own buffer.
+    pub(crate) plugin_owns_source: bool,
     pub(crate) side_effects: bun_ast::SideEffects,
     pub(crate) loader: Option<Loader>,
     pub(crate) jsx: options::jsx::Pragma,
@@ -137,6 +139,8 @@ pub(crate) struct Result {
     /// a function pointer and context pointer to free the
     /// returned source code by the plugin.
     pub(crate) external: ExternalFreeFunction,
+    /// `source.contents` is the plugin's own buffer, which `external` frees.
+    pub(crate) plugin_owns_source: bool,
 }
 // `Result` lives in a bump arena (no Drop on free); boxing the large arm
 // would leak the heap allocation. The size diff is acceptable.
@@ -278,6 +282,7 @@ impl ParseTask {
             // defaults:
             secondary_path_for_commonjs_interop: None,
             external_free_function: ExternalFreeFunction::NONE,
+            plugin_owns_source: false,
             loader: None,
             task: ThreadPoolLib::Task {
                 node: ThreadPoolLib::Node::default(),
@@ -308,6 +313,7 @@ impl Default for ParseTask {
             secondary_path_for_commonjs_interop: None,
             contents_or_fd: ContentsOrFd::Contents(b""),
             external_free_function: ExternalFreeFunction::NONE,
+            plugin_owns_source: false,
             side_effects: bun_ast::SideEffects::HasSideEffects,
             loader: None,
             jsx: Default::default(),
@@ -553,6 +559,7 @@ pub mod parse_worker {
             // defaults:
             secondary_path_for_commonjs_interop: None,
             external_free_function: ExternalFreeFunction::NONE,
+            plugin_owns_source: false,
             task: ThreadPoolLib::Task {
                 node: ThreadPoolLib::Node::default(),
                 callback: task_callback,
@@ -2164,6 +2171,7 @@ pub mod parse_worker {
                                 .take()
                                 .expect("original_contents set alongside original_source")
                         } else {
+                            self.task.plugin_owns_source = true;
                             crate::cache::Contents::External {
                                 ptr,
                                 len: wrapper.result.source_len,
@@ -2171,7 +2179,8 @@ pub mod parse_worker {
                         };
                     // The plugin buffer has exactly one owner:
                     // `self.task.external_free_function` (set above),
-                    // released via `BundleV2.finalizers`.
+                    // released via `BundleV2.finalizers` or, for an emitted
+                    // asset, by the `OutputFile` that adopts the buffer.
                     return Ok(CacheEntry {
                         contents,
                         fd: wrapper.original_source_fd,
@@ -2815,6 +2824,7 @@ pub mod parse_worker {
             // `ExternalFreeFunction`
             // doesn't derive `Copy`, so move it out (task is consumed here).
             external: core::mem::take(&mut this.external_free_function),
+            plugin_owns_source: this.plugin_owns_source,
             watcher_data: match this.contents_or_fd {
                 ContentsOrFd::Fd { file, dir } => WatcherData {
                     fd: file,

--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -98,6 +98,7 @@ fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
         task: Default::default(),
         value,
         external: ExternalFreeFunction::NONE,
+        plugin_owns_source: false,
         watcher_data: WatcherData::NONE,
     });
     let result = bun_core::heap::into_raw(result);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7145,8 +7145,11 @@ pub mod bv2_impl {
             if parse_result.external.function.is_some() {
                 let external = core::mem::take(&mut parse_result.external);
                 match &parse_result.value {
+                    // A plugin that kept the fetched (worker-arena) source and only set a free
+                    // context does not own `source.contents`: copy it, free the context at teardown.
                     parse_task::ResultValue::Success(result)
-                        if result.loader.should_copy_for_bundling() =>
+                        if parse_result.plugin_owns_source
+                            && result.loader.should_copy_for_bundling() =>
                     {
                         if let Some(previous) = this
                             .asset_free_functions

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -116,14 +116,10 @@ pub struct BundleV2<'a> {
     pub(crate) unique_key: u64,
     pub(crate) dynamic_import_entry_points: ArrayHashMap<IndexInt, ()>,
 
-    /// Free callbacks for native `onBeforeParse` buffers whose bytes the parse
-    /// consumed; run when the bundle is torn down.
+    /// Native `onBeforeParse` buffers to free at teardown.
     pub(crate) finalizers: Vec<ExternalFreeFunction>,
-    /// Free callbacks for native `onBeforeParse` buffers that are the
-    /// `source.contents` of a copy-for-bundling asset (`file`, `wasm`, ...),
-    /// keyed by source index. `process_files_to_copy` moves each buffer into
-    /// its `OutputFile` with the callback as the deallocator; whatever is left
-    /// (asset not emitted) is freed at teardown.
+    /// Native `onBeforeParse` buffers that are a copy-loader asset's `source.contents`,
+    /// by source index: `process_files_to_copy` hands them to the `OutputFile`.
     pub(crate) asset_free_functions: ArrayHashMap<IndexInt, ExternalFreeFunction>,
 
     pub(crate) drain_defer_task: DeferredBatchTask,
@@ -4418,13 +4414,10 @@ pub mod bv2_impl {
                                     match asset_free_functions
                                         .fetch_swap_remove(&(index as IndexInt))
                                     {
-                                        // A native `onBeforeParse` plugin owns `b`; its free
-                                        // callback becomes the output's deallocator.
                                         Some((_, external)) => {
                                             let ptr = core::ptr::NonNull::from(b).cast::<u8>();
-                                            // SAFETY: `b` is the buffer the plugin handed over
-                                            // (`Contents::External`), freed only through
-                                            // `external`, which leaves the bundle's hands here.
+                                            // SAFETY: `b` is the plugin's `Contents::External`
+                                            // buffer and `external` is its only owner.
                                             unsafe {
                                                 bun_alloc::OwnedBytes::from_raw_parts(
                                                     ptr,
@@ -7153,8 +7146,6 @@ pub mod bv2_impl {
             if parse_result.external.function.is_some() {
                 let external = core::mem::take(&mut parse_result.external);
                 match &parse_result.value {
-                    // The plugin buffer stays `source.contents` until
-                    // `process_files_to_copy` hands it to the asset's `OutputFile`.
                     parse_task::ResultValue::Success(result)
                         if result.loader.should_copy_for_bundling() =>
                     {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -116,7 +116,15 @@ pub struct BundleV2<'a> {
     pub(crate) unique_key: u64,
     pub(crate) dynamic_import_entry_points: ArrayHashMap<IndexInt, ()>,
 
+    /// Free callbacks for native `onBeforeParse` buffers whose bytes the parse
+    /// consumed; run when the bundle is torn down.
     pub(crate) finalizers: Vec<ExternalFreeFunction>,
+    /// Free callbacks for native `onBeforeParse` buffers that are the
+    /// `source.contents` of a copy-for-bundling asset (`file`, `wasm`, ...),
+    /// keyed by source index. `process_files_to_copy` moves each buffer into
+    /// its `OutputFile` with the callback as the deallocator; whatever is left
+    /// (asset not emitted) is freed at teardown.
+    pub(crate) asset_free_functions: ArrayHashMap<IndexInt, ExternalFreeFunction>,
 
     pub(crate) drain_defer_task: DeferredBatchTask,
 
@@ -2949,6 +2957,7 @@ pub mod bv2_impl {
                 unique_key: 0,
                 dynamic_import_entry_points: ArrayHashMap::new(),
                 finalizers: Vec::new(),
+                asset_free_functions: ArrayHashMap::new(),
                 drain_defer_task: DeferredBatchTask::default(),
                 asynchronous: false,
                 has_any_top_level_await_modules: false,
@@ -4321,6 +4330,7 @@ pub mod bv2_impl {
                     )
                 };
                 let mut additional_output_files: Vec<options::OutputFile> = Vec::new();
+                let mut asset_free_functions = core::mem::take(&mut self.asset_free_functions);
 
                 for reachable_source in reachable_files {
                     let index = reachable_source.get() as usize;
@@ -4401,10 +4411,32 @@ pub mod bv2_impl {
                         // out instead of `to_vec()`-cloning,
                         // which is prohibitively expensive for large assets.
                         let contents_len = source.contents.len();
-                        let contents = match core::mem::take(&mut source.contents) {
-                            std::borrow::Cow::Owned(v) => v.into_boxed_slice(),
-                            std::borrow::Cow::Borrowed(b) => Box::<[u8]>::from(b),
-                        };
+                        let contents: bun_alloc::OwnedBytes =
+                            match core::mem::take(&mut source.contents) {
+                                std::borrow::Cow::Owned(v) => v.into(),
+                                std::borrow::Cow::Borrowed(b) => {
+                                    match asset_free_functions
+                                        .fetch_swap_remove(&(index as IndexInt))
+                                    {
+                                        // A native `onBeforeParse` plugin owns `b`; its free
+                                        // callback becomes the output's deallocator.
+                                        Some((_, external)) => {
+                                            let ptr = core::ptr::NonNull::from(b).cast::<u8>();
+                                            // SAFETY: `b` is the buffer the plugin handed over
+                                            // (`Contents::External`), freed only through
+                                            // `external`, which leaves the bundle's hands here.
+                                            unsafe {
+                                                bun_alloc::OwnedBytes::from_raw_parts(
+                                                    ptr,
+                                                    b.len(),
+                                                    external.into_allocator(),
+                                                )
+                                            }
+                                        }
+                                        None => Box::<[u8]>::from(b).into(),
+                                    }
+                                }
+                            };
 
                         additional_output_files.push(options::OutputFile::init(
                             crate::output_file::Options {
@@ -4431,6 +4463,8 @@ pub mod bv2_impl {
                 }
 
                 self.graph.additional_output_files = additional_output_files;
+                // Plugin buffers of assets that were not emitted: freed at teardown.
+                self.asset_free_functions = asset_free_functions;
             }
             Ok(())
         }
@@ -5070,6 +5104,11 @@ pub mod bv2_impl {
                     finalizer.call();
                 }
                 drop(on_parse_finalizers);
+                let asset_free_functions = core::mem::take(&mut self.asset_free_functions);
+                for finalizer in asset_free_functions.values() {
+                    finalizer.call();
+                }
+                drop(asset_free_functions);
             }
 
             // Plugin file/asset-loader bytes that `process_files_to_copy` will
@@ -7112,13 +7151,22 @@ pub mod bv2_impl {
             // across the `this.*` method calls below (each takes
             // `&mut BundleV2`), so re-borrow `this.graph` at each use site instead.
             if parse_result.external.function.is_some() {
-                let source = parse_result.value.source_index();
-                let loader: Loader = this.graph.input_files.items_loader()[source as usize];
-                // `InputFile.arena` column dropped in the Rust port;
-                // stash the finalizer regardless so plugin-owned bytes are freed.
-                let _ = loader;
-                this.finalizers
-                    .push(core::mem::take(&mut parse_result.external));
+                let external = core::mem::take(&mut parse_result.external);
+                match &parse_result.value {
+                    // The plugin buffer stays `source.contents` until
+                    // `process_files_to_copy` hands it to the asset's `OutputFile`.
+                    parse_task::ResultValue::Success(result)
+                        if result.loader.should_copy_for_bundling() =>
+                    {
+                        if let Some(previous) = this
+                            .asset_free_functions
+                            .insert(parse_result.value.source_index(), external)
+                        {
+                            this.finalizers.push(previous);
+                        }
+                    }
+                    _ => this.finalizers.push(external),
+                }
             }
 
             let mut diff: i32 = -1;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7145,8 +7145,7 @@ pub mod bv2_impl {
             if parse_result.external.function.is_some() {
                 let external = core::mem::take(&mut parse_result.external);
                 match &parse_result.value {
-                    // A plugin that kept the fetched (worker-arena) source and only set a free
-                    // context does not own `source.contents`: copy it, free the context at teardown.
+                    // A plugin that kept the fetched (worker-arena) source does not own `source.contents`.
                     parse_task::ResultValue::Success(result)
                         if parse_result.plugin_owns_source
                             && result.loader.should_copy_for_bundling() =>

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -118,8 +118,7 @@ pub struct BundleV2<'a> {
 
     /// Native `onBeforeParse` buffers to free at teardown.
     pub(crate) finalizers: Vec<ExternalFreeFunction>,
-    /// Native `onBeforeParse` buffers that are a copy-loader asset's `source.contents`,
-    /// by source index: `process_files_to_copy` hands them to the `OutputFile`.
+    /// Plugin-owned `source.contents` of copy-loader assets, by source index, for `process_files_to_copy`.
     pub(crate) asset_free_functions: ArrayHashMap<IndexInt, ExternalFreeFunction>,
 
     pub(crate) drain_defer_task: DeferredBatchTask,

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -387,7 +387,7 @@ bun_dispatch::link_interface! {
 impl Default for output_file::OptionsData {
     fn default() -> Self {
         output_file::OptionsData::Buffer {
-            data: Box::default(),
+            data: bun_alloc::OwnedBytes::new(),
         }
     }
 }

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -843,7 +843,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     Some(output_files.insert_for_sourcemap_or_bytecode(
                         options::OutputFile::init(options::OutputFileInit {
                             data: options::OutputFileData::Buffer {
-                                data: output_source_map,
+                                data: output_source_map.into(),
                             },
                             hash: None,
                             loader: Loader::Json,
@@ -864,7 +864,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 let _ = output_files.insert_for_chunk(options::OutputFile::init(
                     options::OutputFileInit {
                         data: options::OutputFileData::Buffer {
-                            data: Box::default(),
+                            data: bun_alloc::OwnedBytes::new(),
                         },
                         hash: None,
                         loader: chunks[chunk_index_in_chunks_list].content.loader(),
@@ -991,7 +991,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     sourcemap_output_file =
                         Some(options::OutputFile::init(options::OutputFileInit {
                             data: options::OutputFileData::Buffer {
-                                data: output_source_map,
+                                data: output_source_map.into(),
                             },
                             hash: None,
                             loader: Loader::Json,
@@ -1118,7 +1118,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                 loader: Loader::File,
                                 size: Some(bytecode.len()),
                                 display_size: bytecode.len() as u32,
-                                data: options::OutputFileData::Buffer { data: bytecode },
+                                data: options::OutputFileData::Buffer {
+                                    data: bytecode.into(),
+                                },
                                 side: Some(side),
                                 entry_point_index: None,
                                 is_executable: false,
@@ -1183,7 +1185,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                         size: Some(module_info_bytes.len()),
                                         display_size: module_info_bytes.len() as u32,
                                         data: options::OutputFileData::Buffer {
-                                            data: module_info_bytes.clone(),
+                                            data: module_info_bytes.clone().into(),
                                         },
                                         side: Some(side),
                                         entry_point_index: None,
@@ -1228,7 +1230,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             let chunk_index =
                 output_files.insert_for_chunk(options::OutputFile::init(options::OutputFileInit {
                     data: options::OutputFileData::Buffer {
-                        data: code_result.buffer,
+                        data: code_result.buffer.into(),
                     },
                     hash: chunk.template.placeholder.hash,
                     loader: chunk.content.loader(),
@@ -1376,9 +1378,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             loader: Loader::File,
             size: Some(bytes.len()),
             display_size: bytes.len() as u32,
-            data: options::OutputFileData::Buffer {
-                data: bytes.into_boxed_slice(),
-            },
+            data: options::OutputFileData::Buffer { data: bytes.into() },
             side: None,
             entry_point_index: None,
             is_executable: false,
@@ -1397,7 +1397,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             loader: Loader::File,
             size: Some(bytes.len()),
             display_size: bytes.len() as u32,
-            data: options::OutputFileData::Buffer { data: bytes },
+            data: options::OutputFileData::Buffer { data: bytes.into() },
             side: None,
             entry_point_index: None,
             is_executable: false,
@@ -1506,7 +1506,9 @@ fn append_internal_module_bytecode(
             loader: Loader::File,
             size: Some(bytecode.len()),
             display_size: bytecode.len() as u32,
-            data: options::OutputFileData::Buffer { data: bytecode },
+            data: options::OutputFileData::Buffer {
+                data: bytecode.into(),
+            },
             side: None,
             entry_point_index: None,
             is_executable: false,

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -633,10 +633,10 @@ pub(crate) fn write_output_files_to_disk(
             let bytes = if let OutputFileValue::Buffer { bytes } = &mut src.value {
                 core::mem::take(bytes)
             } else {
-                Box::default()
+                bun_alloc::OwnedBytes::new()
             };
-            // `defer src.value.buffer.arena.free(bytes)` — `bytes` is now an
-            // owned Box that drops at end of scope.
+            // `defer src.value.buffer.arena.free(bytes)` — `bytes` now owns the
+            // buffer and frees it through its allocator at end of scope.
 
             let rel_parent = paths::resolve_path::dirname::<paths::platform::Auto>(&src.dest_path);
             if !rel_parent.is_empty() {

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -635,8 +635,6 @@ pub(crate) fn write_output_files_to_disk(
             } else {
                 bun_alloc::OwnedBytes::new()
             };
-            // `defer src.value.buffer.arena.free(bytes)` — `bytes` now owns the
-            // buffer and frees it through its allocator at end of scope.
 
             let rel_parent = paths::resolve_path::dirname::<paths::platform::Auto>(&src.dest_path);
             if !rel_parent.is_empty() {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3016,7 +3016,7 @@ impl<'a> Transpiler<'a> {
                     )?,
                 };
                 output_file.value = crate::output_file::Value::Buffer {
-                    bytes: writer.ctx.written().to_vec().into_boxed_slice(),
+                    bytes: writer.ctx.written().to_vec().into(),
                 };
             }
             options::Loader::Dataurl | options::Loader::Base64 => {
@@ -3212,7 +3212,7 @@ impl<'a> Transpiler<'a> {
             }
         };
         Some(crate::output_file::Value::Buffer {
-            bytes: result.code.into_boxed_slice(),
+            bytes: result.code.into(),
         })
     }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -664,9 +664,7 @@ pub mod store {
             }
         }
 
-        /// Adopt the buffer together with the allocator that owns it (no
-        /// copy). `Drop` frees it through that allocator, so bytes a native
-        /// bundler plugin provided go back through the plugin's callback.
+        /// Adopt the buffer and the allocator that frees it (no copy).
         pub fn from_owned_bytes(bytes: bun_alloc::OwnedBytes) -> Bytes {
             match bytes.into_raw_parts() {
                 Some((ptr, len, allocator)) => Bytes {
@@ -917,8 +915,7 @@ pub mod store {
             Self::init_bytes(Bytes::init(bytes))
         }
 
-        /// Returns a +1-ref heap `Store` over an already-built byte store
-        /// (which may carry a non-global allocator).
+        /// +1-ref heap `Store` over a byte store with any allocator.
         pub fn init_bytes(bytes: Bytes) -> RefPtr<Store> {
             RefPtr::new(Store {
                 data: Data::Bytes(bytes),

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -664,6 +664,22 @@ pub mod store {
             }
         }
 
+        /// Adopt the buffer together with the allocator that owns it (no
+        /// copy). `Drop` frees it through that allocator, so bytes a native
+        /// bundler plugin provided go back through the plugin's callback.
+        pub fn from_owned_bytes(bytes: bun_alloc::OwnedBytes) -> Bytes {
+            match bytes.into_raw_parts() {
+                Some((ptr, len, allocator)) => Bytes {
+                    ptr: Some(ptr),
+                    len: len as SizeType,
+                    cap: len as SizeType,
+                    allocator,
+                    stored_name: Box::default(),
+                },
+                None => Bytes::default(),
+            }
+        }
+
         /// Takes ownership of a `Box<[u8]>` (global allocator, `cap == len`).
         /// Paired with [`Bytes::into_boxed_slice`] for round-tripping the
         /// `is_temporary` handoff in `read_file`.
@@ -898,8 +914,14 @@ pub mod store {
         /// Takes ownership of
         /// `bytes`. Returns a +1-ref heap `Store`.
         pub fn init(bytes: Vec<u8>) -> RefPtr<Store> {
+            Self::init_bytes(Bytes::init(bytes))
+        }
+
+        /// Returns a +1-ref heap `Store` over an already-built byte store
+        /// (which may carry a non-global allocator).
+        pub fn init_bytes(bytes: Bytes) -> RefPtr<Store> {
             RefPtr::new(Store {
-                data: Data::Bytes(Bytes::init(bytes)),
+                data: Data::Bytes(bytes),
                 mime_type: bun_http_types::MimeType::NONE,
                 ref_count: bun_ptr::ThreadSafeRefCount::init(),
                 is_all_ascii: IsAllAscii::default(),

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -2116,6 +2116,25 @@ pub mod cache {
                 unsafe { func(self.ctx) };
             }
         }
+
+        /// Wrap the callback as the allocator of the buffer it frees, so the
+        /// buffer can move into an owner that carries its allocator
+        /// (`bun_alloc::OwnedBytes`, a `Blob` byte store) instead of being
+        /// copied. The callback runs exactly once, on that owner's free.
+        pub fn into_allocator(self) -> bun_alloc::StdAllocator {
+            debug_assert!(self.function.is_some());
+            unsafe fn free(ctx: *mut c_void, _: &mut [u8], _: bun_alloc::Alignment, _: usize) {
+                // SAFETY: `ctx` is the `Box<ExternalFreeFunction>` leaked by
+                // `into_allocator`; the allocator frees each buffer once.
+                let this: Box<ExternalFreeFunction> = unsafe { bun_core::heap::take(ctx.cast()) };
+                this.call();
+            }
+            static VTABLE: bun_alloc::AllocatorVTable = bun_alloc::AllocatorVTable::free_only(free);
+            bun_alloc::StdAllocator {
+                ptr: bun_core::heap::into_raw(Box::new(self)).cast(),
+                vtable: &VTABLE,
+            }
+        }
     }
 
     impl Default for ExternalFreeFunction {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -2117,8 +2117,7 @@ pub mod cache {
             }
         }
 
-        /// The callback as the `StdAllocator` of the buffer it frees, so the buffer
-        /// can move into an owner that carries its allocator (`bun_alloc::OwnedBytes`).
+        /// The callback as the `StdAllocator` that frees the buffer (see `bun_alloc::OwnedBytes`).
         pub fn into_allocator(self) -> bun_alloc::StdAllocator {
             debug_assert!(self.function.is_some());
             unsafe fn free(ctx: *mut c_void, _: &mut [u8], _: bun_alloc::Alignment, _: usize) {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -2117,15 +2117,12 @@ pub mod cache {
             }
         }
 
-        /// Wrap the callback as the allocator of the buffer it frees, so the
-        /// buffer can move into an owner that carries its allocator
-        /// (`bun_alloc::OwnedBytes`, a `Blob` byte store) instead of being
-        /// copied. The callback runs exactly once, on that owner's free.
+        /// The callback as the `StdAllocator` of the buffer it frees, so the buffer
+        /// can move into an owner that carries its allocator (`bun_alloc::OwnedBytes`).
         pub fn into_allocator(self) -> bun_alloc::StdAllocator {
             debug_assert!(self.function.is_some());
             unsafe fn free(ctx: *mut c_void, _: &mut [u8], _: bun_alloc::Alignment, _: usize) {
-                // SAFETY: `ctx` is the `Box<ExternalFreeFunction>` leaked by
-                // `into_allocator`; the allocator frees each buffer once.
+                // SAFETY: `ctx` is the `Box<ExternalFreeFunction>` leaked by `into_allocator`.
                 let this: Box<ExternalFreeFunction> = unsafe { bun_core::heap::take(ctx.cast()) };
                 this.call();
             }

--- a/src/runtime/api/output_file_jsc.rs
+++ b/src/runtime/api/output_file_jsc.rs
@@ -8,6 +8,7 @@
 
 use bun_jsc::{JSGlobalObject, JSValue};
 
+use bun_alloc::OwnedBytes;
 use bun_bundler::options_impl::LoaderExt as _;
 use bun_bundler::output_file::{OutputFile, Value as OutputFileValue};
 use bun_core::Output;
@@ -16,8 +17,9 @@ use bun_http_types::MimeType::MimeType;
 use crate::api::js_bundler::BuildArtifact;
 use crate::node::types::{PathLike, PathOrFileDescriptor};
 use crate::webcore::Blob;
+use crate::webcore::blob::Store as BlobStore;
+use crate::webcore::blob::store::Bytes as BlobBytes;
 use crate::webcore::blob::store::StoreExt as _;
-use crate::webcore::blob::{SizeType as BlobSizeType, Store as BlobStore};
 
 #[inline]
 fn set_blob_mime(blob: &mut Blob, mime: MimeType) {
@@ -28,6 +30,19 @@ fn set_blob_mime(blob: &mut Blob, mime: MimeType) {
         // by `blob`; no other borrow exists yet.
         unsafe { (*store.as_ptr()).mime_type = mime };
     }
+}
+
+/// The output bytes move into the blob's store with their allocator, so a
+/// plugin-provided asset is not copied and is freed through the plugin's
+/// callback when the store is released.
+fn blob_from_output_bytes(bytes: OwnedBytes, global_this: &JSGlobalObject) -> Blob {
+    if bytes.is_empty() {
+        return Blob::init_empty(global_this);
+    }
+    Blob::init_with_store(
+        BlobStore::init_bytes(BlobBytes::from_owned_bytes(bytes)),
+        global_this,
+    )
 }
 
 /// Extension trait wiring `to_js` / `to_blob` onto `OutputFile` from the
@@ -49,7 +64,7 @@ impl OutputFileJsc for OutputFile {
         let value = core::mem::replace(
             &mut self.value,
             OutputFileValue::Buffer {
-                bytes: Box::default(),
+                bytes: OwnedBytes::new(),
             },
         );
 
@@ -108,10 +123,8 @@ impl OutputFileJsc for OutputFile {
                 BuildArtifact::to_js_boxed(build_output, global_object)
             }
             OutputFileValue::Buffer { bytes } => {
-                let bytes_len = bytes.len();
-                let mut blob = Blob::init(bytes.into_vec(), global_object);
+                let mut blob = blob_from_output_bytes(bytes, global_object);
                 set_blob_mime(&mut blob, mime);
-                blob.size.set(bytes_len as BlobSizeType);
 
                 let path: Box<[u8]> = match owned_pathname {
                     Some(p) => Box::from(p),
@@ -144,7 +157,7 @@ impl OutputFileJsc for OutputFile {
         let value = core::mem::replace(
             &mut self.value,
             OutputFileValue::Buffer {
-                bytes: Box::default(),
+                bytes: OwnedBytes::new(),
             },
         );
 
@@ -168,10 +181,8 @@ impl OutputFileJsc for OutputFile {
                 Ok(Blob::init_with_store(file_blob, global_this))
             }
             OutputFileValue::Buffer { bytes } => {
-                let bytes_len = bytes.len();
-                let mut blob = Blob::init(bytes.into_vec(), global_this);
+                let mut blob = blob_from_output_bytes(bytes, global_this);
                 set_blob_mime(&mut blob, mime);
-                blob.size.set(bytes_len as BlobSizeType);
                 Ok(blob)
             }
             OutputFileValue::Noop => {

--- a/src/runtime/api/output_file_jsc.rs
+++ b/src/runtime/api/output_file_jsc.rs
@@ -32,9 +32,7 @@ fn set_blob_mime(blob: &mut Blob, mime: MimeType) {
     }
 }
 
-/// The output bytes move into the blob's store with their allocator, so a
-/// plugin-provided asset is not copied and is freed through the plugin's
-/// callback when the store is released.
+/// The bytes move into the blob's store with their allocator (no copy).
 fn blob_from_output_bytes(bytes: OwnedBytes, global_this: &JSGlobalObject) -> Blob {
     if bytes.is_empty() {
         return Blob::init_empty(global_this);

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1331,7 +1331,7 @@ pub(crate) fn collect_compile_assets(
                 size: bytes.len(),
                 size_without_sourcemap: bytes.len(),
                 value: options::OutputFileValue::Buffer {
-                    bytes: bytes.into_boxed_slice(),
+                    bytes: bytes.into(),
                 },
                 side: Some(options::Side::Client),
                 ..options::OutputFile::zero_value()

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -744,11 +744,12 @@ console.log(JSON.stringify(json))
     expect(exitCode).toBe(0);
   });
 
-  it("hands a plugin-provided file-loader asset to the build artifact without copying it", async () => {
+  it("hands a plugin-provided file-loader asset to the output without copying it", async () => {
     // `.bin` has no default loader, so the import uses the `file` loader and the
-    // plugin-provided bytes become the asset. Without `outdir` the asset stays
-    // in memory as the artifact's blob, so the plugin buffer must stay alive
-    // (not freed) for as long as the artifact does.
+    // plugin-provided bytes become the asset. The plugin buffer is freed through
+    // the plugin's callback when the output that owns it is done with it: right
+    // after the asset is written to `outdir`, and not while an in-memory build
+    // artifact still holds the bytes.
     await Bun.write(path.join(tempdir, "asset_needs_foo.bin"), "asset foo\n");
     await Bun.write(
       path.join(tempdir, "asset_entry.ts"),
@@ -760,38 +761,27 @@ console.log(JSON.stringify(json))
       const tempdir = process.env.BUN_TEST_TEMP_DIR!;
       const napiModule = require(path.join(tempdir, "build/Release/xXx123_foo_counter_321xXx.node"));
       const external = napiModule.createExternal();
+      const entrypoints = [path.join(tempdir, "asset_entry.ts")];
+      const plugins = [
+        {
+          name: "xXx123_foo_counter_321xXx",
+          setup(build) {
+            build.onBeforeParse({ filter: /\\.bin$/ }, { napiModule, symbol: "plugin_impl", external });
+          },
+        },
+      ];
 
-      async function build() {
-        const result = await Bun.build({
-          entrypoints: [path.join(tempdir, "asset_entry.ts")],
-          plugins: [
-            {
-              name: "xXx123_foo_counter_321xXx",
-              setup(build) {
-                build.onBeforeParse({ filter: /\\.bin$/ }, { napiModule, symbol: "plugin_impl", external });
-              },
-            },
-          ],
-        });
-        const asset = result.outputs.find(output => output.kind === "asset");
-        return {
-          success: result.success,
-          text: asset ? await asset.text() : null,
-          freedWhileAlive: napiModule.getCompilationCtxFreedCount(external),
-        };
-      }
+      const written = await Bun.build({ entrypoints, plugins, outdir: path.join(tempdir, "dist-plugin-asset") });
+      const writtenAsset = written.outputs.find(output => output.kind === "asset");
+      const onDisk = writtenAsset ? await writtenAsset.text() : null;
+      const freedAfterWrite = napiModule.getCompilationCtxFreedCount(external);
 
-      let summary = await build();
-      console.log(JSON.stringify(summary));
-      // The artifact is unreachable now, and so is \`text\` (an ASCII blob's
-      // text() is an external string over the store's bytes). Collecting them
-      // releases the store, which frees the plugin buffer through the callback.
-      summary = null;
-      for (let i = 0; i < 20 && napiModule.getCompilationCtxFreedCount(external) === 0; i++) {
-        Bun.gc(true);
-        await Bun.sleep(0);
-      }
-      console.log(JSON.stringify({ freedAfterRelease: napiModule.getCompilationCtxFreedCount(external) }));
+      const inMemory = await Bun.build({ entrypoints, plugins });
+      const asset = inMemory.outputs.find(output => output.kind === "asset");
+      const text = asset ? await asset.text() : null;
+      const freedWhileAlive = napiModule.getCompilationCtxFreedCount(external);
+
+      console.log(JSON.stringify({ written: written.success, onDisk, freedAfterWrite, inMemory: inMemory.success, text, freedWhileAlive }));
     `;
     await Bun.write(path.join(tempdir, "asset_entry_build.ts"), buildScript);
 
@@ -805,13 +795,18 @@ console.log(JSON.stringify(json))
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const lines = stdout.split("\n");
-    const summaryLine = lines.find(line => line.startsWith('{"success"'));
-    const releasedLine = lines.find(line => line.startsWith('{"freedAfterRelease"'));
-    const summary = summaryLine ? JSON.parse(summaryLine) : { stderr, stdout };
-    expect(summary).toEqual({ success: true, text: "asset qoo\n", freedWhileAlive: 0 });
-    expect(releasedLine).toBe('{"freedAfterRelease":1}');
-    expect(stdout.split("Freed compilation ctx!").length - 1).toBe(1);
+    const resultLine = stdout.split("\n").find(line => line.startsWith('{"written"'));
+    const parsed = resultLine ? JSON.parse(resultLine) : { stderr, stdout };
+    expect(parsed).toEqual({
+      written: true,
+      onDisk: "asset qoo\n",
+      freedAfterWrite: 1,
+      inMemory: true,
+      text: "asset qoo\n",
+      // The in-memory artifact owns the second buffer; the count would be 2 if
+      // the bundle had copied the asset and freed the plugin's buffer itself.
+      freedWhileAlive: 1,
+    });
     expect(exitCode).toBe(0);
   });
 

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -810,6 +810,56 @@ console.log(JSON.stringify(json))
     expect(exitCode).toBe(0);
   });
 
+  it("copies a file-loader asset the plugin fetched but did not replace", async () => {
+    // `plugin_impl_keep_source` returns Bun's own fetched buffer and only sets a
+    // context to free. That buffer is not the plugin's, so the asset must be
+    // copied as usual and the context freed when the build finishes, even
+    // though the artifact stays alive.
+    await Bun.write(path.join(tempdir, "asset_plain.bin"), "asset plain\n");
+    await Bun.write(
+      path.join(tempdir, "asset_plain_entry.ts"),
+      `import asset from "./asset_plain.bin";\nconsole.log(asset);\n`,
+    );
+
+    const buildScript = /* ts */ `
+      import * as path from "path";
+      const tempdir = process.env.BUN_TEST_TEMP_DIR!;
+      const napiModule = require(path.join(tempdir, "build/Release/xXx123_foo_counter_321xXx.node"));
+      const external = napiModule.createExternal();
+
+      const result = await Bun.build({
+        entrypoints: [path.join(tempdir, "asset_plain_entry.ts")],
+        plugins: [
+          {
+            name: "xXx123_foo_counter_321xXx",
+            setup(build) {
+              build.onBeforeParse({ filter: /\\.bin$/ }, { napiModule, symbol: "plugin_impl_keep_source", external });
+            },
+          },
+        ],
+      });
+      const asset = result.outputs.find(output => output.kind === "asset");
+      const text = asset ? await asset.text() : null;
+      console.log(JSON.stringify({ success: result.success, text, freed: napiModule.getCompilationCtxFreedCount(external) }));
+    `;
+    await Bun.write(path.join(tempdir, "asset_plain_build.ts"), buildScript);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", path.join(tempdir, "asset_plain_build.ts")],
+      env: { ...bunEnv, BUN_TEST_TEMP_DIR: tempdir },
+      cwd: tempdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const resultLine = stdout.split("\n").find(line => line.startsWith('{"success"'));
+    const parsed = resultLine ? JSON.parse(resultLine) : { stderr, stdout };
+    expect(parsed).toEqual({ success: true, text: "asset plain\n", freed: 1 });
+    expect(exitCode).toBe(0);
+  });
+
   type AdditionalFile = {
     name: string;
     contents: BunFile | string;

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -744,6 +744,77 @@ console.log(JSON.stringify(json))
     expect(exitCode).toBe(0);
   });
 
+  it("hands a plugin-provided file-loader asset to the build artifact without copying it", async () => {
+    // `.bin` has no default loader, so the import uses the `file` loader and the
+    // plugin-provided bytes become the asset. Without `outdir` the asset stays
+    // in memory as the artifact's blob, so the plugin buffer must stay alive
+    // (not freed) for as long as the artifact does.
+    await Bun.write(path.join(tempdir, "asset_needs_foo.bin"), "asset foo\n");
+    await Bun.write(
+      path.join(tempdir, "asset_entry.ts"),
+      `import asset from "./asset_needs_foo.bin";\nconsole.log(asset);\n`,
+    );
+
+    const buildScript = /* ts */ `
+      import * as path from "path";
+      const tempdir = process.env.BUN_TEST_TEMP_DIR!;
+      const napiModule = require(path.join(tempdir, "build/Release/xXx123_foo_counter_321xXx.node"));
+      const external = napiModule.createExternal();
+
+      async function build() {
+        const result = await Bun.build({
+          entrypoints: [path.join(tempdir, "asset_entry.ts")],
+          plugins: [
+            {
+              name: "xXx123_foo_counter_321xXx",
+              setup(build) {
+                build.onBeforeParse({ filter: /\\.bin$/ }, { napiModule, symbol: "plugin_impl", external });
+              },
+            },
+          ],
+        });
+        const asset = result.outputs.find(output => output.kind === "asset");
+        return {
+          success: result.success,
+          text: asset ? await asset.text() : null,
+          freedWhileAlive: napiModule.getCompilationCtxFreedCount(external),
+        };
+      }
+
+      let summary = await build();
+      console.log(JSON.stringify(summary));
+      // The artifact is unreachable now, and so is \`text\` (an ASCII blob's
+      // text() is an external string over the store's bytes). Collecting them
+      // releases the store, which frees the plugin buffer through the callback.
+      summary = null;
+      for (let i = 0; i < 20 && napiModule.getCompilationCtxFreedCount(external) === 0; i++) {
+        Bun.gc(true);
+        await Bun.sleep(0);
+      }
+      console.log(JSON.stringify({ freedAfterRelease: napiModule.getCompilationCtxFreedCount(external) }));
+    `;
+    await Bun.write(path.join(tempdir, "asset_entry_build.ts"), buildScript);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", path.join(tempdir, "asset_entry_build.ts")],
+      env: { ...bunEnv, BUN_TEST_TEMP_DIR: tempdir },
+      cwd: tempdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const lines = stdout.split("\n");
+    const summaryLine = lines.find(line => line.startsWith('{"success"'));
+    const releasedLine = lines.find(line => line.startsWith('{"freedAfterRelease"'));
+    const summary = summaryLine ? JSON.parse(summaryLine) : { stderr, stdout };
+    expect(summary).toEqual({ success: true, text: "asset qoo\n", freedWhileAlive: 0 });
+    expect(releasedLine).toBe('{"freedAfterRelease":1}');
+    expect(stdout.split("Freed compilation ctx!").length - 1).toBe(1);
+    expect(exitCode).toBe(0);
+  });
+
   type AdditionalFile = {
     name: string;
     contents: BunFile | string;

--- a/test/bundler/native_plugin.cc
+++ b/test/bundler/native_plugin.cc
@@ -672,4 +672,22 @@ plugin_impl_bad_free_function_pointer(const OnBeforeParseArguments *args,
   result->free_plugin_source_code_context = random_user_context_free;
 }
 
+// Fetches the source and keeps it as-is: `source_ptr` stays Bun's own buffer,
+// but the plugin still hands Bun a context to free.
+extern "C" BUN_PLUGIN_EXPORT void
+plugin_impl_keep_source(const OnBeforeParseArguments *args,
+                        OnBeforeParseResult *result) {
+  if (result->fetchSourceCode(args, result) != 0) {
+    exit(1);
+  }
+  std::atomic<size_t> *free_counter = nullptr;
+  if (args->external) {
+    free_counter = &((External *)args->external)->compilation_ctx_freed_count;
+  }
+  result->plugin_source_code_context =
+      compilation_ctx_new(nullptr, 0, free_counter);
+  result->free_plugin_source_code_context =
+      (void (*)(void *))compilation_ctx_free;
+}
+
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
### Problem
- A native `onBeforeParse` plugin that provides the bytes of a copy-loader asset (`file`, `wasm`, `napi`, `sqlite`) pays one extra copy of the whole asset. `on_parse_task_complete` (`src/bundler/bundle_v2.rs:7114`) always parked the plugin's free callback in `finalizers`, so `source.contents` stayed a `Cow::Borrowed` alias and `process_files_to_copy` (`bundle_v2.rs:4406`) hit `Cow::Borrowed(b) => Box::from(b)`.
- The Zig bundler had an `InputFile.allocator` column for this. The Rust port dropped it, and with it the zero-copy handoff.

### Fix
- `OutputFile::Value::Buffer` holds a new `bun_alloc::OwnedBytes` (buffer plus the `StdAllocator` that frees it) instead of `Box<[u8]>`. Bundler output keeps the global allocator. A plugin buffer gets `ExternalFreeFunction::into_allocator()`, which wraps the callback as its deallocator.
- `OnBeforeParsePlugin::run` records `ParseTask.plugin_owns_source` when the plugin returned its own buffer. Only then does `on_parse_task_complete` keep the callback of a copy-loader asset in `BundleV2.asset_free_functions` (by source index) for `process_files_to_copy` to adopt the buffer. A plugin that kept the fetched (worker-arena) source and set a free context is copied as before. Callbacks of assets that are never emitted still run at teardown.
- `Bytes::from_owned_bytes` moves the buffer into the artifact's Blob store with its allocator, so `Bun.build()` artifacts are zero-copy too. The callback runs exactly once, when the last owner (`OutputFile`, artifact, or a `text()` string) releases the bytes.
- Verified: `test/bundler/native-plugin.test.ts` (two new tests, the first fails on stock bun with `freedWhileAlive: 2`). Also `bun-build-api`, `bundler_plugin`, `bundler_loader`, `bundler_files`, `bundler_html`, `bun-build-compile`.

### Background
- `onBeforeParse` native plugins return `source_ptr`/`source_len` and a `free_plugin_source_code_context(ctx)` callback. The bundle owns the bytes until it calls the callback. A plugin can also call `fetchSourceCode`, keep Bun's buffer as the result, and still set a context to free.
- A copy loader emits the source bytes unchanged as an asset `OutputFile`. With `outdir` the bytes are written and dropped on the bundle thread. For an in-memory build the `OutputFile` becomes a `BuildArtifact` whose Blob store owns the bytes.
- `StdAllocator` (`bun_alloc`) is a `{ptr, vtable}` free handle already used by the Blob `Bytes` store (mmap, memfd). `OwnedBytes` is the same idea for a plain byte buffer.

<details><summary>Notes</summary>

- Test 1 builds twice with the same plugin `external`. With `outdir`, the callback has run exactly once when `Bun.build()` resolves (the asset was written and its buffer dropped). In memory, the count is still 1 while the artifact is alive. Stock bun reports 2 there: it copied the asset and freed the plugin's buffer at teardown.
- Test 2 uses the new fixture symbol `plugin_impl_keep_source` (fetch, keep `source_ptr`, set a free context) on a `file` import. The context is freed when the build resolves (`freed: 1`) and the asset text is the original file. Without the `plugin_owns_source` guard the bundle adopted the arena bytes and reported `freed: 0`.
- An earlier version of test 1 waited for a GC to free the in-memory artifact. That was not reliable on the release lanes (`freedAfterRelease: 0`), so the test asserts only the deterministic points.
- `OwnedBytes::drop` uses `raw_free`, not `StdAllocator::free`: the latter skips empty slices, but a plugin callback must run for a zero-length buffer too. `Bytes::drop` does skip empty slices, so `blob_from_output_bytes` drops an empty `OwnedBytes` itself and makes an empty Blob.
- The decision uses the parse result's loader (the loader after the plugin ran), not the loader column that `on_parse_task_complete` updates later. This composes with #38172, which makes the plugin-chosen loader take effect.
- `Value` no longer derives `Clone` (nothing used it; a clone would be the copy this PR removes). `OptionsData::Buffer` construction sites use `.into()`.
- `asset.text()` on an ASCII artifact is an external string over the store bytes, so the store (and the plugin buffer) lives as long as that string too.
- Slow-in-debug tests (`bytecode: ...`, `--compile --bytecode`, 400 builds) time out at their default budget in this container's ASAN build and pass with a longer timeout. Unrelated to this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/native-plugin.test.ts

<!-- robobun:evidence:end -->