### PR TITLE
errno: keep the kernel's number when a node:fs syscall fails with a code outside the table

### DIFF
--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -241,10 +241,7 @@ pub mod posix {
 /// `-errno` from `usize`, Darwin/FreeBSD read thread-local errno on `-1`,
 /// Windows ignores `rc` and reads `GetLastError()`/`WSAGetLastError()`).
 pub trait GetErrno: Copy {
-    /// The OS error number behind this return value, `0` when it is a success.
-    /// On POSIX this is the kernel's errno, which is not bound to the `E` table
-    /// (FUSE pass-through, `ENOTSUPP` 524). Store this one in `bun_sys::Error`
-    /// so the user sees the real number.
+    /// The OS error number behind this return value (`0` = success); on POSIX it can lie outside the `E` table.
     fn raw_errno(self) -> u16;
 
     /// [`raw_errno`](Self::raw_errno) decoded into the table; an undeclared code is `E::EUNKNOWN`.
@@ -512,8 +509,7 @@ mod errno_name_tests {
         assert_eq!(e_from_negated(-524), E::EUNKNOWN);
         assert_eq!(e_from_negated(-(E::EUNKNOWN as i32)), E::EUNKNOWN);
 
-        // Linux raw syscalls hand back `-errno` in the return register. The
-        // enum collapses an undeclared code; `raw_errno` keeps it.
+        // Linux raw syscalls hand back `-errno` in the return register.
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             assert_eq!((-524isize as usize).get_errno(), E::EUNKNOWN);
@@ -526,8 +522,7 @@ mod errno_name_tests {
         }
     }
 
-    /// The libc convention: `-1` means failure and the thread-local errno holds
-    /// the code, which can be one the table does not declare.
+    /// libc convention: `-1` means failure and the thread-local errno holds the code.
     #[cfg(not(windows))]
     #[test]
     fn libc_raw_errno_is_the_thread_local_value() {

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -12,15 +12,14 @@ macro_rules! impl_get_errno_libc {
     ($($t:ty),+ $(,)?) => {$(
         impl $crate::GetErrno for $t {
             #[inline]
-            fn get_errno(self) -> $crate::E {
+            fn raw_errno(self) -> u16 {
                 // `as i64` would zero-extend u32, never matching -1. Compare
                 // against the type's own all-ones value instead (== -1 for
                 // signed, == MAX for unsigned — both are libc's failure rc).
                 if self == !(0 as $t) {
-                    u16::try_from($crate::posix::errno())
-                        .map_or($crate::E::EUNKNOWN, $crate::E::from_raw)
+                    u16::try_from($crate::posix::errno()).unwrap_or($crate::E::EUNKNOWN as u16)
                 } else {
-                    $crate::E::SUCCESS
+                    0
                 }
             }
         }
@@ -242,7 +241,17 @@ pub mod posix {
 /// `-errno` from `usize`, Darwin/FreeBSD read thread-local errno on `-1`,
 /// Windows ignores `rc` and reads `GetLastError()`/`WSAGetLastError()`).
 pub trait GetErrno: Copy {
-    fn get_errno(self) -> E;
+    /// The OS error number behind this return value, `0` when it is a success.
+    /// On POSIX this is the kernel's errno, which is not bound to the `E` table
+    /// (FUSE pass-through, `ENOTSUPP` 524). Store this one in `bun_sys::Error`
+    /// so the user sees the real number.
+    fn raw_errno(self) -> u16;
+
+    /// [`raw_errno`](Self::raw_errno) decoded into the table; an undeclared code is `E::EUNKNOWN`.
+    #[inline]
+    fn get_errno(self) -> E {
+        E::from_raw(self.raw_errno())
+    }
 }
 
 // Free-function shim over the trait method. POSIX-only:
@@ -503,13 +512,39 @@ mod errno_name_tests {
         assert_eq!(e_from_negated(-524), E::EUNKNOWN);
         assert_eq!(e_from_negated(-(E::EUNKNOWN as i32)), E::EUNKNOWN);
 
-        // Linux raw syscalls hand back `-errno` in the return register.
+        // Linux raw syscalls hand back `-errno` in the return register. The
+        // enum collapses an undeclared code; `raw_errno` keeps it.
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             assert_eq!((-524isize as usize).get_errno(), E::EUNKNOWN);
+            assert_eq!((-524isize as usize).raw_errno(), 524);
             assert_eq!((-2isize as usize).get_errno(), E::ENOENT);
+            assert_eq!((-2isize as usize).raw_errno(), 2);
             assert_eq!(7usize.get_errno(), E::SUCCESS);
+            assert_eq!(7usize.raw_errno(), 0);
+            assert_eq!((-4096isize as usize).raw_errno(), 0);
         }
+    }
+
+    /// The libc convention: `-1` means failure and the thread-local errno holds
+    /// the code, which can be one the table does not declare.
+    #[cfg(not(windows))]
+    #[test]
+    fn libc_raw_errno_is_the_thread_local_value() {
+        let set_errno = |value: core::ffi::c_int| {
+            // SAFETY: the calling thread's own errno slot, valid for the life of the thread.
+            unsafe { *bun_core::ffi::errno_ptr() = value };
+        };
+        set_errno(524);
+        assert_eq!((-1i32).raw_errno(), 524);
+        assert_eq!((-1i32).get_errno(), E::EUNKNOWN);
+        set_errno(2);
+        assert_eq!((-1i32).raw_errno(), 2);
+        assert_eq!((-1i32).get_errno(), E::ENOENT);
+        // A successful return never consults errno.
+        set_errno(524);
+        assert_eq!(0i32.raw_errno(), 0);
+        assert_eq!(0i32.get_errno(), E::SUCCESS);
     }
 
     /// `win32_errno_name` translation contract: known `GetLastError()` codes

--- a/src/errno/linux_errno.rs
+++ b/src/errno/linux_errno.rs
@@ -190,15 +190,14 @@ use super::GetErrno;
 // the errno is stored in this value
 impl GetErrno for usize {
     #[inline]
-    fn get_errno(self) -> E {
+    fn raw_errno(self) -> u16 {
         // `as` between same-width usize/isize is a bit-reinterpretation
         let signed = self as isize;
-        let int = if signed > -4096 && signed < 0 {
-            -signed
+        if signed > -4096 && signed < 0 {
+            (-signed) as u16
         } else {
             0
-        };
-        E::from_raw(int as u16)
+        }
     }
 }
 

--- a/src/errno/windows_errno.rs
+++ b/src/errno/windows_errno.rs
@@ -355,8 +355,6 @@ use super::GetErrno;
 // Windows errno comes from `GetLastError()` regardless of `rc`, so every impl
 // ignores `self`. Kept to the same concrete-type set as POSIX — a blanket impl
 // would shadow `bun_sys::Error::get_errno` (inherent method) via autoref.
-// There is no host errno number here: the Win32 code is mapped to an `E`
-// discriminant, and that discriminant is what `bun_sys::Error` stores.
 macro_rules! impl_win_get_errno {
     ($($t:ty),*) => {$(
         impl GetErrno for $t {

--- a/src/errno/windows_errno.rs
+++ b/src/errno/windows_errno.rs
@@ -355,9 +355,12 @@ use super::GetErrno;
 // Windows errno comes from `GetLastError()` regardless of `rc`, so every impl
 // ignores `self`. Kept to the same concrete-type set as POSIX — a blanket impl
 // would shadow `bun_sys::Error::get_errno` (inherent method) via autoref.
+// There is no host errno number here: the Win32 code is mapped to an `E`
+// discriminant, and that discriminant is what `bun_sys::Error` stores.
 macro_rules! impl_win_get_errno {
     ($($t:ty),*) => {$(
         impl GetErrno for $t {
+            #[inline] fn raw_errno(self) -> u16 { get_errno(self) as u16 }
             #[inline] fn get_errno(self) -> E { get_errno(self) }
         }
     )*};

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1741,9 +1741,9 @@ impl Poll {
             )
         };
 
-        let errno = sys::get_errno(ctl);
-        if errno != E::SUCCESS {
-            return Err(sys::Error::from_code(errno, sys::Tag::epoll_ctl));
+        match sys::GetErrno::raw_errno(ctl) {
+            0 => {}
+            errno => return Err(sys::Error::new(errno, sys::Tag::epoll_ctl)),
         }
         // Only mark if it successfully registered.
         // If it failed to register, we don't want to unregister it later if

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::ptr;
 
 #[cfg(not(windows))]
-use bun_sys::{self as sys, Fd};
+use bun_sys::{self as sys, Fd, GetErrno as _};
 use bun_uws_sys::Loop as UwsLoop;
 
 pub type Loop = UwsLoop;
@@ -37,7 +37,7 @@ use bun_sys::syslog;
 /// Decodes the -1-sentinel *return-code* convention (the thread-local errno is
 /// only read when `rc` is the all-ones failure value). Do NOT feed it a value
 /// that already is an errno — use [`kevent_change_error`] for those.
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+#[cfg(not(windows))]
 #[inline]
 fn errno_sys<R>(rc: R, syscall: sys::Tag) -> Option<sys::Result<()>>
 where
@@ -762,10 +762,9 @@ impl FilePoll {
                 // indicate the error condition.
             }
 
-            let errno = sys::get_errno(rc);
-            if errno != sys::E::SUCCESS {
+            if let Some(err) = errno_sys(rc, sys::Tag::kqueue) {
                 self.deactivate(loop_);
-                return sys::Result::Err(sys::Error::from_code(errno, sys::Tag::kqueue));
+                return err;
             }
         }
         #[cfg(target_os = "freebsd")]
@@ -968,10 +967,11 @@ impl FilePoll {
                 linux::epoll_ctl(watcher_fd, EPOLL::CTL_DEL, fd.native(), ptr::null_mut())
             };
 
-            match sys::get_errno(ctl) {
+            let errno = ctl.raw_errno();
+            match sys::E::from_raw(errno) {
                 sys::E::SUCCESS => {}
                 e if deregistration_already_gone(e) => {}
-                e => return sys::Result::Err(sys::Error::from_code(e, sys::Tag::epoll_ctl)),
+                _ => return sys::Result::Err(sys::Error::new(errno, sys::Tag::epoll_ctl)),
             }
         }
         #[cfg(target_os = "macos")]
@@ -1064,12 +1064,11 @@ impl FilePoll {
                 )
             };
 
-            let errno = sys::get_errno(rc);
             // Global failure (e.g. EBADF on the kqueue fd): the eventlist
             // was not written, so per-entry checks below would read our
             // own input. Report errno and stop.
             if rc < 0 {
-                return sys::Result::Err(sys::Error::from_code(errno, sys::Tag::kevent));
+                return sys::Result::Err(sys::Error::new(rc.raw_errno(), sys::Tag::kevent));
             }
 
             // If an error occurs while processing an element of the changelist
@@ -1131,10 +1130,11 @@ impl FilePoll {
                     ptr::null(),
                 )
             };
-            match sys::get_errno(rc) {
+            let errno = rc.raw_errno();
+            match sys::E::from_raw(errno) {
                 sys::E::SUCCESS => {}
                 e if deregistration_already_gone(e) => {}
-                e => return sys::Result::Err(sys::Error::from_code(e, sys::Tag::kevent)),
+                _ => return sys::Result::Err(sys::Error::new(errno, sys::Tag::kevent)),
             }
         }
 

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -43,9 +43,9 @@ fn errno_sys<R>(rc: R, syscall: sys::Tag) -> Option<sys::Result<()>>
 where
     R: sys::GetErrno,
 {
-    match sys::get_errno(rc) {
-        sys::E::SUCCESS => None,
-        e => Some(sys::Result::Err(sys::Error::from_code(e, syscall))),
+    match rc.raw_errno() {
+        0 => None,
+        errno => Some(sys::Result::Err(sys::Error::new(errno, syscall))),
     }
 }
 

--- a/src/runtime/allocators/LinuxMemFdAllocator.rs
+++ b/src/runtime/allocators/LinuxMemFdAllocator.rs
@@ -196,7 +196,7 @@ impl LinuxMemFdAllocator {
         // Using huge pages was slower.
         let fd = match sys::memfd_create(label, sys::MemfdFlags::NonExecutable) {
             Err(err) => {
-                return Err(sys::Error::from_code(err.get_errno(), sys::Tag::open));
+                return Err(sys::Error::new(err.errno, sys::Tag::open));
             }
             Ok(fd) => fd,
         };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -65,12 +65,15 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
             ..Default::default()
         })
     }
+    // The four below store `rc.raw_errno()`, the kernel's number, like the
+    // `check!` wrappers in `bun_sys` do: a code outside the `E` table keeps
+    // its value in `err.errno` instead of collapsing to `EUNKNOWN`'s.
     #[inline]
     fn errno_sys<Rc: sys::GetErrno>(rc: Rc, syscall: sys::Tag) -> Option<Self> {
-        match sys::get_errno(rc) {
-            E::SUCCESS => None,
-            e => Some(Err(sys::Error {
-                errno: (e as u16),
+        match rc.raw_errno() {
+            0 => None,
+            errno => Some(Err(sys::Error {
+                errno,
                 syscall,
                 ..Default::default()
             })),
@@ -78,10 +81,10 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
     }
     #[inline]
     fn errno_sys_fd<Rc: sys::GetErrno>(rc: Rc, syscall: sys::Tag, fd: FD) -> Option<Self> {
-        match sys::get_errno(rc) {
-            E::SUCCESS => None,
-            e => Some(Err(sys::Error {
-                errno: (e as u16),
+        match rc.raw_errno() {
+            0 => None,
+            errno => Some(Err(sys::Error {
+                errno,
                 syscall,
                 fd,
                 ..Default::default()
@@ -94,10 +97,10 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
         syscall: sys::Tag,
         path: impl AsRef<[u8]>,
     ) -> Option<Self> {
-        match sys::get_errno(rc) {
-            E::SUCCESS => None,
-            e => Some(Err(sys::Error {
-                errno: (e as u16),
+        match rc.raw_errno() {
+            0 => None,
+            errno => Some(Err(sys::Error {
+                errno,
                 syscall,
                 path: path.as_ref().into(),
                 ..Default::default()
@@ -111,10 +114,10 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
         path: impl AsRef<[u8]>,
         dest: impl AsRef<[u8]>,
     ) -> Option<Self> {
-        match sys::get_errno(rc) {
-            E::SUCCESS => None,
-            e => Some(Err(sys::Error {
-                errno: (e as u16),
+        match rc.raw_errno() {
+            0 => None,
+            errno => Some(Err(sys::Error {
+                errno,
                 syscall,
                 path: path.as_ref().into(),
                 dest: dest.as_ref().into(),
@@ -4889,7 +4892,8 @@ impl NodeFS {
                         0,
                     )
                 } as isize;
-                match sys::get_errno(rc) {
+                let errno = sys::GetErrno::raw_errno(rc);
+                match E::from_raw(errno) {
                     E::SUCCESS => {
                         if rc == 0 {
                             let _ = Syscall::fchmod(dest_fd, stat_.st_mode as Mode);
@@ -4898,10 +4902,10 @@ impl NodeFS {
                     }
                     E::EINTR => continue,
                     E::EXDEV | E::EINVAL | E::EOPNOTSUPP | E::EBADF => break 'cfr,
-                    e => {
+                    _ => {
                         let _ = sys::unlink(dest);
                         return Err(sys::Error {
-                            errno: e as _,
+                            errno,
                             syscall: sys::Tag::copyfile,
                             ..Default::default()
                         });
@@ -8725,7 +8729,8 @@ impl NodeFS {
                         0,
                     )
                 } as isize;
-                match sys::get_errno(rc) {
+                let errno = sys::GetErrno::raw_errno(rc);
+                match E::from_raw(errno) {
                     E::SUCCESS => {
                         if rc == 0 {
                             return Ok(());
@@ -8737,10 +8742,10 @@ impl NodeFS {
                     }
                     E::EINTR => continue,
                     E::EXDEV | E::EINVAL | E::EOPNOTSUPP | E::ENOSYS | E::EBADF => break 'cfr,
-                    e => {
+                    _ => {
                         self.sync_error_buf[..dest.len()].copy_from_slice(dest.as_bytes());
                         return Err(sys::Error {
-                            errno: e as _,
+                            errno,
                             syscall: sys::Tag::copyfile,
                             path: self.sync_error_buf[..dest.len()].into(),
                             ..Default::default()

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -65,9 +65,7 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
             ..Default::default()
         })
     }
-    // The four below store `rc.raw_errno()`, the kernel's number, like the
-    // `check!` wrappers in `bun_sys` do: a code outside the `E` table keeps
-    // its value in `err.errno` instead of collapsing to `EUNKNOWN`'s.
+    // The four below store the kernel's number (`raw_errno`), as the `check!` wrappers in `bun_sys` do.
     #[inline]
     fn errno_sys<Rc: sys::GetErrno>(rc: Rc, syscall: sys::Tag) -> Option<Self> {
         match rc.raw_errno() {

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -907,13 +907,14 @@ impl Linux {
         while running.load(Ordering::Acquire) {
             // SAFETY: buf is valid for buf.0.len() bytes; fd is a plain c_int.
             let rc = unsafe { sys::linux::read(fd.native(), buf.0.as_mut_ptr(), buf.0.len()) };
-            match sys::get_errno(rc) {
+            let errno = sys::GetErrno::raw_errno(rc);
+            match E::from_raw(errno) {
                 E::SUCCESS => {}
                 E::EAGAIN | E::EINTR => continue,
-                errno => {
+                _ => {
                     // Fatal: surface to every watcher, then exit the thread.
                     let err = sys::Error {
-                        errno: errno as u16,
+                        errno,
                         syscall: Tag::read,
                         ..Default::default()
                     };
@@ -1510,10 +1511,10 @@ impl Kqueue {
         if krc < 0 {
             // Registration failed (ENOMEM/EINVAL on a bad fd, etc.). Don't leave a
             // dead entry in the map that will never deliver events.
-            let errno = sys::get_errno(krc);
+            let errno = sys::GetErrno::raw_errno(krc);
             fd.close();
             return Err(sys::Error {
-                errno: errno as u16,
+                errno,
                 syscall: Tag::watch,
                 ..Default::default()
             }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -429,7 +429,7 @@ impl FileResponseStream {
                         adjusted as usize,
                     )
                 };
-                let errno = sys::get_errno(rc);
+                let errno = sys::GetErrno::raw_errno(rc);
                 let sent: u64 =
                     u64::try_from((off - i64::try_from(sf.offset).expect("int cast")).max(0))
                         .unwrap();
@@ -438,7 +438,7 @@ impl FileResponseStream {
                 (errno, sent, sf.remain)
             });
 
-            match errno {
+            match sys::E::from_raw(errno) {
                 sys::E::SUCCESS => {
                     if remain == 0 || sent == 0 {
                         self.end_sendfile();
@@ -450,7 +450,7 @@ impl FileResponseStream {
                 sys::E::EAGAIN => return self.arm_sendfile_writable(),
                 _ => {
                     self.fail_with(
-                        sys::Error::from_code(errno, sys::Tag::sendfile).with_fd(self.fd.get()),
+                        sys::Error::new(errno, sys::Tag::sendfile).with_fd(self.fd.get()),
                     );
                     return false;
                 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2039,8 +2039,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
             server_config::Address::Unix(unix) => {
                 let unix = unix.as_bytes();
-                match bun_sys::get_errno(-1i32) {
-                    bun_sys::E::SUCCESS => jsc::SystemError {
+                match bun_sys::GetErrno::raw_errno(-1i32) {
+                    0 => jsc::SystemError {
                         message: bun_core::String::create_format(format_args!(
                             "Failed to listen on unix socket {}",
                             bun_core::fmt::QuotedFormatter { text: unix }
@@ -2050,8 +2050,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         ..Default::default()
                     }
                     .to_error_instance(global),
-                    e => jsc::SystemError::from(
-                        bun_sys::Error::from_code(e, bun_sys::Tag::listen)
+                    errno => jsc::SystemError::from(
+                        bun_sys::Error::new(errno, bun_sys::Tag::listen)
                             .with_path(unix)
                             .to_system_error(),
                     )

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4891,7 +4891,7 @@ pub fn js_create_socket_pair(global: &JSGlobalObject, _frame: &CallFrame) -> JsR
         let rc =
             unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds_.as_mut_ptr()) };
         if rc != 0 {
-            let err = sys::Error::from_code(sys::get_errno(rc), sys::Tag::socketpair);
+            let err = sys::Error::new(sys::GetErrno::raw_errno(rc), sys::Tag::socketpair);
             return Err(global.throw_value(err.to_js(global)));
         }
 
@@ -4938,8 +4938,8 @@ pub fn js_set_socket_options(global: &JSGlobalObject, callframe: &CallFrame) -> 
                 )
             };
             if rc != 0 {
-                Some(sys::Error::from_code(
-                    sys::get_errno(rc),
+                Some(sys::Error::new(
+                    sys::GetErrno::raw_errno(rc),
                     sys::Tag::setsockopt,
                 ))
             } else {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -418,7 +418,8 @@ impl CopyFile {
                 }
             };
 
-            match bun_sys::get_errno(written) {
+            let errno = bun_sys::GetErrno::raw_errno(written);
+            match bun_sys::E::from_raw(errno) {
                 bun_sys::E::SUCCESS => {}
 
                 // XDEV: cross-device copy not supported
@@ -466,7 +467,6 @@ impl CopyFile {
 
                     self.system_error = Some(
                         bun_sys::Error {
-                            // bare `as` is lossless here (E repr == Error.Int).
                             errno: bun_sys::E::EINVAL as bun_sys::ErrorInt,
                             syscall: USE.tag(),
                             ..Default::default()
@@ -475,17 +475,16 @@ impl CopyFile {
                     );
                     return Err(bun_errno::from_errno(bun_sys::E::EINVAL as i32).into());
                 }
-                errno => {
+                e => {
                     self.system_error = Some(
                         bun_sys::Error {
-                            // bare `as` is lossless here (E repr == Error.Int).
-                            errno: errno as bun_sys::ErrorInt,
+                            errno,
                             syscall: USE.tag(),
                             ..Default::default()
                         }
                         .to_system_error(),
                     );
-                    return Err(bun_errno::from_errno(errno as i32).into());
+                    return Err(e.into());
                 }
             }
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -715,10 +715,10 @@ impl Process {
                     }
                     let err = libc_kill(self.pid, signal as c_int);
                     if err != 0 {
-                        let errno_ = bun_sys::get_errno(err as isize);
+                        let errno = bun_sys::GetErrno::raw_errno(err as isize);
                         // if the process was already killed don't throw
-                        if errno_ != bun_sys::E::ESRCH {
-                            return Err(bun_sys::Error::from_code(errno_, bun_sys::Tag::kill));
+                        if bun_sys::E::from_raw(errno) != bun_sys::E::ESRCH {
+                            return Err(bun_sys::Error::new(errno, bun_sys::Tag::kill));
                         }
                     }
                 }
@@ -3385,12 +3385,13 @@ mod spawn_process_body {
 
                     // SAFETY: valid pollfd array
                     let rc = unsafe { libc::poll(poll_fds_buf.as_mut_ptr(), poll_len as _, -1) };
-                    match bun_sys::get_errno(rc as isize) {
+                    let errno = bun_sys::GetErrno::raw_errno(rc as isize);
+                    match bun_sys::E::from_raw(errno) {
                         bun_sys::E::SUCCESS => {}
                         bun_sys::E::EAGAIN | bun_sys::E::EINTR => continue,
-                        err => {
+                        _ => {
                             cleanup_spawn_posix(&mut out, out_fds, &process, success);
-                            return Ok(Err(bun_sys::Error::from_code(err, bun_sys::Tag::poll)));
+                            return Ok(Err(bun_sys::Error::new(errno, bun_sys::Tag::poll)));
                         }
                     }
                 }
@@ -3905,10 +3906,11 @@ mod spawn_process_body {
 
                 // SAFETY: valid pollfd array
                 let rc = unsafe { libc::poll(buf.as_mut_ptr(), pfds_len as _, timeout_ms) };
-                match bun_sys::get_errno(rc as isize) {
+                let errno = bun_sys::GetErrno::raw_errno(rc as isize);
+                match bun_sys::E::from_raw(errno) {
                     bun_sys::E::SUCCESS => {}
                     bun_sys::E::EAGAIN | bun_sys::E::EINTR => {}
-                    err => return Some(Err(bun_sys::Error::from_code(err, bun_sys::Tag::poll))),
+                    _ => return Some(Err(bun_sys::Error::new(errno, bun_sys::Tag::poll))),
                 }
 
                 if (ppid_fd.fd() != Fd::INVALID && buf[ppid_idx].revents != 0)

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -287,8 +287,10 @@ impl Error {
         }
     }
 
-    /// Decode `self.errno` (+ `from_libuv` on Windows) into a validated `SystemErrno`.
-    /// Shared by `name()` / `get_error_code_tag_name()`; a fallible discriminant lookup.
+    /// Decode `self.errno` (+ `from_libuv` on Windows) into a `SystemErrno`.
+    /// Shared by `name()` / `get_error_code_tag_name()`. `None` only for errno `0`
+    /// on POSIX; a non-zero errno the table does not declare is `EUNKNOWN`, and
+    /// `self.errno` keeps the real number for `to_system_error`.
     #[inline]
     fn resolve_system_errno(&self) -> Option<SystemErrno> {
         #[cfg(windows)]
@@ -304,15 +306,17 @@ impl Error {
             // Do NOT call `SystemErrno::init` here — on Windows its u16/i32 entry points map
             // Win32/WSA error codes to errnos and would corrupt a value that is already a
             // SystemErrno discriminant (e.g. discriminant 1/EPERM → Win32(1) → EISDIR).
-            E::try_from_raw(self.errno).map(|e| SystemErrno::from_raw(e as u16))
+            Some(
+                E::try_from_raw(self.errno)
+                    .map_or(SystemErrno::EUNKNOWN, |e| SystemErrno::from_raw(e as u16)),
+            )
         }
         #[cfg(not(windows))]
         {
-            if self.errno > 0 && self.errno < SystemErrno::MAX {
-                SystemErrno::init(self.errno as i64)
-            } else {
-                None
+            if self.errno == 0 {
+                return None;
             }
+            Some(self.get_errno())
         }
     }
 

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -287,10 +287,7 @@ impl Error {
         }
     }
 
-    /// Decode `self.errno` (+ `from_libuv` on Windows) into a `SystemErrno`.
-    /// Shared by `name()` / `get_error_code_tag_name()`. `None` only for errno `0`
-    /// on POSIX; a non-zero errno the table does not declare is `EUNKNOWN`, and
-    /// `self.errno` keeps the real number for `to_system_error`.
+    /// Decode `self.errno` (+ `from_libuv` on Windows) into a `SystemErrno`; `None` only for errno `0` on POSIX, an undeclared errno is `EUNKNOWN`.
     #[inline]
     fn resolve_system_errno(&self) -> Option<SystemErrno> {
         #[cfg(windows)]

--- a/src/sys/copy_file.rs
+++ b/src/sys/copy_file.rs
@@ -105,12 +105,13 @@ pub fn copy_file_with_state(
         }
         let rc = fcopyfile(in_.native(), out.native(), None, libc::COPYFILE_DATA);
 
-        match crate::get_errno(rc) {
+        let errno = crate::GetErrno::raw_errno(rc);
+        match E::from_raw(errno) {
             E::SUCCESS => return Ok(()),
             // The source file is not a directory, symbolic link, or regular file.
             // Try with the fallback path before giving up.
             E::EOPNOTSUPP => {}
-            e => return Err(crate::Error::from_code(e, Tag::copyfile)),
+            _ => return Err(crate::Error::new(errno, Tag::copyfile)),
         }
     }
 
@@ -196,7 +197,8 @@ pub fn copy_file_with_state(
                 out.native(),
                 rc
             );
-            match crate::get_errno(rc) {
+            let errno = crate::GetErrno::raw_errno(rc);
+            match E::from_raw(errno) {
                 E::SUCCESS => {
                     if rc == 0 {
                         return Ok(());
@@ -205,7 +207,7 @@ pub fn copy_file_with_state(
                 // Cross-filesystem or unsupported fd type — fall back to r/w loop.
                 E::EXDEV | E::EINVAL | E::EOPNOTSUPP | E::EBADF => break,
                 E::EINTR => continue,
-                e => return Err(crate::Error::from_code(e, Tag::copy_file_range)),
+                _ => return Err(crate::Error::new(errno, Tag::copy_file_range)),
             }
         }
     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7411,10 +7411,11 @@ pub fn kevent(
                 timeout.map_or(core::ptr::null(), std::ptr::from_ref),
             )
         };
-        match get_errno(rc) {
+        let errno = GetErrno::raw_errno(rc);
+        match E::from_raw(errno) {
             E::SUCCESS => return Ok(rc as usize),
             E::EINTR => continue,
-            e => return Err(Error::from_code(e, Tag::kevent).with_fd(fd)),
+            _ => return Err(Error::new(errno, Tag::kevent).with_fd(fd)),
         }
     }
 }

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -217,7 +217,7 @@ impl INotifyWatcher {
         // 7) MOVED_TO http.ts
         // We still don't correctly handle MOVED_FROM && MOVED_TO it seems.
         use bun_sys::linux as system;
-        use bun_sys::{E, get_errno};
+        use bun_sys::{E, GetErrno as _};
         let mut i: u32 = 0;
         // reshaped for borrowck — track length instead of borrowing a sub-slice
         // of self.eventlist_bytes across the whole function.
@@ -237,8 +237,8 @@ impl INotifyWatcher {
                         self.eventlist_bytes.0.len(),
                     )
                 };
-                let errno = get_errno(rc);
-                match errno {
+                let errno = rc.raw_errno();
+                match E::from_raw(errno) {
                     E::SUCCESS => {
                         let mut read_len = usize::try_from(rc).expect("int cast");
                         bun_core::scoped_log!(watcher, "{} read {} bytes", self.fd, read_len);
@@ -280,8 +280,8 @@ impl INotifyWatcher {
                                             rest.len(),
                                         )
                                     };
-                                    let e = get_errno(new_rc);
-                                    match e {
+                                    let errno = new_rc.raw_errno();
+                                    match E::from_raw(errno) {
                                         E::SUCCESS => {
                                             read_len += usize::try_from(new_rc).expect("int cast");
                                             break 'outer read_len;
@@ -291,7 +291,7 @@ impl INotifyWatcher {
                                         }
                                         _ => {
                                             return Err(bun_sys::Error {
-                                                errno: e as u32 as _,
+                                                errno,
                                                 syscall: bun_sys::Tag::read,
                                                 ..Default::default()
                                             });
@@ -313,14 +313,14 @@ impl INotifyWatcher {
                             );
                         }
                         return Err(bun_sys::Error {
-                            errno: errno as u32 as _,
+                            errno,
                             syscall: bun_sys::Tag::read,
                             ..Default::default()
                         });
                     }
                     _ => {
                         return Err(bun_sys::Error {
-                            errno: errno as u32 as _,
+                            errno,
                             syscall: bun_sys::Tag::read,
                             ..Default::default()
                         });

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -205,56 +205,83 @@ describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
   }
 });
 
-// The kernel is not bound to the errno table bun knows: FUSE filesystems and
-// some drivers return codes above EHWPOISON (133). Such a code must reach JS
-// as node reports it, `errno` = the negated kernel number, with the `code`
-// string bun uses for an unmapped errno (EUNKNOWN), on both native error
-// paths: the node:fs helpers that decode a return value through `GetErrno`
-// (fsync) and the `bun_sys` wrappers that read the thread-local errno
-// (ftruncate).
+// The kernel is not bound to the errno table bun knows: a FUSE daemon can reply
+// with any code below 512, and in-kernel drivers leak codes above that
+// (ENOTSUPP, 524, from copy_file_range for one). Such a code must reach JS as
+// node reports it, `errno` = the negated kernel number, with the `code` string
+// bun uses for an unmapped errno (EUNKNOWN), on every native error path: the
+// node:fs helpers that decode a return value through `GetErrno` (fsync,
+// copyFile), the `bun_sys` wrappers that read the thread-local errno
+// (ftruncate), and the Bun.write file-to-file copy loop.
 describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
+  // One helper binary per blocked syscall; a case names the syscall it blocks.
+  const helpers = new Map<string, string | null>();
+  const helperFor = (blocked: string) => {
+    if (!helpers.has(blocked)) helpers.set(blocked, tryBuildHelper(blocked));
+    return helpers.get(blocked)!;
+  };
+
+  // Each snippet runs `bun -e` with argv[1] = an existing file; the copy cases
+  // write argv[1] + ".copy". The result line is one JSON object.
+  const report = `console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }))`;
   const cases = [
     {
+      name: "fs.fsyncSync",
+      blocked: "__NR_fsync",
       syscall: "fsync",
-      helperBin: tryBuildHelper("__NR_fsync"),
+      message: (_src: string) => "",
       snippet: `
         import * as fs from "node:fs";
         const fd = fs.openSync(process.argv[1], "r+");
-        try {
-          fs.fsyncSync(fd);
-          console.log(JSON.stringify({ threw: false }));
-        } catch (e) {
-          console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }));
-        }
+        try { fs.fsyncSync(fd); console.log(JSON.stringify({ threw: false })); } catch (e) { ${report}; }
       `,
     },
     {
+      name: "fs.ftruncateSync",
+      blocked: "__NR_ftruncate",
       syscall: "ftruncate",
-      helperBin: tryBuildHelper("__NR_ftruncate"),
+      message: (_src: string) => "",
       snippet: `
         import * as fs from "node:fs";
         const fd = fs.openSync(process.argv[1], "r+");
-        try {
-          fs.ftruncateSync(fd, 0);
-          console.log(JSON.stringify({ threw: false }));
-        } catch (e) {
-          console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }));
-        }
+        try { fs.ftruncateSync(fd, 0); console.log(JSON.stringify({ threw: false })); } catch (e) { ${report}; }
+      `,
+    },
+    {
+      name: "fs.copyFileSync",
+      blocked: "__NR_copy_file_range",
+      syscall: "copyfile",
+      message: (src: string) => ` '${src}' -> '${src}.copy'`,
+      snippet: `
+        import * as fs from "node:fs";
+        try { fs.copyFileSync(process.argv[1], process.argv[1] + ".copy"); console.log(JSON.stringify({ threw: false })); } catch (e) { ${report}; }
+      `,
+    },
+    {
+      name: "Bun.write(Bun.file, Bun.file)",
+      blocked: "__NR_copy_file_range",
+      syscall: "copy_file_range",
+      message: (_src: string) => "",
+      snippet: `
+        try { await Bun.write(Bun.file(process.argv[1] + ".copy"), Bun.file(process.argv[1])); console.log(JSON.stringify({ threw: false })); } catch (e) { ${report}; }
       `,
     },
   ];
 
-  // Runs the case's node:fs call in a bun subprocess whose syscall fails with
-  // `errno`. Returns the parsed result line, or null on an environment skip.
+  // Runs the case in a bun subprocess whose blocked syscall fails with `errno`.
+  // Returns the parsed result line and the source path, or null on an
+  // environment skip.
   async function callWithErrno(c: (typeof cases)[number], errno: number) {
-    if (c.helperBin == null) {
-      console.warn(`SKIP ${c.syscall} seccomp: cc or seccomp headers not available`);
+    const helperBin = helperFor(c.blocked);
+    if (helperBin == null) {
+      console.warn(`SKIP ${c.name} seccomp: cc or seccomp headers not available`);
       return null;
     }
-    using dir = tempDir(`${c.syscall}-seccomp-target`, { "file.txt": "hello" });
-    const out = await runUnderSeccomp(c.helperBin, errno, c.snippet, [join(String(dir), "file.txt")]);
+    using dir = tempDir("errno-seccomp-target", { "file.txt": "hello" });
+    const src = join(String(dir), "file.txt");
+    const out = await runUnderSeccomp(helperBin, errno, c.snippet, [src]);
     if (out == null) {
-      console.warn(`SKIP ${c.syscall} seccomp: seccomp not permitted in this environment`);
+      console.warn(`SKIP ${c.name} seccomp: seccomp not permitted in this environment`);
       return null;
     }
     // Don't assert empty stderr — ASAN builds emit a startup warning there.
@@ -262,31 +289,31 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
       stdout: expect.stringContaining('{"threw":true'),
       exitCode: 0,
     });
-    return JSON.parse(out.stdout.trim());
+    return { result: JSON.parse(out.stdout.trim()), src };
   }
 
-  describe.each(cases)("$syscall", c => {
+  describe.each(cases)("$name", c => {
     test.concurrent("a code above the table keeps its number and reports EUNKNOWN", async () => {
-      const result = await callWithErrno(c, ENOTSUPP);
-      if (result == null) return;
-      expect(result).toEqual({
+      const out = await callWithErrno(c, ENOTSUPP);
+      if (out == null) return;
+      expect(out.result).toEqual({
         threw: true,
         errno: -ENOTSUPP,
         code: "EUNKNOWN",
         syscall: c.syscall,
-        message: `EUNKNOWN: unknown error, ${c.syscall}`,
+        message: `EUNKNOWN: unknown error, ${c.syscall}${c.message(out.src)}`,
       });
     });
 
     test.concurrent("a code in the table keeps its name", async () => {
-      const result = await callWithErrno(c, EACCES);
-      if (result == null) return;
-      expect(result).toEqual({
+      const out = await callWithErrno(c, EACCES);
+      if (out == null) return;
+      expect(out.result).toEqual({
         threw: true,
         errno: -EACCES,
         code: "EACCES",
         syscall: c.syscall,
-        message: `EACCES: permission denied, ${c.syscall}`,
+        message: `EACCES: permission denied, ${c.syscall}${c.message(out.src)}`,
       });
     });
   });

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -206,35 +206,55 @@ describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
 });
 
 // The kernel is not bound to the errno table bun knows: FUSE filesystems and
-// some drivers return codes above EHWPOISON (133). fs.fsyncSync decodes the
-// errno through SystemErrno::from_raw; a code outside the table must report
-// as EUNKNOWN instead of becoming an invalid enum value (a debug build used
-// to die on an assertion there).
+// some drivers return codes above EHWPOISON (133). Such a code must reach JS
+// as node reports it, `errno` = the negated kernel number, with the `code`
+// string bun uses for an unmapped errno (EUNKNOWN), on both native error
+// paths: the node:fs helpers that decode a return value through `GetErrno`
+// (fsync) and the `bun_sys` wrappers that read the thread-local errno
+// (ftruncate).
 describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
-  const helperBin = tryBuildHelper("__NR_fsync");
+  const cases = [
+    {
+      syscall: "fsync",
+      helperBin: tryBuildHelper("__NR_fsync"),
+      snippet: `
+        const fs = require("node:fs");
+        const fd = fs.openSync(process.argv[1], "r+");
+        try {
+          fs.fsyncSync(fd);
+          console.log(JSON.stringify({ threw: false }));
+        } catch (e) {
+          console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }));
+        }
+      `,
+    },
+    {
+      syscall: "ftruncate",
+      helperBin: tryBuildHelper("__NR_ftruncate"),
+      snippet: `
+        const fs = require("node:fs");
+        const fd = fs.openSync(process.argv[1], "r+");
+        try {
+          fs.ftruncateSync(fd, 0);
+          console.log(JSON.stringify({ threw: false }));
+        } catch (e) {
+          console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }));
+        }
+      `,
+    },
+  ];
 
-  const snippet = `
-    const fs = require("node:fs");
-    const fd = fs.openSync(process.argv[1], "r");
-    try {
-      fs.fsyncSync(fd);
-      console.log(JSON.stringify({ threw: false }));
-    } catch (e) {
-      console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }));
-    }
-  `;
-
-  // fs.fsyncSync in a bun subprocess whose fsync(2) fails with `errno`.
-  // Returns the parsed result line, or null on an environment skip.
-  async function fsyncWithErrno(errno: number) {
-    if (helperBin == null) {
-      console.warn("SKIP fsync seccomp: cc or seccomp headers not available");
+  // Runs the case's node:fs call in a bun subprocess whose syscall fails with
+  // `errno`. Returns the parsed result line, or null on an environment skip.
+  async function callWithErrno(c: (typeof cases)[number], errno: number) {
+    if (c.helperBin == null) {
+      console.warn(`SKIP ${c.syscall} seccomp: cc or seccomp headers not available`);
       return null;
     }
-    using dir = tempDir("fsync-seccomp-target", { "file.txt": "hello" });
-    const out = await runUnderSeccomp(helperBin, errno, snippet, [join(String(dir), "file.txt")]);
+    using dir = tempDir(`${c.syscall}-seccomp-target`, { "file.txt": "hello" });
+    const out = await runUnderSeccomp(c.helperBin, errno, c.snippet, [join(String(dir), "file.txt")]);
     if (out == null) {
-      console.warn("SKIP fsync seccomp: seccomp not permitted in this environment");
+      console.warn(`SKIP ${c.syscall} seccomp: seccomp not permitted in this environment`);
       return null;
     }
     // Don't assert empty stderr — ASAN builds emit a startup warning there.
@@ -245,28 +265,29 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
     return JSON.parse(out.stdout.trim());
   }
 
-  test.concurrent("a code above the table reports EUNKNOWN", async () => {
-    const result = await fsyncWithErrno(ENOTSUPP);
-    if (result == null) return;
-    expect(result).toEqual({
-      threw: true,
-      errno: expect.any(Number),
-      code: "EUNKNOWN",
-      syscall: "fsync",
-      message: "EUNKNOWN: unknown error, fsync",
+  for (const c of cases) {
+    test.concurrent(`${c.syscall}: a code above the table keeps its number and reports EUNKNOWN`, async () => {
+      const result = await callWithErrno(c, ENOTSUPP);
+      if (result == null) return;
+      expect(result).toEqual({
+        threw: true,
+        errno: -ENOTSUPP,
+        code: "EUNKNOWN",
+        syscall: c.syscall,
+        message: `EUNKNOWN: unknown error, ${c.syscall}`,
+      });
     });
-    expect(result.errno).toBeLessThan(0);
-  });
 
-  test.concurrent("a code in the table keeps its name", async () => {
-    const result = await fsyncWithErrno(EACCES);
-    if (result == null) return;
-    expect(result).toEqual({
-      threw: true,
-      errno: -EACCES,
-      code: "EACCES",
-      syscall: "fsync",
-      message: "EACCES: permission denied, fsync",
+    test.concurrent(`${c.syscall}: a code in the table keeps its name`, async () => {
+      const result = await callWithErrno(c, EACCES);
+      if (result == null) return;
+      expect(result).toEqual({
+        threw: true,
+        errno: -EACCES,
+        code: "EACCES",
+        syscall: c.syscall,
+        message: `EACCES: permission denied, ${c.syscall}`,
+      });
     });
-  });
+  }
 });

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -105,10 +105,16 @@ function tryBuildHelper(syscall: string): string | null {
 // syscall failing with `errno`. Returns { stdout, stderr, exitCode } on
 // success, or null if the environment refused to install the seccomp filter
 // (skip).
-async function runUnderSeccomp(bin: string, errno: number, snippet: string, args: string[] = []) {
+async function runUnderSeccomp(
+  bin: string,
+  errno: number,
+  snippet: string,
+  args: string[] = [],
+  env: Record<string, string> = {},
+) {
   await using proc = Bun.spawn({
     cmd: [bin, String(errno), bunExe(), "-e", snippet, ...args],
-    env: bunEnv,
+    env: { ...bunEnv, ...env },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -224,11 +230,16 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
   // Each snippet runs `bun -e` with argv[1] = an existing file; the copy cases
   // write argv[1] + ".copy". The result line is one JSON object.
   const report = `console.log(JSON.stringify({ threw: true, errno: e.errno, code: e.code, syscall: e.syscall, message: e.message }))`;
+  // On a reflink-capable tmpdir (btrfs, XFS) fs.copyFile clones the file with
+  // ioctl(FICLONE) and never reaches copy_file_range; turn that fast path off
+  // so the blocked syscall is the one that runs.
+  const noReflink = { BUN_CONFIG_DISABLE_ioctl_ficlonerange: "1" };
   const cases = [
     {
       name: "fs.fsyncSync",
       blocked: "__NR_fsync",
       syscall: "fsync",
+      env: {},
       message: (_src: string) => "",
       snippet: `
         import * as fs from "node:fs";
@@ -240,6 +251,7 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
       name: "fs.ftruncateSync",
       blocked: "__NR_ftruncate",
       syscall: "ftruncate",
+      env: {},
       message: (_src: string) => "",
       snippet: `
         import * as fs from "node:fs";
@@ -251,6 +263,7 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
       name: "fs.copyFileSync",
       blocked: "__NR_copy_file_range",
       syscall: "copyfile",
+      env: noReflink,
       message: (src: string) => ` '${src}' -> '${src}.copy'`,
       snippet: `
         import * as fs from "node:fs";
@@ -261,6 +274,7 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
       name: "Bun.write(Bun.file, Bun.file)",
       blocked: "__NR_copy_file_range",
       syscall: "copy_file_range",
+      env: noReflink,
       message: (_src: string) => "",
       snippet: `
         try { await Bun.write(Bun.file(process.argv[1] + ".copy"), Bun.file(process.argv[1])); console.log(JSON.stringify({ threw: false })); } catch (e) { ${report}; }
@@ -279,7 +293,7 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
     }
     using dir = tempDir("errno-seccomp-target", { "file.txt": "hello" });
     const src = join(String(dir), "file.txt");
-    const out = await runUnderSeccomp(helperBin, errno, c.snippet, [src]);
+    const out = await runUnderSeccomp(helperBin, errno, c.snippet, [src], c.env);
     if (out == null) {
       console.warn(`SKIP ${c.name} seccomp: seccomp not permitted in this environment`);
       return null;

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -218,7 +218,7 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
       syscall: "fsync",
       helperBin: tryBuildHelper("__NR_fsync"),
       snippet: `
-        const fs = require("node:fs");
+        import * as fs from "node:fs";
         const fd = fs.openSync(process.argv[1], "r+");
         try {
           fs.fsyncSync(fd);
@@ -232,7 +232,7 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
       syscall: "ftruncate",
       helperBin: tryBuildHelper("__NR_ftruncate"),
       snippet: `
-        const fs = require("node:fs");
+        import * as fs from "node:fs";
         const fd = fs.openSync(process.argv[1], "r+");
         try {
           fs.ftruncateSync(fd, 0);
@@ -265,8 +265,8 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
     return JSON.parse(out.stdout.trim());
   }
 
-  for (const c of cases) {
-    test.concurrent(`${c.syscall}: a code above the table keeps its number and reports EUNKNOWN`, async () => {
+  describe.each(cases)("$syscall", c => {
+    test.concurrent("a code above the table keeps its number and reports EUNKNOWN", async () => {
       const result = await callWithErrno(c, ENOTSUPP);
       if (result == null) return;
       expect(result).toEqual({
@@ -278,7 +278,7 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
       });
     });
 
-    test.concurrent(`${c.syscall}: a code in the table keeps its name`, async () => {
+    test.concurrent("a code in the table keeps its name", async () => {
       const result = await callWithErrno(c, EACCES);
       if (result == null) return;
       expect(result).toEqual({
@@ -289,5 +289,5 @@ describe.skipIf(!isLinux)("node:fs errno outside the SystemErrno table", () => {
         message: `EACCES: permission denied, ${c.syscall}`,
       });
     });
-  }
+  });
 });


### PR DESCRIPTION
### Problem
- Since #40720, a kernel errno outside the `E` table decodes to `E::EUNKNOWN` (134 on Linux). Every site that built a `bun_sys::Error` from `get_errno(rc)` stored that enum value as the errno: the node:fs `errno_sys*` helpers (`src/runtime/node/node_fs.rs:69-124`, 27 callers), the `Bun.write` file-to-file copy loop, `fs.watch`, and 15 more. `fs.fsyncSync` or `Bun.write(Bun.file, Bun.file)` on a filesystem that returns `ENOTSUPP` (524) throws `errno: -134`. Node reports `-524`, and so did the release build before #40720.
- The `check!` wrappers in `bun_sys` keep the real number, but `Error::resolve_system_errno` (`src/sys/Error.rs:295`) gives up on it: `fs.ftruncateSync` with the same 524 throws `errno: -524` with no `code`.

### Fix
- `GetErrno` gains `raw_errno(self) -> u16`, the OS error number behind a return value, `0` for success. `get_errno()` is now `E::from_raw(self.raw_errno())`. Windows has no host errno, so its impls return the mapped discriminant, which `bun_sys::Error` stores there already.
- Every site that stored the decoded `E` stores `rc.raw_errno()` instead (the match on the variant stays where one exists). That is the convention the 108 `from_code_int` callers in `bun_sys` already follow. `grep 'from_code(.*get_errno'` and `errno: e as` over `src/` find no site left.
- `resolve_system_errno` renders a non-zero errno the table does not declare as `EUNKNOWN` instead of `None`, so `err.code` is always a string, like node. `EUNKNOWN` is the fallback #40720 chose for the enum. This change only stops it from replacing the number.
- Verified: `test/js/node/fs/fs-stat-seccomp-linux.test.ts`, block "node:fs errno outside the SystemErrno table", asserts `errno: -524` and `code: "EUNKNOWN"` for `fs.fsyncSync` (`errno_sys`), `fs.ftruncateSync` (`check!`), `fs.copyFileSync` and `Bun.write(Bun.file, Bun.file)` (both `copy_file_range`). Without the `src/` changes 4 of 11 cases fail. Also `cargo test -p bun_errno`, `fs.test.ts` (563 pass), `fs.watch`, `bun-write`, `spawn`, and `cargo check` plus clippy of the touched crates for linux, darwin, freebsd and windows.

### Background
- `bun_sys::Error` stores the errno as a `u16` and decodes it on read. `to_system_error` negates it into `err.errno` and uses the decoded variant's name as `err.code`.
- `GetErrno` turns a syscall return value into an error: libc wrappers return `-1` and leave the errno in a thread-local, raw Linux syscalls return `-errno` in the result register. `E` is an exhaustive `#[repr(u16)]` enum, so a code outside the table cannot travel through it. The number has to be read before the decode.
- Where such codes come from: a FUSE daemon may reply with any errno below 512 (the kernel rejects larger replies), so 134..511 reach userspace unmapped. Codes above 512 are in-kernel driver values that leak, `ENOTSUPP` (524) being the common one.
- #39340 proposes to render `EUNKNOWN` as `UNKNOWN`, node's name for libuv's `UV_UNKNOWN`. It changes the string only and is independent of this one.

<details><summary>Notes</summary>

Before and after on Linux. The seccomp helper from the test makes the syscall fail with 524:

```
fsync (node_fs errno_sys path)
  main:       {"errno":-134,"code":"EUNKNOWN","syscall":"fsync","message":"EUNKNOWN: unknown error, fsync"}
  this PR:    {"errno":-524,"code":"EUNKNOWN","syscall":"fsync","message":"EUNKNOWN: unknown error, fsync"}
ftruncate (bun_sys check! path)
  main:       {"errno":-524,"syscall":"ftruncate","message":"Unknown Error, ftruncate"}
  this PR:    {"errno":-524,"code":"EUNKNOWN","syscall":"ftruncate","message":"EUNKNOWN: unknown error, ftruncate"}
Bun.write(Bun.file, Bun.file) (blob/copy_file.rs copy_file_range loop)
  main:       {"errno":-134,"code":"EUNKNOWN","syscall":"copy_file_range", ...}
  this PR:    {"errno":-524,"code":"EUNKNOWN","syscall":"copy_file_range", ...}
node 24:      {"errno":-524,"code":"Unknown system error -524","syscall":"fsync","message":"Unknown system error -524: Unknown system error -524, fsync"}
```

Sites converted, beyond the node:fs helpers: `src/runtime/webcore/blob/copy_file.rs` (Bun.write file to file, the two "bare `as` is lossless" comments were wrong and are gone), `src/runtime/node/path_watcher.rs` (fs.watch, inotify read and kqueue registration), `src/watcher/INotifyWatcher.rs` (3), `src/io/posix_event_loop.rs` (kqueue registration, epoll CTL_DEL, kevent), `src/io/lib.rs` (epoll_ctl), `src/sys/lib.rs` (kevent), `src/sys/copy_file.rs` (fcopyfile on macOS, copy_file_range on FreeBSD), `src/spawn/process.rs` (kill, two poll loops), `src/runtime/server/mod.rs` (unix listen), `src/runtime/server/FileResponseStream.rs` (sendfile), `src/runtime/socket/socket_body.rs` (socketpair, setsockopt), `src/runtime/allocators/LinuxMemFdAllocator.rs` (re-tags an existing error and now copies its number). The `errno_sys` helper in `posix_event_loop.rs` is compiled on macOS too now, for the kqueue site. Sites that only match on the variant and never store an errno, or that return a crate `Error::Sys(SystemErrno)`, are unchanged: the enum is the right type there.

Side effects of the `resolve_system_errno` change: `Error::name()` returns `EUNKNOWN` (the strum name) instead of the literal `UNKNOWN` for an undeclared errno, `to_zig_err()` returns `EUNKNOWN` instead of `EIO`, and `process.cwd()`'s failure path (`node_process.rs:454`) reports `code: "EUNKNOWN"` instead of `"UNKNOWN"` in that case. The shell builtins are unchanged: `coreutils_error_map::get(EUNKNOWN)` is `None`, so they keep printing `unknown error {errno}` with the real number. `Listener.rs` already skips `EUNKNOWN` when it builds a node-style listen error.

Other suites run on the debug build: `test/js/node/watch/fs.watch.test.ts` (45 pass), `test/js/bun/io/bun-write.test.js` (59 pass with a 60 s per-test budget; five large-file cases take 7 to 8.5 s in this ASAN container and hit the 5 s default with or without the change), `test/js/bun/spawn/spawn.test.ts` (140 pass), `test/js/node/child_process/child_process.test.ts` (two environment failures: `$SHELL` is not in the test env here, and a GC test hits the 5 s budget), `fs-mkdir`, `util.test.js` (211 pass), `error-name-from-libuv`, `os.test.js` (`userInfo` fails because `$USER` is unset in this container, same on main). `cargo test -p bun_sys` does not link on main (unresolved `bun_core` externals), so that crate's unit tests were not run.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs-stat-seccomp-linux.test.ts

<!-- robobun:evidence:end -->