### PR TITLE
js_parser: report missing await, yield and binding pattern early errors

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4539,8 +4539,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ref_)
     }
 
-    /// A generator declaration may be named "yield", a generator expression
-    /// may not: only the expression's name binds inside the generator.
     pub(crate) fn validate_function_name(&mut self, func: &G::Fn, kind: FnKind) {
         if let Some(name) = &func.name {
             // SAFETY: Symbol.original_name is an arena/source-contents slice valid for 'a.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -21,8 +21,8 @@ use crate::renamer;
 use crate::{
     ARGUMENTS_STR as arguments_str, DeferredArrowArgErrors, DeferredErrors,
     DeferredImportNamespace, EXPORTS_STRING_NAME as exports_string_name, ExprBindingTuple,
-    FindLabelSymbolResult, FnOnlyDataVisit, FnOrArrowDataParse, FnOrArrowDataVisit, IdentifierOpts,
-    ImportItemForNamespaceMap, InvalidLoc, JSXImport, JSXTransformType, Jest,
+    FindLabelSymbolResult, FnKind, FnOnlyDataVisit, FnOrArrowDataParse, FnOrArrowDataVisit,
+    IdentifierOpts, ImportItemForNamespaceMap, InvalidLoc, JSXImport, JSXTransformType, Jest,
     LOC_MODULE_SCOPE as loc_module_scope, LocList, MacroState, ParseStatementOptions, ParsedPath,
     PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap, RuntimeImports, ScopeOrder,
     ScopeOrderList, StrictModeFeature, StringBoolMap, Substitution, TempRef, ThenCatchChain,
@@ -1464,7 +1464,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub(crate) fn log_arrow_arg_errors(&mut self, errors: &mut DeferredArrowArgErrors) {
+    pub(crate) fn log_arrow_arg_errors(&mut self, errors: &DeferredArrowArgErrors) {
         if errors.invalid_expr_await.len > 0 {
             let r = errors.invalid_expr_await;
             self.log().add_range_error(
@@ -1481,6 +1481,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 r,
                 b"Cannot use a \"yield\" expression here",
             );
+        }
+    }
+
+    pub(crate) fn log_deferred_arrow_arg_errors(&mut self, errors: &DeferredErrors) {
+        for paren in errors.invalid_parens.iter() {
+            InvalidLoc {
+                loc: paren.loc,
+                kind: crate::parser::InvalidLocTag::Parentheses,
+            }
+            .add_error(self.log(), self.source);
         }
     }
 
@@ -3278,13 +3288,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     });
                 }
 
-                if ex.is_parenthesized {
-                    invalid_loc.push(InvalidLoc {
-                        loc: self.source.range_of_operator_before(expr.loc, b"(").loc,
-                        kind: crate::parser::InvalidLocTag::Parentheses,
-                    });
-                }
-
                 // p.markSyntaxFeature(Destructing)
                 let mut items = BumpVec::with_capacity_in(ex.items.len_u32() as usize, self.arena);
                 let mut is_spread = false;
@@ -3330,13 +3333,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     invalid_loc.push(InvalidLoc {
                         loc: sp,
                         kind: crate::parser::InvalidLocTag::Spread,
-                    });
-                }
-
-                if ex.is_parenthesized {
-                    invalid_loc.push(InvalidLoc {
-                        loc: self.source.range_of_operator_before(expr.loc, b"(").loc,
-                        kind: crate::parser::InvalidLocTag::Parentheses,
                     });
                 }
                 // p.markSyntaxFeature(compat.Destructuring, p.source.RangeOfOperatorAfter(expr.Loc, "{"))
@@ -3438,6 +3434,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             binding: bind,
             expr: initializer,
         }
+    }
+
+    /// "await" and "yield" cannot bind an identifier where the enclosing
+    /// function (or module) treats them as keywords.
+    pub(crate) fn is_forbidden_await_or_yield_identifier(&self, name: &[u8]) -> bool {
+        (self.fn_or_arrow_data_parse.allow_await != crate::AwaitOrYield::AllowIdent
+            && name == b"await")
+            || (self.fn_or_arrow_data_parse.allow_yield != crate::AwaitOrYield::AllowIdent
+                && name == b"yield")
+    }
+
+    #[cold]
+    #[inline(never)]
+    pub(crate) fn log_invalid_identifier(&mut self, name: &[u8], r: bun_ast::Range) {
+        self.log().add_range_error_fmt(
+            Some(self.source),
+            r,
+            format_args!(
+                "Cannot use {} as an identifier here",
+                bun_core::fmt::quote(name)
+            ),
+        );
     }
 
     #[cold]
@@ -4523,7 +4541,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ref_)
     }
 
-    pub(crate) fn validate_function_name(&mut self, func: &G::Fn) {
+    /// Prevent the function name from being the same as a function-specific
+    /// keyword. A generator declaration may be named "yield" (the name binds
+    /// in the enclosing scope), a generator expression may not (the name binds
+    /// inside the generator itself).
+    pub(crate) fn validate_function_name(&mut self, func: &G::Fn, kind: FnKind) {
         if let Some(name) = &func.name {
             // SAFETY: Symbol.original_name is an arena/source-contents slice valid for 'a.
             let original_name: &[u8] = self.symbols[name.ref_.inner_index() as usize]
@@ -4536,12 +4558,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     js_lexer::range_of_identifier(self.source, name.loc),
                     b"An async function cannot be named \"await\"",
                 );
-            } else if func.flags.contains(Flags::Function::IsGenerator) && original_name == b"yield"
+            } else if func.flags.contains(Flags::Function::IsGenerator)
+                && original_name == b"yield"
+                && kind == FnKind::Expr
             {
                 self.log().add_range_error(
                     Some(self.source),
                     js_lexer::range_of_identifier(self.source, name.loc),
-                    b"An generator function expression cannot be named \"yield\"",
+                    b"A generator function expression cannot be named \"yield\"",
                 );
             }
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3436,8 +3436,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// "await" and "yield" cannot bind an identifier where the enclosing
-    /// function (or module) treats them as keywords.
     pub(crate) fn is_forbidden_await_or_yield_identifier(&self, name: &[u8]) -> bool {
         (self.fn_or_arrow_data_parse.allow_await != crate::AwaitOrYield::AllowIdent
             && name == b"await")
@@ -4541,10 +4539,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ref_)
     }
 
