### PR TITLE
resolver: close three holes in the TypeScript extension rewrite

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -2052,7 +2052,7 @@ impl<'a> ESModule<'a> {
                         };
                     }
 
-                    // Wildcard expansion: tag for `probe_wildcard_extensions` (oven-sh/bun#29679, #10001).
+                    // Wildcard expansion: tag for `probe_target_extensions` (oven-sh/bun#29679, #10001).
                     dedent!();
                     return Resolution {
                         path: Box::<[u8]>::from(result),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3698,16 +3698,15 @@ impl<'a> Resolver<'a> {
                         let ends_with_star = esm_resolution.status == Status::ExactEndsWithStar;
                         esm_resolution.status = Status::ModuleNotFound;
 
-                        if ends_with_star
-                            && self.probe_wildcard_extensions(
-                                resolved_dir_info,
-                                dirname_fd,
-                                package_json,
-                                base,
-                                extension_order,
-                                out,
-                            )
-                        {
+                        if self.probe_target_extensions(
+                            resolved_dir_info,
+                            dirname_fd,
+                            package_json,
+                            base,
+                            extension_order,
+                            ends_with_star,
+                            out,
+                        ) {
                             return MatchStatus::Success;
                         }
                         return MatchStatus::NotFound;
@@ -3721,12 +3720,13 @@ impl<'a> Resolver<'a> {
                 {
                     let ends_with_star = esm_resolution.status == Status::ExactEndsWithStar;
                     if ends_with_star
-                        && self.probe_wildcard_extensions(
+                        && self.probe_target_extensions(
                             resolved_dir_info,
                             dirname_fd,
                             package_json,
                             base,
                             extension_order,
+                            true,
                             out,
                         )
                     {
@@ -3838,24 +3838,29 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Wildcard `exports`/`imports` target isn't a file: probe extensions like `load_as_file` does.
+    /// `exports`/`imports` target isn't a file: probe extensions like `load_as_file` does.
+    ///
+    /// Only a wildcard target (`"./*": "./dist/*"`) gets `extension_order`
+    /// appended when it has no extension (oven-sh/bun#29679). Every target gets
+    /// the TypeScript `.js` → `.ts` rewrite, like esbuild's
+    /// `finalizeImportsExportsResult` (oven-sh/bun#10001).
     ///
     /// Each probe goes through [`DirInfo::get_entry`] so the map walk happens
     /// under `entries_mutex`; `dirname_fd` was captured under the caller's
     /// critical section.
-    fn probe_wildcard_extensions(
+    fn probe_target_extensions(
         &mut self,
         resolved_dir_info: DirInfoRef,
         dirname_fd: FD,
         package_json: &PackageJSON,
         base: &[u8],
         extension_order: options::ExtOrder,
+        is_wildcard: bool,
         out: &mut MatchResult,
     ) -> bool {
         let rfs = self.rfs_ptr();
 
-        // Extensionless target (`"./*": "./dist/*"`): append extension_order (oven-sh/bun#29679).
-        if bun_paths::extension(base).is_empty() {
+        if is_wildcard && bun_paths::extension(base).is_empty() {
             let buf = bufs!(load_as_file);
             buf[..base.len()].copy_from_slice(base);
             for ext in self.opts.ext_order_slice(extension_order).iter() {
@@ -3890,20 +3895,11 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // `.js`/`.jsx`/`.mjs` → `.ts`/`.tsx`/`.mts`: same rewrite as `load_as_file` (oven-sh/bun#10001).
         if let Some(last_dot) = strings::last_index_of_char(base, b'.') {
             let ext = &base[last_dot..];
-            let ts_exts: &[&[u8]] = if ext == b".js" || ext == b".jsx" {
-                &[b".ts", b".tsx", b".mts"]
-            } else if ext == b".mjs"
-                && (!FeatureFlags::DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES
-                    || !(resolved_dir_info.is_node_modules()
-                        || resolved_dir_info.is_inside_node_modules()))
-            {
-                &[b".mts"]
-            } else {
-                &[]
-            };
+            let ts_exts = rewritten_file_extensions(ext, || {
+                resolved_dir_info.is_node_modules() || resolved_dir_info.is_inside_node_modules()
+            });
 
             if !ts_exts.is_empty() {
                 let segment = &base[..last_dot];
@@ -4816,6 +4812,10 @@ impl<'a> Resolver<'a> {
             {
                 if strings::eql_long(key, path, true) {
                     for original_path in value.iter() {
+                        if self.is_type_only_tsconfig_path(original_path) {
+                            continue;
+                        }
+
                         let mut absolute_original_path: &[u8] = original_path;
 
                         if !bun_paths::is_absolute(absolute_original_path) {
@@ -4949,6 +4949,10 @@ impl<'a> Resolver<'a> {
                     continue;
                 };
 
+                if self.is_type_only_tsconfig_path(absolute_original_path) {
+                    continue;
+                }
+
                 if self
                     .load_as_file_or_directory(absolute_original_path, kind, out)
                     .is_success()
@@ -4959,6 +4963,26 @@ impl<'a> Resolver<'a> {
         }
 
         MatchStatus::NotFound
+    }
+
+    /// A `paths` substitution that ends in `.d.ts` is only there for type
+    /// checking. Skip it so the import falls through to the real module,
+    /// like esbuild's `matchTSConfigPaths`.
+    fn is_type_only_tsconfig_path(&mut self, substitution: &[u8]) -> bool {
+        const DTS: &[u8] = b".d.ts";
+        let Some(tail_start) = substitution.len().checked_sub(DTS.len()) else {
+            return false;
+        };
+        if !substitution[tail_start..].eq_ignore_ascii_case(DTS) {
+            return false;
+        }
+        if let Some(debug) = self.debug_logs.as_mut() {
+            debug.add_note_fmt(format_args!(
+                "Ignoring substitution \"{}\" because it ends in \".d.ts\"",
+                bstr::BStr::new(substitution)
+            ));
+        }
+        true
     }
 
     pub(crate) fn load_package_imports(
@@ -5906,39 +5930,15 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // TypeScript-specific behavior: if the extension is ".js" or ".jsx", try
-        // replacing it with ".ts" or ".tsx". At the time of writing this specific
-        // behavior comes from the function "loadModuleFromFile()" in the file
-        // "moduleNameThisResolver.ts" in the TypeScript compiler source code. It
-        // contains this comment:
-        //
-        //   If that didn't work, try stripping a ".js" or ".jsx" extension and
-        //   replacing it with a TypeScript one; e.g. "./foo.js" can be matched
-        //   by "./foo.ts" or "./foo.d.ts"
-        //
-        // We don't care about ".d.ts" files because we can't do anything with
-        // those, so we ignore that part of the behavior.
-        //
-        // See the discussion here for more historical context:
-        // https://github.com/microsoft/TypeScript/issues/4595
+        // TypeScript-specific behavior: try rewriting ".js" to ".ts".
         if let Some(last_dot) = strings::last_index_of_char(base, b'.') {
             let ext = &base[last_dot..base.len()];
-            // NOTE: the node_modules gate only applies to the `.mjs` arm.
-            if ext == b".js"
-                || ext == b".jsx"
-                || (ext == b".mjs"
-                    && (!FeatureFlags::DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES
-                        || !strings::path_contains_node_modules_folder(path)))
-            {
+            let exts =
+                rewritten_file_extensions(ext, || strings::path_contains_node_modules_folder(path));
+            if !exts.is_empty() {
                 let segment = &base[0..last_dot];
                 let tail = &mut bufs!(load_as_file)[path.len() - base.len()..];
                 tail[..segment.len()].copy_from_slice(segment);
-
-                let exts: &[&[u8]] = if ext == b".mjs" {
-                    &[b".mts"]
-                } else {
-                    &[b".ts", b".tsx", b".mts"]
-                };
 
                 for ext_to_replace in exts {
                     let buffer = &mut tail[0..segment.len() + ext_to_replace.len()];
@@ -6781,6 +6781,45 @@ bun_core::comptime_string_map! {
 #[inline]
 fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()
+}
+
+/// TypeScript-specific behavior: if the extension is ".js" or ".jsx", try
+/// replacing it with ".ts" or ".tsx". At the time of writing this specific
+/// behavior comes from the function "loadModuleFromFile()" in the file
+/// "moduleNameResolver.ts" in the TypeScript compiler source code. It
+/// contains this comment:
+///
+///   If that didn't work, try stripping a ".js" or ".jsx" extension and
+///   replacing it with a TypeScript one; e.g. "./foo.js" can be matched
+///   by "./foo.ts" or "./foo.d.ts"
+///
+/// We don't care about ".d.ts" files because we can't do anything with
+/// those, so we ignore that part of the behavior.
+///
+/// See the discussion here for more historical context:
+/// https://github.com/microsoft/TypeScript/issues/4595
+///
+/// Same table as esbuild's `rewrittenFileExtensions`, except that the `.js`
+/// arm also tries `.mts` (oven-sh/bun#12580). `inside_node_modules` only
+/// gates the `.mjs` and `.cjs` arms (`DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES`
+/// never applied to `.js`/`.jsx`).
+fn rewritten_file_extensions(
+    ext: &[u8],
+    inside_node_modules: impl Fn() -> bool,
+) -> &'static [&'static [u8]] {
+    match ext {
+        // Note that the official compiler code always tries ".ts" before
+        // ".tsx" even if the original extension was ".jsx".
+        b".js" | b".jsx" => &[b".ts", b".tsx", b".mts"],
+        b".mjs" | b".cjs"
+            if FeatureFlags::DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES && inside_node_modules() =>
+        {
+            &[]
+        }
+        b".mjs" => &[b".mts"],
+        b".cjs" => &[b".cts"],
+        _ => &[],
+    }
 }
 
 pub struct Dirname;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3839,11 +3839,8 @@ impl<'a> Resolver<'a> {
     }
 
     /// `exports`/`imports` target isn't a file: probe extensions like `load_as_file` does.
-    ///
-    /// Only a wildcard target (`"./*": "./dist/*"`) gets `extension_order`
-    /// appended when it has no extension (oven-sh/bun#29679). Every target gets
-    /// the TypeScript `.js` → `.ts` rewrite, like esbuild's
-    /// `finalizeImportsExportsResult` (oven-sh/bun#10001).
+    /// `is_wildcard` enables the extensionless probe (oven-sh/bun#29679). The
+    /// TypeScript rewrite (oven-sh/bun#10001) runs for every target, as in esbuild.
     ///
     /// Each probe goes through [`DirInfo::get_entry`] so the map walk happens
     /// under `entries_mutex`; `dirname_fd` was captured under the caller's
@@ -4965,9 +4962,8 @@ impl<'a> Resolver<'a> {
         MatchStatus::NotFound
     }
 
-    /// A `paths` substitution that names a declaration file is only there for
-    /// type checking. Skip it so the import falls through to the real module,
-    /// like esbuild's `matchTSConfigPaths` (which checks `.d.ts` only).
+    /// A `paths` substitution that names a declaration file exists for type checking
+    /// only. Skip it, like esbuild's `matchTSConfigPaths` (which checks `.d.ts` only).
     fn is_type_only_tsconfig_path(&mut self, substitution: &[u8]) -> bool {
         const DECLARATION_EXTS: [&[u8]; 3] = [b".d.ts", b".d.mts", b".d.cts"];
         let Some(ext) = DECLARATION_EXTS.iter().find(|ext| {
@@ -6786,33 +6782,16 @@ fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()
 }
 
-/// TypeScript-specific behavior: if the extension is ".js" or ".jsx", try
-/// replacing it with ".ts" or ".tsx". At the time of writing this specific
-/// behavior comes from the function "loadModuleFromFile()" in the file
-/// "moduleNameResolver.ts" in the TypeScript compiler source code. It
-/// contains this comment:
-///
-///   If that didn't work, try stripping a ".js" or ".jsx" extension and
-///   replacing it with a TypeScript one; e.g. "./foo.js" can be matched
-///   by "./foo.ts" or "./foo.d.ts"
-///
-/// We don't care about ".d.ts" files because we can't do anything with
-/// those, so we ignore that part of the behavior.
-///
-/// See the discussion here for more historical context:
-/// https://github.com/microsoft/TypeScript/issues/4595
-///
-/// Same table as esbuild's `rewrittenFileExtensions`, except that the `.js`
-/// arm also tries `.mts` (oven-sh/bun#12580). `inside_node_modules` only
-/// gates the `.mjs` and `.cjs` arms (`DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES`
-/// never applied to `.js`/`.jsx`).
+/// TypeScript matches `./foo.js` with `./foo.ts` (microsoft/TypeScript#4595). This
+/// is esbuild's `rewrittenFileExtensions` table plus Bun's `.js` → `.mts`
+/// (oven-sh/bun#12580). `inside_node_modules` gates only `.mjs` and `.cjs`:
+/// `DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES` never applied to `.js`/`.jsx`.
 fn rewritten_file_extensions(
     ext: &[u8],
     inside_node_modules: impl Fn() -> bool,
 ) -> &'static [&'static [u8]] {
     match ext {
-        // Note that the official compiler code always tries ".ts" before
-        // ".tsx" even if the original extension was ".jsx".
+        // tsc tries `.ts` before `.tsx` even for a `.jsx` import.
         b".js" | b".jsx" => &[b".ts", b".tsx", b".mts"],
         b".mjs" | b".cjs"
             if FeatureFlags::DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES && inside_node_modules() =>

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4894,6 +4894,10 @@ impl<'a> Resolver<'a> {
             }
 
             for original_path in longest_match.original_paths.iter() {
+                if self.is_type_only_tsconfig_path(original_path) {
+                    continue;
+                }
+
                 // Swap out the "*" in the original path for whatever the "*" matched
                 let matched_text =
                     &path[longest_match.prefix.len()..path.len() - longest_match.suffix.len()];
@@ -4946,10 +4950,6 @@ impl<'a> Resolver<'a> {
                     continue;
                 };
 
-                if self.is_type_only_tsconfig_path(absolute_original_path) {
-                    continue;
-                }
-
                 if self
                     .load_as_file_or_directory(absolute_original_path, kind, out)
                     .is_success()
@@ -4962,8 +4962,10 @@ impl<'a> Resolver<'a> {
         MatchStatus::NotFound
     }
 
-    /// A `paths` substitution that names a declaration file exists for type checking
+    /// A `paths` substitution written as a declaration file exists for type checking
     /// only. Skip it, like esbuild's `matchTSConfigPaths` (which checks `.d.ts` only).
+    /// This looks at the tsconfig text, not the `*` expansion: `"@/*": ["./src/*"]`
+    /// must still resolve `import "@/env.d.ts"`.
     fn is_type_only_tsconfig_path(&mut self, substitution: &[u8]) -> bool {
         const DECLARATION_EXTS: [&[u8]; 3] = [b".d.ts", b".d.mts", b".d.cts"];
         let Some(ext) = DECLARATION_EXTS.iter().find(|ext| {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4965,21 +4965,24 @@ impl<'a> Resolver<'a> {
         MatchStatus::NotFound
     }
 
-    /// A `paths` substitution that ends in `.d.ts` is only there for type
-    /// checking. Skip it so the import falls through to the real module,
-    /// like esbuild's `matchTSConfigPaths`.
+    /// A `paths` substitution that names a declaration file is only there for
+    /// type checking. Skip it so the import falls through to the real module,
+    /// like esbuild's `matchTSConfigPaths` (which checks `.d.ts` only).
     fn is_type_only_tsconfig_path(&mut self, substitution: &[u8]) -> bool {
-        const DTS: &[u8] = b".d.ts";
-        let Some(tail_start) = substitution.len().checked_sub(DTS.len()) else {
+        const DECLARATION_EXTS: [&[u8]; 3] = [b".d.ts", b".d.mts", b".d.cts"];
+        let Some(ext) = DECLARATION_EXTS.iter().find(|ext| {
+            substitution
+                .len()
+                .checked_sub(ext.len())
+                .is_some_and(|start| substitution[start..].eq_ignore_ascii_case(ext))
+        }) else {
             return false;
         };
-        if !substitution[tail_start..].eq_ignore_ascii_case(DTS) {
-            return false;
-        }
         if let Some(debug) = self.debug_logs.as_mut() {
             debug.add_note_fmt(format_args!(
-                "Ignoring substitution \"{}\" because it ends in \".d.ts\"",
-                bstr::BStr::new(substitution)
+                "Ignoring substitution \"{}\" because it ends in \"{}\"",
+                bstr::BStr::new(substitution),
+                bstr::BStr::new(ext)
             ));
         }
         true

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1568,6 +1568,127 @@ describe("bundler", () => {
       "/Users/user/project/src/entry.js": [`Could not resolve: "pkg1/foo/bar". Maybe you need to "bun install"?`],
     },
   });
+  // An `exports`/`imports` target that is not on disk gets the same TypeScript
+  // extension rewrite as a relative import (esbuild's `rewrittenFileExtensions`
+  // in `finalizeImportsExportsResult`), for exact and wildcard keys alike.
+  // Bun also tries `.mts` for a `.js` target.
+  for (const [from, to] of [
+    ["js", "ts"],
+    ["js", "tsx"],
+    ["jsx", "ts"],
+    ["jsx", "tsx"],
+    ["mjs", "mts"],
+    ["cjs", "cts"],
+    ["js", "mts"],
+  ]) {
+    itBundled(`packagejson/ExportsImportsRewrite_${from}_to_${to}`, {
+      files: {
+        "/Users/user/project/src/entry.ts": /* ts */ `
+          import { exportsExact } from 'rewrite-pkg/exact'
+          import { exportsWild } from 'rewrite-pkg/wild/a'
+          import { importsExact } from '#exact'
+          import { importsWild } from '#wild/a'
+          console.log(exportsExact, exportsWild, importsExact, importsWild)
+        `,
+        "/Users/user/project/package.json": /* json */ `
+          {
+            "name": "rewrite-pkg",
+            "type": "module",
+            "exports": {
+              "./exact": "./src/exports-exact.${from}",
+              "./wild/*": "./src/exports-wild/*.${from}"
+            },
+            "imports": {
+              "#exact": "./src/imports-exact.${from}",
+              "#wild/*": "./src/imports-wild/*.${from}"
+            }
+          }
+        `,
+        [`/Users/user/project/src/exports-exact.${to}`]: `export const exportsExact = 'exports-exact.${to}'`,
+        [`/Users/user/project/src/exports-wild/a.${to}`]: `export const exportsWild = 'exports-wild.${to}'`,
+        [`/Users/user/project/src/imports-exact.${to}`]: `export const importsExact = 'imports-exact.${to}'`,
+        [`/Users/user/project/src/imports-wild/a.${to}`]: `export const importsWild = 'imports-wild.${to}'`,
+      },
+      run: {
+        stdout: `exports-exact.${to} exports-wild.${to} imports-exact.${to} imports-wild.${to}`,
+      },
+    });
+  }
+  itBundled("packagejson/ExportsImportsRewriteExactTargetOnDiskWins", {
+    files: {
+      "/Users/user/project/src/entry.ts": /* ts */ `
+        import { feature } from 'exact-js-wins/feature'
+        import { feature as feature2 } from '#feature'
+        console.log(feature, feature2)
+      `,
+      "/Users/user/project/package.json": /* json */ `
+        {
+          "name": "exact-js-wins",
+          "type": "module",
+          "exports": { "./feature": "./src/feature.js" },
+          "imports": { "#feature": "./src/feature.js" }
+        }
+      `,
+      "/Users/user/project/src/feature.js": `export const feature = 'js file'`,
+      "/Users/user/project/src/feature.ts": `export const feature = 'ts file'`,
+    },
+    run: {
+      stdout: "js file js file",
+    },
+  });
+  itBundled("packagejson/ExportsImportsRewriteStaysInFamily", {
+    files: {
+      "/Users/user/project/src/entry.ts": /* ts */ `
+        import 'family/c'
+        import '#m'
+      `,
+      "/Users/user/project/package.json": /* json */ `
+        {
+          "name": "family",
+          "type": "module",
+          "exports": { "./c": "./src/c.cjs" },
+          "imports": { "#m": "./src/m.mjs" }
+        }
+      `,
+      "/Users/user/project/src/c.ts": ``,
+      "/Users/user/project/src/c.mts": ``,
+      "/Users/user/project/src/m.ts": ``,
+      "/Users/user/project/src/m.cts": ``,
+    },
+    bundleErrors: {
+      "/Users/user/project/src/entry.ts": [
+        `Could not resolve: "family/c". Maybe you need to "bun install"?`,
+        `Could not resolve: "#m". Maybe you need to "bun install"?`,
+      ],
+    },
+  });
+  // Inside node_modules the `.mjs` → `.mts` and `.cjs` → `.cts` rewrites are
+  // off (`DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES`); `.js` → `.ts` stays on.
+  itBundled("packagejson/ExportsRewriteInsideNodeModules", {
+    files: {
+      "/Users/user/project/src/entry.ts": /* ts */ `
+        import { j } from 'dep/j'
+        import 'dep/c'
+        import 'dep/m'
+        console.log(j)
+      `,
+      "/Users/user/project/node_modules/dep/package.json": /* json */ `
+        {
+          "name": "dep",
+          "exports": { "./c": "./c.cjs", "./m": "./m.mjs", "./j": "./j.js" }
+        }
+      `,
+      "/Users/user/project/node_modules/dep/c.cts": ``,
+      "/Users/user/project/node_modules/dep/m.mts": ``,
+      "/Users/user/project/node_modules/dep/j.ts": `export const j = 'ts'`,
+    },
+    bundleErrors: {
+      "/Users/user/project/src/entry.ts": [
+        `Could not resolve: "dep/c". Maybe you need to "bun install"?`,
+        `Could not resolve: "dep/m". Maybe you need to "bun install"?`,
+      ],
+    },
+  });
   itBundled("packagejson/ExportsNoConditionsMatch", {
     // GENERATED
     files: {

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -1746,10 +1746,52 @@ describe("bundler", () => {
   itBundled("ts/ImportCTS", {
     files: {
       "/entry.ts": `require('./required.cjs')`,
-      "/required.cjs": `console.log('works')`,
+      "/required.cts": `console.log('works')`,
     },
     run: {
       stdout: "works",
+    },
+  });
+  // Same table as esbuild's `rewrittenFileExtensions`, plus Bun's `.js` → `.mts`.
+  itBundled("ts/ImportRewrittenExtensions", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { a } from './a.js'
+        import { b } from './b.js'
+        import { c } from './c.jsx'
+        import { d } from './d.jsx'
+        import { e } from './e.mjs'
+        import { f } from './f.cjs'
+        import { g } from './g.js'
+        console.log(a, b, c, d, e, f, g)
+      `,
+      "/a.ts": `export const a = 'a.ts'`,
+      "/b.tsx": `export const b = 'b.tsx'`,
+      "/c.ts": `export const c = 'c.ts'`,
+      "/d.tsx": `export const d = 'd.tsx'`,
+      "/e.mts": `export const e = 'e.mts'`,
+      "/f.cts": `export const f = 'f.cts'`,
+      "/g.mts": `export const g = 'g.mts'`,
+    },
+    run: {
+      stdout: "a.ts b.tsx c.ts d.tsx e.mts f.cts g.mts",
+    },
+  });
+  itBundled("ts/ImportRewrittenExtensionsStayInFamily", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import './a.cjs'
+        import './b.mjs'
+        import './c.js'
+      `,
+      "/a.ts": ``,
+      "/a.mts": ``,
+      "/b.cts": ``,
+      "/b.ts": ``,
+      "/c.cts": ``,
+    },
+    bundleErrors: {
+      "/entry.ts": [`Could not resolve: "./a.cjs"`, `Could not resolve: "./b.mjs"`, `Could not resolve: "./c.js"`],
     },
   });
   itBundled("ts/SideEffectsFalseWarningTypeDeclarations", {

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -897,6 +897,33 @@ describe("bundler", () => {
       "/Users/user/project/entry.ts": [`Could not resolve: "types-only". Maybe you need to "bun install"?`],
     },
   });
+  // Only the tsconfig text counts. A catch-all alias still resolves a specifier
+  // that names a declaration file itself.
+  itBundled("tsconfig/PathsCatchAllResolvesDeclarationSpecifier", {
+    files: {
+      "/Users/user/project/entry.ts": /* ts */ `
+        import "@/env.d.ts";
+        console.log("ok");
+      `,
+      "/Users/user/project/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@/*": ["./src/*"]
+            }
+          }
+        }
+      `,
+      "/Users/user/project/src/env.d.ts": /* ts */ `
+        declare global { interface Env { FOO: string } }
+        export {};
+      `,
+    },
+    run: {
+      stdout: "ok",
+    },
+  });
   return;
   itBundled("tsconfig/NestedJSX", {
     // GENERATED

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -787,13 +787,11 @@ describe("bundler", () => {
       api.expectFile("/Users/user/project/out.js").toContain(`React.createElement`);
     },
   });
-  return;
   itBundled("tsconfig/PathsTypeOnly", {
-    // GENERATED
     files: {
       "/Users/user/project/entry.ts": /* ts */ `
         import { fib } from "fib";
-  
+
         console.log(fib(10));
       `,
       "/Users/user/project/node_modules/fib/index.js": /* js */ `
@@ -816,7 +814,79 @@ describe("bundler", () => {
         }
       `,
     },
+    run: {
+      stdout: "55",
+    },
   });
+  // A `paths` substitution that ends in `.d.ts` (any case) is skipped, for an
+  // exact key and after `*` substitution. The import falls through to the next
+  // substitution or to node_modules, like esbuild's `matchTSConfigPaths`.
+  itBundled("tsconfig/PathsSkipDeclarationFiles", {
+    files: {
+      "/Users/user/project/entry.ts": /* ts */ `
+        import { x } from "foo";
+        import { y } from "bar/lib";
+        import { u } from "upper";
+        import { v } from "upper-star/up";
+        import { f } from "fallback";
+        console.log(x, y, u, v, f);
+      `,
+      "/Users/user/project/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "foo": ["./types/foo.d.ts"],
+              "bar/*": ["./types/*.d.ts"],
+              "upper": ["./types/upper.D.TS"],
+              "upper-star/*": ["./types/*.D.TS"],
+              "fallback": ["./types/fallback.d.ts", "./src/fallback.ts"]
+            }
+          }
+        }
+      `,
+      "/Users/user/project/types/foo.d.ts": `export declare const x: number;`,
+      "/Users/user/project/types/lib.d.ts": `export declare const y: number;`,
+      "/Users/user/project/types/upper.D.TS": `export declare const u: number;`,
+      "/Users/user/project/types/up.D.TS": `export declare const v: number;`,
+      "/Users/user/project/types/fallback.d.ts": `export declare const f: string;`,
+      "/Users/user/project/src/fallback.ts": `export const f = "fallback.ts";`,
+      "/Users/user/project/node_modules/foo/package.json": `{ "name": "foo", "type": "module", "main": "index.js" }`,
+      "/Users/user/project/node_modules/foo/index.js": `export const x = 123;`,
+      "/Users/user/project/node_modules/bar/package.json": `{ "name": "bar", "type": "module" }`,
+      "/Users/user/project/node_modules/bar/lib.js": `export const y = 456;`,
+      "/Users/user/project/node_modules/upper/package.json": `{ "name": "upper", "type": "module", "main": "index.js" }`,
+      "/Users/user/project/node_modules/upper/index.js": `export const u = 7;`,
+      "/Users/user/project/node_modules/upper-star/package.json": `{ "name": "upper-star", "type": "module" }`,
+      "/Users/user/project/node_modules/upper-star/up.js": `export const v = 8;`,
+    },
+    run: {
+      stdout: "123 456 7 8 fallback.ts",
+    },
+  });
+  itBundled("tsconfig/PathsSkipDeclarationFilesNoFallback", {
+    files: {
+      "/Users/user/project/entry.ts": /* ts */ `
+        import { z } from "types-only";
+        console.log(z);
+      `,
+      "/Users/user/project/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "types-only": ["./types/types-only.d.ts"]
+            }
+          }
+        }
+      `,
+      "/Users/user/project/types/types-only.d.ts": `export declare const z: number;`,
+    },
+    bundleErrors: {
+      "/Users/user/project/entry.ts": [`Could not resolve: "types-only". Maybe you need to "bun install"?`],
+    },
+  });
+  return;
   itBundled("tsconfig/NestedJSX", {
     // GENERATED
     files: {

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -818,9 +818,10 @@ describe("bundler", () => {
       stdout: "55",
     },
   });
-  // A `paths` substitution that ends in `.d.ts` (any case) is skipped, for an
-  // exact key and after `*` substitution. The import falls through to the next
-  // substitution or to node_modules, like esbuild's `matchTSConfigPaths`.
+  // A `paths` substitution that names a declaration file (`.d.ts`, `.d.mts`,
+  // `.d.cts`, any case) is skipped, for an exact key and after `*`
+  // substitution. The import falls through to the next substitution or to
+  // node_modules, like esbuild's `matchTSConfigPaths` does for `.d.ts`.
   itBundled("tsconfig/PathsSkipDeclarationFiles", {
     files: {
       "/Users/user/project/entry.ts": /* ts */ `
@@ -829,7 +830,9 @@ describe("bundler", () => {
         import { u } from "upper";
         import { v } from "upper-star/up";
         import { f } from "fallback";
-        console.log(x, y, u, v, f);
+        import { m } from "esm-types";
+        import { c } from "cjs-types/lib";
+        console.log(x, y, u, v, f, m, c);
       `,
       "/Users/user/project/tsconfig.json": /* json */ `
         {
@@ -840,7 +843,9 @@ describe("bundler", () => {
               "bar/*": ["./types/*.d.ts"],
               "upper": ["./types/upper.D.TS"],
               "upper-star/*": ["./types/*.D.TS"],
-              "fallback": ["./types/fallback.d.ts", "./src/fallback.ts"]
+              "fallback": ["./types/fallback.d.ts", "./src/fallback.ts"],
+              "esm-types": ["./types/esm-types.d.mts"],
+              "cjs-types/*": ["./types/*.d.cts"]
             }
           }
         }
@@ -850,6 +855,8 @@ describe("bundler", () => {
       "/Users/user/project/types/upper.D.TS": `export declare const u: number;`,
       "/Users/user/project/types/up.D.TS": `export declare const v: number;`,
       "/Users/user/project/types/fallback.d.ts": `export declare const f: string;`,
+      "/Users/user/project/types/esm-types.d.mts": `export declare const m: number;`,
+      "/Users/user/project/types/lib.d.cts": `export declare const c: number;`,
       "/Users/user/project/src/fallback.ts": `export const f = "fallback.ts";`,
       "/Users/user/project/node_modules/foo/package.json": `{ "name": "foo", "type": "module", "main": "index.js" }`,
       "/Users/user/project/node_modules/foo/index.js": `export const x = 123;`,
@@ -859,9 +866,13 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/upper/index.js": `export const u = 7;`,
       "/Users/user/project/node_modules/upper-star/package.json": `{ "name": "upper-star", "type": "module" }`,
       "/Users/user/project/node_modules/upper-star/up.js": `export const v = 8;`,
+      "/Users/user/project/node_modules/esm-types/package.json": `{ "name": "esm-types", "main": "index.mjs" }`,
+      "/Users/user/project/node_modules/esm-types/index.mjs": `export const m = 9;`,
+      "/Users/user/project/node_modules/cjs-types/package.json": `{ "name": "cjs-types" }`,
+      "/Users/user/project/node_modules/cjs-types/lib.js": `module.exports.c = 10;`,
     },
     run: {
-      stdout: "123 456 7 8 fallback.ts",
+      stdout: "123 456 7 8 fallback.ts 9 10",
     },
   });
   itBundled("tsconfig/PathsSkipDeclarationFilesNoFallback", {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1363,11 +1363,10 @@ describe("wildcard exports with extensionless target", () => {
 });
 
 // https://github.com/oven-sh/bun/issues/10001
-// Wildcard `imports`/`exports` that point at a `.js` target should also
-// pick up `.ts`/`.tsx`/`.mts` the same way Bun already does for plain
-// file loads (e.g. `import './foo.js'` finds `./foo.ts`). The rewrite
-// is gated on wildcard patterns only — users writing an explicit
-// `"./foo": "./foo.js"` target still get exactly what they asked for.
+// `imports`/`exports` that point at a `.js` target should also pick up
+// `.ts`/`.tsx`/`.mts` the same way Bun already does for plain file loads
+// (e.g. `import './foo.js'` finds `./foo.ts`). Wildcard and exact targets
+// alike, as in esbuild. A target that exists on disk is never rewritten.
 describe("wildcard imports/exports with `.js` → `.ts` rewrite", () => {
   test.concurrent("package.json `imports` wildcard with `.js` target resolves `.ts` file", async () => {
     using dir = tempDir("wildcard-imports-ts", {
@@ -1485,8 +1484,8 @@ describe("wildcard imports/exports with `.js` → `.ts` rewrite", () => {
     });
   });
 
-  test.concurrent("exact (non-wildcard) `.js` target is not rewritten to `.ts`", async () => {
-    using dir = tempDir("exact-no-rewrite", {
+  test.concurrent("exact (non-wildcard) `.js` target is rewritten to `.ts` too", async () => {
+    using dir = tempDir("exact-rewrite", {
       "package.json": JSON.stringify({
         name: "exact-pkg",
         type: "module",
@@ -1499,8 +1498,226 @@ describe("wildcard imports/exports with `.js` → `.ts` rewrite", () => {
       `,
     });
 
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "ts feature",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
+// The TypeScript extension rewrite (`import "./x.js"` finds `x.ts`) uses the
+// same table as esbuild's `rewrittenFileExtensions`, plus Bun's `.js` → `.mts`.
+// It applies to relative imports and to every `exports`/`imports` target,
+// exact or wildcard.
+const tsExtensionRewrites: [from: string, to: string][] = [
+  ["js", "ts"],
+  ["js", "tsx"],
+  ["jsx", "ts"],
+  ["jsx", "tsx"],
+  ["mjs", "mts"],
+  ["cjs", "cts"],
+  // Bun-specific (oven-sh/bun#12580). esbuild and tsc only try `.ts`/`.tsx` here.
+  ["js", "mts"],
+];
+
+describe("TypeScript extension rewrite matrix", () => {
+  test.concurrent.each(tsExtensionRewrites)("`.%s` specifier resolves a `.%s` file everywhere", async (from, to) => {
+    using dir = tempDir(`ts-rewrite-${from}-${to}`, {
+      "package.json": JSON.stringify({
+        name: "rewrite-pkg",
+        type: "module",
+        exports: {
+          "./exact": `./src/exports-exact.${from}`,
+          "./wild/*": `./src/exports-wild/*.${from}`,
+        },
+        imports: {
+          "#exact": `./src/imports-exact.${from}`,
+          "#wild/*": `./src/imports-wild/*.${from}`,
+        },
+      }),
+      [`src/relative.${to}`]: `export const relative = "relative.${to}";`,
+      [`src/exports-exact.${to}`]: `export const exportsExact = "exports-exact.${to}";`,
+      [`src/exports-wild/a.${to}`]: `export const exportsWild = "exports-wild.${to}";`,
+      [`src/imports-exact.${to}`]: `export const importsExact = "imports-exact.${to}";`,
+      [`src/imports-wild/a.${to}`]: `export const importsWild = "imports-wild.${to}";`,
+      "src/entry.ts": `
+        import { relative } from "./relative.${from}";
+        import { exportsExact } from "rewrite-pkg/exact";
+        import { exportsWild } from "rewrite-pkg/wild/a";
+        import { importsExact } from "#exact";
+        import { importsWild } from "#wild/a";
+        console.log(JSON.stringify({ relative, exportsExact, exportsWild, importsExact, importsWild }));
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "src/entry.ts")).toEqual({
+      stdout: JSON.stringify({
+        relative: `relative.${to}`,
+        exportsExact: `exports-exact.${to}`,
+        exportsWild: `exports-wild.${to}`,
+        importsExact: `imports-exact.${to}`,
+        importsWild: `imports-wild.${to}`,
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent.each([
+    ["cjs", ["ts", "tsx", "mts"]],
+    ["mjs", ["ts", "tsx", "cts"]],
+    ["js", ["cts"]],
+  ] as [from: string, present: string[]][])("`.%s` specifier does not pick up %j files", async (from, present) => {
+    using dir = tempDir(`ts-rewrite-negative-${from}`, {
+      ...Object.fromEntries(present.map(ext => [`lib.${ext}`, `export const lib = "${ext}";`])),
+      "entry.ts": `
+          import { lib } from "./lib.${from}";
+          console.log(lib);
+        `,
+    });
+
+    const result = await runWildcardScript(String(dir), "entry.ts");
+    expect(result.stderr).toContain(`Cannot find module './lib.${from}'`);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test.concurrent("an exact target that exists on disk is never rewritten", async () => {
+    using dir = tempDir("ts-rewrite-exact-js-wins", {
+      "package.json": JSON.stringify({
+        name: "exact-js-wins",
+        type: "module",
+        exports: { "./feature": "./src/feature.js" },
+        imports: { "#feature": "./src/feature.js" },
+      }),
+      "src/feature.js": `export const feature = "js file";`,
+      "src/feature.ts": `export const feature = "ts file";`,
+      "index.ts": `
+        import { feature } from "exact-js-wins/feature";
+        import { feature as feature2 } from "#feature";
+        console.log(feature, feature2);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "js file js file",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("an exact target with no extension is not probed", async () => {
+    using dir = tempDir("ts-rewrite-exact-extensionless", {
+      "package.json": JSON.stringify({
+        name: "exact-extensionless",
+        type: "module",
+        imports: { "#feature": "./src/feature" },
+      }),
+      "src/feature.ts": `export const feature = "ts file";`,
+      "index.ts": `
+        import { feature } from "#feature";
+        console.log(feature);
+      `,
+    });
+
     const result = await runWildcardScript(String(dir), "index.ts");
     expect(result.stderr).toContain("Cannot find");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  // Inside node_modules the `.mjs` → `.mts` and `.cjs` → `.cts` rewrites are
+  // off (`DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES`); `.js` → `.ts` stays on.
+  test.concurrent("`.cjs` and `.mjs` targets are not rewritten inside node_modules", async () => {
+    using dir = tempDir("ts-rewrite-node-modules-gate", {
+      "node_modules/dep/package.json": JSON.stringify({
+        name: "dep",
+        exports: { "./c": "./c.cjs", "./m": "./m.mjs", "./j": "./j.js" },
+      }),
+      "node_modules/dep/c.cts": `export const c = "cts";`,
+      "node_modules/dep/m.mts": `export const m = "mts";`,
+      "node_modules/dep/j.ts": `export const j = "ts";`,
+      "index.ts": `
+        for (const specifier of ["dep/c", "dep/m", "dep/j"]) {
+          try {
+            console.log(specifier, Object.values(await import(specifier))[0]);
+          } catch (e) {
+            console.log(specifier, e.code);
+          }
+        }
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: ["dep/c ERR_MODULE_NOT_FOUND", "dep/m ERR_MODULE_NOT_FOUND", "dep/j ts"].join("\n"),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
+// A tsconfig `paths` substitution that ends in `.d.ts` is there for type
+// checking only. The resolver skips it (case-insensitively, like esbuild) and
+// falls through to the next substitution or to node_modules.
+describe("tsconfig paths skip `.d.ts` substitutions", () => {
+  test.concurrent("exact, wildcard, and upper-case `.D.TS` entries fall through", async () => {
+    using dir = tempDir("tsconfig-paths-dts", {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "foo": ["./types/foo.d.ts"],
+            "bar/*": ["./types/*.d.ts"],
+            "upper": ["./types/upper.D.TS"],
+            "upper-star/*": ["./types/*.D.TS"],
+            "fallback": ["./types/fallback.d.ts", "./src/fallback.ts"],
+          },
+        },
+      }),
+      "types/foo.d.ts": `export declare const x: number;`,
+      "types/lib.d.ts": `export declare const y: number;`,
+      "types/upper.D.TS": `export declare const u: number;`,
+      "types/up.D.TS": `export declare const v: number;`,
+      "types/fallback.d.ts": `export declare const f: string;`,
+      "src/fallback.ts": `export const f = "fallback.ts";`,
+      "node_modules/foo/package.json": JSON.stringify({ name: "foo", type: "module", main: "index.js" }),
+      "node_modules/foo/index.js": `export const x = 123;`,
+      "node_modules/bar/package.json": JSON.stringify({ name: "bar", type: "module" }),
+      "node_modules/bar/lib.js": `export const y = 456;`,
+      "node_modules/upper/package.json": JSON.stringify({ name: "upper", type: "module", main: "index.js" }),
+      "node_modules/upper/index.js": `export const u = 7;`,
+      "node_modules/upper-star/package.json": JSON.stringify({ name: "upper-star", type: "module" }),
+      "node_modules/upper-star/up.js": `export const v = 8;`,
+      "entry.ts": `
+        import { x } from "foo";
+        import { y } from "bar/lib";
+        import { u } from "upper";
+        import { v } from "upper-star/up";
+        import { f } from "fallback";
+        console.log(x, y, u, v, f);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "entry.ts")).toEqual({
+      stdout: "123 456 7 8 fallback.ts",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("a `.d.ts`-only alias with no real module still reports the original specifier", async () => {
+    using dir = tempDir("tsconfig-paths-dts-missing", {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { baseUrl: ".", paths: { "types-only": ["./types/types-only.d.ts"] } },
+      }),
+      "types/types-only.d.ts": `export declare const z: number;`,
+      "entry.ts": `
+        import { z } from "types-only";
+        console.log(z);
+      `,
+    });
+
+    const result = await runWildcardScript(String(dir), "entry.ts");
+    expect(result.stderr).toContain(`Cannot find package 'types-only'`);
     expect(result.exitCode).not.toBe(0);
   });
 });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1715,6 +1715,27 @@ describe("tsconfig paths skip `.d.ts` substitutions", () => {
     });
   });
 
+  // Only the tsconfig text counts. A catch-all alias still resolves a specifier
+  // that names a declaration file itself.
+  test.concurrent("a `.d.ts` specifier through a catch-all alias still resolves", async () => {
+    using dir = tempDir("tsconfig-paths-dts-specifier", {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+      }),
+      "src/env.d.ts": `declare global { interface Env { FOO: string } }\nexport {};`,
+      "entry.ts": `
+        import "@/env.d.ts";
+        console.log("ok");
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "entry.ts")).toEqual({
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   test.concurrent("a `.d.ts`-only alias with no real module still reports the original specifier", async () => {
     using dir = tempDir("tsconfig-paths-dts-missing", {
       "tsconfig.json": JSON.stringify({

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1655,11 +1655,12 @@ describe("TypeScript extension rewrite matrix", () => {
   });
 });
 
-// A tsconfig `paths` substitution that ends in `.d.ts` is there for type
-// checking only. The resolver skips it (case-insensitively, like esbuild) and
-// falls through to the next substitution or to node_modules.
+// A tsconfig `paths` substitution that names a declaration file (`.d.ts`,
+// `.d.mts`, `.d.cts`, any case) is there for type checking only. The resolver
+// skips it, like esbuild does for `.d.ts`, and falls through to the next
+// substitution or to node_modules.
 describe("tsconfig paths skip `.d.ts` substitutions", () => {
-  test.concurrent("exact, wildcard, and upper-case `.D.TS` entries fall through", async () => {
+  test.concurrent("exact, wildcard, upper-case, `.d.mts` and `.d.cts` entries fall through", async () => {
     using dir = tempDir("tsconfig-paths-dts", {
       "tsconfig.json": JSON.stringify({
         compilerOptions: {
@@ -1670,6 +1671,8 @@ describe("tsconfig paths skip `.d.ts` substitutions", () => {
             "upper": ["./types/upper.D.TS"],
             "upper-star/*": ["./types/*.D.TS"],
             "fallback": ["./types/fallback.d.ts", "./src/fallback.ts"],
+            "esm-types": ["./types/esm-types.d.mts"],
+            "cjs-types/*": ["./types/*.d.cts"],
           },
         },
       }),
@@ -1678,6 +1681,8 @@ describe("tsconfig paths skip `.d.ts` substitutions", () => {
       "types/upper.D.TS": `export declare const u: number;`,
       "types/up.D.TS": `export declare const v: number;`,
       "types/fallback.d.ts": `export declare const f: string;`,
+      "types/esm-types.d.mts": `export declare const m: number;`,
+      "types/lib.d.cts": `export declare const c: number;`,
       "src/fallback.ts": `export const f = "fallback.ts";`,
       "node_modules/foo/package.json": JSON.stringify({ name: "foo", type: "module", main: "index.js" }),
       "node_modules/foo/index.js": `export const x = 123;`,
@@ -1687,18 +1692,24 @@ describe("tsconfig paths skip `.d.ts` substitutions", () => {
       "node_modules/upper/index.js": `export const u = 7;`,
       "node_modules/upper-star/package.json": JSON.stringify({ name: "upper-star", type: "module" }),
       "node_modules/upper-star/up.js": `export const v = 8;`,
+      "node_modules/esm-types/package.json": JSON.stringify({ name: "esm-types", main: "index.mjs" }),
+      "node_modules/esm-types/index.mjs": `export const m = 9;`,
+      "node_modules/cjs-types/package.json": JSON.stringify({ name: "cjs-types" }),
+      "node_modules/cjs-types/lib.js": `module.exports.c = 10;`,
       "entry.ts": `
         import { x } from "foo";
         import { y } from "bar/lib";
         import { u } from "upper";
         import { v } from "upper-star/up";
         import { f } from "fallback";
-        console.log(x, y, u, v, f);
+        import { m } from "esm-types";
+        import { c } from "cjs-types/lib";
+        console.log(x, y, u, v, f, m, c);
       `,
     });
 
     expect(await runWildcardScript(String(dir), "entry.ts")).toEqual({
-      stdout: "123 456 7 8 fallback.ts",
+      stdout: "123 456 7 8 fallback.ts 9 10",
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1627,32 +1627,36 @@ describe("TypeScript extension rewrite matrix", () => {
 
   // Inside node_modules the `.mjs` → `.mts` and `.cjs` → `.cts` rewrites are
   // off (`DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES`); `.js` → `.ts` stays on.
-  test.concurrent("`.cjs` and `.mjs` targets are not rewritten inside node_modules", async () => {
-    using dir = tempDir("ts-rewrite-node-modules-gate", {
-      "node_modules/dep/package.json": JSON.stringify({
-        name: "dep",
-        exports: { "./c": "./c.cjs", "./m": "./m.mjs", "./j": "./j.js" },
-      }),
-      "node_modules/dep/c.cts": `export const c = "cts";`,
-      "node_modules/dep/m.mts": `export const m = "mts";`,
-      "node_modules/dep/j.ts": `export const j = "ts";`,
-      "index.ts": `
-        for (const specifier of ["dep/c", "dep/m", "dep/j"]) {
-          try {
-            console.log(specifier, Object.values(await import(specifier))[0]);
-          } catch (e) {
-            console.log(specifier, e.code);
-          }
-        }
-      `,
-    });
+  test.concurrent.each([
+    ["dep/c", null],
+    ["dep/m", null],
+    ["dep/j", "ts"],
+  ] as [specifier: string, resolved: string | null][])(
+    "`%s` inside node_modules resolves to %j",
+    async (specifier, resolved) => {
+      using dir = tempDir("ts-rewrite-node-modules-gate", {
+        "node_modules/dep/package.json": JSON.stringify({
+          name: "dep",
+          exports: { "./c": "./c.cjs", "./m": "./m.mjs", "./j": "./j.js" },
+        }),
+        "node_modules/dep/c.cts": `export const c = "cts";`,
+        "node_modules/dep/m.mts": `export const m = "mts";`,
+        "node_modules/dep/j.ts": `export const j = "ts";`,
+        "index.ts": `
+          import * as dep from "${specifier}";
+          console.log(Object.values(dep)[0]);
+        `,
+      });
 
-    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
-      stdout: ["dep/c ERR_MODULE_NOT_FOUND", "dep/m ERR_MODULE_NOT_FOUND", "dep/j ts"].join("\n"),
-      stderr: "",
-      exitCode: 0,
-    });
-  });
+      const result = await runWildcardScript(String(dir), "index.ts");
+      if (resolved === null) {
+        expect(result.stderr).toContain(`Cannot find module '${specifier}'`);
+        expect(result.exitCode).not.toBe(0);
+      } else {
+        expect(result).toEqual({ stdout: resolved, stderr: "", exitCode: 0 });
+      }
+    },
+  );
 });
 
 // A tsconfig `paths` substitution that names a declaration file (`.d.ts`,


### PR DESCRIPTION
### Problem
- `import "./bar.cjs"` does not find `bar.cts`. Both rewrite tables in `src/resolver/resolver.rs` map `.js`/`.jsx` → `.ts`/`.tsx`/`.mts` and `.mjs` → `.mts`, but have no `.cjs` → `.cts` arm. `bun run` and `bun build` both fail with `Could not resolve: "./bar.cjs"`. This is the layout tsc emits for `module: node16` CommonJS.
- An exact `exports`/`imports` target that is not on disk is never rewritten. `handle_esm_resolution` only probed `.ts` for `Status::ExactEndsWithStar`, so `"#utils": "./src/utils.js"` with only `utils.ts` fails with `Cannot find package '#utils'`, while the `"#w/*": "./src/*"` form works.
- `match_tsconfig_paths` follows a substitution that ends in `.d.ts`. People map a package to its typings for type checking only, so the import resolves to the declaration file and fails with `Export named 'x' not found in module '.../types/foo.d.ts'`.

### Fix
- One shared table, `rewritten_file_extensions`, replaces the two copies. It matches esbuild's `rewrittenFileExtensions` (`.js`/`.jsx` → `.ts`, `.tsx`; `.mjs` → `.mts`; `.cjs` → `.cts`) and keeps Bun's `.js` → `.mts` (#12580) so no existing project breaks. The `.cjs` arm follows the `.mjs` arm: off inside node_modules (`DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES`).
- `probe_wildcard_extensions` becomes `probe_target_extensions(is_wildcard)`. Every missing target gets the rewrite, like esbuild's `finalizeImportsExportsResult`. The extensionless probe (#29679) stays wildcard-only, so `ExportsExactMissingExtension` still errors.
- `is_type_only_tsconfig_path` skips a substitution written as `.d.ts`, `.d.mts` or `.d.cts` (ASCII case-insensitive) in the exact loop and in the wildcard loop, like esbuild's `matchTSConfigPaths` (which checks `.d.ts` only). The import falls through to the next substitution or to node_modules.
- Verified: `test/js/bun/resolve/resolve.test.ts` (matrix of `.js`/`.jsx`/`.mjs`/`.cjs` × `.ts`/`.tsx`/`.mts`/`.cts` over relative, exact and wildcard `exports`/`imports`, plus the declaration-file cases), `test/bundler/esbuild/{ts,packagejson,tsconfig}.test.ts` (same matrix for `bun build`). Also `test/js/bun/resolve/`, `bundler_edgecase`, `esbuild/default`, `cli/run/tsconfig-override`.

### Background
- The TypeScript extension rewrite comes from tsc's `loadModuleFromFile`: a TS source imports its sibling by the emitted name (`./foo.js`), so the resolver tries `foo.ts` when `foo.js` is absent. Bun and esbuild skip the `.d.ts` part of that rule because a declaration file has no code.
- `exports`/`imports` resolution returns a `Status`. `Exact` is a plain key (`"./utils"`), `ExactEndsWithStar` is a pattern key (`"./*"`). Both land in `handle_esm_resolution`, which checks that the target exists in the directory listing.
- `match_tsconfig_paths` ports tsc's `tryLoadModuleUsingPaths`: exact keys first, then the longest `*` pattern, each with an ordered list of substitutions that are tried with `load_as_file_or_directory`.

<details><summary>Notes</summary>

Repros (all fail on 1.4.1-canary, pass with this branch, in both `bun x.ts` and `bun build x.ts`):

```ts
// bar.cts: export const b: number = 2;
import { b } from "./bar.cjs"; console.log(b);            // was: Could not resolve "./bar.cjs"
```

```jsonc
// package.json
{ "name": "myapp", "imports": { "#utils": "./src/utils.js", "#w/*": "./src/*" }, "exports": { "./utils": "./src/utils.js" } }
// src/utils.ts: export const hi = "utils.ts";
```
```ts
import { hi } from "#utils"; import { hi as hi2 } from "myapp/utils"; import { hi as hi3 } from "#w/utils.js";
// was: Cannot find package '#utils' (runtime), Could not resolve "#utils" / "myapp/utils" (build); the wildcard form worked
```

```jsonc
// tsconfig.json
{ "compilerOptions": { "baseUrl": ".", "paths": { "foo": ["./types/foo.d.ts"], "bar/*": ["./types/*.d.ts"] } } }
```
```ts
import { x } from "foo"; import { y } from "bar/lib"; // was: Export named 'x' not found in module '.../types/foo.d.ts'
```

Deliberate choices:
- `.js` → `.mts` is kept. esbuild and tsc do not try it, but Bun has since 1.1.19 (#12580). Dropping it is a one-line change in `rewritten_file_extensions` if wanted.
- The node_modules gate: `DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES` (#7259) was written as `.js or .jsx or (.mjs and gate)`, so it never applied to `.js`/`.jsx`. The shared table keeps that. The new `.cjs` arm is gated like `.mjs`. `ExportsRewriteInsideNodeModules` and the runtime twin pin this.
- The exact `exports`/`imports` probe does not append `extension_order` to an extensionless target. That probe (#29679) is a Bun extension to wildcard targets; esbuild and Node reject an extensionless exact target, and `packagejson/ExportsExactMissingExtension` (an esbuild port) asserts the error.
- Both loops check the substitution text as written in tsconfig.json, before the `*` expansion. esbuild expands first and then checks, so esbuild also skips `import "@/env.d.ts"` under `"@/*": ["./src/*"]`. Bun keeps resolving that (it loads a declaration file as an empty module, and it worked before this PR). `tsconfig/PathsCatchAllResolvesDeclarationSpecifier` and the runtime twin pin this.
- `.d.mts` and `.d.cts` are skipped too (review finding). esbuild checks `.d.ts` only. A `.d.mts`/`.d.cts` substitution has no code either, and `module: nodenext` projects map packages to those. Bun already treats all three as declaration files in `pm_diff_normalize.rs` and `run_command.rs`.
- Bun's exact-key loop still falls through to the `*` patterns when no exact substitution loads. esbuild and tsc stop at the exact key. Unchanged here.

`tsconfig/PathsTypeOnly` is the esbuild port of the `.d.ts` skip. It sat below a `return;` in `tsconfig.test.ts`, so it never ran. It is moved above the `return;` with a `run` expectation (`55`). `ts/ImportCTS` goes back to esbuild's shape (`required.cts`); the Bun port had renamed the file to `required.cjs` because the rewrite was missing.

Found while reading `match_tsconfig_paths`, handed off separately: a `paths` key with text after the `*` (`"lib/*/index": ["./src/*.ts"]`) never resolves, because the key's suffix is appended to the target path.

`test/js/bun/resolve/load-same-js-file-a-lot.test.ts` times out in this debug+ASAN container (2000 dynamic imports in 5 s). It does not touch the changed code paths.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->
