### PR TITLE
install: do not duplicate the package.json key when adding a new commit of a git dependency

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1214,6 +1214,36 @@ pub(crate) fn edit(
                 break;
             }
 
+            // For a non-aliased git/github/tarball/folder request, `get_name()` is the
+            // URL or path literal: the before-install edit keys its entry by that
+            // literal, and the slot above was just re-keyed to the resolved package
+            // name. If the list already declared this package under the resolved name
+            // with a different literal (e.g. a new commit hash), that stale entry is
+            // still present, so drop it or the file ends up with a duplicate key.
+            if !request.is_aliased && k < new_dependencies.len() {
+                let resolved_name = request.get_resolved_name(&manager.lockfile);
+                let mut j = new_dependencies.len();
+                while j > 0 {
+                    j -= 1;
+                    if j == k {
+                        continue;
+                    }
+                    if let Some(key) = &new_dependencies[j].key {
+                        if key
+                            .data
+                            .e_string()
+                            .expect("infallible: variant checked")
+                            .eql_bytes(resolved_name)
+                        {
+                            new_dependencies.remove(j);
+                            if j < k {
+                                k -= 1;
+                            }
+                        }
+                    }
+                }
+            }
+
             // There are no early-exit
             // paths between the top of this `for` body and here, so a plain post-loop assert
             // suffices (and avoids a `scopeguard` borrow conflict on

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,9 +1,10 @@
 import type { BunLockFile } from "bun";
-import { file, spawn } from "bun";
+import { $, file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
 import { join, relative, resolve } from "path";
+import { pathToFileURL } from "url";
 import {
   check_npm_auth_type,
   dummyAfterAll,
@@ -2661,6 +2662,68 @@ it("should not add duplicate package.json entries when installing the same tarba
     version: "0.0.1",
     dependencies: {
       baz: tarball_url,
+    },
+  });
+});
+
+it("should not add duplicate package.json entries when installing a different commit of the same git dependency (#40799)", async () => {
+  setHandler(dummyRegistry([]));
+  const gitEnv = {
+    ...env,
+    // Set on the asan lanes, where it makes `bun install` kill its own git clones (#33982).
+    BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+
+  // Two commits in a local repo stand in for two github hashes.
+  await writeFile(join(add_dir, "package.json"), JSON.stringify({ name: "mydep", version: "1.0.0" }));
+  await $`git init -q && git add -A && git commit -q -m one --no-gpg-sign`.cwd(add_dir).env(gitEnv).quiet();
+  const sha1 = (await $`git rev-parse HEAD`.cwd(add_dir).env(gitEnv).text()).trim();
+  await writeFile(join(add_dir, "package.json"), JSON.stringify({ name: "mydep", version: "1.0.1" }));
+  await $`git add -A && git commit -q -m two --no-gpg-sign`.cwd(add_dir).env(gitEnv).quiet();
+  const sha2 = (await $`git rev-parse HEAD`.cwd(add_dir).env(gitEnv).text()).trim();
+
+  const repo_url = `git+${pathToFileURL(add_dir).href}`;
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "host",
+      version: "0.0.1",
+    }),
+  );
+
+  // Install each commit in turn. The second install must overwrite the
+  // existing "mydep" entry, not append a second "mydep" key.
+  for (const sha of [sha1, sha2]) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", `${repo_url}#${sha}`],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: gitEnv,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    const out = await stdout.text();
+    expect(out).toContain("installed mydep@");
+    expect(await exited).toBe(0);
+  }
+
+  // `JSON.parse` collapses duplicate keys, so inspect the raw text to prove the key was reused.
+  const raw2 = await file(join(package_dir, "package.json")).text();
+  expect(raw2.match(/"mydep"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw2)).toStrictEqual({
+    name: "host",
+    version: "0.0.1",
+    dependencies: {
+      mydep: `${repo_url}#${sha2}`,
     },
   });
 });


### PR DESCRIPTION
### Problem
- A second `bun i github:user/repo#<hash>` with a different commit hash appends a second key for the same package to package.json. The file then has two `"mri"` keys. Fixes #40799.
- The cause is in `edit` in `src/install/PackageManager/PackageJSONEditor.rs`. The write-back pass re-keys the placeholder entry to the resolved package name, but it never removes the old entry that already uses that name with the old literal.

### Fix
- After the rebuild loop re-keys the slot for a non-aliased git, github, tarball, or folder request, remove any other entry in the same list whose key equals the resolved package name.
- This is correct because at that point the request owns the resolved name: its slot just received that key, and a second entry under the same key is invalid JSON data that `JSON.parse` and npm collapse anyway.
- A re-run with the same literal is unchanged. The existing value-match path edits the slot in place and never reaches the rebuild loop.
- Verified: `test/cli/install/bun-add.test.ts` (new test, fails on bun 1.4.1 with two keys). Also ran all of `bun-add.test.ts`, `bun-update.test.ts`, and `bun-install-git-deps.test.ts`.

### Background
- For a positional like `github:user/repo#hash`, `UpdateRequest::get_name()` returns the URL literal, because the package name is unknown before the clone.
- `bun add` edits package.json twice. The before-install edit runs before resolution and keys the new entry by the URL literal. After resolution, the write-back edit finds that placeholder by its literal key and re-keys it to the resolved name, for example `mri`.
- When package.json already declares `mri` with a different hash, the old entry does not match the new literal, so the scan leaves it alone. The re-keyed placeholder then sits next to it as a duplicate key.

<details><summary>Notes</summary>

Repro:

```console
$ echo '{"name":"repro","version":"1.0.0"}' > package.json
$ bun i github:lukeed/mri#e73e9f9d5b02124d14ac17dac2c4801687d3e99a
$ bun i github:lukeed/mri#62b9ce4f25e1f7b476c99858c20882d86c010085
$ cat package.json
{
  "name": "repro",
  "version": "1.0.0",
  "dependencies": {
    "mri": "github:lukeed/mri#62b9ce4f25e1f7b476c99858c20882d86c010085",
    "mri": "github:lukeed/mri#e73e9f9d5b02124d14ac17dac2c4801687d3e99a"
  }
}
```

The same happens with `git+file://` URLs and with two tarball URLs that resolve to the same package name, so the test uses a local git repo with two commits and no network.

A first attempt matched the scan by `get_resolved_name()` instead of `get_name()`. That broke the placeholder flow: the write-back no longer found the literal-keyed entry from the before-install edit, took the value-match fallback, and left the key as the URL literal. The placeholder re-key is how every first install gets its proper key, so the fix keeps the literal match and removes the stale entry instead.

The removal loop adjusts the written slot index `k` when it removes an element below it, so a later iteration cannot remove the slot that was just written.

`bun-install.test.ts` has 14 failures in this container, identical with the released bun on main. They are bitbucket.org and gitlab.com network tests, unrelated to this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->