### PR TITLE
dotenv: read an explicit --env-file that is a pipe, FIFO or device

### DIFF
--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -73,6 +73,16 @@ bun --env-file=.env.1 src/index.ts
 bun --env-file=.env.abc --env-file=.env.def run build
 ```
 
+The path does not have to be a regular file. Bun reads a pipe, a FIFO, or a device until the end of the input, so secrets can reach the process without a file on disk:
+
+```sh
+bun --env-file=<(./fetch-secrets.sh) src/index.ts
+
+echo "API_KEY=..." | bun --env-file=/dev/stdin src/index.ts
+```
+
+A pipe can be read only once. Bun reads it when the process starts, and `Worker` threads and `bun test --parallel` workers reuse the values. A process that starts again with the same arguments reads the path again: a `--watch` reload, and children of `child_process.fork()` or `cluster.fork()`, which inherit `execArgv`. A pipe is then empty and a FIFO waits for a new writer, the same as with Node.js.
+
 ## Disabling automatic `.env` loading
 
 Use `--no-env-file` to disable Bun's automatic `.env` file loading, for example in production or CI/CD pipelines where you want to rely solely on system environment variables.

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,8 +595,7 @@ impl Loader {
         }
     }
 
-    /// A `Worker`'s loader: the map plus the explicit entries already marked
-    /// loaded, so a pipe is not read twice.
+    /// A `Worker`'s loader: the map, with the explicit entries marked loaded so a pipe is not read twice.
     pub fn clone_for_worker(&self) -> Result<Loader, AllocError> {
         Ok(Loader {
             map: self.map.clone_with_allocator()?,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,6 +595,21 @@ impl Loader {
         }
     }
 
+    /// The loader a `Worker` starts from. Its map is a copy of this one, so the
+    /// `--env-file` entries loaded here count as loaded there too and the worker
+    /// does not open them again: a pipe can be read once.
+    pub fn clone_for_worker(&self) -> Result<Loader, AllocError> {
+        Ok(Loader {
+            map: self.map.clone_with_allocator()?,
+            default_files_loaded: EnumSet::empty(),
+            custom_files_loaded: self.custom_files_loaded.clone()?,
+            quiet: false,
+            did_load_process: false,
+            reject_unauthorized: Cell::new(None),
+            aws_credentials: None,
+        })
+    }
+
     pub fn load_process(&mut self) -> Result<(), AllocError> {
         if self.did_load_process {
             return Ok(());
@@ -639,6 +654,7 @@ impl Loader {
     ) -> crate::Result<()> {
         // `suffix` is a runtime arg (avoids unstable adt_const_params; cold path).
         let start = bun_core::time::nano_timestamp();
+        let loaded_before = self.loaded_count();
 
         // Create a reusable buffer for parsing multiple files.
         let mut value_buffer: Vec<u8> = Vec::new();
@@ -658,10 +674,16 @@ impl Loader {
             }
         }
 
-        if !self.quiet {
+        // A worker's loader starts with the parent's files already loaded and
+        // has nothing to report.
+        if !self.quiet && self.loaded_count() > loaded_before {
             self.print_loaded(start);
         }
         Ok(())
+    }
+
+    fn loaded_count(&self) -> usize {
+        self.default_files_loaded.len() + self.custom_files_loaded.count()
     }
 
     fn load_explicit_files(
@@ -752,7 +774,7 @@ impl Loader {
     }
 
     pub(crate) fn print_loaded(&self, start: i128) {
-        let count: usize = self.default_files_loaded.len() + self.custom_files_loaded.count();
+        let count = self.loaded_count();
 
         if count == 0 {
             return;
@@ -798,7 +820,7 @@ impl Loader {
 
         // `bun_sys` is errno-based; the match arms below group the recoverable
         // errnos. Any errno not listed propagates.
-        let file = match bun_sys::File::openat(dir, base, ENV_FILE_OPEN_FLAGS, 0) {
+        let file = match bun_sys::File::openat(dir, base, DEFAULT_ENV_FILE_OPEN_FLAGS, 0) {
             Ok(file) => file,
             Err(err) => {
                 use bun_sys::E;
@@ -826,7 +848,7 @@ impl Loader {
             }
         };
 
-        match read_env_file_contents(&file)? {
+        match read_env_file_contents(&file, EnvFileSource::Default)? {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
                 if !self.quiet {
@@ -855,17 +877,23 @@ impl Loader {
             return Ok(());
         }
 
-        let file =
-            match bun_sys::File::openat(bun_sys::Fd::cwd(), file_path, ENV_FILE_OPEN_FLAGS, 0) {
-                Ok(f) => f,
-                Err(_) => {
-                    // prevent retrying
-                    self.custom_files_loaded.insert(file_path)?;
-                    return Ok(());
-                }
-            };
+        // No `O_NONBLOCK`: the user named this path, so a FIFO waits for its
+        // writer here, as in Node and `cat`.
+        let file = match bun_sys::File::openat(
+            bun_sys::Fd::cwd(),
+            file_path,
+            bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
+            0,
+        ) {
+            Ok(f) => f,
+            Err(_) => {
+                // prevent retrying
+                self.custom_files_loaded.insert(file_path)?;
+                return Ok(());
+            }
+        };
 
-        match read_env_file_contents(&file)? {
+        match read_env_file_contents(&file, EnvFileSource::Explicit)? {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
                 if !self.quiet {
@@ -886,16 +914,30 @@ impl Loader {
     }
 }
 
-/// `O_NONBLOCK`: a blocking `open` of a FIFO waits for a writer.
+/// Open flags for a default `.env*` entry. `O_NONBLOCK`: a blocking `open` of
+/// a FIFO waits for a writer.
 #[cfg(unix)]
-const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NONBLOCK;
+const DEFAULT_ENV_FILE_OPEN_FLAGS: i32 =
+    bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NONBLOCK;
 /// No `O_NONBLOCK`: an overlapped Windows handle cannot be read synchronously.
 #[cfg(not(unix))]
-const ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC;
+const DEFAULT_ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC;
+
+/// Where an env file came from. Decides what happens when it is not a regular file.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EnvFileSource {
+    /// A `.env*` name found in the cwd listing. A directory, FIFO, socket or
+    /// device under that name is not an env file and is skipped.
+    Default,
+    /// An `--env-file` argument. Read whatever its kind, as in Node:
+    /// `--env-file=<(cmd)`, `/dev/stdin`, a FIFO.
+    Explicit,
+}
 
 /// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`.
 enum ReadEnvFile {
-    /// Zero-length or not a regular file. The caller marks the slot and returns.
+    /// Zero-length, or a default entry that is not a regular file. The caller
+    /// marks the slot and returns.
     Empty,
     /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
     /// (unless `quiet`), marks the slot, and returns.
@@ -904,12 +946,24 @@ enum ReadEnvFile {
     Bytes(Vec<u8>),
 }
 
-fn read_env_file_contents(file: &bun_sys::File) -> crate::Result<ReadEnvFile> {
+fn read_env_file_contents(
+    file: &bun_sys::File,
+    source: EnvFileSource,
+) -> crate::Result<ReadEnvFile> {
     let stat = file.stat()?;
-    if stat.st_size == 0 || !bun_sys::is_regular_file(stat.st_mode as _) {
+    let result = if bun_sys::is_regular_file(stat.st_mode as _) {
+        if stat.st_size == 0 {
+            return Ok(ReadEnvFile::Empty);
+        }
+        file.read_to_end()
+    } else if source == EnvFileSource::Explicit {
+        // A pipe or device is not seekable, so `read(2)` until EOF, not `pread`.
+        let mut buf = Vec::new();
+        file.read_to_end_into(&mut buf).map(|_| buf)
+    } else {
         return Ok(ReadEnvFile::Empty);
-    }
-    match file.read_to_end() {
+    };
+    match result {
         Ok(buf) if buf.is_empty() => Ok(ReadEnvFile::Empty),
         Ok(buf) => Ok(ReadEnvFile::Bytes(buf)),
         Err(err) => {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,9 +595,8 @@ impl Loader {
         }
     }
 
-    /// The loader a `Worker` starts from. Its map is a copy of this one, so the
-    /// `--env-file` entries loaded here count as loaded there too and the worker
-    /// does not open them again: a pipe can be read once.
+    /// A `Worker`'s loader: the map plus the explicit entries already marked
+    /// loaded, so a pipe is not read twice.
     pub fn clone_for_worker(&self) -> Result<Loader, AllocError> {
         Ok(Loader {
             map: self.map.clone_with_allocator()?,
@@ -674,8 +673,6 @@ impl Loader {
             }
         }
 
-        // A worker's loader starts with the parent's files already loaded and
-        // has nothing to report.
         if !self.quiet && self.loaded_count() > loaded_before {
             self.print_loaded(start);
         }
@@ -877,8 +874,7 @@ impl Loader {
             return Ok(());
         }
 
-        // No `O_NONBLOCK`: the user named this path, so a FIFO waits for its
-        // writer here, as in Node and `cat`.
+        // No `O_NONBLOCK`: an explicit FIFO waits for its writer, as in Node.
         let file = match bun_sys::File::openat(
             bun_sys::Fd::cwd(),
             file_path,
@@ -914,8 +910,7 @@ impl Loader {
     }
 }
 
-/// Open flags for a default `.env*` entry. `O_NONBLOCK`: a blocking `open` of
-/// a FIFO waits for a writer.
+/// `O_NONBLOCK`: a blocking `open` of a FIFO named `.env` waits for a writer.
 #[cfg(unix)]
 const DEFAULT_ENV_FILE_OPEN_FLAGS: i32 =
     bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NONBLOCK;
@@ -923,21 +918,18 @@ const DEFAULT_ENV_FILE_OPEN_FLAGS: i32 =
 #[cfg(not(unix))]
 const DEFAULT_ENV_FILE_OPEN_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC;
 
-/// Where an env file came from. Decides what happens when it is not a regular file.
+/// Decides what happens to an env file that is not a regular file.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum EnvFileSource {
-    /// A `.env*` name found in the cwd listing. A directory, FIFO, socket or
-    /// device under that name is not an env file and is skipped.
+    /// A `.env*` name from the cwd listing: skipped.
     Default,
-    /// An `--env-file` argument. Read whatever its kind, as in Node:
-    /// `--env-file=<(cmd)`, `/dev/stdin`, a FIFO.
+    /// An `--env-file` argument: read whatever its kind, as in Node.
     Explicit,
 }
 
 /// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`.
 enum ReadEnvFile {
-    /// Zero-length, or a default entry that is not a regular file. The caller
-    /// marks the slot and returns.
+    /// Zero-length, or a default entry that is not a regular file. The caller marks the slot.
     Empty,
     /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
     /// (unless `quiet`), marks the slot, and returns.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -128,7 +128,7 @@ pub struct WebWorker {
 /// `start_vm()` on the worker thread.
 struct WorkerVmInit {
     transform_options: bun_options_types::schema::api::TransformOptions,
-    env_map: bun_dotenv::Map,
+    env_loader: bun_dotenv::Loader,
     proxy_env_slots: jsc::rare_data::ProxyEnvSlots,
 }
 
@@ -374,21 +374,21 @@ impl WebWorker {
         // parent's proxy_env_storage: snapshot slots + map under its lock so
         // every slice copied is backed by a ref the snapshot holds.
         let mut proxy_env_slots = jsc::rare_data::ProxyEnvSlots::default();
-        let mut env_map = {
+        let mut env_loader = {
             let parent_slots = parent_ref.proxy_env_storage.lock();
             proxy_env_slots.clone_from(&parent_slots);
-            match parent_ref.env_loader().map.clone_with_allocator() {
-                Ok(m) => m,
+            match parent_ref.env_loader().clone_for_worker() {
+                Ok(loader) => loader,
                 Err(_) => {
                     *error_message = BunString::static_("Out of memory");
                     return core::ptr::null_mut();
                 }
             }
         };
-        proxy_env_slots.sync_into(&mut env_map);
+        proxy_env_slots.sync_into(&mut env_loader.map);
         let init = WorkerVmInit {
             transform_options,
-            env_map,
+            env_loader,
             proxy_env_slots,
         };
 
@@ -664,7 +664,7 @@ impl WebWorker {
         let hooks = runtime_hooks().expect("RuntimeHooks not installed");
         let WorkerVmInit {
             transform_options,
-            env_map,
+            env_loader,
             proxy_env_slots,
         } = init;
 
@@ -674,8 +674,7 @@ impl WebWorker {
         // `heap::alloc`'d and stashed on `self` so `shutdown()` step 5 reclaims
         // it on every path — including the early-terminate checkpoint below,
         // which calls `shutdown()` before the VM exists.
-        let loader_ptr: *mut bun_dotenv::Loader =
-            bun_core::heap::into_raw(Box::new(bun_dotenv::Loader::init_with_map(env_map)));
+        let loader_ptr: *mut bun_dotenv::Loader = bun_core::heap::into_raw(Box::new(env_loader));
         self.worker_env_loader.set(loader_ptr);
 
         // Checkpoint before the expensive part: initWorker builds a full JSC

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -346,8 +346,7 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     }
     // Was `inline for` over a heterogeneous-ish tuple; all elements are
     // (&'static [u8], &[Box<[u8]>]) so a const array + plain for suffices.
-    // `--env-file` and `--no-env-file` are not forwarded: a worker loads no env
-    // file (see `TestCommand::exec`), its environment is the coordinator's map.
+    // No `--env-file`: a worker loads no env file (see `TestCommand::exec`).
     let multi_value_flags: [(&'static [u8], &[Box<[u8]>]); 5] = [
         (b"--conditions\0", &ctx.args.conditions),
         (b"--drop\0", &ctx.args.drop),

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -346,12 +346,11 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     }
     // Was `inline for` over a heterogeneous-ish tuple; all elements are
     // (&'static [u8], &[Box<[u8]>]) so a const array + plain for suffices.
-    let multi_value_flags: [(&'static [u8], &[Box<[u8]>]); 6] = [
+    let multi_value_flags: [(&'static [u8], &[Box<[u8]>]); 5] = [
         (b"--conditions\0", &ctx.args.conditions),
         (b"--drop\0", &ctx.args.drop),
         (b"--main-fields\0", &ctx.args.main_fields),
         (b"--extension-order\0", &ctx.args.extension_order),
-        (b"--env-file\0", &ctx.args.env_files),
         (b"--feature\0", &ctx.args.feature_flags),
     ];
     for (flag, values) in multi_value_flags {
@@ -381,7 +380,10 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     if matches!(ctx.debug.macros, MacroOptions::Disable) {
         argv.push(lit(b"--no-macros\0"));
     }
-    if ctx.args.disable_default_env_files {
+    // The coordinator loaded the `--env-file` entries into the env map the
+    // workers inherit. A pipe or FIFO can be read once, so the workers do not
+    // open the files again. Explicit files disable default `.env` discovery.
+    if ctx.args.disable_default_env_files || !ctx.args.env_files.is_empty() {
         argv.push(lit(b"--no-env-file\0"));
     }
     if let Some(jsx) = &ctx.args.jsx {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -346,6 +346,8 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     }
     // Was `inline for` over a heterogeneous-ish tuple; all elements are
     // (&'static [u8], &[Box<[u8]>]) so a const array + plain for suffices.
+    // `--env-file` and `--no-env-file` are not forwarded: a worker loads no env
+    // file (see `TestCommand::exec`), its environment is the coordinator's map.
     let multi_value_flags: [(&'static [u8], &[Box<[u8]>]); 5] = [
         (b"--conditions\0", &ctx.args.conditions),
         (b"--drop\0", &ctx.args.drop),
@@ -379,12 +381,6 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     }
     if matches!(ctx.debug.macros, MacroOptions::Disable) {
         argv.push(lit(b"--no-macros\0"));
-    }
-    // The coordinator loaded the `--env-file` entries into the env map the
-    // workers inherit. A pipe or FIFO can be read once, so the workers do not
-    // open the files again. Explicit files disable default `.env` discovery.
-    if ctx.args.disable_default_env_files || !ctx.args.env_files.is_empty() {
-        argv.push(lit(b"--no-env-file\0"));
     }
     if let Some(jsx) = &ctx.args.jsx {
         if !jsx.factory.is_empty() {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1906,10 +1906,8 @@ impl TestCommand {
             reporter.reporters.only_failures = true; // only-failures defaults to true for ai agents
         }
 
-        // A `--parallel` worker's environment is the coordinator's env map, which
-        // already holds every `.env` and `--env-file` value. A pipe can be read
-        // once, so the worker opens no env file. `--env-file` also arrives through
-        // `BUN_OPTIONS` in that environment, so the worker decides this itself.
+        // A worker's environment is the coordinator's env map, env files included.
+        // A pipe can be read once, and `BUN_OPTIONS` in that map can carry `--env-file`.
         if ctx.test_options.test_worker {
             ctx.args.env_files.clear();
             ctx.args.disable_default_env_files = true;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1906,15 +1906,24 @@ impl TestCommand {
             reporter.reporters.only_failures = true; // only-failures defaults to true for ai agents
         }
 
+        // A `--parallel` worker's environment is the coordinator's env map, which
+        // already holds every `.env` and `--env-file` value. A pipe can be read
+        // once, so the worker opens no env file. `--env-file` also arrives through
+        // `BUN_OPTIONS` in that environment, so the worker decides this itself.
+        if ctx.test_options.test_worker {
+            ctx.args.env_files.clear();
+            ctx.args.disable_default_env_files = true;
+        }
+
         bun_ast::initialize_store();
         // SAFETY: `init` returns the heap-allocated process-lifetime VM; deref once.
         let vm: &mut VirtualMachine = unsafe {
             &mut *VirtualMachine::init(jsc::virtual_machine::InitOptions {
                 // Clone (not take): ParallelRunner::run_as_coordinator → build_worker_argv
                 // reads ctx.args.{conditions,define,loaders,tsconfig_override,drop,
-                // main_fields,extension_order,env_files,feature_flags,preserve_symlinks,
-                // allow_addons,allow_ffi_cc,disable_default_env_files,jsx} after this point to forward
-                // them to workers.
+                // main_fields,extension_order,feature_flags,preserve_symlinks,
+                // allow_addons,allow_ffi_cc,jsx} after this point to forward them
+                // to workers.
                 transform_options: ctx.args.clone(),
                 debugger: core::mem::take(&mut ctx.runtime_options.debugger),
                 log: core::ptr::NonNull::new(ctx.log),

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1906,8 +1906,7 @@ impl TestCommand {
             reporter.reporters.only_failures = true; // only-failures defaults to true for ai agents
         }
 
-        // A worker's environment is the coordinator's env map, env files included.
-        // A pipe can be read once, and `BUN_OPTIONS` in that map can carry `--env-file`.
+        // The worker's environment already holds the coordinator's env file values, and `BUN_OPTIONS` in it can carry `--env-file`.
         if ctx.test_options.test_worker {
             ctx.args.env_files.clear();
             ctx.args.disable_default_env_files = true;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -795,16 +795,6 @@ describe.concurrent(".env that is not a regular file", () => {
     expect(script.exitCode).toBe(0);
   });
 
-  test.skipIf(isWindows)("--env-file pointing at a FIFO", async () => {
-    using dir = tempDir("dotenv-fifo-arg", files);
-    mkfifo(path.join(String(dir), "fifo"));
-
-    const script = await run(String(dir), "--env-file=fifo,.env.local", "index.ts");
-    expect(script.stderr).toBe("");
-    expect(script.stdout).toBe("1");
-    expect(script.exitCode).toBe(0);
-  });
-
   test.skipIf(isWindows)("unix socket behind a symlink", async () => {
     using dir = tempDir("dotenv-sock", files);
     using listener = Bun.listen({
@@ -821,6 +811,158 @@ describe.concurrent(".env that is not a regular file", () => {
     expect(script.stderr).toBe("");
     expect(script.stdout).toBe("1");
     expect(script.exitCode).toBe(0);
+  });
+});
+
+// An explicit `--env-file` is read whatever kind of file it is, as in Node.
+// `--env-file=<(cmd)` and `--env-file=/dev/stdin` pass secrets without a file
+// on disk. The default `.env` discovery above still skips such files.
+describe.concurrent("--env-file that is not a regular file", () => {
+  const files = {
+    "package.json": JSON.stringify({ name: "dotenv-arg-not-a-file" }),
+    ".env": "BUNTEST_DOTENV=1\n",
+    ".env.a": "BUNTEST_A=1\n",
+    "index.ts":
+      "console.log(Object.entries(process.env).flatMap(([k, v]) => k.startsWith('BUNTEST_') ? [`${k}=${v}`] : []).sort().join(','));",
+  };
+
+  async function run(cwd: string, cmd: string[], env: Record<string, string | undefined> = {}) {
+    await using proc = Bun.spawn({
+      cmd,
+      cwd,
+      env: { ...bunEnv, NODE_ENV: undefined, ...env },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  // `sh` makes a real pipe. `Bun.spawn({ stdin: "pipe" })` is a socket pair,
+  // which `/dev/stdin` cannot reopen on Linux.
+  test.skipIf(isWindows)("a pipe through /dev/stdin", async () => {
+    using dir = tempDir("dotenv-arg-stdin", files);
+
+    const script = await run(String(dir), [
+      "sh",
+      "-c",
+      'echo BUNTEST_PIPE=1 | "$0" --env-file=/dev/stdin index.ts',
+      bunExe(),
+    ]);
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("BUNTEST_PIPE=1");
+    expect(script.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("a pipe in a comma list, and the process env still wins", async () => {
+    using dir = tempDir("dotenv-arg-stdin-list", files);
+
+    const script = await run(
+      String(dir),
+      [
+        "sh",
+        "-c",
+        'printf "BUNTEST_PIPE=1\\nBUNTEST_PROCESS=1\\n" | "$0" --env-file=.env.a,/dev/stdin index.ts',
+        bunExe(),
+      ],
+      { BUNTEST_PROCESS: "P" },
+    );
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("BUNTEST_A=1,BUNTEST_PIPE=1,BUNTEST_PROCESS=P");
+    expect(script.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("process substitution", async () => {
+    using dir = tempDir("dotenv-arg-procsub", files);
+
+    const script = await run(String(dir), ["bash", "-c", '"$0" --env-file=<(echo BUNTEST_SUBST=1) index.ts', bunExe()]);
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("BUNTEST_SUBST=1");
+    expect(script.exitCode).toBe(0);
+  });
+
+  // The writer blocks in open(2) until bun opens the FIFO for reading, and bun
+  // blocks in open(2) until a writer arrives. Either order works, as with `cat`.
+  test.skipIf(isWindows)("a FIFO", async () => {
+    using dir = tempDir("dotenv-arg-fifo", files);
+    mkfifo(path.join(String(dir), "fifo"));
+    await using writer = Bun.spawn({
+      cmd: ["sh", "-c", "echo BUNTEST_FIFO=1 > fifo"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    const script = await run(String(dir), [bunExe(), "--env-file=fifo", "index.ts"]);
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("BUNTEST_FIFO=1");
+    expect(script.exitCode).toBe(0);
+    expect(await writer.exited).toBe(0);
+  });
+
+  // A pipe can be read once, so a worker must not open the `--env-file` entries
+  // again. It gets the values from the parent's env map, like `process.env` in
+  // a Node worker. A key added to the file after startup proves it did not read
+  // the file, and `.env` stays unloaded.
+  test("a worker inherits the values without opening the files again", async () => {
+    using dir = tempDir("dotenv-arg-worker", {
+      ...files,
+      "index.ts": `
+        await Bun.write(new URL("./.env.a", import.meta.url), "BUNTEST_A=1\\nBUNTEST_AFTER_START=1\\n");
+        const worker = new Worker(new URL("./worker.ts", import.meta.url));
+        worker.onmessage = ({ data }) => {
+          console.log(data);
+          worker.terminate();
+        };
+      `,
+      "worker.ts": `
+        postMessage(Object.entries(process.env).flatMap(([k, v]) => k.startsWith("BUNTEST_") ? [k + "=" + v] : []).sort().join(","));
+      `,
+    });
+
+    const script = await run(String(dir), [bunExe(), "--env-file=.env.a", "index.ts"]);
+    expect(script.stderr).toBe("");
+    expect(script.stdout).toBe("BUNTEST_A=1");
+    expect(script.exitCode).toBe(0);
+  });
+
+  // A compiled executable replaces the worker's env options with the standalone
+  // graph's flags after the worker copied them from the parent. The worker must
+  // still leave `.env` alone when `--env-file` came from BUN_OPTIONS.
+  test("a worker in a compiled executable", async () => {
+    const buntestVars = `Object.entries(process.env).flatMap(([k, v]) => k.startsWith("BUNTEST_") ? [k + "=" + v] : []).sort().join(",")`;
+    using dir = tempDir("dotenv-arg-compile-worker", {
+      ...files,
+      "index.js": `
+        const worker = new Worker(new URL("./worker.js", import.meta.url));
+        worker.onmessage = ({ data }) => {
+          console.log("worker " + data);
+          worker.terminate();
+        };
+        console.log("main " + ${buntestVars});
+      `,
+      "worker.js": `postMessage(${buntestVars});`,
+    });
+
+    const build = await run(String(dir), [
+      bunExe(),
+      "build",
+      "--compile",
+      "./index.js",
+      "./worker.js",
+      "--outfile",
+      "app",
+    ]);
+    expect(build.stderr).not.toContain("error:");
+    expect(build.exitCode).toBe(0);
+
+    const exe = path.join(String(dir), isWindows ? "app.exe" : "app");
+    const app = await run(String(dir), [exe], { BUN_OPTIONS: "--env-file=.env.a" });
+    expect(app.stdout).toBe("main BUNTEST_A=1\nworker BUNTEST_A=1");
+    expect(app.exitCode).toBe(0);
   });
 });
 

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1205,37 +1205,44 @@ test("--parallel: workers get the --env-file values and skip the default .env", 
 
 // A FIFO can be read once. The coordinator reads it and passes the values to the
 // workers in their environment. A worker that opened the FIFO again would block
-// in open(2), since no writer is left.
-test.skipIf(isWindows)("--parallel: the coordinator reads a FIFO --env-file once", async () => {
-  const fixture = `import {test,expect} from "bun:test"; test("env", () => { expect(process.env.BUNTEST_FIFO).toBe("1"); expect(process.env.BUNTEST_DOTENV).toBeUndefined(); });`;
-  using dir = tempDir("parallel-env-file-fifo", {
-    "a.test.js": fixture,
-    "b.test.js": fixture,
-    ".env": "BUNTEST_DOTENV=1\n",
+// in open(2), since no writer is left. That environment also carries
+// BUN_OPTIONS, which a worker splices into its own argv.
+for (const route of ["argv", "BUN_OPTIONS"] as const) {
+  test.skipIf(isWindows)(`--parallel: the coordinator reads a FIFO --env-file once (${route})`, async () => {
+    const fixture = `import {test,expect} from "bun:test"; test("env", () => { expect(process.env.BUNTEST_FIFO).toBe("1"); expect(process.env.BUNTEST_DOTENV).toBeUndefined(); });`;
+    using dir = tempDir("parallel-env-file-fifo", {
+      "a.test.js": fixture,
+      "b.test.js": fixture,
+      ".env": "BUNTEST_DOTENV=1\n",
+    });
+    mkfifo(path.join(String(dir), "fifo"));
+    await using writer = Bun.spawn({
+      cmd: ["sh", "-c", "echo BUNTEST_FIFO=1 > fifo"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", ...(route === "argv" ? ["--env-file=fifo"] : [])],
+      env: {
+        ...bunEnv,
+        BUN_TEST_PARALLEL_SCALE_MS: "0",
+        ...(route === "BUN_OPTIONS" ? { BUN_OPTIONS: "--env-file=fifo" } : {}),
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("PARALLEL");
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+    expect(await writer.exited).toBe(0);
   });
-  mkfifo(path.join(String(dir), "fifo"));
-  await using writer = Bun.spawn({
-    cmd: ["sh", "-c", "echo BUNTEST_FIFO=1 > fifo"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdin: "ignore",
-    stdout: "ignore",
-    stderr: "ignore",
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--parallel=2", "--env-file=fifo"],
-    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toContain("PARALLEL");
-  expect(stderr).toContain("2 pass");
-  expect(stderr).toContain("0 fail");
-  expect(exitCode).toBe(0);
-  expect(await writer.exited).toBe(0);
-});
+}
 
 test("--parallel --reporter=junit emits a synthetic suite for crashed files", async () => {
   using dir = tempDir("parallel-junit-crash", {

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { mkfifo } from "mkfifo";
+import path from "path";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -1177,6 +1179,62 @@ test("--parallel forwards --conditions to workers", async () => {
   expect(stderr).toContain("2 pass");
   expect(stderr).toContain("0 fail");
   expect(exitCode).toBe(0);
+});
+
+test("--parallel: workers get the --env-file values and skip the default .env", async () => {
+  const fixture = `import {test,expect} from "bun:test"; test("env", () => { expect(process.env.BUNTEST_CUSTOM).toBe("1"); expect(process.env.BUNTEST_DOTENV).toBeUndefined(); });`;
+  using dir = tempDir("parallel-env-file", {
+    "a.test.js": fixture,
+    "b.test.js": fixture,
+    ".env": "BUNTEST_DOTENV=1\n",
+    ".env.custom": "BUNTEST_CUSTOM=1\n",
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--env-file=.env.custom"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
+// A FIFO can be read once. The coordinator reads it and passes the values to the
+// workers in their environment. A worker that opened the FIFO again would block
+// in open(2), since no writer is left.
+test.skipIf(isWindows)("--parallel: the coordinator reads a FIFO --env-file once", async () => {
+  const fixture = `import {test,expect} from "bun:test"; test("env", () => { expect(process.env.BUNTEST_FIFO).toBe("1"); expect(process.env.BUNTEST_DOTENV).toBeUndefined(); });`;
+  using dir = tempDir("parallel-env-file-fifo", {
+    "a.test.js": fixture,
+    "b.test.js": fixture,
+    ".env": "BUNTEST_DOTENV=1\n",
+  });
+  mkfifo(path.join(String(dir), "fifo"));
+  await using writer = Bun.spawn({
+    cmd: ["sh", "-c", "echo BUNTEST_FIFO=1 > fifo"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--env-file=fifo"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+  expect(await writer.exited).toBe(0);
 });
 
 test("--parallel --reporter=junit emits a synthetic suite for crashed files", async () => {


### PR DESCRIPTION
Fixes #30520.

### Problem
- `--env-file=<(cmd)`, `/dev/stdin` and a FIFO load nothing and say nothing. Node reads them. 1Password serves secrets through a FIFO (#30520).
- `read_env_file_contents` (`src/dotenv/env_loader.rs:907`) returns `Empty` for every non-regular file. #40711 added that so a FIFO named `.env` is skipped. The explicit `--env-file` path shares it.

### Fix
- An explicit entry is read whatever its kind, as in Node: the open has no `O_NONBLOCK`, so a FIFO waits for its writer like `cat`, and `read(2)` runs until EOF instead of `pread`. Default `.env*` discovery keeps the skip.
- A pipe can be read once. A `Worker` starts from `Loader::clone_for_worker`, a copy of the parent's loader with the explicit entries marked loaded, so it does not open them again. A `bun test --parallel` worker loads no env file: its environment is the coordinator's map, and that map can carry `--env-file` in `BUN_OPTIONS` too.
- Correct because the user named the path. Node reads any readable path and blocks on a FIFO with no writer. A re-exec with the same argv (`--watch`, `fork()`) reads the path again, as in Node. The docs say so.
- Verified: 6 tests in `test/cli/run/env.test.ts` (`--env-file that is not a regular file`) and 3 in `test/cli/test/parallel.test.ts`. Seven fail with main's `src/`.

### Background
- `Loader::load` loads the `--env-file` list (`load_env_file_dynamic`) or probes the cwd for the default `.env*` names (`load_env_file`). Both call `read_env_file_contents`.
- `File::read_to_end` reads with `pread`, which fails on a pipe. `File::read_to_end_into` is the `read(2)` loop `bun run -` uses for stdin.
- A `Worker` clones the parent's env map and then runs `configure_defines` with the parent's options, which opened every `--env-file` entry again. The `--parallel` coordinator gives each child its env map and forwards its flags.

<details><summary>Notes</summary>

Repro on main (69c61387):

```
bun --env-file=<(echo A=1) -e 'console.log(process.env.A)'              # undefined, exit 0
echo A=1 | bun --env-file=/dev/stdin -e 'console.log(process.env.A)'    # undefined
mkfifo ff; (echo A=1 > ff &); bun --env-file=ff -e 'console.log(process.env.A)'  # undefined
```

With this change all three print `1`. A writer that connects after bun started also works: bun waits in `open`. Bun 1.4.0 and 1.4.1 exit 1 with no output for the same commands (`pread` on a pipe fails with ESPIPE).

With the loader change alone, `new Worker()` and `bun test --parallel` hang on the FIFO case: they re-open the path and no writer is left. That is why the worker and test runner hunks are here. The worker test rewrites the env file after startup and checks the worker does not see the new key. The parallel FIFO tests fail fast with main's `src/` (the coordinator skips the FIFO) and hang with the loader change alone.

The first revision forwarded `--no-env-file` to the `--parallel` workers instead of the list. Review found that `BUN_OPTIONS=--env-file=fifo` defeats that: the coordinator's env map, which becomes each worker's environment, still carries `BUN_OPTIONS`, and a worker splices it into its own argv. So the worker now clears its env file list itself (`test_command.rs`, under `--test-worker`) and the coordinator forwards neither `--env-file` nor `--no-env-file`. The FIFO test runs both routes.

Why the worker copies the loader's memo instead of clearing `env_files` in its transform options: a compiled executable runs `apply_standalone_runtime_flags` after the worker copied the options, and that resets `disable_default_env_files`. With cleared `env_files` the worker then loaded `.env*` while the main thread did not. The memo does not depend on those flags. The test `a worker in a compiled executable` pins it with `BUN_OPTIONS=--env-file=.env.a`.

`Loader::load` prints the `[0.05ms] ".env"` line only when the call loaded something. A worker's loader starts with the parent's entries marked loaded, and in debug builds its log level is Info, so it printed the parent's list for files it did not open.

What a re-exec does: `--watch` reloads and `child_process.fork()` / `cluster.fork()` children run the same argv, so they open the `--env-file` path again. A pipe is then at EOF and loads nothing (main: loads nothing every time). A FIFO waits for a new writer, which is what Node's `--watch` child and `fork()` child do. 1Password's FIFO serves every open. A reload that reuses the first read is a separate change.

Behavior that did not change:
- An explicit entry that fails to open (missing, socket) is still skipped silently. #36523 makes that fatal and touches `load_env_file_dynamic` too. The conflict is small: its open and read should keep the blocking open and the `read(2)` path from here.
- An explicit entry that is a directory is read, `read(2)` fails with EISDIR, and the message prints in non-quiet mode (`bun install`). That is the behavior before #40711.
- No size bound on the streamed read. `--env-file=/dev/zero` grows until `try_reserve` fails with ENOMEM. Node aborts with `bad_alloc` on the same input, and `bun run -` reads stdin the same way.
- macOS opens `/dev/fd/N` as a dup of the descriptor. No fcntl is done on it.
- Windows never used `O_NONBLOCK`. The only change there is that a non-regular explicit file (a named pipe, `CON`) is read.

The removed test `--env-file pointing at a FIFO` pinned the skip with no writer. Its replacement, `a FIFO`, has a writer. Without one the open waits, as in Node.

Suites run with the debug build: `env.test.ts` (107 pass), `no-envfile.test.ts`, `run-process-env.test.ts`, `parallel.test.ts` (41 pass), `web/workers/worker.test.ts`, `web/workers/worker-entry-point.test.ts`, `node/worker_threads/worker_threads.test.ts`. Three `worker.test.ts` cases under `terminate() races and lifecycle edges` fail or time out at 5 s the same way with main's `src/` in this debug build and are unrelated. `cargo check -p bun_dotenv` for x86_64-pc-windows-msvc and aarch64-apple-darwin, `cargo clippy -p bun_dotenv` clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts, test/cli/run/env.test.ts

<!-- robobun:evidence:end -->
