### PR TITLE
js_parser: lower `using` in a C-style for loop head for targets without it

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -598,6 +598,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // If this is true, then all top-level statements are wrapped in a try/catch
     pub(crate) will_wrap_module_in_try_catch_for_using: bool,
 
+    /// Set by `s_label` while it visits `label: for (using x = y;;) body`. The label has to
+    /// stay on the loop for `continue label` to remain valid, so the try/finally of the
+    /// lowering goes around the outermost label statement. Labels nested inside it and
+    /// `s_for` leave the head alone.
+    pub(crate) label_lowers_for_head_using: bool,
+
     /// Used for react refresh, it must be able to insert `const _s = $RefreshSig$();`
     pub(crate) nearest_stmt_list: Option<NonNull<ListManaged<'a, Stmt>>>,
     // Lifetime caution: points at a stack local saved/restored across calls.
@@ -8748,6 +8754,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             top_level_enums: BumpVec::new_in(arena),
             scopes_in_order_for_enum: Default::default(),
             will_wrap_module_in_try_catch_for_using: false,
+            label_lowers_for_head_using: false,
             nearest_stmt_list: None,
             decorator_class_name: None,
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1344,11 +1344,48 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             _ => {}
         }
 
+        // `label: for (using x = y;;) body`: the lowering wraps the loop in a try/finally,
+        // and every label has to stay on the loop itself for `continue label` to remain
+        // valid. So the outermost label statement is what gets wrapped, here, and the
+        // labels inside it and `s_for` skip the lowering.
+        let lowers_for_head_using =
+            !p.label_lowers_for_head_using && p.using_for_head_to_lower(data.stmt).is_some();
+        if lowers_for_head_using {
+            p.label_lowers_for_head_using = true;
+        }
         data.stmt = p.visit_single_stmt(data.stmt, StmtsKind::None);
+
+        if lowers_for_head_using {
+            p.label_lowers_for_head_using = false;
+            if let Some(init) = p.using_for_head_to_lower(data.stmt) {
+                let wrapped = p.arena.alloc_slice_copy(&[*stmt]);
+                let lowered = Self::lower_using_in_for_head(p, init, wrapped)?;
+                p.pop_scope();
+                stmts.extend_from_slice(&lowered);
+                return Ok(());
+            }
+        }
+
         p.pop_scope();
 
         stmts.push(*stmt);
         Ok(())
+    }
+
+    /// When `stmt`, through any labels on it, is a C-style `for` loop whose head is a `using`
+    /// declaration that the target needs lowered, returns that head.
+    fn using_for_head_to_lower(&self, mut stmt: Stmt) -> Option<Stmt> {
+        loop {
+            match stmt.data {
+                StmtData::SLabel(label) => stmt = label.stmt,
+                StmtData::SFor(for_data) => {
+                    return for_data
+                        .init
+                        .filter(|init| self.is_using_local_to_lower(*init));
+                }
+                _ => return None,
+            }
+        }
     }
 
     fn s_expr(
@@ -1825,6 +1862,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::For,
     ) -> Result<(), Error> {
+        // Taken before anything nested is visited: the flag is meant for this loop only.
+        let label_lowers_using_head = core::mem::take(&mut p.label_lowers_for_head_using);
+
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, stmt.loc)
             .expect("unreachable");
 
@@ -1865,10 +1905,53 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        if !label_lowers_using_head
+            && let Some(init) = data.init
+            && p.is_using_local_to_lower(init)
+        {
+            let wrapped = p.arena.alloc_slice_copy(&[*stmt]);
+            let lowered = Self::lower_using_in_for_head(p, init, wrapped)?;
+            p.pop_scope();
+            stmts.extend_from_slice(&lowered);
+            return Ok(());
+        }
+
         p.pop_scope();
 
         stmts.push(*stmt);
         Ok(())
