### PR TITLE
parser: accept TypeScript arrow return types inside conditionals, `export type` before a newline, and `import type from`

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -722,9 +722,7 @@ impl Expr {
 pub enum EFlags {
     None,
     TsDecorator,
-    /// The expression is the middle operand of a conditional: between its
-    /// `?` and its `:`. A TypeScript arrow return type there is ambiguous
-    /// with the conditional's own `:`.
+    /// Between the `?` and `:` of a conditional, where an arrow return type is ambiguous.
     AfterQuestionAndBeforeColon,
 }
 

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -722,6 +722,10 @@ impl Expr {
 pub enum EFlags {
     None,
     TsDecorator,
+    /// The expression is the middle operand of a conditional: between its
+    /// `?` and its `:`. A TypeScript arrow return type there is ambiguous
+    /// with the conditional's own `:`.
+    AfterQuestionAndBeforeColon,
 }
 
 // `is_missing` lives in the `init`/`allocate` impl block below.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -343,6 +343,16 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// until a constraint attempt actually backtracks, which is rare in real code.
     pub(crate) ts_infer_constraint_backtracks: Vec<u32>,
 
+    /// Outcomes of `is_type_script_arrow_return_type_after_question_and_before_colon`,
+    /// keyed by the byte offset of the `:` shifted left by one, with the low bit set
+    /// when the attempt parsed an arrow function. The outcome depends only on the
+    /// source from that offset on, so the real parse that follows a discarded
+    /// attempt can reuse it. Without this memo every nested
+    /// `a ? (b) : c => <body> : e` inside the body is parsed once by the attempt and
+    /// once for real, which is exponential in the nesting depth. Kept sorted for
+    /// binary search.
+    pub(crate) ts_conditional_arrow_attempts: Vec<u32>,
+
     /// When this flag is enabled, we attempt to fold all expressions that
     /// TypeScript would consider to be "constant expressions". This flag is
     /// enabled inside each enum body block since TypeScript requires numeric
@@ -8764,6 +8774,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             stack_check: bun_core::StackCheck::init(),
             reported_stack_overflow: core::cell::Cell::new(false),
             ts_infer_constraint_backtracks: Vec::new(),
+            ts_conditional_arrow_attempts: Vec::new(),
             arena,
             then_catch_chain: ThenCatchChain {
                 next_target: null_expr_data(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7345,17 +7345,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Capture everything the parse pass mutates, so that a speculative parse
-    /// of a whole expression (not just a type) can be undone with
-    /// [`Self::restore_parser_snapshot`]. The lexer-only backtracking in
-    /// `parse_skip_typescript.rs` is not enough for that: parsing an
-    /// expression declares symbols, pushes scopes, records dynamic imports
-    /// and logs errors through `P::log()`, which ignores
-    /// `lexer.is_log_disabled`.
-    ///
-    /// Growable lists are captured as lengths and truncated on restore. The
-    /// attempt's arena allocations (AST nodes, `Scope`s) are left in the arena
-    /// and become unreachable.
+    /// Everything the parse pass mutates, so that a speculative parse of an
+    /// expression can be undone with [`Self::restore_parser_snapshot`]. The
+    /// lexer-only backtracking in `parse_skip_typescript.rs` only covers
+    /// types: an expression also declares symbols, pushes scopes, records
+    /// dynamic imports and logs through `P::log()`, which ignores
+    /// `lexer.is_log_disabled`. Lists are captured as lengths and truncated
+    /// on restore; the attempt's arena allocations just become unreachable.
     pub(crate) fn parser_snapshot(&self) -> ParserSnapshot<'a> {
         let log = self.log();
         ParserSnapshot {
@@ -7411,10 +7407,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.esm_export_keyword = snapshot.esm_export_keyword;
         self.enclosing_class_keyword = snapshot.enclosing_class_keyword;
 
-        // Every scope pushed since the snapshot is a descendant of the scope
-        // that was current, appended to its `children` (`pop_and_flatten_scope`
-        // re-appends flattened grandchildren there too) and to
-        // `scopes_in_order`, so truncating both drops the whole subtree.
+        // Every scope pushed since is a descendant of the then-current scope, appended
+        // to its `children` (also by `pop_and_flatten_scope`) and to `scopes_in_order`.
         let mut scope = snapshot.current_scope;
         scope.children.truncate(snapshot.current_scope_children_len);
         self.current_scope = scope;
@@ -7423,10 +7417,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.scopes_in_order_for_enum.pop();
         }
 
-        // Symbols declared since the snapshot are only reachable from the
-        // discarded scopes and AST, except for enum and namespace refs, which
-        // also key `ref_to_ts_namespace_member`. Drop those keys too, so a
-        // symbol that later reuses the index does not inherit namespace data.
+        // Enum and namespace symbols also key `ref_to_ts_namespace_member`; a symbol
+        // that later reuses the index must not inherit their namespace data.
         if self.symbols.len() > snapshot.symbols_len {
             self.symbols.truncate(snapshot.symbols_len);
             if TYPESCRIPT {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -118,6 +118,13 @@ impl<'a> ImportRecordList<'a> {
             Self::Borrowed(v) => v.len(),
         }
     }
+    #[inline]
+    fn truncate(&mut self, len: usize) {
+        match self {
+            Self::Owned(v) => v.truncate(len),
+            Self::Borrowed(v) => v.truncate(len),
+        }
+    }
 
     /// Transfer the
     /// backing storage into a `Vec<ImportRecord>` and leave `self` empty
@@ -155,6 +162,33 @@ impl<'a> core::ops::DerefMut for NamedImportsType<'a> {
             Self::Borrowed(v) => *v,
         }
     }
+}
+
+/// See [`P::parser_snapshot`].
+pub(crate) struct ParserSnapshot<'a> {
+    lexer: js_lexer::LexerSnapshot<'a>,
+    log_msgs_len: usize,
+    log_errors: u32,
+    log_warnings: u32,
+    allow_in: bool,
+    allow_private_identifiers: bool,
+    has_classic_runtime_warned: bool,
+    has_non_local_export_declare_inside_namespace: bool,
+    should_fold_typescript_constant_expressions: bool,
+    fn_or_arrow_data_parse: FnOrArrowDataParse,
+    latest_arrow_arg_loc: bun_ast::Loc,
+    forbid_suffix_after_as_loc: bun_ast::Loc,
+    after_arrow_body_loc: bun_ast::Loc,
+    esm_import_keyword: bun_ast::Range,
+    esm_export_keyword: bun_ast::Range,
+    enclosing_class_keyword: bun_ast::Range,
+    current_scope: js_ast::StoreRef<Scope>,
+    current_scope_children_len: usize,
+    scopes_in_order_len: usize,
+    scopes_in_order_for_enum_len: usize,
+    symbols_len: usize,
+    allocated_names_len: usize,
+    import_records_len: usize,
 }
 
 pub(crate) type NeedsJSXType = bool;
@@ -7309,6 +7343,107 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             item.parent = Some(parent);
             VecExt::append(&mut parent.children, item);
         }
+    }
+
+    /// Capture everything the parse pass mutates, so that a speculative parse
+    /// of a whole expression (not just a type) can be undone with
+    /// [`Self::restore_parser_snapshot`]. The lexer-only backtracking in
+    /// `parse_skip_typescript.rs` is not enough for that: parsing an
+    /// expression declares symbols, pushes scopes, records dynamic imports
+    /// and logs errors through `P::log()`, which ignores
+    /// `lexer.is_log_disabled`.
+    ///
+    /// Growable lists are captured as lengths and truncated on restore. The
+    /// attempt's arena allocations (AST nodes, `Scope`s) are left in the arena
+    /// and become unreachable.
+    pub(crate) fn parser_snapshot(&self) -> ParserSnapshot<'a> {
+        let log = self.log();
+        ParserSnapshot {
+            lexer: self.lexer.snapshot(),
+            log_msgs_len: log.msgs.len(),
+            log_errors: log.errors,
+            log_warnings: log.warnings,
+            allow_in: self.allow_in,
+            allow_private_identifiers: self.allow_private_identifiers,
+            has_classic_runtime_warned: self.has_classic_runtime_warned,
+            has_non_local_export_declare_inside_namespace: self
+                .has_non_local_export_declare_inside_namespace,
+            should_fold_typescript_constant_expressions: self
+                .should_fold_typescript_constant_expressions,
+            fn_or_arrow_data_parse: self.fn_or_arrow_data_parse.clone(),
+            latest_arrow_arg_loc: self.latest_arrow_arg_loc,
+            forbid_suffix_after_as_loc: self.forbid_suffix_after_as_loc,
+            after_arrow_body_loc: self.after_arrow_body_loc,
+            esm_import_keyword: self.esm_import_keyword,
+            esm_export_keyword: self.esm_export_keyword,
+            enclosing_class_keyword: self.enclosing_class_keyword,
+            current_scope: self.current_scope,
+            current_scope_children_len: self.current_scope.children.len(),
+            scopes_in_order_len: self.scopes_in_order.len(),
+            scopes_in_order_for_enum_len: self.scopes_in_order_for_enum.len(),
+            symbols_len: self.symbols.len(),
+            allocated_names_len: self.allocated_names.len(),
+            import_records_len: self.import_records.len(),
+        }
+    }
+
+    /// Undo every parse-pass mutation made since [`Self::parser_snapshot`].
+    pub(crate) fn restore_parser_snapshot(&mut self, snapshot: ParserSnapshot<'a>) {
+        self.lexer.restore(&snapshot.lexer);
+
+        let log = self.log();
+        log.msgs.truncate(snapshot.log_msgs_len);
+        log.errors = snapshot.log_errors;
+        log.warnings = snapshot.log_warnings;
+
+        self.allow_in = snapshot.allow_in;
+        self.allow_private_identifiers = snapshot.allow_private_identifiers;
+        self.has_classic_runtime_warned = snapshot.has_classic_runtime_warned;
+        self.has_non_local_export_declare_inside_namespace =
+            snapshot.has_non_local_export_declare_inside_namespace;
+        self.should_fold_typescript_constant_expressions =
+            snapshot.should_fold_typescript_constant_expressions;
+        self.fn_or_arrow_data_parse = snapshot.fn_or_arrow_data_parse;
+        self.latest_arrow_arg_loc = snapshot.latest_arrow_arg_loc;
+        self.forbid_suffix_after_as_loc = snapshot.forbid_suffix_after_as_loc;
+        self.after_arrow_body_loc = snapshot.after_arrow_body_loc;
+        self.esm_import_keyword = snapshot.esm_import_keyword;
+        self.esm_export_keyword = snapshot.esm_export_keyword;
+        self.enclosing_class_keyword = snapshot.enclosing_class_keyword;
+
+        // Every scope pushed since the snapshot is a descendant of the scope
+        // that was current, appended to its `children` (`pop_and_flatten_scope`
+        // re-appends flattened grandchildren there too) and to
+        // `scopes_in_order`, so truncating both drops the whole subtree.
+        let mut scope = snapshot.current_scope;
+        scope.children.truncate(snapshot.current_scope_children_len);
+        self.current_scope = scope;
+        self.scopes_in_order.truncate(snapshot.scopes_in_order_len);
+        while self.scopes_in_order_for_enum.len() > snapshot.scopes_in_order_for_enum_len {
+            self.scopes_in_order_for_enum.pop();
+        }
+
+        // Symbols declared since the snapshot are only reachable from the
+        // discarded scopes and AST, except for enum and namespace refs, which
+        // also key `ref_to_ts_namespace_member`. Drop those keys too, so a
+        // symbol that later reuses the index does not inherit namespace data.
+        if self.symbols.len() > snapshot.symbols_len {
+            self.symbols.truncate(snapshot.symbols_len);
+            if TYPESCRIPT {
+                self.ts_use_counts.truncate(snapshot.symbols_len);
+            }
+            let stale: Vec<Ref> = self
+                .ref_to_ts_namespace_member
+                .keys()
+                .filter(|ref_| ref_.inner_index() as usize >= snapshot.symbols_len)
+                .copied()
+                .collect();
+            for ref_ in stale {
+                self.ref_to_ts_namespace_member.remove(&ref_);
+            }
+        }
+        self.allocated_names.truncate(snapshot.allocated_names_len);
+        self.import_records.truncate(snapshot.import_records_len);
     }
 
     /// When not transpiling we dont use the renamer, so our solution is to generate really

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1577,6 +1577,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         async_range: bun_ast::Range,
         level: Level,
