### PR TITLE
js_parser: lower standard decorators without moving class members

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -40,22 +40,25 @@ type PrivateLoweredMap = HashMap<u32, PrivateLoweredInfo>;
 struct LoweredClass {
     /// `var` statement for the temporaries the class body now refers to.
     temps: Option<Stmt>,
-    /// Evaluates the class decorator list, before the class.
-    before: Option<Expr>,
-    /// What the class decorators returned, and the call that runs their
-    /// extra initializers once the class is bound to its name.
-    decorated: Option<(Ref, Expr)>,
+    class_decorators: Option<ClassDecorators>,
+}
+
+struct ClassDecorators {
+    /// Evaluates the decorator list, before the class.
+    evaluate: Expr,
+    /// What the decorators returned.
+    decorated: Ref,
+    /// Runs their extra initializers, once the class is bound to its name.
+    run_extra_initializers: Expr,
 }
 
 /// How an instance field names an anonymous function it is initialized with.
 #[derive(Clone, Copy)]
 enum FieldName {
-    /// A string or number key.
+    /// A string or number key, or `"#name"` for a private one.
     Key(Expr),
     /// The temporary that holds a computed key.
     Computed(Expr),
-    /// `"#name"`
-    Private(Expr),
     Unknown,
 }
 
@@ -647,33 +650,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         };
         let lowered = self.lower_class_body(&mut s_class.class, stmt.loc, None);
         out.extend(lowered.temps);
-        if let Some(before) = lowered.before {
-            out.push(self.s(
-                S::SExpr {
-                    value: before,
-                    ..Default::default()
-                },
-                stmt.loc,
-            ));
-        }
+        let Some(decorators) = lowered.class_decorators else {
+            out.push(stmt);
+            return;
+        };
+        let name = s_class
+            .class
+            .class_name
+            .expect("a class statement has a name");
+        let decorated = self.use_ref(decorators.decorated, name.loc);
+        let rebind = self.assign_to(name.ref_, decorated, name.loc);
+        out.push(self.expr_stmt(decorators.evaluate, stmt.loc));
         out.push(stmt);
-        if let Some((decorated, run_extra_initializers)) = lowered.decorated {
-            let name = s_class
-                .class
-                .class_name
-                .expect("a class statement has a name");
-            let decorated = self.use_ref(decorated, name.loc);
-            let rebind = self.assign_to(name.ref_, decorated, name.loc);
-            for value in [rebind, run_extra_initializers] {
-                out.push(self.s(
-                    S::SExpr {
-                        value,
-                        ..Default::default()
-                    },
-                    stmt.loc,
-                ));
-            }
-        }
+        out.push(self.expr_stmt(rebind, stmt.loc));
+        out.push(self.expr_stmt(decorators.run_extra_initializers, stmt.loc));
     }
 
     pub(crate) fn lower_standard_decorators_expr(
@@ -688,14 +678,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         {
             stmt_list.push(decl);
         }
-        let Some(before) = lowered.before else {
+        let Some(decorators) = lowered.class_decorators else {
             return expr;
         };
-        if let Some((decorated, run_extra_initializers)) = lowered.decorated {
-            let decorated = self.use_ref(decorated, expr.loc);
-            return Expr::join_all_with_comma(&[before, expr, run_extra_initializers, decorated]);
-        }
-        Expr::join_with_comma(before, expr)
+        let decorated = self.use_ref(decorators.decorated, expr.loc);
+        Expr::join_all_with_comma(&[
+            decorators.evaluate,
+            expr,
+            decorators.run_extra_initializers,
+            decorated,
+        ])
     }
 
     // ── Core lowering ────────────────────────────────────
@@ -985,7 +977,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 constructor = Some(members.len());
             } else if let Some(private_index) = private_index {
                 let name: &'a [u8] = p.symbols[private_index as usize].original_name.slice();
-                field_name = FieldName::Private(p.new_expr(E::EString::init(name), loc));
+                field_name = FieldName::Key(p.new_expr(E::EString::init(name), loc));
             } else {
                 // Only a field that may carry effects has to name its function itself.
                 let names_function = !is_method
@@ -1093,8 +1085,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // ── The leading static block ──
         leading.extend_from_slice(&storage_inits);
         leading.extend_from_slice(&static_brands);
-        let mut before: Option<Expr> = None;
-        let mut decorated_class: Option<(Ref, Expr)> = None;
+        let mut class_decorators_result: Option<ClassDecorators> = None;
         if has_decorators {
             let base = match base_ref {
                 Some(base) => p.use_ref(base, loc),
@@ -1115,7 +1106,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     },
                     loc,
                 );
-                before = Some(p.assign_to(dec, list, loc));
+                let evaluate = p.assign_to(dec, list, loc);
                 let name: &'a [u8] = match &class.class_name {
                     Some(name) => p.symbols[name.ref_.inner_index() as usize]
                         .original_name
@@ -1131,13 +1122,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let name = p.new_expr(E::EString::init(name), loc);
                 let decorated = p.decorate_element(init_ref, 0.0, name, dec, this, None, loc);
                 leading.push(p.assign_to(decorated_ref, decorated, loc));
-                // Runs once the class is bound to its name, which an initializer
-                // may refer to.
                 let decorated = p.use_ref(decorated_ref, loc);
-                decorated_class = Some((
-                    decorated_ref,
-                    p.run_initializers(init_ref, 1.0, decorated, loc),
-                ));
+                class_decorators_result = Some(ClassDecorators {
+                    evaluate,
+                    decorated: decorated_ref,
+                    run_extra_initializers: p.run_initializers(init_ref, 1.0, decorated, loc),
+                });
             } else {
                 let args = [p.use_ref(init_ref, loc), p.new_expr(E::This {}, loc)];
                 leading.push(p.call_rt(loc, b"__decoratorMetadata", &args));
@@ -1199,8 +1189,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         LoweredClass {
             temps: p.drain_capture_temp_decls(temps_before, loc),
-            before,
-            decorated: decorated_class,
+            class_decorators: class_decorators_result,
         }
     }
 
@@ -1359,9 +1348,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         match field_name {
             FieldName::Unknown => value,
-            // `__name` would overwrite a `static name` of a class.
-            FieldName::Private(_) if matches!(value.data, js_ast::ExprData::EClass(_)) => value,
-            FieldName::Private(name) => self.call_rt(value.loc, b"__name", &[value, name]),
             // `{ key: value }[key]` names it as the field would.
             FieldName::Key(key) | FieldName::Computed(key) => {
                 let mut flags = Flags::PROPERTY_NONE;
@@ -1488,6 +1474,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             ..Default::default()
         };
         self.new_expr(E::Function { func }, loc)
+    }
+
+    fn expr_stmt(&mut self, value: Expr, loc: bun_ast::Loc) -> Stmt {
+        self.s(
+            S::SExpr {
+                value,
+                ..Default::default()
+            },
+            loc,
+        )
     }
 
     fn effect_stmts(&mut self, effects: &[Expr], loc: bun_ast::Loc) -> BumpVec<'a, Stmt> {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1290,12 +1290,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return (key_temp, Some(key_temp));
         }
         if !effects.is_empty() {
-            effects.push(key);
+            effects.push(self.key_as_value(prop, key));
             prop.key = Some(Expr::join_all_with_comma(effects));
             prop.flags.insert(Flags::Property::IsComputed);
             effects.clear();
         }
         (key, None)
+    }
+
+    /// The key of `prop` as the expression a computed key needs. The visit pass
+    /// keys the field of a TypeScript parameter property by an identifier.
+    fn key_as_value(&mut self, prop: &Property, key: Expr) -> Expr {
+        if !prop.flags.contains(Flags::Property::IsComputed)
+            && let js_ast::ExprData::EIdentifier(id) = &key.data
+        {
+            let name: &'a [u8] = self.symbols[id.ref_.inner_index() as usize]
+                .original_name
+                .slice();
+            return self.new_expr(E::EString::init(name), key.loc);
+        }
+        key
     }
 
     /// Runs `effects` right after the key of `prop` is evaluated. `key_temp`
@@ -1314,7 +1328,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             parts.push(key_temp);
         } else if !prop.flags.contains(Flags::Property::IsComputed) || Self::is_constant_key(&key) {
             parts.extend_from_slice(effects);
-            parts.push(key);
+            parts.push(self.key_as_value(prop, key));
         } else if let js_ast::ExprData::EBinary(comma) = &key.data
             && comma.op == js_ast::OpCode::BinComma
             && Self::is_constant_key(&comma.right)

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -62,6 +62,68 @@ enum FieldName {
     Unknown,
 }
 
+/// The initializer of a decorated field or accessor.
+struct DecoratedInitializer {
+    /// `__runInitializers(_init, n, this, initializer)`
+    value: Expr,
+    /// Runs the extra initializers once the member is defined.
+    extra: Expr,
+}
+
+fn is_constructor(prop: &Property) -> bool {
+    prop.flags.contains(Flags::Property::IsMethod)
+        && !prop.flags.contains(Flags::Property::IsStatic)
+        && !prop.flags.contains(Flags::Property::IsComputed)
+        && matches!(
+            prop.key.map(|key| key.data),
+            Some(js_ast::ExprData::EString(s)) if s.eql_comptime(b"constructor")
+        )
+}
+
+/// A key whose evaluation cannot be observed, so it can be repeated.
+fn is_constant_key(key: &Expr) -> bool {
+    matches!(
+        key.data,
+        js_ast::ExprData::EString(_) | js_ast::ExprData::ENumber(_)
+    )
+}
+
+/// Which initializer list of `__decorateElement` a decorated accessor or field
+/// gets: static accessors, instance accessors, static fields, instance fields.
+fn initializer_group(prop: &Property) -> Option<usize> {
+    let instance = usize::from(!prop.flags.contains(Flags::Property::IsStatic));
+    if prop.kind == PropertyKind::AutoAccessor {
+        Some(instance)
+    } else if prop.flags.contains(Flags::Property::IsMethod) {
+        None
+    } else {
+        Some(2 + instance)
+    }
+}
+
+/// Puts `inserted` in `constructor` right after a top-level `super()`
+/// statement returns, which is after the last instance field.
+fn insert_after_super<'a>(
+    constructor: &mut Property,
+    inserted: &[Stmt],
+    arena: &'a bun_alloc::Arena,
+) {
+    let func = match &mut constructor.value.as_mut().unwrap().data {
+        js_ast::ExprData::EFunction(f) => &mut **f,
+        _ => unreachable!(),
+    };
+    let body: &[Stmt] = func.func.body.stmts.slice();
+    let after_super = body
+        .iter()
+        .position(|stmt| stmt.is_super_call())
+        .map_or(0, |i| i + 1);
+    let mut stmts = BumpVec::<'a, Stmt>::with_capacity_in(body.len() + inserted.len(), arena);
+    stmts.extend_from_slice(&body[..after_super]);
+    stmts.extend_from_slice(inserted);
+    stmts.extend_from_slice(&body[after_super..]);
+    func.func.body.stmts = bun_ast::StoreSlice::from_bump(stmts);
+}
+
 // ── impl P ───────────────────────────────────────────────────────────────────
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
@@ -747,7 +809,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             {
                 lowered_names.insert(private.ref_.inner_index(), ());
             }
