### PR TITLE
js_parser: keep const references and top-level names in scopes with a direct eval

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1505,7 +1505,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         let ref_ = ident.ref_;
 
-        if self.options.features.inlining {
+        // A direct eval in this scope can declare a new binding with the same
+        // name (sloppy `eval("var x = ...")`), so the constant must stay a
+        // reference.
+        if self.options.features.inlining && !self.current_scope().contains_direct_eval {
             if let Some(replacement) = self.const_values.get(&ref_) {
                 let replacement = *replacement;
                 self.ignore_usage(ref_);
@@ -8029,23 +8032,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // A direct eval at module scope can reach every top-level name. Nested
-        // scopes are pinned in `pop_scope`; the module scope never pops. When
+        // scopes are pinned in `pop_scope`; the module scope never pops, so pin
+        // it here. Without bundling the file is printed on its own and every
+        // top-level name, import bindings included, must keep its name. When
         // the bundler wraps this file in a CommonJS closure those names stay
         // private to it, so pin them too. A flat ESM file's top-level names
         // share the chunk's scope with other files', so they stay renameable
-        // (as in esbuild) and eval may not see them. Import bindings are left
-        // out: the linker merges them into the exporting file's symbol, which
-        // would pin that name in every chunk that references it.
-        if bundling
-            && exports_kind == js_ast::ExportsKind::Cjs
-            && self.module_scope().contains_direct_eval
+        // (as in esbuild) and eval may not see them. When bundling, import
+        // bindings are left out: the linker merges them into the exporting
+        // file's symbol, which would pin that name in every chunk that
+        // references it.
+        if self.module_scope().contains_direct_eval
+            && (!bundling || exports_kind == js_ast::ExportsKind::Cjs)
         {
             let module_scope = self.module_scope_ref();
             for member in module_scope.members.values() {
                 let symbol = &mut self.symbols[member.ref_.inner_index() as usize];
-                if symbol.kind != js_ast::symbol::Kind::Import {
-                    symbol.set_must_not_be_renamed(true);
+                if bundling && symbol.kind == js_ast::symbol::Kind::Import {
+                    continue;
                 }
+                symbol.set_must_not_be_renamed(true);
             }
         }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1505,9 +1505,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         let ref_ = ident.ref_;
 
-        // A direct eval in this scope can declare a new binding with the same
-        // name (sloppy `eval("var x = ...")`), so the constant must stay a
-        // reference.
+        // A sloppy direct eval can declare a binding that shadows the const.
         if self.options.features.inlining && !self.current_scope().contains_direct_eval {
             if let Some(replacement) = self.const_values.get(&ref_) {
                 let replacement = *replacement;
@@ -8031,17 +8029,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // A direct eval at module scope can reach every top-level name. Nested
-        // scopes are pinned in `pop_scope`; the module scope never pops, so pin
-        // it here. Without bundling the file is printed on its own and every
-        // top-level name, import bindings included, must keep its name. When
-        // the bundler wraps this file in a CommonJS closure those names stay
-        // private to it, so pin them too. A flat ESM file's top-level names
-        // share the chunk's scope with other files', so they stay renameable
-        // (as in esbuild) and eval may not see them. When bundling, import
-        // bindings are left out: the linker merges them into the exporting
-        // file's symbol, which would pin that name in every chunk that
-        // references it.
+        // The module scope never goes through `pop_scope`, so its direct-eval
+        // pinning happens here. Exempt, as in esbuild: the top level of a
+        // bundled ESM file (it shares the chunk scope with other files) and,
+        // when bundling, import bindings (the linker merges them into the
+        // exporting file's symbol, which would pin that name in every chunk).
         if self.module_scope().contains_direct_eval
             && (!bundling || exports_kind == js_ast::ExportsKind::Cjs)
         {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8029,17 +8029,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // The module scope never goes through `pop_scope`, so its direct-eval
-        // pinning happens here. Exempt, as in esbuild: the top level of a
-        // bundled ESM file (it shares the chunk scope with other files) and,
-        // when bundling, import bindings (the linker merges them into the
-        // exporting file's symbol, which would pin that name in every chunk).
+        // The module scope never pops; `pop_scope` explains the bundled-ESM exemption.
         if self.module_scope().contains_direct_eval
             && (!bundling || exports_kind == js_ast::ExportsKind::Cjs)
         {
             let module_scope = self.module_scope_ref();
             for member in module_scope.members.values() {
                 let symbol = &mut self.symbols[member.ref_.inner_index() as usize];
+                // The linker merges an import binding into the exporting file's symbol.
                 if bundling && symbol.kind == js_ast::symbol::Kind::Import {
                     continue;
                 }

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -19,6 +19,46 @@ describe("bundler", () => {
     },
     run: { stdout: "top fn" },
   });
+  // A sloppy direct eval can declare a binding that shadows a `const` of an
+  // enclosing scope, so a scope that contains a direct eval keeps its
+  // constants as references instead of inlining their values.
+  itBundled("minify/DirectEvalKeepsConstReference", {
+    files: {
+      "/entry.cjs": /* js */ `
+        const variable = false;
+        (function () {
+          eval("var variable = true");
+          console.log(variable);
+        })();
+        console.log(variable);
+      `,
+    },
+    minifySyntax: true,
+    format: "cjs",
+    outfile: "/out.cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.cjs").toContain("console.log(variable)");
+      api.expectFile("/out.cjs").not.toContain("console.log(!1)");
+    },
+    run: { stdout: "true\nfalse" },
+  });
+  // Without bundling the file is printed on its own, so a direct eval
+  // anywhere in it can reach every top-level name.
+  itBundled("minify/DirectEvalKeepsTopLevelNamesNoBundle", {
+    files: {
+      "/entry.js": /* js */ `
+        var outerVariable = 123;
+        var r = function (code) { var inner = 1; return eval(code) }("outerVariable + inner");
+        console.log(r);
+      `,
+    },
+    bundling: false,
+    minifyIdentifiers: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var outerVariable = 123");
+    },
+    run: { stdout: "124" },
+  });
   itBundled("minify/TemplateStringFolding", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/transpiler/direct-eval.test.ts
+++ b/test/bundler/transpiler/direct-eval.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// A direct eval can declare a binding in the scope that contains it (sloppy
+// `eval("var x = 1")`) and can read any name in the scopes that enclose it.
+// So a scope that contains a direct eval must keep its `const` values as
+// references, and none of the names visible from a direct eval may be
+// renamed, including the top-level names of the file.
+//
+// Every fixture is sloppy CommonJS. `expected` is what Node prints. `keep`
+// lists source text that every transpiled output must still contain.
+const fixtures = {
+  "const shadowed by eval var, one function deep": {
+    source: /* js */ `
+      const variable = false;
+      (function () {
+        eval("var variable = true");
+        console.log(variable);
+      })();
+      console.log(variable);
+    `,
+    expected: "true\nfalse",
+    keep: ["console.log(variable)"],
+  },
+  "const shadowed by eval var, two functions deep": {
+    source: /* js */ `
+      const variable = false;
+      (function () {
+        (function () {
+          eval("var variable = true");
+          console.log(variable);
+        })();
+        console.log(variable);
+      })();
+      console.log(variable);
+    `,
+    expected: "true\nfalse\nfalse",
+    keep: ["console.log(variable)"],
+  },
+  "eval reads top-level names, at module scope": {
+    source: /* js */ `
+      var outerVariable = 123;
+      var inner = 1;
+      console.log(eval("outerVariable + inner"));
+    `,
+    expected: "124",
+    keep: ["outerVariable", "inner"],
+  },
+  "eval reads top-level names, one function deep": {
+    source: /* js */ `
+      var outerVariable = 123;
+      var r = function (code) { var inner = 1; return eval(code) }("outerVariable + inner");
+      console.log(r);
+    `,
+    expected: "124",
+    keep: ["outerVariable", "inner"],
+  },
+  "eval reads top-level names, two functions deep": {
+    source: /* js */ `
+      var outerVariable = 123;
+      function outer() {
+        var middle = 1;
+        return function () { var inner = 1; return eval("outerVariable + middle + inner"); }();
+      }
+      console.log(outer());
+    `,
+    expected: "125",
+    keep: ["outerVariable", "middle", "inner"],
+  },
+};
+
+type Fixture = (typeof fixtures)[keyof typeof fixtures];
+const cases = Object.entries(fixtures) as [string, Fixture][];
+
+async function runFile(cwd: string, file: string): Promise<string> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), file],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return stdout.trim();
+}
+
+async function bunBuild(cwd: string, args: string[]): Promise<void> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", ...args],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}
+
+function expectKept(output: string, fixture: Fixture) {
+  for (const text of fixture.keep) {
+    expect(output).toContain(text);
+  }
+}
+
+describe("direct eval", () => {
+  describe("bun run", () => {
+    test.concurrent.each(cases)(".cjs: %s", async (_name, fixture) => {
+      using dir = tempDir("direct-eval-run", { "entry.cjs": fixture.source });
+      expect(await runFile(String(dir), "entry.cjs")).toBe(fixture.expected);
+    });
+
+    test.concurrent.each(cases)("sloppy .js: %s", async (_name, fixture) => {
+      using dir = tempDir("direct-eval-run-js", {
+        "package.json": JSON.stringify({ type: "commonjs" }),
+        "entry.js": fixture.source,
+      });
+      expect(await runFile(String(dir), "entry.js")).toBe(fixture.expected);
+    });
+  });
+
+  // The bundled output is CommonJS so that it runs in sloppy mode like the
+  // input. In an ES module, `eval("var x")` cannot declare `x` in the
+  // enclosing scope.
+  describe("bun build", () => {
+    const modes = [
+      ["--minify", ["--minify", "--format=cjs"]],
+      ["--minify-syntax", ["--minify-syntax", "--format=cjs"]],
+      ["--no-bundle --minify-identifiers", ["--no-bundle", "--minify-identifiers"]],
+      ["--no-bundle --minify-syntax --target=bun", ["--no-bundle", "--minify-syntax", "--target=bun"]],
+    ] as const;
+
+    for (const [label, args] of modes) {
+      test.concurrent.each(cases)(`${label}: %s`, async (_name, fixture) => {
+        using dir = tempDir("direct-eval-build", { "entry.cjs": fixture.source });
+        await bunBuild(String(dir), ["entry.cjs", "--outfile=out.cjs", ...args]);
+        expectKept(await Bun.file(join(String(dir), "out.cjs")).text(), fixture);
+        expect(await runFile(String(dir), "out.cjs")).toBe(fixture.expected);
+      });
+    }
+  });
+
+  describe("Bun.Transpiler", () => {
+    const modes = [
+      ["minify.identifiers", { minify: { identifiers: true } }],
+      ["inline + minify.syntax", { inline: true, minify: { syntax: true } }],
+    ] as const;
+
+    for (const [label, options] of modes) {
+      test.concurrent.each(cases)(`${label}: %s`, async (_name, fixture) => {
+        const output = new Bun.Transpiler({ loader: "js", target: "bun", ...options }).transformSync(fixture.source);
+        expectKept(output, fixture);
+        using dir = tempDir("direct-eval-transpiler", { "out.cjs": output });
+        expect(await runFile(String(dir), "out.cjs")).toBe(fixture.expected);
+      });
+    }
+  });
+
+  describe("Bun.build", () => {
+    test.concurrent.each(cases)("minify: %s", async (_name, fixture) => {
+      using dir = tempDir("direct-eval-api", { "entry.cjs": fixture.source });
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "entry.cjs")],
+        minify: true,
+        format: "cjs",
+        write: false,
+      });
+      expect(result.success).toBe(true);
+      const output = await result.outputs[0].text();
+      expectKept(output, fixture);
+      await Bun.write(join(String(dir), "out.cjs"), output);
+      expect(await runFile(String(dir), "out.cjs")).toBe(fixture.expected);
+    });
+  });
+});

