### PR TITLE
Coerce TextDecoder ignoreBOM option with ToBoolean

### DIFF
--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -624,13 +624,7 @@ impl TextDecoder {
             }
 
             if let Some(ignore_bom) = options_value.get(global_this, b"ignoreBOM")? {
-                if ignore_bom.is_boolean() {
-                    decoder.ignore_bom = ignore_bom.as_boolean();
-                } else {
-                    return Err(global_this.throw_invalid_arguments(format_args!(
-                        "TextDecoder(options) ignoreBOM is invalid. Expected boolean value",
-                    )));
-                }
+                decoder.ignore_bom = ignore_bom.to_boolean();
             }
         }
 

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -297,10 +297,24 @@ describe("TextDecoder", () => {
     expect(decoder.ignoreBOM).toBe(false);
   });
 
-  it("should throw on invalid input", () => {
-    expect(() => {
-      const decoder = new TextDecoder("utf-8", { fatal: 10, ignoreBOM: {} });
-    }).toThrow();
+  // WebIDL boolean conversion is ToBoolean: any value is valid.
+  // Minifiers emit `{ignoreBOM: 1}` for `{ignoreBOM: true}`. https://github.com/oven-sh/bun/issues/40758
+  it("constructor coerces fatal and ignoreBOM with ToBoolean", () => {
+    const truthy = new TextDecoder("utf-8", { fatal: 10, ignoreBOM: {} });
+    expect({ fatal: truthy.fatal, ignoreBOM: truthy.ignoreBOM }).toEqual({ fatal: true, ignoreBOM: true });
+
+    const falsy = new TextDecoder("utf-8", { fatal: 0, ignoreBOM: "" });
+    expect({ fatal: falsy.fatal, ignoreBOM: falsy.ignoreBOM }).toEqual({ fatal: false, ignoreBOM: false });
+  });
+
+  it.each([
+    [1, true],
+    [0, false],
+  ])("ignoreBOM: %p coerces to %p and controls BOM stripping", (value, expected) => {
+    const decoder = new TextDecoder("utf-8", { ignoreBOM: value });
+    expect(decoder.ignoreBOM).toBe(expected);
+    const withBOM = new Uint8Array([0xef, 0xbb, 0xbf, 0x61, 0x62, 0x63]);
+    expect(decoder.decode(withBOM)).toBe(expected ? "\uFEFFabc" : "abc");
   });
 
   it("should support undifined", () => {


### PR DESCRIPTION
### Problem
- `new TextDecoder("utf-8", { ignoreBOM: 1 })` throws `TypeError: TextDecoder(options) ignoreBOM is invalid. Expected boolean value` (`ERR_INVALID_ARG_TYPE`). Node and browsers accept it and read it as `true`. Minifiers turn `true` and `false` into `1` and `0`, so libraries hit this.
- The cause is a strict `is_boolean()` check in the constructor at `src/runtime/webcore/TextDecoder.rs:626`. Per WebIDL, `TextDecoderOptions.ignoreBOM` is a `boolean` dictionary member, and the conversion is ToBoolean. Any value is valid.

### Fix
- Replace the strict check with `ignore_bom.to_boolean()`. The `fatal` option on the line above already does this.
- `TextDecoderStream` is not affected. Its C++ constructor already calls `toBoolean` (`src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp:142`).
- One existing test asserted the old throw for `{ fatal: 10, ignoreBOM: {} }`. It now asserts the WebIDL coercion instead, which matches Node and browsers.
- Verified: `test/js/web/encoding/text-decoder.test.js` (127 pass, the new tests fail on stock bun). Also `text-decoder-stream.test.ts` and `text-decoder-wpt.test.ts` (332 pass).

### Background
- The Encoding spec defines `TextDecoderOptions` as a WebIDL dictionary with two `boolean` members, `fatal` and `ignoreBOM`. WebIDL boolean conversion never throws. It applies JS ToBoolean, so `1` is `true` and `0` is `false`.
- The new tests check both the `ignoreBOM` getter and the decode behavior (BOM kept with a truthy value, stripped with a falsy one).

Fixes #40758

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-decoder.test.js
bun test v1.4.1 (65362b53b)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [2505.61ms]
(pass) TextDecoder > should decode ascii text [140.57ms]
(pass) TextDecoder > should decode unicode text [2721.08ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [3.10ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array [0.49ms]
(pass) TextDecoder > typedArrays > should decode Uint32Array [0.37ms]
(pass) TextDecoder > typedArrays > should decode Int8Array [0.30ms]
(pass) TextDecoder > typedArrays > should decode Int16Array [0.33ms]
(pass) TextDecoder > typedArrays > should decode Int32Array [0.30ms]
(pass) TextDecoder > typedArrays > should decode Float16Array [0.33ms]
(pass) TextDecoder > typedArrays > should decode Float32Array [0.45ms]
(pass) TextDecoder > typedArrays > should decode Float64Array [0.33ms]
(pass) TextDecoder > typedArrays > should decode DataView [0.32ms]
(pass) TextDecoder > typedArrays > should decode BigInt64Arra
... (truncated)

release without fix: 3 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [6.63ms]
(pass) TextDecoder > should decode ascii text [6.31ms]
(pass) TextDecoder > should decode unicode text [99.21ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [0.13ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array
(pass) TextDecoder > typedArrays > should decode Uint32Array
(pass) TextDecoder > typedArrays > should decode Int8Array
(pass) TextDecoder > typedArrays > should decode Int16Array
(pass) TextDecoder > typedArrays > should decode Int32Array
(pass) TextDecoder > typedArrays > should decode Float16Array
(pass) TextDecoder > typedArrays > should decode Float32Array [0.01ms]
(pass) TextDecoder > typedArrays > should decode Float64Array
(pass) TextDecoder > typedArrays > should decode DataView
(pass) TextDecoder > typedArrays > should decode BigInt64Array [0.02ms]
(pass) TextDecoder > typedArrays > should decode BigUint64Array
(pass) TextDecoder > typedArrays > DOMJIT call [26.55ms]
(pass) TextDecoder > should decode unicode text with multiple consecutive emoji [9.82ms]
(pass) TextDecoder > coe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-decoder.test.js
bun test v1.4.1 (65362b53b)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [2438.65ms]
(pass) TextDecoder > should decode ascii text [134.86ms]
(pass) TextDecoder > should decode unicode text [2659.37ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [2.84ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array [0.44ms]
(pass) TextDecoder > typedArrays > should decode Uint32Array [0.39ms]
(pass) TextDecoder > typedArrays > should decode Int8Array [0.30ms]
(pass) TextDecoder > typedArrays > should decode Int16Array [0.30ms]
(pass) TextDecoder > typedArrays > should decode Int32Array [0.30ms]
(pass) TextDecoder > typedArrays > should decode Float16Array [0.36ms]
(pass) TextDecoder > typedArrays > should decode Float32Array [0.43ms]
(pass) TextDecoder > typedArrays > should decode Float64Array [0.29ms]
(pass) TextDecoder > typedArrays > should decode DataView [0.33ms]
(pass) TextDecoder > typedArrays > should decode BigInt64Arra
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 642ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 25s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+2a9d7ae01
[build] done
bun test v1.4.1-canary.1 (2a9d7ae01)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [5.68ms]
(pass) TextDecoder > should decode ascii text [4.54ms]
(pass) TextDecoder > should decode unicode text [101.88ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [0.09ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array
(pass) TextDecoder > typedArrays > should decode Uint32Array
(pass) TextDecoder > typedArrays > should decode Int8Array
(pass) TextDecoder > typedArrays > should decode Int16Array
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/TextDecoder.rs        |  8 +-------
 test/js/web/encoding/text-decoder.test.js | 22 ++++++++++++++++++----
 2 files changed, 19 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/webcore/TextDecoder.rs             1      2      0
test/js/web/encoding/text-decoder.test.js      1      1      0
```

</details>

**root cause** · written by the author bot

The TextDecoder constructor's Rust implementation performed a strict type check on the ignoreBOM option, throwing a TypeError when the value was not a boolean, even though WebIDL requires boolean dictionary members to be coerced with ToBoolean as browsers, Node, and the adjacent fatal option already do. The fix replaces the strict is_boolean check with to_boolean coercion, so truthy and falsy values such as 1 and 0 are converted rather than rejected. Tests were updated to assert the coerced getter values and to verify that the coerced ignoreBOM value correctly controls BOM stripping during …

<!-- robobun:evidence:end -->