### PR TITLE
bun:ffi: add the full byteOffset in read.*, do not truncate it to int32

### DIFF
--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -531,6 +531,11 @@ fn get_ptr_slice(
 
     if let Some(byte_off) = byte_offset {
         if byte_off.is_number() {
+            if !byte_off.as_number().is_finite() {
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("byteOffset must be a finite number")));
+            }
+
             let off = byte_off.to_int64();
             if off < 0 {
                 addr =
@@ -543,11 +548,6 @@ fn get_ptr_slice(
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "ptr cannot be zero, that would segfault Bun :("
                 )));
-            }
-
-            if !byte_off.as_number().is_finite() {
-                return Err(global_this
-                    .throw_invalid_arguments(format_args!("byteOffset must be a finite number")));
             }
         } else if !byte_off.is_empty_or_undefined_or_null() {
             return Err(

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -266,11 +266,22 @@ pub mod reader {
         };
         let mut addr = base;
         if let Some(off_value) = arguments.get(1) {
-            let off = off_value.to_int32();
-            if off < 0 {
-                addr = addr.saturating_sub(off.unsigned_abs() as usize);
-            } else {
-                addr = addr.saturating_add(off as usize);
+            if off_value.is_number() {
+                if !off_value.as_number().is_finite() {
+                    return Err(global_object.throw_invalid_arguments(format_args!(
+                        "byteOffset must be a finite number"
+                    )));
+                }
+                let off = off_value.to_int64();
+                if off < 0 {
+                    addr = addr
+                        .saturating_sub(usize::try_from(off.unsigned_abs()).unwrap_or(usize::MAX));
+                } else {
+                    addr = addr.saturating_add(usize::try_from(off).unwrap_or(usize::MAX));
+                }
+            } else if !off_value.is_empty_or_undefined_or_null() {
+                return Err(global_object
+                    .throw_invalid_arguments(format_args!("Expected number for byteOffset")));
             }
         }
         if addr == 0 {

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -547,7 +547,7 @@ fn get_ptr_slice(
 
             if !byte_off.as_number().is_finite() {
                 return Err(global_this
-                    .throw_invalid_arguments(format_args!("ptr must be a finite number.")));
+                    .throw_invalid_arguments(format_args!("byteOffset must be a finite number")));
             }
         } else if !byte_off.is_empty_or_undefined_or_null() {
             return Err(

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -31,6 +31,8 @@ describe.each([
     ["a string byteOffset", () => view(address, "garbage" as any, 8), "Expected number for byteOffset"],
     ["an object byteOffset", () => view(address, {} as any, 8), "Expected number for byteOffset"],
     ["an infinite byteOffset", () => view(address, Infinity, 8), "byteOffset must be a finite number"],
+    ["a negative infinite byteOffset", () => view(address, -Infinity, 8), "byteOffset must be a finite number"],
+    ["a NaN byteOffset", () => view(address, NaN, 8), "byteOffset must be a finite number"],
     ["a string byteLength", () => view(address, 0, "x" as any), "length must be a number."],
     ["a zero byteLength", () => view(address, 0, 0), "length must be > 0. This usually means a bug in your code."],
     ["a negative byteLength", () => view(address, 0, -1), "length must be > 0. This usually means a bug in your code."],

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -30,7 +30,7 @@ describe.each([
     ["a sentinel ptr", () => view(0xdeadbeef as any), "ptr to invalid memory, that would segfault Bun :("],
     ["a string byteOffset", () => view(address, "garbage" as any, 8), "Expected number for byteOffset"],
     ["an object byteOffset", () => view(address, {} as any, 8), "Expected number for byteOffset"],
-    ["an infinite byteOffset", () => view(address, Infinity, 8), "ptr must be a finite number."],
+    ["an infinite byteOffset", () => view(address, Infinity, 8), "byteOffset must be a finite number"],
     ["a string byteLength", () => view(address, 0, "x" as any), "length must be a number."],
     ["a zero byteLength", () => view(address, 0, 0), "length must be > 0. This usually means a bug in your code."],
     ["a negative byteLength", () => view(address, 0, -1), "length must be > 0. This usually means a bug in your code."],

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -802,6 +802,86 @@ describe("read edge cases", () => {
     expect(() => read.u8(-1n, 0)).toThrow("Expected a pointer");
     expect(() => CFunction({ ptr: -1n, args: [], returns: "void" })).toThrow(/out of range/);
   });
+
+  it("a byteOffset of 2^31 or more is added in full, not truncated to int32", async () => {
+    // read.X(base, off) reads base + off. A base placed `off` bytes below the
+    // buffer reaches the buffer only when the whole offset is added, so this
+    // checks 4 GiB offsets without a 4 GiB allocation. Runs in a subprocess
+    // because a truncated offset reads unmapped memory and can crash.
+    const src = `
+      const { ptr, read } = require("bun:ffi");
+      const buf = new Uint8Array(32);
+      for (let i = 0; i < buf.length; i++) buf[i] = 0x80 + i;
+      const view = new DataView(buf.buffer);
+      const p = ptr(buf);
+      const at = 8;
+      if (p <= 2 ** 32 + buf.length) throw new Error("buffer address is below 4 GiB: " + p);
+
+      const readers = {
+        u8: [read.u8, view.getUint8(at)],
+        i8: [read.i8, view.getInt8(at)],
+        u16: [read.u16, view.getUint16(at, true)],
+        i16: [read.i16, view.getInt16(at, true)],
+        u32: [read.u32, view.getUint32(at, true)],
+        i32: [read.i32, view.getInt32(at, true)],
+        f32: [read.f32, view.getFloat32(at, true)],
+        f64: [read.f64, view.getFloat64(at, true)],
+        i64: [read.i64, view.getBigInt64(at, true)],
+        u64: [read.u64, view.getBigUint64(at, true)],
+        ptr: [read.ptr, Number(view.getBigUint64(at, true))],
+        intptr: [read.intptr, Number(view.getBigInt64(at, true))],
+      };
+
+      const wrong = [];
+      for (const off of [2 ** 31, 2 ** 31 + 1, 2 ** 32, 2 ** 32 + 1]) {
+        const base = p + at - off;
+        for (const name in readers) {
+          const [fn, want] = readers[name];
+          const got = fn(base, off);
+          if (!Object.is(got, want)) wrong.push(name + "@" + off + ": got " + got + ", want " + want);
+        }
+      }
+      console.log(JSON.stringify(wrong));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "[]\n", stderr: "", exitCode: 0 });
+  });
+
+  it("an undefined or null byteOffset reads at the pointer, other non-numbers throw", async () => {
+    // Runs in a subprocess: an unfixed build reads the JSValue encoding of
+    // `undefined` as the offset, and a debug build asserts on it.
+    const src = `
+      const { ptr, read } = require("bun:ffi");
+      const buf = new Uint8Array([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc]);
+      const p = ptr(buf);
+      const got = { none: read.u8(p), undefined: read.u8(p, undefined), null: read.u8(p, null) };
+      const thrown = {};
+      for (const [label, off] of [["string", "1"], ["bigint", 1n], ["object", {}], ["Infinity", Infinity], ["-Infinity", -Infinity], ["NaN", NaN]]) {
+        try {
+          read.u8(p, off);
+          thrown[label] = "no error";
+        } catch (e) {
+          thrown[label] = e.message;
+        }
+      }
+      console.log(JSON.stringify({ got, thrown }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout)).toEqual({
+      got: { none: 0x11, undefined: 0x11, null: 0x11 },
+      thrown: {
+        string: "Expected number for byteOffset",
+        bigint: "Expected number for byteOffset",
+        object: "Expected number for byteOffset",
+        Infinity: "byteOffset must be a finite number",
+        "-Infinity": "byteOffset must be a finite number",
+        NaN: "byteOffset must be a finite number",
+      },
+    });
+  });
 });
 
 describe("CString", () => {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -804,10 +804,11 @@ describe("read edge cases", () => {
   });
 
   it("a byteOffset of 2^31 or more is added in full, not truncated to int32", async () => {
-    // read.X(base, off) reads base + off. A base placed `off` bytes below the
-    // buffer reaches the buffer only when the whole offset is added, so this
-    // checks 4 GiB offsets without a 4 GiB allocation. Runs in a subprocess
-    // because a truncated offset reads unmapped memory and can crash.
+    // read.X(base, off) reads base + off. A base placed `off` bytes away from
+    // the buffer reaches the buffer only when the whole offset is added, so this
+    // checks 4 GiB offsets in both directions without a 4 GiB allocation. Runs
+    // in a subprocess because a truncated offset reads unmapped memory and can
+    // crash.
     const src = `
       import { ptr, read } from "bun:ffi";
       const buf = new Uint8Array(32);
@@ -833,7 +834,9 @@ describe("read edge cases", () => {
       };
 
       const wrong = [];
-      for (const off of [2 ** 31, 2 ** 31 + 1, 2 ** 32, 2 ** 32 + 1]) {
+      // int32 holds -(2 ** 31) to 2 ** 31 - 1. Every offset here is outside it.
+      const large = [2 ** 31, 2 ** 31 + 1, 2 ** 32, 2 ** 32 + 1];
+      for (const off of [...large, ...large.map(o => -o - 1)]) {
         const base = p + at - off;
         for (const name in readers) {
           const [fn, want] = readers[name];

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -809,7 +809,7 @@ describe("read edge cases", () => {
     // checks 4 GiB offsets without a 4 GiB allocation. Runs in a subprocess
     // because a truncated offset reads unmapped memory and can crash.
     const src = `
-      const { ptr, read } = require("bun:ffi");
+      import { ptr, read } from "bun:ffi";
       const buf = new Uint8Array(32);
       for (let i = 0; i < buf.length; i++) buf[i] = 0x80 + i;
       const view = new DataView(buf.buffer);
@@ -852,7 +852,7 @@ describe("read edge cases", () => {
     // Runs in a subprocess: an unfixed build reads the JSValue encoding of
     // `undefined` as the offset, and a debug build asserts on it.
     const src = `
-      const { ptr, read } = require("bun:ffi");
+      import { ptr, read } from "bun:ffi";
       const buf = new Uint8Array([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc]);
       const p = ptr(buf);
       const got = { none: read.u8(p), undefined: read.u8(p, undefined), null: read.u8(p, null) };


### PR DESCRIPTION
### Problem
- Every `bun:ffi` `read.*` function converts `byteOffset` with `to_int32()` (`src/runtime/ffi/FFIObject.rs:269`). An offset of 2^31 or more saturates to `i32::MAX`, so `read.u8(base, 2**32 + 1)` reads `base + 2^31 - 1` with no error. Code that indexes a region over 2 GiB from `mmap` hits this.
- A non-number offset reaches `asInt32()` on a non-int32 value. A debug build aborts with `ASSERTION FAILED: isInt32()`. A release build uses the low bits of the JSValue encoding: `read.u8(p, undefined)` reads `p + 10`.

### Fix
- `addr_from_args` now handles `byteOffset` like `toArrayBuffer()` and `toBuffer()`: `to_int64()` with saturating add or subtract. `undefined` and `null` mean no offset. Another non-number throws `Expected number for byteOffset`. A non-finite number throws `byteOffset must be a finite number`.
- Correct because a JS number holds every integer up to 2^53 and `to_int64()` keeps all of them. The address is a `usize`, so the int32 step had no purpose.
- `toArrayBuffer()` and `toBuffer()` now throw the same non-finite message (was `ptr must be a finite number.`), and check it before the address math, so `-Infinity` no longer reports `ptr cannot be zero`.
- Verified: two new tests in `test/js/bun/ffi/ffi.test.js` (`read edge cases`) and three rows in `ffi-error-messages.test.ts`. Bun 1.4.1 fails them. Also ran all of `test/js/bun/ffi/`.

### Background
- `read.X(ptr, byteOffset)` reads one value of type X at `ptr + byteOffset`. All twelve readers share `reader::addr_from_args`, which turns the two arguments into one `usize`.
- `JSValue::to_int32()` is not ECMAScript `ToInt32`. It truncates a double and saturates at the `i32` bounds. For a non-number it calls `asInt32()`, which assumes an int32 payload.
- The test reaches a 4 GiB offset without a 4 GiB allocation: `base = ptr(buf) + 8 - off`, for `off` on both sides of the int32 range. Only the full offset lands back in the buffer.

<details><summary>Notes</summary>

- `ptr(buf, null)` has a separate hole in `ptr_`: it calls `off.to_int64()` on `null` and a debug build asserts in `JSC__JSValue__toInt64`. #40732 converts `ptr_` to thrown errors and owns its messages, so the guard is requested there and this PR leaves `ptr_` alone.
- `CString` goes through the same `get_ptr_slice`, but its C++ entry maps a falsy `byteOffset` (including `NaN`) to 0 first. Only `Infinity` and `-Infinity` reach the finite check from `CString`.
- The old DOMJIT fast path took an `int32_t` offset. `headers.h` still declares `Reader__*__fastpath(..., int64_t, int32_t)` but nothing defines or calls them. `ZigGeneratedCode.cpp` registers only the `__slowpath` wrappers.
- #32260 changed the same `addr_from_args` lines to fix the negative offset panic. Main already fixed that panic in #35246 (the test `a negative byteOffset does not abort the process` exists on main), so #32260 was closed as superseded. This PR covers the remaining `to_int64` change.
- Repro from the report, on bun 1.4.1 (linux-x64): `mmap` 6 GiB anonymous, write 171 at `base + 2**32 + 1`, then `read.u8(base, 2**32 + 1)` returns 90 (a marker placed at `base + 2**31 - 1`). With this fix it returns 171.
- On 1.4.1, `read.u8(p, undefined)` returns the byte at `p + 10` and `read.u8(p, null)` the byte at `p + 2`. The debug build aborts on the `isInt32()` assertion in `JSCJSValue.h`.
- Both new tests run the reads in a subprocess. On the unfixed build the truncated offset lands 2 GiB away from the buffer, and the process segfaults (exit 139).
- `ptr argument: ArrayBuffer cells through an FTL-compiled call site` and `integer identities work for all possible values > int64_t` time out at 5 s in the local debug ASAN run. Neither calls `read.*`. Their time goes to 300k ArrayBuffer allocations plus GC, and to 32k BigInt FFI calls. Both pass in CI.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/ffi/ffi.test.js, test/js/bun/ffi/ffi-error-messages.test.ts

<!-- robobun:evidence:end -->