### PR TITLE
js_parser: reject duplicate constructors, optional chains in new targets, and duplicate labels

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -718,10 +718,17 @@ impl Expr {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum EFlags {
-    None,
-    TsDecorator,
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+    #[repr(transparent)]
+    pub struct EFlags: u8 {
+        const TS_DECORATOR = 1 << 0;
+
+        /// Set while parsing the target of `new`. An unparenthesized optional
+        /// chain there ("new a?.b()") is a syntax error, but "new (a?.b)()" is
+        /// not, and a parenthesized expression starts from empty flags.
+        const IS_NEW_TARGET = 1 << 1;
+    }
 }
 
 // `is_missing` lives in the `init`/`allocate` impl block below.

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -34,6 +34,7 @@ pub struct Scope {
 
     // This is used to store the ref of the label symbol for ScopeLabel scopes.
     pub label_ref: Ref,
+    pub label_loc: crate::Loc,
     pub label_stmt_is_loop: bool,
 
     // If a scope contains a direct eval() expression, then none of the symbols
@@ -71,6 +72,7 @@ impl Scope {
         members: MemberHashMap::new_in(AstAlloc),
         generated: AstAlloc::vec(),
         label_ref: Ref::NONE,
+        label_loc: crate::Loc::EMPTY,
         label_stmt_is_loop: false,
         contains_direct_eval: false,
         forbid_arguments: false,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -44,12 +44,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         errors: Option<&mut DeferredErrors>,
         expr: &mut Expr,
     ) -> Result<(), Error> {
-        self.parse_expr_common(level, errors, EFlags::None, expr)
+        self.parse_expr_common(level, errors, EFlags::empty(), expr)
     }
     #[inline]
     pub fn parse_expr(&mut self, level: Level) -> Result<Expr, Error> {
         let mut expr = Expr::EMPTY;
-        self.parse_expr_common(level, None, EFlags::None, &mut expr)?;
+        self.parse_expr_common(level, None, EFlags::empty(), &mut expr)?;
         Ok(expr)
     }
     #[inline]
@@ -187,6 +187,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let scope_index = p
             .push_scope_for_parse_pass(js_ast::scope::Kind::ClassBody, body_loc)
             .expect("unreachable");
+        let mut has_constructor = false;
 
         while !p.lexer.token.is_close_brace_or_eof() {
             if p.lexer.token == T::TSemicolon {
@@ -221,22 +222,38 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // read fields before move (G::Property is not Copy).
                 let prop_kind = property.kind;
                 let prop_key = property.key;
+                let prop_flags = property.flags;
                 properties.push(property);
                 has_auto_accessor =
                     has_auto_accessor || prop_kind == js_ast::g::PropertyKind::AutoAccessor;
 
-                // Forbid decorators on class constructors
-                if opts.ts_decorators.len() > 0 {
-                    if let Some(key) = prop_key {
-                        if let js_ast::expr::Data::EString(str_) = &key.data {
-                            if str_.eql_comptime(b"constructor") {
-                                p.log().add_error(
-                                    Some(p.source),
-                                    first_decorator_loc,
-                                    b"TypeScript does not allow decorators on class constructors",
-                                );
-                            }
+                if let Some(key) = prop_key
+                    && let js_ast::expr::Data::EString(str_) = &key.data
+                    && str_.eql_comptime(b"constructor")
+                {
+                    // Forbid decorators on class constructors
+                    if opts.ts_decorators.len() > 0 {
+                        p.log().add_error(
+                            Some(p.source),
+                            first_decorator_loc,
+                            b"TypeScript does not allow decorators on class constructors",
+                        );
+                    }
+
+                    // A computed key ["constructor"] and a static method named
+                    // "constructor" are ordinary methods, not the constructor.
+                    if prop_flags.contains(Flags::Property::IsMethod)
+                        && !prop_flags.contains(Flags::Property::IsStatic)
+                        && !prop_flags.contains(Flags::Property::IsComputed)
+                    {
+                        if has_constructor {
+                            p.log().add_range_error(
+                                Some(p.source),
+                                crate::lexer::range_of_identifier(p.source, key.loc),
+                                b"Classes cannot contain more than one constructor",
+                            );
                         }
+                        has_constructor = true;
                     }
                 }
 
@@ -935,9 +952,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if p.lexer.token == T::TAsteriskAsterisk {
                 p.lexer.unexpected()?;
             }
-            p.parse_suffix(&mut value, Level::Prefix, None, EFlags::None)?;
+            p.parse_suffix(&mut value, Level::Prefix, None, EFlags::empty())?;
             let mut expr = p.new_expr(E::Await { value }, token_range.loc);
-            p.parse_suffix(&mut expr, Level::Lowest, None, EFlags::None)?;
+            p.parse_suffix(&mut expr, Level::Lowest, None, EFlags::empty())?;
             return Ok(ExprOrLetStmt {
                 stmt_or_expr: js_ast::StmtOrExpr::Expr(expr),
                 ..Default::default()
@@ -962,7 +979,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             ..Default::default()
         };
         if let js_ast::StmtOrExpr::Expr(ref mut e) = result.stmt_or_expr {
-            p.parse_suffix(e, Level::Lowest, None, EFlags::None)?;
+            p.parse_suffix(e, Level::Lowest, None, EFlags::empty())?;
         }
         Ok(result)
     }

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -682,7 +682,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // This will become the new expr
         // Parse target into a local, then construct E::New once.
         let mut target = Expr::EMPTY;
-        p.parse_expr_with_flags(Level::Member, flags, &mut target)?;
+        p.parse_expr_with_flags(Level::Member, flags | EFlags::IS_NEW_TARGET, &mut target)?;
 
         if Self::IS_TYPESCRIPT_ENABLED {
             // Skip over TypeScript type arguments here if there are any

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1025,7 +1025,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let default_name = p.create_default_name(loc);
 
                     let mut expr = p.parse_async_prefix_expr(async_range, Level::Comma)?;
-                    p.parse_suffix(&mut expr, Level::Comma, None, EFlags::None)?;
+                    p.parse_suffix(&mut expr, Level::Comma, None, EFlags::empty())?;
                     p.lexer.expect_or_insert_semicolon()?;
                     let value = js_ast::StmtOrExpr::Expr(expr);
                     return Ok(p.s(
@@ -1414,7 +1414,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TOpenParen | T::TDot => {
                 p.esm_import_keyword = previous_import_keyword; // this wasn't an esm import statement after all
                 let mut expr = p.parse_import_expr(loc, Level::Lowest)?;
-                p.parse_suffix(&mut expr, Level::Lowest, None, EFlags::None)?;
+                p.parse_suffix(&mut expr, Level::Lowest, None, EFlags::empty())?;
                 p.lexer.expect_or_insert_semicolon()?;
                 return Ok(p.s(
                     S::SExpr {
@@ -1704,7 +1704,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             expr = p.parse_async_prefix_expr(async_range, Level::Lowest)?;
-            p.parse_suffix(&mut expr, Level::Lowest, None, EFlags::None)?;
+            p.parse_suffix(&mut expr, Level::Lowest, None, EFlags::empty())?;
         } else {
             let expr_or_let = p.parse_expr_or_let_stmt(opts)?;
             match expr_or_let.stmt_or_expr {

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -124,7 +124,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         optional_chain: &mut Option<OptionalChain>,
         left: &mut Expr,
+        flags: &mut EFlags,
     ) -> CResult {
+        if flags.contains(EFlags::IS_NEW_TARGET) {
+            p.log().add_range_error(
+                Some(p.source),
+                p.lexer.range(),
+                b"Cannot use an unparenthesized optional chain inside the target of \"new\"",
+            );
+            // Report this once per "new" target, not once per "?." in the chain
+            flags.remove(EFlags::IS_NEW_TARGET);
+        }
+
         p.lexer.next()?;
         let mut optional_start: Option<OptionalChain> = Some(OptionalChain::Start);
 
@@ -340,7 +351,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         //   }
         //
         // This matches the behavior of the TypeScript compiler.
-        if flags == EFlags::TsDecorator {
+        if flags.contains(EFlags::TS_DECORATOR) {
             return Ok(Continuation::Done);
         }
 
@@ -449,7 +460,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //             ^
-        p.parse_expr_with_flags(Level::Comma, EFlags::None, &mut e_if.yes)?;
+        p.parse_expr_with_flags(Level::Comma, EFlags::empty(), &mut e_if.yes)?;
 
         p.allow_in = old_allow_in;
 
@@ -459,7 +470,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //                   ^
-        p.parse_expr_with_flags(Level::Comma, EFlags::None, &mut e_if.no)?;
+        p.parse_expr_with_flags(Level::Comma, EFlags::empty(), &mut e_if.no)?;
 
         // condition ? yes : no
         //                     ^
@@ -1434,7 +1445,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         left: &mut Expr,
         level: Level,
         mut errors: Option<&mut DeferredErrors>,
-        flags: EFlags,
+        mut flags: EFlags,
     ) -> Result<(), Error> {
         let p = self;
 
@@ -1546,7 +1557,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 T::TBarBar => Self::sfx_t_bar_bar(p, level, left, flags),
                 T::TAmpersandAmpersand => Self::sfx_t_ampersand_ampersand(p, level, left, flags),
                 T::TQuestion => Self::sfx_t_question(p, level, errors.as_deref_mut(), left),
-                T::TQuestionDot => Self::sfx_t_question_dot(p, level, &mut optional_chain, left),
+                T::TQuestionDot => {
+                    Self::sfx_t_question_dot(p, level, &mut optional_chain, left, &mut flags)
+                }
                 T::TTemplateHead => Self::sfx_t_template_head(
                     p,
                     level,

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -59,7 +59,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 //
                 // This matches the behavior of the TypeScript compiler.
                 let mut expr = Expr::EMPTY;
-                p.parse_expr_with_flags(Level::New, EFlags::TsDecorator, &mut expr)?;
+                p.parse_expr_with_flags(Level::New, EFlags::TS_DECORATOR, &mut expr)?;
                 decorators.push(expr);
             }
         }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1332,7 +1332,41 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let name = p.load_name_from_ref(data.name.ref_);
         let ref_ = p.new_symbol(js_ast::symbol::Kind::Label, name);
         data.name.ref_ = ref_;
+
+        // Duplicate labels are an error. Labels are only visible within the
+        // function they are defined in, so the walk stops at a function boundary.
+        let mut parent = p.current_scope_ref().parent;
+        while let Some(scope) = parent {
+            if scope.kind_stops_hoisting() {
+                break;
+            }
+            if scope.kind == js_ast::scope::Kind::Label
+                && let Some(label_ref) = scope.label_ref.to_nullable()
+                && bun_core::strings::eql(
+                    name,
+                    p.symbols[label_ref.inner_index() as usize]
+                        .original_name
+                        .slice(),
+                )
+            {
+                let notes: Box<[bun_ast::Data]> = Box::new([bun_ast::range_data(
+                    Some(p.source),
+                    js_lexer::range_of_identifier(p.source, scope.label_loc),
+                    format!("The original label \"{}\" is here:", bstr::BStr::new(name)),
+                )]);
+                p.log().add_range_error_fmt_with_notes(
+                    Some(p.source),
+                    js_lexer::range_of_identifier(p.source, data.name.loc),
+                    notes,
+                    format_args!("Duplicate label \"{}\"", bstr::BStr::new(name)),
+                );
+                break;
+            }
+            parent = scope.parent;
+        }
+
         p.cur_scope().label_ref = ref_;
+        p.cur_scope().label_loc = data.name.loc;
         match data.stmt.data {
             StmtData::SFor(_)
             | StmtData::SForIn(_)

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3628,11 +3628,15 @@ pub(crate) mod __gated_printer {
                             return;
                         }
                     } else {
-                        if flags.contains(ExprFlag::HasNonOptionalChainParent) {
+                        // "(a?.b).c" and "new (a?.b)()" need the parentheses
+                        if !flags
+                            .is_disjoint(ExprFlag::HasNonOptionalChainParent | ExprFlag::ForbidCall)
+                        {
                             wrap = true;
                             self.print(b"(");
                         }
-                        flags.remove(ExprFlag::HasNonOptionalChainParent);
+                        flags
+                            .remove_all(ExprFlag::HasNonOptionalChainParent | ExprFlag::ForbidCall);
                     }
                     flags &= ExprFlag::HasNonOptionalChainParent | ExprFlag::ForbidCall;
 
@@ -3682,11 +3686,15 @@ pub(crate) mod __gated_printer {
                             }
                         }
                     } else {
-                        if flags.contains(ExprFlag::HasNonOptionalChainParent) {
+                        // "(a?.[b]).c" and "new (a?.[b])()" need the parentheses
+                        if !flags
+                            .is_disjoint(ExprFlag::HasNonOptionalChainParent | ExprFlag::ForbidCall)
+                        {
                             wrap = true;
                             self.print(b"(");
                         }
-                        flags.remove(ExprFlag::HasNonOptionalChainParent);
+                        flags
+                            .remove_all(ExprFlag::HasNonOptionalChainParent | ExprFlag::ForbidCall);
                     }
 
                     // The index target is not directly followed by `of`.
@@ -4126,9 +4134,8 @@ pub(crate) mod __gated_printer {
 
                     if let Some(tag) = &e.tag {
                         self.add_source_mapping(expr.loc);
-                        // Optional chains are forbidden in template tags
-                        // `Expr::is_optional_chain` is gated upstream; inline its body.
-                        let is_optional_chain = match &expr.data {
+                        // Optional chains are forbidden in template tags: "(a?.b)`x`"
+                        let is_optional_chain = match &tag.data {
                             ExprData::EDot(d) => d.optional_chain.is_some(),
                             ExprData::EIndex(i) => i.optional_chain.is_some(),
                             ExprData::ECall(c) => c.optional_chain.is_some(),
@@ -4139,7 +4146,9 @@ pub(crate) mod __gated_printer {
                             self.print_expr(*tag, Level::Lowest, ExprFlag::none());
                             self.print(b")");
                         } else {
-                            self.print_expr(*tag, Level::Postfix, ExprFlag::none());
+                            // Inside "new", a call in the tag keeps its parentheses:
+                            // "new (foo())`x`()" and not "new foo()`x`()"
+                            self.print_expr(*tag, Level::Postfix, flags & ExprFlag::ForbidCall);
                         }
                     } else {
                         self.add_source_mapping(expr.loc);

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3223,6 +3223,69 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+  // These are early errors in every JS engine. The bundle must fail instead of
+  // emitting a file that fails to load.
+  itBundled("edgecase/DuplicateClassConstructorIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        class A {
+          constructor() {}
+          constructor() {}
+        }
+        console.log(new A());
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ["Classes cannot contain more than one constructor"],
+    },
+  });
+  itBundled("edgecase/OptionalChainInNewTargetIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(new a?.b());
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ['Cannot use an unparenthesized optional chain inside the target of "new"'],
+    },
+  });
+  itBundled("edgecase/DuplicateLabelIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        outer: {
+          outer: console.log(1);
+        }
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ['Duplicate label "outer"'],
+    },
+  });
+  // The printer must keep the parentheses that make these valid: "new foo()\`x\`()"
+  // and "o?.tag\`x\`" are a different program and a syntax error.
+  itBundled("edgecase/ParenthesizedNewTargetAndTemplateTagKeepParens", {
+    files: {
+      "/entry.js": /* js */ `
+        function foo() {
+          return function tag() {
+            return class {
+              constructor() {
+                this.k = "inner";
+              }
+            };
+          };
+        }
+        console.log(new (foo()\`x\`)().k);
+
+        const o = { tag: strings => strings[0], cls: class { constructor() { this.k = "chain"; } } };
+        console.log((o?.tag)\`x\`);
+        console.log(new (o?.cls)().k);
+      `,
+    },
+    run: {
+      stdout: "inner\nx\nchain",
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3512,6 +3512,96 @@ class Foo {
     expectParseError("class Foo { #x() { this.#x += 1 } }", 'Writing to read-only method "#x" will throw');
   });
 
+  it("a class cannot have more than one constructor", () => {
+    const message = "Classes cannot contain more than one constructor";
+    expectParseError("class A { constructor() {} constructor() {} }", message);
+    expectParseError('class A { constructor() {} "constructor"() {} }', message);
+    expectParseError("(class { constructor() {} constructor() {} })", message);
+    expectParseError("class A { constructor() {} x = 1; constructor() {} }", message);
+
+    // A static method, a computed key, and a TypeScript overload signature are
+    // not a second constructor.
+    expectPrinted_(
+      "class A { constructor() {} static constructor() {} }",
+      "class A {\n  constructor() {}\n  static constructor() {}\n}",
+    );
+    expectPrinted_(
+      'class A { constructor() {} ["constructor"]() {} }',
+      'class A {\n  constructor() {}\n  ["constructor"]() {}\n}',
+    );
+    ts.expectPrinted_(
+      "class A { constructor(a: string); constructor(a: number); constructor(a: any) {} }",
+      "class A {\n  constructor(a) {}\n}",
+    );
+    ts.expectParseError("class A { constructor(a: string); constructor(a: any) {} constructor() {} }", message);
+    expectPrinted_(
+      "class A { constructor() {} } class B { constructor() {} }",
+      "class A {\n  constructor() {}\n}\n\nclass B {\n  constructor() {}\n}",
+    );
+  });
+
+  it("the target of new cannot be an unparenthesized optional chain", () => {
+    const message = 'Cannot use an unparenthesized optional chain inside the target of "new"';
+    expectParseError("new a?.b()", message);
+    expectParseError("new a?.b", message);
+    expectParseError("new a?.[0]()", message);
+    expectParseError("new a?.()", message);
+    expectParseError("new a.b?.c()", message);
+    expectParseError("new a?.b.c()", message);
+    expectParseError("new a?.b?.c()", message);
+    expectParseError("new (a?.b)?.c()", message);
+    expectParseError("new new a?.b()()", message);
+
+    // Parenthesized chains, and chains that start after the arguments, are
+    // fine. The printer must keep the parentheses.
+    expectPrinted_("new (a?.b)()", "new (a?.b)");
+    expectPrinted_("new (a?.b)(1)", "new (a?.b)(1)");
+    expectPrinted_("new (a?.[0])()", "new (a?.[0])");
+    expectPrinted_("new (a?.())()", "new (a?.())");
+    expectPrinted_("new (a?.b.c)()", "new (a?.b.c)");
+    expectPrinted_("new (a?.b).c()", "new (a?.b).c");
+    expectPrinted_("new (a().b)()", "new (a()).b");
+    expectPrinted_("new a()?.b", "new a()?.b");
+    expectPrinted_("new a()?.()", "new a()?.()");
+    expectPrinted_("new a.b()", "new a.b");
+
+    // A call inside a tagged template tag is still the target of "new", so it
+    // keeps its parentheses too. "new foo()`x`()" is a different program.
+    expectPrinted_("new (foo()`x`)()", "new (foo())`x`");
+    expectPrinted_("new (foo()`x`)(1)", "new (foo())`x`(1)");
+    expectPrinted_("new (foo.bar()`x`)()", "new (foo.bar())`x`");
+    expectPrinted_("new (foo`x`)()", "new foo`x`");
+    expectPrinted_("new (a?.b)`x`()", "new (a?.b)`x`");
+  });
+
+  it("a parenthesized optional chain used as a template tag keeps its parentheses", () => {
+    expectPrinted_("(a?.b)`x`", "(a?.b)`x`");
+    expectPrinted_("(a?.[0])`x`", "(a?.[0])`x`");
+    expectPrinted_("(a?.())`x`", "(a?.())`x`");
+    expectPrinted_("(a?.b.c)`x`", "(a?.b.c)`x`");
+    expectPrinted_("(a?.b)`x${y}z`", "(a?.b)`x${y}z`");
+    expectPrinted_("a.b`x`", "a.b`x`");
+    expectParseError("a?.b`x`", "Template literals cannot have an optional chain as a tag");
+  });
+
+  it("duplicate labels are an error", () => {
+    expectParseError("outer: { outer: ; }", 'Duplicate label "outer"');
+    expectParseError("a: b: a: ;", 'Duplicate label "a"');
+    expectParseError("a: for (;;) { a: ; }", 'Duplicate label "a"');
+    expectParseError("a: { b: { a: ; } }", 'Duplicate label "a"');
+    expectParseError("function f() { a: { a: ; } }", 'Duplicate label "a"');
+
+    // Labels may repeat in sibling statements and in a nested function,
+    // arrow function, or class static block.
+    expectPrinted_("a: { } a: { }", "a: {}\na: {}");
+    expectPrinted_("a: { (function() { a: ; })() }", "a: {\n  (function() {\n    a:\n      ;\n  })();\n}");
+    expectPrinted_("a: { (() => { a: ; })() }", "a: {\n  (() => {\n    a:\n      ;\n  })();\n}");
+    expectPrinted_(
+      "a: { class X { static { a: ; } } }",
+      "a: {\n  class X {\n    static {\n      a:\n        ;\n    }\n  }\n}",
+    );
+  });
+
   it("class bodies keep `this` and the class name as written", () => {
     expectPrinted_(
       "class Foo { static x = this; static { this.y = Foo } z = () => this }",


### PR DESCRIPTION
### Problem
- `bun build` and `Bun.Transpiler` accept three early errors that every engine and esbuild reject: a class with two constructors, an optional chain in the target of `new` (`new a?.b()`), and a label that repeats an enclosing label (`outer: { outer: ; }`). The bundle is emitted and fails to load in the consumer. `bun run` is saved only by JSC's own parser.
- The checks are missing in `parse_class` (`src/js_parser/parse/mod.rs`), in `pfx_t_new` + `sfx_t_question_dot` (`parse_prefix.rs`, `parse_suffix.rs`), and in `s_label` (`visit/visit_stmt.rs`).
- The printer also drops parentheses that keep such code valid. `new (a?.b)()` prints as `new a?.b`, `new (foo()` + <code>\`x\`</code> + `)()` prints as `new foo()` + <code>\`x\`</code> + `()` (a different program), and `(a?.b)` + <code>\`x\`</code> prints as `a?.b` + <code>\`x\`</code> (a syntax error).

### Fix
- `parse_class` tracks a seen constructor. A second non-static, non-computed method named `constructor` reports `Classes cannot contain more than one constructor`. TypeScript overload signatures are dropped before this check, so they do not count.
- `EFlags` becomes a bitflags set. `pfx_t_new` parses its target with `IS_NEW_TARGET`. When `sfx_t_question_dot` sees that bit it reports `Cannot use an unparenthesized optional chain inside the target of "new"`. A parenthesized expression starts from empty flags, so `new (a?.b)()` still parses. This is esbuild's `exprFlagIsNewTarget`.
- `s_label` walks the parent scopes up to the function boundary. A `Label` scope with the same name reports `Duplicate label "x"`, with a note at the first label. `Scope` gains `label_loc` for that note.
- In the printer, `EDot` and `EIndex` with an optional chain also wrap when `ForbidCall` (the `new` target flag) is set. A template tag now receives `ForbidCall` from its parent, and the optional-chain check for a tag reads the tag instead of the template node.
- Verified: `test/bundler/transpiler/transpiler.test.js` (4 new blocks) and `test/bundler/bundler_edgecase.test.ts` (4 new cases). All of them fail on 1.4.1. Also ran `test/bundler/transpiler/`, `bundler_edgecase`, `bundler_minify`, `bundler_string`, `bundler_cjs*`, `bundler_jsx`, `bundler_decorator_metadata`, `esbuild/{default,ts,lower,dce,extra,importstar*}`, `test/js/bun/transpiler/`.

### Background
- The parser is a port of esbuild. `parse_prefix` parses the start of an expression, then `parse_suffix` loops over the operators that follow it. `EFlags` travels with that one expression and is not inherited by sub-expressions such as a parenthesized group.
- `Level` is the precedence at which an expression is parsed. The target of `new` is parsed at `Level::Member`, so `parse_suffix` only accepts `.`, `?.`, `[`, and template tags there. Nothing in the grammar allows an optional chain at that position unless it is parenthesized.
- Labels are resolved in the visit pass. Each labeled statement pushes a `Label` scope that stores the label's symbol. `find_label_symbol` already walks this chain for `break` and `continue`, and stops at `kind_stops_hoisting()` (a function body or a class static block). The new check walks the same chain.
- In the printer, `ExprFlag::ForbidCall` is set only while printing the target of `new`. It is the equivalent of esbuild's `isNewTarget`. `HasNonOptionalChainParent` marks a `.`/`[` parent that is not part of the chain, which is the other case that needs parentheses.

<details><summary>Notes</summary>

Repro on 1.4.1 (every line is node=1, bun build=0):

```
for s in 'class A { constructor(){} constructor(){} }' 'new a?.b();' 'outer: { outer: ; }'; do
  printf '%s\nexport {}\n' "$s" > se.mjs
  node se.mjs; bun build se.mjs --outfile o.mjs; echo "bun-build=$?"
done
```

Printer output on 1.4.1 for valid input, from `bun build --no-bundle`:

```
new (a?.b)()                     -> new a?.b          (syntax error)
new (foo()`x`)()                 -> new foo()`x`()    (different program, TypeError at run time)
(a?.b)`x`                        -> a?.b`x`           (syntax error)
```

The old `is_optional_chain` check in the template-tag printer matched on `expr.data` (the template itself) instead of `tag.data`, so it was never true.

`new a.b?.(c)` was silently printed as `new a.b(c)` on 1.4.1. `sfx_t_question_dot` consumes `?.` and then returns at `Level::Call` without consuming `(`, so `pfx_t_new` picked the `(` up as the argument list. The new error fires before that happens.

Other probes on the fix: `class A { constructor() {} get constructor() {} }` reports both the getter error and the duplicate error (same as esbuild). `declare class` and abstract overloads are unaffected. `a: { class X { static { a: ; } } }`, `a: { (() => { a: ; })() }`, and `a: {} a: {}` all parse. `new a?.<T>()` in TypeScript reports the new error.

Not in this PR: `({a}) => { "use strict" }` is still accepted. `parse_stmts_up_to` strips the directive before the check in `visit_args` runs. That is a strict-mode rule and is tracked separately.

esbuild's current parser and printer were used as the reference for the messages and for the `isNewTarget` flag. The local esbuild 0.21.5 in `node_modules` has the same printer bug for the tagged template case.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->