### PR TITLE
Honor tsconfig verbatimModuleSyntax, preserveValueImports and importsNotUsedAsValues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,7 @@ version = "0.0.0"
 name = "bun_options_types"
 version = "0.0.0"
 dependencies = [
+ "bitflags",
  "bstr",
  "bun_ast",
  "bun_collections",

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -212,6 +212,10 @@ pub struct Import {
     /// proposal. Only valid with a namespace import (`star_name_loc` is set,
     /// `default_name`/`items` are empty).
     pub phase_defer: bool, // = false
+    /// The source had a `{ ... }` clause. Only consulted while `items` is empty:
+    /// it tells `import {} from 'path'` (which TypeScript elides as type-only,
+    /// and which prints with the braces when kept) from `import 'path'`.
+    pub has_items_clause: bool, // = false
 }
 
 impl Default for Import {
@@ -224,6 +228,7 @@ impl Default for Import {
             import_record_index: u32::MAX,
             is_single_line: false,
             phase_defer: false,
+            has_items_clause: false,
         }
     }
 }

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -110,6 +110,7 @@ pub struct ParseTask {
     pub(crate) emit_decorator_metadata: bool,
     pub(crate) experimental_decorators: bool,
     pub(crate) use_define_for_class_fields: bool,
+    pub(crate) unused_import_flags_ts: options::TSUnusedImportFlags,
     // BACKREF; `None` only before enqueue (`Default`, runtime source).
     pub ctx: Option<bun_ptr::ParentRef<BundleV2<'static>, bun_ptr::Mut>>,
     // Borrows package_json (resolver arena); valid for the bundle pass.
@@ -272,6 +273,7 @@ impl ParseTask {
             emit_decorator_metadata: resolve_result.flags.emit_decorator_metadata(),
             experimental_decorators: resolve_result.flags.experimental_decorators(),
             use_define_for_class_fields: resolve_result.flags.use_define_for_class_fields(),
+            unused_import_flags_ts: resolve_result.flags.unused_import_flags_ts(),
             package_version,
             package_name,
             known_target,
@@ -326,6 +328,7 @@ impl Default for ParseTask {
             emit_decorator_metadata: false,
             experimental_decorators: false,
             use_define_for_class_fields: true,
+            unused_import_flags_ts: options::TSUnusedImportFlags::empty(),
             package_version: ast::StoreStr::EMPTY,
             package_name: ast::StoreStr::EMPTY,
             is_entry_point: false,
@@ -566,6 +569,7 @@ pub mod parse_worker {
             emit_decorator_metadata: false,
             experimental_decorators: false,
             use_define_for_class_fields: true,
+            unused_import_flags_ts: options::TSUnusedImportFlags::empty(),
             package_version: ast::StoreStr::EMPTY,
             package_name: ast::StoreStr::EMPTY,
             is_entry_point: false,
@@ -2482,6 +2486,7 @@ pub mod parse_worker {
         opts.features.minify_keep_names = topts.keep_names;
         opts.features.minify_whitespace = topts.minify_whitespace;
         opts.use_define_for_class_fields = task.use_define_for_class_fields;
+        opts.unused_import_flags_ts = task.unused_import_flags_ts;
         opts.features.emit_decorator_metadata = task.emit_decorator_metadata;
         // emitDecoratorMetadata implies legacy/experimental decorators, as it only
         // makes sense with TypeScript's legacy decorator system (reflect-metadata).

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -325,6 +325,7 @@ impl TargetExt for Target {
 }
 
 pub use bun_options_types::Format;
+pub use bun_options_types::TSUnusedImportFlags;
 pub use bun_options_types::WindowsOptions;
 
 // Re-export of `bun_ast::Loader`.
@@ -1192,6 +1193,7 @@ pub struct BundleOptions<'a> {
     pub emit_decorator_metadata: bool,
     pub experimental_decorators: bool,
     pub use_define_for_class_fields: bool,
+    pub unused_import_flags_ts: TSUnusedImportFlags,
     pub auto_import_jsx: bool,
     pub allow_runtime: bool,
 
@@ -1425,6 +1427,7 @@ impl<'a> BundleOptions<'a> {
             emit_decorator_metadata: self.emit_decorator_metadata,
             experimental_decorators: self.experimental_decorators,
             use_define_for_class_fields: self.use_define_for_class_fields,
+            unused_import_flags_ts: self.unused_import_flags_ts,
             auto_import_jsx: self.auto_import_jsx,
             allow_runtime: self.allow_runtime,
             trim_unused_imports: self.trim_unused_imports,
@@ -1686,6 +1689,7 @@ impl<'a> BundleOptions<'a> {
             emit_decorator_metadata: false,
             experimental_decorators: false,
             use_define_for_class_fields: true,
+            unused_import_flags_ts: TSUnusedImportFlags::empty(),
             auto_import_jsx: true,
             allow_runtime: true,
             trim_unused_imports: None,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -729,6 +729,7 @@ impl<'a> Transpiler<'a> {
                     if let Some(v) = tsconfig.use_define_for_class_fields {
                         self.options.use_define_for_class_fields = v;
                     }
+                    self.options.unused_import_flags_ts = tsconfig.unused_import_flags();
                 }
             }
         }
@@ -988,6 +989,7 @@ pub struct ParseOptions<'a, 'b> {
     pub emit_decorator_metadata: bool,
     pub experimental_decorators: bool,
     pub use_define_for_class_fields: bool,
+    pub unused_import_flags_ts: options::TSUnusedImportFlags,
     pub remove_cjs_module_wrapper: bool,
 
     pub dont_bundle_twice: bool,
@@ -1569,7 +1571,7 @@ impl<'a> Transpiler<'a> {
                     jsx: to_parser_jsx_pragma(jsx),
                     keep_names: true,
                     ignore_dce_annotations: self.options.ignore_dce_annotations,
-                    preserve_unused_imports_ts: false,
+                    unused_import_flags_ts: this_parse.unused_import_flags_ts,
                     use_define_for_class_fields: this_parse.use_define_for_class_fields,
                     suppress_warnings_about_weird_code: true,
                     features: js_ast::RuntimeFeatures::default(),
@@ -2930,6 +2932,7 @@ impl<'a> Transpiler<'a> {
                 let experimental_decorators = resolve_result.flags.experimental_decorators();
                 let use_define_for_class_fields =
                     resolve_result.flags.use_define_for_class_fields();
+                let unused_import_flags_ts = resolve_result.flags.unused_import_flags_ts();
                 // `MacroRemap` (StringArrayHashMap of StringArrayHashMap) has
                 // no nested `Clone` impl (the inner clone is fallible).
                 // Rebuild the outer map, deep-cloning
@@ -2959,6 +2962,7 @@ impl<'a> Transpiler<'a> {
                     emit_decorator_metadata,
                     experimental_decorators,
                     use_define_for_class_fields,
+                    unused_import_flags_ts,
                     virtual_source: None,
                     replace_exports: Default::default(),
                     inject_jest_globals: false,

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -495,6 +495,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 import_record_index,
                 is_single_line: true,
                 default_name,
+                has_items_clause: !items.is_empty(),
                 items,
                 namespace_ref,
                 star_name_loc,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1759,6 +1759,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 default_name: None,
                 star_name_loc: bun_ast::Loc::EMPTY,
                 phase_defer: false,
+                has_items_clause: true,
             },
             bun_ast::Loc::default(),
         );
@@ -1896,6 +1897,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 default_name: None,
                 star_name_loc: bun_ast::Loc::EMPTY,
                 phase_defer: false,
+                has_items_clause: true,
             },
             bun_ast::Loc::default(),
         );
@@ -2065,6 +2067,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     default_name: None,
                     star_name_loc: bun_ast::Loc::EMPTY,
                     phase_defer: false,
+                    has_items_clause: true,
                 },
                 bun_ast::Loc::EMPTY,
             )

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -71,7 +71,7 @@ pub struct Options<'a> {
     pub ts: bool,
     pub keep_names: bool,
     pub ignore_dce_annotations: bool,
-    pub preserve_unused_imports_ts: bool,
+    pub unused_import_flags_ts: options::TSUnusedImportFlags,
     pub use_define_for_class_fields: bool,
     pub suppress_warnings_about_weird_code: bool,
     pub features: RuntimeFeatures,
@@ -126,7 +126,7 @@ impl<'a> Default for Options<'a> {
             ts: false,
             keep_names: true,
             ignore_dce_annotations: false,
-            preserve_unused_imports_ts: false,
+            unused_import_flags_ts: options::TSUnusedImportFlags::empty(),
             use_define_for_class_fields: true,
             suppress_warnings_about_weird_code: true,
             features: RuntimeFeatures::default(),
@@ -176,7 +176,7 @@ impl<'a> Options<'a> {
             ts: self.ts,
             keep_names: self.keep_names,
             ignore_dce_annotations: self.ignore_dce_annotations,
-            preserve_unused_imports_ts: self.preserve_unused_imports_ts,
+            unused_import_flags_ts: self.unused_import_flags_ts,
             use_define_for_class_fields: self.use_define_for_class_fields,
             suppress_warnings_about_weird_code: self.suppress_warnings_about_weird_code,
             features: RuntimeFeatures {
@@ -264,6 +264,11 @@ impl<'a> Options<'a> {
             hasher.update(b"udfcf=0");
         }
 
+        if !self.unused_import_flags_ts.is_empty() {
+            hasher.update(b"ts_unused_imports=");
+            hasher.update(&[self.unused_import_flags_ts.bits()]);
+        }
+
         self.features.hash_for_runtime_transpiler(hasher);
     }
 
@@ -281,7 +286,7 @@ impl<'a> Options<'a> {
             jsx,
             keep_names: true,
             ignore_dce_annotations: false,
-            preserve_unused_imports_ts: false,
+            unused_import_flags_ts: options::TSUnusedImportFlags::empty(),
             use_define_for_class_fields: true,
             suppress_warnings_about_weird_code: true,
             features: RuntimeFeatures::default(),
@@ -461,8 +466,10 @@ impl<'a> Parser<'a> {
             }
         }
 
-        //
-        if TS {
+        // With any of the tsconfig "keep unused imports" settings, an import
+        // statement that survives parsing also survives the transform, so the
+        // "unused unless a binding is used" guess below does not apply.
+        if TS && p.options.unused_import_flags_ts.is_empty() {
             for import_record in p.import_records.items_mut() {
                 // Mark everything as unused
                 // Except:
@@ -1262,6 +1269,7 @@ impl<'a> Parser<'a> {
                             items: bun_ast::StoreSlice::EMPTY,
                             is_single_line: false,
                             phase_defer: false,
+                            has_items_clause: false,
                         },
                         ns_loc,
                     );
@@ -1922,6 +1930,7 @@ impl<'a> Parser<'a> {
                         star_name_loc: bun_ast::Loc::EMPTY,
                         is_single_line: false,
                         phase_defer: false,
+                        has_items_clause: true,
                     },
                     bun_ast::Loc::EMPTY,
                 );

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -116,9 +116,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut items = bun_alloc::ArenaVec::<ClauseItem>::new_in(p.arena);
         p.lexer.expect(T::TOpenBrace)?;
         let mut is_single_line = !p.lexer.has_newline_before;
-        // this variable should not exist if we're not in a typescript file
-        // Declared unconditionally — dead-store elim removes it when !TS.
-        let mut had_type_only_imports = false;
 
         while p.lexer.token != T::TCloseBrace {
             // The alias may be a keyword;
@@ -158,11 +155,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if p.lexer.token == T::TIdentifier {
                             // "import { type as as as } from 'mod'"
                             // "import { type as as foo } from 'mod'"
-                            had_type_only_imports = true;
                             p.lexer.next()?;
                         } else {
                             // "import { type as as } from 'mod'"
-
                             items.push(ClauseItem {
                                 alias: alias.into(),
                                 alias_loc,
@@ -171,8 +166,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             });
                         }
                     } else if p.lexer.token == T::TIdentifier {
-                        had_type_only_imports = true;
-
                         // "import { type as xxx } from 'mod'"
                         original_name = p.lexer.identifier;
                         name = LocRef {
@@ -182,12 +175,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.lexer.expect(T::TIdentifier)?;
 
                         if is_eval_or_arguments(original_name) {
-                            let r = p.source.range_of_string(name.loc);
+                            let r = js_lexer::range_of_identifier(p.source, name.loc);
                             p.log().add_range_error_fmt(
                                 Some(p.source),
                                 r,
                                 format_args!(
-                                    "Cannot use {} as an identifier here",
+                                    "Cannot use \"{}\" as an identifier here",
                                     bstr::BStr::new(original_name)
                                 ),
                             );
@@ -218,7 +211,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // An import where the name is a keyword must have an alias
                         p.lexer.expected_string(b"\"as\"")?;
                     }
-                    had_type_only_imports = true;
                 }
             } else {
                 if p.lexer.is_contextual_keyword(b"as") {
@@ -278,11 +270,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ImportClause {
             items: items.into_bump_slice_mut(),
             is_single_line,
-            had_type_only_imports: if TYPESCRIPT {
-                had_type_only_imports
-            } else {
-                false
-            },
         })
     }
 

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -12,6 +12,7 @@ use js_ast::{Expr, G, LocRef, S, Stmt};
 use js_lexer::T;
 
 use crate::parser::fs;
+use crate::parser::options::TSUnusedImportFlags;
 use crate::parser::{
     AwaitOrYield, DeferredTsDecorators, LexicalDecl, ParseStatementOptions, ParsedPath, Ref,
     StatementScope, StmtList,
@@ -1286,10 +1287,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     if Self::IS_TYPESCRIPT_ENABLED {
                         // export {type Foo} from 'bar';
+                        // export {} from 'bar';
                         // ->
                         // nothing
                         // https://www.typescriptlang.org/play?useDefineForClassFields=true&esModuleInterop=false&declaration=false&target=99&isolatedModules=false&ts=4.5.4#code/KYDwDg9gTgLgBDAnmYcDeAxCEC+cBmUEAtnAOQBGAhlGQNwBQQA
-                        if export_clause.clauses.is_empty() && export_clause.had_type_only_exports {
+                        if export_clause.clauses.is_empty()
+                            && !p
+                                .options
+                                .unused_import_flags_ts
+                                .contains(TSUnusedImportFlags::KEEP_STMT)
+                        {
                             return Ok(p.s(S::TypeScript {}, loc));
                         }
                     }
@@ -1350,7 +1357,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // ->
                     // nothing
                     // https://www.typescriptlang.org/play?useDefineForClassFields=true&esModuleInterop=false&declaration=false&target=99&isolatedModules=false&ts=4.5.4#code/KYDwDg9gTgLgBDAnmYcDeAxCEC+cBmUEAtnAOQBGAhlGQNwBQQA
-                    if export_clause.clauses.is_empty() && export_clause.had_type_only_exports {
+                    if export_clause.clauses.is_empty()
+                        && export_clause.had_type_only_exports
+                        && !p
+                            .options
+                            .unused_import_flags_ts
+                            .contains(TSUnusedImportFlags::KEEP_STMT)
+                    {
                         return Ok(p.s(S::TypeScript {}, loc));
                     }
                 }
@@ -1457,13 +1470,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return Err(crate::Error::SyntaxError);
                 }
                 let import_clause = p.parse_import_clause()?;
-                if Self::IS_TYPESCRIPT_ENABLED {
-                    if import_clause.had_type_only_imports && import_clause.items.is_empty() {
-                        p.lexer.expect_contextual_keyword(b"from")?;
-                        let _ = p.parse_path()?;
-                        p.lexer.expect_or_insert_semicolon()?;
-                        return Ok(p.s(S::TypeScript {}, loc));
-                    }
+                if Self::IS_TYPESCRIPT_ENABLED
+                    && import_clause.items.is_empty()
+                    && !p
+                        .options
+                        .unused_import_flags_ts
+                        .contains(TSUnusedImportFlags::KEEP_STMT)
+                {
+                    // "import {} from 'mod'"
+                    // "import { type Foo } from 'mod'"
+                    //
+                    // A clause with no value bindings is type-only. TypeScript
+                    // drops the statement unless "importsNotUsedAsValues" or
+                    // "verbatimModuleSyntax" asks to keep it.
+                    p.lexer.expect_contextual_keyword(b"from")?;
+                    let _ = p.parse_path()?;
+                    p.lexer.expect_or_insert_semicolon()?;
+                    return Ok(p.s(S::TypeScript {}, loc));
                 }
 
                 stmt = S::Import {
@@ -1473,6 +1496,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // moved into the AST node here; no other &mut alias exists.
                     items: import_clause.items.into(),
                     is_single_line: import_clause.is_single_line,
+                    has_items_clause: true,
                     ..Default::default()
                 };
                 p.lexer.expect_contextual_keyword(b"from")?;
@@ -1621,6 +1645,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         T::TOpenBrace => {
                             let import_clause = p.parse_import_clause()?;
 
+                            // "import d, {} from 'mod'"
+                            // "import d, { type T } from 'mod'"
+                            //
+                            // TypeScript drops an empty clause (compare the `{`
+                            // arm above) unless the statement is kept as written.
+                            stmt.has_items_clause = !Self::IS_TYPESCRIPT_ENABLED
+                                || !import_clause.items.is_empty()
+                                || p.options
+                                    .unused_import_flags_ts
+                                    .contains(TSUnusedImportFlags::KEEP_STMT);
                             // SAFETY: sole owner — fresh arena slice from parse_import_clause,
                             // moved into the AST node here; no other &mut alias exists.
                             stmt.items = import_clause.items.into();

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1303,7 +1303,6 @@ pub(crate) struct ImportClause<'a> {
     /// (`S::Import.items: StoreSlice<ClauseItem>`).
     pub(crate) items: &'a mut [js_ast::ClauseItem],
     pub(crate) is_single_line: bool,
-    pub(crate) had_type_only_imports: bool,
 }
 
 pub struct PropertyOpts {

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -2,6 +2,7 @@
 #![warn(unused_must_use)]
 use crate::lower::lower_esm_exports_hmr::ConvertESMExportsForHmr;
 use crate::p::P;
+use crate::parser::options::TSUnusedImportFlags;
 use crate::parser::{ImportItemForNamespaceMap, Ref};
 use bun_ast::{self as js_ast, Expr, G, LocRef, S, Stmt, Symbol};
 use bun_ast::{ImportRecord, import_record};
@@ -81,19 +82,12 @@ impl<'a> ImportScanner<'a> {
                         continue;
                     }
 
-                    // The official TypeScript compiler always removes unused imported
-                    // symbols. However, we deliberately deviate from the official
-                    // TypeScript compiler's behavior doing this in a specific scenario:
-                    // we are not bundling, symbol renaming is off, and the tsconfig.json
-                    // "importsNotUsedAsValues" setting is present and is not set to
-                    // "remove".
-                    //
-                    // This exists to support the use case of compiling partial modules for
-                    // compile-to-JavaScript languages such as Svelte. These languages try
-                    // to reference imports in ways that are impossible for esbuild to know
-                    // about when esbuild is only given a partial module to compile. Here
-                    // is an example of some Svelte code that might use esbuild to convert
-                    // TypeScript to JavaScript:
+                    // We implement TypeScript's "preserveValueImports" tsconfig.json setting
+                    // to support the use case of compiling partial modules for compile-to-
+                    // JavaScript languages such as Svelte. These languages try to reference
+                    // imports in ways that are impossible for TypeScript and esbuild to know
+                    // about when they are only given a partial module to compile. Here is an
+                    // example of some Svelte code that contains a TypeScript snippet:
                     //
                     //   <script lang="ts">
                     //     import Counter from './Counter.svelte';
@@ -106,24 +100,11 @@ impl<'a> ImportScanner<'a> {
                     //
                     // Tools that use esbuild to compile TypeScript code inside a Svelte
                     // file like this only give esbuild the contents of the <script> tag.
-                    // These tools work around this missing import problem when using the
-                    // official TypeScript compiler by hacking the TypeScript AST to
-                    // remove the "unused import" flags. This isn't possible in esbuild
-                    // because esbuild deliberately does not expose an AST manipulation
-                    // API for performance reasons.
+                    // The "preserveValueImports" setting avoids removing unused import
+                    // names, which means additional code appended after the TypeScript-
+                    // to-JavaScript conversion can still access those unused imports.
                     //
-                    // We deviate from the TypeScript compiler's behavior in this specific
-                    // case because doing so is useful for these compile-to-JavaScript
-                    // languages and is benign in other cases. The rationale is as follows:
-                    //
-                    //   * If "importsNotUsedAsValues" is absent or set to "remove", then
-                    //     we don't know if these imports are values or types. It's not
-                    //     safe to keep them because if they are types, the missing imports
-                    //     will cause run-time failures because there will be no matching
-                    //     exports. It's only safe keep imports if "importsNotUsedAsValues"
-                    //     is set to "preserve" or "error" because then we can assume that
-                    //     none of the imports are types (since the TypeScript compiler
-                    //     would generate an error in that case).
+                    // There are two scenarios where we don't do this:
                     //
                     //   * If we're bundling, then we know we aren't being used to compile
                     //     a partial module. The parser is seeing the entire code for the
@@ -137,8 +118,15 @@ impl<'a> ImportScanner<'a> {
                     //     user is expecting the output to be as small as possible. So we
                     //     should omit unused imports.
                     //
+                    let unused_import_flags = p.options.unused_import_flags_ts;
+                    let keep_values_ts =
+                        unused_import_flags.contains(TSUnusedImportFlags::KEEP_VALUES);
                     let mut did_remove_star_loc = false;
-                    let keep_unused_imports = !p.options.features.trim_unused_imports;
+                    let keep_unused_imports = !p.options.features.trim_unused_imports
+                        || (is_typescript_enabled
+                            && keep_values_ts
+                            && !p.options.bundle
+                            && !p.options.features.minify_identifiers);
                     // TypeScript always trims unused imports. This is important for
                     // correctness since some imports might be fake (only in the type
                     // system and used for type-only imports).
@@ -152,7 +140,8 @@ impl<'a> ImportScanner<'a> {
 
                             // TypeScript has a separate definition of unused
                             if is_typescript_enabled
-                                && p.ts_use_counts[default_name.ref_.inner_index() as usize] != 0
+                                && (p.ts_use_counts[default_name.ref_.inner_index() as usize] != 0
+                                    || keep_values_ts)
                             {
                                 is_unused_in_typescript = false;
                             }
@@ -170,7 +159,8 @@ impl<'a> ImportScanner<'a> {
 
                             // TypeScript has a separate definition of unused
                             if is_typescript_enabled
-                                && p.ts_use_counts[st.namespace_ref.inner_index() as usize] != 0
+                                && (p.ts_use_counts[st.namespace_ref.inner_index() as usize] != 0
+                                    || keep_values_ts)
                             {
                                 is_unused_in_typescript = false;
                             }
@@ -204,9 +194,10 @@ impl<'a> ImportScanner<'a> {
                             }
                         }
 
-                        // Remove items if they are unused
+                        // Remove items if they are unused. In TypeScript an empty
+                        // clause counts as "found": `import {} from 'x'` is type-only.
                         let items: &mut [js_ast::ClauseItem] = st.items.slice_mut();
-                        if !items.is_empty() {
+                        if !items.is_empty() || (is_typescript_enabled && st.has_items_clause) {
                             found_imports = true;
                             let mut items_end: usize = 0;
                             let len = items.len();
@@ -216,7 +207,8 @@ impl<'a> ImportScanner<'a> {
 
                                 // TypeScript has a separate definition of unused
                                 if is_typescript_enabled
-                                    && p.ts_use_counts[ref_.inner_index() as usize] != 0
+                                    && (p.ts_use_counts[ref_.inner_index() as usize] != 0
+                                        || keep_values_ts)
                                 {
                                     is_unused_in_typescript = false;
                                 }
@@ -240,6 +232,11 @@ impl<'a> ImportScanner<'a> {
                             }
 
                             st.items.truncate(items_end);
+                            // An emptied clause prints as a bare import, so the
+                            // statement reads `import "path"` and not `import {} from "path"`.
+                            if items_end == 0 {
+                                st.has_items_clause = false;
+                            }
                         }
 
                         // -- Original Comment --
@@ -268,7 +265,7 @@ impl<'a> ImportScanner<'a> {
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript
-                            && !p.options.preserve_unused_imports_ts)
+                            && !unused_import_flags.contains(TSUnusedImportFlags::KEEP_STMT))
                             || (!is_typescript_enabled
                                 && p.options.features.trim_unused_imports
                                 && found_imports

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -5617,37 +5617,42 @@ pub(crate) mod __gated_printer {
 
                     let import_record = self.import_record(s.import_record_index as usize);
 
-                    self.print_whitespacer(ws!(b"export {"));
-
-                    if !s.is_single_line {
-                        self.indent();
+                    if slice_of(s.items).is_empty() {
+                        // "export {} from 'path'"
+                        self.print_whitespacer(ws!(b"export {} from "));
                     } else {
-                        self.print_space();
-                    }
+                        self.print_whitespacer(ws!(b"export {"));
 
-                    for (i, item) in slice_of(s.items).iter().enumerate() {
-                        if i != 0 {
-                            self.print(b",");
-                            if s.is_single_line {
-                                self.print_space();
-                            }
-                        }
                         if !s.is_single_line {
+                            self.indent();
+                        } else {
+                            self.print_space();
+                        }
+
+                        for (i, item) in slice_of(s.items).iter().enumerate() {
+                            if i != 0 {
+                                self.print(b",");
+                                if s.is_single_line {
+                                    self.print_space();
+                                }
+                            }
+                            if !s.is_single_line {
+                                self.print_newline();
+                                self.print_indent();
+                            }
+                            self.print_export_from_clause_item(item);
+                        }
+
+                        if !s.is_single_line {
+                            self.unindent();
                             self.print_newline();
                             self.print_indent();
+                        } else {
+                            self.print_space();
                         }
-                        self.print_export_from_clause_item(item);
-                    }
 
-                    if !s.is_single_line {
-                        self.unindent();
-                        self.print_newline();
-                        self.print_indent();
-                    } else {
-                        self.print_space();
+                        self.print_whitespacer(ws!(b"} from "));
                     }
-
-                    self.print_whitespacer(ws!(b"} from "));
                     let irp = &import_record.path.text;
                     self.print_import_record_path(import_record);
                     self.print_semicolon_after_statement();
@@ -6051,6 +6056,14 @@ pub(crate) mod __gated_printer {
                         }
                         self.print(b"}");
                         item_count += 1;
+                    } else if s.has_items_clause {
+                        // "import {} from 'path'"
+                        if item_count > 0 {
+                            self.print(b",");
+                        }
+                        self.print_space();
+                        self.print(b"{}");
+                        item_count += 1;
                     }
 
                     if record
@@ -6068,11 +6081,13 @@ pub(crate) mod __gated_printer {
                     }
 
                     if item_count > 0 {
+                        // A space is required after an identifier (`ns` or the
+                        // default name) but not after `}`.
                         if !self.options.minify_whitespace
                             || record
                                 .flags
                                 .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR)
-                            || slice_of(s.items).is_empty()
+                            || (slice_of(s.items).is_empty() && !s.has_items_clause)
                         {
                             self.print(b" ");
                         }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,10 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: TypeScript elides `import {} from "x"` and `import { type as } from "x"`,
+/// and tsconfig `verbatimModuleSyntax` / `preserveValueImports` /
+/// `importsNotUsedAsValues` take part in the features hash.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -802,6 +802,7 @@ impl TranspilerJob {
             emit_decorator_metadata: transpiler.options.emit_decorator_metadata,
             experimental_decorators: transpiler.options.experimental_decorators,
             use_define_for_class_fields: transpiler.options.use_define_for_class_fields,
+            unused_import_flags_ts: transpiler.options.unused_import_flags_ts,
             virtual_source: None,
             replace_exports: Default::default(),
             dont_bundle_twice: true,

--- a/src/options_types/Cargo.toml
+++ b/src/options_types/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 thiserror.workspace = true
+bitflags.workspace = true
 strum.workspace = true
 bstr.workspace = true
 const_format.workspace = true

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -122,6 +122,28 @@ bun_core::comptime_string_map! {
     };
 }
 
+bitflags::bitflags! {
+    /// How the TypeScript parser treats an import whose bindings are unused
+    /// (or type-only). tsconfig's `importsNotUsedAsValues`,
+    /// `preserveValueImports` and `verbatimModuleSyntax` all fold into these
+    /// two bits (see `TSConfigJSON::unused_import_flags`).
+    ///
+    /// | input                                | neither        | KEEP_STMT      | KEEP_VALUES                    | both                           |
+    /// |--------------------------------------|----------------|----------------|--------------------------------|--------------------------------|
+    /// | `import 'foo'`                       | `import 'foo'` | `import 'foo'` | `import 'foo'`                 | `import 'foo'`                 |
+    /// | `import * as unused from 'foo'`      | (removed)      | `import 'foo'` | `import * as unused from 'foo'`| `import * as unused from 'foo'`|
+    /// | `import { unused } from 'foo'`       | (removed)      | `import 'foo'` | `import { unused } from 'foo'` | `import { unused } from 'foo'` |
+    /// | `import { type unused } from 'foo'`  | (removed)      | `import 'foo'` | (removed)                      | `import {} from 'foo'`         |
+    #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+    pub struct TSUnusedImportFlags: u8 {
+        /// `importsNotUsedAsValues` is `"preserve"` or `"error"`: keep the
+        /// statement for its side effects even when every binding is removed.
+        const KEEP_STMT = 1 << 0;
+        /// `preserveValueImports`: keep value bindings that are never used.
+        const KEEP_VALUES = 1 << 1;
+    }
+}
+
 // ─── Target: schema-coupled extension methods ─────────────────────────────
 
 mod sealed {

--- a/src/options_types/lib.rs
+++ b/src/options_types/lib.rs
@@ -23,7 +23,7 @@ pub use jsx as JSX;
 // (`Format`, `ModuleType`, …) are surfaced from this crate.
 pub use bundle_enums::{
     BuiltInModule, BundlePackage, ForceNodeEnv, Format, LOADER_API_NAMES, LoaderExt, ModuleType,
-    TargetExt, WindowsOptions,
+    TSUnusedImportFlags, TargetExt, WindowsOptions,
 };
 
 /// Compiled-standalone-binary virtual filesystem path prefix + predicate.

--- a/src/react_compiler/imports.rs
+++ b/src/react_compiler/imports.rs
@@ -268,6 +268,7 @@ pub(crate) fn add_imports_to_program(
                 import_record_index,
                 is_single_line: true,
                 phase_defer: false,
+                has_items_clause: true,
             },
             Loc::EMPTY,
         ));

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1597,6 +1597,9 @@ impl<'a> Resolver<'a> {
                 if let Some(v) = tsconfig.use_define_for_class_fields {
                     result.flags.set_use_define_for_class_fields(v);
                 }
+                result
+                    .flags
+                    .set_unused_import_flags_ts(tsconfig.unused_import_flags());
             }
 
             // If you use mjs or mts, then you're using esm
@@ -6589,6 +6592,12 @@ impl<'a> Resolver<'a> {
 
                         if let Some(value) = parent_config.preserve_imports_not_used_as_values {
                             mc.preserve_imports_not_used_as_values = Some(value);
+                        }
+                        if let Some(value) = parent_config.preserve_value_imports {
+                            mc.preserve_value_imports = Some(value);
+                        }
+                        if let Some(value) = parent_config.verbatim_module_syntax {
+                            mc.verbatim_module_syntax = Some(value);
                         }
 
                         // TypeScript replaces paths across extends (child overrides parent

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -9,6 +9,7 @@ use ::bun_ast::import_record as ast;
 use ::bun_install_types::resolver_hooks as Install;
 use bun_alloc as allocators;
 use bun_core::MutableString;
+use bun_options_types::TSUnusedImportFlags;
 use bun_sys::Fd as FD;
 
 use crate::dir_info::DirInfoRef;
@@ -126,7 +127,7 @@ impl Default for Result {
 
 bitflags::bitflags! {
     #[derive(Default, Clone, Copy)]
-    pub struct ResultFlags: u8 {
+    pub struct ResultFlags: u16 {
         // Bits 0..=1 encode [`ExternalKind`]; write via `set_external_kind`.
         const IS_EXTERNAL = 1 << 0;
         const REWRITE_IMPORT_PATH = 1 << 1;
@@ -137,6 +138,9 @@ bitflags::bitflags! {
         const EXPERIMENTAL_DECORATORS = 1 << 6;
         /// tsconfig `"useDefineForClassFields": false` was set explicitly.
         const SET_SEMANTICS_FOR_CLASS_FIELDS = 1 << 7;
+        // Bits 8..=9 mirror [`TSUnusedImportFlags`]; write via `set_unused_import_flags_ts`.
+        const TS_KEEP_UNUSED_IMPORT_STMT = 1 << 8;
+        const TS_KEEP_UNUSED_IMPORT_VALUES = 1 << 9;
     }
 }
 
@@ -214,6 +218,30 @@ impl ResultFlags {
     #[inline]
     pub(crate) fn set_use_define_for_class_fields(&mut self, v: bool) {
         self.set(Self::SET_SEMANTICS_FOR_CLASS_FIELDS, !v)
+    }
+    #[inline]
+    pub fn unused_import_flags_ts(self) -> TSUnusedImportFlags {
+        let mut flags = TSUnusedImportFlags::empty();
+        flags.set(
+            TSUnusedImportFlags::KEEP_STMT,
+            self.contains(Self::TS_KEEP_UNUSED_IMPORT_STMT),
+        );
+        flags.set(
+            TSUnusedImportFlags::KEEP_VALUES,
+            self.contains(Self::TS_KEEP_UNUSED_IMPORT_VALUES),
+        );
+        flags
+    }
+    #[inline]
+    pub(crate) fn set_unused_import_flags_ts(&mut self, flags: TSUnusedImportFlags) {
+        self.set(
+            Self::TS_KEEP_UNUSED_IMPORT_STMT,
+            flags.contains(TSUnusedImportFlags::KEEP_STMT),
+        );
+        self.set(
+            Self::TS_KEEP_UNUSED_IMPORT_VALUES,
+            flags.contains(TSUnusedImportFlags::KEEP_VALUES),
+        );
     }
 }
 

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -1,6 +1,7 @@
 use bun_collections::ArrayHashMap;
 use bun_core::strings;
 use bun_js_parser::lexer as js_lexer;
+use bun_options_types::TSUnusedImportFlags;
 use bun_parsers::json_parser;
 use enumset::{EnumSet, EnumSetType};
 
@@ -157,7 +158,12 @@ pub struct TSConfigJSON {
     pub jsx: options::jsx::Pragma,
     pub(crate) jsx_flags: JsxFieldSet,
 
+    /// `None` = unset. `Some(true)` for `"preserve"` and `"error"`.
     pub(crate) preserve_imports_not_used_as_values: Option<bool>,
+    /// `None` = unset.
+    pub(crate) preserve_value_imports: Option<bool>,
+    /// `None` = unset.
+    pub(crate) verbatim_module_syntax: Option<bool>,
 
     pub emit_decorator_metadata: bool,
     pub experimental_decorators: bool,
@@ -175,7 +181,9 @@ impl Default for TSConfigJSON {
             paths: PathsMap::default(),
             jsx: options::jsx::Pragma::default(),
             jsx_flags: JsxFieldSet::empty(),
-            preserve_imports_not_used_as_values: Some(false),
+            preserve_imports_not_used_as_values: None,
+            preserve_value_imports: None,
+            verbatim_module_syntax: None,
             emit_decorator_metadata: false,
             experimental_decorators: false,
             use_define_for_class_fields: None,
@@ -250,6 +258,24 @@ impl TSConfigJSON {
         }
 
         out
+    }
+
+    /// Folds `verbatimModuleSyntax`, `preserveValueImports` and
+    /// `importsNotUsedAsValues` into the two flags the parser acts on.
+    /// `verbatimModuleSyntax` implies both; the other two are the deprecated
+    /// settings it replaced, one per flag.
+    pub fn unused_import_flags(&self) -> TSUnusedImportFlags {
+        if self.verbatim_module_syntax == Some(true) {
+            return TSUnusedImportFlags::KEEP_STMT | TSUnusedImportFlags::KEEP_VALUES;
+        }
+        let mut flags = TSUnusedImportFlags::empty();
+        if self.preserve_value_imports == Some(true) {
+            flags |= TSUnusedImportFlags::KEEP_VALUES;
+        }
+        if self.preserve_imports_not_used_as_values == Some(true) {
+            flags |= TSUnusedImportFlags::KEEP_STMT;
+        }
+        flags
     }
 
     /// Support ${configDir}, but avoid allocating when possible.
@@ -380,6 +406,8 @@ impl TSConfigJSON {
             let mut jsx_v: Option<&bun_ast::E::JsonValue> = None;
             let mut jsx_import_source_v: Option<&bun_ast::E::JsonValue> = None;
             let mut imports_not_used_v: Option<(&bun_ast::E::JsonValue, bun_ast::Loc)> = None;
+            let mut preserve_value_imports_v: Option<&bun_ast::E::JsonValue> = None;
+            let mut verbatim_module_syntax_v: Option<&bun_ast::E::JsonValue> = None;
             let mut module_suffixes_v: Option<(&bun_ast::E::JsonValue, bun_ast::Loc)> = None;
             let mut paths_v: Option<&bun_ast::E::JsonValue> = None;
 
@@ -410,6 +438,12 @@ impl TSConfigJSON {
                         }
                         b"importsNotUsedAsValues" if imports_not_used_v.is_none() => {
                             imports_not_used_v = Some((value, loc))
+                        }
+                        b"preserveValueImports" if preserve_value_imports_v.is_none() => {
+                            preserve_value_imports_v = Some(value)
+                        }
+                        b"verbatimModuleSyntax" if verbatim_module_syntax_v.is_none() => {
+                            verbatim_module_syntax_v = Some(value)
                         }
                         b"moduleSuffixes" if module_suffixes_v.is_none() => {
                             module_suffixes_v = Some((value, loc))
@@ -519,7 +553,9 @@ impl TSConfigJSON {
                         ImportsNotUsedAsValue::Preserve | ImportsNotUsedAsValue::Err => {
                             result.preserve_imports_not_used_as_values = Some(true);
                         }
-                        ImportsNotUsedAsValue::Remove => {}
+                        ImportsNotUsedAsValue::Remove => {
+                            result.preserve_imports_not_used_as_values = Some(false);
+                        }
                         _ => {
                             let _ = log.add_range_warning_fmt(
                                 Some(source),
@@ -532,6 +568,16 @@ impl TSConfigJSON {
                         }
                     }
                 }
+            }
+
+            // Parse "preserveValueImports"
+            if let Some(&bun_ast::E::JsonValue::Boolean(val)) = preserve_value_imports_v {
+                result.preserve_value_imports = Some(val);
+            }
+
+            // Parse "verbatimModuleSyntax"
+            if let Some(&bun_ast::E::JsonValue::Boolean(val)) = verbatim_module_syntax_v {
+                result.verbatim_module_syntax = Some(val);
             }
 
             if let Some((prefixes, loc)) = module_suffixes_v {

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -780,6 +780,9 @@ impl TransformTask {
             use_define_for_class_fields: tsconfig
                 .and_then(|ts| ts.use_define_for_class_fields)
                 .unwrap_or(true),
+            unused_import_flags_ts: tsconfig
+                .map(|ts| ts.unused_import_flags())
+                .unwrap_or_default(),
             macro_js_ctx: MacroJSCtx::ZERO,
             file_fd_ptr: None,
             inject_jest_globals: false,
@@ -1244,6 +1247,11 @@ impl JSTranspiler {
                 .as_deref()
                 .and_then(|ts| ts.use_define_for_class_fields)
                 .unwrap_or(true),
+            unused_import_flags_ts: config
+                .tsconfig
+                .as_deref()
+                .map(|ts| ts.unused_import_flags())
+                .unwrap_or_default(),
             file_fd_ptr: None,
             inject_jest_globals: false,
             set_breakpoint_on_first_line: false,
@@ -1669,6 +1677,13 @@ impl JSTranspiler {
         };
 
         let mut opts = bun_js_parser::ParserOptions::init(jsx, loader);
+        opts.unused_import_flags_ts = self
+            .config
+            .get()
+            .tsconfig
+            .as_deref()
+            .map(|ts| ts.unused_import_flags())
+            .unwrap_or_default();
         // SAFETY: see `transpiler_mut`. The `&mut Transpiler` is reborrowed
         // disjointly for `macro_context` (stored in `opts`) and `options.define`
         // (raw-addr read) below; both end when `opts` is consumed by `scan()`.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2642,6 +2642,10 @@ fn transpile_source_code_inner(
                     use_define_for_class_fields: unsafe {
                         (*jsc_vm).transpiler.options.use_define_for_class_fields
                     },
+                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                    unused_import_flags_ts: unsafe {
+                        (*jsc_vm).transpiler.options.unused_import_flags_ts
+                    },
                     virtual_source,
                     dont_bundle_twice: true,
                     allow_commonjs: true,

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -787,6 +787,149 @@ describe("bundler", () => {
       api.expectFile("/Users/user/project/out.js").toContain(`React.createElement`);
     },
   });
+  itBundled("tsconfig/ImportsNotUsedAsValuesPreserve", {
+    files: {
+      "/Users/user/project/src/entry.ts": /* ts */ `
+        import {x, y} from "./foo"
+        import z from "./foo"
+        import * as ns from "./foo"
+        console.log(1 as x, 2 as z, 3 as ns.y)
+      `,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+        "compilerOptions": {
+          "importsNotUsedAsValues": "preserve"
+        }
+      }
+      `,
+    },
+    bundling: false,
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toBe(`import"./foo";
+import"./foo";
+import"./foo";
+console.log(1, 2, 3);
+`);
+    },
+  });
+  const preserveValueImportsEntry = /* ts */ `
+    import {} from "a"
+    import {b1} from "b"
+    import {c1, type c2} from "c"
+    import {d1, d2, type d3} from "d"
+    import {type e1, type e2} from "e"
+    import f1, {} from "f"
+    import g1, {g2} from "g"
+    import h1, {type h2} from "h"
+    import * as i1 from "i"
+    import "j"
+  `;
+  const keepStmtAndValuesOutput = `import {} from "a";
+import { b1 } from "b";
+import { c1 } from "c";
+import { d1, d2 } from "d";
+import {} from "e";
+import f1, {} from "f";
+import g1, { g2 } from "g";
+import h1, {} from "h";
+import * as i1 from "i";
+import"j";
+`;
+  itBundled("tsconfig/PreserveValueImports", {
+    files: {
+      "/Users/user/project/src/entry.ts": preserveValueImportsEntry,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+        "compilerOptions": {
+          "preserveValueImports": true
+        }
+      }
+      `,
+    },
+    bundling: false,
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toBe(`import { b1 } from "b";
+import { c1 } from "c";
+import { d1, d2 } from "d";
+import f1 from "f";
+import g1, { g2 } from "g";
+import h1 from "h";
+import * as i1 from "i";
+import"j";
+`);
+    },
+  });
+  itBundled("tsconfig/PreserveValueImportsAndImportsNotUsedAsValuesPreserve", {
+    files: {
+      "/Users/user/project/src/entry.ts": preserveValueImportsEntry,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+        "compilerOptions": {
+          "importsNotUsedAsValues": "preserve",
+          "preserveValueImports": true
+        }
+      }
+      `,
+    },
+    bundling: false,
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toBe(keepStmtAndValuesOutput);
+    },
+  });
+  itBundled("tsconfig/VerbatimModuleSyntax", {
+    files: {
+      "/Users/user/project/src/entry.ts": preserveValueImportsEntry,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+        "compilerOptions": {
+          "verbatimModuleSyntax": true
+        }
+      }
+      `,
+    },
+    bundling: false,
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toBe(keepStmtAndValuesOutput);
+    },
+  });
+  // tsc keeps `import { unused }` as written and turns `import { type T }` into
+  // `import {} from`, so both modules run. Only `import type` is erased.
+  itBundled("tsconfig/VerbatimModuleSyntaxBundle", {
+    files: {
+      "/Users/user/project/src/entry.ts": /* ts */ `
+        import { unused } from "./side-effect"
+        import { type T } from "./inline-type"
+        import type { U } from "./erased"
+        console.log("entry")
+      `,
+      "/Users/user/project/src/side-effect.ts": /* ts */ `
+        console.log("side effect")
+        export const unused = 1
+      `,
+      "/Users/user/project/src/inline-type.ts": /* ts */ `
+        console.log("inline type")
+        export type T = number
+      `,
+      "/Users/user/project/src/erased.ts": /* ts */ `
+        console.log("erased")
+        export type U = number
+      `,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+        "compilerOptions": {
+          "verbatimModuleSyntax": true
+        }
+      }
+      `,
+    },
+    run: {
+      stdout: "side effect\ninline type\nentry",
+    },
+  });
   return;
   itBundled("tsconfig/PathsTypeOnly", {
     // GENERATED
@@ -1264,82 +1407,6 @@ describe("bundler", () => {
       `,
     },
     outfile: "/Users/user/project/out.js",
-  });
-  itBundled("tsconfig/ImportsNotUsedAsValuesPreserve", {
-    // GENERATED
-    files: {
-      "/Users/user/project/src/entry.ts": /* ts */ `
-        import {x, y} from "./foo"
-        import z from "./foo"
-        import * as ns from "./foo"
-        console.log(1 as x, 2 as z, 3 as ns.y)
-      `,
-      "/Users/user/project/src/tsconfig.json": /* json */ `
-        {
-        "compilerOptions": {
-          "importsNotUsedAsValues": "preserve"
-        }
-      }
-      `,
-    },
-    format: "esm",
-    outfile: "/Users/user/project/out.js",
-    mode: "convertformat",
-  });
-  itBundled("tsconfig/PreserveValueImports", {
-    // GENERATED
-    files: {
-      "/Users/user/project/src/entry.ts": /* ts */ `
-        import {} from "a"
-        import {b1} from "b"
-        import {c1, type c2} from "c"
-        import {d1, d2, type d3} from "d"
-        import {type e1, type e2} from "e"
-        import f1, {} from "f"
-        import g1, {g2} from "g"
-        import h1, {type h2} from "h"
-        import * as i1 from "i"
-        import "j"
-      `,
-      "/Users/user/project/src/tsconfig.json": /* json */ `
-        {
-        "compilerOptions": {
-          "preserveValueImports": true
-        }
-      }
-      `,
-    },
-    format: "esm",
-    outfile: "/Users/user/project/out.js",
-    mode: "convertformat",
-  });
-  itBundled("tsconfig/PreserveValueImportsAndImportsNotUsedAsValuesPreserve", {
-    // GENERATED
-    files: {
-      "/Users/user/project/src/entry.ts": /* ts */ `
-        import {} from "a"
-        import {b1} from "b"
-        import {c1, type c2} from "c"
-        import {d1, d2, type d3} from "d"
-        import {type e1, type e2} from "e"
-        import f1, {} from "f"
-        import g1, {g2} from "g"
-        import h1, {type h2} from "h"
-        import * as i1 from "i"
-        import "j"
-      `,
-      "/Users/user/project/src/tsconfig.json": /* json */ `
-        {
-        "compilerOptions": {
-          "importsNotUsedAsValues": "preserve",
-          "preserveValueImports": true
-        }
-      }
-      `,
-    },
-    format: "esm",
-    outfile: "/Users/user/project/out.js",
-    mode: "convertformat",
   });
   itBundled("tsconfig/Target", {
     // GENERATED

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3436,6 +3436,40 @@ console.log(resolve.length)
     );
   });
 
+  it("type only imports", () => {
+    const exp = ts.expectPrinted_;
+    // `import { type ... }` grammar, matching esbuild's parseImportClause table.
+    exp("import { type Foo } from 'mod'", "");
+    exp("import { type Foo as Bar } from 'mod'; Bar", "Bar");
+    exp("import { type if as yy } from 'mod'; yy", "yy");
+    exp("import { type 'xx' as yy } from 'mod'; yy", "yy");
+    exp("import { type } from 'mod'; type", 'import { type } from "mod";\ntype');
+    exp("import { type, as } from 'mod'; type; as", 'import { type, as } from "mod";\ntype;\nas');
+    // Type-only import of a binding named `as`.
+    exp("import { type as } from 'mod'", "");
+    exp("import { type as as foo } from 'mod'; foo", "foo");
+    exp("import { type as as as } from 'mod'; as", "as");
+    // Value import of a binding named `type`.
+    exp("import { type as xxx } from 'mod'; xxx", 'import { type as xxx } from "mod";\nxxx');
+    exp("import { type as as } from 'mod'; as", 'import { type as as } from "mod";\nas');
+    exp("import { \\u0074ype Foo, Bar } from 'mod'; Bar", 'import { Bar } from "mod";\nBar');
+
+    // A clause with no value bindings is type-only, like tsc treats it.
+    exp("import {} from 'mod'", "");
+    exp("import {} from 'mod'; x", "x");
+    exp("import d, {} from 'mod'; d", 'import d from "mod";\nd');
+    exp("import d, { type T } from 'mod'; d", 'import d from "mod";\nd');
+    exp("export {} from 'mod'", "");
+    exp("export { type Foo } from 'mod'", "");
+    // Unlike `import {} from 'mod'`, a bare import always runs for its side effects.
+    exp("import 'mod'", 'import"mod"');
+
+    // JavaScript has no type-only imports; the empty clause is printed as written.
+    const js = new Bun.Transpiler({ loader: "js" });
+    expect(js.transformSync("import {} from 'mod'")).toBe('import {} from "mod";\n');
+    expect(js.transformSync("import d, {} from 'mod'; d")).toBe('import d, {} from "mod";\nd;\n');
+  });
+
   it("type only exports", () => {
     let { expectPrinted_, expectParseError } = ts;
     expectPrinted_("export type {foo, bar as baz} from 'bar'", "");

--- a/test/bundler/transpiler/ts-unused-imports.test.ts
+++ b/test/bundler/transpiler/ts-unused-imports.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// TypeScript removes an import whose bindings are only used as types. Three
+// tsconfig settings change that: `verbatimModuleSyntax`, `preserveValueImports`
+// and `importsNotUsedAsValues: "preserve"`. Like esbuild, Bun folds them into
+// two behaviors: keep unused value bindings, and keep the statement (as a bare
+// import) once every binding is gone. `verbatimModuleSyntax` does both.
+
+const fixture = {
+  "b.ts": `
+    console.log("b side effect");
+    export const unused = 1;
+    export const used = 2;
+  `,
+  "uv.ts": `
+    console.log("uv side effect");
+    export type T = number;
+    export const v = 3;
+  `,
+  "entry.ts": `
+    import { unused } from "./b";
+    import { type T, v } from "./uv";
+    import * as ns from "./b";
+    console.log("a");
+  `,
+};
+
+const entrySource = fixture["entry.ts"];
+
+const keepValuesOutput = `import { unused } from "./b";
+import { v } from "./uv";
+import * as ns from "./b";
+console.log("a");
+`;
+
+const keepStmtOutput = `import"./b";
+import"./uv";
+import"./b";
+console.log("a");
+`;
+
+const settings = [
+  {
+    name: "verbatimModuleSyntax",
+    compilerOptions: { verbatimModuleSyntax: true },
+    transformed: keepValuesOutput,
+  },
+  {
+    name: "preserveValueImports",
+    compilerOptions: { preserveValueImports: true },
+    transformed: keepValuesOutput,
+  },
+  {
+    name: 'importsNotUsedAsValues: "preserve"',
+    compilerOptions: { importsNotUsedAsValues: "preserve" },
+    transformed: keepStmtOutput,
+  },
+];
+
+async function spawnBun(cwd: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
+    cwd,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.each(settings)("tsconfig $name", ({ compilerOptions, transformed }) => {
+  const tsconfig = JSON.stringify({ compilerOptions });
+
+  test.concurrent("bun run evaluates the imported modules", async () => {
+    using dir = tempDir("ts-unused-imports-run", { ...fixture, "tsconfig.json": tsconfig });
+    const { stdout, stderr, exitCode } = await spawnBun(String(dir), "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("b side effect\nuv side effect\na\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bun build includes the imported modules", async () => {
+    using dir = tempDir("ts-unused-imports-bundle", { ...fixture, "tsconfig.json": tsconfig });
+    const { stdout, stderr, exitCode } = await spawnBun(String(dir), "build", "--minify-whitespace", "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toBe('console.log("b side effect");console.log("uv side effect");console.log("a");\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bun build --no-bundle keeps the imports", async () => {
+    using dir = tempDir("ts-unused-imports-no-bundle", { ...fixture, "tsconfig.json": tsconfig });
+    const { stdout, stderr, exitCode } = await spawnBun(String(dir), "build", "--no-bundle", "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toBe(transformed);
+    expect(exitCode).toBe(0);
+  });
+
+  test("Bun.Transpiler keeps the imports", () => {
+    const transpiler = new Bun.Transpiler({ loader: "ts", trimUnusedImports: true, tsconfig });
+    expect(transpiler.transformSync(entrySource)).toBe(transformed);
+    expect(transpiler.scanImports(entrySource)).toEqual([
+      { kind: "import-statement", path: "./b" },
+      { kind: "import-statement", path: "./uv" },
+      { kind: "import-statement", path: "./b" },
+    ]);
+  });
+
+  test.concurrent("the setting is inherited through extends", async () => {
+    using dir = tempDir("ts-unused-imports-extends", {
+      ...fixture,
+      "base.json": tsconfig,
+      // No "compilerOptions" key at all: the value must come from the parent.
+      "tsconfig.json": JSON.stringify({ extends: "./base.json" }),
+    });
+    const { stdout, stderr, exitCode } = await spawnBun(String(dir), "build", "--no-bundle", "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toBe(transformed);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a child tsconfig can turn the setting off again", async () => {
+    const off = Object.fromEntries(
+      Object.entries(compilerOptions).map(([key, value]) => [key, value === true ? false : "remove"]),
+    );
+    using dir = tempDir("ts-unused-imports-extends-off", {
+      ...fixture,
+      "base.json": tsconfig,
+      "tsconfig.json": JSON.stringify({ extends: "./base.json", compilerOptions: off }),
+    });
+    const { stdout, stderr, exitCode } = await spawnBun(String(dir), "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("a\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+// The four rows of esbuild's TSUnusedImportFlags table (internal/config/config.go).
+describe("Bun.Transpiler unused import table", () => {
+  const inputs = [
+    "import 'foo'",
+    "import * as unused from 'foo'",
+    "import { unused } from 'foo'",
+    "import { type unused } from 'foo'",
+  ];
+  const bare = 'import"foo";\n';
+  const star = 'import * as unused from "foo";\n';
+  const named = 'import { unused } from "foo";\n';
+  const empty = 'import {} from "foo";\n';
+
+  test.each([
+    [{}, [bare, "", "", ""]],
+    [{ importsNotUsedAsValues: "preserve" }, [bare, bare, bare, bare]],
+    [{ importsNotUsedAsValues: "error" }, [bare, bare, bare, bare]],
+    [{ preserveValueImports: true }, [bare, star, named, ""]],
+    [{ importsNotUsedAsValues: "preserve", preserveValueImports: true }, [bare, star, named, empty]],
+    [{ verbatimModuleSyntax: true }, [bare, star, named, empty]],
+  ])("%j", (compilerOptions, expected) => {
+    const transpiler = new Bun.Transpiler({
+      loader: "ts",
+      trimUnusedImports: true,
+      tsconfig: JSON.stringify({ compilerOptions }),
+    });
+    expect(inputs.map(input => transpiler.transformSync(input))).toEqual(expected);
+  });
+});
+
+describe("without a tsconfig setting", () => {
+  test.concurrent("bun run drops imports that are unused as values", async () => {
+    using dir = tempDir("ts-unused-imports-default", {
+      ...fixture,
+      "tsconfig.json": JSON.stringify({ compilerOptions: { importsNotUsedAsValues: "remove" } }),
+    });
+    const { stdout, stderr, exitCode } = await spawnBun(String(dir), "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("a\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // tsc treats a clause with no value bindings as type-only, so the module
+  // is not evaluated. `import 'x'` (no clause) still is.
+  test.concurrent("bun run drops an empty import clause like tsc does", async () => {
+    using dir = tempDir("ts-unused-imports-empty-clause", {
+      ...fixture,
+      "entry.ts": `
+        import {} from "./b";
+        import { type as } from "./uv";
+        export {} from "./uv";
+        console.log("a");
+      `,
+    });
+    const { stdout, stderr, exitCode } = await spawnBun(String(dir), "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("a\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("verbatimModuleSyntax keeps an empty import clause", async () => {
+    using dir = tempDir("ts-unused-imports-empty-clause-verbatim", {
+      ...fixture,
+      "tsconfig.json": JSON.stringify({ compilerOptions: { verbatimModuleSyntax: true } }),
+      "entry.ts": `
+        import {} from "./b";
+        import { type as } from "./uv";
+        export {} from "./uv";
+        console.log("a");
+      `,
+    });
+    const run = await spawnBun(String(dir), "entry.ts");
+    expect(run.stderr).toBe("");
+    expect(run.stdout).toBe("b side effect\nuv side effect\na\n");
+    expect(run.exitCode).toBe(0);
+
+    const build = await spawnBun(String(dir), "build", "--no-bundle", "entry.ts");
+    expect(build.stderr).toBe("");
+    expect(build.stdout).toBe(`import {} from "./b";
+import {} from "./uv";
+export {} from "./uv";
+console.log("a");
+`);
+    expect(build.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- The TypeScript parser ignores `verbatimModuleSyntax`, `preserveValueImports` and `importsNotUsedAsValues: "preserve"`. `TSConfigJSON` parses only the last one, and nothing feeds it to the parser: `preserve_unused_imports_ts` is `false` at every construction site. So `import { unused } from "./b"` is removed in `bun run`, `bun build`, `--no-bundle` and `Bun.Transpiler`, and `./b` never runs where tsc runs it. The `extends` merge also reset an inherited `"preserve"`, because the child's default was `Some(false)`.
- The opposite mistake too: `import {} from "x"` and `import { type as } from "x"` are type-only for tsc, but Bun kept them as `import "x"`. `scan_imports.rs` tested `!items.is_empty()`, so an empty clause looked like a bare import, and `parse_import_clause` neither pushed an item nor flagged `{ type as }` as type-only.

### Fix
- Port esbuild's shape. `TSUnusedImportFlags { KEEP_STMT, KEEP_VALUES }` (`src/options_types/bundle_enums.rs`) is computed by `TSConfigJSON::unused_import_flags()`: `verbatimModuleSyntax` sets both, `preserveValueImports` sets `KEEP_VALUES`, `"preserve"`/`"error"` set `KEEP_STMT`. The three settings are `Option<bool>` so `extends` merges each one only when the child sets it.
- The flags travel through `ResultFlags` (resolver), `ParseTask`, `ParseOptions` and `BundleOptions` to the parser's `unused_import_flags_ts`, so all four entry points read them. They take part in the runtime transpiler cache hash, and the cache version is bumped.
- `S::Import.has_items_clause` records that the source had a `{ ... }` clause. In TypeScript an empty clause is dropped unless `KEEP_STMT` is set (`parse_stmt.rs`), counts as "found imports" in `scan_imports.rs`, and prints as `import {} from "x"` when kept. `parse_import_clause` follows esbuild's `type as` grammar table.
- Verified: `test/bundler/transpiler/ts-unused-imports.test.ts` (the matrix: bun run, bun build, --no-bundle, Bun.Transpiler, extends, each setting), `test/bundler/esbuild/tsconfig.test.ts` (esbuild's own fixtures, now asserted), `test/bundler/transpiler/transpiler.test.js` (grammar). Also ran `test/bundler/esbuild/{ts,importstar_ts,default}.test.ts`, `test/bundler/transpiler/`, `test/js/bun/typescript/`, `test/js/bun/resolve/`, `test/bundler/bundler_{edgecase,regressions,minify,jsx}.test.ts`, `test/bake/dev/{esm,bundle}.test.ts`, `test/cli/run/transpiler-cache.test.ts`.

### Background
- tsc removes an import whose bindings are never used as values, because they may be types. `verbatimModuleSyntax` (the TS 5 default, also in `bun init`'s tsconfig) turns that off: only `import type` and `type` specifiers are erased. `import { type T } from "x"` becomes `import {} from "x"` and still evaluates `x`.
- `preserveValueImports` and `importsNotUsedAsValues` are the older, now deprecated, halves of that: keep the bindings, or keep the statement (as a bare import) once every binding is gone.
- `scan_imports.rs` runs after the visit pass, when symbol use counts and `ts_use_counts` (uses that count for TypeScript) are known. Like esbuild, it skips trimming entirely under `KEEP_VALUES` unless bundling or minifying identifiers, where the linker would otherwise error on bindings that do not exist.
- Behavior change to be aware of: in a project with `verbatimModuleSyntax: true`, `import { SomeType } from "./x"` without `type` is now kept and fails at runtime. tsc reports that code as TS1484, so it was already a type error.

<details><summary>Notes</summary>

Outputs per setting for the repro (`c.ts`: `import { unused } from "./b"; import { type T, v } from "./uv"; import * as ns from "./b"; console.log("a")`):

- `verbatimModuleSyntax` / `preserveValueImports`, `--no-bundle`: `import { unused } from "./b"; import { v } from "./uv"; import * as ns from "./b";`
- `importsNotUsedAsValues: "preserve"`, `--no-bundle`: `import"./b"; import"./uv"; import"./b";`
- all three, `bun run` and `bun build`: `b side effect`, `uv side effect`, `a`.
- no setting: `console.log("a")` only, and `e.ts` (`import {} from "remove1"; import { type Foo } from "b1"; import { type as } from "b2"; export {}`) prints `export {};`.

A differential run of 23 import forms through `Bun.Transpiler` and esbuild 0.21.5 (`--tsconfig-raw`) across none / preserve / preserveValueImports / both / verbatim agrees on every form. The only textual difference is esbuild's `--format=esm` linker rewriting `export {} from "x"` as `import {} from "x"`; in pass-through mode esbuild prints `export {} from "x"` as Bun does.

Other details:

- `export {} from "x"` in TypeScript is now dropped like `export { type Foo } from "x"` (tsc and esbuild drop both). `export { type Foo }` without `from` is unchanged.
- `Bun.Transpiler.scanImports` gets the same flags, and the scan-only pass no longer marks statements unused when any flag is set.
- `ResultFlags` grows from `u8` to `u16` for the two new bits.
- The `import {} from "x"` printer form only applies when `has_items_clause` is set and `items` is empty. In JavaScript the clause is printed as written.
- The runtime transpiler cache version goes from 27 to 28 so cached output of `import {} from "x"` in TypeScript is not reused.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 27 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/tsconfig.test.ts test/bundler/transpiler/transpiler.test.js test/bundler/transpiler/ts-unused-imports.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/4] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/4] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_A
... (truncated)

release without fix: 33 failed, 25 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.10ms]
(pass) Bun.Transpiler > normalizes \r\n [0.16ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.15ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.04ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.57ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.27ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [8.82ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.56ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.08ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 25 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/tsconfig.test.ts test/bundler/transpiler/transpiler.test.js test/bundler/transpiler/ts-unused-imports.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.37ms]
(pass) Bun.Transpiler > normalizes \r\n [6.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.73ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.51ms]
(pass) Bun.Transpiler > property access inlining > works [2.79ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.82ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [50.01ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [22.98ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal i
... (truncated)

release with fix: 25 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8f10198eca
  features     baseline

23 deps, 131 codegen, 1172 objects in 717ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [22.00ms]
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] gen ErrorCode+*.h
[5/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1216] fetch zlib
[zlib] up to date
[7/1216] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [7.00ms]
[8/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [14.00ms]
[9/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Pro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
Cargo.lock                                        |   1 +
 src/ast/s.rs                                      |   5 +
 src/bundler/ParseTask.rs                          |   5 +
 src/bundler/options.rs                            |   4 +
 src/bundler/transpiler.rs                         |   6 +-
 src/js_parser/lower/lower_esm_exports_hmr.rs      |   1 +
 src/js_parser/p.rs                                |   3 +
 src/js_parser/parse/parse_entry.rs                |  21 +-
 src/js_parser/parse/parse_import_export.rs        |  17 +-
 src/js_parser/parse/parse_stmt.rs                 |  52 ++++-
 src/js_parser/parser.rs                           |   1 -
 src/js_parser/scan/scan_imports.rs                |  71 ++++---
 src/js_printer/lib.rs                             |  59 +++---
 src/jsc/RuntimeTranspilerCache.rs                 |   5 +-
 src/jsc/RuntimeTranspilerStore.rs                 |   1 +
 src/options_types/Cargo.toml                      |   1 +
 src/options_types/bundle_enums.rs                 |  22 +++
 src/options_types/lib.rs                          |   2 +-
 src/react_compiler/imports.rs                     |   1 +
 src/resolver/resolver.rs                          |   9 +
 src/resolver/result.rs                            |  30 ++-
 src/resolver/tsconfig_json.rs                     |  50 ++++-
 src/runtime/api/JSTranspiler.rs                   |  15 ++
 src/runtime/jsc_hooks.rs                          |   4 +
 test/bundler/esbuild/tsconfig.test.ts             | 219 +++++++++++++--------
 test/bundler/transpiler/transpiler.test.js        |  34 ++++
 test/bundler/transpiler/ts-unused-imports.test.ts | 223 ++++++++++++++++++++++
 27 files changed, 690 insertions(+), 172 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
Cargo.lock                                        0      0      0
src/ast/s.rs                                      1      1      0
src/bundler/ParseTask.rs                          0      0      0
src/bundler/options.rs                            0      0      0
src/bundler/transpiler.rs                         0      0      0
src/js_parser/lower/lower_esm_exports_hmr.rs      0      0      0
src/js_parser/p.rs                                0      0      0
src/js_parser/parse/parse_entry.rs                4      4      0
src/js_parser/parse/parse_import_export.rs        3      5      0
src/js_parser/parse/parse_stmt.rs                 3      7      0
src/js_parser/parser.rs                           1      1      0
src/js_parser/scan/scan_imports.rs                2      7      0
src/js_printer/lib.rs                             3      3      0
src/jsc/RuntimeTranspilerCache.rs                 1      2      0
src/jsc/RuntimeTranspilerStore.rs                 0      0      0
src/options_types/Cargo.toml                      0      0      0
(+ 11 more files)
```

</details>

<!-- robobun:evidence:end -->