### PR TITLE
parser: report strict-mode early errors and accept legacy sloppy syntax

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1674,6 +1674,10 @@ pub struct EString {
     pub next: Option<StoreRef<EString>>,
     pub end: Option<StoreRef<EString>>,
     pub rope_len: u32,
+    /// Location of the first legacy octal escape (`\1`, `\08`, `\8`) in the
+    /// literal's source text, or `Loc::EMPTY`. The lexer decodes these
+    /// leniently; the visit pass reports them where strict mode forbids them.
+    pub legacy_octal_loc: crate::Loc,
     pub prefer_template: bool,
     pub is_utf16: bool,
     /// Set only by the TOML parser on a date/time literal (`data` is its
@@ -1710,6 +1714,7 @@ impl Default for EString {
             next: None,
             end: None,
             rope_len: 0,
+            legacy_octal_loc: crate::Loc::EMPTY,
             is_utf16: false,
             toml_datetime: None,
         }
@@ -1758,6 +1763,7 @@ impl EString {
             next: None,
             end: None,
             rope_len: 0,
+            legacy_octal_loc: crate::Loc::EMPTY,
             is_utf16: false,
             toml_datetime: None,
         }
@@ -2022,6 +2028,7 @@ impl EString {
             next: self.next,
             end: self.end,
             rope_len: self.rope_len,
+            legacy_octal_loc: self.legacy_octal_loc,
             is_utf16: self.is_utf16,
             toml_datetime: self.toml_datetime,
         }

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1674,9 +1674,7 @@ pub struct EString {
     pub next: Option<StoreRef<EString>>,
     pub end: Option<StoreRef<EString>>,
     pub rope_len: u32,
-    /// Location of the first legacy octal escape (`\1`, `\08`, `\8`) in the
-    /// literal's source text, or `Loc::EMPTY`. The lexer decodes these
-    /// leniently; the visit pass reports them where strict mode forbids them.
+    /// Backslash of the first legacy octal escape (`\1`, `\08`, `\8`), or `Loc::EMPTY`.
     pub legacy_octal_loc: crate::Loc,
     pub prefer_template: bool,
     pub is_utf16: bool,

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2137,6 +2137,7 @@ impl Data {
                     next: el.next,
                     end: el.end,
                     rope_len: el.rope_len,
+                    legacy_octal_loc: el.legacy_octal_loc,
                     is_utf16: el.is_utf16,
                     toml_datetime: el.toml_datetime,
                 });

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2687,6 +2687,23 @@ impl Source {
         }
     }
 
