### PR TITLE
bundler: keep "use strict" inside the wrapper of a non-entry module

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4277,6 +4277,16 @@ impl InsideWrapperPrefix {
 }
 
 impl InsideWrapperPrefix {
+    /// A directive is only a directive while it leads the function body, so
+    /// the dependency calls that `append_sync_dependency` and
+    /// `append_async_dependency` insert at `sync_dependencies_end` must land
+    /// after it.
+    pub(crate) fn append_directive(&mut self, stmt: Stmt) {
+        debug_assert!(self.stmts.is_empty());
+        self.stmts.push(stmt);
+        self.sync_dependencies_end += 1;
+    }
+
     pub(crate) fn append_non_dependency(&mut self, stmt: Stmt) -> Result<(), AllocError> {
         self.stmts.push(stmt);
         Ok(())

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4277,10 +4277,7 @@ impl InsideWrapperPrefix {
 }
 
 impl InsideWrapperPrefix {
-    /// A directive is only a directive while it leads the function body, so
-    /// the dependency calls that `append_sync_dependency` and
-    /// `append_async_dependency` insert at `sync_dependencies_end` must land
-    /// after it.
+    /// Keeps the directive ahead of the dependency calls inserted at `sync_dependencies_end`.
     pub(crate) fn append_directive(&mut self, stmt: Stmt) {
         debug_assert!(self.stmts.is_empty());
         self.stmts.push(stmt);

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -255,23 +255,21 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     let output_format = c.options.output_format;
 
     // The top-level directive must come first (the non-wrapped case is handled
-    // by the chunk generation code, although only for the entry point)
+    // by the chunk generation code, although only for the entry point file,
+    // whose directive `post_process_js_chunk` prints at the top of the chunk)
     if flags.wrap != WrapKind::None
         && ast
             .flags
             .contains(AstFlags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
-        && !chunk.is_entry_point()
+        && !c.graph.files.items_entry_point_kind()[source_index].is_entry_point()
         && !output_format.is_always_strict_mode()
     {
-        stmts
-            .inside_wrapper_prefix
-            .append_non_dependency(Stmt::alloc(
-                S::Directive {
-                    value: bun_ast::StoreStr::new(b"use strict"),
-                },
-                bun_ast::Loc::EMPTY,
-            ))
-            .expect("unreachable");
+        stmts.inside_wrapper_prefix.append_directive(Stmt::alloc(
+            S::Directive {
+                value: bun_ast::StoreStr::new(b"use strict"),
+            },
+            bun_ast::Loc::EMPTY,
+        ));
     }
 
     // `convert_stmts_for_chunk` takes `&mut c` inside the loop body, so capture

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -255,13 +255,19 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     let output_format = c.options.output_format;
 
     // The top-level directive must come first (the non-wrapped case is handled
-    // by the chunk generation code, although only for the entry point file,
-    // whose directive `post_process_js_chunk` prints at the top of the chunk)
+    // by the chunk generation code, although only for the chunk's own entry
+    // point file, whose directive `post_process_js_chunk` prints at the top of
+    // the chunk). esbuild checks the file's entry point kind here, but it links
+    // each entry point on its own when code splitting is off. This graph is
+    // shared, so another entry point that this chunk pulls in as a wrapped
+    // dependency still needs the directive inside its wrapper.
+    let is_chunk_entry_point =
+        chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
     if flags.wrap != WrapKind::None
         && ast
             .flags
             .contains(AstFlags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
-        && !c.graph.files.items_entry_point_kind()[source_index].is_entry_point()
+        && !is_chunk_entry_point
         && !output_format.is_always_strict_mode()
     {
         stmts.inside_wrapper_prefix.append_directive(Stmt::alloc(

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -255,8 +255,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     let output_format = c.options.output_format;
 
     // The top-level directive must come first (the non-wrapped case is handled
-    // by the chunk generation code, although only for the chunk's own entry
-    // point). Another entry point can be a wrapped dependency of this chunk.
+    // by the chunk generation code, although only for the chunk's own entry point)
     let is_chunk_entry_point =
         chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
     if flags.wrap != WrapKind::None

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -256,11 +256,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
     // The top-level directive must come first (the non-wrapped case is handled
     // by the chunk generation code, although only for the chunk's own entry
-    // point file, whose directive `post_process_js_chunk` prints at the top of
-    // the chunk). esbuild checks the file's entry point kind here, but it links
-    // each entry point on its own when code splitting is off. This graph is
-    // shared, so another entry point that this chunk pulls in as a wrapped
-    // dependency still needs the directive inside its wrapper.
+    // point). Another entry point can be a wrapped dependency of this chunk.
     let is_chunk_entry_point =
         chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
     if flags.wrap != WrapKind::None

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -460,10 +460,10 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "52c1e0868de8da5d8bf4b89d68afbd027f3c64fdce490cd46800674b0de3f0c1",
+          "js": "7cf9dd3d8bc03517a212eed923d3d3f8d856d53cd6d7fd915af776f50e645dd3",
           "jsc": {
-            "bytes": 1999232,
-            "sha256": "a6043ef5e8aaae25c9581e6802fc2508f0b7b2fb0681be536768f9d09ef4cac6",
+            "bytes": 2004632,
+            "sha256": "3bf715e72f2789878902f0d3bbaa6668d6f6fd0627cc15415ed16ee24235a6b5",
           },
         },
         "bun build --bytecode --minify features.js": {
@@ -488,10 +488,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode all.js": {
-          "js": "46d723ea07e5e2d8db673a51fec52b3248edcd3e216029f243d8172244f7cd2c",
+          "js": "73f27a1414b26406c14a9d4c95cc8a5eb7271fad3792bfc020d39df02e7cf907",
           "jsc": {
-            "bytes": 2178792,
-            "sha256": "c5d1eaae5c4d198b1f8e0d768bb41502162081c75b67249032e66a2b95e26ec1",
+            "bytes": 2184416,
+            "sha256": "3d1f952144dcd37335b757b12b5a8cfa9497ad7d14cc8fbe37ff9cf5f822b088",
           },
         },
         "bun build --bytecode big.js": {
@@ -509,10 +509,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode happy-dom/lib/index.js": {
-          "js": "148f0d3e4baf485281725f859deb3e717a6da25a4a08de9af288d5ef54b6414b",
+          "js": "f7873071421bccffe16fbadc85101e62ca1c10839ef3c6bb9c752ecd7f7f3b3a",
           "jsc": {
-            "bytes": 2528840,
-            "sha256": "d68b260282a74f545c15b5a3b812b69cb4e828972f85c5de60f8307b73c43e57",
+            "bytes": 2528864,
+            "sha256": "05d8e99e966ef0cf9bf07e86baadb47d926cc33d494dd61140259d83b039d15a",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
@@ -523,10 +523,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "e685164a8316f60b665bc3d47e42b4623cfe7385f87310e655478a50ecd8f959",
+          "js": "bfac43a2b4c87364807617387203fcfbf65ac7dd9ac01a7d044bdd15781df49d",
           "jsc": {
-            "bytes": 23806352,
-            "sha256": "5f23309532d868e1c985d568207c92b77a7f3974e5c6c3f37b21accf7d429327",
+            "bytes": 23874144,
+            "sha256": "b950f7985eb2c8f6ab4fbeecdf32c803daab464a800255be98c55253cd56b941",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -537,10 +537,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {
-          "js": "e2cf34c8eb6f5952a33ca91e3949b28786349cf97ea3fbf0b3b8500dbccd4860",
+          "js": "54451a126f78d48cafb01c7c3e9e459bf0f2821d084ed15d29adccfdf2d06875",
           "jsc": {
-            "bytes": 980080,
-            "sha256": "32fa8492ad9fdf3ea31395756898d556df9dc6bdfbac9bba07bcafa748ab38ca",
+            "bytes": 980088,
+            "sha256": "56e259fd06b1fba8ed7dcc1aef8d785a39b4190e45a67479851932c6bbef3b9a",
           },
         },
         "bun build --bytecode records.js": {
@@ -565,10 +565,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode undici/index.js": {
-          "js": "d0bd3791e7c8f77a06814429d5d95cb26a06baaa3c135502bcd3e984310f1d2c",
+          "js": "7ebc1a93fd924da1107ea2c12bc0a684686717fb6e382ba90d34bd3f1a9062c3",
           "jsc": {
-            "bytes": 937000,
-            "sha256": "d7cff4df84668b14987703bcd950a6753a574cf48e4372e4fe8779f747c0ed89",
+            "bytes": 937032,
+            "sha256": "ecb2f5eb5472bd2fbd8ab08cf64494afa66a5cb74f352cb26c543f0a32b96a79",
           },
         },
         "vm.Script big.js": {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -743,6 +743,33 @@ describe("bundler", () => {
       expect(code.split('"use strict"')).toHaveLength(3);
     },
   });
+  // Two entry points where one requires the other. Only the chunk's own entry file has its directive printed at the
+  // top of that chunk. Inside the other chunk the same file is a wrapped dependency and keeps the directive there.
+  itBundled("cjs2esm/UseStrictEntryPointWrappedInsideOtherEntryPoint", {
+    files: {
+      "/a.cjs": /* js */ `
+        const b = require('./b.cjs');
+        console.log('a', (function() { return this === undefined; })(), 'b', b);
+      `,
+      "/b.cjs": /* js */ `
+        "use strict";
+        module.exports = (function() { return this === undefined; })();
+      `,
+    },
+    entryPoints: ["/a.cjs", "/b.cjs"],
+    outdir: "/out",
+    outputPaths: ["/out/a.js", "/out/b.js"],
+    format: "cjs",
+    onAfterBundle(api) {
+      const a = api.readFile("/out/a.js");
+      expect(a).not.toStartWith('"use strict"');
+      expect(a).toMatch(/require_b = __commonJS\(function\([^)]*\) \{\s*"use strict";/);
+      const b = api.readFile("/out/b.js");
+      expect(b).toStartWith('"use strict";\n');
+      expect(b.split('"use strict"')).toHaveLength(2);
+    },
+    run: { file: "/out/a.js", runtime: "node", stdout: "a false b true" },
+  });
   // An ESM file that a CommonJS file require()s is wrapped in __esm. Its "use strict" has to stay ahead of the
   // init_*() calls for its own wrapped imports, or it stops being a directive.
   itBundled("cjs2esm/UseStrictInsideESMWrapperBeforeInitCalls", {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -796,4 +796,31 @@ describe("bundler", () => {
     },
     run: { runtime: "node", stdout: "dep\ntrue 1" },
   });
+  // The same ordering inside a __commonJS wrapper: a file that mixes `import` with `module.exports`.
+  itBundled("cjs2esm/UseStrictInsideCommonJSWrapperBeforeInitCalls", {
+    files: {
+      "/entry.js": /* js */ `
+        const mixed = require('./mixed.js');
+        console.log(mixed.strict, mixed.dep);
+      `,
+      "/mixed.js": /* js */ `
+        "use strict";
+        import { dep } from './dep.mjs';
+        module.exports = { strict: (function() { return this === undefined; })(), dep };
+      `,
+      "/dep.mjs": /* js */ `
+        console.log('dep');
+        export const dep = 1;
+      `,
+    },
+    format: "cjs",
+    outfile: "/out.cjs",
+    minifySyntax: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.cjs")).toMatch(
+        /require_mixed = __commonJS\(function\([^)]*\) \{\s*"use strict";\s*init_dep\(\);/,
+      );
+    },
+    run: { runtime: "node", stdout: "dep\ntrue 1" },
+  });
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -667,4 +667,106 @@ describe("bundler", () => {
     cjs2esm: true,
     run: { stdout: "[1,2]" },
   });
+
+  // A non-entry CommonJS module that starts with "use strict" keeps that directive as the first
+  // statement of its __commonJS wrapper. The entry is ESM, so nothing else makes the output strict.
+  // Each module exports whether its own body ran in strict mode. The cjs and iife outputs run under
+  // node: bun runs a script with no CommonJS markers as an ES module, which is strict throughout.
+  const useStrictWrapperFiles = {
+    "/entry.mjs": /* js */ `
+      import strict from './strict.cjs';
+      import sloppy from './sloppy.cjs';
+      console.log(strict, sloppy);
+    `,
+    "/strict.cjs": /* js */ `
+      "use strict";
+      module.exports = (function() { return this === undefined; })();
+    `,
+    "/sloppy.cjs": /* js */ `
+      module.exports = (function() { return this === undefined; })();
+    `,
+  };
+  const strictWrapperDirective = /require_strict = __commonJS\(function\([^)]*\) \{\s*"use strict";/;
+  const sloppyWrapperDirective = /require_sloppy = __commonJS\(function\([^)]*\) \{\s*"use strict";/;
+  itBundled("cjs2esm/UseStrictInsideCommonJSWrapperCJS", {
+    files: useStrictWrapperFiles,
+    format: "cjs",
+    outfile: "/out.cjs",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.cjs");
+      expect(code).not.toStartWith('"use strict"');
+      expect(code).toMatch(strictWrapperDirective);
+      expect(code).not.toMatch(sloppyWrapperDirective);
+    },
+    run: { runtime: "node", stdout: "true false" },
+  });
+  itBundled("cjs2esm/UseStrictInsideCommonJSWrapperIIFE", {
+    files: useStrictWrapperFiles,
+    format: "iife",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).not.toStartWith('"use strict"');
+      expect(code).toMatch(strictWrapperDirective);
+      expect(code).not.toMatch(sloppyWrapperDirective);
+    },
+    run: { runtime: "node", stdout: "true false" },
+  });
+  // ESM output is strict everywhere, so the directive is redundant and not printed.
+  itBundled("cjs2esm/UseStrictInsideCommonJSWrapperESM", {
+    files: useStrictWrapperFiles,
+    format: "esm",
+    outfile: "/out.mjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.mjs")).not.toContain("use strict");
+    },
+    run: { stdout: "true true" },
+  });
+  // The directive of the entry point file is printed once at the top of the output, not inside its wrapper.
+  itBundled("cjs2esm/UseStrictEntryPointDirectiveStaysAtTop", {
+    files: {
+      "/entry.cjs": /* js */ `
+        "use strict";
+        const strict = require('./strict.cjs');
+        module.exports = { entry: (function() { return this === undefined; })(), strict };
+      `,
+      "/strict.cjs": /* js */ `
+        "use strict";
+        module.exports = (function() { return this === undefined; })();
+      `,
+    },
+    format: "iife",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toStartWith('"use strict";\n');
+      expect(code).toMatch(strictWrapperDirective);
+      expect(code).not.toMatch(/require_entry = __commonJS\(function\([^)]*\) \{\s*"use strict";/);
+      expect(code.split('"use strict"')).toHaveLength(3);
+    },
+  });
+  // An ESM file that a CommonJS file require()s is wrapped in __esm. Its "use strict" has to stay ahead of the
+  // init_*() calls for its own wrapped imports, or it stops being a directive.
+  itBundled("cjs2esm/UseStrictInsideESMWrapperBeforeInitCalls", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require('./lib.mjs');
+        console.log(lib.strict, lib.dep);
+      `,
+      "/lib.mjs": /* js */ `
+        "use strict";
+        import { dep } from './dep.mjs';
+        export const strict = (function() { return this === undefined; })();
+        export { dep };
+      `,
+      "/dep.mjs": /* js */ `
+        console.log('dep');
+        export const dep = 1;
+      `,
+    },
+    format: "cjs",
+    outfile: "/out.cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.cjs")).toMatch(/init_lib = __esm\(\(\) => \{\s*"use strict";\s*init_dep\(\);/);
+    },
+    run: { runtime: "node", stdout: "dep\ntrue 1" },
+  });
 });


### PR DESCRIPTION
### Problem
- `--format=cjs` and `--format=iife` output drops the `"use strict"` of every CommonJS module wrapped in `__commonJS(...)`, so those modules run sloppy unless the entry point makes the output strict. esbuild keeps it inside each wrapper.
- `generateCodeForFileInChunkJS.rs:263` has the code, gated on `!chunk.is_entry_point()`. Without code splitting every chunk is an entry point chunk, so it never ran.

### Fix
- Gate on "this file is the chunk's own entry point". That file keeps its directive at the top of the chunk. Every other wrapped file gets it inside its wrapper.
- Add `InsideWrapperPrefix::append_directive`. It moves `sync_dependencies_end` past the directive so the `init_x()` calls for wrapped ESM imports land after it.
- Correct because the wrapper body is the only place that scopes strictness to one module, as in esbuild. esbuild checks the file's entry point kind, but bun links one shared graph: with `bun build a.cjs b.cjs`, `b` is an entry point and a wrapped dependency of `a.js`. ESM output still skips the directive.
- Verified: `test/bundler/bundler_cjs2esm.test.ts`, 7 new cases, 6 fail on the released build. Other suites in Notes.

### Background
- `__commonJS(function(exports, module) { ... })` defers a CommonJS module's body to its first `require`. A required ESM module gets `__esm(() => { ... })`. The parser turns a module-level `"use strict"` into a flag. The linker prints it again.
- `StmtList.inside_wrapper_prefix` opens a wrapper body: `init_x()` calls at `sync_dependencies_end`, then `var ns = require_x()`, then the module's parts. A directive counts only at the start of a body.
- `bundler_bytecode_portable.test.ts` pins bundler output hashes and says to update them when the output changes.

<details><summary>Notes</summary>

Reproduction on bun 1.4.1:

```
# cjs.cjs
"use strict"; module.exports = (function(){ return this === undefined })();
# entry.mjs
import strict from "./cjs.cjs"; console.log(strict);
```

`bun build entry.mjs --format=cjs --outfile=out.cjs && node out.cjs` prints `false`. With this change it prints `true`, and the wrapper reads `__commonJS(function(exports2, module2) { "use strict"; ... })`.

Two entry points: `bun build a.cjs b.cjs --format=cjs` where sloppy `a.cjs` requires strict `b.cjs`. On the base branch, and with a file-level entry point check, `a.js` runs `b` sloppy. esbuild prints the directive inside `require_b` in `a.js` because `b` is not an entry point in `a`'s separate link. Test: `cjs2esm/UseStrictEntryPointWrappedInsideOtherEntryPoint`.

Why node runs the cjs and iife outputs in the tests: bun's runtime treats a script with no CommonJS markers as an ES module, which is strict throughout, and it drops function-body `"use strict"` in CommonJS (#31807). Node can observe the difference. The bundler_edgecase file already runs one test under node.

The brief's original probe (`typeof this` inside an exported function called as `fn()`) is not enough on its own: bun prints the call as `import_cjs.default()`, so `this` is the namespace object in both modes. That is the separate printer issue in #40829. The tests here compute strictness inside the module body with an IIFE.

Code splitting is rejected for any format other than esm (`bundle_v2.rs:3024`), and esm output skips the directive, so the chunk/file distinction only matters in the single-chunk case.

Probe of the cursor move: with `append_non_dependency` instead of `append_directive`, the `UseStrictInsideESMWrapperBeforeInitCalls` output is `__esm(() => { init_dep(); "use strict"; ... })`.

A mixed file (`import` plus `module.exports`) that imports a wrapped ESM module prints `__commonJS(function(exports2, module2) { "use strict"; init_dep(); ... })`, also with `--minify`. Test: `cjs2esm/UseStrictInsideCommonJSWrapperBeforeInitCalls`.

A diff of the undici bundle before and after is exactly 71 added `"use strict";` lines, one per strict module.

Review probes, all compared against esbuild 0.21.5 on the same inputs: a file that starts with `"use client"; "use strict";` prints both in the wrapper prologue (`"use strict"; "use client";`). A strict module that uses neither `exports` nor `module` gets `__commonJS(function() { "use strict"; ... })`. `--sourcemap=external` still produces a valid map with the synthesized statement. Two limitations are shared with esbuild and unchanged here: a strict ESM file that is flattened into cjs output without a wrapper stays sloppy, and a function declaration hoisted out of an `__esm` closure stays sloppy. Both tools print `true {} false false` for that probe.

Separate pre-existing issue seen while testing, not changed here: `--format=iife` with a CommonJS entry point defines `require_entry = __commonJS(...)` but never calls it. esbuild appends `require_entry();`. #37843 tracks it.

Suites run with the debug build: `bundler_cjs2esm`, `bundler_edgecase`, `bundler_cjs`, `bundler_npm`, `bundler_splitting`, `bun-build-api`, `bundler_bytecode_portable` (needs `--timeout 1500000` on a debug build, all 22 pass with the updated snapshot), `esbuild/default`, `esbuild/extra`, `esbuild/lower`, `esbuild/tsconfig`, `esbuild/importstar`, `esbuild/packagejson`, `esbuild/dce`, `transpiler/react-compiler`.
</details>
