### PR TITLE
Bun.password: report a too-small output buffer as NoSpaceLeft, not ENOSPC

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -50,6 +50,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "FrameworkRouter.rs": "runtime/bake/FrameworkRouter.rs",
   "Listener.rs": "runtime/socket/Listener.rs",
   "MarkdownObject.rs": "runtime/api/MarkdownObject.rs",
+  "PasswordObject.rs": "runtime/crypto/PasswordObject.rs",
   "SecureContext.rs": "runtime/api/bun/SecureContext.rs",
   "Stat.rs": "runtime/node/Stat.rs",
   "bindgen_test.rs": "jsc/bindgen_test.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -179,9 +179,7 @@ export const setMaxMarkdownBlockBytesForTesting: (limit: number) => number = $ne
   1,
 );
 
-// `Bun.password.hashSync` with an output buffer of `bufferLength` bytes
-// (at most the 4096 the real call uses), so the `NoSpaceLeft` error for an
-// encoded hash that does not fit is reachable.
+// `Bun.password.hashSync` with a caller-sized output buffer (at most 4096 bytes).
 export const hashPasswordIntoBufferForTesting: (
   password: string | ArrayBufferView,
   algorithm: Parameters<typeof Bun.password.hashSync>[1],

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -179,6 +179,15 @@ export const setMaxMarkdownBlockBytesForTesting: (limit: number) => number = $ne
   1,
 );
 
