### PR TITLE
resolver: resolve tsconfig extends like tsc (packages, exports, arrays, configDir)

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -724,8 +724,12 @@ impl<'a> Transpiler<'a> {
                     if self.options.transform_options.jsx.is_none() {
                         self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx);
                     }
-                    self.options.emit_decorator_metadata = tsconfig.emit_decorator_metadata;
-                    self.options.experimental_decorators = tsconfig.experimental_decorators;
+                    if let Some(v) = tsconfig.emit_decorator_metadata {
+                        self.options.emit_decorator_metadata = v;
+                    }
+                    if let Some(v) = tsconfig.experimental_decorators {
+                        self.options.experimental_decorators = v;
+                    }
                     if let Some(v) = tsconfig.use_define_for_class_fields {
                         self.options.use_define_for_class_fields = v;
                     }

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -14,6 +14,10 @@ pub enum Error {
     VersionSpecifierNotAllowedHere,
     #[error("ParseErrorAlreadyLogged")]
     ParseErrorAlreadyLogged,
+    /// A tsconfig.json `extends` chain reached a file that is already being
+    /// parsed higher up the same chain.
+    #[error("ParseErrorImportCycle")]
+    ParseErrorImportCycle,
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
     #[error(transparent)]
@@ -35,6 +39,7 @@ impl Error {
             Self::ModuleNotFound => "ModuleNotFound",
             Self::VersionSpecifierNotAllowedHere => "VersionSpecifierNotAllowedHere",
             Self::ParseErrorAlreadyLogged => "ParseErrorAlreadyLogged",
+            Self::ParseErrorImportCycle => "ParseErrorImportCycle",
             Self::Sys(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
             Self::Core(e) => e.name(),

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -14,8 +14,7 @@ pub enum Error {
     VersionSpecifierNotAllowedHere,
     #[error("ParseErrorAlreadyLogged")]
     ParseErrorAlreadyLogged,
-    /// A tsconfig.json `extends` chain reached a file that is already being
-    /// parsed higher up the same chain.
+    /// A tsconfig.json `extends` chain reached a file it is already parsing.
     #[error("ParseErrorImportCycle")]
     ParseErrorImportCycle,
     #[error(transparent)]

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -114,6 +114,10 @@ pub struct PackageJSON {
 
     pub(crate) exports: Option<ExportsMap>,
     pub(crate) imports: Option<ExportsMap>,
+
+    /// The "tsconfig" field: the config file a tsconfig.json `extends` of this
+    /// package's bare name loads, relative to the package directory.
+    pub(crate) tsconfig: Option<Box<[u8]>>,
 }
 
 // hand-rolled `Default` because `#[derive(Default)]` would zero
@@ -141,6 +145,7 @@ impl Default for PackageJSON {
             browser_map: BrowserMap::default(),
             exports: None,
             imports: None,
+            tsconfig: None,
         }
     }
 }
@@ -502,6 +507,7 @@ impl PackageJSON {
             side_effects: SideEffects::Unspecified,
             exports: None,
             imports: None,
+            tsconfig: None,
         };
         // shadow as `&Source`; the owned value is reconstructed at the bottom
         // (Source isn't `Clone`).
@@ -524,6 +530,14 @@ impl PackageJSON {
             if let Some(name_str) = name_json.expr.as_utf8_string_literal() {
                 if !name_str.is_empty() {
                     package_json.name = Box::from(name_str);
+                }
+            }
+        }
+
+        if let Some(tsconfig_json) = json.as_property(b"tsconfig") {
+            if let Some(tsconfig_str) = tsconfig_json.expr.as_utf8_string_literal() {
+                if !tsconfig_str.is_empty() {
+                    package_json.tsconfig = Some(Box::from(tsconfig_str));
                 }
             }
         }

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -115,8 +115,7 @@ pub struct PackageJSON {
     pub(crate) exports: Option<ExportsMap>,
     pub(crate) imports: Option<ExportsMap>,
 
-    /// The "tsconfig" field: the config file a tsconfig.json `extends` of this
-    /// package's bare name loads, relative to the package directory.
+    /// The "tsconfig" field: the file `extends: "<this package>"` loads.
     pub(crate) tsconfig: Option<Box<[u8]>>,
 }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -258,7 +258,7 @@ use crate::fs as Fs;
 use crate::fs::FilenameStoreAppender;
 use crate::node_fallbacks as NodeFallbackModules;
 use crate::package_json::{BrowserMap, ESModule, PackageJSON};
-use crate::tsconfig_json::TSConfigJSON;
+use crate::tsconfig_json::{TSConfigExtends, TSConfigJSON};
 
 pub use crate::data_url::DataURL;
 pub use crate::dir_info as DirInfo;
@@ -989,7 +989,7 @@ impl<'a> Resolver<'a> {
         let Some(tsconfig) = dir_info.enclosing_tsconfig_json else {
             return MatchStatus::NotFound;
         };
-        if tsconfig.paths.count() == 0 {
+        if !tsconfig.has_paths() {
             return MatchStatus::NotFound;
         }
         self.match_tsconfig_paths(tsconfig, import_path, kind, out)
@@ -1589,10 +1589,12 @@ impl<'a> Resolver<'a> {
             if let Some(tsconfig) = dir.enclosing_tsconfig_json {
                 result.jsx = tsconfig.merge_jsx(core::mem::take(&mut result.jsx));
                 result.flags.set_emit_decorator_metadata(
-                    result.flags.emit_decorator_metadata() || tsconfig.emit_decorator_metadata,
+                    result.flags.emit_decorator_metadata()
+                        || tsconfig.emit_decorator_metadata == Some(true),
                 );
                 result.flags.set_experimental_decorators(
-                    result.flags.experimental_decorators() || tsconfig.experimental_decorators,
+                    result.flags.experimental_decorators()
+                        || tsconfig.experimental_decorators == Some(true),
                 );
                 if let Some(v) = tsconfig.use_define_for_class_fields {
                     result.flags.set_use_define_for_class_fields(v);
@@ -1780,7 +1782,7 @@ impl<'a> Resolver<'a> {
             // First, check path overrides from the nearest enclosing TypeScript "tsconfig.json" file
             if let Ok(Some(dir_info)) = self.dir_info_cached(source_dir) {
                 if let Some(tsconfig) = dir_info.enclosing_tsconfig_json {
-                    if tsconfig.paths.count() > 0 {
+                    if tsconfig.has_paths() {
                         let mut res = MatchResult::default();
                         if self
                             .match_tsconfig_paths(tsconfig, import_path, kind, &mut res)
@@ -2520,7 +2522,7 @@ impl<'a> Resolver<'a> {
 
         if let Some(tsconfig) = dir_info.enclosing_tsconfig_json {
             // Try path substitutions first
-            if tsconfig.paths.count() > 0 {
+            if tsconfig.has_paths() {
                 if self
                     .match_tsconfig_paths(tsconfig, import_path, kind, out)
                     .is_success()
@@ -4016,11 +4018,34 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// Parses `file` and merges in its `extends` chain. The returned config is
+    /// the one `dir_info_uncached` interns for the directory.
     pub(crate) fn parse_tsconfig(
         &mut self,
         file: &[u8],
         dirname_fd: FD,
     ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
+        let mut chain = TSConfigChain {
+            config_dir: Box::default(),
+            visiting: Vec::new(),
+            sources: Vec::new(),
+        };
+        self.parse_tsconfig_in_chain(file, dirname_fd, &mut chain)
+    }
+
+    /// One level of an `extends` chain: parses `file`, resolves and merges each
+    /// of its bases (recursively), then layers the file's own settings on top.
+    /// This is the shape of esbuild's `parseTSConfig`.
+    fn parse_tsconfig_in_chain(
+        &mut self,
+        file: &[u8],
+        dirname_fd: FD,
+        chain: &mut TSConfigChain,
+    ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
+        if chain.visiting.iter().any(|visiting| *visiting == file) {
+            return Err(crate::Error::ParseErrorImportCycle);
+        }
+
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
         let mut entry = self.caches.fs.read_file_with_allocator(
@@ -4060,45 +4085,373 @@ impl<'a> Resolver<'a> {
         };
 
         let source = bun_ast::Source::init_path_string_owned(key_path, contents);
-        let file_dir = source.path.source_dir();
+
+        let is_root = chain.visiting.is_empty();
+        if is_root {
+            chain.config_dir = Box::from(source.path.source_dir());
+        }
+        chain.visiting.push(key_path);
 
         // SAFETY: BACKREF — `self.log` (see `log()` NOTE); disjoint from `self.caches`,
         // narrow `&mut` for this call only.
-        let mut result =
-            match TSConfigJSON::parse(unsafe { &mut *self.log() }, &source, &mut self.caches.json)?
-            {
-                Some(r) => r,
-                None => return Ok(None),
-            };
+        let parsed = TSConfigJSON::parse(
+            unsafe { &mut *self.log() },
+            &source,
+            &mut self.caches.json,
+            &chain.config_dir,
+        );
+        let mut own = match parsed {
+            Ok(Some(own)) => own,
+            Ok(None) => {
+                chain.visiting.pop();
+                return Ok(None);
+            }
+            Err(err) => {
+                chain.visiting.pop();
+                return Err(err);
+            }
+        };
 
-        if result.has_base_url() {
-            // this might leak
-            if !bun_paths::is_absolute(&result.base_url) {
-                // NOTE: `base_url: Box<[u8]>` owns its bytes, so
-                // copy `abs_buf`'s thread-local result directly instead of
-                // double-copying through the `dirname_store` arena.
-                let abs = self
+        let extends = core::mem::take(&mut own.extends);
+        let merged = self.merge_tsconfig_extends(&source, own, &extends, chain);
+        chain.visiting.pop();
+        let mut result = merged?;
+
+        // A relative "baseUrl" resolves against the file that declares it. An
+        // inherited one is already absolute.
+        if result.has_base_url() && !bun_paths::is_absolute(&result.base_url) {
+            // NOTE: `base_url: Box<[u8]>` owns its bytes, so
+            // copy `abs_buf`'s thread-local result directly instead of
+            // double-copying through the `dirname_store` arena.
+            let abs = self.fs_ref().abs_buf(
+                &[source.path.source_dir(), &result.base_url[..]],
+                bufs!(tsconfig_base_url),
+            );
+            result.base_url = Box::from(abs);
+        }
+
+        // Kept until the root returns: the check below needs the source of
+        // whichever file in the chain declared "paths".
+        chain.sources.push(source);
+
+        if is_root {
+            let paths_source = result.paths.as_ref().and_then(|paths| {
+                chain
+                    .sources
+                    .iter()
+                    .find(|s| s.path.text == &*paths.source_path)
+            });
+            // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call only.
+            result.remove_paths_that_need_base_url(unsafe { &mut *self.log() }, paths_source);
+        }
+
+        Ok(Some(result))
+    }
+
+    /// Bases apply in `extends` order, so a later one overrides an earlier one,
+    /// and the file's own settings override every base.
+    fn merge_tsconfig_extends(
+        &mut self,
+        source: &bun_ast::Source,
+        own: Box<TSConfigJSON>,
+        extends: &[TSConfigExtends],
+        chain: &mut TSConfigChain,
+    ) -> crate::CrateResult<Box<TSConfigJSON>> {
+        if extends.is_empty() {
+            return Ok(own);
+        }
+        let mut merged = TSConfigJSON::new(TSConfigJSON {
+            abs_path: own.abs_path.clone(),
+            ..Default::default()
+        });
+        for extends_entry in extends {
+            if let Some(base) = self.resolve_tsconfig_extends(source, extends_entry, chain)? {
+                merged.apply_extended_config(base);
+            }
+        }
+        merged.apply_extended_config(own);
+        Ok(merged)
+    }
+
+    /// Finds and parses one `extends` entry of `source` the way tsc's
+    /// `getExtendsConfigPath` does: a relative or absolute path is tried as
+    /// written and then with ".json" added, anything else is a package
+    /// specifier looked up in the `node_modules` of each ancestor directory.
+    /// `None` means the base is unusable, and the reason is already logged.
+    fn resolve_tsconfig_extends(
+        &mut self,
+        source: &bun_ast::Source,
+        extends: &TSConfigExtends,
+        chain: &mut TSConfigChain,
+    ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
+        let spec: &[u8] = &extends.spec;
+        if !spec.is_empty() {
+            if bun_paths::is_package_path(spec) {
+                match self.resolve_tsconfig_extends_package(source, extends, chain)? {
+                    TSConfigProbe::Found(base) => return Ok(Some(base)),
+                    TSConfigProbe::Failed => return Ok(None),
+                    // Bun used to resolve every `extends` value against the
+                    // file's directory, so a bare sibling name ("base.json")
+                    // keeps working through the fallback below.
+                    TSConfigProbe::Missing => {}
+                }
+            }
+            match self.resolve_tsconfig_extends_relative(source, extends, chain)? {
+                TSConfigProbe::Found(base) => return Ok(Some(base)),
+                TSConfigProbe::Failed => return Ok(None),
+                TSConfigProbe::Missing => {}
+            }
+        }
+        self.warn_missing_tsconfig_base(source, extends);
+        Ok(None)
+    }
+
+    /// The path arm of [`Self::resolve_tsconfig_extends`]: the value as written,
+    /// relative to the file, then with ".json" added.
+    fn resolve_tsconfig_extends_relative(
+        &mut self,
+        source: &bun_ast::Source,
+        extends: &TSConfigExtends,
+        chain: &mut TSConfigChain,
+    ) -> crate::CrateResult<TSConfigProbe> {
+        let spec: &[u8] = &extends.spec;
+        let file_dir = source.path.source_dir();
+        let mut buf = bun_paths::path_buffer_pool::get();
+        // "." and ".." name a directory, and TypeScript reads its tsconfig.json.
+        let extends_file: &[u8] = if spec == b"." || spec == b".." {
+            self.fs_ref()
+                .abs_buf(&[file_dir, spec, b"tsconfig.json"], &mut buf[..])
+        } else if bun_paths::is_absolute(spec) {
+            self.fs_ref().abs_buf(&[spec], &mut buf[..])
+        } else {
+            self.fs_ref().abs_buf(&[file_dir, spec], &mut buf[..])
+        };
+        match self.probe_tsconfig_extends(source, extends, extends_file, false, chain)? {
+            TSConfigProbe::Missing => {}
+            found_or_failed => return Ok(found_or_failed),
+        }
+
+        // tsc adds ".json" only when the path as written is not a file (a
+        // directory of the same name does not count) and does not already end
+        // in ".json".
+        if extends_file.ends_with(b".json") {
+            return Ok(TSConfigProbe::Missing);
+        }
+        let mut with_json_buf = bun_paths::path_buffer_pool::get();
+        let Some(with_json) = concat_path_into(&mut with_json_buf[..], &[extends_file, b".json"])
+        else {
+            return Ok(TSConfigProbe::Missing);
+        };
+        self.probe_tsconfig_extends(source, extends, with_json, false, chain)
+    }
+
+    /// The package-specifier arm of [`Self::resolve_tsconfig_extends`]. This
+    /// walks `node_modules` directories by hand instead of going through
+    /// `dir_info_cached`: the caller is inside `dir_info_uncached`, which holds
+    /// the directory cache locks, and the rules differ from module resolution
+    /// anyway (only ".json" files, `require` conditions, no directory matches).
+    fn resolve_tsconfig_extends_package(
+        &mut self,
+        source: &bun_ast::Source,
+        extends: &TSConfigExtends,
+        chain: &mut TSConfigChain,
+    ) -> crate::CrateResult<TSConfigProbe> {
+        use crate::package_json::{IncludeDependencies, IncludeScripts, Package, Status};
+
+        let spec: &[u8] = &extends.spec;
+        let Some(package_name) = Package::parse_name(spec) else {
+            return Ok(TSConfigProbe::Missing);
+        };
+        let package_subpath = &spec[package_name.len()..];
+
+        let mut current: &[u8] = source.path.source_dir();
+        loop {
+            // A `node_modules` directory has no `node_modules` of its own.
+            if bun_paths::basename(current) != b"node_modules" {
+                let mut pkg_dir_buf = bun_paths::path_buffer_pool::get();
+                let pkg_dir: &[u8] = self.fs_ref().abs_buf(
+                    &[current, b"node_modules", package_name],
+                    &mut pkg_dir_buf[..],
+                );
+                let mut join_buf = bun_paths::path_buffer_pool::get();
+                let mut join: &[u8] = self
                     .fs_ref()
-                    .abs_buf(&[file_dir, &result.base_url[..]], bufs!(tsconfig_base_url));
-                result.base_url = Box::from(abs);
+                    .abs_buf(&[current, b"node_modules", spec], &mut join_buf[..]);
+
+                let mut package_json_buf = bun_paths::path_buffer_pool::get();
+                let package_json_path: &[u8] = self
+                    .fs_ref()
+                    .abs_buf(&[pkg_dir, b"package.json"], &mut package_json_buf[..]);
+                // `PackageJSON::parse` logs an error for a missing file, so
+                // check first. The parsed value is dropped at the end of this
+                // block: the directory cache parses its own copy later if the
+                // package is ever resolved as a module.
+                let package_json = if bun_sys::exists(package_json_path) {
+                    PackageJSON::parse::<{ IncludeDependencies::None }>(
+                        self,
+                        pkg_dir,
+                        FD::INVALID,
+                        None,
+                        IncludeScripts::IgnoreScripts,
+                    )
+                } else {
+                    None
+                };
+                if let Some(package_json) = package_json.as_ref() {
+                    if let Some(exports_map) = package_json.exports.as_ref() {
+                        // TypeScript resolves the subpath through "exports" as a
+                        // `require`, and an "exports" map that does not name it
+                        // ends the search: there is no file system fallback.
+                        let mut subpath_buf = bun_paths::path_buffer_pool::get();
+                        let Some(esm_subpath) =
+                            concat_path_into(&mut subpath_buf[..], &[b".", package_subpath])
+                        else {
+                            return Ok(TSConfigProbe::Missing);
+                        };
+                        let mut module_type = package_json.module_type;
+                        let resolution = ESModule {
+                            conditions: &self.opts.conditions.require,
+                            debug_logs: self.debug_logs.as_mut(),
+                            module_type: &mut module_type,
+                        }
+                        .resolve(b"/", esm_subpath, &exports_map.root);
+                        if !(matches!(resolution.status, Status::Exact | Status::ExactEndsWithStar)
+                            && resolution.path.first() == Some(&SEP))
+                        {
+                            return Ok(TSConfigProbe::Missing);
+                        }
+                        let mut target_buf = bun_paths::path_buffer_pool::get();
+                        let target: &[u8] = self.fs_ref().abs_buf(
+                            &[
+                                pkg_dir,
+                                strings::without_leading_path_separator(&resolution.path),
+                            ],
+                            &mut target_buf[..],
+                        );
+                        return self.probe_tsconfig_extends(source, extends, target, true, chain);
+                    }
+
+                    // The "tsconfig" field names the base a bare package name loads.
+                    if let Some(tsconfig_field) = package_json.tsconfig.as_deref() {
+                        join = if bun_paths::is_absolute(tsconfig_field) {
+                            self.fs_ref().abs_buf(&[tsconfig_field], &mut join_buf[..])
+                        } else {
+                            self.fs_ref()
+                                .abs_buf(&[pkg_dir, tsconfig_field], &mut join_buf[..])
+                        };
+                    }
+                }
+
+                // tsc's order: the tsconfig.json of a directory, the path as
+                // written, then the path with ".json" added.
+                let mut candidate_buf = bun_paths::path_buffer_pool::get();
+                let candidates: [&[&[u8]]; 3] = [
+                    &[join, SEP_STR.as_bytes(), b"tsconfig.json"],
+                    &[join],
+                    &[join, b".json"],
+                ];
+                for parts in candidates {
+                    let Some(candidate) = concat_path_into(&mut candidate_buf[..], parts) else {
+                        continue;
+                    };
+                    match self.probe_tsconfig_extends(source, extends, candidate, true, chain)? {
+                        TSConfigProbe::Missing => {}
+                        found_or_failed => return Ok(found_or_failed),
+                    }
+                }
+            }
+
+            match bun_paths::dirname(current) {
+                Some(parent) if parent.len() < current.len() => current = parent,
+                _ => break,
             }
         }
 
-        if result.paths.count() > 0
-            && (result.base_url_for_paths.is_empty()
-                || !bun_paths::is_absolute(&result.base_url_for_paths))
-        {
-            // this might leak
-            let abs = self
-                .fs_ref()
-                .abs_buf(&[file_dir, &result.base_url[..]], bufs!(tsconfig_base_url));
-            result.base_url_for_paths = Box::from(abs);
-        }
+        Ok(TSConfigProbe::Missing)
+    }
 
-        // NOTE: return the `Box` so the caller (`dir_info_uncached`) takes
-        // ownership — intermediate configs in an extends-chain are dropped via
-        // `heap::take`, the final one is interned into the DirInfo cache.
-        Ok(Some(result))
+    /// Tries one candidate path for an `extends` base. With `follow_symlinks`,
+    /// the file is parsed under its real path, so a symlinked workspace package
+    /// (how every package manager installs one) interprets its own relative
+    /// "baseUrl" and "paths" from where it lives, like tsc and esbuild do.
+    fn probe_tsconfig_extends(
+        &mut self,
+        source: &bun_ast::Source,
+        extends: &TSConfigExtends,
+        candidate: &[u8],
+        follow_symlinks: bool,
+        chain: &mut TSConfigChain,
+    ) -> crate::CrateResult<TSConfigProbe> {
+        use bun_errno::SystemErrno as E;
+        // Only files count. Users name directories after their configs
+        // ("./config/base" next to "config/base.json"), and a bare package name
+        // is tried as a path too.
+        if is_directory(candidate) {
+            return Ok(TSConfigProbe::Missing);
+        }
+        let mut real_path_buf = bun_paths::path_buffer_pool::get();
+        let candidate: &[u8] = if follow_symlinks && !self.opts.preserve_symlinks {
+            match realpath(candidate, &mut real_path_buf) {
+                Some(real) => real,
+                // Only a missing file fails to resolve here. The read below
+                // reports anything else.
+                None => candidate,
+            }
+        } else {
+            candidate
+        };
+        match self.parse_tsconfig_in_chain(candidate, FD::INVALID, chain) {
+            Ok(Some(base)) => Ok(TSConfigProbe::Found(base)),
+            // The JSON did not parse. The parser logged the error.
+            Ok(None) | Err(crate::Error::ParseErrorAlreadyLogged) => Ok(TSConfigProbe::Failed),
+            // Not a file at that path. A directory of the same name is not a match.
+            Err(crate::Error::Sys(E::ENOENT | E::ENOTDIR | E::EISDIR)) => {
+                Ok(TSConfigProbe::Missing)
+            }
+            Err(crate::Error::ParseErrorImportCycle) => {
+                // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call only.
+                unsafe { &mut *self.log() }.add_range_warning_fmt(
+                    Some(source),
+                    source.range_of_string(extends.loc),
+                    format_args!(
+                        "Base config file {} forms cycle",
+                        bun_core::fmt::quote(&extends.spec)
+                    ),
+                );
+                Ok(TSConfigProbe::Failed)
+            }
+            Err(err @ (crate::Error::Alloc(_) | crate::Error::Overflow(_))) => Err(err),
+            Err(err) => {
+                // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call only.
+                unsafe { &mut *self.log() }.add_range_error_fmt(
+                    Some(source),
+                    source.range_of_string(extends.loc),
+                    format_args!(
+                        "Cannot read file {}: {}",
+                        bun_core::fmt::quote(candidate),
+                        bstr::BStr::new(err.name())
+                    ),
+                );
+                Ok(TSConfigProbe::Failed)
+            }
+        }
+    }
+
+    fn warn_missing_tsconfig_base(&mut self, source: &bun_ast::Source, extends: &TSConfigExtends) {
+        // Packages ship tsconfig.json files that extend bases they do not
+        // depend on. Nothing the user can do about those, so stay quiet.
+        if source.path.is_node_module() {
+            return;
+        }
+        // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call only.
+        unsafe { &mut *self.log() }.add_range_warning_fmt(
+            Some(source),
+            source.range_of_string(extends.loc),
+            format_args!(
+                "Cannot find base config file {}",
+                bun_core::fmt::quote(&extends.spec)
+            ),
+        );
     }
 
     pub fn bin_dirs(&self) -> &[&'static [u8]] {
@@ -4788,14 +5141,10 @@ impl<'a> Resolver<'a> {
             ));
         }
 
-        let mut abs_base_url: &[u8] = &tsconfig.base_url_for_paths;
-
-        // The explicit base URL should take precedence over the implicit base URL
-        // if present. This matters when a tsconfig.json file overrides "baseUrl"
-        // from another extended tsconfig.json file but doesn't override "paths".
-        if tsconfig.has_base_url() {
-            abs_base_url = &tsconfig.base_url;
-        }
+        let Some(paths) = tsconfig.paths.as_ref() else {
+            return MatchStatus::NotFound;
+        };
+        let abs_base_url: &[u8] = tsconfig.paths_base_dir();
 
         if let Some(debug) = self.debug_logs.as_mut() {
             debug.add_note_fmt(format_args!(
@@ -4808,18 +5157,14 @@ impl<'a> Resolver<'a> {
         {
             // NOTE: ArrayHashMap has no `&self` (key,value) iterator; zip the
             // parallel `keys()`/`values()` slices (insertion order).
-            for (key, value) in tsconfig
-                .paths
-                .keys()
-                .iter()
-                .zip(tsconfig.paths.values().iter())
-            {
+            for (key, value) in paths.map.keys().iter().zip(paths.map.values().iter()) {
                 if strings::eql_long(key, path, true) {
                     for original_path in value.iter() {
+                        let original_path: &[u8] = &original_path.text;
                         let mut absolute_original_path: &[u8] = original_path;
 
                         if !bun_paths::is_absolute(absolute_original_path) {
-                            let parts: [&[u8]; 2] = [abs_base_url, original_path.as_ref()];
+                            let parts: [&[u8]; 2] = [abs_base_url, original_path];
                             absolute_original_path =
                                 self.fs_ref().abs_buf(&parts, bufs!(tsconfig_path_abs));
                         }
@@ -4838,19 +5183,14 @@ impl<'a> Resolver<'a> {
         struct TSConfigMatch<'b> {
             prefix: &'b [u8],
             suffix: &'b [u8],
-            original_paths: &'b [Box<[u8]>],
+            original_paths: &'b [crate::tsconfig_json::TSConfigPath],
         }
 
         let mut longest_match: Option<TSConfigMatch> = None;
         let mut longest_match_prefix_length: i32 = -1;
         let mut longest_match_suffix_length: i32 = -1;
 
-        for (key, original_paths) in tsconfig
-            .paths
-            .keys()
-            .iter()
-            .zip(tsconfig.paths.values().iter())
-        {
+        for (key, original_paths) in paths.map.keys().iter().zip(paths.map.values().iter()) {
             if let Some(star) = strings::index_of_char(key, b'*') {
                 let star = star as usize;
                 let prefix: &[u8] = if star == 0 { b"" } else { &key[0..star] };
@@ -4897,6 +5237,7 @@ impl<'a> Resolver<'a> {
             }
 
             for original_path in longest_match.original_paths.iter() {
+                let original_path: &[u8] = &original_path.text;
                 // Swap out the "*" in the original path for whatever the "*" matched
                 let matched_text =
                     &path[longest_match.prefix.len()..path.len() - longest_match.suffix.len()];
@@ -6515,114 +6856,11 @@ impl<'a> Resolver<'a> {
                         None
                     }
                 };
-                // NOTE: assigning info.tsconfig_json here and then freeing that
-                // allocation in the merge loop below before reassigning would
-                // leave a briefly-dangling reference
-                // (Option<&'static TSConfigJSON>, dir_info.rs) — UB.
-                // Defer the assignment to after the merge —
-                // it is always overwritten when parsed_tsconfig.is_some(), and DirInfo defaults
-                // tsconfig_json to None otherwise.
+                // `parse_tsconfig` already merged the `extends` chain. The Box is
+                // interned into DirInfo and outlives the resolver.
                 if let Some(tsconfig_json) = parsed_tsconfig {
-                    let mut parent_configs: BoundedArray<*mut TSConfigJSON, 64> =
-                        BoundedArray::default();
-                    parent_configs.append(tsconfig_json)?;
-                    // `current`/`parent_config_ptr`/`merged_config` are heap TSConfigJSON
-                    // allocations from `parse_tsconfig` (heap::alloc); uniquely owned by
-                    // this extends-chain walk and freed via heap::take below. Hold as
-                    // `BackRef` (pointee outlives holder) so the loop body reads via safe
-                    // `Deref` instead of three open-coded raw-ptr derefs.
-                    let mut current = bun_ptr::BackRef::from(
-                        core::ptr::NonNull::new(tsconfig_json).expect("heap alloc"),
-                    );
-                    while !current.extends.is_empty() {
-                        let ts_dir_name = Dirname::dirname(&current.abs_path);
-                        let abs_path = ResolvePath::join_abs_string_buf(
-                            ts_dir_name,
-                            bufs!(tsconfig_path_abs),
-                            &[ts_dir_name, &current.extends],
-                            bun_paths::Platform::AUTO,
-                        );
-                        let parent_config_maybe: Option<*mut TSConfigJSON> =
-                            match self.parse_tsconfig(abs_path, FD::INVALID) {
-                                Ok(v) => v.map(bun_core::heap::into_raw),
-                                Err(err) => {
-                                    let _ = self.log_mut().add_debug_fmt(
-                                        None,
-                                        bun_ast::Loc::EMPTY,
-                                        format_args!(
-                                            "{} loading tsconfig.json extends {}",
-                                            bstr::BStr::new(err.name()),
-                                            bun_core::fmt::quote(abs_path)
-                                        ),
-                                    );
-                                    break;
-                                }
-                            };
-                        if let Some(parent_config) = parent_config_maybe {
-                            parent_configs.append(parent_config)?;
-                            current = bun_ptr::BackRef::from(
-                                core::ptr::NonNull::new(parent_config).expect("heap alloc"),
-                            );
-                        } else {
-                            break;
-                        }
-                    }
-
-                    let merged_config = parent_configs.pop().unwrap();
-                    // starting from the base config (end of the list)
-                    // successively apply the inheritable attributes to the next config
-                    while let Some(parent_config_ptr) = parent_configs.pop() {
-                        // SAFETY: see loop-wide note above.
-                        let parent_config = unsafe { &mut *parent_config_ptr };
-                        // SAFETY: see loop-wide note above.
-                        let mc = unsafe { &mut *merged_config };
-                        mc.emit_decorator_metadata =
-                            mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
-                        if let Some(v) = parent_config.use_define_for_class_fields {
-                            mc.use_define_for_class_fields = Some(v);
-                        }
-                        if !parent_config.base_url.is_empty() {
-                            mc.base_url = core::mem::take(&mut parent_config.base_url);
-                        }
-                        mc.jsx = parent_config.merge_jsx(mc.jsx.clone());
-                        mc.jsx_flags.insert_all(parent_config.jsx_flags);
-
-                        if let Some(value) = parent_config.preserve_imports_not_used_as_values {
-                            mc.preserve_imports_not_used_as_values = Some(value);
-                        }
-
-                        // TypeScript replaces paths across extends (child overrides parent
-                        // entirely), so when a more-specific config defines paths, replace
-                        // rather than merge. base_url_for_paths is set whenever the paths
-                        // key is present in the JSON (even if empty), so it discriminates
-                        // "not defined" from "defined as {}" — the latter clears inherited
-                        // paths per TypeScript semantics.
-                        if !parent_config.base_url_for_paths.is_empty() {
-                            // The previous merged_config.paths is being replaced;
-                            // dropping the map frees the values automatically, so the
-                            // PathsMap from the deeper config doesn't leak.
-                            mc.paths = core::mem::take(&mut parent_config.paths);
-                            mc.base_url_for_paths =
-                                core::mem::take(&mut parent_config.base_url_for_paths);
-                        } else {
-                            // paths were not moved to merged_config, so they're still owned
-                            // by parent_config. base_url_for_paths.len == 0 implies the map
-                            // is empty (it's only set when the `paths` key is present in the
-                            // JSON), so this is a no-op but documents the ownership.
-                            // (Drop handles parent_config.paths.)
-                        }
-                        // Every scalar/reference we need has been copied into merged_config
-                        // (strings live in dirname_store or default_allocator and outlive the
-                        // struct). The heap-allocated TSConfigJSON itself is no longer needed;
-                        // without this, every intermediate config in an extends chain leaks on
-                        // each dir_info_uncached() call, which is especially bad under HMR where
-                        // bust_dir_cache triggers a re-parse of the whole chain on every reload.
-                        // SAFETY: parent_config_ptr came from TSConfigJSON::new (heap::alloc)
-                        TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config_ptr) });
-                    }
-                    // `merged_config` is a leaked Box (heap::alloc) interned into DirInfo; outlives the resolver.
                     info.tsconfig_json = Some(
-                        core::ptr::NonNull::new(merged_config).expect("heap::alloc is non-null"),
+                        core::ptr::NonNull::new(tsconfig_json).expect("heap::alloc is non-null"),
                     );
                 }
                 info.enclosing_tsconfig_json = info.tsconfig_json();
@@ -6634,6 +6872,32 @@ impl<'a> Resolver<'a> {
 }
 
 // ─── nested helper types ───────────────────────────────────────────────────
+
+/// One walk of a tsconfig.json `extends` chain, rooted at the file that
+/// `dir_info_uncached` (or `--tsconfig-override`) named.
+struct TSConfigChain {
+    /// Directory of the root config. Every "${configDir}" in the chain expands
+    /// to it, the way tsc substitutes the template after the merge.
+    config_dir: Box<[u8]>,
+    /// Files being parsed right now, root first. A base that is already on the
+    /// stack forms a cycle. A diamond (two branches that share one base) does
+    /// not, because a finished branch pops its entry.
+    visiting: Vec<&'static [u8]>,
+    /// Every file parsed so far, kept alive until the root returns so the
+    /// post-merge "paths" check can point its warnings at the file that
+    /// declared the offending entry.
+    sources: Vec<bun_ast::Source>,
+}
+
+/// Outcome of trying one candidate path for an `extends` base.
+enum TSConfigProbe {
+    Found(Box<TSConfigJSON>),
+    /// Nothing usable at that path. Try the next candidate.
+    Missing,
+    /// The file exists but cannot be used. The reason is already logged, and
+    /// the search stops.
+    Failed,
+}
 
 enum DependencyToResolve {
     NotFound,
@@ -6781,6 +7045,46 @@ bun_core::comptime_string_map! {
 #[inline]
 fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()
+}
+
+/// `stat` for one `extends` candidate. False for a missing path.
+fn is_directory(path: &[u8]) -> bool {
+    let mut buf = bun_paths::path_buffer_pool::get();
+    let Some(path_z) = nul_terminate_into(&mut buf, path) else {
+        return false;
+    };
+    matches!(
+        bun_sys::exists_at_type(FD::cwd(), path_z),
+        Ok(bun_sys::ExistsAtType::Directory)
+    )
+}
+
+/// `realpath` for one `extends` candidate. `None` when the path does not
+/// resolve (it does not exist, or a component is not a directory).
+fn realpath<'b>(path: &[u8], out: &'b mut PathBuffer) -> Option<&'b [u8]> {
+    let mut buf = bun_paths::path_buffer_pool::get();
+    let path_z = nul_terminate_into(&mut buf, path)?;
+    bun_sys::realpath(path_z, out).ok()
+}
+
+/// Copies `path` into `buf` with a NUL terminator. `None` when it does not fit.
+fn nul_terminate_into<'b>(buf: &'b mut PathBuffer, path: &[u8]) -> Option<&'b bun_core::ZStr> {
+    if path.len() >= buf.len() {
+        return None;
+    }
+    buf[..path.len()].copy_from_slice(path);
+    buf[path.len()] = 0;
+    Some(bun_core::ZStr::from_buf(&buf[..], path.len()))
+}
+
+/// Byte-concatenates `parts` into `buf` (no separator handling). `None` when
+/// the result does not fit.
+fn concat_path_into<'b>(buf: &'b mut [u8], parts: &[&[u8]]) -> Option<&'b [u8]> {
+    let len: usize = parts.iter().map(|p| p.len()).sum();
+    if len > buf.len() {
+        return None;
+    }
+    Some(::bun_core::concat_into(buf, parts))
 }
 
 pub struct Dirname;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4308,7 +4308,11 @@ impl<'a> Resolver<'a> {
                     }
 
                     // The "tsconfig" field names the base a bare package name loads.
-                    if let Some(tsconfig_field) = package_json.tsconfig.as_deref() {
+                    if let Some(tsconfig_field) = package_json
+                        .tsconfig
+                        .as_deref()
+                        .filter(|_| package_subpath.is_empty())
+                    {
                         join = if bun_paths::is_absolute(tsconfig_field) {
                             self.fs_ref().abs_buf(&[tsconfig_field], &mut join_buf[..])
                         } else {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4018,8 +4018,7 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Parses `file` and merges in its `extends` chain. The returned config is
-    /// the one `dir_info_uncached` interns for the directory.
+    /// Parses `file` and merges in its `extends` chain.
     pub(crate) fn parse_tsconfig(
         &mut self,
         file: &[u8],
@@ -4033,9 +4032,7 @@ impl<'a> Resolver<'a> {
         self.parse_tsconfig_in_chain(file, dirname_fd, &mut chain)
     }
 
-    /// One level of an `extends` chain: parses `file`, resolves and merges each
-    /// of its bases (recursively), then layers the file's own settings on top.
-    /// This is the shape of esbuild's `parseTSConfig`.
+    /// One level of an `extends` chain, the shape of esbuild's `parseTSConfig`.
     fn parse_tsconfig_in_chain(
         &mut self,
         file: &[u8],
@@ -4117,12 +4114,8 @@ impl<'a> Resolver<'a> {
         chain.visiting.pop();
         let mut result = merged?;
 
-        // A relative "baseUrl" resolves against the file that declares it. An
-        // inherited one is already absolute.
+        // A relative "baseUrl" is relative to the file that declares it.
         if result.has_base_url() && !bun_paths::is_absolute(&result.base_url) {
-            // NOTE: `base_url: Box<[u8]>` owns its bytes, so
-            // copy `abs_buf`'s thread-local result directly instead of
-            // double-copying through the `dirname_store` arena.
             let abs = self.fs_ref().abs_buf(
                 &[source.path.source_dir(), &result.base_url[..]],
                 bufs!(tsconfig_base_url),
@@ -4130,8 +4123,7 @@ impl<'a> Resolver<'a> {
             result.base_url = Box::from(abs);
         }
 
-        // Kept until the root returns: the check below needs the source of
-        // whichever file in the chain declared "paths".
+        // The check below may need the source of the base that declared "paths".
         chain.sources.push(source);
 
         if is_root {
@@ -4148,8 +4140,7 @@ impl<'a> Resolver<'a> {
         Ok(Some(result))
     }
 
-    /// Bases apply in `extends` order, so a later one overrides an earlier one,
-    /// and the file's own settings override every base.
+    /// A later base overrides an earlier one. The file's own settings override every base.
     fn merge_tsconfig_extends(
         &mut self,
         source: &bun_ast::Source,
@@ -4173,10 +4164,7 @@ impl<'a> Resolver<'a> {
         Ok(merged)
     }
 
-    /// Finds and parses one `extends` entry of `source` the way tsc's
-    /// `getExtendsConfigPath` does: a relative or absolute path is tried as
-    /// written and then with ".json" added, anything else is a package
-    /// specifier looked up in the `node_modules` of each ancestor directory.
+    /// Finds and parses one `extends` entry the way tsc's `getExtendsConfigPath` does.
     /// `None` means the base is unusable, and the reason is already logged.
     fn resolve_tsconfig_extends(
         &mut self,
@@ -4190,9 +4178,7 @@ impl<'a> Resolver<'a> {
                 match self.resolve_tsconfig_extends_package(source, extends, chain)? {
                     TSConfigProbe::Found(base) => return Ok(Some(base)),
                     TSConfigProbe::Failed => return Ok(None),
-                    // Bun used to resolve every `extends` value against the
-                    // file's directory, so a bare sibling name ("base.json")
-                    // keeps working through the fallback below.
+                    // Older Bun resolved every value as a path, so a bare "base.json" still works.
                     TSConfigProbe::Missing => {}
                 }
             }
@@ -4206,8 +4192,7 @@ impl<'a> Resolver<'a> {
         Ok(None)
     }
 
-    /// The path arm of [`Self::resolve_tsconfig_extends`]: the value as written,
-    /// relative to the file, then with ".json" added.
+    /// The path arm: the value as written, relative to the file, then with ".json" added.
     fn resolve_tsconfig_extends_relative(
         &mut self,
         source: &bun_ast::Source,
@@ -4231,9 +4216,7 @@ impl<'a> Resolver<'a> {
             found_or_failed => return Ok(found_or_failed),
         }
 
-        // tsc adds ".json" only when the path as written is not a file (a
-        // directory of the same name does not count) and does not already end
-        // in ".json".
+        // tsc adds ".json" only when the value is not a file and does not end in ".json".
         if extends_file.ends_with(b".json") {
             return Ok(TSConfigProbe::Missing);
         }
@@ -4245,11 +4228,8 @@ impl<'a> Resolver<'a> {
         self.probe_tsconfig_extends(source, extends, with_json, false, chain)
     }
 
-    /// The package-specifier arm of [`Self::resolve_tsconfig_extends`]. This
-    /// walks `node_modules` directories by hand instead of going through
-    /// `dir_info_cached`: the caller is inside `dir_info_uncached`, which holds
-    /// the directory cache locks, and the rules differ from module resolution
-    /// anyway (only ".json" files, `require` conditions, no directory matches).
+    /// The package arm. It walks ancestor `node_modules` by hand: the caller is
+    /// inside `dir_info_uncached`, which holds the directory cache locks.
     fn resolve_tsconfig_extends_package(
         &mut self,
         source: &bun_ast::Source,
@@ -4282,10 +4262,7 @@ impl<'a> Resolver<'a> {
                 let package_json_path: &[u8] = self
                     .fs_ref()
                     .abs_buf(&[pkg_dir, b"package.json"], &mut package_json_buf[..]);
-                // `PackageJSON::parse` logs an error for a missing file, so
-                // check first. The parsed value is dropped at the end of this
-                // block: the directory cache parses its own copy later if the
-                // package is ever resolved as a module.
+                // `PackageJSON::parse` logs an error for a missing file, so check first.
                 let package_json = if bun_sys::exists(package_json_path) {
                     PackageJSON::parse::<{ IncludeDependencies::None }>(
                         self,
@@ -4299,9 +4276,7 @@ impl<'a> Resolver<'a> {
                 };
                 if let Some(package_json) = package_json.as_ref() {
                     if let Some(exports_map) = package_json.exports.as_ref() {
-                        // TypeScript resolves the subpath through "exports" as a
-                        // `require`, and an "exports" map that does not name it
-                        // ends the search: there is no file system fallback.
+                        // tsc resolves through "exports" as a `require`, with no fallback.
                         let mut subpath_buf = bun_paths::path_buffer_pool::get();
                         let Some(esm_subpath) =
                             concat_path_into(&mut subpath_buf[..], &[b".", package_subpath])
@@ -4342,8 +4317,7 @@ impl<'a> Resolver<'a> {
                     }
                 }
 
-                // tsc's order: the tsconfig.json of a directory, the path as
-                // written, then the path with ".json" added.
+                // tsc's order: <dir>/tsconfig.json, the path as written, then with ".json".
                 let mut candidate_buf = bun_paths::path_buffer_pool::get();
                 let candidates: [&[&[u8]]; 3] = [
                     &[join, SEP_STR.as_bytes(), b"tsconfig.json"],
@@ -4370,10 +4344,8 @@ impl<'a> Resolver<'a> {
         Ok(TSConfigProbe::Missing)
     }
 
-    /// Tries one candidate path for an `extends` base. With `follow_symlinks`,
-    /// the file is parsed under its real path, so a symlinked workspace package
-    /// (how every package manager installs one) interprets its own relative
-    /// "baseUrl" and "paths" from where it lives, like tsc and esbuild do.
+    /// Tries one candidate path. With `follow_symlinks`, a symlinked workspace package
+    /// is parsed under its real path, so its relative "paths" resolve from where it lives.
     fn probe_tsconfig_extends(
         &mut self,
         source: &bun_ast::Source,
@@ -4383,9 +4355,7 @@ impl<'a> Resolver<'a> {
         chain: &mut TSConfigChain,
     ) -> crate::CrateResult<TSConfigProbe> {
         use bun_errno::SystemErrno as E;
-        // Only files count. Users name directories after their configs
-        // ("./config/base" next to "config/base.json"), and a bare package name
-        // is tried as a path too.
+        // Only files count: "./config/base" can be a directory next to "config/base.json".
         if is_directory(candidate) {
             return Ok(TSConfigProbe::Missing);
         }
@@ -4393,8 +4363,6 @@ impl<'a> Resolver<'a> {
         let candidate: &[u8] = if follow_symlinks && !self.opts.preserve_symlinks {
             match realpath(candidate, &mut real_path_buf) {
                 Some(real) => real,
-                // Only a missing file fails to resolve here. The read below
-                // reports anything else.
                 None => candidate,
             }
         } else {
@@ -4402,14 +4370,13 @@ impl<'a> Resolver<'a> {
         };
         match self.parse_tsconfig_in_chain(candidate, FD::INVALID, chain) {
             Ok(Some(base)) => Ok(TSConfigProbe::Found(base)),
-            // The JSON did not parse. The parser logged the error.
+            // The JSON did not parse, and the parser logged the error.
             Ok(None) | Err(crate::Error::ParseErrorAlreadyLogged) => Ok(TSConfigProbe::Failed),
-            // Not a file at that path. A directory of the same name is not a match.
             Err(crate::Error::Sys(E::ENOENT | E::ENOTDIR | E::EISDIR)) => {
                 Ok(TSConfigProbe::Missing)
             }
             Err(crate::Error::ParseErrorImportCycle) => {
-                // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call only.
+                // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call.
                 unsafe { &mut *self.log() }.add_range_warning_fmt(
                     Some(source),
                     source.range_of_string(extends.loc),
@@ -4422,7 +4389,7 @@ impl<'a> Resolver<'a> {
             }
             Err(err @ (crate::Error::Alloc(_) | crate::Error::Overflow(_))) => Err(err),
             Err(err) => {
-                // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call only.
+                // SAFETY: BACKREF — `self.log` (see `log()` NOTE), narrow `&mut` for this call.
                 unsafe { &mut *self.log() }.add_range_error_fmt(
                     Some(source),
                     source.range_of_string(extends.loc),
@@ -4438,8 +4405,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn warn_missing_tsconfig_base(&mut self, source: &bun_ast::Source, extends: &TSConfigExtends) {
-        // Packages ship tsconfig.json files that extend bases they do not
-        // depend on. Nothing the user can do about those, so stay quiet.
+        // A package's own config is not actionable for the user.
         if source.path.is_node_module() {
             return;
         }
@@ -6856,8 +6822,7 @@ impl<'a> Resolver<'a> {
                         None
                     }
                 };
-                // `parse_tsconfig` already merged the `extends` chain. The Box is
-                // interned into DirInfo and outlives the resolver.
+                // Interned into DirInfo, so it outlives the resolver.
                 if let Some(tsconfig_json) = parsed_tsconfig {
                     info.tsconfig_json = Some(
                         core::ptr::NonNull::new(tsconfig_json).expect("heap::alloc is non-null"),
@@ -6873,19 +6838,13 @@ impl<'a> Resolver<'a> {
 
 // ─── nested helper types ───────────────────────────────────────────────────
 
-/// One walk of a tsconfig.json `extends` chain, rooted at the file that
-/// `dir_info_uncached` (or `--tsconfig-override`) named.
+/// One walk of a tsconfig.json `extends` chain.
 struct TSConfigChain {
-    /// Directory of the root config. Every "${configDir}" in the chain expands
-    /// to it, the way tsc substitutes the template after the merge.
+    /// Directory of the root config: what "${configDir}" means in every file of the chain.
     config_dir: Box<[u8]>,
-    /// Files being parsed right now, root first. A base that is already on the
-    /// stack forms a cycle. A diamond (two branches that share one base) does
-    /// not, because a finished branch pops its entry.
+    /// Files being parsed, root first. A base already on the stack forms a cycle.
     visiting: Vec<&'static [u8]>,
-    /// Every file parsed so far, kept alive until the root returns so the
-    /// post-merge "paths" check can point its warnings at the file that
-    /// declared the offending entry.
+    /// Every parsed file, kept until the root returns for the post-merge "paths" warnings.
     sources: Vec<bun_ast::Source>,
 }
 
@@ -6894,8 +6853,7 @@ enum TSConfigProbe {
     Found(Box<TSConfigJSON>),
     /// Nothing usable at that path. Try the next candidate.
     Missing,
-    /// The file exists but cannot be used. The reason is already logged, and
-    /// the search stops.
+    /// The file exists but cannot be used. The reason is logged, and the search stops.
     Failed,
 }
 
@@ -7047,7 +7005,6 @@ fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()
 }
 
-/// `stat` for one `extends` candidate. False for a missing path.
 fn is_directory(path: &[u8]) -> bool {
     let mut buf = bun_paths::path_buffer_pool::get();
     let Some(path_z) = nul_terminate_into(&mut buf, path) else {
@@ -7059,8 +7016,7 @@ fn is_directory(path: &[u8]) -> bool {
     )
 }
 
-/// `realpath` for one `extends` candidate. `None` when the path does not
-/// resolve (it does not exist, or a component is not a directory).
+/// `None` when the path does not resolve.
 fn realpath<'b>(path: &[u8], out: &'b mut PathBuffer) -> Option<&'b [u8]> {
     let mut buf = bun_paths::path_buffer_pool::get();
     let path_z = nul_terminate_into(&mut buf, path)?;
@@ -7077,8 +7033,7 @@ fn nul_terminate_into<'b>(buf: &'b mut PathBuffer, path: &[u8]) -> Option<&'b bu
     Some(bun_core::ZStr::from_buf(&buf[..], path.len()))
 }
 
-/// Byte-concatenates `parts` into `buf` (no separator handling). `None` when
-/// the result does not fit.
+/// Byte concatenation, no separator handling. `None` when the result does not fit.
 fn concat_path_into<'b>(buf: &'b mut [u8], parts: &[&[u8]]) -> Option<&'b [u8]> {
     let len: usize = parts.iter().map(|p| p.len()).sum();
     if len > buf.len() {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4039,7 +4039,8 @@ impl<'a> Resolver<'a> {
         dirname_fd: FD,
         chain: &mut TSConfigChain,
     ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
-        if chain.visiting.iter().any(|visiting| *visiting == file) {
+        let visiting: &[&[u8]] = &chain.visiting;
+        if visiting.contains(&file) {
             return Err(crate::Error::ParseErrorImportCycle);
         }
 

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -331,7 +331,7 @@ impl TSConfigJSON {
 
         if self.jsx_flags.contains(JsxField::ImportSource) {
             out.import_source = self.jsx.import_source.clone();
-            out.package_name = self.jsx.package_name.clone();
+            out.package_name.clone_from(&self.jsx.package_name);
         }
 
         if self.jsx_flags.contains(JsxField::Runtime) {

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -118,7 +118,38 @@ impl JsonCache {
 // Probably like 5-10
 // Array iteration is faster and deterministically ordered in that case.
 // Both keys and values are owned (`Box`/`Vec`) and freed when the map drops.
-pub(crate) type PathsMap = ArrayHashMap<Box<[u8]>, Vec<Box<[u8]>>>;
+pub(crate) type PathsMap = ArrayHashMap<Box<[u8]>, Vec<TSConfigPath>>;
+
+/// One fallback entry of a `compilerOptions.paths` array.
+pub(crate) struct TSConfigPath {
+    pub(crate) text: Box<[u8]>,
+    /// Position of the string in the file that declared it, for the warning
+    /// when a non-relative entry survives to a merged config without `baseUrl`.
+    pub(crate) loc: bun_ast::Loc,
+}
+
+/// `compilerOptions.paths` together with the file that declared it. Across an
+/// `extends` chain the whole map is inherited or replaced as one unit.
+pub(crate) struct TSConfigPaths {
+    pub(crate) map: PathsMap,
+    /// Absolute path of the tsconfig file whose `paths` this is. When no file in
+    /// the chain sets `baseUrl`, relative entries resolve against its directory.
+    pub(crate) source_path: Box<[u8]>,
+}
+
+impl TSConfigPaths {
+    pub(crate) fn source_dir(&self) -> &[u8] {
+        bun_paths::dirname(&self.source_path).unwrap_or(&self.source_path)
+    }
+}
+
+/// One entry of the top-level `extends` field (a string, or one item of a
+/// TypeScript 5.0 array).
+pub(crate) struct TSConfigExtends {
+    pub(crate) spec: Box<[u8]>,
+    /// Position of the string in the file, for diagnostics about the base.
+    pub(crate) loc: bun_ast::Loc,
+}
 
 // Hand-listed Pragma fields actually used below.
 #[derive(EnumSetType, Debug)]
@@ -132,35 +163,40 @@ pub(crate) enum JsxField {
 
 pub(crate) type JsxFieldSet = EnumSet<JsxField>;
 
+/// The settings bun reads from one tsconfig.json, after its `extends` chain is
+/// merged in. Every field that a base config can supply has an "unset" state
+/// (`None`, an empty `Box`, or a missing `jsx_flags` bit), so a later file in the
+/// chain overrides an earlier one only where it sets the field.
 pub struct TSConfigJSON {
     pub(crate) abs_path: Box<[u8]>,
 
-    /// The absolute path of "compilerOptions.baseUrl"
+    /// The absolute path of "compilerOptions.baseUrl". Empty when unset.
     pub(crate) base_url: Box<[u8]>,
 
-    /// This is used if "Paths" is non-nil. It's equal to "BaseURL" except if
-    /// "BaseURL" is missing, in which case it is as if "BaseURL" was ".". This
-    /// is to implement the "paths without baseUrl" feature from TypeScript 4.1.
-    /// More info: https://github.com/microsoft/TypeScript/issues/31869
-    pub(crate) base_url_for_paths: Box<[u8]>,
-
-    pub(crate) extends: Box<[u8]>,
+    /// The `extends` entries of this file, in order. `Resolver::parse_tsconfig`
+    /// drains them while it merges the chain, so a merged config has none.
+    pub(crate) extends: Vec<TSConfigExtends>,
     /// The verbatim values of "compilerOptions.paths". The keys are patterns to
     /// match and the values are arrays of fallback paths to search. Each key and
     /// each fallback path can optionally have a single "*" wildcard character.
     /// If both the key and the value have a wildcard, the substring matched by
     /// the wildcard is substituted into the fallback path. The keys represent
     /// module-style path names and the fallback paths are relative to the
-    /// "baseUrl" value in the "tsconfig.json" file.
-    pub(crate) paths: PathsMap,
+    /// "baseUrl" value in the "tsconfig.json" file, or to the directory of the
+    /// file that declared "paths" when no file in the chain sets "baseUrl"
+    /// (the TypeScript 4.1 "paths without baseUrl" feature,
+    /// https://github.com/microsoft/TypeScript/issues/31869).
+    /// `Some` whenever the "paths" key is present, even as `{}`: an empty object
+    /// in a derived file clears inherited paths.
+    pub(crate) paths: Option<TSConfigPaths>,
 
     pub jsx: options::jsx::Pragma,
     pub(crate) jsx_flags: JsxFieldSet,
 
     pub(crate) preserve_imports_not_used_as_values: Option<bool>,
 
-    pub emit_decorator_metadata: bool,
-    pub experimental_decorators: bool,
+    pub emit_decorator_metadata: Option<bool>,
+    pub experimental_decorators: Option<bool>,
     /// `None` = unset (keeps native [[Define]] class-field semantics).
     pub use_define_for_class_fields: Option<bool>,
 }
@@ -170,14 +206,13 @@ impl Default for TSConfigJSON {
         Self {
             abs_path: Box::default(),
             base_url: Box::default(),
-            base_url_for_paths: Box::default(),
-            extends: Box::default(),
-            paths: PathsMap::default(),
+            extends: Vec::new(),
+            paths: None,
             jsx: options::jsx::Pragma::default(),
             jsx_flags: JsxFieldSet::empty(),
-            preserve_imports_not_used_as_values: Some(false),
-            emit_decorator_metadata: false,
-            experimental_decorators: false,
+            preserve_imports_not_used_as_values: None,
+            emit_decorator_metadata: None,
+            experimental_decorators: None,
             use_define_for_class_fields: None,
         }
     }
@@ -226,6 +261,86 @@ impl TSConfigJSON {
         !self.base_url.is_empty()
     }
 
+    /// True when "paths" has at least one usable entry.
+    pub(crate) fn has_paths(&self) -> bool {
+        self.paths.as_ref().is_some_and(|p| p.map.count() > 0)
+    }
+
+    /// The directory that relative "paths" entries resolve against: "baseUrl"
+    /// when any file in the chain sets it, otherwise the directory of the file
+    /// that declared "paths". This matters when a derived config overrides
+    /// "baseUrl" but inherits "paths".
+    pub(crate) fn paths_base_dir(&self) -> &[u8] {
+        if self.has_base_url() {
+            return &self.base_url;
+        }
+        match self.paths.as_ref() {
+            Some(paths) => paths.source_dir(),
+            None => b".",
+        }
+    }
+
+    /// Layers `other` on top of `self`: every setting `other` has is copied,
+    /// every setting it lacks keeps the value already in `self`. The resolver
+    /// calls this once per base config (in `extends` order) and then once with
+    /// the file's own settings, so the file overrides its bases and a later
+    /// base overrides an earlier one, the way tsc merges a chain.
+    pub(crate) fn apply_extended_config(&mut self, mut other: Box<TSConfigJSON>) {
+        if other.has_base_url() {
+            self.base_url = core::mem::take(&mut other.base_url);
+        }
+        // TypeScript replaces "paths" across extends rather than merging the
+        // maps, so the whole map moves as one unit.
+        if other.paths.is_some() {
+            self.paths = other.paths.take();
+        }
+        self.jsx = other.merge_jsx(core::mem::take(&mut self.jsx));
+        self.jsx_flags.insert_all(other.jsx_flags);
+        if let Some(v) = other.preserve_imports_not_used_as_values {
+            self.preserve_imports_not_used_as_values = Some(v);
+        }
+        if let Some(v) = other.emit_decorator_metadata {
+            self.emit_decorator_metadata = Some(v);
+        }
+        if let Some(v) = other.experimental_decorators {
+            self.experimental_decorators = Some(v);
+        }
+        if let Some(v) = other.use_define_for_class_fields {
+            self.use_define_for_class_fields = Some(v);
+        }
+        TSConfigJSON::destroy(other);
+    }
+
+    /// Drops the non-relative "paths" entries of a merged config that has no
+    /// "baseUrl", with a warning for each. tsc allows "baseUrl" and "paths" to
+    /// come from different files of an `extends` chain, so this check has to
+    /// wait until the chain is merged. `source` is the file that declared
+    /// "paths", so the warnings point at the offending strings.
+    pub(crate) fn remove_paths_that_need_base_url(
+        &mut self,
+        log: &mut bun_ast::Log,
+        source: Option<&bun_ast::Source>,
+    ) {
+        if self.has_base_url() {
+            return;
+        }
+        let Some(paths) = self.paths.as_mut() else {
+            return;
+        };
+        paths.map.retain(|_, values| {
+            values.retain(|value| match source {
+                Some(source) => Self::is_valid_tsconfig_path_no_base_url_pattern(
+                    &value.text,
+                    log,
+                    source,
+                    value.loc,
+                ),
+                None => Self::is_relative_or_absolute_path(&value.text),
+            });
+            !values.is_empty()
+        });
+    }
+
     pub fn merge_jsx(&self, current: options::jsx::Pragma) -> options::jsx::Pragma {
         let mut out = current;
 
@@ -239,6 +354,7 @@ impl TSConfigJSON {
 
         if self.jsx_flags.contains(JsxField::ImportSource) {
             out.import_source = self.jsx.import_source.clone();
+            out.package_name = self.jsx.package_name.clone();
         }
 
         if self.jsx_flags.contains(JsxField::Runtime) {
@@ -264,9 +380,13 @@ impl TSConfigJSON {
     // "${configDir}" with "./" and then convert it to an absolute path sometimes.
     // We convert it to an absolute path during module resolution, so we shouldn't need to do that here.
     // https://github.com/microsoft/TypeScript/blob/ef802b1e4ddaf8d6e61d6005614dd796520448f8/src/compiler/commandLineParser.ts#L3243-L3245
+    //
+    // `config_dir` is the directory of the root config of the `extends` chain,
+    // not of the file that contains the template: tsc substitutes after the
+    // merge, so a base config's "${configDir}" means the extending project.
     fn str_replacing_templates(
         input: Box<[u8]>,
-        source: &bun_ast::Source,
+        config_dir: &[u8],
     ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
         const TEMPLATE: &[u8] = b"${configDir}";
         let mut remaining: &[u8] = &input;
@@ -275,7 +395,6 @@ impl TSConfigJSON {
             cap: 0,
             ptr: None,
         };
-        let config_dir = source.path.source_dir();
 
         // There's only one template variable we support, so we can keep this simple for now.
         while let Some(index) = strings::index_of(remaining, TEMPLATE) {
@@ -307,10 +426,15 @@ impl TSConfigJSON {
         Ok(Box::from(&written[..len]))
     }
 
+    /// Parses one file. `extends` is recorded, not followed: the resolver
+    /// walks the chain and merges with [`Self::apply_extended_config`].
+    /// `config_dir` is what "${configDir}" expands to (the directory of the
+    /// root config of the chain).
     pub fn parse(
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
         json_cache: &mut JsonCache,
+        config_dir: &[u8],
     ) -> Result<Option<Box<TSConfigJSON>>, crate::Error> {
         // Unfortunately "tsconfig.json" isn't actually JSON. It's some other
         // format that appears to be defined by the implementation details of the
@@ -331,7 +455,6 @@ impl TSConfigJSON {
 
         let mut result = TSConfigJSON {
             abs_path: Box::from(source.path.text),
-            paths: PathsMap::default(),
             ..Default::default()
         };
         // PERF: avoid re-scanning each JSON object's
@@ -344,12 +467,14 @@ impl TSConfigJSON {
         // guards), then handle them below in the original fixed order so any
         // inter-field ordering (`baseUrl` before `paths`, `jsx` before
         // `jsxImportSource`) is preserved.
-        let mut extends_value: Option<&bun_ast::E::JsonValue> = None;
+        let mut extends_value: Option<(&bun_ast::E::JsonValue, bun_ast::Loc)> = None;
         let mut compiler_opts: Option<&bun_ast::E::JsonValue> = None;
         if let bun_ast::ExprData::EObjectJSON(obj) = &json.data {
             for property in obj.get().properties() {
                 match property.key.slice() {
-                    b"extends" if extends_value.is_none() => extends_value = Some(&property.value),
+                    b"extends" if extends_value.is_none() => {
+                        extends_value = Some((&property.value, property.key_loc))
+                    }
                     b"compilerOptions" if compiler_opts.is_none() => {
                         compiler_opts = Some(&property.value)
                     }
@@ -358,14 +483,30 @@ impl TSConfigJSON {
             }
         }
 
-        if let Some(extends_value) = extends_value {
-            if !source.path.is_node_module() {
-                if let Some(str) = extends_value.as_str() {
-                    result.extends = Box::from(str);
+        // Parse "extends": a string, or an array of strings (TypeScript 5.0).
+        if let Some((extends_value, key_loc)) = extends_value {
+            let value_loc =
+                json_parser::property_value_loc(&source.contents, key_loc).unwrap_or(key_loc);
+            if let Some(str) = extends_value.as_str() {
+                result.extends.push(TSConfigExtends {
+                    spec: Box::from(str),
+                    loc: value_loc,
+                });
+            } else if let Some(array) = extends_value.as_array() {
+                let mut item_cursor = json_parser::array_item_loc(&source.contents, value_loc, 0);
+                for item in array.items() {
+                    let item_loc = item_cursor.unwrap_or(value_loc);
+                    item_cursor = item_cursor
+                        .and_then(|cur| json_parser::array_next_item_loc(&source.contents, cur));
+                    if let Some(str) = item.as_str() {
+                        result.extends.push(TSConfigExtends {
+                            spec: Box::from(str),
+                            loc: item_loc,
+                        });
+                    }
                 }
             }
         }
-        let mut has_base_url = false;
 
         // Parse "compilerOptions"
         if let Some(compiler_opts) = compiler_opts {
@@ -423,23 +564,24 @@ impl TSConfigJSON {
             // Parse "baseUrl"
             if let Some(base_url_prop) = base_url_v {
                 if let Some(base_url) = base_url_prop.as_str() {
+                    // tsc resolves "" against the config directory, the same as ".".
+                    let base_url: &[u8] = if base_url.is_empty() { b"." } else { base_url };
                     result.base_url =
-                        match Self::str_replacing_templates(Box::from(base_url), source) {
+                        match Self::str_replacing_templates(Box::from(base_url), config_dir) {
                             Ok(v) => v,
                             Err(_) => return Ok(None),
                         };
-                    has_base_url = true;
                 }
             }
 
             // Parse "emitDecoratorMetadata"
             if let Some(&bun_ast::E::JsonValue::Boolean(val)) = emit_decorator_metadata_v {
-                result.emit_decorator_metadata = val;
+                result.emit_decorator_metadata = Some(val);
             }
 
             // Parse "experimentalDecorators"
             if let Some(&bun_ast::E::JsonValue::Boolean(val)) = experimental_decorators_v {
-                result.experimental_decorators = val;
+                result.experimental_decorators = Some(val);
             }
 
             // Parse "useDefineForClassFields"
@@ -564,12 +706,7 @@ impl TSConfigJSON {
                     bun_analytics::features::tsconfig_paths
                         .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
-                    result.base_url_for_paths = if !result.base_url.is_empty() {
-                        result.base_url.clone()
-                    } else {
-                        Box::from(b".".as_slice())
-                    };
-                    result.paths = PathsMap::default();
+                    let mut paths_map = PathsMap::default();
                     for property in paths.properties() {
                         let key = property.key.slice();
                         let key_loc = property.key_loc;
@@ -604,50 +741,44 @@ impl TSConfigJSON {
                                 let array = e_array.get().items();
 
                                 if !array.is_empty() {
-                                    let mut values: Vec<Box<[u8]>> =
+                                    let mut values: Vec<TSConfigPath> =
                                         Vec::with_capacity(array.len());
                                     let array_loc =
                                         json_parser::property_value_loc(&source.contents, key_loc)
                                             .unwrap_or(key_loc);
                                     let mut item_cursor =
                                         json_parser::array_item_loc(&source.contents, array_loc, 0);
-                                    // errdefer allocator.free(values) — handled by Drop.
                                     for item in array.iter() {
-                                        let this_item_loc = item_cursor.unwrap_or(key_loc);
+                                        let item_loc = item_cursor.unwrap_or(key_loc);
                                         item_cursor = item_cursor.and_then(|cur| {
                                             json_parser::array_next_item_loc(&source.contents, cur)
                                         });
                                         if let Some(str_) = item.as_str() {
-                                            let item_loc = this_item_loc;
                                             let str = match Self::str_replacing_templates(
                                                 Box::from(str_),
-                                                source,
+                                                config_dir,
                                             ) {
                                                 Ok(v) => v,
                                                 Err(_) => return Ok(None),
                                             };
-                                            // errdefer allocator.free(str) — handled by Drop.
+                                            // Non-relative entries are only valid with a
+                                            // "baseUrl", which another file of the chain can
+                                            // supply. `remove_paths_that_need_base_url` checks
+                                            // that once the chain is merged.
                                             if Self::is_valid_tsconfig_path_pattern(
                                                 &str, log, source, item_loc,
-                                            ) && (has_base_url
-                                                || Self::is_valid_tsconfig_path_no_base_url_pattern(
-                                                    &str, log, source, item_loc,
-                                                ))
-                                            {
-                                                values.push(str);
+                                            ) {
+                                                values.push(TSConfigPath {
+                                                    text: str,
+                                                    loc: item_loc,
+                                                });
                                             }
                                         }
                                     }
                                     if !values.is_empty() {
-                                        // Invalid patterns are filtered out above, so count <= array.len.
-                                        // Shrink the allocation so the slice stored in the map is exactly
-                                        // what was allocated — callers that later free these values
-                                        // (the extends-merge in the resolver) pass the stored slice
-                                        // to the allocator, which requires the original length.
                                         values.shrink_to_fit();
-                                        let _ = result.paths.put(Box::from(key), values);
+                                        let _ = paths_map.put(Box::from(key), values);
                                     }
-                                    // else: Every entry was invalid; nothing to store. `values` drops here.
                                 }
                             }
                             _ => {
@@ -662,12 +793,12 @@ impl TSConfigJSON {
                             }
                         }
                     }
+                    result.paths = Some(TSConfigPaths {
+                        map: paths_map,
+                        source_path: Box::from(source.path.text),
+                    });
                 }
             }
-        }
-
-        if cfg!(debug_assertions) && has_base_url {
-            debug_assert!(!result.base_url.is_empty());
         }
 
         Ok(Some(TSConfigJSON::new(result)))
@@ -738,12 +869,9 @@ impl TSConfigJSON {
         Some(strings::tokenize(text, b".").map(Box::from).collect())
     }
 
-    pub(crate) fn is_valid_tsconfig_path_no_base_url_pattern(
-        text: &[u8],
-        log: &mut bun_ast::Log,
-        source: &bun_ast::Source,
-        loc: bun_ast::Loc,
-    ) -> bool {
+    /// The "paths" entries tsc accepts without a "baseUrl": relative (`./x`,
+    /// `../x`, `.`, `..`) or absolute (POSIX or DOS drive) paths.
+    fn is_relative_or_absolute_path(text: &[u8]) -> bool {
         let c0: u8;
         let c1: u8;
         let c2: u8;
@@ -784,7 +912,16 @@ impl TSConfigJSON {
         }
 
         // Absolute unix "/"
-        if bun_paths::is_sep_any(c0) {
+        bun_paths::is_sep_any(c0)
+    }
+
+    pub(crate) fn is_valid_tsconfig_path_no_base_url_pattern(
+        text: &[u8],
+        log: &mut bun_ast::Log,
+        source: &bun_ast::Source,
+        loc: bun_ast::Loc,
+    ) -> bool {
+        if Self::is_relative_or_absolute_path(text) {
             return true;
         }
 

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -633,7 +633,9 @@ impl TSConfigJSON {
                         ImportsNotUsedAsValue::Preserve | ImportsNotUsedAsValue::Err => {
                             result.preserve_imports_not_used_as_values = Some(true);
                         }
-                        ImportsNotUsedAsValue::Remove => {}
+                        ImportsNotUsedAsValue::Remove => {
+                            result.preserve_imports_not_used_as_values = Some(false);
+                        }
                         _ => {
                             let _ = log.add_range_warning_fmt(
                                 Some(source),

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -123,17 +123,14 @@ pub(crate) type PathsMap = ArrayHashMap<Box<[u8]>, Vec<TSConfigPath>>;
 /// One fallback entry of a `compilerOptions.paths` array.
 pub(crate) struct TSConfigPath {
     pub(crate) text: Box<[u8]>,
-    /// Position of the string in the file that declared it, for the warning
-    /// when a non-relative entry survives to a merged config without `baseUrl`.
+    /// Position of the string in the file that declared it, for diagnostics after the merge.
     pub(crate) loc: bun_ast::Loc,
 }
 
-/// `compilerOptions.paths` together with the file that declared it. Across an
-/// `extends` chain the whole map is inherited or replaced as one unit.
+/// `compilerOptions.paths` and the file that declared it.
 pub(crate) struct TSConfigPaths {
     pub(crate) map: PathsMap,
-    /// Absolute path of the tsconfig file whose `paths` this is. When no file in
-    /// the chain sets `baseUrl`, relative entries resolve against its directory.
+    /// Without a "baseUrl" anywhere in the chain, relative entries resolve against its directory.
     pub(crate) source_path: Box<[u8]>,
 }
 
@@ -143,11 +140,9 @@ impl TSConfigPaths {
     }
 }
 
-/// One entry of the top-level `extends` field (a string, or one item of a
-/// TypeScript 5.0 array).
+/// One entry of the top-level `extends` field (a string, or one item of a TypeScript 5.0 array).
 pub(crate) struct TSConfigExtends {
     pub(crate) spec: Box<[u8]>,
-    /// Position of the string in the file, for diagnostics about the base.
     pub(crate) loc: bun_ast::Loc,
 }
 
@@ -163,18 +158,15 @@ pub(crate) enum JsxField {
 
 pub(crate) type JsxFieldSet = EnumSet<JsxField>;
 
-/// The settings bun reads from one tsconfig.json, after its `extends` chain is
-/// merged in. Every field that a base config can supply has an "unset" state
-/// (`None`, an empty `Box`, or a missing `jsx_flags` bit), so a later file in the
-/// chain overrides an earlier one only where it sets the field.
+/// Every field a base config can supply has an "unset" state (`None`, an empty `Box`,
+/// a missing `jsx_flags` bit), so a file in an `extends` chain only overrides what it sets.
 pub struct TSConfigJSON {
     pub(crate) abs_path: Box<[u8]>,
 
     /// The absolute path of "compilerOptions.baseUrl". Empty when unset.
     pub(crate) base_url: Box<[u8]>,
 
-    /// The `extends` entries of this file, in order. `Resolver::parse_tsconfig`
-    /// drains them while it merges the chain, so a merged config has none.
+    /// Drained by `Resolver::parse_tsconfig`, so a merged config has none.
     pub(crate) extends: Vec<TSConfigExtends>,
     /// The verbatim values of "compilerOptions.paths". The keys are patterns to
     /// match and the values are arrays of fallback paths to search. Each key and
@@ -182,12 +174,9 @@ pub struct TSConfigJSON {
     /// If both the key and the value have a wildcard, the substring matched by
     /// the wildcard is substituted into the fallback path. The keys represent
     /// module-style path names and the fallback paths are relative to the
-    /// "baseUrl" value in the "tsconfig.json" file, or to the directory of the
-    /// file that declared "paths" when no file in the chain sets "baseUrl"
-    /// (the TypeScript 4.1 "paths without baseUrl" feature,
-    /// https://github.com/microsoft/TypeScript/issues/31869).
-    /// `Some` whenever the "paths" key is present, even as `{}`: an empty object
-    /// in a derived file clears inherited paths.
+    /// "baseUrl" value in the "tsconfig.json" file, or to the declaring file's
+    /// directory without one (https://github.com/microsoft/TypeScript/issues/31869).
+    /// `Some` whenever the key is present: `"paths": {}` clears inherited paths.
     pub(crate) paths: Option<TSConfigPaths>,
 
     pub jsx: options::jsx::Pragma,
@@ -261,15 +250,11 @@ impl TSConfigJSON {
         !self.base_url.is_empty()
     }
 
-    /// True when "paths" has at least one usable entry.
     pub(crate) fn has_paths(&self) -> bool {
         self.paths.as_ref().is_some_and(|p| p.map.count() > 0)
     }
 
-    /// The directory that relative "paths" entries resolve against: "baseUrl"
-    /// when any file in the chain sets it, otherwise the directory of the file
-    /// that declared "paths". This matters when a derived config overrides
-    /// "baseUrl" but inherits "paths".
+    /// What relative "paths" entries resolve against.
     pub(crate) fn paths_base_dir(&self) -> &[u8] {
         if self.has_base_url() {
             return &self.base_url;
@@ -280,17 +265,12 @@ impl TSConfigJSON {
         }
     }
 
-    /// Layers `other` on top of `self`: every setting `other` has is copied,
-    /// every setting it lacks keeps the value already in `self`. The resolver
-    /// calls this once per base config (in `extends` order) and then once with
-    /// the file's own settings, so the file overrides its bases and a later
-    /// base overrides an earlier one, the way tsc merges a chain.
+    /// Copies every setting `other` has onto `self`.
     pub(crate) fn apply_extended_config(&mut self, mut other: Box<TSConfigJSON>) {
         if other.has_base_url() {
             self.base_url = core::mem::take(&mut other.base_url);
         }
-        // TypeScript replaces "paths" across extends rather than merging the
-        // maps, so the whole map moves as one unit.
+        // tsc replaces "paths" across extends instead of merging the maps.
         if other.paths.is_some() {
             self.paths = other.paths.take();
         }
@@ -311,11 +291,8 @@ impl TSConfigJSON {
         TSConfigJSON::destroy(other);
     }
 
-    /// Drops the non-relative "paths" entries of a merged config that has no
-    /// "baseUrl", with a warning for each. tsc allows "baseUrl" and "paths" to
-    /// come from different files of an `extends` chain, so this check has to
-    /// wait until the chain is merged. `source` is the file that declared
-    /// "paths", so the warnings point at the offending strings.
+    /// Drops non-relative "paths" entries when no file in the merged chain set "baseUrl".
+    /// `source` is the file that declared "paths".
     pub(crate) fn remove_paths_that_need_base_url(
         &mut self,
         log: &mut bun_ast::Log,
@@ -381,9 +358,7 @@ impl TSConfigJSON {
     // We convert it to an absolute path during module resolution, so we shouldn't need to do that here.
     // https://github.com/microsoft/TypeScript/blob/ef802b1e4ddaf8d6e61d6005614dd796520448f8/src/compiler/commandLineParser.ts#L3243-L3245
     //
-    // `config_dir` is the directory of the root config of the `extends` chain,
-    // not of the file that contains the template: tsc substitutes after the
-    // merge, so a base config's "${configDir}" means the extending project.
+    // `config_dir` is the root config's directory: tsc substitutes after the merge.
     fn str_replacing_templates(
         input: Box<[u8]>,
         config_dir: &[u8],
@@ -426,10 +401,7 @@ impl TSConfigJSON {
         Ok(Box::from(&written[..len]))
     }
 
-    /// Parses one file. `extends` is recorded, not followed: the resolver
-    /// walks the chain and merges with [`Self::apply_extended_config`].
-    /// `config_dir` is what "${configDir}" expands to (the directory of the
-    /// root config of the chain).
+    /// Parses one file. `extends` is recorded, not followed.
     pub fn parse(
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
@@ -761,10 +733,8 @@ impl TSConfigJSON {
                                                 Ok(v) => v,
                                                 Err(_) => return Ok(None),
                                             };
-                                            // Non-relative entries are only valid with a
-                                            // "baseUrl", which another file of the chain can
-                                            // supply. `remove_paths_that_need_base_url` checks
-                                            // that once the chain is merged.
+                                            // Another file of the chain can supply "baseUrl":
+                                            // `remove_paths_that_need_base_url` checks later.
                                             if Self::is_valid_tsconfig_path_pattern(
                                                 &str, log, source, item_loc,
                                             ) {
@@ -869,8 +839,6 @@ impl TSConfigJSON {
         Some(strings::tokenize(text, b".").map(Box::from).collect())
     }
 
-    /// The "paths" entries tsc accepts without a "baseUrl": relative (`./x`,
-    /// `../x`, `.`, `..`) or absolute (POSIX or DOS drive) paths.
     fn is_relative_or_absolute_path(text: &[u8]) -> bool {
         let c0: u8;
         let c1: u8;

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -309,10 +309,13 @@ impl Config {
                 // TODO: JSC -> Ast conversion
                 // SAFETY: VirtualMachine::get() returns the live singleton on the JS thread.
                 let vm = VirtualMachine::get().as_mut();
+                let source =
+                    bun_ast::Source::init_path_string(b"tsconfig.json", &self.tsconfig_buf[..]);
                 if let Ok(Some(parsed_tsconfig)) = TSConfigJSON::parse(
                     &mut self.log,
-                    &bun_ast::Source::init_path_string(b"tsconfig.json", &self.tsconfig_buf[..]),
+                    &source,
                     &mut vm.transpiler.resolver.caches.json,
+                    source.path.source_dir(),
                 ) {
                     self.tsconfig = Some(parsed_tsconfig);
                 }
@@ -775,8 +778,10 @@ impl TransformTask {
             path: source.path,
             virtual_source: Some(source),
             replace_exports: self.replace_exports.entries.clone().expect("OOM"),
-            experimental_decorators: tsconfig.is_some_and(|ts| ts.experimental_decorators),
-            emit_decorator_metadata: tsconfig.is_some_and(|ts| ts.emit_decorator_metadata),
+            experimental_decorators: tsconfig
+                .is_some_and(|ts| ts.experimental_decorators == Some(true)),
+            emit_decorator_metadata: tsconfig
+                .is_some_and(|ts| ts.emit_decorator_metadata == Some(true)),
             use_define_for_class_fields: tsconfig
                 .and_then(|ts| ts.use_define_for_class_fields)
                 .unwrap_or(true),
@@ -1234,11 +1239,11 @@ impl JSTranspiler {
             experimental_decorators: config
                 .tsconfig
                 .as_deref()
-                .is_some_and(|ts| ts.experimental_decorators),
+                .is_some_and(|ts| ts.experimental_decorators == Some(true)),
             emit_decorator_metadata: config
                 .tsconfig
                 .as_deref()
-                .is_some_and(|ts| ts.emit_decorator_metadata),
+                .is_some_and(|ts| ts.emit_decorator_metadata == Some(true)),
             use_define_for_class_fields: config
                 .tsconfig
                 .as_deref()

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -514,6 +514,166 @@ describe("bundler", () => {
       "/Users/user/project/src/entry.ts": [`Could not resolve: "@helpers/x". Maybe you need to "bun install"?`],
     },
   });
+  // "extends" with a package specifier resolves through node_modules the way
+  // tsc does: an exact file, a bare package name (its tsconfig.json), and a
+  // file without the ".json" extension.
+  itBundled("tsconfig/ExtendsPackageExactFile", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "@scope/configs/tsconfig.base.json"
+        }
+      `,
+      "/Users/user/project/node_modules/@scope/configs/tsconfig.base.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
+  itBundled("tsconfig/ExtendsPackageDirectory", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "my-configs"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
+  itBundled("tsconfig/ExtendsPackageImplicitJson", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "my-configs/base"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/base.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
+  // The package config itself extends a sibling file, and the effective
+  // options live only in the base (the @adonisjs/tsconfig layout). The chain
+  // must keep going even though the config sits inside node_modules.
+  itBundled("tsconfig/ExtendsPackageLayered", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "my-configs/tsconfig.app.json"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/tsconfig.app.json": /* json */ `
+        {
+          "extends": "./tsconfig.base.json"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/tsconfig.base.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
+  // TypeScript 5 array extends: later entries override earlier ones, and the
+  // leaf config overrides all of them.
+  itBundled("tsconfig/ExtendsArrayOverrideOrder", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": ["./a.json", "./b.json"]
+        }
+      `,
+      "/Users/user/project/src/a.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "fromA"
+          }
+        }
+      `,
+      "/Users/user/project/src/b.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsxFactory": "fromB"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`fromB("div", null)`);
+      api.expectFile("/Users/user/project/out.js").not.toContain(`fromA`);
+    },
+  });
+  itBundled("tsconfig/ExtendsArrayNested", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": ["./a.json", "./b.json"]
+        }
+      `,
+      "/Users/user/project/src/a.json": /* json */ `
+        {
+          "compilerOptions": { "jsxFactory": "fromA" }
+        }
+      `,
+      "/Users/user/project/src/b.json": /* json */ `
+        {
+          "extends": "./b-base.json"
+        }
+      `,
+      "/Users/user/project/src/b-base.json": /* json */ `
+        {
+          "compilerOptions": { "jsx": "react", "jsxFactory": "fromBBase" }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`fromBBase("div", null)`);
+    },
+  });
   itBundled("tsconfig/JSX", {
     files: {
       "/Users/user/project/entry.tsx": `console.log(<><div/><div/></>)`,

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -203,9 +203,11 @@ describe.concurrent("bun run", () => {
           });
         });
 
-        for (let withLogLevel of [true, false]) {
+        // A base config that cannot be found is a warning: shown at the default
+        // and "debug" log levels, hidden at "error".
+        for (const logLevel of [undefined, "debug", "error"]) {
           it(
-            "valid tsconfig.json with invalid extends doesn't crash" + (withLogLevel ? " (log level debug)" : ""),
+            "valid tsconfig.json with invalid extends doesn't crash" + (logLevel ? ` (log level ${logLevel})` : ""),
             async () => {
               using dir = tempDir("bun-run-tsconfig-extends", {
                 "package.json": JSON.stringify({
@@ -221,7 +223,7 @@ describe.concurrent("bun run", () => {
                   2,
                 ),
                 "index.js": "console.log('hi')",
-                ...(withLogLevel ? { "bunfig.toml": `logLevel = "debug"` } : {}),
+                ...(logLevel ? { "bunfig.toml": `logLevel = "${logLevel}"` } : {}),
               });
 
               await using proc = Bun.spawn({
@@ -244,10 +246,10 @@ describe.concurrent("bun run", () => {
                 proc.exited,
               ]);
 
-              if (withLogLevel) {
-                expect(stderr.trim()).toContain("ENOENT loading tsconfig.json extends");
+              if (logLevel === "error") {
+                expect(stderr.trim()).not.toContain("Cannot find base config file");
               } else {
-                expect(stderr.trim()).not.toContain("ENOENT loading tsconfig.json extends");
+                expect(stderr.trim()).toContain('Cannot find base config file "!!!bad!!!"');
               }
 
               expect(stdout).toBe("hi\n");

--- a/test/js/bun/resolve/tsconfig-extends.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends.test.ts
@@ -517,6 +517,20 @@ describe("tsconfig extends", () => {
       expect(stdout).toBe(jsxExpected);
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a missing entry is a warning and its siblings still apply", async () => {
+      using dir = tempDir("tsconfig-extends-array-missing", {
+        ...noAutoInstall,
+        "real.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
+        "tsconfig.json": JSON.stringify({ extends: ["./missing.json", "./real.json"] }),
+        "lib/mod.ts": `export default "from-lib";`,
+        "index.ts": `import x from "@lib/mod"; console.log(x);`,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "index.ts");
+      expect(stderr).toContain('Cannot find base config file "./missing.json"');
+      expect(stdout).toBe("from-lib\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("nested chains", () => {

--- a/test/js/bun/resolve/tsconfig-extends.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends.test.ts
@@ -299,6 +299,23 @@ describe("tsconfig extends", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.concurrent('package.json "tsconfig" field does not apply to a subpath', async () => {
+      using dir = tempDir("tsconfig-extends-pkg-tsconfig-field-subpath", {
+        ...noAutoInstall,
+        "node_modules/expo/package.json": JSON.stringify({ name: "expo", tsconfig: "./configs/other.json" }),
+        "node_modules/expo/configs/other.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "WRONG", jsxFragmentFactory: "WRONG" },
+        }),
+        "node_modules/expo/tsconfig.base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "expo/tsconfig.base" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
     test.concurrent('package.json "exports" subpath', async () => {
       using dir = tempDir("tsconfig-extends-pkg-exports", {
         ...noAutoInstall,

--- a/test/js/bun/resolve/tsconfig-extends.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends.test.ts
@@ -167,14 +167,16 @@ describe("tsconfig extends", () => {
       expect(exitCode).toBe(0);
     });
 
-    test.concurrent("'.' and '..' mean the tsconfig.json in that directory", async () => {
+    test.concurrent("'..' means the tsconfig.json in that directory", async () => {
       using dir = tempDir("tsconfig-extends-dot", {
         ...noAutoInstall,
         "tsconfig.json": JSON.stringify(jsxBase),
         "sub/tsconfig.json": JSON.stringify({ extends: ".." }),
         "sub/app.tsx": jsxApp,
       });
-      const { stdout, stderr, exitCode } = await runFile(String(dir), "sub/app.tsx");
+      // The runtime reads JSX settings from the tsconfig.json of the working
+      // directory, so run from `sub` to make `extends: ".."` the config in use.
+      const { stdout, stderr, exitCode } = await runFile(join(String(dir), "sub"), "app.tsx");
       expect(stderr).toBe("");
       expect(stdout).toBe(jsxExpected);
       expect(exitCode).toBe(0);

--- a/test/js/bun/resolve/tsconfig-extends.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends.test.ts
@@ -1,0 +1,775 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { mkdirSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+
+// tsconfig.json "extends" resolution. The matrix follows tsc (and esbuild's
+// port of it): relative paths with an implicit ".json", package specifiers
+// looked up in node_modules (bare name, "pkg/file", "pkg/file.json", the
+// package.json "tsconfig" field, and "exports"), TS 5.0 arrays, and the way
+// inherited "paths" / "baseUrl" / "${configDir}" combine across the chain.
+
+async function runFile(dir: string, entry: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+async function build(dir: string, entry: string, ...extra: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", entry, ...extra],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// jsx: "react" with custom factories. No import is needed at runtime, so the
+// factory names in the output prove which config was applied.
+const jsxBase = {
+  compilerOptions: { jsx: "react", jsxFactory: "h", jsxFragmentFactory: "Frag" },
+};
+const jsxApp = `
+  function h(tag: any, _props: any) { return "h:" + (typeof tag === "string" ? tag : tag.name); }
+  function Frag() {}
+  console.log(<div />, <></>);
+`;
+const jsxExpected = "h:div h:Frag\n";
+
+// A node_modules directory disables auto-install, so a bare specifier that
+// "paths" fails to remap is a resolution error instead of a registry fetch.
+const noAutoInstall = { "node_modules/.keep": "" };
+
+function expectJsxBuild(out: string) {
+  expect(out).toContain('h("div"');
+  expect(out).toContain("h(Frag");
+  expect(out).not.toContain("jsxDEV");
+}
+
+// A legacy (experimentalDecorators) method decorator receives three
+// arguments. A standard decorator receives two.
+const decoratorApp = `
+  function dec(..._args: any[]) { console.log("dec args:", _args.length); }
+  class A { @dec m() {} }
+  new A();
+`;
+
+describe("tsconfig extends", () => {
+  describe("relative", () => {
+    test.concurrent("implicit .json extension (bun run)", async () => {
+      using dir = tempDir("tsconfig-extends-implicit-json", {
+        ...noAutoInstall,
+        "config/base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "./config/base" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("implicit .json extension (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-implicit-json-build", {
+        ...noAutoInstall,
+        "config/base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "./config/base" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "app.tsx", "--external", "*");
+      expect(stderr).toBe("");
+      expectJsxBuild(stdout);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("explicit .json extension", async () => {
+      using dir = tempDir("tsconfig-extends-explicit-json", {
+        ...noAutoInstall,
+        "config/base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "./config/base.json" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a directory with the same name as the base is skipped", async () => {
+      using dir = tempDir("tsconfig-extends-dir-shadow", {
+        ...noAutoInstall,
+        // "./config/base" names both a directory and a ".json" file. tsc only
+        // accepts files here, so "./config/base.json" is the base.
+        "config/base/tsconfig.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "WRONG", jsxFragmentFactory: "WRONG" },
+        }),
+        "config/base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "./config/base" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a bare sibling name without './' still resolves relative to the file", async () => {
+      // tsc rejects this shape, but older Bun versions accepted it.
+      using dir = tempDir("tsconfig-extends-bare-sibling", {
+        ...noAutoInstall,
+        "base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "base.json" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("the leaf's experimentalDecorators survives a single-string chain", async () => {
+      // The NestJS and TypeORM shape: the base has no decorator settings.
+      using dir = tempDir("tsconfig-extends-leaf-decorators", {
+        ...noAutoInstall,
+        "base.json": JSON.stringify({ compilerOptions: { target: "ES2022" } }),
+        "tsconfig.json": JSON.stringify({
+          extends: "./base.json",
+          compilerOptions: { experimentalDecorators: true },
+        }),
+        "app.ts": decoratorApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("dec args: 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a relative path into node_modules follows that file's own extends", async () => {
+      using dir = tempDir("tsconfig-extends-relative-into-node-modules", {
+        "node_modules/pkg/package.json": JSON.stringify({ name: "pkg" }),
+        "node_modules/pkg/app.json": JSON.stringify({ extends: "./flags.json" }),
+        "node_modules/pkg/flags.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "./node_modules/pkg/app.json" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("'.' and '..' mean the tsconfig.json in that directory", async () => {
+      using dir = tempDir("tsconfig-extends-dot", {
+        ...noAutoInstall,
+        "tsconfig.json": JSON.stringify(jsxBase),
+        "sub/tsconfig.json": JSON.stringify({ extends: ".." }),
+        "sub/app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "sub/app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("package specifier", () => {
+    test.concurrent("bare package name resolves to <pkg>/tsconfig.json (bun run)", async () => {
+      using dir = tempDir("tsconfig-extends-bare-pkg", {
+        ...noAutoInstall,
+        "node_modules/@tsconfig/strictest/package.json": JSON.stringify({ name: "@tsconfig/strictest" }),
+        "node_modules/@tsconfig/strictest/tsconfig.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "@tsconfig/strictest" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("bare package name resolves to <pkg>/tsconfig.json (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-bare-pkg-build", {
+        ...noAutoInstall,
+        "node_modules/@tsconfig/strictest/package.json": JSON.stringify({ name: "@tsconfig/strictest" }),
+        "node_modules/@tsconfig/strictest/tsconfig.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "@tsconfig/strictest" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "app.tsx", "--external", "*");
+      expect(stderr).toBe("");
+      expectJsxBuild(stdout);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("<pkg>/tsconfig.json with paths and experimentalDecorators (bun run)", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-file-json", {
+        ...noAutoInstall,
+        "node_modules/@tsconfig/strictest/package.json": JSON.stringify({ name: "@tsconfig/strictest" }),
+        "node_modules/@tsconfig/strictest/tsconfig.json": JSON.stringify({
+          compilerOptions: { experimentalDecorators: true, paths: { "@lib/*": ["../../../lib/*"] } },
+        }),
+        "lib/x.ts": `export const v = "lib-v";`,
+        "tsconfig.json": JSON.stringify({ extends: "@tsconfig/strictest/tsconfig.json" }),
+        "d.ts": `
+          import { v } from "@lib/x";
+          ${decoratorApp}
+          console.log(v);
+        `,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "d.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("dec args: 3\nlib-v\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("<pkg>/tsconfig.json with paths and experimentalDecorators (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-file-json-build", {
+        ...noAutoInstall,
+        "node_modules/@tsconfig/strictest/package.json": JSON.stringify({ name: "@tsconfig/strictest" }),
+        "node_modules/@tsconfig/strictest/tsconfig.json": JSON.stringify({
+          compilerOptions: { experimentalDecorators: true, paths: { "@lib/*": ["../../../lib/*"] } },
+        }),
+        "lib/x.ts": `export const v = "lib-v";`,
+        "tsconfig.json": JSON.stringify({ extends: "@tsconfig/strictest/tsconfig.json" }),
+        "d.ts": `
+          import { v } from "@lib/x";
+          ${decoratorApp}
+          console.log(v);
+        `,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "d.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toContain("lib-v");
+      // Legacy decorators lower through this helper; standard decorators do not.
+      expect(stdout).toContain("__legacyDecorateClassTS");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("<pkg>/file resolves to <pkg>/file.json", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-file", {
+        ...noAutoInstall,
+        "node_modules/expo/package.json": JSON.stringify({ name: "expo" }),
+        "node_modules/expo/tsconfig.base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "expo/tsconfig.base" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("<pkg>/file.json", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-file-ext", {
+        ...noAutoInstall,
+        "node_modules/expo/package.json": JSON.stringify({ name: "expo" }),
+        "node_modules/expo/tsconfig.base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "expo/tsconfig.base.json" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent('package.json "tsconfig" field', async () => {
+      using dir = tempDir("tsconfig-extends-pkg-tsconfig-field", {
+        ...noAutoInstall,
+        "node_modules/@my/config/package.json": JSON.stringify({
+          name: "@my/config",
+          tsconfig: "./configs/base.json",
+        }),
+        "node_modules/@my/config/configs/base.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "@my/config" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent('package.json "exports" subpath', async () => {
+      using dir = tempDir("tsconfig-extends-pkg-exports", {
+        ...noAutoInstall,
+        "node_modules/@cfg/base/package.json": JSON.stringify({
+          name: "@cfg/base",
+          exports: { "./tsconfig": "./dist/the-config.json" },
+        }),
+        "node_modules/@cfg/base/dist/the-config.json": JSON.stringify(jsxBase),
+        "tsconfig.json": JSON.stringify({ extends: "@cfg/base/tsconfig" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent('package.json "exports" with conditions', async () => {
+      using dir = tempDir("tsconfig-extends-pkg-exports-cond", {
+        ...noAutoInstall,
+        "node_modules/@cfg/base/package.json": JSON.stringify({
+          name: "@cfg/base",
+          exports: { "./tsconfig": { require: "./dist/the-config.json", default: "./dist/wrong.json" } },
+        }),
+        "node_modules/@cfg/base/dist/the-config.json": JSON.stringify(jsxBase),
+        "node_modules/@cfg/base/dist/wrong.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "WRONG", jsxFragmentFactory: "WRONG" },
+        }),
+        "tsconfig.json": JSON.stringify({ extends: "@cfg/base/tsconfig" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("node_modules in an ancestor directory (bun run)", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-ancestor", {
+        ...noAutoInstall,
+        "node_modules/@tsconfig/node20/package.json": JSON.stringify({ name: "@tsconfig/node20" }),
+        "node_modules/@tsconfig/node20/tsconfig.json": JSON.stringify(jsxBase),
+        "packages/app/tsconfig.json": JSON.stringify({ extends: "@tsconfig/node20/tsconfig.json" }),
+        "packages/app/app.tsx": jsxApp,
+      });
+      // The runtime reads JSX settings from the tsconfig.json of the working
+      // directory, so run from the package.
+      const { stdout, stderr, exitCode } = await runFile(join(String(dir), "packages", "app"), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("node_modules in an ancestor directory (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-ancestor-build", {
+        ...noAutoInstall,
+        "node_modules/@tsconfig/node20/package.json": JSON.stringify({ name: "@tsconfig/node20" }),
+        "node_modules/@tsconfig/node20/tsconfig.json": JSON.stringify(jsxBase),
+        "packages/app/tsconfig.json": JSON.stringify({ extends: "@tsconfig/node20/tsconfig.json" }),
+        "packages/app/app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "packages/app/app.tsx", "--external", "*");
+      expect(stderr).toBe("");
+      expectJsxBuild(stdout);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a symlinked workspace package resolves its paths from its real location", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-symlink", {
+        "packages/cfg/package.json": JSON.stringify({ name: "@repo/cfg" }),
+        "packages/cfg/tsconfig.json": JSON.stringify({
+          compilerOptions: { paths: { "@shared/*": ["../shared/*"] } },
+        }),
+        "packages/shared/util.ts": `export const v = "shared-util";`,
+        "apps/web/node_modules/.keep": "",
+        "apps/web/tsconfig.json": JSON.stringify({ extends: "@repo/cfg/tsconfig.json" }),
+        "apps/web/entry.ts": `import { v } from "@shared/util"; console.log(v);`,
+      });
+      mkdirSync(join(String(dir), "apps", "web", "node_modules", "@repo"));
+      symlinkSync(
+        join(String(dir), "packages", "cfg"),
+        join(String(dir), "apps", "web", "node_modules", "@repo", "cfg"),
+        isWindows ? "junction" : "dir",
+      );
+      const { stdout, stderr, exitCode } = await runFile(join(String(dir), "apps", "web"), "entry.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("shared-util\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("jsxImportSource is inherited through a chain inside node_modules", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-jsx-import-source", {
+        ...noAutoInstall,
+        "node_modules/@vue/tsconfig/package.json": JSON.stringify({ name: "@vue/tsconfig" }),
+        "node_modules/@vue/tsconfig/tsconfig.json": JSON.stringify({
+          compilerOptions: { jsx: "react-jsx", jsxImportSource: "vue" },
+        }),
+        "node_modules/@vue/tsconfig/tsconfig.dom.json": JSON.stringify({
+          extends: "./tsconfig.json",
+          compilerOptions: { lib: ["DOM"] },
+        }),
+        "tsconfig.json": JSON.stringify({ extends: "@vue/tsconfig/tsconfig.dom.json" }),
+        "app.tsx": `console.log(<div />);`,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "app.tsx", "--external", "*");
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`from "vue/jsx-runtime"`);
+      expect(stdout).not.toContain("jsxDEV");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a base inside node_modules can extend another file", async () => {
+      using dir = tempDir("tsconfig-extends-pkg-chain", {
+        ...noAutoInstall,
+        "node_modules/astro/package.json": JSON.stringify({ name: "astro" }),
+        "node_modules/astro/tsconfigs/base.json": JSON.stringify(jsxBase),
+        "node_modules/astro/tsconfigs/strict.json": JSON.stringify({ extends: "./base.json" }),
+        "tsconfig.json": JSON.stringify({ extends: "astro/tsconfigs/strict" }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("array", () => {
+    test.concurrent("every entry is applied, later entries override earlier ones (bun run)", async () => {
+      using dir = tempDir("tsconfig-extends-array", {
+        ...noAutoInstall,
+        "base1.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "WRONG", jsxFragmentFactory: "Frag" },
+        }),
+        "base2.json": JSON.stringify({ compilerOptions: { jsxFactory: "h", experimentalDecorators: true } }),
+        "tsconfig.json": JSON.stringify({ extends: ["./base1.json", "./base2.json"] }),
+        "app.tsx": `
+          ${jsxApp}
+          ${decoratorApp}
+        `,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected + "dec args: 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("every entry is applied, later entries override earlier ones (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-array-build", {
+        ...noAutoInstall,
+        "base1.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "WRONG", jsxFragmentFactory: "Frag" },
+        }),
+        "base2.json": JSON.stringify({ compilerOptions: { jsxFactory: "h" } }),
+        "tsconfig.json": JSON.stringify({ extends: ["./base1.json", "./base2.json"] }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "app.tsx", "--external", "*");
+      expect(stderr).toBe("");
+      expectJsxBuild(stdout);
+      expect(stdout).not.toContain("WRONG");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("the file's own options override every base", async () => {
+      using dir = tempDir("tsconfig-extends-array-own", {
+        ...noAutoInstall,
+        "base1.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "WRONG1", jsxFragmentFactory: "Frag" },
+        }),
+        "base2.json": JSON.stringify({ compilerOptions: { jsxFactory: "WRONG2" } }),
+        "tsconfig.json": JSON.stringify({
+          extends: ["./base1.json", "./base2.json"],
+          compilerOptions: { jsxFactory: "h" },
+        }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("mixes relative and package entries", async () => {
+      using dir = tempDir("tsconfig-extends-array-mixed", {
+        ...noAutoInstall,
+        "node_modules/@tsconfig/node20/package.json": JSON.stringify({ name: "@tsconfig/node20" }),
+        "node_modules/@tsconfig/node20/tsconfig.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "h" },
+        }),
+        "local.json": JSON.stringify({ compilerOptions: { jsxFragmentFactory: "Frag" } }),
+        "tsconfig.json": JSON.stringify({ extends: ["@tsconfig/node20", "./local.json"] }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("nested chains", () => {
+    test.concurrent("three levels: relative, package, relative", async () => {
+      using dir = tempDir("tsconfig-extends-nested", {
+        ...noAutoInstall,
+        "node_modules/preset/package.json": JSON.stringify({ name: "preset" }),
+        "node_modules/preset/tsconfig.json": JSON.stringify({
+          extends: "./inner/base.json",
+          compilerOptions: { jsxFragmentFactory: "Frag" },
+        }),
+        "node_modules/preset/inner/base.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: "WRONG", experimentalDecorators: true },
+        }),
+        "config/mid.json": JSON.stringify({ extends: "preset", compilerOptions: { jsxFactory: "h" } }),
+        "tsconfig.json": JSON.stringify({ extends: "./config/mid" }),
+        "app.tsx": `
+          ${jsxApp}
+          ${decoratorApp}
+        `,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.tsx");
+      expect(stderr).toBe("");
+      expect(stdout).toBe(jsxExpected + "dec args: 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("useDefineForClassFields is inherited from the root of the chain", async () => {
+      using dir = tempDir("tsconfig-extends-udfcf", {
+        ...noAutoInstall,
+        "base/root.json": JSON.stringify({ compilerOptions: { useDefineForClassFields: false } }),
+        "base/mid.json": JSON.stringify({ extends: "./root" }),
+        "tsconfig.json": JSON.stringify({ extends: "./base/mid.json" }),
+        "index.ts": `
+          let setterCalled = false;
+          class Base { set p(v: any) { setterCalled = true; } get p() { return "getter"; } }
+          class C extends Base { p: any = "field"; }
+          new C();
+          console.log(setterCalled);
+        `,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "index.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("true\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a derived file can turn an inherited boolean back off", async () => {
+      using dir = tempDir("tsconfig-extends-bool-override", {
+        ...noAutoInstall,
+        "base.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+        "tsconfig.json": JSON.stringify({
+          extends: "./base.json",
+          compilerOptions: { experimentalDecorators: false },
+        }),
+        "app.ts": decoratorApp,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("dec args: 2\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("${configDir}", () => {
+    test.concurrent("in an inherited paths entry, resolves to the root tsconfig directory (bun run)", async () => {
+      using dir = tempDir("tsconfig-extends-configdir-paths", {
+        ...noAutoInstall,
+        "base/tsconfig.json": JSON.stringify({
+          compilerOptions: { paths: { "js/*": ["${configDir}/dist/js/*"] } },
+        }),
+        "base/dist/js/foo.ts": `export default "WRONG";`,
+        "app/tsconfig.json": JSON.stringify({ extends: "../base/tsconfig.json" }),
+        "app/dist/js/foo.ts": `export default "app-foo";`,
+        "app/src/main.ts": `import x from "js/foo"; console.log(x);`,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app/src/main.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("app-foo\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("in an inherited paths entry, resolves to the root tsconfig directory (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-configdir-paths-build", {
+        ...noAutoInstall,
+        "base/tsconfig.json": JSON.stringify({
+          compilerOptions: { paths: { "js/*": ["${configDir}/dist/js/*"] } },
+        }),
+        "base/dist/js/foo.ts": `export default "WRONG";`,
+        "app/tsconfig.json": JSON.stringify({ extends: "../base/tsconfig.json" }),
+        "app/dist/js/foo.ts": `export default "app-foo";`,
+        "app/src/main.ts": `import x from "js/foo"; console.log(x);`,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "app/src/main.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toContain("app-foo");
+      expect(stdout).not.toContain("WRONG");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("in an inherited baseUrl, resolves to the root tsconfig directory", async () => {
+      using dir = tempDir("tsconfig-extends-configdir-baseurl", {
+        ...noAutoInstall,
+        "base/tsconfig.json": JSON.stringify({
+          compilerOptions: { baseUrl: "${configDir}/src", paths: { "util/*": ["lib/util/*"] } },
+        }),
+        "base/src/lib/util/a.ts": `export default "WRONG";`,
+        "app/tsconfig.json": JSON.stringify({ extends: "../base/tsconfig.json" }),
+        "app/src/lib/util/a.ts": `export default "app-a";`,
+        "app/src/main.ts": `import a from "util/a"; console.log(a);`,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app/src/main.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("app-a\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("in the root config itself, resolves to its own directory", async () => {
+      using dir = tempDir("tsconfig-extends-configdir-root", {
+        ...noAutoInstall,
+        "base/tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react", jsxFactory: "h" } }),
+        "app/tsconfig.json": JSON.stringify({
+          extends: "../base/tsconfig.json",
+          compilerOptions: { paths: { "js/*": ["${configDir}/dist/js/*"] } },
+        }),
+        "app/dist/js/foo.ts": `export default "app-foo";`,
+        "app/src/main.ts": `import x from "js/foo"; console.log(x);`,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "app/src/main.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("app-foo\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("paths and baseUrl split across the chain", () => {
+    test.concurrent("paths in the base, baseUrl in the leaf (bun run)", async () => {
+      using dir = tempDir("tsconfig-extends-split-paths-base", {
+        ...noAutoInstall,
+        "base/tsconfig.base.json": JSON.stringify({ compilerOptions: { paths: { foo: ["lib/foo.ts"] } } }),
+        "tsconfig.json": JSON.stringify({
+          extends: "./base/tsconfig.base.json",
+          compilerOptions: { baseUrl: "." },
+        }),
+        "lib/foo.ts": `export const v = "lib-foo";`,
+        "entry.ts": `import { v } from "foo"; console.log(v);`,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "entry.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("lib-foo\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("paths in the base, baseUrl in the leaf (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-split-paths-base-build", {
+        ...noAutoInstall,
+        "base/tsconfig.base.json": JSON.stringify({ compilerOptions: { paths: { foo: ["lib/foo.ts"] } } }),
+        "tsconfig.json": JSON.stringify({
+          extends: "./base/tsconfig.base.json",
+          compilerOptions: { baseUrl: "." },
+        }),
+        "lib/foo.ts": `export const v = "lib-foo";`,
+        "entry.ts": `import { v } from "foo"; console.log(v);`,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "entry.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toContain("lib-foo");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("baseUrl in the base, paths in the leaf", async () => {
+      using dir = tempDir("tsconfig-extends-split-baseurl-base", {
+        ...noAutoInstall,
+        // A relative baseUrl is resolved against the file that declares it.
+        "base/tsconfig.base.json": JSON.stringify({ compilerOptions: { baseUrl: "./src" } }),
+        "base/src/lib/foo.ts": `export const v = "base-src-foo";`,
+        "tsconfig.json": JSON.stringify({
+          extends: "./base/tsconfig.base.json",
+          compilerOptions: { paths: { foo: ["lib/foo.ts"] } },
+        }),
+        "lib/foo.ts": `export const v = "WRONG";`,
+        "entry.ts": `import { v } from "foo"; console.log(v);`,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "entry.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("base-src-foo\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("paths without any baseUrl resolve against the file that declares them", async () => {
+      using dir = tempDir("tsconfig-extends-paths-no-baseurl", {
+        ...noAutoInstall,
+        "base/tsconfig.base.json": JSON.stringify({ compilerOptions: { paths: { "@/*": ["./src/*"] } } }),
+        "base/src/a.ts": `export const v = "base-a";`,
+        "tsconfig.json": JSON.stringify({ extends: "./base/tsconfig.base.json" }),
+        "src/a.ts": `export const v = "WRONG";`,
+        "entry.ts": `import { v } from "@/a"; console.log(v);`,
+      });
+      const { stdout, stderr, exitCode } = await runFile(String(dir), "entry.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("base-a\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("non-relative paths still warn when no file in the chain sets baseUrl", async () => {
+      using dir = tempDir("tsconfig-extends-paths-warn", {
+        ...noAutoInstall,
+        "base/tsconfig.base.json": JSON.stringify({ compilerOptions: { paths: { foo: ["lib/foo.ts"] } } }),
+        "tsconfig.json": JSON.stringify({ extends: "./base/tsconfig.base.json" }),
+        "lib/foo.ts": `export const v = "lib-foo";`,
+        "entry.ts": `import { v } from "foo"; console.log(v);`,
+      });
+      const { stderr, exitCode } = await build(String(dir), "entry.ts");
+      expect(stderr).toContain('Non-relative path "lib/foo.ts" is not allowed when "baseUrl" is not set');
+      expect(stderr).toContain('Could not resolve: "foo"');
+      expect(exitCode).not.toBe(0);
+    });
+  });
+
+  describe("diagnostics", () => {
+    test.concurrent("a missing base config is a warning (bun build)", async () => {
+      using dir = tempDir("tsconfig-extends-missing", {
+        ...noAutoInstall,
+        "tsconfig.json": JSON.stringify({ extends: "@does-not/exist" }),
+        "entry.ts": `console.log("ok");`,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "entry.ts");
+      expect(stderr).toContain('Cannot find base config file "@does-not/exist"');
+      expect(stdout).toContain('console.log("ok")');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a missing base config does not break bun run", async () => {
+      using dir = tempDir("tsconfig-extends-missing-run", {
+        ...noAutoInstall,
+        "tsconfig.json": JSON.stringify({ extends: "./nope" }),
+        "entry.ts": `console.log("ok");`,
+      });
+      const { stdout, exitCode } = await runFile(String(dir), "entry.ts");
+      expect(stdout).toBe("ok\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("an extends cycle is a warning, not a hang", async () => {
+      using dir = tempDir("tsconfig-extends-cycle", {
+        ...noAutoInstall,
+        "tsconfig.json": JSON.stringify({ extends: "./base.json", compilerOptions: { jsxFactory: "h" } }),
+        "base.json": JSON.stringify({
+          extends: "./tsconfig",
+          compilerOptions: { jsx: "react", jsxFragmentFactory: "Frag" },
+        }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "app.tsx", "--external", "*");
+      expect(stderr).toContain('Base config file "./tsconfig" forms cycle');
+      expectJsxBuild(stdout);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a diamond is not a cycle", async () => {
+      using dir = tempDir("tsconfig-extends-diamond", {
+        ...noAutoInstall,
+        "shared.json": JSON.stringify(jsxBase),
+        "left.json": JSON.stringify({ extends: "./shared.json" }),
+        "right.json": JSON.stringify({ extends: "./shared.json" }),
+        "tsconfig.json": JSON.stringify({ extends: ["./left.json", "./right.json"] }),
+        "app.tsx": jsxApp,
+      });
+      const { stdout, stderr, exitCode } = await build(String(dir), "app.tsx", "--external", "*");
+      expect(stderr).toBe("");
+      expectJsxBuild(stdout);
+      expect(exitCode).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6326
Fixes #5524
Fixes #5277
Fixes #23695
Fixes #34494

### Problem
- tsconfig `extends` only worked for a relative path with an explicit `.json`. Package specifiers (`@tsconfig/node20`, `@vue/tsconfig/tsconfig.dom.json`, `expo/tsconfig.base`), the package.json `tsconfig` field and `exports` map, `./base` without `.json`, and TS 5.0 arrays were dropped with a debug-level log. Every inherited `paths`, `baseUrl`, `jsx*`, decorator and `useDefineForClassFields` setting was lost, in `bun run` and `bun build`.
- The walk in `dir_info_uncached` joined the value onto the file's directory and `break`ed on any error (`src/resolver/resolver.rs`). `TSConfigJSON::parse` read `extends` with `as_str()` only, expanded `${configDir}` to the containing file's directory, and rejected non-relative `paths` per file instead of on the merged result (`src/resolver/tsconfig_json.rs`).

### Fix
- `parse_tsconfig` is recursive, the shape of esbuild's `parseTSConfig`. Each file's bases are resolved and merged in order with `apply_extended_config`, then the file's own settings go on top. `${configDir}` is the root config's directory for the whole chain. The non-relative `paths` check runs once on the merged config.
- Package specifiers walk ancestor `node_modules` by hand (the directory cache lock is held): `exports` with `require` conditions, then the `tsconfig` field (bare names only), then `<pkg>/tsconfig.json`, `<pkg>/file`, `<pkg>/file.json`. Hits are parsed under their real path unless `--preserve-symlinks` is set. A bare sibling name (`"base.json"`) still falls back to the relative lookup, so it keeps working.
- `paths` keep the file that declared them, so relative entries resolve against that file when no `baseUrl` exists. Decorator flags are `Option<bool>`, so a derived `false` overrides a base `true`.
- Verified: `test/js/bun/resolve/tsconfig-extends.test.ts` (44 tests, 38 fail on 1.4.1) and six `tsconfig/Extends*` cases in `test/bundler/esbuild/tsconfig.test.ts` (all six fail on 1.4.1). Also the decorator and `useDefineForClassFields` suites, and the extends leak test.

### Background
- `dir_info_uncached` parses the `tsconfig.json` of every directory the resolver visits and interns the result. It holds the directory cache locks, so the extends walk cannot call `dir_info_cached`.
- tsc resolves a relative `baseUrl` against the file that declares it, `paths` against `baseUrl` or else the declaring file's directory, and `${configDir}` against the root config after the merge. `paths` replaces across the chain rather than merging.
- A missing base is a warning (`Cannot find base config file "..."`), a cycle too (`Base config file "..." forms cycle`). The missing-base warning stays quiet for a file inside `node_modules`, as in esbuild. A cycle always warns, because the user's own config is part of it.

<details><summary>Notes</summary>

Behavior changes beyond the matrix:

- A tsconfig inside `node_modules` now follows its own `extends` (esbuild does the same). Before, `extends` was ignored for every file under `node_modules`, so a chain such as `@vue/tsconfig/tsconfig.dom.json` -> `./tsconfig.json` stopped after one hop. This also applies to a relative `extends: "./node_modules/pkg/app.json"`.
- A base that cannot be found was silent. It is now a warning in `bun build` and `bun run`, which already print the other tsconfig diagnostics at the default log level. The warning is suppressed for a file inside `node_modules`. A missing entry of an array does not drop its siblings.
- `importsNotUsedAsValues` from a base is no longer overridden by the derived file's default.
- `merge_jsx` copies `package_name` along with `import_source` when `jsxImportSource` is inherited.

Not changed: the runtime reads JSX settings from the `tsconfig.json` of the working directory, not the entry file's nearest one. The ancestor `node_modules` test runs from the package directory for that reason. `--tsconfig-override` still prints an `Internal error: directory mismatch` line (it passes the root directory fd to `parse_tsconfig`), which is separate from this change.

Known limits, found in a second review pass over the walk (ownership of each `Box<TSConfigJSON>`, `visiting` push and pop balance, the path buffer pool under recursion, Windows paths, errno mapping). None is a defect of this change:

- The walk has no depth cap. The old code stopped at 64 files. Here the `visiting` stack bounds it by the number of distinct file paths, and a symlink loop ends with `ELOOP` from the kernel after about 40 hops, reported as `Cannot read file ...: ELOOP`.
- When the nearest `node_modules` copy of a package has an `exports` map that does not list the requested file, the walk stops and reports the base as missing, as Node does. tsc keeps looking in higher `node_modules` directories.
- The joins of `extends` values use the unchecked `abs_buf`, as the old walk did. A value longer than the path buffer is the same class of problem as #39626.
- `ENAMETOOLONG` and Windows `EINVAL` (a value with `*` or `?`) on a candidate log `Cannot read file` as an error instead of the missing-base warning.

Issues: #5277, #23695 and #34494 were closed as duplicates of #6326. All five report the package specifier form (`@acme/configuration/tsconfig.base.json`, `pkg/tsconfig` through `exports`, `astro/tsconfigs/strictest`, `@hypernym/tsconfig`, `@adonisjs/tsconfig/tsconfig.app.json` which extends a sibling). Each shape has a test here.

Related PRs: #34496 was an earlier, narrower fix for the package specifier and array forms. It is closed in favor of this PR. Its bundler cases (`tsconfig/ExtendsPackage*`, `tsconfig/ExtendsArray*`) and its missing-array-entry case are folded in here. The symlink realpath and the bare sibling fallback come from its review. Open PRs that touch the same area: #38719 (per-file tsconfig at runtime) reads the decorator flags that are `Option<bool>` after this change, #36673 (ignore tsconfig.json inside node_modules) removes the auto-discovery that makes the extends walk run for package directories, and #33208 adds its own cycle detection to the old walk.

Suites run: `test/js/bun/resolve/tsconfig-extends.test.ts`, `tsconfig-extends-leak.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`, `ts.test.ts`, `default.test.ts`, `bundler_edgecase.test.ts`, `bundler_jsx.test.ts`, `bundler_decorator_metadata.test.ts`, `transpiler/decorators.test.ts`, `es-decorators*.test.ts`, `ts-use-define-for-class-fields.test.ts`, `jsx-tsconfig-react-jsx.test.ts`, `runtime-transpiler.test.ts`, `transpiler.test.js`, `transpiler-tsconfig-uaf.test.ts`, `cli/run/tsconfig-override.test.ts`, `cli/install/bun-run.test.ts`, `bun-build-api.test.ts` (two bytecode tests time out at 5 s under the debug build, unrelated), `cli.test.ts`, `resolve.test.ts`, `resolve-ts.test.ts`, `resolve-error.test.ts`, `jsonc.test.ts`, and regression tests 07261, 11664, 19652, 24364, 25622, 27526, 27575. `cargo check -p bun_resolver` also passes for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.
</details>
