### PR TITLE
console: add console.createTask()

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1188,6 +1188,13 @@ interface Console {
    */
   count(label?: string): void;
   countReset(label?: string): void;
+  /**
+   * Create a named task to which async operations can be attributed by
+   * inspector frontends. The returned task's `run` method calls the given
+   * function and returns its result.
+   * @param name The task name. Must be a non-empty string.
+   */
+  createTask(name: string): { run<T>(fn: () => T): T };
   debug(...data: any[]): void;
   dir(item?: any, options?: any): void;
   dirxml(...data: any[]): void;

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -61,6 +61,7 @@ using namespace JSC;
     macro(close) \
     macro(cmd) \
     macro(code) \
+    macro(consoleTask) \
     macro(createCommonJSModule) \
     macro(createFIFO) \
     macro(createInternalModuleById) \

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -149,14 +149,19 @@ export function createCreateTask() {
     return f.$call(undefined);
   }
 
-  return function createTask(name) {
-    if (typeof name !== "string" || name.length === 0) {
-      throw new Error("First argument must be a non-empty string.");
-    }
-    const task = { run };
-    $putByIdDirectPrivate(task, "consoleTask", true);
-    return task;
+  // a shorthand method, so `new console.createTask(...)` throws like in Node
+  // and the function name survives bundling
+  const { createTask } = {
+    createTask(name: string) {
+      if (typeof name !== "string" || name.length === 0) {
+        throw new Error("First argument must be a non-empty string.");
+      }
+      const task = { run };
+      $putByIdDirectPrivate(task, "consoleTask", true);
+      return task;
+    },
   };
+  return createTask;
 }
 
 // This is the `console.Console` constructor. It is mostly copied from Node.

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -136,15 +136,11 @@ export function write(this: Console, input) {
   return wrote;
 }
 
-// Returns the `console.createTask` function. Called lazily from a custom
-// getter in ZigGlobalObject.cpp so the shared `run` method is created once per
-// global object. Node implements this in the V8 inspector (v8-console.cc);
-// `run` brackets the callback with async-stack tagging for an attached
-// inspector frontend. Bun has no equivalent inspector hook, so the task only
-// validates its arguments and invokes the callback, which is the observable
-// behavior when no frontend is attached. Tasks are marked with a private name,
-// like Node's internal slot, so user code cannot forge or break the receiver
-// check.
+// Node implements createTask in the V8 inspector (v8-console.cc), where `run`
+// brackets the callback with async-stack tagging for an attached frontend.
+// Bun has no such inspector hook, so `run` validates and invokes the callback,
+// Node's observable behavior with no frontend attached. The private name
+// mirrors Node's internal-slot receiver check.
 export function createCreateTask() {
   function run(f) {
     if (!$isCallable(f)) {

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -136,11 +136,8 @@ export function write(this: Console, input) {
   return wrote;
 }
 
-// Node implements createTask in the V8 inspector (v8-console.cc), where `run`
-// brackets the callback with async-stack tagging for an attached frontend.
-// Bun has no such inspector hook, so `run` validates and invokes the callback,
-// Node's observable behavior with no frontend attached. The private name
-// mirrors Node's internal-slot receiver check.
+// Node's createTask (v8-console.cc) only adds inspector async-stack tagging
+// on top of this. The private name mirrors Node's internal-slot receiver check.
 export function createCreateTask() {
   function run(f) {
     if (!$isCallable(f)) {

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -137,20 +137,20 @@ export function write(this: Console, input) {
 }
 
 // Returns the `console.createTask` function. Called lazily from a custom
-// getter in ZigGlobalObject.cpp so the WeakSet and the shared `run` method are
-// created once per global object. Node implements this in the V8 inspector
-// (v8-console.cc); `run` brackets the callback with async-stack tagging for an
-// attached inspector frontend. Bun has no equivalent inspector hook, so the
-// task only validates its arguments and invokes the callback, which is the
-// observable behavior when no frontend is attached.
+// getter in ZigGlobalObject.cpp so the shared `run` method is created once per
+// global object. Node implements this in the V8 inspector (v8-console.cc);
+// `run` brackets the callback with async-stack tagging for an attached
+// inspector frontend. Bun has no equivalent inspector hook, so the task only
+// validates its arguments and invokes the callback, which is the observable
+// behavior when no frontend is attached. Tasks are marked with a private name,
+// like Node's internal slot, so user code cannot forge or break the receiver
+// check.
 export function createCreateTask() {
-  const tasks = new WeakSet();
-
   function run(f) {
     if (!$isCallable(f)) {
       throw new Error("First argument must be a function.");
     }
-    if (!tasks.has(this)) {
+    if (!$isObject(this) || !$getByIdDirectPrivate(this, "consoleTask")) {
       throw new Error("'run' called with illegal receiver.");
     }
     return f.$call(undefined);
@@ -161,7 +161,7 @@ export function createCreateTask() {
       throw new Error("First argument must be a non-empty string.");
     }
     const task = { run };
-    tasks.add(task);
+    $putByIdDirectPrivate(task, "consoleTask", true);
     return task;
   };
 }

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -136,6 +136,36 @@ export function write(this: Console, input) {
   return wrote;
 }
 
+// Returns the `console.createTask` function. Called lazily from a custom
+// getter in ZigGlobalObject.cpp so the WeakSet and the shared `run` method are
+// created once per global object. Node implements this in the V8 inspector
+// (v8-console.cc); `run` brackets the callback with async-stack tagging for an
+// attached inspector frontend. Bun has no equivalent inspector hook, so the
+// task only validates its arguments and invokes the callback, which is the
+// observable behavior when no frontend is attached.
+export function createCreateTask() {
+  const tasks = new WeakSet();
+
+  function run(f) {
+    if (!$isCallable(f)) {
+      throw new Error("First argument must be a function.");
+    }
+    if (!tasks.has(this)) {
+      throw new Error("'run' called with illegal receiver.");
+    }
+    return f.$call(undefined);
+  }
+
+  return function createTask(name) {
+    if (typeof name !== "string" || name.length === 0) {
+      throw new Error("First argument must be a non-empty string.");
+    }
+    const task = { run };
+    tasks.add(task);
+    return task;
+  };
+}
+
 // This is the `console.Console` constructor. It is mostly copied from Node.
 // https://github.com/nodejs/node/blob/d2c7c367741bdcb6f7f77f55ce95a745f0b29fef/lib/internal/console/constructor.js
 // Some parts are copied from imported files and inlined here. Not too much of a performance issue

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2713,8 +2713,7 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleConstructor, (JSGlobalObject * globalObject, 
     return JSValue::encode(result);
 }
 
-// `console.createTask`. The builtin returns the createTask function with its
-// per-global closure state, so it is materialized once on first access.
+// `console.createTask`, materialized on first access
 JSC_DEFINE_CUSTOM_GETTER(getConsoleCreateTask, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName property))
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2713,6 +2713,26 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleConstructor, (JSGlobalObject * globalObject, 
     return JSValue::encode(result);
 }
 
+// `console.createTask`. The builtin returns the createTask function with its
+// per-global closure state, so it is materialized once on first access.
+JSC_DEFINE_CUSTOM_GETTER(getConsoleCreateTask, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName property))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto console = JSValue::decode(thisValue).getObject();
+    JSC::JSFunction* createCreateTask = JSC::JSFunction::create(vm, globalObject, consoleObjectCreateCreateTaskCodeGenerator(vm), globalObject);
+    JSC::MarkedArgumentBuffer args;
+    JSC::CallData callData = JSC::getCallData(createCreateTask);
+    NakedPtr<JSC::Exception> returnedException = nullptr;
+    auto result = JSC::profiledCall(globalObject, ProfilingReason::API, createCreateTask, callData, console, args, returnedException);
+    if (returnedException) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        throwException(globalObject, scope, returnedException.get());
+        return {};
+    }
+    console->putDirect(vm, property, result, 0);
+    return JSValue::encode(result);
+}
+
 // `console._stdout` is equal to `process.stdout`
 JSC_DEFINE_CUSTOM_GETTER(getConsoleStdout, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName property))
 {
@@ -2974,6 +2994,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     consoleObject->putDirectBuiltinFunction(vm, this, vm.propertyNames->asyncIteratorSymbol, consoleObjectAsyncIteratorCodeGenerator(vm), PropertyAttribute::Builtin | 0);
     consoleObject->putDirectBuiltinFunction(vm, this, clientData->builtinNames().writePublicName(), consoleObjectWriteCodeGenerator(vm), PropertyAttribute::Builtin | 0);
     consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "Console"_s), CustomGetterSetter::create(vm, getConsoleConstructor, nullptr), PropertyAttribute::CustomValue | 0);
+    consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "createTask"_s), CustomGetterSetter::create(vm, getConsoleCreateTask, nullptr), PropertyAttribute::CustomValue | 0);
     consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "_stdout"_s), CustomGetterSetter::create(vm, getConsoleStdout, nullptr), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue | 0);
     consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "_stderr"_s), CustomGetterSetter::create(vm, getConsoleStderr, nullptr), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue | 0);
 }

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -88,3 +88,78 @@ test("console._stderr", () => {
     configurable: true,
   });
 });