+        flags: EFlags,
     ) -> Result<Expr, Error> {
         let p = self;
         // "async function() {}"
@@ -1669,6 +1670,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         level,
                         ParenExprOpts {
                             is_async: true,
+                            is_after_question_and_before_colon: flags
+                                == EFlags::AfterQuestionAndBeforeColon,
                             ..Default::default()
                         },
                     );

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -498,7 +498,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.fn_or_arrow_data_parse = old_fn_or_arrow_data;
 
         // Are these arguments to an arrow function?
-        if p.lexer.token == T::TEqualsGreaterThan
+        let mut is_arrow_fn = p.lexer.token == T::TEqualsGreaterThan;
+        if is_arrow_fn
             || opts.force_arrow_fn
             || (Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TColon)
         {
@@ -541,17 +542,41 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 });
             }
 
+            let mut arrow_data = FnOrArrowDataParse {
+                allow_await: if opts.is_async {
+                    AwaitOrYield::AllowExpr
+                } else {
+                    AwaitOrYield::AllowIdent
+                },
+                ..Default::default()
+            };
+
             // Avoid parsing TypeScript code like "a ? (1 + 2) : (3 + 4)" as an arrow
             // function. The ":" after the ")" may be a return type annotation, so we
             // attempt to convert the expressions to bindings first before deciding
             // whether this is an arrow function, and only pick an arrow function if
             // there were no conversion errors.
-            if p.lexer.token == T::TEqualsGreaterThan
-                || (Self::IS_TYPESCRIPT_ENABLED
-                    && invalid_log.is_empty()
-                    && p.try_skip_type_script_arrow_return_type_with_backtracking())
-                || opts.force_arrow_fn
-            {
+            if Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TColon && invalid_log.is_empty() {
+                if opts.is_after_question_and_before_colon {
+                    // Only do this very expensive check if we must
+                    is_arrow_fn = p
+                        .is_type_script_arrow_return_type_after_question_and_before_colon(
+                            &arrow_data,
+                        )?;
+                    if is_arrow_fn {
+                        // We know this will succeed because we've already done it once above
+                        p.lexer.next()?;
+                        p.skip_typescript_return_type()?;
+                    }
+                } else {
+                    // Otherwise, do the less expensive check
+                    is_arrow_fn = p.try_skip_type_script_arrow_return_type_with_backtracking();
+                }
+            }
+
+            // Arrow function parsing may be forced if this parenthesized expression
+            // was prefixed by a TypeScript type parameter list such as "<T,>()"
+            if is_arrow_fn || opts.force_arrow_fn {
                 p.maybe_comma_spread_error(comma_after_spread);
                 p.log_arrow_arg_errors(&mut arrow_arg_errors);
 
@@ -562,14 +587,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         loc_.add_error(p.log(), p.source);
                     }
                 }
-                let mut arrow_data = FnOrArrowDataParse {
-                    allow_await: if opts.is_async {
-                        AwaitOrYield::AllowExpr
-                    } else {
-                        AwaitOrYield::AllowIdent
-                    },
-                    ..Default::default()
-                };
                 let args_slice: &'a mut [G::Arg] = args.into_bump_slice_mut();
                 let mut arrow = p.parse_arrow_body(args_slice, &mut arrow_data)?;
                 arrow.is_async = opts.is_async;

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -574,8 +574,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
-            // Arrow function parsing may be forced if this parenthesized expression
-            // was prefixed by a TypeScript type parameter list such as "<T,>()"
             if is_arrow_fn || opts.force_arrow_fn {
                 p.maybe_comma_spread_error(comma_after_spread);
                 p.log_arrow_arg_errors(&mut arrow_arg_errors);

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -44,7 +44,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::Super {}, loc))
     }
 