+// `Bun.password.hashSync` with an output buffer of `bufferLength` bytes
+// (at most the 4096 the real call uses), so the `NoSpaceLeft` error for an
+// encoded hash that does not fit is reachable.
+export const hashPasswordIntoBufferForTesting: (
+  password: string | ArrayBufferView,
+  algorithm: Parameters<typeof Bun.password.hashSync>[1],
+  bufferLength: number,
+) => string = $newRustFunction("PasswordObject.rs", "hashPasswordIntoBufferForTesting", 3);
+
 export const npm_manifest_test_helpers = $rust("npm.rs", "PackageManifest.bindings.generate") as {
   /**
    * Returns the parsed manifest file. Currently only returns an array of available versions.

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -266,13 +266,26 @@ impl Algorithm {
 pub(crate) type HashError = crate::Error;
 
 impl PasswordObject {
+    /// Scratch buffer for the encoded hash. The longest output, an argon2 PHC
+    /// string with ten-digit cost parameters, is about 133 bytes.
+    const OUTPUT_BUFFER_LEN: usize = 4096;
+
     // This is purposely simple because nobody asked to make it more complicated
     pub(crate) fn hash(password: &[u8], algorithm: AlgorithmValue) -> Result<Box<[u8]>, HashError> {
+        let mut outbuf = [0u8; Self::OUTPUT_BUFFER_LEN];
+        Self::hash_into(password, algorithm, &mut outbuf).map(Box::<[u8]>::from)
+    }
+
+    /// Writes the encoded hash into `outbuf` and returns the populated prefix.
+    fn hash_into<'a>(
+        password: &[u8],
+        algorithm: AlgorithmValue,
+        outbuf: &'a mut [u8],
+    ) -> Result<&'a [u8], HashError> {
         match algorithm {
             AlgorithmValue::Argon2i(argon)
             | AlgorithmValue::Argon2d(argon)
             | AlgorithmValue::Argon2id(argon) => {
-                let mut outbuf = [0u8; 4096];
                 let hash_options = pwhash::argon2::HashOptions {
                     params: argon.to_params(),
                     // allocator dropped — global mimalloc
@@ -288,26 +301,18 @@ impl PasswordObject {
                 // we don't expose this option
                 // but since it parses from phc format, it's possible that it will be set
                 // eventually we should do something that about that.
-                let out_bytes = pwhash::argon2::str_hash(password, hash_options, &mut outbuf)?;
-                Ok(Box::<[u8]>::from(out_bytes))
+                pwhash::argon2::str_hash(password, hash_options, outbuf)
             }
             AlgorithmValue::Bcrypt(cost) => {
-                let mut outbuf = [0u8; 4096];
                 // bcrypt silently truncates passwords longer than 72 bytes
                 // we use SHA512 to hash the password if it's longer than 72 bytes
-                // The digest gets its own 64-byte buffer
-                // (SHA512::final wants `&mut [u8; DIGEST]`).
                 let mut digest = [0u8; SHA512::DIGEST];
                 let mut password_to_use = password;
-                let outbuf_slice: &mut [u8];
                 if password.len() > 72 {
                     let mut sha_512 = SHA512::init();
                     sha_512.update(password);
                     sha_512.r#final(&mut digest);
                     password_to_use = &digest;
-                    outbuf_slice = &mut outbuf[SHA512::DIGEST..];
-                } else {
-                    outbuf_slice = &mut outbuf[..];
                 }
 
                 let hash_options = pwhash::bcrypt::HashOptions {
@@ -318,9 +323,7 @@ impl PasswordObject {
                     // allocator dropped
                     encoding: pwhash::Encoding::Crypt,
                 };
-                let out_bytes =
-                    pwhash::bcrypt::str_hash(password_to_use, hash_options, outbuf_slice)?;
-                Ok(Box::<[u8]>::from(out_bytes))
+                pwhash::bcrypt::str_hash(password_to_use, hash_options, outbuf)
             }
         }
     }
@@ -871,6 +874,48 @@ fn js_password_object_verify_sync(
         Box::<[u8]>::from(hash_.slice()),
         algorithm,
     )
+}
+
+/// `bun:internal-for-testing`'s `hashPasswordIntoBufferForTesting(password,
+/// algorithm, bufferLength)`: `Bun.password.hashSync` with an output buffer of
+/// `bufferLength` bytes (at most `OUTPUT_BUFFER_LEN`), so the `NoSpaceLeft`
+/// error of `pwhash::*::str_hash` is reachable.
+#[bun_jsc::host_fn]
+pub(crate) fn hash_password_into_buffer_for_testing(
+    global_object: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    let [password_value, algorithm_value, length_value] = callframe.arguments_as_array::<3>();
+
+    let mut algorithm = AlgorithmValue::DEFAULT;
+    if !algorithm_value.is_empty_or_undefined_or_null() {
+        algorithm = AlgorithmValue::from_js(global_object, algorithm_value)?;
+    }
+
+    let Some(password) = StringOrBuffer::from_js(global_object, password_value)? else {
+        return Err(global_object.throw_invalid_argument_type(
+            "hash",
+            "password",
+            "string or TypedArray",
+        ));
+    };
+
+    if !length_value.is_number() {
+        return Err(global_object.throw_invalid_arguments(format_args!(
+            "hashPasswordIntoBufferForTesting expects a buffer length"
+        )));
+    }
+    let length = usize::try_from(length_value.coerce_to_int64(global_object)?.max(0))
+        .expect("non-negative i64 fits usize");
+    let mut outbuf = vec![0u8; length.min(PasswordObject::OUTPUT_BUFFER_LEN)];
+
+    match PasswordObject::hash_into(password.slice(), algorithm, &mut outbuf) {
+        Err(err) => {
+            let error_instance = password_error_instance(&err, HashOp::ERR_VERB, global_object);
+            Err(global_object.throw_value(error_instance))
+        }
+        Ok(bytes) => Ok(EncodedSlice::latin1(bytes).to_js(global_object)),
+    }
 }
 
 const UNKNOWN_PASSWORD_ALGORITHM_MESSAGE: &str = "unknown algorithm, expected one of: \"bcrypt\", \"argon2id\", \"argon2d\", \"argon2i\" (default is \"argon2id\")";

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -266,8 +266,7 @@ impl Algorithm {
 pub(crate) type HashError = crate::Error;
 
 impl PasswordObject {
-    /// Scratch buffer for the encoded hash. The longest output, an argon2 PHC
-    /// string with ten-digit cost parameters, is about 133 bytes.
+    /// Room for the longest encoded hash, an argon2 PHC string of about 133 bytes.
     const OUTPUT_BUFFER_LEN: usize = 4096;
 
     // This is purposely simple because nobody asked to make it more complicated
@@ -876,10 +875,7 @@ fn js_password_object_verify_sync(
     )
 }
 
-/// `bun:internal-for-testing`'s `hashPasswordIntoBufferForTesting(password,
-/// algorithm, bufferLength)`: `Bun.password.hashSync` with an output buffer of
-/// `bufferLength` bytes (at most `OUTPUT_BUFFER_LEN`), so the `NoSpaceLeft`
-/// error of `pwhash::*::str_hash` is reachable.
+/// `bun:internal-for-testing`: `Bun.password.hashSync` with a caller-sized output buffer.
 #[bun_jsc::host_fn]
 pub(crate) fn hash_password_into_buffer_for_testing(
     global_object: &JSGlobalObject,

--- a/src/runtime/crypto/pwhash.rs
+++ b/src/runtime/crypto/pwhash.rs
@@ -155,9 +155,8 @@ pub mod argon2 {
         let encoded = vendor::hash_encoded(password, &salt, &config).map_err(|e| map_err(&e))?;
         let bytes = encoded.as_bytes();
 
-        // Error `NoSpaceLeft` if the encoded hash overflows the caller buffer.
         if bytes.len() > out.len() {
-            return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOSPC));
+            return Err(crate::Error::Core(bun_core::Error::NoSpaceLeft));
         }
         out[..bytes.len()].copy_from_slice(bytes);
         Ok(&out[..bytes.len()])
@@ -309,7 +308,7 @@ pub mod bcrypt {
         out: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
         if out.len() < HASH_LENGTH {
-            return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOSPC));
+            return Err(crate::Error::Core(bun_core::Error::NoSpaceLeft));
         }
         // Bun only ever requests `.crypt`. A `.phc` request would need the
         // `$bcrypt$…` PHC serializer, which the Rust `bcrypt` crate does not

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -1,4 +1,5 @@
 import { password } from "bun";
+import { hashPasswordIntoBufferForTesting } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
@@ -544,4 +545,50 @@ test("verifySync reads the password buffer only after every argument has been co
   };
   expect(password.verifySync(passwordBytes, hashObject as any)).toBeFalse();
   expect(passwordBytes.byteLength).toBe(0);
+});
+
+// `Bun.password.hash` writes the encoded hash into a 4096-byte buffer, far
+// more than the ~133 bytes the longest PHC string needs, so the "does not
+// fit" error is only reachable through the internal hook that takes the
+// buffer length as an argument.
+describe("an output buffer too small for the encoded hash", () => {
+  const cases = [
+    { name: "bcrypt", algorithm: { algorithm: "bcrypt", cost: 4 }, password: "correct horse" },
+    // Passwords longer than 72 bytes take the SHA-512 pre-hash path.
+    {
+      name: "bcrypt, long password",
+      algorithm: { algorithm: "bcrypt", cost: 4 },
+      password: Buffer.alloc(100, "p").toString(),
+    },
+    { name: "argon2id", algorithm: { algorithm: "argon2id", memoryCost: 8, timeCost: 1 }, password: "correct horse" },
+    { name: "argon2d", algorithm: { algorithm: "argon2d", memoryCost: 8, timeCost: 1 }, password: "correct horse" },
+    { name: "argon2i", algorithm: { algorithm: "argon2i", memoryCost: 8, timeCost: 1 }, password: "correct horse" },
+  ] as const;
+
+  function hashError(plaintext: string, algorithm: (typeof cases)[number]["algorithm"], bufferLength: number) {
+    try {
+      return { hash: hashPasswordIntoBufferForTesting(plaintext, algorithm, bufferLength) };
+    } catch (e: any) {
+      return { name: e.name, code: e.code, message: e.message };
+    }
+  }
+
+  test.each(cases)("$name", ({ algorithm, password: plaintext }) => {
+    // The buffer size the real call uses gives a regular hash.
+    const hashed = hashPasswordIntoBufferForTesting(plaintext, algorithm, 4096);
+    expect(password.verifySync(plaintext, hashed)).toBeTrue();
+
+    // A buffer of exactly the encoded length fits.
+    const exact = hashPasswordIntoBufferForTesting(plaintext, algorithm, hashed.length);
+    expect(exact).toHaveLength(hashed.length);
+    expect(password.verifySync(plaintext, exact)).toBeTrue();
+
+    // One byte less does not, and the error code is derived from the
+    // `NoSpaceLeft` name, not from an errno name.
+    expect(hashError(plaintext, algorithm, hashed.length - 1)).toEqual({
+      name: "Error",
+      code: "PASSWORD_NO_SPACE_LEFT",
+      message: 'Password hashing failed with error "NoSpaceLeft"',
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `Bun.password.hash` reports a too-small output buffer as `crate::Error::Sys(ENOSPC)` (`src/runtime/crypto/pwhash.rs:160` and `:312`).
- `password_error_instance` (`src/runtime/crypto/PasswordObject.rs`) builds the JS `code` by upper-snake-casing `err.name()`. The errno name `ENOSPC` has no lowercase letters, so the code is `PASSWORD_E_N_O_S_P_C` and the message names `"ENOSPC"`.
- The branch is not reachable from JS today: the callers pass a 4096-byte buffer, and the longest output is about 133 bytes. The wrong code surfaces as soon as the buffer sizing changes.

### Fix
- Both sites return `crate::Error::Core(bun_core::Error::NoSpaceLeft)`. This is the variant the tree uses for a full caller buffer (`src/io/write.rs:187`, `src/resolver/error.rs:52`). `Error::name()` gives `NoSpaceLeft`, so the code is `PASSWORD_NO_SPACE_LEFT`, as the Zig implementation produced from `error.NoSpaceLeft`.
- To make the path testable, `PasswordObject::hash` is split into `hash` (owns the 4096-byte buffer) and `hash_into` (takes any buffer). `bun:internal-for-testing` exposes `hash_into` as `hashPasswordIntoBufferForTesting(password, algorithm, bufferLength)`, the same pattern as `setMaxMarkdownBlockBytesForTesting`. The production path is unchanged.
- The bcrypt arm no longer offsets the output by `SHA512::DIGEST`. The digest has its own array since the Rust port, so the offset only wasted 64 bytes.
- Verified: `test/js/bun/util/password.test.ts`, new block "an output buffer too small for the encoded hash". Without the `pwhash.rs` change it fails with `PASSWORD_E_N_O_S_P_C`. The whole file passes on the debug build (81 pass, 8 skip).

### Background
- `crate::Error` in `bun_runtime` is a `thiserror` enum. `Sys(SystemErrno)` wraps an errno and names itself after it (`ENOSPC`). `Core(bun_core::Error)` wraps the foundation crate's errors, which have PascalCase names such as `NoSpaceLeft`.
- `PascalToUpperUnderscoreCaseFormatter` writes `_` before each uppercase letter and uppercases the rest. It gives a sensible result only for PascalCase input.
- `bun:internal-for-testing` is the built-in module that exposes internal hooks to the test suite. `$newRustFunction("PasswordObject.rs", ...)` needs the file registered in `src/codegen/generate-js2native.ts`.

<details><summary>Notes</summary>

Test matrix: bcrypt with a short password, bcrypt with a 100-byte password (the SHA-512 pre-hash path), argon2id, argon2d, argon2i. For each: a 4096-byte buffer gives a hash that verifies, a buffer of exactly the encoded length fits, one byte less fails with `{ name: "Error", code: "PASSWORD_NO_SPACE_LEFT", message: 'Password hashing failed with error "NoSpaceLeft"' }`.

Fail-before output (hook present, `pwhash.rs` at main):

```
-   "code": "PASSWORD_NO_SPACE_LEFT",
-   "message": "Password hashing failed with error "NoSpaceLeft"",
+   "code": "PASSWORD_E_N_O_S_P_C",
+   "message": "Password hashing failed with error "ENOSPC"",
```

Earlier manual check, before the hook existed: a throwaway debug build with both `[0u8; 4096]` buffers shrunk to `[0u8; 16]` gave `PASSWORD_E_N_O_S_P_C` from `hash` and `hashSync` for bcrypt and argon2id, and `PASSWORD_NO_SPACE_LEFT` with the `pwhash.rs` change.

Why the hook and not a public-API test: the longest argon2 PHC string is `$argon2id$v=19$m=<10 digits>,t=<10 digits>,p=1$<43 chars>$<43 chars>`, about 133 bytes, and bcrypt always writes 60 bytes. A Rust unit test inside `bun_runtime` does not link on its own (the crate is the staticlib that the C++ link completes).

A larger alternative is to drop the caller buffer and return the owned `String` that `argon2::hash_encoded` and `bcrypt::HashParts::format_for_version` already produce. That removes the branch and the 4 KiB stack buffer. It also changes the `str_hash` signatures that #37582 edits, so this PR keeps the buffer.

Suites run: `test/js/bun/util/password.test.ts` (81 pass, 8 skip on the debug build).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/password.test.ts

<!-- robobun:evidence:end -->