### PR TITLE
js_parser: mangle switch case bodies after every case is visited

### DIFF
--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1571,9 +1571,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        if !p.options.features.minify_syntax || !p.options.features.dead_code_elimination {
+        // A case body is one slice of the switch block scope, so a `let` or
+        // `const` declared here can still be used by a later case that has not
+        // been visited yet. `s_switch` mangles every case body once all of them
+        // have been visited and the use counts are final.
+        if kind == StmtsKind::SwitchStmt {
             return Ok(());
         }
+
+        if p.options.features.minify_syntax && p.options.features.dead_code_elimination {
+            p.mangle_stmts(stmts);
+        }
+        Ok(())
+    }
+
+    /// The minify-syntax pass over one visited statement list: drops fully
+    /// inlined constants, inlines single-use `let`/`const` declarations into the
+    /// statement that follows them, and merges adjacent statements.
+    ///
+    /// Every use of a `let`/`const` declared in `stmts` must have been visited
+    /// before this runs, since it trusts `use_count_estimate`.
+    fn mangle_stmts(&mut self, stmts: &mut ListManaged<'a, Stmt>) {
+        let p = self;
 
         // SAFETY: current_scope is a valid arena ptr for the parse.
         if p.current_scope().parent.is_some() && !p.current_scope().contains_direct_eval {
@@ -1934,7 +1953,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // stmts.deinit(); — Drop handles freeing the old buffer (BumpVec is arena-backed).
         *stmts = output;
-        Ok(())
     }
 }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2107,6 +2107,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             p.fn_or_arrow_data_visit.is_inside_switch = old_is_inside_switch;
 
+            // All case bodies share this block scope, so a `let`/`const`
+            // declared in one case can be used by a later case. Only now, with
+            // every case visited, are the use counts final.
+            if p.options.features.minify_syntax && p.options.features.dead_code_elimination {
+                for i in 0..cases.len() {
+                    let mut _stmts = stmts_to_list(p.arena, cases[i].body);
+                    p.mangle_stmts(&mut _stmts);
+                    cases[i].body = list_to_stmts(_stmts);
+                }
+            }
+
             for i in 0..cases.len() {
                 if p.should_lower_using_declarations(cases[i].body.slice()) {
                     lowered_using = true;

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,9 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: The single-use `let`/`const` inliner no longer deletes a declaration
+/// in one switch case clause that a later clause still uses.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1614,6 +1614,50 @@ describe("bundler", () => {
       expect(code.match(/let keep = /g)).toHaveLength(10);
     },
   });
+
+  // A `let`/`const` declared in one case clause is scoped to the whole switch
+  // block, so a later clause can still read or assign it. The single-use
+  // inliner used to run per clause and deleted `tag`, `s` and `n` after it
+  // had only seen the uses in the declaring clause. `only` has its single use
+  // in the same clause and must still be inlined.
+  itBundled("minify/SwitchCaseDeclUsedInLaterCase", {
+    files: {
+      "/entry.js": /* js */ `
+        function capture(v) { return v; }
+        function fallthrough(k) {
+          switch (k) {
+            case 1: const tag = { id: 1 }; capture(tag);
+            case 2: return typeof tag;
+          }
+        }
+        function defaultClause() {
+          switch (1) {
+            case 1: let s = "s1"; capture(s.length);
+            default: { return s + "!"; }
+          }
+        }
+        function reassigned(k) {
+          switch (k) {
+            case 1: let n = k; capture(n);
+            case 2: n = 5; return n;
+          }
+        }
+        function sameClause(v) {
+          switch (v) {
+            case 1: const only = v; return capture(only + 1);
+          }
+        }
+        console.log(JSON.stringify([fallthrough(1), defaultClause(), reassigned(1), sameClause(1)]));
+      `,
+    },
+    capture: ["v", "tag", "s.length", "n", "v + 1"],
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    target: "bun",
+    run: {
+      stdout: '["object","s1!",5,2]',
+    },
+  });
 });
 
 // The runtime transpiler (`bun run`/`bun test`) implicitly enables
