### PR TITLE
bake: keep a __proto__ export an own key of the dev server ssr manifest entry

### DIFF
--- a/src/runtime/bake/hmr-runtime-server.ts
+++ b/src/runtime/bake/hmr-runtime-server.ts
@@ -166,7 +166,9 @@ server_exports = {
         try {
           const exports = await loadExports<{}>(uid);
 
-          const client = {};
+          // Keyed by user export names. A null prototype keeps an export named
+          // "__proto__" an own key instead of hitting the Object.prototype setter.
+          const client = Object.create(null);
           for (const exportName of Object.keys(exports)) {
             serverManifest[uid + "#" + exportName] = {
               id: uid,

--- a/src/runtime/bake/hmr-runtime-server.ts
+++ b/src/runtime/bake/hmr-runtime-server.ts
@@ -174,9 +174,7 @@ server_exports = {
               chunks: [],
             };
           }
-          // Object.fromEntries defines own keys, so an export named "__proto__"
-          // does not hit the Object.prototype setter like `client[exportName] = ...`
-          // would. The result is a plain object like the production manifest entry.
+          // Defines own keys, so an export named "__proto__" does not set the prototype.
           ssrManifest[uid] = Object.fromEntries(
             exportNames.map(exportName => [exportName, { specifier: "ssr:" + uid, name: exportName }]),
           );

--- a/src/runtime/bake/hmr-runtime-server.ts
+++ b/src/runtime/bake/hmr-runtime-server.ts
@@ -165,22 +165,21 @@ server_exports = {
       for (const uid of componentManifestAdd) {
         try {
           const exports = await loadExports<{}>(uid);
+          const exportNames = Object.keys(exports);
 
-          // Keyed by user export names. A null prototype keeps an export named
-          // "__proto__" an own key instead of hitting the Object.prototype setter.
-          const client = Object.create(null);
-          for (const exportName of Object.keys(exports)) {
+          for (const exportName of exportNames) {
             serverManifest[uid + "#" + exportName] = {
               id: uid,
               name: exportName,
               chunks: [],
             };
-            client[exportName] = {
-              specifier: "ssr:" + uid,
-              name: exportName,
-            };
           }
-          ssrManifest[uid] = client;
+          // Object.fromEntries defines own keys, so an export named "__proto__"
+          // does not hit the Object.prototype setter like `client[exportName] = ...`
+          // would. The result is a plain object like the production manifest entry.
+          ssrManifest[uid] = Object.fromEntries(
+            exportNames.map(exportName => [exportName, { specifier: "ssr:" + uid, name: exportName }]),
+          );
         } catch (err) {
           console.log(err);
         }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -358,6 +358,64 @@ devTest("removing 'use client' from a component with a pending resolution failur
     expect(res).toBeInstanceOf(Response);
   },
 });
+// The HMR runtime builds the per-module ssrManifest entry by assigning
+// `entry[exportName]`. An export named "__proto__" must become an own key, not
+// the prototype of the entry, and its serverManifest id must be removed again
+// when the module stops being a client component.
+devTest("client component exported as __proto__ is an own key of the ssr manifest", {
+  framework: minimalFramework,
+  files: {
+    "components/impl.ts": `
+      export function Client() { return "client"; }
+      export function Other() { return "other"; }
+    `,
+    // Re-exported imports are lowered to getters, so the module namespace has
+    // an own "__proto__" key for the runtime to register.
+    "components/Client.ts": `
+      "use client";
+      import { Client, Other } from "./impl";
+      export { Client as __proto__, Other as other };
+    `,
+    "routes/index.ts": `
+      import * as client from '../components/Client';
+      import { ssrManifest, serverManifest } from 'bun:bake/server';
+      export default function(req, meta) {
+        // JSON.stringify only serializes own keys of each manifest entry.
+        return new Response(JSON.stringify({
+          exports: Object.keys(client),
+          ssr: ssrManifest,
+          server: Object.keys(serverManifest).sort(),
+        }));
+      }
+    `,
+  },
+  async test(dev) {
+    expect(await dev.fetch("/").json()).toEqual({
+      exports: ["__proto__", "other"],
+      ssr: {
+        "components/Client.ts": {
+          ["__proto__"]: { specifier: "ssr:components/Client.ts", name: "__proto__" },
+          other: { specifier: "ssr:components/Client.ts", name: "other" },
+        },
+      },
+      server: ["components/Client.ts#__proto__", "components/Client.ts#other"],
+    });
+
+    // Dropping the directive removes the module from both manifests.
+    await dev.write(
+      "components/Client.ts",
+      `
+        import { Client, Other } from "./impl";
+        export { Client as __proto__, Other as other };
+      `,
+    );
+    expect(await dev.fetch("/").json()).toEqual({
+      exports: ["__proto__", "other"],
+      ssr: {},
+      server: [],
+    });
+  },
+});
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),


### PR DESCRIPTION
### Problem
- In the dev server, a `"use client"` export named `__proto__` is missing from its `ssrManifest` entry. When the module stops being a client component, `serverManifest["<file>#__proto__"]` stays behind.
- `registerUpdate` (`src/runtime/bake/hmr-runtime-server.ts`) built the entry with `client[exportName] = {...}` on a plain object. For `"__proto__"` that calls the `Object.prototype.__proto__` setter and replaces the entry prototype. The delete loop (`for...in`) then never sees `__proto__`.

### Fix
- Build the entry with `Object.fromEntries` over the export names. It defines own data properties, so `__proto__` becomes a key like any other.
- The entry stays a plain object, the shape the production build emits as an object literal (#40812 keeps `__proto__` a computed key there). Dev and prod entries have the same keys, prototype, and attributes.
- The only consumer in the tree, `react-server-dom-bun`, reads `moduleMap[id][name]` and `moduleMap[id]["*"]`. Unchanged.
- Verified: `test/bake/dev/bundle.test.ts` ("client component exported as __proto__ ..."). The released bun fails both assertions. Also ran that whole file, `esm.test.ts`, `react-response.test.ts`, `request-cookies.test.ts`.

### Background
- `bun:bake/server` exposes two maps. `serverManifest` maps `"<file>#<export>"` to a client module id. `ssrManifest` maps a client file id to one entry per export, `{ specifier: "ssr:<file>", name }`. React's Flight client uses them during SSR.
- In dev, `registerUpdate` fills the maps after each bundle: it loads the server-side module and iterates `Object.keys(exports)`. Removing the directive runs the delete branch.
- The test re-exports imported functions. The HMR export lowering emits getters for those, so the module namespace has an own `__proto__` key today, independent of #40812.

<details><summary>Notes</summary>

Repro output with the released bun (v1.4.1-canary.1), page returns `JSON.stringify({ exports, ssr: ssrManifest, server: Object.keys(serverManifest) })`:

```
{"exports":["__proto__","other"],
 "ssr":{"components/Client.ts":{"other":{"specifier":"ssr:components/Client.ts","name":"other"}}},
 "server":["components/Client.ts#__proto__","components/Client.ts#other"]}
```

After removing `"use client"` from the file:

```
{"exports":["__proto__","other"],"ssr":{},"server":["components/Client.ts#__proto__"]}
```

With the fix the first response lists both `__proto__` and `other` under `ssr`, and the second response has `server: []`.

The first revision of this PR used `Object.create(null)` for the entry. The self-review pointed out that this makes the dev entry differ from the production one (no `Object.prototype`, so `entry.hasOwnProperty(...)` throws in dev only). `Object.fromEntries` gives the same result for `__proto__` and keeps the shape identical. Checked with a probe: `Object.getPrototypeOf(entry) === Object.prototype`, and the `__proto__` property is enumerable, writable, and configurable.

`serverManifest` keys are `"<file>#<export>"` and `ssrManifest` keys are project-relative file paths, so neither can equal `__proto__`. Those two objects are left as they are.

The export-clause form `export { Client as __proto__ }` of a local function, and `export function __proto__`, are lowered to a plain `{ __proto__: ... }` property today, which sets the prototype of the exports object itself. So those forms never reach this code with a `__proto__` key until the bundler fix in #40812 lands. The test uses the re-export form so it exercises this runtime fix on its own.

Two adjacent observations, not changed here:
- `import.meta.hot.on("__proto__", cb)` hits the same class of bug in `eventHandlers` (`src/runtime/bake/hmr-module.ts:32`): `eventHandlers.__proto__` is `Object.prototype`, so `??= []` skips and `.push` throws.
- `DevServer.rs` calls `registerUpdate` and drops the returned promise. A `"use client"` module with three or more top-level awaits can be rendered on the first request before its manifest entry exists. The second request sees it. The test module has no top-level await, so the test is not affected.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.1 (65362b53b)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-A7Fj08
[0;30mdev|[0m Started development server: http://localhost:38761
[0;30mdev|[0m [32mBundled page in 200ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 54ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 53ms[
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-ebr2xj
[0;30mdev|[0m Started development server: http://localhost:44639
[0;30mdev|[0m [32mBundled page in 3ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 3ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 2ms[0m[2m:[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [205.21ms]
[0;30mdev|[0m Started development server: http://localhos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.1 (65362b53b)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-eOnEoc
[0;30mdev|[0m Started development server: http://localhost:36831
[0;30mdev|[0m [32mBundled page in 153ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 58ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 52ms[
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e9a659fe6d
  features     baseline

23 deps, 131 codegen, 1172 objects in 697ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [5.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1244] gen bindgenv2
[4/1244] fetch zlib
[zlib] up to date
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] gen ErrorCode+*.h
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] gen .bind.ts → GeneratedBindings.cpp
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 K
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/hmr-runtime-server.ts | 13 ++++----
 test/bake/dev/bundle.test.ts           | 58 ++++++++++++++++++++++++++++++++++
 2 files changed, 64 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/bake/hmr-runtime-server.ts      3      3      0
test/bake/dev/bundle.test.ts                2      2      0
```

</details>

<!-- robobun:evidence:end -->