--- a/test/bundler/transpiler/direct-eval.test.ts
+++ b/test/bundler/transpiler/direct-eval.test.ts
@@ -9,7 +9,9 @@ import { join } from "node:path";
 // renamed, including the top-level names of the file.
 //
 // Every fixture is sloppy CommonJS. `expected` is what Node prints. `keep`
-// lists source text that every transpiled output must still contain.
+// matches code outside the eval string that every transpiled output must
+// still contain: the reference that must not be inlined, or the declaration
+// whose name must not change (`\s*` because `--minify` prints `a=1,b=2`).
 const fixtures = {
   "const shadowed by eval var, one function deep": {
     source: /* js */ `
@@ -21,7 +23,7 @@ const fixtures = {
       console.log(variable);
     `,
     expected: "true\nfalse",
-    keep: ["console.log(variable)"],
+    keep: [/console\.log\(variable\)/],
   },
   "const shadowed by eval var, two functions deep": {
     source: /* js */ `
@@ -36,7 +38,7 @@ const fixtures = {
       console.log(variable);
     `,
     expected: "true\nfalse\nfalse",
-    keep: ["console.log(variable)"],
+    keep: [/console\.log\(variable\)/],
   },
   "eval reads top-level names, at module scope": {
     source: /* js */ `
@@ -45,7 +47,7 @@ const fixtures = {
       console.log(eval("outerVariable + inner"));
     `,
     expected: "124",
-    keep: ["outerVariable", "inner"],
+    keep: [/\bouterVariable\s*=\s*123\b/, /\binner\s*=\s*1\b/],
   },
   "eval reads top-level names, one function deep": {
     source: /* js */ `
@@ -54,7 +56,7 @@ const fixtures = {
       console.log(r);
     `,
     expected: "124",
-    keep: ["outerVariable", "inner"],
+    keep: [/\bouterVariable\s*=\s*123\b/, /\binner\s*=\s*1\b/],
   },
   "eval reads top-level names, two functions deep": {
     source: /* js */ `
@@ -66,7 +68,7 @@ const fixtures = {
       console.log(outer());
     `,
     expected: "125",
-    keep: ["outerVariable", "middle", "inner"],
+    keep: [/\bouterVariable\s*=\s*123\b/, /\bmiddle\s*=\s*1\b/, /\binner\s*=\s*1\b/],
   },
 };
 