@@ -1644,6 +1688,44 @@ test("runtime transpiler does not collapse single-return arrow bodies", async ()
   expect(withArgs).toContain("return a + b * c");
   expect(withArgs).toContain("{");
   expect(noArgs).toContain("return 42");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+// The runtime transpiler runs the same single-use inliner. A `const` declared
+// in one case clause and read after a fall-through into the next clause must
+// keep its declaration.
+test("runtime transpiler keeps a switch case declaration that a later case reads", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      /* js */ `
+        function f(k) {
+          switch (k) {
+            case 1: const tag = { id: 1 }; use(tag);
+            case 2: return typeof tag;
+          }
+        }
+        function g() {
+          switch (1) {
+            case 1: let s = "s1"; use(s.length);
+            default: { return s + "!"; }
+          }
+        }
+        function use(v) { return v; }
+        let r;
+        try { r = g(); } catch (e) { r = e.constructor.name; }
+        console.log(JSON.stringify([f(1), r]));
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe('["object","s1!"]\n');
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- With minify-syntax on (`bun file.js`, `bun build --minify-syntax`), a `let`/`const` declared in one `case` clause and used in a later clause is inlined into its first use and the declaration is deleted. `case 1: const tag = {}; use(tag); case 2: return tag;` becomes `case 1: use({}); case 2: return tag;`.
- The cause is the single-use inliner at the tail of `visit_stmts` (`src/js_parser/visit/mod.rs`). It trusts `use_count_estimate`, but `s_switch` (`src/js_parser/visit/visit_stmt.rs`) calls `visit_stmts` once per case body, so uses in later cases are not counted yet. esbuild has the same bug.

### Fix
- Move the minify-syntax tail of `visit_stmts` into `mangle_stmts`. `visit_stmts` skips it for `StmtsKind::SwitchStmt`. `s_switch` runs it on each case body after every case is visited, when every use in the switch scope is counted.
- Case bodies keep the same output as any other block: a single use in the same clause is still inlined, and statement merging is unchanged.
- `RuntimeTranspilerCache::EXPECTED_VERSION` goes to 28 so cached output from the old inliner is not reused.
- Verified: `test/bundler/bundler_minify.test.ts` (two new tests, both fail on 1.4.1). The other suites run are listed in the notes.

### Background
- The visit pass counts uses per symbol as it walks the AST. Once a statement list is visited, `visit_stmts` mangles it: the inliner replaces the single use of a `let`/`const` with its initializer and drops the declaration.
- A `switch` pushes one block scope for all of its cases, but each case body is a separate statement list, so this one scope is visited in several `visit_stmts` calls. Every other construct visits a scope in one call.
- `StmtsKind::SwitchStmt` already defers `using` lowering to the switch level for the same reason.
- #30936 (open) guards the inliner with `is_inside_switch`, which turns it off at any depth inside a switch, and also disables const folding in switch bodies to keep TDZ errors. This PR only fixes the dangling use. Const folding across cases (#18477) is unchanged.

<details><summary>Notes</summary>

Repro from the report, run as `bun sw.mjs` (node prints `["object","s1!"]`):

```js
function f(k) {
  switch (k) {
    case 1: const tag = { id: 1 }; use(tag);
    case 2: return typeof tag;
  }
}
function g() { switch (1) { case 1: let s = "s1"; use(s.length); default: { return s + "!"; } } }
function use(v) { return v; }
let r; try { r = g(); } catch (e) { r = e.constructor.name; }
console.log(JSON.stringify([f(1), r]));
```

1.4.1 prints `["undefined","ReferenceError"]`. With this change it prints `["object","s1!"]`.

Other shapes checked against node with the fixed build (all match): a Duff-style decoder that pushes onto an array declared in the first case (1.4.1 throws `acc is not defined`), a declaration read only by a closure in a later case, a `let` reassigned in the `default` clause, a nested switch sharing a declaration with the outer case, and a declaration used as a later `case` value. Case values are visited in the same loop as the bodies, so a declaration used in a later `case t:` expression had the same bug.

Why defer instead of guarding: a guard on `kind == SwitchStmt` (or on `is_inside_switch`, as in #30936) would stop inlining `case 1: const x = foo(); return x.y;` shapes, which are common in unbraced case clauses. Deferring the whole mangle pass keeps the output identical to a braced block. `bun build --minify-syntax` output for a file with mixed same-case and cross-case declarations is byte-identical between 1.4.1 and this build except for the declarations that must now stay.

esbuild 0.21.5 and 0.25.1 produce the same wrong output for the repro. The current esbuild `mangleStmts` still runs per case body.

Suites run with the debug build, all green: `test/bundler/bundler_minify.test.ts`, `bundler_edgecase`, `bundler_regressions`, `bundler_cjs2esm`, `bundler_minify_symbol_for`, `transpiler_constant_fold_eqeq`, `esbuild/{dce,default,ts,lower,extra}`, `transpiler/transpiler.test.js`, `transpiler/runtime-transpiler`, `cli/run/transpiler-cache`. `cargo clippy -p bun_js_parser` is clean. `cargo fmt --check` and prettier pass.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [802.38ms]
(pass) bundler > minify/TemplateStringFolding [175.59ms]
(pass) bundler > minify/StringAdditionFolding [111.38ms]
(pass) bundler > minify/FunctionExpressionRemoveName [113.69ms]
(pass) bundler > minify/KeepNamesPreservesNames [94.40ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [85.26ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1142.83ms]
(pass) bundler > minify/MergeAdjacentVars [358.93ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [457.79ms]
(pass) bundler > minify/Infinity [112.05ms]
(pass) bundler > minify+whitespace/Infinity [98.19ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [431.10ms]
(pass) bundler > minify/SameTargetDestructuringAfterOtherDecl [436.20ms]
(pass) bundler > minify/SameTargetDestructuringMultipleRuns [351.68ms]
(pass) bundler > minify/SameTargetDestructuringStopsWhenTargetRebound [3
... (truncated)

release without fix: 7 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [21.53ms]
(pass) bundler > minify/TemplateStringFolding [3.69ms]
(pass) bundler > minify/StringAdditionFolding [3.95ms]
(pass) bundler > minify/FunctionExpressionRemoveName [3.56ms]
(pass) bundler > minify/KeepNamesPreservesNames [3.38ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [2.90ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [14.81ms]
(pass) bundler > minify/MergeAdjacentVars [10.22ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [9.29ms]
(pass) bundler > minify/Infinity [3.14ms]
(pass) bundler > minify+whitespace/Infinity [2.78ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [9.17ms]
361 |       `,
362 |     },
363 |     minifySyntax: true,
364 |     onAfterBundle(api) {
365 |       api.expectFile("/out.js").toContain("{ random: Math_random, random: Math_random2 } = Math");
366 |       api.expectFile("/out.js").toContain("{ cos: Math_cos, sin: Math_sin } = Math");
                                      ^
error: expect(received).toContain(expected)

Expected to contain: "{ 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [876.55ms]
(pass) bundler > minify/TemplateStringFolding [175.25ms]
(pass) bundler > minify/StringAdditionFolding [118.77ms]
(pass) bundler > minify/FunctionExpressionRemoveName [100.84ms]
(pass) bundler > minify/KeepNamesPreservesNames [98.12ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [82.30ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1207.93ms]
(pass) bundler > minify/MergeAdjacentVars [365.53ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [502.12ms]
(pass) bundler > minify/Infinity [129.52ms]
(pass) bundler > minify+whitespace/Infinity [96.99ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [385.92ms]
(pass) bundler > minify/SameTargetDestructuringAfterOtherDecl [422.95ms]
(pass) bundler > minify/SameTargetDestructuringMultipleRuns [344.71ms]
(pass) bundler > minify/SameTargetDestructuringStopsWhenTargetRebound [3
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     06d24c5627
  features     baseline

23 deps, 131 codegen, 1172 objects in 670ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] gen .bind.ts → GeneratedBindings.cpp
[5/1244] gen ErrorCode+*.h
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[11
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/mod.rs          | 22 +++++++++-
 src/js_parser/visit/visit_stmt.rs   | 11 +++++
 src/jsc/RuntimeTranspilerCache.rs   |  4 +-
 test/bundler/bundler_minify.test.ts | 82 +++++++++++++++++++++++++++++++++++++
 4 files changed, 116 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js_parser/visit/mod.rs               7      4      0
src/js_parser/visit/visit_stmt.rs        1      2      0
src/jsc/RuntimeTranspilerCache.rs        3      1      0
test/bundler/bundler_minify.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->