-    /// Prevent the function name from being the same as a function-specific
-    /// keyword. A generator declaration may be named "yield" (the name binds
-    /// in the enclosing scope), a generator expression may not (the name binds
-    /// inside the generator itself).
+    /// A generator declaration may be named "yield", a generator expression
+    /// may not: only the expression's name binds inside the generator.
     pub(crate) fn validate_function_name(&mut self, func: &G::Fn, kind: FnKind) {
         if let Some(name) = &func.name {
             // SAFETY: Symbol.original_name is an arena/source-contents slice valid for 'a.

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -554,10 +554,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // function. The ":" after the ")" may be a return type annotation, so we
             // attempt to convert the expressions to bindings first before deciding
             // whether this is an arrow function, and only pick an arrow function if
-            // there were no conversion errors.
+            // there were no conversion errors. A parenthesized item such as
+            // "a ? ((b)) : c => d" is a conversion error too.
             if p.lexer.token == T::TEqualsGreaterThan
                 || (Self::IS_TYPESCRIPT_ENABLED
                     && invalid_log.is_empty()
+                    && errors.invalid_parens.is_empty()
                     && p.try_skip_type_script_arrow_return_type_with_backtracking())
                 || opts.force_arrow_fn
             {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -435,10 +435,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let old_allow_in = p.allow_in;
         p.allow_in = true;
 
-        // Forbid "await" and "yield", but only for arrow functions. The errors
-        // are recorded into `fn_or_arrow_data_parse.arrow_arg_errors` while the
-        // arguments are parsed and copied back out below, once we know whether
-        // this is an arrow function.
+        // Forbid "await" and "yield", but only for arrow functions
         let old_fn_or_arrow_data = p.fn_or_arrow_data_parse.clone();
         p.fn_or_arrow_data_parse.arrow_arg_errors = DeferredArrowArgErrors::default();
         p.fn_or_arrow_data_parse.track_arrow_arg_errors = true;
@@ -554,8 +551,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // function. The ":" after the ")" may be a return type annotation, so we
             // attempt to convert the expressions to bindings first before deciding
             // whether this is an arrow function, and only pick an arrow function if
-            // there were no conversion errors. A parenthesized item such as
-            // "a ? ((b)) : c => d" is a conversion error too.
+            // there were no conversion errors.
             if p.lexer.token == T::TEqualsGreaterThan
                 || (Self::IS_TYPESCRIPT_ENABLED
                     && invalid_log.is_empty()
@@ -596,8 +592,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // parent scope as if the scope was never pushed in the first place.
         p.pop_and_flatten_scope(scope_index);
 
-        // A plain parenthesized expression is still part of the arguments of an
-        // enclosing arrow function candidate: "(x = (await y)) => {}"
+        // "(x = (await y)) => {}" is still an error
         if p.fn_or_arrow_data_parse.track_arrow_arg_errors {
             arrow_arg_errors.merge_into(&mut p.fn_or_arrow_data_parse.arrow_arg_errors);
         }
@@ -1222,8 +1217,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     loc,
                 );
 
-                // A shorthand property binds the key as an identifier, so a
-                // reserved word is only valid as a key: "{ if: x }" but not "{ if }"
+                // "{ if: x }" is valid but "{ if }" is not
                 if p.lexer.token != T::TColon
                     && p.lexer.token != T::TOpenParen
                     && crate::lexer::keyword(name).is_none()

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -112,17 +112,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.next()?;
         }
 
+        // The yield expression only has a value in certain cases
         let mut value: Option<ExprNodeIndex> = None;
-        match p.lexer.token {
-            T::TCloseBrace
-            | T::TCloseParen
-            | T::TCloseBracket
-            | T::TColon
-            | T::TComma
-            | T::TSemicolon => {}
-            _ => {
-                if is_star || !p.lexer.has_newline_before {
-                    value = Some(p.parse_expr(Level::Yield)?);
+        if is_star {
+            // "yield*" always delegates to an operand
+            value = Some(p.parse_expr(Level::Yield)?);
+        } else {
+            match p.lexer.token {
+                T::TCloseBrace
+                | T::TCloseParen
+                | T::TCloseBracket
+                | T::TColon
+                | T::TComma
+                | T::TSemicolon => {}
+                _ => {
+                    if !p.lexer.has_newline_before {
+                        value = Some(p.parse_expr(Level::Yield)?);
+                    }
                 }
             }
         }
@@ -412,7 +418,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let p = self;
         let mut items_list = BumpVec::<Expr>::new_in(p.arena);
         let mut errors = DeferredErrors::default();
-        let mut arrow_arg_errors = DeferredArrowArgErrors::default();
         let mut spread_range = bun_ast::Range::default();
         let mut type_colon_range = bun_ast::Range::default();
         let mut comma_after_spread = bun_ast::Loc::EMPTY;
@@ -430,9 +435,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let old_allow_in = p.allow_in;
         p.allow_in = true;
 
-        // Forbid "await" and "yield", but only for arrow functions
+        // Forbid "await" and "yield", but only for arrow functions. The errors
+        // are recorded into `fn_or_arrow_data_parse.arrow_arg_errors` while the
+        // arguments are parsed and copied back out below, once we know whether
+        // this is an arrow function.
         let old_fn_or_arrow_data = p.fn_or_arrow_data_parse.clone();
-        p.fn_or_arrow_data_parse.arrow_arg_errors = arrow_arg_errors;
+        p.fn_or_arrow_data_parse.arrow_arg_errors = DeferredArrowArgErrors::default();
         p.fn_or_arrow_data_parse.track_arrow_arg_errors = true;
 
         // Scan over the comma-separated arguments or expressions
@@ -495,6 +503,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.allow_in = old_allow_in;
 
         // Also restore "await" and "yield" expression errors
+        let arrow_arg_errors = p.fn_or_arrow_data_parse.arrow_arg_errors;
         p.fn_or_arrow_data_parse = old_fn_or_arrow_data;
 
         // Are these arguments to an arrow function?
@@ -553,7 +562,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 || opts.force_arrow_fn
             {
                 p.maybe_comma_spread_error(comma_after_spread);
-                p.log_arrow_arg_errors(&mut arrow_arg_errors);
+                p.log_arrow_arg_errors(&arrow_arg_errors);
+                p.log_deferred_arrow_arg_errors(&errors);
 
                 // Now that we've decided we're an arrow function, report binding pattern
                 // conversion errors
@@ -583,6 +593,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // scope we did earlier. This needs to flatten any child scopes into the
         // parent scope as if the scope was never pushed in the first place.
         p.pop_and_flatten_scope(scope_index);
+
+        // A plain parenthesized expression is still part of the arguments of an
+        // enclosing arrow function candidate: "(x = (await y)) => {}"
+        if p.fn_or_arrow_data_parse.track_arrow_arg_errors {
+            arrow_arg_errors.merge_into(&mut p.fn_or_arrow_data_parse.arrow_arg_errors);
+        }
 
         // If this isn't an arrow function, then types aren't allowed
         if type_colon_range.len > 0 {
@@ -977,17 +993,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TIdentifier => {
                 let name = p.lexer.identifier;
-                if (p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
-                    && name == b"await")
-                    || (p.fn_or_arrow_data_parse.allow_yield != AwaitOrYield::AllowIdent
-                        && name == b"yield")
-                {
-                    // TODO: add fmt to addRangeError
-                    p.log().add_range_error(
-                        Some(p.source),
-                        p.lexer.range(),
-                        b"Cannot use \"yield\" or \"await\" here.",
-                    );
+                if p.is_forbidden_await_or_yield_identifier(name) {
+                    p.log_invalid_identifier(name, p.lexer.range());
                 }
 
                 let ref_ = p.store_name_in_ref(name);
@@ -1155,7 +1162,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TDotDotDot => {
                 p.lexer.next()?;
-                let ident_ref = p.store_name_in_ref(p.lexer.identifier);
+                let name = p.lexer.identifier;
+                if p.lexer.token == T::TIdentifier && p.is_forbidden_await_or_yield_identifier(name)
+                {
+                    p.log_invalid_identifier(name, p.lexer.range());
+                }
+                let ident_ref = p.store_name_in_ref(name);
                 let value = p.b(B::Identifier { r#ref: ident_ref }, p.lexer.loc());
                 p.lexer.expect(T::TIdentifier)?;
                 return Ok(B::Property {
@@ -1191,7 +1203,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             _ => {
                 let name = p.lexer.identifier;
-                let loc = p.lexer.loc();
+                let name_range = p.lexer.range();
+                let loc = name_range.loc;
 
                 if !p.lexer.is_identifier_or_keyword() {
                     p.lexer.expect(T::TIdentifier)?;
@@ -1207,7 +1220,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     loc,
                 );
 
-                if p.lexer.token != T::TColon && p.lexer.token != T::TOpenParen {
+                // A shorthand property binds the key as an identifier, so a
+                // reserved word is only valid as a key: "{ if: x }" but not "{ if }"
+                if p.lexer.token != T::TColon
+                    && p.lexer.token != T::TOpenParen
+                    && crate::lexer::keyword(name).is_none()
+                {
+                    // Forbid invalid identifiers
+                    if p.is_forbidden_await_or_yield_identifier(name) {
+                        p.log_invalid_identifier(name, name_range);
+                    }
+
                     let ref_ = p.store_name_in_ref(name);
                     let value = p.b(B::Identifier { r#ref: ref_ }, loc);
                     let mut default_value: Option<Expr> = None;

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -114,6 +114,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )?;
         p.fn_or_arrow_data_parse.has_argument_decorators = false;
 
+        // Checked before the forward declaration early return so that
+        // TypeScript overload signatures are covered too
+        p.validate_function_name(&func, FnKind::Stmt);
+
         if Self::IS_TYPESCRIPT_ENABLED {
             // Don't output anything if it's just a forward declaration of a function
             if opts.is_typescript_declare
@@ -169,8 +173,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if has_if_scope {
             p.pop_scope();
         }
-
-        p.validate_function_name(&func, FnKind::Stmt);
 
         Ok(p.s(S::Function { func }, loc))
     }

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -5,7 +5,7 @@ use crate::js_lexer;
 use crate::js_lexer::T;
 use crate::p::P;
 use crate::parser::{
-    ARGUMENTS_STR as arguments_str, AwaitOrYield, FnOrArrowDataParse, LexicalDecl,
+    ARGUMENTS_STR as arguments_str, AwaitOrYield, FnKind, FnOrArrowDataParse, LexicalDecl,
     ParseStatementOptions, TypeParameterFlag,
 };
 use bun_ast as js_ast;
@@ -54,6 +54,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !opts.is_name_optional || p.lexer.token == T::TIdentifier {
             let name_loc = p.lexer.loc();
             name_text = p.lexer.identifier;
+
+            // The name binds in the enclosing scope, so it cannot be a keyword
+            // there. An async function named "await" is reported by
+            // validate_function_name instead.
+            if p.lexer.token == T::TIdentifier
+                && p.is_forbidden_await_or_yield_identifier(name_text)
+                && !(is_async && name_text == b"await")
+            {
+                p.log_invalid_identifier(
+                    name_text,
+                    js_lexer::range_of_identifier(p.source, name_loc),
+                );
+            }
             p.lexer.expect(T::TIdentifier)?;
             // Difference
             let ref_ = p.new_symbol(js_ast::symbol::Kind::Other, name_text);
@@ -156,6 +169,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if has_if_scope {
             p.pop_scope();
         }
+
+        p.validate_function_name(&func, FnKind::Stmt);
 
         Ok(p.s(S::Function { func }, loc))
     }
@@ -476,7 +491,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )?;
         p.fn_or_arrow_data_parse.has_argument_decorators = false;
 
-        p.validate_function_name(&func);
+        p.validate_function_name(&func, FnKind::Expr);
         p.pop_scope();
 
         Ok(p.new_expr(E::Function { func }, loc))

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -55,9 +55,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let name_loc = p.lexer.loc();
             name_text = p.lexer.identifier;
 
-            // The name binds in the enclosing scope, so it cannot be a keyword
-            // there. An async function named "await" is reported by
-            // validate_function_name instead.
+            // An async function named "await" is reported by validate_function_name
             if p.lexer.token == T::TIdentifier
                 && p.is_forbidden_await_or_yield_identifier(name_text)
                 && !(is_async && name_text == b"await")
@@ -114,8 +112,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )?;
         p.fn_or_arrow_data_parse.has_argument_decorators = false;
 
-        // Checked before the forward declaration early return so that
-        // TypeScript overload signatures are covered too
+        // Before the forward declaration early return, to cover overload signatures
         p.validate_function_name(&func, FnKind::Stmt);
 
         if Self::IS_TYPESCRIPT_ENABLED {

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -44,8 +44,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::Super {}, loc))
     }
 
-    fn pfx_t_open_paren(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_open_paren(
+        p: &mut Self,
+        level: Level,
+        errors: Option<&mut DeferredErrors>,
+    ) -> PResult<Expr> {
         let loc = p.lexer.loc();
+
+        // A parenthesized expression is not a valid binding pattern. Defer the
+        // error until we know whether the enclosing construct is an arrow
+        // function argument list: "([ (x) ]) => {}" is an error, "[ (x) ] = y"
+        // is not.
+        if let Some(errors) = errors {
+            errors.invalid_parens.push(p.lexer.range());
+        }
+
         p.lexer.next()?;
 
         // Arrow functions aren't allowed in the middle of expressions
@@ -774,7 +787,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            // noop
+            // Parentheses are valid in an assignment pattern "[(x)] = y" but not
+            // in a binding pattern "([(x)] = y) => {}", which is only known once
+            // the enclosing parenthesized expression ends.
+            if let Some(errors) = errors {
+                errors
+                    .invalid_parens
+                    .append(&mut self_errors.invalid_parens);
+            }
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);
@@ -859,8 +879,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.lexer.expect(T::TCloseBrace)?;
         p.allow_in = old_allow_in;
 
+        // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            // Is this a binding pattern?
+            // See the array literal case above
+            if let Some(errors) = errors {
+                errors
+                    .invalid_parens
+                    .append(&mut self_errors.invalid_parens);
+            }
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);
@@ -1003,7 +1029,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TOpenBrace => Self::pfx_t_open_brace(p, errors),
             T::TLessThan => Self::pfx_t_less_than(p, level, errors, flags),
             T::TImport => Self::pfx_t_import(p, level),
-            T::TOpenParen => Self::pfx_t_open_paren(p, level),
+            T::TOpenParen => Self::pfx_t_open_paren(p, level, errors),
             T::TPrivateIdentifier => Self::pfx_t_private_identifier(p, level),
             T::TIdentifier => Self::pfx_t_identifier(p, level),
             T::TFalse => Self::pfx_t_false(p),

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -51,10 +51,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> PResult<Expr> {
         let loc = p.lexer.loc();
 
-        // A parenthesized expression is not a valid binding pattern. Defer the
-        // error until we know whether the enclosing construct is an arrow
-        // function argument list: "([ (x) ]) => {}" is an error, "[ (x) ] = y"
-        // is not.
+        // "([ (x) ]) => {}" is an error, "[ (x) ] = y" is not
         if let Some(errors) = errors {
             errors.invalid_parens.push(p.lexer.range());
         }
@@ -787,9 +784,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            // Parentheses are valid in an assignment pattern "[(x)] = y" but not
-            // in a binding pattern "([(x)] = y) => {}", which is only known once
-            // the enclosing parenthesized expression ends.
+            // "[(x)] = y" is valid, "([(x)] = y) => {}" is not
             if let Some(errors) = errors {
                 errors
                     .invalid_parens
@@ -881,7 +876,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            // See the array literal case above
+            // "{ a: (x) } = y" is valid, "({ a: (x) } = y) => {}" is not
             if let Some(errors) = errors {
                 errors
                     .invalid_parens

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -555,24 +555,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         && js_lexer::keyword(name).is_none();
 
                     if is_shorthand_property {
-                        if (p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
-                            && name == b"await")
-                            || (p.fn_or_arrow_data_parse.allow_yield != AwaitOrYield::AllowIdent
-                                && name == b"yield")
-                        {
-                            if name == b"await" {
-                                p.log().add_range_error(
-                                    Some(p.source),
-                                    name_range,
-                                    b"Cannot use \"await\" here",
-                                );
-                            } else {
-                                p.log().add_range_error(
-                                    Some(p.source),
-                                    name_range,
-                                    b"Cannot use \"yield\" here",
-                                );
-                            }
+                        if p.is_forbidden_await_or_yield_identifier(name) {
+                            p.log_invalid_identifier(name, name_range);
                         }
 
                         let ref_ = p.store_name_in_ref(name);

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1293,8 +1293,7 @@ pub struct DeferredErrors {
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
 
-    /// These errors are for arrow functions: a parenthesized expression is not
-    /// a valid binding pattern, "([ (x) ]) => {}"
+    /// These errors are for arrow functions
     pub(crate) invalid_parens: smallvec::SmallVec<[bun_ast::Range; 2]>,
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1188,6 +1188,13 @@ pub enum AwaitOrYield {
     ForbidAll = 2,
 }
 
+/// Whether a `function` keyword starts a declaration or an expression.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FnKind {
+    Stmt,
+    Expr,
+}
+
 /// This is function-specific information used during parsing. It is saved and
 /// restored on the call stack around code that parses nested functions and
 /// arrow expressions.
@@ -1280,21 +1287,26 @@ pub struct FnOnlyDataVisit {
 /// destructuring assignment until we hit the "=" operator later on.
 /// This object defers errors about being in one state or the other
 /// until we discover which state we're in.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct DeferredErrors {
     /// These are errors for expressions
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
+
+    /// These errors are for arrow functions: a parenthesized expression is not
+    /// a valid binding pattern, "([ (x) ]) => {}"
+    pub(crate) invalid_parens: smallvec::SmallVec<[bun_ast::Range; 2]>,
 }
 
 impl DeferredErrors {
-    pub(crate) fn merge_into(&self, to: &mut DeferredErrors) {
+    pub(crate) fn merge_into(&mut self, to: &mut DeferredErrors) {
         to.invalid_expr_default_value = self
             .invalid_expr_default_value
             .or(to.invalid_expr_default_value);
         to.invalid_expr_after_question = self
             .invalid_expr_after_question
             .or(to.invalid_expr_after_question);
+        to.invalid_parens.append(&mut self.invalid_parens);
     }
 }
 
@@ -1640,6 +1652,17 @@ impl Default for DeferredArrowArgErrors {
         Self {
             invalid_expr_await: bun_ast::Range::NONE,
             invalid_expr_yield: bun_ast::Range::NONE,
+        }
+    }
+}
+
+impl DeferredArrowArgErrors {
+    pub(crate) fn merge_into(&self, to: &mut DeferredArrowArgErrors) {
+        if self.invalid_expr_await.len > 0 {
+            to.invalid_expr_await = self.invalid_expr_await;
+        }
+        if self.invalid_expr_yield.len > 0 {
+            to.invalid_expr_yield = self.invalid_expr_yield;
         }
     }
 }

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3223,6 +3223,113 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+  // "await" is a keyword at the top level of a module, and an ordinary
+  // identifier at the top level of a script (the CJS output format).
+  itBundled("edgecase/AwaitAsBindingNameCJSOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        var { await } = { await: 1 };
+        function f() { var { ...await } = { a: 3 }; return await; }
+        console.log(await, f());
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var { await } = { await: 1 };");
+      // The nested binding is renamed because it shadows the top-level one
+      api.expectFile("/out.js").toMatch(/var \{ \.\.\.await\d* \} = \{ a: 3 \};/);
+    },
+  });
+  itBundled("edgecase/AwaitAsBindingNameESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        var { await } = { await: 1 };
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/entry.js": ['Cannot use "await" as an identifier here'],
+    },
+  });
+  itBundled("edgecase/FunctionNamedAwaitCJSOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        function await() { return "await"; }
+        console.log(await());
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("function await() {");
+    },
+  });
+  itBundled("edgecase/FunctionNamedAwaitESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        function await() { return "await"; }
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/entry.js": ['Cannot use "await" as an identifier here'],
+    },
+  });
+  // These are errors in both scripts and modules
+  itBundled("edgecase/AsyncFunctionNamedAwaitIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        async function await() {}
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/entry.js": ['An async function cannot be named "await"'],
+    },
+  });
+  itBundled("edgecase/AwaitExpressionInArrowArgumentsIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        async function f() { (x = await y) => {} }
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/entry.js": ['Cannot use an "await" expression here'],
+    },
+  });
+  itBundled("edgecase/YieldAsBindingNameInGeneratorIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        function* g() { var { yield } = {} }
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/entry.js": ['Cannot use "yield" as an identifier here'],
+    },
+  });
+  itBundled("edgecase/YieldStarWithoutOperandIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        function* g() { x = yield * }
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/entry.js": ["Unexpected }"],
+    },
+  });
+  itBundled("edgecase/ParenthesizedArrowBindingIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        x = ([ (y) ]) => 0;
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/entry.js": ["Unexpected parentheses in binding pattern"],
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2661,6 +2661,20 @@ console.log(<div {...obj} key="after" />);`),
     throw new Error("Expected parse error for code\n\t" + code);
   };
 
+  // Like expectParseError, but only compares the first error when the parser
+  // reports several (an AggregateError has the generic "Parse error" message)
+  const expectFirstParseError = (code, message) => {
+    try {
+      parsed(code, false, false);
+    } catch (er) {
+      const err = er instanceof AggregateError ? er.errors[0] : er;
+      expect(err.message).toBe(message);
+      return;
+    }
+
+    throw new Error("Expected parse error for code\n\t" + code);
+  };
+
   describe("parser", () => {
     it("arrays", () => {
       expectPrinted("[]", "[]");
@@ -2789,6 +2803,236 @@ console.log(<div {...obj} key="after" />);`),
       //   "await delete x",
       //   "Delete of a bare identifier cannot be used in an ECMAScript module"
       // );
+    });
+
+    it("yield expressions", () => {
+      expectPrinted_("function *foo() { x = yield }", "function* foo() {\n  x = yield;\n}");
+      expectPrinted_("function *foo() { x = yield; }", "function* foo() {\n  x = yield;\n}");
+      expectPrinted_("function *foo() { (x = yield) }", "function* foo() {\n  x = yield;\n}");
+      expectPrinted_("function *foo() { [x = yield] }", "function* foo() {\n  x = yield;\n}");
+      expectPrinted_("function *foo() { x = (yield, yield) }", "function* foo() {\n  x = (yield, yield);\n}");
+      expectPrinted_("function *foo() { x = y ? yield : yield }", "function* foo() {\n  x = y ? yield : yield;\n}");
+      expectPrinted_("function *foo() { x = yield y }", "function* foo() {\n  x = yield y;\n}");
+      expectPrinted_("function *foo() { (x = yield y) }", "function* foo() {\n  x = yield y;\n}");
+      expectPrinted_("function *foo() { x = yield \n y }", "function* foo() {\n  x = yield;\n  y;\n}");
+      expectPrinted_("function *foo() { x = yield * y }", "function* foo() {\n  x = yield* y;\n}");
+      expectPrinted_("function *foo() { (x = yield * y) }", "function* foo() {\n  x = yield* y;\n}");
+      expectPrinted_("function *foo() { x = yield * \n y }", "function* foo() {\n  x = yield* y;\n}");
+      expectPrinted_("function foo() { x = yield * y }", "function foo() {\n  x = yield * y;\n}");
+      expectPrinted_("function foo() { (x = yield * y) }", "function foo() {\n  x = yield * y;\n}");
+
+      // "yield*" always delegates to an operand. Dropping the "*" would change
+      // the meaning of the program.
+      expectParseError("function *foo() { x = yield * }", "Unexpected }");
+      expectParseError("function *foo() { (x = yield *) }", "Unexpected )");
+      expectParseError("function *foo() { [x = yield *] }", "Unexpected ]");
+      expectParseError("function *foo() { x = yield *; }", "Unexpected ;");
+      expectParseError("function *foo() { x = yield *, y }", "Unexpected ,");
+      expectParseError("function *foo() { x = y ? yield * : z }", "Unexpected :");
+      expectParseError("async function *foo() { x = yield * }", "Unexpected }");
+      expectParseError("class C { *foo() { x = yield * } }", "Unexpected }");
+      expectParseError("function *foo() { x = yield \n * y }", "Unexpected *");
+      ts.expectParseError("function *foo() { x = yield * }", "Unexpected }");
+      ts.expectParseError("function *foo() { (x = yield *) }", "Unexpected )");
+    });
+
+    it("await and yield expressions in arrow function arguments", () => {
+      expectPrinted_("async function foo() { (x = await y) }", "async function foo() {\n  x = await y;\n}");
+      expectPrinted_("(x = await y)", "x = await y");
+      expectPrinted_("async(x = await y)", "async(x = await y)");
+      expectPrinted_("function *foo() { (x = yield y) }", "function* foo() {\n  x = yield y;\n}");
+      expectPrinted_("x = (y = () => {}) => {}", "x = (y = () => {}) => {}");
+      expectPrinted_("x = async (y = () => {}) => {}", "x = async (y = () => {}) => {}");
+      expectPrinted_("x = async (y = async () => await z) => {}", "x = async (y = async () => await z) => {}");
+      expectPrinted_("function foo() { (x = await) => {} }", "function foo() {}");
+      expectPrinted_(
+        "function *foo() { x = (y = function*() { yield z }) => {} }",
+        "function* foo() {\n  x = (y = function* () {\n    yield z;\n  }) => {};\n}",
+      );
+      expectPrinted_(
+        "async function foo() { x = (y = async function() { await z }) => {} }",
+        "async function foo() {\n  x = (y = async function() {\n    await z;\n  }) => {};\n}",
+      );
+
+      // Module top level
+      expectParseError("(x = await y) => {}", 'Cannot use an "await" expression here');
+      expectParseError("async (x = await y) => {}", 'Cannot use an "await" expression here');
+      expectParseError("(x = (await y)) => {}", 'Cannot use an "await" expression here');
+      expectParseError("(x, y = await z) => {}", 'Cannot use an "await" expression here');
+      expectParseError("([x = await y]) => {}", 'Cannot use an "await" expression here');
+      expectParseError("({x = await y}) => {}", 'Cannot use an "await" expression here');
+      ts.expectParseError("(x = await y): void => {}", 'Cannot use an "await" expression here');
+
+      // Inside an async function, a generator, an async generator, a class method and a static block
+      expectParseError("async function foo() { (x = await y) => {} }", 'Cannot use an "await" expression here');
+      expectParseError("async function foo() { async (x = await y) => {} }", 'Cannot use an "await" expression here');
+      expectParseError("async function foo() { (x = (await y)) => {} }", 'Cannot use an "await" expression here');
+      expectParseError("async function *foo() { (x = await y) => {} }", 'Cannot use an "await" expression here');
+      expectParseError("async function *foo() { (x = yield y) => {} }", 'Cannot use a "yield" expression here');
+      expectParseError("function *foo() { (x = yield y) => {} }", 'Cannot use a "yield" expression here');
+      expectParseError("function *foo() { (x = yield) => {} }", 'Cannot use a "yield" expression here');
+      expectParseError("function *foo() { (x = (yield y)) => {} }", 'Cannot use a "yield" expression here');
+      expectParseError("function *foo() { async (x = yield y) => {} }", 'Cannot use a "yield" expression here');
+      expectParseError("class C { async foo() { (x = await y) => {} } }", 'Cannot use an "await" expression here');
+      expectParseError("class C { *foo() { (x = yield y) => {} } }", 'Cannot use a "yield" expression here');
+      expectFirstParseError("class C { static { (x = await y) => {} } }", 'The keyword "await" cannot be used here');
+
+      ts.expectParseError("(x = await y) => {}", 'Cannot use an "await" expression here');
+      ts.expectParseError("async (x = await y) => {}", 'Cannot use an "await" expression here');
+      ts.expectParseError("(x: number = await y) => {}", 'Cannot use an "await" expression here');
+      ts.expectParseError("async function foo() { (x = await y) => {} }", 'Cannot use an "await" expression here');
+      ts.expectParseError("function *foo() { (x = yield y) => {} }", 'Cannot use a "yield" expression here');
+    });
+
+    it("await and yield as binding names", () => {
+      expectPrinted_("function foo() { var { yield } = {} }", "function foo() {\n  var { yield } = {};\n}");
+      expectPrinted_("function foo() { var { ...yield } = {} }", "function foo() {\n  var { ...yield } = {};\n}");
+      expectPrinted_("function foo() { var {} = { yield } }", "function foo() {\n  var {} = { yield };\n}");
+      expectPrinted_("var { await: x, yield: y } = {}", "var { await: x, yield: y } = {}");
+      expectPrinted_("function *foo() { var { yield: y } = {} }", "function* foo() {\n  var { yield: y } = {};\n}");
+      expectPrinted_("function *foo() { ({ yield: y } = {}) }", "function* foo() {\n  ({ yield: y } = {});\n}");
+
+      // Module top level
+      expectParseError("var { await } = {}", 'Cannot use "await" as an identifier here');
+      expectParseError("var { await = 1 } = {}", 'Cannot use "await" as an identifier here');
+      expectParseError("var { ...await } = {}", 'Cannot use "await" as an identifier here');
+      expectParseError("var {} = { await }", 'Cannot use "await" as an identifier here');
+      expectParseError("let { x: { await } } = {}", 'Cannot use "await" as an identifier here');
+      expectParseError("for (var { await } of x) ;", 'Cannot use "await" as an identifier here');
+      expectParseError("({ await } = {})", 'Cannot use "await" as an identifier here');
+      expectParseError("({ await }) => {}", 'Cannot use "await" as an identifier here');
+      expectParseError("try {} catch ({ await }) {}", 'Cannot use "await" as an identifier here');
+
+      // Inside an async function, an async generator, a class method and a static block
+      expectParseError("async function foo() { var { await } = {} }", 'Cannot use "await" as an identifier here');
+      expectParseError("async function foo() { var { ...await } = {} }", 'Cannot use "await" as an identifier here');
+      expectParseError("async function foo() { var {} = { await } }", 'Cannot use "await" as an identifier here');
+      expectParseError("async function *foo() { var { await } = {} }", 'Cannot use "await" as an identifier here');
+      expectParseError("async function *foo() { var {} = { await } }", 'Cannot use "await" as an identifier here');
+      expectParseError("class C { async foo() { var { await } = {} } }", 'Cannot use "await" as an identifier here');
+      expectParseError("class C { async foo() { var {} = { await } } }", 'Cannot use "await" as an identifier here');
+      expectParseError("class C { async *foo() { var { await } = {} } }", 'Cannot use "await" as an identifier here');
+      expectParseError("class C { async *foo() { var {} = { await } } }", 'Cannot use "await" as an identifier here');
+      expectParseError("class C { static { var { await } = {} } }", 'Cannot use "await" as an identifier here');
+      expectParseError("class C { static { var {} = { await } } }", 'Cannot use "await" as an identifier here');
+      expectParseError("const f = async () => { var { await } = {} }", 'Cannot use "await" as an identifier here');
+
+      // Inside a generator and an async generator
+      expectParseError("function *foo() { var { yield } = {} }", 'Cannot use "yield" as an identifier here');
+      expectParseError("function *foo() { var { yield = 1 } = {} }", 'Cannot use "yield" as an identifier here');
+      expectParseError("function *foo() { var { ...yield } = {} }", 'Cannot use "yield" as an identifier here');
+      expectParseError("function *foo() { var {} = { yield } }", 'Cannot use "yield" as an identifier here');
+      expectParseError("function *foo() { let [{ yield }] = [] }", 'Cannot use "yield" as an identifier here');
+      expectParseError("function *foo() { ({ yield } = {}) }", 'Cannot use "yield" as an identifier here');
+      expectParseError("async function *foo() { var { yield } = {} }", 'Cannot use "yield" as an identifier here');
+      expectParseError("class C { *foo() { var { yield } = {} } }", 'Cannot use "yield" as an identifier here');
+      expectParseError("({ *foo() { var { yield } = {} } })", 'Cannot use "yield" as an identifier here');
+
+      ts.expectParseError("var { await } = {}", 'Cannot use "await" as an identifier here');
+      ts.expectParseError("async function foo() { var { await } = {} }", 'Cannot use "await" as an identifier here');
+      ts.expectParseError("function *foo() { var { yield } = {} }", 'Cannot use "yield" as an identifier here');
+      ts.expectParseError("class C { static { var { await } = {} } }", 'Cannot use "await" as an identifier here');
+    });
+
+    it("reserved words as shorthand binding names", () => {
+      expectPrinted_("var { if: a, class: b, true: c, null: d } = x", "var { if: a, class: b, true: c, null: d } = x");
+      expectPrinted_("function f({ if: a, class: b }) {}", "function f({ if: a, class: b }) {}");
+      expectPrinted_("x = { if: 1, class: 2 }", "x = { if: 1, class: 2 }");
+      expectPrinted_(
+        "var { of, as, get, set, async, static: s } = x",
+        "var { of, as, get, set, async, static: s } = x",
+      );
+
+      expectFirstParseError("var { if } = x", 'Expected ":" but found "}"');
+      expectFirstParseError("var { class } = x", 'Expected ":" but found "}"');
+      expectFirstParseError("var { true } = x", 'Expected ":" but found "}"');
+      expectFirstParseError("var { null } = x", 'Expected ":" but found "}"');
+      expectFirstParseError("var { this } = x", 'Expected ":" but found "}"');
+      expectFirstParseError("var { if = 1 } = x", 'Expected ":" but found "="');
+      expectFirstParseError("let { if, x } = y", 'Expected ":" but found ","');
+      expectFirstParseError("x = { if }", 'Expected ":" but found "}"');
+      expectFirstParseError("({ if } = x)", 'Expected ":" but found "}"');
+      expectFirstParseError("function f({ class }) {}", 'Expected ":" but found "}"');
+      expectFirstParseError("const f = ({ typeof }) => {}", 'Expected ":" but found "}"');
+      ts.expectParseError("var { if } = x", 'Expected ":" but found "}"');
+      ts.expectParseError("function f({ class }) {}", 'Expected ":" but found "}"');
+    });
+
+    it("parenthesized expressions in arrow function binding patterns", () => {
+      // Parentheses are valid around an assignment target
+      expectPrinted_("[ (y) ] = 0", "[y] = 0");
+      expectPrinted_("([ (y) ] = 0)", "[y] = 0");
+      expectPrinted_("[ ...(y) ] = 0", "[...y] = 0");
+      expectPrinted_("({ y: (z) } = 0)", "({ y: z } = 0)");
+      expectPrinted_("({ ...(y) } = 0)", "({ ...y } = 0)");
+      expectPrinted_("[[(x)] = y] = z", "[[x] = y] = z");
+      expectPrintedNoTrim("for ([ (y) ] of z) ;", "for ([y] of z)\n  ;\n");
+      expectPrinted_("x = ([ (y) ] = z)", "x = [y] = z");
+      expectPrinted_("x = ({ y: (z) } = w)", "x = { y: z } = w");
+
+      // Parentheses around a default value are fine
+      expectPrinted_("x = ([ y = [ (z) ] ]) => 0", "x = ([y = [z]]) => 0;\n");
+      expectPrinted_("x = ([ y = [ ...(z) ] ]) => 0", "x = ([y = [...z]]) => 0;\n");
+      expectPrinted_("x = ({ y = { y: (z) } }) => 0", "x = ({ y = { y: z } }) => 0;\n");
+      expectPrinted_("x = ({ y = { ...(y) } }) => 0", "x = ({ y = { ...y } }) => 0;\n");
+      expectPrinted_("x = (y = (z)) => 0", "x = (y = z) => 0;\n");
+      expectPrinted_("x = ([y] = [(z)]) => 0", "x = ([y] = [z]) => 0;\n");
+      expectPrinted_("x = (y = (z) => 0) => 0", "x = (y = (z) => 0) => 0;\n");
+
+      // Parentheses are not valid around a binding
+      expectParseError("x = ((y)) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ([ (y) ]) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ([ ...(y) ]) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ({ y: (z) }) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ({ ...(y) }) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ({ y: (z) = 1 }) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ([ (y) ] = z) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ({ y: (z) } = w) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ([ [ (y) ] = z ]) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = ([ ([]) ] = z) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = async ((y)) => 0", "Unexpected parentheses in binding pattern");
+      expectParseError("x = async ([ (y) ]) => 0", "Unexpected parentheses in binding pattern");
+      expectFirstParseError("x = ({ (y) }) => 0", 'Expected identifier but found "("');
+      ts.expectParseError("x = ((y)) => 0", "Unexpected parentheses in binding pattern");
+      ts.expectParseError("x = ([ (y) ]) => 0", "Unexpected parentheses in binding pattern");
+      ts.expectParseError("x = ([ (y) ]): void => 0", "Unexpected parentheses in binding pattern");
+      ts.expectParseError("x = <T,>([ (y) ]) => 0", "Unexpected parentheses in binding pattern");
+    });
+
+    it("function declarations named await or yield", () => {
+      expectPrinted_("function foo() { function await() {} }", "function foo() {\n  function await() {}\n}");
+      expectPrinted_("function *yield() {}", "function* yield() {}");
+      expectPrinted_("async function *yield() {}", "async function* yield() {}");
+      expectPrinted_("function foo() { x = function await() {} }", "function foo() {\n  x = function await() {};\n}");
+      expectPrinted_("x = { async await() {} }", "x = { async await() {} }");
+      expectPrinted_("x = { async *await() {} }", "x = { async* await() {} }");
+      expectPrinted_("class Foo { async await() {} }", "class Foo {\n  async await() {}\n}");
+      expectPrinted_("class Foo { async *await() {} }", "class Foo {\n  async* await() {}\n}");
+      expectPrinted_("class Foo { *yield() {} }", "class Foo {\n  *yield() {}\n}");
+
+      expectParseError("async function await() {}", 'An async function cannot be named "await"');
+      expectParseError("async function *await() {}", 'An async function cannot be named "await"');
+      expectParseError("export async function await() {}", 'An async function cannot be named "await"');
+      expectParseError("export default async function await() {}", 'An async function cannot be named "await"');
+      expectParseError("(async function await() {})", 'An async function cannot be named "await"');
+      expectParseError("(async function *await() {})", 'An async function cannot be named "await"');
+      expectParseError("function foo() { async function await() {} }", 'An async function cannot be named "await"');
+      expectParseError("function foo() { (async function await() {}) }", 'An async function cannot be named "await"');
+      expectParseError("(function *yield() {})", 'A generator function expression cannot be named "yield"');
+      expectParseError("(async function *yield() {})", 'A generator function expression cannot be named "yield"');
+      expectParseError("function await() {}", 'Cannot use "await" as an identifier here');
+      expectParseError("async function foo() { function await() {} }", 'Cannot use "await" as an identifier here');
+      expectParseError("class C { static { function await() {} } }", 'Cannot use "await" as an identifier here');
+      expectParseError("function *foo() { function yield() {} }", 'Cannot use "yield" as an identifier here');
+      expectParseError("function *foo() { function *yield() {} }", 'Cannot use "yield" as an identifier here');
+      expectParseError(
+        "async function *foo() { async function yield() {} }",
+        'Cannot use "yield" as an identifier here',
+      );
+      expectPrinted_("function foo() { function *yield() {} }", "function foo() {\n  function* yield() {}\n}");
+      ts.expectParseError("async function await() {}", 'An async function cannot be named "await"');
+      ts.expectParseError("async function *await() {}", 'An async function cannot be named "await"');
+      ts.expectParseError("(function *yield() {})", 'A generator function expression cannot be named "yield"');
     });
 
     it("import assert", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2995,8 +2995,19 @@ console.log(<div {...obj} key="after" />);`),
       expectFirstParseError("x = ({ (y) }) => 0", 'Expected identifier but found "("');
       ts.expectParseError("x = ((y)) => 0", "Unexpected parentheses in binding pattern");
       ts.expectParseError("x = ([ (y) ]) => 0", "Unexpected parentheses in binding pattern");
-      ts.expectParseError("x = ([ (y) ]): void => 0", "Unexpected parentheses in binding pattern");
       ts.expectParseError("x = <T,>([ (y) ]) => 0", "Unexpected parentheses in binding pattern");
+
+      // In TypeScript, a ":" after the ")" may start an arrow function return
+      // type. A parenthesized item rules the arrow function out, so the ":" is
+      // the one of the conditional expression.
+      ts.expectPrinted_("x = cond ? (([a])) : T => 0", "x = cond ? [a] : (T) => 0;\n");
+      ts.expectPrinted_("x = cond ? (({a})) : T => 0", "x = cond ? { a } : (T) => 0;\n");
+      ts.expectPrinted_("x = cond ? ((a)) : T => 0", "x = cond ? a : (T) => 0;\n");
+      ts.expectPrinted_("x = cond ? ([(a)]) : T => 0", "x = cond ? [a] : (T) => 0;\n");
+      ts.expectPrinted_("x = cond ? ([a]) : (T) => 0", "x = cond ? [a] : (T) => 0;\n");
+      ts.expectPrinted_("x = cond ? ([a]): T => 0 : 1", "x = cond ? ([a]) => 0 : 1;\n");
+      ts.expectParseError("x = ([ (y) ]): void => 0", 'Expected ";" but found ":"');
+      ts.expectParseError("x = ((y)): void => 0", 'Expected ";" but found ":"');
     });
 
     it("function declarations named await or yield", () => {
@@ -3033,6 +3044,13 @@ console.log(<div {...obj} key="after" />);`),
       ts.expectParseError("async function await() {}", 'An async function cannot be named "await"');
       ts.expectParseError("async function *await() {}", 'An async function cannot be named "await"');
       ts.expectParseError("(function *yield() {})", 'A generator function expression cannot be named "yield"');