-    fn pfx_t_open_paren(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_open_paren(p: &mut Self, level: Level, flags: EFlags) -> PResult<Expr> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
 
@@ -62,7 +62,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Ok(value);
         }
 
-        p.parse_paren_expr(loc, level, ParenExprOpts::default())
+        p.parse_paren_expr(
+            loc,
+            level,
+            ParenExprOpts {
+                is_after_question_and_before_colon: flags == EFlags::AfterQuestionAndBeforeColon,
+                ..Default::default()
+            },
+        )
     }
 
     #[inline]
@@ -1003,7 +1010,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TOpenBrace => Self::pfx_t_open_brace(p, errors),
             T::TLessThan => Self::pfx_t_less_than(p, level, errors, flags),
             T::TImport => Self::pfx_t_import(p, level),
-            T::TOpenParen => Self::pfx_t_open_paren(p, level),
+            T::TOpenParen => Self::pfx_t_open_paren(p, level, flags),
             T::TPrivateIdentifier => Self::pfx_t_private_identifier(p, level),
             T::TIdentifier => Self::pfx_t_identifier(p, level),
             T::TFalse => Self::pfx_t_false(p),

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -126,7 +126,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::PrivateIdentifier { ref_ }, loc))
     }
 
-    fn pfx_t_identifier(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_identifier(p: &mut Self, level: Level, flags: EFlags) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let name = p.lexer.identifier;
 
@@ -150,7 +150,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if (raw.as_ptr() == name.as_ptr() && raw.len() == name.len())
                     || AsyncPrefixExpression::find(raw) == AsyncPrefixExpression::IsAsync
                 {
-                    return p.parse_async_prefix_expr(name_range, level);
+                    return p.parse_async_prefix_expr(name_range, level, flags);
                 }
             }
 
@@ -1012,7 +1012,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TImport => Self::pfx_t_import(p, level),
             T::TOpenParen => Self::pfx_t_open_paren(p, level, flags),
             T::TPrivateIdentifier => Self::pfx_t_private_identifier(p, level),
-            T::TIdentifier => Self::pfx_t_identifier(p, level),
+            T::TIdentifier => Self::pfx_t_identifier(p, level, flags),
             T::TFalse => Self::pfx_t_false(p),
             T::TTrue => Self::pfx_t_true(p),
             T::TNull => Self::pfx_t_null(p),

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1578,12 +1578,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// caller when this returns true. Parsing an expression mutates parser
     /// state, so the whole parser is restored from a snapshot. The current
     /// scope is the arrow's `FunctionArgs` scope; no arguments are declared so
-    /// that its members stay untouched.
+    /// that its members stay untouched. The outcome is memoized by the offset
+    /// of the ":" in `ts_conditional_arrow_attempts`, so the real parse does not
+    /// repeat the attempts nested inside the body.
     pub(crate) fn is_type_script_arrow_return_type_after_question_and_before_colon(
         &mut self,
         arrow_data: &FnOrArrowDataParse,
     ) -> Result<bool, Error> {
         self.mark_type_script_only();
+        debug_assert!(self.lexer.start <= (u32::MAX >> 1) as usize);
+        let memo_key = self.lexer.start as u32;
+        if let Ok(i) = self
+            .ts_conditional_arrow_attempts
+            .binary_search_by_key(&memo_key, |&packed| packed >> 1)
+        {
+            return Ok(self.ts_conditional_arrow_attempts[i] & 1 == 1);
+        }
+
         let snapshot = self.parser_snapshot();
         self.lexer.is_log_disabled = true;
 
@@ -1598,12 +1609,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         })();
 
         self.restore_parser_snapshot(snapshot);
-        match result {
-            Ok(()) => Ok(true),
+        let is_arrow_fn = match result {
+            Ok(()) => true,
             // Stack and memory exhaustion are not properties of the attempt
-            Err(err @ (Error::StackOverflow | Error::Alloc(_))) => Err(err),
-            Err(_) => Ok(false),
+            Err(err @ (Error::StackOverflow | Error::Alloc(_))) => return Err(err),
+            Err(_) => false,
+        };
+
+        // Re-search for the insertion point: attempts nested inside this one may
+        // have added entries of their own.
+        if let Err(insert_at) = self
+            .ts_conditional_arrow_attempts
+            .binary_search_by_key(&memo_key, |&packed| packed >> 1)
+        {
+            self.ts_conditional_arrow_attempts
+                .insert(insert_at, (memo_key << 1) | is_arrow_fn as u32);
         }
+        Ok(is_arrow_fn)
     }
 
     // ─────────────────────── try_* wrappers ───────────────────────

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -2,7 +2,9 @@
 use crate::Error;
 use crate::lexer::T;
 use crate::p::P;
-use crate::parser::{ParseStatementOptions, Ref, SkipTypeParameterResult, TypeParameterFlag};
+use crate::parser::{
+    FnOrArrowDataParse, ParseStatementOptions, Ref, SkipTypeParameterResult, TypeParameterFlag,
+};
 use crate::typescript;
 use crate::typescript::SkipTypeOptions;
 use crate::typescript::identifier::{Kind as TsIdentKind, kind_for_identifier};
@@ -1562,6 +1564,59 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Err(crate::Error::Backtrack);
         }
         Ok(())
+    }
+
+    /// Decides whether the ":" after the ")" of a parenthesized expression is
+    /// an arrow function return type when that expression is the middle
+    /// operand of a conditional, i.e. between its "?" and ":". Separate from
+    /// `try_skip_type_script_arrow_return_type_with_backtracking` because it
+    /// is much more expensive: it has to parse the arrow body.
+    ///
+    /// The TypeScript compiler parses the whole arrow function and then
+    /// backtracks to the colon unless another colon follows the body:
+    ///
+    ///   x = a ? (b) : c => d;
+    ///   y = a ? (b) : c => d : e;
+    ///
+    /// In "x" the first colon pairs with the "?" because the arrow function
+    /// "(b) : c => d" is not followed by a colon. In "y" the first colon starts
+    /// a return type because the arrow function is followed by a colon. So the
+    /// colon before the arrow body must pair with the "?" unless there is
+    /// another colon to pair with it after the body.
+    ///
+    /// The body is parsed once here and thrown away, then parsed again by the
+    /// caller when this returns true. Unlike the lexer-only backtracking above,
+    /// parsing an expression mutates parser state, so the whole parser is
+    /// restored from a snapshot. The current scope is the arrow's
+    /// `FunctionArgs` scope; the body is parsed with no arguments declared so
+    /// that scope's members stay untouched.
+    pub(crate) fn is_type_script_arrow_return_type_after_question_and_before_colon(
+        &mut self,
+        arrow_data: &FnOrArrowDataParse,
+    ) -> Result<bool, Error> {
+        self.mark_type_script_only();
+        let snapshot = self.parser_snapshot();
+        self.lexer.is_log_disabled = true;
+
+        let mut data = arrow_data.clone();
+        let result: Result<(), Error> = (|| {
+            self.lexer.expect(T::TColon)?;
+            self.skip_typescript_return_type()?;
+            self.parse_arrow_body(&mut [], &mut data)?;
+            // There must be a colon following the arrow function body to pair
+            // with the leading "?"
+            self.lexer.expect(T::TColon)?;
+            Ok(())
+        })();
+
+        self.restore_parser_snapshot(snapshot);
+        match result {
+            Ok(()) => Ok(true),
+            // A syntax error in the attempt means the colon pairs with the "?".
+            // Running out of stack or memory is not a property of the attempt.
+            Err(err @ (Error::StackOverflow | Error::Alloc(_))) => Err(err),
+            Err(_) => Ok(false),
+        }
     }
 
     // ─────────────────────── try_* wrappers ───────────────────────

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1566,30 +1566,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// Decides whether the ":" after the ")" of a parenthesized expression is
-    /// an arrow function return type when that expression is the middle
-    /// operand of a conditional, i.e. between its "?" and ":". Separate from
-    /// `try_skip_type_script_arrow_return_type_with_backtracking` because it
-    /// is much more expensive: it has to parse the arrow body.
+    /// Whether the ":" after a parenthesized expression that sits between the
+    /// "?" and ":" of a conditional starts an arrow function return type. The
+    /// TypeScript compiler parses the whole arrow function and keeps it only
+    /// when another ":" follows its body:
     ///