+
+describe("console.createTask", () => {
+  test("exists on the global console and node:console", () => {
+    expect(typeof console.createTask).toBe("function");
+    const consoleModule = require("node:console");
+    expect(consoleModule.createTask).toBe(console.createTask);
+  });
+
+  test("run calls the function and returns its result", () => {
+    const task = console.createTask("test task");
+    expect(task.run(() => 42)).toBe(42);
+    // the task is recurring: run can be called again
+    expect(task.run(() => 7)).toBe(7);
+  });
+
+  test("task shape matches Node", () => {
+    const t1 = console.createTask("a");
+    const t2 = console.createTask("b");
+    expect(Object.getOwnPropertyNames(t1)).toEqual(["run"]);
+    expect(Object.getPrototypeOf(t1)).toBe(Object.prototype);
+    // Node shares one run function across tasks
+    expect(t1.run).toBe(t2.run);
+  });
+
+  test("createTask validates the name", () => {
+    expect(() => console.createTask("")).toThrow("First argument must be a non-empty string.");
+    expect(() => (console as any).createTask(123)).toThrow("First argument must be a non-empty string.");
+    expect(() => (console as any).createTask()).toThrow("First argument must be a non-empty string.");
+  });
+
+  test("run validates the function before the receiver", () => {
+    const t1 = console.createTask("a");
+    const t2 = console.createTask("b");
+    expect(() => (t1 as any).run(5)).toThrow("First argument must be a function.");
+    expect(() => (t1.run as any).call({}, () => 1)).toThrow("'run' called with illegal receiver.");
+    expect(() => (t1.run as any).call({}, 5)).toThrow("First argument must be a function.");
+    // another task is a valid receiver in Node
+    expect((t1.run as any).call(t2, () => 9)).toBe(9);
+  });
+
+  test("run propagates exceptions and the task stays usable", () => {
+    const task = console.createTask("boom");
+    expect(() =>
+      task.run(() => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    expect(task.run(() => 1)).toBe(1);
+  });
+
+  test("the callback is called with an undefined receiver", () => {
+    const task = console.createTask("this");
+    expect(
+      task.run(function (this: unknown) {
+        return this;
+      } as any),
+    ).toBeUndefined();
+  });
+
+  test("createTask is an enumerable own property of console", () => {
+    void console.createTask;
+    expect(Object.keys(console)).toContain("createTask");
+    expect(Object.getOwnPropertyDescriptor(console, "createTask")).toEqual({
+      value: console.createTask,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  test("Console class instances do not have createTask", () => {
+    const c = new Console({ stdout: process.stdout, stderr: process.stderr });
+    expect("createTask" in c).toBe(false);
+  });
+});

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Console } from "node:console";
+import consoleModule, { Console } from "node:console";
 
 import { Writable } from "node:stream";
 
@@ -92,7 +92,6 @@ test("console._stderr", () => {
 describe("console.createTask", () => {
   test("exists on the global console and node:console", () => {
     expect(typeof console.createTask).toBe("function");
-    const consoleModule = require("node:console");
     expect(consoleModule.createTask).toBe(console.createTask);
   });
 

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -157,6 +157,10 @@ describe("console.createTask", () => {
     });
   });
 
+  test("createTask is not a constructor", () => {
+    expect(() => new (console.createTask as any)("x")).toThrow(TypeError);
+  });
+
   test("Console class instances do not have createTask", () => {
     const c = new Console({ stdout: process.stdout, stderr: process.stderr });
     expect("createTask" in c).toBe(false);


### PR DESCRIPTION
### Problem

- `console.createTask` is `undefined` on the global console and on `node:console`. The issue repro fails with `TypeError: consoleModule.createTask is not a function`. Node v26 has the function on both.
- React and Next.js feature-detect `console.createTask()` and call `task.run()` for development async-stack diagnostics. Under Bun these paths fall back.

### Fix

- Add a `createCreateTask` builtin in `src/js/builtins/ConsoleObject.ts`. It returns a `createTask` function that validates a non-empty string name and returns a task object whose `run(fn)` calls `fn` and returns its result.
- Attach it to the global console in `ZigGlobalObject.cpp` as a lazy `CustomValue` getter, the same pattern as `console.Console`. `node:console` re-exports the global console, so both surfaces get it.
- The observable behavior matches Node v26.3.0, verified against it: error messages and check order for a bad name, a non-function argument, and an illegal receiver, a shared `run` function across tasks, cross-task receivers, exception propagation, reusable tasks, and property enumerability. `Console` class instances do not get the function, same as Node.
- Verified: `test/js/node/console/console.test.ts` (9 new tests, 8 fail on stock bun). Also `test/js/bun/console/` and the bun-types integration test.

### Background

- Node implements this API in the V8 inspector (`v8-console.cc`). `run` brackets the callback with `asyncTaskStarted` / `asyncTaskFinished` so an attached DevTools frontend can stitch async stacks. With no frontend attached, the only observable behavior is validation plus calling the callback.
- Bun has no equivalent inspector hook for async task tagging, so `run` does not emit inspector events. Userland behavior is identical.
- The task registry is a per-global `WeakSet` captured in the builtin closure. `run` checks membership, which reproduces Node's internal-slot receiver check.

Fixes #40795

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/console/console.test.ts
bun test v1.4.1 (65362b53b)

test/js/node/console/console.test.ts:
(pass) console.Console > global instanceof Console [17.34ms]
(pass) console.Console > new Console instanceof Console [28.89ms]

(pass) console.Console > it can write to a stream [177.38ms]
(pass) console.Console > can enable colors [22.17ms]
(pass) console.Console > stderr and stdout are separate [18.39ms]
(pass) console._stdout [2.24ms]
(pass) console._stderr [2.97ms]
89 |   });
90 | });
91 | 
92 | describe("console.createTask", () => {
93 |   test("exists on the global console and node:console", () => {
94 |     expect(typeof console.createTask).toBe("function");
                                           ^
error: expect(received).toBe(expected)

Expected: "function"
Received: "undefined"

      at <anonymous> (/workspace/bun/test/js/node/console/console.test.ts:94:39)
(fail) console.createTask > exists on the global console and node:console [4.37ms]
94 |     expect(typeof console.createTask).toBe("function");
95 |     expect(conso
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (94fdbc06e)

test/js/node/console/console.test.ts:
(pass) console.Console > global instanceof Console [0.03ms]
(pass) console.Console > new Console instanceof Console [0.42ms]

(pass) console.Console > it can write to a stream [2.95ms]
(pass) console.Console > can enable colors [0.41ms]
(pass) console.Console > stderr and stdout are separate [0.24ms]
(pass) console._stdout [0.04ms]
(pass) console._stderr [0.02ms]
(pass) console.createTask > exists on the global console and node:console [0.06ms]
(pass) console.createTask > run calls the function and returns its result [0.08ms]
(pass) console.createTask > task shape matches Node [0.03ms]
(pass) console.createTask > createTask validates the name [0.07ms]
(pass) console.createTask > run validates the function before the receiver [0.10ms]
(pass) console.createTask > run propagates exceptions and the task stays usable [0.04ms]
(pass) console.createTask > the callback is called with an undefined receiver [0.02ms]
(pass) console.createTask > createTask is an enumerable own property of console [0.04ms]
156 |       configurable: true,
157 |     });
158 |   });
159 | 
160 |   test("createTask is not a 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/console/console.test.ts
bun test v1.4.1 (65362b53b)

test/js/node/console/console.test.ts:
(pass) console.Console > global instanceof Console [17.88ms]
(pass) console.Console > new Console instanceof Console [27.96ms]

(pass) console.Console > it can write to a stream [176.15ms]
(pass) console.Console > can enable colors [21.85ms]
(pass) console.Console > stderr and stdout are separate [17.93ms]
(pass) console._stdout [2.36ms]
(pass) console._stderr [2.64ms]
(pass) console.createTask > exists on the global console and node:console [4.22ms]
(pass) console.createTask > run calls the function and returns its result [5.75ms]
(pass) console.createTask > task shape matches Node [2.73ms]
(pass) console.createTask > createTask validates the name [6.61ms]
(pass) console.createTask > run validates the function before the receiver [8.71ms]
(pass) console.createTask > run propagates exceptions and the task stays usable [5.01ms]
(pass) console.createTask > the callback is called with an undefined receiver [2.16ms]
(pass) console.create
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 638ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (7851ms)
Bundle modules (38ms)
Postprocesss modules (197ms)
Bundle Functions (525ms)
Generate Code (42ms)

[8.66s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  51 internal functions across 16 files
[3/125] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/globals.d.ts      |  7 ++++
 src/js/builtins/BunBuiltinNames.h    |  1 +
 src/js/builtins/ConsoleObject.ts     | 28 +++++++++++++
 src/jsc/bindings/ZigGlobalObject.cpp | 20 +++++++++
 test/js/node/console/console.test.ts | 80 +++++++++++++++++++++++++++++++++++-
 5 files changed, 135 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
packages/bun-types/globals.d.ts           1      1      0
src/js/builtins/BunBuiltinNames.h         1      2      0
src/js/builtins/ConsoleObject.ts          3      9      0
src/jsc/bindings/ZigGlobalObject.cpp      2      4      0
test/js/node/console/console.test.ts      1      3      0
```

</details>

**root cause** · written by the author bot

Bun never implemented `console.createTask()`, so the property was absent from both the global console and `node:console`, breaking feature detection in frameworks like React that rely on it. The fix adds a `createTask` implementation in the console builtin that mirrors Node v26.3.0's observable behavior, validating the task name and callback with Node's exact plain Error messages, guarding `run()` with a private internal-slot receiver check, and invoking the callback directly since Bun has no inspector async-task tagging hook. The function is materialized lazily on first access via a custom…

<!-- robobun:evidence:end -->