+      // TypeScript overload signatures have no body
+      ts.expectParseError("async function await(): void;", 'An async function cannot be named "await"');
+      ts.expectParseError(
+        "async function foo() { function await(): void; function await(): void {} }",
+        'Cannot use "await" as an identifier here',
+      );
+      ts.expectPrinted_("function foo(): void;\nfunction foo(): void {}", "function foo() {}");
     });
 
     it("import assert", () => {


### PR DESCRIPTION
### Problem
- Two inputs miscompile with no diagnostic. `function* g() { x = yield * }` prints as `x = yield;` because `parse_yield_expr` (`src/js_parser/parse/mod.rs`) skips the operand when the next token closes the expression, even after `*`. `(x = await y) => {}` and `function* g() { (x = yield y) => {} }` are accepted because `parse_paren_expr` copies `arrow_arg_errors` into `fn_or_arrow_data_parse` by value and never reads the recorded errors back.
- Other early errors are missing, so `bun build` emits code that engines reject: `var { await } = {}` in an async function or module (`parse_property_binding` does not check shorthand names), `([ (y) ]) => 0` (a parenthesized identifier is not tracked as an invalid binding), `async function await() {}` (`validate_function_name` runs only for function expressions), and `var { if } = x` (reserved word as a shorthand binding).

### Fix
- Each change is a port of the matching esbuild code: `parseYieldExpr`, the `arrowArgErrors` pointer, `parsePropertyBinding`, `deferredErrors.invalidParens` with `logDeferredArrowArgErrors`, and `validateFunctionName` from both `parseFnStmt` and `parseFnExpr`. The messages are esbuild's, except that a parenthesized binding keeps Bun's existing `Unexpected parentheses in binding pattern`.
- `invalid_parens` records every `(` parsed in a binding context. A parenthesized expression that is not an arrow function passes its `await`/`yield` errors up to its parent, so `(x = (await y)) => {}` is also rejected (node rejects it, esbuild does not).
- Reserved words are rejected as shorthand bindings, and `function yield() {}` is rejected inside a generator. Node rejects both, esbuild accepts them.
- Verified: `test/bundler/transpiler/transpiler.test.js` (6 new blocks) and `test/bundler/bundler_edgecase.test.ts` (9 new cases, CJS and ESM output). Also `test/bundler/esbuild/{default,ts,lower,dce}.test.ts`, `test/js/bun/transpiler`, `bundler_minify`, `bundler_regressions`.

### Background
- `DeferredErrors` collects errors for an array or object literal that may turn out to be a binding pattern (arrow arguments) or an expression. The literal parser merges them into the enclosing `parse_paren_expr`, which logs them once it sees `=>`. `invalid_parens` is a new member: a parenthesized expression is a valid assignment target (`[(x)] = y`) but never a valid binding.
- `DeferredArrowArgErrors` does the same for `await` and `yield` expressions inside parenthesized arguments. `fn_or_arrow_data_parse` is the per-function parse state that is saved and restored around nested functions. Before this change the errors were written into a copy of that state and lost on restore.
- A function declaration's name binds in the enclosing scope, a function expression's name binds inside the function. So `function* yield() {}` is valid at the top level of a script, but `(function* yield() {})` is not.

<details><summary>Notes</summary>

- Supersedes #36228, which covered only the `validate_function_name` part. That PR accepted `async function await() {}` in scripts (node does). This one follows esbuild and rejects it everywhere, as requested.
- The `is_parenthesized` checks in `convert_expr_to_binding` are removed because `invalid_parens` now covers them. An array or object followed by `=` keeps only its parentheses errors (`([(x)] = y) => {}` is an error, `[(x)] = y` is not).
- In TypeScript, `parse_paren_expr` only tries to read a `:` after the `)` as an arrow function return type when `invalid_parens` is empty too. So `a ? (([b])) : T => c` stays a conditional expression, as before, and `a ? ((b)) : T => c` now parses the way tsc parses it.
- `validate_function_name` runs before the TypeScript forward declaration early return, so `async function await(): void;` is reported as well.
- `Bun.Transpiler` and the runtime always parse with `top_level_await`, so the module-level cases are tested there. The script-level cases (`var { await } = {}` and `function await() {}` are valid) use `bun build --format=cjs` in `bundler_edgecase.test.ts` and check the output text, because the runtime would parse the output as a module again.
- Transpiling all 47,654 JS/TS files under `test/node_modules` with the old and the new binary gives the same 625 failures (pre-existing, for example `.d.ts` content parsed as `.ts`). No new false positives.
- The `Cannot use "yield" or "await" here.` and `Cannot use "await" here` messages of `parse_binding` and the object literal shorthand are unified to esbuild's `Cannot use "await" as an identifier here`.
- Not changed, for parity with esbuild: `function foo({ await }) {}` and `function foo() { var { await } = {} }` in a module are accepted, because the function's own `await` mode is `AllowIdent`. `([(x)] = y) => {}` with the parenthesized target inside a defaulted pattern is rejected here but accepted by esbuild 0.25.1.
- Related esbuild tests: `TestYield`, `TestAsync`, `TestArrow` and the `var { await } = {}` block in `js_parser_test.go`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->
