### PR TITLE
compile: no GC churn while a standalone executable loads its module graph

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-533-2bb23271";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-533-2bb23271";
+export const WEBKIT_VERSION = "d71031a973e6f8838a1b10282dbe332ff012f04a";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -998,8 +998,8 @@ impl VirtualMachine {
     }
 
     /// Let the main VM's heap take the executable's initial module graph without collecting: everything allocated
-    /// while it loads is live, so collections before it finishes only re-mark it. The budget is the size of the embedded
-    /// payload (capped); after the first collection JSC's usual sizing applies. Workers load a fraction of the graph and
+    /// while it loads is live, so collections before it finishes only re-mark it. The budget is what loading the graph
+    /// reads (bytecode, records, string table; capped); after the first collection JSC's usual sizing applies. Workers load a fraction of the graph and
     /// keep the default.
     fn let_heap_take_initial_module_graph(
         &self,
@@ -1010,7 +1010,7 @@ impl VirtualMachine {
         }
         const MIN_BUDGET: usize = 8 * 1024 * 1024;
         const MAX_BUDGET: usize = 128 * 1024 * 1024;
-        let budget = graph.payload_len().clamp(MIN_BUDGET, MAX_BUDGET);
+        let budget = graph.module_graph_load_bytes().clamp(MIN_BUDGET, MAX_BUDGET);
         if budget > MIN_BUDGET {
             JSC__Heap__setInitialAllocationBudget(self.jsc_vm(), budget);
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1001,7 +1001,10 @@ impl VirtualMachine {
     /// while it loads is live, so collections before it finishes only re-mark it. The budget is the size of the embedded
     /// payload (capped); after the first collection JSC's usual sizing applies. Workers load a fraction of the graph and
     /// keep the default.
-    fn let_heap_take_initial_module_graph(&self, graph: &'static dyn bun_resolver::StandaloneModuleGraph) {
+    fn let_heap_take_initial_module_graph(
+        &self,
+        graph: &'static dyn bun_resolver::StandaloneModuleGraph,
+    ) {
         unsafe extern "C" {
             safe fn JSC__Heap__setInitialAllocationBudget(vm: &VM, bytes: usize);
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1010,7 +1010,9 @@ impl VirtualMachine {
         }
         const MIN_BUDGET: usize = 8 * 1024 * 1024;
         const MAX_BUDGET: usize = 128 * 1024 * 1024;
-        let budget = graph.module_graph_load_bytes().clamp(MIN_BUDGET, MAX_BUDGET);
+        let budget = graph
+            .module_graph_load_bytes()
+            .clamp(MIN_BUDGET, MAX_BUDGET);
         if budget > MIN_BUDGET {
             JSC__Heap__setInitialAllocationBudget(self.jsc_vm(), budget);
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -997,17 +997,27 @@ impl VirtualMachine {
         self.event_loop_mut()
     }
 
-    /// Hand the executable's shared bytecode string table (if any) to JSC as this VM's `DecoderStringTable`.
+    /// Hand the executable's shared bytecode string table (if any) to JSC as this VM's `DecoderStringTable`, and let the
+    /// heap take the initial module graph without collecting: everything allocated while it loads is live, so collections
+    /// before it finishes only re-mark it. The budget scales with the embedded payload; after the first collection JSC's
+    /// usual sizing applies.
     fn install_bytecode_string_table(
         &self,
         graph: &'static dyn bun_resolver::StandaloneModuleGraph,
     ) {
+        unsafe extern "C" {
+            fn Bun__DecoderStringTable__install(vm: *mut VM, bytes: *const u8, len: usize);
+            safe fn JSC__Heap__setInitialAllocationBudget(vm: &VM, bytes: usize);
+        }
+        const MIN_BUDGET: usize = 8 * 1024 * 1024;
+        const MAX_BUDGET: usize = 128 * 1024 * 1024;
+        let budget = (graph.payload_len() / 4).clamp(MIN_BUDGET, MAX_BUDGET);
+        if budget > MIN_BUDGET {
+            JSC__Heap__setInitialAllocationBudget(self.jsc_vm(), budget);
+        }
         let table = graph.bytecode_string_table();
         if table.is_empty() {
             return;
-        }
-        unsafe extern "C" {
-            fn Bun__DecoderStringTable__install(vm: *mut VM, bytes: *const u8, len: usize);
         }
         // SAFETY: `jsc_vm` set in `init()`; `table` is a mmapped process-lifetime span from the executable's own section.
         unsafe { Bun__DecoderStringTable__install(self.jsc_vm, table.as_ptr(), table.len()) };

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -999,7 +999,7 @@ impl VirtualMachine {
 
     /// Hand the executable's shared bytecode string table (if any) to JSC as this VM's `DecoderStringTable`, and let the
     /// heap take the initial module graph without collecting: everything allocated while it loads is live, so collections
-    /// before it finishes only re-mark it. The budget scales with the embedded payload; after the first collection JSC's
+    /// before it finishes only re-mark it. The budget is the size of the embedded payload (capped); after the first collection JSC's
     /// usual sizing applies.
     fn install_bytecode_string_table(
         &self,
@@ -1011,7 +1011,7 @@ impl VirtualMachine {
         }
         const MIN_BUDGET: usize = 8 * 1024 * 1024;
         const MAX_BUDGET: usize = 128 * 1024 * 1024;
-        let budget = (graph.payload_len() / 4).clamp(MIN_BUDGET, MAX_BUDGET);
+        let budget = graph.payload_len().clamp(MIN_BUDGET, MAX_BUDGET);
         if budget > MIN_BUDGET {
             JSC__Heap__setInitialAllocationBudget(self.jsc_vm(), budget);
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -997,16 +997,12 @@ impl VirtualMachine {
         self.event_loop_mut()
     }
 
-    /// Hand the executable's shared bytecode string table (if any) to JSC as this VM's `DecoderStringTable`, and let the
-    /// heap take the initial module graph without collecting: everything allocated while it loads is live, so collections
-    /// before it finishes only re-mark it. The budget is the size of the embedded payload (capped); after the first collection JSC's
-    /// usual sizing applies.
-    fn install_bytecode_string_table(
-        &self,
-        graph: &'static dyn bun_resolver::StandaloneModuleGraph,
-    ) {
+    /// Let the main VM's heap take the executable's initial module graph without collecting: everything allocated
+    /// while it loads is live, so collections before it finishes only re-mark it. The budget is the size of the embedded
+    /// payload (capped); after the first collection JSC's usual sizing applies. Workers load a fraction of the graph and
+    /// keep the default.
+    fn let_heap_take_initial_module_graph(&self, graph: &'static dyn bun_resolver::StandaloneModuleGraph) {
         unsafe extern "C" {
-            fn Bun__DecoderStringTable__install(vm: *mut VM, bytes: *const u8, len: usize);
             safe fn JSC__Heap__setInitialAllocationBudget(vm: &VM, bytes: usize);
         }
         const MIN_BUDGET: usize = 8 * 1024 * 1024;
@@ -1014,6 +1010,16 @@ impl VirtualMachine {
         let budget = graph.payload_len().clamp(MIN_BUDGET, MAX_BUDGET);
         if budget > MIN_BUDGET {
             JSC__Heap__setInitialAllocationBudget(self.jsc_vm(), budget);
+        }
+    }
+
+    /// Hand the executable's shared bytecode string table (if any) to JSC as this VM's `DecoderStringTable`.
+    fn install_bytecode_string_table(
+        &self,
+        graph: &'static dyn bun_resolver::StandaloneModuleGraph,
+    ) {
+        unsafe extern "C" {
+            fn Bun__DecoderStringTable__install(vm: *mut VM, bytes: *const u8, len: usize);
         }
         let table = graph.bytecode_string_table();
         if table.is_empty() {
@@ -4075,6 +4081,7 @@ impl VirtualMachine {
         let vm_ref = unsafe { &mut *vm };
         vm_ref.transpiler.resolver.standalone_module_graph = Some(graph);
         vm_ref.install_bytecode_string_table(graph);
+        vm_ref.let_heap_take_initial_module_graph(graph);
         // Avoid reading from tsconfig.json & package.json when in standalone mode
         vm_ref.transpiler.configure_linker_with_auto_jsx(false);
         vm_ref.transpiler.resolver.store_fd = false;

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -220,6 +220,11 @@ extern "C" void Bun__EncoderStringTable__serialize(JSC::EncoderStringTable* tabl
     append(ctx, bytes.span().data(), bytes.size());
 }
 
+extern "C" void JSC__Heap__setInitialAllocationBudget(JSC::VM* vm, size_t bytes)
+{
+    vm->heap.setInitialAllocationBudget(bytes);
+}
+
 extern "C" void Bun__DecoderStringTable__install(JSC::VM* vm, const uint8_t* bytes, size_t len)
 {
     ASSERT(vm->clientData);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3161,11 +3161,6 @@ void JSC__JSGlobalObject__deleteModuleRegistryEntry(JSC::JSGlobalObject* global,
     moduleLoader->removeEntry(identifier);
 }
 
-void JSC__Heap__setInitialAllocationBudget(JSC::VM* vm, size_t bytes)
-{
-    vm->heap.setInitialAllocationBudget(bytes);
-}
-
 void JSC__VM__collectAsync(JSC::VM* vm)
 {
     JSC::JSLockHolder lock(*vm);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3161,6 +3161,11 @@ void JSC__JSGlobalObject__deleteModuleRegistryEntry(JSC::JSGlobalObject* global,
     moduleLoader->removeEntry(identifier);
 }
 
+void JSC__Heap__setInitialAllocationBudget(JSC::VM* vm, size_t bytes)
+{
+    vm->heap.setInitialAllocationBudget(bytes);
+}
+
 void JSC__VM__collectAsync(JSC::VM* vm)
 {
     JSC::JSLockHolder lock(*vm);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -929,7 +929,9 @@ impl WebWorker {
         self.set_status(Status::Running);
 
         // don't run the GC if we don't actually need to
-        if vm.is_event_loop_alive() || vm.event_loop_mut().tick_concurrent_with_count() > 0 {
+        if vm.standalone_module_graph.is_none()
+            && (vm.is_event_loop_alive() || vm.event_loop_mut().tick_concurrent_with_count() > 0)
+        {
             vm.global().vm().release_weak_refs();
             // `Arena = bumpalo::Bump` has no collect; global mimalloc
             // handles reclamation.

--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -40,4 +40,8 @@ pub trait StandaloneModuleGraph: Send + Sync {
     fn bytecode_string_table(&self) -> &'static [u8] {
         &[]
     }
+    /// Size of the embedded payload (sources, bytecode, module records) in bytes.
+    fn payload_len(&self) -> usize {
+        0
+    }
 }

--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -40,8 +40,9 @@ pub trait StandaloneModuleGraph: Send + Sync {
     fn bytecode_string_table(&self) -> &'static [u8] {
         &[]
     }
-    /// Size of the embedded payload (sources, bytecode, module records) in bytes.
-    fn payload_len(&self) -> usize {
+    /// Bytes the VM reads to load the module graph: each module's bytecode (or its source when it has none), module
+    /// records, builtin bytecode and the shared string table — not source maps or embedded assets.
+    fn module_graph_load_bytes(&self) -> usize {
         0
     }
 }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1463,8 +1463,12 @@ impl Run<'_> {
             Err(err) => entry_point_load_failed(vm, &err.into()),
         }
 
-        // don't run the GC if we don't actually need to
-        if vm.is_event_loop_alive() || vm.event_loop_ref().tick_concurrent_with_count() > 0 {
+        // Drop what transpiling and linking the entry graph left behind before settling into the event loop. A
+        // standalone executable has no transpiler garbage, and its unlinked code blocks came from the embedded bytecode
+        // cache — deleting them here only means decoding them again on first call — so leave its heap to the collector.
+        if vm.standalone_module_graph.is_none()
+            && (vm.is_event_loop_alive() || vm.event_loop_ref().tick_concurrent_with_count() > 0)
+        {
             vm.global().vm().release_weak_refs();
             // `bun_alloc::Arena` has no per-heap collect to run alongside this
             // GC; it would only be a memory-usage hint, not correctness.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -337,7 +337,11 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
             .iter()
             .map(|f| if f.bytecode.is_empty() { f.contents.len() } else { f.bytecode.len() } + f.module_info.len())
             .sum();
-        let builtins: usize = self.builtin_bytecode.iter().map(|&(_, bytes)| bytes.len()).sum();
+        let builtins: usize = self
+            .builtin_bytecode
+            .iter()
+            .map(|&(_, bytes)| bytes.len())
+            .sum();
         modules + builtins + self.bytecode_string_table.len()
     }
 }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -330,6 +330,9 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
     fn bytecode_string_table(&self) -> &'static [u8] {
         self.bytecode_string_table
     }
+    fn payload_len(&self) -> usize {
+        self.bytes.len()
+    }
 }
 
 #[repr(C)]

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -330,8 +330,15 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
     fn bytecode_string_table(&self) -> &'static [u8] {
         self.bytecode_string_table
     }
-    fn payload_len(&self) -> usize {
-        self.bytes.len()
+    fn module_graph_load_bytes(&self) -> usize {
+        let modules: usize = self
+            .files
+            .values()
+            .iter()
+            .map(|f| if f.bytecode.is_empty() { f.contents.len() } else { f.bytecode.len() } + f.module_info.len())
+            .sum();
+        let builtins: usize = self.builtin_bytecode.iter().map(|&(_, bytes)| bytes.len()).sum();
+        modules + builtins + self.bytecode_string_table.len()
     }
 }
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -335,6 +335,7 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
             .files
             .values()
             .iter()
+            .filter(|f| f.loader.is_javascript_like() || !f.bytecode.is_empty())
             .map(|f| if f.bytecode.is_empty() { f.contents.len() } else { f.bytecode.len() } + f.module_info.len())
             .sum();
         let builtins: usize = self

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1579,3 +1579,31 @@ test("compile --compile-executable-path rejects a template shorter than the exec
     expect(exitCode).toBe(1);
   }
 }, 60_000);
+
+// The startup path used to release weak refs, drop every unlinked code block and run a synchronous full collection right
+// after a standalone executable's entry module finished evaluating, i.e. before its first turn of the event loop.
+test("a standalone executable does not run a synchronous full GC after loading its entry point", async () => {
+  using dir = tempDir("compile-no-postload-gc", {
+    "app.js": `setTimeout(() => console.log("done"), 1);`,
+  });
+  const cwd = String(dir);
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "app.js", "--outfile", "app"],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await build.exited).toBe(0);
+  await using proc = Bun.spawn({
+    cmd: [join(cwd, isWindows ? "app.exe" : "app")],
+    env: { ...bunEnv, BUN_JSC_logGC: "1" },
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("done\n");
+  expect(stderr).not.toContain("FullCollection");
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1609,7 +1609,7 @@ test("a standalone executable does not run a synchronous full GC after loading i
   expect(stdout).toBe("done\n");
   // Heap::notifyIsSafeToCollect logs this at VM creation whenever logGC is on, collection or not, so it proves the
   // option reached the compiled binary without depending on any GC happening.
-  expect(stderr).toMatch(/\[GC<0x[0-9a-f]+>: starting /);
+  expect(stderr).toMatch(/\[GC<(0x)?[0-9a-fA-F]+>: starting /); // %p: "0x7f…" on POSIX, "00007FF6…" on Windows
   expect(stderr).not.toContain("FullCollection");
   expect(exitCode).toBe(0);
 });

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1607,7 +1607,9 @@ test("a standalone executable does not run a synchronous full GC after loading i
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("done\n");
-  expect(stderr).toContain("[GC<"); // logGC is live
+  // Heap::notifyIsSafeToCollect logs this at VM creation whenever logGC is on, collection or not, so it proves the
+  // option reached the compiled binary without depending on any GC happening.
+  expect(stderr).toMatch(/\[GC<0x[0-9a-f]+>: starting /);
   expect(stderr).not.toContain("FullCollection");
   expect(exitCode).toBe(0);
 });

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1594,16 +1594,20 @@ test("a standalone executable does not run a synchronous full GC after loading i
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await build.exited).toBe(0);
+  const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildStderr).not.toContain("error");
+  expect(buildExit).toBe(0);
   await using proc = Bun.spawn({
     cmd: [join(cwd, isWindows ? "app.exe" : "app")],
-    env: { ...bunEnv, BUN_JSC_logGC: "1" },
+    // BUN_DESTRUCT_VM_ON_EXIT would add an exit-time full collection to the log.
+    env: { ...bunEnv, BUN_JSC_logGC: "1", BUN_DESTRUCT_VM_ON_EXIT: undefined },
     cwd,
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("done\n");
+  expect(stderr).toContain("[GC<"); // logGC is live
   expect(stderr).not.toContain("FullCollection");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Two changes to how a `bun build --compile` executable treats the GC heap during startup. Depends on oven-sh/WebKit#533 (`Heap::setInitialAllocationBudget`), now merged; `WEBKIT_VERSION` is pinned to its merged SHA `d71031a973e6`.

1. **Don't collect while the embedded module graph is loading.** A compiled app decodes and evaluates its whole module graph before any of it can become garbage, but the heap starts with Bun's 8 MB budget: a large app pays an eden collection at 8 MB that frees nothing, which (via `minEdenToOldGenerationRatio`) forces a full re-mark at ~16 MB, then more edens from the allocation-paced timer. When a standalone graph is present, give the first cycle a budget equal to the embedded payload size (clamped 8–128 MB); after the first collection JSC's normal sizing applies. Small executables (payload < 8 MB) are unchanged.

2. **Don't `deleteAllUnlinkedCodeBlocks` + synchronous full GC after the entry point loads** when running from a standalone graph. `Run::start` does this to drop transpiler/linker garbage after `bun run`; a compiled app has none, the unlinked code blocks it deletes were just decoded from the bytecode cache (so they get decoded again on first call), and the collection lands on the main thread right as the program starts its real work.

| Claude Code CLI 2.1.252, Linux x64 | before | after |
|---|---|---|
| collections before the REPL prompt | 4 (E 8 MB → F 16 → E 37 → E 51; ~18 ms pause) | **0** (first eden ≈ 60 MB, after first paint) |
| `claude --help` (hyperfine ×30) | 177 ms | **165 ms** |
| time to prompt (median of 20, ×2) | 442 / 455 ms | **427 / 433 ms** |
| RSS at prompt | 197 MB | 203 MB |

### How did you verify your code works?

`bundler_compile_splitting.test.ts`, `bun-build-compile.test.ts`; `BUN_JSC_logGC=1` on the CLI above (counts in the table); a compiled fixture that allocates ~100 MB of garbage at startup still collects it (`Bun.gc` + `process.memoryUsage`).

