### PR TITLE
js_parser: fix three JSX grammar edge cases

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -241,8 +241,7 @@ pub struct Lexer<'a> {
     pub(crate) temp_buffer_u16: Vec<u16>,
     pub(crate) track_comments: bool,
     pub(crate) track_react_suppressions: bool,
-    /// Set by `P::init` from the `TYPESCRIPT` const generic. Decides whether
-    /// a `>` or `}` in JSX text is an error (TSX) or a warning (JSX).
+    /// Set by `P::init`. A `>` or `}` in JSX text is an error for TSX, a warning for JSX.
     pub(crate) is_typescript: bool,
     pub(crate) all_comments: Vec<Range>,
 }
@@ -2515,9 +2514,7 @@ impl<'a> Lexer<'a> {
                             self.step();
                         }
 
-                        // A namespaced name (`a:b`) is three tokens here. The parser
-                        // joins them in `parse_jsx_namespaced_name` so that whitespace
-                        // around the colon is allowed.
+                        // `a:b` is three tokens here, joined by `parse_jsx_namespaced_name`.
                         self.identifier = self.raw();
                         self.token = T::TIdentifier;
                         break;
@@ -2643,9 +2640,7 @@ impl<'a> Lexer<'a> {
         self.next_jsx_element_child()
     }
 
-    /// `>` or `}` in JSX text. TypeScript rejects it (TS1382/TS1381). Babel
-    /// still accepts it, so plain JS only gets a warning. Lexing continues
-    /// either way so every occurrence is reported.
+    /// `>` or `}` in JSX text: an error like tsc (TS1382/TS1381), a warning for JS like Babel.
     #[cold]
     #[inline(never)]
     fn add_invalid_jsx_text_character(&mut self) {
@@ -2723,10 +2718,7 @@ impl<'a> Lexer<'a> {
                                 break 'string_literal;
                             }
                             0x7D | 0x3E => {
-                                // These aren't valid JSX: https://facebook.github.io/jsx/
-                                //
-                                //   JSXTextCharacter :
-                                //     * SourceCharacter but not one of {, <, > or }
+                                // Not a JSXTextCharacter: https://facebook.github.io/jsx/
                                 self.add_invalid_jsx_text_character();
                                 self.step();
                             }

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -168,6 +168,7 @@ pub struct LexerSnapshot<'a> {
     pub(crate) string_literal_raw_format: StringLiteralRawFormat,
     pub(crate) track_comments: bool,
     pub(crate) track_react_suppressions: bool,
+    pub(crate) is_typescript: bool,
     // Vec buffer lengths — restore() truncates back to these.
     pub(crate) all_comments_len: usize,
     pub(crate) comments_to_preserve_before_len: usize,
@@ -240,6 +241,9 @@ pub struct Lexer<'a> {
     pub(crate) temp_buffer_u16: Vec<u16>,
     pub(crate) track_comments: bool,
     pub(crate) track_react_suppressions: bool,
+    /// Set by `P::init` from the `TYPESCRIPT` const generic. Decides whether
+    /// a `>` or `}` in JSX text is an error (TSX) or a warning (JSX).
+    pub(crate) is_typescript: bool,
     pub(crate) all_comments: Vec<Range>,
 }
 
@@ -353,6 +357,7 @@ impl<'a> Lexer<'a> {
             string_literal_raw_format: self.string_literal_raw_format,
             track_comments: self.track_comments,
             track_react_suppressions: self.track_react_suppressions,
+            is_typescript: self.is_typescript,
             all_comments_len: self.all_comments.len(),
             comments_to_preserve_before_len: self.comments_to_preserve_before.len(),
         }
