### PR TITLE
bundler: create copied --no-bundle outputs with the default mode and close both fds

### DIFF
--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -252,30 +252,25 @@ impl OutputFile {
     }
 
     pub(crate) fn copy_to(&self, rel_path: &[u8], dir: Fd) -> Result<(), Error> {
-        let mut out_buf = PathBuffer::uninit();
-        let fd_out = bun_sys::openat(
+        // Both `File`s close on Drop. The source is opened first so a missing
+        // source does not leave an empty destination behind.
+        let src = bun_sys::File::openat(Fd::cwd(), self.src_path.text, bun_sys::O::RDONLY, 0)?;
+        let dest = bun_sys::File::openat(
             dir,
-            resolve_path::z(rel_path, &mut out_buf),
+            rel_path,
             bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
-            0o644,
-        )?;
-        let mut in_buf = PathBuffer::uninit();
-        let fd_in = bun_sys::openat(
-            Fd::cwd(),
-            resolve_path::z(self.src_path.text, &mut in_buf),
-            bun_sys::O::RDONLY,
-            0,
+            if self.is_executable { 0o777 } else { 0o666 },
         )?;
 
         #[cfg(windows)]
         {
-            let _ = (fd_out, fd_in);
+            let _ = (&src, &dest);
             // use paths instead of bun.getFdPathW()
             panic!("TODO windows");
         }
         #[cfg(not(windows))]
         {
-            bun_sys::copy_file(fd_in, fd_out)?;
+            bun_sys::copy_file(src.handle(), dest.handle())?;
             Ok(())
         }
     }

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -252,8 +252,6 @@ impl OutputFile {
     }
 
     pub(crate) fn copy_to(&self, rel_path: &[u8], dir: Fd) -> Result<(), Error> {
-        // Both `File`s close on Drop. The source is opened first so a missing
-        // source does not leave an empty destination behind.
         let src = bun_sys::File::openat(Fd::cwd(), self.src_path.text, bun_sys::O::RDONLY, 0)?;
         let dest = bun_sys::File::openat(
             dir,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3044,7 +3044,7 @@ impl<'a> Transpiler<'a> {
             | options::Loader::Wasm
             | options::Loader::File
             | options::Loader::Napi => {
-                output_file.value = self.build_copied_file_output(file_path_text, file_path_ext)?;
+                self.build_copied_file_output(&mut output_file, file_path_text, file_path_ext)?;
             }
         }
 
@@ -3223,20 +3223,24 @@ impl<'a> Transpiler<'a> {
     #[inline(never)]
     fn build_copied_file_output(
         &mut self,
+        output_file: &mut options::OutputFile,
         file_path_text: &'static [u8],
         file_path_ext: &[u8],
-    ) -> crate::Result<crate::output_file::Value> {
-        let hashed_name = self
-            .linker
-            .get_hashed_filename(&bun_paths::fs::Path::init(file_path_text), None)?;
+    ) -> crate::Result<()> {
+        let file = bun_sys::File::openat(FD::cwd(), file_path_text, bun_sys::O::RDONLY, 0)?;
+        // The copy keeps the source's executable bit, like `cp` does.
+        output_file.is_executable = (file.stat()?.st_mode as u32) & 0o111 != 0;
+        let hashed_name = self.linker.get_hashed_filename(
+            &bun_paths::fs::Path::init(file_path_text),
+            Some(file.handle()),
+        )?;
         let mut pathname = Vec::with_capacity(hashed_name.len() + file_path_ext.len());
         pathname.extend_from_slice(hashed_name);
         pathname.extend_from_slice(file_path_ext);
-        Ok(crate::output_file::Value::Copy(
-            crate::output_file::FileOperation {
-                pathname: pathname.into_boxed_slice(),
-            },
-        ))
+        output_file.value = crate::output_file::Value::Copy(crate::output_file::FileOperation {
+            pathname: pathname.into_boxed_slice(),
+        });
+        Ok(())
     }
 }
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -799,6 +799,63 @@ describe.concurrent("--no-bundle with --outdir", () => {
   });
 });
 
+// Entry points with the `file` loader are copied verbatim (OutputFile::copy_to).
+// The copy is written with the default create mode, so the umask applies, and
+// it keeps the source's executable bit. The copy is currently named
+// `<source>-<hash>.<ext>`, so the tests locate it by glob.
+describe.concurrent.skipIf(isWindows)("--no-bundle copies file loader entry points", () => {
+  function findCopy(dir: string, name: string): string {
+    const ext = path.extname(name);
+    const matches = Array.from(new Bun.Glob(`**/${name}-*${ext}`).scanSync({ cwd: dir, absolute: true }));
+    expect(matches).toHaveLength(1);
+    return matches[0];
+  }
+
+  async function buildWithUmask(dir: string, umask: string, entry: string) {
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `umask ${umask} && exec "$0" "$@"`, bunExe(), "build", "--no-bundle", entry, "--outdir=dist"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  test("creates the copy with mode 0666 masked by the umask", async () => {
+    using dir = tempDir("no-bundle-copy-umask", {
+      "src/asset.bin": "binary payload\n",
+    });
+
+    await buildWithUmask(String(dir), "002", "./src/asset.bin");
+
+    const copy = findCopy(String(dir), "asset.bin");
+    expect(fs.readFileSync(copy, "utf8")).toBe("binary payload\n");
+    expect((fs.statSync(copy).mode & 0o777).toString(8)).toBe("664");
+  });
+
+  test("keeps the executable bit of the source", async () => {
+    using dir = tempDir("no-bundle-copy-exec", {
+      "src/tool.bin": "#!/bin/sh\necho hi\n",
+      "src/data.bin": "not a program\n",
+    });
+    fs.chmodSync(path.join(String(dir), "src", "tool.bin"), 0o755);
+    fs.chmodSync(path.join(String(dir), "src", "data.bin"), 0o644);
+
+    await buildWithUmask(String(dir), "022", "./src/tool.bin");
+    await buildWithUmask(String(dir), "022", "./src/data.bin");
+
+    const tool = findCopy(String(dir), "tool.bin");
+    const data = findCopy(String(dir), "data.bin");
+    expect(fs.readFileSync(tool, "utf8")).toBe("#!/bin/sh\necho hi\n");
+    expect((fs.statSync(tool).mode & 0o777).toString(8)).toBe("755");
+    expect((fs.statSync(data).mode & 0o777).toString(8)).toBe("644");
+  });
+});
+
 describe("CLI argument error messages", () => {
   test("--format with an unrecognized value echoes the value back", async () => {
     using dir = tempDir("build-format-err", { "in.js": "console.log(1)" });


### PR DESCRIPTION
### Problem
- `bun build --no-bundle` copies entry points with the `file`, `wasm`, `napi`, `bunsh`, `sqlite`, and `html` loaders. `OutputFile::copy_to` (`src/bundler/OutputFile.rs:254`) created the destination with a hard-coded `0o644`. Under `umask 002` the copy is `0644` where every other created file is `0664`. It ignored `is_executable`, and nothing set that flag for a copy, so an executable source gave a non-executable copy.
- The POSIX arm never closed the two descriptors it opened. With `ulimit -n 12` and 8 copied entry points the released build fails with `EMFILE: failed to write file '""'`.

### Fix
- `copy_to` creates the destination with `0o666`, or `0o777` when `is_executable` is set, so the umask applies as it does for `bun_sys::File::create`. Both descriptors are `bun_sys::File` values and close on drop. The source is opened first, so a missing source no longer leaves an empty destination.
- The copy arm in `Transpiler::build_with_resolve_result_eager` (`src/bundler/transpiler.rs`, `build_copied_file_output`) opens the source once, reads its mode with `fstat`, and sets `is_executable` when any execute bit is set. The same handle feeds `get_hashed_filename`.
- Verified: `test/bundler/cli.test.ts`, new `--no-bundle copies file loader entry points` block. Both tests get `0644` on the released build and pass with this change. Also ran `cli.test.ts`, `bundler_naming.test.ts`, `test/bake/dev/production.test.ts`, and `test/internal/source-lints`.

### Background
- `--no-bundle` transpiles each entry point on its own through `Transpiler::transform`, not `BundleV2`. Loaders with no transpiled form record a `Value::Copy`, and `OutputFile::write_to_disk` later calls `copy_to`.
- `is_executable` on an `OutputFile` marks an output as a program. JS chunks set it for a hashbang entry. The `Value::Buffer` write uses it to pick `0o755`.
- The mode passed to `open(2)` is masked by the process umask.

<details><summary>Notes</summary>

- The copied file is still written next to the source as `<source>-<hash>.<ext>` with an empty `dest_path`. That is a separate pre-existing bug, noted in #35644 and addressed by #38123, which replaces `copy_to` with a buffered write. The new tests locate the copy by glob so they do not depend on where it lands.
- While testing with many entry points: `bun build --no-bundle` with 9 or more copied entry points panics in `resolve_path::longest_common_path` (`index -= 1` underflow when an input path is empty). Reproduces on the released build, unrelated to this change, filed separately.
- fd leak check: `ulimit -n 12; bun build --no-bundle --outdir out src/a1.bin ... src/a8.bin`. Released build: 4 `EMFILE` failures. This build: exit 0.
- Test modes: `0664` under `umask 002` for a `0644` source, `0755` for a `0755` source under `umask 022`, `0644` for a `0644` source under `umask 022`.
- `cargo check -p bun_bundler` passes for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`. The Windows arm of `copy_to` is unchanged (`panic!("TODO windows")`), so the tests are skipped on Windows.
- The `Value::Buffer` arm of `write_to_disk` keeps its `0o755` / `0o644` modes. Changing those is a user-visible change to transpiled output and is out of scope here.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->