+    /// The range of the legacy octal escape (`\1`, `\08`, `\012`, `\8`) whose
+    /// backslash is at `loc`.
+    pub fn range_of_legacy_octal_escape(&self, loc: Loc) -> Range {
+        let text = &self.contents[loc.i()..];
+        let mut r = Range { loc, len: 0 };
+        if text.len() >= 2 && text[0] == b'\\' {
+            r.len = 2;
+            while r.len < 4 && (r.len as usize) < text.len() {
+                if !text[r.len as usize].is_ascii_digit() {
+                    break;
+                }
+                r.len += 1;
+            }
+        }
+        r
+    }
+
     pub fn range_of_string(&self, loc: Loc) -> Range {
         if loc.start < 0 {
             return Range::NONE;

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2687,8 +2687,7 @@ impl Source {
         }
     }
 
-    /// The range of the legacy octal escape (`\1`, `\08`, `\012`, `\8`) whose
-    /// backslash is at `loc`.
+    /// Range of the legacy octal escape (`\1`, `\08`, `\8`) whose backslash is at `loc`.
     pub fn range_of_legacy_octal_escape(&self, loc: Loc) -> Range {
         let text = &self.contents[loc.i()..];
         let mut r = Range { loc, len: 0 };

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -42,6 +42,8 @@ pub struct Comment {
 
 pub struct Directive {
     pub value: StoreStr, // arena-owned
+    /// See `EString::legacy_octal_loc`.
+    pub legacy_octal_loc: crate::Loc,
 }
 
 #[derive(Default)]

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -29,12 +29,20 @@ pub struct Scope {
     /// so iteration yields safe `Deref` instead of `unsafe { child.as_ref() }`.
     pub children: AstVec<StoreRef<Scope>>,
     pub members: MemberHashMap,
+    /// Members that a later declaration in the same scope replaced (`var x;
+    /// var x` or `function f() {} function f() {}`). `hoist_symbols` reads
+    /// this to report duplicate function declarations once it knows whether
+    /// the scope ended up in strict mode. `AstVec`: arena-backed.
+    pub replaced: AstVec<Member>,
     /// `AstVec`: arena-backed.
     pub generated: AstVec<Ref>,
 
     // This is used to store the ref of the label symbol for ScopeLabel scopes.
     pub label_ref: Ref,
     pub label_stmt_is_loop: bool,
+
+    /// The location of the "use strict" directive for `ExplicitStrictMode`.
+    pub use_strict_loc: crate::Loc,
 
     // If a scope contains a direct eval() expression, then none of the symbols
     // inside that scope can be renamed. We conservatively assume that the
@@ -69,9 +77,11 @@ impl Scope {
         parent: None,
         children: AstAlloc::vec(),
         members: MemberHashMap::new_in(AstAlloc),
+        replaced: AstAlloc::vec(),
         generated: AstAlloc::vec(),
         label_ref: Ref::NONE,
         label_stmt_is_loop: false,
+        use_strict_loc: crate::Loc::EMPTY,
         contains_direct_eval: false,
         forbid_arguments: false,
         strict_mode: StrictModeKind::SloppyMode,

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -29,10 +29,7 @@ pub struct Scope {
     /// so iteration yields safe `Deref` instead of `unsafe { child.as_ref() }`.
     pub children: AstVec<StoreRef<Scope>>,
     pub members: MemberHashMap,
-    /// Members that a later declaration in the same scope replaced (`var x;
-    /// var x` or `function f() {} function f() {}`). `hoist_symbols` reads
-    /// this to report duplicate function declarations once it knows whether
-    /// the scope ended up in strict mode. `AstVec`: arena-backed.
+    /// Members that a later declaration in this scope replaced (`function f() {} function f() {}`).
     pub replaced: AstVec<Member>,
     /// `AstVec`: arena-backed.
     pub generated: AstVec<Ref>,

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -268,6 +268,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
             .append_non_dependency(Stmt::alloc(
                 S::Directive {
                     value: bun_ast::StoreStr::new(b"use strict"),
+                    legacy_octal_loc: bun_ast::Loc::EMPTY,
                 },
                 bun_ast::Loc::EMPTY,
             ))

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -223,13 +223,9 @@ pub struct Lexer<'a> {
     pub(crate) has_react_hooks_block_suppression: bool,
     pub(crate) preserve_all_comments_before: bool,
     pub(crate) is_legacy_octal_literal: bool,
-    /// Location of the backslash of the most recent legacy octal escape
-    /// (`\1`, `\08`, `\8`) decoded by `to_e_string`. Compared against the
-    /// string token's start to tell whether it belongs to the current literal.
+    /// Backslash of the most recent legacy octal escape decoded by `to_e_string`.
     pub(crate) legacy_octal_loc: Loc,
-    /// Range of the first `-->` or `<!--` legacy HTML comment marker. These
-    /// are an error in ECMAScript modules, which the parser only knows once
-    /// the whole file is scanned.
+    /// The first `-->` or `<!--` marker; an error once the file is known to be an ES module.
     pub(crate) legacy_html_comment_range: Range,
     pub(crate) is_log_disabled: bool,
     pub(crate) comments_to_preserve_before: Vec<js_ast::G::Comment>,
@@ -497,18 +493,14 @@ impl<'a> Lexer<'a> {
                             continue;
                         }
 
-                        // legacy octal escapes: 1-3 octal digits, decoded leniently.
-                        // Sloppy mode allows them, and the parser reports them in the
-                        // visit pass when the scope turns out to be strict.
+                        // legacy octal escapes: 1-3 digits, an error only in strict mode
                         0x30..=0x37 => {
                             // `iter` is on the first digit; the backslash is one byte before it.
                             let octal_start = (iter.i as usize).saturating_sub(1);
 
                             let mut is_bad = false;
                             let mut value: i64 = (c2 - 0x30) as i64;
-                            // Every path below leaves `iter` on the last consumed digit, so a
-                            // digit that is not part of the escape is lexed again by the outer
-                            // loop. `iterator.next` leaves `iter` untouched at end of text.
+                            // Every path leaves `iter` on the last consumed digit.
                             let mut prev = iter;
 
                             if iterator.next(&mut iter) {
@@ -2036,8 +2028,7 @@ impl<'a> Lexer<'a> {
         self.scan_legacy_html_comment_body("-->");
     }
 
-    /// Handles the legacy `<!--` HTML single-line open comment. Entered with
-    /// `self.code_point` on the `!` of `<!--`.
+    /// Handles `<!--`. Entered with `self.code_point` on the `!`.
     #[cold]
     #[inline(never)]
     fn scan_legacy_html_open_comment(&mut self) {
@@ -2048,8 +2039,7 @@ impl<'a> Lexer<'a> {
         self.scan_legacy_html_comment_body("<!--");
     }
 
-    /// Records the marker of the first legacy HTML comment (they are an error
-    /// in an ECMAScript module), warns, and consumes the rest of the line.
+    /// Records the first marker, warns, and consumes the rest of the line.
     fn scan_legacy_html_comment_body(&mut self, marker: &str) {
         if self.legacy_html_comment_range.len == 0 {
             self.legacy_html_comment_range = self.range();

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -152,6 +152,8 @@ pub struct LexerSnapshot<'a> {
     pub(crate) has_react_hooks_block_suppression: bool,
     pub(crate) preserve_all_comments_before: bool,
     pub(crate) is_legacy_octal_literal: bool,
+    pub(crate) legacy_octal_loc: Loc,
+    pub(crate) legacy_html_comment_range: Range,
     pub(crate) is_log_disabled: bool,
     pub(crate) code_point: CodePoint,
     pub(crate) identifier: &'a [u8],
@@ -221,6 +223,14 @@ pub struct Lexer<'a> {
     pub(crate) has_react_hooks_block_suppression: bool,
     pub(crate) preserve_all_comments_before: bool,
     pub(crate) is_legacy_octal_literal: bool,
+    /// Location of the backslash of the most recent legacy octal escape
+    /// (`\1`, `\08`, `\8`) decoded by `to_e_string`. Compared against the
+    /// string token's start to tell whether it belongs to the current literal.
+    pub(crate) legacy_octal_loc: Loc,
+    /// Range of the first `-->` or `<!--` legacy HTML comment marker. These
+    /// are an error in ECMAScript modules, which the parser only knows once
+    /// the whole file is scanned.
+    pub(crate) legacy_html_comment_range: Range,
     pub(crate) is_log_disabled: bool,
     pub(crate) comments_to_preserve_before: Vec<js_ast::G::Comment>,
     pub(crate) code_point: CodePoint,
@@ -337,6 +347,8 @@ impl<'a> Lexer<'a> {
             has_react_hooks_block_suppression: self.has_react_hooks_block_suppression,
             preserve_all_comments_before: self.preserve_all_comments_before,
             is_legacy_octal_literal: self.is_legacy_octal_literal,
+            legacy_octal_loc: self.legacy_octal_loc,
+            legacy_html_comment_range: self.legacy_html_comment_range,
             is_log_disabled: self.is_log_disabled,
             code_point: self.code_point,
             identifier: self.identifier,
@@ -375,6 +387,8 @@ impl<'a> Lexer<'a> {
         self.has_react_hooks_block_suppression = original.has_react_hooks_block_suppression;
         self.preserve_all_comments_before = original.preserve_all_comments_before;
         self.is_legacy_octal_literal = original.is_legacy_octal_literal;
+        self.legacy_octal_loc = original.legacy_octal_loc;
+        self.legacy_html_comment_range = original.legacy_html_comment_range;
         self.is_log_disabled = original.is_log_disabled;
         self.code_point = original.code_point;
         self.identifier = original.identifier;
@@ -483,81 +497,73 @@ impl<'a> Lexer<'a> {
                             continue;
                         }
 
-                        // legacy octal literals
+                        // legacy octal escapes: 1-3 octal digits, decoded leniently.
+                        // Sloppy mode allows them, and the parser reports them in the
+                        // visit pass when the scope turns out to be strict.
                         0x30..=0x37 => {
-                            let octal_start = (iter.i as usize + width2 as usize).saturating_sub(2);
+                            // `iter` is on the first digit; the backslash is one byte before it.
+                            let octal_start = (iter.i as usize).saturating_sub(1);
 
-                            // 1-3 digit octal
                             let mut is_bad = false;
                             let mut value: i64 = (c2 - 0x30) as i64;
+                            // Every path below leaves `iter` on the last consumed digit, so a
+                            // digit that is not part of the escape is lexed again by the outer
+                            // loop. `iterator.next` leaves `iter` untouched at end of text.
                             let mut prev = iter;
 
-                            if !iterator.next(&mut iter) {
-                                if value == 0 {
-                                    buf.push(0);
-                                    return Ok(());
-                                }
-                                self.syntax_error()?;
-                                return Ok(());
-                            }
-
-                            let c3: CodePoint = iter.c;
-
-                            match c3 {
-                                0x30..=0x37 => {
-                                    value = value * 8 + (c3 - 0x30) as i64;
-                                    prev = iter;
-                                    if !iterator.next(&mut iter) {
-                                        return self.syntax_error();
-                                    }
-
-                                    let c4 = iter.c;
-                                    match c4 {
-                                        0x30..=0x37 => {
-                                            let temp = value * 8 + (c4 - 0x30) as i64;
-                                            if temp < 256 {
-                                                value = temp;
-                                            } else {
-                                                iter = prev;
+                            if iterator.next(&mut iter) {
+                                match iter.c {
+                                    0x30..=0x37 => {
+                                        value = value * 8 + (iter.c - 0x30) as i64;
+                                        prev = iter;
+                                        if iterator.next(&mut iter) {
+                                            match iter.c {
+                                                0x30..=0x37 => {
+                                                    let temp = value * 8 + (iter.c - 0x30) as i64;
+                                                    if temp < 256 {
+                                                        value = temp;
+                                                    } else {
+                                                        iter = prev;
+                                                    }
+                                                }
+                                                0x38 | 0x39 => {
+                                                    is_bad = true;
+                                                    iter = prev;
+                                                }
+                                                _ => {
+                                                    iter = prev;
+                                                }
                                             }
                                         }
-                                        0x38 | 0x39 => {
-                                            is_bad = true;
-                                        }
-                                        _ => {
-                                            iter = prev;
-                                        }
                                     }
-                                }
-                                0x38 | 0x39 => {
-                                    is_bad = true;
-                                }
-                                _ => {
-                                    iter = prev;
+                                    0x38 | 0x39 => {
+                                        is_bad = true;
+                                        iter = prev;
+                                    }
+                                    _ => {
+                                        iter = prev;
+                                    }
                                 }
                             }
 
                             iter.c = i32::try_from(value).expect("int cast");
-                            if is_bad {
-                                // `octal_start` is text-relative like `iter.i`;
-                                // map back to absolute source position the same
-                                // way every sibling error path does (e.g.
-                                // `start + hex_start` in the `\u{}` branch).
-                                self.add_range_error(
-                                    Range {
-                                        loc: Loc {
-                                            start: i32::try_from(start + octal_start)
-                                                .expect("int cast"),
-                                        },
-                                        len: i32::try_from(iter.i as usize - octal_start).unwrap(),
-                                    },
-                                    format_args!("Invalid legacy octal literal"),
-                                )
-                                .expect("unreachable");
+
+                            // Forbid the use of octal escapes other than "\0"
+                            let octal_end = iter.i as usize + iter.width as usize;
+                            if is_bad || &text[octal_start..octal_end] != b"\\0" {
+                                self.legacy_octal_loc = Loc {
+                                    start: i32::try_from(start + octal_start).expect("int cast"),
+                                };
                             }
                         }
                         0x38 | 0x39 => {
                             iter.c = c2;
+
+                            // Forbid the invalid octal escapes "\8" and "\9"
+                            self.legacy_octal_loc = Loc {
+                                start: i32::try_from(start + (iter.i as usize).saturating_sub(1))
+                                    .expect("int cast"),
+                            };
                         }
                         // 2-digit hexadecimal
                         0x78 => {
@@ -972,16 +978,6 @@ impl<'a> Lexer<'a> {
             self.expect(T::TSemicolon)?;
         }
         Ok(())
-    }
-
-    #[cold]
-    #[inline(never)]
-    pub(crate) fn add_unsupported_syntax_error(&mut self, msg: &[u8]) -> Result<(), Error> {
-        self.add_error(
-            self.end,
-            format_args!("Unsupported syntax: {}", bstr::BStr::new(msg)),
-        );
-        Err(Error::SyntaxError)
     }
 
     // This is an edge case that doesn't really exist in the wild, so it doesn't
@@ -1638,10 +1634,8 @@ impl<'a> Lexer<'a> {
                         // Handle legacy HTML-style comments
                         0x21 => {
                             if self.peek("--".len()) == b"--" {
-                                self.add_unsupported_syntax_error(
-                                    b"Legacy HTML comments not implemented yet!",
-                                )?;
-                                return Ok(());
+                                self.scan_legacy_html_open_comment();
+                                continue;
                             }
 
                             self.token = T::TLessThan;
@@ -2039,10 +2033,34 @@ impl<'a> Lexer<'a> {
     fn scan_legacy_html_close_comment(&mut self) {
         // Consume the `>` of `-->`.
         self.step();
-        self.log().add_range_warning(
+        self.scan_legacy_html_comment_body("-->");
+    }
+
+    /// Handles the legacy `<!--` HTML single-line open comment. Entered with
+    /// `self.code_point` on the `!` of `<!--`.
+    #[cold]
+    #[inline(never)]
+    fn scan_legacy_html_open_comment(&mut self) {
+        // Consume the `!--` of `<!--`.
+        self.step();
+        self.step();
+        self.step();
+        self.scan_legacy_html_comment_body("<!--");
+    }
+
+    /// Records the marker of the first legacy HTML comment (they are an error
+    /// in an ECMAScript module), warns, and consumes the rest of the line.
+    fn scan_legacy_html_comment_body(&mut self, marker: &str) {
+        if self.legacy_html_comment_range.len == 0 {
+            self.legacy_html_comment_range = self.range();
+        }
+        self.log().add_range_warning_fmt(
             Some(self.source),
             self.range(),
-            b"Treating \"-->\" as the start of a legacy HTML single-line comment",
+            format_args!(
+                "Treating \"{}\" as the start of a legacy HTML single-line comment",
+                marker
+            ),
         );
 
         loop {
@@ -2229,6 +2247,8 @@ impl<'a> Lexer<'a> {
             has_react_hooks_block_suppression: false,
             preserve_all_comments_before: false,
             is_legacy_octal_literal: false,
+            legacy_octal_loc: Loc::EMPTY,
+            legacy_html_comment_range: Range::NONE,
             is_log_disabled: false,
             comments_to_preserve_before: Vec::new(),
             code_point: -1,
@@ -3036,6 +3056,10 @@ impl<'a> Lexer<'a> {
                 }
                 0x30..=0x37 | 0x5F => {
                     base = 8.0;
+                    self.is_legacy_octal_literal = true;
+                }
+                // "08" and "09" are decimal, but strict mode forbids them too.
+                0x38 | 0x39 => {
                     self.is_legacy_octal_literal = true;
                 }
                 _ => {}

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5342,7 +5342,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub(crate) fn is_valid_assignment_target(&self, expr: &Expr) -> bool {
         match &expr.data {
             js_ast::ExprData::EIdentifier(ident) => {
-                !(self.is_strict_mode()
+                // The renamer keeps `eval` and `arguments`, so ESM output is strict here too.
+                !((self.is_strict_mode() || self.is_strict_mode_output_format())
                     && is_eval_or_arguments(self.load_name_from_ref(ident.ref_)))
             }
             js_ast::ExprData::EDot(e) => e.optional_chain.is_none(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -266,10 +266,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     pub(crate) hoisted_ref_for_sloppy_mode_block_fn: RefRefMap,
 
-    /// Source ranges of legacy octal number literals (`010`, `08`), keyed by
-    /// the literal's `Loc.start`. `E::Number` is stored inline in `Expr` with
-    /// no room for a flag, and whether the literal is an error is only known
-    /// in the visit pass once the scope's strict mode is final.
+    /// Legacy octal number literals (`010`, `08`) by `Loc.start`, for the visit pass.
     pub(crate) legacy_octal_literals: HashMap<i32, bun_ast::Range>,
 
     // Used for forcing CommonJS
@@ -2864,9 +2861,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.options.bundle || self.options.features.minify_identifiers
     }
 
-    /// True when the file has syntax that makes it an ECMAScript module. The
-    /// module type from the file extension or package.json does not count: a
-    /// file with no import or export is evaluated as CommonJS at runtime.
+    /// ESM syntax only; a `.mjs` file with no import or export runs as CommonJS.
     #[inline]
     pub(crate) fn is_file_considered_esm(&self) -> bool {
         self.esm_import_keyword.len > 0
@@ -2874,12 +2869,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             || self.top_level_await_keyword.len > 0
     }
 
-    /// Duplicate function declarations are forbidden in nested blocks in strict
-    /// mode. Separately, they are also forbidden at the top-level of modules.
-    /// This check is delayed until hoisting instead of being done when the
-    /// functions are declared because the whole file has to be scanned to know
-    /// whether it is in strict mode (or is a module): an `export {}` clause can
-    /// come at the end of the file.
+    /// Runs at hoisting time because `export {}` at the end of the file can make the scope strict.
     fn check_for_duplicate_function_declarations(&mut self, scope: js_ast::StoreRef<Scope>) {
         let is_module_top_level = scope.parent.is_none() && self.is_file_considered_esm();
         let is_strict_block = scope.strict_mode != js_ast::StrictModeKind::SloppyMode
@@ -4384,8 +4374,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// Explains why `scope` is in strict mode: the phrase that completes
-    /// "... cannot be used {}" and the note that points at the trigger.
+    /// The phrase that completes "... cannot be used {}" and the note that points at the trigger.
     pub(crate) fn why_strict_mode(
         &self,
         scope: js_ast::StoreRef<Scope>,
@@ -4665,8 +4654,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ref_)
     }
 
-    /// Call while the lexer is on a `TNumericLiteral` that became the
-    /// `E::Number` at `loc`. Remembers legacy octal literals for the visit pass.
+    /// Call while the lexer is on the `TNumericLiteral` that became the `E::Number` at `loc`.
     pub(crate) fn check_for_legacy_octal_literal(&mut self, loc: bun_ast::Loc) {
         if self.lexer.is_legacy_octal_literal {
             let range = self.lexer.range();
@@ -4674,10 +4662,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Strict mode forbids declaring a reserved word, `eval`, or `arguments`.
-    /// Runs in the visit pass so the scope's strict mode is final (ESM and class
-    /// bodies only become strict after parsing, and a function's own
-    /// "use strict" applies to its name and parameters).
+    /// Visit-pass check, since ESM and class bodies only become strict after parsing.
     pub(crate) fn validate_declared_symbol_name(&mut self, loc: bun_ast::Loc, name: &[u8]) {
         if js_lexer::is_strict_mode_reserved_word(name) {
             self.mark_strict_mode_feature(

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -266,6 +266,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     pub(crate) hoisted_ref_for_sloppy_mode_block_fn: RefRefMap,
 
+    /// Source ranges of legacy octal number literals (`010`, `08`), keyed by
+    /// the literal's `Loc.start`. `E::Number` is stored inline in `Expr` with
+    /// no room for a flag, and whether the literal is an error is only known
+    /// in the visit pass once the scope's strict mode is final.
+    pub(crate) legacy_octal_literals: HashMap<i32, bun_ast::Range>,
+
     // Used for forcing CommonJS
     pub(crate) has_with_scope: bool,
 
@@ -2712,6 +2718,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // Legacy HTML comments are not allowed in ESM files
+        if self.lexer.legacy_html_comment_range.len > 0 && self.is_file_considered_esm() {
+            let notes = self.why_es_module();
+            self.log().add_range_error_fmt_with_notes(
+                Some(self.source),
+                self.lexer.legacy_html_comment_range,
+                notes,
+                format_args!(
+                    "Legacy HTML single-line comments are not allowed in ECMAScript modules"
+                ),
+            );
+        }
+
         // ECMAScript modules are always interpreted as strict mode. This has to be
         // done before "hoistSymbols" because strict mode can alter hoisting (!).
         if self.esm_import_keyword.len > 0 {
@@ -2845,6 +2864,94 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.options.bundle || self.options.features.minify_identifiers
     }
 
+    /// True when the file has syntax that makes it an ECMAScript module. The
+    /// module type from the file extension or package.json does not count: a
+    /// file with no import or export is evaluated as CommonJS at runtime.
+    #[inline]
+    pub(crate) fn is_file_considered_esm(&self) -> bool {
+        self.esm_import_keyword.len > 0
+            || self.esm_export_keyword.len > 0
+            || self.top_level_await_keyword.len > 0
+    }
+
+    /// Duplicate function declarations are forbidden in nested blocks in strict
+    /// mode. Separately, they are also forbidden at the top-level of modules.
+    /// This check is delayed until hoisting instead of being done when the
+    /// functions are declared because the whole file has to be scanned to know
+    /// whether it is in strict mode (or is a module): an `export {}` clause can
+    /// come at the end of the file.
+    fn check_for_duplicate_function_declarations(&mut self, scope: js_ast::StoreRef<Scope>) {
+        let is_module_top_level = scope.parent.is_none() && self.is_file_considered_esm();
+        let is_strict_block = scope.strict_mode != js_ast::StrictModeKind::SloppyMode
+            && scope.kind == js_ast::scope::Kind::Block;
+        if !is_module_top_level && !is_strict_block {
+            return;
+        }
+
+        for replaced in scope.replaced.slice() {
+            let symbol = &self.symbols[replaced.ref_.inner_index() as usize];
+            if !symbol.kind.is_function() {
+                continue;
+            }
+            // `Symbol.original_name` is an arena-owned `StoreStr` valid for 'a.
+            let name: &'a [u8] = symbol.original_name.slice();
+            let Some(member) = scope.members.get(name).copied() else {
+                continue;
+            };
+            if !self.symbols[member.ref_.inner_index() as usize]
+                .kind
+                .is_function()
+            {
+                continue;
+            }
+
+            // The "why" note prefixes the reason that the scope is a module or strict.
+            let (mut why_text, why_notes) = if is_module_top_level {
+                (
+                    b"Duplicate top-level function declarations are not allowed in an ECMAScript module."
+                        .to_vec(),
+                    self.why_es_module(),
+                )
+            } else {
+                let (where_, notes) = self.why_strict_mode(scope);
+                (
+                    format!(
+                        "Duplicate function declarations are not allowed in nested blocks {}.",
+                        bstr::BStr::new(where_)
+                    )
+                    .into_bytes(),
+                    notes,
+                )
+            };
+            let mut why_location = None;
+            if let Some(note) = why_notes.into_vec().pop() {
+                why_text.push(b' ');
+                why_text.extend_from_slice(&note.text);
+                why_location = note.location;
+            }
+
+            let notes: Box<[bun_ast::Data]> = Box::new([
+                bun_ast::range_data(
+                    Some(self.source),
+                    js_lexer::range_of_identifier(self.source, replaced.loc),
+                    format!("\"{}\" was originally declared here", bstr::BStr::new(name))
+                        .into_bytes(),
+                ),
+                bun_ast::Data {
+                    text: why_text.into(),
+                    location: why_location,
+                },
+            ]);
+
+            self.log().add_range_error_fmt_with_notes(
+                Some(self.source),
+                js_lexer::range_of_identifier(self.source, member.loc),
+                notes,
+                format_args!("\"{}\" has already been declared", bstr::BStr::new(name)),
+            );
+        }
+    }
+
     fn hoist_symbols(&mut self, mut scope: js_ast::StoreRef<js_ast::Scope>) {
         // This runs before the visit pass, so it walks the scope tree at the full
         // nesting depth the parser allowed; deep trees must error here instead of
@@ -2853,6 +2960,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.report_stack_overflow(bun_ast::Loc::EMPTY);
             return;
         }
+
+        self.check_for_duplicate_function_declarations(scope);
 
         // `StoreRef` is the arena back-pointer with safe `Deref`/`DerefMut` —
         // scope is arena-owned and valid for the parser 'a lifetime; the visit
@@ -3180,6 +3289,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `parent != scope` (fresh alloc) so the two `&mut` do not alias.
         VecExt::append(&mut parent.children, scope);
         scope.strict_mode = parent.strict_mode;
+        scope.use_strict_loc = parent.use_strict_loc;
 
         self.current_scope = scope;
 
@@ -4221,7 +4331,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         r: bun_ast::Range,
         detail: &[u8],
     ) -> Result<(), crate::Error> {
+        let mut can_be_transformed = false;
         let text: &'a [u8] = match feature {
+            StrictModeFeature::WithStatement => b"With statements",
+            StrictModeFeature::DeleteBareName => b"Delete of a bare identifier",
+            StrictModeFeature::ForInVarInit => {
+                can_be_transformed = true;
+                b"Variable initializers inside for-in loops"
+            }
             StrictModeFeature::EvalOrArguments => bun_alloc::arena_format!(
                 in self.arena,
                 "Declarations with the name \"{}\"",
@@ -4236,47 +4353,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             )
             .into_bump_str()
             .as_bytes(),
+            StrictModeFeature::LegacyOctalLiteral => b"Legacy octal literals",
+            StrictModeFeature::LegacyOctalEscape => b"Legacy octal escape sequences",
+            StrictModeFeature::IfElseFunctionStmt => b"Function declarations inside if statements",
+            StrictModeFeature::LabelFunctionStmt => b"Function declarations inside labels",
         };
 
-        let scope = self.current_scope();
         if self.is_strict_mode() {
-            let mut why: &'a [u8] = b"";
-            let mut where_: bun_ast::Range = bun_ast::Range::NONE;
-            match scope.strict_mode {
-                js_ast::StrictModeKind::ImplicitStrictModeImport => {
-                    where_ = self.esm_import_keyword
-                }
-                js_ast::StrictModeKind::ImplicitStrictModeExport => {
-                    where_ = self.esm_export_keyword
-                }
-                js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait => {
-                    where_ = self.top_level_await_keyword
-                }
-                js_ast::StrictModeKind::ImplicitStrictModeClass => {
-                    why = b"All code inside a class is implicitly in strict mode";
-                    where_ = self.enclosing_class_keyword;
-                }
-                _ => {}
-            }
-            if why.is_empty() {
-                why = bun_alloc::arena_format!(
-                    in self.arena,
-                    "This file is implicitly in strict mode because of the \"{}\" keyword here",
-                    bstr::BStr::new(self.source.text_for_range(where_))
-                )
-                .into_bump_str()
-                .as_bytes();
-            }
-            // bun_ast::Data is !Copy (Cow) — build the notes Box directly.
-            let notes: Box<[bun_ast::Data]> =
-                Box::new([bun_ast::range_data(Some(self.source), where_, why.to_vec())]);
+            let (where_, notes) = self.why_strict_mode(self.current_scope);
             self.log().add_range_error_fmt_with_notes(
                 Some(self.source),
                 r,
                 notes,
-                format_args!("{} cannot be used in strict mode", bstr::BStr::new(text)),
+                format_args!(
+                    "{} cannot be used {}",
+                    bstr::BStr::new(text),
+                    bstr::BStr::new(where_)
+                ),
             );
-        } else if self.is_strict_mode_output_format() {
+        } else if !can_be_transformed && self.is_strict_mode_output_format() {
             self.log().add_range_error_fmt(
                 Some(self.source),
                 r,
@@ -4287,6 +4382,60 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
         Ok(())
+    }
+
+    /// Explains why `scope` is in strict mode: the phrase that completes
+    /// "... cannot be used {}" and the note that points at the trigger.
+    pub(crate) fn why_strict_mode(
+        &self,
+        scope: js_ast::StoreRef<Scope>,
+    ) -> (&'static [u8], Box<[bun_ast::Data]>) {
+        match scope.strict_mode {
+            js_ast::StrictModeKind::ImplicitStrictModeClass => (
+                b"in strict mode",
+                Box::new([bun_ast::range_data(
+                    Some(self.source),
+                    self.enclosing_class_keyword,
+                    b"All code inside a class is implicitly in strict mode".as_slice(),
+                )]),
+            ),
+            js_ast::StrictModeKind::ExplicitStrictMode => (
+                b"in strict mode",
+                Box::new([bun_ast::range_data(
+                    Some(self.source),
+                    self.source.range_of_string(scope.use_strict_loc),
+                    b"Strict mode is triggered by the \"use strict\" directive here:".as_slice(),
+                )]),
+            ),
+            js_ast::StrictModeKind::ImplicitStrictModeImport
+            | js_ast::StrictModeKind::ImplicitStrictModeExport
+            | js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait => {
+                (b"in an ECMAScript module", self.why_es_module())
+            }
+            js_ast::StrictModeKind::SloppyMode => (b"in strict mode", Box::new([])),
+        }
+    }
+
+    /// The note that says which syntax made this file an ECMAScript module.
+    pub(crate) fn why_es_module(&self) -> Box<[bun_ast::Data]> {
+        const BECAUSE: &str = "This file is considered to be an ECMAScript module because";
+        let (range, what): (bun_ast::Range, &str) = if self.esm_export_keyword.len > 0 {
+            (self.esm_export_keyword, "of the \"export\" keyword here:")
+        } else if self.top_level_await_keyword.len > 0 {
+            (
+                self.top_level_await_keyword,
+                "of the top-level \"await\" keyword here:",
+            )
+        } else if self.esm_import_keyword.len > 0 {
+            (self.esm_import_keyword, "of the \"import\" keyword here:")
+        } else {
+            return Box::new([]);
+        };
+        Box::new([bun_ast::range_data(
+            Some(self.source),
+            range,
+            format!("{BECAUSE} {what}").into_bytes(),
+        )])
     }
 
     #[inline]
@@ -4438,18 +4587,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<Ref, crate::Error> {
         // p.checkForNonBMPCodePoint(loc, name)
 
-        // Forbid declaring a symbol with a reserved word in strict mode
-        if self.is_strict_mode()
-            && name.as_ptr() != arguments_str.as_ptr()
-            && bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
-        {
-            self.mark_strict_mode_feature(
-                StrictModeFeature::ReservedWord,
-                js_lexer::range_of_identifier(self.source, loc),
-                name,
-            )?;
-        }
-
         // Allocate a new symbol
         let mut ref_ = self.new_symbol(kind, name);
 
@@ -4471,6 +4608,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `Scope` — see `Scope::get_or_put_member_with_hash`.
         let mut scope: js_ast::StoreRef<js_ast::Scope> = self.current_scope;
         let scope_kind = scope.kind;
+        let mut replaced: Option<js_ast::scope::Member> = None;
         // SAFETY: see key-lifetime note above — `name: &'a [u8]` outlives the
         // arena-owned `Scope` map.
         let entry = unsafe { scope.members.get_or_put_borrowed(name) };
@@ -4502,6 +4640,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 MR::ReplaceWithNew => {
                     self.symbols[symbol_idx].link.set(ref_);
+                    replaced = Some(existing);
 
                     // If these are both functions, remove the overwritten declaration
                     if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
@@ -4520,7 +4659,41 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
         *entry.value_ptr = js_ast::scope::Member { ref_, loc };
+        if let Some(existing) = replaced {
+            VecExt::append(&mut scope.replaced, existing);
+        }
         Ok(ref_)
+    }
+
+    /// Call while the lexer is on a `TNumericLiteral` that became the
+    /// `E::Number` at `loc`. Remembers legacy octal literals for the visit pass.
+    pub(crate) fn check_for_legacy_octal_literal(&mut self, loc: bun_ast::Loc) {
+        if self.lexer.is_legacy_octal_literal {
+            let range = self.lexer.range();
+            self.legacy_octal_literals.insert(loc.start, range);
+        }
+    }
+
+    /// Strict mode forbids declaring a reserved word, `eval`, or `arguments`.
+    /// Runs in the visit pass so the scope's strict mode is final (ESM and class
+    /// bodies only become strict after parsing, and a function's own
+    /// "use strict" applies to its name and parameters).
+    pub(crate) fn validate_declared_symbol_name(&mut self, loc: bun_ast::Loc, name: &[u8]) {
+        if js_lexer::is_strict_mode_reserved_word(name) {
+            self.mark_strict_mode_feature(
+                StrictModeFeature::ReservedWord,
+                js_lexer::range_of_identifier(self.source, loc),
+                name,
+            )
+            .expect("unreachable");
+        } else if is_eval_or_arguments(name) {
+            self.mark_strict_mode_feature(
+                StrictModeFeature::EvalOrArguments,
+                js_lexer::range_of_identifier(self.source, loc),
+                name,
+            )
+            .expect("unreachable");
+        }
     }
 
     pub(crate) fn validate_function_name(&mut self, func: &G::Fn) {
@@ -5181,7 +5354,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub(crate) fn is_valid_assignment_target(&self, expr: &Expr) -> bool {
         match &expr.data {
             js_ast::ExprData::EIdentifier(ident) => {
-                !is_eval_or_arguments(self.load_name_from_ref(ident.ref_))
+                !(self.is_strict_mode()
+                    && is_eval_or_arguments(self.load_name_from_ref(ident.ref_)))
             }
             js_ast::ExprData::EDot(e) => e.optional_chain.is_none(),
             js_ast::ExprData::EIndex(e) => e.optional_chain.is_none(),
@@ -8138,6 +8312,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     remaining_stmts[0] = self.s(
                         S::Directive {
                             value: b"use strict".into(),
+                            legacy_octal_loc: bun_ast::Loc::EMPTY,
                         },
                         self.module_scope_directive_loc,
                     );
@@ -8686,6 +8861,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_classic_runtime_warned: false,
             macro_call_count: 0,
             hoisted_ref_for_sloppy_mode_block_fn: Default::default(),
+            legacy_octal_literals: Default::default(),
             has_with_scope: false,
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4665,12 +4665,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// Visit-pass check, since ESM and class bodies only become strict after parsing.
     pub(crate) fn validate_declared_symbol_name(&mut self, loc: bun_ast::Loc, name: &[u8]) {
         if js_lexer::is_strict_mode_reserved_word(name) {
-            self.mark_strict_mode_feature(
-                StrictModeFeature::ReservedWord,
-                js_lexer::range_of_identifier(self.source, loc),
-                name,
-            )
-            .expect("unreachable");
+            // The bundler renames a bound reserved word (`package` to `_package`).
+            if self.is_strict_mode() {
+                self.mark_strict_mode_feature(
+                    StrictModeFeature::ReservedWord,
+                    js_lexer::range_of_identifier(self.source, loc),
+                    name,
+                )
+                .expect("unreachable");
+            }
         } else if is_eval_or_arguments(name) {
             self.mark_strict_mode_feature(
                 StrictModeFeature::EvalOrArguments,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1334,7 +1334,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let notes = p.why_es_module();
             p.log().add_range_error_fmt_with_notes(
                 Some(p.source),
-                p.source.range_of_legacy_octal_escape(p.lexer.legacy_octal_loc),
+                p.source
+                    .range_of_legacy_octal_escape(p.lexer.legacy_octal_loc),
                 notes,
                 format_args!(
                     "Legacy octal escape sequences cannot be used in an ECMAScript module"

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1495,14 +1495,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 scope.strict_mode = StrictModeKind::ExplicitStrictMode;
                                 scope.use_strict_loc = directive_loc;
 
-                                // Inside a function, strict mode actually propagates from the child
-                                // scope to the parent scope:
-                                //
-                                //   // This is a syntax error
-                                //   function fn(arguments) {
-                                //     "use strict";
-                                //   }
-                                //
+                                // The directive also covers the parameters.
                                 if scope.kind == js_ast::scope::Kind::FunctionBody {
                                     if let Some(mut parent) = scope.parent {
                                         if parent.kind == js_ast::scope::Kind::FunctionArgs

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -298,7 +298,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.rescan_close_brace_as_template_token()?;
 
             let tail: E::TemplateContents = if !include_raw {
-                E::TemplateContents::Cooked(p.lexer.to_e_string()?)
+                let mut cooked = p.lexer.to_e_string()?;
+                if p.lexer.legacy_octal_loc.start > tail_loc.start {
+                    cooked.legacy_octal_loc = p.lexer.legacy_octal_loc;
+                }
+                E::TemplateContents::Cooked(cooked)
             } else {
                 E::TemplateContents::Raw(p.lexer.raw_template_contents().into())
             };
@@ -329,6 +333,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let loc = p.lexer.loc();
         let mut str_ = p.lexer.to_e_string()?;
         str_.prefer_template = p.lexer.token == T::TNoSubstitutionTemplateLiteral;
+        if p.lexer.legacy_octal_loc.start > loc.start {
+            str_.legacy_octal_loc = p.lexer.legacy_octal_loc;
+        }
 
         let expr = p.new_expr(str_, loc);
         p.lexer.next()?;
@@ -1167,7 +1174,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             T::TNumericLiteral => {
                 key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                // check for legacy octal literal
+                p.check_for_legacy_octal_literal(key.loc);
                 p.lexer.next()?;
             }
             T::TStringLiteral => {
@@ -1448,7 +1455,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut return_without_semicolon_start: i32 = -1;
         opts.lexical_decl = LexicalDecl::AllowAll;
-        let mut is_directive_prologue = true;
+        let mut is_directive_prologue = opts.allow_directive_prologue;
 
         loop {
             for comment in p.lexer.comments_to_preserve_before.iter() {
@@ -1483,8 +1490,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if str_.eql_comptime(b"use strict") {
                                 skip = true;
                                 // Track "use strict" directives
-                                p.current_scope_mut().strict_mode =
-                                    StrictModeKind::ExplicitStrictMode;
+                                let directive_loc = expr.value.loc;
+                                let scope = p.current_scope_mut();
+                                scope.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                scope.use_strict_loc = directive_loc;
+
+                                // Inside a function, strict mode actually propagates from the child
+                                // scope to the parent scope:
+                                //
+                                //   // This is a syntax error
+                                //   function fn(arguments) {
+                                //     "use strict";
+                                //   }
+                                //
+                                if scope.kind == js_ast::scope::Kind::FunctionBody {
+                                    if let Some(mut parent) = scope.parent {
+                                        if parent.kind == js_ast::scope::Kind::FunctionArgs
+                                            && parent.strict_mode == StrictModeKind::SloppyMode
+                                        {
+                                            parent.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                            parent.use_strict_loc = directive_loc;
+                                        }
+                                    }
+                                }
+
                                 if p.current_scope == p.module_scope {
                                     p.module_scope_directive_loc = stmt.loc;
                                 }
@@ -1499,6 +1528,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 stmt = Stmt::alloc(
                                     S::Directive {
                                         value: bun_ast::StoreStr::new(bytes),
+                                        legacy_octal_loc: str_.legacy_octal_loc,
                                     },
                                     stmt.loc,
                                 );

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1328,6 +1328,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             loader: None,
         };
 
+        // An import or export statement makes the file a module, and the module
+        // scope only becomes strict after the parse pass, so report this here.
+        if p.lexer.legacy_octal_loc.start > path.loc.start {
+            let notes = p.why_es_module();
+            p.log().add_range_error_fmt_with_notes(
+                Some(p.source),
+                p.source.range_of_legacy_octal_escape(p.lexer.legacy_octal_loc),
+                notes,
+                format_args!(
+                    "Legacy octal escape sequences cannot be used in an ECMAScript module"
+                ),
+            );
+        }
+
         if p.lexer.token == T::TNoSubstitutionTemplateLiteral {
             p.lexer.next()?;
         } else {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1328,8 +1328,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             loader: None,
         };
 
-        // An import or export statement makes the file a module, and the module
-        // scope only becomes strict after the parse pass, so report this here.
+        // An import or export path makes the file a module; the scope is only strict after parsing.
         if p.lexer.legacy_octal_loc.start > path.loc.start {
             let notes = p.why_es_module();
             p.log().add_range_error_fmt_with_notes(

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -438,6 +438,7 @@ impl<'a> Parser<'a> {
         // Parse the file in the first pass, but do not bind symbols
         let mut opts = ParseStatementOptions {
             scope: StatementScope::Module,
+            allow_directive_prologue: true,
             ..Default::default()
         };
 
@@ -825,6 +826,7 @@ impl<'a> Parser<'a> {
         // Parse the file in the first pass, but do not bind symbols
         let mut opts = ParseStatementOptions {
             scope: StatementScope::Module,
+            allow_directive_prologue: true,
             ..Default::default()
         };
         let mut parse_tracer = bun_core::perf::trace("JSParser::parse");

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -501,7 +501,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         p.lexer.expect(T::TOpenBrace)?;
-        let mut opts = ParseStatementOptions::default();
+        let mut opts = ParseStatementOptions {
+            allow_directive_prologue: true,
+            ..Default::default()
+        };
         let stmts = p.parse_stmts_up_to(T::TCloseBrace, &mut opts)?;
         p.lexer.next()?;
 

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -225,7 +225,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.lexer.next()?;
                     original_name = p.lexer.identifier;
                     name = LocRef {
-                        loc: alias_loc,
+                        loc: p.lexer.loc(),
                         ref_: p.store_name_in_ref(original_name),
                     };
                     p.lexer.expect(T::TIdentifier)?;

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use crate::lexer::{self as js_lexer, T};
 use crate::p::P;
-use crate::parser::{ExportClauseResult, ImportClause, is_eval_or_arguments};
+use crate::parser::{ExportClauseResult, ImportClause};
 use bun_alloc::ArenaVecExt as _;
 use bun_ast::LexerLog as _;
 use bun_ast::expr::Data as ExprData;
@@ -181,18 +181,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         };
                         p.lexer.expect(T::TIdentifier)?;
 
-                        if is_eval_or_arguments(original_name) {
-                            let r = p.source.range_of_string(name.loc);
-                            p.log().add_range_error_fmt(
-                                Some(p.source),
-                                r,
-                                format_args!(
-                                    "Cannot use {} as an identifier here",
-                                    bstr::BStr::new(original_name)
-                                ),
-                            );
-                        }
-
                         items.push(ClauseItem {
                             alias: alias.into(),
                             alias_loc,
@@ -232,19 +220,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 } else if !is_identifier {
                     // An import where the name is a keyword must have an alias
                     p.lexer.expected_string(b"\"as\"")?;
-                }
-
-                // Reject forbidden names
-                if is_eval_or_arguments(original_name) {
-                    let r = js_lexer::range_of_identifier(p.source, name.loc);
-                    p.log().add_range_error_fmt(
-                        Some(p.source),
-                        r,
-                        format_args!(
-                            "Cannot use \"{}\" as an identifier here",
-                            bstr::BStr::new(original_name)
-                        ),
-                    );
                 }
 
                 items.push(ClauseItem {

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -280,7 +280,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn pfx_t_template_head(p: &mut Self) -> PResult<Expr> {
         let loc = p.lexer.loc();
-        let head = p.lexer.to_e_string()?;
+        let mut head = p.lexer.to_e_string()?;
+        if p.lexer.legacy_octal_loc.start > loc.start {
+            head.legacy_octal_loc = p.lexer.legacy_octal_loc;
+        }
 
         let (parts, _tail_loc) = p.parse_template_parts(false)?;
 
@@ -301,7 +304,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn pfx_t_numeric_literal(p: &mut Self) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let value = p.new_expr(E::Number::new(p.lexer.number), loc);
-        // p.checkForLegacyOctalLiteral()
+        p.check_for_legacy_octal_literal(loc);
         p.lexer.next()?;
         Ok(value)
     }

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -261,7 +261,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match p.lexer.token {
                 T::TNumericLiteral => {
                     key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                    // p.checkForLegacyOctalLiteral()
+                    p.check_for_legacy_octal_literal(key.loc);
                     p.lexer.next()?;
                 }
                 T::TStringLiteral => {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1466,7 +1466,6 @@ pub struct ParseStatementOptions<'a> {
     pub(crate) is_typescript_declare: bool,
     pub(crate) is_for_loop_init: bool,
     /// Only a module body or a function body starts with a directive prologue.
-    /// A string statement at the start of a block is an expression.
     pub(crate) allow_directive_prologue: bool,
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -670,8 +670,9 @@ pub enum RelocateVarsMode {
 }
 
 #[derive(Default)]
-pub struct VisitArgsOpts<'a> {
-    pub(crate) body: &'a [Stmt],
+pub struct VisitArgsOpts {
+    /// `Fn.body.loc`, the location of the body's opening brace.
+    pub(crate) body_loc: bun_ast::Loc,
     pub(crate) has_rest_arg: bool,
     /// This is true if the function is an arrow function or a method
     pub(crate) is_unique_formal_parameters: bool,
@@ -1054,8 +1055,15 @@ pub struct ParsedPath<'a> {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum StrictModeFeature {
+    WithStatement,
+    DeleteBareName,
+    ForInVarInit,
     EvalOrArguments,
     ReservedWord,
+    LegacyOctalLiteral,
+    LegacyOctalEscape,
+    IfElseFunctionStmt,
+    LabelFunctionStmt,
 }
 
 #[derive(Clone, Copy)]
@@ -1457,6 +1465,9 @@ pub struct ParseStatementOptions<'a> {
     pub(crate) is_name_optional: bool,
     pub(crate) is_typescript_declare: bool,
     pub(crate) is_for_loop_init: bool,
+    /// Only a module body or a function body starts with a directive prologue.
+    /// A string statement at the start of a block is an expression.
+    pub(crate) allow_directive_prologue: bool,
 }
 
 impl<'a> ParseStatementOptions<'a> {

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -57,6 +57,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
             all_stmts.push(self.s(
                 S::Directive {
                     value: b"use strict".into(),
+                    legacy_octal_loc: bun_ast::Loc::EMPTY,
                 },
                 self.module_scope_directive_loc,
             ));

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -113,8 +113,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.push_scope_for_visit_pass(ScopeKind::FunctionBody, body_loc)
             .expect("unreachable");
 
-        // The function's own "use strict" directive applies to its name, so the
-        // name is checked against the body scope rather than the enclosing one.
+        // The body's own "use strict" applies to the name, so check it in the body scope.
         if let Some(name) = func.name {
             if let Some(name_ref) = name.ref_.to_nullable() {
                 let symbol_name = self.load_name_from_ref(name_ref);
@@ -184,10 +183,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         func
     }
 
-    /// The location of the function body's own "use strict" directive, if any.
-    /// The parse pass drops the directive statement and records it on the body
-    /// scope, which is a child of the current (FunctionArgs) scope. A directive
-    /// inherited from an enclosing scope is located before the body.
+    /// The body's own "use strict" directive, read from the FunctionBody child scope.
     fn fn_body_use_strict_loc(&self, body_loc: bun_ast::Loc) -> Option<bun_ast::Loc> {
         let args_scope = self.current_scope();
         debug_assert!(args_scope.kind == ScopeKind::FunctionArgs);

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -224,11 +224,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Section 15.1.1 Static Semantics: Early Errors: "Multiple occurrences of
         // the same BindingIdentifier in a FormalParameterList is only allowed for
         // functions which have simple parameter lists and which are not defined in
-        // strict mode code."
+        // strict mode code." The ESM output is strict mode code too.
         if opts.is_unique_formal_parameters
             || strict_loc.is_some()
             || !has_simple_args
             || self.is_strict_mode()
+            || self.is_strict_mode_output_format()
         {
             duplicate_args_check = Some(StringVoidMap::get());
         }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -11,7 +11,7 @@ use crate::p::{LowerUsingDeclarationsContext, P};
 use crate::parser::{
     ExprIn, FnOnlyDataVisit, FnOrArrowDataVisit, ImportItemForNamespaceMap, PrependTempRefsOpts,
     Ref, RelocateVarsMode, ScopeOrder, StmtsKind, StrictModeFeature, StringVoidMap, VisitArgsOpts,
-    VisitDeclOpts, is_eval_or_arguments,
+    VisitDeclOpts,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast as js_ast;
@@ -90,15 +90,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if let Some(name) = func.name {
             if let Some(name_ref) = name.ref_.to_nullable() {
                 self.record_declared_symbol(name_ref);
-                let symbol_name = self.load_name_from_ref(name_ref);
-                if is_eval_or_arguments(symbol_name) {
-                    self.mark_strict_mode_feature(
-                        StrictModeFeature::EvalOrArguments,
-                        js_lexer::range_of_identifier(self.source, name.loc),
-                        symbol_name,
-                    )
-                    .expect("unreachable");
-                }
             }
         }
 
@@ -112,13 +103,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             args,
             &VisitArgsOpts {
                 has_rest_arg: func.flags.contains(flags::Function::HasRestArg),
-                body: body_stmts,
-                is_unique_formal_parameters: true,
+                body_loc,
+                is_unique_formal_parameters: func
+                    .flags
+                    .contains(flags::Function::IsUniqueFormalParameters),
             },
         );
 
         self.push_scope_for_visit_pass(ScopeKind::FunctionBody, body_loc)
             .expect("unreachable");
+
+        // The function's own "use strict" directive applies to its name, so the
+        // name is checked against the body scope rather than the enclosing one.
+        if let Some(name) = func.name {
+            if let Some(name_ref) = name.ref_.to_nullable() {
+                let symbol_name = self.load_name_from_ref(name_ref);
+                self.validate_declared_symbol_name(name.loc, symbol_name);
+            }
+        }
         // Stmt is Copy — copy the slice into a bump-backed Vec.
         let mut stmts = BumpVec::with_capacity_in(body_stmts.len(), self.arena);
         stmts.extend_from_slice(body_stmts);
@@ -182,8 +184,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         func
     }
 
+    /// The location of the function body's own "use strict" directive, if any.
+    /// The parse pass drops the directive statement and records it on the body
+    /// scope, which is a child of the current (FunctionArgs) scope. A directive
+    /// inherited from an enclosing scope is located before the body.
+    fn fn_body_use_strict_loc(&self, body_loc: bun_ast::Loc) -> Option<bun_ast::Loc> {
+        let args_scope = self.current_scope();
+        debug_assert!(args_scope.kind == ScopeKind::FunctionArgs);
+        args_scope
+            .children
+            .slice()
+            .iter()
+            .find(|child| child.kind == ScopeKind::FunctionBody)
+            .filter(|body| {
+                body.strict_mode == StrictModeKind::ExplicitStrictMode
+                    && body.use_strict_loc.start > body_loc.start
+            })
+            .map(|body| body.use_strict_loc)
+    }
+
     pub(crate) fn visit_args(&mut self, args: &mut [G::Arg], opts: &VisitArgsOpts) {
-        let strict_loc = fn_body_contains_use_strict(opts.body);
+        let strict_loc = self.fn_body_use_strict_loc(opts.body_loc);
         let has_simple_args = Self::is_simple_parameter_list(args, opts.has_rest_arg);
         // StringVoidMap::get returns a pool guard; Drop releases.
         let mut duplicate_args_check: Option<
@@ -612,14 +633,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let name: &'a [u8] = self.symbols[bind.r#ref.inner_index() as usize]
                     .original_name
                     .slice();
-                if is_eval_or_arguments(name) {
-                    self.mark_strict_mode_feature(
-                        StrictModeFeature::EvalOrArguments,
-                        js_lexer::range_of_identifier(self.source, binding.loc),
-                        name,
-                    )
-                    .expect("unreachable");
-                }
+                self.validate_declared_symbol_name(binding.loc, name);
                 if let Some(dup) = duplicate_arg_check {
                     if dup.get_or_put_contains(name) {
                         self.log().add_range_error_fmt(
@@ -758,6 +772,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if has_if_scope {
             self.push_scope_for_visit_pass(ScopeKind::Block, stmt.loc)
                 .expect("unreachable");
+            if self.is_strict_mode() {
+                self.mark_strict_mode_feature(
+                    StrictModeFeature::IfElseFunctionStmt,
+                    js_lexer::range_of_identifier(self.source, stmt.loc),
+                    b"",
+                )
+                .expect("unreachable");
+            }
         }
 
         let old_is_inside_single_stmt_body = self.is_inside_single_stmt_body;
@@ -799,6 +821,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.enclosing_class_keyword = class.class_keyword;
         self.vis_scope()
             .recursive_set_strict_mode(StrictModeKind::ImplicitStrictModeClass);
+        if let Some(name) = class.class_name {
+            let original_name: &'a [u8] = self.symbols[name.ref_.inner_index() as usize]
+                .original_name
+                .slice();
+            self.validate_declared_symbol_name(name.loc, original_name);
+        }
 
         // Insert a shadowing name that spans the whole class, which matches
         // JavaScript's semantics. The class body (and extends clause) "captures" the
@@ -1945,24 +1973,4 @@ fn scopes_for_enum_at<'a>(
     map.get(&loc)
         .copied()
         .expect("scopes_in_order_for_enum miss for enum stmt loc")
-}
-
-fn fn_body_contains_use_strict(body: &[Stmt]) -> Option<bun_ast::Loc> {
-    use bun_ast::stmt::Data as StmtData;
-    for stmt in body {
-        // "use strict" has to appear at the top of the function body
-        // but we can allow comments
-        match &stmt.data {
-            StmtData::SComment(_) => continue,
-            StmtData::SDirective(dir) => {
-                // SAFETY: arena-owned slice valid for the parse.
-                if dir.value.slice() == b"use strict" {
-                    return Some(stmt.loc);
-                }
-            }
-            StmtData::SEmpty(_) => {}
-            _ => return None,
-        }
-    }
-    None
 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -92,13 +92,34 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // not emitted: it is not necessary and it was causing breakages.
     }
 
-    fn e_string(_: &mut Self, _e: &mut Expr, _: ExprIn) {
-        // If you're using this, you're probably not using 0-prefixed legacy octal notation
-        // if e.LegacyOctalLoc.Start > 0 {
+    fn e_string(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        let str_ = e.data.e_string().expect("infallible: variant checked");
+        let legacy_octal_loc = str_.legacy_octal_loc;
+        if legacy_octal_loc.start > 0 {
+            if str_.prefer_template {
+                p.log().add_range_error(
+                    Some(p.source),
+                    p.source.range_of_legacy_octal_escape(legacy_octal_loc),
+                    b"Legacy octal escape sequences cannot be used in template literals",
+                );
+            } else if p.is_strict_mode() {
+                p.mark_strict_mode_feature(
+                    StrictModeFeature::LegacyOctalEscape,
+                    p.source.range_of_legacy_octal_escape(legacy_octal_loc),
+                    b"",
+                )
+                .expect("unreachable");
+            }
+        }
     }
 
-    fn e_number(_: &mut Self, _e: &mut Expr, _: ExprIn) {
-        // idc about legacy octal loc
+    fn e_number(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        if !p.legacy_octal_literals.is_empty() && p.is_strict_mode() {
+            if let Some(range) = p.legacy_octal_literals.get(&e.loc.start).copied() {
+                p.mark_strict_mode_feature(StrictModeFeature::LegacyOctalLiteral, range, b"")
+                    .expect("unreachable");
+            }
+        }
     }
 
     fn e_this(p: &mut Self, e: &mut Expr, _: ExprIn) {
@@ -688,6 +709,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = expr.data.e_template().expect("infallible: variant checked");
         if e_.tag.is_some() {
             p.visit_expr(e_.tag.as_mut().unwrap());
+        } else {
+            // Untagged templates never allow legacy octal escapes, in any mode.
+            let legacy_octal_loc = core::iter::once(&e_.head)
+                .chain(e_.parts().iter().map(|part| &part.tail))
+                .find_map(|contents| match contents {
+                    E::TemplateContents::Cooked(cooked) if cooked.legacy_octal_loc.start > 0 => {
+                        Some(cooked.legacy_octal_loc)
+                    }
+                    _ => None,
+                });
+            if let Some(legacy_octal_loc) = legacy_octal_loc {
+                p.log().add_range_error(
+                    Some(p.source),
+                    p.source.range_of_legacy_octal_escape(legacy_octal_loc),
+                    b"Legacy octal escape sequences cannot be used in template literals",
+                );
+            }
         }
 
         // Visit the interpolation values before the macro dispatch below: its
@@ -1218,6 +1256,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             Op::UnDelete => {
+                if matches!(e_.value.data, Data::EIdentifier(_)) {
+                    p.mark_strict_mode_feature(
+                        StrictModeFeature::DeleteBareName,
+                        js_lexer::range_of_identifier(p.source, e_.value.loc),
+                        b"",
+                    )
+                    .expect("unreachable");
+                }
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
             }
             _ => {
@@ -2432,7 +2478,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             args_mut,
             &VisitArgsOpts {
                 has_rest_arg: e_.has_rest_arg,
-                body: dupe,
+                body_loc: e_.body.loc,
                 is_unique_formal_parameters: true,
             },
         );

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -344,8 +344,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return;
             }
 
-            // The renamer rewrites a bound reserved word, but an unbound one is
-            // printed as written and the ESM output would not parse.
+            // The renamer leaves an unbound reserved word as written; ESM output would not parse.
             if !p.is_strict_mode()
                 && p.is_strict_mode_output_format()
                 && js_lexer::is_strict_mode_reserved_word(name)

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -729,7 +729,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = expr.data.e_template().expect("infallible: variant checked");
         if e_.tag.is_some() {
             p.visit_expr(e_.tag.as_mut().unwrap());
-        } else {
+        } else if !p.is_revisit_for_substitution {
             // Untagged templates never allow legacy octal escapes, in any mode.
             let legacy_octal_loc = core::iter::once(&e_.head)
                 .chain(e_.parts().iter().map(|part| &part.tail))

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -93,6 +93,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn e_string(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        // The substitution revisit walks an already-visited literal; its errors are logged.
+        if p.is_revisit_for_substitution {
+            return;
+        }
         let str_ = e.data.e_string().expect("infallible: variant checked");
         let legacy_octal_loc = str_.legacy_octal_loc;
         if legacy_octal_loc.start > 0 {
@@ -114,6 +118,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn e_number(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        if p.is_revisit_for_substitution {
+            return;
+        }
         if !p.legacy_octal_literals.is_empty() && p.is_strict_mode() {
             if let Some(range) = p.legacy_octal_literals.get(&e.loc.start).copied() {
                 p.mark_strict_mode_feature(StrictModeFeature::LegacyOctalLiteral, range, b"")
@@ -335,6 +342,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 *e = p.value_for_require(expr.loc);
                 return;
+            }
+
+            // The renamer rewrites a bound reserved word, but an unbound one is
+            // printed as written and the ESM output would not parse.
+            if !p.is_strict_mode()
+                && p.is_strict_mode_output_format()
+                && js_lexer::is_strict_mode_reserved_word(name)
+            {
+                p.mark_strict_mode_feature(
+                    StrictModeFeature::ReservedWord,
+                    js_lexer::range_of_identifier(p.source, expr.loc),
+                    name,
+                )
+                .expect("unreachable");
             }
         }
 
@@ -1256,7 +1277,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             Op::UnDelete => {
-                if matches!(e_.value.data, Data::EIdentifier(_)) {
+                if matches!(e_.value.data, Data::EIdentifier(_)) && !p.is_revisit_for_substitution {
                     p.mark_strict_mode_feature(
                         StrictModeFeature::DeleteBareName,
                         js_lexer::range_of_identifier(p.source, e_.value.loc),

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -169,16 +169,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// An import makes the file a module, so a reserved word cannot be an imported binding.
+    /// An import makes the file a module, so its bindings are strict mode declarations.
     fn validate_import_name(&mut self, loc: bun_ast::Loc, ref_: Ref) -> Result<(), Error> {
         let name = self.load_name_from_ref(ref_);
-        if js_lexer::is_strict_mode_reserved_word(name) {
-            self.mark_strict_mode_feature(
-                StrictModeFeature::ReservedWord,
-                js_lexer::range_of_identifier(self.source, loc),
-                name,
-            )?;
-        }
+        self.validate_declared_symbol_name(loc, name);
         Ok(())
     }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -148,19 +148,38 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::Import,
     ) -> Result<(), Error> {
         p.record_declared_symbol(data.namespace_ref);
+        if let Some(star_name_loc) = data.star_name_loc.to_nullable() {
+            p.validate_import_name(star_name_loc, data.namespace_ref)?;
+        }
 
         if let Some(default_name) = data.default_name {
             p.record_declared_symbol(default_name.ref_);
+            p.validate_import_name(default_name.loc, default_name.ref_)?;
         }
 
         let items = data.items.slice();
         if !items.is_empty() {
             for item in items.iter() {
                 p.record_declared_symbol(item.name.ref_);
+                p.validate_import_name(item.name.loc, item.name.ref_)?;
             }
         }
 
         stmts.push(*stmt);
+        Ok(())
+    }
+
+    /// An import makes the file a module, so a reserved word cannot be an imported binding.
+    /// `eval` and `arguments` are rejected in the parse pass.
+    fn validate_import_name(&mut self, loc: bun_ast::Loc, ref_: Ref) -> Result<(), Error> {
+        let name = self.load_name_from_ref(ref_);
+        if js_lexer::is_strict_mode_reserved_word(name) {
+            self.mark_strict_mode_feature(
+                StrictModeFeature::ReservedWord,
+                js_lexer::range_of_identifier(self.source, loc),
+                name,
+            )?;
+        }
         Ok(())
     }
 
@@ -2195,6 +2214,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         p.record_declared_symbol(data.name.ref_);
+        // The enum lowers to a `var` with this name.
+        let enum_name = p.load_name_from_ref(data.name.ref_);
+        p.validate_declared_symbol_name(data.name.loc, enum_name);
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Entry, stmt.loc)?;
         p.record_declared_symbol(data.arg);
 
@@ -2388,6 +2410,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::Namespace,
     ) -> Result<(), Error> {
         p.record_declared_symbol(data.name.ref_);
+        // The namespace lowers to a `var` with this name.
+        let namespace_name = p.load_name_from_ref(data.name.ref_);
+        p.validate_declared_symbol_name(data.name.loc, namespace_name);
 
         // Scan ahead for any variables inside this namespace. This must be done
         // ahead of time before visiting any statements inside the namespace

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -170,7 +170,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// An import makes the file a module, so a reserved word cannot be an imported binding.
-    /// `eval` and `arguments` are rejected in the parse pass.
     fn validate_import_name(&mut self, loc: bun_ast::Loc, ref_: Ref) -> Result<(), Error> {
         let name = self.load_name_from_ref(ref_);
         if js_lexer::is_strict_mode_reserved_word(name) {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -4,7 +4,7 @@ use crate::lexer as js_lexer;
 use crate::p::{P, ReactRefreshExportKind};
 use crate::parser::{
     PrependTempRefsOpts, ReactRefresh, Ref, RelocateVarsMode, SideEffects, StmtsKind,
-    statement_cares_about_scope,
+    StrictModeFeature, statement_cares_about_scope,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast::flags;
@@ -68,7 +68,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // points into the arena, not into `*stmt`.
         let data_copy = stmt.data;
         match data_copy {
-            StmtData::SDirective(_) | StmtData::SComment(_) | StmtData::SEmpty(_) => {
+            StmtData::SDirective(directive) => {
+                // Directives do not end the const local prefix
+                p.cur_scope().is_after_const_local_prefix = was_after_after_const_local_prefix;
+                let legacy_octal_loc = directive.legacy_octal_loc;
+                if legacy_octal_loc.start > 0 && p.is_strict_mode() {
+                    p.mark_strict_mode_feature(
+                        StrictModeFeature::LegacyOctalEscape,
+                        p.source.range_of_legacy_octal_escape(legacy_octal_loc),
+                        b"",
+                    )?;
+                }
+                stmts.push(*stmt);
+                Ok(())
+            }
+            StmtData::SComment(_) | StmtData::SEmpty(_) => {
                 p.cur_scope().is_after_const_local_prefix = was_after_after_const_local_prefix;
                 stmts.push(*stmt);
                 Ok(())
@@ -1327,9 +1341,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::Label,
     ) -> Result<(), Error> {
+        // Forbid functions inside labels in strict mode
+        if p.is_strict_mode() && matches!(data.stmt.data, StmtData::SFunction(_)) {
+            p.mark_strict_mode_feature(
+                StrictModeFeature::LabelFunctionStmt,
+                js_lexer::range_of_identifier(p.source, data.stmt.loc),
+                b"",
+            )?;
+        }
+
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Label, stmt.loc)
             .expect("unreachable");
         let name = p.load_name_from_ref(data.name.ref_);
+        if js_lexer::is_strict_mode_reserved_word(name) {
+            p.mark_strict_mode_feature(
+                StrictModeFeature::ReservedWord,
+                js_lexer::range_of_identifier(p.source, data.name.loc),
+                name,
+            )?;
+        }
         let ref_ = p.new_symbol(js_ast::symbol::Kind::Label, name);
         data.name.ref_ = ref_;
         p.cur_scope().label_ref = ref_;
@@ -1621,6 +1651,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::With,
     ) -> Result<(), Error> {
+        p.mark_strict_mode_feature(
+            StrictModeFeature::WithStatement,
+            js_lexer::range_of_identifier(p.source, stmt.loc),
+            b"",
+        )?;
         p.visit_expr(&mut data.value);
 
         p.push_scope_for_visit_pass(js_ast::scope::Kind::With, data.body_loc)
@@ -1893,6 +1928,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let decl: &mut G::Decl = &mut local.decls.slice_mut()[0];
                         if let js_ast::binding::Data::BIdentifier(b_id) = decl.binding.data {
                             if let Some(val) = decl.value {
+                                p.mark_strict_mode_feature(
+                                    StrictModeFeature::ForInVarInit,
+                                    p.source.range_of_operator_before(val.loc, b"="),
+                                    b"",
+                                )?;
                                 let id_ref = b_id.r#ref;
                                 stmts.push(Stmt::assign(
                                     Expr::init_identifier(id_ref, decl.binding.loc),

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,9 +55,7 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-/// Version 28: The parser reports strict-mode early errors (legacy octal
-/// literals, `with`, duplicate functions, ...) that older entries silently
-/// transpiled, and keeps a block-level "use strict" string as a statement.
+/// Version 28: The parser reports strict-mode early errors that older entries transpiled.
 const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,10 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: The parser reports strict-mode early errors (legacy octal
+/// literals, `with`, duplicate functions, ...) that older entries silently
+/// transpiled, and keeps a block-level "use strict" string as a statement.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -482,6 +482,7 @@ fn codegen_reactive_function(
         directives.push(Stmt::alloc(
             S::Directive {
                 value: store_str(d.as_bytes()),
+                legacy_octal_loc: Loc::EMPTY,
             },
             Loc::EMPTY,
         ));

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3317,6 +3317,27 @@ describe("bundler", () => {
       "/entry.js": ['"package" is a reserved word and cannot be used with the ESM output format due to strict mode'],
     },
   });
+  // The printer writes numbers in decimal and escapes as `\xNN`, so legacy octal
+  // syntax never reaches the output and is not an error for ESM output.
+  itBundled("edgecase/SloppyLegacyOctalESMOutputIsReprinted", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(JSON.stringify(require("./dep.cjs")));
+      `,
+      "/dep.cjs": /* js */ `
+        var n = 010, m = 08, s = "\\1", t = "\\012";
+        module.exports = [n, m, s, t];
+      `,
+    },
+    format: "esm",
+    run: { stdout: '[8,8,"\\u0001","\\n"]' },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("var n = 8");
+      expect(out).not.toContain("010");
+      expect(out).not.toContain("\\1");
+    },
+  });
   // A for-in initializer is lowered to an assignment before the loop, so it is
   // not an error for any output format.
   itBundled("edgecase/SloppyForInInitializerIsLowered", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3465,7 +3465,8 @@ describe("bundler", () => {
         function f() { let n = 010; return n + 1; }
         function g() { let s = "\\1"; return s + "a"; }
         function h() { let d = delete x; return d + 1; }
-        console.log(f(), g(), h());
+        function t(a) { let y = 5; return \`\\1\${a}\` + y; }
+        console.log(f(), g(), h(), t(1));
       `,
     },
     minifySyntax: true,
@@ -3474,7 +3475,41 @@ describe("bundler", () => {
         "Legacy octal literals cannot be used in strict mode",
         "Legacy octal escape sequences cannot be used in strict mode",
         "Delete of a bare identifier cannot be used in strict mode",
+        "Legacy octal escape sequences cannot be used in template literals",
       ],
+    },
+  });
+  // `eval` and `arguments` are not renamed, so an assignment to them in a
+  // sloppy file cannot go into ESM output.
+  itBundled("edgecase/SloppyEvalAssignmentESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs"));
+      `,
+      "/dep.cjs": /* js */ `
+        eval = 0;
+        arguments++;
+        module.exports = typeof eval;
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/dep.cjs": ["Invalid assignment target", "Invalid assignment target"],
+    },
+  });
+  itBundled("edgecase/SloppyEvalAssignmentCJSOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs"));
+      `,
+      "/dep.cjs": /* js */ `
+        eval = 0;
+        module.exports = typeof eval;
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("eval = 0;");
     },
   });
 });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3223,6 +3223,81 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+  // A `with` statement in a sloppy CommonJS dependency cannot run inside an
+  // ESM bundle (modules are strict), so bundling it to ESM is an error in the
+  // dependency instead of a SyntaxError when the bundle loads.
+  itBundled("edgecase/SloppyWithStatementESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        const dep = require("./dep.cjs");
+        console.log(dep);
+      `,
+      "/dep.cjs": /* js */ `
+        var obj = { foo() { return "foo" } };
+        with (obj) { module.exports = foo() }
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/dep.cjs": ["With statements cannot be used with the ESM output format due to strict mode"],
+    },
+  });
+  itBundled("edgecase/SloppyDeleteBareNameESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        x = 1;
+        delete x;
+        console.log(typeof x);
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/entry.js": ["Delete of a bare identifier cannot be used with the ESM output format due to strict mode"],
+    },
+  });
+  itBundled("edgecase/SloppyWithStatementCJSOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        const dep = require("./dep.cjs");
+        console.log(dep);
+      `,
+      "/dep.cjs": /* js */ `
+        var obj = { foo() { return "foo" } };
+        with (obj) { module.exports = foo() }
+      `,
+    },
+    format: "cjs",
+    run: { stdout: "foo" },
+  });
+  // A for-in initializer is lowered to an assignment before the loop, so it is
+  // not an error for any output format.
+  itBundled("edgecase/SloppyForInInitializerIsLowered", {
+    files: {
+      "/entry.js": /* js */ `
+        for (var i = "init" in {}) ;
+        console.log(i);
+      `,
+    },
+    format: "esm",
+    run: { stdout: "init" },
+  });
+  // The sloppy-mode constructs that an ES module rejects are reported in the
+  // file that has ESM syntax, no matter the output format.
+  itBundled("edgecase/StrictModeConstructsInESMFileCJSOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        export let n = 010;
+        with (x) y;
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/entry.js": [
+        "Legacy octal literals cannot be used in an ECMAScript module",
+        "With statements cannot be used in an ECMAScript module",
+      ],
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3346,6 +3346,116 @@ describe("bundler", () => {
       ],
     },
   });
+  // Only the "esm" output format is strict mode code. An IIFE keeps the sloppy
+  // constructs as written.
+  itBundled("edgecase/SloppyWithStatementIIFEOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        var scope = { greeting: "hi" };
+        with (scope) { console.log(greeting); }
+      `,
+    },
+    format: "iife",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("with (scope)");
+    },
+    run: { stdout: "hi" },
+  });
+  // A duplicate parameter name is only valid in sloppy mode, and the renamer
+  // does not change it, so it cannot go into ESM output.
+  itBundled("edgecase/SloppyDuplicateParametersESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs"));
+      `,
+      "/dep.cjs": /* js */ `
+        function f(a, a) { return a }
+        module.exports = f(1, 2);
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/dep.cjs": ['"a" cannot be bound multiple times in the same parameter list'],
+    },
+  });
+  itBundled("edgecase/SloppyDuplicateParametersCJSOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs"));
+      `,
+      "/dep.cjs": /* js */ `
+        function f(a, a) { return a }
+        module.exports = f(1, 2);
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("function f(a, a)");
+    },
+  });
+  // The renamer only renames bound symbols. An unbound reserved word is printed
+  // as written, so it would make the ESM output a syntax error.
+  itBundled("edgecase/SloppyUnboundReservedWordESMOutputIsAnError", {
+    files: {
+      "/entry.cjs": /* js */ `
+        exports.x = 1;
+        console.log(package);
+        static = 2;
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/entry.cjs": [
+        '"package" is a reserved word and cannot be used with the ESM output format due to strict mode',
+        '"static" is a reserved word and cannot be used with the ESM output format due to strict mode',
+      ],
+    },
+  });
+  itBundled("edgecase/SloppyUnboundReservedWordCJSOutput", {
+    files: {
+      "/entry.cjs": /* js */ `
+        exports.x = 1;
+        console.log(typeof package);
+      `,
+    },
+    format: "cjs",
+    run: { stdout: "undefined" },
+  });
+  itBundled("edgecase/SloppyUnboundReservedWordReplacedByDefine", {
+    files: {
+      "/entry.cjs": /* js */ `
+        exports.x = 1;
+        console.log(package);
+      `,
+    },
+    format: "esm",
+    define: {
+      package: "123",
+    },
+    run: { stdout: "123" },
+  });
+  // `--minify-syntax` substitutes a single-use `let` into the next statement
+  // and visits the result again. The strict-mode errors of the substituted
+  // expression must not be reported a second time.
+  itBundled("edgecase/StrictModeErrorsReportedOnceWithMinifySyntax", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        function f() { let n = 010; return n + 1; }
+        function g() { let s = "\\1"; return s + "a"; }
+        function h() { let d = delete x; return d + 1; }
+        console.log(f(), g(), h());
+      `,
+    },
+    minifySyntax: true,
+    bundleErrors: {
+      "/entry.js": [
+        "Legacy octal literals cannot be used in strict mode",
+        "Legacy octal escape sequences cannot be used in strict mode",
+        "Delete of a bare identifier cannot be used in strict mode",
+      ],
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3269,6 +3269,54 @@ describe("bundler", () => {
     format: "cjs",
     run: { stdout: "foo" },
   });
+  // Sloppy-mode constructs that the bundler rewrites are not an error for ESM
+  // output: the renamer renames bound reserved words, and block-level function
+  // declarations in an `if` or a label are lowered to `let` plus a `var`.
+  itBundled("edgecase/SloppyReservedWordBindingsESMOutputAreRenamed", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs"));
+      `,
+      "/dep.cjs": /* js */ `
+        var package = 1, interface = 2;
+        function f(static) { return static + package + interface }
+        function protected() {}
+        try {} catch (private) {}
+        module.exports = f(3) + typeof protected;
+      `,
+    },
+    format: "esm",
+    run: { stdout: "6function" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var _package = 1");
+    },
+  });
+  itBundled("edgecase/SloppyBlockLevelFunctionsESMOutputAreLowered", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs"));
+      `,
+      "/dep.cjs": /* js */ `
+        lbl: function f() {}
+        if (0) function g() {}
+        module.exports = typeof f + typeof g;
+      `,
+    },
+    format: "esm",
+    run: { stdout: "functionundefined" },
+  });
+  // Labels are not renamed, so a reserved word as a label is still an error.
+  itBundled("edgecase/SloppyReservedWordLabelESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        package: for (;;) break package;
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/entry.js": ['"package" is a reserved word and cannot be used with the ESM output format due to strict mode'],
+    },
+  });
   // A for-in initializer is lowered to an assignment before the loop, so it is
   // not an error for any output format.
   itBundled("edgecase/SloppyForInInitializerIsLowered", {

--- a/test/bundler/transpiler/strict-mode.test.ts
+++ b/test/bundler/transpiler/strict-mode.test.ts
@@ -1,0 +1,591 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Strict-mode early errors. The cases follow esbuild's TestStrictMode corpus:
+// sloppy code must parse, and the same code must be rejected once it is strict
+// because of a "use strict" directive, an ECMAScript module, or a class body.
+
+// Warnings (for example the legacy HTML comment warning) also make
+// `transformSync` throw, so only errors are recorded.
+const transpiler = new Bun.Transpiler({ loader: "js", logLevel: "error" });
+
+type ParseMessage = { message: string; notes: { message: string; position: { line: number; column: number } }[] };
+
+function parseErrors(code: string): ParseMessage[] {
+  try {
+    transpiler.transformSync(code);
+  } catch (e: any) {
+    const errors: any[] = e instanceof AggregateError ? e.errors : [e];
+    return errors.map(err => ({
+      message: err.message,
+      notes: (err.notes ?? []).map((note: any) => ({
+        message: note.message,
+        position: { line: note.position.line, column: note.position.column },
+      })),
+    }));
+  }
+  return [];
+}
+
+function expectParseError(code: string, ...messages: string[]) {
+  expect(parseErrors(code).map(e => e.message)).toEqual(messages);
+}
+
+function expectNoParseError(code: string) {
+  expect(parseErrors(code)).toEqual([]);
+}
+
+const useStrictNote = 'Strict mode is triggered by the "use strict" directive here:';
+const exportNote = 'This file is considered to be an ECMAScript module because of the "export" keyword here:';
+const classNote = "All code inside a class is implicitly in strict mode";
+
+describe("strict mode early errors", () => {
+  describe("sloppy mode accepts legacy syntax", () => {
+    const sloppy = [
+      "with (x) y",
+      "delete x",
+      "for (var x = y in z) ;",
+      "if (0) function f() {}",
+      "if (0) ; else function f() {}",
+      "x: function f() {}",
+      "function f(a, a) {}",
+      "(function(a, a) {})",
+      "({ f: function(a, a) {} })",
+      "({ f: function*(a, a) {} })",
+      "({ f: async function(a, a) {} })",
+      "eval++",
+      "eval = 0",
+      "eval += 0",
+      "[eval] = 0",
+      "arguments++",
+      "arguments = 0",
+      "arguments += 0",
+      "[arguments] = 0",
+      "function eval() {}",
+      "function arguments() {}",
+      "function f(eval) {}",
+      "function f(arguments) {}",
+      "({ f(eval) {} })",
+      "({ f(arguments) {} })",
+      "let protected",
+      "let protecte\\u0064",
+      "let x = protected",
+      "let x = protecte\\u0064",
+      "protected: 0",
+      "var static, implements, interface, package, private, public, yield",
+      "0123",
+      "08",
+      "({0123: 4})",
+      "let {0123: x} = y",
+      "let x = '\\0'",
+      "let x = '\\00'",
+      "let x = '\\1'",
+      "let x = '\\01'",
+      "let x = 'a\\7'",
+      "let x = '\\08'",
+      "let x = '\\09'",
+      "let x = '\\008'",
+      "let x = '\\012'",
+      "let x = '\\8'",
+      "let x = '\\9'",
+      "'\\00'",
+      "'\\08'",
+      "function f() {} function f() {}",
+      "function f() {} function *f() {}",
+      "async function f() {} function f() {}",
+      "{ function f() {} function f() {} }",
+      "var x; var x",
+      "-->",
+      "x\n--> a comment",
+      "<!-- a comment\nx",
+      "x <!-- a comment\ny",
+    ];
+    for (const code of sloppy) {
+      test(JSON.stringify(code), () => expectNoParseError(code));
+    }
+  });
+
+  describe("legacy octal escapes decode leniently in sloppy mode", () => {
+    test("1 to 3 octal digits, also at the end of the string", () => {
+      expect(transpiler.transformSync("x = ['\\1', '\\01', 'a\\7', '\\101', '\\1a', '\\0', '\\00']")).toBe(
+        'x = ["\\x01", "\\x01", "a\\x07", "A", "\\x01a", "\\x00", "\\x00"];\n',
+      );
+    });
+    test("\\08 and \\09 are \\0 followed by a digit", () => {
+      expect(transpiler.transformSync("x = ['\\08', '\\09', '\\008', '\\18']")).toBe(
+        'x = ["\\x008", "\\x009", "\\x008", "\\x018"];\n',
+      );
+    });
+    test("\\8 and \\9 are the digit itself", () => {
+      expect(transpiler.transformSync("x = ['\\8', '\\9', 'a\\8']")).toBe('x = ["8", "9", "a8"];\n');
+    });
+    test("4-digit sequences stop at 255", () => {
+      expect(transpiler.transformSync("x = ['\\400', '\\377']")).toBe('x = [" 0", "ÿ"];\n');
+    });
+  });
+
+  describe('"use strict" directive', () => {
+    const cases: [string, string][] = [
+      ["'use strict'; with (x) y", "With statements cannot be used in strict mode"],
+      ["'use strict'; delete x", "Delete of a bare identifier cannot be used in strict mode"],
+      [
+        "'use strict'; for (var x = y in z) ;",
+        "Variable initializers inside for-in loops cannot be used in strict mode",
+      ],
+      [
+        "'use strict'; if (0) function f() {}",
+        "Function declarations inside if statements cannot be used in strict mode",
+      ],
+      [
+        "'use strict'; if (0) ; else function f() {}",
+        "Function declarations inside if statements cannot be used in strict mode",
+      ],
+      ["'use strict'; x: function f() {}", "Function declarations inside labels cannot be used in strict mode"],
+      ["'use strict'; eval++", "Invalid assignment target"],
+      ["'use strict'; eval = 0", "Invalid assignment target"],
+      ["'use strict'; eval += 0", "Invalid assignment target"],
+      ["'use strict'; [eval] = 0", "Invalid assignment target"],
+      ["'use strict'; arguments++", "Invalid assignment target"],
+      ["'use strict'; arguments = 0", "Invalid assignment target"],
+      ["'use strict'; arguments += 0", "Invalid assignment target"],
+      ["'use strict'; [arguments] = 0", "Invalid assignment target"],
+      ["'use strict'; function eval() {}", 'Declarations with the name "eval" cannot be used in strict mode'],
+      ["'use strict'; function arguments() {}", 'Declarations with the name "arguments" cannot be used in strict mode'],
+      ["'use strict'; function f(eval) {}", 'Declarations with the name "eval" cannot be used in strict mode'],
+      [
+        "'use strict'; function f(arguments) {}",
+        'Declarations with the name "arguments" cannot be used in strict mode',
+      ],
+      ["'use strict'; class eval {}", 'Declarations with the name "eval" cannot be used in strict mode'],
+      ["'use strict'; class arguments {}", 'Declarations with the name "arguments" cannot be used in strict mode'],
+      ["'use strict'; var arguments = 1", 'Declarations with the name "arguments" cannot be used in strict mode'],
+      ["'use strict'; let protected", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; let protecte\\u0064", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; let x = protected", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; let x = protecte\\u0064", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; protected: 0", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; protecte\\u0064: 0", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; function protected() {}", '"protected" is a reserved word and cannot be used in strict mode'],
+      [
+        "'use strict'; function protecte\\u0064() {}",
+        '"protected" is a reserved word and cannot be used in strict mode',
+      ],
+      ["'use strict'; (function protected() {})", '"protected" is a reserved word and cannot be used in strict mode'],
+      [
+        "'use strict'; (function protecte\\u0064() {})",
+        '"protected" is a reserved word and cannot be used in strict mode',
+      ],
+      ["'use strict'; class static {}", '"static" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; (class static {})", '"static" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; try {} catch (protected) {}", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; var package = 1", '"package" is a reserved word and cannot be used in strict mode'],
+      ["'use strict'; 0123", "Legacy octal literals cannot be used in strict mode"],
+      ["'use strict'; ({0123: 4})", "Legacy octal literals cannot be used in strict mode"],
+      ["'use strict'; let {0123: x} = y", "Legacy octal literals cannot be used in strict mode"],
+      ["'use strict'; 08", "Legacy octal literals cannot be used in strict mode"],
+      ["'use strict'; ({08: 4})", "Legacy octal literals cannot be used in strict mode"],
+      ["'use strict'; let {08: x} = y", "Legacy octal literals cannot be used in strict mode"],
+      ["'use strict'; let x = '\\00'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; let x = '\\08'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; let x = '\\008'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; let x = '\\1'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; let x = '\\012'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; let x = '\\8'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; '\\00'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; '\\08'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; '\\008'", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'\\00'; 'use strict';", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'\\08'; 'use strict';", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'\\008'; 'use strict';", "Legacy octal escape sequences cannot be used in strict mode"],
+      ["'use strict'; function f(a, a) {}", '"a" cannot be bound multiple times in the same parameter list'],
+      ["'use strict'; (function(a, a) {})", '"a" cannot be bound multiple times in the same parameter list'],
+      ["'use strict'; ((a, a) => {})", '"a" cannot be bound multiple times in the same parameter list'],
+    ];
+    for (const [code, message] of cases) {
+      test(JSON.stringify(code), () => expectParseError(code, message));
+    }
+
+    test("\\0 is not a legacy octal escape", () => {
+      expectNoParseError("'use strict'; let x = '\\0'");
+      expectNoParseError("'use strict'; '\\0'");
+    });
+
+    test("the note points at the directive", () => {
+      expect(parseErrors("'use strict';\nwith (x) y")).toEqual([
+        {
+          message: "With statements cannot be used in strict mode",
+          notes: [{ message: useStrictNote, position: { line: 1, column: 1 } }],
+        },
+      ]);
+    });
+
+    test("a directive inside a block is not a directive", () => {
+      expectNoParseError("{ 'use strict'; with (x) y }");
+      expectNoParseError("if (0) { 'use strict'; with (x) y }");
+      expectNoParseError("while (0) { 'use strict'; with (x) y }");
+      expectNoParseError("try { 'use strict'; with (x) y } catch {}");
+      expectNoParseError("try {} catch { 'use strict'; with (x) y }");
+      expectNoParseError("try {} finally { 'use strict'; with (x) y }");
+      expectNoParseError("`use strict`; with (x) y");
+    });
+
+    test("strict mode does not leak out of a function or class", () => {
+      expectNoParseError("function f() { 'use strict' } with (x) y");
+      expectNoParseError("with (x) y; function f() { 'use strict' }");
+      expectNoParseError("class f {} with (x) y");
+      expectNoParseError("with (x) y; class f {}");
+    });
+  });
+
+  describe("function body directive", () => {
+    const evalDecl = 'Declarations with the name "eval" cannot be used in strict mode';
+    const argsDecl = 'Declarations with the name "arguments" cannot be used in strict mode';
+    const bindingError = '"a" cannot be bound multiple times in the same parameter list';
+    const cases: [string, string][] = [
+      ["function f() { 'use strict'; with (x) y }", "With statements cannot be used in strict mode"],
+      ["function f() { 'use strict'; function y() { with (x) y } }", "With statements cannot be used in strict mode"],
+      ["function eval() { 'use strict' }", evalDecl],
+      ["function arguments() { 'use strict' }", argsDecl],
+      ["function f(eval) { 'use strict' }", evalDecl],
+      ["function f(arguments) { 'use strict' }", argsDecl],
+      ["({ f(eval) { 'use strict' } })", evalDecl],
+      ["({ f(arguments) { 'use strict' } })", argsDecl],
+      ["(eval) => { 'use strict' }", evalDecl],
+      ["function protected() { 'use strict' }", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["function f(a, a) { 'use strict' }", bindingError],
+      ["function *f(a, a) { 'use strict' }", bindingError],
+      ["async function f(a, a) { 'use strict' }", bindingError],
+      ["(function(a, a) { 'use strict' })", bindingError],
+      ["(function*(a, a) { 'use strict' })", bindingError],
+      ["(async function(a, a) { 'use strict' })", bindingError],
+      ["function f(a, [a]) {}", bindingError],
+      ["function f([a], a) {}", bindingError],
+      ["(function(a, [a]) {})", bindingError],
+      ["({ f(a, a) {} })", bindingError],
+      ["({ *f(a, a) {} })", bindingError],
+      ["({ async f(a, a) {} })", bindingError],
+      ["(a, a) => {}", bindingError],
+      ["class A { m(a, a) {} }", bindingError],
+    ];
+    for (const [code, message] of cases) {
+      test(JSON.stringify(code), () => expectParseError(code, message));
+    }
+
+    describe('"use strict" needs a simple parameter list', () => {
+      const nonSimple = 'Cannot use a "use strict" directive in a function with a non-simple parameter list';
+      const cases: [string, string[]][] = [
+        ["function f() { 'use strict' }", []],
+        ["function f(x) { 'use strict' }", []],
+        ["function f([x]) { 'use strict' }", [nonSimple]],
+        ["function f({x}) { 'use strict' }", [nonSimple]],
+        ["function f(x = 1) { 'use strict' }", [nonSimple]],
+        ["function f(x, ...y) { 'use strict' }", [nonSimple]],
+        ["(function() { 'use strict' })", []],
+        ["(function(x) { 'use strict' })", []],
+        ["(function([x]) { 'use strict' })", [nonSimple]],
+        ["(function({x}) { 'use strict' })", [nonSimple]],
+        ["(function(x = 1) { 'use strict' })", [nonSimple]],
+        ["(function(x, ...y) { 'use strict' })", [nonSimple]],
+        ["() => { 'use strict' }", []],
+        ["(x) => { 'use strict' }", []],
+        ["([x]) => { 'use strict' }", [nonSimple]],
+        ["({x}) => { 'use strict' }", [nonSimple]],
+        ["(x = 1) => { 'use strict' }", [nonSimple]],
+        ["(x, ...y) => { 'use strict' }", [nonSimple]],
+        ["({ m([x]) { 'use strict' } })", [nonSimple]],
+        ["class A { m(x = 1) { 'use strict' } }", [nonSimple]],
+        // An outer directive does not count as the function's own.
+        ["'use strict'; function f([x]) {}", []],
+        ["'use strict'; function f([x]) { 'use strict' }", [nonSimple]],
+      ];
+      for (const [code, messages] of cases) {
+        test(JSON.stringify(code), () => expectParseError(code, ...messages));
+      }
+    });
+
+    test("the note points at the directive inside the function", () => {
+      expect(parseErrors("function f(arguments) {\n  'use strict'\n}")).toEqual([
+        {
+          message: 'Declarations with the name "arguments" cannot be used in strict mode',
+          notes: [{ message: useStrictNote, position: { line: 2, column: 3 } }],
+        },
+      ]);
+    });
+  });
+
+  describe("ECMAScript module", () => {
+    const cases: [string, string][] = [
+      ["with (x) y; export {}", "With statements cannot be used in an ECMAScript module"],
+      ["delete x; export {}", "Delete of a bare identifier cannot be used in an ECMAScript module"],
+      [
+        "for (var x = y in z) ; export {}",
+        "Variable initializers inside for-in loops cannot be used in an ECMAScript module",
+      ],
+      [
+        "if (0) function f() {} export {}",
+        "Function declarations inside if statements cannot be used in an ECMAScript module",
+      ],
+      [
+        "if (0) ; else function f() {} export {}",
+        "Function declarations inside if statements cannot be used in an ECMAScript module",
+      ],
+      ["x: function f() {} export {}", "Function declarations inside labels cannot be used in an ECMAScript module"],
+      ["function f(a, a) {}; export {}", '"a" cannot be bound multiple times in the same parameter list'],
+      ["(function(a, a) {}); export {}", '"a" cannot be bound multiple times in the same parameter list'],
+      ["export {}; let eval = 1", 'Declarations with the name "eval" cannot be used in an ECMAScript module'],
+      ["await 1; var arguments = 1", 'Declarations with the name "arguments" cannot be used in an ECMAScript module'],
+      ["var protected; export {}", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["class protected {} export {}", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["(class protected {}); export {}", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      [
+        "function protected() {} export {}",
+        '"protected" is a reserved word and cannot be used in an ECMAScript module',
+      ],
+      [
+        "(function protected() {}); export {}",
+        '"protected" is a reserved word and cannot be used in an ECMAScript module',
+      ],
+      ["class static {}\nexport {}", '"static" is a reserved word and cannot be used in an ECMAScript module'],
+      ["protected: 0; export {}", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["export let n = 010", "Legacy octal literals cannot be used in an ECMAScript module"],
+      ["export let n = 08", "Legacy octal literals cannot be used in an ECMAScript module"],
+      ["export let o = { 0123: 4 }", "Legacy octal literals cannot be used in an ECMAScript module"],
+      ["let x = '\\00'; export {}", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["let x = '\\09'; export {}", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["let x = '\\009'; export {}", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["export let t = '\\012'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["'\\00'; export {}", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["'\\09'; export {}", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["'\\009'; export {}", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["import.meta; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["import 'x'; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["import * as x from 'x'; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["import x from 'x'; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["import {x} from 'x'; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["export {}; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["export let x; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["export function x() {} with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["export class x {} with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["await 0; with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["with (y) z; await 0", "With statements cannot be used in an ECMAScript module"],
+      ["for await (x of y); with (y) z", "With statements cannot be used in an ECMAScript module"],
+      ["with (y) z; for await (x of y);", "With statements cannot be used in an ECMAScript module"],
+    ];
+    for (const [code, message] of cases) {
+      test(JSON.stringify(code), () => expectParseError(code, message));
+    }
+
+    test("dynamic import does not make the file a module", () => {
+      expectNoParseError("import(x); with (y) z");
+      expectNoParseError("import('x'); with (y) z");
+      expectNoParseError("with (y) z; import(x)");
+      expectNoParseError("(import('x')); with (y) z");
+    });
+
+    test("\\0 is not a legacy octal escape", () => {
+      expectNoParseError("let x = '\\0'; export {}");
+    });
+
+    test("the note points at the export keyword", () => {
+      expect(parseErrors("with (x) y;\nexport {}")).toEqual([
+        {
+          message: "With statements cannot be used in an ECMAScript module",
+          notes: [{ message: exportNote, position: { line: 2, column: 1 } }],
+        },
+      ]);
+    });
+  });
+
+  describe("class body", () => {
+    const cases: [string, string][] = [
+      ["class f { x() { with (x) y } }", "With statements cannot be used in strict mode"],
+      ["class f { x() { function y() { with (x) y } } }", "With statements cannot be used in strict mode"],
+      ["class f { x() { delete x } }", "Delete of a bare identifier cannot be used in strict mode"],
+      ["class f { x() { return 010 } }", "Legacy octal literals cannot be used in strict mode"],
+      ["class f { x() { return '\\01' } }", "Legacy octal escape sequences cannot be used in strict mode"],
+      [
+        "class f { x() { function protected() {} } }",
+        '"protected" is a reserved word and cannot be used in strict mode',
+      ],
+      ["class f { x() { var package } }", '"package" is a reserved word and cannot be used in strict mode'],
+      ["class A { m(arguments) {} }", 'Declarations with the name "arguments" cannot be used in strict mode'],
+      ["class A { m() { eval = 0 } }", "Invalid assignment target"],
+      ["class A { static { yield } }", '"yield" is a reserved word and cannot be used in strict mode'],
+      // The class name is part of the class, so it is strict mode code too.
+      ["class protected {}", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["(class protected {})", '"protected" is a reserved word and cannot be used in strict mode'],
+      ["class eval {}", 'Declarations with the name "eval" cannot be used in strict mode'],
+      ["(class arguments {})", 'Declarations with the name "arguments" cannot be used in strict mode'],
+    ];
+    for (const [code, message] of cases) {
+      test(JSON.stringify(code), () => expectParseError(code, message));
+    }
+
+    test("the note points at the class keyword", () => {
+      expect(parseErrors("class f {\n  x() { with (x) y }\n}")).toEqual([
+        {
+          message: "With statements cannot be used in strict mode",
+          notes: [{ message: classNote, position: { line: 1, column: 1 } }],
+        },
+      ]);
+    });
+  });
+
+  describe("legacy octal escapes in template literals", () => {
+    const message = "Legacy octal escape sequences cannot be used in template literals";
+    test("are always an error in untagged templates", () => {
+      expectParseError("`\\8`", message);
+      expectParseError("`\\01`", message);
+      expectParseError("`a${b}\\1`", message);
+      expectParseError("`\\1${b}c`", message);
+      expectParseError("export let u = `\\8`", message);
+    });
+    test("are allowed in tagged templates", () => {
+      expectNoParseError("tag`\\8`");
+      expectNoParseError("tag`\\01${x}\\8`");
+    });
+  });
+
+  describe("duplicate function declarations", () => {
+    const alreadyDeclared = '"f" has already been declared';
+    const cases = [
+      "function f() {} function f() {}",
+      "function f() {} function *f() {}",
+      "function *f() {} function f() {}",
+      "function f() {} async function f() {}",
+      "async function f() {} function f() {}",
+      "function f() {} async function *f() {}",
+      "async function *f() {} function f() {}",
+    ];
+
+    describe("are allowed at the top level of a script and of a function", () => {
+      for (const code of cases) {
+        test(JSON.stringify(code), () => {
+          expectNoParseError(code);
+          expectNoParseError("'use strict'; " + code);
+          expectNoParseError("function foo() { 'use strict'; " + code + " }");
+        });
+      }
+    });
+
+    describe("are an error at the top level of a module", () => {
+      for (const code of cases) {
+        test(JSON.stringify(code + " export {}"), () => {
+          expectParseError(code + " export {}", alreadyDeclared);
+        });
+      }
+      test("the notes explain why", () => {
+        expect(parseErrors("function f() {} function f() {}\nexport {}")).toEqual([
+          {
+            message: alreadyDeclared,
+            notes: [
+              { message: '"f" was originally declared here', position: { line: 1, column: 10 } },
+              {
+                message: `Duplicate top-level function declarations are not allowed in an ECMAScript module. ${exportNote}`,
+                position: { line: 2, column: 1 },
+              },
+            ],
+          },
+        ]);
+      });
+    });
+
+    describe("are an error in nested blocks in strict mode", () => {
+      const strictCases: [string, string][] = [
+        ["'use strict'; { function f() {} function f() {} }", useStrictNote],
+        ["'use strict'; switch (0) { case 1: function f() {} default: function f() {} }", useStrictNote],
+        ["function foo() { 'use strict'; { function f() {} function f() {} } }", useStrictNote],
+        [
+          "function foo() { 'use strict'; switch (0) { case 1: function f() {} default: function f() {} } }",
+          useStrictNote,
+        ],
+        ["{ function f() {} function f() {} } export {}", exportNote],
+        ["switch (0) { case 1: function f() {} default: function f() {} } export {}", exportNote],
+      ];
+      for (const [code, note] of strictCases) {
+        test(JSON.stringify(code), () => {
+          const errors = parseErrors(code);
+          expect(errors.map(e => e.message)).toEqual([alreadyDeclared]);
+          expect(errors[0].notes.map(n => n.message)).toEqual([
+            '"f" was originally declared here',
+            expect.stringContaining(note),
+          ]);
+        });
+      }
+    });
+
+    test("var is never a duplicate", () => {
+      expectNoParseError("var x; var x");
+      expectNoParseError("'use strict'; var x; var x");
+      expectNoParseError("var x; var x; export {}");
+      expectNoParseError("'use strict'; { var x; var x }");
+    });
+  });
+
+  describe("legacy HTML comments", () => {
+    const message = "Legacy HTML single-line comments are not allowed in ECMAScript modules";
+    test("are an error in a module", () => {
+      expectParseError("export {}\n--> commented out", message);
+      expectParseError("<!-- commented out\nexport {}", message);
+      expectParseError("import 'x'\n--> commented out", message);
+    });
+    test("are comments in a script", () => {
+      expect(transpiler.transformSync("x\n--> commented out\ny")).toBe("x;\ny;\n");
+      expect(transpiler.transformSync("<!-- commented out\nx")).toBe("x;\n");
+      expect(transpiler.transformSync("x <!-- commented out\ny")).toBe("x;\ny;\n");
+    });
+    test("--> without a newline before it is a decrement", () => {
+      expect(transpiler.transformSync("x-->y")).toBe("x-- > y;\n");
+    });
+  });
+});
+
+describe("sloppy CommonJS runs as written", () => {
+  test.concurrent("duplicate parameters, assignments to eval and arguments, legacy octal escapes", async () => {
+    using dir = tempDir("strict-mode-sloppy", {
+      "sloppy.cjs": `
+        function f(a, a) { return a; }
+        eval = 0; arguments++; [eval] = [0];
+        var s1 = "\\1", s2 = "\\01", s3 = "a\\7", s4 = "\\08", s5 = "\\09", s6 = "\\8";
+        var n = 010;
+        var obj = { foo() { return "foo"; } };
+        var w;
+        with (obj) { w = foo(); }
+        console.log(JSON.stringify([f(1, 2), eval, s1, s2, s3, s4, s5, s6, n, w]));
+        module.exports = 1;
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "sloppy.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      JSON.stringify([2, 0, "\u0001", "\u0001", "a\u0007", "\u00008", "\u00009", "8", 8, "foo"]) + "\n",
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("the same code in an ES module is a syntax error", async () => {
+    using dir = tempDir("strict-mode-esm", {
+      "strict.mjs": `
+        var obj = { foo() { return "foo"; } };
+        with (obj) { foo(); }
+        export {};
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "strict.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("With statements cannot be used in an ECMAScript module");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/bundler/transpiler/strict-mode.test.ts
+++ b/test/bundler/transpiler/strict-mode.test.ts
@@ -360,7 +360,10 @@ describe("strict mode early errors", () => {
       ["import protected from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
       ["import * as protected from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
       ["import { protected } from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
-      ["import { x as protected } from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      [
+        "import { x as protected } from 'x'",
+        '"protected" is a reserved word and cannot be used in an ECMAScript module',
+      ],
       ["import 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
       ["export * from 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
       ["export { x } from 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],

--- a/test/bundler/transpiler/strict-mode.test.ts
+++ b/test/bundler/transpiler/strict-mode.test.ts
@@ -110,9 +110,7 @@ describe("strict mode early errors", () => {
       "<!-- a comment\nx",
       "x <!-- a comment\ny",
     ];
-    for (const code of sloppy) {
-      test(JSON.stringify(code), () => expectNoParseError(code));
-    }
+    test.each(sloppy)("%j", code => expectNoParseError(code));
   });
 
   describe("legacy octal escapes decode leniently in sloppy mode", () => {
@@ -211,9 +209,7 @@ describe("strict mode early errors", () => {
       ["'use strict'; (function(a, a) {})", '"a" cannot be bound multiple times in the same parameter list'],
       ["'use strict'; ((a, a) => {})", '"a" cannot be bound multiple times in the same parameter list'],
     ];
-    for (const [code, message] of cases) {
-      test(JSON.stringify(code), () => expectParseError(code, message));
-    }
+    test.each(cases)("%j", (code, message) => expectParseError(code, message));
 
     test("\\0 is not a legacy octal escape", () => {
       expectNoParseError("'use strict'; let x = '\\0'");
@@ -277,9 +273,7 @@ describe("strict mode early errors", () => {
       ["(a, a) => {}", bindingError],
       ["class A { m(a, a) {} }", bindingError],
     ];
-    for (const [code, message] of cases) {
-      test(JSON.stringify(code), () => expectParseError(code, message));
-    }
+    test.each(cases)("%j", (code, message) => expectParseError(code, message));
 
     describe('"use strict" needs a simple parameter list', () => {
       const nonSimple = 'Cannot use a "use strict" directive in a function with a non-simple parameter list';
@@ -308,9 +302,7 @@ describe("strict mode early errors", () => {
         ["'use strict'; function f([x]) {}", []],
         ["'use strict'; function f([x]) { 'use strict' }", [nonSimple]],
       ];
-      for (const [code, messages] of cases) {
-        test(JSON.stringify(code), () => expectParseError(code, ...messages));
-      }
+      test.each(cases)("%j", (code, messages) => expectParseError(code, ...messages));
     });
 
     test("the note points at the directive inside the function", () => {
@@ -391,9 +383,7 @@ describe("strict mode early errors", () => {
       ["for await (x of y); with (y) z", "With statements cannot be used in an ECMAScript module"],
       ["with (y) z; for await (x of y);", "With statements cannot be used in an ECMAScript module"],
     ];
-    for (const [code, message] of cases) {
-      test(JSON.stringify(code), () => expectParseError(code, message));
-    }
+    test.each(cases)("%j", (code, message) => expectParseError(code, message));
 
     test("dynamic import does not make the file a module", () => {
       expectNoParseError("import(x); with (y) z");
@@ -467,9 +457,7 @@ describe("strict mode early errors", () => {
       ["class eval {}", 'Declarations with the name "eval" cannot be used in strict mode'],
       ["(class arguments {})", 'Declarations with the name "arguments" cannot be used in strict mode'],
     ];
-    for (const [code, message] of cases) {
-      test(JSON.stringify(code), () => expectParseError(code, message));
-    }
+    test.each(cases)("%j", (code, message) => expectParseError(code, message));
 
     test("the note points at the class keyword", () => {
       expect(parseErrors("class f {\n  x() { with (x) y }\n}")).toEqual([
@@ -509,21 +497,15 @@ describe("strict mode early errors", () => {
     ];
 
     describe("are allowed at the top level of a script and of a function", () => {
-      for (const code of cases) {
-        test(JSON.stringify(code), () => {
-          expectNoParseError(code);
-          expectNoParseError("'use strict'; " + code);
-          expectNoParseError("function foo() { 'use strict'; " + code + " }");
-        });
-      }
+      test.each(cases)("%j", code => {
+        expectNoParseError(code);
+        expectNoParseError("'use strict'; " + code);
+        expectNoParseError("function foo() { 'use strict'; " + code + " }");
+      });
     });
 
     describe("are an error at the top level of a module", () => {
-      for (const code of cases) {
-        test(JSON.stringify(code + " export {}"), () => {
-          expectParseError(code + " export {}", alreadyDeclared);
-        });
-      }
+      test.each(cases)("%j export {}", code => expectParseError(code + " export {}", alreadyDeclared));
       test("the notes explain why", () => {
         expect(parseErrors("function f() {} function f() {}\nexport {}")).toEqual([
           {
@@ -552,16 +534,14 @@ describe("strict mode early errors", () => {
         ["{ function f() {} function f() {} } export {}", exportNote],
         ["switch (0) { case 1: function f() {} default: function f() {} } export {}", exportNote],
       ];
-      for (const [code, note] of strictCases) {
-        test(JSON.stringify(code), () => {
-          const errors = parseErrors(code);
-          expect(errors.map(e => e.message)).toEqual([alreadyDeclared]);
-          expect(errors[0].notes.map(n => n.message)).toEqual([
-            '"f" was originally declared here',
-            expect.stringContaining(note),
-          ]);
-        });
-      }
+      test.each(strictCases)("%j", (code, note) => {
+        const errors = parseErrors(code);
+        expect(errors.map(e => e.message)).toEqual([alreadyDeclared]);
+        expect(errors[0].notes.map(n => n.message)).toEqual([
+          '"f" was originally declared here',
+          expect.stringContaining(note),
+        ]);
+      });
     });
 
     test("var is never a duplicate", () => {

--- a/test/bundler/transpiler/strict-mode.test.ts
+++ b/test/bundler/transpiler/strict-mode.test.ts
@@ -8,12 +8,13 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // Warnings (for example the legacy HTML comment warning) also make
 // `transformSync` throw, so only errors are recorded.
 const transpiler = new Bun.Transpiler({ loader: "js", logLevel: "error" });
+const tsTranspiler = new Bun.Transpiler({ loader: "ts", logLevel: "error" });
 
 type ParseMessage = { message: string; notes: { message: string; position: { line: number; column: number } }[] };
 
-function parseErrors(code: string): ParseMessage[] {
+function parseErrors(code: string, t: Bun.Transpiler = transpiler): ParseMessage[] {
   try {
-    transpiler.transformSync(code);
+    t.transformSync(code);
   } catch (e: any) {
     const errors: any[] = e instanceof AggregateError ? e.errors : [e];
     return errors.map(err => ({
@@ -33,6 +34,14 @@ function expectParseError(code: string, ...messages: string[]) {
 
 function expectNoParseError(code: string) {
   expect(parseErrors(code)).toEqual([]);
+}
+
+function expectTSParseError(code: string, ...messages: string[]) {
+  expect(parseErrors(code, tsTranspiler).map(e => e.message)).toEqual(messages);
+}
+
+function expectNoTSParseError(code: string) {
+  expect(parseErrors(code, tsTranspiler)).toEqual([]);
 }
 
 const useStrictNote = 'Strict mode is triggered by the "use strict" directive here:';
@@ -90,6 +99,7 @@ describe("strict mode early errors", () => {
       "let x = '\\9'",
       "'\\00'",
       "'\\08'",
+      "require('\\1')",
       "function f() {} function f() {}",
       "function f() {} function *f() {}",
       "async function f() {} function f() {}",
@@ -347,6 +357,13 @@ describe("strict mode early errors", () => {
       ],
       ["class static {}\nexport {}", '"static" is a reserved word and cannot be used in an ECMAScript module'],
       ["protected: 0; export {}", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["import protected from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["import * as protected from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["import { protected } from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["import { x as protected } from 'x'", '"protected" is a reserved word and cannot be used in an ECMAScript module'],
+      ["import 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["export * from 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
+      ["export { x } from 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
       ["export let n = 010", "Legacy octal literals cannot be used in an ECMAScript module"],
       ["export let n = 08", "Legacy octal literals cannot be used in an ECMAScript module"],
       ["export let o = { 0123: 4 }", "Legacy octal literals cannot be used in an ECMAScript module"],
@@ -393,6 +410,36 @@ describe("strict mode early errors", () => {
           notes: [{ message: exportNote, position: { line: 2, column: 1 } }],
         },
       ]);
+    });
+
+    test("the error points at the imported binding, not the alias", () => {
+      let error: any;
+      try {
+        transpiler.transformSync("import { x as protected } from 'x'");
+      } catch (e: any) {
+        error = e instanceof AggregateError ? e.errors[0] : e;
+      }
+      expect(error?.message).toBe('"protected" is a reserved word and cannot be used in an ECMAScript module');
+      expect(error?.position).toMatchObject({ line: 1, column: 15, length: 9 });
+    });
+  });
+
+  describe("TypeScript declarations that lower to var", () => {
+    const reserved = '"protected" is a reserved word and cannot be used in strict mode';
+    const reservedInModule = '"protected" is a reserved word and cannot be used in an ECMAScript module';
+    test("enum", () => {
+      expectNoTSParseError("enum protected { A }");
+      expectTSParseError("'use strict'; enum protected { A }", reserved);
+      expectTSParseError("enum protected { A }\nexport {}", reservedInModule);
+    });
+    test("namespace", () => {
+      expectNoTSParseError("namespace protected { export let x = 1 }");
+      expectTSParseError("'use strict'; namespace protected { export let x = 1 }", reserved);
+      expectTSParseError("namespace protected { export let x = 1 }\nexport {}", reservedInModule);
+    });
+    test("import equals", () => {
+      expectNoTSParseError("import protected = require('x')");
+      expectTSParseError("'use strict'; import protected = require('x')", reserved);
     });
   });
 

--- a/test/bundler/transpiler/strict-mode.test.ts
+++ b/test/bundler/transpiler/strict-mode.test.ts
@@ -356,6 +356,16 @@ describe("strict mode early errors", () => {
         "import { x as protected } from 'x'",
         '"protected" is a reserved word and cannot be used in an ECMAScript module',
       ],
+      ["import eval from 'x'", 'Declarations with the name "eval" cannot be used in an ECMAScript module'],
+      [
+        "import * as arguments from 'x'",
+        'Declarations with the name "arguments" cannot be used in an ECMAScript module',
+      ],
+      ["import { eval } from 'x'", 'Declarations with the name "eval" cannot be used in an ECMAScript module'],
+      [
+        "import { x as arguments } from 'x'",
+        'Declarations with the name "arguments" cannot be used in an ECMAScript module',
+      ],
       ["import 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
       ["export * from 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],
       ["export { x } from 'x\\1'", "Legacy octal escape sequences cannot be used in an ECMAScript module"],

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2676,7 +2676,9 @@ console.log(<div {...obj} key="after" />);`),
     });
 
     it("exponentiation", () => {
-      expectPrinted("(delete x) ** 0", "(delete x) ** 0");
+      // `expectPrinted` wraps the code in `export default`, and deleting a
+      // bare identifier is an error in an ECMAScript module.
+      expectPrinted_("(delete x) ** 0", "(delete x) ** 0");
       expectPrinted("(delete x.prop) ** 0", "(delete x.prop) ** 0");
       expectPrinted("(delete x[0]) ** 0", "(delete x[0]) ** 0");
 
@@ -2705,7 +2707,7 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted("(~1) ** 2", "(~1) ** 2");
       expectPrinted("(!1) ** 2", "false ** 2");
       expectPrinted("(void x) ** 2", "(void x) ** 2");
-      expectPrinted("(delete x) ** 2", "(delete x) ** 2");
+      expectPrinted_("(delete x) ** 2", "(delete x) ** 2");
       expectPrinted("(typeof x) ** 2", "(typeof x) ** 2");
       expectPrinted("undefined ** 2", "undefined ** 2");
 
@@ -3540,14 +3542,17 @@ class Foo {
     );
 
     // Strict mode implied by `export`, by a class body, and by top-level await.
-    expectParseError("export {}; let eval = 1", 'Declarations with the name "eval" cannot be used in strict mode');
+    expectParseError(
+      "export {}; let eval = 1",
+      'Declarations with the name "eval" cannot be used in an ECMAScript module',
+    );
     expectParseError(
       "class A { m(arguments) {} }",
       'Declarations with the name "arguments" cannot be used in strict mode',
     );
     expectParseError(
       "await 1; var arguments = 1",
-      'Declarations with the name "arguments" cannot be used in strict mode',
+      'Declarations with the name "arguments" cannot be used in an ECMAScript module',
     );
 
     // Sloppy mode allows all of them when the transpiler is not bundling.

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -138,11 +138,6 @@ export function pgErrorResponse(fields: { S: string; C: string; M: string; [k: s
   return buf;
 }
 
-// PostgreSQL FE/BE protocol §55.7 ParameterStatus: Byte1('S') Int32(len) String(name) String(value)
-export function pgParameterStatus(name: string, value: string): Buffer {
-  return pgRaw("S", Buffer.concat([pgCString(name), pgCString(value)]));
-}
-
 // PostgreSQL FE/BE protocol §55.7 NotificationResponse: Byte1('A') Int32(len) Int32(pid) String(channel) String(payload)
 export function pgNotificationResponse(pid: number, channel: string, payload: string): Buffer {
   return pgRaw("A", Buffer.concat([pgInt32(pid), pgCString(channel), pgCString(payload)]));

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -299,27 +299,28 @@ describe("invalid-escape caret points at the backslash (#31134)", () => {
       pattern: "\\u{110000}",
       expectCol: 7,
     },
-    // Legacy-octal `\08`/`\09`:
+    // Legacy-octal `\08`/`\09`. Sloppy mode allows them, so the error needs
+    // strict mode:
     {
       name: "\\08 double-quote with prefix",
-      source: 'var a = "aaaaa\\08";',
-      msg: "Invalid legacy octal literal",
+      source: '"use strict"; var a = "aaaaa\\08";',
+      msg: "Legacy octal escape sequences cannot be used in strict mode",
       pattern: "\\08",
-      expectCol: 15,
+      expectCol: 29,
     },
     {
       name: "\\08 double-quote without prefix",
-      source: 'var a = "\\08";',
-      msg: "Invalid legacy octal literal",
+      source: '"use strict"; var a = "\\08";',
+      msg: "Legacy octal escape sequences cannot be used in strict mode",
       pattern: "\\08",
-      expectCol: 10,
+      expectCol: 24,
     },
     {
       name: "\\09 single-quote with prefix",
-      source: "var a = 'aaaaa\\09';",
-      msg: "Invalid legacy octal literal",
+      source: "\"use strict\"; var a = 'aaaaa\\09';",
+      msg: "Legacy octal escape sequences cannot be used in strict mode",
       pattern: "\\09",
-      expectCol: 15,
+      expectCol: 29,
     },
   ];
 


### PR DESCRIPTION
Fixes #32185
Fixes #32193

### Problem
- Sloppy CommonJS is rejected for strict-only rules: `function f(a, a) {}`, `eval = 0`, `"\1"`. Node runs them.
- Most strict-mode early errors go unreported: `with`, `delete x`, `010`, reserved words as class or import names, duplicate `function f(){}` in a module. `bun build` then emits a bundle that fails at load.
- Cause: `StrictModeFeature` (`src/js_parser/parser.rs`) only had two variants, names were checked in the parse pass before ESM or class strictness was known, and the lexer hard-errored on octal escapes.

### Fix
- Port esbuild's model. Each construct calls `mark_strict_mode_feature`, which reports "in strict mode", "in an ECMAScript module", or "with the ESM output format" for a sloppy file bundled to `esm`. A note points at the directive or keyword.
- Names are validated in the visit pass (`validate_declared_symbol_name`) after strict mode is final. This covers class, import, TypeScript enum and namespace names. The lexer decodes octal escapes leniently and records their location.
- A sloppy file bundled to `esm` is also an error for a duplicate parameter name and an unbound reserved word. The renamer rewrites neither, so the output would not parse. A bound one (`var package`) is renamed and allowed.
- Verified: `test/bundler/transpiler/strict-mode.test.ts` (267 cases from esbuild's `TestStrictMode`, all fail on the unfixed build) and `test/bundler/bundler_edgecase.test.ts`. Also `test/bundler/` esbuild ports, cjs2esm, minify, transpiler, and `test/js/bun/transpiler/`.

### Background
- The parse pass builds the AST and scopes. The visit pass walks them with the final scope state. ESM strictness is only known after parsing (`export {}` can come last), so these checks belong in the visit pass.
- `is_strict_mode_output_format()` is true when bundling to `esm`. The bundle is a module, so a sloppy construct the bundler cannot rewrite is an error there.
- `--minify-syntax` substitutes a single-use `let` into the next statement and visits the result again (`is_revisit_for_substitution`). Literal visitors skip that revisit, so an error is reported once.

<details><summary>Notes</summary>

Supersedes #35968, #35959, #32188 and #32197, and the parts of #35969 that do not concern `var await` in a sloppy script. Their test cases are folded into the two test files here. The `--minify-syntax` duplicate report, the import clause names, the TypeScript enum and namespace names, the duplicate parameters and the unbound reserved word for `esm` output come from those PRs.

Left for other sessions, as requested: duplicate `constructor`, duplicate labels, `new a?.b`. Also left: `var await = 1` in a sloppy script is still rejected (esbuild does the same, node accepts it), and a `.mjs` file without import or export syntax is not treated as a module (#32177).

The ESM wording changed from "cannot be used in strict mode" to "cannot be used in an ECMAScript module", as in esbuild. Two existing expectations in `transpiler.test.js` were updated.

Compared against esbuild 0.18.6 and 0.25.1 and current main for every case in the new test file. The intentional differences: bun's message style ("\"f\" has already been declared" instead of "The symbol \"f\" has already been declared"); bun does not treat `.mjs` or `"type": "module"` as ESM without import/export syntax, because the runtime evaluates such files as CommonJS; a bound reserved word in a sloppy file bundled to `esm` output is not an error, because bun's renamer rewrites it to `_package` (esbuild errors). A reserved word as a label or as an unbound reference is not renamed and is an error (esbuild accepts the unbound reference and emits output that does not parse). Import clause names and TypeScript enum and namespace names are checked (node rejects them, esbuild does not). `import "\1"` is an error in bun and not in esbuild.

`Scope.use_strict_loc` records the directive that made a scope strict. A function body's directive also applies to its parameter scope, which is how `function f(arguments) { "use strict" }` is rejected. `hoist_symbols` reports duplicate function declarations in strict blocks and at the top level of a module from the new `Scope.replaced` list. `-->` and `<!--` are recorded by the lexer and are an error in a module.

`test/regression/issue/invalid-escape-sequences.test.ts` pinned the caret position of the old "Invalid legacy octal literal" error for `"\08"` in sloppy code. That input is valid, so the three cases now use `"use strict"` and the new message. The `\8`/`\9` and `\0` followed by `8`/`9` escapes decode to the digit character, as in node: `"\08" === "\0" + "8"`.

Seen while working, not part of this change: `bun build` drops a function body's `"use strict"` directive from its output (`function f() { "use strict"; return this }` prints without the directive), which changes `this` for `--format=cjs` and `iife` output.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->