### PR TITLE
js_printer: fold same-target declarators only when the target reads as one stable value

### DIFF
--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -118,12 +118,9 @@ bitflags::bitflags! {
 
         const REMOVE_OVERWRITTEN_FUNCTION_DECLARATION = 1 << 4;
 
-        /// Set on the root of a symbol's link chain when the file assigns the
-        /// variable after its declaration, or when `arguments` can rebind it
-        /// (a parameter of a sloppy-mode function that uses `arguments`).
-        /// HMR uses it to decide when live binding code is needed. The
-        /// printer uses it to decide whether two reads of the variable see
-        /// the same value.
+        /// The file assigns this variable after its declaration (or a mapped
+        /// `arguments` object can). Set on the root of the symbol's link
+        /// chain. Read by HMR live bindings and the printer's same-target fold.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
     }
 }

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -118,7 +118,12 @@ bitflags::bitflags! {
 
         const REMOVE_OVERWRITTEN_FUNCTION_DECLARATION = 1 << 4;
 
-        /// Used in HMR to decide when live binding code is needed.
+        /// Set on the root of a symbol's link chain when the file assigns the
+        /// variable after its declaration, or when `arguments` can rebind it
+        /// (a parameter of a sloppy-mode function that uses `arguments`).
+        /// HMR uses it to decide when live binding code is needed. The
+        /// printer uses it to decide whether two reads of the variable see
+        /// the same value.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
     }
 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8043,16 +8043,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // A direct eval at module scope can reach every top-level name. Nested
