### PR TITLE
test(shell): gate the external-command output redirect pin test on a server

### DIFF
--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3254,21 +3254,36 @@ describe("stdin redirect from a zero-length buffer delivers EOF to the spawned c
   });
 });
 
-test("output redirect buffer for an external command stays attached until the command finishes", async () => {
+test("output redirect buffer for an external command stays attached while the child's stdout is open", async () => {
   // `> ${buf}` for an external (non-builtin) command stores the buffer and
   // copies the child's stdout into it as chunks arrive across event-loop
-  // turns. The backing store must therefore stay attached for the whole
-  // duration of the command so those writes land in memory the caller still
-  // owns. (The builtin equivalent of this test is directly above; this one
-  // spawns a real subprocess so it goes through the subprocess output path.)
+  // turns. The backing store is pinned (a detach attempt copies instead) from
+  // the moment the command starts until the child's stdout reaches EOF, which
+  // is the last point at which the shell writes into it. (The builtin
+  // equivalent of this test is above; this one spawns a real subprocess so it
+  // goes through the subprocess output path.)
+  //
+  // The child blocks on an HTTP request that is answered only after the detach
+  // attempt below, so its stdout is guaranteed to still be open at that point.
+  // Without the gate, a child that exits before the parent's first read of the
+  // pipe delivers EOF synchronously inside `.then()`, the pin is already gone,
+  // and the detach succeeds.
   const buffer = new Uint8Array(new ArrayBuffer(1 << 16));
-  const childCode = "console.log('external-redirect-output')";
+  const gate = Promise.withResolvers<void>();
+  await using server = Bun.serve({
+    port: 0,
+    async fetch() {
+      await gate.promise;
+      return new Response("external-redirect-output");
+    },
+  });
+  const childCode = `console.log(await fetch(${JSON.stringify(String(server.url))}).then(r => r.text()))`;
   const promise = $`${BUN} -e ${childCode} > ${buffer}`.env(bunEnv).nothrow();
   // Calling .then() starts the interpreter synchronously, so the redirect
-  // slot already holds the buffer while the child process is still running.
+  // slot already holds the buffer while the child process is still starting.
   const running = promise.then(o => o);
 
-  // Attempting to detach the redirect target while the command is in flight
+  // Attempting to detach the redirect target while the child's stdout is open
   // must leave the buffer attached (refusing the detach by throwing is also
   // acceptable).
   try {
@@ -3276,9 +3291,17 @@ test("output redirect buffer for an external command stays attached until the co
   } catch {}
   expect(buffer.buffer.detached).toBe(false);
 
+  gate.resolve();
   const result = await running;
   expect(stringifyBuffer(buffer)).toEqual("external-redirect-output\n");
   expect(result.exitCode).toBe(0);
+
+  // The pin is released with the pipe reader once the shell has seen EOF,
+  // which can be the same I/O callback that settles the promise. Wait for that
+  // callback to return before checking that the buffer is detachable again.
+  await new Promise(resolve => setImmediate(resolve));
+  buffer.buffer.transfer();
+  expect(buffer.buffer.detached).toBe(true);
 });
 
 test("cd treats interpolated arguments starting with tilde or dash as literal directory names", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3285,23 +3285,17 @@ test("output redirect buffer for an external command stays attached while the ch
 
   // Attempting to detach the redirect target while the child's stdout is open
   // must leave the buffer attached (refusing the detach by throwing is also
-  // acceptable).
+  // acceptable). Release the child before asserting so it always finishes.
   try {
     buffer.buffer.transfer();
   } catch {}
-  expect(buffer.buffer.detached).toBe(false);
-
+  const detachedWhileOpen = buffer.buffer.detached;
   gate.resolve();
+  expect(detachedWhileOpen).toBe(false);
+
   const result = await running;
   expect(stringifyBuffer(buffer)).toEqual("external-redirect-output\n");
   expect(result.exitCode).toBe(0);
-
-  // The pin is released with the pipe reader once the shell has seen EOF,
-  // which can be the same I/O callback that settles the promise. Wait for that
-  // callback to return before checking that the buffer is detachable again.
-  await new Promise(resolve => setImmediate(resolve));
-  buffer.buffer.transfer();
-  expect(buffer.buffer.detached).toBe(true);
 });
 
 test("cd treats interpolated arguments starting with tilde or dash as literal directory names", async () => {


### PR DESCRIPTION
### Problem
- `test/js/bun/shell/bunshell.test.ts` "output redirect buffer for an external command stays attached until the command finishes" failed once in CI (build 107642, debian 13 x64): `expect(buffer.buffer.detached).toBe(false)`, received `true`. It passed on retry.
- The test assumes the child `bun -e` process is still running when `.then()` returns. The pin on the `> ${buf}` target lives in the subprocess `PipeReader` (`src/runtime/shell/subproc.rs`, `BufferedOutput::ArrayBuffer`) and drops at stdout EOF. `spawn_async` reads the pipe eagerly, so a child that has already exited delivers EOF inside `.then()`, and `transfer()` detaches the buffer.

### Fix
- The child now blocks on a request to a `Bun.serve({ port: 0 })` server. The test answers it only after the detach attempt, so the child's stdout cannot reach EOF before the assertion runs. The gate is released before the assertion, so the child always finishes.
- No runtime change. The pin covers exactly the window in which the shell writes into the buffer. Nothing writes into it after EOF, so a detach after that point is harmless.
- Verified: `bun bd test test/js/bun/shell/bunshell.test.ts -t redirect` (42 pass). The new test passed 15 of 15 runs on one CPU shared with three busy loops.

### Background
- `$\`cmd > ${buf}\`` stores the child's stdout into `buf`. The bytes arrive through a pipe across event loop turns, so the shell pins the `ArrayBuffer` (`PinnedArrayBuffer::root`). A `transfer()` of a pinned buffer copies instead of detaching.
- `ShellPromise.then()` starts the interpreter synchronously: it pins the redirect target, spawns the child, and does one eager read of the stdout pipe before it returns to JS.

<details><summary>Notes</summary>

Probes with the release binary (`bun 1.4.1`) on linux-x64:

- Original test shape with `/bin/echo hi > ${buf}`, process pinned to one CPU with `taskset`: the buffer was detachable inside `.then()` in 4 of 50 runs. Without the CPU pin: 0 of 50.
- Original test shape with a `bun -e` child: 0 of 120 runs, with and without CPU contention. The window is a parent stall longer than bun's startup, which is why the CI failure is rare.
- A child that runs `fs.closeSync(1)` and then sleeps 800 ms: the buffer became detachable 12 ms in, while the command ran for 810 ms. This confirms the pin ends at stdout EOF, not at process exit.

An earlier revision of this PR also asserted that the buffer is detachable again right after `await running`. That assertion needs one `setImmediate` turn today: when stdout EOF is the event that settles the promise (a grandchild held stdout open past the child's exit), `PipeReader::on_reader_done` still holds the pin while `Interpreter::finish` runs the microtask checkpoint. That is a separate runtime change (release the pin before the promise settles) and is not part of this deflake.

The sibling builtin test uses `ls`, which always suspends on a thread pool task, so it does not have this race. The stdin test copies the bytes at spawn time and does not depend on timing.
</details>
