### PR TITLE
resolver: declare filename_store_backing once

### DIFF
--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -33,7 +33,9 @@ pub(crate) type FilenameStoreBacking =
 pub(crate) type EntryStoreBacking = allocators::BSSList<Entry, { preallocate::counts::FILES * 2 }>;
 
 // Per-monomorphization singleton storage, emitted at the declare site via
-// `bss_*!` macros (returns `*mut`).
+// `bss_*!` macros (returns `*mut`). Each declare site owns its own storage:
+// `crate::fs::FilenameStore` re-exports `filename_store_backing` from here so
+// it and `FilenameStoreAppender` share one store.
 bun_alloc::bss_string_list! { pub filename_store_backing : preallocate::counts::FILES * 2, 64 + 1 }
 bun_alloc::bss_list! { pub entry_store_backing : Entry, preallocate::counts::FILES * 2 }
 

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -73,8 +73,11 @@ pub mod fs {
 
     // `BSSStringList(2048, 128)` → `<{2048*2}, {128+1}>`
     bun_alloc::bss_string_list! { pub dirname_store_backing : 4096, 129 }
-    // `BSSStringList(4096, 64)` → `<{4096*2}, {64+1}>`
-    bun_alloc::bss_string_list! { pub filename_store_backing : 8192, 65 }
+    // `bss_singleton!` emits one private `STORAGE` per declare site, so the
+    // filename store is declared once, in `fs_full`, and shared with the
+    // `readdir` appender (`FilenameStoreAppender`). A second declaration here
+    // would be a separate store that `exists`/`as_interned` cannot see into.
+    pub use crate::fs_full::filename_store_backing;
 
     /// Port of `FileSystem.DirnameStore` (`BSSStringList<2048,128>`).
     pub struct DirnameStore(());

--- a/test/internal/source-lints/bss-singleton-unique.test.ts
+++ b/test/internal/source-lints/bss-singleton-unique.test.ts
@@ -1,0 +1,89 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `bun_alloc::bss_singleton!` (and its `bss_list!` / `bss_string_list!` /
+// `bss_map_inner!` wrappers) emits a private `static STORAGE` inside the
+// accessor fn at each declare site. Two declarations with the same name are
+// two separate process-lifetime heaps, not two names for one store: a slice
+// interned through one reads as "not ours" to the other's `exists()` /
+// `as_interned()`, and the second store costs its own backing buffer (about
+// 532 KiB for a `BSSStringList<8192, 65>`).
+//
+// The resolver once declared `filename_store_backing` in both
+// `src/resolver/fs.rs` (the readdir basename appender) and
+// `src/resolver/lib.rs` (`FilenameStore::instance()`), so resolved paths and
+// directory-entry names were interned into different stores. Rust cannot
+// reject that at compile time: the statics are fn-local and item names are
+// only unique per module. A declare site is the single owner of its storage;
+// every other user re-exports or imports the accessor.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout).
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const VIS = String.raw`(?:pub(?:\([^)]*\))?\s+)?`;
+// `bss_list! { pub name : T, N }`, `bss_string_list! { name : N, M }`,
+// `bss_map_inner! { pub(crate) name : T, N, B }`.
+const TYPED = new RegExp(String.raw`\bbss_(?:list|string_list|map_inner)!\s*[{(]\s*${VIS}([A-Za-z_]\w*)\s*:`, "g");
+// `bss_singleton! { #[attr] pub fn name() -> T }`. The macro definitions in
+// bun_alloc spell the name as `$name`, which `\w` does not match.
+const RAW = new RegExp(String.raw`\bbss_singleton!\s*[{(](?:\s*#\[[^\]]*\])*\s*${VIS}fn\s+([A-Za-z_]\w*)\s*\(`, "g");
+
+const declarations = new Map<string, string[]>();
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  const content = await file(abs).text();
+  if (!content.includes("bss_")) continue;
+  // Strip `//` comments so prose mentions of a declaration do not count.
+  const lines = content.split("\n").map(line => line.replace(/\/\/.*/, ""));
+  for (const [index, line] of lines.entries()) {
+    for (const re of [TYPED, RAW]) {
+      re.lastIndex = 0;
+      for (let m = re.exec(line); m !== null; m = re.exec(line)) {
+        const name = m[1];
+        const sites = declarations.get(name) ?? [];
+        sites.push(`${source}:${index + 1}`);
+        declarations.set(name, sites);
+      }
+    }
+  }
+}
+
+test("scans the known bss singleton declare sites", () => {
+  // Guards against the regexes or the tracked/realpath filters over-firing and
+  // leaving nothing to scan, which would make the uniqueness check vacuous.
+  expect([...declarations.keys()]).toEqual(
+    expect.arrayContaining([
+      "dirname_store_backing",
+      "filename_store_backing",
+      "entry_store_backing",
+      "entries_option_map",
+    ]),
+  );
+});
+
+test("every bss singleton name is declared exactly once", () => {
+  const duplicates: string[] = [];
+  for (const [name, sites] of [...declarations].sort(([a], [b]) => a.localeCompare(b))) {
+    if (sites.length > 1) duplicates.push(`${name}: ${sites.join(", ")}`);
+  }
+  expect(duplicates).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `filename_store_backing` is declared twice: `bss_string_list!` in module `fs_full` (`src/resolver/fs.rs:37`, used by `FilenameStoreAppender` for readdir basenames) and again in module `fs` (`src/resolver/lib.rs:77`, used by `FilenameStore::instance()` through `string_store_impl!`).
- `bss_singleton!` (`src/bun_alloc/lib.rs:1039`) emits a private `static STORAGE` per declare site. So these are two separate `BSSStringList<8192, 65>` heaps. Directory-entry names longer than 31 bytes land in one store, resolved paths in the other, and `FilenameStore::exists()` / `as_interned()` only check the second. The first store also costs its own slot in the 4 MiB `bss_*` arena (532 KiB backing buffer plus a 128 KiB slice table).

### Fix
- Keep the declaration in `fs.rs`, next to the `FilenameStoreBacking` type alias, and replace the one in `lib.rs` with `pub use crate::fs_full::filename_store_backing;`. `FilenameStore` and `FilenameStoreAppender` now resolve to the same singleton. This restores the original design, where `FileSystem.FilenameStore.instance` backed both readdir and path interning.
- A new source lint, `test/internal/source-lints/bss-singleton-unique.test.ts`, scans every `bss_list!` / `bss_string_list!` / `bss_map_inner!` / `bss_singleton!` declare site and fails when a name is declared more than once. Rust cannot reject this at compile time: the statics are fn-local and item names are only unique per module.
- Verified: the lint fails on main (`filename_store_backing: src/resolver/fs.rs:37, src/resolver/lib.rs:77`) and passes with this change. Also ran `test/bundler/bundler_edgecase.test.ts`, `test/bundler/bundler_npm.test.ts`, `test/js/bun/resolve/import-meta*.test.*`, `test/cli/install/bun-add.test.ts`, `test/cli/test/path-ignore-patterns.test.ts`, `test/cli/test/concurrent-test-glob.test.ts`.

### Background
- A `BSSStringList` is an append-only, never-freed string arena: a fixed backing buffer plus a heap overflow list. The resolver widens slices it returns to `&'static`.
- `FilenameStore::exists(slice)` is a pointer-range check against that fixed backing buffer. `dupe_alloc` (`lib.rs:532`) and `intern_transpile_path` (`src/runtime/jsc_hooks.rs:4127`) use it to skip a re-intern when a path is already in the store.
- `bss_string_list! { name : COUNT, LEN }` expands to an accessor fn `name() -> *mut BSSStringList<COUNT, LEN>` with the storage pointer in a fn-local `static`. Two expansions with the same name are two stores.

<details><summary>Notes</summary>

- No JS-observable behavior depends on the split. Every consumer of `Entry::base()` joins the basename into a fresh buffer and re-interns through `FilenameStore::instance()` or `DirnameStore` before the bytes become a `Path.text`, `Entry.abs_path`, or a transpile path. So no `exists()` caller ever saw a slice from the readdir store. The fix is a memory and consistency cleanup, not a behavior change.
- Effect on the fixed buffer: readdir basenames longer than 31 bytes now share the 532 KiB buffer with resolved paths, which is how the original `FileSystem.FilenameStore` worked. Entries that spill into the overflow list are still `'static` but read as not interned to `exists()`; that is pre-existing.
- `test/cli/run/require-cache.test.ts` "don't leak file paths" fails locally under a plain `bun bd` build both with and without this change (69 to 73 MB RSS delta in both cases). The fixture picks its threshold by checking for `bun-asan` in `process.execPath`, so an ASAN `bun-debug` binary gets the 48 MB release bound. It is not related to this change.
- The lint matches the macro definitions' `$name` as non-identifiers and strips `//` comments, so prose mentions such as the `bss_list!{entry_store_backing}` note in `fs.rs` do not count as declarations.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/bss-singleton-unique.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-9.cpp.o
[2/7] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[3/7] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[4/7] gen cpp.rs (cppbind)
[4/7] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/internal/source-lints/bss-singleton-unique.test.ts:
(pass) scans the known bss singleton declare sites [0.40ms]
83 | test("every bss singleton name is declared exactly once", () => {
84 |   const duplicates: string[] = [];
85 |   for (const [name, sites] of [...declarations].sort(([a], [b]) => a.localeCompare(b))) {
86 |     if (sites.length > 1) duplicates.push(`${name}: ${sites.join(", ")}`);
87 |   }
88 |   expect(duplicates).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "filename_store_backing: src/resolver/fs.rs:37, src/resolver/lib.rs:77",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/bss-singleton-unique.test.ts:88:22)
(fail) every bss singleton name is declared exactly once [0.61ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [1160.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/bss-singleton-unique.test.ts
bun test v1.4.1 (65362b53b)

test/internal/source-lints/bss-singleton-unique.test.ts:
(pass) scans the known bss singleton declare sites [6.61ms]
(pass) every bss singleton name is declared exactly once [6.70ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [23.29s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f27fb531ca
  features     baseline

23 deps, 131 codegen, 1172 objects in 735ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [12.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1244] gen bindgenv2
[4/1244] gen ErrorCode+*.h
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/fs.rs                                 |  4 +-
 src/resolver/lib.rs                                |  7 +-
 .../source-lints/bss-singleton-unique.test.ts      | 89 ++++++++++++++++++++++
 3 files changed, 97 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/resolver/fs.rs                                           2      3      0
src/resolver/lib.rs                                          2      1      0
test/internal/source-lints/bss-singleton-unique.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->