### PR TITLE
js_printer: compare linked symbols when a destructuring group rebinds its target

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2261,14 +2261,19 @@ pub(crate) mod __gated_printer {
                         if target_e_dot.optional_chain.is_some() {
                             break 'brk;
                         }
-                        let target_ref = target_id.ref_;
+                        // Compare symbols, not raw refs. A `var` that re-declares
+                        // a parameter or an earlier `var` gets its own ref, linked
+                        // to the existing symbol, so `n` in `var n = n.next` and
+                        // the `n` it reads are two refs for one variable.
+                        let symbols = self.renamer.symbols();
+                        let target_ref = symbols.follow(target_id.ref_);
 
                         // A group evaluates its target once, before any
                         // assignment, but the original declarators execute in
                         // order. A declarator that binds the target itself can
                         // only be the last member of a group: a later member
                         // would read the rebound target.
-                        if first_binding.get().r#ref.eql(target_ref) {
+                        if symbols.follow(first_binding.get().r#ref).eql(target_ref) {
                             break 'brk;
                         }
 
@@ -2281,11 +2286,13 @@ pub(crate) mod __gated_printer {
                         let ExprData::EIdentifier(second_id) = &second_e_dot.target.data else {
                             break 'brk;
                         };
-                        if second_e_dot.optional_chain.is_some() || !second_id.ref_.eql(target_ref)
+                        if second_e_dot.optional_chain.is_some()
+                            || !symbols.follow(second_id.ref_).eql(target_ref)
                         {
                             break 'brk;
                         }
-                        let mut target_rebound = second_binding.get().r#ref.eql(target_ref);
+                        let mut target_rebound =
+                            symbols.follow(second_binding.get().r#ref).eql(target_ref);
 
                         {
                             // Reset the temporary bindings array early on
@@ -2326,10 +2333,13 @@ pub(crate) mod __gated_printer {
                                 let ExprData::EIdentifier(id) = &e_dot.target.data else {
                                     break;
                                 };
-                                if e_dot.optional_chain.is_some() || !id.ref_.eql(target_ref) {
+                                if e_dot.optional_chain.is_some()
+                                    || !symbols.follow(id.ref_).eql(target_ref)
+                                {
                                     break;
                                 }
-                                target_rebound = binding.get().r#ref.eql(target_ref);
+                                target_rebound =
+                                    symbols.follow(binding.get().r#ref).eql(target_ref);
 
                                 temp_bindings.push(B::Property {
                                     flags: Default::default(),

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -410,6 +410,40 @@ describe("bundler", () => {
     minifySyntax: true,
     run: { stdout: "1 99\n5" },
   });
+  // A `var` that re-declares a parameter or an earlier `var` gets its own
+  // symbol, linked to the existing one. The rebound-target check must compare
+  // the linked symbols, or `var n = n.next, n = n.next` folds into
+  // `{ next: n, next: n } = n` and both members read the original `n`.
+  const sameTargetRedeclaredFiles = {
+    "/entry.js": /* js */ `
+      const L = { v: 0, next: { v: 1, next: { v: 2, next: null } } };
+      function param(n) { var n = n.next, n = n.next; return n.v; }
+      function redecl() { var n = L; var n = n.next, n = n.next; return n.v; }
+      function later(n) { var n = n.next, v = n.v; var n; return v; }
+      function mixed(n) { var a = n.next, n = n.next, b = n.v; return [a.v, n.v, b].join(""); }
+      console.log(param(L), redecl(), later(L), mixed(L));
+    `,
+  };
+  itBundled("minify/SameTargetDestructuringSkipsRedeclaredTarget", {
+    files: sameTargetRedeclaredFiles,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var n = n.next, n = n.next");
+      api.expectFile("/out.js").toContain("var n = L, n = n.next, n = n.next");
+      api.expectFile("/out.js").toContain("var n = n.next, v = n.v, n;");
+      api.expectFile("/out.js").toContain("var { next: a, next: n } = n, b = n.v");
+    },
+    run: { stdout: "2 2 1 111" },
+  });
+  itBundled("minify/SameTargetDestructuringSkipsRedeclaredTargetWithoutMinify", {
+    files: sameTargetRedeclaredFiles,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var n = n.next, n = n.next");
+      api.expectFile("/out.js").toContain("var n = n.next, v = n.v;");
+      api.expectFile("/out.js").toContain("var { next: a, next: n } = n, b = n.v");
+    },
+    run: { stdout: "2 2 1 111" },
+  });
   // A `using` declaration admits only identifier bindings, so the transform
   // must not rewrite its declarators into an object pattern.
   itBundled("minify/SameTargetDestructuringSkipsUsingDecls", {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5586,3 +5586,104 @@ describe("multi-line comment scanning", () => {
     expectParseError(`/*${pad600}🦊`, message);
   });
 });
+
+// The printer folds `var a = obj.x, b = obj.y` into `var { x: a, y: b } = obj`.
+// A pattern evaluates `obj` once, so a declarator that rebinds `obj` must end
+// the group. A `var` that re-declares a parameter or an earlier `var` gets its
+// own symbol, linked to the existing one. The check has to compare the linked
+// symbols, or `var n = n.next, n = n.next` folds into `{ next: n, next: n } = n`
+// and both members read the original `n`.
+describe("same-target destructuring with a re-declared target", () => {
+  const plain = new Bun.Transpiler({ loader: "js" });
+  const minifier = new Bun.Transpiler({ loader: "js", minifyWhitespace: true, minify: { syntax: true } });
+
+  it("keeps a run that rebinds a re-declared parameter", () => {
+    expect(plain.transformSync("function f(n) { var n = n.next, n = n.next; return n; }")).toBe(
+      "function f(n) {\n  var n = n.next, n = n.next;\n  return n;\n}\n",
+    );
+    expect(plain.transformSync("function f(o) { var o = o.o, o = o.o, o = o.o; return o; }")).toBe(
+      "function f(o) {\n  var o = o.o, o = o.o, o = o.o;\n  return o;\n}\n",
+    );
+    expect(plain.transformSync("function f() { try {} catch (n) { var n = n.next, n = n.next; } }")).toBe(
+      "function f() {\n  try {} catch (n) {\n    var n = n.next, n = n.next;\n  }\n}\n",
+    );
+  });
+
+  it("keeps a run whose target is re-declared again later in the scope", () => {
+    expect(plain.transformSync("function f(n) { var n = n.next, v = n.v; var n; return v; }")).toBe(
+      "function f(n) {\n  var n = n.next, v = n.v;\n  var n;\n  return v;\n}\n",
+    );
+  });
+
+  it("ends the group at a re-declared parameter that rebinds the target", () => {
+    expect(plain.transformSync("function f(n) { var a = n.next, n = n.next, b = n.v; return [a, n, b]; }")).toBe(
+      "function f(n) {\n  var { next: a, next: n } = n, b = n.v;\n  return [a, n, b];\n}\n",
+    );
+  });
+
+  it("keeps a run that rebinds an earlier var after the statements merge", () => {
+    expect(minifier.transformSync("function f() { var n = L; var n = n.next, n = n.next; return n; }")).toBe(
+      "function f(){var n=L,n=n.next,n=n.next;return n}",
+    );
+    expect(minifier.transformSync("function f() { for (var n = L, n = n.next, n = n.next; ; ) return n; }")).toBe(
+      "function f(){for(var n=L,n=n.next,n=n.next;;)return n}",
+    );
+  });
+
+  it("still folds a run with distinct bindings", () => {
+    expect(plain.transformSync("function f(o) { var a = o.a, b = o.b; return [a, b]; }")).toBe(
+      "function f(o) {\n  var { a, b } = o;\n  return [a, b];\n}\n",
+    );
+    expect(minifier.transformSync("function f() { var o = M; var a = o.a, b = o.b; return [a, b]; }")).toBe(
+      "function f(){var o=M,{a,b}=o;return[a,b]}",
+    );
+  });
+
+  it("walks a linked list with var re-declarations at runtime", async () => {
+    using dir = tempDir("same-target-redecl", {
+      "walk.js": /* js */ `
+        const L = { v: 0, next: { v: 1, next: { v: 2, next: null } } };
+        const M = { o: { o: { o: "deep" } } };
+        console.log(
+          JSON.stringify({
+            param: (function (n) { var n = n.next, n = n.next; return n.v; })(L),
+            redecl: (function () { var n = L; var n = n.next, n = n.next; return n.v; })(),
+            oneStmt: (function () { var n = L, n = n.next, n = n.next; return n.v; })(),
+            chain3: (function () { var o = M; var o = o.o, o = o.o, o = o.o; return o; })(),
+            arrow: ((n) => { var n = n.next, n = n.next; return n.v; })(L),
+            method: ({ m(n) { var n = n.next, n = n.next; return n.v; } }).m(L),
+            forHead: (function () { for (var n = L, n = n.next, n = n.next; ; ) return n.v; })(),
+            catchParam: (function () { try { throw L; } catch (n) { var n = n.next, n = n.next; return n.v; } })(),
+            laterRedecl: (function (n) { var n = n.next, v = n.v; var n; return v; })(L),
+            mixed: (function (n) { var a = n.next, n = n.next, b = n.v; return [a.v, n.v, b]; })(L),
+            assign: (function () { var n = L; n = n.next, n = n.next; return n.v; })(),
+          }),
+        );
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "walk.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      param: 2,
+      redecl: 2,
+      oneStmt: 2,
+      chain3: "deep",
+      arrow: 2,
+      method: 2,
+      forHead: 2,
+      catchParam: 2,
+      laterRedecl: 1,
+      mixed: [1, 1, 1],
+      assign: 2,
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `bun file.js` computes the wrong node for a linked-list walk written with `var` re-declarations. `function (n) { var n = n.next, n = n.next; return n.v; }` returns the first `next`, not the second. The printer emits `var { next: n, next: n } = n;`, which reads both members from the original `n`. `bun build` with and without `--minify` emits the same pattern.
- The cause is the rebound-target check in `print_decls` (`src/js_printer/lib.rs:2271`). It compares raw refs. A `var` that re-declares a parameter or an earlier `var` gets a fresh ref, linked to the existing symbol (`src/js_parser/p.rs:4503`), so the two refs differ and the check never fires.
- #40691 applied the transform to every run in a list. The runtime merges adjacent `var` statements, so `var n = L; var n = n.next, n = n.next;` now folds too. On 1.4.x only the parameter shape was wrong at runtime.

### Fix
- Resolve both refs with `symbols().follow()` before the comparison, as `name_for_symbol` does. A declarator whose binding follows to the target's symbol ends the group.
- Correct because two refs that follow to one symbol print as one identifier and are one variable at runtime. A run with distinct bindings still folds: `var a = o.a, b = o.b` stays `var { a, b } = o`.
- Verified: `test/bundler/transpiler/transpiler.test.js` (six cases: printed output, and a spawned `bun walk.js` checked against node's values) and `test/bundler/bundler_minify.test.ts` (two `itBundled` cases). Also ran the bundler, transpiler and esbuild suites, and the 16 pinned hashes in `bundler_bytecode_portable.test.ts` are unchanged.

### Background
- `print_decls` prints the declarator list of one `var`/`let`/`const` statement. Under `SAME_TARGET_BECOMES_DESTRUCTURING` it folds a run of `a = obj.x, b = obj.y` into one object pattern at print time.
- A `Ref` names a symbol slot. When the parser merges two declarations of one name, it links the older symbol to the newer one instead of rewriting the AST. `symbol::Map::follow` walks the links to the canonical symbol.
- A function body re-declaring a parameter, and a `var` in a `catch` block named like the catch binding, link the same way.

<details><summary>Notes</summary>

Shapes the runtime test covers, with node's values: `param` 2, `redecl` 2, `oneStmt` 2, `chain3` "deep", `arrow` 2, `method` 2, `forHead` 2, `catchParam` 2, `laterRedecl` 1, `mixed` [1, 1, 1], `assign` 2 (control).

Before this fix, main printed:

```js
function param(n) { var { next: n, next: n } = n; return n.v; }
function redecl() { var n = L, { next: n, next: n } = n; return n.v; }
function later(n) { var { next: n, v } = n, n; return v; }
```

Only a re-declaration that is not the last one for its name in the scope is affected. The last declaration holds the canonical ref, so raw equality happened to work for it. That is why `var a = n.next, n = n.next, b = n.v` was already correct on main.

Release behavior: the 1.4.1 runtime was wrong for `param`, `arrow`, `method`, `catchParam`, `laterRedecl` and `mixed`. Plain `bun build` in 1.4.1 was also wrong for `redecl` and `chain3`. The other shapes broke on main after #40691.

At module scope the parser lowers a `var` inside `catch` to assignments plus a hoisted `var n;`, so that shape never reaches this transform. Inside a function it stays a `var` and is covered.

Suites run: `bundler_minify`, `transpiler`, `bundler_edgecase`, `esbuild/default`, `esbuild/dce`, `bundler_minify_symbol_for`, `bundler_npm`, all green. `bundler_bytecode_portable` times out locally on the big corpus under the debug build, so the JS hashes of all 16 bundler builds were compared to the inline snapshot directly, and all match.
</details>