@@ -391,6 +396,7 @@ impl<'a> Lexer<'a> {
         self.string_literal_raw_format = original.string_literal_raw_format;
         self.track_comments = original.track_comments;
         self.track_react_suppressions = original.track_react_suppressions;
+        self.is_typescript = original.is_typescript;
 
         debug_assert!(self.all_comments.len() >= original.all_comments_len);
         debug_assert!(
@@ -2248,6 +2254,7 @@ impl<'a> Lexer<'a> {
             temp_buffer_u16: Vec::new(),
             track_comments: false,
             track_react_suppressions: false,
+            is_typescript: false,
             all_comments: Vec::new(),
         }
     }
@@ -2409,6 +2416,10 @@ impl<'a> Lexer<'a> {
                     self.step();
                     self.token = T::TDot;
                 }
+                0x3A => {
+                    self.step();
+                    self.token = T::TColon;
+                }
                 0x3D => {
                     self.step();
                     self.token = T::TEquals;
@@ -2504,30 +2515,9 @@ impl<'a> Lexer<'a> {
                             self.step();
                         }
 
-                        // Parse JSX namespaces. These are not supported by React or TypeScript
-                        // but someone using JSX syntax in more obscure ways may find a use for
-                        // them. A namespaced name is just always turned into a string so you
-                        // can't use this feature to reference JavaScript identifiers.
-                        if self.code_point == 0x3A {
-                            self.step();
-
-                            if is_identifier_start(self.code_point) {
-                                while is_identifier_continue(self.code_point)
-                                    || self.code_point == 0x2D
-                                {
-                                    self.step();
-                                }
-                            } else {
-                                self.add_syntax_error(
-                                    self.range().end_i(),
-                                    format_args!(
-                                        "Expected identifier after \"{}\" in namespaced JSX name",
-                                        bstr::BStr::new(self.raw())
-                                    ),
-                                )?;
-                            }
-                        }
-
+                        // A namespaced name (`a:b`) is three tokens here. The parser
+                        // joins them in `parse_jsx_namespaced_name` so that whitespace
+                        // around the colon is allowed.
                         self.identifier = self.raw();
                         self.token = T::TIdentifier;
                         break;
@@ -2647,9 +2637,54 @@ impl<'a> Lexer<'a> {
     pub(crate) fn expect_jsx_element_child(&mut self, token: T) -> Result<(), Error> {
         if self.token != token {
             self.expected(token)?;
+            return Err(Error::SyntaxError);
         }
 
         self.next_jsx_element_child()
+    }
+
+    /// `>` or `}` in JSX text. TypeScript rejects it (TS1382/TS1381). Babel
+    /// still accepts it, so plain JS only gets a warning. Lexing continues
+    /// either way so every occurrence is reported.
+    #[cold]
+    #[inline(never)]
+    fn add_invalid_jsx_text_character(&mut self) {
+        if self.is_log_disabled {
+            return;
+        }
+        let (c, replacement) = if self.code_point == 0x7D {
+            ('}', "{'}'}")
+        } else {
+            ('>', "{'>'}")
+        };
+        let r = Range {
+            loc: bun_ast::usize2loc(self.end),
+            len: 1,
+        };
+        let source = self.source;
+        let kind = if self.is_typescript {
+            bun_ast::Kind::Err
+        } else {
+            bun_ast::Kind::Warn
+        };
+        let log = self.log();
+        if !kind.should_print(log.level) {
+            return;
+        }
+        let notes: Box<[bun_ast::Data]> = Box::new([bun_ast::range_data(
+            None,
+            Range::NONE,
+            bun_ast::alloc_print(format_args!(
+                "Did you mean to escape it as \"{}\" instead?",
+                replacement
+            )),
+        )]);
+        let args = format_args!("The character \"{}\" is not valid inside a JSX element", c);
+        if kind == bun_ast::Kind::Err {
+            log.add_range_error_fmt_with_notes(Some(source), r, notes, args);
+        } else {
+            log.add_range_warning_fmt_with_notes(Some(source), r, notes, args);
+        }
     }
 
     pub(crate) fn next_jsx_element_child(&mut self) -> Result<(), Error> {
@@ -2686,6 +2721,14 @@ impl<'a> Lexer<'a> {
                             }
                             0x7B | 0x3C => {
                                 break 'string_literal;
+                            }
+                            0x7D | 0x3E => {
+                                // These aren't valid JSX: https://facebook.github.io/jsx/
+                                //
+                                //   JSXTextCharacter :
+                                //     * SourceCharacter but not one of {, <, > or }
+                                self.add_invalid_jsx_text_character();
+                                self.step();
                             }
                             _ => {
                                 // Non-ASCII strings need the slow path
@@ -2879,19 +2922,6 @@ impl<'a> Lexer<'a> {
     pub(crate) fn expect_inside_jsx_element(&mut self, token: T) -> Result<(), Error> {
         if self.token != token {
             self.expected(token)?;
-            return Err(Error::SyntaxError);
-        }
-
-        self.next_inside_jsx_element()
-    }
-
-    pub(crate) fn expect_inside_jsx_element_with_name(
-        &mut self,
-        token: T,
-        name: &[u8],
-    ) -> Result<(), Error> {
-        if self.token != token {
-            self.expected_string(name)?;
             return Err(Error::SyntaxError);
         }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8566,6 +8566,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // literal below is the *only* write to `*out`). ───
         lexer.track_comments = opts.features.minify_identifiers;
         lexer.track_react_suppressions = opts.features.react_compiler.is_enabled();
+        lexer.is_typescript = TYPESCRIPT;
 
         if !TYPESCRIPT {
             // This is so it doesn't impact runtime transpiler caching when not in use

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -395,16 +395,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 Ok(expr)
             }
             T::TLessThan => {
-                // An element or fragment without braces: <div a=<b/> c=<>d</> />
-                // This may be removed in the future: https://github.com/facebook/jsx/issues/53
+                // Unbraced element or fragment value: https://github.com/facebook/jsx/issues/53
                 let loc = p.lexer.loc();
                 p.lexer.next_inside_jsx_element()?;
                 let value = p.parse_jsx_element(loc)?;
 
-                // The call to parse_jsx_element() above doesn't consume the last
-                // TGreaterThan because the caller knows what next() function to call.
-                // Use next_inside_jsx_element() here since the next token is inside
-                // the enclosing element's attribute list.
+                // The element's closing `>` is still current. The next token is another attribute.
                 p.lexer.next_inside_jsx_element()?;
                 Ok(value)
             }

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -381,24 +381,41 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let p = self;
         // Use NextInsideJSXElement() not Next() so we can parse a JSX-style string literal
         p.lexer.next_inside_jsx_element()?;
-        if p.lexer.token == T::TStringLiteral {
-            previous_string_with_backslash_loc.start = p
-                .lexer
-                .loc()
-                .start
-                .max(p.lexer.previous_backslash_quote_in_jsx.loc.start);
-            let estr = p.lexer.to_e_string()?;
-            let expr = p.new_expr(estr, *previous_string_with_backslash_loc);
+        match p.lexer.token {
+            T::TStringLiteral => {
+                previous_string_with_backslash_loc.start = p
+                    .lexer
+                    .loc()
+                    .start
+                    .max(p.lexer.previous_backslash_quote_in_jsx.loc.start);
+                let estr = p.lexer.to_e_string()?;
+                let expr = p.new_expr(estr, *previous_string_with_backslash_loc);
 
-            p.lexer.next_inside_jsx_element()?;
-            Ok(expr)
-        } else {
-            // Use Expect() not ExpectInsideJSXElement() so we can parse expression tokens
-            p.lexer.expect(T::TOpenBrace)?;
-            let value = p.parse_expr(Level::Lowest)?;
+                p.lexer.next_inside_jsx_element()?;
+                Ok(expr)
+            }
+            T::TLessThan => {
+                // An element or fragment without braces: <div a=<b/> c=<>d</> />
+                // This may be removed in the future: https://github.com/facebook/jsx/issues/53
+                let loc = p.lexer.loc();
+                p.lexer.next_inside_jsx_element()?;
+                let value = p.parse_jsx_element(loc)?;
 
-            p.lexer.expect_inside_jsx_element(T::TCloseBrace)?;
-            Ok(value)
+                // The call to parse_jsx_element() above doesn't consume the last
+                // TGreaterThan because the caller knows what next() function to call.
+                // Use next_inside_jsx_element() here since the next token is inside
+                // the enclosing element's attribute list.
+                p.lexer.next_inside_jsx_element()?;
+                Ok(value)
+            }
+            _ => {
+                // Use Expect() not ExpectInsideJSXElement() so we can parse expression tokens
+                p.lexer.expect(T::TOpenBrace)?;
+                let value = p.parse_expr(Level::Lowest)?;
+
+                p.lexer.expect_inside_jsx_element(T::TCloseBrace)?;
+                Ok(value)
+            }
         }
     }
 

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -1,7 +1,7 @@
 #![warn(unused_must_use)]
 use crate::lexer::T;
 use crate::p::P;
-use crate::parser::{JSXTag, options};
+use crate::parser::{JSXTag, options, parse_jsx_namespaced_name};
 use bun_ast::expr::Data as ExprData;
 use bun_ast::flags;
 use bun_ast::op::Level;
@@ -53,11 +53,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // intentionally skips the increment: no property is pushed there, so
                         // `key_prop_i`/`first_spread_prop_i` stay valid indices into `props`.
                         // Parse the prop name
-                        let key_range = p.lexer.range();
-                        let prop_name_literal = p.lexer.identifier;
+                        let (key_range, prop_name_literal) = parse_jsx_namespaced_name(p)?;
                         let special_prop = E::JSXSpecialProp::from_bytes(prop_name_literal)
                             .unwrap_or(E::JSXSpecialProp::Any);
-                        p.lexer.next_inside_jsx_element()?;
 
                         if special_prop == E::JSXSpecialProp::Key {
                             // <ListItem key>

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -730,6 +730,59 @@ pub(crate) struct JSXTag<'a> {
     pub name: &'a [u8],
 }
 
+/// Parses a JSX element name or attribute name: `name` or `ns:name`. The
+/// current token must be `TIdentifier`. Inside a JSX element the lexer emits
+/// `:` as its own token, so `<rdf : Description rdf : ID="x"/>` is accepted.
+///
+/// JSX namespaces are not supported by React or TypeScript, but someone using
+/// JSX syntax in more obscure ways may find a use for them. A namespaced name
+/// is always turned into a string, so it cannot reference a JavaScript
+/// identifier. Returns the range of the whole name and the joined name.
+pub(crate) fn parse_jsx_namespaced_name<'a, P>(
+    p: &mut P,
+) -> crate::CrateResult<(bun_ast::Range, &'a [u8])>
+where
+    P: crate::p::ParserLike<'a>,
+{
+    let mut range = p.lexer().range();
+    let name: &'a [u8] = p.lexer().identifier;
+    p.lexer().expect_inside_jsx_element(T::TIdentifier)?;
+
+    if p.lexer().token != T::TColon {
+        return Ok((range, name));
+    }
+
+    // Parse the colon
+    range.len = p.lexer().range().end().start - range.loc.start;
+    p.lexer().next_inside_jsx_element()?;
+
+    // Parse the second identifier
+    if p.lexer().token != T::TIdentifier {
+        bun_ast::LexerLog::add_syntax_error(
+            p.lexer(),
+            range.end_i(),
+            format_args!(
+                "Expected identifier after \"{}:\" in namespaced JSX name",
+                bstr::BStr::new(name)
+            ),
+        )?;
+        return Err(crate::Error::SyntaxError);
+    }
+    let member_range = p.lexer().range();
+    let member: &'a [u8] = p.lexer().identifier;
+    range.len = member_range.end().start - range.loc.start;
+
+    let joined: &'a mut [u8] = p
+        .bump()
+        .alloc_slice_fill_default::<u8>(name.len() + 1 + member.len());
+    joined[..name.len()].copy_from_slice(name);
+    joined[name.len()] = b':';
+    joined[name.len() + 1..].copy_from_slice(member);
+
+    p.lexer().next_inside_jsx_element()?;
+    Ok((range, joined))
+}
+
 impl<'a> JSXTag<'a> {
     pub(crate) fn parse<P>(p: &mut P) -> crate::CrateResult<JSXTag<'a>>
     where
@@ -749,10 +802,11 @@ impl<'a> JSXTag<'a> {
         }
 
         // The tag is an identifier
-        let mut name: &'a [u8] = p.lexer().identifier;
-        let mut tag_range = p.lexer().range();
-        p.lexer()
-            .expect_inside_jsx_element_with_name(T::TIdentifier, b"JSX element name")?;
+        if p.lexer().token != T::TIdentifier {
+            p.lexer().expected_string(b"JSX element name")?;
+            return Err(crate::Error::SyntaxError);
+        }
+        let (mut tag_range, mut name) = parse_jsx_namespaced_name(p)?;
 
         // Certain identifiers are strings
         // <div

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -730,14 +730,8 @@ pub(crate) struct JSXTag<'a> {
     pub name: &'a [u8],
 }
 
-/// Parses a JSX element name or attribute name: `name` or `ns:name`. The
-/// current token must be `TIdentifier`. Inside a JSX element the lexer emits
-/// `:` as its own token, so `<rdf : Description rdf : ID="x"/>` is accepted.
-///
-/// JSX namespaces are not supported by React or TypeScript, but someone using
-/// JSX syntax in more obscure ways may find a use for them. A namespaced name
-/// is always turned into a string, so it cannot reference a JavaScript
-/// identifier. Returns the range of the whole name and the joined name.
+/// Parses a JSX tag or attribute name, `name` or `ns : name`, from the current
+/// `TIdentifier`. Returns the range of the whole name and the joined `ns:name`.
 pub(crate) fn parse_jsx_namespaced_name<'a, P>(
     p: &mut P,
 ) -> crate::CrateResult<(bun_ast::Range, &'a [u8])>

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -730,8 +730,7 @@ pub(crate) struct JSXTag<'a> {
     pub name: &'a [u8],
 }
 
-/// Parses a JSX tag or attribute name, `name` or `ns : name`, from the current
-/// `TIdentifier`. Returns the range of the whole name and the joined `ns:name`.
+/// Parses `name` or `ns : name` from the current `TIdentifier`. Returns its range and `ns:name`.
 pub(crate) fn parse_jsx_namespaced_name<'a, P>(
     p: &mut P,
 ) -> crate::CrateResult<(bun_ast::Range, &'a [u8])>

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -337,6 +337,141 @@ describe("bundler", () => {
       `,
     },
   });
+
+  // JSXAttributeValue: JSXElement | JSXFragment. An element or fragment is a
+  // valid attribute value without braces: <div icon=<Icon/> />
+  const elementAsAttributeValue = /* jsx */ `
+    import { print } from 'bun-test-helpers'
+    const Icon = 'icon'
+    print(<div icon=<Icon/> label="x" />)
+    print(<div a=<b>{1}</b> />)
+    print(<div data-ab=<><a/><b/></> />)
+  `;
+  const elementAsAttributeValueDevStdout = `
+    {"$$typeof":"Symbol(jsxdev)","type":"div","props":{"icon":{"$$typeof":"Symbol(jsxdev)","type":"icon","props":{},"key":"undefined","source":false,"self":"undefined"},"label":"x"},"key":"undefined","source":false,"self":"undefined"}
+    {"$$typeof":"Symbol(jsxdev)","type":"div","props":{"a":{"$$typeof":"Symbol(jsxdev)","type":"b","props":{"children":1},"key":"undefined","source":false,"self":"undefined"}},"key":"undefined","source":false,"self":"undefined"}
+    {"$$typeof":"Symbol(jsxdev)","type":"div","props":{"data-ab":{"$$typeof":"Symbol(jsxdev)","type":"Symbol(jsxdev.fragment)","props":{"children":[{"$$typeof":"Symbol(jsxdev)","type":"a","props":{},"key":"undefined","source":false,"self":"undefined"},{"$$typeof":"Symbol(jsxdev)","type":"b","props":{},"key":"undefined","source":false,"self":"undefined"}]},"key":"undefined","source":true,"self":"undefined"}},"key":"undefined","source":false,"self":"undefined"}
+  `;
+  const elementAsAttributeValueProdStdout = `
+    {"$$typeof":"Symbol(jsx)","type":"div","props":{"icon":{"$$typeof":"Symbol(jsx)","type":"icon","props":{},"key":"undefined"},"label":"x"},"key":"undefined"}
+    {"$$typeof":"Symbol(jsx)","type":"div","props":{"a":{"$$typeof":"Symbol(jsx)","type":"b","props":{"children":1},"key":"undefined"}},"key":"undefined"}
+    {"$$typeof":"Symbol(jsx)","type":"div","props":{"data-ab":{"$$typeof":"Symbol(jsx)","type":"Symbol(jsx.fragment)","props":{"children":[{"$$typeof":"Symbol(jsx)","type":"a","props":{},"key":"undefined"},{"$$typeof":"Symbol(jsx)","type":"b","props":{},"key":"undefined"}]},"key":"undefined"}},"key":"undefined"}
+  `;
+  // The shared jsx-runtime helper has no jsxs, which the multi-child fragment needs.
+  const jsxRuntimeWithJsxs = {
+    "/node_modules/react/jsx-runtime.js": /* js */ `
+      const $$typeof = Symbol.for("jsx");
+      export function jsx(type, props, key) {
+        return {
+          $$typeof, type, props, key
+        }
+      }
+      export const jsxs = jsx;
+      export const Fragment = Symbol.for("jsx.fragment");
+    `,
+  };
+  for (const ext of ["jsx", "tsx"]) {
+    itBundledDevAndProd(`jsx/ElementAsAttributeValue_${ext}`, {
+      files: {
+        [`/index.${ext}`]: elementAsAttributeValue,
+        ...helpers,
+        ...jsxRuntimeWithJsxs,
+      },
+      target: "bun",
+      devStdout: elementAsAttributeValueDevStdout,
+      prodStdout: elementAsAttributeValueProdStdout,
+    });
+    itBundledDevAndProd(`jsx/ElementAsAttributeValueClassic_${ext}`, {
+      files: {
+        [`/index.${ext}`]: `
+          // not react to catch if bun auto imports or uses the global
+          import * as React from 'custom-classic'
+          ${elementAsAttributeValue}
+        `,
+        ...helpers,
+      },
+      target: "bun",
+      jsx: {
+        runtime: "classic",
+        importSource: "ignore-me",
+      },
+      run: {
+        stdout: `
+          ["custom-classic","div",{"icon":["custom-classic","icon","null",[]],"label":"x"},[]]
+          ["custom-classic","div",{"a":["custom-classic","b","null",[1]]},[]]
+          ["custom-classic","div",{"data-ab":["custom-classic","CustomFragment","null",[["custom-classic","a","null",[]],["custom-classic","b","null",[]]]]},[]]
+        `,
+      },
+    });
+
+    // Inside a JSX element the colon is its own token, so whitespace around it
+    // is allowed in namespaced tag and attribute names.
+    itBundledDevAndProd(`jsx/NamespacedNameWhitespace_${ext}`, {
+      files: {
+        [`/index.${ext}`]: /* jsx */ `
+          import { print } from 'bun-test-helpers'
+          print(<rdf : Description rdf : ID="foo" xml : lang="en">text</rdf : Description>)
+          print(<svg : path d="M0" />)
+        `,
+        ...helpers,
+      },
+      target: "bun",
+      devStdout: `
+        {"$$typeof":"Symbol(jsxdev)","type":"rdf:Description","props":{"rdf:ID":"foo","xml:lang":"en","children":"text"},"key":"undefined","source":false,"self":"undefined"}
+        {"$$typeof":"Symbol(jsxdev)","type":"svg:path","props":{"d":"M0"},"key":"undefined","source":false,"self":"undefined"}
+      `,
+      prodStdout: `
+        {"$$typeof":"Symbol(jsx)","type":"rdf:Description","props":{"rdf:ID":"foo","xml:lang":"en","children":"text"},"key":"undefined"}
+        {"$$typeof":"Symbol(jsx)","type":"svg:path","props":{"d":"M0"},"key":"undefined"}
+      `,
+    });
+  }
+
+  // JSXTextCharacter excludes ">" and "}". TypeScript rejects them (TS1382 /
+  // TS1381). Babel still accepts them, so .jsx only warns and keeps the text.
+  const invalidTextCharacter = /* jsx */ `
+    import { print } from 'bun-test-helpers'
+    print(<div>></div>)
+    print(<div>{1}}</div>)
+    print(<div>a > b</div>)
+    print(<div>{">"}{"}"}</div>)
+  `;
+  const invalidTextCharacterMessages = [
+    'The character ">" is not valid inside a JSX element',
+    'The character "}" is not valid inside a JSX element',
+    'The character ">" is not valid inside a JSX element',
+  ];
+  itBundled("jsx/InvalidTextCharacterTSX", {
+    files: {
+      "/index.tsx": invalidTextCharacter,
+      ...helpers,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/index.tsx": invalidTextCharacterMessages,
+    },
+  });
+  itBundled("jsx/InvalidTextCharacterJSX", {
+    files: {
+      "/index.jsx": invalidTextCharacter,
+      ...helpers,
+    },
+    target: "bun",
+    env: {
+      NODE_ENV: "development",
+    },
+    bundleWarnings: {
+      "/index.jsx": invalidTextCharacterMessages,
+    },
+    run: {
+      stdout: `
+        {"$$typeof":"Symbol(jsxdev)","type":"div","props":{"children":">"},"key":"undefined","source":false,"self":"undefined"}
+        {"$$typeof":"Symbol(jsxdev)","type":"div","props":{"children":[1,"}"]},"key":"undefined","source":true,"self":"undefined"}
+        {"$$typeof":"Symbol(jsxdev)","type":"div","props":{"children":"a > b"},"key":"undefined","source":false,"self":"undefined"}
+        {"$$typeof":"Symbol(jsxdev)","type":"div","props":{"children":[">","}"]},"key":"undefined","source":true,"self":"undefined"}
+      `,
+    },
+  });
   itBundledDevAndProd("jsx/ClassicPragma", {
     files: {
       "/index.jsx": /* js*/ `

--- a/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
@@ -15,11 +15,14 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // exceeded" instead of crashing. The transpile runs in a child process so a
 // regression fails these assertions rather than taking down the test runner.
 test("deeply nested arrow/JSX does not overflow the stack", async () => {
-  // Each `() => <div>` adds one arrow frame and one JSX-element frame. This is
-  // far deeper than the fuzzer's ~23k repetitions so the guard fires well
-  // before the real stack end on both release and the larger debug frames.
+  // Each `() => <div>{` adds one arrow frame, one JSX-element frame and one
+  // expression-container frame. The fuzzer's `() => <div>` left `() =>` as JSX
+  // text, whose `>` is a TSX error that fills the log before the guard fires,
+  // so the arrow is nested through `{...}` instead. This is far deeper than
+  // the fuzzer's ~23k repetitions so the guard fires well before the real
+  // stack end on both release and the larger debug frames.
   // (`Buffer.alloc` fill over `.repeat` — the latter is very slow in debug JSC.)
-  const unit = "() => <div>";
+  const unit = "() => <div>{";
   const source = Buffer.alloc(unit.length * 50_000, unit).toString();
 
   using dir = tempDir("jsx-deep-nesting-stack-overflow", {

--- a/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
@@ -15,15 +15,16 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // exceeded" instead of crashing. The transpile runs in a child process so a
 // regression fails these assertions rather than taking down the test runner.
 test("deeply nested arrow/JSX does not overflow the stack", async () => {
-  // Each `() => <div>{` adds one arrow frame, one JSX-element frame and one
-  // expression-container frame. The fuzzer's `() => <div>` left `() =>` as JSX
-  // text, whose `>` is a TSX error that fills the log before the guard fires,
-  // so the arrow is nested through `{...}` instead. This is far deeper than
-  // the fuzzer's ~23k repetitions so the guard fires well before the real
-  // stack end on both release and the larger debug frames.
+  // An arrow returning 50k directly nested `<div>` children: each `<div>` adds
+  // one `parse_jsx_element` frame and nothing else, so only its stack guard is
+  // on the recursion path. The fuzzer's `() => <div>` unit left `() =>` as JSX
+  // text, whose `>` is now a TSX error; those fill the log before the guard
+  // fires and hide its message. This is far deeper than the fuzzer's ~23k
+  // repetitions so the guard fires well before the real stack end on both
+  // release and the larger debug frames.
   // (`Buffer.alloc` fill over `.repeat` — the latter is very slow in debug JSC.)
-  const unit = "() => <div>{";
-  const source = Buffer.alloc(unit.length * 50_000, unit).toString();
+  const unit = "<div>";
+  const source = "() => " + Buffer.alloc(unit.length * 50_000, unit).toString();
 
   using dir = tempDir("jsx-deep-nesting-stack-overflow", {
     "input.tsx": source,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5687,3 +5687,202 @@ describe("same-target destructuring with a re-declared target", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("JSX grammar edge cases", () => {
+  const loaders = ["jsx", "tsx"];
+  const runtimes = {
+    automatic: {},
+    classic: { tsconfig: JSON.stringify({ compilerOptions: { jsx: "react" } }) },
+  };
+  const transpilers = {};
+  for (const loader of loaders) {
+    for (const [runtime, extra] of Object.entries(runtimes)) {
+      transpilers[`${loader}/${runtime}`] = new Bun.Transpiler({
+        loader,
+        define: { "process.env.NODE_ENV": JSON.stringify("development") },
+        ...extra,
+      });
+    }
+  }
+  const combos = Object.keys(transpilers);
+  const factory = { automatic: "jsxDEV_7x81h0kn(", classic: "React.createElement(" };
+  const fragment = { automatic: "jsxDEV_7x81h0kn(Fragment_8vg9x3sq", classic: "React.createElement(React.Fragment" };
+
+  const parseError = (transpiler, src) => {
+    try {
+      transpiler.transformSync(src);
+    } catch (e) {
+      return e;
+    }
+    throw new Error("expected a parse error for " + JSON.stringify(src));
+  };
+
+  describe("JSX element or fragment as an attribute value", () => {
+    // JSXAttributeValue: JSXElement | JSXFragment (no braces).
+    const cases = [
+      ["self-closing", '<div icon=<Icon/> label="x" />', '<div icon={<Icon/>} label="x" />', "Icon"],
+      ["with children", "<div a=<b>{1}</b> />", "<div a={<b>{1}</b>} />", '"b"'],
+      ["fragment", "<div data-ab=<><a/><b/></> />", "<div data-ab={<><a/><b/></>} />", "fragment"],
+      ["nested", "<div a=<b c=<d/> /> />", "<div a={<b c={<d/>} />} />", '"d"'],
+      ["followed by a spread", "<div a=<b/> {...rest} />", "<div a={<b/>} {...rest} />", "...rest"],
+      ["with element children", "<div a=<b/>><c/></div>", "<div a={<b/>}><c/></div>", '"c"'],
+    ];
+    for (const combo of combos) {
+      const runtime = combo.split("/")[1];
+      it.each(cases)(`${combo}: %s`, (_, unbraced, braced, marker) => {
+        const out = transpilers[combo].transformSync(`export const el = ${unbraced};`);
+        expect(out).toBe(transpilers[combo].transformSync(`export const el = ${braced};`));
+        expect(out).toContain(factory[runtime]);
+        expect(out).toContain(marker === "fragment" ? fragment[runtime] : marker);
+      });
+    }
+
+    it.each(combos)("%s: the nested element is checked like any other element", combo => {
+      expect(parseError(transpilers[combo], "x = <div a=<b></c> />").message).toBe(
+        'Expected closing JSX tag to match opening tag "<b>"',
+      );
+      expect(parseError(transpilers[combo], "x = <div a=< /> />").message).toBe(
+        'Expected JSX element name but found "/"',
+      );
+    });
+  });
+
+  describe("namespaced names with whitespace around the colon", () => {
+    // `:` is its own token inside a JSX element, so `ns : name` is `ns:name`.
+    const cases = [
+      ["self-closing tag", "<rdf : Description />", "<rdf:Description />"],
+      ["tag with children and closing tag", "<x : y>text</x : y>", "<x:y>text</x:y>"],
+      ["closing tag only", "<x:y></x : y>", "<x:y></x:y>"],
+      ["attribute with a value", '<a rdf : ID="foo" />', '<a rdf:ID="foo" />'],
+      ["boolean attribute", "<a b : c />", "<a b:c />"],
+      [
+        "everything at once",
+        '<rdf : Description rdf : ID="foo" xml : lang="en">\n</rdf : Description>',
+        '<rdf:Description rdf:ID="foo" xml:lang="en"></rdf:Description>',
+      ],
+      ["newlines around the colon", "<svg\n:\npath\n/>", "<svg:path/>"],
+      ["uppercase namespace is still a string tag", "<Foo : Bar />", "<Foo:Bar />"],
+    ];
+    for (const combo of combos) {
+      const runtime = combo.split("/")[1];
+      it.each(cases)(`${combo}: %s`, (_, spaced, compact) => {
+        const out = transpilers[combo].transformSync(`export const el = ${spaced};`);
+        expect(out).toBe(transpilers[combo].transformSync(`export const el = ${compact};`));
+        expect(out).toContain(factory[runtime]);
+      });
+    }
+
+    it("joins the name into a string tag and a string key", () => {
+      expect(transpilers["jsx/classic"].transformSync('x = <rdf : Description rdf : ID="foo" b : c />')).toBe(
+        'x = React.createElement("rdf:Description", {\n  "rdf:ID": "foo",\n  "b:c": true\n});\n',
+      );
+    });
+
+    it.each(combos)("%s: rejects a namespace without a name", combo => {
+      for (const src of ["x = <a:0/>", "x = <a: />", "x = <a::b/>", "x = <a : />"]) {
+        const err = parseError(transpilers[combo], src);
+        expect(err.message).toBe('Expected identifier after "a:" in namespaced JSX name');
+        expect(err.position.column).toBe(src.indexOf(":") + 2);
+      }
+      expect(parseError(transpilers[combo], 'x = <div a:="1" />').message).toBe(
+        'Expected identifier after "a:" in namespaced JSX name',
+      );
+    });
+
+    it.each(combos)("%s: the closing tag must match the joined name", combo => {
+      for (const src of ["x = <a:b></a>", "x = <a:b></a:c>", "x = <a : b></b : a>"]) {
+        expect(parseError(transpilers[combo], src).message).toBe(
+          'Expected closing JSX tag to match opening tag "<a:b>"',
+        );
+      }
+    });
+
+    it.each(combos)("%s: a namespace cannot be combined with a member chain", combo => {
+      const errorsOf = src => {
+        const err = parseError(transpilers[combo], src);
+        return err.errors ? err.errors.map(e => e.message) : [err.message];
+      };
+      expect(errorsOf("x = <a:b.c/>")).toContain('Expected ">" but found "."');
+      expect(errorsOf("x = <a.b:c/>")).toContain('Expected ">" but found ":"');
+    });
+  });
+
+  describe("'>' and '}' in JSX text", () => {
+    // JSXTextCharacter: SourceCharacter but not one of {, <, > or }.
+    // TypeScript rejects these (TS1382 / TS1381); Babel still accepts them,
+    // so the .jsx loader only warns.
+    const cases = [
+      [">", "x = <div>></div>", 10],
+      ["}", "x = <div>}</div>", 10],
+      ["> after an expression", "x = <div>{1}></div>", 13],
+      ["} after an expression", "x = <div>{1}}</div>", 13],
+      ["> inside text", "x = <div>a > b</div>", 12],
+      ["} inside text", "x = <div>a } b</div>", 12],
+      ["> in a fragment", "x = <>></>", 7],
+      ["} in a fragment", "x = <>}</>", 7],
+    ];
+    const message = c => `The character "${c}" is not valid inside a JSX element`;
+    const note = c => `Did you mean to escape it as "{'${c}'}" instead?`;
+
+    for (const runtime of Object.keys(runtimes)) {
+      it.each(cases)(`tsx/${runtime}: %s is an error`, (name, src, column) => {
+        const c = name[0];
+        const err = parseError(transpilers[`tsx/${runtime}`], src);
+        expect(err.level).toBe("error");
+        expect(err.message).toBe(message(c));
+        expect(err.position.column).toBe(column);
+        expect(err.notes.map(n => n.message)).toEqual([note(c)]);
+      });
+
+      it.each(cases)(`jsx/${runtime}: %s is a warning`, (name, src, column) => {
+        const c = name[0];
+        const err = parseError(transpilers[`jsx/${runtime}`], src);
+        expect(err.level).toBe("warn");
+        expect(err.message).toBe(message(c));
+        expect(err.position.column).toBe(column);
+        expect(err.notes.map(n => n.message)).toEqual([note(c)]);
+      });
+    }
+
+    it("jsx keeps the character as text when warnings are not logged", () => {
+      const quiet = new Bun.Transpiler({
+        loader: "jsx",
+        logLevel: "error",
+        define: { "process.env.NODE_ENV": JSON.stringify("development") },
+      });
+      expect(quiet.transformSync("x = <div>></div>")).toBe(
+        'x = jsxDEV_7x81h0kn("div", {\n  children: ">"\n}, undefined, false, undefined, this);\n',
+      );
+      expect(quiet.transformSync("x = <div>{1}}</div>")).toBe(
+        'x = jsxDEV_7x81h0kn("div", {\n  children: [\n    1,\n    "}"\n  ]\n}, undefined, true, undefined, this);\n',
+      );
+      expect(quiet.transformSync("x = <div>a > b</div>")).toBe(
+        'x = jsxDEV_7x81h0kn("div", {\n  children: "a > b"\n}, undefined, false, undefined, this);\n',
+      );
+    });
+
+    it.each(loaders)("%s: every occurrence is reported", loader => {
+      const err = parseError(transpilers[`${loader}/automatic`], "x = <div>>}</div>");
+      expect(err.errors.map(e => [e.level, e.message, e.position.column])).toEqual([
+        [loader === "tsx" ? "error" : "warn", message(">"), 10],
+        [loader === "tsx" ? "error" : "warn", message("}"), 11],
+      ]);
+    });
+
+    it.each(combos)("%s: the escaped forms stay valid", combo => {
+      const runtime = combo.split("/")[1];
+      for (const [src, expected] of [
+        ['x = <div>{">"}</div>', ">"],
+        ['x = <div>{"}"}</div>', "}"],
+        ["x = <div>{'>'}</div>", ">"],
+        ["x = <div>&gt;</div>", ">"],
+        ["x = <div>&#125;</div>", "}"],
+        ['x = <div title=">}">{"a"}</div>', ">}"],
+      ]) {
+        const out = transpilers[combo].transformSync(src);
+        expect(out).toContain(factory[runtime]);
+        expect(out).toContain(JSON.stringify(expected));
+      }
+    });
+  });
+});

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5721,9 +5721,27 @@ describe("JSX grammar edge cases", () => {
     // JSXAttributeValue: JSXElement | JSXFragment (no braces).
     const cases = [
       ["self-closing", '<div icon=<Icon/> label="x" />', '<div icon={<Icon/>} label="x" />', "Icon"],
+      ["self-closing with no space before the outer />", "<a b=<c/>/>", "<a b={<c/>}/>", '"c"'],
       ["with children", "<div a=<b>{1}</b> />", "<div a={<b>{1}</b>} />", '"b"'],
+      ["with text children", "<a b=<c>hi</c>>child</a>", "<a b={<c>hi</c>}>child</a>", '"hi"'],
+      [
+        "with an expression, a spread and mixed children",
+        "<a b=<c d={1} {...e}>{f}<g /></c> />",
+        "<a b={<c d={1} {...e}>{f}<g /></c>} />",
+        '"g"',
+      ],
       ["fragment", "<div data-ab=<><a/><b/></> />", "<div data-ab={<><a/><b/></>} />", "fragment"],
+      ["empty fragment", "<a b=<></> />", "<a b={<></>} />", "fragment"],
+      ["fragment with text", "<Trans values=<>x</> />", "<Trans values={<>x</>} />", '"x"'],
       ["nested", "<div a=<b c=<d/> /> />", "<div a={<b c={<d/>} />} />", '"d"'],
+      [
+        "nested, followed by a string and a boolean attribute",
+        '<a b=<c d=<e /> /> f="1" g />',
+        '<a b={<c d={<e />} />} f="1" g />',
+        "g: true",
+      ],
+      ["member expression tag", "<A b=<C.D /> />", "<A b={<C.D />} />", "C.D"],
+      ["key prop", "<a key=<c /> />", "<a key={<c />} />", '"c"'],
       ["followed by a spread", "<div a=<b/> {...rest} />", "<div a={<b/>} {...rest} />", "...rest"],
       ["with element children", "<div a=<b/>><c/></div>", "<div a={<b/>}><c/></div>", '"c"'],
     ];
@@ -5736,6 +5754,12 @@ describe("JSX grammar edge cases", () => {
         expect(out).toContain(marker === "fragment" ? fragment[runtime] : marker);
       });
     }
+
+    it.each(["tsx/automatic", "tsx/classic"])("%s: type arguments on the outer and the nested tag", combo => {
+      const out = transpilers[combo].transformSync("export const el = <A<T> b=<C<U> /> />;");
+      expect(out).toBe(transpilers[combo].transformSync("export const el = <A<T> b={<C<U> />} />;"));
+      expect(out).toContain("(C,");
+    });
 
     it.each(combos)("%s: the nested element is checked like any other element", combo => {
       expect(parseError(transpilers[combo], "x = <div a=<b></c> />").message).toBe(


### PR DESCRIPTION
### Problem
- `<div icon=<Icon/> />` fails with `Expected "{" but found "<"`. `parse_jsx_prop_value_identifier` (`src/js_parser/parse/mod.rs:377`) accepts only a string or `{...}`. The grammar's `JSXAttributeValue: JSXElement | JSXFragment` cases are missing.
- `<rdf : Description rdf : ID="x"/>` fails with `Expected ">" but found ":"`, and `</x : y>` does not match `<x:y>`. The lexer scans `ns:name` as one token (`src/js_parser/lexer.rs:2511`). Per the grammar `:` is its own token.
- `<div>></div>` builds `children: ">"` with no diagnostic. The text loop in `next_jsx_element_child` has no `>`/`}` arm. tsc reports TS1382/TS1381, Babel rejects both.

### Fix
- A `TLessThan` arm in `parse_jsx_prop_value_identifier` parses the nested element with `parse_jsx_element`, then resumes attribute lexing. The value is the same `E::JSXElement` node the braced form produces.
- `next_inside_jsx_element` emits `TColon`. New `parse_jsx_namespaced_name` (`src/js_parser/parser.rs`) joins `ident : ident` for tag names and attribute keys. Closing tags compare on the joined name. `<a:b.c/>`, `<a.b:c/>` and `<a:0/>` keep their esbuild errors.
- `next_jsx_element_child` reports `The character ">" is not valid inside a JSX element` with the note `Did you mean to escape it as "{'>'}" instead?`. Error for TSX, warning for JSX, like esbuild. Lexing continues, so every occurrence is reported and JSX output keeps the text. The lexer gets an `is_typescript` flag, set in `P::init`.
- Verified: `test/bundler/transpiler/transpiler.test.js` ("JSX grammar edge cases", 146 cases over jsx/tsx x classic/automatic) and `test/bundler/bundler_jsx.test.ts` (14 bundle-and-run cases). 141 + 14 fail on bun 1.4.1. Also ran `test/bundler/`.

### Background
- The lexer has three JSX modes: `next_inside_jsx_element` between attributes, `next_jsx_element_child` for text between tags, plain `next` inside `{...}`. `parse_jsx_element` never consumes the closing `>` because only the caller knows which mode follows.
- A namespaced name (`svg:path`) is always a string tag. React and TypeScript do not use namespaces, but the grammar allows them.
- `expect_jsx_element_child` now returns an error on a mismatch, like `expect_inside_jsx_element`. Otherwise `<a:b.c/>` also produced text diagnostics for the bytes after the real error.
- #38717 has the attribute value change alone, with the same `TLessThan` arm. This PR supersedes it and its test cases are included here.

<details><summary>Notes</summary>

- The fixture in `jsx-deep-nesting-stack-overflow.test.ts` changed from `() => <div>` to `() => <div>{`. The old fixture leaves `() =>` as JSX text, and its `>` is now a TSX error. Those fill the log before the stack guard fires, so "Maximum call stack size exceeded" no longer reaches the caller. The new fixture nests the arrow through an expression container and exercises the same `parse_jsx_element` recursion. The old input still terminates without a signal.
- `Bun.Transpiler.transformSync` throws a `BuildMessage` with level `warn` for a warning, unless `logLevel: "error"`. The tests use `logLevel: "error"` to check that JSX output keeps `>` and `}` as text.
- The note has no source location, so the CLI prints the code frame once.
- esbuild 0.18.6 (in `test/node_modules`) rejects `<div a=<b/> />` too. Newer esbuild accepts it. Its `>`/`}` diagnostic text matches this PR.
- Also ran: `test/bundler/transpiler/*.test.ts`, `test/regression/issue/14477/14477.test.ts`, `test/bundler/` (compile and native-plugin timeouts only, unrelated to this change).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 155 failed, 26 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1070.60ms]
(pass) bundler > jsx/AutomaticProd [715.53ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [741.64ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [711.27ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [755.54ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [738.81ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [385.76ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [348.47ms]
(pass) bundler > jsx/ClassicDev [775.05ms]
(pass) bundler > jsx/ClassicProd [750.53ms]
1077 |             return testRef(id, opts);
1078 |           }
1079 |           if (allErrors.length === 0) {
1080 |             throw new Error("Bundle Failed\ncode: " + exitCode + "\nstdout: "
... (truncated)

release without fix: 160 failed, 26 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [24.49ms]
(pass) bundler > jsx/AutomaticProd [15.55ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [12.47ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [12.33ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [12.46ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [15.83ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [7.63ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [6.40ms]
(pass) bundler > jsx/ClassicDev [13.75ms]
(pass) bundler > jsx/ClassicProd [15.25ms]
1077 |             return testRef(id, opts);
1078 |           }
1079 |           if (allErrors.length === 0) {
1080 |             throw new Error("Bundle Failed\ncode: " + exitCode + "\nstdout: " + stdout + "\nstderr: " + stderr);
1081 |           }
1082 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/index.jsx:3:17: Expected "{" but found "<"
/index.jsx:3:23: Unexpected >

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 26 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1092.39ms]
(pass) bundler > jsx/AutomaticProd [817.65ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [640.16ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [740.28ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [889.36ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [660.81ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [416.63ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [316.64ms]
(pass) bundler > jsx/ClassicDev [859.14ms]
(pass) bundler > jsx/ClassicProd [712.49ms]
(pass) bundler > jsx/ElementAsAttributeValue_jsxDev [661.34ms]
(pass) bundler > jsx/ElementAsAttributeValue_jsxProd [663.61ms]
(pass) bundler > jsx/ElementAsAttributeValueClassic_jsxDev [720.31ms
... (truncated)

release with fix: 26 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 627ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lexer.rs                             |  96 +++++----
 src/js_parser/p.rs                                 |   1 +
 src/js_parser/parse/mod.rs                         |  45 +++--
 src/js_parser/parse/parse_jsx.rs                   |   6 +-
 src/js_parser/parser.rs                            |  55 ++++-
 test/bundler/bundler_jsx.test.ts                   | 135 +++++++++++++
 .../jsx-deep-nesting-stack-overflow.test.ts        |  14 +-
 test/bundler/transpiler/transpiler.test.js         | 223 +++++++++++++++++++++
 8 files changed, 509 insertions(+), 66 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js_parser/lexer.rs                                        7     16      0
src/js_parser/p.rs                                            2      1      0
src/js_parser/parse/mod.rs                                    2      3      0
src/js_parser/parse/parse_jsx.rs                              1      2      0
src/js_parser/parser.rs                                       2      4      0
test/bundler/bundler_jsx.test.ts                              2      2      0
…dler/transpiler/jsx-deep-nesting-stack-overflow.test.ts      2      3      0
test/bundler/transpiler/transpiler.test.js                    3      0      0
```

</details>

<!-- robobun:evidence:end -->