-    /// The TypeScript compiler parses the whole arrow function and then
-    /// backtracks to the colon unless another colon follows the body:
+    ///   x = a ? (b) : c => d;      // "(b)" is an expression, ":" pairs with "?"
+    ///   y = a ? (b) : c => d : e;  // "(b) : c => d" is an arrow function
     ///
-    ///   x = a ? (b) : c => d;
-    ///   y = a ? (b) : c => d : e;
-    ///
-    /// In "x" the first colon pairs with the "?" because the arrow function
-    /// "(b) : c => d" is not followed by a colon. In "y" the first colon starts
-    /// a return type because the arrow function is followed by a colon. So the
-    /// colon before the arrow body must pair with the "?" unless there is
-    /// another colon to pair with it after the body.
-    ///
-    /// The body is parsed once here and thrown away, then parsed again by the
-    /// caller when this returns true. Unlike the lexer-only backtracking above,
-    /// parsing an expression mutates parser state, so the whole parser is
-    /// restored from a snapshot. The current scope is the arrow's
-    /// `FunctionArgs` scope; the body is parsed with no arguments declared so
-    /// that scope's members stay untouched.
+    /// The body is parsed here and thrown away, then parsed again by the
+    /// caller when this returns true. Parsing an expression mutates parser
+    /// state, so the whole parser is restored from a snapshot. The current
+    /// scope is the arrow's `FunctionArgs` scope; no arguments are declared so
+    /// that its members stay untouched.
     pub(crate) fn is_type_script_arrow_return_type_after_question_and_before_colon(
         &mut self,
         arrow_data: &FnOrArrowDataParse,
@@ -1603,8 +1592,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.lexer.expect(T::TColon)?;
             self.skip_typescript_return_type()?;
             self.parse_arrow_body(&mut [], &mut data)?;
-            // There must be a colon following the arrow function body to pair
-            // with the leading "?"
+            // The ":" that pairs with the "?"
             self.lexer.expect(T::TColon)?;
             Ok(())
         })();