+    }
+
+    /// Whether `stmt` is a `using` / `await using` declaration that the target needs lowered.
+    fn is_using_local_to_lower(&self, stmt: Stmt) -> bool {
+        self.options.features.lower_using
+            && matches!(stmt.data, StmtData::SLocal(local) if local.kind.is_using())
+    }
+
+    /// Lowers the `using` / `await using` declaration `init` in the head of a C-style `for`
+    /// loop. The bindings are constant, so there are no per-iteration copies, and the
+    /// resources are disposed once, when the loop exits by any path. That makes the loop
+    /// itself (`wrapped`: the loop, or the label statement around it) the try body:
+    ///
+    ///   let stack = [];
+    ///   try {
+    ///     for (const x = __using(stack, y, 0); test; update) body
+    ///   } catch (e) {
+    ///     var err = e, hasErr = 1;
+    ///   } finally {
+    ///     __callDispose(stack, err, hasErr);
+    ///   }
+    ///
+    /// Must run while the loop's own scope (or the label scope) is still current, so that
+    /// the head becomes `const` and not the module-level `var` of a wrapped module.
+    fn lower_using_in_for_head(
+        p: &mut Self,
+        init: Stmt,
+        wrapped: &'a mut [Stmt],
+    ) -> Result<StmtList<'a>, Error> {
+        let mut ctx = crate::p::LowerUsingDeclarationsContext::init(p)?;
+        ctx.scan_stmts(p, &mut [init]);
+        Ok(ctx.finalize(p, wrapped, false))
     }
 
     fn s_for_in(

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2369,6 +2369,145 @@ describe("bundler", () => {
     },
   });
 
