### PR TITLE
compile: embed bytecode for builtins reached through lazy require() too

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1407,7 +1407,8 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 }
 
 /// `--compile --bytecode`: the executable also carries ahead-of-time bytecode for the internal modules (node:fs, …) the
-/// bundle imports and everything those require while loading, so their first `require` decodes instead of parsing. One
+/// bundle imports and everything those can require (while loading or lazily later), so their first `require` decodes
+/// instead of parsing. One
 /// `OutputKind::BuiltinBytecode` per module; StandaloneModuleGraph::to_bytes lays them out and InternalModuleRegistry
 /// picks them up by id. The modules, their ids and (when compiling for another platform) their sources come from the
 /// builtins section of the executable the bundle is going into.

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -432,10 +432,8 @@ const internalModulesStamp = (() => {
   return new DataView(h.digest().buffer).getUint32(0);
 })();
 
-// require() edges between JS internal modules that run when the module itself is evaluated (ids are enum order), as
-// offsets into one flat list. The bundled output is unminified with top-level statements at column 0 and function
-// bodies indented, so a registry lookup on an unindented line is one the module wrapper executes eagerly; lookups inside
-// functions are lazy and left out (an ahead-of-time build would rather not carry modules that may never load).
+// require() edges between JS internal modules (ids are enum order), as offsets into one flat list. `bun build --compile
+// --bytecode` embeds bytecode for the builtins an app imports plus everything reachable through this table.
 const internalModuleDependencyTable = (() => {
   const jsModules = moduleList.slice(0, nativeStartIndex);
   const requireRe = /internalModuleRegistry, ?(\d+)/g;
@@ -445,12 +443,12 @@ const internalModuleDependencyTable = (() => {
     offsets.push(flat.length);
     const src = outputs.get(id.slice(0, -3).replaceAll("/", path.sep)) ?? "";
     const edges = new Set<number>();
-    for (const line of src.split("\n")) {
-      if (/^\s/.test(line)) continue;
-      for (const m of line.matchAll(requireRe)) {
-        const dep = Number(m[1]);
-        if (dep !== n && dep < nativeStartIndex) edges.add(dep);
-      }
+    // Lazy require() calls inside functions count too: internal/util/inspect, internal/fs/watch and friends are only
+    // ever reached that way, and the first is loaded by nearly every program (util.inspect, format, console, error
+    // paths). Carrying bytecode for a module that never loads costs bytes; parsing one that does costs startup time.
+    for (const m of src.matchAll(requireRe)) {
+      const dep = Number(m[1]);
+      if (dep !== n && dep < nativeStartIndex) edges.add(dep);
     }
     flat.push(...[...edges].sort((a, b) => a - b));
   });

--- a/src/exe_format/builtins.rs
+++ b/src/exe_format/builtins.rs
@@ -161,7 +161,7 @@ impl<'a> Builtins<'a> {
         (0..self.count).find(|&id| self.module(id).is_some_and(|m| m.name == name))
     }
 
-    /// The modules `id` requires while it is being evaluated.
+    /// The modules `id` can require: at evaluation or later, from a lazy `require()` inside one of its functions.
     pub fn dependencies(&self, id: u32) -> impl Iterator<Item = u32> + 'a {
         let (start, end) = if id < self.count {
             (


### PR DESCRIPTION
### What does this PR do?

`bun build --compile --bytecode` embeds bytecode for the builtin modules an app imports plus their dependencies, but the dependency table only followed `require()` calls that a builtin's *top level* executes. Anything reached from inside a function — `internal/util/inspect` (behind `util.inspect`, `util.format`, console formatting, `events` error paths), `internal/fs/watch`, `internal/fs/watchfile`, `internal/cluster/primary`, `internal/stream/promises`, … — never got bytecode and was parsed from source on first use. `internal/util/inspect` alone is ~75 KB and ~2 ms to parse, and nearly every program touches it.

This makes the table follow every `require()` edge. Cost: somewhat more builtin bytecode per executable (+170 KB for a hello-world that touches `util.inspect`, +0.7 MB for a large CLI).

| Claude Code CLI (`--compile --bytecode --splitting`) | before | after |
|---|---|---|
| source parses before the REPL prompt | 135 (5.2 ms) | 100 (3.3 ms) — the rest are JSC builtins / app `new Function` |
| first `util.inspect` access | 2.6–3.6 ms | 0.8–1.0 ms |
| binary size | 422.9 MB | 423.6 MB |

### How did you verify your code works?

`BUN_JSC_reportParseTimes=1` on compiled fixtures and on the CLI above (with a local JSC patch that prints the source URL per parse) before/after; `bun-build-compile.test.ts` / `bundler_compile.test.ts` bytecode cases.
