### PR TITLE
install: sort workspace deps by resolved name when writing bun.lock

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1328,10 +1328,8 @@ impl Stringifier {
             any = true;
         }
 
-        // Sort by the current dependency name at write time. The parse-time sort can be
-        // stale: a `github:`/`git:`/tarball dep added with no alias is sorted under its
-        // version literal, and `assign_resolution` later rewrites the name in place
-        // without a re-sort.
+        // Re-sort by current name: a no-alias git/tarball dep sorts under its version
+        // literal at parse time, and `assign_resolution` renames it without a re-sort.
         let deps_list = pkg_deps[pkg_id as usize];
         let mut deps_sort_buf: Vec<DependencyID> = (deps_list.begin()..deps_list.end()).collect();
         TreeDepsSortCtx {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -163,6 +163,18 @@ impl<'a> TreeDepsSortCtx<'a> {
             r.name.slice(self.string_buf),
         )
     }
+
+    fn sort(&self, dep_ids: &mut [DependencyID]) {
+        index_sort::sort_indices(dep_ids, &mut |a, b| {
+            if self.is_less_than(a, b) {
+                core::cmp::Ordering::Less
+            } else if self.is_less_than(b, a) {
+                core::cmp::Ordering::Greater
+            } else {
+                core::cmp::Ordering::Equal
+            }
+        });
+    }
 }
 
 /// The slot order every existing bun.lock has its `trustedDependencies` and
