### PR TITLE
json5: point hex and unicode escape errors at the offending character

### DIFF
--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -732,14 +732,9 @@ impl<'a> JSON5Parser<'a> {
                 buf.push(0);
             }
             b'x' => {
-                // \xHH hex escape
-                let value = self
-                    .source
-                    .get(self.pos..self.pos + 2)
-                    .and_then(|s| bun_core::fmt::hex_pair_value(s[0], s[1]))
-                    .ok_or(ParseError::InvalidHexEscape)?;
-                self.pos += 2;
-                append_codepoint_to_utf8(buf, i32::from(value))?;
+                // \xHH hex escape (2 hex digits fit in 8 bits, cast is lossless)
+                let value = self.read_hex_digits(2, ParseError::InvalidHexEscape)?;
+                append_codepoint_to_utf8(buf, value as i32)?;
             }
             b'u' => {
                 // \uHHHH unicode escape
@@ -1043,10 +1038,21 @@ impl<'a> JSON5Parser<'a> {
     // ── Helper Functions ──
 
     fn read_hex4(&mut self) -> Result<i32, ParseError> {
-        let v = bun_core::fmt::parse_hex4(&self.source[self.pos..])
-            .ok_or(ParseError::InvalidUnicodeEscape)?;
-        self.pos += 4;
-        Ok(i32::from(v))
+        // 4 hex digits fit in 16 bits, cast is lossless
+        let v = self.read_hex_digits(4, ParseError::InvalidUnicodeEscape)?;
+        Ok(v as i32)
+    }
+
+    /// Reads exactly `count` hex digits at `pos`. On failure `pos` is left on
+    /// the first byte that is not a hex digit (or at EOF), so the reported
+    /// error location points at the offending character.
+    fn read_hex_digits(&mut self, count: usize, err: ParseError) -> Result<u32, ParseError> {
+        let (value, consumed) = bun_core::fmt::parse_hex_prefix(&self.source[self.pos..], count);
+        self.pos += consumed;
+        if consumed < count {
+            return Err(err);
+        }
+        Ok(value)
     }
 
     fn read_codepoint(&self) -> Option<Codepoint> {

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -2,7 +2,7 @@
 // Expected values verified against json5@2.2.3 reference implementation.
 import { JSON5 } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("escape sequences", () => {
   test("\\v vertical tab", () => {
@@ -96,6 +96,51 @@ describe("escape sequences", () => {
     expect(() => JSON5.parse('"\\u041"')).toThrow("Invalid unicode escape: expected 4 hex digits");
     expect(() => JSON5.parse('"\\u41"')).toThrow("Invalid unicode escape: expected 4 hex digits");
     expect(() => JSON5.parse('"\\u"')).toThrow("Invalid unicode escape: expected 4 hex digits");
+  });
+
+  test("hex and unicode escape errors point at the first byte that is not a hex digit", async () => {
+    // Columns are 1-based. The caret must land on the marked character, not on
+    // the first digit of the escape.
+    const unicode = "Invalid unicode escape: expected 4 hex digits";
+    const hex = "Invalid hex escape";
+    const cases = [
+      { file: "string-u.json5", source: '{ a: "\\u12G4" }', message: unicode, column: 11 }, // G
+      { file: "string-x.json5", source: '{ a: "\\x1G" }', message: hex, column: 10 }, // G
+      { file: "string-u-short.json5", source: '{ a: "\\u41" }', message: unicode, column: 11 }, // closing quote
+      { file: "string-x-short.json5", source: '{ a: "\\x" }', message: hex, column: 9 }, // closing quote
+      { file: "string-u-low.json5", source: '{ a: "\\uD83D\\uDE0Z" }', message: unicode, column: 18 }, // Z
+      { file: "key-u.json5", source: "{ \\u00G1: 1 }", message: unicode, column: 7 }, // G
+    ];
+    using dir = tempDir("json5-escape-loc", {
+      ...Object.fromEntries(cases.map(c => [c.file, c.source])),
+      "index.js": `
+        const out = [];
+        for (const file of ${JSON.stringify(cases.map(c => c.file))}) {
+          try {
+            await import("./" + file);
+            out.push({ file, message: "parsed without error" });
+          } catch (e) {
+            out.push({ file, message: e.message, line: e.position.line, column: e.position.column });
+          }
+        }
+        console.log(JSON.stringify(out));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(
+      cases.map(c => ({ file: c.file, message: c.message, line: 1, column: c.column })),
+    );
+    expect(exitCode).toBe(0);
   });
 
   test("surrogate pairs", () => {


### PR DESCRIPTION
### Problem
- A JSON5 parse error for a bad `\xHH` or `\uHHHH` escape puts the caret on the first hex digit, not on the bad character. For `{ a: "\u12G4" }` the error says `bad.json5:1:9` (the `1`). The right column is `1:11` (the `G`). The message text is correct, only the column is off.
- The cause is in `src/parsers/json5.rs`. The `\x` arm of `parse_escape_sequence` (line 734) and `read_hex4` (line 1045) decode the digits with `hex_pair_value` / `parse_hex4` and advance `pos` only after a successful decode. `to_error` reports scanner errors at `pos`, so the location is the start of the digits.

### Fix
- Add `read_hex_digits(count, err)`. It reads up to `count` digits with `bun_core::fmt::parse_hex_prefix`, advances `pos` by the number of digits it accepted, and returns `err` when fewer than `count` were accepted. `pos` is then on the first byte that is not a hex digit, or at EOF.
- The `\x` arm and `read_hex4` call this helper. `read_hex4` also serves `\u` escapes in identifiers and the low half of a surrogate pair, so those locations are fixed too.
- Correct because every `ParseError` ends the parse, so nothing reads `pos` after a failed escape except the error reporter. Accepted values are unchanged: a full run of digits produces the same `u32` as before.
- Verified: `test/js/bun/json5/json5.test.ts` (new test, 5 of its 6 cases fail on the released bun). Also `test/js/bun/json5/json5-test-suite.test.ts` and `test/js/bun/resolve/json5/json5.test.js`.

### Background
- `JSON5Parser` is a hand written scanner over the raw source bytes. `pos` is the byte cursor. When a scan step fails, `to_error` turns the `ParseError` into an `Error { pos }` and `add_to_log` converts that to the `Loc` shown in the `file:line:col` of the message.
- `parse_hex_prefix(input, max_digits)` in `src/bun_core/fmt.rs` consumes hex digits from the front of a slice and returns `(value, digits_consumed)`. It never fails. The CSS parser and the shell `echo` builtin already use it the same way.
- `Bun.JSON5.parse` does not expose a location, so the test imports `.json5` files and reads `position.line` / `position.column` from the thrown `BuildMessage`.

<details><summary>Notes</summary>

Before the fix, the released bun (1.4.1) reported these columns for the test cases:

| source | expected | before |
| --- | --- | --- |
| `{ a: "\u12G4" }` | 11 (`G`) | 9 |
| `{ a: "\x1G" }` | 10 (`G`) | 8 |
| `{ a: "\u41" }` | 11 (`"`) | 9 |
| `{ a: "\x" }` | 9 (`"`) | 9 |
| `{ a: "\uD83D\uDE0Z" }` | 18 (`Z`) | 15 |
| `{ \u00G1: 1 }` | 7 (`G`) | 5 |

The `\x` with zero digits case was already right, because zero digits means `pos` never moved. It is in the test to pin the EOF side of the helper.

The JS lexer reports a bad string escape at the opening quote of the string with a generic `Syntax Error`. JSON imports go through JSC and report no location. Neither was changed.

`parse_hex4` and `hex_pair_value` keep their other callers (`MetafileBuilder.rs`, `uuid.rs`, `integrity.rs`, `data_url.rs`, `css_parser.rs`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/json5/json5.test.ts

<!-- robobun:evidence:end -->