### PR TITLE
resolver: resolve "#" subpath imports under --packages=external and accept "#/" specifiers

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2598,8 +2598,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // "import 'pkg'" when all packages are external, e.g. the `dep` that
-        // `"#dep": "dep"` remapped to.
+        // "import 'pkg'" when all packages are external, e.g. the target of `"#dep": "dep"`.
         if kind != ast::ImportKind::EntryPointBuild
             && kind != ast::ImportKind::EntryPointRun
             && self.opts.packages == options::Packages::External

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -940,9 +940,7 @@ impl<'a> Resolver<'a> {
     }
 
     pub(crate) fn is_external_pattern(&self, import_path: &[u8]) -> bool {
-        // A "#" specifier is a package-private subpath import. It goes through
-        // the enclosing package.json "imports" map first; `load_node_modules`
-        // applies `packages = external` to whatever the map remaps it to.
+        // "#" subpath imports resolve through the "imports" map first.
         if self.opts.packages == options::Packages::External
             && is_package_path(import_path)
             && !import_path.starts_with(b"#")
@@ -2600,11 +2598,8 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // "import 'pkg'" when all packages are external (vs. "import './pkg'").
-        // `resolve_without_symlinks` already externalized plain package paths,
-        // so this catches the ones it let through: the package path a "#"
-        // import was remapped to (`"#dep": "dep"`), a "#" import with no
-        // "imports" map to consult, and browser-field remaps.
+        // "import 'pkg'" when all packages are external, e.g. the `dep` that
+        // `"#dep": "dep"` remapped to.
         if kind != ast::ImportKind::EntryPointBuild
             && kind != ast::ImportKind::EntryPointRun
             && self.opts.packages == options::Packages::External
@@ -5023,8 +5018,7 @@ impl<'a> Resolver<'a> {
         }
         let imports_map = package_json.imports.as_ref().unwrap();
 
-        // PACKAGE_IMPORTS_RESOLVE rejects exactly "#" and exactly "#/". Longer
-        // "#/..." specifiers are valid (Node 25.4, nodejs/node#60864).
+        // PACKAGE_IMPORTS_RESOLVE, as of nodejs/node#60864: only these two are invalid.
         if import_path == b"#" || import_path == b"#/" {
             if let Some(debug) = self.debug_logs.as_mut() {
                 debug.add_note_fmt(format_args!(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -940,7 +940,13 @@ impl<'a> Resolver<'a> {
     }
 
     pub(crate) fn is_external_pattern(&self, import_path: &[u8]) -> bool {
-        if self.opts.packages == options::Packages::External && is_package_path(import_path) {
+        // A "#" specifier is a package-private subpath import. It goes through
+        // the enclosing package.json "imports" map first; `load_node_modules`
+        // applies `packages = external` to whatever the map remaps it to.
+        if self.opts.packages == options::Packages::External
+            && is_package_path(import_path)
+            && !import_path.starts_with(b"#")
+        {
             return true;
         }
         self.matches_user_external_pattern(import_path)
@@ -2592,6 +2598,37 @@ impl<'a> Resolver<'a> {
                     is_self_reference = true;
                 }
             }
+        }
+
+        // "import 'pkg'" when all packages are external (vs. "import './pkg'").
+        // `resolve_without_symlinks` already externalized plain package paths,
+        // so this catches the ones it let through: the package path a "#"
+        // import was remapped to (`"#dep": "dep"`), a "#" import with no
+        // "imports" map to consult, and browser-field remaps.
+        if kind != ast::ImportKind::EntryPointBuild
+            && kind != ast::ImportKind::EntryPointRun
+            && self.opts.packages == options::Packages::External
+            && is_package_path(import_path)
+        {
+            if let Some(debug) = self.debug_logs.as_mut() {
+                debug.add_note(
+                    b"Marking this path as external because it's a package path".to_vec(),
+                );
+                debug.decrease_indent();
+            }
+            let text = match self.fs_ref().dirname_store.append_slice(import_path) {
+                Ok(text) => text,
+                Err(err) => return MatchStatus::Failure(err),
+            };
+            *out = MatchResult {
+                path_pair: PathPair {
+                    primary: Path::init(text),
+                    secondary: None,
+                },
+                is_external: true,
+                ..Default::default()
+            };
+            return MatchStatus::Success;
         }
 
         let esm_ = crate::package_json::Package::parse(import_path, bufs!(esm_subpath));
@@ -4986,10 +5023,12 @@ impl<'a> Resolver<'a> {
         }
         let imports_map = package_json.imports.as_ref().unwrap();
 
-        if import_path.len() == 1 || import_path.starts_with(b"#/") {
+        // PACKAGE_IMPORTS_RESOLVE rejects exactly "#" and exactly "#/". Longer
+        // "#/..." specifiers are valid (Node 25.4, nodejs/node#60864).
+        if import_path == b"#" || import_path == b"#/" {
             if let Some(debug) = self.debug_logs.as_mut() {
                 debug.add_note_fmt(format_args!(
-                    "The path \"{}\" must not equal \"#\" and must not start with \"#/\"",
+                    "The path \"{}\" must not equal \"#\" or \"#/\"",
                     bstr::BStr::new(import_path)
                 ));
             }

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "../expectBundled";
 
 // Tests ported from:
@@ -1827,7 +1827,27 @@ describe("bundler", () => {
       "/Users/user/project/src/entry.js": [`Could not resolve: "#". Maybe you need to "bun install"?`],
     },
   });
-  itBundled("packagejson/ImportsErrorStartsWithHashSlash", {
+  // Exactly "#/" is an invalid specifier (PACKAGE_IMPORTS_RESOLVE), even with
+  // an "imports" entry that would otherwise match it. esbuild resolves it.
+  itBundled("packagejson/ImportsErrorEqualsHashSlash", {
+    skipOnEsbuild: true,
+    files: {
+      "/Users/user/project/src/entry.js": `import '#/'`,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/": "./index.js",
+            "#/*": "./src/*"
+          }
+        }
+      `,
+      "/Users/user/project/src/index.js": `console.log('index.js')`,
+    },
+    bundleErrors: {
+      "/Users/user/project/src/entry.js": [`Could not resolve: "#/". Maybe you need to "bun install"?`],
+    },
+  });
+  itBundled("packagejson/ImportsErrorHashSlashNotDefined", {
     files: {
       "/Users/user/project/src/entry.js": `import '#/foo'`,
       "/Users/user/project/src/package.json": /* json */ `
@@ -1838,6 +1858,217 @@ describe("bundler", () => {
     },
     bundleErrors: {
       "/Users/user/project/src/entry.js": [`Could not resolve: "#/foo". Maybe you need to "bun install"?`],
+    },
+  });
+  // Specifiers that start with "#/" are valid since Node.js 25.4 (nodejs/node#60864).
+  itBundled("packagejson/ImportsHashSlashWithWildcard", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/foo.js'
+        import '#/bar/baz.js'
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/*": "./src/*"
+          }
+        }
+      `,
+      "/Users/user/project/src/src/foo.js": `console.log('foo.js')`,
+      "/Users/user/project/src/src/bar/baz.js": `console.log('bar/baz.js')`,
+    },
+    run: {
+      stdout: `foo.js\nbar/baz.js`,
+    },
+  });
+  itBundled("packagejson/ImportsHashSlashExactMatch", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/utils'
+        import '#/config.js'
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/utils": "./utils.js",
+            "#/config.js": "./config.js"
+          }
+        }
+      `,
+      "/Users/user/project/src/utils.js": `console.log('utils.js')`,
+      "/Users/user/project/src/config.js": `console.log('config.js')`,
+    },
+    run: {
+      stdout: `utils.js\nconfig.js`,
+    },
+  });
+  itBundled("packagejson/ImportsHashSlashWithConditions", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/lib'
+        require('#/lib')
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#/*": {
+              "import": "./esm/*.js",
+              "require": "./cjs/*.js"
+            }
+          }
+        }
+      `,
+      "/Users/user/project/src/esm/lib.js": `console.log('esm/lib.js')`,
+      "/Users/user/project/src/cjs/lib.js": `console.log('cjs/lib.js')`,
+    },
+    run: {
+      stdout: `esm/lib.js\ncjs/lib.js`,
+    },
+  });
+  itBundled("packagejson/ImportsHashSlashSymmetricWithExports", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import '#/components/button.js'
+        import '#/utils/format.js'
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "exports": { "./*": "./src/*" },
+          "imports": { "#/*": "./src/*" }
+        }
+      `,
+      "/Users/user/project/src/src/components/button.js": `console.log('button.js')`,
+      "/Users/user/project/src/src/utils/format.js": `console.log('format.js')`,
+    },
+    run: {
+      stdout: `button.js\nformat.js`,
+    },
+  });
+  // `--packages=external` must not treat a "#" specifier as a package. It
+  // resolves through the "imports" map: a file target is bundled, a package
+  // target becomes the external package path. The output lands outside the
+  // source package, where the runtime cannot see its "imports" map, and
+  // `dep` only exists at runtime.
+  itBundled("packagejson/ImportsPackagesExternal", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import { internal } from '#internal'
+        import { d } from '#dep'
+        import { d as direct } from 'dep'
+        import { sub } from '#dep/sub.js'
+        import { cond } from '#cond'
+        import { condDep } from '#cond-dep'
+        import { root } from '#/foo.js'
+        import { nested } from '#internal/bar.js'
+        console.log(internal, d, direct, sub, cond, condDep, root, nested)
+      `,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "name": "app",
+          "imports": {
+            "#internal": "./lib/internal.js",
+            "#dep": "dep",
+            "#dep/*": "dep/*",
+            "#cond": { "import": "./lib/cond-import.js", "default": "./lib/cond-default.js" },
+            "#cond-dep": { "import": "dep/esm.js", "default": "dep/cjs.js" },
+            "#/*": "./src/*",
+            "#internal/*": "./lib/*"
+          }
+        }
+      `,
+      "/Users/user/project/src/lib/internal.js": `export const internal = 'internal'`,
+      "/Users/user/project/src/lib/cond-import.js": `export const cond = 'cond-import'`,
+      "/Users/user/project/src/lib/cond-default.js": `export const cond = 'cond-default'`,
+      "/Users/user/project/src/src/foo.js": `export const root = 'foo'`,
+      "/Users/user/project/src/lib/bar.js": `export const nested = 'bar'`,
+    },
+    packages: "external",
+    runtimeFiles: {
+      "/node_modules/dep/package.json": `{ "name": "dep", "version": "1.0.0" }`,
+      "/node_modules/dep/index.js": `export const d = 'dep'`,
+      "/node_modules/dep/sub.js": `export const sub = 'dep/sub'`,
+      "/node_modules/dep/esm.js": `export const condDep = 'dep/esm'`,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toContain(`"#`);
+      expect(out).toContain(`from "dep"`);
+      expect(out).toContain(`from "dep/sub.js"`);
+      expect(out).toContain(`from "dep/esm.js"`);
+      expect(out).toContain(`"internal"`);
+      expect(out).toContain(`"cond-import"`);
+      expect(out).not.toContain(`"cond-default"`);
+    },
+    run: {
+      stdout: "internal dep dep dep/sub cond-import dep/esm foo bar",
+    },
+  });
+  // A "#" specifier the "imports" map does not define is an error, also
+  // under `--packages=external`.
+  itBundled("packagejson/ImportsPackagesExternalErrorNotDefined", {
+    files: {
+      "/Users/user/project/src/entry.js": `import '#missing'`,
+      "/Users/user/project/src/package.json": /* json */ `
+        {
+          "imports": {
+            "#internal": "./internal.js"
+          }
+        }
+      `,
+      "/Users/user/project/src/internal.js": `console.log('internal.js')`,
+    },
+    packages: "external",
+    bundleErrors: {
+      "/Users/user/project/src/entry.js": [`Could not resolve: "#missing". Maybe you need to "bun install"?`],
+    },
+  });
+  // With no "imports" map at all, `--packages=external` leaves a "#"
+  // specifier in the output like any other package path.
+  itBundled("packagejson/ImportsPackagesExternalNoImportsMap", {
+    files: {
+      "/Users/user/project/src/entry.js": `import '#foo'`,
+      "/Users/user/project/src/package.json": `{ "name": "app" }`,
+    },
+    packages: "external",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`"#foo"`);
+    },
+  });
+  // `--external` matches the specifier as written. "#internal" matches
+  // itself. "dep" matches the direct import only: the "#dep" entry resolves
+  // to the dep package on disk and is bundled.
+  itBundled("packagejson/ImportsUserExternal", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import { internal } from '#internal'
+        import { d } from '#dep'
+        import { d as direct } from 'dep'
+        console.log(internal, d, direct)
+      `,
+      "/Users/user/project/package.json": /* json */ `
+        {
+          "name": "app",
+          "imports": {
+            "#internal": "./src/internal.js",
+            "#dep": "dep"
+          }
+        }
+      `,
+      "/Users/user/project/src/internal.js": `export const internal = 'internal'`,
+      "/Users/user/project/node_modules/dep/package.json": `{ "name": "dep", "version": "1.0.0" }`,
+      "/Users/user/project/node_modules/dep/index.js": `export const d = 'dep'`,
+    },
+    external: ["#internal", "dep"],
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      const out = api.readFile("/Users/user/project/out.js");
+      expect(out).toContain(`from "#internal"`);
+      expect(out).toContain(`from "dep"`);
+      expect(out).not.toContain(`from "#dep"`);
+      expect(out).toContain(`= "dep"`);
+    },
+    run: {
+      stdout: "internal dep dep",
     },
   });
   itBundled("packagejson/MainFieldsErrorMessageDefault", {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1689,3 +1689,98 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
     expect(exitCode).toBe(0);
   });
 });
+
+// Specifiers that start with "#/" are valid subpath imports since Node.js 25.4
+// (nodejs/node#60864). Only exactly "#" and "#/" are invalid.
+describe.concurrent('package.json "imports" keys that start with "#/"', () => {
+  const fixture = {
+    "package.json": JSON.stringify({
+      name: "app",
+      type: "module",
+      imports: {
+        "#/*": "./src/*",
+        "#/config": "./src/config.js",
+        "#/lib/*": { import: "./src/lib/*.mjs", default: "./src/lib/*.cjs" },
+        "#dep": "dep",
+      },
+    }),
+    "src/foo.js": `export const v = 42;`,
+    "src/config.js": `export const config = "config";`,
+    "src/lib/util.mjs": `export const util = "esm";`,
+    "src/lib/util.cjs": `exports.util = "cjs";`,
+    "node_modules/dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+    "node_modules/dep/index.js": `export const d = "dep";`,
+  };
+
+  it("wildcard, exact, and conditional entries resolve with import", async () => {
+    using dir = tempDir("imports-hash-slash", {
+      ...fixture,
+      "index.js": `
+        import { v } from "#/foo.js";
+        import { config } from "#/config";
+        import { util } from "#/lib/util";
+        import { d } from "#dep";
+        console.log(JSON.stringify({ v, config, util, d }));
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.js")).toEqual({
+      stdout: JSON.stringify({ v: 42, config: "config", util: "esm", d: "dep" }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("wildcard, exact, and conditional entries resolve with require", async () => {
+    using dir = tempDir("imports-hash-slash-cjs", {
+      ...fixture,
+      "index.cjs": `
+        const { v } = require("#/foo.js");
+        const { config } = require("#/config");
+        const { util } = require("#/lib/util");
+        console.log(JSON.stringify({ v, config, util }));
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.cjs")).toEqual({
+      stdout: JSON.stringify({ v: 42, config: "config", util: "cjs" }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("import.meta.resolve and require.resolve map them to the file", async () => {
+    using dir = tempDir("imports-hash-slash-resolve", {
+      ...fixture,
+      "index.js": `
+        import { createRequire } from "node:module";
+        import { sep } from "node:path";
+        const require = createRequire(import.meta.url);
+        console.log(import.meta.resolve("#/foo.js").endsWith("/src/foo.js"));
+        console.log(require.resolve("#/config").replaceAll(sep, "/").endsWith("/src/config.js"));
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.js")).toEqual({
+      stdout: "true\ntrue",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.each(["#", "#/"])("exactly %j is rejected", async (specifier: string) => {
+    using dir = tempDir("imports-hash-slash-invalid", {
+      ...fixture,
+      "index.js": `
+        try {
+          await import(${JSON.stringify(specifier)});
+          console.log("resolved");
+        } catch (e) {
+          console.log(e.code);
+        }
+      `,
+    });
+    expect(await runWildcardScript(String(dir), "index.js")).toEqual({
+      stdout: "ERR_MODULE_NOT_FOUND",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1701,6 +1701,7 @@ describe.concurrent('package.json "imports" keys that start with "#/"', () => {
         "#/*": "./src/*",
         "#/config": "./src/config.js",
         "#/lib/*": { import: "./src/lib/*.mjs", default: "./src/lib/*.cjs" },
+        "#plain": "./src/plain.js",
         "#dep": "dep",
       },
     }),
@@ -1708,6 +1709,7 @@ describe.concurrent('package.json "imports" keys that start with "#/"', () => {
     "src/config.js": `export const config = "config";`,
     "src/lib/util.mjs": `export const util = "esm";`,
     "src/lib/util.cjs": `exports.util = "cjs";`,
+    "src/plain.js": `export const plain = "plain";`,
     "node_modules/dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
     "node_modules/dep/index.js": `export const d = "dep";`,
   };
@@ -1719,12 +1721,14 @@ describe.concurrent('package.json "imports" keys that start with "#/"', () => {
         import { v } from "#/foo.js";
         import { config } from "#/config";
         import { util } from "#/lib/util";
+        import { plain } from "#plain";
         import { d } from "#dep";
-        console.log(JSON.stringify({ v, config, util, d }));
+        const { config: dynamic } = await import("#/config");
+        console.log(JSON.stringify({ v, config, util, plain, d, dynamic }));
       `,
     });
     expect(await runWildcardScript(String(dir), "index.js")).toEqual({
-      stdout: JSON.stringify({ v: 42, config: "config", util: "esm", d: "dep" }),
+      stdout: JSON.stringify({ v: 42, config: "config", util: "esm", plain: "plain", d: "dep", dynamic: "config" }),
       stderr: "",
       exitCode: 0,
     });
@@ -1737,11 +1741,12 @@ describe.concurrent('package.json "imports" keys that start with "#/"', () => {
         const { v } = require("#/foo.js");
         const { config } = require("#/config");
         const { util } = require("#/lib/util");
-        console.log(JSON.stringify({ v, config, util }));
+        const { plain } = require("#plain");
+        console.log(JSON.stringify({ v, config, util, plain }));
       `,
     });
     expect(await runWildcardScript(String(dir), "index.cjs")).toEqual({
-      stdout: JSON.stringify({ v: 42, config: "config", util: "cjs" }),
+      stdout: JSON.stringify({ v: 42, config: "config", util: "cjs", plain: "plain" }),
       stderr: "",
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem
- `bun build --packages=external` treats every `#` specifier as an external package. The output keeps `import { internal } from "#internal"` and `import { d } from "#dep"`, so the bundle only runs from inside the source package. The cause is `is_external_pattern` in `src/resolver/resolver.rs:942`: `is_package_path("#internal")` is true, so the specifier never reaches the `imports` map.
- Any specifier that starts with `#/` fails in `bun run` and `bun build` (`Cannot find module '#/foo.js'`, `Could not resolve: "#/foo.js"`). `load_package_imports` (`resolver.rs:5023`) rejected the whole `#/` prefix. Node.js 25.4 (nodejs/node#60864) only rejects exactly `#` and `#/`, so `"#/*": "./src/*"` is a valid root alias.

### Fix
- `is_external_pattern` skips `#` specifiers, like esbuild's `!strings.HasPrefix(importPath, "#")`. They resolve through the `imports` map first.
- `load_node_modules` marks a package path external under `packages = external` after the `imports` lookup, like esbuild's `loadNodeModules`. So `"#dep": "dep"` prints as `import { d } from "dep"` (`ExternalRewritePath`), and a file target is bundled. The check skips entry points (#12734).
- `load_package_imports` rejects only exactly `#` and exactly `#/`.
- Verified: `test/bundler/esbuild/packagejson.test.ts` (`ImportsHashSlash*`, `ImportsPackagesExternal*`, `ImportsUserExternal`; 6 fail on the released bun) and `test/js/bun/resolve/resolve.test.ts` (`"#/"` block; 3 fail on the released bun). Also `bundler_edgecase.test.ts -t External`, `bundler_browser.test.ts`, `esbuild/default.test.ts -t External`, `regression/issue/32492.test.ts`, and all of `resolve.test.ts`.

### Background
- A subpath import is a `#` specifier that the nearest package.json `imports` map rewrites. The target is a relative file, a bare package path, or a conditions object. Node resolves it only from inside that package, so a bundle deployed elsewhere cannot resolve `#internal` at runtime.
- `--packages=external` leaves bare package paths as imports in the output. esbuild applies it after the `imports` lookup, in `loadNodeModules`, so the remapped target decides: file targets bundle, package targets stay external.
- `MatchResult.is_external` becomes `ExternalKind::ExternalRewritePath`, which makes the bundler replace the import path text with the resolved one. The `#fs` to `node:fs` case already used it.

<details><summary>Notes</summary>

- Output of `bun build src/in.js --packages=external` now matches esbuild 0.28.2 byte for byte on the repro (`#internal` inlined, `#dep` and `dep` both printed as `from "dep"`, `#cond` resolved by condition).
- `--external dep` with `import "#dep"`: the pattern matches the specifier as written, so `#dep` still bundles `dep` while the direct `dep` import stays external. esbuild does the same. `--external '#internal'` keeps `#internal`. Both are covered by `ImportsUserExternal`.
- A `#` specifier the `imports` map does not define is now a build error under `--packages=external` (it used to be silently external). A `#` specifier with no `imports` map at all still stays external, as in esbuild.
- esbuild 0.27.2 also accepts exactly `#/` when an exact `"#/"` key exists. Node rejects it. This PR follows Node, and `ImportsErrorEqualsHashSlash` is `skipOnEsbuild`.
- `bun test --changed` scans the module graph with `packages = external`. Local `#` imports are now followed to their files.
- The `load_node_modules` check also reaches a `browser` field remap from a relative file to a package (`"browser": {"./shim.js": "some-pkg"}`). Under `--packages=external` the output now keeps `import "some-pkg"` instead of bundling it. esbuild has done the same since 0.19.0, which moved its `--packages=external` check after the `tsconfig.json` and `imports` lookups.
- The `#/` half (the `load_package_imports` change and the `#/` tests) lands on its own in #35898, which closes #28995. This PR keeps the `--packages=external` part and is to be rebased onto #35898.
- Follow-up, not in this PR: the printer emits `import"#foo";` without a space for a side-effect import. Handed off separately.

</details>


Related: #28995 (the `#/` fix for it lands in #35898).