-        // scopes are pinned in `pop_scope`; the module scope never pops. When
-        // the bundler wraps this file in a CommonJS closure those names stay
-        // private to it, so pin them too. A flat ESM file's top-level names
-        // share the chunk's scope with other files', so they stay renameable
-        // (as in esbuild) and eval may not see them. Import bindings are left
-        // out: the linker merges them into the exporting file's symbol, which
-        // would pin that name in every chunk that references it.
-        //
-        // Whatever the name, the eval can assign the variable.
+        // A direct eval at module scope can assign every top-level variable and
+        // reach every top-level name. Nested scopes are pinned in `pop_scope`;
+        // the module scope never pops. When the bundler wraps this file in a
+        // CommonJS closure those names stay private to it, so pin them too. A
+        // flat ESM file's top-level names share the chunk's scope with other
+        // files', so they stay renameable (as in esbuild) and eval may not see
+        // them. Import bindings are left out: the linker merges them into the
+        // exporting file's symbol, which would pin that name in every chunk
+        // that references it.
         if self.module_scope().contains_direct_eval {
             let pin = bundling && exports_kind == js_ast::ExportsKind::Cjs;
             let module_scope = self.module_scope_ref();

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8051,15 +8051,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // (as in esbuild) and eval may not see them. Import bindings are left
         // out: the linker merges them into the exporting file's symbol, which
         // would pin that name in every chunk that references it.
-        if bundling
-            && exports_kind == js_ast::ExportsKind::Cjs
-            && self.module_scope().contains_direct_eval
-        {
+        //
+        // Whatever the name, the eval can assign the variable.
+        if self.module_scope().contains_direct_eval {
+            let pin = bundling && exports_kind == js_ast::ExportsKind::Cjs;
             let module_scope = self.module_scope_ref();
             for member in module_scope.members.values() {
-                let symbol = &mut self.symbols[member.ref_.inner_index() as usize];
-                if symbol.kind != js_ast::symbol::Kind::Import {
-                    symbol.set_must_not_be_renamed(true);
+                let kind = self.symbols[member.ref_.inner_index() as usize].kind;
+                if kind == js_ast::symbol::Kind::Import {
+                    continue;
+                }
+                if kind != js_ast::symbol::Kind::Unbound {
+                    self.record_assignment(member.ref_);
+                }
+                if pin {
+                    self.symbols[member.ref_.inner_index() as usize].set_must_not_be_renamed(true);
                 }
             }
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1464,10 +1464,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Hoisting and re-declaration link the refs of one variable into a chain
-    /// (`var n` in a block, `var n` after a parameter `n`). A fact about the
-    /// variable, such as "something assigns it", belongs on the symbol at the
-    /// end of that chain, which is the one `symbol::Map::follow` returns.
+    /// Marks the root of the link chain, the symbol `symbol::Map::follow`
+    /// returns. A block `var n` hoisted onto a parameter `n` is a linked ref
+    /// of the same variable.
     pub(crate) fn record_assignment(&mut self, ref_: Ref) {
         let mut ref_ = ref_;
         loop {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1464,6 +1464,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Hoisting and re-declaration link the refs of one variable into a chain
+    /// (`var n` in a block, `var n` after a parameter `n`). A fact about the
+    /// variable, such as "something assigns it", belongs on the symbol at the
+    /// end of that chain, which is the one `symbol::Map::follow` returns.
+    pub(crate) fn record_assignment(&mut self, ref_: Ref) {
+        let mut ref_ = ref_;
+        loop {
+            let symbol = &mut self.symbols[ref_.inner_index() as usize];
+            if !symbol.has_link() {
+                symbol.set_has_been_assigned_to(true);
+                return;
+            }
+            ref_ = symbol.link.get();
+        }
+    }
+
     pub(crate) fn log_arrow_arg_errors(&mut self, errors: &mut DeferredArrowArgErrors) {
         if errors.invalid_expr_await.len > 0 {
             let r = errors.invalid_expr_await;

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -173,6 +173,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             loc: body_loc,
         };
 
+        // In sloppy mode, a function with a simple parameter list maps
+        // `arguments` onto its parameters: `arguments[0] = v` rebinds the
+        // first one. Any use of `arguments` can reach such a write.
+        if !self.is_strict_mode()
+            && func.arguments_ref.is_valid()
+            && self.symbols[func.arguments_ref.inner_index() as usize].use_count_estimate > 0
+            && Self::is_simple_parameter_list(
+                func.args.slice(),
+                func.flags.contains(flags::Function::HasRestArg),
+            )
+        {
+            for arg in func.args.slice() {
+                if let BData::BIdentifier(id) = arg.binding.data {
+                    self.record_assignment(id.r#ref);
+                }
+            }
+        }
+
         self.pop_scope();
         self.pop_scope();
 

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -173,9 +173,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             loc: body_loc,
         };
 
-        // In sloppy mode, a function with a simple parameter list maps
-        // `arguments` onto its parameters: `arguments[0] = v` rebinds the
-        // first one. Any use of `arguments` can reach such a write.
+        // A sloppy-mode function with a simple parameter list has a mapped
+        // `arguments` object: `arguments[0] = v` rebinds the first parameter.
         if !self.is_strict_mode()
             && func.arguments_ref.is_valid()
             && self.symbols[func.arguments_ref.inner_index() as usize].use_count_estimate > 0

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -246,7 +246,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.commonjs_module_exports_assigned_deoptimized = true;
             }
 
-            p.symbols[result.r#ref.inner_index() as usize].set_has_been_assigned_to(true);
+            p.record_assignment(result.r#ref);
         }
 
         let mut original_name: Option<&[u8]> = None;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2230,6 +2230,8 @@ pub(crate) mod __gated_printer {
                     //
                     // Caveats:
                     //   - Same consecutive target
+                    //   - The target reads as the same value every time
+                    //     (see `is_stable_destructuring_target`)
                     //   - No optional chaining
                     //   - No computed property access
                     //   - Identifier bindings only
@@ -2267,6 +2269,10 @@ pub(crate) mod __gated_printer {
                         // the `n` it reads are two refs for one variable.
                         let symbols = self.renamer.symbols();
                         let target_ref = symbols.follow(target_id.ref_);
+
+                        if !self.is_stable_destructuring_target(target_id, target_ref) {
+                            break 'brk;
+                        }
 
                         // A group evaluates its target once, before any
                         // assignment, but the original declarators execute in
@@ -2392,6 +2398,31 @@ pub(crate) mod __gated_printer {
                 }
                 decls = &decls[1..];
             }
+        }
+
+        /// A destructuring group reads its target once where the declarators
+        /// it replaces read it once per member. That is the same program only
+        /// when every read is a pure read of the same value. A getter on the
+        /// first property runs between two reads, so the target must be a
+        /// symbol this file declares and never assigns after its declaration,
+        /// reached without a `with` scope or a direct `eval`. An unbound name
+        /// may be an accessor on the global object. The known pure globals
+        /// (`Math`, `Object`, ...) are the exception, as in dead-code
+        /// elimination.
+        fn is_stable_destructuring_target(&self, id: &E::Identifier, target_ref: Ref) -> bool {
+            if id.must_keep_due_to_with_stmt() {
+                return false;
+            }
+            let Some(symbol) = self.symbols().get_const(target_ref) else {
+                return false;
+            };
+            if symbol.has_been_assigned_to() || symbol.namespace_alias.is_some() {
+                return false;
+            }
+            if symbol.kind == js_ast::symbol::Kind::Unbound {
+                return id.can_be_removed_if_unused();
+            }
+            !symbol.must_not_be_renamed()
         }
 
         #[inline]

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2230,8 +2230,7 @@ pub(crate) mod __gated_printer {
                     //
                     // Caveats:
                     //   - Same consecutive target
-                    //   - The target reads as the same value every time
-                    //     (see `is_stable_destructuring_target`)
+                    //   - A stable target (`is_stable_destructuring_target`)
                     //   - No optional chaining
                     //   - No computed property access
                     //   - Identifier bindings only
@@ -2400,15 +2399,10 @@ pub(crate) mod __gated_printer {
             }
         }
 
-        /// A destructuring group reads its target once where the declarators
-        /// it replaces read it once per member. That is the same program only
-        /// when every read is a pure read of the same value. A getter on the
-        /// first property runs between two reads, so the target must be a
-        /// symbol this file declares and never assigns after its declaration,
-        /// reached without a `with` scope or a direct `eval`. An unbound name
-        /// may be an accessor on the global object. The known pure globals
-        /// (`Math`, `Object`, ...) are the exception, as in dead-code
-        /// elimination.
+        /// The group reads its target once where the declarators read it once
+        /// each, and a getter on the first property runs in between. The
+        /// target must be a declared symbol that nothing assigns, outside
+        /// `with` and direct `eval`, or a known pure global such as `Math`.
         fn is_stable_destructuring_target(&self, id: &E::Identifier, target_ref: Ref) -> bool {
             if id.must_keep_due_to_with_stmt() {
                 return false;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2269,7 +2269,7 @@ pub(crate) mod __gated_printer {
                         let symbols = self.renamer.symbols();
                         let target_ref = symbols.follow(target_id.ref_);
 
-                        if !self.is_stable_destructuring_target(target_id, target_ref) {
+                        if !self.is_stable_destructuring_target(*target_id, target_ref) {
                             break 'brk;
                         }
 
@@ -2403,7 +2403,7 @@ pub(crate) mod __gated_printer {
         /// each, and a getter on the first property runs in between. The
         /// target must be a declared symbol that nothing assigns, outside
         /// `with` and direct `eval`, or a known pure global such as `Math`.
-        fn is_stable_destructuring_target(&self, id: &E::Identifier, target_ref: Ref) -> bool {
+        fn is_stable_destructuring_target(&self, id: E::Identifier, target_ref: Ref) -> bool {
             if id.must_keep_due_to_with_stmt() {
                 return false;
             }

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -460,10 +460,10 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "52c1e0868de8da5d8bf4b89d68afbd027f3c64fdce490cd46800674b0de3f0c1",
+          "js": "721d67b0c2135aad554c9962b4e4505a4d6856b50da537fee7566d43f6cfdbda",
           "jsc": {
-            "bytes": 1999232,
-            "sha256": "a6043ef5e8aaae25c9581e6802fc2508f0b7b2fb0681be536768f9d09ef4cac6",
+            "bytes": 1998992,
+            "sha256": "f2631b3ba2b532e52183d5e6a44a7dbf5c0515b368d95fc692bf0e5ad15eb8f6",
           },
         },
         "bun build --bytecode --minify features.js": {
@@ -488,10 +488,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode all.js": {
-          "js": "46d723ea07e5e2d8db673a51fec52b3248edcd3e216029f243d8172244f7cd2c",
+          "js": "a2f566b81700f852fef68247aef22af8b916858de30e4dc787846fd874c9e4d2",
           "jsc": {
-            "bytes": 2178792,
-            "sha256": "c5d1eaae5c4d198b1f8e0d768bb41502162081c75b67249032e66a2b95e26ec1",
+            "bytes": 2178656,
+            "sha256": "f743f4e9cff325bfd8d344f2dead6a8ba6b9933393a09c75334429ead924c480",
           },
         },
         "bun build --bytecode big.js": {
@@ -523,17 +523,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "e685164a8316f60b665bc3d47e42b4623cfe7385f87310e655478a50ecd8f959",
+          "js": "f9d0c270d3f41997b904689435104703b1f8b6b1c67ead48dff30e7354890cfd",
           "jsc": {
-            "bytes": 23806352,
-            "sha256": "5f23309532d868e1c985d568207c92b77a7f3974e5c6c3f37b21accf7d429327",
+            "bytes": 23806376,
+            "sha256": "1e2e31a113d8b5ca3e9cd73820d465e678756c0942023480569f785b15987dcf",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
-          "js": "13a679d20c26bbedc60746eaaf804ae5396086e330d25eed49b633d74c56771a",
+          "js": "e372f1aec6b2bba20581abfce3b7273aae0ec4f593ed2aa4aa5c60c66836856d",
           "jsc": {
-            "bytes": 347608,
-            "sha256": "cad0b454f93314b33e62d31613ec9b8cb70d7fff3fd3f5eec8e516ff1e76b697",
+            "bytes": 347488,
+            "sha256": "531d6bb544c53641289a44e72ac096560b19d360c2ee19b77483987c367b9b5e",
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -444,6 +444,68 @@ describe("bundler", () => {
     },
     run: { stdout: "2 2 1 111" },
   });
+  // The pattern reads its target once where the declarators read it once
+  // each. An unbound global may be an accessor on globalThis, and a getter on
+  // the first property may reassign a variable the file assigns somewhere.
+  // Only a declared symbol that nothing assigns, or a known pure global such
+  // as `Math`, reads as the same value both times.
+  itBundled("minify/SameTargetDestructuringSkipsUnstableTarget", {
+    files: {
+      "/entry.js": /* js */ `
+        let reads = 0;
+        Object.defineProperty(globalThis, "CFG", {
+          get() {
+            reads++;
+            return { host: "h", port: 1 };
+          },
+          configurable: true,
+        });
+        function globalHead() {
+          reads = 0;
+          var h = CFG.host, p = CFG.port;
+          return [h, p, reads];
+        }
+        function globalMid() {
+          reads = 0;
+          var z = 0, h = CFG.host, p = CFG.port;
+          return [z, h, p, reads];
+        }
+        function getterReassigns() {
+          var cur = { get a() { cur = nxt; return "a1"; }, b: "b1" }, nxt = { a: "a2", b: "b2" };
+          var x = cur.a, y = cur.b;
+          return x + y;
+        }
+        function blockHoisted() {
+          var swap;
+          { var o; swap = () => { o = { a: "a2", b: "b2" }; }; }
+          var o = { get a() { swap(); return "a1"; }, b: "b1" };
+          var a = o.a, b = o.b;
+          return a + b;
+        }
+        function stable(param) {
+          var local = { a: "a1", b: "b1" };
+          var a = local.a, b = local.b;
+          var c = param.a, d = param.b;
+          var cos = Math.cos, sin = Math.sin;
+          return [a + b, c + d, typeof cos(0), typeof sin(0)];
+        }
+        console.log(JSON.stringify([globalHead(), globalMid(), getterReassigns(), blockHoisted(), stable({ a: "a2", b: "b2" })]));
+      `,
+    },
+    minifySyntax: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var h = CFG.host, p = CFG.port");
+      api.expectFile("/out.js").toContain("var z = 0, h = CFG.host, p = CFG.port");
+      // `--minify-syntax` merges the adjacent `var` statements, so these runs
+      // start mid-list.
+      api.expectFile("/out.js").toContain(", x = cur.a, y = cur.b;");
+      api.expectFile("/out.js").toContain(", a = o.a, b = o.b;");
+      api.expectFile("/out.js").toContain("{ a, b } = local");
+      api.expectFile("/out.js").toContain("{ a: c, b: d } = param");
+      api.expectFile("/out.js").toContain("{ cos, sin } = Math");
+    },
+    run: { stdout: '[["h",1,2],[0,"h",1,2],"a1b2","a1b2",["a1b1","a2b2","number","number"]]' },
+  });
   // A `using` declaration admits only identifier bindings, so the transform
   // must not rewrite its declarators into an object pattern.
   itBundled("minify/SameTargetDestructuringSkipsUsingDecls", {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -489,7 +489,10 @@ describe("bundler", () => {
           var cos = Math.cos, sin = Math.sin;
           return [a + b, c + d, typeof cos(0), typeof sin(0)];
         }
-        console.log(JSON.stringify([globalHead(), globalMid(), getterReassigns(), blockHoisted(), stable({ a: "a2", b: "b2" })]));
+        var top = { get a() { swapTop(); return "a1"; }, b: "b1" };
+        var swapTop = () => eval("top = { a: 'a2', b: 'b2' }");
+        var ta = top.a, tb = top.b;
+        console.log(JSON.stringify([globalHead(), globalMid(), getterReassigns(), blockHoisted(), stable({ a: "a2", b: "b2" }), ta + tb]));
       `,
     },
     minifySyntax: true,
@@ -503,8 +506,10 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("{ a, b } = local");
       api.expectFile("/out.js").toContain("{ a: c, b: d } = param");
       api.expectFile("/out.js").toContain("{ cos, sin } = Math");
+      // The direct eval can assign any top-level variable.
+      api.expectFile("/out.js").toContain(", ta = top.a, tb = top.b;");
     },
-    run: { stdout: '[["h",1,2],[0,"h",1,2],"a1b2","a1b2",["a1b1","a2b2","number","number"]]' },
+    run: { stdout: '[["h",1,2],[0,"h",1,2],"a1b2","a1b2",["a1b1","a2b2","number","number"],"a1b2"]' },
   });
   // A `using` declaration admits only identifier bindings, so the transform
   // must not rewrite its declarators into an object pattern.

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -60,14 +60,14 @@ describe("bundler", () => {
           ["react.development.js:524:'getContextName'", "1:5623:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
           ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
-          ["entry.tsx:6:'\"Content-Type\"'", '100:18806:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19060:void"],
-          ["entry.tsx:23:'await'", "100:19159:await"],
+          ["entry.tsx:6:'\"Content-Type\"'", '100:18817:"Content-Type"'],
+          ["entry.tsx:11:'<html>'", "100:19071:void"],
+          ["entry.tsx:23:'await'", "100:19170:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221984,
+      "out/entry.js": 221995,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5758,6 +5758,19 @@ describe("same-target destructuring with an unstable target", () => {
     expect(
       plain.transformSync("function f() { var o = M; var g = () => eval(s); var a = o.a, b = o.b; return [a, b]; }"),
     ).toBe("function f() {\n  var o = M;\n  var g = () => eval(s);\n  var a = o.a, b = o.b;\n  return [a, b];\n}\n");
+    // A direct eval anywhere in the file can reach a top-level variable.
+    expect(plain.transformSync("var o = M; var g = () => eval(s); var a = o.a, b = o.b; console.log(a, b);")).toBe(
+      "var o = M;\nvar g = () => eval(s);\nvar a = o.a, b = o.b;\nconsole.log(a, b);\n",
+    );
+    expect(
+      minifier.transformSync("var o = M; function g() { return eval(s); } var a = o.a, b = o.b; console.log(a, b);"),
+    ).toBe("var o=M;function g(){return eval(s)}var a=o.a,b=o.b;console.log(a,b);");
+    expect(plain.transformSync("var o = M; var a = o.a, b = o.b; console.log(a, b, Math.cos, Math.sin);")).toBe(
+      "var o = M;\nvar { a, b } = o;\nconsole.log(a, b, Math.cos, Math.sin);\n",
+    );
+    expect(plain.transformSync("var o = M; var a = Math.cos, b = Math.sin; eval(s); console.log(a, b);")).toBe(
+      "var o = M;\nvar { cos: a, sin: b } = Math;\neval(s);\nconsole.log(a, b);\n",
+    );
   });
 
   it("keeps the reads of a parameter when a sloppy function uses arguments", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5687,3 +5687,222 @@ describe("same-target destructuring with a re-declared target", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// The pattern reads `obj` once where the declarators read it once each. The
+// fold is only valid when both reads are pure reads of the same value: a
+// symbol this file declares and never assigns, outside `with` and direct
+// eval, or a known pure global like `Math`. An unbound global may be an
+// accessor, and a getter on the first property may reassign a captured
+// variable before the second read.
+describe("same-target destructuring with an unstable target", () => {
+  const plain = new Bun.Transpiler({ loader: "js" });
+  const minifier = new Bun.Transpiler({ loader: "js", minifyWhitespace: true, minify: { syntax: true } });
+
+  it("keeps the reads of an unbound global", () => {
+    expect(plain.transformSync("function f() { var h = CFG.host, p = CFG.port; return [h, p]; }")).toBe(
+      "function f() {\n  var h = CFG.host, p = CFG.port;\n  return [h, p];\n}\n",
+    );
+    expect(minifier.transformSync("function f() { var z = 0, h = CFG.host, p = CFG.port; return [z, h, p]; }")).toBe(
+      "function f(){var z=0,h=CFG.host,p=CFG.port;return[z,h,p]}",
+    );
+  });
+
+  it("keeps the reads of a variable that the file assigns", () => {
+    expect(
+      plain.transformSync("function f() { var o = M; var g = () => { o = N; }; var a = o.a, b = o.b; return [a, b]; }"),
+    ).toBe(
+      "function f() {\n  var o = M;\n  var g = () => {\n    o = N;\n  };\n  var a = o.a, b = o.b;\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f(o) { var a = o.a, b = o.b; o = N; return [a, b]; }")).toBe(
+      "function f(o) {\n  var a = o.a, b = o.b;\n  o = N;\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f(o) { var a = o.a, b = o.b; o++; return [a, b]; }")).toBe(
+      "function f(o) {\n  var a = o.a, b = o.b;\n  o++;\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f(o) { var a = o.a, b = o.b; [o] = N; return [a, b]; }")).toBe(
+      "function f(o) {\n  var a = o.a, b = o.b;\n  [o] = N;\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f(o) { var a = o.a, b = o.b; for (o of N); return [a, b]; }")).toBe(
+      "function f(o) {\n  var a = o.a, b = o.b;\n  for (o of N)\n    ;\n  return [a, b];\n}\n",
+    );
+    expect(minifier.transformSync("var o = M; var a = o.a, b = o.b; o = N; console.log(a, b);")).toBe(
+      "var o=M,a=o.a,b=o.b;o=N;console.log(a,b);",
+    );
+  });
+
+  it("keeps the reads when a block var hoists onto the variable", () => {
+    // The block `var o` gets its own symbol, linked to the function-level
+    // `o`. The assignment inside the block must count for the variable.
+    expect(
+      plain.transformSync(
+        "function f() { var g; { var o; g = () => { o = N; }; } var o = M; var a = o.a, b = o.b; return [a, b]; }",
+      ),
+    ).toBe(
+      "function f() {\n  var g;\n  {\n    var o;\n    g = () => {\n      o = N;\n    };\n  }\n  var o = M;\n  var a = o.a, b = o.b;\n  return [a, b];\n}\n",
+    );
+  });
+
+  it("keeps the reads inside a with statement", () => {
+    expect(plain.transformSync("function f(s) { with (s) { var a = o.a, b = o.b; } return [a, b]; }")).toBe(
+      "function f(s) {\n  with (s) {\n    var a = o.a, b = o.b;\n  }\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f(s) { var o = M; with (s) { var a = o.a, b = o.b; } return [a, b]; }")).toBe(
+      "function f(s) {\n  var o = M;\n  with (s) {\n    var a = o.a, b = o.b;\n  }\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f(s) { with (s) { var a = Math.cos, b = Math.sin; } return [a, b]; }")).toBe(
+      "function f(s) {\n  with (s) {\n    var a = Math.cos, b = Math.sin;\n  }\n  return [a, b];\n}\n",
+    );
+  });
+
+  it("keeps the reads when a direct eval can reach the variable", () => {
+    expect(
+      plain.transformSync("function f() { var o = M; var g = () => eval(s); var a = o.a, b = o.b; return [a, b]; }"),
+    ).toBe("function f() {\n  var o = M;\n  var g = () => eval(s);\n  var a = o.a, b = o.b;\n  return [a, b];\n}\n");
+  });
+
+  it("keeps the reads of a parameter when a sloppy function uses arguments", () => {
+    expect(
+      plain.transformSync(
+        "function f(o) { var g = () => { arguments[0] = N; }; var a = o.a, b = o.b; return [a, b]; }",
+      ),
+    ).toBe(
+      "function f(o) {\n  var g = () => {\n    arguments[0] = N;\n  };\n  var a = o.a, b = o.b;\n  return [a, b];\n}\n",
+    );
+    expect(
+      plain.transformSync("function f(o) { var n = arguments.length; var a = o.a, b = o.b; return [a, b, n]; }"),
+    ).toBe("function f(o) {\n  var n = arguments.length;\n  var a = o.a, b = o.b;\n  return [a, b, n];\n}\n");
+    // Strict mode (a class body) and non-simple parameter lists do not map
+    // `arguments` onto the parameters. Nested functions have their own
+    // `arguments`.
+    expect(
+      plain.transformSync(
+        "class C { m(o) { var g = () => { arguments[0] = N; }; var a = o.a, b = o.b; return [a, b]; } }",
+      ),
+    ).toBe(
+      "class C {\n  m(o) {\n    var g = () => {\n      arguments[0] = N;\n    };\n    var { a, b } = o;\n    return [a, b];\n  }\n}\n",
+    );
+    expect(
+      plain.transformSync(
+        "function f(o = 1) { var g = () => { arguments[0] = N; }; var a = o.a, b = o.b; return [a, b]; }",
+      ),
+    ).toBe(
+      "function f(o = 1) {\n  var g = () => {\n    arguments[0] = N;\n  };\n  var { a, b } = o;\n  return [a, b];\n}\n",
+    );
+    expect(
+      plain.transformSync("function f(o) { function g() { arguments[0] = N; } var a = o.a, b = o.b; return [a, b]; }"),
+    ).toBe("function f(o) {\n  function g() {\n    arguments[0] = N;\n  }\n  var { a, b } = o;\n  return [a, b];\n}\n");
+  });
+
+  it("still folds a stable target", () => {
+    expect(plain.transformSync("function f() { var o = M; var a = o.a, b = o.b; return [a, b]; }")).toBe(
+      "function f() {\n  var o = M;\n  var { a, b } = o;\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f(o) { var a = o.a, b = o.b; return [a, b]; }")).toBe(
+      "function f(o) {\n  var { a, b } = o;\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f() { const o = M; var a = o.a, b = o.b; return [a, b]; }")).toBe(
+      "function f() {\n  const o = M;\n  var { a, b } = o;\n  return [a, b];\n}\n",
+    );
+    expect(plain.transformSync("function f() { var a = Math.cos, b = Math.sin; return [a, b]; }")).toBe(
+      "function f() {\n  var { cos: a, sin: b } = Math;\n  return [a, b];\n}\n",
+    );
+    expect(minifier.transformSync("var o = M; var a = o.a, b = o.b; console.log(a, b);")).toBe(
+      "var o=M,{a,b}=o;console.log(a,b);",
+    );
+  });
+
+  it("reads an unstable target once per declarator at runtime", async () => {
+    // A `.cjs` file runs in sloppy mode, which `with` and the mapped
+    // `arguments` object need.
+    using dir = tempDir("same-target-unstable", {
+      "unstable.cjs": /* js */ `
+        let reads = 0;
+        Object.defineProperty(globalThis, "CFG", {
+          get() {
+            reads++;
+            return { host: "h", port: 1 };
+          },
+          configurable: true,
+        });
+        function globalHead() {
+          reads = 0;
+          var h = CFG.host, p = CFG.port;
+          return [h, p, reads];
+        }
+        function globalMid() {
+          reads = 0;
+          var z = 0, h = CFG.host, p = CFG.port;
+          return [z, h, p, reads];
+        }
+        function getterReassigns() {
+          var cur = { get a() { cur = nxt; return "a1"; }, b: "b1" }, nxt = { a: "a2", b: "b2" };
+          var x = cur.a, y = cur.b;
+          return x + y;
+        }
+        function withScope() {
+          var has = 0;
+          var scope = new Proxy({ o: { a: "a", b: "b" } }, { has(t, k) { if (k === "o") has++; return k in t; } });
+          with (scope) { var a = o.a, b = o.b; }
+          return [a, b, has];
+        }
+        var hook;
+        function argumentsAlias(o) {
+          hook = () => { arguments[0] = { a: "a2", b: "b2" }; };
+          var a = o.a, b = o.b;
+          return a + b;
+        }
+        function blockHoisted() {
+          var swap;
+          { var o; swap = () => { o = { a: "a2", b: "b2" }; }; }
+          var o = { get a() { swap(); return "a1"; }, b: "b1" };
+          var a = o.a, b = o.b;
+          return a + b;
+        }
+        function directEval() {
+          var o = { get a() { run(); return "a1"; }, b: "b1" };
+          var run = () => eval("o = { a: 'a2', b: 'b2' }");
+          var a = o.a, b = o.b;
+          return a + b;
+        }
+        function stable() {
+          var o = { get a() { return "a1"; }, b: "b1" };
+          var a = o.a, b = o.b;
+          return a + b;
+        }
+        console.log(
+          JSON.stringify({
+            globalHead: globalHead(),
+            globalMid: globalMid(),
+            getterReassigns: getterReassigns(),
+            withScope: withScope(),
+            argumentsAlias: argumentsAlias({ get a() { hook(); return "a1"; }, b: "b1" }),
+            blockHoisted: blockHoisted(),
+            directEval: directEval(),
+            stable: stable(),
+          }),
+        );
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "unstable.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      globalHead: ["h", 1, 2],
+      globalMid: [0, "h", 1, 2],
+      getterReassigns: "a1b2",
+      withScope: ["a", "b", 2],
+      argumentsAlias: "a1b2",
+      blockHoisted: "a1b2",
+      directEval: "a1b2",
+      stable: "a1b1",
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- The printer folds `var h = CFG.host, p = CFG.port` into `var { host: h, port: p } = CFG`. The pattern reads `CFG` once where the declarators read it once each. When the second read can differ from the first, the program changes: an accessor on `globalThis` runs once instead of twice, a getter on the first property that reassigns a captured variable is ignored by the second read (`var x = cur.a, y = cur.b` prints `a1b1` instead of `a1b2`), and a `with` scope runs its `has` trap once.
- The cause is the eligibility check in `print_decls` (`src/js_printer/lib.rs:2236`). It only compares the target refs. A run at the head of a list has folded since the fold exists. A run that starts mid-list, including one that `--minify-syntax` creates by merging adjacent `var` statements, folds since #40691.

### Fix
- `is_stable_destructuring_target` (`src/js_printer/lib.rs`) gates the fold. The target must be a symbol this file declares and never assigns after its declaration, reached outside a `with` scope and outside a scope with a direct `eval`. An unbound identifier folds only when it is a known pure global such as `Math`, the same assumption dead-code elimination makes.
- The parser makes `has_been_assigned_to` reliable for this check. An assignment marks the root of the symbol's link chain (`record_assignment`, `src/js_parser/p.rs`): before, `{ var o; g = () => { o = N } }` marked the block's hoisted symbol while the printer read the function-level root. In a sloppy-mode function with a simple parameter list that uses `arguments`, the parameters count as assigned (`arguments[0] = v` rebinds the first one). When the file contains a direct `eval`, every top-level variable counts as assigned, because the module scope never pops and so never gets the `must_not_be_renamed` pin that nested scopes get.
- Verified: `test/bundler/transpiler/transpiler.test.js` (the new `unstable target` block, 7 of 8 tests fail on main) and `test/bundler/bundler_minify.test.ts` (`SameTargetDestructuringSkipsUnstableTarget`). Also the full `bundler_minify`, `transpiler`, `bundler_npm`, `bundler_edgecase`, `bundler_cjs2esm`, `esbuild/default`, `esbuild/dce`, and `bake/dev/esm` files.
- Two output snapshots move with the output. `bundler_npm.test.ts` moves three source map columns by 11: react-dom's `server.browser.js` assigns `l` in an if/else before `l.version, l.renderToString, ...`, so that run no longer folds. `bundler_bytecode_portable.test.ts` gets new hashes for four corpus bundles (lodash reassigns the `context` parameter before `var Array = context.Array, ...`). The new values are identical on every CI platform.

### Background
- `print_decls` prints one `var`/`let`/`const` declaration list. The same-target fold (`SAME_TARGET_BECOMES_DESTRUCTURING`) runs there for every run of two or more declarators `x = T.p` with the same identifier `T`, with or without `--minify`.
- A `Symbol` is a variable the parser found. `has_been_assigned_to` is set on the symbol when the file assigns it after its declaration. HMR already uses it to decide when an export needs a live binding.
- Hoisting and re-declaration link several symbols into a chain for one variable (`var n` in a block, `var n` after a parameter `n`). `symbol::Map::follow` returns the root of the chain. The printer compares roots.
- `Kind::Unbound` marks an identifier the file does not declare. The parser sets `can_be_removed_if_unused` on such an identifier when it is in the known-pure-globals table (`src/js_parser/defines_table.rs`), and `must_keep_due_to_with_stmt` when a `with` body encloses the reference. Symbols in a nested scope that contains a direct `eval` get `must_not_be_renamed` in `pop_scope`.

<details><summary>Notes</summary>

Source of the report: a differential fuzz run. The `once.mjs` program from the report prints `[1,2,"a1b2"]` on bun 1.4.1 and `[1,1,"a1b1"]` on main before this change. node prints `[2,2,"a1b2"]`. With this change bun prints `[2,2,"a1b2"]`.

Fold decisions after the change, checked through `Bun.Transpiler` on 70 shapes. Still folds: a local `var`, `let`, or `const` that nothing assigns, a parameter of a strict or `arguments`-free function, a function or class declaration, a catch parameter, a never-assigned module-level or exported `var`, `import * as ns`, `var o = require(...)`, `Math`, `Object`, `console`, `globalThis`. No longer folds: an unbound identifier outside the pure-globals table (`CFG`, `process`), any symbol the file assigns (`=`, `+=`, `++`, `[o] = ...`, `for (o of ...)`, `for (o in ...)`, from any closure), a reference inside `with`, a symbol in a scope that contains a direct `eval`, a top-level symbol in a file that contains a direct `eval`, a symbol with a TypeScript namespace alias, and the `arguments` object.

The link-root change is needed. A build with the printer guard alone still prints `a1b1` for `blockHoisted` in the new runtime test. The block's `var o` links to the function-level `o`, `find_symbol` resolves `o = ...` inside the block to the block's symbol, and the printer reads the root.

The `arguments` rule follows the spec: only a sloppy-mode function with a simple parameter list has a mapped arguments object. A class body, a `"use strict"` body, a default or rest parameter, and a nested non-arrow function (own `arguments`) keep the fold.

The top-level eval rule marks module-scope members as assigned instead of pinning their names. The bundler keeps the flat-ESM trade-off from esbuild: top-level names in an ESM file stay renameable even with a direct eval, and the existing `must_not_be_renamed` pin stays limited to bundled CommonJS files. `bun run` does not reach the fold for module-level declaration lists, so the gap showed only in `Bun.Transpiler` and `bun build` output.

The transpiler drops a function-level `"use strict"` directive (a separate bug, reported separately). Until that is fixed, a function that relies on that directive for an unmapped `arguments` object is strict for the parser and sloppy at runtime.

`bundler_compile.test.ts > compile/HelloWorldWithProcessVersionsBun` fails locally on main with and without this change (the debug build's `process.versions.bun` carries `-debug`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_npm.test.ts, test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->