@@ -673,21 +685,11 @@ impl Stringifier {
                 tree_deps_sort_buf.clear();
                 tree_deps_sort_buf.extend_from_slice(dependencies);
 
-                {
-                    let ctx = TreeDepsSortCtx {
-                        string_buf: buf,
-                        deps_buf,
-                    };
-                    index_sort::sort_indices(&mut tree_deps_sort_buf, &mut |a, b| {
-                        if ctx.is_less_than(a, b) {
-                            core::cmp::Ordering::Less
-                        } else if ctx.is_less_than(b, a) {
-                            core::cmp::Ordering::Greater
-                        } else {
-                            core::cmp::Ordering::Equal
-                        }
-                    });
+                TreeDepsSortCtx {
+                    string_buf: buf,
+                    deps_buf,
                 }
+                .sort(&mut tree_deps_sort_buf);
 
                 for &dep_id in &tree_deps_sort_buf {
                     let pkg_id = resolution_buf[dep_id as usize];
@@ -772,21 +774,11 @@ impl Stringifier {
                     // there might be duplicate names due to dependency behaviors,
                     // but we print behaviors in different groups so it won't affect
                     // the result
-                    {
-                        let ctx = TreeDepsSortCtx {
-                            string_buf: buf,
-                            deps_buf,
-                        };
-                        index_sort::sort_indices(&mut pkg_deps_sort_buf, &mut |a, b| {
-                            if ctx.is_less_than(a, b) {
-                                core::cmp::Ordering::Less
-                            } else if ctx.is_less_than(b, a) {
-                                core::cmp::Ordering::Greater
-                            } else {
-                                core::cmp::Ordering::Equal
-                            }
-                        });
+                    TreeDepsSortCtx {
+                        string_buf: buf,
+                        deps_buf,
                     }
+                    .sort(&mut pkg_deps_sort_buf);
 
                     // INFO = { prod/dev/optional/peer dependencies, os, cpu, libc (TODO), bin, binDir }
 
@@ -1336,9 +1328,22 @@ impl Stringifier {
             any = true;
         }
 
+        // Sort by the current dependency name at write time. The parse-time sort can be
+        // stale: a `github:`/`git:`/tarball dep added with no alias is sorted under its
+        // version literal, and `assign_resolution` later rewrites the name in place
+        // without a re-sort.
+        let deps_list = pkg_deps[pkg_id as usize];
+        let mut deps_sort_buf: Vec<DependencyID> = (deps_list.begin()..deps_list.end()).collect();
+        TreeDepsSortCtx {
+            string_buf: buf,
+            deps_buf,
+        }
+        .sort(&mut deps_sort_buf);
+
         for &(group_name, group_behavior) in WORKSPACE_DEPENDENCY_GROUPS.iter() {
             let mut first = true;
-            for dep in pkg_deps[pkg_id as usize].get(deps_buf) {
+            for &dep_id in &deps_sort_buf {
+                let dep = &deps_buf[dep_id as usize];
                 if !dep.behavior.intersects(group_behavior) {
                     continue;
                 }

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -586,3 +586,36 @@ test.concurrent("installs a git+file:// dependency", async () => {
   expect(await lockedPackages(project)).toEqual(locked);
   expect(exitCode).toBe(0);
 });
+
+// issue #40803: `bun install <git url>` (no alias) sorted the workspace dep
+// under its version literal. The real name is only known once the repo is
+// fetched; it is rewritten in place after resolution, so the written key
+// landed at the literal's position ("git..." here, between nothing and
+// "hhh-first") instead of its own.
+test.concurrent("bun install <git url> sorts the workspace dependency by its resolved name", async () => {
+  using dir = tempDir("git-dep-sort", {
+    "project/package.json": JSON.stringify({
+      name: "project",
+      version: "1.0.0",
+      dependencies: { "hhh-first": "file:./hhh-first", "jjj-last": "file:./jjj-last" },
+    }),
+    "project/hhh-first/package.json": JSON.stringify({ name: "hhh-first", version: "1.0.0" }),
+    "project/jjj-last/package.json": JSON.stringify({ name: "jjj-last", version: "1.0.0" }),
+  });
+  const root = String(dir);
+  const project = join(root, "project");
+  const bare = await makeSharedRepo(root, [{ name: "iii-middle", branch: "main" }], "sort-repo.git");
+
+  const first = await runInstall(project, join(root, "cache"), {});
+  expect(first.stderr).toContain("Saved lockfile");
+  expect(first.exitCode).toBe(0);
+
+  const second = await runInstall(project, join(root, "cache"), {}, `git+${pathToFileURL(bare)}#main`);
+  expect(second.stderr).toContain("Saved lockfile");
+  expect(second.exitCode).toBe(0);
+
+  const lockfile = Bun.JSONC.parse(await Bun.file(join(project, "bun.lock")).text()) as {
+    workspaces: Record<string, { dependencies: Record<string, string> }>;
+  };
+  expect(Object.keys(lockfile.workspaces[""].dependencies)).toEqual(["hhh-first", "iii-middle", "jjj-last"]);
+});

--- a/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
@@ -275,15 +275,15 @@ exports[`yarn.lock migration basic migration with realistic complex yarn.lock: c
     "": {
       "name": "complex-app",
       "dependencies": {
+        "@babel/core": "^7.20.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "@babel/core": "^7.20.0",
         "webpack": "^5.75.0",
       },
       "devDependencies": {
         "@types/react": "^18.0.0",
-        "typescript": "^4.9.0",
         "eslint": "^8.0.0",
+        "typescript": "^4.9.0",
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2",
@@ -3186,8 +3186,8 @@ exports[`bun pm migrate for existing yarn.lock yarn.lock with packages that have
     "": {
       "name": "os-cpu-test",
       "dependencies": {
-        "fsevents": "^2.3.2",
         "esbuild": "^0.17.0",
+        "fsevents": "^2.3.2",
       },
     },
   },


### PR DESCRIPTION
### Problem
- `bun i github:user/repo` writes the dependency key at the wrong position in the `workspaces` section of `bun.lock`. After `bun i formidable handlebars` then `bun i github:lukeed/clsx`, the root `dependencies` map reads `formidable, clsx, handlebars` (issue #40803).
- The real package name is unknown until the repo is fetched, so the dependency enters the lockfile buffer under its version literal (`github:lukeed/clsx`) and is sorted there (`src/install/lockfile/Package.rs:3056`). `assign_resolution` (`src/install/PackageManager/PackageManagerResolution.rs:267`) later rewrites the name in place to `clsx` without a re-sort. `write_workspace_deps` then iterated the stale buffer order.

### Fix
- `write_workspace_deps` (`src/install/lockfile/bun.lock.rs`) now sorts the package's dependency ids by their current name at write time, with the same `TreeDepsSortCtx` comparator the `packages` section already uses for this exact reason.
- The comparator and the name order match the parse-time sort, so a lockfile built through the normal parse path is written byte for byte the same as before. Two cases change: the stale-name case, and yarn.lock migration, which inserted workspace deps in yarn.lock order and now writes them alphabetized. The two migration snapshots are updated.
- The two existing copies of the `TreeDepsSortCtx` sort closure are folded into one `sort` method. No behavior change there.
- Verified: `test/cli/install/bun-install-git-deps.test.ts` (new test, fails on stock bun). Also ran bun-lock, lockfile-only, bun-update-lockfile-sync, both frozen-lockfile suites, bun-add, bun-lockb, migrate-bun-lockb-v2, and yarn-lock-migration.

### Background
- A package's dependencies live as a slice into one shared buffer. Re-sorting that buffer after resolution is not safe: dependency ids are raw indices into it and are stored in the tree and the hoisted list. A write-time index sort leaves the buffer alone.
- The `packages` section of the writer already builds a sorted id list per package for the same reason, so its output was never affected. Only the `workspaces` section read the buffer directly.
- The same holds for any no-alias `git:`, `github:`, or tarball-URL add. The new test uses a local `git+file://` repo, so it stays hermetic.

<details><summary>Notes</summary>

- The dependency groups (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`) are written by an outer loop that filters on behavior, so the write-time sort only needs name order. A name that appears in two groups is split by the filter, as in the `packages` section.
- `package.json` is edited with the resolved name (`UpdateRequest::get_resolved_name`), so a delete of `bun.lock` plus a fresh `bun i` already produced the right order. Only the add path wrote the stale position, and a later no-change install preserved it. This matches the report.
- Fail-before: `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-install-git-deps.test.ts -t "sorts the workspace dependency"` fails with `iii-middle` before `hhh-first`. Passes with the fix.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-git-deps.test.ts
bun test v1.4.1 (65362b53b)

test/cli/install/bun-install-git-deps.test.ts:
(pass) installs every github: dependency that appears directly and transitively [1130.30ms]
(pass) installs every tarball-URL dependency that appears directly and transitively [1586.61ms]
(pass) hoisted linker installs the locked commit from a cold cache after the branch moves [1738.20ms]
(pass) installs every git dependency from a lockfile on a cold cache when deps share one repo [1903.67ms]
(pass) installs a git+file:// dependency [487.76ms]
(pass) isolated linker installs the locked commit from a cold cache after the branch moves [1294.06ms]
615 |   expect(second.exitCode).toBe(0);
616 | 
617 |   const lockfile = Bun.JSONC.parse(await Bun.file(join(project, "bun.lock")).text()) as {
618 |     workspaces: Record<string, { dependencies: Record<string, string> }>;
619 |   };
620 |   expect(Object.keys(lockfile.workspaces[""].dependencies)).toEqual(["hhh-first", "iii-middle", "jjj-last"]);
                           
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (8020b6142)

test/cli/install/bun-install-git-deps.test.ts:
(pass) installs every tarball-URL dependency that appears directly and transitively [141.63ms]
(pass) installs every github: dependency that appears directly and transitively [154.75ms]
(pass) bun install <git url> sorts the workspace dependency by its resolved name [285.50ms]
(pass) installs a git+file:// dependency [293.54ms]
(pass) isolated linker installs the locked commit from a cold cache after the branch moves [370.48ms]
(pass) hoisted linker installs the locked commit from a cold cache after the branch moves [423.44ms]
(pass) installs every git dependency from a lockfile on a cold cache when deps share one repo [447.36ms]
(pass) installs every git dependency when many branches of one repo appear directly and transitively [726.87ms]

 8 pass
 0 fail
 10 snapshots, 78 expect() calls
Ran 8 tests across 1 file. [857.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-git-deps.test.ts
bun test v1.4.1 (65362b53b)

test/cli/install/bun-install-git-deps.test.ts:
(pass) installs every github: dependency that appears directly and transitively [734.73ms]
(pass) installs every tarball-URL dependency that appears directly and transitively [984.85ms]
(pass) hoisted linker installs the locked commit from a cold cache after the branch moves [1097.26ms]
(pass) installs every git dependency from a lockfile on a cold cache when deps share one repo [1212.95ms]
(pass) installs every git dependency when many branches of one repo appear directly and transitively [1447.73ms]
(pass) installs a git+file:// dependency [409.96ms]
(pass) isolated linker installs the locked commit from a cold cache after the branch moves [768.63ms]
(pass) bun install <git url> sorts the workspace dependency by its resolved name [466.78ms]

 8 pass
 0 fail
 10 snapshots, 78 expect() calls
Ran 8 tests across 1 file. [4.25s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 667ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/lockfile/bun.lock.rs                   | 61 ++++++++++++----------
 test/cli/install/bun-install-git-deps.test.ts      | 33 ++++++++++++
 .../__snapshots__/yarn-lock-migration.test.ts.snap |  6 +--
 3 files changed, 68 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/install/lockfile/bun.lock.rs                              6      6      0
test/cli/install/bun-install-git-deps.test.ts                 3      1      0
…igration/__snapshots__/yarn-lock-migration.test.ts.snap      0      0      0
```

</details>

**root cause** · written by the author bot

When a git or tarball dependency is installed without an alias, the lockfile's workspace dependencies are sorted at parse time under the version literal (for example "github:user/repo"), and assign_resolution later rewrites the entry's name to the actual package name without triggering a re-sort, leaving the entry in the wrong alphabetical position. The fix re-sorts the dependencies by their current names at stringify time, so the lockfile is written using the final resolved names and the entries land in correct alphabetical order.

<!-- robobun:evidence:end -->