@@ -95,14 +97,14 @@ async function bunBuild(cwd: string, args: string[]): Promise<void> {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 }
 
 function expectKept(output: string, fixture: Fixture) {
-  for (const text of fixture.keep) {
-    expect(output).toContain(text);
+  for (const pattern of fixture.keep) {
+    expect(output).toMatch(pattern);
   }
 }
 


### PR DESCRIPTION
### Problem
- A function that calls `eval("var variable = true")` and then logs `variable` prints the inlined outer `const` value `false` under `bun file.cjs`. Node prints `true`. `handle_identifier` (`src/js_parser/p.rs:1508`) inlined the const, and the runtime transpiler has inlining on.
- `bun build --no-bundle --minify-identifiers` and `Bun.Transpiler` with `minify.identifiers` renamed top-level names that an eval string reads: `var outerVariable = 123` became `var e = 123`, then `ReferenceError: outerVariable is not defined`. #40518 pinned the module scope only for `bundling && exports_kind == Cjs`.

### Fix
- `handle_identifier` skips the const substitution when `current_scope().contains_direct_eval` is set.
- The module scope is pinned when it contains a direct eval, unless the file is a flat bundled ESM file. Import bindings are skipped only when bundling, where the linker merges them into the exporting file's symbol.
- Both rules match esbuild's `handleIdentifier` and `popScope`. esbuild 0.25.1 prints the same output for every test fixture.
- Verified: `test/bundler/transpiler/direct-eval.test.ts` (45 cases, 24 fail on bun 1.4.1) and two cases in `test/bundler/bundler_minify.test.ts`.

### Background
- A direct eval runs in the caller's scope. Sloppy `eval("var x")` adds `x` to the nearest function scope, and the code can read every enclosing name. The parser sets `Scope::contains_direct_eval` on the call's scope and its parents. `pop_scope` pins every scope with the flag, but the module scope never pops.
- `const_values` drives const inlining: a `const` with a literal value at the start of a block is recorded, and later reads become the literal.
- `must_not_be_renamed` is the symbol flag the minify renamer reads. A pinned symbol keeps its name.

<details><summary>Notes</summary>

Test matrix, five sloppy CommonJS fixtures (const shadowed by an eval'd `var` one and two functions deep, and an eval that reads top-level names at module scope, one and two functions deep) run through:

- `bun entry.cjs` and `bun entry.js` with `"type": "commonjs"`
- `bun build --minify --format=cjs`, `bun build --minify-syntax --format=cjs`
- `bun build --no-bundle --minify-identifiers`, `bun build --no-bundle --minify-syntax --target=bun`
- `new Bun.Transpiler({ minify: { identifiers: true } })`, `new Bun.Transpiler({ inline: true, minify: { syntax: true } })`
- `Bun.build({ minify: true, format: "cjs" })`

Each output is run and its stdout compared with Node's. The bundled outputs use `--format=cjs` and a `.cjs` file name so that they run in sloppy mode like the input. In an ES module a direct `eval("var x")` cannot declare `x` in the enclosing scope, so an ESM-format output prints the same before and after the fix. `Bun.build` has no `bundle: false` option, so the API transform path is covered through `Bun.Transpiler`.

Without `--target=bun`, `bun build --no-bundle --minify-syntax` has `features.inlining` off and never inlined. `--target=bun` turns inlining on, which is why that flag is in the matrix.

The const that is no longer inlined keeps a non-zero use count, so the existing decl-removal pass in `visit/mod.rs` keeps its declaration.

Limitation shared with esbuild: the eval is detected during the visit pass. A `const` read that is visited before the eval call, or that sits in a sibling block the eval does not mark, is still inlined. Parity with esbuild was the requested behavior.

The module scope is never popped through `pop_scope`, so its pinning lives at the end of `to_ast`, once `exports_kind` is known. #35955 is an older open PR for the module-scope pinning in bundled CJS files. #40518 merged that half. This PR covers the transform-mode half and the const inlining.

Suites run: `esbuild/default`, `esbuild/splitting`, `bundler_splitting`, `bundler_minify`, `bundler_edgecase`, `bundler_cjs2esm`, `bundler_string`, `transpiler/transpiler.test.js`. `bundler_bytecode_portable.test.ts` was also run. Its heavy `all.js` and `libraries.js` cases hit their 5 s timeout in this debug build (200 ms to 2 s on the release binary) and are unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 26 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts test/bundler/transpiler/direct-eval.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [1258.97ms]
35 |     },
36 |     minifySyntax: true,
37 |     format: "cjs",
38 |     outfile: "/out.cjs",
39 |     onAfterBundle(api) {
40 |       api.expectFile("/out.cjs").toContain("console.log(variable)");
                                      ^
error: expect(received).toContain(expected)

Expected to contain: "console.log(variable)"
Received: "// entry.cjs\nvar variable = !1;\n(function() {\n  eval(\"var variable = true\"), console.log(!1);\n})();\nconsole.log(!1);\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_minify.test.ts:40:34)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1602:13)
(fail) bundler > minify/DirectEvalKeepsConstReference [249.61ms]
53 |       `,
54 |     },
55 |     bundling: false,
56 |     minifyIdentifiers: true,
57 |     onAfterBundle(api) {
58 |       api.expec
... (truncated)

release without fix: 31 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [25.91ms]
35 |     },
36 |     minifySyntax: true,
37 |     format: "cjs",
38 |     outfile: "/out.cjs",
39 |     onAfterBundle(api) {
40 |       api.expectFile("/out.cjs").toContain("console.log(variable)");
                                      ^
error: expect(received).toContain(expected)

Expected to contain: "console.log(variable)"
Received: "// entry.cjs\nvar variable = !1;\n(function() {\n  eval(\"var variable = true\"), console.log(!1);\n})();\nconsole.log(!1);\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_minify.test.ts:40:34)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1602:13)
(fail) bundler > minify/DirectEvalKeepsConstReference [5.20ms]
53 |       `,
54 |     },
55 |     bundling: false,
56 |     minifyIdentifiers: true,
57 |     onAfterBundle(api) {
58 |       api.expectFile("/out.js").toContain("var outerVariable = 123");
                                     ^
error: expect(received).toContain(expected)

Expected to contain: "var outerVariable = 123"
Received: "var e = 123
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts test/bundler/transpiler/direct-eval.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [907.41ms]
(pass) bundler > minify/DirectEvalKeepsConstReference [401.57ms]
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesNoBundle [478.88ms]
(pass) bundler > minify/TemplateStringFolding [148.40ms]
(pass) bundler > minify/StringAdditionFolding [170.05ms]
(pass) bundler > minify/FunctionExpressionRemoveName [139.65ms]
(pass) bundler > minify/KeepNamesPreservesNames [142.08ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [118.77ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1198.95ms]
(pass) bundler > minify/MergeAdjacentVars [493.16ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [525.16ms]
(pass) bundler > minify/Infinity [123.93ms]
(pass) bundler > minify+whitespace/Infinity [99.89ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [388.07ms]
(pass) bundler > minify/SameTarge
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 697ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                          |  23 ++--
 test/bundler/bundler_minify.test.ts         |  40 +++++++
 test/bundler/transpiler/direct-eval.test.ts | 180 ++++++++++++++++++++++++++++
 3 files changed, 229 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js_parser/p.rs                              10      5      0
test/bundler/bundler_minify.test.ts              1      2      0
test/bundler/transpiler/direct-eval.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->