### PR TITLE
Lower the .bun section alignment on ELF so PT_LOAD segments do not overlap

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1114,16 +1114,14 @@ extern "C" void Bun__signpost_emit(os_log_t log, os_signpost_type_t type, os_sig
 #if OS(DARWIN) || defined(__linux__) || defined(__FreeBSD__)
 
 #if OS(DARWIN)
-// exe_format/macho.rs expands the __BUN segment in place and keeps the payload
-// 16KB-aligned (the page size on Apple Silicon).
+// exe_format/macho.rs expands the __BUN segment in place at this alignment
+// (the page size on Apple Silicon).
 #define BLOB_HEADER_ALIGNMENT (16 * 1024)
 #else
-// On ELF the section only ever holds this 8-byte header; exe_format/elf.rs
-// appends the payload at a page-aligned vaddr. An alignment above the linker's
-// max-page-size raises the RW PT_LOAD's p_align past the other segments', and
-// lld then places it so that round_down(p_vaddr, p_align) overlaps the previous
-// segment's pages. The kernel ignores p_align at execve so the binary runs, but
-// strict loaders (UPX's stub) map the overlap and corrupt the image (#40752).
+// ELF: the section holds only this 8-byte header; exe_format/elf.rs places the
+// --compile payload at a page-aligned vaddr itself. A larger alignment raises
+// the RW PT_LOAD's p_align past the page size, which makes it overlap the
+// previous segment under strict-p_align loaders like UPX's stub (#40752).
 #define BLOB_HEADER_ALIGNMENT 8
 #endif
 

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1113,7 +1113,19 @@ extern "C" void Bun__signpost_emit(os_log_t log, os_signpost_type_t type, os_sig
 
 #if OS(DARWIN) || defined(__linux__) || defined(__FreeBSD__)
 
-#define BLOB_HEADER_ALIGNMENT 16 * 1024
+#if OS(DARWIN)
+// exe_format/macho.rs expands the __BUN segment in place and keeps the payload
+// 16KB-aligned (the page size on Apple Silicon).
+#define BLOB_HEADER_ALIGNMENT (16 * 1024)
+#else
+// On ELF the section only ever holds this 8-byte header; exe_format/elf.rs
+// appends the payload at a page-aligned vaddr. An alignment above the linker's
+// max-page-size raises the RW PT_LOAD's p_align past the other segments', and
+// lld then places it so that round_down(p_vaddr, p_align) overlaps the previous
+// segment's pages. The kernel ignores p_align at execve so the binary runs, but
+// strict loaders (UPX's stub) map the overlap and corrupt the image (#40752).
+#define BLOB_HEADER_ALIGNMENT 8
+#endif
 
 extern "C" {
 struct BlobHeader {

--- a/test/bundler/compile-elf-segment-layout.test.ts
+++ b/test/bundler/compile-elf-segment-layout.test.ts
@@ -115,11 +115,7 @@ test.skipIf(!isLinux)(
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [, buildErr, buildExit] = await Promise.all([
-      build.stdout.text(),
-      build.stderr.text(),
-      build.exited,
-    ]);
+    const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect(buildErr).not.toContain("error:");
     expect(buildExit).toBe(0);
 

--- a/test/bundler/compile-elf-segment-layout.test.ts
+++ b/test/bundler/compile-elf-segment-layout.test.ts
@@ -16,8 +16,8 @@
 // https://github.com/oven-sh/bun/issues/40752
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isFreeBSD, isLinux, readElf64ProgramHeaders, tempDir } from "harness";
 import type { Elf64ProgramHeader } from "harness";
+import { bunEnv, bunExe, isFreeBSD, isLinux, readElf64ProgramHeaders, tempDir } from "harness";
 import { join } from "node:path";
 
 type LoadSegment = Pick<Elf64ProgramHeader, "vaddr" | "memsz" | "align">;

--- a/test/bundler/compile-elf-segment-layout.test.ts
+++ b/test/bundler/compile-elf-segment-layout.test.ts
@@ -16,55 +16,15 @@
 // https://github.com/oven-sh/bun/issues/40752
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { closeSync, openSync, readSync } from "node:fs";
+import { bunEnv, bunExe, isFreeBSD, isLinux, readElf64ProgramHeaders, tempDir } from "harness";
+import type { Elf64ProgramHeader } from "harness";
 import { join } from "node:path";
 
-/** Read `len` bytes from `fd` at absolute `offset`. */
-function preadExact(fd: number, offset: number, len: number): Buffer {
-  const buf = Buffer.alloc(len);
-  let got = 0;
-  while (got < len) {
-    const n = readSync(fd, buf, got, len - got, offset + got);
-    if (n === 0) throw new Error(`short read at ${offset}`);
-    got += n;
-  }
-  return buf;
-}
+type LoadSegment = Pick<Elf64ProgramHeader, "vaddr" | "memsz" | "align">;
 
-interface LoadSegment {
-  vaddr: bigint;
-  memsz: bigint;
-  align: bigint;
-}
-
-/** PT_LOAD program headers of an ELF64 little-endian file. */
+/** PT_LOAD program headers of an ELF64 file. */
 function readLoadSegments(path: string): LoadSegment[] {
-  const fd = openSync(path, "r");
-  try {
-    const ehdr = preadExact(fd, 0, 64);
-    if (ehdr.readUInt32BE(0) !== 0x7f454c46) throw new Error("not ELF");
-    if (ehdr[4] !== 2) throw new Error("only ELF64 supported"); // EI_CLASS
-    if (ehdr[5] !== 1) throw new Error("only little-endian supported"); // EI_DATA
-
-    const e_phoff = Number(ehdr.readBigUInt64LE(32));
-    const e_phentsize = ehdr.readUInt16LE(54);
-    const e_phnum = ehdr.readUInt16LE(56);
-
-    const loads: LoadSegment[] = [];
-    for (let i = 0; i < e_phnum; i++) {
-      const ph = preadExact(fd, e_phoff + i * e_phentsize, e_phentsize);
-      if (ph.readUInt32LE(0) !== 1 /* PT_LOAD */) continue;
-      loads.push({
-        vaddr: ph.readBigUInt64LE(16),
-        memsz: ph.readBigUInt64LE(40),
-        align: ph.readBigUInt64LE(48),
-      });
-    }
-    return loads;
-  } finally {
-    closeSync(fd);
-  }
+  return readElf64ProgramHeaders(path).filter(ph => ph.type === 1 /* PT_LOAD */);
 }
 
 /**
@@ -95,11 +55,11 @@ function expectNoOverlap(path: string) {
   }
 }
 
-test.skipIf(!isLinux)("bun binary has no PT_LOAD overlap under strict p_align", () => {
+test.skipIf(!(isLinux || isFreeBSD))("bun binary has no PT_LOAD overlap under strict p_align", () => {
   expectNoOverlap(bunExe());
 });
 
-test.skipIf(!isLinux)(
+test.skipIf(!(isLinux || isFreeBSD))(
   "compiled executable has no PT_LOAD overlap under strict p_align",
   async () => {
     using dir = tempDir("elf-segment-layout", {

--- a/test/bundler/compile-elf-segment-layout.test.ts
+++ b/test/bundler/compile-elf-segment-layout.test.ts
@@ -115,7 +115,11 @@ test.skipIf(!isLinux)(
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [buildErr, buildExit] = await Promise.all([build.stderr.text(), build.exited]);
+    const [, buildErr, buildExit] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
     expect(buildErr).not.toContain("error:");
     expect(buildExit).toBe(0);
 

--- a/test/bundler/compile-elf-segment-layout.test.ts
+++ b/test/bundler/compile-elf-segment-layout.test.ts
@@ -16,8 +16,8 @@
 // https://github.com/oven-sh/bun/issues/40752
 
 import { expect, test } from "bun:test";
-import { closeSync, openSync, readSync } from "node:fs";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { closeSync, openSync, readSync } from "node:fs";
 import { join } from "node:path";
 
 /** Read `len` bytes from `fd` at absolute `offset`. */
@@ -122,11 +122,7 @@ test.skipIf(!isLinux)(
     expectNoOverlap(out);
 
     await using run = Bun.spawn({ cmd: [out], env: bunEnv, cwd, stderr: "pipe", stdout: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      run.stdout.text(),
-      run.stderr.text(),
-      run.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("hello from compiled\n");
     expect(exitCode).toBe(0);

--- a/test/bundler/compile-elf-segment-layout.test.ts
+++ b/test/bundler/compile-elf-segment-layout.test.ts
@@ -1,0 +1,135 @@
+// The `.bun` section (the standalone module graph header) used to be declared
+// with 16KB alignment on ELF. That raised the RW PT_LOAD's p_align to 0x4000
+// while the other segments stayed at 0x1000, and lld assigned the RW p_vaddr
+// without keeping round_down(p_vaddr, 0x4000) clear of the previous segment's
+// pages. The kernel ignores p_align at execve, so the plain binary ran, but a
+// loader that honors p_align (UPX's decompression stub) mapped the RW segment
+// over the tail of the R E segment and the embedded module source read back
+// corrupted: `SyntaxError: Invalid character: '\0'`.
+//
+// These tests assert the strict-p_align non-overlap invariant on the bun
+// binary itself and on a `--compile` output (the file UPX processes):
+// for each PT_LOAD pair sorted by vaddr,
+//   round_down(next.p_vaddr, next.align) >= round_up(prev.p_vaddr + prev.p_memsz, prev.align)
+// where align = max(p_align, page size).
+//
+// https://github.com/oven-sh/bun/issues/40752
+
+import { expect, test } from "bun:test";
+import { closeSync, openSync, readSync } from "node:fs";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+/** Read `len` bytes from `fd` at absolute `offset`. */
+function preadExact(fd: number, offset: number, len: number): Buffer {
+  const buf = Buffer.alloc(len);
+  let got = 0;
+  while (got < len) {
+    const n = readSync(fd, buf, got, len - got, offset + got);
+    if (n === 0) throw new Error(`short read at ${offset}`);
+    got += n;
+  }
+  return buf;
+}
+
+interface LoadSegment {
+  vaddr: bigint;
+  memsz: bigint;
+  align: bigint;
+}
+
+/** PT_LOAD program headers of an ELF64 little-endian file. */
+function readLoadSegments(path: string): LoadSegment[] {
+  const fd = openSync(path, "r");
+  try {
+    const ehdr = preadExact(fd, 0, 64);
+    if (ehdr.readUInt32BE(0) !== 0x7f454c46) throw new Error("not ELF");
+    if (ehdr[4] !== 2) throw new Error("only ELF64 supported"); // EI_CLASS
+    if (ehdr[5] !== 1) throw new Error("only little-endian supported"); // EI_DATA
+
+    const e_phoff = Number(ehdr.readBigUInt64LE(32));
+    const e_phentsize = ehdr.readUInt16LE(54);
+    const e_phnum = ehdr.readUInt16LE(56);
+
+    const loads: LoadSegment[] = [];
+    for (let i = 0; i < e_phnum; i++) {
+      const ph = preadExact(fd, e_phoff + i * e_phentsize, e_phentsize);
+      if (ph.readUInt32LE(0) !== 1 /* PT_LOAD */) continue;
+      loads.push({
+        vaddr: ph.readBigUInt64LE(16),
+        memsz: ph.readBigUInt64LE(40),
+        align: ph.readBigUInt64LE(48),
+      });
+    }
+    return loads;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Mapped range of a PT_LOAD under strict p_align semantics: what a loader
+ * that honors p_align (like UPX's stub) maps for the segment.
+ */
+function strictRange({ vaddr, memsz, align }: LoadSegment): [bigint, bigint] {
+  const a = align > 0x1000n ? align : 0x1000n; // mapping granularity is at least a page
+  const start = vaddr & ~(a - 1n);
+  const end = (vaddr + memsz + a - 1n) & ~(a - 1n);
+  return [start, end];
+}
+
+function expectNoOverlap(path: string) {
+  const loads = readLoadSegments(path).sort((a, b) => (a.vaddr < b.vaddr ? -1 : 1));
+  expect(loads.length).toBeGreaterThan(1);
+  for (let i = 1; i < loads.length; i++) {
+    const [, prevEnd] = strictRange(loads[i - 1]);
+    const [nextStart] = strictRange(loads[i]);
+    if (nextStart < prevEnd) {
+      const fmt = (s: LoadSegment) =>
+        `vaddr=0x${s.vaddr.toString(16)} memsz=0x${s.memsz.toString(16)} align=0x${s.align.toString(16)}`;
+      throw new Error(
+        `PT_LOAD segments overlap under strict p_align semantics by 0x${(prevEnd - nextStart).toString(16)} bytes:\n` +
+          `  ${fmt(loads[i - 1])}\n  ${fmt(loads[i])}`,
+      );
+    }
+  }
+}
+
+test.skipIf(!isLinux)("bun binary has no PT_LOAD overlap under strict p_align", () => {
+  expectNoOverlap(bunExe());
+});
+
+test.skipIf(!isLinux)(
+  "compiled executable has no PT_LOAD overlap under strict p_align",
+  async () => {
+    using dir = tempDir("elf-segment-layout", {
+      "index.ts": `console.log("hello from compiled");`,
+    });
+    const cwd = String(dir);
+    const out = join(cwd, "app");
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", join(cwd, "index.ts"), "--outfile", out],
+      env: bunEnv,
+      cwd,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [buildErr, buildExit] = await Promise.all([build.stderr.text(), build.exited]);
+    expect(buildErr).not.toContain("error:");
+    expect(buildExit).toBe(0);
+
+    expectNoOverlap(out);
+
+    await using run = Bun.spawn({ cmd: [out], env: bunEnv, cwd, stderr: "pipe", stdout: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      run.stdout.text(),
+      run.stderr.text(),
+      run.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("hello from compiled\n");
+    expect(exitCode).toBe(0);
+  },
+  180_000,
+);

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2308,3 +2308,63 @@ export const rss: () => number =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? (Bun.unsafe.memoryFootprint as () => number)
     : process.memoryUsage.rss;
+
+/** Read exactly `len` bytes from `fd` at absolute `offset`. */
+export function preadExact(fd: number, offset: number, len: number): Buffer {
+  const buf = Buffer.alloc(len);
+  let got = 0;
+  while (got < len) {
+    const n = fs.readSync(fd, buf, got, len - got, offset + got);
+    if (n === 0) throw new Error(`short read at ${offset}`);
+    got += n;
+  }
+  return buf;
+}
+
+/** One ELF64 program header, fields as in Elf64_Phdr. */
+export interface Elf64ProgramHeader {
+  type: number;
+  flags: number;
+  offset: bigint;
+  vaddr: bigint;
+  paddr: bigint;
+  filesz: bigint;
+  memsz: bigint;
+  align: bigint;
+}
+
+/** Program headers of an ELF64 binary (either endianness). */
+export function readElf64ProgramHeaders(path: string): Elf64ProgramHeader[] {
+  const fd = openSync(path, "r");
+  try {
+    const ehdr = preadExact(fd, 0, 64);
+    if (ehdr.readUInt32BE(0) !== 0x7f454c46) throw new Error("not ELF");
+    if (ehdr[4] !== 2) throw new Error("only ELF64 supported"); // EI_CLASS
+    const le = ehdr[5] === 1; // EI_DATA
+    const u16 = (b: Buffer, o: number) => (le ? b.readUInt16LE(o) : b.readUInt16BE(o));
+    const u32 = (b: Buffer, o: number) => (le ? b.readUInt32LE(o) : b.readUInt32BE(o));
+    const u64 = (b: Buffer, o: number) => (le ? b.readBigUInt64LE(o) : b.readBigUInt64BE(o));
+
+    const e_phoff = Number(u64(ehdr, 32));
+    const e_phentsize = u16(ehdr, 54);
+    const e_phnum = u16(ehdr, 56);
+
+    const headers: Elf64ProgramHeader[] = [];
+    for (let i = 0; i < e_phnum; i++) {
+      const ph = preadExact(fd, e_phoff + i * e_phentsize, e_phentsize);
+      headers.push({
+        type: u32(ph, 0),
+        flags: u32(ph, 4),
+        offset: u64(ph, 8),
+        vaddr: u64(ph, 16),
+        paddr: u64(ph, 24),
+        filesz: u64(ph, 32),
+        memsz: u64(ph, 40),
+        align: u64(ph, 48),
+      });
+    }
+    return headers;
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/test/js/bun/binary/tls-segment-size.test.ts
+++ b/test/js/bun/binary/tls-segment-size.test.ts
@@ -15,20 +15,8 @@
 // every platform rather than only showing up as a Windows size bump.
 
 import { describe, expect, test } from "bun:test";
-import { isFreeBSD, isLinux, isWindows } from "harness";
-import { closeSync, openSync, readSync } from "node:fs";
-
-/** Read `len` bytes from `fd` at absolute `offset`. */
-function preadExact(fd: number, offset: number, len: number): Buffer {
-  const buf = Buffer.alloc(len);
-  let got = 0;
-  while (got < len) {
-    const n = readSync(fd, buf, got, len - got, offset + got);
-    if (n === 0) throw new Error(`short read at ${offset}`);
-    got += n;
-  }
-  return buf;
-}
+import { isFreeBSD, isLinux, isWindows, preadExact, readElf64ProgramHeaders } from "harness";
+import { closeSync, openSync } from "node:fs";
 
 /**
  * ELF: size of the PT_TLS segment's in-memory template (p_memsz). This is
@@ -37,30 +25,8 @@ function preadExact(fd: number, offset: number, len: number): Buffer {
  * the main image.
  */
 function elfTlsMemSize(path: string): number {
-  const fd = openSync(path, "r");
-  try {
-    const ehdr = preadExact(fd, 0, 64);
-    if (ehdr.readUInt32BE(0) !== 0x7f454c46) throw new Error("not ELF");
-    if (ehdr[4] !== 2) throw new Error("only ELF64 supported"); // EI_CLASS
-    const le = ehdr[5] === 1; // EI_DATA
-    const u16 = (b: Buffer, o: number) => (le ? b.readUInt16LE(o) : b.readUInt16BE(o));
-    const u64 = (b: Buffer, o: number) => (le ? b.readBigUInt64LE(o) : b.readBigUInt64BE(o));
-
-    const e_phoff = Number(u64(ehdr, 32));
-    const e_phentsize = u16(ehdr, 54);
-    const e_phnum = u16(ehdr, 56);
-
-    for (let i = 0; i < e_phnum; i++) {
-      const ph = preadExact(fd, e_phoff + i * e_phentsize, e_phentsize);
-      const p_type = le ? ph.readUInt32LE(0) : ph.readUInt32BE(0);
-      if (p_type === 7 /* PT_TLS */) {
-        return Number(u64(ph, 40)); // p_memsz
-      }
-    }
-    return 0; // no TLS segment
-  } finally {
-    closeSync(fd);
-  }
+  const tls = readElf64ProgramHeaders(path).find(ph => ph.type === 7 /* PT_TLS */);
+  return tls ? Number(tls.memsz) : 0;
 }
 
 /**


### PR DESCRIPTION
### Problem
- A UPX-compressed `bun build --compile` executable fails on linux with `SyntaxError: Invalid character: '\0'` (#40752). The uncompressed executable runs.
- The `.bun` section is declared with 16KB alignment (`BLOB_HEADER_ALIGNMENT` in `src/jsc/bindings/c-bindings.cpp`). That raises the RW `PT_LOAD`'s `p_align` to 0x4000 while every other segment stays at 0x1000, and lld assigns the RW `p_vaddr` so that `round_down(p_vaddr, p_align)` overlaps the last pages of the executable segment. Linux `execve` ignores `p_align`, so the plain binary runs. UPX's stub honors it, maps the overlap, and the embedded module source reads back corrupted.

### Fix
- Keep `BLOB_HEADER_ALIGNMENT` at 16KB on Mach-O, where `exe_format/macho.rs` expands the `__BUN` segment in place at that alignment. Lower it to 8 on ELF.
- On ELF the section only ever holds the 8-byte header. `exe_format/elf.rs` appends the `--compile` payload at a page-aligned virtual address it computes itself, so nothing depends on the section alignment.
- With the fix every `PT_LOAD` has `p_align` 0x1000 and the strict mapping ranges no longer intersect. A UPX 5.2.0-packed debug build starts and runs correctly.
- Verified: `test/bundler/compile-elf-segment-layout.test.ts` (both tests fail on bun 1.4.1 with a 0x3000 overlap). Also `bun-build-compile.test.ts`, `compile-asset-bunfs.test.ts`, `tls-segment-size.test.ts`, and `regression/issue/29290.test.ts`.

### Background
- A `PT_LOAD` program header tells the loader to map a file range at `p_vaddr`. `p_align` declares the mapping granularity: a strict loader maps `[round_down(p_vaddr, p_align), round_up(p_vaddr + p_memsz, p_align))`. A segment's `p_align` is the largest alignment of any section inside it.
- Linux maps at page granularity and ignores `p_align`, which hides the overlap. UPX's decompression stub performs the mapping itself and honors `p_align`. The UPX maintainer's analysis is in upx/upx#18906.
- The `.bun` section holds the standalone module graph header. At `--compile` time bun appends the payload past every existing mapping and grows the RW `PT_LOAD` to cover it (`exe_format/elf.rs`).

<details><summary>Notes</summary>

Layout of the official bun-v1.4.1 linux-x64 binary (`readelf -lW`), which `--compile` inherits:

```
LOAD  0x000000  0x0000000000200000  ...  0x147c3d0 0x147c3d0 R   0x1000
LOAD  0x147d200 0x0000000001743200  ...  0x31f6ed0 0x31f6ed0 R E 0x1000
LOAD  0x46770d0 0x000000000493b0d0  ...  0x0a6f50  0x266dd8  RW  0x4000
```

The R E segment's strict mapping ends at `round_up(0x1743200 + 0x31f6ed0, 0x1000) = 0x493b000`. The RW segment's strict mapping starts at `round_down(0x493b0d0, 0x4000) = 0x4938000`. Overlap: 0x3000. Bun 1.4.0 has the same shape with a 0x2000 overlap, and 1.4.0 + UPX 5.2.0 reproduces the reporter's failure reliably.

After the fix the debug build links as:

```
LOAD  0x000000  0x0000000000200000 ... R   0x1000
LOAD  0x7e12800 0x0000000008013800 ... R E 0x1000
LOAD  0x190b5290 0x00000000192b7290 ... RW  0x1000
```

End-to-end check: UPX refuses files over its size cap, and a debug `--compile` output is 816MB, so the packed run used a stripped copy of the fixed debug bun (484MB). `upx -1` packed it and the packed binary runs `--version` and `-e` correctly. With the old layout the stub maps the RW segment over the executable segment's tail, so any packed binary with this shape is corrupt. The full compiled-app repro needs a release-linked binary.

The three `--bytecode` tests in `bun-build-compile.test.ts` time out on this builder with and without the change (checked by stashing the fix and rerunning). They are container-speed failures, not caused by this diff.

aarch64 is unaffected: its segments already use `p_align` 0x10000, which is larger than the old 16KB, so the RW `p_align` does not change there.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/binary/tls-segment-size.test.ts, test/bundler/compile-elf-segment-layout.test.ts

<!-- robobun:evidence:end -->