### PR TITLE
js_printer: print esbuild's pretty-mode spaces in bare import, for(;;), and empty export-from

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6082,8 +6082,6 @@ pub(crate) mod __gated_printer {
                         }
                         self.print_whitespacer(ws!(b"from "));
                     } else {
-                        // Bare `import "x"`: no binding above printed the space
-                        // after the keyword.
                         self.print_space();
                     }
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6077,6 +6077,10 @@ pub(crate) mod __gated_printer {
                             self.print(b" ");
                         }
                         self.print_whitespacer(ws!(b"from "));
+                    } else {
+                        // Bare `import "x"`: no binding above printed the space
+                        // after the keyword.
+                        self.print_space();
                     }
 
                     self.print_import_record_path(record);

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -5619,9 +5619,12 @@ pub(crate) mod __gated_printer {
 
                     self.print_whitespacer(ws!(b"export {"));
 
+                    // `export {} from "x"` stays `{}`, like SExportClause above.
+                    let has_items = !slice_of(s.items).is_empty();
+
                     if !s.is_single_line {
                         self.indent();
-                    } else {
+                    } else if has_items {
                         self.print_space();
                     }
 
@@ -5643,7 +5646,7 @@ pub(crate) mod __gated_printer {
                         self.unindent();
                         self.print_newline();
                         self.print_indent();
-                    } else {
+                    } else if has_items {
                         self.print_space();
                     }
 
@@ -5829,6 +5832,7 @@ pub(crate) mod __gated_printer {
                     }
 
                     self.print(b";");
+                    self.print_space();
 
                     if let Some(test) = &s.test {
                         self.print_expr(*test, Level::Lowest, ExprFlag::none());

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -481,52 +481,52 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode acorn/dist/acorn.mjs": {
-          "js": "2ed858fa1b38a20673cee13a857ccdaedb9da0a325ebc47e81c4851de77eef3c",
+          "js": "c4a3cf8c55897447544822d5731ed35ae4eb40a88d95c63847d767871274ecd7",
           "jsc": {
             "bytes": 266176,
-            "sha256": "9fec89f154cf2ae1593f52d49bb3ba6bae0634a56e4cc8fe76aabf6abb70bfe1",
+            "sha256": "d42c31ae07014516869a9da49d0d6e183b6f0bc39bd254a26f44f08d52cacff7",
           },
         },
         "bun build --bytecode all.js": {
-          "js": "46d723ea07e5e2d8db673a51fec52b3248edcd3e216029f243d8172244f7cd2c",
+          "js": "af4ff9da9e0219c6c3bf86b274042ade24494dcc7decad4b96a08cda2e8ff323",
           "jsc": {
-            "bytes": 2178792,
-            "sha256": "c5d1eaae5c4d198b1f8e0d768bb41502162081c75b67249032e66a2b95e26ec1",
+            "bytes": 2178800,
+            "sha256": "edc6cccc45074beaf778938758b0c4e05e4a5080f229ce8ba0ad75c96a433798",
           },
         },
         "bun build --bytecode big.js": {
-          "js": "df5367354d3dbd2b81114585fb2a21d058910c869ece4404ef015c0efaf5c689",
+          "js": "4055fb09ca2d50e4fdae9e4d5e32240a184e8ef6df14f44ce6f101804485c6c3",
           "jsc": {
             "bytes": 168656,
-            "sha256": "cf4792f2ea174083447f9fa12860dce4e08ac5a22774cc80c3ea02b5ffb87e64",
+            "sha256": "a8620c1cdc66458b0b2759213c2fd88655d56fc61d9e1dac13a5dc221400674b",
           },
         },
         "bun build --bytecode features.js": {
-          "js": "2ee211924620db96d6e99e9490bfe0ee60a3bc6b003f37940c5631e6eabc2c73",
+          "js": "51dbb0caf27e477731d3a9b2f85f0940f7d0de84621c321ff49c6835353c11de",
           "jsc": {
             "bytes": 48048,
-            "sha256": "457b0f1c9172a8964bf79d7b102076d410da468d4728e3731964884cbaecfa6e",
+            "sha256": "9a0007cd917df10e54aa6a70fdeb18bce1c385c20de7e72fb5e0c121b7f3a2e1",
           },
         },
         "bun build --bytecode happy-dom/lib/index.js": {
-          "js": "148f0d3e4baf485281725f859deb3e717a6da25a4a08de9af288d5ef54b6414b",
+          "js": "886cf1b590590cd7e53bf69a1778178b51a9a17b9a2a0f366d1710d9ea1ac2ba",
           "jsc": {
             "bytes": 2528840,
-            "sha256": "d68b260282a74f545c15b5a3b812b69cb4e828972f85c5de60f8307b73c43e57",
+            "sha256": "a888c041ca6d4645cba6ab1c89093e3b502bb435e288ffd3ac90b7be4b8ebf0f",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
-          "js": "c9a2ba9f6b6a662e6bdfd44128bc66284276f5eac2a8875adb4578472328dc9f",
+          "js": "82ec98d00af8fd84d6af3612071d230655d1090e1a858f3a2a29472ef49a3d40",
           "jsc": {
             "bytes": 280016,
-            "sha256": "2a99c33a2516e2d41187bc322ddd4523318530b51c60c3d9a8bd566d4f2929a1",
+            "sha256": "cb005d5e6c3acc1a35880ae12d501c0a6b0758a711ff48e5355da2f8158aea18",
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "e685164a8316f60b665bc3d47e42b4623cfe7385f87310e655478a50ecd8f959",
+          "js": "e9b7ab3c967dc9f1f8b9bec7b79be860ce90b077d78ac80ab30b8b536a5bd886",
           "jsc": {
-            "bytes": 23806352,
-            "sha256": "5f23309532d868e1c985d568207c92b77a7f3974e5c6c3f37b21accf7d429327",
+            "bytes": 23806448,
+            "sha256": "adcb89b11eff35aacd142a1e4481f4d62bde8b906fb874b07424dcc08e3424f4",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -537,17 +537,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {
-          "js": "e2cf34c8eb6f5952a33ca91e3949b28786349cf97ea3fbf0b3b8500dbccd4860",
+          "js": "91ba3f2205cac7aed6dc68523512a69d1e95588133d5215dcd659ee3f509f703",
           "jsc": {
             "bytes": 980080,
-            "sha256": "32fa8492ad9fdf3ea31395756898d556df9dc6bdfbac9bba07bcafa748ab38ca",
+            "sha256": "f1fac049b590d8885375c84c4ef976eabfd4bc9c14c2ddb1f82b0e20ad87bbaf",
           },
         },
         "bun build --bytecode records.js": {
-          "js": "c87ea35df4ad6b2063402c9901ef4775a82f12594f280db76f50695f4b0eba13",
+          "js": "b6043e51a95d1836c46fb6473c8fade4aca5c9f596689c9e34bdba09b3659892",
           "jsc": {
             "bytes": 91800,
-            "sha256": "e58b77a8ed116cb6d48d82496d214eb11f8cc6b821049851b60c1f2fb27ebeea",
+            "sha256": "52e450840ec4896ca01265b748ef4b59d9d579ee42974003847eaa35ed28e939",
           },
         },
         "bun build --bytecode shapes.js": {
@@ -558,17 +558,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode svelte/compiler/index.js": {
-          "js": "5ced9487e680d82a45548d0f509ecc5c931f06485a2d17bac56ddd60e3ede785",
+          "js": "d956060e2ea64e9355729bea96e20f200f67d4f1bcc80f8b7b325f3f4d026152",
           "jsc": {
-            "bytes": 1996728,
-            "sha256": "1e224f518c1be57eb53460723b34128ca4c310bbe75a7a1ea93a900e24c3db74",
+            "bytes": 1996976,
+            "sha256": "247efe83fb47e2ffe7f65f031746de95fa98802b1698426d5b20917d8ef63775",
           },
         },
         "bun build --bytecode undici/index.js": {
-          "js": "d0bd3791e7c8f77a06814429d5d95cb26a06baaa3c135502bcd3e984310f1d2c",
+          "js": "090112c006dc051feea3647bc9fc0d75bc26cda074acadc85afe9e26a90fff09",
           "jsc": {
             "bytes": 937000,
-            "sha256": "d7cff4df84668b14987703bcd950a6753a574cf48e4372e4fe8779f747c0ed89",
+            "sha256": "4fb8369202d18c3e55852ebc0a4e5b73604f81ab212e7e4bd1799a72e8823078",
           },
         },
         "vm.Script big.js": {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -252,6 +252,39 @@ describe("bundler", () => {
       stdout: "1",
     },
   });
+  itBundled("edgecase/ExternalSideEffectImportSpace", {
+    files: {
+      "/entry.js": /* js */ `
+        import "side";
+        import { a } from "named";
+        import * as ns from "star";
+        console.log(a, ns);
+      `,
+    },
+    external: ["side", "named", "star"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain(`import "side";\n`);
+      expect(out).toContain(`import { a } from "named";\n`);
+      expect(out).toContain(`import * as ns from "star";\n`);
+    },
+  });
+  itBundled("edgecase/ExternalSideEffectImportSpaceMinified", {
+    files: {
+      "/entry.js": /* js */ `
+        import "side";
+        import { a } from "named";
+        import * as ns from "star";
+        console.log(a, ns);
+      `,
+    },
+    external: ["side", "named", "star"],
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain(`import"side";import{a}from"named";import*as ns from"star";`);
+    },
+  });
   itBundled("edgecase/ValidLoaderSeenAsInvalid", {
     files: {
       "/entry.js": /* js */ `console.log(1)`,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -252,13 +252,14 @@ describe("bundler", () => {
       stdout: "1",
     },
   });
-  itBundled("edgecase/ExternalSideEffectImportSpace", {
+  itBundled("edgecase/PrettyStatementSpacing", {
     files: {
       "/entry.js": /* js */ `
         import "side";
         import { a } from "named";
         import * as ns from "star";
-        console.log(a, ns);
+        for (let i = 0; i < 3; i++) console.log(a, ns, i);
+        for (;;) break;
       `,
     },
     external: ["side", "named", "star"],
@@ -267,15 +268,18 @@ describe("bundler", () => {
       expect(out).toContain(`import "side";\n`);
       expect(out).toContain(`import { a } from "named";\n`);
       expect(out).toContain(`import * as ns from "star";\n`);
+      expect(out).toContain(`for (let i = 0; i < 3; i++)\n`);
+      expect(out).toContain(`for (; ; )\n`);
     },
   });
-  itBundled("edgecase/ExternalSideEffectImportSpaceMinified", {
+  itBundled("edgecase/PrettyStatementSpacingMinified", {
     files: {
       "/entry.js": /* js */ `
         import "side";
         import { a } from "named";
         import * as ns from "star";
-        console.log(a, ns);
+        for (let i = 0; i < 3; i++) console.log(a, ns, i);
+        for (;;) break;
       `,
     },
     external: ["side", "named", "star"],
@@ -283,6 +287,7 @@ describe("bundler", () => {
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
       expect(out).toContain(`import"side";import{a}from"named";import*as ns from"star";`);
+      expect(out).toContain(`for(let i=0;i<3;i++)console.log(a,ns,i);for(;;)break;`);
     },
   });
   itBundled("edgecase/ValidLoaderSeenAsInvalid", {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1660,7 +1660,7 @@ export default class {
       ts.expectPrinted_("for (async as any of [7]);", "for ((async) of [7])\n  ;\n");
       ts.expectPrinted_("for (async satisfies T of [7]);", "for ((async) of [7])\n  ;\n");
       ts.expectPrinted_("for (async! of [7]);", "for ((async) of [7])\n  ;\n");
-      ts.expectPrinted_("for (async of => {};;);", "for (async (of) => {};; )\n  ;\n");
+      ts.expectPrinted_("for (async of => {};;);", "for (async (of) => {}; ; )\n  ;\n");
       ts.expectPrinted_(
         "async function f() { for await (async of [7]); }",
         "async function f() {\n  for await ((async) of [7])\n    ;\n}",
@@ -2842,6 +2842,38 @@ console.log(<div {...obj} key="after" />);`),
       );
     });
 
+    it("for loop and export-from whitespace", () => {
+      const code = [
+        `for (let i = 0; i < 3; i++) {}`,
+        `for (;;) {}`,
+        `for (; x; ) {}`,
+        `for (i = 0; ; i++) {}`,
+        `export {} from "empty";`,
+        `export { a } from "named";`,
+        `export { b as c, d } from "aliased";`,
+      ].join("\n");
+
+      const pretty = new Bun.Transpiler({ loader: "js" }).transformSync(code);
+      expect(pretty).toBe(
+        [
+          `for (let i = 0; i < 3; i++) {}`,
+          `for (; ; ) {}`,
+          `for (; x; ) {}`,
+          `for (i = 0; ; i++) {}`,
+          `export {} from "empty";`,
+          `export { a } from "named";`,
+          `export { b as c, d } from "aliased";`,
+          ``,
+        ].join("\n"),
+      );
+
+      const minified = new Bun.Transpiler({ loader: "js", minifyWhitespace: true }).transformSync(code);
+      expect(minified).toBe(
+        `for(let i=0;i<3;i++){}for(;;){}for(;x;){}for(i=0;;i++){}` +
+          `export{}from"empty";export{a}from"named";export{b as c,d}from"aliased";`,
+      );
+    });
+
     it("import with separator-only or trailing-separator path", () => {
       expectPrinted_(`import "/"`, `import "/"`);
       expectPrinted_(`import "//"`, `import "//"`);
@@ -2851,6 +2883,7 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_(`export * from "/"`, `export * from "/"`);
       expectPrinted_(`export * from "foo//"`, `export * from "foo//"`);
       expectPrinted_(`export { a } from "/"`, `export { a } from "/"`);
+      expectPrinted_(`export {} from "/"`, `export {} from "/"`);
     });
 
     it("empty string as import/export clause alias", () => {
@@ -3992,7 +4025,7 @@ console.log(foo, array);
         "let x = arg0;\nwhile (x)\n  return 1;",
         // "let x = arg0;\nfor (; x; )\n  return 1;",
       );
-      check("let x = arg0; for (; x; ) return 1;", "let x = arg0;\nfor (;x; )\n  return 1;");
+      check("let x = arg0; for (; x; ) return 1;", "let x = arg0;\nfor (; x; )\n  return 1;");
 
       // Can substitute an expression without side effects into a branch due to optional chaining
       // TODO:
@@ -4767,7 +4800,7 @@ console.log("boop");
     expectPrinted_("async function f() { await using.foo() }", "async function f() {\n  await using.foo();\n}");
     expectPrinted_(
       "async function f() { for (await using instanceof o;;); }",
-      "async function f() {\n  for (await using instanceof o;; )\n    ;\n}",
+      "async function f() {\n  for (await using instanceof o; ; )\n    ;\n}",
     );
     expectBunPrinted_("await using instanceof o", "await using instanceof o");
   });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -806,7 +806,7 @@ describe("Bun.Transpiler", () => {
       exp("x<true> y", "x < true > y;\n");
       exp("x<true>\ny", "x;\ny;\n");
       exp("x<true>\nif (y) {}", "x;\nif (y)");
-      exp("x<true>\nimport 'y'", 'x;\nimport"y";\n');
+      exp("x<true>\nimport 'y'", 'x;\nimport "y";\n');
       exp("x<true>\nimport('y')", 'x;\nimport("y");\n');
       exp("x<true>\na(import.meta)", "x;\na(import.meta);\n");
       exp("x<true> import('y')", 'x < true > import("y");\n');
@@ -814,7 +814,7 @@ describe("Bun.Transpiler", () => {
       exp("new x<number> y", "new x < number > y");
       exp("new x<number>\ny", "new x;\ny");
       exp("new x<number>\nif (y) {}", "new x;\nif (y)");
-      exp("new x<true>\nimport 'y'", 'new x;\nimport"y"');
+      exp("new x<true>\nimport 'y'", 'new x;\nimport "y"');
       exp("new x<true>\nimport('y')", 'new x;\nimport("y")');
       exp("new x<true>\na(import.meta)", "new x;\na(import.meta)");
       exp("new x<true> import('y')", 'new x < true > import("y")');
@@ -2807,12 +2807,47 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_(`import { name } from '".ts';`, `import { name } from '".ts'`);
     });
 
+    it("import statement whitespace for every binding shape", () => {
+      const code = [
+        `import "side";`,
+        `import def from "def";`,
+        `import { a, b as c } from "named";`,
+        `import def2, { d } from "both";`,
+        `import * as ns from "star";`,
+        `import def3, * as ns2 from "defstar";`,
+        `import defer * as lazy from "deferred";`,
+        `console.log(def, a, c, def2, d, ns, def3, ns2, lazy);`,
+      ].join("\n");
+
+      const pretty = new Bun.Transpiler({ loader: "js" }).transformSync(code);
+      expect(pretty).toBe(
+        [
+          `import "side";`,
+          `import def from "def";`,
+          `import { a, b as c } from "named";`,
+          `import def2, { d } from "both";`,
+          `import * as ns from "star";`,
+          `import def3, * as ns2 from "defstar";`,
+          `import defer * as lazy from "deferred";`,
+          `console.log(def, a, c, def2, d, ns, def3, ns2, lazy);`,
+          ``,
+        ].join("\n"),
+      );
+
+      const minified = new Bun.Transpiler({ loader: "js", minifyWhitespace: true }).transformSync(code);
+      expect(minified).toBe(
+        `import"side";import def from"def";import{a,b as c}from"named";import def2,{d}from"both";` +
+          `import*as ns from"star";import def3,*as ns2 from"defstar";import defer*as lazy from"deferred";` +
+          `console.log(def,a,c,def2,d,ns,def3,ns2,lazy);`,
+      );
+    });
+
     it("import with separator-only or trailing-separator path", () => {
-      expectPrinted_(`import "/"`, `import"/"`);
-      expectPrinted_(`import "//"`, `import"//"`);
-      expectPrinted_(`import "///"`, `import"///"`);
-      expectPrinted_(`import "foo//"`, `import"foo//"`);
-      expectPrinted_(`import "foo///"`, `import"foo///"`);
+      expectPrinted_(`import "/"`, `import "/"`);
+      expectPrinted_(`import "//"`, `import "//"`);
+      expectPrinted_(`import "///"`, `import "///"`);
+      expectPrinted_(`import "foo//"`, `import "foo//"`);
+      expectPrinted_(`import "foo///"`, `import "foo///"`);
       expectPrinted_(`export * from "/"`, `export * from "/"`);
       expectPrinted_(`export * from "foo//"`, `export * from "foo//"`);
       expectPrinted_(`export { a } from "/"`, `export { a } from "/"`);


### PR DESCRIPTION
### Problem
- Three arms of `print_stmt` in `src/js_printer/lib.rs` print non-minified whitespace that differs from esbuild, the printer's reference. A bare import prints `import"foo";`. A for loop prints `for (;; )`. An empty export-from prints `export {  } from "x";`.
- Each is a `print_space()` the Rust port carried over from the Zig printer. `SImport` (line 6074) spaces only `from`, `SFor` (line 5834) only the second `;`, `SExportFrom` (lines 5625, 5649) the inside of an empty `{ }`.

### Fix
- `SImport`: with zero bindings, `print_space()` before the path. `SFor`: `print_space()` after the first `;` too. `SExportFrom`: inner spaces only when the clause has items, as `SExportClause` already does.
- Correct because the other import shapes keep their own space calls, so none gains a double space, and `import defer` always has a binding. The output now matches esbuild: `import "foo"`, `for (; ; )`, `export {} from "x"`. `print_space()` is a no-op under `minify_whitespace`, so minified output is byte-identical.
- `transpiler.test.js` had eight expectations of the old output. `bundler_bytecode_portable.test.ts` hashes non-minified bundler output, where every for loop moved one space, so its snapshot is regenerated.
- Verified: `test/bundler/transpiler/transpiler.test.js` (two new tests, 14 shapes, both whitespace modes), `test/bundler/bundler_edgecase.test.ts` (`PrettyStatementSpacing` plus a minified twin), the rest of `test/bundler/`.

### Background
- `js_printer` turns the AST back into JavaScript text for the bundler and the runtime transpiler.
- `print_space()` prints one space unless `minify_whitespace` is on. `print_whitespacer` prints a string normally and a space-stripped copy under minify.
- `item_count` in the import arm counts the binding groups printed. It gates the ` from ` that must follow a binding.

<details><summary>Notes</summary>

- Repro on bun 1.4.1: `echo 'import "foo"' > x.js && bun build x.js --external foo` prints `import"foo";`.
- All three quirks date back to the Zig printer (`git show c8b4c3607e^:src/js_printer.zig`, the `s_import`, `s_for`, and `s_export_from` arms). The Rust port carried them over unchanged.
- The first revision of this PR fixed only the import arm. The self-review found the two sibling arms with the same pattern and the same provenance. A diff of about 50 statement forms against esbuild 0.21.5 showed these three as the only pretty-mode whitespace defects. The other differences (`{}` blocks, `if`/`else` layout, `void 0`) are deliberate Bun style.
- Considered the esbuild structure for the import arm (`print_space()` right after the keyword and `print_space_before_identifier()` before each identifier). Rejected: `import defer` needs a real space before `defer` under minify, and `print_space_before_identifier` reads one byte, so a namespace name that ends in a multi-byte character would lose the space before `from` under minify.
- Every import, for, and export-from shape was printed under `--minify-whitespace` before and after. The bytes are identical.
- The bundler rewrites `export {} from "x"` to `import "x"`, so the empty export-from shape is only reachable through `Bun.Transpiler` and `bun build --no-bundle`. The bundler test therefore covers imports and for loops, and the transpiler test covers all three.
- The bytecode snapshot: only the non-minified `bun build --bytecode` entries changed (13 of them). The `--minify` entries, the `vm.Script` entries, and the builtin corpus are unchanged. Some bytecode sizes grew by a few bytes because column offsets moved. Regenerated with `--update-snapshots`, the case the file's header comment describes (a change that moves the output on every platform).
- The only other hits for the old for-loop output are `test/snapshots/*.js`, Zig-era files that no test reads. They are left alone.
- Local runs covered all of `test/bundler/` except `bundler_compile.test.ts`. `test/bundler/transpiler/jsx-production.test.ts` times out for a few of its 32 concurrent spawn tests under the debug build in this container (each passes alone in about 4s, the per-test limit is 5s). It does not touch statement printing.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts, test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->