### PR TITLE
js_parser: validate TypeScript class member modifiers like esbuild

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2438,6 +2438,7 @@ pub mod parse_worker {
             crate::transpiler::to_parser_jsx_pragma(task.jsx.clone()),
             loader,
         );
+        opts.ts_no_ambiguous_less_than = matches!(source.path.name().ext, b".mts" | b".cts");
         opts.bundle = true;
         opts.warn_about_unbundled_modules = false;
         // `AllowUnresolved` is the same nominal type on

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1566,6 +1566,7 @@ impl<'a> Transpiler<'a> {
                 use js_ast::parser::options as p_opts;
                 let mut opts = js_ast::ParserOptions::<'_> {
                     ts: loader.is_typescript(),
+                    ts_no_ambiguous_less_than: matches!(source.path.name().ext, b".mts" | b".cts"),
                     jsx: to_parser_jsx_pragma(jsx),
                     keep_names: true,
                     ignore_dce_annotations: self.options.ignore_dce_annotations,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -242,8 +242,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 has_decorators = has_decorators || opts.has_argument_decorators;
             } else {
-                // The property was dropped (e.g. a TypeScript overload signature or
-                // abstract method), which drops its decorators and computed key too.
+                // The property was dropped (e.g. a TypeScript overload signature,
+                // "declare" field or abstract method), which drops its decorators and
+                // computed key too. Decorators on such a member are an error in
+                // TypeScript, except inside a "declare class" body which is erased.
+                if !class_opts.is_type_script_declare && opts.ts_decorators.len() > 0 {
+                    p.log().add_range_error(
+                        Some(p.source),
+                        bun_ast::Range {
+                            loc: first_decorator_loc,
+                            len: 1,
+                        },
+                        b"Decorators are not valid here",
+                    );
+                }
                 // Discard any scopes recorded while parsing them or the visit pass
                 // will hit a scope order mismatch.
                 p.discard_scopes_up_to(property_scope_index);

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -242,10 +242,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 has_decorators = has_decorators || opts.has_argument_decorators;
             } else {
-                // The property was dropped (e.g. a TypeScript overload signature,
-                // "declare" field or abstract method), which drops its decorators and
-                // computed key too. Decorators on such a member are an error in
-                // TypeScript, except inside a "declare class" body which is erased.
+                // The property was dropped (e.g. a TypeScript overload signature or
+                // "declare" field), which drops its decorators and computed key too.
                 if !class_opts.is_type_script_declare && opts.ts_decorators.len() > 0 {
                     p.log().add_range_error(
                         Some(p.source),

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1675,11 +1675,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if Self::IS_TYPESCRIPT_ENABLED
                         && (!p.is_jsx_enabled() || p.is_ts_arrow_fn_jsx()?)
                     {
+                        // ".mts" and ".cts" files reject a "<" that a JSX file would read as an element
+                        let less_than_range = p.lexer.range();
+                        let is_ambiguous_less_than =
+                            p.options.ts_no_ambiguous_less_than && !p.is_ts_arrow_fn_jsx()?;
                         match p
                             .try_skip_type_script_type_parameters_then_open_paren_with_backtracking(
                             ) {
                             SkipTypeParameterResult::DidNotSkipAnything => {}
                             result => {
+                                if is_ambiguous_less_than {
+                                    p.log().add_range_error(
+                                        Some(p.source),
+                                        less_than_range,
+                                        b"This syntax is not allowed in files with the \".mts\" or \".cts\" extension",
+                                    );
+                                }
                                 p.lexer.next()?;
                                 return p.parse_paren_expr(
                                     async_range.loc,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1684,15 +1684,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             ) {
                             SkipTypeParameterResult::DidNotSkipAnything => {}
                             result => {
-                                if is_ambiguous_less_than {
-                                    p.log().add_range_error(
-                                        Some(p.source),
-                                        less_than_range,
-                                        b"This syntax is not allowed in files with the \".mts\" or \".cts\" extension",
-                                    );
-                                }
                                 p.lexer.next()?;
-                                return p.parse_paren_expr(
+                                let expr = p.parse_paren_expr(
                                     async_range.loc,
                                     level,
                                     ParenExprOpts {
@@ -1701,7 +1694,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             == SkipTypeParameterResult::DefinitelyTypeParameters,
                                         ..Default::default()
                                     },
-                                );
+                                )?;
+                                // "async<T>(x)" is a call of a function named "async" and stays valid
+                                if is_ambiguous_less_than
+                                    && matches!(expr.data, js_ast::ExprData::EArrow(_))
+                                {
+                                    p.log().add_range_error(
+                                        Some(p.source),
+                                        less_than_range,
+                                        b"This syntax is not allowed in files with the \".mts\" or \".cts\" extension",
+                                    );
+                                }
+                                return Ok(expr);
                             }
                         }
                     }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -69,6 +69,11 @@ pub struct Parser<'a> {
 pub struct Options<'a> {
     pub jsx: options::JSX::Pragma,
     pub ts: bool,
+    /// Set for the ".mts" and ".cts" extensions (TypeScript 4.5). In those files an
+    /// expression that starts with "<" and that a ".tsx" file would read as a JSX
+    /// element is a syntax error: the "<T>x" cast and the "<T>() => {}" arrow
+    /// function. "<T,>() => {}" and "<T extends U>() => {}" stay allowed.
+    pub ts_no_ambiguous_less_than: bool,
     pub keep_names: bool,
     pub ignore_dce_annotations: bool,
     pub preserve_unused_imports_ts: bool,
@@ -124,6 +129,7 @@ impl<'a> Default for Options<'a> {
         Options {
             jsx: options::JSX::Pragma::default(),
             ts: false,
+            ts_no_ambiguous_less_than: false,
             keep_names: true,
             ignore_dce_annotations: false,
             preserve_unused_imports_ts: false,
@@ -174,6 +180,7 @@ impl<'a> Options<'a> {
         Options {
             jsx: self.jsx.clone(),
             ts: self.ts,
+            ts_no_ambiguous_less_than: self.ts_no_ambiguous_less_than,
             keep_names: self.keep_names,
             ignore_dce_annotations: self.ignore_dce_annotations,
             preserve_unused_imports_ts: self.preserve_unused_imports_ts,
@@ -256,6 +263,10 @@ impl<'a> Options<'a> {
             hasher.update(b"NO_TS");
         }
 
+        if self.ts_no_ambiguous_less_than {
+            hasher.update(b"TS_NO_AMBIGUOUS_LESS_THAN");
+        }
+
         if self.ignore_dce_annotations {
             hasher.update(b"no_dce");
         }
@@ -278,6 +289,7 @@ impl<'a> Options<'a> {
         // (see field comment); caller overwrites before use.
         let mut opts = Options {
             ts: loader.is_typescript(),
+            ts_no_ambiguous_less_than: false,
             jsx,
             keep_names: true,
             ignore_dce_annotations: false,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -69,10 +69,8 @@ pub struct Parser<'a> {
 pub struct Options<'a> {
     pub jsx: options::JSX::Pragma,
     pub ts: bool,
-    /// Set for the ".mts" and ".cts" extensions (TypeScript 4.5). In those files an
-    /// expression that starts with "<" and that a ".tsx" file would read as a JSX
-    /// element is a syntax error: the "<T>x" cast and the "<T>() => {}" arrow
-    /// function. "<T,>() => {}" and "<T extends U>() => {}" stay allowed.
+    /// ".mts" and ".cts" files reject the JSX-ambiguous "<T>x" cast and "<T>() => {}"
+    /// arrow function. "<T,>() => {}" and "<T extends U>() => {}" stay valid.
     pub ts_no_ambiguous_less_than: bool,
     pub keep_names: bool,
     pub ignore_dce_annotations: bool,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -69,8 +69,7 @@ pub struct Parser<'a> {
 pub struct Options<'a> {
     pub jsx: options::JSX::Pragma,
     pub ts: bool,
-    /// ".mts" and ".cts" files reject the JSX-ambiguous "<T>x" cast and "<T>() => {}"
-    /// arrow function. "<T,>() => {}" and "<T extends U>() => {}" stay valid.
+    /// ".mts" and ".cts" files reject the JSX-ambiguous "<T>x" cast and "<T>() => {}" arrow
     pub ts_no_ambiguous_less_than: bool,
     pub keep_names: bool,
     pub ignore_dce_annotations: bool,

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -954,6 +954,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if Self::IS_TYPESCRIPT_ENABLED {
             // This is either an old-style type cast or a generic lambda function
 
+            // TypeScript 4.5 introduced the ".mts" and ".cts" extensions that forbid
+            // the use of an expression starting with "<" that would be ambiguous
+            // when the file is in JSX mode.
+            if p.options.ts_no_ambiguous_less_than && !p.is_ts_arrow_fn_jsx()? {
+                p.log().add_range_error(
+                    Some(p.source),
+                    p.lexer.range(),
+                    b"This syntax is not allowed in files with the \".mts\" or \".cts\" extension",
+                );
+            }
+
             // "<T>(x)"
             // "<T>(x) => {}"
             match p.try_skip_type_script_type_parameters_then_open_paren_with_backtracking() {

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -954,9 +954,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if Self::IS_TYPESCRIPT_ENABLED {
             // This is either an old-style type cast or a generic lambda function
 
-            // TypeScript 4.5 introduced the ".mts" and ".cts" extensions that forbid
-            // the use of an expression starting with "<" that would be ambiguous
-            // when the file is in JSX mode.
+            // ".mts" and ".cts" files reject a "<" that a JSX file would read as an element
             if p.options.ts_no_ambiguous_less_than && !p.is_ts_arrow_fn_jsx()? {
                 p.log().add_range_error(
                     Some(p.source),

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -511,6 +511,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             && p.lexer.token == T::TOpenBrace
                             && name == b"static"
                         {
+                            if !opts.declare_range.is_empty() {
+                                p.log().add_range_error(
+                                    Some(p.source),
+                                    opts.declare_range,
+                                    b"\"declare\" cannot be used with a static block",
+                                );
+                            }
+
                             let loc = p.lexer.loc();
                             p.lexer.next()?;
 

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -438,10 +438,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             if let Some(mut prop) =
                                                 p.parse_property(kind, opts, None)?
                                             {
-                                                // A "declare" field only survives when
-                                                // TypeScript experimental decorators need
-                                                // to run on it. Standard decorators are
-                                                // rejected on it (see parse_class).
+                                                // Only experimental decorators keep the field
                                                 if prop.kind == PropertyKind::Normal
                                                     && prop.value.is_none()
                                                     && opts.ts_decorators.len() > 0
@@ -649,8 +646,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
-            // Parse a class field with an optional initial value. A definite assignment
-            // assertion ("foo!") forces the field path, so "foo!() {}" fails on the "(".
+            // Parse a class field with an optional initial value
             if opts.is_class
                 && (kind == PropertyKind::Normal || kind == PropertyKind::AutoAccessor)
                 && !opts.is_async

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -282,6 +282,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         || (opts.ts_decorators.len() > 0 && !p.options.features.standard_decorators)
                     {
                         p.lexer.expected(T::TIdentifier)?;
+                    } else if !opts.declare_range.is_empty() {
+                        p.log().add_range_error(
+                            Some(p.source),
+                            opts.declare_range,
+                            b"\"declare\" cannot be used with a private identifier",
+                        );
                     }
 
                     let ident = p.lexer.identifier;
@@ -301,6 +307,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if p.lexer.token == T::TColon && was_identifier && opts.is_class {
                             match expr.data {
                                 js_ast::ExprData::EIdentifier(_) => {
+                                    if !opts.declare_range.is_empty() {
+                                        p.log().add_range_error(
+                                            Some(p.source),
+                                            opts.declare_range,
+                                            b"\"declare\" cannot be used with an index signature",
+                                        );
+                                    }
+
                                     p.lexer.next()?;
                                     p.skip_type_script_type(Level::Lowest)?;
                                     p.lexer.expect(T::TCloseBracket)?;
@@ -412,21 +426,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         }
                                     }
                                     PropertyModifierKeyword::PDeclare => {
-                                        // skip declare keyword entirely
                                         // https://github.com/oven-sh/bun/issues/1907
                                         if opts.is_class
                                             && Self::IS_TYPESCRIPT_ENABLED
                                             && !p.lexer.has_newline_before
+                                            && opts.declare_range.is_empty()
                                             && raw == b"declare"
                                         {
+                                            opts.declare_range = name_range;
                                             let scope_index = p.scopes_in_order.len();
-                                            if let Some(_prop) =
+                                            if let Some(mut prop) =
                                                 p.parse_property(kind, opts, None)?
                                             {
-                                                let mut prop = _prop;
+                                                // A "declare" field only survives when
+                                                // TypeScript experimental decorators need
+                                                // to run on it. Standard decorators are
+                                                // rejected on it (see parse_class).
                                                 if prop.kind == PropertyKind::Normal
                                                     && prop.value.is_none()
                                                     && opts.ts_decorators.len() > 0
+                                                    && !p.options.features.standard_decorators
                                                 {
                                                     prop.kind = PropertyKind::Declare;
                                                     return Ok(Some(prop));
@@ -446,16 +465,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         {
                                             opts.is_ts_abstract = true;
                                             let scope_index = p.scopes_in_order.len();
-                                            if let Some(prop) =
+                                            if let Some(mut prop) =
                                                 p.parse_property(kind, opts, None)?
                                             {
                                                 if prop.kind == PropertyKind::Normal
                                                     && prop.value.is_none()
                                                     && opts.ts_decorators.len() > 0
+                                                    && !p.options.features.standard_decorators
                                                 {
-                                                    let mut prop_ = prop;
-                                                    prop_.kind = PropertyKind::Abstract;
-                                                    return Ok(Some(prop_));
+                                                    prop.kind = PropertyKind::Abstract;
+                                                    return Ok(Some(prop));
                                                 }
                                             }
                                             p.discard_scopes_up_to(scope_index);
@@ -630,12 +649,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
-            // Parse a class field with an optional initial value
+            // Parse a class field with an optional initial value. A definite assignment
+            // assertion ("foo!") forces the field path, so "foo!() {}" fails on the "(".
             if opts.is_class
                 && (kind == PropertyKind::Normal || kind == PropertyKind::AutoAccessor)
                 && !opts.is_async
                 && !opts.is_generator
-                && p.lexer.token != T::TOpenParen
                 && !has_type_parameters
                 && (p.lexer.token != T::TOpenParen || has_definite_assignment_assertion_operator)
             {
@@ -677,16 +696,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if p.lexer.token == T::TEquals {
-                    if Self::IS_TYPESCRIPT_ENABLED {
-                        if !opts.declare_range.is_empty() {
-                            p.log().add_range_error(
-                                Some(p.source),
-                                p.lexer.range(),
-                                b"Class fields that use \"declare\" cannot be initialized",
-                            );
-                        }
-                    }
-
                     p.lexer.next()?;
 
                     // "this" and "super" property access is allowed in field initializers
@@ -764,6 +773,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 || opts.is_async
                 || opts.is_generator
             {
+                if Self::IS_TYPESCRIPT_ENABLED && !opts.declare_range.is_empty() {
+                    let what: &[u8] = match kind {
+                        PropertyKind::Get => b"getter",
+                        PropertyKind::Set => b"setter",
+                        _ => b"method",
+                    };
+                    p.log().add_range_error_fmt(
+                        Some(p.source),
+                        opts.declare_range,
+                        format_args!(
+                            "\"declare\" cannot be used with a {}",
+                            bstr::BStr::new(what)
+                        ),
+                    );
+                }
+
                 return Self::parse_method_expression(
                     p,
                     kind,

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -782,9 +782,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         return Ok(());
                     }
 
-                    // `unexpected` only records the error. Fail here too, so a type
-                    // argument list such as "Array<>" or "Array<number,>" that is tried
-                    // with backtracking is rejected instead of accepted.
                     self.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -108,6 +108,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                             if self.lexer.token != T::TIdentifier {
                                 self.lexer.unexpected()?;
+                                return Err(crate::Error::SyntaxError);
                             }
 
                             found_identifier = true;
@@ -126,6 +127,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 self.lexer.next()?;
                             } else {
                                 self.lexer.unexpected()?;
+                                return Err(crate::Error::SyntaxError);
                             }
                         }
                     }
@@ -145,8 +147,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.lexer.expect(T::TCloseBrace)?;
             }
             _ => {
-                // try p.lexer.unexpected();
-                return Err(crate::Error::Backtrack);
+                self.lexer.unexpected()?;
+                return Err(crate::Error::SyntaxError);
             }
         }
         Ok(())
@@ -769,6 +771,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     {
                         if self.lexer.token != T::TFunction {
                             self.lexer.unexpected()?;
+                            return Err(crate::Error::SyntaxError);
                         }
                         self.lexer.next()?;
 
@@ -779,7 +782,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         return Ok(());
                     }
 
+                    // `unexpected` only records the error. Fail here too, so a type
+                    // argument list such as "Array<>" or "Array<number,>" that is tried
+                    // with backtracking is rejected instead of accepted.
                     self.lexer.unexpected()?;
+                    return Err(crate::Error::SyntaxError);
                 }
             }
             break;

--- a/src/runtime/cli/pm_diff_normalize.rs
+++ b/src/runtime/cli/pm_diff_normalize.rs
@@ -212,6 +212,7 @@ fn parse_js<'a>(
     options: Options,
 ) -> Option<Box<bun_ast::Ast<'a>>> {
     let mut opts = bun_js_parser::ParserOptions::init(Default::default(), loader);
+    opts.ts_no_ambiguous_less_than = matches!(source.path.name().ext, b".mts" | b".cts");
     // Print what is there: no dead-code removal, no macro execution, no import trimming.
     opts.features.dead_code_elimination = options.dce;
     opts.features.no_macros = true;

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -235,39 +235,24 @@ describe("dropped TypeScript class members discard scopes", () => {
   // so visiting a later scope of a different kind hit "Scope mismatch while visiting".
   const cases: [name: string, source: string, expected: string[]][] = [
     [
-      "arrow decorator on a method overload signature plus an arrow parameter decorator",
-      "class C {\r@((td) => { })oo(): oo;\n h(@(() => {})ny) {}}",
-      ["class C"],
-    ],
-    [
-      "arrow decorator on a method overload signature followed by a nested block",
-      "class C { @((td) => { })oo(): oo; h() { { let x; } } }",
-      ["class C"],
-    ],
-    [
-      "arrow decorator on an abstract method",
-      "abstract class C { @((td) => { })abstract oo(): void; h() { { let x; } } }",
-      ["class C"],
-    ],
-    [
-      "arrow decorator on a declare method",
-      "class C { @((td) => { })declare oo(): void;\n h() { { let x; } } }",
-      ["class C"],
-    ],
-    [
-      "arrow decorator on an index signature",
-      "class C { @((td) => { })[key: string]: any;\n h() { { let x; } } }",
-      ["class C"],
-    ],
-    [
-      "arrow decorator on a method overload signature followed by a function after the class",
-      "class C { @((td) => { })oo(): oo; }\nfunction f() { { let x; } }",
-      ["class C", "function f"],
-    ],
-    [
       "arrow function in the computed key of a method overload signature",
       "class C { [((x) => x)('foo')](): void; h() { { let x; } } }",
       ["class C"],
+    ],
+    [
+      "arrow function in the computed key of a method overload signature followed by a function after the class",
+      "class C { [((x) => x)('foo')](): void; }\nfunction f() { { let x; } }",
+      ["class C", "function f"],
+    ],
+    [
+      "arrow functions in the computed keys of an abstract method and a declare field",
+      "abstract class C { abstract [((x) => x)('foo')](): void; declare [((x) => x)('bar')]: number; h() { { let x; } } }",
+      ["class C"],
+    ],
+    [
+      "arrow decorators inside a declare class body followed by a function and a class",
+      "declare class C { @((td) => { })oo(): oo; h(@(() => {})ny) {} }\nfunction f() { { let x; } }\nclass D { h() { { let y; } } }",
+      ["function f", "class D"],
     ],
   ];
 
@@ -290,5 +275,48 @@ describe("dropped TypeScript class members discard scopes", () => {
       expect(stdout).toContain(substring);
     }
     expect(exitCode).toBe(0);
+  });
+
+  // Outside of a "declare class" body, decorators on a dropped member are a syntax
+  // error ("Decorators are not valid here"), like tsc and esbuild report. The parse
+  // stops there, so the scopes of the dropped member are never visited.
+  const rejected: [name: string, source: string][] = [
+    [
+      "arrow decorator on a method overload signature plus an arrow parameter decorator",
+      "class C {\r@((td) => { })oo(): oo;\n h(@(() => {})ny) {}}",
+    ],
+    [
+      "arrow decorator on a method overload signature followed by a nested block",
+      "class C { @((td) => { })oo(): oo; h() { { let x; } } }",
+    ],
+    [
+      "arrow decorator on an abstract method",
+      "abstract class C { @((td) => { })abstract oo(): void; h() { { let x; } } }",
+    ],
+    ["arrow decorator on a declare method", "class C { @((td) => { })declare oo(): void;\n h() { { let x; } } }"],
+    ["arrow decorator on an index signature", "class C { @((td) => { })[key: string]: any;\n h() { { let x; } } }"],
+    [
+      "arrow decorator on a method overload signature followed by a function after the class",
+      "class C { @((td) => { })oo(): oo; }\nfunction f() { { let x; } }",
+    ],
+  ];
+
+  test.concurrent.each(rejected)("%s is rejected", async (_name, source) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(new Bun.Transpiler({ loader: "tsx" }).transformSync(${JSON.stringify(source)}))`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Decorators are not valid here");
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1499,6 +1499,12 @@ function foo() {}
       },
     );
 
+    it("declare is not valid on a static block", () => {
+      const err = ts.expectParseError;
+      err('class Foo { declare static { console.log("ran") } }', '"declare" cannot be used with a static block');
+      err('class Foo { static declare { console.log("ran") } }', 'Expected ";" but found "{"');
+    });
+
     it("declare on a plain class field is erased", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
@@ -1635,11 +1641,13 @@ function foo() {}
         const f2 = <T extends string>(x: T) => x;
         const f3 = <T, U>(x: T, y: U) => [x, y];
         const f4 = <const T,>(x: T) => x;
+        const f5 = async <T,>(x: T) => x;
+        const f6 = async <T extends string>(x: T) => x;
         const a = 1, b = 2, c = 3;
         const g = a < b;
         const h = (a < b) > c;
         const arr = new Array<number>(1);
-        console.log(JSON.stringify([f1(1), f2("s"), f3(1, 2), f4(3), g, h, arr.length, (1 as any) + 1]));
+        console.log(JSON.stringify([f1(1), f2("s"), f3(1, 2), f4(3), g, h, arr.length, (1 as any) + 1, typeof f5, typeof f6]));
       `;
       // [file, source, stdout when run (null when the file is rejected)]
       const cases = [
@@ -1649,8 +1657,12 @@ function foo() {}
         ["arrow.cts", "let f = <T>() => {};", null],
         ["arrow-args.mts", "let f = <T>(x: T) => x;", null],
         ["arrow-args.cts", "let f = <T>(x: T) => x;", null],
-        ["allowed.mts", allowedSource, '[1,"s",[1,2],3,true,false,1,2]'],
-        ["allowed.cts", allowedSource, '[1,"s",[1,2],3,true,false,1,2]'],
+        ["async-arrow.mts", "let f = async <T>() => {};", null],
+        ["async-arrow.cts", "let f = async <T>() => {};", null],
+        ["async-arrow-args.mts", "let f = async <T>(x: T) => x;", null],
+        ["async-arrow-args.cts", "let f = async <T>(x: T) => x;", null],
+        ["allowed.mts", allowedSource, '[1,"s",[1,2],3,true,false,1,2,"function","function"]'],
+        ["allowed.cts", allowedSource, '[1,"s",[1,2],3,true,false,1,2,"function","function"]'],
         [
           "allowed.ts",
           "let y = 1; let a = <any>y; let f = <T>() => a; console.log(JSON.stringify([a, f()]));",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1661,6 +1661,17 @@ function foo() {}
         ["async-arrow.cts", "let f = async <T>() => {};", null],
         ["async-arrow-args.mts", "let f = async <T>(x: T) => x;", null],
         ["async-arrow-args.cts", "let f = async <T>(x: T) => x;", null],
+        // A call of a function named "async" with type arguments is not an arrow function.
+        [
+          "async-call.mts",
+          "const async = <T,>(x: T) => x; console.log(async<number>(42), async<string>('s'));",
+          "42 s",
+        ],
+        [
+          "async-call.cts",
+          "const async = <T,>(x: T) => x; console.log(async<number>(42), async<string>('s'));",
+          "42 s",
+        ],
         ["allowed.mts", allowedSource, '[1,"s",[1,2],3,true,false,1,2,"function","function"]'],
         ["allowed.cts", allowedSource, '[1,"s",[1,2],3,true,false,1,2,"function","function"]'],
         [

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1467,6 +1467,248 @@ function foo() {}
       exp("let x: abstract new <T>() => Foo<T>", "let x");
     });
 
+    it("declare is only valid on a plain class field", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      // Every member the modifier is not valid on is rejected instead of being
+      // silently deleted from the class. Matches esbuild's ts_parser_test.go.
+      for (const modifiers of ["declare ", "declare static ", "static declare "]) {
+        err(`class Foo { ${modifiers}foo() }`, '"declare" cannot be used with a method');
+        err(`class Foo { ${modifiers}foo() { console.log("ran") } }`, '"declare" cannot be used with a method');
+        err(`class Foo { ${modifiers}foo?(): void }`, '"declare" cannot be used with a method');
+        err(`class Foo { ${modifiers}async foo() {} }`, '"declare" cannot be used with a method');
+        err(`class Foo { ${modifiers}*foo() {} }`, '"declare" cannot be used with a method');
+        err(`class Foo { ${modifiers}['foo']() {} }`, '"declare" cannot be used with a method');
+        err(`class Foo { ${modifiers}get foo() { return 1 } }`, '"declare" cannot be used with a getter');
+        err(`class Foo { ${modifiers}set foo(v) {} }`, '"declare" cannot be used with a setter');
+        err(`class Foo { ${modifiers}#foo }`, '"declare" cannot be used with a private identifier');
+        err(`class Foo { ${modifiers}#foo = 1 }`, '"declare" cannot be used with a private identifier');
+        err(`class Foo { ${modifiers}[foo: string]: number }`, '"declare" cannot be used with an index signature');
+      }
+      // The second "declare" is a field name, not a modifier.
+      err("class Foo { declare declare foo }", 'Expected ";" but found "foo"');
+
+      // Plain fields are still erased, with or without an initializer.
+      exp("class Foo { declare foo }", "class Foo {\n}");
+      exp("class Foo { declare foo: number }", "class Foo {\n}");
+      exp("class Foo { declare foo = 1 }", "class Foo {\n}");
+      exp("class Foo { declare foo?: number }", "class Foo {\n}");
+      exp("class Foo { declare foo!: number }", "class Foo {\n}");
+      exp("class Foo { declare [foo]: number }", "class Foo {\n}");
+      exp("class Foo { declare 'foo': number }", "class Foo {\n}");
+      exp("class Foo { declare static foo: number }", "class Foo {\n}");
+      exp("class Foo { static declare foo = 1 }", "class Foo {\n}");
+      // A newline after "declare" makes it a field named "declare".
+      exp("class Foo { declare\n foo() { return 1 } }", "class Foo {\n  declare;\n  foo() {\n    return 1;\n  }\n}");
+      // A quoted key, or a key in an object literal, is a plain property name.
+      exp("class Foo { 'declare'() { return 1 } }", "class Foo {\n  declare() {\n    return 1;\n  }\n}");
+      exp("x = { declare() { return 1 } }", "x = { declare() {\n  return 1;\n} }");
+      exp("x = { declare: 1, get declare2() { return 1 } }", "x = { declare: 1, get declare2() {\n  return 1;\n} }");
+    });
+
+    it("definite assignment assertion forces a class field", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      exp("class Foo { a?; b!; x?() {} }", "class Foo {\n  a;\n  b;\n  x() {}\n}");
+      exp("class Foo { foo!: number }", "class Foo {\n  foo;\n}");
+      exp("class Foo { foo!: number = 0 }", "class Foo {\n  foo = 0;\n}");
+      exp("class Foo { static foo!: number }", "class Foo {\n  static foo;\n}");
+      exp("class Foo { foo?(): void {} }", "class Foo {\n  foo() {}\n}");
+      exp("class Foo { foo?<T>() {} }", "class Foo {\n  foo() {}\n}");
+      exp("class Foo { [foo]?<T>() {} }", "class Foo {\n  [foo]() {}\n}");
+
+      // "foo!" can only be a field, so a method body after it is an error.
+      err("class Foo { foo!() {} }", 'Expected ";" but found "("');
+      err("class Foo { a?; b!; x?() {}  y!() {} }", 'Expected ";" but found "("');
+      err("class Foo { static foo!() {} }", 'Expected ";" but found "("');
+      err("class Foo { foo!<T>() {} }", 'Expected ";" but found "<"');
+      err("class Foo { [foo]!<T>() {} }", 'Expected ";" but found "<"');
+      err("class Foo { accessor foo!() {} }", 'Expected ";" but found "("');
+      err("class Foo { *foo!() {} }", 'Expected "(" but found "!"');
+      err("class Foo { get foo!() {} }", 'Expected "(" but found "!"');
+      err("class Foo { set foo!(x) {} }", 'Expected "(" but found "!"');
+      err("class Foo { async foo!() {} }", 'Expected "(" but found "!"');
+    });
+
+    it("type argument lists need an argument and reject a trailing comma", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      exp("const t = Array<number>;", "const t = Array;\n");
+      exp("const t = Array<number, string>;", "const t = Array;\n");
+      exp("const t = Array<number>();", "const t = Array();\n");
+      exp("const t = Array<Array<number>>();", "const t = Array();\n");
+      exp("let x: Array<number> = [];", "let x = [];\n");
+      // Type parameter lists still allow the trailing comma.
+      exp("let f = <T,>() => {};", "let f = () => {};\n");
+
+      err("const t1 = Array<number,>;", 'Expected identifier but found ">"');
+      err("const t2 = Array< >;", "Unexpected >");
+      err("const t3 = Array< , >;", "Unexpected ,");
+      err("const t4 = Array<number,>();", 'Expected identifier but found ">"');
+      err("const t5 = Array< >();", "Unexpected >");
+      err("const t6 = f<T,>;", 'Expected identifier but found ">"');
+      err("let x: Array<number,> = [];", "Unexpected >");
+      err("let x: Array<> = [];", "Unexpected >");
+    });
+
+    it("function type parameters reject a reserved word as a binding", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      exp("type T = ({ ...rest }) => {};", "");
+      exp("type T = ({ if: x }) => {};", "");
+      exp("type T = ({ if: x, 'else': y, 1: z }) => {};", "");
+      exp("type T = ([a, ...b]) => {};", "");
+
+      err("type T = ({ ...if }) => {};", "Unexpected ...");
+      err("type T = ({ if }) => {};", 'Expected ";" but found "=>"');
+      err("type T = ([...if]) => {};", "Unexpected if");
+      err("type T = { foo(1): void };", "Unexpected 1");
+    });
+
+    it("decorators are not valid on a declare or abstract field unless experimentalDecorators is set", () => {
+      const err = ts.expectParseError;
+
+      err("class Foo { @dec declare foo: any; @dec bar: any }", "Decorators are not valid here");
+      err("class Foo { @dec declare static foo: any }", "Decorators are not valid here");
+      err("class Foo { @dec static declare foo: any }", "Decorators are not valid here");
+      err("abstract class Foo { @dec abstract foo: any }", "Decorators are not valid here");
+      err("abstract class Foo { @dec abstract foo(): void }", "Decorators are not valid here");
+      err("class Foo { @dec foo(): void; @dec foo(): void {} }", "Decorators are not valid here");
+      err("class Foo { @dec [key: string]: any }", "Decorators are not valid here");
+      // A "declare class" body is erased as a whole.
+      ts.expectPrinted_("declare class Foo { @dec declare foo: any; @dec bar(): void }", "");
+
+      // TypeScript experimental decorators are allowed on declare and abstract
+      // fields. The decorator call is kept and the field is still erased.
+      const legacy = new Bun.Transpiler({
+        loader: "ts",
+        tsconfig: { compilerOptions: { experimentalDecorators: true } },
+      });
+      for (const code of [
+        "class Foo { @dec declare foo: any; @dec bar: any }",
+        "abstract class Foo { @dec abstract foo: any; @dec bar: any }",
+      ]) {
+        const out = legacy.transformSync(code);
+        expect(out).toContain("class Foo {\n}");
+        expect(out).toContain('Foo.prototype, "foo", undefined);');
+        expect(out).toContain('Foo.prototype, "bar", undefined);');
+      }
+      expect(() => legacy.transformSync("class Foo { @dec foo(): void; @dec foo(): void {} }")).toThrow(
+        "Decorators are not valid here",
+      );
+      expect(() => legacy.transformSync("abstract class Foo { @dec abstract foo(): void }")).toThrow(
+        "Decorators are not valid here",
+      );
+    });
+
+    describe("the .mts and .cts extensions", () => {
+      // TypeScript 4.5 rejects the expressions that start with "<" and that a
+      // ".tsx" file would read as a JSX element: the "<T>x" cast and the
+      // "<T>() => {}" arrow function. "<T,>" and "<T extends X>" stay allowed.
+      const message = 'This syntax is not allowed in files with the ".mts" or ".cts" extension';
+      const rejected = {
+        "cast.mts": "let y = 1; let a = <any>y;",
+        "cast.cts": "let y = 1; let a = <any>y;",
+        "arrow.mts": "let f = <T>() => {};",
+        "arrow.cts": "let f = <T>() => {};",
+        "arrow-args.mts": "let f = <T>(x: T) => x;",
+        "arrow-args.cts": "let f = <T>(x: T) => x;",
+      };
+      const allowedSource = `
+        const f1 = <T,>(x: T) => x;
+        const f2 = <T extends string>(x: T) => x;
+        const f3 = <T, U>(x: T, y: U) => [x, y];
+        const f4 = <const T,>(x: T) => x;
+        const a = 1, b = 2, c = 3;
+        const g = a < b;
+        const h = (a < b) > c;
+        const arr = new Array<number>(1);
+        console.log(JSON.stringify([f1(1), f2("s"), f3(1, 2), f4(3), g, h, arr.length, (1 as any) + 1]));
+      `;
+      const allowed = {
+        "allowed.mts": allowedSource,
+        "allowed.cts": allowedSource,
+        "allowed.ts": "let y = 1; let a = <any>y; let f = <T>() => a; console.log(JSON.stringify([a, f()]));",
+      };
+
+      async function run(cmd, cwd) {
+        await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { stdout, stderr, exitCode };
+      }
+
+      it.concurrent("bun build rejects the ambiguous syntax", async () => {
+        using dir = tempDir("ts-no-ambiguous-less-than-build", { ...rejected, ...allowed });
+        for (const file of Object.keys(rejected)) {
+          const { stderr, exitCode } = await run([bunExe(), "build", "--no-bundle", file], String(dir));
+          expect({ file, hasError: stderr.includes(message), exitCode }).toEqual({ file, hasError: true, exitCode: 1 });
+        }
+        for (const file of Object.keys(allowed)) {
+          const { stderr, exitCode } = await run([bunExe(), "build", "--no-bundle", file], String(dir));
+          expect({ file, stderr, exitCode }).toEqual({ file, stderr: "", exitCode: 0 });
+        }
+      });
+
+      it.concurrent("bun run rejects the ambiguous syntax", async () => {
+        using dir = tempDir("ts-no-ambiguous-less-than-run", { ...rejected, ...allowed });
+        for (const file of Object.keys(rejected)) {
+          const { stderr, exitCode } = await run([bunExe(), file], String(dir));
+          expect({ file, hasError: stderr.includes(message), exitCode }).toEqual({ file, hasError: true, exitCode: 1 });
+        }
+        for (const [file, expected] of [
+          ["allowed.mts", '[1,"s",[1,2],3,true,false,1,2]'],
+          ["allowed.cts", '[1,"s",[1,2],3,true,false,1,2]'],
+          ["allowed.ts", "[1,1]"],
+        ]) {
+          const { stdout, stderr, exitCode } = await run([bunExe(), file], String(dir));
+          expect({ file, stdout: stdout.trim(), stderr, exitCode }).toEqual({
+            file,
+            stdout: expected,
+            stderr: "",
+            exitCode: 0,
+          });
+        }
+      });
+    });
+
+    it("a class member that declare cannot apply to is an error at runtime too", async () => {
+      using dir = tempDir("ts-declare-class-member", {
+        "method.ts": `
+          class B { declare foo() { console.log("ran") } }
+          new B().foo();
+        `,
+        "decorated.ts": `
+          function d(v: any, ctx: any) { console.log("dec", ctx.kind, ctx.name) }
+          class F { @d declare foo: any; @d bar: any }
+          console.log(Object.keys(new F()));
+        `,
+        "tsconfig.json": `{ "compilerOptions": { "experimentalDecorators": false } }`,
+      });
+      for (const [file, expected] of [
+        ["method.ts", '"declare" cannot be used with a method'],
+        ["decorated.ts", "Decorators are not valid here"],
+      ]) {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), file],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ file, stdout, hasError: stderr.includes(expected), exitCode }).toEqual({
+          file,
+          stdout: "",
+          hasError: true,
+          exitCode: 1,
+        });
+      }
+    });
+
     it("as", () => {
       const exp = ts.expectPrinted_;
       exp("x as 1 < 1", "x < 1");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1467,25 +1467,42 @@ function foo() {}
       exp("let x: abstract new <T>() => Foo<T>", "let x");
     });
 
-    it("declare is only valid on a plain class field", () => {
+    // Every member the "declare" modifier is not valid on is rejected instead of being
+    // silently deleted from the class. Matches esbuild's ts_parser_test.go.
+    describe.each(["declare ", "declare static ", "static declare "])(
+      "%sis only valid on a plain class field",
+      modifiers => {
+        const err = ts.expectParseError;
+
+        it("rejects a method", () => {
+          err(`class Foo { ${modifiers}foo() }`, '"declare" cannot be used with a method');
+          err(`class Foo { ${modifiers}foo() { console.log("ran") } }`, '"declare" cannot be used with a method');
+          err(`class Foo { ${modifiers}foo?(): void }`, '"declare" cannot be used with a method');
+          err(`class Foo { ${modifiers}async foo() {} }`, '"declare" cannot be used with a method');
+          err(`class Foo { ${modifiers}*foo() {} }`, '"declare" cannot be used with a method');
+          err(`class Foo { ${modifiers}['foo']() {} }`, '"declare" cannot be used with a method');
+        });
+
+        it("rejects a getter and a setter", () => {
+          err(`class Foo { ${modifiers}get foo() { return 1 } }`, '"declare" cannot be used with a getter');
+          err(`class Foo { ${modifiers}set foo(v) {} }`, '"declare" cannot be used with a setter');
+        });
+
+        it("rejects a private identifier", () => {
+          err(`class Foo { ${modifiers}#foo }`, '"declare" cannot be used with a private identifier');
+          err(`class Foo { ${modifiers}#foo = 1 }`, '"declare" cannot be used with a private identifier');
+        });
+
+        it("rejects an index signature", () => {
+          err(`class Foo { ${modifiers}[foo: string]: number }`, '"declare" cannot be used with an index signature');
+        });
+      },
+    );
+
+    it("declare on a plain class field is erased", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
 
-      // Every member the modifier is not valid on is rejected instead of being
-      // silently deleted from the class. Matches esbuild's ts_parser_test.go.
-      for (const modifiers of ["declare ", "declare static ", "static declare "]) {
-        err(`class Foo { ${modifiers}foo() }`, '"declare" cannot be used with a method');
-        err(`class Foo { ${modifiers}foo() { console.log("ran") } }`, '"declare" cannot be used with a method');
-        err(`class Foo { ${modifiers}foo?(): void }`, '"declare" cannot be used with a method');
-        err(`class Foo { ${modifiers}async foo() {} }`, '"declare" cannot be used with a method');
-        err(`class Foo { ${modifiers}*foo() {} }`, '"declare" cannot be used with a method');
-        err(`class Foo { ${modifiers}['foo']() {} }`, '"declare" cannot be used with a method');
-        err(`class Foo { ${modifiers}get foo() { return 1 } }`, '"declare" cannot be used with a getter');
-        err(`class Foo { ${modifiers}set foo(v) {} }`, '"declare" cannot be used with a setter');
-        err(`class Foo { ${modifiers}#foo }`, '"declare" cannot be used with a private identifier');
-        err(`class Foo { ${modifiers}#foo = 1 }`, '"declare" cannot be used with a private identifier');
-        err(`class Foo { ${modifiers}[foo: string]: number }`, '"declare" cannot be used with an index signature');
-      }
       // The second "declare" is a field name, not a modifier.
       err("class Foo { declare declare foo }", 'Expected ";" but found "foo"');
 
@@ -1569,7 +1586,7 @@ function foo() {}
       err("type T = { foo(1): void };", "Unexpected 1");
     });
 
-    it("decorators are not valid on a declare or abstract field unless experimentalDecorators is set", () => {
+    it("standard decorators are not valid on a class member TypeScript erases", () => {
       const err = ts.expectParseError;
 
       err("class Foo { @dec declare foo: any; @dec bar: any }", "Decorators are not valid here");
@@ -1581,28 +1598,31 @@ function foo() {}
       err("class Foo { @dec [key: string]: any }", "Decorators are not valid here");
       // A "declare class" body is erased as a whole.
       ts.expectPrinted_("declare class Foo { @dec declare foo: any; @dec bar(): void }", "");
+    });
 
-      // TypeScript experimental decorators are allowed on declare and abstract
-      // fields. The decorator call is kept and the field is still erased.
+    describe("TypeScript experimental decorators on a declare or abstract field", () => {
+      // The decorator call is kept and the field is still erased.
       const legacy = new Bun.Transpiler({
         loader: "ts",
         tsconfig: { compilerOptions: { experimentalDecorators: true } },
       });
-      for (const code of [
+
+      it.each([
         "class Foo { @dec declare foo: any; @dec bar: any }",
         "abstract class Foo { @dec abstract foo: any; @dec bar: any }",
-      ]) {
+      ])("keep the decorator call for %s", code => {
         const out = legacy.transformSync(code);
         expect(out).toContain("class Foo {\n}");
         expect(out).toContain('Foo.prototype, "foo", undefined);');
         expect(out).toContain('Foo.prototype, "bar", undefined);');
-      }
-      expect(() => legacy.transformSync("class Foo { @dec foo(): void; @dec foo(): void {} }")).toThrow(
-        "Decorators are not valid here",
-      );
-      expect(() => legacy.transformSync("abstract class Foo { @dec abstract foo(): void }")).toThrow(
-        "Decorators are not valid here",
-      );
+      });
+
+      it.each([
+        "class Foo { @dec foo(): void; @dec foo(): void {} }",
+        "abstract class Foo { @dec abstract foo(): void }",
+      ])("are still rejected on %s", code => {
+        expect(() => legacy.transformSync(code)).toThrow("Decorators are not valid here");
+      });
     });
 
     describe("the .mts and .cts extensions", () => {
@@ -1610,14 +1630,6 @@ function foo() {}
       // ".tsx" file would read as a JSX element: the "<T>x" cast and the
       // "<T>() => {}" arrow function. "<T,>" and "<T extends X>" stay allowed.
       const message = 'This syntax is not allowed in files with the ".mts" or ".cts" extension';
-      const rejected = {
-        "cast.mts": "let y = 1; let a = <any>y;",
-        "cast.cts": "let y = 1; let a = <any>y;",
-        "arrow.mts": "let f = <T>() => {};",
-        "arrow.cts": "let f = <T>() => {};",
-        "arrow-args.mts": "let f = <T>(x: T) => x;",
-        "arrow-args.cts": "let f = <T>(x: T) => x;",
-      };
       const allowedSource = `
         const f1 = <T,>(x: T) => x;
         const f2 = <T extends string>(x: T) => x;
@@ -1629,11 +1641,22 @@ function foo() {}
         const arr = new Array<number>(1);
         console.log(JSON.stringify([f1(1), f2("s"), f3(1, 2), f4(3), g, h, arr.length, (1 as any) + 1]));
       `;
-      const allowed = {
-        "allowed.mts": allowedSource,
-        "allowed.cts": allowedSource,
-        "allowed.ts": "let y = 1; let a = <any>y; let f = <T>() => a; console.log(JSON.stringify([a, f()]));",
-      };
+      // [file, source, stdout when run (null when the file is rejected)]
+      const cases = [
+        ["cast.mts", "let y = 1; let a = <any>y;", null],
+        ["cast.cts", "let y = 1; let a = <any>y;", null],
+        ["arrow.mts", "let f = <T>() => {};", null],
+        ["arrow.cts", "let f = <T>() => {};", null],
+        ["arrow-args.mts", "let f = <T>(x: T) => x;", null],
+        ["arrow-args.cts", "let f = <T>(x: T) => x;", null],
+        ["allowed.mts", allowedSource, '[1,"s",[1,2],3,true,false,1,2]'],
+        ["allowed.cts", allowedSource, '[1,"s",[1,2],3,true,false,1,2]'],
+        [
+          "allowed.ts",
+          "let y = 1; let a = <any>y; let f = <T>() => a; console.log(JSON.stringify([a, f()]));",
+          "[1,1]",
+        ],
+      ];
 
       async function run(cmd, cwd) {
         await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
@@ -1641,72 +1664,63 @@ function foo() {}
         return { stdout, stderr, exitCode };
       }
 
-      it.concurrent("bun build rejects the ambiguous syntax", async () => {
-        using dir = tempDir("ts-no-ambiguous-less-than-build", { ...rejected, ...allowed });
-        for (const file of Object.keys(rejected)) {
+      describe.each(cases)("%s", (file, source, expected) => {
+        it.concurrent("bun build", async () => {
+          using dir = tempDir("ts-no-ambiguous-less-than-build", { [file]: source });
           const { stderr, exitCode } = await run([bunExe(), "build", "--no-bundle", file], String(dir));
-          expect({ file, hasError: stderr.includes(message), exitCode }).toEqual({ file, hasError: true, exitCode: 1 });
-        }
-        for (const file of Object.keys(allowed)) {
-          const { stderr, exitCode } = await run([bunExe(), "build", "--no-bundle", file], String(dir));
-          expect({ file, stderr, exitCode }).toEqual({ file, stderr: "", exitCode: 0 });
-        }
-      });
+          if (expected === null) {
+            expect({ hasError: stderr.includes(message), exitCode }).toEqual({ hasError: true, exitCode: 1 });
+          } else {
+            expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+          }
+        });
 
-      it.concurrent("bun run rejects the ambiguous syntax", async () => {
-        using dir = tempDir("ts-no-ambiguous-less-than-run", { ...rejected, ...allowed });
-        for (const file of Object.keys(rejected)) {
-          const { stderr, exitCode } = await run([bunExe(), file], String(dir));
-          expect({ file, hasError: stderr.includes(message), exitCode }).toEqual({ file, hasError: true, exitCode: 1 });
-        }
-        for (const [file, expected] of [
-          ["allowed.mts", '[1,"s",[1,2],3,true,false,1,2]'],
-          ["allowed.cts", '[1,"s",[1,2],3,true,false,1,2]'],
-          ["allowed.ts", "[1,1]"],
-        ]) {
+        it.concurrent("bun run", async () => {
+          using dir = tempDir("ts-no-ambiguous-less-than-run", { [file]: source });
           const { stdout, stderr, exitCode } = await run([bunExe(), file], String(dir));
-          expect({ file, stdout: stdout.trim(), stderr, exitCode }).toEqual({
-            file,
-            stdout: expected,
-            stderr: "",
-            exitCode: 0,
-          });
-        }
+          if (expected === null) {
+            expect({ hasError: stderr.includes(message), exitCode }).toEqual({ hasError: true, exitCode: 1 });
+          } else {
+            expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: expected, stderr: "", exitCode: 0 });
+          }
+        });
       });
     });
 
-    it("a class member that declare cannot apply to is an error at runtime too", async () => {
-      using dir = tempDir("ts-declare-class-member", {
-        "method.ts": `
-          class B { declare foo() { console.log("ran") } }
-          new B().foo();
-        `,
-        "decorated.ts": `
-          function d(v: any, ctx: any) { console.log("dec", ctx.kind, ctx.name) }
-          class F { @d declare foo: any; @d bar: any }
-          console.log(Object.keys(new F()));
-        `,
-        "tsconfig.json": `{ "compilerOptions": { "experimentalDecorators": false } }`,
-      });
-      for (const [file, expected] of [
-        ["method.ts", '"declare" cannot be used with a method'],
-        ["decorated.ts", "Decorators are not valid here"],
-      ]) {
+    describe.each([
+      [
+        "a declare method",
+        `class B { declare foo() { console.log("ran") } }
+         new B().foo();`,
+        '"declare" cannot be used with a method',
+      ],
+      [
+        "a standard decorator on a declare field",
+        `function d(v: any, ctx: any) { console.log("dec", ctx.kind, ctx.name) }
+         class F { @d declare foo: any; @d bar: any }
+         console.log(Object.keys(new F()));`,
+        "Decorators are not valid here",
+      ],
+    ])("%s is an error at runtime too", (_name, source, expected) => {
+      it.concurrent("bun run", async () => {
+        using dir = tempDir("ts-declare-class-member", {
+          "index.ts": source,
+          "tsconfig.json": `{ "compilerOptions": { "experimentalDecorators": false } }`,
+        });
         await using proc = Bun.spawn({
-          cmd: [bunExe(), file],
+          cmd: [bunExe(), "index.ts"],
           env: bunEnv,
           cwd: String(dir),
           stdout: "pipe",
           stderr: "pipe",
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect({ file, stdout, hasError: stderr.includes(expected), exitCode }).toEqual({
-          file,
+        expect({ stdout, hasError: stderr.includes(expected), exitCode }).toEqual({
           stdout: "",
           hasError: true,
           exitCode: 1,
         });
-      }
+      });
     });
 
     it("as", () => {


### PR DESCRIPTION
### Problem
- `class B { declare foo() { ... } }` deletes `foo` with no diagnostic, so `new B().foo()` fails with `TypeError: new B().foo is not a function`. Same for `declare` on a getter, setter, `#private` member, index signature and static block. Cause: the `PDeclare` arm in `src/js_parser/parse/parse_property.rs` returns `Ok(None)`, and `PropertyOpts::declare_range` is never set.
- With standard decorators, `@d declare foo: T` becomes a real field and `d` runs. `foo!() {}` parses as a method because a stale `&& token != TOpenParen` precedes the ported check. `Array<number,>` and `({ ...if }) => {}` are accepted because the TypeScript skipper does not return `Err` after `Lexer::unexpected()`, which only records the error.
- `.mts` and `.cts` files accept `<any>y` and `<T>() => {}`, which tsc and esbuild reject.

### Fix
- Set `opts.declare_range` and report `"declare" cannot be used with a method` / `getter` / `setter` / `a private identifier` / `an index signature` / `a static block`. `declare foo: T` and `declare foo = 1` stay erased.
- Keep a decorated `declare`/`abstract` field only with `experimentalDecorators`. `parse_class` reports `Decorators are not valid here` for decorators on any dropped member outside a `declare class`. Drop the stale condition. Return `Err(SyntaxError)` after `unexpected()` in `parse_skip_typescript.rs`.
- Add the parser option `ts_no_ambiguous_less_than`, set from the `.mts`/`.cts` extension by the bundler, the runtime transpiler and `bun pm diff`. The `<` and `async <` arms report `This syntax is not allowed in files with the ".mts" or ".cts" extension` unless the lookahead sees `<T,>`, `<T = X>` or `<T extends X>`.
- Verified: `test/bundler/transpiler/transpiler.test.js` (33 generated tests fail on the current release) and `scope-mismatch-panic.test.ts`. The other suites are listed in Notes.

### Background
- `parse_property` is a port of esbuild's `parseProperty`. Modifier keywords re-enter it for the member that follows, with `PropertyOpts` carrying the modifier state.
- Bun's lexer reports errors and keeps going. In a backtracking attempt the log is disabled, so a skipper that does not return `Err` cannot make the attempt fail.
- `features.standard_decorators` is false only for a TypeScript file with `experimentalDecorators` or `emitDecoratorMetadata`. The `PropertyKind::Declare`/`Abstract` markers drive the legacy `__legacyDecorateClassTS` lowering.
- esbuild models the `.mts`/`.cts` rule as `NoAmbiguousLessThan` on a dedicated loader. Bun's `Loader` enum crosses FFI and is visible to JS, so this is a parser option derived from the path.

<details><summary>Notes</summary>

- Reference: esbuild `internal/js_parser/ts_parser_test.go` (`TestTSClass`, `TestTSDecorators`, `TestTSNoAmbiguousLessThan`). The first error for every repro line matches esbuild 0.25.1, except that Bun prints `Unexpected >` where esbuild prints `Unexpected ">"` (existing Bun convention).
- tsc 6.0 output for the repros: TS1031 `'declare' modifier cannot appear on class elements of this kind`, TS18019 for `#private`, TS1071 for the index signature, TS1184 for the static block, TS1206 `Decorators are not valid here`, TS1249 for decorated overloads, TS1009/TS1099 for the type argument lists, TS7059/TS7060 for `.mts` (also for `async <T>() => {}`, which esbuild does not check).
- `declare foo = 1`: tsc reports TS1039 from the checker, esbuild and Bun strip it. Kept as is (the request asked for it to stay stripped).
- `declare accessor foo: T` stays erased without a diagnostic: tsc erases it as well (TS1243 is a checker diagnostic) and esbuild erases it.
- The dead "Class fields that use declare cannot be initialized" check is removed: esbuild allows the initializer and `declare_range` would have activated it.
- The runtime transpiler cache is keyed by content hash plus an options hash, not by path. The new option is part of the options hash so identical content in `a.ts` and `b.mts` does not share an entry.
- Decorated members dropped by the parser used to be covered by `scope-mismatch-panic.test.ts` as a success path. They are a syntax error now, so those cases assert the error, and the success path keeps the computed key cases plus decorators inside a `declare class` body.
- Related open PRs: #38126 also drops decorated `declare`/`abstract` fields under standard decorators, but silently. This PR reports the error instead, as requested, and covers the other members too. #38706 (modifiers followed by a newline) edits a different arm of `parse_property` and does not conflict.
- Suites run with `bun bd test`: `transpiler.test.js`, `scope-mismatch-panic.test.ts`, `esbuild/ts.test.ts`, `esbuild/default.test.ts`, `decorators.test.ts`, `es-decorators.test.ts`, `es-decorators-esbuild.test.ts`, `decorator-metadata.test.ts`, `ts-use-define-for-class-fields.test.ts`, `bundler_decorator_metadata.test.ts`, `bundler_edgecase`, `bundler_regressions`, `bundler_loader`, `bundler_jsx`, `resolve.test.ts`, `require-extensions.test.ts`, `test/js/bun/transpiler/`. `cargo check` and `rustfmt --check` clean.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 48 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/scope-mismatch-panic.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/scope-mismatch-panic.test.ts:
(pass) scope mismatch panic regression test > should not panic with scope mismatch when arrow function is followed by array literal [658.91ms]
(pass) scope mismatch panic regression test > should not panic with simpler arrow function followed by array [270.92ms]
(pass) scope mismatch panic regression test > correctly rejects direct indexing into block body arrow function [254.34ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation reports the macro error [273.80ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation in dead code is erased [327.18ms]
(pass) macro tagged templates visit their interpolations > member-expression macro tag with function interpolation reports the macro error [342.72ms]
(pass) TypeScript 'declare' statements discard scopes of
... (truncated)

release without fix: 4 failed, 22 skipped
bun test v1.4.1-canary.1 (fb8d7a237)

test/bundler/transpiler/scope-mismatch-panic.test.ts:
(pass) scope mismatch panic regression test > should not panic with scope mismatch when arrow function is followed by array literal [14.23ms]
(pass) scope mismatch panic regression test > should not panic with simpler arrow function followed by array [4.95ms]
(pass) scope mismatch panic regression test > correctly rejects direct indexing into block body arrow function [4.44ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation reports the macro error [7.41ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation in dead code is erased [6.86ms]
(pass) macro tagged templates visit their interpolations > member-expression macro tag with function interpolation reports the macro error [6.36ms]
(pass) TypeScript 'declare' statements discard scopes of dropped statements > declare global containing nested blocks followed by a class [13.99ms]
(pass) TypeScript 'declare' statements discard scopes of dropped statements > declare const with an arrow function initializer followed by 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/scope-mismatch-panic.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/scope-mismatch-panic.test.ts:
(pass) scope mismatch panic regression test > should not panic with scope mismatch when arrow function is followed by array literal [771.05ms]
(pass) scope mismatch panic regression test > should not panic with simpler arrow function followed by array [430.84ms]
(pass) scope mismatch panic regression test > correctly rejects direct indexing into block body arrow function [352.09ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation in dead code is erased [440.34ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation reports the macro error [515.17ms]
(pass) macro tagged templates visit their interpolations > member-expression macro tag with function interpolation reports the macro error [365.83ms]
(pass) TypeScript 'declare' statements discard scopes of
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 604ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ParseTask.rs                           |   1 +
 src/bundler/transpiler.rs                          |   1 +
 src/js_parser/parse/mod.rs                         |  31 ++-
 src/js_parser/parse/parse_entry.rs                 |   9 +
 src/js_parser/parse/parse_prefix.rs                |   9 +
 src/js_parser/parse/parse_property.rs              |  65 +++--
 src/js_parser/parse/parse_skip_typescript.rs       |   8 +-
 src/runtime/cli/pm_diff_normalize.rs               |   1 +
 .../transpiler/scope-mismatch-panic.test.ts        |  78 ++++--
 test/bundler/transpiler/transpiler.test.js         | 279 +++++++++++++++++++++
 10 files changed, 434 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/bundler/ParseTask.rs                                  1      2      0
src/bundler/transpiler.rs                                 2      1      0
src/js_parser/parse/mod.rs                                4      6      0
src/js_parser/parse/parse_entry.rs                        3      8      0
src/js_parser/parse/parse_prefix.rs                       2      2      0
src/js_parser/parse/parse_property.rs                     4      9      0
src/js_parser/parse/parse_skip_typescript.rs              6      5      0
src/runtime/cli/pm_diff_normalize.rs                      1      1      0
test/bundler/transpiler/scope-mismatch-panic.test.ts      1      1      0
test/bundler/transpiler/transpiler.test.js                8     10      0
```

</details>

<!-- robobun:evidence:end -->