### PR TITLE
test(install): run verdaccio under node in CI instead of the binary under test

### DIFF
--- a/test/cli/install/registry/slowbuffer-shim.cjs
+++ b/test/cli/install/registry/slowbuffer-shim.cjs
@@ -1,0 +1,5 @@
+// Preloaded into verdaccio when the harness hosts it on node (`VerdaccioRegistry.start`).
+// Node 26 removed `SlowBuffer`. verdaccio -> jwa -> buffer-equal-constant-time reads
+// `SlowBuffer.prototype` at load time, so verdaccio exits before it listens without this alias.
+const buffer = require("node:buffer");
+buffer.SlowBuffer ??= buffer.Buffer;

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1928,10 +1928,17 @@ export class VerdaccioRegistry {
     // whatever `localhost` resolves to, which is `::1` on hosts that list it first,
     // while the install client connects to 127.0.0.1 and every request is refused.
     const listen = `127.0.0.1:${this.port}`;
+    // In CI the `bun` on PATH is the binary under test. Verdaccio is a node application: under the ASAN
+    // build it needs seconds to start and about a second per request, so CI hosts it on the runner's node.
+    const node = isCI ? nodeExe() : null;
     this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", listen], {
       silent,
-      // Prefer using a release build of Bun since it's faster
-      execPath: isCI ? bunExe() : Bun.which("bun") || bunExe(),
+      // Locally, prefer the release build of Bun on PATH since it's faster than a debug build.
+      execPath: node ?? (isCI ? bunExe() : Bun.which("bun") || bunExe()),
+      // Node 26 removed `SlowBuffer`; verdaccio's dependency buffer-equal-constant-time reads it at load time.
+      execArgv: node
+        ? ["--require", join(import.meta.dir, "cli", "install", "registry", "slowbuffer-shim.cjs")]
+        : undefined,
       env: {
         ...(bunEnv as any),
         NODE_NO_WARNINGS: "1",


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-add-catalog.test.ts` took 15.7s on debian 13 x64-asan (build 107567): 8.9s before the first test result, 6.9s for the 149 cases. The 8.9s is the verdaccio start.
- `VerdaccioRegistry.start()` (`test/harness.ts:1934`) forks verdaccio with `execPath: isCI ? bunExe() : ...`, so in CI verdaccio runs under the binary under test. Under the ASAN build it needs seconds to start and about a second per request. All 31 install test files that use the registry pay this.
- Earlier passes on this file (#39549, #40327, #40636) cut spawns or warmed the install cache. Neither touches the verdaccio host.

### Fix
- In CI, fork verdaccio under the runner's `node` (`nodeExe()`), and keep the old `execPath` when node is not found. Local runs are unchanged.
- Node 26 removed `SlowBuffer`, which verdaccio's dependency `buffer-equal-constant-time` reads at load time. `test/cli/install/registry/slowbuffer-shim.cjs` is preloaded with `--require` and aliases it to `Buffer`.
- Correct because verdaccio is a node application and node is on every lane: the CI runner is node, and the bootstrap scripts install it. Bun forking a node child with JSON IPC is covered on every lane by `spawn.ipc.bun-node.test.ts`.
- Verified on the x64-asan lane (build 107764 against 107567): the 31 verdaccio files take 387s instead of 472s. A warm verdaccio start takes 0.5 to 0.9s instead of 2.5 to 3.2s. The first start in each shard still costs 4 to 9s (was 6 to 14s), so `bun-add-catalog`, first in its shard in both builds, goes 15.7s to 13.6s. Five verdaccio files pass on Windows.

### Background
- `VerdaccioRegistry` starts one verdaccio per test file in `beforeAll` and waits for its `verdaccio_started` IPC message. `child_process.fork` passes the channel as `NODE_CHANNEL_FD`, which node honors.
- `isCI` is `process.env.CI !== undefined`. The CI runner prepends the tested binary's directory to `PATH`.

<details><summary>Notes</summary>

**CI timeline, build 107567, x64-asan shard 01a04773-7699-41a0-a559-c9bbdff24dae.** `bun test` header at +0.08s, first test result at +8.86s, summary at +15.73s. The file was the first verdaccio user in its shard. Across the 31 verdaccio files in that build's asan shards, the first-result window is 6.2 to 13.8s for the first verdaccio user of a shard and 2.5 to 3.2s for later ones, so the cost repeats for every verdaccio file, not once per shard.

**Why the earlier levers did not work here.** The cases run 272 child processes five at a time (the ASAN `--max-concurrency` default). #39549 cut 46 of them and measured 16.45s against 15.68s. #40636 seeded every case from a warm cache and took 23.2s and 25.1s on this lane (builds 106828, 106845). The verdaccio host was never touched.

**CI measurement, x64-asan lane, build 107764 against 107567.** Sum over the 31 verdaccio files: 471.9s to 387.0s. Sum of the windows from the `bun test` header to the first test result: 170.2s to 94.6s. In every shard the first verdaccio start is the slow one (4.0 to 8.7s, was 6.2 to 13.8s) and every later one takes 0.5 to 0.9s (was 2.5 to 3.2s). The job boots its service containers in the same minute, so the first start competes for the machine. Per file, with the shard position varying between builds: `catalogs` 17.1s to 9.2s, `bun-prune` 17.3s to 10.6s, `pnpm-lock-v9` 16.4s to 8.7s, `bun-publish` 16.9s to 10.6s, `config-precedence` 8.0s to 2.1s, `bun-install-registry` 60.3s to 53.1s, `bun-add-catalog` 15.7s to 13.6s.

**Why an in-process registry for one file does not beat this.** In build 107661 the first version of this PR served `bun-add-catalog` in-process: 7.0s, first result at +0.24s. The next verdaccio file in that shard, `bun-install-lifecycle-scripts`, then paid the cold start instead (+6.69s, against +0.70s in build 107764). The shard's total did not move.

**Previous shape of this PR.** The first version added a `FixtureRegistry` class (the fixture store served by `Bun.serve`) and switched this one file to it: 7.0s on the x64-asan lane in build 107661 against 15.7s. A self-review found the same per-file time comes from fixing the host line, for all 31 files at once, including the auth and publish files an in-process server cannot serve. It also found the in-process server returned the stored packuments without the `hasInstallScript` flag verdaccio derives for the abbreviated format, which bun reads from the manifest (`src/install/npm.rs:2424`). That class and a set of exact-output assertions for this file are dropped from this PR; the assertions are on branch `farm/3c0737d7/bun-add-catalog-fixture-registry-and-assertions` and are independent of the speed change.

**`#19483`.** The `isCI ? bunExe()` branch came from 428b9a92de ("test ci fix"), whose PR body is empty. Before it, CI resolved `bun` from PATH, which the runner points at the tested binary as well, so CI has always hosted verdaccio on the binary under test.

**Measurements.** Debug ASAN build, 16 cores. Without `CI`, verdaccio runs under the release bun and the file takes 15.4 to 16.6s either way. Node-hosted verdaccio answers `GET /no-deps` in about 25ms against about 1.3s under the ASAN binary. `bun-install-registry.test.ts`: 248 pass, 0 fail, 103.8s under node host in CI configuration. On Windows the two files that import `bun:internal-for-testing` could not run on the canary; the five that could all pass.
</details>
