### PR TITLE
macros: fail the build on process.exit, Error returns, sparse arrays, and promises that never settle

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2841,6 +2841,7 @@ pub mod asan {
         safe fn __asan_describe_address(ptr: *const c_void);
         safe fn __lsan_register_root_region(ptr: *const c_void, size: usize);
         safe fn __lsan_unregister_root_region(ptr: *const c_void, size: usize);
+        safe fn __lsan_ignore_object(ptr: *const c_void);
     }
 
     #[inline]
@@ -2885,6 +2886,15 @@ pub mod asan {
         __lsan_unregister_root_region(ptr, size);
         #[cfg(not(bun_asan))]
         let _ = (ptr, size);
+    }
+    /// The heap allocation containing `ptr` is owned through a reference LeakSanitizer cannot follow (e.g. a
+    /// tagged pointer); do not report it. Its owner is still responsible for freeing it.
+    #[inline]
+    pub fn lsan_ignore_object(ptr: *const c_void) {
+        #[cfg(bun_asan)]
+        __lsan_ignore_object(ptr);
+        #[cfg(not(bun_asan))]
+        let _ = ptr;
     }
 }
 

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2887,8 +2887,7 @@ pub mod asan {
         #[cfg(not(bun_asan))]
         let _ = (ptr, size);
     }