@@ -1612,8 +1600,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.restore_parser_snapshot(snapshot);
         match result {
             Ok(()) => Ok(true),
-            // A syntax error in the attempt means the colon pairs with the "?".
-            // Running out of stack or memory is not a property of the attempt.
+            // Stack and memory exhaustion are not properties of the attempt
             Err(err @ (Error::StackOverflow | Error::Alloc(_))) => Err(err),
             Err(_) => Ok(false),
         }

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1548,32 +1548,39 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if default_name == b"type" {
                         match p.lexer.token {
                             T::TIdentifier => {
-                                let name = p.lexer.identifier;
-                                let name_loc = p.lexer.loc();
-                                p.lexer.next()?;
+                                // A name of "from" is left to the code below when this is
+                                // "import type from 'bar';" (a value import named "type"), or
+                                // when only "import foo = bar" is valid here and the guard
+                                // below has to reject it.
+                                let import_equals_only = opts.is_export
+                                    || (opts.scope.is_namespace() && !opts.is_typescript_declare);
+                                let leave_from = p.lexer.identifier == b"from"
+                                    && (import_equals_only
+                                        || p.next_token_matches(|p| {
+                                            matches!(
+                                                p.lexer.token,
+                                                T::TStringLiteral
+                                                    | T::TNoSubstitutionTemplateLiteral
+                                            )
+                                        }));
+                                if !leave_from {
+                                    let name = p.lexer.identifier;
+                                    let name_loc = p.lexer.loc();
+                                    p.lexer.next()?;
 
-                                if p.lexer.token == T::TEquals {
-                                    // "import type foo = require('bar');" (foo may be "from")
-                                    opts.is_typescript_declare = true;
-                                    return p.parse_type_script_import_equals_stmt(
-                                        loc, opts, name_loc, name,
-                                    );
-                                } else if name == b"from"
-                                    && matches!(
-                                        p.lexer.token,
-                                        T::TStringLiteral | T::TNoSubstitutionTemplateLiteral
-                                    )
-                                {
-                                    // "import type from 'bar';" imports the default export as "type"
-                                    let path = p.parse_path()?;
-                                    p.lexer.expect_or_insert_semicolon()?;
-                                    return p.process_import_statement(stmt, path, loc, false);
-                                } else {
-                                    // "import type foo from 'bar';" (foo may be "from")
-                                    p.lexer.expect_contextual_keyword(b"from")?;
-                                    let _ = p.parse_path()?;
-                                    p.lexer.expect_or_insert_semicolon()?;
-                                    return Ok(p.s(S::TypeScript {}, loc));
+                                    if p.lexer.token == T::TEquals {
+                                        // "import type foo = require('bar');" (foo may be "from")
+                                        opts.is_typescript_declare = true;
+                                        return p.parse_type_script_import_equals_stmt(
+                                            loc, opts, name_loc, name,
+                                        );
+                                    } else {
+                                        // "import type foo from 'bar';" (foo may be "from")
+                                        p.lexer.expect_contextual_keyword(b"from")?;
+                                        let _ = p.parse_path()?;
+                                        p.lexer.expect_or_insert_semicolon()?;
+                                        return Ok(p.s(S::TypeScript {}, loc));
+                                    }
                                 }
                             }
                             T::TAsterisk => {

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -923,8 +923,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 // "export type foo = ..."
                                 let type_range = p.lexer.range();
                                 p.lexer.next()?;
-                                // "export type\n{ foo }" and "export type\n* from 'bar'" are
-                                // fine: only a type alias name must be on the same line.
+                                // "export type\n{ foo }" and "export type\n* from 'bar'" are fine
                                 if p.lexer.has_newline_before
                                     && p.lexer.token != T::TOpenBrace
                                     && p.lexer.token != T::TAsterisk
@@ -1553,22 +1552,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 p.lexer.next()?;
 
                                 if p.lexer.token == T::TEquals {
-                                    // "import type foo = require('bar');"
-                                    // "import type from = require('bar');"
-                                    // "import type foo = bar.baz;"
+                                    // "import type foo = require('bar');" (foo may be "from")
                                     opts.is_typescript_declare = true;
                                     return p.parse_type_script_import_equals_stmt(
                                         loc, opts, name_loc, name,
                                     );
                                 } else if p.lexer.token == T::TStringLiteral && name == b"from" {
-                                    // "import type from 'bar';"
-                                    // A value import of the default export, named "type".
+                                    // "import type from 'bar';" imports the default export as "type"
                                     let path = p.parse_path()?;
                                     p.lexer.expect_or_insert_semicolon()?;
                                     return p.process_import_statement(stmt, path, loc, false);
                                 } else {
-                                    // "import type foo from 'bar';"
-                                    // "import type from from 'bar';"
+                                    // "import type foo from 'bar';" (foo may be "from")
                                     p.lexer.expect_contextual_keyword(b"from")?;
                                     let _ = p.parse_path()?;
                                     p.lexer.expect_or_insert_semicolon()?;

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -923,7 +923,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 // "export type foo = ..."
                                 let type_range = p.lexer.range();
                                 p.lexer.next()?;
-                                if p.lexer.has_newline_before {
+                                // "export type\n{ foo }" and "export type\n* from 'bar'" are
+                                // fine: only a type alias name must be on the same line.
+                                if p.lexer.has_newline_before
+                                    && p.lexer.token != T::TOpenBrace
+                                    && p.lexer.token != T::TAsterisk
+                                {
                                     p.log().add_error_fmt(
                                         Some(p.source),
                                         type_range.end(),
@@ -1485,7 +1490,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return Err(crate::Error::SyntaxError);
                 }
 
-                let mut default_name = p.lexer.identifier;
+                let default_name = p.lexer.identifier;
                 let default_name_raw = p.lexer.raw();
                 stmt = S::Import {
                     namespace_ref: Ref::NONE,
@@ -1543,28 +1548,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if default_name == b"type" {
                         match p.lexer.token {
                             T::TIdentifier => {
-                                if p.lexer.identifier != b"from" {
-                                    default_name = p.lexer.identifier;
-                                    stmt.default_name.as_mut().unwrap().loc = p.lexer.loc();
-                                    p.lexer.next()?;
+                                let name = p.lexer.identifier;
+                                let name_loc = p.lexer.loc();
+                                p.lexer.next()?;
 
-                                    if p.lexer.token == T::TEquals {
-                                        // "import type foo = require('bar');"
-                                        // "import type foo = bar.baz;"
-                                        opts.is_typescript_declare = true;
-                                        return p.parse_type_script_import_equals_stmt(
-                                            loc,
-                                            opts,
-                                            stmt.default_name.unwrap().loc,
-                                            default_name,
-                                        );
-                                    } else {
-                                        // "import type foo from 'bar';"
-                                        p.lexer.expect_contextual_keyword(b"from")?;
-                                        let _ = p.parse_path()?;
-                                        p.lexer.expect_or_insert_semicolon()?;
-                                        return Ok(p.s(S::TypeScript {}, loc));
-                                    }
+                                if p.lexer.token == T::TEquals {
+                                    // "import type foo = require('bar');"
+                                    // "import type from = require('bar');"
+                                    // "import type foo = bar.baz;"
+                                    opts.is_typescript_declare = true;
+                                    return p.parse_type_script_import_equals_stmt(
+                                        loc, opts, name_loc, name,
+                                    );
+                                } else if p.lexer.token == T::TStringLiteral && name == b"from" {
+                                    // "import type from 'bar';"
+                                    // A value import of the default export, named "type".
+                                    let path = p.parse_path()?;
+                                    p.lexer.expect_or_insert_semicolon()?;
+                                    return p.process_import_statement(stmt, path, loc, false);
+                                } else {
+                                    // "import type foo from 'bar';"
+                                    // "import type from from 'bar';"
+                                    p.lexer.expect_contextual_keyword(b"from")?;
+                                    let _ = p.parse_path()?;
+                                    p.lexer.expect_or_insert_semicolon()?;
+                                    return Ok(p.s(S::TypeScript {}, loc));
                                 }
                             }
                             T::TAsterisk => {

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1028,7 +1028,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     let default_name = p.create_default_name(loc);
 
-                    let mut expr = p.parse_async_prefix_expr(async_range, Level::Comma)?;
+                    let mut expr =
+                        p.parse_async_prefix_expr(async_range, Level::Comma, EFlags::None)?;
                     p.parse_suffix(&mut expr, Level::Comma, None, EFlags::None)?;
                     p.lexer.expect_or_insert_semicolon()?;
                     let value = js_ast::StmtOrExpr::Expr(expr);
@@ -1557,7 +1558,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     return p.parse_type_script_import_equals_stmt(
                                         loc, opts, name_loc, name,
                                     );
-                                } else if p.lexer.token == T::TStringLiteral && name == b"from" {
+                                } else if name == b"from"
+                                    && matches!(
+                                        p.lexer.token,
+                                        T::TStringLiteral | T::TNoSubstitutionTemplateLiteral
+                                    )
+                                {
                                     // "import type from 'bar';" imports the default export as "type"
                                     let path = p.parse_path()?;
                                     p.lexer.expect_or_insert_semicolon()?;
@@ -1706,7 +1712,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return p.parse_fn_stmt(async_range.loc, opts, Some(async_range));
             }
 
-            expr = p.parse_async_prefix_expr(async_range, Level::Lowest)?;
+            expr = p.parse_async_prefix_expr(async_range, Level::Lowest, EFlags::None)?;
             p.parse_suffix(&mut expr, Level::Lowest, None, EFlags::None)?;
         } else {
             let expr_or_let = p.parse_expr_or_let_stmt(opts)?;

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1551,18 +1551,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 // A name of "from" is left to the code below when this is
                                 // "import type from 'bar';" (a value import named "type"), or
                                 // when only "import foo = bar" is valid here and the guard
-                                // below has to reject it.
+                                // below has to reject everything but "import type from = bar".
                                 let import_equals_only = opts.is_export
                                     || (opts.scope.is_namespace() && !opts.is_typescript_declare);
                                 let leave_from = p.lexer.identifier == b"from"
-                                    && (import_equals_only
-                                        || p.next_token_matches(|p| {
+                                    && p.next_token_matches(|p| {
+                                        if import_equals_only {
+                                            p.lexer.token != T::TEquals
+                                        } else {
                                             matches!(
                                                 p.lexer.token,
                                                 T::TStringLiteral
                                                     | T::TNoSubstitutionTemplateLiteral
                                             )
-                                        }));
+                                        }
+                                    });
                                 if !leave_from {
                                     let name = p.lexer.identifier;
                                     let name_loc = p.lexer.loc();

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -464,8 +464,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //                   ^
-        // When this conditional is itself the "yes" branch of an outer one, its
-        // "no" branch is still between the outer "?" and ":".
+        // Still between the "?" and ":" of an outer conditional when nested in its "yes"
         let no_flags = if flags == EFlags::AfterQuestionAndBeforeColon {
             flags
         } else {

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -403,6 +403,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         errors: Option<&mut DeferredErrors>,
         left: &mut Expr,
+        flags: EFlags,
     ) -> CResult {
         if level.gte(Level::Conditional) {
             return Ok(Continuation::Done);
@@ -449,7 +450,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //             ^
-        p.parse_expr_with_flags(Level::Comma, EFlags::None, &mut e_if.yes)?;
+        p.parse_expr_with_flags(
+            Level::Comma,
+            EFlags::AfterQuestionAndBeforeColon,
+            &mut e_if.yes,
+        )?;
 
         p.allow_in = old_allow_in;
 
@@ -459,7 +464,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //                   ^
-        p.parse_expr_with_flags(Level::Comma, EFlags::None, &mut e_if.no)?;
+        // When this conditional is itself the "yes" branch of an outer one, its
+        // "no" branch is still between the outer "?" and ":".
+        let no_flags = if flags == EFlags::AfterQuestionAndBeforeColon {
+            flags
+        } else {
+            EFlags::None
+        };
+        p.parse_expr_with_flags(Level::Comma, no_flags, &mut e_if.no)?;
 
         // condition ? yes : no
         //                     ^
@@ -1545,7 +1557,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 T::TBarBar => Self::sfx_t_bar_bar(p, level, left, flags),
                 T::TAmpersandAmpersand => Self::sfx_t_ampersand_ampersand(p, level, left, flags),
-                T::TQuestion => Self::sfx_t_question(p, level, errors.as_deref_mut(), left),
+                T::TQuestion => Self::sfx_t_question(p, level, errors.as_deref_mut(), left, flags),
                 T::TQuestionDot => Self::sfx_t_question_dot(p, level, &mut optional_chain, left),
                 T::TTemplateHead => Self::sfx_t_template_head(
                     p,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1177,6 +1177,7 @@ impl<'arena> ScopeOrder<'arena> {
 pub struct ParenExprOpts {
     pub(crate) is_async: bool,
     pub(crate) force_arrow_fn: bool,
+    pub(crate) is_after_question_and_before_colon: bool,
 }
 
 #[repr(u8)]

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -430,6 +430,11 @@ describe("Bun.Transpiler", () => {
       errStartsWith("import type from, {foo} from 'bar'", 'Expected "from" but found ","');
       errStartsWith("import type * as foo = require('bar')", 'Expected "from" but found "="');
       errStartsWith("import type {foo} = require('bar')", 'Expected "from" but found "="');
+
+      // Where only "import foo = bar" is valid, "import type from 'mod'" is not a default import
+      errStartsWith("export import type from 'mod'", 'Expected "=" but found "from"');
+      errStartsWith("namespace N { import type from 'mod' }", 'Expected "=" but found "from"');
+      exp("export import type = require('mod'); type", 'export const type = require("mod");\n');
     });
 
     it("runs TypeScript that tsc accepts at these parse edges", async () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -288,6 +288,162 @@ describe("Bun.Transpiler", () => {
       err("x = a ? b c", 'Expected ":" but found "c"');
     });
 
+    it("arrow function return type between the ? and : of a conditional", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      // "(b) : c => d" is only an arrow function with a return type when another
+      // ":" follows its body. Otherwise the ":" pairs with the "?".
+      exp("x = a ? (b) : c => d", "x = a ? b : (c) => d;\n");
+      exp("x = a ? (b) : c => d : e", "x = a ? (b) => d : e;\n");
+      exp("x = a ? (b) : (c) => d", "x = a ? b : (c) => d;\n");
+      exp("x = a ? (b = 1) : c => c + 1", "x = a ? b = 1 : (c) => c + 1;\n");
+      exp("const r = a ? (x = 1) : y => y + 1", "const r = a ? x = 1 : (y) => y + 1;\n");
+      exp("x = a ? (b) : c => { return d }", "x = a ? b : (c) => {\n  return d;\n};\n");
+      exp("x = a ? (b) : c => { return d } : e", "x = a ? (b) => {\n  return d;\n} : e;\n");
+      exp("x = a ? (b) : c => d ? e : f", "x = a ? b : (c) => d ? e : f;\n");
+      exp("x = a ? (b) : c => d ? e : f : g", "x = a ? (b) => d ? e : f : g;\n");
+      exp("x = a ? (b) : c => e : f ? (g) : h => i", "x = a ? (b) => e : f ? g : (h) => i;\n");
+      exp("x = a ? (b) : c => e : f ? (g) : h => i : j", "x = a ? (b) => e : f ? (g) => i : j;\n");
+      exp("x = [a ? (b) : c => d, e]", "x = [a ? b : (c) => d, e];\n");
+      exp("x = f(a ? (b) : c => d, e)", "x = f(a ? b : (c) => d, e);\n");
+      exp("x = a ? (b, c) : d => e : f", "x = a ? (b, c) => e : f;\n");
+      exp("x = a ? ([b], {c}) : d => e : f", "x = a ? ([b], { c }) => e : f;\n");
+      exp("x = a ? (...b) : d => e : f", "x = a ? (...b) => e : f;\n");
+      exp("x = a ? (b?: number) : d => e : f", "x = a ? (b) => e : f;\n");
+      exp("x = a ? (b) : c<d> => e : f", "x = a ? (b) => e : f;\n");
+      exp("x = a ? (b) : c is d => e : f", "x = a ? (b) => e : f;\n");
+      exp("a ? (1 + 2) : (3 + 4)", "a ? 1 + 2 : 3 + 4;\n");
+
+      // https://github.com/evanw/esbuild/issues/4241
+      exp("x = a ? (b = c) : d", "x = a ? b = c : d;\n");
+      exp("x = a ? (b = c) : d => e", "x = a ? b = c : (d) => e;\n");
+      exp("x = a ? (b = c) : T => d : (e = f)", "x = a ? (b = c) => d : e = f;\n");
+      exp("x = a ? (b = c) : T => d : (e = f) : T => g", "x = a ? (b = c) => d : (e = f) => g;\n");
+      exp("x = a ? b ? c : (d = e) : f => g", "x = a ? b ? c : d = e : (f) => g;\n");
+      exp("x = a ? b ? (c = d) => e : (f = g) : h => i", "x = a ? b ? (c = d) => e : f = g : (h) => i;\n");
+      exp("x = a ? b ? (c = d) : T => e : (f = g) : h => i", "x = a ? b ? (c = d) => e : f = g : (h) => i;\n");
+      exp(
+        "x = a ? b ? (c = d) : T => e : (f = g) : (h = i) : T => j",
+        "x = a ? b ? (c = d) => e : f = g : (h = i) => j;\n",
+      );
+      exp("x = a ? (b) : T => c : d", "x = a ? (b) => c : d;\n");
+      exp("x = a ? b - (c) : d => e", "x = a ? b - c : (d) => e;\n");
+      exp("x = a ? b = (c) : T => d : e", "x = a ? b = (c) => d : e;\n");
+      err("x = a ? (b = c) : T => d : (e = f) : g", 'Expected ";" but found ":"');
+      err("x = a ? b ? (c = d) : T => e : (f = g)", 'Expected ":" but found end of file');
+      err("x = a ? - (b) : c => d : e", 'Expected ";" but found ":"');
+      err("x = a ? b - (c) : d => e : f", 'Expected ";" but found ":"');
+      err("x = a ? (b) : (c) => d : e", 'Expected ";" but found ":"');
+
+      // Newlines are important (they trigger backtracking)
+      exp("x = (\n  a ? (b = c) : { d: e }\n)", "x = a ? b = c : { d: e };\n");
+
+      // The attempt to parse the arrow body must see the same parser state as
+      // the real parse: private names and the "in" operator.
+      exp(
+        "x = class { #y; y = a ? (b : T) : T => this.#y : c }",
+        "x = class {\n  #y;\n  y = a ? (b) => this.#y : c;\n};\n",
+      );
+      exp("for (x = a ? () : T => b in c : d; ; ) ;", "for (x = a ? () => (b in c) : d;; )\n  ;\n");
+
+      // A discarded attempt must leave no scopes, symbols, import records or
+      // enum bookkeeping behind.
+      exp(
+        "x = a ? (b) : c => { function f(q = () => { let z = 1; return z }) { class K { #p; m() { return this.#p } } return new K } return f() }",
+        "x = a ? b : (c) => {\n  function f(q = () => {\n    let z = 1;\n    return z;\n  }) {\n\n    class K {\n      #p;\n      m() {\n        return this.#p;\n      }\n    }\n    return new K;\n  }\n  return f();\n};\n",
+      );
+      exp(
+        "x = a ? (b) : c => { import('d'); return import.meta.url }",
+        'x = a ? b : (c) => {\n  import("d");\n  return import.meta.url;\n};\n',
+      );
+      exp(
+        "x = a ? (b) : c => { import('d'); return import.meta.url } : e",
+        'x = a ? (b) => {\n  import("d");\n  return import.meta.url;\n} : e;\n',
+      );
+      const enumBody = "enum E { A = 1, B = A * 2 } return E.B";
+      const enumOut = '  let E;\n  ((E) => {\n    E[E["A"] = 1] = "A";\n    E[E["B"] = 2] = "B";\n  })(E ||= {});\n  return 2 /* B */;\n';
+      exp(`x = a ? (b) : c => { ${enumBody} }`, `x = a ? b : (c) => {\n${enumOut}};\n`);
+      exp(`x = a ? (b) : c => { ${enumBody} } : e`, `x = a ? (b) => {\n${enumOut}} : e;\n`);
+      exp(
+        "x = a ? (b) : c => { return a ? (b) : c => d : e } : f",
+        "x = a ? (b) => {\n  return a ? (b) => d : e;\n} : f;\n",
+      );
+    });
+
+    it("type-only import syntax", () => {
+      const exp = ts.expectPrinted_;
+      const errStartsWith = (code, prefix) => {
+        let message;
+        try {
+          ts.parsed(code, false, false);
+        } catch (er) {
+          message = (er instanceof AggregateError ? er.errors[0] : er).message;
+        }
+        expect(message).toStartWith(prefix);
+      };
+
+      exp("import type foo from 'bar'; x", "x;\n");
+      exp("import type foo from 'bar'\nx", "x;\n");
+      exp("import type from from 'bar'; x", "x;\n");
+      exp("import type * as foo from 'bar'; x", "x;\n");
+      exp("import type {foo, bar as baz} from 'bar'; x", "x;\n");
+      exp("import type foo = require('bar'); x", "x;\n");
+      exp("import type foo = bar.baz; x", "x;\n");
+      exp("import type from = require('bar'); x", "x;\n");
+
+      // "type" is a regular binding name here
+      exp("import type = bar; type", "const type = bar;\n");
+      exp("import type = foo.bar; type", "const type = foo.bar;\n");
+      exp("import type = require('type'); type", 'const type = require("type");\n');
+      exp("import type from 'bar'; type", 'import type from "bar";\ntype;\n');
+      exp("import type, { a } from 'mod'; type, a", 'import type, { a } from "mod";\ntype, a;\n');
+      exp("import { type } from 'mod'; type", 'import { type } from "mod";\ntype;\n');
+
+      errStartsWith("import type", 'Expected "from" but found ""');
+      errStartsWith("import type foo, * as foo from 'bar'", 'Expected "from" but found ","');
+      errStartsWith("import type foo, {foo} from 'bar'", 'Expected "from" but found ","');
+      errStartsWith("import type from, * as foo from 'bar'", 'Expected "from" but found ","');
+      errStartsWith("import type from, {foo} from 'bar'", 'Expected "from" but found ","');
+      errStartsWith("import type * as foo = require('bar')", 'Expected "from" but found "="');
+      errStartsWith("import type {foo} = require('bar')", 'Expected "from" but found "="');
+    });
+
+    it("runs TypeScript that tsc accepts at these parse edges", async () => {
+      using dir = tempDir("ts-parse-edges", {
+        "mod.ts": "export default 'default export';",
+        "index.ts": `
+          import type from from "./mod";
+          import type from = require("./mod");
+          import type { T } from "./mod";
+          type U = number;
+          export type
+          { U };
+          export type
+          * as ns from "./mod";
+          declare const unused: T;
+          const a = true, d = "d";
+          let x: any;
+          x = a ? (d) : c => c;
+          console.log(x);
+          x = a ? (d) : c => d : "e";
+          console.log(x("arg"));
+          const r = a ? (x = 1) : y => y + 1;
+          console.log(r);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("d\narg\n1\n");
+      expect(exitCode).toBe(0);
+    });
+
     it("contextual keywords used as plain identifiers keep their statements", () => {
       const exp = ts.expectPrinted_;
 
@@ -1005,6 +1161,9 @@ function foo() {}
       exp("type x = {0: number, readonly 1: boolean}\na([])", "a([]);\n");
       exp("type x = {'a': number, readonly 'b': boolean}\na([])", "a([]);\n");
       exp("type\nFoo = {}", "type;\nFoo = {};\n");
+      exp("export type\n{ Foo } \n x", "x;\n");
+      exp("export type\n* from 'foo' \n x", "x;\n");
+      exp("export type\n* as ns from 'foo' \n x", "x;\n");
       err("export type\nFoo = {}", 'Unexpected newline after "type"');
       exp("let x: {x: 'a', y: false, z: null}", "let x;\n");
       exp("let x: {foo(): void}", "let x;\n");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -434,6 +434,7 @@ describe("Bun.Transpiler", () => {
       // Where only "import foo = bar" is valid, "import type from 'mod'" is not a default import
       errStartsWith("export import type from 'mod'", 'Expected "=" but found "from"');
       errStartsWith("namespace N { import type from 'mod' }", 'Expected "=" but found "from"');
+      exp("export import type from = require('mod'); x", "x;\n");
       exp("export import type = require('mod'); type", 'export const type = require("mod");\n');
     });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -362,7 +362,8 @@ describe("Bun.Transpiler", () => {
         'x = a ? (b) => {\n  import("d");\n  return import.meta.url;\n} : e;\n',
       );
       const enumBody = "enum E { A = 1, B = A * 2 } return E.B";
-      const enumOut = '  let E;\n  ((E) => {\n    E[E["A"] = 1] = "A";\n    E[E["B"] = 2] = "B";\n  })(E ||= {});\n  return 2 /* B */;\n';
+      const enumOut =
+        '  let E;\n  ((E) => {\n    E[E["A"] = 1] = "A";\n    E[E["B"] = 2] = "B";\n  })(E ||= {});\n  return 2 /* B */;\n';
       exp(`x = a ? (b) : c => { ${enumBody} }`, `x = a ? b : (c) => {\n${enumOut}};\n`);
       exp(`x = a ? (b) : c => { ${enumBody} } : e`, `x = a ? (b) => {\n${enumOut}} : e;\n`);
       exp(

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -315,6 +315,12 @@ describe("Bun.Transpiler", () => {
       exp("x = a ? (b) : c is d => e : f", "x = a ? (b) => e : f;\n");
       exp("a ? (1 + 2) : (3 + 4)", "a ? 1 + 2 : 3 + 4;\n");
 
+      // The same rule for "async (...)": a call to "async" or an async arrow
+      exp("x = a ? async (b) : c => d", "x = a ? async(b) : (c) => d;\n");
+      exp("x = a ? async (b) : c => d : e", "x = a ? async (b) => d : e;\n");
+      exp("x = a ? async (b) : c => await d : e", "x = a ? async (b) => await d : e;\n");
+      exp("x = a ? async (b) : c => d ? e : f", "x = a ? async(b) : (c) => d ? e : f;\n");
+
       // https://github.com/evanw/esbuild/issues/4241
       exp("x = a ? (b = c) : d", "x = a ? b = c : d;\n");
       exp("x = a ? (b = c) : d => e", "x = a ? b = c : (d) => e;\n");
@@ -370,6 +376,21 @@ describe("Bun.Transpiler", () => {
         "x = a ? (b) : c => { return a ? (b) : c => d : e } : f",
         "x = a ? (b) => {\n  return a ? (b) => d : e;\n} : f;\n",
       );
+
+      // The attempt parses the body, so an attempt nested in the body must not
+      // run again when the body is parsed for real: 2^40 parses would hang.
+      let kept = "d";
+      let discarded = "d";
+      let keptOut = "d";
+      let discardedOut = "d";
+      for (let i = 0; i < 40; i++) {
+        kept = `a ? (b) : c => ${kept} : e`;
+        keptOut = `a ? (b) => ${keptOut} : e`;
+        discarded = `a ? (b) : c => ${discarded}`;
+        discardedOut = `a ? b : (c) => ${discardedOut}`;
+      }
+      exp(`x = ${kept}`, `x = ${keptOut};\n`);
+      exp(`x = ${discarded}`, `x = ${discardedOut};\n`);
     });
 
     it("type-only import syntax", () => {
@@ -398,6 +419,7 @@ describe("Bun.Transpiler", () => {
       exp("import type = foo.bar; type", "const type = foo.bar;\n");
       exp("import type = require('type'); type", 'const type = require("type");\n');
       exp("import type from 'bar'; type", 'import type from "bar";\ntype;\n');
+      exp("import type from `bar`; type", 'import type from "bar";\ntype;\n');
       exp("import type, { a } from 'mod'; type, a", 'import type, { a } from "mod";\ntype, a;\n');
       exp("import { type } from 'mod'; type", 'import { type } from "mod";\ntype;\n');
 


### PR DESCRIPTION
### Problem
- Three TypeScript-only edges that tsc accepts fail in `bun run` and `bun build`: `x = a ? (b) : c => d` (`Expected ":" but found ";"`), `export type` with a newline before `{ T }` or `* as ns from` (`Unexpected newline after "type"`), and `import type from from "x"` / `import type from = require("x")` (`Expected string but found "from"`).
- Causes: `parse_paren_expr` (`src/js_parser/parse/mod.rs:552`) commits to an arrow function once `: c =>` skips as a return type, even between the `?` and `:` of a conditional. The `SType` arm (`parse_stmt.rs:926`) rejects every newline after `type`. The `import type` path (`parse_stmt.rs:1546`) tests whether the name is `from` instead of the token after it.

### Fix
- The `?` branch parses its middle operand with the new `EFlags::AfterQuestionAndBeforeColon`. With it, `parse_paren_expr` (also on the `async (` path) parses the return type and the arrow body speculatively and keeps the arrow only when another `:` follows the body. This is tsc's rule and esbuild's implementation (evanw/esbuild#4241). The outcome is memoized by the offset of the `:` (`ts_conditional_arrow_attempts`), otherwise nested shapes cost 2^depth body parses.
- A body parse mutates more than the lexer, so the new `P::parser_snapshot` / `restore_parser_snapshot` rewind the parse-pass state: log messages, scopes, symbols, import records, enum bookkeeping, and the flags nested parsers save and restore.
- `export type` needs the next token on the same line only for a type alias name. `import type <ident>` consumes the name, then dispatches on `=`, a path (a value import named `type`), or `from`.
- Verified: `test/bundler/transpiler/transpiler.test.js` (three new blocks and three `export type` lines, all fail on the release bun). Also `test/bundler/esbuild/`, `test/bundler/transpiler/`, `bundler_edgecase`, `bundler_regressions`, `bundler_minify`.

### Background
- The parse pass builds the AST, declares symbols and records every scope in `scopes_in_order`. The visit pass replays that list, so a speculative parse that leaves a scope behind panics with a scope mismatch.
- The existing TypeScript backtracking (`lexer_backtracker_bool`) snapshots only the lexer. Skipping a type declares nothing, so that is enough there. An arrow body needs the parser-level snapshot.
- `P::log()` writes to the shared `Log` and ignores `lexer.is_log_disabled`, so the snapshot records the message count and truncates on restore.

### Performance
No measurable change on real code. Every new path is gated on TypeScript, so JavaScript files are untouched.

Release builds of the base commit and this PR, `Bun.Transpiler.transformSync` in-process, min of 10 runs, 3 process launches each. Corpus: 7055 `.ts`/`.tsx` files, 91 MB, containing 2700 `? (` sites.

| build | run 1 | run 2 | run 3 |
|---|---|---|---|
| base | 699 ms | 726 ms | 709 ms |
| PR | 710 ms | 741 ms | 713 ms |

Synthetic worst case, 50,000 lines of one shape, min of 10:

| shape | base | PR |
|---|---|---|
| `x = a ? (b) : c;` | 15.6 ms | 19.2 ms |
| `x = a ? (b) : c ? (d) : e;` | 25.7 ms | 34.3 ms |
| `x = a ? (b) : T => {…} : e;` (arrow kept, body parsed twice) | 80 ms | 120 ms |
| `x = a ? (b + 1) : c;` (not a binding, no attempt) | 17.4 ms | 17.3 ms |

The added cost is about 70 ns per `cond ? (ident) : y` site: one parser snapshot plus a failed `=>` expect. Only the kept-arrow shape pays for a second body parse.

### Cross-check against esbuild and tsc
All 74 parse cases from the new tests were run through esbuild 0.28.2, tsc 5.9 and tsc 7.0.2 (`transpileModule` / `tsc --noCheck`, plus a full check where the parser alone was not enough).

- 67 cases agree in all three.
- `a ? async (b) : c => d` and `a ? async (b) : c => d ? e : f`: tsc accepts, esbuild rejects. Bun follows tsc.
- ``import type from `bar` ``: tsc accepts, esbuild rejects. Bun follows tsc.
- `import type foo, * as foo from 'bar'` and `import type foo, {foo} from 'bar'`: tsc's parser accepts, its checker rejects with TS1363. Bun and esbuild reject at parse time.
- `export import type from 'mod'`: tsc rejects with TS1191. esbuild emits it silently. Bun rejects.
- `namespace N { import type from 'mod' }`: tsc rejects with TS1147. esbuild emits it silently. Bun rejects.

The runtime fixture in the new test prints the same `d`, `arg`, `1` when compiled by tsc 5, tsc 7 and esbuild and run with Node.

<details><summary>Notes</summary>

Behavior checked against tsc 6.0.2 and the current esbuild source for these shapes (all agree with the new output):

- `a ? (b) : c => d` → `a ? b : (c) => d`
- `a ? (b) : c => d : e` → `a ? (b) => d : e`
- `a ? (b) : (c) => d` → `a ? b : (c) => d`
- `a ? (b) : (c) => d : e` → error in tsc (`';' expected`), esbuild and bun: `(c) => d` skips as a function type, so the `:` after `d` is unexpected.
- `a ? b ? (c = d) : T => e : (f = g)` → error `Expected ":" but found end of file` (the nested `no` branch inherits the flag, as in esbuild).
- `a ? async (b) : c => d` → `a ? async(b) : (c) => d` and `a ? async (b) : c => d : e` → `a ? async (b) => d : e`. tsc accepts both, esbuild does not thread the flag into its async path. Bun does, since it is the same decision one call site over.

Intentionally excluded sibling: the `<T>(...)` paths (`pfx_t_less_than`, `async <T>(`). There the decision is tangled with type assertions (`<T>(b)` in a `.ts` file) and `force_arrow_fn`; esbuild excludes them too.

Complexity: the attempt parses the body and the caller parses it again, so without a memo every nested `a ? (b) : c => <body> : e` doubled the work per level. Measured on the debug build before the memo: depth 12 took 0.5 s, depth 18 took 20 s. The outcome depends only on the position of the `:` (the attempt and the real parse reach it with the same state), so it is memoized like `ts_infer_constraint_backtracks`. Depth 60 of either shape now parses in about 0.3 s in the debug build; the test file covers depth 40 for both shapes.

The speculation runs only when the parenthesized items convert to bindings without error and the next token is `:`. In the common `cond ? (a) : b` case it fails at the first token after the skipped type, the same work the old `try_skip_type_script_arrow_return_type_with_backtracking` did, plus one snapshot copy.

Cases exercised against the debug build (debug assertions on) through both the discarded and the kept speculation path: nested function and class scopes with `pop_and_flatten_scope`, private names, `in` inside a `for` initializer, `import()` and `import.meta` in the body, a TS `enum` in the body (`scopes_in_order_for_enum`, `ref_to_ts_namespace_member`), regex and template literals, JSX in `.tsx`, decorators, nested conditionals with the same shape inside the body. Transpiling every `.ts`/`.tsx` under `src/js`, `test/js`, `test/bundler`, `test/cli` and `packages/bun-types` (2251 files) gives the same result as before for every file.

`import type from \`x\`` (template literal path) keeps parsing as a value import named `type`, as on main: the check accepts the same tokens as `parse_path`.

`export import type from 'x'` and `import type from 'x'` inside a non-declare namespace body stay rejected as on main (`Expected "=" but found "from"`): the `from` token is left for the existing import-equals guard there.

Errors in the attempt are swallowed except `StackOverflow` and `Alloc`, which propagate.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [8.60ms]
(pass) Bun.Transpiler > normalizes \r\n [8.19ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.85ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.47ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [5.41ms]
(pass) Bun.Transpiler > property access inlining > works [4.04ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.25ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [54.84ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [26.56ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [344.67ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 1 failed, 22 skipped
bun test v1.4.1-canary.1 (f0b9ea7eb)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.11ms]
(pass) Bun.Transpiler > normalizes \r\n [0.13ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.64ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.31ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [8.12ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.57ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.06ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.57ms]
(pass) Bun.Transpiler > normalizes \r\n [6.02ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.19ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.44ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.33ms]
(pass) Bun.Transpiler > property access inlining > works [2.62ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.81ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [49.90ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [23.26ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [506.69ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1177ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
^[[1m^[[92m   Compiling^[[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/expr.rs                              |   2 +
 src/js_parser/p.rs                           | 138 ++++++++++++++++++++
 src/js_parser/parse/mod.rs                   |  48 ++++---
 src/js_parser/parse/parse_prefix.rs          |  19 ++-
 src/js_parser/parse/parse_skip_typescript.rs |  66 +++++++++-
 src/js_parser/parse/parse_stmt.rs            |  47 +++++--
 src/js_parser/parse/parse_suffix.rs          |  17 ++-
 src/js_parser/parser.rs                      |   1 +
 test/bundler/transpiler/transpiler.test.js   | 188 +++++++++++++++++++++++++++
 9 files changed, 487 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/ast/expr.rs                                   1      3      0
src/js_parser/p.rs                               11      9      0
src/js_parser/parse/mod.rs                        4      7      0
src/js_parser/parse/parse_prefix.rs               3      5      0
src/js_parser/parse/parse_skip_typescript.rs      5      6      0
src/js_parser/parse/parse_stmt.rs                10     15      0
src/js_parser/parse/parse_suffix.rs               6      6      0
src/js_parser/parser.rs                           1      2      0
test/bundler/transpiler/transpiler.test.js        7      8      0
```

</details>

<!-- robobun:evidence:end -->

