### PR TITLE
macros: classify a returned Response or Blob by its MIME essence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,6 @@ dependencies = [
  "bun_collections",
  "bun_core",
  "bun_dotenv",
- "bun_http_types",
  "bun_js_parser",
  "bun_jsc",
  "bun_parsers",

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -258,7 +258,6 @@ let mime = mime_type::by_extension(b"html");            // MimeType
 let mime = mime_type::by_extension_no_default(b"xyz");  // Option<MimeType>
 
 mime.category   // Category::Javascript | Css | Html | Json | Image | Text | Wasm | ...
-mime.category.is_text_like()
 ```
 
 Common constants: `JAVASCRIPT`, `JSON`, `HTML`, `CSS`, `TEXT`, `WASM`, `ICO`, `OTHER`.

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -257,13 +257,6 @@ impl Category {
         Category::Other
     }
 
-    pub fn is_text_like(self) -> bool {
-        matches!(
-            self,
-            Category::Javascript | Category::Html | Category::Text | Category::Css | Category::Json
-        )
-    }
-
     pub fn autoset_filename(self) -> bool {
         !matches!(
             self,

--- a/src/js_parser_jsc/Cargo.toml
+++ b/src/js_parser_jsc/Cargo.toml
@@ -19,7 +19,6 @@ bun_bundler.workspace = true
 bun_parsers.workspace = true
 bun_collections.workspace = true
 bun_dotenv.workspace = true
-bun_http_types.workspace = true
 bun_js_parser.workspace = true
 bun_jsc.workspace = true
 bun_ast.workspace = true

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -1064,16 +1064,14 @@ fn expr_from_blob(
 ) -> crate::Result<Expr> {
     use bun_ast::{E, ExprData, StoreStr as Str};
 
-    // `type/subtype` without the parameters. `Response.json()` and most
-    // servers send `application/json;charset=utf-8`.
+    // MIME essence: `type/subtype` with the parameters cut off.
     let essence: &[u8] = match strings::index_of_char_usize(content_type, b';') {
         Some(semicolon) => &content_type[..semicolon],
         None => content_type,
     }
     .trim_ascii();
 
-    // `application/json`, `text/json`, and the `+json` structured syntax
-    // suffix (RFC 6839): `application/ld+json`, `application/vnd.api+json`.
+    // `+json` is the RFC 6839 structured syntax suffix: `application/ld+json`.
     let is_json = essence.ends_with(b"/json") || essence.ends_with(b"+json");
 
     if is_json {

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -1063,13 +1063,20 @@ fn expr_from_blob(
     loc: bun_ast::Loc,
 ) -> crate::Result<Expr> {
     use bun_ast::{E, ExprData, StoreStr as Str};
-    use bun_http_types::MimeType::{Category, MimeType};
 
-    // `Response.json()` and most servers send parameters (`;charset=utf-8`),
-    // so classify through the same parser the runtime uses for blob types.
-    let mime_type = MimeType::init(content_type, false, None);
+    // `type/subtype` without the parameters. `Response.json()` and most
+    // servers send `application/json;charset=utf-8`.
+    let essence: &[u8] = match strings::index_of_char_usize(content_type, b';') {
+        Some(semicolon) => &content_type[..semicolon],
+        None => content_type,
+    }
+    .trim_ascii();
 
-    if mime_type.category == Category::Json {
+    // `application/json`, `text/json`, and the `+json` structured syntax
+    // suffix (RFC 6839): `application/ld+json`, `application/vnd.api+json`.
+    let is_json = essence.ends_with(b"/json") || essence.ends_with(b"+json");
+
+    if is_json {
         let source = &Source::init_path_string(b"fetch.json", bytes);
         let mut out_expr: Expr = match bun_parsers::json::parse_for_macro(source, log, bump) {
             Ok(e) => e,
@@ -1084,7 +1091,16 @@ fn expr_from_blob(
         return Ok(out_expr);
     }
 
-    if mime_type.category.is_text_like() {
+    let is_text_like = essence.starts_with(b"text/")
+        || matches!(
+            essence,
+            b"application/javascript"
+                | b"application/x-javascript"
+                | b"application/ecmascript"
+                | b"application/xml"
+        );
+
+    if is_text_like {
         let mut output = bun_core::MutableString::init_empty();
         bun_core::quote_for_json(bytes, &mut output, true)?;
         let owned = output.to_owned_slice();

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -237,6 +237,69 @@ test("a macro that returns a JSON or text Response or Blob is inlined by its con
   expect(exitCode).toBe(0);
 });
 
+// The classification follows the MIME essence, not the category table the runtime uses for blob types:
+// any `+json` suffix or `/json` subtype is JSON, and the JavaScript and XML `application/*` types are text.
+// The data URL keeps the raw content type, parameters included.
+test("a Response or Blob returned from a macro is classified by its MIME essence", async () => {
+  const json = '{"a":1}';
+  const cases: [type: string, body: string, expected: unknown][] = [
+    ["application/json", json, { a: 1 }],
+    ["application/json; charset=utf-8", json, { a: 1 }],
+    ["application/vnd.api+json", json, { a: 1 }],
+    ["application/ld+json", json, { a: 1 }],
+    ["application/ld+json; charset=utf-8", json, { a: 1 }],
+    ["application/manifest+json", json, { a: 1 }],
+    ["application/geo+json", json, { a: 1 }],
+    ["text/json", json, { a: 1 }],
+    ["application/javascript", "1+1", "1+1"],
+    ["application/javascript; charset=utf-8", "1+1", "1+1"],
+    ["application/x-javascript", "1+1", "1+1"],
+    ["application/ecmascript", "1+1", "1+1"],
+    ["application/xml", "<a/>", "<a/>"],
+    ["text/plain", "hi", "hi"],
+    ["text/html", "<b>hi</b>", "<b>hi</b>"],
+    ["text/javascript", "1+1", "1+1"],
+    ["text/xml", "<a/>", "<a/>"],
+    ["image/png", "png", "data:image/png;base64,cG5n"],
+    ["application/octet-stream", "bin", "data:application/octet-stream;base64,Ymlu"],
+    ["application/wasm", "wasm", "data:application/wasm;base64,d2FzbQ=="],
+    ["application/x-ndjson", '{"a":1}\n{"a":2}\n', "data:application/x-ndjson;base64,eyJhIjoxfQp7ImEiOjJ9Cg=="],
+  ];
+  using dir = tempDir("macro-mime-essence", {
+    "m.ts": [
+      `export function resp(type: string, body: string) {`,
+      `  return new Response(body, { headers: { "content-type": type } });`,
+      `}`,
+      `export function blob(type: string, body: string) {`,
+      `  return new Blob([body], { type });`,
+      `}`,
+    ].join("\n"),
+    "index.ts": [
+      `import { resp, blob } from "./m.ts" with { type: "macro" };`,
+      `console.log(JSON.stringify([`,
+      ...cases.map(([type, body]) => `  resp(${JSON.stringify(type)}, ${JSON.stringify(body)}),`),
+      ...cases.map(([type, body]) => `  blob(${JSON.stringify(type)}, ${JSON.stringify(body)}),`),
+      `]));`,
+      ``,
+    ].join("\n"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const expected = cases.map(([, , expected]) => expected);
+  // Debug builds print "[macro] call <name>" to stdout before the script's own output.
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
+    lastLine: JSON.stringify([...expected, ...expected]),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 // A macro's `await` is serviced by the VM's macro event loop, so completions have to be routed by which
 // loop was current when their work started: what the macro started goes to the macro loop (or the wait
 // hangs), what the program started stays on the regular loop (or program callbacks run mid-transpile),


### PR DESCRIPTION
### Problem
- A macro that returns a `Response` or `Blob` typed `application/ld+json`, `application/vnd.api+json` or any other `+json` type is inlined as a base64 string (`"data:application/vnd.api+json;base64,eyJhIjoxfQ=="`) instead of the parsed object. `text/json` becomes the raw JSON text as a string. `application/javascript`, `application/x-javascript`, `application/ecmascript` and `application/xml` become data URLs instead of the source text. Bun 1.4.0 handled all of these.
- #40700 made `expr_from_blob` (`src/js_parser_jsc/Macro.rs:1058`) classify through `MimeType::init`. That parser only maps `application/json` and `application/geo+json` to `Category::Json`. Every other `application/*` type, `application/javascript` included, is `Category::Application`, which is not text-like. `text/json` is `Category::Text`.

### Fix
- `expr_from_blob` cuts the content type at the first `;` and trims it. That is the MIME essence (`type/subtype`). It then applies the 1.4.0 rules to the essence: a `/json` or `+json` ending parses as JSON, a `text/` prefix or one of the four `application/*` script and XML types inlines as a string, everything else stays a data URL.
- This keeps the #40700 fix. `Response.json()` and servers send `application/json;charset=utf-8`, and the essence drops the parameter before the compare. `+json` is the structured syntax suffix from RFC 6839, so a JSON:API or JSON-LD endpoint gets the object the macro author expects.
- `bun_js_parser_jsc` no longer needs `bun_http_types`. The dependency is removed from its `Cargo.toml` and `Cargo.lock`. `Category::is_text_like` (added by #40700 for this call site) is deleted from `src/http_types/MimeType.rs` and from the `src/CLAUDE.md` snippet.
- Verified: `test/bundler/transpiler/macro-test.test.ts` (new test with 21 content types, each as a `Response` and as a `Blob`; on main 12 of the 42 cells fail). Also ran the rest of that file, `transpiler.test.js` and the macro regression tests.

### Background
- A macro result becomes an AST node in `Run::coerce`. A `Response` or `Request` is first reduced to its body `Blob`. `expr_from_blob` picks the node shape from the blob's content type: a parsed JSON object, a string, or a base64 `data:` URL that keeps the raw content type.
- A `Response` with a `content-type` header gets its blob type from `MimeType::init` on that header (`src/runtime/webcore/Body.rs:2146`). `application/json` becomes `application/json;charset=utf-8`, `application/ld+json` is kept as is. So the content type the macro sees may or may not carry parameters.
- `bun_http_types::MimeType::init` is the runtime's blob type classifier. Its `Category` drives things like `Content-Disposition` and data URL loaders, so this change leaves it alone and keeps the macro rules local to the macro.

<details><summary>Notes</summary>

Matrix on main (e0ead955) with `bun run e.ts`, where each macro returns `new Response(body, { headers: { "content-type": type } })`:

```
R application/json                       {"a":1}
R application/json; charset=utf-8        {"a":1}
R application/vnd.api+json               "data:application/vnd.api+json;base64,eyJhIjoxfQ=="
R application/ld+json                    "data:application/ld+json;base64,eyJhIjoxfQ=="
R application/manifest+json              "data:application/manifest+json;base64,eyJhIjoxfQ=="
R application/geo+json                   {"a":1}
R text/json                              "{\"a\":1}"
R application/javascript                 "data:application/javascript;base64,MSsx"
R application/x-javascript               "data:application/x-javascript;base64,MSsx"
R application/ecmascript                 "data:application/ecmascript;base64,MSsx"
R application/xml                        "data:application/xml;base64,PGEvPg=="
R text/plain                             "1+1"
R image/png                              "data:image/png;base64,MSsx"
R Application/JSON                       "data:Application/JSON;base64,eyJhIjoxfQ=="
```

With this change the `+json`, `text/json` and `application/*` script rows give `{"a":1}`, `"1+1"` and `"<a/>"`. The other rows do not change. Bun 1.4.0 gave the same values for those rows but turned `application/json; charset=utf-8` and `Response.json()` into data URLs (the bug #40700 fixed).

The compare stays case-sensitive, like `MimeType::init` and the rest of the runtime. A `Blob` built in JS is lowercased by the `Blob` constructor. A header value is used verbatim.

A `Blob` typed `application/javascript` already inlined as text on main, because the `Blob` constructor maps that type to the `text/javascript;charset=utf-8` constant. The same type with a `charset` parameter did not. Both inline as text now.

#40059 rewrites `expr_from_blob` with the same essence rules as part of a larger change. The two conflict only in that function body and one `Cargo.toml` line.

Suites run with the debug build: `test/bundler/transpiler/macro-test.test.ts` (24 pass), `test/bundler/transpiler/transpiler.test.js`, `test/bundler/transpiler/scope-mismatch-panic.test.ts`, `test/regression/issue/{03830,22656,26360,39900}.test.ts` (230 pass, 1 skip, 21 todo, 0 fail).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-19.cpp.o
[2/9] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/9] gen cpp.rs (cppbind)
[3/9] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (57d374ae3)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.03ms]
(pass) latin1 string
(pass) ascii string
(pass) type coercion [0.04ms]
(pass) escaping [0.15ms]
(pass) utf16 string
(pass) import aliases [0.02ms]
(pass) default import
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.05ms]
(pass) object argument with a sparse numeric key [11.50ms]
(pass) object destructuring of a macro result keeps every bound property regardless of key order or repeated keys [10.39ms]
(pass) a macro that returns a JSON or text Response or Blob is inlined by its content type [13.75ms]
(pass) a Response or Blob returned from a macro is classified by its MIME essence [13.05ms]
(pass) event loop routing around macros > a fetch() inside the macro that it does not await still lets the process exit [11.59ms]
(pass) event loop routing around macros > a WebAssembly.compile() inside the macro that it does not await still lets the process exit [10.63ms]
(pass) event loop routing around macros > a crypto.subtle.digest() inside the macro that it does not await still lets the process exit [11.39ms]
(pass) event loop rout
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 623ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[2/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[3/9] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[4/9] gen cpp.rs (cppbind)
[4/9] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
Cargo.lock                                 |  1 -
 src/CLAUDE.md                              |  1 -
 src/http_types/MimeType.rs                 |  7 ----
 src/js_parser_jsc/Cargo.toml               |  1 -
 src/js_parser_jsc/Macro.rs                 | 26 +++++++++---
 test/bundler/transpiler/macro-test.test.ts | 63 ++++++++++++++++++++++++++++++
 6 files changed, 83 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
Cargo.lock                                      0      0      0
src/CLAUDE.md                                   0      1      0
src/http_types/MimeType.rs                      1      1      0
src/js_parser_jsc/Cargo.toml                    0      0      0
src/js_parser_jsc/Macro.rs                      4      4      0
test/bundler/transpiler/macro-test.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->