-            if let Some(group) = Self::initializer_group(prop) {
+            if let Some(group) = initializer_group(prop) {
                 for later in &mut next_initializer[group + 1..] {
                     *later += 1;
                 }
@@ -990,7 +1052,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // ── Members that stay as written ──
             let mut field_name = FieldName::Unknown;
             let mut name_expr = key;
-            if Self::is_constructor(&prop) {
+            if is_constructor(&prop) {
                 constructor = Some(members.len());
             } else if let Some(private_index) = private_index {
                 let name: &'a [u8] = p.symbols[private_index as usize].original_name.slice();
@@ -1010,7 +1072,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     dec_ref.is_some() || names_function,
                 );
                 last_key_host = Some((members.len(), key_temp));
-                if Self::is_constant_key(&name_expr) {
+                if is_constant_key(&name_expr) {
                     field_name = FieldName::Key(name_expr);
                 } else if names_function {
                     field_name = FieldName::Computed(name_expr);
@@ -1023,7 +1085,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 decorate[group]
                     .push(p.decorate_element(init_ref, flags, name_expr, dec, this, None, loc));
                 if !is_method {
-                    let (value, extra) = p.decorated_initializer(
+                    let DecoratedInitializer { value, extra } = p.decorated_initializer(
                         init_ref,
                         next_initializer[group],
                         prop.initializer,
@@ -1187,7 +1249,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !constructor_effects.is_empty() {
             match constructor {
                 Some(constructor) => {
-                    p.run_after_super(&mut members[constructor], &constructor_effects, loc);
+                    let stmts = p.effect_stmts(&constructor_effects, loc);
+                    insert_after_super(&mut members[constructor], &stmts, p.arena);
                 }
                 None => {
                     new_constructor =
@@ -1215,38 +1278,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let ref_ = self.generate_temp_var(name);
         self.temp_refs_to_declare.push(TempRef { r#ref: ref_ });
         ref_
-    }
-
-    fn is_constructor(prop: &Property) -> bool {
-        prop.flags.contains(Flags::Property::IsMethod)
-            && !prop.flags.contains(Flags::Property::IsStatic)
-            && !prop.flags.contains(Flags::Property::IsComputed)
-            && matches!(
-                prop.key.map(|key| key.data),
-                Some(js_ast::ExprData::EString(s)) if s.eql_comptime(b"constructor")
-            )
-    }
-
-    /// A key whose evaluation cannot be observed, so it can be repeated.
-    fn is_constant_key(key: &Expr) -> bool {
-        matches!(
-            key.data,
-            js_ast::ExprData::EString(_) | js_ast::ExprData::ENumber(_)
-        )
-    }
-
-    /// Which initializer list of `__decorateElement` a decorated accessor or
-    /// field gets: static accessors, instance accessors, static fields,
-    /// instance fields.
-    fn initializer_group(prop: &Property) -> Option<usize> {
-        let instance = usize::from(!prop.flags.contains(Flags::Property::IsStatic));
-        if prop.kind == PropertyKind::AutoAccessor {
-            Some(instance)
-        } else if prop.flags.contains(Flags::Property::IsMethod) {
-            None
-        } else {
-            Some(2 + instance)
-        }
     }
 
     /// `__decorateElement(_init, flags, name, _dec, target[, extra])`
@@ -1297,7 +1328,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> (Expr, Option<Expr>) {
         let key = prop.key.expect("a class member has a key");
         let is_constant =
-            !prop.flags.contains(Flags::Property::IsComputed) || Self::is_constant_key(&key);
+            !prop.flags.contains(Flags::Property::IsComputed) || is_constant_key(&key);
         if !is_constant && reuse_key {
             let key_ref = self.declared_temp(b"_computedKey");
             effects.push(self.assign_to(key_ref, key, key.loc));
@@ -1343,12 +1374,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             parts.push(key);
             parts.extend_from_slice(effects);
             parts.push(key_temp);
-        } else if !prop.flags.contains(Flags::Property::IsComputed) || Self::is_constant_key(&key) {
+        } else if !prop.flags.contains(Flags::Property::IsComputed) || is_constant_key(&key) {
             parts.extend_from_slice(effects);
             parts.push(self.key_as_value(prop, key));
         } else if let js_ast::ExprData::EBinary(comma) = &key.data
             && comma.op == js_ast::OpCode::BinComma
-            && Self::is_constant_key(&comma.right)
+            && is_constant_key(&comma.right)
         {
             parts.push(comma.left);
             parts.extend_from_slice(effects);
@@ -1427,7 +1458,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         index: usize,
         initializer: Option<Expr>,
         loc: bun_ast::Loc,
-    ) -> (Expr, Expr) {
+    ) -> DecoratedInitializer {
         let mut args = BumpVec::<Expr>::with_capacity_in(4, self.arena);
         args.push(self.use_ref(init_ref, loc));
         args.push(self.new_expr(E::Number::new(((4 + 2 * index) << 1) as f64), loc));
@@ -1436,7 +1467,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let value = self.call_runtime(loc, b"__runInitializers", ExprNodeList::from_bump_vec(args));
         let this = self.new_expr(E::This {}, loc);
         let extra = self.run_initializers(init_ref, (((5 + 2 * index) << 1) | 1) as f64, this, loc);
-        (value, extra)
+        DecoratedInitializer { value, extra }
     }
 
     /// `__privateAdd(this, storage, initializer)`. `decorated` is the
@@ -1451,8 +1482,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut effects = BumpVec::<Expr>::with_capacity_in(2, self.arena);
         let (value, extra) = match decorated {
             Some((init_ref, index)) => {
-                let (value, extra) = self.decorated_initializer(init_ref, index, initializer, loc);
-                (value, Some(extra))
+                let decorated = self.decorated_initializer(init_ref, index, initializer, loc);
+                (decorated.value, Some(decorated.extra))
             }
             None => (
                 initializer.unwrap_or_else(|| self.new_expr(E::Undefined {}, loc)),
@@ -1529,25 +1560,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             ));
         }
         stmts
-    }
-
-    /// Runs `effects` in `constructor` right after a top-level `super()`
-    /// statement returns, which is after the last instance field.
-    fn run_after_super(&mut self, constructor: &mut Property, effects: &[Expr], loc: bun_ast::Loc) {
-        let func = match &mut constructor.value.as_mut().unwrap().data {
-            js_ast::ExprData::EFunction(f) => &mut **f,
-            _ => unreachable!(),
-        };
-        let body: &[Stmt] = func.func.body.stmts.slice();
-        let after_super = body
-            .iter()
-            .position(|stmt| stmt.is_super_call())
-            .map_or(0, |i| i + 1);
-        let mut stmts = BumpVec::<Stmt>::with_capacity_in(body.len() + effects.len(), self.arena);
-        stmts.extend_from_slice(&body[..after_super]);
-        stmts.extend(self.effect_stmts(effects, loc));
-        stmts.extend_from_slice(&body[after_super..]);
-        func.func.body.stmts = bun_ast::StoreSlice::from_bump(stmts);
     }
 
     /// `constructor() { super(...arguments); effects }`

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -504,6 +504,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         js_ast::StmtNodeList::from_bump(new_stmts)
     }
 
+    /// The declaration in the head of `for (const { a = this.#x } of ...)`. An
+    /// assignment target there is not a read and stays as written.
+    fn rewrite_private_accesses_in_loop_head(&mut self, init: &mut Stmt, map: &PrivateLoweredMap) {
+        if matches!(init.data, js_ast::StmtData::SLocal(_)) {
+            self.rewrite_private_accesses_in_stmts(core::slice::from_mut(init), map);
+        }
+    }
+
     fn rewrite_private_accesses_in_stmts(&mut self, stmts: &mut [Stmt], map: &PrivateLoweredMap) {
         for stmt_item in stmts.iter_mut() {
             match &mut stmt_item.data {
@@ -563,6 +571,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     data.body = body;
                 }
                 js_ast::StmtData::SForIn(data) => {
+                    let mut init = data.init;
+                    self.rewrite_private_accesses_in_loop_head(&mut init, map);
+                    data.init = init;
                     let mut v = data.value;
                     self.rewrite_private_accesses_in_expr(&mut v, map);
                     data.value = v;
@@ -571,6 +582,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     data.body = body;
                 }
                 js_ast::StmtData::SForOf(data) => {
+                    let mut init = data.init;
+                    self.rewrite_private_accesses_in_loop_head(&mut init, map);
+                    data.init = init;
                     let mut v = data.value;
                     self.rewrite_private_accesses_in_expr(&mut v, map);
                     data.value = v;
@@ -611,6 +625,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let body = data.body.slice_mut();
                     self.rewrite_private_accesses_in_stmts(body, map);
                     if let Some(c) = &mut data.catch {
+                        if let Some(binding) = c.binding {
+                            self.rewrite_private_accesses_in_binding(binding, map);
+                        }
                         let cb = c.body.slice_mut();
                         self.rewrite_private_accesses_in_stmts(cb, map);
                     }

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::too_many_arguments, clippy::needless_late_init)]
 //! Lowering for TC39 standard ES decorators.
 
 use bun_alloc::ArenaVecExt as _;
@@ -7,14 +6,11 @@ use bun_collections::{HashMap, VecExt};
 
 use crate::lexer as js_lexer;
 use crate::p::P;
-use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, TempRef, is_eval_or_arguments};
+use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, TempRef};
 use bun_ast::g::{DeclList, Property, PropertyKind};
 use bun_ast::{self as js_ast, B, E, Expr, ExprNodeList, Flags, G, S, Stmt};
 
 type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
-
-// Round-C lowered `const JSX: JSXTransformType` → `J: JsxT`, so this is
-// a direct `impl P` block.
 
 // ── Local helper types ───────────────────────────────────────────────────────
 
@@ -41,102 +37,26 @@ impl PrivateLoweredInfo {
 
 type PrivateLoweredMap = HashMap<u32, PrivateLoweredInfo>;
 
-struct FieldInitEntry {
-    prop: Property,
-    is_private: bool,
-    is_accessor: bool,
+struct LoweredClass {
+    /// `var` statement for the temporaries the class body now refers to.
+    temps: Option<Stmt>,
+    /// Evaluates the class decorator list, before the class.
+    before: Option<Expr>,
+    /// What the class decorators returned, and the call that runs their
+    /// extra initializers once the class is bound to its name.
+    decorated: Option<(Ref, Expr)>,
 }
 
+/// How an instance field names an anonymous function it is initialized with.
 #[derive(Clone, Copy)]
-enum StaticElementKind {
-    Block,
-    FieldOrAccessor,
-}
-
-#[derive(Clone, Copy)]
-struct StaticElement {
-    kind: StaticElementKind,
-    index: usize,
-}
-
-#[derive(Clone, Copy)]
-enum RewriteKind {
-    ReplaceRef { old: Ref, new: Ref },
-    ReplaceThis { ref_: Ref, loc: bun_ast::Loc },
-}
-
-// ── Shallow-copy helpers (Property / Class are not `Clone` because they hold
-//    raw arena pointers; copying the raw pointers is intentional). ──
-
-#[inline]
-fn prop_copy(p: &Property) -> Property {
-    Property {
-        initializer: p.initializer,
-        kind: p.kind,
-        flags: p.flags,
-        class_static_block: p.class_static_block,
-        ts_decorators: bun_alloc::AstAlloc::vec(),
-        key: p.key,
-        value: p.value,
-        // SAFETY: this duplicates ownership of any heap allocation inside
-        // `Metadata` (`MDot` owns a global-heap `Vec<Ref>`), but the source
-        // `Property` is an arena-resident AST node whose `Drop` never runs
-        // (AST stores are bulk-freed without dropping — see the
-        // `bun_alloc::ast_alloc` module docs), so at most one of the two
-        // copies ever reaches drop glue; no double free.
-        ts_metadata: unsafe { core::ptr::read(&raw const p.ts_metadata) },
-    }
-}
-
-#[inline]
-fn prop_full_copy(p: &Property) -> Property {
-    // Same as `prop_copy` but preserves `ts_decorators` (used for the "keep
-    // undecorated property as-is" path).
-    // SAFETY: Vec is repr-compatible with a (ptr,len,cap,origin) POD; the
-    // arena owns the buffer for the parser lifetime. Shallow copy via read.
-    let ts_decorators = unsafe { core::ptr::read(&raw const p.ts_decorators) };
-    Property {
-        initializer: p.initializer,
-        kind: p.kind,
-        flags: p.flags,
-        class_static_block: p.class_static_block,
-        ts_decorators,
-        key: p.key,
-        value: p.value,
-        // SAFETY: see `prop_copy`.
-        ts_metadata: unsafe { core::ptr::read(&raw const p.ts_metadata) },
-    }
-}
-
-#[inline]
-fn class_copy(c: &G::Class) -> G::Class {
-    G::Class {
-        class_keyword: c.class_keyword,
-        // SAFETY: see `prop_full_copy`.
-        ts_decorators: unsafe { core::ptr::read(&raw const c.ts_decorators) },
-        class_name: c.class_name,
-        extends: c.extends,
-        body_loc: c.body_loc,
-        close_brace_loc: c.close_brace_loc,
-        properties: c.properties,
-        has_decorators: c.has_decorators,
-        should_lower_standard_decorators: c.should_lower_standard_decorators,
-    }
-}
-
-/// Whether a context-inferred name (`export default` → "default", object
-/// property keys, assignment targets) can be attached to a lowered anonymous
-/// class expression as its syntactic binding name. Class bodies are always
-/// strict mode code and the output may be a module, so reserved words
-/// ("default", "let", "await", …), `eval`/`arguments`, and non-identifier
-/// strings would turn `_class = class <name> {}` into a syntax error.
-#[inline]
-fn can_be_class_binding_name(name: &[u8]) -> bool {
-    js_lexer::is_identifier(name)
-        && js_lexer::keyword(name).is_none()
-        && !js_lexer::is_strict_mode_reserved_word(name)
-        && name != b"await"
-        && !is_eval_or_arguments(name)
+enum FieldName {
+    /// A string or number key.
+    Key(Expr),
+    /// The temporary that holds a computed key.
+    Computed(Expr),
+    /// `"#name"`
+    Private(Expr),
+    Unknown,
 }
 
 // ── impl P ───────────────────────────────────────────────────────────────────
@@ -172,74 +92,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ref_
     }
 
-    /// Single var declaration statement.
-    fn var_decl(&mut self, ref_: Ref, value: Option<Expr>, l: bun_ast::Loc) -> Stmt {
-        let binding = self.b(B::Identifier { r#ref: ref_ }, l);
-        let decls = DeclList::from_slice(&[G::Decl { binding, value }]);
-        self.s(
-            S::Local {
-                decls,
-                ..Default::default()
-            },
-            l,
-        )
-    }
-
-    /// Two-variable declaration statement.
-    fn var_decl2(
-        &mut self,
-        r1: Ref,
-        v1: Option<Expr>,
-        r2: Ref,
-        v2: Option<Expr>,
-        l: bun_ast::Loc,
-    ) -> Stmt {
-        let b1 = self.b(B::Identifier { r#ref: r1 }, l);
-        let b2 = self.b(B::Identifier { r#ref: r2 }, l);
-        let decls = DeclList::from_slice(&[
-            G::Decl {
-                binding: b1,
-                value: v1,
-            },
-            G::Decl {
-                binding: b2,
-                value: v2,
-            },
-        ]);
-        self.s(
-            S::Local {
-                decls,
-                ..Default::default()
-            },
-            l,
-        )
-    }
-
     /// recordUsage + Expr.assign.
     fn assign_to(&mut self, ref_: Ref, value: Expr, l: bun_ast::Loc) -> Expr {
-        self.record_usage(ref_);
-        Expr::assign(
-            self.new_expr(
-                E::Identifier {
-                    ref_,
-                    ..Default::default()
-                },
-                l,
-            ),
-            value,
-        )
+        Expr::assign(self.use_ref(ref_, l), value)
     }
 
-    /// new WeakMap() expression.
-    fn new_weak_map_expr(&mut self, l: bun_ast::Loc) -> Expr {
-        let ref_ = self.find_symbol(l, b"WeakMap").expect("unreachable").r#ref;
-        let target = self.new_expr(
-            E::Identifier {
-                ref_,
-                ..Default::default()
-            },
-            l,
-        );
+    /// `new WeakMap` / `new WeakSet`
+    fn new_global_expr(&mut self, name: &'static [u8], l: bun_ast::Loc) -> Expr {
+        let ref_ = self.find_symbol(l, name).expect("unreachable").r#ref;
+        let target = self.new_expr(E::Identifier::init(ref_), l);
         self.new_expr(
             E::New {
                 target,
@@ -251,40 +112,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    /// new WeakSet() expression.
-    fn new_weak_set_expr(&mut self, l: bun_ast::Loc) -> Expr {
-        let ref_ = self.find_symbol(l, b"WeakSet").expect("unreachable").r#ref;
-        let target = self.new_expr(
-            E::Identifier {
-                ref_,
-                ..Default::default()
-            },
-            l,
-        );
-        self.new_expr(
-            E::New {
-                target,
-                args: bun_alloc::AstAlloc::vec(),
-                close_parens_loc: l,
-                ..Default::default()
-            },
-            l,
-        )
-    }
-
-    /// Create a static block property from a single expression.
-    fn make_static_block(&mut self, expr: Expr, l: bun_ast::Loc) -> Property {
-        let bump = self.arena;
-        let stmt = self.s(
-            S::SExpr {
-                value: expr,
-                ..Default::default()
-            },
-            l,
-        );
-        let stmts = bump.alloc_slice_copy(&[stmt]);
-        let stmts_list = bun_alloc::AstVec::<Stmt>::from_arena_slice(stmts);
-        let sb = bump.alloc(G::ClassStaticBlock {
+    /// `static { a; b; }`
+    fn make_static_block(&mut self, exprs: &[Expr], l: bun_ast::Loc) -> Property {
+        let stmts = self.effect_stmts(exprs, l);
+        let stmts_list = bun_alloc::AstVec::<Stmt>::from_arena_slice(stmts.into_bump_slice_mut());
+        let sb = self.arena.alloc(G::ClassStaticBlock {
             loc: l,
             stmts: stmts_list,
         });
@@ -295,111 +127,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Build property access: target.name or target[key].
-    fn member_target(&mut self, target_expr: Expr, prop: &Property) -> Expr {
-        let key_expr = prop.key.expect("infallible: prop has key");
-        if prop.flags.contains(Flags::Property::IsComputed)
-            || matches!(key_expr.data, js_ast::ExprData::ENumber(_))
-        {
-            return self.new_expr(
-                E::Index {
-                    target: target_expr,
-                    index: key_expr,
-                    optional_chain: None,
-                    is_import_property_use: false,
-                },
-                key_expr.loc,
-            );
-        }
-        if let js_ast::ExprData::EString(s) = &key_expr.data {
-            // `E::Dot.name` is a UTF-8 `Str`; a UTF-16 `EString.data` stores
-            // u16-count bytes that are garbage as UTF-8. Fall through to
-            // `E::Index` for UTF-16 keys so the printer emits `["…"]`.
-            if s.is_utf8() {
-                return self.new_expr(
-                    E::Dot {
-                        target: target_expr,
-                        name: s.data,
-                        name_loc: key_expr.loc,
-                        ..Default::default()
-                    },
-                    key_expr.loc,
-                );
-            }
-        }
-        self.new_expr(
-            E::Index {
-                target: target_expr,
-                index: key_expr,
-                optional_chain: None,
-                is_import_property_use: false,
-            },
-            key_expr.loc,
-        )
-    }
-
-    fn init_flag(idx: usize) -> f64 {
-        ((4 + 2 * idx) << 1) as f64
-    }
-
-    fn extra_init_flag(idx: usize) -> f64 {
-        (((5 + 2 * idx) << 1) | 1) as f64
-    }
-
-    /// Emit __privateAdd for a given storage ref.
-    fn emit_private_add(
-        &mut self,
-        is_static: bool,
-        storage_ref: Ref,
-        value: Option<Expr>,
-        loc: bun_ast::Loc,
-        constructor_inject: &mut BumpVec<'_, Stmt>,
-        static_blocks: &mut BumpVec<'_, Property>,
-    ) {
-        let target = self.new_expr(E::This {}, loc);
-        let storage = self.use_ref(storage_ref, loc);
-        let call = if let Some(v) = value {
-            self.call_rt(loc, b"__privateAdd", &[target, storage, v])
-        } else {
-            self.call_rt(loc, b"__privateAdd", &[target, storage])
-        };
-        if is_static {
-            static_blocks.push(self.make_static_block(call, loc));
-        } else {
-            constructor_inject.push(self.s(
-                S::SExpr {
-                    value: call,
-                    ..Default::default()
-                },
-                loc,
-            ));
-        }
-    }
-
-    /// Get the method kind code (1=method, 2=getter, 3=setter).
-    fn method_kind(prop: &Property) -> u8 {
-        match prop.kind {
-            PropertyKind::Get => 2,
-            PropertyKind::Set => 3,
-            _ => 1,
-        }
-    }
-
-    /// Get fn variable suffix for a given kind code.
-    fn fn_suffix(k: u8) -> &'static [u8] {
-        if k == 2 {
-            b"_get"
-        } else if k == 3 {
-            b"_set"
-        } else {
-            b"_fn"
-        }
-    }
-
-    fn bump_name2(&self, a: &[u8], b: &[u8]) -> &'a [u8] {
-        let mut v = BumpVec::<u8>::new_in(self.arena);
+    fn bump_name3(&self, a: &[u8], b: &[u8], c: &[u8]) -> &'a [u8] {
+        let mut v = BumpVec::<u8>::with_capacity_in(a.len() + b.len() + c.len(), self.arena);
         v.extend_from_slice(a);
         v.extend_from_slice(b);
+        v.extend_from_slice(c);
         v.into_bump_slice()
     }
 
@@ -409,239 +141,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             && s.is_utf8()
             && js_lexer::is_identifier(&s.data)
         {
-            return self.bump_name2(b"_", &s.data);
+            return self.bump_name3(b"_", &s.data, b"");
         }
         b"_accessor_storage"
-    }
-
-    // ── Generic tree rewriter ────────────────────────────
-
-    fn rewrite_expr(&mut self, expr: &mut Expr, kind: RewriteKind) {
-        match kind {
-            RewriteKind::ReplaceRef { old, new } => {
-                if let js_ast::ExprData::EIdentifier(id) = &expr.data {
-                    if id.ref_.eql(old) {
-                        self.record_usage(new);
-                        expr.data = js_ast::ExprData::EIdentifier(E::Identifier {
-                            ref_: new,
-                            ..Default::default()
-                        });
-                        return;
-                    }
-                }
-            }
-            RewriteKind::ReplaceThis { ref_, loc } => {
-                if matches!(expr.data, js_ast::ExprData::EThis(_)) {
-                    *expr = self.use_ref(ref_, loc);
-                    return;
-                }
-            }
-        }
-        match &mut expr.data {
-            js_ast::ExprData::EBinary(e) => {
-                self.rewrite_expr(&mut e.left, kind);
-                self.rewrite_expr(&mut e.right, kind);
-            }
-            js_ast::ExprData::ECall(e) => {
-                let mut t = e.target;
-                self.rewrite_expr(&mut t, kind);
-                e.target = t;
-                for a in e.args.slice_mut() {
-                    self.rewrite_expr(a, kind);
-                }
-            }
-            js_ast::ExprData::ENew(e) => {
-                let mut t = e.target;
-                self.rewrite_expr(&mut t, kind);
-                e.target = t;
-                for a in e.args.slice_mut() {
-                    self.rewrite_expr(a, kind);
-                }
-            }
-            js_ast::ExprData::EIndex(e) => {
-                self.rewrite_expr(&mut e.target, kind);
-                self.rewrite_expr(&mut e.index, kind);
-            }
-            js_ast::ExprData::EDot(e) => self.rewrite_expr(&mut e.target, kind),
-            js_ast::ExprData::ESpread(e) => self.rewrite_expr(&mut e.value, kind),
-            js_ast::ExprData::EUnary(e) => self.rewrite_expr(&mut e.value, kind),
-            js_ast::ExprData::EIf(e) => {
-                self.rewrite_expr(&mut e.test, kind);
-                self.rewrite_expr(&mut e.yes, kind);
-                self.rewrite_expr(&mut e.no, kind);
-            }
-            js_ast::ExprData::EArray(e) => {
-                for item in e.items.slice_mut() {
-                    self.rewrite_expr(item, kind);
-                }
-            }
-            js_ast::ExprData::EObject(e) => {
-                for prop in e.properties.slice_mut() {
-                    if let Some(v) = &mut prop.value {
-                        self.rewrite_expr(v, kind);
-                    }
-                    if let Some(ini) = &mut prop.initializer {
-                        self.rewrite_expr(ini, kind);
-                    }
-                }
-            }
-            js_ast::ExprData::ETemplate(e) => {
-                if let Some(t) = &mut e.tag {
-                    self.rewrite_expr(t, kind);
-                }
-                // SAFETY: arena-owned slice; unique access via `&mut e`.
-                for part in e.parts_mut().iter_mut() {
-                    self.rewrite_expr(&mut part.value, kind);
-                }
-            }
-            js_ast::ExprData::EArrow(e) => {
-                let stmts = e.body.stmts.slice_mut();
-                self.rewrite_stmts(stmts, kind);
-            }
-            js_ast::ExprData::EFunction(e) => match kind {
-                RewriteKind::ReplaceThis { .. } => {}
-                RewriteKind::ReplaceRef { .. } => {
-                    let stmts = e.func.body.stmts.slice_mut();
-                    if !stmts.is_empty() {
-                        self.rewrite_stmts(stmts, kind);
-                    }
-                }
-            },
-            js_ast::ExprData::EClass(_) => {}
-            _ => {}
-        }
-    }
-
-    fn rewrite_stmts(&mut self, stmts: &mut [Stmt], kind: RewriteKind) {
-        for cur_stmt in stmts.iter_mut() {
-            let cur_loc = cur_stmt.loc;
-            match &mut cur_stmt.data {
-                js_ast::StmtData::SExpr(sexpr) => {
-                    let mut val = sexpr.value;
-                    self.rewrite_expr(&mut val, kind);
-                    *cur_stmt = self.s(
-                        S::SExpr {
-                            value: val,
-                            does_not_affect_tree_shaking: sexpr.does_not_affect_tree_shaking,
-                        },
-                        cur_loc,
-                    );
-                }
-                js_ast::StmtData::SLocal(local) => {
-                    for decl in local.decls.slice_mut() {
-                        if let Some(v) = &mut decl.value {
-                            self.rewrite_expr(v, kind);
-                        }
-                    }
-                }
-                js_ast::StmtData::SReturn(ret) => {
-                    if let Some(v) = &mut ret.value {
-                        self.rewrite_expr(v, kind);
-                    }
-                }
-                js_ast::StmtData::SThrow(data) => self.rewrite_expr(&mut data.value, kind),
-                js_ast::StmtData::SIf(data) => {
-                    let mut t = data.test;
-                    self.rewrite_expr(&mut t, kind);
-                    data.test = t;
-                    let mut yes = data.yes;
-                    self.rewrite_stmts(core::slice::from_mut(&mut yes), kind);
-                    data.yes = yes;
-                    if let Some(no) = &mut data.no {
-                        self.rewrite_stmts(core::slice::from_mut(no), kind);
-                    }
-                }
-                js_ast::StmtData::SBlock(data) => {
-                    let stmts = data.stmts.slice_mut();
-                    self.rewrite_stmts(stmts, kind);
-                }
-                js_ast::StmtData::SFor(data) => {
-                    if let Some(fi) = &mut data.init {
-                        self.rewrite_stmts(core::slice::from_mut(fi), kind);
-                    }
-                    if let Some(t) = &mut data.test {
-                        self.rewrite_expr(t, kind);
-                    }
-                    if let Some(u) = &mut data.update {
-                        self.rewrite_expr(u, kind);
-                    }
-                    let mut body = data.body;
-                    self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
-                    data.body = body;
-                }
-                js_ast::StmtData::SForIn(data) => {
-                    let mut v = data.value;
-                    self.rewrite_expr(&mut v, kind);
-                    data.value = v;
-                    let mut body = data.body;
-                    self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
-                    data.body = body;
-                }
-                js_ast::StmtData::SForOf(data) => {
-                    let mut v = data.value;
-                    self.rewrite_expr(&mut v, kind);
-                    data.value = v;
-                    let mut body = data.body;
-                    self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
-                    data.body = body;
-                }
-                js_ast::StmtData::SWhile(data) => {
-                    let mut t = data.test;
-                    self.rewrite_expr(&mut t, kind);
-                    data.test = t;
-                    let mut body = data.body;
-                    self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
-                    data.body = body;
-                }
-                js_ast::StmtData::SDoWhile(data) => {
-                    let mut t = data.test;
-                    self.rewrite_expr(&mut t, kind);
-                    data.test = t;
-                    let mut body = data.body;
-                    self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
-                    data.body = body;
-                }
-                js_ast::StmtData::SSwitch(data) => {
-                    let mut t = data.test;
-                    self.rewrite_expr(&mut t, kind);
-                    data.test = t;
-                    let cases = data.cases.slice_mut();
-                    for case in cases.iter_mut() {
-                        if let Some(v) = &mut case.value {
-                            self.rewrite_expr(v, kind);
-                        }
-                        let body = case.body.slice_mut();
-                        self.rewrite_stmts(body, kind);
-                    }
-                }
-                js_ast::StmtData::STry(data) => {
-                    let body = data.body.slice_mut();
-                    self.rewrite_stmts(body, kind);
-                    if let Some(c) = &mut data.catch {
-                        let cb = c.body.slice_mut();
-                        self.rewrite_stmts(cb, kind);
-                    }
-                    if let Some(f) = &mut data.finally {
-                        let fb = f.stmts.slice_mut();
-                        self.rewrite_stmts(fb, kind);
-                    }
-                }
-                js_ast::StmtData::SLabel(data) => {
-                    let mut s = data.stmt;
-                    self.rewrite_stmts(core::slice::from_mut(&mut s), kind);
-                    data.stmt = s;
-                }
-                js_ast::StmtData::SWith(data) => {
-                    let mut v = data.value;
-                    self.rewrite_expr(&mut v, kind);
-                    data.value = v;
-                    let mut body = data.body;
-                    self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
-                    data.body = body;
-                }
-                _ => {}
-            }
-        }
     }
 
     // ── Private access rewriting ─────────────────────────
@@ -776,8 +278,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     (obj_expr, self.new_expr(E::This {}, obj_expr.loc))
                                 }
                                 _ => {
-                                    let tmp_ref = self.generate_temp_var(b"_obj");
-                                    self.temp_refs_to_declare.push(TempRef { r#ref: tmp_ref });
+                                    let tmp_ref = self.declared_temp(b"_obj");
                                     let write = self.assign_to(tmp_ref, obj_expr, expr_loc);
                                     let read = self.use_ref(tmp_ref, expr_loc);
                                     (write, read)
@@ -851,41 +352,103 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_ast::ExprData::EObject(e) => {
                 for prop in e.properties.slice_mut() {
-                    if let Some(v) = &mut prop.value {
-                        self.rewrite_private_accesses_in_expr(v, map);
-                    }
-                    if let Some(ini) = &mut prop.initializer {
-                        self.rewrite_private_accesses_in_expr(ini, map);
-                    }
+                    self.rewrite_private_accesses_in_property(prop, map);
                 }
             }
             js_ast::ExprData::ETemplate(e) => {
                 if let Some(t) = &mut e.tag {
                     self.rewrite_private_accesses_in_expr(t, map);
                 }
-                // SAFETY: see `rewrite_expr` ETemplate.
                 for part in e.parts_mut().iter_mut() {
                     self.rewrite_private_accesses_in_expr(&mut part.value, map);
                 }
             }
             js_ast::ExprData::EFunction(e) => {
-                let temps_before = self.temp_refs_to_declare.len();
-                let stmts = e.func.body.stmts.slice_mut();
-                self.rewrite_private_accesses_in_stmts(stmts, map);
-                e.func.body.stmts = self.declare_capture_temps_in_fn_body(
-                    e.func.body.stmts,
-                    temps_before,
-                    e.func.body.loc,
-                );
+                self.rewrite_private_accesses_in_fn(e.func.args, &mut e.func.body, map);
             }
             js_ast::ExprData::EArrow(e) => {
-                let temps_before = self.temp_refs_to_declare.len();
-                let stmts = e.body.stmts.slice_mut();
-                self.rewrite_private_accesses_in_stmts(stmts, map);
-                e.body.stmts =
-                    self.declare_capture_temps_in_fn_body(e.body.stmts, temps_before, e.body.loc);
+                self.rewrite_private_accesses_in_fn(e.args, &mut e.body, map);
             }
+            js_ast::ExprData::EClass(e) => self.rewrite_private_accesses_in_class(e, map),
             _ => {}
+        }
+    }
+
+    fn rewrite_private_accesses_in_fn(
+        &mut self,
+        args: bun_ast::StoreSlice<G::Arg>,
+        body: &mut G::FnBody,
+        map: &PrivateLoweredMap,
+    ) {
+        // A `var` of the body is not visible to a parameter default: the
+        // receiver temporaries of the defaults stay with the enclosing function.
+        for arg in args.slice_mut() {
+            self.rewrite_private_accesses_in_binding(arg.binding, map);
+            if let Some(default) = &mut arg.default {
+                self.rewrite_private_accesses_in_expr(default, map);
+            }
+        }
+        let temps_before = self.temp_refs_to_declare.len();
+        self.rewrite_private_accesses_in_stmts(body.stmts.slice_mut(), map);
+        body.stmts = self.declare_capture_temps_in_fn_body(body.stmts, temps_before, body.loc);
+    }
+
+    fn rewrite_private_accesses_in_class(&mut self, class: &mut G::Class, map: &PrivateLoweredMap) {
+        if let Some(extends) = &mut class.extends {
+            self.rewrite_private_accesses_in_expr(extends, map);
+        }
+        for prop in class.properties.slice_mut() {
+            self.rewrite_private_accesses_in_property(prop, map);
+        }
+    }
+
+    fn rewrite_private_accesses_in_property(
+        &mut self,
+        prop: &mut Property,
+        map: &PrivateLoweredMap,
+    ) {
+        if prop.flags.contains(Flags::Property::IsComputed)
+            && let Some(key) = &mut prop.key
+        {
+            self.rewrite_private_accesses_in_expr(key, map);
+        }
+        if let Some(value) = &mut prop.value {
+            self.rewrite_private_accesses_in_expr(value, map);
+        }
+        if let Some(initializer) = &mut prop.initializer {
+            self.rewrite_private_accesses_in_expr(initializer, map);
+        }
+        if let Some(block) = prop.class_static_block_mut() {
+            self.rewrite_private_accesses_in_stmts(block.stmts.slice_mut(), map);
+        }
+    }
+
+    fn rewrite_private_accesses_in_binding(
+        &mut self,
+        binding: js_ast::Binding,
+        map: &PrivateLoweredMap,
+    ) {
+        match binding.data {
+            js_ast::b::B::BArray(mut array) => {
+                for item in array.items_mut() {
+                    self.rewrite_private_accesses_in_binding(item.binding, map);
+                    if let Some(default) = &mut item.default_value {
+                        self.rewrite_private_accesses_in_expr(default, map);
+                    }
+                }
+            }
+            js_ast::b::B::BObject(mut object) => {
+                for prop in object.properties_mut() {
+                    if prop.flags.contains(Flags::Property::IsComputed) {
+                        self.rewrite_private_accesses_in_expr(&mut prop.key, map);
+                    }
+                    self.rewrite_private_accesses_in_binding(prop.value, map);
+                    if let Some(default) = &mut prop.default_value {
+                        self.rewrite_private_accesses_in_expr(default, map);
+                    }
+                }
+            }
+            js_ast::b::B::BIdentifier(_) | js_ast::b::B::BMissing(_) => {}
         }
     }
 
@@ -954,10 +517,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 js_ast::StmtData::SLocal(data) => {
                     for decl in data.decls.slice_mut() {
+                        self.rewrite_private_accesses_in_binding(decl.binding, map);
                         if let Some(v) = &mut decl.value {
                             self.rewrite_private_accesses_in_expr(v, map);
                         }
                     }
+                }
+                js_ast::StmtData::SFunction(data) => {
+                    let args = data.func.args;
+                    self.rewrite_private_accesses_in_fn(args, &mut data.func.body, map);
+                }
+                js_ast::StmtData::SClass(data) => {
+                    self.rewrite_private_accesses_in_class(&mut data.class, map);
                 }
                 js_ast::StmtData::SIf(data) => {
                     let mut t = data.test;
@@ -1070,1109 +641,910 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: Stmt,
         out: &mut BumpVec<'a, Stmt>,
     ) {
-        // Every call site is the visitStmt `s_class` branch. `Stmt` and the
-        // `StoreRef<S::Class>` payload are both `Copy`, so we can hold a copy
-        // of the arena handle while still passing `stmt` by value below.
-        // `StoreRef::DerefMut` is the safe arena-backref accessor; no raw
-        // pointer round-trip needed.
         let mut s_class = match stmt.data {
             js_ast::StmtData::SClass(c) => c,
             _ => unreachable!(),
         };
-        self.lower_impl(&mut s_class.class, stmt.loc, None, false, Some(stmt), out);
+        let lowered = self.lower_class_body(&mut s_class.class, stmt.loc, None);
+        out.extend(lowered.temps);
+        if let Some(before) = lowered.before {
+            out.push(self.s(
+                S::SExpr {
+                    value: before,
+                    ..Default::default()
+                },
+                stmt.loc,
+            ));
+        }
+        out.push(stmt);
+        if let Some((decorated, run_extra_initializers)) = lowered.decorated {
+            let name = s_class
+                .class
+                .class_name
+                .expect("a class statement has a name");
+            let decorated = self.use_ref(decorated, name.loc);
+            let rebind = self.assign_to(name.ref_, decorated, name.loc);
+            for value in [rebind, run_extra_initializers] {
+                out.push(self.s(
+                    S::SExpr {
+                        value,
+                        ..Default::default()
+                    },
+                    stmt.loc,
+                ));
+            }
+        }
     }
 
     pub(crate) fn lower_standard_decorators_expr(
         &mut self,
+        expr: Expr,
         class: &mut G::Class,
-        loc: bun_ast::Loc,
         name_from_context: Option<&'a [u8]>,
     ) -> Expr {
-        let bump = self.arena;
-        let mut out = BumpVec::<Stmt>::new_in(bump);
-        self.lower_impl(class, loc, name_from_context, true, None, &mut out);
-        if out.is_empty() {
-            return self.new_expr(E::Missing {}, loc);
+        let lowered = self.lower_class_body(class, expr.loc, name_from_context);
+        if let Some(decl) = lowered.temps
+            && let Some(stmt_list) = self.nearest_stmt_list_mut()
+        {
+            stmt_list.push(decl);
         }
-        match &out[0].data {
-            js_ast::StmtData::SExpr(s) => s.value,
-            _ => unreachable!(),
+        let Some(before) = lowered.before else {
+            return expr;
+        };
+        if let Some((decorated, run_extra_initializers)) = lowered.decorated {
+            let decorated = self.use_ref(decorated, expr.loc);
+            return Expr::join_all_with_comma(&[before, expr, run_extra_initializers, decorated]);
         }
+        Expr::join_with_comma(before, expr)
     }
 
     // ── Core lowering ────────────────────────────────────
 
+    /// Rewrites `class` in place. Members stay where they are written, so
+    /// fields, static blocks, `this`, `super` and `#private` names keep their
+    /// native behavior; what the runtime helpers need is added around them.
+    /// Decorator lists are evaluated in the key of their member and applied by
+    /// a leading `static {}`. What has to run between two instance fields rides
+    /// in the initializer of the next one, or the constructor after the last.
+    /// A `#private` name with a decorated member becomes a WeakMap or WeakSet,
+    /// which is how the helpers reach it; its methods become function expressions.
     #[allow(clippy::too_many_lines)]
-    fn lower_impl(
+    fn lower_class_body(
         &mut self,
         class: &mut G::Class,
         loc: bun_ast::Loc,
         name_from_context: Option<&'a [u8]>,
-        is_expr: bool,
-        original_stmt: Option<Stmt>,
-        out: &mut BumpVec<'a, Stmt>,
-    ) {
+    ) -> LoweredClass {
         let p = self;
         let bump = p.arena;
+        let temps_before = p.temp_refs_to_declare.len();
 
-        // Receiver-capture temporaries created by `rewrite_private_accesses_in_expr`
-        // land in `temp_refs_to_declare`; everything pushed past this point is
-        // declared in a `var` statement alongside the other lowering variables
-        // right before output assembly.
-        let temp_refs_before = p.temp_refs_to_declare.len();
+        let class_decorators: ExprNodeList = bun_alloc::AstAlloc::take(&mut class.ts_decorators);
+        let has_class_decorators = class_decorators.len_u32() > 0;
 
-        // ── Phase 1: Setup ───────────────────────────────
-        let mut class_name_ref: Ref;
-        let mut class_name_loc: bun_ast::Loc;
-        let mut expr_class_ref: Option<Ref> = None;
-        let mut expr_class_is_anonymous = false;
-        let mut expr_var_decls = BumpVec::<G::Decl>::new_in(bump);
-
-        if is_expr {
-            let ecr = p.generate_temp_var(b"_class");
-            expr_class_ref = Some(ecr);
-            let binding = p.b(B::Identifier { r#ref: ecr }, loc);
-            expr_var_decls.push(G::Decl {
-                binding,
-                value: None,
-            });
-            if let Some(cn) = &class.class_name {
-                class_name_ref = cn.ref_;
-                class_name_loc = cn.loc;
-            } else {
-                class_name_ref = ecr;
-                class_name_loc = loc;
-                expr_class_is_anonymous = true;
-                if let Some(name) = name_from_context
-                    && can_be_class_binding_name(name)
-                {
-                    class.class_name = Some(js_ast::LocRef {
-                        ref_: p.new_sym(js_ast::symbol::Kind::Other, name),
-                        loc,
-                    });
-                }
-            }
-        } else {
-            class_name_ref = class.class_name.as_ref().unwrap().ref_;
-            class_name_loc = class.class_name.as_ref().unwrap().loc;
-        }
-
-        let mut inner_class_ref: Ref = class_name_ref;
-        if !is_expr {
-            // SAFETY: original_name is arena-owned for 'a.
-            let cns: &'a [u8] = p.symbols[class_name_ref.inner_index() as usize]
-                .original_name
-                .slice();
-            let name = p.bump_name2(b"_", cns);
-            inner_class_ref = p.generate_temp_var(name);
-        }
-
-        // `ExprNodeList = Vec<Expr>` owns its
-        // buffer, so this MUST be a real ownership transfer; the previous
-        // `ptr::read` left a second owner in the local that dropped at function
-        // exit, freeing the buffer that `E::Array { items }` (Phase-2/5 below)
-        // still pointed at → use-after-poison in `expr_can_be_removed_if_unused`.
-        let mut class_decorators: ExprNodeList =
-            bun_alloc::AstAlloc::take(&mut class.ts_decorators);
-        let class_decorators_len = class_decorators.len_u32() as usize;
-
-        let init_ref = p.generate_temp_var(b"_init");
-        if is_expr {
-            let binding = p.b(B::Identifier { r#ref: init_ref }, loc);
-            expr_var_decls.push(G::Decl {
-                binding,
-                value: None,
-            });
-        }
-
-        let mut base_ref: Option<Ref> = None;
-        if class.extends.is_some() {
-            let br = p.generate_temp_var(b"_base");
-            base_ref = Some(br);
-            if is_expr {
-                let binding = p.b(B::Identifier { r#ref: br }, loc);
-                expr_var_decls.push(G::Decl {
-                    binding,
-                    value: None,
-                });
-            }
-        }
-
-        // ── Phase 2: Pre-evaluate decorators/keys ────────
-        let mut class_dec_ref: Option<Ref> = None;
-        let mut class_dec_stmt: Stmt = Stmt::empty();
-        let mut class_dec_assign_expr: Option<Expr> = None;
-        if class_decorators_len > 0 {
-            let cdr = p.generate_temp_var(b"_dec");
-            class_dec_ref = Some(cdr);
-            // Move ownership into the AST node — `class_decorators` is not read
-            // again on this branch (Phase-5's else-arm only runs when
-            // `class_dec_ref` is `None`, i.e. `class_decorators_len == 0`).
-            let items = bun_alloc::AstAlloc::take(&mut class_decorators);
-            let arr = p.new_expr(
-                E::Array {
-                    items,
-                    ..Default::default()
-                },
-                loc,
-            );
-            if is_expr {
-                let binding = p.b(B::Identifier { r#ref: cdr }, loc);
-                expr_var_decls.push(G::Decl {
-                    binding,
-                    value: None,
-                });
-                class_dec_assign_expr = Some(p.assign_to(cdr, arr, loc));
-            } else {
-                class_dec_stmt = p.var_decl(cdr, Some(arr), loc);
-            }
-        }
-
-        let mut prop_dec_refs: HashMap<usize, Ref> = HashMap::default();
-        let mut computed_key_refs: HashMap<usize, Ref> = HashMap::default();
-        let mut pre_eval_stmts = BumpVec::<Stmt>::new_in(bump);
-
-        let props_slice: &mut [Property] = class.properties.slice_mut();
-        for (prop_idx, prop) in props_slice.iter_mut().enumerate() {
-            if prop.kind == PropertyKind::ClassStaticBlock {
-                continue;
-            }
-            if prop.ts_decorators.len_u32() > 0 {
-                let dec_ref = p.generate_temp_var(b"_dec");
-                prop_dec_refs.insert(prop_idx, dec_ref);
-                // SAFETY: shallow-reborrow arena Vec.
-                let items: ExprNodeList = unsafe { core::ptr::read(&raw const prop.ts_decorators) };
-                let arr = p.new_expr(
-                    E::Array {
-                        items,
-                        ..Default::default()
-                    },
-                    loc,
-                );
-                pre_eval_stmts.push(p.var_decl(dec_ref, Some(arr), loc));
-            }
-            if prop.flags.contains(Flags::Property::IsComputed)
-                && prop.key.is_some()
-                && prop.ts_decorators.len_u32() > 0
-            {
-                let key_ref = p.generate_temp_var(b"_computedKey");
-                computed_key_refs.insert(prop_idx, key_ref);
-                let key_loc = prop.key.expect("infallible: prop has key").loc;
-                pre_eval_stmts.push(p.var_decl(key_ref, prop.key, loc));
-                prop.key = Some(p.use_ref(key_ref, key_loc));
-            }
-        }
-
-        // Replace class name refs in pre-eval expressions for inner binding
-        {
-            let replacement_ref = if is_expr {
-                expr_class_ref.unwrap_or(class_name_ref)
-            } else {
-                inner_class_ref
-            };
-            if !replacement_ref.eql(class_name_ref) {
-                let rk = RewriteKind::ReplaceRef {
-                    old: class_name_ref,
-                    new: replacement_ref,
-                };
-                for pre_stmt in pre_eval_stmts.iter_mut() {
-                    if let js_ast::StmtData::SLocal(local) = &mut pre_stmt.data {
-                        for decl in local.decls.slice_mut() {
-                            if let Some(v) = &mut decl.value {
-                                p.rewrite_expr(v, rk);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // For named class expressions: swap to expr_class_ref for suffix ops
-        let mut original_class_name_for_decorator: Option<&'a [u8]> = None;
-        if is_expr
-            && !expr_class_is_anonymous
-            && let Some(ecr) = expr_class_ref
-        {
-            // SAFETY: see above.
-            original_class_name_for_decorator = Some(
-                p.symbols[class_name_ref.inner_index() as usize]
-                    .original_name
-                    .slice(),
-            );
-            class_name_ref = ecr;
-            class_name_loc = loc;
-        }
-
-        // ── Phase 3: __decoratorStart + base decls ───────
-        let init_start_expr: Expr = {
-            let base_expr = if let Some(br) = base_ref {
-                p.new_expr(
-                    E::Identifier {
-                        ref_: br,
-                        ..Default::default()
-                    },
-                    loc,
-                )
-            } else {
-                p.new_expr(E::Undefined {}, loc)
-            };
-            p.call_rt(loc, b"__decoratorStart", &[base_expr])
-        };
-
-        let mut base_decl_stmt: Stmt = Stmt::empty();
-        if !is_expr {
-            if let Some(br) = base_ref {
-                base_decl_stmt = p.var_decl(br, class.extends, loc);
-            }
-        }
-
-        let base_assign_expr: Option<Expr> = if is_expr && let Some(br) = base_ref {
-            Some(p.assign_to(br, class.extends.unwrap(), loc))
-        } else {
-            None
-        };
-
-        if let Some(br) = base_ref {
-            class.extends = Some(p.use_ref(br, loc));
-        }
-
-        let init_decl_stmt: Stmt = if !is_expr {
-            p.var_decl(init_ref, Some(init_start_expr), loc)
-        } else {
-            Stmt::empty()
-        };
-
-        // ── Phase 4: Property loop ───────────────────────
-        let mut suffix_exprs = BumpVec::<Expr>::new_in(bump);
-        let mut constructor_inject_stmts = BumpVec::<Stmt>::new_in(bump);
-        let mut new_properties = BumpVec::<Property>::new_in(bump);
-        let mut static_non_field_elements = BumpVec::<Expr>::new_in(bump);
-        let mut instance_non_field_elements = BumpVec::<Expr>::new_in(bump);
-        let mut has_static_private_methods = false;
-        let mut has_instance_private_methods = false;
-        let mut static_field_decorate = BumpVec::<Expr>::new_in(bump);
-        let mut instance_field_decorate = BumpVec::<Expr>::new_in(bump);
-        let mut static_accessor_count: usize = 0;
-        let mut instance_accessor_count: usize = 0;
-        let mut static_init_entries = BumpVec::<FieldInitEntry>::new_in(bump);
-        let mut instance_init_entries = BumpVec::<FieldInitEntry>::new_in(bump);
-        let mut static_element_order = BumpVec::<StaticElement>::new_in(bump);
-        let mut extracted_static_blocks =
-            BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
-        let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
-        let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
-        let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
-        let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
-
-        // Pre-scan: determine if all private members need lowering
-        let mut lower_all_private = false;
-        {
-            let mut has_any_private = false;
-            let mut has_any_decorated = false;
-            let cprops: &[Property] = class.properties.slice();
-            for cprop in cprops.iter() {
-                if cprop.kind == PropertyKind::ClassStaticBlock {
-                    continue;
-                }
-                if cprop.ts_decorators.len_u32() > 0 {
-                    has_any_decorated = true;
-                    if cprop.key.is_some()
-                        && matches!(
-                            cprop.key.unwrap().data,
-                            js_ast::ExprData::EPrivateIdentifier(_)
-                        )
-                    {
-                        lower_all_private = true;
-                        break;
-                    }
-                }
-                if cprop.key.is_some()
-                    && matches!(
-                        cprop.key.unwrap().data,
-                        js_ast::ExprData::EPrivateIdentifier(_)
-                    )
-                {
-                    has_any_private = true;
-                }
-            }
-            if !lower_all_private && has_any_private && has_any_decorated {
-                lower_all_private = true;
-            }
-        }
-
-        let props_slice2: &mut [Property] = class.properties.slice_mut();
-        for (prop_idx, prop) in props_slice2.iter_mut().enumerate() {
+        // `__decorateElement` numbers the initializer lists of accessors and
+        // fields in the order it is called: static accessors, instance
+        // accessors, static fields, instance fields.
+        let mut next_initializer = [0usize; 4];
+        let mut has_member_decorators = false;
+        let mut lowered_names: HashMap<u32, ()> = HashMap::default();
+        for prop in class.properties.slice() {
             if prop.ts_decorators.len_u32() == 0 {
-                // ── Non-decorated property ──
-                if lower_all_private
-                    && let Some(nk_expr) = prop.key
-                    && matches!(nk_expr.data, js_ast::ExprData::EPrivateIdentifier(_))
-                    && prop.kind != PropertyKind::ClassStaticBlock
-                    && prop.kind != PropertyKind::AutoAccessor
-                {
-                    let npriv_ref = match &nk_expr.data {
-                        js_ast::ExprData::EPrivateIdentifier(pi) => pi.ref_,
-                        _ => unreachable!(),
-                    };
-                    let npriv_inner = npriv_ref.inner_index();
-                    // SAFETY: arena-owned.
-                    let npriv_orig: &'a [u8] =
-                        p.symbols[npriv_inner as usize].original_name.slice();
-
-                    if prop.flags.contains(Flags::Property::IsMethod) {
-                        // Non-decorated private method/getter/setter → WeakSet + fn extraction
-                        let nk = Self::method_kind(prop);
-                        let existing = private_lowered_map.get(&npriv_inner).copied();
-                        let ws_ref = if let Some(ex) = existing {
-                            ex.storage_ref
-                        } else {
-                            let nm = p.bump_name2(b"_", &npriv_orig[1..]);
-                            p.generate_temp_var(nm)
-                        };
-                        let fn_nm = {
-                            let mut v = BumpVec::<u8>::new_in(bump);
-                            v.push(b'_');
-                            v.extend_from_slice(&npriv_orig[1..]);
-                            v.extend_from_slice(Self::fn_suffix(nk));
-                            v.into_bump_slice()
-                        };
-                        let fn_ref = p.generate_temp_var(fn_nm);
-
-                        let mut new_info =
-                            existing.unwrap_or_else(|| PrivateLoweredInfo::new(ws_ref));
-                        if nk == 1 {
-                            new_info.method_fn_ref = Some(fn_ref);
-                        } else if nk == 2 {
-                            new_info.getter_fn_ref = Some(fn_ref);
-                        } else {
-                            new_info.setter_fn_ref = Some(fn_ref);
-                        }
-                        private_lowered_map.insert(npriv_inner, new_info);
-
-                        if existing.is_none() {
-                            let wse = p.new_weak_set_expr(loc);
-                            prefix_stmts.push(p.var_decl2(ws_ref, Some(wse), fn_ref, None, loc));
-                        } else {
-                            prefix_stmts.push(p.var_decl(fn_ref, None, loc));
-                        }
-
-                        // Assign function: _fn = function() { ... }
-                        let val = prop
-                            .value
-                            .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
-                        let assign = p.assign_to(fn_ref, val, loc);
-                        prefix_stmts.push(p.s(
-                            S::SExpr {
-                                value: assign,
-                                ..Default::default()
-                            },
-                            loc,
-                        ));
-
-                        // __privateAdd (once per name)
-                        if !emitted_private_adds.contains_key(&npriv_inner) {
-                            emitted_private_adds.insert(npriv_inner, ());
-                            p.emit_private_add(
-                                prop.flags.contains(Flags::Property::IsStatic),
-                                ws_ref,
-                                None,
-                                loc,
-                                &mut constructor_inject_stmts,
-                                &mut static_private_add_blocks,
-                            );
-                        }
-                        continue;
-                    } else {
-                        // Non-decorated private field → WeakMap
-                        let wm_nm = p.bump_name2(b"_", &npriv_orig[1..]);
-                        let wm_ref = p.generate_temp_var(wm_nm);
-                        private_lowered_map.insert(npriv_inner, PrivateLoweredInfo::new(wm_ref));
-                        let wme = p.new_weak_map_expr(loc);
-                        prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
-
-                        let init_val = prop
-                            .initializer
-                            .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
-                        let this_e = p.new_expr(E::This {}, loc);
-                        let wm_e = p.use_ref(wm_ref, loc);
-                        let call = p.call_rt(loc, b"__privateAdd", &[this_e, wm_e, init_val]);
-                        if !prop.flags.contains(Flags::Property::IsStatic) {
-                            constructor_inject_stmts.push(p.s(
-                                S::SExpr {
-                                    value: call,
-                                    ..Default::default()
-                                },
-                                loc,
-                            ));
-                        } else {
-                            static_private_add_blocks.push(p.make_static_block(call, loc));
-                        }
-                        continue;
-                    }
+                continue;
+            }
+            has_member_decorators = true;
+            if let Some(key) = prop.key
+                && let js_ast::ExprData::EPrivateIdentifier(private) = &key.data
+            {
+                lowered_names.insert(private.ref_.inner_index(), ());
+            }
+            if let Some(group) = Self::initializer_group(prop) {
+                for later in &mut next_initializer[group + 1..] {
+                    *later += 1;
                 }
-                // Undecorated auto-accessor → WeakMap + getter/setter
-                if prop.kind == PropertyKind::AutoAccessor {
-                    let accessor_name = p.accessor_storage_name(prop.key);
-                    let wm_ref = p.generate_temp_var(accessor_name);
-                    let wme = p.new_weak_map_expr(loc);
-                    prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
+            }
+        }
+        let has_decorators = has_class_decorators || has_member_decorators;
+        let init_ref = if has_decorators {
+            p.declared_temp(b"_init")
+        } else {
+            Ref::NONE
+        };
+        let mut base_ref: Option<Ref> = None;
+        if has_decorators && let Some(extends) = class.extends {
+            let base = p.declared_temp(b"_base");
+            class.extends = Some(p.assign_to(base, extends, extends.loc));
+            base_ref = Some(base);
+        }
 
-                    // Getter: get foo() { return __privateGet(this, _foo); }
-                    let this_e = p.new_expr(E::This {}, loc);
-                    let wm_e = p.use_ref(wm_ref, loc);
-                    let get_ret = p.call_rt(loc, b"__privateGet", &[this_e, wm_e]);
-                    let get_body = bump.alloc_slice_copy(&[p.s(
-                        S::Return {
-                            value: Some(get_ret),
-                        },
-                        loc,
-                    )]);
-                    let get_fn = G::Fn {
-                        body: G::FnBody {
-                            stmts: bun_ast::StoreSlice::new_mut(get_body),
-                            loc,
-                        },
-                        ..Default::default()
-                    };
+        let mut members = BumpVec::<Property>::with_capacity_in(class.properties.len() + 4, bump);
+        let mut key_effects = BumpVec::<Expr>::new_in(bump);
+        let mut instance_effects = BumpVec::<Expr>::new_in(bump);
+        let mut first_instance_host: Option<(usize, FieldName)> = None;
+        let mut last_key_host: Option<(usize, Option<Expr>)> = None;
+        let mut constructor: Option<usize> = None;
+        let mut storage_inits = BumpVec::<Expr>::new_in(bump);
+        let mut static_brands = BumpVec::<Expr>::new_in(bump);
+        let mut instance_brands = BumpVec::<Expr>::new_in(bump);
+        let mut decorate: [BumpVec<'a, Expr>; 4] = [
+            BumpVec::new_in(bump),
+            BumpVec::new_in(bump),
+            BumpVec::new_in(bump),
+            BumpVec::new_in(bump),
+        ];
+        let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
 
-                    // Setter: set foo(v) { __privateSet(this, _foo, v); }
-                    let setter_param_ref = p.new_sym(js_ast::symbol::Kind::Other, b"v");
-                    let this_e2 = p.new_expr(E::This {}, loc);
-                    let wm_e2 = p.use_ref(wm_ref, loc);
-                    let v_e = p.use_ref(setter_param_ref, loc);
-                    let set_call = p.call_rt(loc, b"__privateSet", &[this_e2, wm_e2, v_e]);
-                    let set_body = bump.alloc_slice_copy(&[p.s(
-                        S::SExpr {
-                            value: set_call,
-                            ..Default::default()
-                        },
-                        loc,
-                    )]);
-                    let setter_binding = p.b(
-                        B::Identifier {
-                            r#ref: setter_param_ref,
-                        },
-                        loc,
-                    );
-                    let setter_fn_args = bump.alloc(G::Arg {
-                        binding: setter_binding,
-                        ..Default::default()
-                    });
-                    let set_fn = G::Fn {
-                        args: bun_ast::StoreSlice::new_mut(core::slice::from_mut(setter_fn_args)),
-                        body: G::FnBody {
-                            stmts: bun_ast::StoreSlice::new_mut(set_body),
-                            loc,
-                        },
-                        ..Default::default()
-                    };
-
-                    let mut getter_flags = prop.flags;
-                    getter_flags.insert(Flags::Property::IsMethod);
-                    new_properties.push(Property {
-                        key: prop.key,
-                        value: Some(p.new_expr(E::Function { func: get_fn }, loc)),
-                        kind: PropertyKind::Get,
-                        flags: getter_flags,
-                        ..Default::default()
-                    });
-                    new_properties.push(Property {
-                        key: prop.key,
-                        value: Some(p.new_expr(E::Function { func: set_fn }, loc)),
-                        kind: PropertyKind::Set,
-                        flags: getter_flags,
-                        ..Default::default()
-                    });
-
-                    let init_val = prop
-                        .initializer
-                        .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
-                    if !prop.flags.contains(Flags::Property::IsStatic) {
-                        let this_e3 = p.new_expr(E::This {}, loc);
-                        let wm_e3 = p.use_ref(wm_ref, loc);
-                        let call = p.call_rt(loc, b"__privateAdd", &[this_e3, wm_e3, init_val]);
-                        constructor_inject_stmts.push(p.s(
-                            S::SExpr {
-                                value: call,
-                                ..Default::default()
-                            },
-                            loc,
-                        ));
-                    } else {
-                        let cn_e = p.use_ref(class_name_ref, class_name_loc);
-                        let wm_e3 = p.use_ref(wm_ref, loc);
-                        suffix_exprs.push(p.call_rt(
-                            loc,
-                            b"__privateAdd",
-                            &[cn_e, wm_e3, init_val],
-                        ));
-                    }
-                    continue;
-                }
-                // Static blocks → extract to suffix
-                if prop.kind == PropertyKind::ClassStaticBlock {
-                    if let Some(sb) = prop.class_static_block {
-                        static_element_order.push(StaticElement {
-                            kind: StaticElementKind::Block,
-                            index: extracted_static_blocks.len(),
-                        });
-                        extracted_static_blocks.push(sb);
-                    }
-                    continue;
-                }
-                new_properties.push(prop_full_copy(prop));
+        for slot in class.properties.slice_mut().iter_mut() {
+            let mut prop = core::mem::take(slot);
+            if prop.kind == PropertyKind::ClassStaticBlock {
+                members.push(prop);
                 continue;
             }
 
-            // ── Decorated property ──
-            let mut flags: f64;
-            if prop.flags.contains(Flags::Property::IsMethod) {
-                flags = match prop.kind {
-                    PropertyKind::Get => 2.0,
-                    PropertyKind::Set => 3.0,
-                    _ => 1.0,
-                };
-            } else {
-                flags = match prop.kind {
-                    PropertyKind::AutoAccessor => 4.0,
-                    _ => 5.0,
-                };
+            let key = prop.key.expect("a class member has a key");
+            let private_index = match &key.data {
+                js_ast::ExprData::EPrivateIdentifier(private) => Some(private.ref_.inner_index()),
+                _ => None,
+            };
+            let decorators: ExprNodeList = bun_alloc::AstAlloc::take(&mut prop.ts_decorators);
+            // An undecorated `accessor #x` behaves like the field `#x`.
+            if private_index.is_some()
+                && prop.kind == PropertyKind::AutoAccessor
+                && decorators.len_u32() == 0
+            {
+                prop.kind = PropertyKind::Normal;
             }
-            if prop.flags.contains(Flags::Property::IsStatic) {
-                flags += 8.0;
-            }
-            let key_expr = prop.key.expect("infallible: prop has key");
-            let is_private = matches!(key_expr.data, js_ast::ExprData::EPrivateIdentifier(_));
-            if is_private {
-                flags += 16.0;
-            }
+            let is_static = prop.flags.contains(Flags::Property::IsStatic);
+            let is_method = prop.flags.contains(Flags::Property::IsMethod);
+            let kind: u8 = match prop.kind {
+                PropertyKind::Get => 2,
+                PropertyKind::Set => 3,
+                PropertyKind::AutoAccessor => 4,
+                _ if is_method => 1,
+                _ => 5,
+            };
+            let flags = f64::from(
+                kind + if is_static { 8 } else { 0 } + if private_index.is_some() { 16 } else { 0 },
+            );
+            let group = usize::from(!is_static) + if kind == 5 { 2 } else { 0 };
 
-            let decorator_array = if let Some(dec_ref) = prop_dec_refs.get(&prop_idx).copied() {
-                p.use_ref(dec_ref, loc)
-            } else {
-                // SAFETY: shallow-reborrow arena Vec.
-                let items: ExprNodeList = unsafe { core::ptr::read(&raw const prop.ts_decorators) };
-                p.new_expr(
+            let dec_ref = if decorators.len_u32() > 0 {
+                let dec = p.declared_temp(b"_dec");
+                let list = p.new_expr(
                     E::Array {
-                        items,
+                        items: decorators,
                         ..Default::default()
                     },
                     loc,
-                )
-            };
-
-            let k = (flags as u8) & 7;
-
-            let mut dec_arg_count: usize = 5;
-            let mut private_storage_ref: Option<Ref> = None;
-            let mut private_extra_ref: Option<Ref> = None;
-            let mut private_method_fn_ref: Option<Ref> = None;
-
-            if is_private {
-                let priv_ref = match &key_expr.data {
-                    js_ast::ExprData::EPrivateIdentifier(pi) => pi.ref_,
-                    _ => unreachable!(),
-                };
-                let priv_inner = priv_ref.inner_index();
-                // SAFETY: arena-owned.
-                let private_orig: &'a [u8] = p.symbols[priv_inner as usize].original_name.slice();
-
-                if (1..=3).contains(&k) {
-                    let existing = private_lowered_map.get(&priv_inner).copied();
-                    let ws_ref = if let Some(ex) = existing {
-                        ex.storage_ref
-                    } else {
-                        let nm = p.bump_name2(b"_", &private_orig[1..]);
-                        p.generate_temp_var(nm)
-                    };
-                    private_storage_ref = Some(ws_ref);
-                    let fn_nm = {
-                        let mut v = BumpVec::<u8>::new_in(bump);
-                        v.push(b'_');
-                        v.extend_from_slice(&private_orig[1..]);
-                        v.extend_from_slice(Self::fn_suffix(k));
-                        v.into_bump_slice()
-                    };
-                    let fn_ref = p.generate_temp_var(fn_nm);
-                    private_method_fn_ref = Some(fn_ref);
-
-                    let mut new_info = existing.unwrap_or_else(|| PrivateLoweredInfo::new(ws_ref));
-                    if k == 1 {
-                        new_info.method_fn_ref = Some(fn_ref);
-                    } else if k == 2 {
-                        new_info.getter_fn_ref = Some(fn_ref);
-                    } else {
-                        new_info.setter_fn_ref = Some(fn_ref);
-                    }
-                    private_lowered_map.insert(priv_inner, new_info);
-
-                    if existing.is_none() {
-                        let wse = p.new_weak_set_expr(loc);
-                        prefix_stmts.push(p.var_decl2(ws_ref, Some(wse), fn_ref, None, loc));
-                    } else {
-                        prefix_stmts.push(p.var_decl(fn_ref, None, loc));
-                    }
-                    dec_arg_count = 6;
-                } else if k == 5 {
-                    let nm = p.bump_name2(b"_", &private_orig[1..]);
-                    let wm_ref = p.generate_temp_var(nm);
-                    private_storage_ref = Some(wm_ref);
-                    private_lowered_map.insert(priv_inner, PrivateLoweredInfo::new(wm_ref));
-                    let wme = p.new_weak_map_expr(loc);
-                    prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
-                    dec_arg_count = 5;
-                } else if k == 4 {
-                    let nm = p.bump_name2(b"_", &private_orig[1..]);
-                    let wm_ref = p.generate_temp_var(nm);
-                    private_storage_ref = Some(wm_ref);
-                    let acc_nm = {
-                        let mut v = BumpVec::<u8>::new_in(bump);
-                        v.push(b'_');
-                        v.extend_from_slice(&private_orig[1..]);
-                        v.extend_from_slice(b"_acc");
-                        v.into_bump_slice()
-                    };
-                    let acc_ref = p.generate_temp_var(acc_nm);
-                    private_method_fn_ref = Some(acc_ref);
-                    private_lowered_map.insert(
-                        priv_inner,
-                        PrivateLoweredInfo {
-                            storage_ref: wm_ref,
-                            method_fn_ref: None,
-                            getter_fn_ref: None,
-                            setter_fn_ref: None,
-                            accessor_desc_ref: Some(acc_ref),
-                        },
-                    );
-                    let wme = p.new_weak_map_expr(loc);
-                    prefix_stmts.push(p.var_decl2(wm_ref, Some(wme), acc_ref, None, loc));
-                    dec_arg_count = 6;
-                }
-            } else if k == 4 {
-                // Decorated public auto-accessor → WeakMap
-                let accessor_name = p.accessor_storage_name(Some(key_expr));
-                let wm_ref = p.generate_temp_var(accessor_name);
-                private_extra_ref = Some(wm_ref);
-                let wme = p.new_weak_map_expr(loc);
-                prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
-                dec_arg_count = 6;
-            }
-
-            // Build __decorateElement args
-            let target_ref = if is_expr && let Some(ecr) = expr_class_ref {
-                ecr
-            } else {
-                class_name_ref
-            };
-            let mut dec_args = BumpVec::with_capacity_in(dec_arg_count, bump);
-            dec_args.push(p.new_expr(
-                E::Identifier {
-                    ref_: init_ref,
-                    ..Default::default()
-                },
-                loc,
-            ));
-            dec_args.push(p.new_expr(E::Number::new(flags), loc));
-            dec_args.push(if is_private {
-                let priv_ref = match &key_expr.data {
-                    js_ast::ExprData::EPrivateIdentifier(pi) => pi.ref_,
-                    _ => unreachable!(),
-                };
-                // `original_name` is an arena-owned `StoreStr`.
-                let priv_name = E::Str::new(
-                    p.symbols[priv_ref.inner_index() as usize]
-                        .original_name
-                        .slice(),
                 );
-                p.new_expr(
-                    E::EString {
-                        data: priv_name,
-                        ..Default::default()
-                    },
-                    loc,
-                )
+                key_effects.push(p.assign_to(dec, list, loc));
+                Some(dec)
             } else {
-                key_expr
-            });
-            dec_args.push(decorator_array);
-
-            if is_private && let Some(storage_ref) = private_storage_ref {
-                dec_args.push(p.use_ref(storage_ref, loc));
-                if dec_arg_count == 6 {
-                    if (1..=3).contains(&k) {
-                        dec_args.push(
-                            prop.value
-                                .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc)),
-                        );
-                    } else if k == 4 {
-                        dec_args.push(p.use_ref(storage_ref, loc));
-                    } else {
-                        dec_args.push(p.new_expr(E::Undefined {}, loc));
-                    }
-                }
-            } else {
-                p.record_usage(target_ref);
-                dec_args.push(p.new_expr(
-                    E::Identifier {
-                        ref_: target_ref,
-                        ..Default::default()
-                    },
-                    class_name_loc,
-                ));
-                if dec_arg_count == 6 {
-                    if let Some(extra_ref) = private_extra_ref {
-                        dec_args.push(p.use_ref(extra_ref, loc));
-                    } else {
-                        dec_args.push(p.new_expr(E::Undefined {}, loc));
-                    }
-                }
-            }
-
-            let dec_args_list = ExprNodeList::from_bump_vec(dec_args);
-            let raw_element = p.call_runtime(loc, b"__decorateElement", dec_args_list);
-            let element = if let Some(fn_ref) = private_method_fn_ref {
-                p.assign_to(fn_ref, raw_element, loc)
-            } else {
-                raw_element
+                None
             };
 
-            // Categorize the element
-            if k >= 4 {
-                let mut prop_shallow = prop_copy(prop);
-                if is_private {
-                    if let Some(ps_ref) = private_storage_ref {
-                        prop_shallow.key = Some(p.new_expr(
-                            E::Identifier {
-                                ref_: ps_ref,
-                                ..Default::default()
-                            },
-                            loc,
-                        ));
+            // ── `#private` member of a lowered name ──
+            if let Some(private_index) = private_index
+                && lowered_names.contains_key(&private_index)
+            {
+                let private_name: &'a [u8] =
+                    p.symbols[private_index as usize].original_name.slice();
+                let name_expr = p.new_expr(E::EString::init(private_name), loc);
+                let existing = private_lowered_map.get(&private_index).copied();
+                let storage = if let Some(existing) = existing {
+                    existing.storage_ref
+                } else {
+                    let name = p.bump_name3(b"_", &private_name[1..], b"");
+                    let storage = p.declared_temp(name);
+                    let container =
+                        p.new_global_expr(if is_method { b"WeakSet" } else { b"WeakMap" }, loc);
+                    storage_inits.push(p.assign_to(storage, container, loc));
+                    storage
+                };
+                let mut info = existing.unwrap_or_else(|| PrivateLoweredInfo::new(storage));
+                let storage_expr = p.use_ref(storage, loc);
+
+                if is_method {
+                    if existing.is_none() {
+                        let this = p.new_expr(E::This {}, loc);
+                        let brand = p.call_rt(loc, b"__privateAdd", &[this, storage_expr]);
+                        if is_static {
+                            static_brands.push(brand);
+                        } else {
+                            instance_brands.push(brand);
+                        }
                     }
+                    let (suffix, slot): (&[u8], _) = match kind {
+                        2 => (b"_get", &mut info.getter_fn_ref),
+                        3 => (b"_set", &mut info.setter_fn_ref),
+                        _ => (b"_fn", &mut info.method_fn_ref),
+                    };
+                    let fn_name = p.bump_name3(b"_", &private_name[1..], suffix);
+                    let fn_ref = p.declared_temp(fn_name);
+                    *slot = Some(fn_ref);
+                    private_lowered_map.insert(private_index, info);
+                    let body = prop
+                        .value
+                        .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
+                    if let Some(dec) = dec_ref {
+                        let decorated = p.decorate_element(
+                            init_ref,
+                            flags,
+                            name_expr,
+                            dec,
+                            storage_expr,
+                            Some(body),
+                            loc,
+                        );
+                        decorate[group].push(p.assign_to(fn_ref, decorated, loc));
+                    } else {
+                        storage_inits.push(p.assign_to(fn_ref, body, loc));
+                    }
+                    continue;
                 }
-                if let Some(pe_ref) = private_extra_ref {
-                    prop_shallow.value = Some(p.new_expr(
-                        E::Identifier {
-                            ref_: pe_ref,
-                            ..Default::default()
-                        },
+
+                let mut initializer_index = None;
+                if let Some(dec) = dec_ref {
+                    let extra = (kind == 4).then_some(storage_expr);
+                    let mut decorated = p.decorate_element(
+                        init_ref,
+                        flags,
+                        name_expr,
+                        dec,
+                        storage_expr,
+                        extra,
+                        loc,
+                    );
+                    if kind == 4 {
+                        let name = p.bump_name3(b"_", &private_name[1..], b"_acc");
+                        let descriptor = p.declared_temp(name);
+                        info.accessor_desc_ref = Some(descriptor);
+                        decorated = p.assign_to(descriptor, decorated, loc);
+                    }
+                    decorate[group].push(decorated);
+                    initializer_index = Some((init_ref, next_initializer[group]));
+                    next_initializer[group] += 1;
+                }
+                private_lowered_map.insert(private_index, info);
+                let effects =
+                    p.storage_init_effects(storage, prop.initializer, initializer_index, loc);
+                if is_static {
+                    members.push(p.make_static_block(&effects, loc));
+                } else {
+                    instance_effects.extend_from_slice(&effects);
+                }
+                continue;
+            }
+
+            // ── `accessor x` ──
+            if kind == 4 {
+                let storage_name = p.accessor_storage_name(prop.key);
+                let storage = p.declared_temp(storage_name);
+                let container = p.new_global_expr(b"WeakMap", loc);
+                storage_inits.push(p.assign_to(storage, container, loc));
+
+                // Hosting key effects makes the getter's key computed; the
+                // setter repeats the key as it was.
+                let mut setter_flags = prop.flags;
+                setter_flags.insert(Flags::Property::IsMethod);
+                let (name_expr, key_temp) = p.host_key_effects(&mut prop, &mut key_effects, true);
+                let mut getter_flags = prop.flags;
+                getter_flags.insert(Flags::Property::IsMethod);
+                let getter = p.accessor_getter(storage, loc);
+                last_key_host = Some((members.len(), key_temp));
+                members.push(Property {
+                    key: prop.key,
+                    value: Some(getter),
+                    kind: PropertyKind::Get,
+                    flags: getter_flags,
+                    ..Default::default()
+                });
+                // `__decorateElement` defines a decorated accessor itself: the
+                // getter only holds the key.
+                if dec_ref.is_none() {
+                    let setter = p.accessor_setter(storage, loc);
+                    members.push(Property {
+                        key: Some(name_expr),
+                        value: Some(setter),
+                        kind: PropertyKind::Set,
+                        flags: setter_flags,
+                        ..Default::default()
+                    });
+                }
+
+                let mut initializer_index = None;
+                if let Some(dec) = dec_ref {
+                    let this = p.new_expr(E::This {}, loc);
+                    let storage_expr = p.use_ref(storage, loc);
+                    decorate[group].push(p.decorate_element(
+                        init_ref,
+                        flags,
+                        name_expr,
+                        dec,
+                        this,
+                        Some(storage_expr),
                         loc,
                     ));
+                    initializer_index = Some((init_ref, next_initializer[group]));
+                    next_initializer[group] += 1;
                 }
-
-                let is_accessor = k == 4;
-                let init_entry = FieldInitEntry {
-                    prop: prop_shallow,
-                    is_private,
-                    is_accessor,
-                };
-
-                if prop.flags.contains(Flags::Property::IsStatic) {
-                    if is_accessor {
-                        static_non_field_elements.push(element);
-                        static_accessor_count += 1;
-                    } else {
-                        static_field_decorate.push(element);
-                    }
-                    static_element_order.push(StaticElement {
-                        kind: StaticElementKind::FieldOrAccessor,
-                        index: static_init_entries.len(),
-                    });
-                    static_init_entries.push(init_entry);
+                let effects =
+                    p.storage_init_effects(storage, prop.initializer, initializer_index, loc);
+                if is_static {
+                    members.push(p.make_static_block(&effects, loc));
                 } else {
-                    if is_accessor {
-                        instance_non_field_elements.push(element);
-                        instance_accessor_count += 1;
-                    } else {
-                        instance_field_decorate.push(element);
-                    }
-                    instance_init_entries.push(init_entry);
+                    instance_effects.extend_from_slice(&effects);
                 }
-            } else if is_private && private_storage_ref.is_some() {
-                let priv_inner2 = match &key_expr.data {
-                    js_ast::ExprData::EPrivateIdentifier(pi) => pi.ref_.inner_index(),
-                    _ => unreachable!(),
-                };
-                if !emitted_private_adds.contains_key(&priv_inner2) {
-                    emitted_private_adds.insert(priv_inner2, ());
-                    p.emit_private_add(
-                        prop.flags.contains(Flags::Property::IsStatic),
-                        private_storage_ref.unwrap(),
-                        None,
+                continue;
+            }
+
+            // ── Members that stay as written ──
+            let mut field_name = FieldName::Unknown;
+            let mut name_expr = key;
+            if Self::is_constructor(&prop) {
+                constructor = Some(members.len());
+            } else if let Some(private_index) = private_index {
+                let name: &'a [u8] = p.symbols[private_index as usize].original_name.slice();
+                field_name = FieldName::Private(p.new_expr(E::EString::init(name), loc));
+            } else {
+                // Only a field that may carry effects has to name its function itself.
+                let names_function = !is_method
+                    && !is_static
+                    && (!instance_effects.is_empty() || first_instance_host.is_none())
+                    && prop
+                        .initializer
+                        .is_some_and(|value| value.is_anonymous_named());
+                let key_temp;
+                (name_expr, key_temp) = p.host_key_effects(
+                    &mut prop,
+                    &mut key_effects,
+                    dec_ref.is_some() || names_function,
+                );
+                last_key_host = Some((members.len(), key_temp));
+                if Self::is_constant_key(&name_expr) {
+                    field_name = FieldName::Key(name_expr);
+                } else if names_function {
+                    field_name = FieldName::Computed(name_expr);
+                }
+            }
+
+            let mut extra_initializer: Option<Expr> = None;
+            if let Some(dec) = dec_ref {
+                let this = p.new_expr(E::This {}, loc);
+                decorate[group]
+                    .push(p.decorate_element(init_ref, flags, name_expr, dec, this, None, loc));
+                if !is_method {
+                    let (value, extra) = p.decorated_initializer(
+                        init_ref,
+                        next_initializer[group],
+                        prop.initializer,
                         loc,
-                        &mut constructor_inject_stmts,
-                        &mut static_private_add_blocks,
                     );
+                    next_initializer[group] += 1;
+                    prop.initializer = Some(value);
+                    extra_initializer = Some(extra);
                 }
-                if prop.flags.contains(Flags::Property::IsStatic) {
-                    static_non_field_elements.push(element);
-                    has_static_private_methods = true;
-                } else {
-                    instance_non_field_elements.push(element);
-                    has_instance_private_methods = true;
+            }
+
+            if !is_method && !is_static {
+                if !instance_effects.is_empty() {
+                    instance_effects.push(p.hosted_initializer(prop.initializer, field_name, loc));
+                    prop.initializer = Some(Expr::join_all_with_comma(&instance_effects));
+                    instance_effects.clear();
                 }
-            } else {
-                let new_prop = prop_copy(prop);
-                new_properties.push(new_prop);
-                if prop.flags.contains(Flags::Property::IsStatic) {
-                    static_non_field_elements.push(element);
+                first_instance_host.get_or_insert((members.len(), field_name));
+            }
+            members.push(prop);
+            if let Some(extra) = extra_initializer {
+                if is_static {
+                    members.push(p.make_static_block(&[extra], loc));
                 } else {
-                    instance_non_field_elements.push(element);
+                    instance_effects.push(extra);
                 }
             }
         }
 
-        // ── Phase 5: Rewrite private accesses ────────────
-        if !private_lowered_map.is_empty() {
-            for nprop in new_properties.iter_mut() {
-                if let Some(v) = &mut nprop.value {
-                    p.rewrite_private_accesses_in_expr(v, &private_lowered_map);
-                }
-                if let Some(sb) = nprop.class_static_block_mut() {
-                    p.rewrite_private_accesses_in_stmts(sb.stmts.slice_mut(), &private_lowered_map);
-                }
+        // ── Decorator lists written after the last key that can hold them ──
+        let mut leading = BumpVec::<Expr>::new_in(bump);
+        if !key_effects.is_empty() {
+            if let Some((host, key_temp)) = last_key_host {
+                p.append_key_effects(&mut members[host], &key_effects, key_temp);
+            } else {
+                // No member has a key: `static [(lists, "__decorators")]() {}`,
+                // deleted before anything can see it.
+                let key = p.new_expr(E::EString::from_static(b"__decorators"), loc);
+                key_effects.push(key);
+                let mut flags = Flags::PropertySet::from(Flags::Property::IsMethod);
+                flags.insert(Flags::Property::IsStatic);
+                flags.insert(Flags::Property::IsComputed);
+                members.push(Property {
+                    key: Some(Expr::join_all_with_comma(&key_effects)),
+                    value: Some(p.new_expr(
+                        E::Function {
+                            func: G::Fn::default(),
+                        },
+                        loc,
+                    )),
+                    flags,
+                    ..Default::default()
+                });
+                let this = p.new_expr(E::This {}, loc);
+                let member = p.new_expr(
+                    E::Index {
+                        target: this,
+                        index: key,
+                        optional_chain: None,
+                        is_import_property_use: false,
+                    },
+                    loc,
+                );
+                leading.push(p.new_expr(
+                    E::Unary {
+                        op: js_ast::OpCode::UnDelete,
+                        value: member,
+                        flags:
+                            E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                    },
+                    loc,
+                ));
             }
-            for entry in instance_init_entries.iter_mut() {
-                if let Some(ini) = &mut entry.prop.initializer {
-                    p.rewrite_private_accesses_in_expr(ini, &private_lowered_map);
-                }
-            }
-            for entry in static_init_entries.iter_mut() {
-                if let Some(ini) = &mut entry.prop.initializer {
-                    p.rewrite_private_accesses_in_expr(ini, &private_lowered_map);
-                }
-            }
-            for sb_ptr in extracted_static_blocks.iter_mut() {
-                // `StoreRef::DerefMut` — arena-owned, safe under the StoreRef invariant.
-                let sb = &mut **sb_ptr;
-                p.rewrite_private_accesses_in_stmts(sb.stmts.slice_mut(), &private_lowered_map);
-            }
-            for elem in static_non_field_elements.iter_mut() {
-                p.rewrite_private_accesses_in_expr(elem, &private_lowered_map);
-            }
-            for elem in instance_non_field_elements.iter_mut() {
-                p.rewrite_private_accesses_in_expr(elem, &private_lowered_map);
-            }
-            for elem in static_field_decorate.iter_mut() {
-                p.rewrite_private_accesses_in_expr(elem, &private_lowered_map);
-            }
-            for elem in instance_field_decorate.iter_mut() {
-                p.rewrite_private_accesses_in_expr(elem, &private_lowered_map);
-            }
-            p.rewrite_private_accesses_in_stmts(&mut pre_eval_stmts, &private_lowered_map);
-            p.rewrite_private_accesses_in_stmts(&mut prefix_stmts, &private_lowered_map);
         }
 
-        // ── Phase 6: Emit suffix ─────────────────────────
-        let static_field_count = static_field_decorate.len();
-        let total_accessor_count = static_accessor_count + instance_accessor_count;
-        let static_field_base_idx = total_accessor_count;
-        let instance_accessor_base_idx = static_accessor_count;
-        let instance_field_base_idx = total_accessor_count + static_field_count;
-
-        suffix_exprs.extend_from_slice(&static_non_field_elements);
-        suffix_exprs.extend_from_slice(&instance_non_field_elements);
-        suffix_exprs.extend_from_slice(&static_field_decorate);
-        suffix_exprs.extend_from_slice(&instance_field_decorate);
-
-        // 5: Class decorator
-        if class_decorators_len > 0 {
-            p.record_usage(class_name_ref);
-            let class_name_str: E::Str = if let Some(name) = original_class_name_for_decorator {
-                name.into()
-            } else if is_expr && expr_class_is_anonymous {
-                name_from_context.unwrap_or(b"").into()
-            } else {
-                // `original_name` is an arena-owned `StoreStr`.
-                E::Str::new(
-                    p.symbols[class_name_ref.inner_index() as usize]
-                        .original_name
-                        .slice(),
-                )
+        // ── The leading static block ──
+        leading.extend_from_slice(&storage_inits);
+        leading.extend_from_slice(&static_brands);
+        let mut before: Option<Expr> = None;
+        let mut decorated_class: Option<(Ref, Expr)> = None;
+        if has_decorators {
+            let base = match base_ref {
+                Some(base) => p.use_ref(base, loc),
+                None => p.new_expr(E::Undefined {}, loc),
             };
-
-            let mut cls_dec_args = BumpVec::with_capacity_in(5, bump);
-            cls_dec_args.push(p.new_expr(
-                E::Identifier {
-                    ref_: init_ref,
-                    ..Default::default()
-                },
-                loc,
-            ));
-            cls_dec_args.push(p.new_expr(E::Number::new(0.0), loc));
-            cls_dec_args.push(p.new_expr(
-                E::EString {
-                    data: class_name_str,
-                    ..Default::default()
-                },
-                loc,
-            ));
-            cls_dec_args.push(if let Some(cdr) = class_dec_ref {
-                p.use_ref(cdr, loc)
-            } else {
-                // `class_dec_ref` is `None` ⇒ `class_decorators_len == 0`, so
-                // this is an empty list. Still `take` (not `ptr::read`) so the
-                // local can never own a second copy of a live buffer.
-                let items = bun_alloc::AstAlloc::take(&mut class_decorators);
-                p.new_expr(
+            let start = p.call_rt(loc, b"__decoratorStart", &[base]);
+            leading.push(p.assign_to(init_ref, start, loc));
+            let has_static_method_decorators = !decorate[0].is_empty();
+            for group in &decorate {
+                leading.extend_from_slice(group);
+            }
+            if has_class_decorators {
+                let dec = p.declared_temp(b"_dec");
+                let list = p.new_expr(
                     E::Array {
-                        items,
+                        items: class_decorators,
                         ..Default::default()
                     },
                     loc,
-                )
-            });
-            cls_dec_args.push(if is_expr {
-                p.use_ref(expr_class_ref.unwrap(), loc)
+                );
+                before = Some(p.assign_to(dec, list, loc));
+                let name: &'a [u8] = match &class.class_name {
+                    Some(name) => p.symbols[name.ref_.inner_index() as usize]
+                        .original_name
+                        .slice(),
+                    None => name_from_context.unwrap_or(b""),
+                };
+                let decorated_ref = p.declared_temp(if js_lexer::is_identifier(name) {
+                    p.bump_name3(b"_", name, b"")
+                } else {
+                    b"_class"
+                });
+                let this = p.new_expr(E::This {}, loc);
+                let name = p.new_expr(E::EString::init(name), loc);
+                let decorated = p.decorate_element(init_ref, 0.0, name, dec, this, None, loc);
+                leading.push(p.assign_to(decorated_ref, decorated, loc));
+                // Runs once the class is bound to its name, which an initializer
+                // may refer to.
+                let decorated = p.use_ref(decorated_ref, loc);
+                decorated_class = Some((
+                    decorated_ref,
+                    p.run_initializers(init_ref, 1.0, decorated, loc),
+                ));
             } else {
-                p.new_expr(
-                    E::Identifier {
-                        ref_: class_name_ref,
-                        ..Default::default()
-                    },
-                    class_name_loc,
-                )
-            });
-
-            let cls_dec_list = ExprNodeList::from_bump_vec(cls_dec_args);
-            let dec_call = p.call_runtime(loc, b"__decorateElement", cls_dec_list);
-            suffix_exprs.push(p.assign_to(class_name_ref, dec_call, class_name_loc));
+                let args = [p.use_ref(init_ref, loc), p.new_expr(E::This {}, loc)];
+                leading.push(p.call_rt(loc, b"__decoratorMetadata", &args));
+            }
+            if has_static_method_decorators {
+                let this = p.new_expr(E::This {}, loc);
+                leading.push(p.run_initializers(init_ref, 3.0, this, loc));
+            }
         }
 
-        // 6: Static method extra initializers
-        if !static_non_field_elements.is_empty() || has_static_private_methods {
-            let i_e = p.use_ref(init_ref, loc);
-            let n_e = p.new_expr(E::Number::new(3.0), loc);
-            let c_e = p.use_ref(class_name_ref, class_name_loc);
-            suffix_exprs.push(p.call_rt(loc, b"__runInitializers", &[i_e, n_e, c_e]));
+        // ── What runs before the first instance field ──
+        let mut instance_prologue = instance_brands;
+        if !decorate[1].is_empty() {
+            let this = p.new_expr(E::This {}, loc);
+            instance_prologue.push(p.run_initializers(init_ref, 5.0, this, loc));
+        }
+        let mut constructor_effects = BumpVec::<Expr>::new_in(bump);
+        if let Some((host, field_name)) = first_instance_host {
+            if !instance_prologue.is_empty() {
+                let host = &mut members[host];
+                instance_prologue.push(p.hosted_initializer(host.initializer, field_name, loc));
+                host.initializer = Some(Expr::join_all_with_comma(&instance_prologue));
+            }
+        } else {
+            constructor_effects.extend_from_slice(&instance_prologue);
+        }
+        constructor_effects.extend_from_slice(&instance_effects);
+
+        let mut leading = (!leading.is_empty()).then(|| p.make_static_block(&leading, loc));
+        if !private_lowered_map.is_empty() {
+            for member in members.iter_mut().chain(leading.as_mut()) {
+                p.rewrite_private_accesses_in_property(member, &private_lowered_map);
+            }
+            for effect in constructor_effects.iter_mut() {
+                p.rewrite_private_accesses_in_expr(effect, &private_lowered_map);
+            }
         }
 
-        // 7: Static elements in source order
-        {
-            let mut s_accessor_idx: usize = 0;
-            let mut s_field_idx: usize = 0;
-            for elem in static_element_order.iter() {
-                match elem.kind {
-                    StaticElementKind::Block => {
-                        // `StoreRef::DerefMut` — arena-owned, safe under the StoreRef invariant.
-                        let sb = &mut *extracted_static_blocks[elem.index];
-                        let stmts_slice = sb.stmts.slice_mut();
-                        p.rewrite_stmts(
-                            stmts_slice,
-                            RewriteKind::ReplaceThis {
-                                ref_: class_name_ref,
-                                loc: class_name_loc,
-                            },
-                        );
-
-                        let all_exprs = stmts_slice
-                            .iter()
-                            .all(|s| matches!(s.data, js_ast::StmtData::SExpr(_)));
-
-                        if all_exprs {
-                            for sb_stmt in stmts_slice.iter() {
-                                match &sb_stmt.data {
-                                    js_ast::StmtData::SExpr(s) => suffix_exprs.push(s.value),
-                                    _ => unreachable!(),
-                                }
-                            }
-                        } else {
-                            // Wrap in IIFE
-                            let stmts_ptr = bun_ast::StoreSlice::new_mut(stmts_slice);
-                            let iife_body = p.new_expr(
-                                E::Arrow {
-                                    body: G::FnBody {
-                                        loc,
-                                        stmts: stmts_ptr,
-                                    },
-                                    is_async: false,
-                                    ..Default::default()
-                                },
-                                loc,
-                            );
-                            suffix_exprs.push(p.new_expr(
-                                E::Call {
-                                    target: iife_body,
-                                    args: bun_alloc::AstAlloc::vec(),
-                                    ..Default::default()
-                                },
-                                loc,
-                            ));
-                        }
-                    }
-                    StaticElementKind::FieldOrAccessor => {
-                        let entry = &static_init_entries[elem.index];
-                        let field_idx: usize = if entry.is_accessor {
-                            let idx = s_accessor_idx;
-                            s_accessor_idx += 1;
-                            idx
-                        } else {
-                            let idx = static_field_base_idx + s_field_idx;
-                            s_field_idx += 1;
-                            idx
-                        };
-
-                        let mut run_args = BumpVec::with_capacity_in(4, bump);
-                        run_args.push(p.use_ref(init_ref, loc));
-                        run_args.push(p.new_expr(E::Number::new(Self::init_flag(field_idx)), loc));
-                        run_args.push(p.use_ref(class_name_ref, class_name_loc));
-                        if let Some(init_val) = entry.prop.initializer {
-                            run_args.push(init_val);
-                        }
-                        let run_args_list = ExprNodeList::from_bump_vec(run_args);
-                        let run_init_call =
-                            p.call_runtime(loc, b"__runInitializers", run_args_list);
-
-                        if entry.is_accessor || entry.is_private {
-                            let wm_ref_expr = if entry.is_accessor && !entry.is_private {
-                                entry.prop.value.expect("infallible: prop has value")
-                            } else {
-                                entry.prop.key.expect("infallible: prop has key")
-                            };
-                            let cn_e = p.use_ref(class_name_ref, class_name_loc);
-                            suffix_exprs.push(p.call_rt(
-                                loc,
-                                b"__privateAdd",
-                                &[cn_e, wm_ref_expr, run_init_call],
-                            ));
-                        } else {
-                            let cn_e = p.use_ref(class_name_ref, class_name_loc);
-                            let assign_target = p.member_target(cn_e, &entry.prop);
-                            suffix_exprs.push(Expr::assign(assign_target, run_init_call));
-                        }
-
-                        // Extra initializer
-                        let i_e = p.use_ref(init_ref, loc);
-                        let n_e = p.new_expr(E::Number::new(Self::extra_init_flag(field_idx)), loc);
-                        let c_e = p.use_ref(class_name_ref, class_name_loc);
-                        suffix_exprs.push(p.call_rt(loc, b"__runInitializers", &[i_e, n_e, c_e]));
-                    }
+        let mut new_constructor = None;
+        if !constructor_effects.is_empty() {
+            match constructor {
+                Some(constructor) => {
+                    p.run_after_super(&mut members[constructor], &constructor_effects, loc);
+                }
+                None => {
+                    new_constructor =
+                        Some(p.new_constructor(class.extends.is_some(), &constructor_effects, loc));
                 }
             }
         }
 
-        // 8: Class extra initializers
-        if class_decorators_len > 0 {
-            let i_e = p.use_ref(init_ref, loc);
-            let n_e = p.new_expr(E::Number::new(1.0), loc);
-            let c_e = p.use_ref(class_name_ref, class_name_loc);
-            suffix_exprs.push(p.call_rt(loc, b"__runInitializers", &[i_e, n_e, c_e]));
-        }
+        let mut properties = BumpVec::<Property>::with_capacity_in(members.len() + 2, bump);
+        properties.extend(new_constructor);
+        properties.extend(leading);
+        properties.extend(members);
+        class.properties = bun_ast::StoreSlice::from_bump(properties);
+        class.has_decorators = false;
+        class.should_lower_standard_decorators = false;
 
-        // 9: __decoratorMetadata
+        LoweredClass {
+            temps: p.drain_capture_temp_decls(temps_before, loc),
+            before,
+            decorated: decorated_class,
+        }
+    }
+
+    /// A temporary the `var` next to the class declares.
+    fn declared_temp(&mut self, name: &'a [u8]) -> Ref {
+        let ref_ = self.generate_temp_var(name);
+        self.temp_refs_to_declare.push(TempRef { r#ref: ref_ });
+        ref_
+    }
+
+    fn is_constructor(prop: &Property) -> bool {
+        prop.flags.contains(Flags::Property::IsMethod)
+            && !prop.flags.contains(Flags::Property::IsStatic)
+            && !prop.flags.contains(Flags::Property::IsComputed)
+            && matches!(
+                prop.key.map(|key| key.data),
+                Some(js_ast::ExprData::EString(s)) if s.eql_comptime(b"constructor")
+            )
+    }
+
+    /// A key whose evaluation cannot be observed, so it can be repeated.
+    fn is_constant_key(key: &Expr) -> bool {
+        matches!(
+            key.data,
+            js_ast::ExprData::EString(_) | js_ast::ExprData::ENumber(_)
+        )
+    }
+
+    /// Which initializer list of `__decorateElement` a decorated accessor or
+    /// field gets: static accessors, instance accessors, static fields,
+    /// instance fields.
+    fn initializer_group(prop: &Property) -> Option<usize> {
+        let instance = usize::from(!prop.flags.contains(Flags::Property::IsStatic));
+        if prop.kind == PropertyKind::AutoAccessor {
+            Some(instance)
+        } else if prop.flags.contains(Flags::Property::IsMethod) {
+            None
+        } else {
+            Some(2 + instance)
+        }
+    }
+
+    /// `__decorateElement(_init, flags, name, _dec, target[, extra])`
+    fn decorate_element(
+        &mut self,
+        init_ref: Ref,
+        flags: f64,
+        name: Expr,
+        dec: Ref,
+        target: Expr,
+        extra: Option<Expr>,
+        loc: bun_ast::Loc,
+    ) -> Expr {
+        let mut args = BumpVec::<Expr>::with_capacity_in(6, self.arena);
+        args.push(self.use_ref(init_ref, loc));
+        args.push(self.new_expr(E::Number::new(flags), loc));
+        args.push(name);
+        args.push(self.use_ref(dec, loc));
+        args.push(target);
+        args.extend(extra);
+        self.call_runtime(loc, b"__decorateElement", ExprNodeList::from_bump_vec(args))
+    }
+
+    /// `__runInitializers(_init, flags, target)`
+    fn run_initializers(
+        &mut self,
+        init_ref: Ref,
+        flags: f64,
+        target: Expr,
+        loc: bun_ast::Loc,
+    ) -> Expr {
+        let args = [
+            self.use_ref(init_ref, loc),
+            self.new_expr(E::Number::new(flags), loc),
+            target,
+        ];
+        self.call_rt(loc, b"__runInitializers", &args)
+    }
+
+    /// Moves `effects` into the key of `prop` so they run where the member is
+    /// defined. Returns the key as `__decorateElement` names it; `reuse_key`
+    /// keeps a computed key in a temporary for that, which is also returned.
+    fn host_key_effects(
+        &mut self,
+        prop: &mut Property,
+        effects: &mut BumpVec<'a, Expr>,
+        reuse_key: bool,
+    ) -> (Expr, Option<Expr>) {
+        let key = prop.key.expect("a class member has a key");
+        let is_constant =
+            !prop.flags.contains(Flags::Property::IsComputed) || Self::is_constant_key(&key);
+        if !is_constant && reuse_key {
+            let key_ref = self.declared_temp(b"_computedKey");
+            effects.push(self.assign_to(key_ref, key, key.loc));
+            prop.key = Some(Expr::join_all_with_comma(effects));
+            effects.clear();
+            let key_temp = self.use_ref(key_ref, key.loc);
+            return (key_temp, Some(key_temp));
+        }
+        if !effects.is_empty() {
+            effects.push(key);
+            prop.key = Some(Expr::join_all_with_comma(effects));
+            prop.flags.insert(Flags::Property::IsComputed);
+            effects.clear();
+        }
+        (key, None)
+    }
+
+    /// Runs `effects` right after the key of `prop` is evaluated. `key_temp`
+    /// is the temporary `host_key_effects` left the key in.
+    fn append_key_effects(
+        &mut self,
+        prop: &mut Property,
+        effects: &[Expr],
+        key_temp: Option<Expr>,
+    ) {
+        let key = prop.key.expect("a class member has a key");
+        let mut parts = BumpVec::<Expr>::with_capacity_in(effects.len() + 2, self.arena);
+        if let Some(key_temp) = key_temp {
+            parts.push(key);
+            parts.extend_from_slice(effects);
+            parts.push(key_temp);
+        } else if !prop.flags.contains(Flags::Property::IsComputed) || Self::is_constant_key(&key) {
+            parts.extend_from_slice(effects);
+            parts.push(key);
+        } else if let js_ast::ExprData::EBinary(comma) = &key.data
+            && comma.op == js_ast::OpCode::BinComma
+            && Self::is_constant_key(&comma.right)
         {
-            let i_e = p.use_ref(init_ref, loc);
-            let c_e = p.use_ref(class_name_ref, class_name_loc);
-            suffix_exprs.push(p.call_rt(loc, b"__decoratorMetadata", &[i_e, c_e]));
+            parts.push(comma.left);
+            parts.extend_from_slice(effects);
+            parts.push(comma.right);
+        } else {
+            let key_ref = self.declared_temp(b"_computedKey");
+            parts.push(self.assign_to(key_ref, key, key.loc));
+            parts.extend_from_slice(effects);
+            parts.push(self.use_ref(key_ref, key.loc));
         }
+        prop.key = Some(Expr::join_all_with_comma(&parts));
+        prop.flags.insert(Flags::Property::IsComputed);
+    }
 
-        // ── Phase 7: Constructor injection ───────────────
-        if !instance_non_field_elements.is_empty() || has_instance_private_methods {
-            let i_e = p.use_ref(init_ref, loc);
-            let n_e = p.new_expr(E::Number::new(5.0), loc);
-            let t_e = p.new_expr(E::This {}, loc);
-            let call = p.call_rt(loc, b"__runInitializers", &[i_e, n_e, t_e]);
-            constructor_inject_stmts.push(p.s(
+    /// The initializer of a field that is about to go behind a comma. There an
+    /// anonymous function or class is not named by the field any more.
+    fn hosted_initializer(
+        &mut self,
+        initializer: Option<Expr>,
+        field_name: FieldName,
+        loc: bun_ast::Loc,
+    ) -> Expr {
+        let Some(value) = initializer else {
+            return self.new_expr(E::Undefined {}, loc);
+        };
+        if !value.is_anonymous_named() {
+            return value;
+        }
+        match field_name {
+            FieldName::Unknown => value,
+            // `__name` would overwrite a `static name` of a class.
+            FieldName::Private(_) if matches!(value.data, js_ast::ExprData::EClass(_)) => value,
+            FieldName::Private(name) => self.call_rt(value.loc, b"__name", &[value, name]),
+            // `{ key: value }[key]` names it as the field would.
+            FieldName::Key(key) | FieldName::Computed(key) => {
+                let mut flags = Flags::PROPERTY_NONE;
+                if matches!(field_name, FieldName::Computed(_))
+                    || matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"__proto__"))
+                {
+                    flags.insert(Flags::Property::IsComputed);
+                }
+                let mut properties = bun_alloc::AstAlloc::vec();
+                VecExt::append(
+                    &mut properties,
+                    Property {
+                        key: Some(key),
+                        value: Some(value),
+                        flags,
+                        ..Default::default()
+                    },
+                );
+                let object = self.new_expr(
+                    E::Object {
+                        properties,
+                        is_single_line: true,
+                        ..Default::default()
+                    },
+                    value.loc,
+                );
+                self.new_expr(
+                    E::Index {
+                        target: object,
+                        index: key,
+                        optional_chain: None,
+                        is_import_property_use: false,
+                    },
+                    value.loc,
+                )
+            }
+        }
+    }
+
+    /// `__runInitializers(_init, n, this, initializer)` for the value of a
+    /// decorated field or accessor, and the call that runs the extra
+    /// initializers once it is defined.
+    fn decorated_initializer(
+        &mut self,
+        init_ref: Ref,
+        index: usize,
+        initializer: Option<Expr>,
+        loc: bun_ast::Loc,
+    ) -> (Expr, Expr) {
+        let mut args = BumpVec::<Expr>::with_capacity_in(4, self.arena);
+        args.push(self.use_ref(init_ref, loc));
+        args.push(self.new_expr(E::Number::new(((4 + 2 * index) << 1) as f64), loc));
+        args.push(self.new_expr(E::This {}, loc));
+        args.extend(initializer);
+        let value = self.call_runtime(loc, b"__runInitializers", ExprNodeList::from_bump_vec(args));
+        let this = self.new_expr(E::This {}, loc);
+        let extra = self.run_initializers(init_ref, (((5 + 2 * index) << 1) | 1) as f64, this, loc);
+        (value, extra)
+    }
+
+    /// `__privateAdd(this, storage, initializer)`. `decorated` is the
+    /// `_init` temporary and the index of the member's initializer list.
+    fn storage_init_effects(
+        &mut self,
+        storage: Ref,
+        initializer: Option<Expr>,
+        decorated: Option<(Ref, usize)>,
+        loc: bun_ast::Loc,
+    ) -> BumpVec<'a, Expr> {
+        let mut effects = BumpVec::<Expr>::with_capacity_in(2, self.arena);
+        let (value, extra) = match decorated {
+            Some((init_ref, index)) => {
+                let (value, extra) = self.decorated_initializer(init_ref, index, initializer, loc);
+                (value, Some(extra))
+            }
+            None => (
+                initializer.unwrap_or_else(|| self.new_expr(E::Undefined {}, loc)),
+                None,
+            ),
+        };
+        let this = self.new_expr(E::This {}, loc);
+        let storage = self.use_ref(storage, loc);
+        effects.push(self.call_rt(loc, b"__privateAdd", &[this, storage, value]));
+        effects.extend(extra);
+        effects
+    }
+
+    /// `function() { return __privateGet(this, storage) }`
+    fn accessor_getter(&mut self, storage: Ref, loc: bun_ast::Loc) -> Expr {
+        let this = self.new_expr(E::This {}, loc);
+        let storage = self.use_ref(storage, loc);
+        let get = self.call_rt(loc, b"__privateGet", &[this, storage]);
+        let body = self
+            .arena
+            .alloc_slice_copy(&[self.s(S::Return { value: Some(get) }, loc)]);
+        let func = G::Fn {
+            body: G::FnBody {
+                stmts: bun_ast::StoreSlice::new_mut(body),
+                loc,
+            },
+            ..Default::default()
+        };
+        self.new_expr(E::Function { func }, loc)
+    }
+
+    /// `function(v) { __privateSet(this, storage, v) }`
+    fn accessor_setter(&mut self, storage: Ref, loc: bun_ast::Loc) -> Expr {
+        let param = self.new_sym(js_ast::symbol::Kind::Other, b"v");
+        let this = self.new_expr(E::This {}, loc);
+        let storage = self.use_ref(storage, loc);
+        let value = self.use_ref(param, loc);
+        let set = self.call_rt(loc, b"__privateSet", &[this, storage, value]);
+        let body = self.effect_stmts(&[set], loc);
+        let arg = self.arena.alloc(G::Arg {
+            binding: self.b(B::Identifier { r#ref: param }, loc),
+            ..Default::default()
+        });
+        let func = G::Fn {
+            args: bun_ast::StoreSlice::new_mut(core::slice::from_mut(arg)),
+            body: G::FnBody {
+                stmts: bun_ast::StoreSlice::from_bump(body),
+                loc,
+            },
+            ..Default::default()
+        };
+        self.new_expr(E::Function { func }, loc)
+    }
+
+    fn effect_stmts(&mut self, effects: &[Expr], loc: bun_ast::Loc) -> BumpVec<'a, Stmt> {
+        let mut stmts = BumpVec::<Stmt>::with_capacity_in(effects.len(), self.arena);
+        for effect in effects {
+            stmts.push(self.s(
+                S::SExpr {
+                    value: *effect,
+                    ..Default::default()
+                },
+                loc,
+            ));
+        }
+        stmts
+    }
+
+    /// Runs `effects` in `constructor` right after a top-level `super()`
+    /// statement returns, which is after the last instance field.
+    fn run_after_super(&mut self, constructor: &mut Property, effects: &[Expr], loc: bun_ast::Loc) {
+        let func = match &mut constructor.value.as_mut().unwrap().data {
+            js_ast::ExprData::EFunction(f) => &mut **f,
+            _ => unreachable!(),
+        };
+        let body: &[Stmt] = func.func.body.stmts.slice();
+        let after_super = body
+            .iter()
+            .position(|stmt| stmt.is_super_call())
+            .map_or(0, |i| i + 1);
+        let mut stmts = BumpVec::<Stmt>::with_capacity_in(body.len() + effects.len(), self.arena);
+        stmts.extend_from_slice(&body[..after_super]);
+        stmts.extend(self.effect_stmts(effects, loc));
+        stmts.extend_from_slice(&body[after_super..]);
+        func.func.body.stmts = bun_ast::StoreSlice::from_bump(stmts);
+    }
+
+    /// `constructor() { super(...arguments); effects }`
+    fn new_constructor(
+        &mut self,
+        is_derived: bool,
+        effects: &[Expr],
+        loc: bun_ast::Loc,
+    ) -> Property {
+        let mut stmts = BumpVec::<Stmt>::with_capacity_in(effects.len() + 1, self.arena);
+        if is_derived {
+            let arguments = self.new_sym(js_ast::symbol::Kind::Unbound, arguments_str);
+            let arguments = self.new_expr(E::Identifier::init(arguments), loc);
+            let spread = self.new_expr(E::Spread { value: arguments }, loc);
+            let target = self.new_expr(E::Super {}, loc);
+            let call = self.new_expr(
+                E::Call {
+                    target,
+                    args: ExprNodeList::init_one(spread),
+                    ..Default::default()
+                },
+                loc,
+            );
+            stmts.push(self.s(
                 S::SExpr {
                     value: call,
                     ..Default::default()
@@ -2180,364 +1552,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 loc,
             ));
         }
-
-        // Instance field/accessor init + extra-init
-        {
-            let mut i_accessor_idx: usize = 0;
-            let mut i_field_idx: usize = 0;
-            for entry in instance_init_entries.iter() {
-                let field_idx: usize = if entry.is_accessor {
-                    let idx = instance_accessor_base_idx + i_accessor_idx;
-                    i_accessor_idx += 1;
-                    idx
-                } else {
-                    let idx = instance_field_base_idx + i_field_idx;
-                    i_field_idx += 1;
-                    idx
-                };
-
-                let mut run_args = BumpVec::with_capacity_in(4, bump);
-                run_args.push(p.use_ref(init_ref, loc));
-                run_args.push(p.new_expr(E::Number::new(Self::init_flag(field_idx)), loc));
-                run_args.push(p.new_expr(E::This {}, loc));
-                if let Some(init_val) = entry.prop.initializer {
-                    run_args.push(init_val);
-                }
-                let run_args_list = ExprNodeList::from_bump_vec(run_args);
-                let run_init_call = p.call_runtime(loc, b"__runInitializers", run_args_list);
-
-                if entry.is_accessor || entry.is_private {
-                    let wm_ref_expr = if entry.is_accessor && !entry.is_private {
-                        entry.prop.value.expect("infallible: prop has value")
-                    } else {
-                        entry.prop.key.expect("infallible: prop has key")
-                    };
-                    let t_e = p.new_expr(E::This {}, loc);
-                    let call = p.call_rt(loc, b"__privateAdd", &[t_e, wm_ref_expr, run_init_call]);
-                    constructor_inject_stmts.push(p.s(
-                        S::SExpr {
-                            value: call,
-                            ..Default::default()
-                        },
-                        loc,
-                    ));
-                } else {
-                    let t_e = p.new_expr(E::This {}, loc);
-                    let mt = p.member_target(t_e, &entry.prop);
-                    constructor_inject_stmts.push(Stmt::assign(mt, run_init_call));
-                }
-
-                // Extra initializer
-                let i_e = p.use_ref(init_ref, loc);
-                let n_e = p.new_expr(E::Number::new(Self::extra_init_flag(field_idx)), loc);
-                let t_e = p.new_expr(E::This {}, loc);
-                let call = p.call_rt(loc, b"__runInitializers", &[i_e, n_e, t_e]);
-                constructor_inject_stmts.push(p.s(
-                    S::SExpr {
-                        value: call,
-                        ..Default::default()
-                    },
-                    loc,
-                ));
-            }
-        }
-
-        // Inject into constructor
-        if !constructor_inject_stmts.is_empty() {
-            let mut found_constructor = false;
-            for nprop in new_properties.iter_mut() {
-                if !nprop.flags.contains(Flags::Property::IsMethod) || nprop.key.is_none() {
-                    continue;
-                }
-                let is_ctor = match &nprop.key.unwrap().data {
-                    js_ast::ExprData::EString(s) => s.eql_comptime(b"constructor"),
-                    _ => false,
-                };
-                if !is_ctor {
-                    continue;
-                }
-                let func = match &mut nprop.value.as_mut().unwrap().data {
-                    js_ast::ExprData::EFunction(f) => &mut **f,
-                    _ => unreachable!(),
-                };
-                let body_slice: &[Stmt] = func.func.body.stmts.slice();
-                let mut body_stmts = BumpVec::<Stmt>::with_capacity_in(
-                    body_slice.len() + constructor_inject_stmts.len(),
-                    bump,
-                );
-                body_stmts.extend_from_slice(body_slice);
-                let mut super_index: Option<usize> = None;
-                for (index, item) in body_stmts.iter().enumerate() {
-                    let js_ast::StmtData::SExpr(se) = &item.data else {
-                        continue;
-                    };
-                    let js_ast::ExprData::ECall(call) = &se.value.data else {
-                        continue;
-                    };
-                    if !matches!(call.target.data, js_ast::ExprData::ESuper(_)) {
-                        continue;
-                    }
-                    super_index = Some(index);
-                    break;
-                }
-                let insert_at = if let Some(j) = super_index { j + 1 } else { 0 };
-                // BumpVec has no `splice`; rebuild.
-                let mut spliced = BumpVec::<Stmt>::with_capacity_in(
-                    body_stmts.len() + constructor_inject_stmts.len(),
-                    bump,
-                );
-                spliced.extend_from_slice(&body_stmts[..insert_at]);
-                spliced.extend_from_slice(&constructor_inject_stmts);
-                spliced.extend_from_slice(&body_stmts[insert_at..]);
-                func.func.body.stmts = bun_ast::StoreSlice::new_mut(spliced.into_bump_slice_mut());
-                found_constructor = true;
-                break;
-            }
-
-            if !found_constructor {
-                let mut ctor_stmts = BumpVec::<Stmt>::new_in(bump);
-                if class.extends.is_some() {
-                    let target = p.new_expr(E::Super {}, loc);
-                    let args_ref = p.new_sym(js_ast::symbol::Kind::Unbound, arguments_str);
-                    let inner = p.new_expr(
-                        E::Identifier {
-                            ref_: args_ref,
-                            ..Default::default()
-                        },
-                        loc,
-                    );
-                    let spread = p.new_expr(E::Spread { value: inner }, loc);
-                    let arg_slice = bump.alloc_slice_copy(&[spread]);
-                    let call_args = ExprNodeList::from_arena_slice(arg_slice);
-                    let call = p.new_expr(
-                        E::Call {
-                            target,
-                            args: call_args,
-                            ..Default::default()
-                        },
-                        loc,
-                    );
-                    ctor_stmts.push(p.s(
-                        S::SExpr {
-                            value: call,
-                            ..Default::default()
-                        },
-                        loc,
-                    ));
-                }
-                ctor_stmts.extend_from_slice(&constructor_inject_stmts);
-                let ctor_body_ptr = bun_ast::StoreSlice::new_mut(ctor_stmts.into_bump_slice_mut());
-                let func = G::Fn {
-                    name: None,
-                    open_parens_loc: bun_ast::Loc::EMPTY,
-                    args: bun_ast::StoreSlice::EMPTY,
-                    body: G::FnBody {
-                        loc,
-                        stmts: ctor_body_ptr,
-                    },
-                    ..Default::default()
-                };
-                let value = Some(p.new_expr(E::Function { func }, loc));
-                let key = Some(p.new_expr(
-                    E::EString {
-                        data: b"constructor".into(),
-                        ..Default::default()
-                    },
-                    loc,
-                ));
-                new_properties.insert(
-                    0,
-                    G::Property {
-                        flags: Flags::Property::IsMethod.into(),
-                        key,
-                        value,
-                        ..Default::default()
-                    },
-                );
-            }
-        }
-
-        // Static private __privateAdd blocks at beginning
-        if !static_private_add_blocks.is_empty() {
-            let mut merged = BumpVec::<Property>::with_capacity_in(
-                static_private_add_blocks.len() + new_properties.len(),
-                bump,
-            );
-            for sp in static_private_add_blocks.drain(..) {
-                merged.push(sp);
-            }
-            for np in new_properties.drain(..) {
-                merged.push(np);
-            }
-            new_properties = merged;
-        }
-
-        class.properties = bun_ast::StoreSlice::new_mut(new_properties.into_bump_slice_mut());
-        class.has_decorators = false;
-        class.should_lower_standard_decorators = false;
-
-        // Declare the receiver-capture temporaries that were created outside any
-        // function body (field initializers, static blocks, pre-eval/decorate
-        // expressions). Temps created inside method/function/arrow bodies were
-        // already declared there by `declare_capture_temps_in_fn_body`. Static
-        // blocks, static initializers, and decorate expressions run at most
-        // once per class evaluation; instance field initializers run once per
-        // construction and share the hoisted binding across constructions,
-        // matching where esbuild declares these temps.
-        if let Some(decl_stmt) = p.drain_capture_temp_decls(temp_refs_before, loc) {
-            prefix_stmts.push(decl_stmt);
-        }
-
-        // ── Phase 8: Assemble output ─────────────────────
-        if is_expr {
-            let mut comma_parts = BumpVec::<Expr>::new_in(bump);
-            if let Some(cda) = class_dec_assign_expr {
-                comma_parts.push(cda);
-            }
-            if let Some(ba) = base_assign_expr {
-                comma_parts.push(ba);
-            }
-
-            // Can't capture `&mut self` in a closure while also calling
-            // `p.method()`, so inline both call sites against a `&[Stmt]`
-            // slice array.
-            for stmts_list in [&pre_eval_stmts[..], &prefix_stmts[..]] {
-                for pstmt in stmts_list.iter() {
-                    match &pstmt.data {
-                        js_ast::StmtData::SExpr(se) => {
-                            comma_parts.push(se.value);
-                        }
-                        js_ast::StmtData::SLocal(local) => {
-                            for decl_item in local.decls.slice() {
-                                let ref_ = match decl_item.binding.data {
-                                    js_ast::b::B::BIdentifier(b) => b.r#ref,
-                                    _ => unreachable!(),
-                                };
-                                let binding = p.b(B::Identifier { r#ref: ref_ }, loc);
-                                expr_var_decls.push(G::Decl {
-                                    binding,
-                                    value: None,
-                                });
-                                if let Some(val) = decl_item.value {
-                                    p.record_usage(ref_);
-                                    comma_parts.push(Expr::assign(
-                                        p.new_expr(
-                                            E::Identifier {
-                                                ref_,
-                                                ..Default::default()
-                                            },
-                                            loc,
-                                        ),
-                                        val,
-                                    ));
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-
-            // _init = __decoratorStart(...)
-            comma_parts.push(p.assign_to(init_ref, init_start_expr, loc));
-
-            // _class = class { ... }
-            let class_expr = p.new_expr(class_copy(class), loc);
-            comma_parts.push(p.assign_to(expr_class_ref.unwrap(), class_expr, loc));
-
-            comma_parts.extend_from_slice(&suffix_exprs);
-
-            // Final value
-            let final_ref = if class_decorators_len > 0 {
-                class_name_ref
-            } else {
-                expr_class_ref.unwrap()
-            };
-            comma_parts.push(p.use_ref(final_ref, loc));
-
-            // Build comma chain
-            let mut result = comma_parts[0];
-            for part in &comma_parts[1..] {
-                result = p.new_expr(
-                    E::Binary {
-                        op: js_ast::OpCode::BinComma,
-                        left: result,
-                        right: *part,
-                    },
-                    loc,
-                );
-            }
-
-            // Emit var declarations
-            if !expr_var_decls.is_empty() {
-                let decls = DeclList::from_bump_vec(expr_var_decls);
-                let var_decl_stmt = p.s(
-                    S::Local {
-                        decls,
-                        ..Default::default()
-                    },
-                    loc,
-                );
-                if let Some(stmt_list) = p.nearest_stmt_list_mut() {
-                    stmt_list.push(var_decl_stmt);
-                }
-            }
-
-            out.push(p.s(
-                S::SExpr {
-                    value: result,
-                    ..Default::default()
-                },
+        stmts.extend(self.effect_stmts(effects, loc));
+        let func = G::Fn {
+            body: G::FnBody {
                 loc,
-            ));
-            return;
-        }
-
-        // Statement mode
-        if !matches!(class_dec_stmt.data, js_ast::StmtData::SEmpty(_)) {
-            out.push(class_dec_stmt);
-        }
-        if !matches!(base_decl_stmt.data, js_ast::StmtData::SEmpty(_)) {
-            out.push(base_decl_stmt);
-        }
-        out.extend_from_slice(&pre_eval_stmts);
-        out.extend_from_slice(&prefix_stmts);
-        out.push(init_decl_stmt);
-        out.push(original_stmt.unwrap());
-        for expr in suffix_exprs.iter() {
-            out.push(p.s(
-                S::SExpr {
-                    value: *expr,
-                    ..Default::default()
-                },
-                expr.loc,
-            ));
-        }
-        // Inner class binding: let _Foo = Foo
-        if !inner_class_ref.eql(class_name_ref) {
-            p.record_usage(class_name_ref);
-            let binding = p.b(
-                B::Identifier {
-                    r#ref: inner_class_ref,
-                },
-                loc,
-            );
-            let value = Some(p.new_expr(
-                E::Identifier {
-                    ref_: class_name_ref,
-                    ..Default::default()
-                },
-                class_name_loc,
-            ));
-            let decls = DeclList::from_slice(&[G::Decl { binding, value }]);
-            out.push(p.s(
-                S::Local {
-                    kind: S::Kind::KLet,
-                    decls,
-                    ..Default::default()
-                },
-                loc,
-            ));
+                stmts: bun_ast::StoreSlice::from_bump(stmts),
+            },
+            ..Default::default()
+        };
+        Property {
+            flags: Flags::Property::IsMethod.into(),
+            key: Some(self.new_expr(E::EString::from_static(b"constructor"), loc)),
+            value: Some(self.new_expr(E::Function { func }, loc)),
+            ..Default::default()
         }
     }
 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -10019,10 +10019,10 @@ impl LowerUsingDeclarationsContext {
                     continue;
                 }
                 js_ast::StmtData::SClass(mut c) => {
-                    // An export can't go in try/catch. A class whose definition runs code
-                    // (`extends`, computed keys, static blocks) can't move out of it either.
-                    let runs_code = c.class.extends.is_some()
-                        || c.class.properties.slice().iter().any(|property| {
+                    // An export can't go in try/catch. A class with static blocks or computed
+                    // keys (every class with lowered decorators) reads what is declared there.
+                    let runs_code = c.is_export
+                        && c.class.properties.slice().iter().any(|property| {
                             property.kind == js_ast::g::PropertyKind::ClassStaticBlock
                                 || property.flags.contains(js_ast::flags::Property::IsComputed)
                         });

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -10019,8 +10019,7 @@ impl LowerUsingDeclarationsContext {
                     continue;
                 }
                 js_ast::StmtData::SClass(mut c) => {
-                    // An export can't go in try/catch. A class with static blocks or computed
-                    // keys (every class with lowered decorators) reads what is declared there.
+                    // An exported class leaves the try block unless it has static blocks or computed keys.
                     let runs_code = c.is_export
                         && c.class.properties.slice().iter().any(|property| {
                             property.kind == js_ast::g::PropertyKind::ClassStaticBlock

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -10018,10 +10018,44 @@ impl LowerUsingDeclarationsContext {
                     result.push(stmt);
                     continue;
                 }
-                js_ast::StmtData::SClass(c) => {
-                    if c.is_export {
-                        // can't go in try/catch; hoist out
+                js_ast::StmtData::SClass(mut c) => {
+                    // An export can't go in try/catch. A class whose definition runs code
+                    // (`extends`, computed keys, static blocks) can't move out of it either.
+                    let runs_code = c.class.extends.is_some()
+                        || c.class.properties.slice().iter().any(|property| {
+                            property.kind == js_ast::g::PropertyKind::ClassStaticBlock
+                                || property.flags.contains(js_ast::flags::Property::IsComputed)
+                        });
+                    if c.is_export && !runs_code {
                         result.push(stmt);
+                        continue;
+                    }
+                    if c.is_export {
+                        let name = c.class.class_name.expect("an exported class has a name");
+                        exports.push(js_ast::ClauseItem {
+                            name: LocRef {
+                                loc: name.loc,
+                                ref_: name.ref_,
+                            },
+                            alias: p.symbols[name.ref_.inner_index() as usize].original_name,
+                            alias_loc: name.loc,
+                            ..Default::default()
+                        });
+                        let class = core::mem::take(&mut c.class);
+                        let value = p.new_expr(class, stmt.loc);
+                        let binding = p.b(B::Identifier { r#ref: name.ref_ }, name.loc);
+                        stmts[end as usize] = p.s(
+                            S::Local {
+                                kind: js_ast::s::Kind::KVar,
+                                decls: G::DeclList::init_one(G::Decl {
+                                    binding,
+                                    value: Some(value),
+                                }),
+                                ..Default::default()
+                            },
+                            stmt.loc,
+                        );
+                        end += 1;
                         continue;
                     }
                 }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1220,7 +1220,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             if Self::IS_TYPESCRIPT_ENABLED {
-                // `lower_standard_decorators_stmt` owns field placement for such classes.
+                // Standard decorator lowering wraps field initializers where they are.
                 let use_define = self.options.use_define_for_class_fields
                     || class.should_lower_standard_decorators;
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2766,7 +2766,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Lower standard decorators for class expressions
         if e_.should_lower_standard_decorators {
-            *e = p.lower_standard_decorators_expr(&mut e_, expr.loc, decorator_name_from_context);
+            *e = p.lower_standard_decorators_expr(expr, &mut e_, decorator_name_from_context);
             return;
         }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -59,7 +59,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
 /// Version 31: Standard decorator lowering temporaries have a per-file counter in their name (`_init$1`).
-const EXPECTED_VERSION: u32 = 31;
+/// Version 32: Standard decorator lowering keeps class members in place.
+const EXPECTED_VERSION: u32 = 32;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -31,6 +31,17 @@ async function runDecorator(code: string) {
   return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
 
+async function runIn(cwd: string, args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
+    cwd,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
 describe("ES Decorators", () => {
   describe("class decorators", () => {
     test("basic class decorator", async () => {
@@ -1299,6 +1310,353 @@ describe("ES Decorators", () => {
     });
   });
 
+  // A lowered class keeps its members where they are written. Decorator lists
+  // are evaluated in the key of their member, a leading static block applies
+  // them, and what runs between two instance fields rides in the next one.
+  describe("members stay where they are written", () => {
+    test.concurrent("undecorated fields initialize in source order next to decorated fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {}; const log = (s) => (console.log("init", s), s);
+        class Foo { @dec a = log("a"); b = log(this.a === "a" ? "b (a set)" : "b (a NOT set)"); @dec c = log("c"); }
+        new Foo();
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("init a\ninit b (a set)\ninit c\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("decorated fields are defined, not assigned", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        class Base { set a(v) { console.log("BASE SETTER", v) } }
+        class Bar extends Base { @dec a = 1 }
+        console.log(JSON.stringify(Object.getOwnPropertyDescriptor(new Bar(), "a")));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('{"value":1,"writable":true,"enumerable":true,"configurable":true}\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("static fields and static blocks keep their order next to decorated members", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        class S { @dec static x = console.log(1); static { console.log(2) } static y = console.log(3) }
+        class T { static { console.log(1) } static x = console.log(2); @dec m() {} }
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1\n2\n3\n1\n2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent(
+      "undecorated private members stay native, and every initializer reaches a lowered one",
+      async () => {
+        const { stdout, stderr, exitCode } = await runDecorator(`
+        function d(t, k) {}
+        class D { static #p = 5; static a = D.#p; static b = this.#p; #q = 6; d = this.#q; e() { return D.#p + this.#q } @d m() {} }
+        class E {
+          @d #low = 7;
+          @d static #slow = 8;
+          a = this.#low;
+          b = () => this.#low;
+          static c = E.#slow;
+          static { E.d = this.#slow; }
+          [(o => o.#low, "f")] = #low in this;
+          static read(o) { function inner() { return o.#low } class N { static v = o.#low } return [inner(), N.v, (({ x = o.#low }) => x)({})] }
+        }
+        const e = new E();
+        console.log(D.a, D.b, new D().d, new D().e(), e.a, e.b(), E.c, E.d, e.f, E.read(e));
+      `);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("5 5 6 11 7 7 8 8 true [ 7, 7, 7 ]\n");
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    test.concurrent("new.target stays undefined in field initializers and static blocks", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        class C {
+          @dec m() {}
+          static a = new.target;
+          @dec b = new.target;
+          c = () => new.target;
+          d = function () { return new.target; };
+          static { C.sb = new.target; }
+        }
+        class D extends C { e = new.target; }
+        const c = new C(), d = new D(), fn = d.d;
+        console.log(C.a, c.b, c.c(), C.sb, d.b, d.e, new fn() === fn);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("undefined undefined undefined undefined undefined undefined true\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("super resolves from the class as written when a class decorator replaces it", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        const wrap = (C) => class extends C { static sg() { return "wrapper" } greet() { return "wrapper" } };
+        class B { greet() { return "B" } static sg() { return "B" } }
+        @wrap class C extends B {
+          @dec x = super.greet();
+          greet() { return "C" }
+          static sg() { return "C" }
+          #m() { return super.greet() }
+          static #s() { return super.sg() }
+          call() { return [this.x, this.#m(), C.#s()] }
+          @dec static y = super.sg();
+          static { C.blk = super.sg(); }
+        }
+        console.log(new C().call(), C.y, C.blk, Object.getPrototypeOf(C) !== B);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('[ "B", "B", "B" ] B B true\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("super.m?.() in a static initializer keeps short-circuiting the rest of its chain", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        class B { static get maybe() { return undefined } static sg() { return "B" } }
+        class C extends B {
+          @dec m() {}
+          @dec static z = super.maybe?.().value;
+          static w = super.sg?.().length;
+          static { C.blk = super.maybe?.()?.x ?? "none"; }
+        }
+        console.log(C.z, C.w, C.blk);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("undefined 1 none\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("the inner name of a named class expression resolves in private methods", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        const A = class Foo {
+          @dec a = 1;
+          #m() { return Foo }
+          @dec #n() { return Foo }
+          static #s() { return [Foo, this] }
+          call() { return [this.#m(), this.#n()] }
+          static scall() { return Foo.#s() }
+        };
+        console.log(new A().call().every(c => c === A), A.scall()[0] === A, A.scall()[1] === A);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("true true true\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("decorator lists are evaluated where their member is written", async () => {
+      // In the key of the member, so: in order with computed keys, with the
+      // outer \`this\`, \`await\` and \`arguments\`, inside the private scope of
+      // the class, and before the class binding is initialized. A decorated
+      // \`#private\` member has no key of its own and uses a neighbor's.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        const K = (n) => (log.push("k:" + n), n);
+        const D = (n, ...rest) => (log.push("d:" + n), () => {});
+        async function outer() {
+          class A {
+            @D(1) #first = 0;
+            [K("a")] = 0;
+            @D(2, this.tag, arguments[0]) b() {}
+            static [K("c")]() {}
+            @D(3) #p = 0;
+            @D(4) static #q() {}
+            @D(await 5) accessor e = 0;
+            [K("f")]() {}
+            @D(6, (o) => o.#p, () => A) #last = 0;
+            constructor() {}
+            static { log.push("static") }
+          }
+          return log.join(" ");
+        }
+        console.log(await outer.call({ tag: "t" }, "arg"));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("d:1 k:a d:2 k:c d:3 d:4 d:5 k:f d:6 static\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a decorator expression sees the outer this, its own class only after it is defined", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const fns = [];
+        const capture = (fn) => { fns.push(fn); try { fn(); fns.push("no TDZ") } catch (e) { fns.push(e.constructor.name) } return () => {} };
+        function outer() {
+          class A { @capture(() => [this.tag, A]) m() {} @capture(() => [this.tag, A]) #p() {} }
+          return A;
+        }
+        const A = outer.call({ tag: "t" });
+        console.log(fns[1], fns[3], fns[0]()[0], fns[0]()[1] === A, fns[2]()[0], fns[2]()[1] === A);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ReferenceError ReferenceError t true t true\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent(
+      "class decorators run before static fields, extra initializers right after their field",
+      async () => {
+        const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        const cls = (C, ctx) => { log.push("class:" + Object.hasOwn(C, "s")); ctx.addInitializer(function () { log.push("class extra:" + this.s) }) };
+        const field = (v, ctx) => { ctx.addInitializer(function () { log.push(ctx.name + " extra:" + Object.keys(this)) }) };
+        const method = field;
+        @cls class A {
+          static s = (log.push("s"), 1);
+          @field a = (log.push("a"), 1);
+          accessor b = (log.push("b"), 2);
+          @field c = (log.push("c"), 3);
+          @method m() {}
+        }
+        log.push("new");
+        new A();
+        console.log(log.join(" | "));
+      `);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("class:false | s | class extra:1 | new | m extra: | a | a extra:a | b | c | c extra:a,c\n");
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    test.concurrent("an anonymous class expression keeps the name its context gives it", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        const A = class { @dec x = 1 };
+        const B = @dec class { accessor y = 2 };
+        const o = { C: class { @dec static #z = 3 } };
+        console.log(A.name, B.name, o.C.name, JSON.stringify((class { @dec m() {} }).name));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('A B C ""\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("decorator lists no key of the class can hold are evaluated before it", async () => {
+      // Only \`#private\` members and a constructor: no computed key to borrow.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        const D = (n, d) => (log.push("d:" + n), d ?? ((v, ctx) => { log.push("apply:" + ctx.name) }));
+        class A { @D(1) #a = 1; @D(2) static #b() {} constructor() { log.push("ctor:" + this.#a) } }
+        new A();
+        function outer() { return class { @D(3, this.dec) #x = 1; @D("3b", arguments[0]) #w = 2; constructor() { log.push("x:" + this.#x + this.#w) } } }
+        new (outer.call({ dec: (v, ctx) => { log.push("this.dec:" + ctx.name) } }, (v, ctx) => { log.push("arguments[0]:" + ctx.name) }))();
+        const late = Promise.resolve((v, ctx) => { log.push("awaited:" + ctx.name) });
+        const E = class { @D(4, await late) #y = 1 };
+        function* gen() { return class { @D(5, yield) #z = 1 }; }
+        const it = gen(); it.next(); it.next((v, ctx) => { log.push("yielded:" + ctx.name) });
+        console.log(log.join(" "), JSON.stringify(E.name));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        'd:1 d:2 apply:#b apply:#a ctor:1 d:3 d:3b this.dec:#x arguments[0]:#w x:12 d:4 awaited:#y d:5 yielded:#z "E"\n',
+      );
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a field that carries the effects of its neighbors keeps naming its function", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        class A { @dec m() {} first = () => {}; accessor a = 1; afterAccessor = class {}; plain = function () {}; @dec d = 1; afterField = () => {}; "q r" = () => {}; }
+        class B { accessor a = 1; onlyAccessors = () => {}; }
+        const a = new A();
+        console.log(JSON.stringify([a.first.name, a.afterAccessor.name, a.plain.name, a.afterField.name, a["q r"].name, new B().onlyAccessors.name]));
+        const k = "dyn", sym = Symbol("desc");
+        class C {
+          accessor a = 1; [k] = function () {};
+          accessor b = 2; 123 = class {};
+          accessor c = 3; [sym] = () => {};
+          accessor d = 4; #p = () => {}; privateName() { return this.#p.name }
+          accessor f = 6; #own = class { static name = "own" }; ownName() { return this.#own.name }
+          accessor e = 5; ["__proto__"] = function () {};
+        }
+        const c = new C();
+        console.log(JSON.stringify([c[k].name, c[123].name, c[sym].name, c.privateName(), c.ownName(), c["__proto__"].name, Object.getPrototypeOf(c) === C.prototype]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        '["first","afterAccessor","plain","afterField","q r","onlyAccessors"]\n["dyn","123","[desc]","#p","own","__proto__",true]\n',
+      );
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent(
+      "a class with no key for its decorator lists: private names, extends and the inner name",
+      async () => {
+        const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v) => v, order = [];
+        let inB, inA;
+        class B { @(inB = (o) => #m in o, dec) #m() { return 1 } }
+        class A { #y = 1; @(inA = (o) => #y in o, dec) #m() {} static {} }
+        class E extends (order.push("extends"), Object) { @(order.push("dec m"), dec) #m() {} @(order.push("dec x"), dec) #x = 1; }
+        const later = [];
+        const lazy = (f) => (later.push(f), dec);
+        const X = class Inner extends Object { @lazy(() => Inner) #p; constructor() { super() } };
+        console.log(inB(new B()), inA(new A()), inA({}), order.join(","), later[0]() === X);
+        let x = 5, seen;
+        const o = { x: class { @dec #p = 1; static { seen = x } } };
+        function g() { var h = class { @dec #p() {} static { this.self = () => h } }; const was = h; h = null; return [was.name, was.self()] }
+        console.log(o.x.name, seen, JSON.stringify(g()));
+        const Named = class Self { @lazy(() => Self) #q() {} };
+        class Symbol {}
+        class Shadow { @dec #s = 1 }
+        console.log(later[1]() === Named, JSON.stringify([B, A, Shadow].map(C => Object.getOwnPropertyNames(C))));
+      `);
+        expect(stderr).toBe("");
+        expect(stdout).toBe(
+          'true true false extends,dec m,dec x true\nx 5 ["h",null]\ntrue [["length","name","prototype"],["length","name","prototype"],["length","name","prototype"]]\n',
+        );
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    test.concurrent("a class decorator on a class whose context name is not an identifier", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => { console.log(ctx.kind, ctx.name) };
+        const o = { "a-b c": @dec class {} };
+        class Q { static "x y" = @dec class { @dec m() {} } }
+        console.log(o["a-b c"].name, Q["x y"].name);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("class a-b c\nmethod m\nclass x y\na-b c x y\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("an exported decorated class next to a lowered top-level using", async () => {
+      using dir = tempDir("es-dec-using", {
+        "entry.js": `
+          const dec = (v, ctx) => {};
+          using res = { [Symbol.dispose]() { console.log("disposed") } };
+          export @dec class A { @dec m() { return 1 } }
+          export class B extends A { @dec accessor x = 2 }
+          console.log(new A().m(), new B().x);
+        `,
+      });
+      const build = await runIn(String(dir), ["build", "--target=browser", "entry.js", "--outfile=out.js"]);
+      expect({ stderr: filterStderr(build.stderr), exitCode: build.exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      const { stdout, stderr, exitCode } = await runIn(String(dir), ["out.js"]);
+      expect(filterStderr(stderr)).toBe("");
+      expect(stdout).toBe("1 2\ndisposed\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a class decorator's initializers run once the class is bound to its name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        function register(v, ctx) { ctx.addInitializer(function () { log.push(A === this, typeof A.create, A.ready) }) }
+        @register class A { static create() { return new A() } static ready = (log.push("static field"), true) }
+        console.log(log.join(" "));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("static field true function true\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("accessor with TypeScript annotations", () => {
     test("accessor with definite assignment assertion (!)", async () => {
       using dir = tempDir("es-dec-accessor-bang", {
@@ -1353,6 +1711,758 @@ describe("ES Decorators", () => {
       expect(filterStderr(rawStderr)).toBe("");
       expect(stdout).toBe("undefined\nworld\n");
       expect(exitCode).toBe(0);
+    });
+  });
+});
+
+// One fixture holds a matrix of decorated members and prints one JSON object;
+// each cell is then its own test. It runs as .js and .ts, and through `bun build`.
+
+const kinds = ["field", "method", "getter", "setter", "accessor"] as const;
+const placements = ["instance", "static"] as const;
+const visibilities = ["public", "private"] as const;
+type Kind = (typeof kinds)[number];
+type Placement = (typeof placements)[number];
+type Visibility = (typeof visibilities)[number];
+
+type Cell = {
+  kind: Kind;
+  placement: Placement;
+  visibility: Visibility;
+  classDecorated: boolean;
+  derived: boolean;
+};
+
+const cells: Cell[] = [];
+for (const kind of kinds) {
+  for (const placement of placements) {
+    for (const visibility of visibilities) {
+      for (const classDecorated of [false, true]) {
+        for (const derived of [false, true]) {
+          cells.push({ kind, placement, visibility, classDecorated, derived });
+        }
+      }
+    }
+  }
+}
+
+function cellName(cell: Cell) {
+  const flags = [cell.classDecorated ? "class decorator" : "", cell.derived ? "derived" : ""].filter(Boolean);
+  return `${cell.kind}/${cell.placement}/${cell.visibility}${flags.length ? ` (${flags.join(", ")})` : ""}`;
+}
+
+// One class per cell: the decorated member `x` sits between undecorated
+// instance fields, private fields, static fields and a static block. `dec`
+// replaces every kind of member with one that appends "!" to its value, so
+// the result also shows the decorator's return value was applied to the right
+// member and nothing else.
+function matrixClass(cell: Cell) {
+  const { kind, placement, visibility, classDecorated, derived } = cell;
+  const s = placement === "static" ? "static " : "";
+  const name = visibility === "private" ? "#x" : "x";
+  const self = placement === "static" ? "C" : "this";
+  let member: string;
+  let reader: string;
+  switch (kind) {
+    case "field":
+      member = `@decApply ${s}${name} = L("x");`;
+      reader = `${s}read() { return ${self}.${name}; }`;
+      break;
+    case "accessor":
+      member = `@decApply ${s}accessor ${name} = L("x");`;
+      reader = `${s}read() { return ${self}.${name}; }`;
+      break;
+    case "method":
+      member = `@decApply ${s}${name}() { return "x"; }`;
+      reader = `${s}read() { return ${self}.${name}(); }`;
+      break;
+    case "getter":
+      member = `@decApply ${s}get ${name}() { return "x"; }`;
+      reader = `${s}read() { return ${self}.${name}; }`;
+      break;
+    case "setter":
+      member = `@decApply ${s}set ${name}(v) { side = v; }`;
+      reader = `${s}read() { ${self}.${name} = "x"; return side; }`;
+      break;
+  }
+  const id = JSON.stringify(cellName(cell));
+  return `
+{
+  let side;
+  class B { constructor() { L("base"); } }
+  log.length = 0;
+  ctxs = {};
+  ${classDecorated ? "@decApply " : ""}class C ${derived ? "extends B " : ""}{
+    static sBefore = L("sBefore");
+    static { L("sBlock"); }
+    iBefore = L("iBefore");
+    #p = L("#p");
+    iPriv = (L("iPriv"), this.#p);
+    ${member}
+    iAfter = L("iAfter");
+    static sAfter = L("sAfter");
+    static #sp = L("#sp");
+    static sPriv = (L("sPriv"), C.#sp);
+    #m() { return "m"; }
+    callM() { return this.#m(); }
+    has() { return #p in this; }
+    ${reader}
+  }
+  const defLog = log.slice();
+  log.length = 0;
+  const inst = new C();
+  out[${id}] = {
+    defLog,
+    ctorLog: log.slice(),
+    value: ${placement === "static" ? "C.read()" : "inst.read()"},
+    iPriv: inst.iPriv,
+    sPriv: C.sPriv,
+    callM: inst.callM(),
+    has: inst.has(),
+    ctx: ctxs[${JSON.stringify(name)}],
+    classCtx: ctxs["C"] ?? null,
+    isInstance: inst instanceof C${derived ? " && inst instanceof B" : ""},
+  };
+}`;
+}
+
+function matrixExpected(cell: Cell) {
+  const { kind, placement, visibility, classDecorated, derived } = cell;
+  const name = visibility === "private" ? "#x" : "x";
+  const isFieldLike = kind === "field" || kind === "accessor";
+  // Decorators are called before any static member is initialized; the class
+  // decorator last. Static fields and blocks then run in source order.
+  const defLog = [`dec:${name}`];
+  if (classDecorated) defLog.push("dec:C");
+  defLog.push("sBefore", "sBlock");
+  if (isFieldLike && placement === "static") defLog.push("x");
+  defLog.push("sAfter", "#sp", "sPriv");
+  // Instance fields run after super() returns, in source order.
+  const ctorLog = derived ? ["base"] : [];
+  ctorLog.push("iBefore", "#p", "iPriv");
+  if (isFieldLike && placement === "instance") ctorLog.push("x");
+  ctorLog.push("iAfter");
+  return {
+    defLog,
+    ctorLog,
+    value: "x!",
+    iPriv: "#p",
+    sPriv: "#sp",
+    callM: "m",
+    has: true,
+    ctx: { kind, name, static: placement === "static", private: visibility === "private" },
+    classCtx: classDecorated ? { kind: "class", name: "C", static: null, private: null } : null,
+    isInstance: true,
+  };
+}
+
+const fixturePrelude = `
+const log = [];
+const L = (name) => (log.push(name), name);
+let ctxs = {};
+const dec = (value, ctx) => {
+  log.push("dec:" + String(ctx.name));
+  ctxs[String(ctx.name)] = { kind: ctx.kind, name: ctx.name, static: ctx.static ?? null, private: ctx.private ?? null };
+};
+const decApply = (value, ctx) => {
+  dec(value, ctx);
+  switch (ctx.kind) {
+    case "field": return (v) => v + "!";
+    case "accessor": return { init: (v) => v + "!" };
+    case "method": return function (...args) { return value.call(this, ...args) + "!"; };
+    case "getter": return function () { return value.call(this) + "!"; };
+    case "setter": return function (v) { value.call(this, v + "!"); };
+  }
+};
+const out = {};
+const pending = [];
+`;
+
+// Fields keep [[Define]] semantics: a setter on the base class is not invoked,
+// and the instance gets an own data property.
+const installSection = `
+{
+  const calls = [];
+  class Base {
+    set f(v) { calls.push("f:" + v); }
+    set g(v) { calls.push("g:" + v); }
+    static set sf(v) { calls.push("sf:" + v); }
+    static set sg(v) { calls.push("sg:" + v); }
+  }
+  class D extends Base {
+    @dec f = 1;
+    g = 2;
+    @dec static sf = 3;
+    static sg = 4;
+    bar;
+  }
+  const d = new D();
+  const own = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+  out.install = {
+    calls,
+    own: [own(d, "f"), own(d, "g"), own(d, "bar")],
+    staticOwn: [own(D, "sf"), own(D, "sg")],
+    values: [d.f, d.g, d.bar, D.sf, D.sg],
+  };
+}`;
+
+const installExpected = {
+  calls: [],
+  own: [true, true, true],
+  staticOwn: [true, true],
+  values: [1, 2, null, 3, 4],
+};
+
+const extraSections = `
+// \`this\` in a static initializer, decorated or not, is the class.
+{
+  class S {
+    @dec static x = this;
+    static y = () => this;
+    static z = this.x;
+  }
+  out.staticThis = [S.x === S, S.y() === S, S.z === S];
+}
+
+// Two decorated classes in one scope keep separate decorator contexts.
+{
+  const seen = [];
+  const decInit = (value, ctx) => {
+    ctx.addInitializer(function () { seen.push(ctx.name + ":" + this.constructor.name); });
+  };
+  class A1 { @decInit m() {} }
+  class B1 { @decInit n() {} }
+  new A1();
+  new B1();
+  out.twoClasses = seen;
+}
+
+// Generated names do not clash with user bindings.
+{
+  let _init = "user";
+  let _x = "user_x";
+  let _dec = "user_dec";
+  class V { @dec m() {} #x = 1; getX() { return this.#x; } }
+  out.collision = [_init, _x, _dec, new V().getX()];
+}
+
+// Undecorated \`accessor\` fields: initialization order is kept, and a class
+// without decorators gets no Symbol.metadata.
+{
+  log.length = 0;
+  class T {
+    accessor a = L("a");
+    b = L("b");
+    static accessor c = L("c");
+    static d = L("d");
+  }
+  const defLog = log.slice();
+  log.length = 0;
+  const t = new T();
+  out.accessorOnly = { defLog, ctorLog: log.slice(), values: [t.a, t.b, T.c, T.d], symbols: Object.getOwnPropertySymbols(T).length };
+}
+
+// Decorator expressions and computed keys evaluate in source order, once.
+{
+  log.length = 0;
+  const K = (n) => (log.push("k:" + n), n);
+  const D = (n) => (log.push("d:" + n), dec);
+  class Q {
+    [K("m")]() { return "mv"; }
+    @D("f") [K("f")] = L("fv");
+    static [K("s")] = L("sv");
+    [K("g")] = L("gv");
+  }
+  const defLog = log.slice();
+  log.length = 0;
+  const q = new Q();
+  out.computed = { defLog, ctorLog: log.slice(), values: [q.m(), q.f, Q.s, q.g] };
+  new Q();
+  out.computedTwice = log.slice();
+}
+
+// A named class expression: its static code sees the class by its inner name.
+{
+  log.length = 0;
+  const E = class Named {
+    @dec m() {}
+    static self = Named;
+    static { L("eblk"); }
+    y = Named;
+  };
+  out.namedExpr = { defLog: log.slice(), self: E.self === E, y: new E().y === E };
+}
+
+// Derived class with an explicit constructor: fields initialize after super().
+{
+  log.length = 0;
+  class Base2 { constructor() { L("base"); } }
+  class Der extends Base2 {
+    a = L("a");
+    @dec b = L("b");
+    constructor() { L("pre"); super(); L("post"); }
+  }
+  new Der();
+  out.derived = log.slice();
+}
+
+// Private accessors and private methods next to a decorated member.
+{
+  class PA {
+    @dec m() {}
+    accessor #acc = L("acc");
+    static accessor #sacc = 5;
+    get acc() { return this.#acc; }
+    set acc(v) { this.#acc = v; }
+    static bump() { return ++PA.#sacc; }
+    static { PA.#sacc += 10; }
+  }
+  const pa = new PA();
+  const before = pa.acc;
+  pa.acc = 7;
+  out.privateAccessor = [before, pa.acc, PA.bump()];
+}
+
+// Undecorated \`#private\` members of a decorated class stay native, so every
+// update and compound assignment form works on them.
+{
+  let n = 0;
+  class U {
+    @dec m() {}
+    #x = "5";
+    #b = 1n;
+    static #s = 1;
+    static run(o) {
+      const mk = () => (n++, o);
+      const r1 = ++o.#x;
+      const r2 = o.#x++;
+      o.#x -= 1;
+      o.#x ??= 100;
+      o.#b++;
+      U.#s += 2;
+      mk().#x *= 2;
+      mk().#x ||= 0;
+      return [r1, r2, o.#x, o.#b.toString() + "n", U.#s, n];
+    }
+  }
+  out.privateUpdates = U.run(new U());
+}
+
+// \`super\`, \`this\` and nested scopes in the static code of a decorated
+// class. The expected values are what node prints for the same class without
+// the decorator.
+{
+  let n = 0;
+  class SBase {
+    static count = 10;
+    static get y() { return "by"; }
+    static m(a) { return "bm:" + a + ":" + this.name; }
+    static set z(v) { SBase.z_ = v; }
+  }
+  class SDer extends SBase {
+    @dec static q = 1;
+    static a = super.y;
+    static b = super.m("arg");
+    static c = (super.z = 5);
+    static d = () => super["y"];
+    static { SDer.e = super.m("blk"); }
+    static f = (super.count += 5);
+    static g = ++super.count;
+    static h = super.count++;
+    static i = (super.z ??= 7);
+    static j = super[(n++, "y")];
+    static k = (super[(n++, "count")] -= 1);
+    static l = (super[(n++, "count")]--, SDer.count);
+    static obj = { [this.q]: this.q, m() { return super.toString === Object.prototype.toString; } };
+    static fn = (a = this.q, { b = this.q } = {}) => [a, b];
+    static nested = class Inner extends (this.q, SBase) { static [this.q] = 2; static w = SDer.q; };
+    static asyncFn = async () => { await null; return this.q; };
+    static { const { x = this.q } = {}; const [y = this.q] = []; SDer.destructured = [x, y]; }
+  }
+  out.superStatic = [SDer.a, SDer.b, SDer.c, SDer.d(), SDer.e, SDer.f, SDer.g, SDer.h, SDer.i, SDer.j, SDer.k, SDer.l, SDer.count, SBase.count, SBase.z_, n];
+  out.staticScopes = [SDer.obj[1], SDer.obj.m(), SDer.fn(), SDer.nested[1], SDer.nested.w, SDer.destructured];
+  pending.push(SDer.asyncFn().then((v) => { out.staticScopesAsync = v; }));
+}
+
+// The inner name of a class expression, in nested scopes of its static code.
+{
+  const E = class Named {
+    @dec m() {}
+    static #p = 3;
+    static inner = class { static w = Named.#p; static [Named.#p] = "k"; m() { return Named; } };
+    static obj = { [Named.#p]: Named.#p, get g() { return Named.#p; } };
+    static fn = (a = Named.#p, { b = Named.#p } = {}) => [a, b, Named];
+    static { const { x = Named.#p } = {}; for (const y of [Named.#p]) Named.z = x + y; }
+  };
+  out.namedExprNested = [E.inner.w, E.inner[3], new E.inner().m() === E, E.obj[3], E.obj.g, E.fn().slice(0, 2), E.fn()[2] === E, E.z];
+}
+
+// Every form of \`super\` and of an undecorated private member in a decorated
+// class, with \`Reflect\` and \`Object\` shadowed. The expected values are what
+// node prints for the same class without the decorator.
+{
+  const Reflect = null;
+  const Object = null;
+  class SB {
+    static v = 1;
+    static get g() { return "g"; }
+    static tag(s, ...vals) { return this.name + ":" + s.raw.join("|") + vals.join(","); }
+    static sm() { return "sm:" + this.name; }
+    greet() { return "hi:" + this.n; }
+  }
+  class SC extends SB {
+    @dec static m() {}
+    n = 7;
+    static y = super.v;
+    static opt1 = super.missing?.();
+    static opt2 = super.sm?.();
+    static destructured = ([super.d1, { k: super.d2 = 9 }, ...super.rest] = [5, {}, 6, 7], [SC.d1, SC.d2, SC.rest]);
+    static loop = (() => {
+      const seen = [];
+      for (super.it of [1, 2]) seen.push(SC.it);
+      for (super.key in { a: 1 }) seen.push(SC.key);
+      return seen;
+    })();
+    static {
+      try {
+        SC.fail = (super.g = 1);
+      } catch (e) {
+        SC.readonlyError = e.constructor.name + ": " + e.message;
+      }
+    }
+    #pm() { return super.greet() + "/" + super.sm?.() + "/" + super.missing?.(); }
+    static #spm() { return super.sm() + "/" + super.g; }
+    #tag(s, ...vals) { return this.n + ":" + s.raw.join("|") + vals.join(","); }
+    #a = 1;
+    #b = 2;
+    swap() {
+      [this.#a, this.#b] = [this.#b, this.#a];
+      ({ x: this.#a = 10 } = {});
+      for (this.#b of [30]) {}
+      return [this.#a, this.#b];
+    }
+    call() { return [this.#pm(), SC.#spm(), this.#tag\`q\${1}\`]; }
+  }
+  out.superForms = [SC.y, SC.opt1, SC.opt2, SC.destructured, SC.loop, SC.readonlyError];
+  out.privateForms = [new SC().call(), new SC().swap()];
+}
+
+// https://github.com/oven-sh/bun/issues/28118
+{
+  const id = (value, context) => value;
+  class Broken {
+    @id accessor label = "";
+    #name = "hello";
+    #callback = () => this.#name;
+    run() { return this.#callback(); }
+  }
+  out.issue28118 = new Broken().run();
+}
+
+// https://github.com/oven-sh/bun/issues/31917
+{
+  const pick = (x) => x;
+  const C = class Foo {
+    static #m = function (tag) { return { tag }; };
+    @dec static s = Foo.#m("s").tag;
+    @dec static t = pick(this).#m("t").tag;
+  };
+  out.issue31917 = [C.s, C.t];
+}
+
+// https://github.com/oven-sh/bun/issues/31929
+{
+  const C = class Foo {
+    @dec static s = (class { @dec static x = Foo; }).x;
+  };
+  out.issue31929 = [typeof C.s, C.s === C];
+}
+
+// https://github.com/oven-sh/bun/issues/28010 and /28316: each class keeps
+// its own decorator context, so subclasses and siblings do not mix up
+// field initializer slots.
+{
+  const seen = [];
+  const decorate = (name) => (_value, context) => (initialValue) => {
+    seen.push(name + ":" + String(context.name) + "=" + initialValue);
+    return initialValue;
+  };
+  class Parent {
+    @decorate("Parent.foo") foo = "parent_foo";
+    @decorate("Parent.shared") shared = "parent_shared";
+  }
+  class Child extends Parent {
+    @decorate("Child.foo") foo = "child_foo";
+    @decorate("Child.childOnly") childOnly = "child_childOnly";
+  }
+  new Child();
+  out.issue28010 = seen;
+}
+
+// https://github.com/oven-sh/bun/issues/29837
+{
+  class A { accessor name = "A"; }
+  class B extends A {
+    accessor name = "B";
+    names() { return [this.name, super.name]; }
+  }
+  out.issue29837 = new B().names();
+}
+
+// Private names in static blocks and static initializers of a lowered class:
+// brand checks, private calls, a function declared in the block, and a nested
+// class that keeps its own private fields.
+{
+  class SB {
+    @dec m() {}
+    #a() { return "a"; }
+    static #s() { return "s"; }
+    accessor #x = 0;
+    static accessor y = #a in new SB();
+    static {
+      function check(o) { return #a in o; }
+      SB.checks = [#a in new SB(), #a in {}, #x in new SB(), check(new SB()), check({}), this.#s()];
+      class Inner { accessor b = 1; #y = 0; inc() { return this.#y++; } }
+      const inner = new Inner();
+      inner.inc();
+      SB.inner = [inner.inc(), inner.b];
+    }
+    inc() { return this.#x++; }
+  }
+  const sb = new SB();
+  sb.inc();
+  out.staticBlockPrivate = [SB.checks, SB.y, SB.inner, sb.inc()];
+}
+
+// A plain function in a static initializer keeps its own \`this\`, and a
+// shadowing binding of the class name wins.
+{
+  const C = class Foo {
+    @dec static fn = function () { return this; };
+    @dec static shadow = (function Foo() { return Foo; })();
+  };
+  const obj = {};
+  out.nestedScopes = [C.fn.call(obj) === obj, typeof C.shadow === "function" && C.shadow !== C];
+}
+
+// Generated names avoid globals the file references only after the class,
+// a method parameter named like a lowered member's storage, and a class
+// named like a temporary.
+{
+  globalThis._init = "global init";
+  globalThis._G = "global G";
+  class G { @dec m() {} }
+  class Store {
+    #value = 0;
+    @dec set(_value) { this.#value = _value; return this; }
+    get() { return this.#value; }
+  }
+  const answer = (value, ctx) => () => 42;
+  @dec class init { @dec m() { return init; } }
+  const K = class { @answer x = 1; };
+  out.temporaryNames = [_init, _G, typeof G, new Store().set(5).get(), new init().m() === init, new K().x];
+}
+
+// The temporary that captures a private call receiver does not clobber a
+// user binding of the same name, and two class expressions in sibling blocks
+// do not share their hoisted temporaries.
+{
+  const _obj = "outer";
+  class R {
+    @dec m() {}
+    #secret() { return "secret"; }
+    static #staticSecret() { return "static secret"; }
+    self() { return this; }
+    static self() { return R; }
+    run() { return [this.self().#secret(), _obj]; }
+    static { R.fromBlock = [R.self().#staticSecret(), _obj]; }
+  }
+  let A2, B2;
+  { A2 = class { @dec m() {} accessor x = "a"; }; }
+  const a2 = new A2();
+  { B2 = class { @dec m() {} accessor x = "b"; }; }
+  out.temporaryScopes = [...new R().run(), ...R.fromBlock, a2.x, new B2().x];
+}
+
+// Accessor keys that are not identifiers.
+{
+  class SK {
+    accessor "x y" = 1;
+    @dec accessor "x-y" = 2;
+    static accessor "x y" = 3;
+    accessor 0 = 4;
+  }
+  const sk = new SK();
+  sk["x y"] += 10;
+  out.accessorKeys = [sk["x y"], sk["x-y"], SK["x y"], sk[0]];
+}
+
+// https://github.com/oven-sh/bun/issues/31921: a class with accessors and no
+// decorators. Its private names stay reachable from its static code, and
+// static accessor initializers keep their order against static blocks.
+{
+  log.length = 0;
+  const C1 = class Foo {
+    static #m = function (tag) { return { tag }; };
+    static accessor a = Foo.#m("a").tag;
+  };
+  const C2 = class Foo {
+    static accessor a = 1;
+    static #m = 5;
+    static { L(this.#m); }
+  };
+  const C3 = class {
+    static accessor a = L("a");
+    static { L("block"); }
+    static accessor b = L("b");
+  };
+  out.issue31921 = [C1.a, C2.a, C3.a, C3.b, log.slice()];
+}
+
+// Accessor storage is per member: an instance and a static accessor of one
+// name, a user \`#a\` next to \`accessor a\`, and an enclosing class's private
+// name do not share it. A computed accessor key evaluates once and is shared
+// by the getter and the setter, with and without a decorator in the class.
+{
+  let n = 0;
+  const key = (k) => (n++, k);
+  class N {
+    #a = 1;
+    accessor a = 2;
+    static accessor a = 3;
+    accessor [key("k")] = 4;
+    priv() { return this.#a; }
+  }
+  class M {
+    @dec m() {}
+    accessor [key("k")] = 5;
+  }
+  class Outer {
+    static #a = 6;
+    static make() { return class { static accessor a = Outer.#a; }; }
+  }
+  const nn = new N();
+  nn.a += 10;
+  N.a += 10;
+  nn.k += 10;
+  const mm = new M();
+  mm.k += 10;
+  const desc = Object.getOwnPropertyDescriptor(N.prototype, "k");
+  out.accessorStorage = [nn.a, N.a, nn.priv(), nn.k, mm.k, n, typeof desc.get, typeof desc.set, Outer.make().a];
+}
+`;
+
+const extraExpected = {
+  staticThis: [true, true, true],
+  twoClasses: ["m:A1", "n:B1"],
+  collision: ["user", "user_x", "user_dec", 1],
+  accessorOnly: { defLog: ["c", "d"], ctorLog: ["a", "b"], values: ["a", "b", "c", "d"], symbols: 0 },
+  computed: {
+    defLog: ["k:m", "d:f", "k:f", "k:s", "k:g", "dec:f", "sv"],
+    ctorLog: ["fv", "gv"],
+    values: ["mv", "fv", "sv", "gv"],
+  },
+  computedTwice: ["fv", "gv", "fv", "gv"],
+  namedExpr: { defLog: ["dec:m", "eblk"], self: true, y: true },
+  derived: ["dec:b", "pre", "base", "a", "b", "post"],
+  privateAccessor: ["acc", 7, 16],
+  privateUpdates: [6, 6, 12, "2n", 3, 2],
+  superStatic: ["by", "bm:arg:SDer", 5, "by", "bm:blk:SDer", 15, 11, 10, 7, "by", 9, 9, 9, 10, 7, 3],
+  staticScopes: [1, true, [1, 1], 2, 1, [1, 1]],
+  staticScopesAsync: 1,
+  namedExprNested: [3, "k", true, 3, 3, [3, 3], true, 6],
+  superForms: [1, null, "sm:SC", [5, 9, [6, 7]], [1, 2, "a"], "TypeError: Attempted to assign to readonly property."],
+  privateForms: [
+    ["hi:7/undefined/undefined", "sm:SC/g", "7:q|1"],
+    [10, 30],
+  ],
+  issue28118: "hello",
+  issue31917: ["s", "t"],
+  issue31929: ["function", true],
+  issue28010: [
+    "Parent.foo:foo=parent_foo",
+    "Parent.shared:shared=parent_shared",
+    "Child.foo:foo=child_foo",
+    "Child.childOnly:childOnly=child_childOnly",
+  ],
+  issue29837: ["B", "A"],
+  staticBlockPrivate: [[true, false, true, true, false, "s"], true, [1, 1], 1],
+  nestedScopes: [true, true],
+  temporaryNames: ["global init", "global G", "function", 5, true, 42],
+  temporaryScopes: ["secret", "outer", "static secret", "outer", "a", "b"],
+  accessorKeys: [11, 2, 3, 4],
+  issue31921: ["a", 1, "a", "b", [5, "a", "block", "b"]],
+  accessorStorage: [12, 13, 1, 14, 15, 2, "function", "function", 6],
+};
+
+function buildFixture() {
+  let src = fixturePrelude;
+  for (const cell of cells) {
+    src += matrixClass(cell);
+  }
+  src += installSection;
+  src += extraSections;
+  src += `\nPromise.all(pending).then(() => console.log(JSON.stringify(out)));\n`;
+  return src;
+}
+
+function buildExpected() {
+  const expected: Record<string, unknown> = {};
+  for (const cell of cells) {
+    expected[cellName(cell)] = matrixExpected(cell);
+  }
+  expected.install = installExpected;
+  Object.assign(expected, extraExpected);
+  return expected;
+}
+
+type Mode = {
+  name: string;
+  file: string;
+  bundle: boolean;
+};
+
+const modes: Mode[] = [
+  { name: ".js", file: "main.js", bundle: false },
+  { name: ".ts", file: "main.ts", bundle: false },
+  { name: ".js bundled", file: "main.js", bundle: true },
+];
+
+// Runs the fixture once per mode.
+async function runMode(mode: Mode) {
+  using dir = tempDir("es-dec-matrix", {
+    [mode.file]: buildFixture(),
+    "tsconfig.json": "{}",
+  });
+  let entry = mode.file;
+  if (mode.bundle) {
+    const build = await runIn(String(dir), ["build", mode.file, "--target=bun", "--outfile=bundled.js"]);
+    if (build.exitCode !== 0) return { out: {}, stderr: build.stderr, exitCode: build.exitCode };
+    entry = "bundled.js";
+  }
+  const { stdout, stderr, exitCode } = await runIn(String(dir), [entry]);
+  return { out: exitCode === 0 ? JSON.parse(stdout) : {}, stderr: filterStderr(stderr), exitCode };
+}
+
+const matrixRuns = await Promise.all(modes.map(runMode));
+
+describe("ES decorators lowering matrix", () => {
+  modes.forEach((mode, i) => {
+    describe(mode.name, () => {
+      const { out, stderr, exitCode } = matrixRuns[i];
+      const expected = buildExpected();
+
+      test("the fixture runs", () => {
+        expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+        expect(Object.keys(out).sort()).toEqual(Object.keys(expected).sort());
+      });
+
+      for (const key of Object.keys(expected)) {
+        test(key, () => {
+          // JSON turns `undefined` into `null`.
+          expect(out[key]).toEqual(expected[key]);
+        });
+      }
     });
   });
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -2478,7 +2478,7 @@ async function runMode(mode: Mode) {
   let entry = mode.file;
   if (mode.bundle) {
     const build = await runIn(String(dir), ["build", mode.file, "--target=bun", "--outfile=bundled.js"]);
-    if (build.exitCode !== 0) return { out: {}, stderr: build.stderr, exitCode: build.exitCode };
+    if (build.exitCode !== 0) return { out: {}, stderr: filterStderr(build.stderr), exitCode: build.exitCode };
     entry = "bundled.js";
   }
   const { stdout, stderr, exitCode } = await runIn(String(dir), [entry]);

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1679,6 +1679,23 @@ describe("ES Decorators", () => {
       expect(stdout).toBe('[5,["x"],6,["y"],[1,2]]\n');
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a decorated private name in the head of a loop or in a catch binding", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        class A {
+          @dec #x = 1;
+          forOf(a) { const out = []; for (const { v = this.#x } of a) out.push(v); return out; }
+          forIn(o) { const out = []; for (const { nope = this.#x } in o) out.push(nope); return out; }
+          caught() { try { throw {}; } catch ({ v = this.#x }) { return v; } }
+        }
+        const a = new A();
+        console.log(JSON.stringify([a.forOf([{}, { v: 2 }]), a.forIn({ k: 0 }), a.caught()]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[[1,2],[1],1]\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("accessor with TypeScript annotations", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1655,6 +1655,30 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("static field true function true\n");
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a TypeScript parameter property that holds the decorator lists keeps its name", async () => {
+      // The field of \`constructor(public x)\` is the only member with a key.
+      using dir = tempDir("es-dec-param-prop-key", {
+        "tsconfig.json": "{}",
+        "test.ts": `
+          const dec = (v: any, ctx: any) => {};
+          const seen: unknown[] = [];
+          class C { @dec #a = 1; constructor(public x: number) { seen.push(this.#a); } }
+          const c = new C(5);
+          function scope() {
+            const y = "outer";
+            class D { @dec #b = 2; constructor(public y: number) { seen.push(this.#b); } }
+            return new D(6);
+          }
+          const d = scope();
+          console.log(JSON.stringify([c.x, Object.keys(c), d.y, Object.keys(d), seen]));
+        `,
+      });
+      const { stdout, stderr, exitCode } = await runIn(String(dir), ["test.ts"]);
+      expect(filterStderr(stderr)).toBe("");
+      expect(stdout).toBe('[5,["x"],6,["y"],[1,2]]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("accessor with TypeScript annotations", () => {


### PR DESCRIPTION
### What was wrong

Lowering a class with standard decorators (or a bare `accessor`) moved part of the class out of its body: decorated fields into the constructor, decorated static fields and every static block to after the class, decorator lists to before it. Whatever moved lost the context it was written in, and whatever stayed ran in a different order:

```js
class A { @dec a = 1; b = this.a }          // b saw a === undefined: `b` stayed, `a` moved
class A extends B { @dec x = 1 }            // B's `set x` ran: `this.x = …` instead of a field
class A { @dec static x = this }            // `this` was the module's
class A extends B { @dec static x = super.y; static { super.z } }   // SyntaxError
const C = class Foo { @dec static s = Foo.f() }                     // ReferenceError: Foo
class A { accessor x; static #m; static { this.#m } }               // SyntaxError: #m (#31921)
class A { @dec m() {} #q = 1; d = this.#q }                         // SyntaxError: #q (#28118)
class A { static accessor a; static {} static accessor b }          // ran a, b, block
```

Every `#private` member was turned into a WeakMap as soon as one member was decorated, so that moved code could still reach it, and the hand-written walker that rewrites those accesses misses many forms (`this.#x++`, `this.#x ??= v`, nested functions and classes, parameter defaults).

### The fix

`lower_class_body` (`src/js_parser/lower/lower_decorators.rs`, mostly rewritten: +912 −1889) no longer moves members. Fields, static blocks and undecorated `#private` members stay native, so order, [[Define]] semantics, `this`, `super`, `new.target` and private names are right by construction instead of by rewriting. What the runtime helpers need is added around them:

```js
class A extends (_base = B) {
  static {                                  // first static element
    _init = __decoratorStart(_base);
    __decorateElement(_init, 1, "m", _dec2, this);
    __decorateElement(_init, 5, "a", _dec, this);
    __decoratorMetadata(_init, this);
  }
  [(_dec = [dec], "a")] = __runInitializers(_init, 8, this, 1);      // still a field
  b = (__runInitializers(_init, 11, this), this.a);                  // a's extra initializers, then b
  [(_dec2 = [dec], "m")]() {}
}
```

- **Decorator lists** are evaluated in the computed key of their member. That is their position in the spec: in order with computed keys, with the outer `this` / `await` / `arguments`, inside the class's private scope, before the class binding is initialized. A decorated `#private` member has no key and borrows a neighbor's. A class with no usable key at all (only `#private` members and a constructor) gets a `static [(lists, "__decorators")]() {}` that the leading block deletes first.
- **A leading `static {}`** applies the decorators in the helper's order, the class decorators last, so they run before any static field, as the spec says.
- **Decorated fields** keep their place and wrap their initializer. Decorated static fields are followed by a `static {}` for their extra initializers.
- **Between two instance fields** there is nowhere to put a statement, so accessor storage, lowered `#private` fields and extra initializers ride in the initializer of the next instance field, or in the constructor after the last one. An anonymous function or class in that initializer is still named by its field: `h = (effects, { h: () => {} }.h)` (the JIT sinks the object; 1e7 constructions measure the same with and without it).
- **Only `#private` names with a decorated member become WeakMaps**, because `__decorateElement` reaches them through `__privateGet`. The access rewriter now also walks nested functions, classes, parameter and destructuring defaults and object keys.
- An undecorated `accessor #x` is a plain `#x` field. A class with only accessors gets no `_init` and no `Symbol.metadata`. A class expression without class decorators is returned as is, so its context names it; `(class { @dec x }).name` is `""`, not `_class$1`. The inner binding that used to name such classes (and captured references to outer variables of the same name) is gone.
- The extra initializers of class decorators still run after the class is bound to its name, so they can refer to it.
- `LowerUsingDeclarationsContext::finalize` (`p.rs`) moves every `export class` in front of the `try` it wraps a module with top-level `using` in. A lowered class applies its decorators in a static block and evaluates their lists in its keys, so an exported class with static blocks or computed keys now stays in place as `var A = class A {}` plus an export clause, like exported `const`s already do.
- The generic `ReplaceThis` / `ReplaceRef` tree rewriter, static block extraction (and its arrow IIFE), `inner_class_ref` (`let _Foo = Foo`, which nothing read) and the `prop_copy` / `class_copy` `ptr::read`s are deleted. No new runtime helpers.
- `RuntimeTranspilerCache` version 31 → 32.

### Behaviour that changes on purpose

- Static fields and static blocks of a class with **class decorators** now run after the class decorators (spec, tsc); before, undecorated ones ran first.
- When a class decorator **returns a different class**, static members stay on the class as written, and a static block that names its own class sees that one too (methods and fields already did). `@wrap class A { @dec static accessor n = 1 }; A.n` now throws like the native `static #n` on a subclass does; 1.4.1 installed decorated static members on what the decorator returned.
- Decorated fields are defined, not assigned (the second example above).

### Tests

All in `test/bundler/transpiler/es-decorators.test.ts` (68 → 416 tests):

- "members stay where they are written": 18 single-purpose tests (order, [[Define]], static order, `new.target`, `super`, decorator lists in key position, class decorators before static fields, anonymous class names, function names on fields that carry effects, classes with no usable key, exported class next to a lowered `using`). 12 fail on 1.4.1; the other 6 pin what 1.4.1 already did right and the new placement has to keep.
- "ES decorators lowering matrix" (330 tests, built from the fixture of the previous revision): member kind × static × private × class decorator × derived, each cell a class with undecorated instance, private and static fields and a static block around the decorated member, run as `.js`, `.ts` and through `bun build`; plus fixture sections for the reported repros (#28118, #31917, #31921, #31929) and for `super` / `this` / private forms in static code, checked against what node prints for the undecorated class. On 1.4.1 the fixture does not load.
- Unchanged and passing: `es-decorators-esbuild.test.ts` (esbuild's 147 decorator tests), `decorators.test.ts`, `decorator-metadata.test.ts`, `bundler_edgecase.test.ts`, `transpiler.test.js`, `ts-use-define-for-class-fields.test.ts`, `lower-using-bun-target.test.ts`, `regression/issue/{27526,27575}`.
- I also compared 500 randomly generated classes (all member kinds, static / private / computed, class and member decorators, `extends`, explicit constructors) against TypeScript's ES2022 decorator emit under node, as `bun run`, `bun build` and `bun build --minify`: no difference except 8 cases where tsc's own output throws (anonymous class with a static accessor).

### Cost

Release builds of the same tree with and without `src/`, `bun build` of 3000 decorated classes (1.1 MB), user-space instructions: 529.8 M → 520.0 M bundled, 437.3 M → 429.4 M with `--no-bundle`, 568.4 M → 552.9 M with `--minify`. 3000 undecorated classes: 197.7 M → 197.6 M. The binary is 28 KB smaller. The output for that fixture is 6% larger (static blocks and computed keys).

### Not in this PR

- `this.#x++`, `this.#x += v`, destructuring and `for-of` targets, `o?.#x` and tagged templates **on a decorated `#x`** still print invalid or wrong code, and `super` in a decorated `#m()` is a SyntaxError: its body still becomes a function expression. Both are unchanged; undecorated privates no longer reach that path. Fixing them needs `__privateWrapper` / `__superGet`-style runtime helpers.
- Effects after the last instance field go into the constructor after a top-level `super(...)` statement, as before. `const r = super()` or `if (x) super(); else super()` still puts them first. When an instance field follows, they now ride in it and this works.
- With TypeScript's `useDefineForClassFields: false`, fields of a decorated class are still defined, as on main.
- From the previous revision of this PR, dropped: the `__superGet` / `__superSet` / `__superWrapper` / `__privateWrapper` helpers and the rewriters that used them (no longer needed for static code), the parse errors for `@x static {}` and parameter decorators in JS (#35544), and `var {…} = require("bun:wrap")` for CommonJS-wrapped modules (a decorated class in a `.cjs` file still fails to load; it is a module wrapper bug, not a lowering one).
- A class expression evaluated more than once still shares its `var` temporaries: #38933, #38904.

Fixes #28118
Fixes #31917
Fixes #31921

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 10 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 343 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [310.54ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [292.39ms]
(pass) ES Decorators > class decorators > class decorator can replace class [309.17ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [377.09ms]
(pass) ES Decorators > method decorators > instance method decorator [293.94ms]
(pass) ES Decorators > method decorators > static method decorator [302.05ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [397.91ms]
(pass) ES Decorators > getter decorators > getter decorator [409.87ms]
(pass) ES Decorators > setter decorators > setter decorator [378.03ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [297.63ms]
(pass) ES Decorators > field decorators > multiple field decorators [297.73ms]
(
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (d83b736c3)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [7.49ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [9.75ms]
(pass) ES Decorators > class decorators > class decorator can replace class [6.42ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [7.29ms]
(pass) ES Decorators > method decorators > instance method decorator [6.36ms]
(pass) ES Decorators > method decorators > static method decorator [6.63ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [6.29ms]
(pass) ES Decorators > getter decorators > getter decorator [6.35ms]
(pass) ES Decorators > setter decorators > setter decorator [6.33ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [6.88ms]
(pass) ES Decorators > field decorators > multiple field decorators [6.84ms]
(pass) ES Decorators > field decorators > static field decorator [7.26ms]
(pass) ES Decorators > non-ASCII string-literal keys > Bun.Transpiler output preserves the key [0.88ms]
(pass) ES Deco
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [338.17ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [308.25ms]
(pass) ES Decorators > class decorators > class decorator can replace class [396.76ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [316.26ms]
(pass) ES Decorators > method decorators > instance method decorator [391.13ms]
(pass) ES Decorators > method decorators > static method decorator [393.40ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [317.29ms]
(pass) ES Decorators > getter decorators > getter decorator [334.81ms]
(pass) ES Decorators > setter decorators > setter decorator [310.19ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [312.04ms]
(pass) ES Decorators > field decorators > multiple field decorators [303.38ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 625ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_js
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lower/lower_decorators.rs       | 2852 +++++++++----------------
 src/js_parser/p.rs                            |   39 +-
 src/js_parser/visit/mod.rs                    |    2 +-
 src/js_parser/visit/visit_expr.rs             |    2 +-
 src/jsc/RuntimeTranspilerCache.rs             |    3 +-
 test/bundler/transpiler/es-decorators.test.ts | 1151 ++++++++++
 6 files changed, 2150 insertions(+), 1899 deletions(-)
```

</details>

**gate history** · 7 passed · 1 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/lower/lower_decorators.rs           44     37     33
src/js_parser/p.rs                                 6      3     29
src/js_parser/visit/mod.rs                         2      2     29
src/js_parser/visit/visit_expr.rs                  1      0     28
src/jsc/RuntimeTranspilerCache.rs                  1      1     28
test/bundler/transpiler/es-decorators.test.ts      3      2     27
```

</details>

<!-- robobun:evidence:end -->