### PR TITLE
bun test --parallel: stop silently respawning workers that exit before ready

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -78,9 +78,7 @@ pub(crate) struct FileTestRecords {
 }
 
 /// Consecutive pre-`.ready` exits a worker slot tolerates before the slot
-/// stops respawning. Without the cap, a worker that deterministically dies
-/// during init (before the IPC handshake) is respawned forever with no
-/// output and the run never ends.
+/// stops respawning.
 const MAX_STARTUP_FAILURES: u8 = 2;
 
 /// Why the run stopped dispatching files. A worker panic overrides `Bail`
@@ -593,11 +591,9 @@ impl<'a> Coordinator<'a> {
         // the IPC pipe has been drained and this reap actually runs.
         self.live_workers -= 1;
         self.flush_captured(w);
-        // Spawned but exited before the IPC handshake — an init failure
-        // (startup crash, failed fd-3 adopt, bad bunfig in the worker's
-        // bootstrap). `inflight` is None, so the mid-file handling below
-        // never fires; without the per-slot cap this slot would respawn
-        // forever, silently.
+        // Exited before the IPC handshake. `inflight` is None for these, so
+        // the mid-file handling below never fires; the per-slot cap is what
+        // bounds the respawn loop.
         let startup_failure = w.inflight.is_none() && !w.reached_ready;
         let worker_idx = w.idx;
         if let Some(idx) = w.inflight {
@@ -647,9 +643,8 @@ impl<'a> Coordinator<'a> {
             }
         } else if startup_failure {
             w.startup_failures += 1;
-            // A fatal signal during init is a Bun bug just as much as one
-            // mid-file — abort the whole run so the crash's stderr (already
-            // flushed via flush_captured) isn't buried under retries.
+            // A crash signal during init aborts the whole run, same as a
+            // mid-file crash.
             if is_panic_status(status) {
                 self.abort_on_worker_startup_panic(status);
             }
@@ -665,9 +660,8 @@ impl<'a> Coordinator<'a> {
             && self.has_undispatched_files();
 
         if startup_failure && self.stop_reason.is_none() {
-            // `can_respawn` is false either because the slot hit the cap or
-            // because no work remains. Only the former warrants the red
-            // error; the latter is benign (other workers ran everything).
+            // A false `can_respawn` is benign when no work remains; only the
+            // cap warrants the red error.
             self.break_dots();
             let mut buf = [0u8; 32];
             let desc = bstr::BStr::new(describe_status(&mut buf, status));
@@ -791,8 +785,8 @@ impl<'a> Coordinator<'a> {
         self.terminate_workers_after_panic(b"aborted: worker panicked");
     }
 
-    /// `abort_on_worker_panic` for the pre-`.ready` case — there is no file
-    /// to name because nothing was dispatched to the worker yet.
+    /// `abort_on_worker_panic` for the pre-`.ready` case: no file was
+    /// dispatched yet, so there is none to name.
     fn abort_on_worker_startup_panic(&mut self, status: &SpawnStatus) {
         self.break_dots();
         let mut buf = [0u8; 32];

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -77,6 +77,12 @@ pub(crate) struct FileTestRecords {
     pub(crate) elapsed_ns: u64,
 }
 
+/// Consecutive pre-`.ready` exits a worker slot tolerates before the slot
+/// stops respawning. Without the cap, a worker that deterministically dies
+/// during init (before the IPC handshake) is respawned forever with no
+/// output and the run never ends.
+const MAX_STARTUP_FAILURES: u8 = 2;
+
 /// Why the run stopped dispatching files. A worker panic overrides `Bail`
 /// (see `abort_on_worker_panic`); nothing clears it.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -420,7 +426,11 @@ impl<'a> Coordinator<'a> {
 
     pub(crate) fn on_frame(&mut self, w: &mut Worker, kind: frame::Kind, rd: &mut frame::Reader) {
         match kind {
-            frame::Kind::Ready => self.assign_work_or_retry(w),
+            frame::Kind::Ready => {
+                w.reached_ready = true;
+                w.startup_failures = 0;
+                self.assign_work_or_retry(w);
+            }
             frame::Kind::FileStart => {
                 let _ = rd.u32();
             }
@@ -583,6 +593,13 @@ impl<'a> Coordinator<'a> {
         // the IPC pipe has been drained and this reap actually runs.
         self.live_workers -= 1;
         self.flush_captured(w);
+        // Spawned but exited before the IPC handshake — an init failure
+        // (startup crash, failed fd-3 adopt, bad bunfig in the worker's
+        // bootstrap). `inflight` is None, so the mid-file handling below
+        // never fires; without the per-slot cap this slot would respawn
+        // forever, silently.
+        let startup_failure = w.inflight.is_none() && !w.reached_ready;
+        let worker_idx = w.idx;
         if let Some(idx) = w.inflight {
             self.break_dots();
             self.ensure_header(idx);
@@ -628,14 +645,57 @@ impl<'a> Coordinator<'a> {
             if panicked {
                 self.abort_on_worker_panic(idx, status);
             }
+        } else if startup_failure {
+            w.startup_failures += 1;
+            // A fatal signal during init is a Bun bug just as much as one
+            // mid-file — abort the whole run so the crash's stderr (already
+            // flushed via flush_captured) isn't buried under retries.
+            if is_panic_status(status) {
+                self.abort_on_worker_startup_panic(status);
+            }
         }
 
         // SAFETY: fresh derivation — `abort_on_worker_panic` above retags the slots.
         let w = unsafe { &mut *self.workers.as_mut_ptr().add(slot) };
         w.process = None;
+        let startup_failures = w.startup_failures;
+
+        let can_respawn = self.stop_reason.is_none()
+            && startup_failures < MAX_STARTUP_FAILURES
+            && self.has_undispatched_files();
+
+        if startup_failure && self.stop_reason.is_none() {
+            // `can_respawn` is false either because the slot hit the cap or
+            // because no work remains. Only the former warrants the red
+            // error; the latter is benign (other workers ran everything).
+            self.break_dots();
+            let mut buf = [0u8; 32];
+            let desc = bstr::BStr::new(describe_status(&mut buf, status));
+            if can_respawn {
+                bun_core::pretty_error!(
+                    "<r><yellow>warn<r>: test worker {} exited during startup ({}), retrying\n",
+                    worker_idx + 1,
+                    desc,
+                );
+            } else if startup_failures >= MAX_STARTUP_FAILURES {
+                bun_core::pretty_error!(
+                    "<r><red>error<r>: test worker {} exited during startup ({}) {} times\n",
+                    worker_idx + 1,
+                    desc,
+                    startup_failures,
+                );
+            } else {
+                bun_core::pretty_error!(
+                    "<r><d>test worker {} exited during startup ({})<r>\n",
+                    worker_idx + 1,
+                    desc,
+                );
+            }
+            Output::flush();
+        }
 
         let mut respawned = false;
-        if self.stop_reason.is_none() && self.has_undispatched_files() {
+        if can_respawn {
             // SAFETY: fresh derivation — `has_undispatched_files` read the slots.
             let w = unsafe { &mut *self.workers.as_mut_ptr().add(slot) };
             w.ipc = Default::default();
@@ -643,6 +703,7 @@ impl<'a> Coordinator<'a> {
             let w_ptr = std::ptr::from_mut::<Worker>(w).cast_const();
             w.out = WorkerPipe::new(w_ptr);
             w.err = WorkerPipe::new(w_ptr);
+            w.reached_ready = false;
             match w.start() {
                 Ok(()) => {
                     respawned = true;
@@ -727,6 +788,26 @@ impl<'a> Coordinator<'a> {
             bstr::BStr::new(self.rel_path(file_idx)),
         );
         Output::flush();
+        self.terminate_workers_after_panic(b"aborted: worker panicked");
+    }
+
+    /// `abort_on_worker_panic` for the pre-`.ready` case — there is no file
+    /// to name because nothing was dispatched to the worker yet.
+    fn abort_on_worker_startup_panic(&mut self, status: &SpawnStatus) {
+        self.break_dots();
+        let mut buf = [0u8; 32];
+        bun_core::pretty_error!(
+            concat!(
+                "\n<red>error<r>: a test worker process crashed with <b>{}<r> during startup.\n",
+                "This indicates a bug in Bun or in a native addon, not in the test itself. Aborting.\n",
+            ),
+            bstr::BStr::new(describe_status(&mut buf, status)),
+        );
+        Output::flush();
+        self.terminate_workers_after_panic(b"aborted: worker panicked during startup");
+    }
+
+    fn terminate_workers_after_panic(&mut self, sweep_reason: &'static [u8]) {
         // .shutdown() only takes effect between files, so a worker that's
         // mid-file would keep producing output after the panic banner.
         // Terminate the whole process group (same as the SIGINT path) so the
@@ -777,7 +858,7 @@ impl<'a> Coordinator<'a> {
         if already_stopped {
             return;
         }
-        self.abort_queued_files(b"aborted: worker panicked");
+        self.abort_queued_files(sweep_reason);
     }
 
     /// Mark every not-yet-dispatched file as failed so `drive()` can exit

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -69,6 +69,16 @@ pub struct Worker {
     /// this and `ipc.done` so trailing IPC frames are decoded first.
     pub(crate) exit_status: Option<Status>,
     pub(crate) reap_pending: bool,
+    /// Set when this process sends `.ready`; reset before each respawn. A
+    /// reap with `inflight == None` and `!reached_ready` is a startup failure
+    /// (the process died before the IPC handshake), as opposed to a clean
+    /// post-shutdown exit.
+    pub(crate) reached_ready: bool,
+    /// Consecutive (re)spawns of this slot that exited before `.ready`; reset
+    /// on `.ready`. `reap_worker`'s mid-file handling is keyed on `inflight`,
+    /// so pre-ready exits bypass it; this counter bounds the respawn loop so
+    /// a worker that can never finish init doesn't spin forever.
+    pub(crate) startup_failures: u8,
 }
 
 impl Worker {

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -69,15 +69,12 @@ pub struct Worker {
     /// this and `ipc.done` so trailing IPC frames are decoded first.
     pub(crate) exit_status: Option<Status>,
     pub(crate) reap_pending: bool,
-    /// Set when this process sends `.ready`; reset before each respawn. A
-    /// reap with `inflight == None` and `!reached_ready` is a startup failure
-    /// (the process died before the IPC handshake), as opposed to a clean
-    /// post-shutdown exit.
+    /// Set when this process sends `.ready`; reset before each respawn.
+    /// `inflight == None` with `!reached_ready` at reap distinguishes a
+    /// startup failure from a clean post-shutdown exit.
     pub(crate) reached_ready: bool,
-    /// Consecutive (re)spawns of this slot that exited before `.ready`; reset
-    /// on `.ready`. `reap_worker`'s mid-file handling is keyed on `inflight`,
-    /// so pre-ready exits bypass it; this counter bounds the respawn loop so
-    /// a worker that can never finish init doesn't spin forever.
+    /// Consecutive (re)spawns of this slot that exited before `.ready`;
+    /// reset on `.ready`. Bounds the respawn loop in `reap_worker`.
     pub(crate) startup_failures: u8,
 }
 

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -527,13 +527,10 @@ impl<'a> WorkerLoop<'a> {
             WORKER_CMDS.write(Some(&raw mut self.cmds));
         }
 
-        // Test hook for the coordinator's pre-ready exit path: "abort" dies
-        // by SIGABRT (the startup-panic branch), anything else exits 1 (the
-        // bounded-respawn branch). Real triggers (an init crash, a failed
-        // fd-3 adopt) aren't reproducible from a test; this lets
-        // parallel-startup-failure.test.ts assert both branches. Compiled
-        // only into debug/ASAN builds so a stray env var can't disable
-        // --parallel for users of a release build.
+        // Test hook: "abort" dies by SIGABRT (the startup-panic branch),
+        // anything else exits 1 (the bounded-respawn branch). Real init
+        // failures aren't reproducible from a test. Debug/ASAN builds only,
+        // so a stray env var can't disable --parallel in a release build.
         if cfg!(any(debug_assertions, bun_asan)) {
             // SAFETY: env loader is initialized before the test runner runs.
             if let Some(mode) =

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -527,20 +527,27 @@ impl<'a> WorkerLoop<'a> {
             WORKER_CMDS.write(Some(&raw mut self.cmds));
         }
 
-        // Test hook for the coordinator's pre-ready exit path. Real triggers
-        // (an init crash, a failed fd-3 adopt) aren't reproducible from a
-        // test; this lets parallel-startup-failure.test.ts assert the respawn
-        // loop is bounded. Same pattern as BUN_TEST_PARALLEL_SCALE_MS.
-        // SAFETY: env loader is initialized before the test runner runs.
-        if unsafe { &*vm.transpiler.env }
-            .get(b"BUN_TEST_WORKER_EXIT_BEFORE_READY")
-            .is_some()
-        {
-            bun_core::pretty_errorln!(
-                "test worker exiting before ready (BUN_TEST_WORKER_EXIT_BEFORE_READY)"
-            );
-            Output::flush();
-            Global::exit(1);
+        // Test hook for the coordinator's pre-ready exit path: "abort" dies
+        // by SIGABRT (the startup-panic branch), anything else exits 1 (the
+        // bounded-respawn branch). Real triggers (an init crash, a failed
+        // fd-3 adopt) aren't reproducible from a test; this lets
+        // parallel-startup-failure.test.ts assert both branches. Compiled
+        // only into debug/ASAN builds so a stray env var can't disable
+        // --parallel for users of a release build.
+        if cfg!(any(debug_assertions, bun_asan)) {
+            // SAFETY: env loader is initialized before the test runner runs.
+            if let Some(mode) =
+                unsafe { &*vm.transpiler.env }.get(b"BUN_TEST_WORKER_EXIT_BEFORE_READY")
+            {
+                bun_core::pretty_errorln!(
+                    "test worker exiting before ready (BUN_TEST_WORKER_EXIT_BEFORE_READY)"
+                );
+                Output::flush();
+                if bun_core::strings::eql(mode, b"abort") {
+                    std::process::abort();
+                }
+                Global::exit(1);
+            }
         }
 
         // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -533,9 +533,8 @@ impl<'a> WorkerLoop<'a> {
         // so a stray env var can't disable --parallel in a release build.
         if cfg!(any(debug_assertions, bun_asan)) {
             // SAFETY: env loader is initialized before the test runner runs.
-            if let Some(mode) =
-                unsafe { &*vm.transpiler.env }.get(b"BUN_TEST_WORKER_EXIT_BEFORE_READY")
-            {
+            let env = unsafe { &*vm.transpiler.env };
+            if let Some(mode) = env.get(b"BUN_TEST_WORKER_EXIT_BEFORE_READY") {
                 bun_core::pretty_errorln!(
                     "test worker exiting before ready (BUN_TEST_WORKER_EXIT_BEFORE_READY)"
                 );

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -132,6 +132,8 @@ pub(crate) fn run_as_coordinator(
             alive: false,
             exit_status: None,
             reap_pending: false,
+            reached_ready: false,
+            startup_failures: 0,
         });
         let w: *mut Worker = workers.last_mut().unwrap();
         // SAFETY: w points into workers; Vec will not reallocate (capacity == k)
@@ -523,6 +525,22 @@ impl<'a> WorkerLoop<'a> {
         // SAFETY: single-threaded worker; WORKER_CMDS is only read on this thread
         unsafe {
             WORKER_CMDS.write(Some(&raw mut self.cmds));
+        }
+
+        // Test hook for the coordinator's pre-ready exit path. Real triggers
+        // (an init crash, a failed fd-3 adopt) aren't reproducible from a
+        // test; this lets parallel-startup-failure.test.ts assert the respawn
+        // loop is bounded. Same pattern as BUN_TEST_PARALLEL_SCALE_MS.
+        // SAFETY: env loader is initialized before the test runner runs.
+        if unsafe { &*vm.transpiler.env }
+            .get(b"BUN_TEST_WORKER_EXIT_BEFORE_READY")
+            .is_some()
+        {
+            bun_core::pretty_errorln!(
+                "test worker exiting before ready (BUN_TEST_WORKER_EXIT_BEFORE_READY)"
+            );
+            Output::flush();
+            Global::exit(1);
         }
 
         // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer

--- a/test/cli/test/parallel-startup-failure.test.ts
+++ b/test/cli/test/parallel-startup-failure.test.ts
@@ -1,0 +1,60 @@
+// Kept separate from parallel.test.ts: that file has several tests that
+// routinely exceed the 5s default timeout under ASAN debug (each test
+// spawns a coordinator + multiple workers), and file-level pass/fail is
+// what the surrounding tooling checks. This test must be evaluated in
+// isolation from those unrelated timing-sensitive cases.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("--parallel terminates when a worker exits before sending .ready", async () => {
+  // A worker that spawns OK but dies during init (before the IPC handshake)
+  // has `inflight == None`, so the mid-file crash handling in reap_worker
+  // never applied and the coordinator would respawn the slot forever with
+  // no output (issue #40782). The run must terminate with a non-zero exit
+  // after a bounded number of attempts.
+  //
+  // Real triggers (startup crash, failed fd-3 adopt) aren't reproducible
+  // from a test, so the worker loop honours BUN_TEST_WORKER_EXIT_BEFORE_READY.
+  using dir = tempDir("parallel-pre-ready-exit", {
+    "a.test.js": `import {test,expect} from "bun:test"; test("a",()=>expect(1).toBe(1));`,
+    "b.test.js": `import {test,expect} from "bun:test"; test("b",()=>expect(1).toBe(1));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2"],
+    env: { ...bunEnv, BUN_TEST_WORKER_EXIT_BEFORE_READY: "1" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  // Generous race window: under ASAN each worker exec+init can take
+  // several seconds, and up to 4 spawn before the cap halts the run.
+  // The bug this guards against is an *infinite* respawn loop, so the
+  // exact bound isn't important — only that the run terminates.
+  const result = await Promise.race([
+    Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]),
+    Bun.sleep(45_000).then(() => "TIMEOUT" as const),
+  ]);
+  if (result === "TIMEOUT") proc.kill("SIGKILL");
+  expect(result).not.toBe("TIMEOUT");
+  const [, stderr, exitCode] = result as [string, string, number];
+  // Assert only on coordinator-generated output: try_reap gates on ipc.done
+  // but not err.done, so the worker's own stderr line can race the reap and
+  // be dropped before it's captured. The coordinator prints "exited during
+  // startup" synchronously inside reap_worker, once per pre-ready reap — a
+  // reliable spawn counter.
+  expect(stderr).toContain("exited during startup");
+  // Both queued files were accounted for (marked failed, not silently dropped).
+  expect(stderr).toContain("a.test.js");
+  expect(stderr).toContain("b.test.js");
+  // Respawns are capped per slot at MAX_STARTUP_FAILURES=2; with K=2 the
+  // worst case is 4 spawns. Slot 0 alone guarantees >=2: its first reap has
+  // startup_failures=1 < 2 and undispatched files remain (no worker reaches
+  // .ready, so no range is ever consumed), so it respawns once before
+  // hitting the cap. Slot 1 may additionally spawn if maybe_scale_up ticks
+  // in the window between slot 0's process exit and its reap.
+  const spawns = (stderr.match(/exited during startup/g) ?? []).length;
+  expect(spawns).toBeGreaterThanOrEqual(2);
+  expect(spawns).toBeLessThanOrEqual(4);
+  expect(exitCode).not.toBe(0);
+}, 60_000);

--- a/test/cli/test/parallel-startup-failure.test.ts
+++ b/test/cli/test/parallel-startup-failure.test.ts
@@ -5,25 +5,24 @@
 // isolation from those unrelated timing-sensitive cases.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 
-test("--parallel terminates when a worker exits before sending .ready", async () => {
-  // A worker that spawns OK but dies during init (before the IPC handshake)
-  // has `inflight == None`, so the mid-file crash handling in reap_worker
-  // never applied and the coordinator would respawn the slot forever with
-  // no output (issue #40782). The run must terminate with a non-zero exit
-  // after a bounded number of attempts.
-  //
-  // Real triggers (startup crash, failed fd-3 adopt) aren't reproducible
-  // from a test, so the worker loop honours BUN_TEST_WORKER_EXIT_BEFORE_READY.
-  using dir = tempDir("parallel-pre-ready-exit", {
+// The BUN_TEST_WORKER_EXIT_BEFORE_READY hook is compiled only into
+// debug/ASAN builds so a stray env var can't disable --parallel in release.
+const hasHook = isDebug || isASAN;
+
+function makeDir(prefix: string) {
+  return tempDir(prefix, {
     "a.test.js": `import {test,expect} from "bun:test"; test("a",()=>expect(1).toBe(1));`,
     "b.test.js": `import {test,expect} from "bun:test"; test("b",()=>expect(1).toBe(1));`,
   });
+}
+
+async function runParallel(dir: string, mode: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--parallel=2"],
-    env: { ...bunEnv, BUN_TEST_WORKER_EXIT_BEFORE_READY: "1" },
-    cwd: String(dir),
+    env: { ...bunEnv, BUN_TEST_WORKER_EXIT_BEFORE_READY: mode },
+    cwd: dir,
     stderr: "pipe",
     stdout: "pipe",
   });
@@ -37,7 +36,17 @@ test("--parallel terminates when a worker exits before sending .ready", async ()
   ]);
   if (result === "TIMEOUT") proc.kill("SIGKILL");
   expect(result).not.toBe("TIMEOUT");
-  const [, stderr, exitCode] = result as [string, string, number];
+  return result as [string, string, number];
+}
+
+test.skipIf(!hasHook)("--parallel terminates when a worker exits before sending .ready", async () => {
+  // A worker that spawns OK but dies during init (before the IPC handshake)
+  // has `inflight == None`, so the mid-file crash handling in reap_worker
+  // never applied and the coordinator would respawn the slot forever with
+  // no output (issue #40782). The run must terminate with a non-zero exit
+  // after a bounded number of attempts.
+  using dir = makeDir("parallel-pre-ready-exit");
+  const [, stderr, exitCode] = await runParallel(String(dir), "1");
   // Assert only on coordinator-generated output: try_reap gates on ipc.done
   // but not err.done, so the worker's own stderr line can race the reap and
   // be dropped before it's captured. The coordinator prints "exited during
@@ -56,5 +65,21 @@ test("--parallel terminates when a worker exits before sending .ready", async ()
   const spawns = (stderr.match(/exited during startup/g) ?? []).length;
   expect(spawns).toBeGreaterThanOrEqual(2);
   expect(spawns).toBeLessThanOrEqual(4);
+  expect(exitCode).not.toBe(0);
+}, 60_000);
+
+test.skipIf(!hasHook)("--parallel aborts the whole run when a worker crashes before sending .ready", async () => {
+  // A fatal signal during init is a Bun bug just like one mid-file: the
+  // coordinator must print the crash banner, sweep the queued files, and
+  // end the run instead of retrying the slot.
+  using dir = makeDir("parallel-pre-ready-crash");
+  const [, stderr, exitCode] = await runParallel(String(dir), "abort");
+  expect(stderr).toContain("crashed with");
+  expect(stderr).toContain("during startup");
+  // Queued files are swept, not silently dropped, and not retried.
+  expect(stderr).toContain("aborted: worker panicked during startup");
+  expect(stderr).toContain("a.test.js");
+  expect(stderr).toContain("b.test.js");
+  expect(stderr).not.toContain("retrying");
   expect(exitCode).not.toBe(0);
 }, 60_000);

--- a/test/cli/test/parallel-startup-failure.test.ts
+++ b/test/cli/test/parallel-startup-failure.test.ts
@@ -39,47 +39,55 @@ async function runParallel(dir: string, mode: string) {
   return result as [string, string, number];
 }
 
-test.skipIf(!hasHook)("--parallel terminates when a worker exits before sending .ready", async () => {
-  // A worker that spawns OK but dies during init (before the IPC handshake)
-  // has `inflight == None`, so the mid-file crash handling in reap_worker
-  // never applied and the coordinator would respawn the slot forever with
-  // no output (issue #40782). The run must terminate with a non-zero exit
-  // after a bounded number of attempts.
-  using dir = makeDir("parallel-pre-ready-exit");
-  const [, stderr, exitCode] = await runParallel(String(dir), "1");
-  // Assert only on coordinator-generated output: try_reap gates on ipc.done
-  // but not err.done, so the worker's own stderr line can race the reap and
-  // be dropped before it's captured. The coordinator prints "exited during
-  // startup" synchronously inside reap_worker, once per pre-ready reap — a
-  // reliable spawn counter.
-  expect(stderr).toContain("exited during startup");
-  // Both queued files were accounted for (marked failed, not silently dropped).
-  expect(stderr).toContain("a.test.js");
-  expect(stderr).toContain("b.test.js");
-  // Respawns are capped per slot at MAX_STARTUP_FAILURES=2; with K=2 the
-  // worst case is 4 spawns. Slot 0 alone guarantees >=2: its first reap has
-  // startup_failures=1 < 2 and undispatched files remain (no worker reaches
-  // .ready, so no range is ever consumed), so it respawns once before
-  // hitting the cap. Slot 1 may additionally spawn if maybe_scale_up ticks
-  // in the window between slot 0's process exit and its reap.
-  const spawns = (stderr.match(/exited during startup/g) ?? []).length;
-  expect(spawns).toBeGreaterThanOrEqual(2);
-  expect(spawns).toBeLessThanOrEqual(4);
-  expect(exitCode).not.toBe(0);
-}, 60_000);
+test.skipIf(!hasHook)(
+  "--parallel terminates when a worker exits before sending .ready",
+  async () => {
+    // A worker that spawns OK but dies during init (before the IPC handshake)
+    // has `inflight == None`, so the mid-file crash handling in reap_worker
+    // never applied and the coordinator would respawn the slot forever with
+    // no output (issue #40782). The run must terminate with a non-zero exit
+    // after a bounded number of attempts.
+    using dir = makeDir("parallel-pre-ready-exit");
+    const [, stderr, exitCode] = await runParallel(String(dir), "1");
+    // Assert only on coordinator-generated output: try_reap gates on ipc.done
+    // but not err.done, so the worker's own stderr line can race the reap and
+    // be dropped before it's captured. The coordinator prints "exited during
+    // startup" synchronously inside reap_worker, once per pre-ready reap — a
+    // reliable spawn counter.
+    expect(stderr).toContain("exited during startup");
+    // Both queued files were accounted for (marked failed, not silently dropped).
+    expect(stderr).toContain("a.test.js");
+    expect(stderr).toContain("b.test.js");
+    // Respawns are capped per slot at MAX_STARTUP_FAILURES=2; with K=2 the
+    // worst case is 4 spawns. Slot 0 alone guarantees >=2: its first reap has
+    // startup_failures=1 < 2 and undispatched files remain (no worker reaches
+    // .ready, so no range is ever consumed), so it respawns once before
+    // hitting the cap. Slot 1 may additionally spawn if maybe_scale_up ticks
+    // in the window between slot 0's process exit and its reap.
+    const spawns = (stderr.match(/exited during startup/g) ?? []).length;
+    expect(spawns).toBeGreaterThanOrEqual(2);
+    expect(spawns).toBeLessThanOrEqual(4);
+    expect(exitCode).not.toBe(0);
+  },
+  60_000,
+);
 
-test.skipIf(!hasHook)("--parallel aborts the whole run when a worker crashes before sending .ready", async () => {
-  // A fatal signal during init is a Bun bug just like one mid-file: the
-  // coordinator must print the crash banner, sweep the queued files, and
-  // end the run instead of retrying the slot.
-  using dir = makeDir("parallel-pre-ready-crash");
-  const [, stderr, exitCode] = await runParallel(String(dir), "abort");
-  expect(stderr).toContain("crashed with");
-  expect(stderr).toContain("during startup");
-  // Queued files are swept, not silently dropped, and not retried.
-  expect(stderr).toContain("aborted: worker panicked during startup");
-  expect(stderr).toContain("a.test.js");
-  expect(stderr).toContain("b.test.js");
-  expect(stderr).not.toContain("retrying");
-  expect(exitCode).not.toBe(0);
-}, 60_000);
+test.skipIf(!hasHook)(
+  "--parallel aborts the whole run when a worker crashes before sending .ready",
+  async () => {
+    // A fatal signal during init is a Bun bug just like one mid-file: the
+    // coordinator must print the crash banner, sweep the queued files, and
+    // end the run instead of retrying the slot.
+    using dir = makeDir("parallel-pre-ready-crash");
+    const [, stderr, exitCode] = await runParallel(String(dir), "abort");
+    expect(stderr).toContain("crashed with");
+    expect(stderr).toContain("during startup");
+    // Queued files are swept, not silently dropped, and not retried.
+    expect(stderr).toContain("aborted: worker panicked during startup");
+    expect(stderr).toContain("a.test.js");
+    expect(stderr).toContain("b.test.js");
+    expect(stderr).not.toContain("retrying");
+    expect(exitCode).not.toBe(0);
+  },
+  60_000,
+);

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -154,6 +154,7 @@ test/js/node/test/parallel/test-http-server-keepalive-req-gc.js
 # Timeouts
 test/js/node/test/parallel/test-cluster-primary-kill.js
 test/cli/test/parallel.test.ts
+test/cli/test/parallel-startup-failure.test.ts
 
 # bun.assert(!this.hasPendingActivity() or jsc.VirtualMachine.get().isShuttingDown());
 # @call(bun.callmod_inline, Subprocess.finalize, .{thisValue});


### PR DESCRIPTION
Fixes #40782. Supersedes #29434 (same fix, rebased onto current main after the Rust port).

### Problem
- `bun test --parallel` respawns a worker forever when the worker process exits before it sends the ready frame. The run prints only the header line and never ends. The repro in #40782 shows a fresh worker PID every few hundred ms with no output.
- Cause: `Coordinator::reap_worker` (src/runtime/cli/test/parallel/Coordinator.rs:586) keys all exit accounting on `w.inflight`. Files are dispatched only after ready, so a pre-ready exit leaves `inflight == None`. Nothing is reported and the slot respawns unconditionally.

### Fix
- Track `reached_ready` and consecutive `startup_failures` per worker slot. A reap with `inflight == None` and `!reached_ready` is a startup failure.
- Report each pre-ready exit with its exit status. After 2 consecutive startup failures the slot stops respawning. When no live worker remains, the queued files are marked failed and the run exits non-zero.
- A pre-ready exit from a crash signal aborts the whole run, through the same path as the existing mid-file `abort_on_worker_panic`.
- Verified: test/cli/test/parallel-startup-failure.test.ts, two tests: the bounded-respawn path and the startup-crash abort path (both fail without the fix). Also all 38 tests in test/cli/test/parallel.test.ts.

### Background
- The coordinator spawns workers from the self-exe path and dispatches one file at a time over an fd-3 IPC channel. A worker sends ready only after VM init, bunfig discovery, env loading, and fd-3 adoption succeed. Any clean exit in that window produced the silent loop.
- `BUN_TEST_WORKER_EXIT_BEFORE_READY` is a test hook in the worker loop. A real init failure is not reproducible from outside the worker. It compiles only into debug/ASAN builds, so a stray env var cannot disable `--parallel` in a release build. The value `abort` dies by SIGABRT to exercise the startup-crash path.

<details><summary>Notes</summary>

Realistic probe (replace the bun binary with an exit-0 shim after the parent starts, so every later worker dies at startup): before this change the coordinator logged 8192 respawns in a 10 s window with no output. With this change:

```
bun test v1.4.1 (65362b53b) 2x PARALLEL
warn: test worker 2 exited during startup (exit code 0), retrying
error: test worker 2 exited during startup (exit code 0) 2 times
```

The run then continues on the remaining live workers, or exits non-zero when none remain.

#29434 carried the same design (reviewed green there) but targeted the pre-port Zig tree and mirrored .zig files that no longer exist. This PR applies it to the current Rust code: `stop_reason` instead of the old `bailed` flag, and the sibling-kill loop shared between `abort_on_worker_panic` and the new `abort_on_worker_startup_panic` via `terminate_workers_after_panic`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/parallel-startup-failure.test.ts
bun test v1.4.1 (65362b53b)

test/cli/test/parallel-startup-failure.test.ts:
52 |     // Assert only on coordinator-generated output: try_reap gates on ipc.done
53 |     // but not err.done, so the worker's own stderr line can race the reap and
54 |     // be dropped before it's captured. The coordinator prints "exited during
55 |     // startup" synchronously inside reap_worker, once per pre-ready reap — a
56 |     // reliable spawn counter.
57 |     expect(stderr).toContain("exited during startup");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "exited during startup"
Received: "\na.test.js:\n(pass) a [1.49ms]\n\nb.test.js:\n(pass) b [1.01ms]\n\n 2 pass\n 0 fail\n 2 expect() calls\nRan 2 tests across 2 files. [671.00ms]\n"

      at <anonymous> (/workspace/bun/test/cli/test/parallel-startup-failure.test.ts:57:20)
(fail) --parallel terminates when a worker exits before sending .ready [799.94ms]
78 |     // A fatal signal during init is a Bun
... (truncated)

release without fix: 2 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/cli/test/parallel-startup-failure.test.ts:
(skip) --parallel terminates when a worker exits before sending .ready
(skip) --parallel aborts the whole run when a worker crashes before sending .ready

 0 pass
 2 skip
 0 fail
Ran 2 tests across 1 file. [88.00ms]
__F:0:S:2
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/parallel-startup-failure.test.ts
bun test v1.4.1 (65362b53b)

test/cli/test/parallel-startup-failure.test.ts:
(pass) --parallel terminates when a worker exits before sending .ready [724.75ms]
(pass) --parallel aborts the whole run when a worker crashes before sending .ready [549.91ms]

 2 pass
 0 fail
 15 expect() calls
Ran 2 tests across 1 file. [3.21s]
__F:0:S:0

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/24] gen cpp.rs (cppbind)
[3/24] gen JS modules (bundle-modules)
Preprocess modules (7636ms)
Bundle modules (66ms)
Postprocesss modules (35ms)
Bundle Functions (462ms)
Generate Code (41ms)

[8.25s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_exe_format v0.0.0 (/workspace/bun/src/exe_format)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test/parallel/Coordinator.rs   | 81 +++++++++++++++++++++-
 src/runtime/cli/test/parallel/Worker.rs        |  7 ++
 src/runtime/cli/test/parallel/runner.rs        | 21 ++++++
 test/cli/test/parallel-startup-failure.test.ts | 93 ++++++++++++++++++++++++++
 test/no-validate-leaksan.txt                   |  1 +
 5 files changed, 200 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/runtime/cli/test/parallel/Coordinator.rs        2      6      0
src/runtime/cli/test/parallel/Worker.rs             2      2      0
src/runtime/cli/test/parallel/runner.rs             3      6      0
test/cli/test/parallel-startup-failure.test.ts      0      2      0
test/no-validate-leaksan.txt                        1      2      0
```

</details>

**root cause** · written by the author bot

The parallel test coordinator treated any worker exit as a routine slot vacancy, so a worker that died during bootstrap, before signaling readiness, was silently respawned in an endless loop with no error ever surfaced to the user. The fix tracks per-worker readiness and consecutive pre-ready failures, classifies such exits as startup failures, and caps respawns at two per slot. Once the cap is hit the run aborts with per-exit diagnostics and a nonzero exit status instead of spinning forever.

<!-- robobun:evidence:end -->