-    /// The heap allocation containing `ptr` is owned through a reference LeakSanitizer cannot follow (e.g. a
-    /// tagged pointer); do not report it. Its owner is still responsible for freeing it.
+    /// Do not report the allocation containing `ptr`: its owner holds it through a reference LSAN cannot follow (a tagged pointer).
     #[inline]
     pub fn lsan_ignore_object(ptr: *const c_void) {
         #[cfg(bun_asan)]

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -563,6 +563,8 @@ pub(crate) struct Run<'a> {
     pub(crate) source: &'a Source,
     pub(crate) visited: VisitMap,
     pub(crate) is_top_level: bool,
+    /// `run` recurses once per nesting level of the returned value, on a bundler pool thread's stack.
+    pub(crate) stack_check: bun_core::StackCheck,
 }
 
 impl<'a> Run<'a> {
@@ -603,6 +605,7 @@ impl<'a> Run<'a> {
             source,
             visited: VisitMap::default(),
             is_top_level: false,
+            stack_check: bun_core::StackCheck::init(),
         };
 
         // `runner.visited` dropped at scope exit (was `defer runner.visited.deinit(allocator)`)
@@ -620,6 +623,14 @@ impl<'a> Run<'a> {
 
     pub(crate) fn run(&mut self, value: JSValue) -> Result<Expr, MacroError> {
         use ConsoleObject::formatter::Tag as T;
+        if !self.stack_check.is_safe_to_recurse() {
+            self.log.add_error_fmt(
+                Some(self.source),
+                self.caller.loc,
+                format_args!("macro return value is too deeply nested"),
+            );
+            return Err(MacroError::MacroFailed);
+        }
         // `Tag::get` returns `TagResult { tag: TagPayload, .. }`;
         // collapse the payload to its discriminant via `.tag()`.
         match T::get(value, self.global)?.tag.tag() {

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -188,6 +188,18 @@ impl MacroContext {
                 hash,
             ) {
                 Ok(m) => m,
+                Err(crate::Error::MacroLoadStalled) => {
+                    *macro_entry.value_ptr = Macro::disabled_sentinel();
+                    log.add_range_error_fmt(
+                        Some(source),
+                        import_range,
+                        format_args!(
+                            "macro \"{}\" never finished loading: its top-level await is pending and nothing is keeping the event loop alive",
+                            bstr::BStr::new(import_record_path)
+                        ),
+                    );
+                    return Err(crate::Error::MacroFailed);
+                }
                 Err(e) => {
                     *macro_entry.value_ptr = Macro::disabled_sentinel();
                     return Err(e);
@@ -462,13 +474,21 @@ impl Macro {
         let unwrapped = unsafe {
             (*loaded_result).unwrap(&*(*vm).jsc_vm, jsc::PromiseUnwrapMode::LeaveUnhandled)
         };
-        if let jsc::PromiseResult::Rejected(result) = unwrapped {
-            // SAFETY: `vm.global` is the live per-thread global; `loaded_result`
-            // is a live promise cell.
-            unsafe {
-                (*vm).unhandled_rejection(&*(*vm).global, result, (*loaded_result).to_js());
+        match unwrapped {
+            jsc::PromiseResult::Rejected(result) => {
+                // SAFETY: `vm.global` is the live per-thread global; `loaded_result`
+                // is a live promise cell.
+                unsafe {
+                    (*vm).unhandled_rejection(&*(*vm).global, result, (*loaded_result).to_js());
+                }
+                return Err(crate::Error::MacroLoadError);
             }
-            return Err(crate::Error::MacroLoadError);
+            // The wait gave up: nothing keeps the loop alive for the module's
+            // top-level await (or the VM was stopped). A `Macro` returned here
+            // would have its first call find no registered function and leave
+            // the call in the output as an unbound reference.
+            jsc::PromiseResult::Pending => return Err(crate::Error::MacroLoadStalled),
+            jsc::PromiseResult::Fulfilled(_) => {}
         }
 
         Ok(Macro {
@@ -559,11 +579,17 @@ impl<'a> Run<'a> {
         };
 
         let global = vm.global();
-        let result = vm.run_with_api_lock(|| {
-            macro_callback
-                .call(global, JSValue::ZERO, args)
-                .unwrap_or_else(|_| global.try_take_exception().unwrap_or_default())
-        });
+        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args))
+        {
+            Ok(result) => result,
+            // The macro threw: report it (with its stack) and fail this expansion.
+            Err(JsError::Thrown) => {
+                let err = global.take_exception(JsError::Thrown);
+                vm.as_mut().uncaught_exception(global, err, false);
+                return Err(MacroError::MacroFailed);
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         let mut runner = Run {
             caller,
@@ -578,7 +604,17 @@ impl<'a> Run<'a> {
 
         // `runner.visited` dropped at scope exit (was `defer runner.visited.deinit(allocator)`)
 
-        runner.run(result)
+        match runner.run(result) {
+            // Converting the macro's return value threw (a getter, an iterator, a toString): report it the
+            // way a throw from the macro function itself is reported above, rather than leaving it pending
+            // under the parser.
+            Err(MacroError::Js(JsError::Thrown)) => {
+                let err = global.take_exception(JsError::Thrown);
+                vm.as_mut().uncaught_exception(global, err, false);
+                Err(MacroError::MacroFailed)
+            }
+            other => other,
+        }
     }
 
     pub(crate) fn run(&mut self, value: JSValue) -> Result<Expr, MacroError> {
@@ -625,10 +661,13 @@ impl<'a> Run<'a> {
         use ConsoleObject::formatter::Tag as T;
         match tag {
             T::Error => {
+                // Report it the way a throw is reported, then fail the
+                // expansion. Returning `self.caller` here would leave the call
+                // in the output with its import gone: an unbound reference.
                 // SAFETY: `vm()` is the per-thread VM; uniquely accessed here.
                 let _ =
                     unsafe { (*self.macro_.vm()).uncaught_exception(self.global, value, false) };
-                return Ok(self.caller);
+                return Err(MacroError::MacroFailed);
             }
             T::Undefined => {
                 if self.is_top_level {
@@ -698,6 +737,24 @@ impl<'a> Run<'a> {
                 }
 
                 let mut iter = JSArrayIterator::init(value, self.global)?;
+
+                // Every index up to `length` becomes an element of the literal,
+                // holes as `undefined`. Only a length the JS heap actually backs
+                // keeps that proportional: `[,,1]` with `length = 1e9` would
+                // otherwise become a billion `undefined`s.
+                if let Err(stored) = value.indexed_storage_covers(iter.len) {
+                    self.log.add_error_fmt(
+                        Some(self.source),
+                        self.caller.loc,
+                        format_args!(
+                            "cannot coerce a sparse array to Bun's AST: its length is {} but it holds {} element{}. Please return a dense array",
+                            iter.len,
+                            stored,
+                            if stored == 1 { "" } else { "s" },
+                        ),
+                    );
+                    return Err(MacroError::MacroFailed);
+                }
 
                 // Process all array items
                 let mut array = ExprNodeList::init_capacity(iter.len as usize);
@@ -837,10 +894,25 @@ impl<'a> Run<'a> {
 
                 let _ = self.macro_.vm();
                 let vm = VirtualMachine::get();
-                // The VM stopped before the macro's promise settled: throw its termination and unwind.
-                vm.as_mut()
-                    .wait_for_promise(promise)
-                    .map_err(|stopped| MacroError::Js(stopped.throw(self.global)))?;
+                match vm.as_mut().wait_for_promise_until_idle(promise) {
+                    Ok(()) => {}
+                    // The VM stopped before the macro's promise settled: throw its termination and unwind.
+                    Err(jsc::Unsettled::Stopped(stopped)) => {
+                        return Err(MacroError::Js(stopped.throw(self.global)));
+                    }
+                    // Node's exit-13 condition, applied to the macro: nothing
+                    // keeps the loop alive, so waiting on it would be a hang.
+                    Err(jsc::Unsettled::Idle) => {
+                        self.log.add_error_fmt(
+                            Some(self.source),
+                            self.caller.loc,
+                            format_args!(
+                                "macro returned a promise that never settles: no timer, I/O, or task is keeping the event loop alive"
+                            ),
+                        );
+                        return Err(MacroError::MacroFailed);
+                    }
+                }
 
                 let promise_result = promise.result(vm.jsc_vm());
                 let rejected = promise.status() == jsc::js_promise::Status::Rejected;

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -465,7 +465,7 @@ impl Macro {
         }
 
         // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
-        let loaded_result = unsafe {
+        let (loaded_result, waited) = unsafe {
             (*vm).load_macro_entry_point(input_specifier, function_name, specifier, hash)
         }?;
 
@@ -483,11 +483,14 @@ impl Macro {
                 }
                 return Err(crate::Error::MacroLoadError);
             }
-            // The wait gave up: nothing keeps the loop alive for the module's
-            // top-level await (or the VM was stopped). A `Macro` returned here
-            // would have its first call find no registered function and leave
-            // the call in the output as an unbound reference.
-            jsc::PromiseResult::Pending => return Err(crate::Error::MacroLoadStalled),
+            // A `Macro` returned here would leave its first call in the output as an
+            // unbound reference.
+            jsc::PromiseResult::Pending => {
+                return Err(match waited {
+                    Err(jsc::Unsettled::Idle) => crate::Error::MacroLoadStalled,
+                    _ => crate::Error::JSError,
+                });
+            }
             jsc::PromiseResult::Fulfilled(_) => {}
         }
 
@@ -605,9 +608,7 @@ impl<'a> Run<'a> {
         // `runner.visited` dropped at scope exit (was `defer runner.visited.deinit(allocator)`)
 
         match runner.run(result) {
-            // Converting the macro's return value threw (a getter, an iterator, a toString): report it the
-            // way a throw from the macro function itself is reported above, rather than leaving it pending
-            // under the parser.
+            // A throw while converting the result (a getter) is reported like a throw from the macro.
             Err(MacroError::Js(JsError::Thrown)) => {
                 let err = global.take_exception(JsError::Thrown);
                 vm.as_mut().uncaught_exception(global, err, false);
@@ -661,9 +662,7 @@ impl<'a> Run<'a> {
         use ConsoleObject::formatter::Tag as T;
         match tag {
             T::Error => {
-                // Report it the way a throw is reported, then fail the
-                // expansion. Returning `self.caller` here would leave the call
-                // in the output with its import gone: an unbound reference.
+                // Returning `self.caller` would leave the call in the output with its import gone.
                 // SAFETY: `vm()` is the per-thread VM; uniquely accessed here.
                 let _ =
                     unsafe { (*self.macro_.vm()).uncaught_exception(self.global, value, false) };
@@ -738,16 +737,22 @@ impl<'a> Run<'a> {
 
                 let mut iter = JSArrayIterator::init(value, self.global)?;
 
-                // Every index up to `length` becomes an element of the literal,
-                // holes as `undefined`. Only a length the JS heap actually backs
-                // keeps that proportional: `[,,1]` with `length = 1e9` would
-                // otherwise become a billion `undefined`s.
+                // Every index below `length` becomes an element (holes as `undefined`), so
+                // `[,,1]` with `length = 1e9` would be a billion `undefined`s.
                 if let Err(stored) = value.indexed_storage_covers(iter.len) {
-                    self.log.add_error_fmt(
+                    self.log.add_range_error_fmt_with_notes(
                         Some(self.source),
-                        self.caller.loc,
+                        Range {
+                            loc: self.caller.loc,
+                            ..Default::default()
+                        },
+                        Box::new([bun_ast::range_data(
+                            None,
+                            Range::NONE,
+                            b"return a dense array",
+                        )]),
                         format_args!(
-                            "cannot coerce a sparse array to Bun's AST: its length is {} but it holds {} element{}. Please return a dense array",
+                            "cannot coerce a sparse array to Bun's AST: its length is {} but it holds {} element{}",
                             iter.len,
                             stored,
                             if stored == 1 { "" } else { "s" },
@@ -900,8 +905,7 @@ impl<'a> Run<'a> {
                     Err(jsc::Unsettled::Stopped(stopped)) => {
                         return Err(MacroError::Js(stopped.throw(self.global)));
                     }
-                    // Node's exit-13 condition, applied to the macro: nothing
-                    // keeps the loop alive, so waiting on it would be a hang.
+                    // Node's exit-13 condition: the wait would never end.
                     Err(jsc::Unsettled::Idle) => {
                         self.log.add_error_fmt(
                             Some(self.source),

--- a/src/js_parser_jsc/error.rs
+++ b/src/js_parser_jsc/error.rs
@@ -6,6 +6,9 @@ pub enum Error {
     MacroNotFound,
     #[error("MacroLoadError")]
     MacroLoadError,
+    /// The macro module's top-level await has nothing left that could settle it.
+    #[error("MacroLoadStalled")]
+    MacroLoadStalled,
     #[error("MacroFailed")]
     MacroFailed,
     #[error("JSError")]
@@ -31,6 +34,7 @@ impl Error {
             Self::ModuleNotFound => "ModuleNotFound",
             Self::MacroNotFound => "MacroNotFound",
             Self::MacroLoadError => "MacroLoadError",
+            Self::MacroLoadStalled => "MacroLoadStalled",
             Self::MacroFailed => "MacroFailed",
             Self::JSError => "JSError",
             Self::Alloc(_) => "OutOfMemory",

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2557,13 +2557,9 @@ impl JSValue {
             index => Some(index as u32),
         }
     }
-    /// `Ok(())` when `self` (an object) holds storage for `length` indexed
-    /// slots, so iterating them yields at most as much as the JS heap already
-    /// holds: a dense array, holes included, or an arguments object of that
-    /// many arguments. `Err(stored)` when `length` runs past its storage, which
-    /// is a sparse array (`[,,1]` with `length = 1e9`, `a[2**32 - 2] = 1`) or an
-    /// array-like whose `length` property was written past its elements;
-    /// `stored` is the number of elements it does hold.
+    /// `Ok(())` when `self` (an object) backs `length` indexed slots with storage (a dense array,
+    /// holes included). `Err(stored)` when `length` runs past that storage (a sparse array, or a
+    /// `length` property written past the elements), with the number of elements it does hold.
     pub fn indexed_storage_covers(self, length: u32) -> Result<(), u32> {
         debug_assert!(self.is_object());
         unsafe extern "C" {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2557,6 +2557,29 @@ impl JSValue {
             index => Some(index as u32),
         }
     }
+    /// `Ok(())` when `self` (an object) holds storage for `length` indexed
+    /// slots, so iterating them yields at most as much as the JS heap already
+    /// holds: a dense array, holes included, or an arguments object of that
+    /// many arguments. `Err(stored)` when `length` runs past its storage, which
+    /// is a sparse array (`[,,1]` with `length = 1e9`, `a[2**32 - 2] = 1`) or an
+    /// array-like whose `length` property was written past its elements;
+    /// `stored` is the number of elements it does hold.
+    pub fn indexed_storage_covers(self, length: u32) -> Result<(), u32> {
+        debug_assert!(self.is_object());
+        unsafe extern "C" {
+            safe fn Bun__JSObject__indexedStorageCovers(
+                this: JSValue,
+                length: u32,
+                out_stored_count: &mut u32,
+            ) -> bool;
+        }
+        let mut stored: u32 = 0;
+        if Bun__JSObject__indexedStorageCovers(self, length, &mut stored) {
+            Ok(())
+        } else {
+            Err(stored)
+        }
+    }
     /// `JSValue.getNameProperty` — the value's `.name` (function/class
     /// name). Empty for empty/`undefined`/`null`.
     pub fn get_name_property(self, global: &JSGlobalObject) -> JsResult<bun_core::String> {

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -231,6 +231,8 @@ impl SavedSourceMap {
     pub(crate) fn put_value(&mut self, path: &[u8], value: Value) -> bun_js_printer::Result<()> {
         use bun_collections::zig_hash_map::MapEntry as Entry;
 
+        // The table owns `value`'s allocation through a tagged pointer, which LeakSanitizer cannot follow.
+        bun_core::asan::lsan_ignore_object(value.as_uintptr() as usize as *const c_void);
         self.lock();
         // Note: reshaped for borrowck — explicit unlock paired manually.
 
@@ -283,6 +285,8 @@ impl SavedSourceMap {
             // the returned `Arc`.
             let result = Arc::new(ParsedSourceMap::from_internal(ism));
             *mapping = Value::init(Arc::into_raw(Arc::clone(&result))).ptr();
+            // As in `put_value`: owned by the table through a tagged pointer.
+            bun_core::asan::lsan_ignore_object(Arc::as_ptr(&result).cast());
             self.unlock();
             return SourceMap::ParseUrl {
                 map: Some(result),

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -37,6 +37,7 @@ unsafe extern "C" {
     safe fn JSC__VM__releaseWeakRefs(vm: &VM);
     safe fn JSC__VM__drainMicrotasks(vm: &VM);
     safe fn JSC__VM__blockBytesAllocated(vm: &VM) -> usize;
+    safe fn Bun__JSCTaskScheduler__hasPendingWork(vm: &VM) -> bool;
 }
 
 bun_opaque::opaque_ffi! {
@@ -100,6 +101,14 @@ impl VM {
 
     pub fn execution_forbidden(&self) -> bool {
         JSC__VM__executionForbidden(self)
+    }
+
+    /// JSC still holds deferred work it will post to this VM's loop later: an
+    /// `Atomics.waitAsync` timeout, a `FinalizationRegistry` callback, a wasm
+    /// compile. Only some of those keep the loop alive, so a promise waiting
+    /// on one can still settle with nothing else pending.
+    pub fn has_pending_deferred_work(&self) -> bool {
+        Bun__JSCTaskScheduler__hasPendingWork(self)
     }
 
     // These four functions fire VM traps. To understand what that means, see VMTraps.h for a giant explainer.

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -103,10 +103,8 @@ impl VM {
         JSC__VM__executionForbidden(self)
     }
 
-    /// JSC still holds deferred work it will post to this VM's loop later: an
-    /// `Atomics.waitAsync` timeout, a `FinalizationRegistry` callback, a wasm
-    /// compile. Only some of those keep the loop alive, so a promise waiting
-    /// on one can still settle with nothing else pending.
+    /// JSC will still post deferred work to this VM (an `Atomics.waitAsync` timeout, a wasm
+    /// compile); not all of it keeps the loop alive.
     pub fn has_pending_deferred_work(&self) -> bool {
         Bun__JSCTaskScheduler__hasPendingWork(self)
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1295,13 +1295,9 @@ impl VirtualMachine {
         }
     }
 
-    /// Something keeps the current loop alive: an active platform handle (a
-    /// socket, a ref'd timer, a keep-alive ref), a task in flight or queued, a
-    /// posting from another thread, or deferred work JSC holds for this VM. The
-    /// same question as [`Self::is_event_loop_alive`] minus whether the program
-    /// already failed, plus JSC's tickets that do not hold the loop open (an
-    /// `Atomics.waitAsync` timeout): what a wait on a pending promise asks
-    /// before it concludes that nothing will settle it.
+    /// Something can still run JS on the current loop: [`Self::is_event_loop_alive`] without
+    /// `unhandled_error_counter`, plus JSC's deferred work (an `Atomics.waitAsync` timeout does
+    /// not keep the loop alive).
     pub fn has_pending_work(&self) -> bool {
         let el = self.event_loop_shared();
         self.has_pending_work_excluding_immediates()
@@ -1561,7 +1557,7 @@ impl VirtualMachine {
         function_name: &[u8],
         specifier: &[u8],
         hash: i32,
-    ) -> crate::CrateResult<*mut JSInternalPromise> {
+    ) -> crate::CrateResult<(*mut JSInternalPromise, Result<(), jsc::Unsettled>)> {
         use bun_bundler::entry_points::{Fs, MacroEntryPoint};
         use bun_collections::hash_map::Entry;
         let entry_point: *mut MacroEntryPoint = match self.macro_entry_points.entry(hash) {
@@ -1591,11 +1587,11 @@ impl VirtualMachine {
         // SAFETY: `entry_point` was just inserted (heap-allocated) or fetched
         // from the cache; it lives for the VM lifetime.
         let path: &[u8] = unsafe { &*entry_point }.source.path.text;
-        let promise = self.run_with_api_lock(|| {
+        let loaded = self.run_with_api_lock(|| {
             // SAFETY: per-thread VM; the API lock guarantees JSC is held.
             VirtualMachine::get().as_mut()._load_macro_entry_point(path)
         });
-        promise.ok_or(crate::CrateError::JSError)
+        loaded.ok_or(crate::CrateError::JSError)
     }
 
     pub fn is_watcher_enabled(&self) -> bool {
@@ -5224,20 +5220,19 @@ impl VirtualMachine {
         }
     }
 
-    /// Loads and evaluates a macro entry module, waiting for its promise. The
-    /// promise is still pending on return when the module's top-level `await`
-    /// can never settle (nothing left on the loop) or the VM was stopped.
+    /// Loads and evaluates a macro entry module. The promise is still pending on return when the
+    /// wait gave up (`Idle`: its top-level `await` can never settle; `Stopped`: the VM stopped).
     #[inline]
     pub(crate) fn _load_macro_entry_point(
         &mut self,
         entry_path: &[u8],
-    ) -> Option<*mut JSInternalPromise> {
+    ) -> Option<(*mut JSInternalPromise, Result<(), jsc::Unsettled>)> {
         let path_str = bun_core::String::from_bytes(entry_path);
         let promise =
             jsc::JSModuleLoader::load_and_evaluate_module_ptr(self.global, Some(&path_str))?
                 .as_ptr();
-        let _ = self.wait_for_promise_until_idle(jsc::AnyPromise::Internal(promise));
-        Some(promise)
+        let waited = self.wait_for_promise_until_idle(jsc::AnyPromise::Internal(promise));
+        Some((promise, waited))
     }
 
     /// Prints an error-like JS value to the console via the error handler.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1295,20 +1295,33 @@ impl VirtualMachine {
         }
     }
 
-    pub fn is_event_loop_alive_excluding_immediates(&self) -> bool {
+    /// Something keeps the current loop alive: an active platform handle (a
+    /// socket, a ref'd timer, a keep-alive ref), a task in flight or queued, a
+    /// posting from another thread, or deferred work JSC holds for this VM. The
+    /// same question as [`Self::is_event_loop_alive`] minus whether the program
+    /// already failed, plus JSC's tickets that do not hold the loop open (an
+    /// `Atomics.waitAsync` timeout): what a wait on a pending promise asks
+    /// before it concludes that nothing will settle it.
+    pub fn has_pending_work(&self) -> bool {
         let el = self.event_loop_shared();
-        let active = self
-            .platform_loop_opt()
-            .map(|h| h.is_active())
-            .unwrap_or(false);
-        self.unhandled_error_counter == 0
-            && ((active as usize)
-                + self.active_tasks
-                + el.tasks.readable_length()
-                + el.yield_tasks.len()
-                + (el.has_concurrent_tasks() as usize)
-                + (el.has_pending_refs() as usize)
-                > 0)
+        self.has_pending_work_excluding_immediates()
+            || !el.immediate_tasks.is_empty()
+            || !el.next_immediate_tasks.is_empty()
+            || self.jsc_vm().has_pending_deferred_work()
+    }
+
+    fn has_pending_work_excluding_immediates(&self) -> bool {
+        let el = self.event_loop_shared();
+        self.platform_loop_opt().is_some_and(|h| h.is_active())
+            || self.active_tasks > 0
+            || el.tasks.readable_length() > 0
+            || !el.yield_tasks.is_empty()
+            || el.has_concurrent_tasks()
+            || el.has_pending_refs()
+    }
+
+    pub fn is_event_loop_alive_excluding_immediates(&self) -> bool {
+        self.unhandled_error_counter == 0 && self.has_pending_work_excluding_immediates()
     }
 
     pub fn is_event_loop_alive(&self) -> bool {
@@ -2774,6 +2787,15 @@ impl VirtualMachine {
     #[inline]
     pub fn wait_for_promise(&mut self, promise: jsc::AnyPromise) -> Result<(), jsc::Stopped> {
         self.event_loop_mut().wait_for_promise(promise)
+    }
+
+    /// Forwarder for [`crate::event_loop::EventLoop::wait_for_promise_until_idle`].
+    #[inline]
+    pub fn wait_for_promise_until_idle(
+        &mut self,
+        promise: jsc::AnyPromise,
+    ) -> Result<(), jsc::Unsettled> {
+        self.event_loop_mut().wait_for_promise_until_idle(promise)
     }
 
     /// `eventLoop().autoTick()` — dispatched through the runtime hook
@@ -5202,7 +5224,9 @@ impl VirtualMachine {
         }
     }
 
-    /// Loads and evaluates a macro entry module, waiting for its promise.
+    /// Loads and evaluates a macro entry module, waiting for its promise. The
+    /// promise is still pending on return when the module's top-level `await`
+    /// can never settle (nothing left on the loop) or the VM was stopped.
     #[inline]
     pub(crate) fn _load_macro_entry_point(
         &mut self,
@@ -5212,7 +5236,7 @@ impl VirtualMachine {
         let promise =
             jsc::JSModuleLoader::load_and_evaluate_module_ptr(self.global, Some(&path_str))?
                 .as_ptr();
-        let _ = self.wait_for_promise(jsc::AnyPromise::Internal(promise));
+        let _ = self.wait_for_promise_until_idle(jsc::AnyPromise::Internal(promise));
         Some(promise)
     }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -857,9 +857,8 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUptime, (JSC::JSGlobalObject * lexicalG
     return JSC::JSValue::encode(JSC::jsNumber(result));
 }
 
-// A macro runs in the VM of whichever thread is transpiling: a bundler worker,
-// or the program's own main thread mid-`require()`. Exiting from inside one
-// would take down the build, or the program that is only importing the file.
+// A macro runs in the transpiling thread's VM (a bundler worker, or the program
+// itself mid-require()): exiting from one would exit the build or the program.
 static bool isRunningMacro(Zig::GlobalObject* globalObject)
 {
     return Bun__VM__currentLoopKind(globalObject->bunVM()) == BunLoopKind::Macro;
@@ -3717,7 +3716,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     if (isRunningMacro(defaultGlobalObject(globalObject))) [[unlikely]] {
-        throwTypeError(globalObject, throwScope, "process.exit() cannot be called from a macro"_s);
+        throwTypeError(globalObject, throwScope, "process.reallyExit() cannot be called from a macro"_s);
         return {};
     }
     uint8_t exitCode = 0;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -857,11 +857,23 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUptime, (JSC::JSGlobalObject * lexicalG
     return JSC::JSValue::encode(JSC::jsNumber(result));
 }
 
+// A macro runs in the VM of whichever thread is transpiling: a bundler worker,
+// or the program's own main thread mid-`require()`. Exiting from inside one
+// would take down the build, or the program that is only importing the file.
+static bool isRunningMacro(Zig::GlobalObject* globalObject)
+{
+    return Bun__VM__currentLoopKind(globalObject->bunVM()) == BunLoopKind::Macro;
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionExit, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto* zigGlobal = defaultGlobalObject(globalObject);
+    if (isRunningMacro(zigGlobal)) [[unlikely]] {
+        throwTypeError(globalObject, throwScope, "process.exit() cannot be called from a macro"_s);
+        return {};
+    }
     auto process = zigGlobal->processObject();
 
     auto code = callFrame->argument(0);
@@ -1823,6 +1835,12 @@ static void restoreDefaultSignalDisposition(int signalNumber)
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionAbort, (JSGlobalObject * globalObject, CallFrame*))
 {
+    if (isRunningMacro(defaultGlobalObject(globalObject))) [[unlikely]] {
+        auto& vm = JSC::getVM(globalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        throwTypeError(globalObject, throwScope, "process.abort() cannot be called from a macro"_s);
+        return {};
+    }
 #if OS(WINDOWS)
     // Raising SIGABRT is handled in the CRT in windows, calling _exit() with ambiguous code "3" by default.
     // This adjustment to the abort behavior gives a more sane exit code on abort, by calling _exit directly with code 134.
@@ -3698,6 +3716,10 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
 {
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    if (isRunningMacro(defaultGlobalObject(globalObject))) [[unlikely]] {
+        throwTypeError(globalObject, throwScope, "process.exit() cannot be called from a macro"_s);
+        return {};
+    }
     uint8_t exitCode = 0;
     JSValue arg0 = callFrame->argument(0);
     if (arg0.isAnyInt()) {

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -157,14 +157,23 @@ extern "C" void Bun__deleteDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
     delete job;
 }
 
-// JSC still holds a ticket whose completion it will post to this VM later,
-// whether or not that ticket keeps the event loop alive (an Atomics.waitAsync
-// timeout does not). A wait that gives up on an idle loop asks this first.
+// A ticket JSC will still post to the VM's current loop, whether or not it keeps
+// that loop alive (an Atomics.waitAsync timeout does not).
 extern "C" bool Bun__JSCTaskScheduler__hasPendingWork(JSC::VM* vm)
 {
-    auto& scheduler = WebCore::clientData(*vm)->deferredWorkTimer;
+    auto* clientData = WebCore::clientData(*vm);
+    BunLoopKind loopKind = Bun__VM__currentLoopKind(clientData->bunVM);
+    auto& scheduler = clientData->deferredWorkTimer;
     Locker<Lock> holder { scheduler.m_lock };
-    return !scheduler.m_pendingTicketsKeepingEventLoopAlive.isEmpty() || !scheduler.m_pendingTicketsOther.isEmpty();
+    for (auto& ticket : scheduler.m_pendingTicketsKeepingEventLoopAlive) {
+        if (ticket.value == loopKind)
+            return true;
+    }
+    for (auto& ticket : scheduler.m_pendingTicketsOther) {
+        if (ticket.value == loopKind)
+            return true;
+    }
+    return false;
 }
 
 }

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -157,4 +157,14 @@ extern "C" void Bun__deleteDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
     delete job;
 }
 
+// JSC still holds a ticket whose completion it will post to this VM later,
+// whether or not that ticket keeps the event loop alive (an Atomics.waitAsync
+// timeout does not). A wait that gives up on an idle loop asks this first.
+extern "C" bool Bun__JSCTaskScheduler__hasPendingWork(JSC::VM* vm)
+{
+    auto& scheduler = WebCore::clientData(*vm)->deferredWorkTimer;
+    Locker<Lock> holder { scheduler.m_lock };
+    return !scheduler.m_pendingTicketsKeepingEventLoopAlive.isEmpty() || !scheduler.m_pendingTicketsOther.isEmpty();
+}
+
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -38,6 +38,8 @@
 #include "JavaScriptCore/BytecodeIndex.h"
 #include "JavaScriptCore/CodeBlock.h"
 #include "JavaScriptCore/Completion.h"
+#include "JavaScriptCore/DirectArguments.h"
+#include "JavaScriptCore/ScopedArguments.h"
 #include "JavaScriptCore/ErrorInstance.h"
 #include "JavaScriptCore/ExceptionHelpers.h"
 #include "JavaScriptCore/ExceptionScope.h"
@@ -7243,6 +7245,71 @@ extern "C" uint64_t Bun__JSArray__nextPresentIndex(
     default:
         ASSERT_NOT_REACHED();
         return start;
+    }
+}
+
+// Whether `value` holds storage for `length` indexed slots. A dense array's
+// butterfly backs every slot of its length (holes included), so whatever is
+// built from its elements is proportional to the JS heap it already occupies.
+// A sparse array is not: `[,,1]` with `length = 1e9` keeps one element in a
+// vector of three and `a[2**32 - 2] = 1` keeps one in the sparse map, yet
+// iterating `length` indices yields a billion `undefined`s. Arguments objects
+// keep their elements off the butterfly and their `length` property can be
+// written past them. When the storage falls short, `*outStoredCount` is the
+// number of elements it does hold.
+extern "C" bool Bun__JSObject__indexedStorageCovers(
+    JSC::EncodedJSValue encodedValue,
+    uint32_t length,
+    uint32_t* outStoredCount)
+{
+    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
+    if (!value.isObject())
+        return false;
+    JSC::JSObject* object = value.getObject();
+
+    switch (object->type()) {
+    case JSC::DirectArgumentsType:
+        *outStoredCount = uncheckedDowncast<JSC::DirectArguments>(object)->internalLength();
+        return length <= *outStoredCount;
+    case JSC::ScopedArgumentsType:
+        *outStoredCount = uncheckedDowncast<JSC::ScopedArguments>(object)->internalLength();
+        return length <= *outStoredCount;
+    default:
+        break;
+    }
+
+    switch (object->indexingType() & JSC::IndexingShapeMask) {
+    case JSC::UndecidedShape:
+    case JSC::Int32Shape:
+    case JSC::DoubleShape:
+    case JSC::ContiguousShape:
+        *outStoredCount = object->butterfly()->publicLength();
+        return length <= *outStoredCount;
+
+    case JSC::ArrayStorageShape:
+    case JSC::SlowPutArrayStorageShape: {
+        JSC::ArrayStorage* storage = object->butterfly()->arrayStorage();
+        unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
+        // The vector backs its slots whether or not they are filled; only
+        // what lies past it (or lives in the map) is unbacked.
+        uint64_t backed = usedVectorLength;
+        uint64_t stored = 0;
+        for (unsigned i = 0; i < usedVectorLength; ++i) {
+            if (storage->m_vector[i])
+                stored++;
+        }
+        if (JSC::SparseArrayValueMap* map = storage->m_sparseMap.get()) {
+            backed += map->size();
+            stored += map->size();
+        }
+        *outStoredCount = static_cast<uint32_t>(std::min<uint64_t>(stored, std::numeric_limits<uint32_t>::max()));
+        return length <= backed;
+    }
+
+    default:
+        // No indexed storage at all.
+        *outStoredCount = 0;
+        return length == 0;
     }
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7248,15 +7248,10 @@ extern "C" uint64_t Bun__JSArray__nextPresentIndex(
     }
 }
 
-// Whether `value` holds storage for `length` indexed slots. A dense array's
-// butterfly backs every slot of its length (holes included), so whatever is
-// built from its elements is proportional to the JS heap it already occupies.
-// A sparse array is not: `[,,1]` with `length = 1e9` keeps one element in a
-// vector of three and `a[2**32 - 2] = 1` keeps one in the sparse map, yet
-// iterating `length` indices yields a billion `undefined`s. Arguments objects
-// keep their elements off the butterfly and their `length` property can be
-// written past them. When the storage falls short, `*outStoredCount` is the
-// number of elements it does hold.
+// Whether `value` backs `length` indexed slots with storage: a dense array does
+// (holes included); `[,,1]` with `length = 1e9` or `a[2**32 - 2] = 1` does not.
+// Arguments objects keep their elements off the butterfly, and their `length`
+// property can be written past them. `*outStoredCount` is the element count.
 extern "C" bool Bun__JSObject__indexedStorageCovers(
     JSC::EncodedJSValue encodedValue,
     uint32_t length,
@@ -7290,8 +7285,7 @@ extern "C" bool Bun__JSObject__indexedStorageCovers(
     case JSC::SlowPutArrayStorageShape: {
         JSC::ArrayStorage* storage = object->butterfly()->arrayStorage();
         unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
-        // The vector backs its slots whether or not they are filled; only
-        // what lies past it (or lives in the map) is unbacked.
+        // Vector slots are backed whether or not they are filled.
         uint64_t backed = usedVectorLength;
         uint64_t stored = 0;
         for (unsigned i = 0; i < usedVectorLength; ++i) {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -202,6 +202,17 @@ impl Stopped {
     }
 }
 
+/// Why [`EventLoop::wait_for_promise_until_idle`] returned with its promise still pending.
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unsettled {
+    #[error(transparent)]
+    Stopped(Stopped),
+    /// Nothing keeps the loop alive any more ([`VirtualMachine::has_pending_work`]):
+    /// the condition under which a program would have exited with it unsettled.
+    #[error("Idle")]
+    Idle,
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // §Dispatch hot-path — `tick_queue_with_count` is the per-tick dispatch over
 // `Task { tag, ptr }`. Per PORTING.md, the *high tier owns the match loop*:
@@ -1116,6 +1127,37 @@ impl EventLoop {
             if promise.status() == PromiseStatus::Pending {
                 self.auto_tick();
             }
+        }
+        Ok(())
+    }
+
+    /// [`Self::wait_for_promise`], but gives up once nothing keeps the loop
+    /// alive ([`VirtualMachine::has_pending_work`]): where a program would have
+    /// exited with `promise` unsettled, this returns `Idle` with it pending. A
+    /// wait that has to finish (a macro, whose caller holds the parse) uses this
+    /// so such a promise is an error rather than a hang.
+    pub fn wait_for_promise_until_idle(
+        &mut self,
+        promise: jsc::AnyPromise,
+    ) -> Result<(), Unsettled> {
+        let jsc_vm = self.vm_ref().jsc_vm();
+        while promise.status() == PromiseStatus::Pending {
+            if jsc_vm.execution_forbidden()
+                || !self.vm_ref().script_allowed()
+                || self.global_ref().has_pending_termination_exception()
+            {
+                return Err(Unsettled::Stopped(Stopped));
+            }
+            self.tick();
+            if promise.status() != PromiseStatus::Pending {
+                break;
+            }
+            // After the drain, so a reaction queued by the last task (or a
+            // handle it opened) counts.
+            if !self.vm_ref().has_pending_work() {
+                return Err(Unsettled::Idle);
+            }
+            self.auto_tick();
         }
         Ok(())
     }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -207,8 +207,7 @@ impl Stopped {
 pub enum Unsettled {
     #[error(transparent)]
     Stopped(Stopped),
-    /// Nothing keeps the loop alive any more ([`VirtualMachine::has_pending_work`]):
-    /// the condition under which a program would have exited with it unsettled.
+    /// Nothing keeps the loop alive ([`VirtualMachine::has_pending_work`]): a program would have exited here.
     #[error("Idle")]
     Idle,
 }
@@ -1131,29 +1130,31 @@ impl EventLoop {
         Ok(())
     }
 
-    /// [`Self::wait_for_promise`], but gives up once nothing keeps the loop
-    /// alive ([`VirtualMachine::has_pending_work`]): where a program would have
-    /// exited with `promise` unsettled, this returns `Idle` with it pending. A
-    /// wait that has to finish (a macro, whose caller holds the parse) uses this
-    /// so such a promise is an error rather than a hang.
+    /// [`Self::wait_for_promise`], but returns `Idle` with `promise` still pending once nothing
+    /// keeps the loop alive ([`VirtualMachine::has_pending_work`]), where a program would have exited.
     pub fn wait_for_promise_until_idle(
         &mut self,
         promise: jsc::AnyPromise,
     ) -> Result<(), Unsettled> {
         let jsc_vm = self.vm_ref().jsc_vm();
+        let stopped = |this: &Self| {
+            jsc_vm.execution_forbidden()
+                || !this.vm_ref().script_allowed()
+                || this.global_ref().has_pending_termination_exception()
+        };
         while promise.status() == PromiseStatus::Pending {
-            if jsc_vm.execution_forbidden()
-                || !self.vm_ref().script_allowed()
-                || self.global_ref().has_pending_termination_exception()
-            {
+            if stopped(self) {
                 return Err(Unsettled::Stopped(Stopped));
             }
             self.tick();
             if promise.status() != PromiseStatus::Pending {
                 break;
             }
-            // After the drain, so a reaction queued by the last task (or a
-            // handle it opened) counts.
+            // A task in that tick may have requested the stop; a stop is never idle.
+            if stopped(self) {
+                return Err(Unsettled::Stopped(Stopped));
+            }
+            // After the drain, so what the last task queued or opened counts.
             if !self.vm_ref().has_pending_work() {
                 return Err(Unsettled::Idle);
             }

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1237,7 +1237,8 @@ pub mod job;
 pub use self::event_loop::{
     AnyEventLoop, AnyTaskWithExtraContext, ConcurrentCppTask, ConcurrentTask, CppTask,
     DeferredTaskQueue, EventLoopHandle, EventLoopTask, GarbageCollectionController, ManagedTask,
-    MiniEventLoop, PosixSignalHandle, PosixSignalTask, Stopped, Task, WorkPool, WorkPoolTask,
+    MiniEventLoop, PosixSignalHandle, PosixSignalTask, Stopped, Task, Unsettled, WorkPool,
+    WorkPoolTask,
 };
 pub use self::job::{Completion, Job, JobContext, JsPtr, JsThread, Protected};
 #[cfg(unix)]

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -406,7 +406,7 @@ describe("a hostile macro", () => {
         .split("\n")
         .filter(line => !line.startsWith("[macro]"))
         .join("\n"),
-      stderr: stderr.replaceAll(String(dir), "[dir]"),
+      stderr: stderr.replaceAll(String(dir), "[dir]").replaceAll("\\", "/"),
       exitCode,
       signalCode: proc.signalCode,
     };

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -381,6 +381,180 @@ describe("event loop routing around macros", () => {
   });
 });
 
+// A macro produces a value for the file being bundled, nothing else: it cannot take the process down,
+// every failure is a located build error, and what it returns has to fit in the output.
+describe("a hostile macro", () => {
+  async function build(files: Record<string, string>) {
+    using dir = tempDir("macro-hostile", {
+      ...files,
+      "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nexport const v = m();\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      // Each of these hung or exited the process before its fix. Bounded so a regression fails instead.
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      // Debug builds print "[macro] call <name>" to stdout before the output.
+      stdout: stdout
+        .split("\n")
+        .filter(line => !line.startsWith("[macro]"))
+        .join("\n"),
+      stderr: stderr.replaceAll(String(dir), "[dir]"),
+      exitCode,
+      signalCode: proc.signalCode,
+    };
+  }
+
+  test.concurrent.each([
+    ["process.exit()", `process.exit(42)`, "process.exit() cannot be called from a macro"],
+    ["process.reallyExit()", `process.reallyExit(42)`, "process.exit() cannot be called from a macro"],
+    ["process.abort()", `process.abort()`, "process.abort() cannot be called from a macro"],
+  ])("%s inside a macro fails the build instead of the process", async (_name, call, message) => {
+    const { stderr, exitCode, signalCode } = await build({ "m.ts": `export function m() { ${call}; }` });
+    expect({ exitCode, signalCode, stderr }).toEqual({
+      exitCode: 1,
+      signalCode: null,
+      stderr: expect.stringContaining(message),
+    });
+    expect(stderr).toContain("error: macro threw exception");
+  });
+
+  // Bun.build() runs macros on its bundler threads; the program that called it must outlive them.
+  test.concurrent("process.exit() inside a macro does not exit the Bun.build() caller", async () => {
+    using dir = tempDir("macro-hostile-api", {
+      "m.ts": `export function m() { process.exit(42); }`,
+      "user.ts": `import { m } from "./m.ts" with { type: "macro" };\nexport const v = m();\n`,
+      "build.ts": [
+        `const result = await Bun.build({ entrypoints: ["./user.ts"], throw: false });`,
+        `console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => log.message) }));`,
+      ].join("\n"),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "build.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ lastLine: stdout.trim().split("\n").pop(), stderr, exitCode }).toEqual({
+      lastLine: JSON.stringify({ success: false, logs: ["macro threw exception"] }),
+      stderr: expect.stringContaining("process.exit() cannot be called from a macro"),
+      exitCode: 0,
+    });
+  });
+
+  // Before: the error was printed and the call was left in the output, with its import gone.
+  test.concurrent("returning an Error fails the build instead of leaving the call in the output", async () => {
+    const { stdout, stderr, exitCode } = await build({
+      "m.ts": `export function m() { return new Error("returned, not thrown"); }`,
+    });
+    expect({ exitCode, stdout, stderr }).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: expect.stringContaining("error: returned, not thrown"),
+    });
+    expect(stderr).toContain("error: macro threw exception");
+  });
+
+  // Every index up to `length` becomes an element of the literal. JSC only backs a dense array's length
+  // with storage; a sparse one (length set past its elements, or an index in the sparse map) would
+  // inflate without bound: `[,,1]` with `length = 1e9` is a billion `undefined`s.
+  test.concurrent.each([
+    [
+      "length set past its elements",
+      `const a = [, , 1]; a.length = 200000; return a;`,
+      "its length is 200000 but it holds 1 element",
+    ],
+    [
+      "an element in the sparse map",
+      `const a = []; a[150000] = 1; return a;`,
+      "its length is 150001 but it holds 1 element",
+    ],
+    [
+      "an arguments object whose length was overwritten",
+      `return (function () { "use strict"; arguments.length = 200000; return arguments; })(4, 5);`,
+      "its length is 200000 but it holds 2 elements",
+    ],
+  ])("a sparse array (%s) is refused with a located error", async (_name, body, message) => {
+    const { stderr, exitCode } = await build({ "m.ts": `export function m() { ${body} }` });
+    expect({ exitCode, stderr }).toEqual({
+      exitCode: 1,
+      stderr: expect.stringContaining(
+        `error: cannot coerce a sparse array to Bun's AST: ${message}. Please return a dense array`,
+      ),
+    });
+    expect(stderr).toContain("at [dir]/index.ts:2:18");
+  });
+
+  test.concurrent("dense arrays with holes, arguments objects, and doubles are still inlined", async () => {
+    const { stdout, stderr, exitCode } = await build({
+      "m.ts": [
+        `export function m() {`,
+        `  return [[1, , 3], new Array(3), (function () { return arguments; })(4, 5), [1.5, , 2.5], new Array(200000).fill(7).length];`,
+        `}`,
+      ].join("\n"),
+    });
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(stdout.replace(/\s+/g, "")).toContain(
+      "varv=[[1,undefined,3],[undefined,undefined,undefined],[4,5],[1.5,undefined,2.5],200000];",
+    );
+  });
+
+  // Before: the parse spun on the promise forever (100% CPU). A program in the same state, a pending await
+  // with nothing keeping the event loop alive, would have exited; the macro fails the same way.
+  test.concurrent("a returned promise that can never settle is a located error", async () => {
+    const { stderr, exitCode, signalCode } = await build({
+      "m.ts": `export function m() { return new Promise(() => {}); }`,
+    });
+    expect({ exitCode, signalCode, stderr }).toEqual({
+      exitCode: 1,
+      signalCode: null,
+      stderr: expect.stringContaining(
+        "error: macro returned a promise that never settles: no timer, I/O, or task is keeping the event loop alive",
+      ),
+    });
+    expect(stderr).toContain("at [dir]/index.ts:2:18");
+  });
+
+  test.concurrent("a macro module whose top-level await can never settle is a located error", async () => {
+    const { stderr, exitCode, signalCode } = await build({
+      "m.ts": `await new Promise(() => {});\nexport function m() { return 1; }`,
+    });
+    expect({ exitCode, signalCode, stderr }).toEqual({
+      exitCode: 1,
+      signalCode: null,
+      stderr: expect.stringContaining(
+        `error: macro "./m.ts" never finished loading: its top-level await is pending and nothing is keeping the event loop alive`,
+      ),
+    });
+    expect(stderr).toContain("at [dir]/index.ts:1:19");
+  });
+
+  // Promises that do settle keep working, including ones nothing on the loop holds open for: JSC posts
+  // an Atomics.waitAsync timeout itself, and it does not keep the event loop alive.
+  test.concurrent("a returned promise that will settle is awaited", async () => {
+    const { stdout, stderr, exitCode } = await build({
+      "m.ts": [
+        `export async function m() {`,
+        `  const { value } = Atomics.waitAsync(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `  await new Promise(resolve => setTimeout(resolve, 10));`,
+        `  return [await value, await Bun.file(import.meta.path).text().then(text => text.length > 0)];`,
+        `}`,
+      ].join("\n"),
+    });
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(stdout.replace(/\s+/g, "")).toContain(`varv=["timed-out",true];`);
+  });
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -507,6 +507,22 @@ describe("a hostile macro", () => {
     );
   });
 
+  // The value-to-AST walk recurses once per nesting level on a bundler pool thread's stack. Before: a
+  // stack overflow, SIGSEGV with nothing printed.
+  test.concurrent.each([
+    ["objects", `v = { v }`],
+    ["arrays", `v = [v]`],
+  ])("a return value nested 100000 %s deep is a located error", async (_name, wrap) => {
+    const { stderr, exitCode, signalCode } = await build({
+      "m.ts": `export function m() { let v: unknown = 1; for (let i = 0; i < 100000; i++) ${wrap}; return v; }`,
+    });
+    expect({ exitCode, signalCode, stderr }).toEqual({
+      exitCode: 1,
+      signalCode: null,
+      stderr: expect.stringContaining("error: macro return value is too deeply nested\n    at [dir]/index.ts:2:18"),
+    });
+  });
+
   // Before: the parse spun on the promise forever (100% CPU). A program in the same state, a pending await
   // with nothing keeping the event loop alive, would have exited; the macro fails the same way.
   test.concurrent("a returned promise that can never settle is a located error", async () => {

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -414,7 +414,7 @@ describe("a hostile macro", () => {
 
   test.concurrent.each([
     ["process.exit()", `process.exit(42)`, "process.exit() cannot be called from a macro"],
-    ["process.reallyExit()", `process.reallyExit(42)`, "process.exit() cannot be called from a macro"],
+    ["process.reallyExit()", `process.reallyExit(42)`, "process.reallyExit() cannot be called from a macro"],
     ["process.abort()", `process.abort()`, "process.abort() cannot be called from a macro"],
   ])("%s inside a macro fails the build instead of the process", async (_name, call, message) => {
     const { stderr, exitCode, signalCode } = await build({ "m.ts": `export function m() { ${call}; }` });
@@ -487,11 +487,10 @@ describe("a hostile macro", () => {
     const { stderr, exitCode } = await build({ "m.ts": `export function m() { ${body} }` });
     expect({ exitCode, stderr }).toEqual({
       exitCode: 1,
-      stderr: expect.stringContaining(
-        `error: cannot coerce a sparse array to Bun's AST: ${message}. Please return a dense array`,
-      ),
+      stderr: expect.stringContaining(`error: cannot coerce a sparse array to Bun's AST: ${message}\n`),
     });
     expect(stderr).toContain("at [dir]/index.ts:2:18");
+    expect(stderr).toContain("note: return a dense array");
   });
 
   test.concurrent("dense arrays with holes, arguments objects, and doubles are still inlined", async () => {


### PR DESCRIPTION
### Problem
- A macro can take down the process that runs the build. `process.exit(42)` exits it, including a program that called `Bun.build()`. A returned `Error` leaves `var v = m();` in the output with its import gone. A throw reads `cannot coerce Exception (JSType(0)) to Bun's AST`.
- A macro can exhaust or stall the build (`Run::coerce`, `src/js_parser_jsc/Macro.rs`). `[,,1]` with `length = 1e9` becomes a billion `undefined`s. `new Promise(() => {})` spins `wait_for_promise` forever. A value nested 10000 deep overflows the stack: SIGSEGV, no message.

### Fix
- `process.exit()`, `reallyExit()`, `abort()` and a `kill()` of the current process throw a `TypeError` while the macro loop is current. Every macro failure prints with `run_error_handler` and is a located build error. A macro that failed to load fails each later use.
- An array is accepted only when JSC backs its `length` with storage (`Bun__JSObject__indexedStorageCovers`). The value walk carries the parser's `StackCheck`.
- `wait_for_promise_until_idle` gives up when nothing keeps the loop alive, where a program would have exited with the promise unsettled.
- Verified: `test/bundler/transpiler/macro-test.test.ts`, 21 new cases, 19 fail before this PR. Also `regression/issue/39900`, `03830`, `22656`, `26360`.

### Background
- A macro runs in the VM of the thread that transpiles: a bundler worker for `bun build`, the program's own VM for a `require()`d file. `Bun__VM__currentLoopKind` reports the macro loop while one runs.
- `uncaught_exception` is the fatal-error report: exit code 1 and a dead event loop, even when the program catches the failed `require()`.
- `Run::coerce` turns every index below `length` into an AST element. An `ArrayStorage` array can have `length` `2^32 - 1` and hold one value.

Overlap: #40059 also covers `process.exit()` and a returned or thrown `Error`. The array bound, the idle wait and the stack check are not in it.

<details><summary>Notes</summary>

Review round of 2026-09-18 (e37bf9d): a file loaded with `require()` runs its macros in the program's own VM, so reporting a macro failure through `uncaught_exception` / `unhandled_rejection` set exit code 1 and `unhandled_error_counter`, and the program's loop was abandoned even though it caught the failed `require()`. All six report sites (throw, throw while converting, returned `Error`, `BuildMessage`/`ResolveMessage`, rejected promise, module load rejection) now print with `run_error_handler`. The returned promise is marked handled before the wait because `tick()` ends with `handle_rejected_promises()`. `MacroContext::call` no longer returns the caller for a disabled entry. `Process_functionReallyKill` refuses a signal above 0 aimed at the current process (pid 0, -1, own pid, and `-getpgrp()` through `killReachesThisProcess`, ac9730f); signal 0 and signals to children still work.

Not caused by this PR: on release builds a macro result nested a few thousand levels deep passes the stack check (release frames are small), is printed, and then `bun run` spins in JSC's parser. The same happens with no macro: `(0, eval)("var x = " + "{v:".repeat(2900) + "1" + "}".repeat(2900))` never returns, while depth 2850 parses in 13 ms. `parseAssignmentExpression` re-parses a failed `{`/`[` expression as a destructuring pattern even when the failure was "Stack exhausted", so each level past the limit descends twice. That needs a WebKit change and is tracked separately.

Known limits, not changed here: the platform loop has one `active` count shared by the VM's two embedded loops, so in a program (not a bundler worker) that has a listening server or a ref'd timer, a never-settling macro promise in a `require()`d file still waits as before; the shared count can delay the error but cannot report a promise that something could still settle. A dense array has no element cap: it already occupies 8 bytes per slot in the JS heap, so the AST stays a constant factor of memory the macro paid for. Also: a frozen or sealed array that has holes is refused (its elements live in the sparse map and the holes have no storage; any fixed allowance for unbacked slots reopens the growth in aggregate). The `process.*` guards test the loop kind, not whether a macro frame is on the stack, because an async macro's continuation runs inside the wait's tick. After a macro awaits `WebAssembly.compile()` on a bundler worker, that worker's loop keeps a stale keep-alive (the ticket is ref'd on the macro loop and released on the regular loop), so a later never-settling macro promise on the same worker still hangs; that bookkeeping is outside this diff and is tracked separately.

Reproduction on stock 1.4.1 (`bun build` of a file importing each macro with `{ type: "macro" }`):

- `process.exit(42)`: exit code 42 from both `bun build` and a `Bun.build()` host script.
- `return new Error("e")`: `error: e` on stderr, exit 0, output `var v = retError();` and no import.
- `throw new Error("boom")`: `error: cannot coerce Exception (JSType(0)) to Bun's AST`.
- `const a = [,,1]; a.length = 1e9; return a;`: RSS passes 2.5 GB, no error. Same for `a.length = 2**32 - 1; a[2**32 - 2] = 1`.
- `return new Promise(() => {})`: hangs at 100% CPU. Same for `await new Promise(() => {})` at the macro module's top level.
- `let v = 1; for (let i = 0; i < 10000; i++) v = { v }; return v;`: exit 139 (SIGSEGV), no output. The debug build dies at depth 1000.

The sparse rule in JSC's terms: `[,,1].length = 1e9` exceeds `MAX_STORAGE_VECTOR_LENGTH` so `JSArray::setLength` converts to ArrayStorage and only stores the new length; `a.length = 200000` (past `MIN_SPARSE_ARRAY_INDEX` with one element) does the same through `isDenseEnoughForVector`; `a[150000] = 1` goes to the sparse map. `new Array(200000)` allocates a 200000-slot butterfly (`MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH` is 128M), so it is dense and is still inlined as `undefined`s. The test uses 200000 rather than 1e9 so the fail-before run does not need gigabytes.

Idle detection: the check runs after `tick()` drains microtasks, so a reaction queued by the last task counts, and the stop conditions are re-checked after that tick so a stop is never reported as idle. It follows Node's exit-13 rule: `setTimeout(...).unref()` and `AbortSignal.timeout()` awaited alone are reported as never settling, as a program awaiting them at top level would exit. `unhandled_error_counter` is left out on purpose: under `bun test` an unhandled rejection inside a macro would otherwise read as idle. Probed and still working inside a macro: `Bun.sleep`, `setImmediate`, `process.nextTick`, `setInterval`, `fs.promises`, `Bun.file().text()`, `Bun.write`, `Bun.spawn`, `Bun.$`, `fetch`, `Bun.serve` + `fetch`, `Bun.listen` + `Bun.connect`, `dns.lookup`, `zlib`, `Bun.password.hash`, `crypto.subtle.digest`, `WebAssembly.compile`, `Atomics.waitAsync` with a timeout, `Worker`, `MessageChannel`, `BroadcastChannel`, a `ReadableStream` fed by a timer, `bun:sqlite`.

Not changed: a synchronous infinite loop (`while (true) {}`) in a macro still hangs, and so does `Atomics.waitAsync` with no timeout and no other thread (JSC registers the same `AtSomePoint` ticket with and without a timeout). A deadline would need `VM::addTerminationDeadline` and a policy for the limit; that is a product decision and is left out of this PR.

Debug-build observation: the `Bun.build` bytecode tests in `bun-build-api.test.ts` and `process-on.test.ts > should work inside --compile` exceed the 5 s test timeout when the file runs alongside other spawning tests, with or without this change.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 4 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.3 (367d939d9)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call symbolKeys
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] ca
... (truncated)

release without fix: 13 FAILED
bun test v1.4.3-canary.1 (367d939d9)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.06ms]
(pass) latin1 string [0.04ms]
(pass) ascii string [0.02ms]
(pass) type coercion [0.11ms]
(pass) object with Symbol keys [0.07ms]
(pass) escaping [0.26ms]
(pass) utf16 string [0.02ms]
(pass) import aliases [0.04ms]
(pass) default import [0.02ms]
(pass) namespace import [0.03ms]
(pass) ireturnapromise [0.11ms]
(pass) object argument with a sparse numeric key [13.33ms]
(pass) object destructuring of a macro result keeps every bound property regardless of key order or repeated keys [11.34ms]
(pass) a macro that returns a JSON or text Response or Blob is inlined by its content type [16.11ms]
(pass) a Response or Blob returned from a macro is classified by its MIME essence [8.41ms]
488 |     ["process.exit()", `process.exit(42)`, "process.exit() cannot be called from a macro"],
489 |     ["process.reallyExit()", `process.reallyExit(42)`, "process.reallyExit() cannot be called from a macro"],
490 |     ["process.abort()", `process.abort()`, "process.abort() cannot be called from a macro"],
491 |   ])("%s inside a macro fails the build instead
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.3 (367d939d9)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call symbolKeys
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] ca
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8de818a41e
  features     lto, baseline

23 deps, 131 codegen, 1176 objects in 1725ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1250] install /workspace/bun
bun install v1.4.3-canary.1 (367d939d9)

Checked 22 installs across 61 packages (no changes) [47.00ms]
[2/1250] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (367d939d9)

Checked 1 install across 2 packages (no changes) [11.00ms]
[3/1250] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (367d939d9)

Checked 111 installs across 104 packages (no changes) [21.00ms]
[4/1250] gen ErrorCode+*.h
[5/1250] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 KB  (entry point)

[6/1250] gen bindgenv2
[7/1250] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 96ms
[8/1250] gen .bind.ts → GeneratedBindings.cpp
[9/1250] gen bake.{client,server,
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser_jsc/Macro.rs                 | 123 +++++++++++++---
 src/js_parser_jsc/error.rs                 |   4 +
 src/jsc/JSValue.rs                         |  19 +++
 src/jsc/SavedSourceMap.rs                  |   4 +
 src/jsc/VM.rs                              |   7 +
 src/jsc/VirtualMachine.rs                  |  59 +++++---
 src/jsc/bindings/BunProcess.cpp            |  21 +++
 src/jsc/bindings/JSCTaskScheduler.cpp      |  19 +++
 src/jsc/bindings/bindings.cpp              |  61 ++++++++
 src/jsc/event_loop.rs                      |  43 ++++++
 src/jsc/lib.rs                             |   3 +-
 test/bundler/transpiler/macro-test.test.ts | 226 +++++++++++++++++++++++++++++
 12 files changed, 550 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser_jsc/Macro.rs                     13     22     27
src/js_parser_jsc/error.rs                      1      3     27
src/jsc/JSValue.rs                              2      2     27
src/jsc/SavedSourceMap.rs                       2      2     27
src/jsc/VM.rs                                   2      4     27
src/jsc/VirtualMachine.rs                       8     10     27
src/jsc/bindings/BunProcess.cpp                 4      5     27
src/jsc/bindings/JSCTaskScheduler.cpp           4      5     27
src/jsc/bindings/bindings.cpp                   2      5     27
src/jsc/event_loop.rs                           7      9     27
src/jsc/lib.rs                                  1      2     27
test/bundler/transpiler/macro-test.test.ts      9     10     27
```

</details>

<!-- robobun:evidence:end -->