+  // `using` in the head of a C-style for loop: the bindings are constant (no per-iteration
+  // copies) and every resource is disposed once, in reverse order, when the loop exits.
+  const usingInForHeadPrelude = `
+    const out: string[] = [];
+    function mk(name: string) {
+      return { name, [Symbol.dispose]() { out.push("dispose " + name); } };
+    }
+  `;
+
+  itBundled("edgecase/UsingInForLoopHead", {
+    files: {
+      "/entry.ts": `
+        ${usingInForHeadPrelude}
+        const fns: (() => string)[] = [];
+        for (using a = mk("a"), b = mk("b"); fns.length < 2; ) {
+          fns.push(() => a.name + b.name);
+          out.push("body " + fns.length);
+        }
+        out.push("after " + fns.map(f => f()).join(","));
+        for (using c = mk("c"); false; ) {}
+        console.log(out.join("\\n"));
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\busing\s/);
+    },
+    run: {
+      stdout: "body 1\nbody 2\ndispose b\ndispose a\nafter ab,ab\ndispose c",
+    },
+  });
+
+  itBundled("edgecase/UsingInForLoopHeadLabel", {
+    files: {
+      "/entry.ts": `
+        ${usingInForHeadPrelude}
+        let i = 0;
+        outer: for (using a = mk("a"); i < 3; i++) {
+          for (;;) {
+            out.push("inner " + i + " " + a.name);
+            if (i < 1) continue outer;
+            break outer;
+          }
+        }
+        out.push("after");
+        let j = 0;
+        x: y: for (using b = mk("b"); j < 3; j++) {
+          if (j == 1) continue y;
+          if (j == 2) break x;
+          out.push("nested " + j + " " + b.name);
+        }
+        out.push("after nested");
+        console.log(out.join("\\n"));
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\busing\s/);
+    },
+    run: {
+      stdout: "inner 0 a\ninner 1 a\ndispose a\nafter\nnested 0 b\ndispose b\nafter nested",
+    },
+  });
+
+  itBundled("edgecase/UsingInForLoopHeadThrows", {
+    files: {
+      "/entry.ts": `
+        ${usingInForHeadPrelude}
+        function boom(): never { throw new Error("boom"); }
+        try {
+          for (using a = mk("a"), b = boom(); ; ) {}
+        } catch (e: any) {
+          out.push("caught " + e.message);
+        }
+        try {
+          for (using c = { [Symbol.dispose]() { throw new Error("dispose-err"); } }; ; ) {
+            throw new Error("body-err");
+          }
+        } catch (e: any) {
+          out.push(e.constructor.name + " " + e.error.message + " " + e.suppressed.message);
+        }
+        console.log(out.join("\\n"));
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\busing\s/);
+    },
+    run: {
+      stdout: "dispose a\ncaught boom\nSuppressedError dispose-err body-err",
+    },
+  });
+
+  itBundled("edgecase/AwaitUsingInForLoopHead", {
+    files: {
+      "/entry.ts": `
+        ${usingInForHeadPrelude}
+        function amk(name: string) {
+          return { name, async [Symbol.asyncDispose]() { out.push("async dispose " + name); } };
+        }
+        async function main() {
+          for (await using a = amk("a"), b = mk("b"); ; ) {
+            out.push("body " + a.name + b.name);
+            break;
+          }
+          out.push("after");
+        }
+        await main();
+        console.log(out.join("\\n"));
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\busing\s/);
+    },
+    run: {
+      stdout: "body ab\ndispose b\nasync dispose a\nafter",
+    },
+  });
+
+  // A top-level `using` makes the module body a try/finally with `var` declarations. The
+  // loop head must still become `const`, scoped to the loop, and not a second `var a`.
+  itBundled("edgecase/UsingInForLoopHeadShadowsTopLevelUsing", {
+    files: {
+      "/entry.ts": `
+        ${usingInForHeadPrelude}
+        using a = mk("outer");
+        for (using a = mk("loop"); ; ) {
+          out.push("body " + a.name);
+          break;
+        }
+        out.push("after " + a.name);
+        console.log(out.join("\\n"));
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\busing\s/);
+    },
+    run: {
+      stdout: "body loop\ndispose loop\nafter outer",
+    },
+  });
+
   itBundled("edgecase/NoOutWithTwoFiles", {
     files: {
       "/entry.ts": `

--- a/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
+++ b/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
@@ -178,3 +178,57 @@ export {
 };
 "
 `;
+
+exports[`Bun.Transpiler using in a C-style for loop head is lowered around the whole loop 1`] = `
+"let __bun_temp_ref_1$ = [];
+try {
+for (const a = __using(__bun_temp_ref_1$, b, 0);; )
+c(a);
+} catch (__bun_temp_ref_2$) {
+var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+__callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}"
+`;
+
+exports[`Bun.Transpiler using in a C-style for loop head is lowered around the whole loop 2`] = `
+"let __bun_temp_ref_1$ = [];
+try {
+for (const a = __using(__bun_temp_ref_1$, b, 1);; )
+c(a);
+} catch (__bun_temp_ref_2$) {
+var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+var __bun_temp_ref_5$ = __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+__bun_temp_ref_5$ && await __bun_temp_ref_5$;
+}"
+`;
+
+exports[`Bun.Transpiler using in a C-style for loop head is lowered around the whole loop 3`] = `
+"let __bun_temp_ref_1$ = [];
+try {
+for (const a = __using(__bun_temp_ref_1$, b, 0), c = __using(__bun_temp_ref_1$, d, 0);e(a); f(c)) {
+g(a);
+}
+} catch (__bun_temp_ref_2$) {
+var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+__callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}"
+`;
+
+exports[`Bun.Transpiler using in a C-style for loop head is lowered around the whole loop 4`] = `
+"let __bun_temp_ref_1$ = [];
+try {
+x:
+for (const a = __using(__bun_temp_ref_1$, b, 0);; ) {
+if (c)
+continue x;
+break x;
+}
+} catch (__bun_temp_ref_2$) {
+var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+__callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}"
+`;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4720,6 +4720,15 @@ console.log("boop");
     expectCapturePrintedSnapshot(`for await (await using a of b) { c(a); a(c) }`);
   });
 
+  it("using in a C-style for loop head is lowered around the whole loop", () => {
+    // The bindings are constant and the resources are disposed once, when the loop exits.
+    expectCapturePrintedSnapshot(`for (using a = b;;) c(a)`);
+    expectCapturePrintedSnapshot(`for (await using a = b;;) c(a)`);
+    expectCapturePrintedSnapshot(`for (using a = b, c = d; e(a); f(c)) { g(a); }`);
+    // The label stays on the loop so that "continue x" remains valid.
+    expectCapturePrintedSnapshot(`x: for (using a = b;;) { if (c) continue x; break x; }`);
+  });
+
   it("await of the identifier 'using' is not an await using declaration", () => {
     // "await using" only starts a declaration when followed by an identifier on
     // the same line. Otherwise it's an "await" expression of the identifier "using".

--- a/test/js/bun/resolve/lower-using-bun-target.test.ts
+++ b/test/js/bun/resolve/lower-using-bun-target.test.ts
@@ -13,6 +13,10 @@ await f();
 for (using z of [{ [Symbol.dispose]() { console.log("for-of disposed"); } }]) {
   console.log("for-of body");
 }
+for (using w = { [Symbol.dispose]() { console.log("for-head disposed"); } }; ; ) {
+  console.log("for-head body");
+  break;
+}
 using top = { [Symbol.dispose]() { console.log("top-level disposed"); } };
 console.log("done");
 `;
@@ -24,6 +28,8 @@ const expectedStdout =
   "async disposed\n" +
   "for-of body\n" +
   "for-of disposed\n" +
+  "for-head body\n" +
+  "for-head disposed\n" +
   "done\n" +
   "top-level disposed\n";
 
@@ -91,6 +97,7 @@ console.log(url, disposed);`,
     expect(out).toContain("using x =");
     expect(out).toContain("await using y =");
     expect(out).toContain("for (using z of ");
+    expect(out).toContain("for (using w =");
     expect(out).toContain("using top =");
   });
 
@@ -102,6 +109,7 @@ console.log(url, disposed);`,
     expect(out).not.toContain("using x =");
     expect(out).not.toContain("await using y =");
     expect(out).not.toContain("for (using z of ");
+    expect(out).not.toContain("for (using w =");
     expect(out).not.toContain("using top =");
   });
 
@@ -125,6 +133,7 @@ console.log(url, disposed);`,
     expect(stdout).toContain("using x =");
     expect(stdout).toContain("await using y =");
     expect(stdout).toContain("for (using z of ");
+    expect(stdout).toContain("for (using w =");
     expect(stdout).toContain("using top =");
     expect(exitCode).toBe(0);
   });
@@ -149,6 +158,7 @@ console.log(url, disposed);`,
     expect(stdout).not.toContain("using x =");
     expect(stdout).not.toContain("await using y =");
     expect(stdout).not.toContain("for (using z of ");
+    expect(stdout).not.toContain("for (using w =");
     expect(stdout).not.toContain("using top =");
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
### Problem
- `bun build --target=browser` (also `--target=node` and `Bun.Transpiler({ target: "browser" })`) prints a `using` declaration in a classic for loop head unchanged: `for (using a = mk("a"), b = mk("b"); out.length < 1; ) {`. The output uses syntax the target cannot parse. Block-level `using` and `for (using x of y)` heads are lowered.
- Cause: `s_for` (`src/js_parser/visit/visit_stmt.rs`) never calls `LowerUsingDeclarationsContext`. `s_for_of` and the statement-list lowering in `visit_stmts` do.

### Fix
- `s_for` rewrites the head with the existing context (`const a = __using(stack, mk("a"), 0), ...`) and wraps the whole loop in the usual `let stack = []; try { for ... } catch (e) { var err = e, hasErr = 1 } finally { __callDispose(stack, err, hasErr) }`. `await using` heads get the `promise && await promise` finally the context already emits.
- Correct because the spec makes `using` bindings constant (`IsConstantDeclaration` is true, so `perIterationLets` is empty) and runs `DisposeResources` once, after `ForBodyEvaluation`, for normal exit, `break`, `continue` out of the loop, `return`, and throw. JSC's `for-using-initializer-continue-dispose-once.js` and `for-using-initializer-dispose-on-false-condition.js` pass when lowered by this build and run under node.
- `label: for (using x = y;;)`: the label stays on the loop, otherwise `continue label` becomes a syntax error. `s_label` sets `p.label_lowers_for_head_using`, `s_for` takes the flag and skips, and `s_label` wraps the outermost label statement. The head is lowered while the loop or label scope is current, so it becomes `const`, not the `var` a wrapped module gives its top-level `using` declarations.
- Verified: `test/bundler/bundler_edgecase.test.ts` (5 new `UsingInForLoopHead*` cases, all fail on 1.4.1), `test/bundler/transpiler/transpiler.test.js` (4 new snapshots), `test/js/bun/resolve/lower-using-bun-target.test.ts` (for head added to the shared source). Also `explicit-resource-management`, `bundler_minify`, `esbuild/{default,lower,ts}`, `regression/issue/11100`, and `test/internal/source-lints`.

### Background
- `using x = v` disposes `v` (`Symbol.dispose`) when its scope exits. `await using` uses `Symbol.asyncDispose`. `--target=bun` keeps the syntax because JSC runs it natively. Other targets lower it: `lower_using` is set, and `__using` / `__callDispose` from `src/runtime.bun.js` are imported or inlined.
- `LowerUsingDeclarationsContext` (`src/js_parser/p.rs`) is the shared lowering. `scan_stmts` turns `using` locals into `const` with `__using` calls on a stack temp, `finalize` wraps a statement list in the try/catch/finally.
- In a classic for head the declaration lives in a scope around the whole loop, so disposal happens once after the loop. In a for-of head a new binding is created per iteration, which is why `s_for_of` lowers into the body instead.
- A module with a top-level `using` is itself wrapped in a try (`will_wrap_module_in_try_catch_for_using`), and `scan_stmts` turns declarations directly in the module scope into `var` so exports and hoisted functions still reach them.

<details><summary>Notes</summary>

- esbuild has the same gap (0.25.1 prints the head unchanged), so there is no esbuild reference for this piece. TypeScript lowers `for (using x = y;;)` into `{ using x = y; for (;;) ... }` (`visitForStatement` in `esnext.ts`), which is the same disposal point.
- V8 (node 26) disposes a for-head `using` once per iteration when a closure in the body captures the binding, and wraps a body error in two `SuppressedError`s for the same reason. JSC disposes once. The spec and JSC's own stress tests say once, so the lowering follows them. The new tests' expected output matches native bun.
- The label flag: `s_label` sets it only when the statement, through any label chain, is a for with a `using` head to lower. `s_for` takes it before visiting the head, so a nested loop in the head or body cannot consume it. Labels inside the chain see it set and do not lower. `a: b: for (using x = y;;)` lowers to `let stack; try { a: b: for (...) }`.
- `for (using x = null;;)` keeps working: `__using` ignores `null`/`undefined`.
- A lazily wrapped module (`__esm(() => { ... })`) hoists the `let stack` like any other top-level local: `var __stack; ... __stack = []` inside the closure. Checked with `--target=node --format=esm` and a dynamic `import()`.
- The runtime transpiler cache version is not bumped: `bun run` targets bun, where `lower_using` is off, so its output does not change.
- Self-review findings. Semantics: 12 more programs (return and `yield` inside the loop, generator `.return()`, async generators, rejected `Symbol.asyncDispose`, `null` and non-disposable values, nested labels, `switch` in the body, `try/finally` with `continue`, class static blocks, top-level `await using`) give the same output lowered under node as native bun. Blast radius: transpiling 9524 files under `test/`, `src/js/` and `packages/bun-types` with target browser on this build and on 1.4.1 differs only in 6 files that contain no `using` (changes from other commits since 1.4.1, for example #40786).
- One cosmetic artifact in dead code: `if (false) for (using a = mk();;) {}` lowers before the dead-code filter runs, so the filter drops `let __stack = []` (a non-`var` local) but keeps the `try` (its catch declares `var`s). The unreachable `try` references an undeclared `__stack`. The output is valid and never runs. The switch lowering has the same shape. The for-of lowering does not, because its `let` sits inside the loop body.
</details>

