### PR TITLE
js_parser: keep "use strict" and the directive prologue in the output

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -50,9 +50,7 @@ pub struct Ast<'a> {
     // `hashbang`/`directives` are slices into source text. `StoreStr` records
     // them under the same lifetime-erased contract as `StoreRef`.
     pub hashbang: StoreStr,
-    /// The module-level directive prologue (`"use strict"`, `"use client"`, ...)
-    /// in source order. The parser strips it out of `parts` so the printer and
-    /// the linker emit it first, ahead of hoisted or generated statements.
+    /// Module-level directive prologue, in source order, stripped from `parts` so it prints first.
     pub directives: StoreSlice<StoreStr>,
     pub parts: PartList<'a>,
     // This list may be mutated later, so we should store the capacity

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -11,7 +11,7 @@ use bun_collections::{ArrayHashMap, StringArrayHashMap, StringHashMap};
 use crate::runtime;
 use crate::{
     CharFreq, ExportsKind, Expr, InlinedEnumValue, LocRef, NamedExport, NamedImport, Part, Range,
-    Ref, Scope, SlotCounts, StoreStr, Target,
+    Ref, Scope, SlotCounts, StoreSlice, StoreStr, Target,
 };
 
 use crate::part::List as PartList;
@@ -47,10 +47,13 @@ pub struct Ast<'a> {
     /// they can be manipulated efficiently without a full AST traversal
     pub import_records: ImportRecordList<'a>,
 
-    // `hashbang`/`directive` are slices into source text. `StoreStr` records
+    // `hashbang`/`directives` are slices into source text. `StoreStr` records
     // them under the same lifetime-erased contract as `StoreRef`.
     pub hashbang: StoreStr,
-    pub directive: Option<StoreStr>,
+    /// The module-level directive prologue (`"use strict"`, `"use client"`, ...)
+    /// in source order. The parser strips it out of `parts` so the printer and
+    /// the linker emit it first, ahead of hoisted or generated statements.
+    pub directives: StoreSlice<StoreStr>,
     pub parts: PartList<'a>,
     // This list may be mutated later, so we should store the capacity
     pub symbols: SymbolList<'a>,
@@ -109,7 +112,7 @@ impl<'a> Ast<'a> {
             top_level_await_keyword: Range::NONE,
             import_records: ImportRecordList::new_in(arena),
             hashbang: StoreStr::EMPTY,
-            directive: None,
+            directives: StoreSlice::EMPTY,
             parts: PartList::new_in(arena),
             symbols: SymbolList::new_in(arena),
             module_scope: Scope::default(),

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -47,8 +47,7 @@ pub struct Ast<'a> {
     /// they can be manipulated efficiently without a full AST traversal
     pub import_records: ImportRecordList<'a>,
 
-    // `hashbang` is a slice into source text. `StoreStr` records it under the
-    // same lifetime-erased contract as `StoreRef`.
+    // `hashbang` is a slice into source text, held under the lifetime-erased `StoreRef` contract.
     pub hashbang: StoreStr,
     /// Module-level directive prologue (`S::Directive` statements), stripped from `parts` so it prints first.
     pub directives: StoreSlice<Stmt>,

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -11,7 +11,7 @@ use bun_collections::{ArrayHashMap, StringArrayHashMap, StringHashMap};
 use crate::runtime;
 use crate::{
     CharFreq, ExportsKind, Expr, InlinedEnumValue, LocRef, NamedExport, NamedImport, Part, Range,
-    Ref, Scope, SlotCounts, StoreSlice, StoreStr, Target,
+    Ref, Scope, SlotCounts, Stmt, StoreSlice, StoreStr, Target,
 };
 
 use crate::part::List as PartList;
@@ -47,11 +47,11 @@ pub struct Ast<'a> {
     /// they can be manipulated efficiently without a full AST traversal
     pub import_records: ImportRecordList<'a>,
 
-    // `hashbang`/`directives` are slices into source text. `StoreStr` records
-    // them under the same lifetime-erased contract as `StoreRef`.
+    // `hashbang` is a slice into source text. `StoreStr` records it under the
+    // same lifetime-erased contract as `StoreRef`.
     pub hashbang: StoreStr,
-    /// Module-level directive prologue, in source order, stripped from `parts` so it prints first.
-    pub directives: StoreSlice<StoreStr>,
+    /// Module-level directive prologue (`S::Directive` statements), stripped from `parts` so it prints first.
+    pub directives: StoreSlice<Stmt>,
     pub parts: PartList<'a>,
     // This list may be mutated later, so we should store the capacity
     pub symbols: SymbolList<'a>,

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -45,8 +45,7 @@ pub struct Scope {
     pub forbid_arguments: bool,
 
     pub strict_mode: StrictModeKind,
-    /// The `"use strict"` directive that made this scope strict, when
-    /// `strict_mode` is `ExplicitStrictMode`. Used for error notes.
+    /// The `"use strict"` directive that made this scope strict, for error notes.
     pub use_strict_loc: Loc,
 
     pub is_after_const_local_prefix: bool,

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -1,11 +1,11 @@
 use bun_alloc::{AstAlloc, AstVec};
 use bun_collections::{StringHashMap, VecExt};
 
-use crate::StrictModeKind;
 use crate::base::Ref;
 use crate::nodes::StoreRef;
 use crate::symbol::{self, Symbol};
 use crate::ts::TSNamespaceScope;
+use crate::{Loc, StrictModeKind};
 
 /// Backed by `AstAlloc` so the table allocation *and* the per-key boxes land
 /// in the thread-local AST `mi_heap` and are reclaimed by the same
@@ -45,6 +45,9 @@ pub struct Scope {
     pub forbid_arguments: bool,
 
     pub strict_mode: StrictModeKind,
+    /// The `"use strict"` directive that made this scope strict, when
+    /// `strict_mode` is `ExplicitStrictMode`. Used for error notes.
+    pub use_strict_loc: Loc,
 
     pub is_after_const_local_prefix: bool,
 
@@ -75,6 +78,7 @@ impl Scope {
         contains_direct_eval: false,
         forbid_arguments: false,
         strict_mode: StrictModeKind::SloppyMode,
+        use_strict_loc: Loc::EMPTY,
         is_after_const_local_prefix: false,
         ts_namespace: None,
     };

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -554,6 +554,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             top_level_await_keyword: Range::NONE,
             nested_scope_slot_counts: Default::default(),
             hashbang: b"".into(),
+            directives: bun_ast::StoreSlice::EMPTY,
             css: None,
             url_for_css: b"",
             require_ref: Ref::NONE,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4282,9 +4282,7 @@ impl InsideWrapperPrefix {
         Ok(())
     }
 
-    /// A directive prologue has to be the first thing in the wrapper, ahead
-    /// of the dependency calls that `append_sync_dependency` inserts at
-    /// `sync_dependencies_end`. Call this before any dependency is appended.
+    /// Directives stay ahead of the `init_*()` calls that `append_sync_dependency` inserts.
     pub(crate) fn append_directive(&mut self, directive: bun_ast::StoreStr) {
         debug_assert!(self.stmts.len() == self.sync_dependencies_end && !self.has_async_dependency);
         self.stmts

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4282,6 +4282,16 @@ impl InsideWrapperPrefix {
         Ok(())
     }
 
+    /// A directive prologue has to be the first thing in the wrapper, ahead
+    /// of the dependency calls that `append_sync_dependency` inserts at
+    /// `sync_dependencies_end`. Call this before any dependency is appended.
+    pub(crate) fn append_directive(&mut self, directive: bun_ast::StoreStr) {
+        debug_assert!(self.stmts.len() == self.sync_dependencies_end && !self.has_async_dependency);
+        self.stmts
+            .push(Stmt::alloc(S::Directive { value: directive }, Loc::EMPTY));
+        self.sync_dependencies_end += 1;
+    }
+
     pub(crate) fn append_non_dependency_slice(&mut self, stmts: &[Stmt]) -> Result<(), AllocError> {
         self.stmts.extend_from_slice(stmts);
         Ok(())

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4283,10 +4283,9 @@ impl InsideWrapperPrefix {
     }
 
     /// Directives stay ahead of the `init_*()` calls that `append_sync_dependency` inserts.
-    pub(crate) fn append_directive(&mut self, directive: bun_ast::StoreStr) {
+    pub(crate) fn append_directive(&mut self, directive: Stmt) {
         debug_assert!(self.stmts.len() == self.sync_dependencies_end && !self.has_async_dependency);
-        self.stmts
-            .push(Stmt::alloc(S::Directive { value: directive }, Loc::EMPTY));
+        self.stmts.push(directive);
         self.sync_dependencies_end += 1;
     }
 

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -31,7 +31,9 @@ use bun_ast::import_record;
 use bun_core::strings;
 
 use bun_ast::ast_result::Ast;
-use bun_ast::{CharFreq, ExportsKind, Ref, Scope, SlotCounts, StoreSlice, StoreStr, TlaCheck};
+use bun_ast::{
+    CharFreq, ExportsKind, Ref, Scope, SlotCounts, Stmt, StoreSlice, StoreStr, TlaCheck,
+};
 use bun_ast::{part, symbol};
 
 pub(crate) type CommonJSNamedExports = bun_ast::ast_result::CommonJSNamedExports;
@@ -59,7 +61,7 @@ pub struct BundledAst<'arena> {
     // round-trip.
     pub(crate) hashbang: StoreStr,
     /// The file's directive prologue, in source order. See `Ast.directives`.
-    pub(crate) directives: StoreSlice<StoreStr>,
+    pub(crate) directives: StoreSlice<Stmt>,
     pub(crate) parts: part::List<'arena>,
     // See `CssAstRef` doc for the arena drop-order invariant that backs the
     // safe `Deref`.
@@ -107,7 +109,7 @@ bun_collections::multi_array_columns! {
         exports_kind: ExportsKind,
         import_records: import_record::List<'arena>,
         hashbang: StoreStr,
-        directives: StoreSlice<StoreStr>,
+        directives: StoreSlice<Stmt>,
         parts: part::List<'arena>,
         css: CssCol,
         url_for_css: &'arena [u8],

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -31,7 +31,7 @@ use bun_ast::import_record;
 use bun_core::strings;
 
 use bun_ast::ast_result::Ast;
-use bun_ast::{CharFreq, ExportsKind, Ref, Scope, SlotCounts, StoreStr, TlaCheck};
+use bun_ast::{CharFreq, ExportsKind, Ref, Scope, SlotCounts, StoreSlice, StoreStr, TlaCheck};
 use bun_ast::{part, symbol};
 
 pub(crate) type CommonJSNamedExports = bun_ast::ast_result::CommonJSNamedExports;
@@ -58,6 +58,8 @@ pub struct BundledAst<'arena> {
     // Ast.hashbang is `StoreStr`; mirror it here so init/to_ast can
     // round-trip.
     pub(crate) hashbang: StoreStr,
+    /// The file's directive prologue, in source order. See `Ast.directives`.
+    pub(crate) directives: StoreSlice<StoreStr>,
     pub(crate) parts: part::List<'arena>,
     // See `CssAstRef` doc for the arena drop-order invariant that backs the
     // safe `Deref`.
@@ -105,6 +107,7 @@ bun_collections::multi_array_columns! {
         exports_kind: ExportsKind,
         import_records: import_record::List<'arena>,
         hashbang: StoreStr,
+        directives: StoreSlice<StoreStr>,
         parts: part::List<'arena>,
         css: CssCol,
         url_for_css: &'arena [u8],
@@ -143,8 +146,7 @@ bitflags::bitflags! {
         const FORCE_CJS_TO_ESM = 1 << 4;
         const HAS_LAZY_EXPORT = 1 << 5;
         const COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED = 1 << 6;
-        const HAS_EXPLICIT_USE_STRICT_DIRECTIVE = 1 << 7;
-        const HAS_IMPORT_META = 1 << 8;
+        const HAS_IMPORT_META = 1 << 7;
         // _padding: u7 fills the rest
     }
 }
@@ -160,6 +162,7 @@ impl<'arena> BundledAst<'arena> {
             exports_kind: ExportsKind::None,
             import_records: import_record::List::new_in(arena),
             hashbang: StoreStr::EMPTY,
+            directives: StoreSlice::EMPTY,
             parts: part::List::new_in(arena),
             css: None,
             url_for_css: b"",
@@ -197,6 +200,7 @@ impl<'arena> BundledAst<'arena> {
             import_records: self.import_records,
 
             hashbang: self.hashbang,
+            directives: self.directives,
             parts: self.parts,
             // This list may be mutated later, so we should store the capacity
             symbols: self.symbols,
@@ -250,14 +254,6 @@ impl<'arena> BundledAst<'arena> {
             commonjs_module_exports_assigned_deoptimized: self
                 .flags
                 .contains(Flags::COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED),
-            directive: if self
-                .flags
-                .contains(Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
-            {
-                Some(StoreStr::new(b"use strict"))
-            } else {
-                None
-            },
             has_import_meta: self.flags.contains(Flags::HAS_IMPORT_META),
             ..Ast::empty_in(arena)
         }
@@ -276,10 +272,6 @@ impl<'arena> BundledAst<'arena> {
             Flags::COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED,
             ast.commonjs_module_exports_assigned_deoptimized,
         );
-        flags.set(
-            Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE,
-            ast.directive.is_some_and(|d| d == b"use strict"),
-        );
         flags.set(Flags::HAS_IMPORT_META, ast.has_import_meta);
 
         Self {
@@ -291,6 +283,7 @@ impl<'arena> BundledAst<'arena> {
             import_records: ast.import_records,
 
             hashbang: ast.hashbang,
+            directives: ast.directives,
             parts: ast.parts,
             css: None,
             url_for_css: b"",

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -259,10 +259,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
     let output_format = c.options.output_format;
 
-    // The top-level directives must come first. The chunk generation code
-    // prints them at the top of the chunk for the chunk's own entry point.
-    // Every other wrapped file gets them inside its wrapper, including an
-    // entry point that another entry point's chunk pulls in as a dependency.
+    // The chunk's own entry point gets its directives from `post_process_js_chunk` instead.
     let is_chunk_entry_point_file =
         chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
     if flags.wrap != WrapKind::None && !is_chunk_entry_point_file {

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -78,6 +78,11 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
             let hmr_api_ref = ast.wrapper_ref;
 
+            // The module's directive prologue leads the HMR wrapper body.
+            for directive in ast.directives.slice() {
+                stmts.inside_wrapper_prefix.append_directive(*directive);
+            }
+
             // SAFETY: see `parts` raw-pointer note above.
             for part in unsafe { (*parts).iter() } {
                 let part_stmts: &[Stmt] = part.stmts.slice();
@@ -254,24 +259,20 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
     let output_format = c.options.output_format;
 
-    // The top-level directive must come first (the non-wrapped case is handled
-    // by the chunk generation code, although only for the entry point)
-    if flags.wrap != WrapKind::None
-        && ast
-            .flags
-            .contains(AstFlags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
-        && !chunk.is_entry_point()
-        && !output_format.is_always_strict_mode()
-    {
-        stmts
-            .inside_wrapper_prefix
-            .append_non_dependency(Stmt::alloc(
-                S::Directive {
-                    value: bun_ast::StoreStr::new(b"use strict"),
-                },
-                bun_ast::Loc::EMPTY,
-            ))
-            .expect("unreachable");
+    // The top-level directives must come first. The chunk generation code
+    // prints them at the top of the chunk for the chunk's own entry point.
+    // Every other wrapped file gets them inside its wrapper, including an
+    // entry point that another entry point's chunk pulls in as a dependency.
+    let is_chunk_entry_point_file =
+        chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
+    if flags.wrap != WrapKind::None && !is_chunk_entry_point_file {
+        for directive in ast.directives.slice() {
+            // Every ES module is already in strict mode
+            if output_format.is_always_strict_mode() && directive.slice() == b"use strict" {
+                continue;
+            }
+            stmts.inside_wrapper_prefix.append_directive(*directive);
+        }
     }
 
     // `convert_stmts_for_chunk` takes `&mut c` inside the loop body, so capture

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -265,7 +265,9 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     if flags.wrap != WrapKind::None && !is_chunk_entry_point_file {
         for directive in ast.directives.slice() {
             // Every ES module is already in strict mode
-            if output_format.is_always_strict_mode() && directive.slice() == b"use strict" {
+            if output_format.is_always_strict_mode()
+                && matches!(directive.data, bun_ast::StmtData::SDirective(d) if d.value.slice() == b"use strict")
+            {
                 continue;
             }
             stmts.inside_wrapper_prefix.append_directive(*directive);

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -411,8 +411,10 @@ pub(crate) fn post_process_js_chunk(
     }
 
     // Add the top-level directives if present (but omit "use strict" in ES
-    // modules because all ES modules are automatically in strict mode)
-    if chunk.is_entry_point() {
+    // modules because all ES modules are automatically in strict mode). The dev
+    // server output is a registry of module closures, each with its own prologue,
+    // so a chunk-level directive would apply to every module in it.
+    if chunk.is_entry_point() && output_format != options::OutputFormat::InternalBakeDev {
         let directives = c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
 
         for stmt in directives.slice() {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -411,9 +411,8 @@ pub(crate) fn post_process_js_chunk(
     }
 
     // Add the top-level directives if present (but omit "use strict" in ES
-    // modules because all ES modules are automatically in strict mode). The dev
-    // server output is a registry of module closures, each with its own prologue,
-    // so a chunk-level directive would apply to every module in it.
+    // modules because all ES modules are automatically in strict mode)
+    // The dev server wraps every module in its own closure, which gets the prologue instead.
     if chunk.is_entry_point() && output_format != options::OutputFormat::InternalBakeDev {
         let directives = c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
 

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -410,14 +410,26 @@ pub(crate) fn post_process_js_chunk(
         newline_before_comment = true;
     }
 
-    // Add the top-level directive if present (but omit "use strict" in ES
+    // Add the top-level directives if present (but omit "use strict" in ES
     // modules because all ES modules are automatically in strict mode)
-    if chunk.is_entry_point() && !output_format.is_always_strict_mode() {
-        let flags = c.graph.ast.items_flags()[chunk.entry_point.source_index() as usize];
+    if chunk.is_entry_point() {
+        let directives = c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
 
-        if flags.contains(crate::bundled_ast::Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE) {
-            j.push_static(b"\"use strict\";\n");
-            line_offset.advance(b"\"use strict\";\n");
+        for directive in directives.slice() {
+            let directive = directive.slice();
+            if directive == b"use strict" && output_format.is_always_strict_mode() {
+                continue;
+            }
+            let mut buf = MutableString::init_empty();
+            let _ = js_printer::quote_for_json(directive, &mut buf, is_bun); // fmt::Result into Vec<u8> is infallible
+            bun_core::handle_oom(buf.append_slice(if c.options.minify_whitespace {
+                b";"
+            } else {
+                b";\n"
+            }));
+            let quoted = buf.take_slice();
+            line_offset.advance(&quoted);
+            j.push_owned(quoted.into_boxed_slice());
             newline_before_comment = true;
         }
     }

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -415,8 +415,11 @@ pub(crate) fn post_process_js_chunk(
     if chunk.is_entry_point() {
         let directives = c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
 
-        for directive in directives.slice() {
-            let directive = directive.slice();
+        for stmt in directives.slice() {
+            let js_ast::StmtData::SDirective(directive) = stmt.data else {
+                continue;
+            };
+            let directive = directive.value.slice();
             if directive == b"use strict" && output_format.is_always_strict_mode() {
                 continue;
             }

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -421,7 +421,9 @@ pub(crate) fn post_process_js_chunk(
                 continue;
             }
             let mut buf = MutableString::init_empty();
-            let _ = js_printer::quote_for_json(directive, &mut buf, is_bun); // fmt::Result into Vec<u8> is infallible
+            // The printer escapes string literals ASCII-only for the bun target (`print_with_writer`).
+            let ascii_only = is_bun;
+            let _ = js_printer::quote_for_json(directive, &mut buf, ascii_only); // fmt::Result into Vec<u8> is infallible
             bun_core::handle_oom(buf.append_slice(if c.options.minify_whitespace {
                 b";"
             } else {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5202,6 +5202,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Remember a legacy octal literal (`010`) for the strict-mode check in
+    /// the visit pass. The list stays sorted by location so `e_number` can
+    /// binary search it: a parse attempt that backtracks (TypeScript arrow
+    /// function detection) can lex a literal again, or reach an earlier one.
+    pub(crate) fn record_legacy_octal_literal(&mut self, range: bun_ast::Range) {
+        let list = &mut self.legacy_octal_literals;
+        match list.last() {
+            Some(last) if last.loc.start >= range.loc.start => {
+                let idx = list.partition_point(|r| r.loc.start < range.loc.start);
+                if list.get(idx).map(|r| r.loc.start) != Some(range.loc.start) {
+                    list.insert(idx, range);
+                }
+            }
+            _ => list.push(range),
+        }
+    }
+
     /// This is only allowed to be called if allow_runtime is true
     /// If --target=bun, this does nothing.
     pub(crate) fn record_usage_of_runtime_require(&mut self) {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8296,16 +8296,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let char_freq: Option<js_ast::CharFreq> = self.compute_character_frequency();
 
-        let directives: bun_ast::StoreSlice<bun_ast::StoreStr> = if directives.is_empty() {
-            bun_ast::StoreSlice::EMPTY
-        } else {
-            bun_ast::StoreSlice::new(arena.alloc_slice_fill_with(directives.len(), |i| {
-                match directives[i].data {
-                    js_ast::StmtData::SDirective(directive) => directive.value,
-                    _ => unreachable!("module directives are S::Directive statements"),
-                }
-            }))
-        };
+        let directives = bun_ast::StoreSlice::new(directives);
 
         // Scope is not `Clone` (Vec/HashMap members), so move it out and leave
         // a default in `*self.module_scope`. `to_ast` is terminal — the parser

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -447,7 +447,6 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) delete_target: js_ast::ExprData,
     pub(crate) loop_body: js_ast::StmtData,
     pub(crate) module_scope: js_ast::StoreRef<js_ast::Scope>,
-    pub(crate) module_scope_directive_loc: bun_ast::Loc,
     pub(crate) is_control_flow_dead: bool,
 
     /// True while `visit_single_stmt` is visiting a non-block body. `if`,
@@ -542,6 +541,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // makes it easier to quickly scan the top-level statements for "var" locals
     // with the guarantee that all will be found.
     pub(crate) relocated_top_level_vars: List<'a, js_ast::LocRef>,
+
+    // Source ranges of legacy octal literals (`010`), in source order. Whether
+    // one is an error depends on strict mode, which is only fully known in the
+    // visit pass (an `export` further down makes the whole file strict).
+    pub(crate) legacy_octal_literals: List<'a, bun_ast::Range>,
 
     // ArrowFunction is a special case in the grammar. Although it appears to be
     // a PrimaryExpression, it's actually an AssignmentExpression. This means if
@@ -3180,6 +3184,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `parent != scope` (fresh alloc) so the two `&mut` do not alias.
         VecExt::append(&mut parent.children, scope);
         scope.strict_mode = parent.strict_mode;
+        scope.use_strict_loc = parent.use_strict_loc;
 
         self.current_scope = scope;
 
@@ -4236,6 +4241,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             )
             .into_bump_str()
             .as_bytes(),
+            StrictModeFeature::LegacyOctalLiteral => b"Legacy octal literals",
         };
 
         let scope = self.current_scope();
@@ -4256,7 +4262,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     why = b"All code inside a class is implicitly in strict mode";
                     where_ = self.enclosing_class_keyword;
                 }
-                _ => {}
+                js_ast::StrictModeKind::ExplicitStrictMode => {
+                    why = b"Strict mode is triggered by the \"use strict\" directive here";
+                    where_ = self.source.range_of_string(scope.use_strict_loc);
+                }
+                js_ast::StrictModeKind::SloppyMode => {}
             }
             if why.is_empty() {
                 why = bun_alloc::arena_format!(
@@ -5181,7 +5191,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub(crate) fn is_valid_assignment_target(&self, expr: &Expr) -> bool {
         match &expr.data {
             js_ast::ExprData::EIdentifier(ident) => {
-                !is_eval_or_arguments(self.load_name_from_ref(ident.ref_))
+                // Assigning to "eval" or "arguments" is only an error in strict mode
+                !self.is_strict_mode() || !is_eval_or_arguments(self.load_name_from_ref(ident.ref_))
             }
             js_ast::ExprData::EDot(e) => e.optional_chain.is_none(),
             js_ast::ExprData::EIndex(e) => e.optional_chain.is_none(),
@@ -7800,6 +7811,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         exports_kind: js_ast::ExportsKind,
         wrap_mode: WrapMode,
         hashbang: &'a [u8],
+        // The module-level directive prologue, as `S::Directive` statements in
+        // source order. `_parse` strips them out of the top-level statements.
+        mut directives: &'a [Stmt],
     ) -> Result<Box<js_ast::Ast<'a>>, crate::Error> {
         use crate::lower::lower_esm_exports_hmr::ConvertESMExportsForHmr;
         use crate::scan::scan_imports::ImportScanner;
@@ -8117,32 +8131,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 };
             }
 
-            let mut total_stmts_count: usize = 0;
+            // The directive prologue moves inside the wrapper so that a
+            // "use strict" still governs the module's code.
+            let mut total_stmts_count: usize = directives.len();
             for part in parts.iter() {
                 total_stmts_count += part.stmts.len();
             }
-
-            let preserve_strict_mode = self.module_scope().strict_mode
-                == js_ast::StrictModeKind::ExplicitStrictMode
-                && !(parts.len() > 0
-                    && parts[0].stmts.len() > 0
-                    && matches!(parts[0].stmts[0].data, js_ast::StmtData::SDirective(_)));
-
-            total_stmts_count += usize::from(preserve_strict_mode);
 
             // Stmt is not Default; fill with `Stmt::empty()`.
             let stmts_to_copy = arena.alloc_slice_fill_with(total_stmts_count, |_| Stmt::empty());
             {
                 let mut remaining_stmts = &mut stmts_to_copy[..];
-                if preserve_strict_mode {
-                    remaining_stmts[0] = self.s(
-                        S::Directive {
-                            value: b"use strict".into(),
-                        },
-                        self.module_scope_directive_loc,
-                    );
-                    remaining_stmts = &mut remaining_stmts[1..];
-                }
+                remaining_stmts[..directives.len()].copy_from_slice(directives);
+                remaining_stmts = &mut remaining_stmts[directives.len()..];
+                directives = &[];
 
                 for part in parts.iter() {
                     let src = part.stmts.slice();
@@ -8189,7 +8191,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if self.options.repl_mode {
             // `apply_repl_transforms` is declared in ast::repl_transforms as an
             // `impl P` mixin.
-            self.apply_repl_transforms(parts, arena)?;
+            if self.apply_repl_transforms(parts, arena, directives)? {
+                directives = &[];
+            }
         }
 
         let mut top_level_symbols_to_parts = bun_ast::ast_result::TopLevelSymbolToParts::default();
@@ -8282,7 +8286,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let char_freq: Option<js_ast::CharFreq> = self.compute_character_frequency();
 
-        let module_scope_strict = self.module_scope().strict_mode;
+        let directives: bun_ast::StoreSlice<bun_ast::StoreStr> = if directives.is_empty() {
+            bun_ast::StoreSlice::EMPTY
+        } else {
+            bun_ast::StoreSlice::new(arena.alloc_slice_fill_with(directives.len(), |i| {
+                match directives[i].data {
+                    js_ast::StmtData::SDirective(directive) => directive.value,
+                    _ => unreachable!("module directives are S::Directive statements"),
+                }
+            }))
+        };
+
         // Scope is not `Clone` (Vec/HashMap members), so move it out and leave
         // a default in `*self.module_scope`. `to_ast` is terminal — the parser
         // does not touch `module_scope` afterwards.
@@ -8340,11 +8354,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             export_keyword: self.esm_export_keyword,
             top_level_symbols_to_parts,
             char_freq,
-            directive: if module_scope_strict == js_ast::StrictModeKind::ExplicitStrictMode {
-                Some(bun_ast::StoreStr::new(b"use strict"))
-            } else {
-                None
-            },
+            directives,
             nested_scope_slot_counts,
 
             require_ref,
@@ -8724,7 +8734,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             import_items_for_namespace: Default::default(),
             is_import_item: Default::default(),
             scope_order_to_visit: &[],
-            module_scope_directive_loc: bun_ast::Loc::default(),
             is_control_flow_dead: false,
             is_inside_single_stmt_body: false,
             is_revisit_for_substitution: false,
@@ -8734,6 +8743,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             temp_refs_to_declare: BumpVec::new_in(arena),
             temp_ref_count: 0,
             relocated_top_level_vars: BumpVec::new_in(arena),
+            legacy_octal_literals: BumpVec::new_in(arena),
             after_arrow_body_loc: bun_ast::Loc::EMPTY,
             const_values: Default::default(),
             binary_expression_stack: BumpVec::new_in(arena),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -542,9 +542,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // with the guarantee that all will be found.
     pub(crate) relocated_top_level_vars: List<'a, js_ast::LocRef>,
 
-    // Source ranges of legacy octal literals (`010`), in source order. Whether
-    // one is an error depends on strict mode, which is only fully known in the
-    // visit pass (an `export` further down makes the whole file strict).
+    // Legacy octal literals (`010`), sorted by location. Strict mode is only final in the visit pass.
     pub(crate) legacy_octal_literals: List<'a, bun_ast::Range>,
 
     // ArrowFunction is a special case in the grammar. Although it appears to be
@@ -5202,10 +5200,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Remember a legacy octal literal (`010`) for the strict-mode check in
-    /// the visit pass. The list stays sorted by location so `e_number` can
-    /// binary search it: a parse attempt that backtracks (TypeScript arrow
-    /// function detection) can lex a literal again, or reach an earlier one.
+    /// Keeps `legacy_octal_literals` sorted: a backtracking parse attempt can lex a literal twice.
     pub(crate) fn record_legacy_octal_literal(&mut self, range: bun_ast::Range) {
         let list = &mut self.legacy_octal_literals;
         match list.last() {
@@ -7828,8 +7823,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         exports_kind: js_ast::ExportsKind,
         wrap_mode: WrapMode,
         hashbang: &'a [u8],
-        // The module-level directive prologue, as `S::Directive` statements in
-        // source order. `_parse` strips them out of the top-level statements.
+        // Module-level directives, stripped from the top-level statements by `_parse`.
         mut directives: &'a [Stmt],
     ) -> Result<Box<js_ast::Ast<'a>>, crate::Error> {
         use crate::lower::lower_esm_exports_hmr::ConvertESMExportsForHmr;
@@ -8148,8 +8142,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 };
             }
 
-            // The directive prologue moves inside the wrapper so that a
-            // "use strict" still governs the module's code.
+            // The directive prologue moves inside the wrapper.
             let mut total_stmts_count: usize = directives.len();
             for part in parts.iter() {
                 total_stmts_count += part.stmts.len();

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4239,6 +4239,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             )
             .into_bump_str()
             .as_bytes(),
+            StrictModeFeature::AssignToEvalOrArguments => bun_alloc::arena_format!(
+                in self.arena,
+                "Assignments to \"{}\"",
+                bstr::BStr::new(detail)
+            )
+            .into_bump_str()
+            .as_bytes(),
             StrictModeFeature::LegacyOctalLiteral => b"Legacy octal literals",
         };
 

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -335,6 +335,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(expr)
     }
 
+    /// Whether the string literal at `loc` is spelled `"use strict"` or `'use strict'`
+    /// in the source. Only an unescaped spelling is a Use Strict Directive.
+    fn source_has_use_strict_token(&self, loc: bun_ast::Loc) -> bool {
+        const RAW: &[u8] = b"use strict";
+        let contents = self.source.contents();
+        let start = loc.i() + 1;
+        let end = start + RAW.len();
+        contents.get(start..end) == Some(RAW) && contents.get(end) == contents.get(loc.i())
+    }
+
     pub(crate) fn parse_call_args(&mut self) -> Result<ExprListLoc, Error> {
         // Allow "in" inside call arguments; restored on every exit path
         let old_allow_in = self.allow_in;
@@ -1479,13 +1489,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 is_directive_prologue = false;
                 if let js_ast::stmt::Data::SExpr(expr) = &stmt.data {
                     if let js_ast::expr::Data::EString(str_) = &expr.value.data {
-                        if !str_.prefer_template {
+                        // A directive is a bare string token: `("use strict")` ends the prologue.
+                        if !str_.prefer_template && expr.value.loc == stmt.loc {
                             is_directive_prologue = true;
 
                             if str_.eql_comptime(b"use asm") && !p.options.repl_mode {
                                 // Dropped: the output would fail asm.js validation. The REPL keeps it, like node.
                                 skip = true;
                                 stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});
+                            } else if str_.eql_comptime(b"use strict")
+                                && !p.source_has_use_strict_token(expr.value.loc)
+                            {
+                                // `"use\x20strict"` cooks to the same value, but a Use Strict
+                                // Directive has no escape sequence. It stays a string statement.
                             } else {
                                 let directive_loc = expr.value.loc;
                                 let is_use_strict = str_.eql_comptime(b"use strict");

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1492,17 +1492,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if !str_.prefer_template && expr.value.loc == stmt.loc {
                             is_directive_prologue = true;
 
-                            if str_.eql_comptime(b"use asm") && !p.options.repl_mode {
-                                // Dropped: the output would fail asm.js validation. The REPL keeps it, like node.
-                                skip = true;
-                                stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});
-                            } else if str_.eql_comptime(b"use strict")
-                                && !p.source_has_use_strict_token(expr.value.loc)
-                            {
-                                // `"use\x20strict"` cooks to the same value but stays a string statement.
+                            let is_use_strict = str_.eql_comptime(b"use strict");
+                            // `"use\x20strict"` cooks to the same value but is not a Use Strict Directive.
+                            let escaped_use_strict =
+                                is_use_strict && !p.source_has_use_strict_token(expr.value.loc);
+                            if str_.eql_comptime(b"use asm") || escaped_use_strict {
+                                // Dropped outside the REPL: asm.js fails validation after transformation, and the printer cannot keep the escape.
+                                if !p.options.repl_mode {
+                                    skip = true;
+                                    stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});
+                                }
                             } else {
                                 let directive_loc = expr.value.loc;
-                                let is_use_strict = str_.eql_comptime(b"use strict");
                                 let bytes = str_.string(p.arena).expect("OOM");
                                 stmt = Stmt::alloc(
                                     S::Directive {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1483,13 +1483,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             is_directive_prologue = true;
 
                             if str_.eql_comptime(b"use asm") && !p.options.repl_mode {
-                                // Deliberately remove "use asm" directives. The asm.js
-                                // validator would reject the transformed output and
-                                // engines print a warning when validation fails.
-                                //
-                                // In the REPL the directive stays a string
-                                // statement so it evaluates as the result,
-                                // like node ('use asm' prints 'use asm').
+                                // Dropped: the output would fail asm.js validation. The REPL keeps it, like node.
                                 skip = true;
                                 stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});
                             } else {
@@ -1509,14 +1503,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     scope.strict_mode = StrictModeKind::ExplicitStrictMode;
                                     scope.use_strict_loc = directive_loc;
 
-                                    // Inside a function, strict mode propagates from the
-                                    // body scope to the argument scope:
-                                    //
-                                    //   // This is a syntax error
-                                    //   function fn(arguments) {
-                                    //     "use strict";
-                                    //   }
-                                    //
+                                    // The body's directive governs the parameters too: `function fn(arguments) { "use strict" }` is an error.
                                     if scope.kind == js_ast::scope::Kind::FunctionBody {
                                         if let Some(mut parent) = scope.parent {
                                             if parent.kind == js_ast::scope::Kind::FunctionArgs

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1167,7 +1167,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             T::TNumericLiteral => {
                 key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                // check for legacy octal literal
+                if p.lexer.is_legacy_octal_literal {
+                    p.record_legacy_octal_literal(p.lexer.range());
+                }
                 p.lexer.next()?;
             }
             T::TStringLiteral => {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1448,7 +1448,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut return_without_semicolon_start: i32 = -1;
         opts.lexical_decl = LexicalDecl::AllowAll;
-        let mut is_directive_prologue = true;
+        let mut is_directive_prologue = opts.allow_directive_prologue;
 
         loop {
             for comment in p.lexer.comments_to_preserve_before.iter() {
@@ -1480,21 +1480,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if !str_.prefer_template {
                             is_directive_prologue = true;
 
-                            if str_.eql_comptime(b"use strict") {
-                                skip = true;
-                                // Track "use strict" directives
-                                p.current_scope_mut().strict_mode =
-                                    StrictModeKind::ExplicitStrictMode;
-                                if p.current_scope == p.module_scope {
-                                    p.module_scope_directive_loc = stmt.loc;
-                                }
-                            } else if str_.eql_comptime(b"use asm") && !p.options.repl_mode {
+                            if str_.eql_comptime(b"use asm") && !p.options.repl_mode {
+                                // Deliberately remove "use asm" directives. The asm.js
+                                // validator would reject the transformed output and
+                                // engines print a warning when validation fails.
+                                //
                                 // In the REPL the directive stays a string
                                 // statement so it evaluates as the result,
                                 // like node ('use asm' prints 'use asm').
                                 skip = true;
                                 stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});
                             } else {
+                                let directive_loc = expr.value.loc;
+                                let is_use_strict = str_.eql_comptime(b"use strict");
                                 let bytes = str_.string(p.arena).expect("OOM");
                                 stmt = Stmt::alloc(
                                     S::Directive {
@@ -1502,6 +1500,33 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     },
                                     stmt.loc,
                                 );
+
+                                if is_use_strict {
+                                    // Track "use strict" directives
+                                    let mut scope = p.current_scope;
+                                    scope.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                    scope.use_strict_loc = directive_loc;
+
+                                    // Inside a function, strict mode propagates from the
+                                    // body scope to the argument scope:
+                                    //
+                                    //   // This is a syntax error
+                                    //   function fn(arguments) {
+                                    //     "use strict";
+                                    //   }
+                                    //
+                                    if scope.kind == js_ast::scope::Kind::FunctionBody {
+                                        if let Some(mut parent) = scope.parent {
+                                            if parent.kind == js_ast::scope::Kind::FunctionArgs
+                                                && parent.strict_mode == StrictModeKind::SloppyMode
+                                            {
+                                                parent.strict_mode =
+                                                    StrictModeKind::ExplicitStrictMode;
+                                                parent.use_strict_loc = directive_loc;
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -335,8 +335,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(expr)
     }
 
-    /// Whether the string literal at `loc` is spelled `"use strict"` or `'use strict'`
-    /// in the source. Only an unescaped spelling is a Use Strict Directive.
+    /// Only an unescaped `"use strict"` or `'use strict'` token is a Use Strict Directive.
     fn source_has_use_strict_token(&self, loc: bun_ast::Loc) -> bool {
         const RAW: &[u8] = b"use strict";
         let contents = self.source.contents();
@@ -1500,8 +1499,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             } else if str_.eql_comptime(b"use strict")
                                 && !p.source_has_use_strict_token(expr.value.loc)
                             {
-                                // `"use\x20strict"` cooks to the same value, but a Use Strict
-                                // Directive has no escape sequence. It stays a string statement.
+                                // `"use\x20strict"` cooks to the same value but stays a string statement.
                             } else {
                                 let directive_loc = expr.value.loc;
                                 let is_use_strict = str_.eql_comptime(b"use strict");

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -438,6 +438,7 @@ impl<'a> Parser<'a> {
         // Parse the file in the first pass, but do not bind symbols
         let mut opts = ParseStatementOptions {
             scope: StatementScope::Module,
+            allow_directive_prologue: true,
             ..Default::default()
         };
 
@@ -628,6 +629,7 @@ impl<'a> Parser<'a> {
             exports_kind,
             WrapMode::None,
             b"",
+            &[],
         )?))
     }
 }
@@ -825,6 +827,7 @@ impl<'a> Parser<'a> {
         // Parse the file in the first pass, but do not bind symbols
         let mut opts = ParseStatementOptions {
             scope: StatementScope::Module,
+            allow_directive_prologue: true,
             ..Default::default()
         };
         let mut parse_tracer = bun_core::perf::trace("JSParser::parse");
@@ -896,6 +899,48 @@ impl<'a> Parser<'a> {
                 import_bindings,
             )));
         }
+
+        // Strip off all leading directives. They go on `Ast.directives` so
+        // that the printer and the linker can emit them ahead of hoisted
+        // imports and generated statements, where a directive prologue has
+        // to be for engines and tools to honor it.
+        let directives: &'a [Stmt];
+        let stmts: &'a mut [Stmt] = {
+            let mut directive_list = BumpVec::<Stmt>::new_in(p.arena);
+            let mut total_count: usize = 0;
+            let mut kept_count: usize = 0;
+            for i in 0..stmts.len() {
+                let stmt = stmts[i];
+                match stmt.data {
+                    js_ast::StmtData::SComment(_) => {
+                        stmts[kept_count] = stmt;
+                        kept_count += 1;
+                        total_count += 1;
+                    }
+                    js_ast::StmtData::SDirective(directive) => {
+                        // Remove duplicate directives
+                        let is_duplicate = directive_list.iter().any(|existing| {
+                            matches!(existing.data, js_ast::StmtData::SDirective(prev)
+                                if prev.value.slice() == directive.value.slice())
+                        });
+                        if !is_duplicate {
+                            directive_list.push(stmt);
+                        }
+                        total_count += 1;
+                    }
+                    // Stop when the directive prologue ends
+                    _ => break,
+                }
+            }
+            directives = directive_list.into_bump_slice();
+            if kept_count < total_count {
+                stmts.copy_within(total_count.., kept_count);
+                let new_len = stmts.len() - (total_count - kept_count);
+                stmts.split_at_mut(new_len).0
+            } else {
+                stmts
+            }
+        };
 
         let mut before = BumpVec::<js_ast::Part>::new_in(p.arena);
         let mut after = BumpVec::<js_ast::Part>::new_in(p.arena);
@@ -2170,7 +2215,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let ast = p.to_ast(&mut parts, exports_kind, wrap_mode, hashbang)?;
+        let ast = p.to_ast(&mut parts, exports_kind, wrap_mode, hashbang, directives)?;
 
         if reject_import_statements {
             // An empty range marks a parser-generated record, like the JSX runtime import.

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -900,10 +900,7 @@ impl<'a> Parser<'a> {
             )));
         }
 
-        // Strip off all leading directives. They go on `Ast.directives` so
-        // that the printer and the linker can emit them ahead of hoisted
-        // imports and generated statements, where a directive prologue has
-        // to be for engines and tools to honor it.
+        // Strip the directive prologue into `Ast.directives`, which prints ahead of hoisted statements.
         let directives: &'a [Stmt];
         let stmts: &'a mut [Stmt] = {
             let mut directive_list = BumpVec::<Stmt>::new_in(p.arena);

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -501,7 +501,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         p.lexer.expect(T::TOpenBrace)?;
-        let mut opts = ParseStatementOptions::default();
+        let mut opts = ParseStatementOptions {
+            allow_directive_prologue: true,
+            ..Default::default()
+        };
         let stmts = p.parse_stmts_up_to(T::TCloseBrace, &mut opts)?;
         p.lexer.next()?;
 

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -301,7 +301,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn pfx_t_numeric_literal(p: &mut Self) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let value = p.new_expr(E::Number::new(p.lexer.number), loc);
-        // p.checkForLegacyOctalLiteral()
+        if p.lexer.is_legacy_octal_literal {
+            p.legacy_octal_literals.push(p.lexer.range());
+        }
         p.lexer.next()?;
         Ok(value)
     }

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -302,7 +302,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let loc = p.lexer.loc();
         let value = p.new_expr(E::Number::new(p.lexer.number), loc);
         if p.lexer.is_legacy_octal_literal {
-            p.legacy_octal_literals.push(p.lexer.range());
+            p.record_legacy_octal_literal(p.lexer.range());
         }
         p.lexer.next()?;
         Ok(value)

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -261,7 +261,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match p.lexer.token {
                 T::TNumericLiteral => {
                     key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                    // p.checkForLegacyOctalLiteral()
+                    if p.lexer.is_legacy_octal_literal {
+                        p.legacy_octal_literals.push(key_range);
+                    }
                     p.lexer.next()?;
                 }
                 T::TStringLiteral => {

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -262,7 +262,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 T::TNumericLiteral => {
                     key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
                     if p.lexer.is_legacy_octal_literal {
-                        p.legacy_octal_literals.push(key_range);
+                        p.record_legacy_octal_literal(key_range);
                     }
                     p.lexer.next()?;
                 }

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -265,6 +265,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let mut _opts = ParseStatementOptions {
                 scope: StatementScope::Namespace,
                 is_typescript_declare: opts.is_typescript_declare,
+                // The body becomes a function body when the namespace is lowered, and tsc keeps its prologue.
+                allow_directive_prologue: true,
                 ..ParseStatementOptions::default()
             };
             stmts = p.parse_stmts_up_to(T::TCloseBrace, &mut _opts)?;

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1055,6 +1055,7 @@ pub struct ParsedPath<'a> {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum StrictModeFeature {
     EvalOrArguments,
+    AssignToEvalOrArguments,
     ReservedWord,
     LegacyOctalLiteral,
 }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1056,6 +1056,7 @@ pub struct ParsedPath<'a> {
 pub enum StrictModeFeature {
     EvalOrArguments,
     ReservedWord,
+    LegacyOctalLiteral,
 }
 
 #[derive(Clone, Copy)]
@@ -1457,6 +1458,10 @@ pub struct ParseStatementOptions<'a> {
     pub(crate) is_name_optional: bool,
     pub(crate) is_typescript_declare: bool,
     pub(crate) is_for_loop_init: bool,
+    /// Only a module body or a function body starts with a directive
+    /// prologue. A string statement at the start of a block, a class static
+    /// block, or a TypeScript namespace is an ordinary expression statement.
+    pub(crate) allow_directive_prologue: bool,
 }
 
 impl<'a> ParseStatementOptions<'a> {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1458,9 +1458,7 @@ pub struct ParseStatementOptions<'a> {
     pub(crate) is_name_optional: bool,
     pub(crate) is_typescript_declare: bool,
     pub(crate) is_for_loop_init: bool,
-    /// Only a module body or a function body starts with a directive
-    /// prologue. A string statement at the start of a block, a class static
-    /// block, or a TypeScript namespace is an ordinary expression statement.
+    /// Only a module body or a function body starts with a directive prologue.
     pub(crate) allow_directive_prologue: bool,
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -355,7 +355,7 @@ pub mod Runtime {
         pub(crate) fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 17] = [
+            let bools: [bool; 18] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -373,6 +373,8 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
+                // The eval entry point (-e, -p, stdin) is printed without the CommonJS wrapper.
+                self.remove_cjs_module_wrapper,
                 // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
             ];
 

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -21,8 +21,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// This transforms code for interactive evaluation:
     /// - Wraps the last expression in { value: expr } for result capture
     /// - Wraps code with await in async IIFE with variable hoisting
-    /// - Puts the module-level `directives` back in front (node's repl evaluates them);
-    ///   returns `false` when the parts were left untouched
+    /// - Puts the module-level `directives` back in front; returns `false` if parts were left as is
     pub(crate) fn apply_repl_transforms<'bump>(
         &mut self,
         parts: &mut BumpVec<'bump, js_ast::Part>,

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -21,46 +21,37 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// This transforms code for interactive evaluation:
     /// - Wraps the last expression in { value: expr } for result capture
     /// - Wraps code with await in async IIFE with variable hoisting
+    ///
+    /// `directives` is the module-level directive prologue that `_parse`
+    /// stripped from the top-level statements. Node's repl evaluates a
+    /// directive as a string expression, so the transform puts the directives
+    /// back in front of the statements. Returns `true` when it did so (the
+    /// caller then drops them from `Ast.directives`), `false` when it left the
+    /// parts untouched.
     pub(crate) fn apply_repl_transforms<'bump>(
         &mut self,
         parts: &mut BumpVec<'bump, js_ast::Part>,
         bump: &'bump Bump,
-    ) -> Result<(), bun_alloc::AllocError> {
+        directives: &[Stmt],
+    ) -> Result<bool, bun_alloc::AllocError> {
         // Skip transform if there's a top-level return (indicates module pattern)
         if self.has_top_level_return {
-            return Ok(());
+            return Ok(false);
         }
 
         // Collect all statements
-        let mut total_stmts_count: usize = 0;
+        let mut total_stmts_count: usize = directives.len();
         for part in parts.iter() {
             total_stmts_count += part.stmts.len();
         }
 
-        // A prologue "use strict" was consumed into module-scope strict mode and dropped, but
-        // node's repl still evaluates the directive as a string expression. Reinject it at the
-        // front, like the CJS wrapper's preserve_strict_mode.
-        let reinject_strict = self.module_scope().strict_mode
-            == js_ast::StrictModeKind::ExplicitStrictMode
-            && !(!parts.is_empty()
-                && !parts[0].stmts.is_empty()
-                && matches!(parts[0].stmts[0].data, StmtData::SDirective(_)));
-        total_stmts_count += usize::from(reinject_strict);
-
         if total_stmts_count == 0 {
-            return Ok(());
+            return Ok(true);
         }
 
         // Collect all statements into a single array
         let mut all_stmts = BumpVec::with_capacity_in(total_stmts_count, bump);
-        if reinject_strict {
-            all_stmts.push(self.s(
-                S::Directive {
-                    value: b"use strict".into(),
-                },
-                self.module_scope_directive_loc,
-            ));
-        }
+        all_stmts.extend_from_slice(directives);
         for part in parts.iter() {
             for stmt in part.stmts.iter() {
                 all_stmts.push(*stmt);
@@ -80,7 +71,8 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         }
 
         // Apply transform with is_async based on presence of top-level await
-        self.repl_transform_with_hoisting(parts, all_stmts, bump, has_top_level_await)
+        self.repl_transform_with_hoisting(parts, all_stmts, bump, has_top_level_await)?;
+        Ok(true)
     }
 
     /// Transform code with hoisting and IIFE wrapper

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -21,13 +21,8 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// This transforms code for interactive evaluation:
     /// - Wraps the last expression in { value: expr } for result capture
     /// - Wraps code with await in async IIFE with variable hoisting
-    ///
-    /// `directives` is the module-level directive prologue that `_parse`
-    /// stripped from the top-level statements. Node's repl evaluates a
-    /// directive as a string expression, so the transform puts the directives
-    /// back in front of the statements. Returns `true` when it did so (the
-    /// caller then drops them from `Ast.directives`), `false` when it left the
-    /// parts untouched.
+    /// - Puts the module-level `directives` back in front (node's repl evaluates them);
+    ///   returns `false` when the parts were left untouched
     pub(crate) fn apply_repl_transforms<'bump>(
         &mut self,
         parts: &mut BumpVec<'bump, js_ast::Part>,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1759,9 +1759,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match stmt.data {
                 StmtData::SEmpty(_) => continue,
 
-                // skip directives for now
-                StmtData::SDirective(_) => continue,
-
                 StmtData::SLocal(local) => {
                     // Merge adjacent local statements
                     if output.len() > 0 {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -97,8 +97,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // if e.LegacyOctalLoc.Start > 0 {
     }
 
-    fn e_number(_: &mut Self, _e: &mut Expr, _: ExprIn) {
-        // idc about legacy octal loc
+    fn e_number(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        if !p.legacy_octal_literals.is_empty() && p.is_strict_mode() {
+            // Parsed in source order, so the ranges are sorted by start.
+            if let Ok(i) = p
+                .legacy_octal_literals
+                .binary_search_by_key(&e.loc.start, |r| r.loc.start)
+            {
+                let range = p.legacy_octal_literals[i];
+                p.mark_strict_mode_feature(StrictModeFeature::LegacyOctalLiteral, range, b"")
+                    .expect("unreachable");
+            }
+        }
     }
 
     fn e_this(p: &mut Self, e: &mut Expr, _: ExprIn) {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -9,7 +9,8 @@ use crate::lexer as js_lexer;
 use crate::p::P;
 use crate::parser::{
     ExprIn, FnOrArrowDataVisit, IdentifierOpts, PrependTempRefsOpts, ReactRefresh, Ref,
-    StrictModeFeature, ThenCatchChain, TransposeState, VisitArgsOpts, float_to_int32, prefill,
+    StrictModeFeature, ThenCatchChain, TransposeState, VisitArgsOpts, float_to_int32,
+    is_eval_or_arguments, prefill,
 };
 use crate::scan::scan_side_effects::SideEffects;
 use bun_alloc::ArenaVecExt as _;
@@ -46,9 +47,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return;
         }
 
-        if in_.assign_target != js_ast::AssignTarget::None && !self.is_valid_assignment_target(e) {
-            self.log()
-                .add_error(Some(self.source), e.loc, b"Invalid assignment target");
+        if in_.assign_target != js_ast::AssignTarget::None {
+            if !self.is_valid_assignment_target(e) {
+                self.log()
+                    .add_error(Some(self.source), e.loc, b"Invalid assignment target");
+            } else if let Data::EIdentifier(id) = &e.data
+                && self.is_strict_mode_output_format()
+            {
+                // Valid in this sloppy file, a SyntaxError once it is bundled into an ES module
+                let name = self.load_name_from_ref(id.ref_);
+                if is_eval_or_arguments(name) {
+                    self.mark_strict_mode_feature(
+                        StrictModeFeature::AssignToEvalOrArguments,
+                        js_lexer::range_of_identifier(self.source, e.loc),
+                        name,
+                    )
+                    .expect("unreachable");
+                }
+            }
         }
 
         // Explicit match over the tags that have a visitor defined below.

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7679,6 +7679,14 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     }
     printer.binary_expression_stack = Vec::new();
 
+    // Add the top-level directives if present
+    for directive in tree.directives.slice() {
+        printer.print_indent();
+        printer.print_string_literal_utf8(directive.slice(), false);
+        printer.print(b";");
+        printer.print_newline();
+    }
+
     if !printer.options.bundling
         && tree.uses_require_ref
         && tree.exports_kind == js_ast::ExportsKind::Esm

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7680,11 +7680,10 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     printer.binary_expression_stack = Vec::new();
 
     // Add the top-level directives if present
-    for directive in tree.directives.slice() {
-        printer.print_indent();
-        printer.print_string_literal_utf8(directive.slice(), false);
-        printer.print(b";");
-        printer.print_newline();
+    for stmt in tree.directives.slice() {
+        printer.print_stmt(*stmt)?;
+        printer.writer.get_error()?;
+        printer.print_semicolon_if_needed();
     }
 
     if !printer.options.bundling

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,9 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: Function-level "use strict" directives are preserved, and the
+/// module-level directive prologue is printed ahead of every other statement.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,8 +55,7 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-/// Version 28: Function-level "use strict" directives are preserved, and the
-/// module-level directive prologue is printed ahead of every other statement.
+/// Version 28: function-level "use strict" is preserved and the module prologue prints first.
 const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -129,6 +129,8 @@ fn collect_body_directives(stmts: &[Stmt]) -> Vec<&[u8]> {
     for s in stmts {
         match &s.data {
             StmtData::SDirective(d) => out.push(d.value.slice()),
+            // A preserved legal comment does not end the prologue.
+            StmtData::SComment(_) => continue,
             _ => break,
         }
     }

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -154,8 +154,8 @@ function shapesSource() {
 // escapes and spelled literally is one binding), line continuations, HTML-like comments, and the sloppy-only lexical
 // forms Bun's transpiler refuses: duplicate parameter names, legacy octal literals and octal string escapes. Also the
 // strict-mode contrast to records.js's sloppy section (block-scoped function declarations, unmapped arguments,
-// undefined this, eval's own scope), here rather than there because the bundler drops function-level "use strict"
-// directives. Line and column bookkeeping for all of these ends up in the cached functions' positions.
+// undefined this, eval's own scope). Line and column bookkeeping for all of these ends up in the cached functions'
+// positions.
 function sourceFormsSource() {
   const LS = " ",
     PS = " ",
@@ -460,17 +460,17 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "52c1e0868de8da5d8bf4b89d68afbd027f3c64fdce490cd46800674b0de3f0c1",
+          "js": "25b65d9d720f4e97e29d41a4c72bd4ec3e4d332a2591b9a5f51f3c192d5ba3f4",
           "jsc": {
-            "bytes": 1999232,
-            "sha256": "a6043ef5e8aaae25c9581e6802fc2508f0b7b2fb0681be536768f9d09ef4cac6",
+            "bytes": 2005304,
+            "sha256": "5b107fac617ce7dc97eebbc22d12df18d1f2d74fd76e51400200ea98672398e1",
           },
         },
         "bun build --bytecode --minify features.js": {
-          "js": "d49da0aa39824bf9eba2af5d3a010525ad14ca5c1cedc0d8adcfdd5f4984a0d0",
+          "js": "4ad35138f5930c4f8a62623d924e067c18311ba1f3a4962bc885d95c5f15e787",
           "jsc": {
-            "bytes": 46152,
-            "sha256": "db36543ec2430a8cbdce13a6a980148f502e2c6b135cf95f62b6743c3fa30968",
+            "bytes": 46184,
+            "sha256": "796fde826041fb15474a053b1a3003f6d3aba80939d1e8963d6308806e24de87",
           },
         },
         "bun build --bytecode --minify records.js": {
@@ -488,10 +488,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode all.js": {
-          "js": "46d723ea07e5e2d8db673a51fec52b3248edcd3e216029f243d8172244f7cd2c",
+          "js": "e0a1810989c04c90dcbbb1d385fd17c44c2782a44472c098440460c5f671a3ed",
           "jsc": {
-            "bytes": 2178792,
-            "sha256": "c5d1eaae5c4d198b1f8e0d768bb41502162081c75b67249032e66a2b95e26ec1",
+            "bytes": 2185120,
+            "sha256": "17bbb2faba55df5076d903c83716b1e2df061d503582702002ccfbec0eee7c37",
           },
         },
         "bun build --bytecode big.js": {
@@ -502,17 +502,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode features.js": {
-          "js": "2ee211924620db96d6e99e9490bfe0ee60a3bc6b003f37940c5631e6eabc2c73",
+          "js": "b05307fa5b1b7c7528b1cd416d59c04ab14767266127ed38afcfde5bdbf218b5",
           "jsc": {
-            "bytes": 48048,
-            "sha256": "457b0f1c9172a8964bf79d7b102076d410da468d4728e3731964884cbaecfa6e",
+            "bytes": 48072,
+            "sha256": "f4508d34513d7236426f5d69cf2c16cddae5526da2e2890d923ce431bac3d2c9",
           },
         },
         "bun build --bytecode happy-dom/lib/index.js": {
-          "js": "148f0d3e4baf485281725f859deb3e717a6da25a4a08de9af288d5ef54b6414b",
+          "js": "f7873071421bccffe16fbadc85101e62ca1c10839ef3c6bb9c752ecd7f7f3b3a",
           "jsc": {
-            "bytes": 2528840,
-            "sha256": "d68b260282a74f545c15b5a3b812b69cb4e828972f85c5de60f8307b73c43e57",
+            "bytes": 2528864,
+            "sha256": "05d8e99e966ef0cf9bf07e86baadb47d926cc33d494dd61140259d83b039d15a",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
@@ -523,10 +523,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "e685164a8316f60b665bc3d47e42b4623cfe7385f87310e655478a50ecd8f959",
+          "js": "300a7201a31c77268b85d64ee0194e2403c5a65846fe9fd501906bcf79a57877",
           "jsc": {
-            "bytes": 23806352,
-            "sha256": "5f23309532d868e1c985d568207c92b77a7f3974e5c6c3f37b21accf7d429327",
+            "bytes": 23880368,
+            "sha256": "9a0261739654b6ff6b17e1dfedeb7c44093c059a958c5cfab87b29fb5354d962",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -537,10 +537,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {
-          "js": "e2cf34c8eb6f5952a33ca91e3949b28786349cf97ea3fbf0b3b8500dbccd4860",
+          "js": "e513619b81bb92166dc0d12b4f8488c73aefd711b135b7e573d62eddb0f4ca22",
           "jsc": {
-            "bytes": 980080,
-            "sha256": "32fa8492ad9fdf3ea31395756898d556df9dc6bdfbac9bba07bcafa748ab38ca",
+            "bytes": 980088,
+            "sha256": "6b1d78003b60f95baa4aff77720efdcc9db71bc4ca75e5629e9ea05834309f36",
           },
         },
         "bun build --bytecode records.js": {
@@ -558,17 +558,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode svelte/compiler/index.js": {
-          "js": "5ced9487e680d82a45548d0f509ecc5c931f06485a2d17bac56ddd60e3ede785",
+          "js": "0eff03c2dab84e6093e7b470c9880a2278445d1c03682c2b5f37e3ffc62cf466",
           "jsc": {
-            "bytes": 1996728,
-            "sha256": "1e224f518c1be57eb53460723b34128ca4c310bbe75a7a1ea93a900e24c3db74",
+            "bytes": 2002216,
+            "sha256": "be24a2e66a76dee8c7e8234f38e7048c6224bb99292047392af2b3f9d898fd84",
           },
         },
         "bun build --bytecode undici/index.js": {
-          "js": "d0bd3791e7c8f77a06814429d5d95cb26a06baaa3c135502bcd3e984310f1d2c",
+          "js": "7ebc1a93fd924da1107ea2c12bc0a684686717fb6e382ba90d34bd3f1a9062c3",
           "jsc": {
-            "bytes": 937000,
-            "sha256": "d7cff4df84668b14987703bcd950a6753a574cf48e4372e4fe8779f747c0ed89",
+            "bytes": 937032,
+            "sha256": "ecb2f5eb5472bd2fbd8ab08cf64494afa66a5cb74f352cb26c543f0a32b96a79",
           },
         },
         "vm.Script big.js": {

--- a/test/bundler/bundler_directive.test.ts
+++ b/test/bundler/bundler_directive.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+// Directive prologues: `"use strict"`, `"use client"`, and friends at the top
+// of a module or a function body.
+describe("bundler", () => {
+  // A strict function throws on an assignment to an undeclared name and gets
+  // `undefined` as `this` when called without a receiver. The probes are
+  // CommonJS (`module.exports`) so that the module itself is sloppy and only
+  // the directives make code strict. An ES module is strict everywhere.
+  const strictProbe = /* js */ `
+    function f() { "use strict"; try { undeclared123 = 1; return "sloppy" } catch { return "strict" } }
+    function g() { "use strict"; return this === undefined }
+    console.log(f(), g());
+    module.exports = f;
+  `;
+
+  itBundled("directive/FunctionLevelUseStrictNoBundle", {
+    files: {
+      "/entry.cjs": strictProbe,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js").match(/"use strict";/g)).toHaveLength(2);
+    },
+    run: { stdout: "strict true" },
+  });
+
+  itBundled("directive/FunctionLevelUseStrictBundle", {
+    files: {
+      "/entry.js": strictProbe,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js").match(/"use strict";/g)).toHaveLength(2);
+    },
+    run: { stdout: "strict true" },
+  });
+
+  itBundled("directive/FunctionLevelUseStrictBundleMinify", {
+    files: {
+      "/entry.js": strictProbe,
+    },
+    format: "cjs",
+    minifySyntax: true,
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js").match(/"use strict";/g)).toHaveLength(2);
+    },
+    run: { stdout: "strict true" },
+  });
+
+  itBundled("directive/ArrowAndMethodBodies", {
+    files: {
+      "/entry.cjs": /* js */ `
+        const arrow = () => { "use strict"; try { undeclared123 = 1; return "sloppy" } catch { return "strict" } };
+        const obj = { method() { "use strict"; return this } };
+        class A { static m() { "use strict"; return this } }
+        console.log(arrow(), obj.method.call(undefined), A.m.call(undefined));
+        module.exports = A;
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js").match(/"use strict";/g)).toHaveLength(3);
+    },
+    run: { stdout: "strict undefined undefined" },
+  });
+
+  itBundled("directive/TopLevelUseStrictNoBundle", {
+    files: {
+      "/entry.cjs": /* js */ `
+        "use strict";
+        function f() { return typeof this }
+        console.log(f());
+        module.exports = f;
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith('"use strict";\n');
+    },
+    run: { stdout: "undefined" },
+  });
+
+  // The JSX runtime import is injected at the top of the file. The directive
+  // prologue still has to come before it.
+  itBundled("directive/DirectivesBeforeInjectedImportsNoBundle", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        "use client";
+        "use strict";
+        export const X = () => <div />;
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith('"use client";\n"use strict";\nimport ');
+    },
+  });
+
+  itBundled("directive/DirectivesAtEntryChunkTop", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        "use client";
+        import { foo } from "./foo";
+        export const X = () => <div>{foo}</div>;
+      `,
+      "/foo.js": `export const foo = 1;`,
+    },
+    external: ["react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith('"use client";\n');
+    },
+  });
+
+  // Minification used to drop every directive that is not "use strict".
+  itBundled("directive/UseClientMinify", {
+    files: {
+      "/entry.js": /* js */ `
+        "use client";
+        export const x = 1;
+      `,
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith('"use client";var ');
+    },
+  });
+
+  itBundled("directive/MultipleDirectivesNoBundle", {
+    files: {
+      "/entry.js": /* js */ `
+        // A comment before the prologue does not end it
+        "use strict";
+        /* neither does a block comment */
+        'use client';
+        "use strict";
+        console.log("body");
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      // Duplicates are removed
+      api.expectFile("/out.js").toStartWith('"use strict";\n"use client";\nconsole.log("body");\n');
+    },
+    run: { stdout: "body" },
+  });
+
+  itBundled("directive/MultipleDirectivesMinifyNoBundle", {
+    files: {
+      "/entry.js": /* js */ `
+        'use strict'
+        'use loose'
+        console.log("body")
+      `,
+    },
+    bundling: false,
+    minifySyntax: true,
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith('"use strict";"use loose";console.log("body");');
+    },
+  });
+
+  itBundled("directive/UseAsmIsRemoved", {
+    files: {
+      "/entry.js": /* js */ `
+        "use asm";
+        function f() { "use asm"; return 1 }
+        console.log(f());
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("use asm");
+    },
+    run: { stdout: "1" },
+  });
+
+  // A template literal is never a directive, and a string statement that
+  // follows a non-directive statement is not one either.
+  itBundled("directive/NonDirectiveStrings", {
+    files: {
+      "/entry.cjs": /* js */ `
+        function tpl() { \`use strict\`; return typeof this }
+        function late() { var x = 1; "use strict"; return typeof this }
+        console.log(tpl(), late());
+        module.exports = tpl;
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain('"use strict"');
+    },
+    run: { stdout: "object object" },
+  });
+
+  // Only a module or function body has a directive prologue. A string at the
+  // start of a block is an expression statement and does not switch the
+  // enclosing scope to strict mode.
+  itBundled("directive/StringInBlockIsNotADirective", {
+    files: {
+      "/entry.cjs": /* js */ `
+        { 'use strict'; var eval = 1 }
+        if (1) { 'use strict'; eval = 2 }
+        class A { static { "use strict"; } }
+        console.log(eval, typeof A);
+        module.exports = A;
+      `,
+    },
+    bundling: false,
+    run: { stdout: "2 function" },
+  });
+
+  itBundled("directive/SloppyAssignmentToEvalAndArguments", {
+    files: {
+      "/entry.cjs": /* js */ `
+        eval = 1;
+        function f() { arguments = 2; return arguments }
+        console.log(eval, f());
+        module.exports = f;
+      `,
+    },
+    bundling: false,
+    run: { stdout: "1 2" },
+  });
+
+  itBundled("directive/StrictAssignmentToEvalIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        eval = 1;
+      `,
+    },
+    bundling: false,
+    bundleErrors: {
+      "/entry.js": ["Invalid assignment target"],
+    },
+  });
+
+  itBundled("directive/UseStrictWithNonSimpleParameterList", {
+    files: {
+      "/entry.js": /* js */ `
+        function f(a = 1) { "use strict"; return a }
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ['Cannot use a "use strict" directive in a function with a non-simple parameter list'],
+    },
+  });
+
+  itBundled("directive/UseStrictAppliesToParameters", {
+    files: {
+      "/entry.js": /* js */ `
+        function f(arguments) { "use strict"; }
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ['Declarations with the name "arguments" cannot be used in strict mode'],
+    },
+  });
+
+  itBundled("directive/LegacyOctalLiteralInStrictFunction", {
+    files: {
+      "/entry.js": /* js */ `
+        function h() { "use strict"; return 010 }
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ["Legacy octal literals cannot be used in strict mode"],
+    },
+  });
+
+  itBundled("directive/LegacyOctalLiteralInSloppyFunction", {
+    files: {
+      "/entry.cjs": /* js */ `
+        function h() { return 010 }
+        console.log(h(), { 010: "key" }[8]);
+        module.exports = h;
+      `,
+    },
+    bundling: false,
+    run: { stdout: "8 key" },
+  });
+
+  // A wrapped CommonJS file that ends up in the entry chunk keeps its
+  // file-level directive inside the wrapper.
+  itBundled("directive/WrappedCJSFileInEntryChunk", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./a.cjs"));
+      `,
+      "/a.cjs": /* js */ `
+        "use strict";
+        function f() { return typeof this }
+        module.exports = f();
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toMatch(/__commonJS\(\(?function\([^)]*\) \{\n\s*"use strict";/);
+    },
+    run: { stdout: "undefined" },
+  });
+
+  // All ES modules are strict, so the directive is redundant there.
+  itBundled("directive/WrappedCJSFileInESMOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./a.cjs"));
+      `,
+      "/a.cjs": /* js */ `
+        "use strict";
+        function f() { return typeof this }
+        module.exports = f();
+      `,
+    },
+    format: "esm",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain('"use strict"');
+    },
+    run: { stdout: "undefined" },
+  });
+
+  // An entry point that another entry point requires is wrapped inside the
+  // other chunk. There it is a dependency and keeps its directive inside the
+  // wrapper. In its own chunk the directive is at the top.
+  itBundled("directive/EntryPointWrappedInsideOtherEntryPoint", {
+    files: {
+      "/a.cjs": /* js */ `
+        console.log("a", require("./b.cjs"));
+      `,
+      "/b.cjs": /* js */ `
+        "use strict";
+        module.exports = (function () { return typeof this })();
+        console.log("b", module.exports);
+      `,
+    },
+    entryPoints: ["/a.cjs", "/b.cjs"],
+    outdir: "/out",
+    outputPaths: ["/out/a.js", "/out/b.js"],
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out/a.js")).toMatch(/__commonJS\(\(?function\([^)]*\) \{\n\s*"use strict";/);
+      api.expectFile("/out/a.js").not.toStartWith('"use strict"');
+      api.expectFile("/out/b.js").toStartWith('"use strict";\n');
+    },
+    run: [
+      { file: "/out/a.js", stdout: "b undefined\na undefined" },
+      { file: "/out/b.js", stdout: "b undefined" },
+    ],
+  });
+
+  // The prologue has to come before the `init_*()` calls that the linker
+  // inserts for the module's dependencies.
+  itBundled("directive/WrappedESMFileDirectivesBeforeDependencies", {
+    files: {
+      "/entry.js": /* js */ `
+        const a = require("./a.mjs");
+        console.log(a.x);
+      `,
+      "/a.mjs": /* js */ `
+        "use strict";
+        "use other";
+        import { b } from "./b.mjs";
+        export const x = b + 1;
+      `,
+      "/b.mjs": /* js */ `
+        export const b = 1;
+        console.log("b side effect");
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toMatch(/__esm\(\(\) => \{\n\s*"use strict";\n\s*"use other";\n\s*init_b\(\);/);
+    },
+    run: { stdout: "b side effect\n2" },
+  });
+
+  itBundled("directive/TargetBunCJSEntry", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        function f() { return typeof this }
+        console.log(f());
+      `,
+    },
+    target: "bun",
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('(function(exports, require, module, __filename, __dirname) {"use strict";');
+    },
+    run: { stdout: "undefined" },
+  });
+});

--- a/test/bundler/bundler_directive.test.ts
+++ b/test/bundler/bundler_directive.test.ts
@@ -227,6 +227,45 @@ describe("bundler", () => {
     run: { stdout: "1 2" },
   });
 
+  // A sloppy CommonJS dependency keeps these assignments in cjs output. Node
+  // runs the output: bun treats a script without CommonJS markers as an ES
+  // module, which is strict.
+  itBundled("directive/SloppyAssignmentToArgumentsBundledCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs")());
+      `,
+      "/dep.cjs": /* js */ `
+        function f() { arguments = 2; return arguments }
+        module.exports = f;
+      `,
+    },
+    format: "cjs",
+    run: { runtime: "node", stdout: "2" },
+  });
+
+  // An ES module is strict everywhere, so the same assignment cannot be
+  // bundled into esm output. It is an error at build time, not at load time.
+  itBundled("directive/SloppyAssignmentToArgumentsBundledESM", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./dep.cjs")());
+      `,
+      "/dep.cjs": /* js */ `
+        function f() { arguments = 2; return arguments }
+        eval = 3;
+        module.exports = f;
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/dep.cjs": [
+        'Assignments to "arguments" cannot be used with the ESM output format due to strict mode',
+        'Assignments to "eval" cannot be used with the ESM output format due to strict mode',
+      ],
+    },
+  });
+
   itBundled("directive/StrictAssignmentToEvalIsAnError", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_directive.test.ts
+++ b/test/bundler/bundler_directive.test.ts
@@ -99,6 +99,23 @@ describe("bundler", () => {
     },
   });
 
+  // An escaped "use strict" is not a Use Strict Directive. It does not end the
+  // prologue either: the directives after it are still hoisted.
+  itBundled("directive/EscapedUseStrictKeepsThePrologueNoBundle", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        "use\\x20strict";
+        "use client";
+        export const X = () => <div />;
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith('"use client";\nimport ');
+      api.expectFile("/out.js").not.toContain("use strict");
+    },
+  });
+
   itBundled("directive/DirectivesAtEntryChunkTop", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/bundler_directive.test.ts
+++ b/test/bundler/bundler_directive.test.ts
@@ -197,6 +197,27 @@ describe("bundler", () => {
     run: { stdout: "object object" },
   });
 
+  // A Use Strict Directive is spelled without escape sequences, and a
+  // parenthesized string is not a directive at all: it ends the prologue. Node
+  // runs both functions sloppy and accepts the non-simple parameter list.
+  itBundled("directive/EscapedOrParenthesizedUseStrict", {
+    files: {
+      "/entry.cjs": /* js */ `
+        function escaped(a = 1) { "use\\x20strict"; return typeof this }
+        function unicode() { '\\u0075se strict'; return typeof this }
+        function paren(a = 1) { ("use strict"); return typeof this }
+        function after(a = 1) { ("first"); "use strict"; return typeof this }
+        console.log(escaped(), unicode(), paren(), after());
+        module.exports = after;
+      `,
+    },
+    bundling: false,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("use strict");
+    },
+    run: { stdout: "object object object object" },
+  });
+
   // Only a module or function body has a directive prologue. A string at the
   // start of a block is an expression statement and does not switch the
   // enclosing scope to strict mode.
@@ -457,5 +478,30 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain('(function(exports, require, module, __filename, __dirname) {"use strict";');
     },
     run: { stdout: "undefined" },
+  });
+
+  // The dev server output is a registry of module closures. Each closure starts
+  // with its own module's prologue, and the chunk itself gets no copy: a
+  // chunk-level directive would apply to every module in the registry.
+  itBundled("directive/DevServerModuleClosures", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        "use potato";
+        import { x } from "./dep.js";
+        console.log(x);
+      `,
+      "/dep.js": /* js */ `
+        "use tomato";
+        export const x = 1;
+      `,
+    },
+    format: "internal_bake_dev",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toMatch(/\{\s*"use strict";\s*"use potato";/);
+      expect(out).toMatch(/\{\s*"use tomato";/);
+      expect(out).not.toStartWith('"use strict"');
+    },
   });
 });

--- a/test/bundler/bundler_directive.test.ts
+++ b/test/bundler/bundler_directive.test.ts
@@ -333,6 +333,17 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("directive/LegacyOctalPropertyKeyInStrictFunction", {
+    files: {
+      "/entry.js": /* js */ `
+        function h() { "use strict"; return { 010: "key" } }
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ["Legacy octal literals cannot be used in strict mode"],
+    },
+  });
+
   itBundled("directive/LegacyOctalLiteralInSloppyFunction", {
     files: {
       "/entry.cjs": /* js */ `

--- a/test/bundler/bundler_directive.test.ts
+++ b/test/bundler/bundler_directive.test.ts
@@ -305,6 +305,32 @@ describe("bundler", () => {
     run: { stdout: "undefined" },
   });
 
+  // The directive inside the wrapper keeps its location, so it maps back to
+  // the source like any other statement.
+  itBundled("directive/WrappedDirectiveSourceMap", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./a.cjs"));
+      `,
+      "/a.cjs": /* js */ `
+        "use strict";
+        module.exports = (function () { return typeof this })();
+      `,
+    },
+    format: "cjs",
+    outdir: "/out",
+    sourceMap: "external",
+    snapshotSourceMap: {
+      "entry.js.map": {
+        files: ["../a.cjs", "../entry.js"],
+        mappings: [
+          ["a.cjs:1:'\"use strict\"'", '5:2:"use strict"'],
+          ["a.cjs:2:'module.exports'", "6:2:module2.exports"],
+        ],
+      },
+    },
+  });
+
   // All ES modules are strict, so the directive is redundant there.
   itBundled("directive/WrappedCJSFileInESMOutput", {
     files: {

--- a/test/bundler/bundler_directive.test.ts
+++ b/test/bundler/bundler_directive.test.ts
@@ -345,7 +345,8 @@ describe("bundler", () => {
   });
 
   // The directive inside the wrapper keeps its location, so it maps back to
-  // the source like any other statement.
+  // the source like any other statement: the `EAAA` segment on generated
+  // line 5 is `"use strict"` (column 2) mapped to a.cjs line 1, column 0.
   itBundled("directive/WrappedDirectiveSourceMap", {
     files: {
       "/entry.js": /* js */ `
@@ -362,10 +363,8 @@ describe("bundler", () => {
     snapshotSourceMap: {
       "entry.js.map": {
         files: ["../a.cjs", "../entry.js"],
-        mappings: [
-          ["a.cjs:1:'\"use strict\"'", '5:2:"use strict"'],
-          ["a.cjs:2:'module.exports'", "6:2:module2.exports"],
-        ],
+        mappingsExactMatch:
+          ";;;;EAAA;AAAA,EACA,QAAO,UAAW,QAAS,GAAG;AAAA,IAAE,OAAO,OAAO;AAAA,IAAQ;AAAA;;;ACDtD,QAAQ,eAAsB;",
       },
     },
   });

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -55,17 +55,17 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5623:at"],
+          ["react.development.js:524:'getContextName'", "1:5636:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
-          ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
+          ["react.development.js:696:''Component'", '1:7698:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18806:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19060:void"],
+          ["entry.tsx:11:'<html>'", "100:18863:{children"],
           ["entry.tsx:23:'await'", "100:19159:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221984,
+      "out/entry.js": 222036,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -59,7 +59,7 @@ describe("bundler", () => {
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
           ["react.development.js:696:''Component'", '1:7698:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18806:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:18863:{children"],
+          ["entry.tsx:11:'<html>'", "100:19060:void"],
           ["entry.tsx:23:'await'", "100:19159:await"],
         ],
       },

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2656,7 +2656,6 @@ describe.concurrent("bundler", () => {
     minifySyntax: true,
     minifyWhitespace: true,
     bundling: false,
-    todo: true,
     onAfterBundle(api) {
       assert(api.readFile("/out.js").includes('"use strict";'), '"use strict"; was emitted');
     },

--- a/test/bundler/transpiler/preserve-use-strict-cjs.test.ts
+++ b/test/bundler/transpiler/preserve-use-strict-cjs.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunRun } from "harness";
+import { readFileSync, rmSync } from "fs";
+import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
 import path from "path";
 
 test.concurrent(`"use strict'; preserves strict mode in CJS`, async () => {
@@ -8,4 +9,60 @@ test.concurrent(`"use strict'; preserves strict mode in CJS`, async () => {
 
 test.concurrent(`sloppy mode by default in CJS`, async () => {
   expect(await bunRun(path.join(import.meta.dir, "sloppy-mode-fixture.ts"))).toSpawn();
+});
+
+test.concurrent(`"use strict"; after another directive preserves strict mode in CJS`, async () => {
+  expect(await bunRun(path.join(import.meta.dir, "strict-mode-after-directive-fixture.cjs"))).toSpawn("strict");
+});
+
+test.concurrent(`"use strict"; after another directive preserves strict mode with the inspector enabled`, async () => {
+  // With the inspector enabled the runtime transpiler does not minify syntax,
+  // so the "use client" directive stays in the output as the first statement.
+  // The transpiler used to skip "use strict" in that case, and the module ran
+  // in sloppy mode only while it was being debugged.
+  const socket = `/tmp/bun-use-strict-inspect-${process.pid}-${Date.now()}.sock`;
+  try {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "strict-mode-after-directive-fixture.cjs")],
+      env: { ...bunEnv, BUN_INSPECT: isWindows ? "127.0.0.1:0" : "ws+unix://" + socket },
+      stdout: "pipe",
+      // The inspector prints its listening address here.
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("this is not undefined");
+    expect(stdout).toBe("strict\n");
+    expect(exitCode).toBe(0);
+  } finally {
+    rmSync(socket, { force: true });
+  }
+});
+
+test.concurrent(`"use strict"; after another directive preserves strict mode under bun test --coverage`, async () => {
+  // --coverage turns syntax minification off for the whole process, the same
+  // way the inspector does, so a test suite used to see such modules in
+  // sloppy mode only when coverage was enabled.
+  using dir = tempDir("use-strict-coverage", {
+    "lib.cjs": readFileSync(path.join(import.meta.dir, "strict-mode-after-directive-fixture.cjs"), "utf8"),
+    "lib.test.ts": `
+      import { expect, test } from "bun:test";
+      test("lib is strict", () => {
+        expect(require("./lib.cjs")).toEqual({ FORCE_COMMON_JS: true });
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "./lib.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The fixture throws before it exports anything when it runs in sloppy mode.
+  expect(stderr).not.toContain("this is not undefined");
+  expect(stderr).toContain("1 pass");
+  // The test runner prints its banner to stdout too.
+  expect(stdout).toEndWith("strict\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -753,6 +753,40 @@ describe("bundler", () => {
     },
   });
 
+  // A preserved legal comment ahead of an opt-out directive does not end the
+  // directive prologue, at the module level or inside a function body.
+  itBundled("react-compiler/OptOutDirectiveAfterLegalComment", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        /*! @license MIT */
+        "use no memo";
+        export function Hello({ name }) {
+          return <div>Hello {name}</div>;
+        }
+      `,
+      "/fn.jsx": /* jsx */ `
+        export function Hello({ name }) {
+          /*! @license MIT */
+          "use no memo";
+          return <div>Hello {name}</div>;
+        }
+      `,
+    },
+    entryPoints: ["/entry.jsx", "/fn.jsx"],
+    outdir: "/out",
+    reactCompiler: true,
+    backend: "cli",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      for (const file of ["/out/entry.js", "/out/fn.js"]) {
+        const out = api.readFile(file);
+        expect(out).toContain("@license MIT");
+        expect(out).not.toContain("react/compiler-runtime");
+        expect(out).not.toMatch(/\b_c\(\d+\)/);
+      }
+    },
+  });
+
   // A compiled component that needs zero memo slots must not import the
   // runtime. The import is registered from codegen next to the `_c(N)` call,
   // so a body with nothing to memoize leaves `react/compiler-runtime` out.

--- a/test/bundler/transpiler/strict-mode-after-directive-fixture.cjs
+++ b/test/bundler/transpiler/strict-mode-after-directive-fixture.cjs
@@ -1,0 +1,15 @@
+"use client";
+"use strict";
+
+function checkThis() {
+  if (this !== undefined) {
+    throw new Error("this is not undefined");
+  }
+}
+
+checkThis();
+console.log("strict");
+
+module.exports = {
+  FORCE_COMMON_JS: true,
+};

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4751,9 +4751,22 @@ class A {
     expect(() => new Bun.Transpiler().transformSync(`function f() { "use strict"; return 010 }`)).toThrow(
       "Legacy octal literals cannot be used in strict mode",
     );
+    // Object literal keys and destructuring keys are literals too
+    expect(() => new Bun.Transpiler().transformSync(`"use strict"; var o = { 010: 1 }`)).toThrow(
+      "Legacy octal literals cannot be used in strict mode",
+    );
+    expect(() => new Bun.Transpiler().transformSync(`"use strict"; var { 010: x } = o`)).toThrow(
+      "Legacy octal literals cannot be used in strict mode",
+    );
+    expect(() => new Bun.Transpiler().transformSync(`function f() { "use strict"; var { 010: x } = o }`)).toThrow(
+      "Legacy octal literals cannot be used in strict mode",
+    );
     expect(new Bun.Transpiler().transformSync(`function f() { return 010 }`)).toBe(`function f() {
   return 8;
 }
+`);
+    expect(new Bun.Transpiler().transformSync(`var { 010: x } = o, { 07: y } = o;`))
+      .toBe(`var { 8: x } = o, { 7: y } = o;
 `);
   });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4741,6 +4741,15 @@ class A {
     expect(new Bun.Transpiler().transformSync("function f() { `use strict`; var package = 1 }")).not.toContain(
       "use strict",
     );
+    // A Use Strict Directive has no escape sequence, and a parenthesized string
+    // ends the prologue. Neither makes the function strict.
+    expect(
+      new Bun.Transpiler().transformSync(`function f(a = 1) { "use\\x20strict"; var package = 1 }
+  function g() { '\\u0075se strict'; var package = 2 }
+  function h(a = 1) { ("use strict"); var package = 3 }
+  function i(a = 1) { ("first"); "use strict"; var package = 4 }
+  ("use strict"); var package = 5;`),
+    ).not.toContain("use strict");
     // A directive prologue applies to the parameters as well
     expect(() => new Bun.Transpiler().transformSync(`function f(arguments) { "use strict" }`)).toThrow(
       'Declarations with the name "arguments" cannot be used in strict mode',

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4670,15 +4670,91 @@ console.log("boop");
 `,
     );
   });
-  it("does not preserve use strict (for now)", () => {
+  it("preserves use strict", () => {
     expect(
       new Bun.Transpiler().transformSync(`"use strict";
   console.log("boop");
   `),
     ).toBe(
-      `console.log("boop");
+      `"use strict";
+console.log("boop");
 `,
     );
+  });
+  it("preserves the directive prologue ahead of everything else", () => {
+    // Duplicates are dropped. "use asm" is removed on purpose.
+    expect(
+      new Bun.Transpiler().transformSync(`"use strict";
+  'use client';
+  "use asm";
+  "use strict";
+  console.log("boop");
+  `),
+    ).toBe(
+      `"use strict";
+"use client";
+console.log("boop");
+`,
+    );
+  });
+  it("preserves directives in function bodies", () => {
+    expect(
+      new Bun.Transpiler().transformSync(
+        `function f(a) { "use strict"; "use other"; return a }
+  const g = () => { "use strict"; return 1 };
+  class A { m() { "use strict"; return 2 } }`,
+      ),
+    ).toBe(
+      `function f(a) {
+  "use strict";
+  "use other";
+  return a;
+}
+const g = () => {
+  "use strict";
+  return 1;
+};
+
+class A {
+  m() {
+    "use strict";
+    return 2;
+  }
+}
+`,
+    );
+    expect(
+      new Bun.Transpiler({ minifyWhitespace: true, minify: { syntax: true } }).transformSync(
+        `function f(a) { "use strict"; return a }`,
+      ),
+    ).toBe(`function f(a){"use strict";return a}`);
+  });
+  it("only treats a string at the start of a module or function body as a directive", () => {
+    // A block is not a directive prologue, so "use strict" does not make the
+    // scope strict: `var eval` and `eval = 1` are accepted.
+    expect(
+      new Bun.Transpiler().transformSync(`{ 'use strict'; var eval = 1 }
+  if (1) { 'use strict'; eval = 1 }
+  class A { static { "use strict"; } }`),
+    ).not.toContain('"use strict"');
+    // A template literal is never a directive
+    expect(new Bun.Transpiler().transformSync("function f() { `use strict`; var package = 1 }")).not.toContain(
+      "use strict",
+    );
+    // A directive prologue applies to the parameters as well
+    expect(() => new Bun.Transpiler().transformSync(`function f(arguments) { "use strict" }`)).toThrow(
+      'Declarations with the name "arguments" cannot be used in strict mode',
+    );
+    expect(() => new Bun.Transpiler().transformSync(`function f(a = 1) { "use strict"; return a }`)).toThrow(
+      'Cannot use a "use strict" directive in a function with a non-simple parameter list',
+    );
+    expect(() => new Bun.Transpiler().transformSync(`function f() { "use strict"; return 010 }`)).toThrow(
+      "Legacy octal literals cannot be used in strict mode",
+    );
+    expect(new Bun.Transpiler().transformSync(`function f() { return 010 }`)).toBe(`function f() {
+  return 8;
+}
+`);
   });
 
   it("can parse 'a<b>' as typescript", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4750,6 +4750,14 @@ class A {
   function i(a = 1) { ("first"); "use strict"; var package = 4 }
   ("use strict"); var package = 5;`),
     ).not.toContain("use strict");
+    // A namespace body is lowered to a function body and keeps its prologue, as in tsc
+    expect(new Bun.Transpiler({ loader: "ts" }).transformSync(`namespace N { "use strict"; export const x = 1 }`))
+      .toBe(`var N;
+((N) => {
+  "use strict";
+  N.x = 1;
+})(N ||= {});
+`);
     // A directive prologue applies to the parameters as well
     expect(() => new Bun.Transpiler().transformSync(`function f(arguments) { "use strict" }`)).toThrow(
       'Declarations with the name "arguments" cannot be used in strict mode',

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -113,6 +113,23 @@ describe.concurrent("run-cjs", () => {
       expect(result).toEqual({ stdout: "2 object object 3 8\n", stderr: "", exitCode: 0 });
     });
 
+    test("an escaped or parenthesized 'use strict' is not a Use Strict Directive", async () => {
+      const result = await run(
+        {
+          "entry.cjs": `
+            function escaped(a = 1) { "use\\x20strict"; return typeof this }
+            function unicode() { '\\u0075se strict'; return typeof this }
+            function paren(a = 1) { ("use strict"); return typeof this }
+            function after(a = 1) { ("first"); "use strict"; return typeof this }
+            ("use strict");
+            console.log(escaped(), unicode(), paren(), after(), typeof this, 010);
+          `,
+        },
+        "entry.cjs",
+      );
+      expect(result).toEqual({ stdout: "object object object object object 8\n", stderr: "", exitCode: 0 });
+    });
+
     test("'use strict' in a function with a non-simple parameter list is a SyntaxError", async () => {
       const result = await run({ "entry.cjs": `function f(a = 1) { "use strict"; return a }` }, "entry.cjs");
       expect(result.stderr).toContain(

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -130,6 +130,26 @@ describe.concurrent("run-cjs", () => {
       expect(result).toEqual({ stdout: "object object object object object 8\n", stderr: "", exitCode: 0 });
     });
 
+    // tsc keeps the directive in the IIFE it lowers a namespace body to.
+    test("a 'use strict' at the start of a TypeScript namespace body makes the namespace strict", async () => {
+      const result = await run(
+        {
+          "entry.cts": `
+            namespace N {
+              "use strict";
+              export const strict = (function () { return this === undefined })();
+            }
+            namespace M {
+              export const strict = (function () { return this === undefined })();
+            }
+            console.log(N.strict, M.strict);
+          `,
+        },
+        "entry.cts",
+      );
+      expect(result).toEqual({ stdout: "true false\n", stderr: "", exitCode: 0 });
+    });
+
     test("'use strict' in a function with a non-simple parameter list is a SyntaxError", async () => {
       const result = await run({ "entry.cjs": `function f(a = 1) { "use strict"; return a }` }, "entry.cjs");
       expect(result.stderr).toContain(

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -44,4 +44,88 @@ describe.concurrent("run-cjs", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "custom-loader\n", exitCode: 0 });
   });
+
+  // A CommonJS module is sloppy unless a directive says otherwise, so these
+  // run as `.cjs` files: in an ES module every function is strict already.
+  describe.concurrent("directive prologue", () => {
+    async function run(files: Record<string, string>, entry: string) {
+      using dir = tempDir("run-cjs-directive", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), entry],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test("a function-level 'use strict' makes the function strict", async () => {
+      const result = await run(
+        {
+          "entry.cjs": `
+            function f() { "use strict"; try { undeclared123 = 1; return "sloppy" } catch { return "strict" } }
+            function g() { "use strict"; return this === undefined }
+            const arrow = () => { "use strict"; try { undeclared456 = 1; return "sloppy" } catch { return "strict" } };
+            const obj = { method() { "use strict"; return this === undefined } };
+            console.log(f(), g(), arrow(), obj.method.call(undefined));
+          `,
+        },
+        "entry.cjs",
+      );
+      expect(result).toEqual({ stdout: "strict true strict true\n", stderr: "", exitCode: 0 });
+    });
+
+    test("a module-level 'use strict' makes the module strict", async () => {
+      const result = await run(
+        {
+          "entry.cjs": `
+            "use strict";
+            function f() { return typeof this }
+            console.log(f(), require("./lib.cjs"));
+          `,
+          "lib.cjs": `
+            "use client";
+            "use strict";
+            module.exports = (function () { return typeof this })();
+          `,
+        },
+        "entry.cjs",
+      );
+      expect(result).toEqual({ stdout: "undefined undefined\n", stderr: "", exitCode: 0 });
+    });
+
+    test("a string statement outside of a prologue is not a directive", async () => {
+      const result = await run(
+        {
+          "entry.cjs": `
+            { 'use strict'; var eval = 1 }
+            if (1) { 'use strict'; eval = 2 }
+            function tpl() { \`use strict\`; return typeof this }
+            function late() { var x = 1; "use strict"; return typeof this }
+            function sloppy() { arguments = 3; return arguments }
+            console.log(eval, tpl(), late(), sloppy(), 010);
+          `,
+        },
+        "entry.cjs",
+      );
+      expect(result).toEqual({ stdout: "2 object object 3 8\n", stderr: "", exitCode: 0 });
+    });
+
+    test("'use strict' in a function with a non-simple parameter list is a SyntaxError", async () => {
+      const result = await run({ "entry.cjs": `function f(a = 1) { "use strict"; return a }` }, "entry.cjs");
+      expect(result.stderr).toContain(
+        'Cannot use a "use strict" directive in a function with a non-simple parameter list',
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    test("a legacy octal literal in a strict function is a SyntaxError", async () => {
+      const result = await run({ "entry.cjs": `function h() { "use strict"; return 010 }` }, "entry.cjs");
+      expect(result.stderr).toContain("Legacy octal literals cannot be used in strict mode");
+      expect(result.stderr).toContain('Strict mode is triggered by the "use strict" directive here');
+      expect(result.exitCode).toBe(1);
+    });
+  });
 });

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -5,6 +5,22 @@ import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep } from "path";
 
+// Prints whether the code around it runs in strict mode. A plain function call
+// sees `this === undefined` only in strict mode, and assigning to an undeclared
+// name throws only in strict mode.
+const strictModeProbe = `
+var thisIsUndefined = (function () { return this === undefined; })();
+var undeclaredThrows = false;
+try {
+  someUndeclaredNameForTheStrictModeProbe = 1;
+} catch (e) {
+  undeclaredThrows = e instanceof ReferenceError;
+}
+console.log(JSON.stringify({ thisIsUndefined, undeclaredThrows }));
+`;
+const strictResult = JSON.stringify({ thisIsUndefined: true, undeclaredThrows: true }) + "\n";
+const sloppyResult = JSON.stringify({ thisIsUndefined: false, undeclaredThrows: false }) + "\n";
+
 for (const flag of ["-e", "--print"]) {
   describe(`bun ${flag}`, () => {
     test("it works", async () => {
@@ -247,6 +263,11 @@ function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {
       expect(stdout.toString("utf8")).toEqual(code + "\n");
     }
   });
+
+  test('a leading "use strict" makes the script strict', async () => {
+    const { stdout } = run(`"use strict";` + strictModeProbe);
+    expect(stdout.toString("utf8")).toEqual(strictResult);
+  });
 }
 
 describe("bun run - < file-path.js", () => {
@@ -347,4 +368,104 @@ test("uncaught error from a CommonJS-sniffed stdin entry reports and exits 1", a
   expect(stderr).toContain("stdin-cjs-uncaught");
   expect(stdout).toBe("");
   expect(exitCode).toBe(1);
+});
+
+// The eval entry point (-e, -p, stdin) is transpiled as CommonJS without the
+// module wrapper and then evaluated as a classic script. The transpiler consumes
+// a module-level "use strict" while parsing, so it has to emit the directive
+// again, or the script runs in sloppy mode. Node honors the directive.
+describe.concurrent('"use strict" in the eval entry point', () => {
+  async function runBun(args: string[], cwd?: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("bun -e honors a leading directive", async () => {
+    const { stdout, stderr, exitCode } = await runBun(["-e", `"use strict";` + strictModeProbe]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(strictResult);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -e stays sloppy without the directive", async () => {
+    // `module.exports` forces CommonJS. Without it the eval source is an ES
+    // module, which is always strict.
+    const { stdout, stderr, exitCode } = await runBun(["-e", `module.exports;` + strictModeProbe]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(sloppyResult);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -e is strict when the directive follows a comment", async () => {
+    const { stdout, stderr, exitCode } = await runBun(["-e", `// leading comment\n'use strict';` + strictModeProbe]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(strictResult);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -e is strict when another directive comes first", async () => {
+    const { stdout, stderr, exitCode } = await runBun(["-e", `"use client"; "use strict";` + strictModeProbe]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(strictResult);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -e as an ES module is strict", async () => {
+    // An import statement makes the eval source an ES module, which is strict
+    // with or without the directive.
+    const code = `"use strict"; import { ok } from "node:assert"; ok(true);` + strictModeProbe;
+    const { stdout, stderr, exitCode } = await runBun(["-e", code]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(strictResult);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -p honors a leading directive", async () => {
+    const { stdout, stderr, exitCode } = await runBun([
+      "-p",
+      `"use strict"; (function () { return this === undefined; })()`,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -p is strict when another directive comes first", async () => {
+    // -p keeps the other directive as a statement (it disables dead code
+    // elimination), so "use strict" has to be emitted in front of it.
+    const { stdout, stderr, exitCode } = await runBun([
+      "-p",
+      `"use client"; "use strict"; (function () { return this === undefined; })()`,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -p prints a lone directive like node does", async () => {
+    const { stdout, stderr, exitCode } = await runBun(["-p", `"use strict"`]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("use strict\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a required CommonJS file is strict when another directive comes first", async () => {
+    // Same directive handling, but through the CommonJS module wrapper. The
+    // -p entry point disables dead code elimination for every module in the
+    // process, so "use client" survives as the first statement of the file.
+    using dir = tempDir("eval-use-strict", {
+      "strict-after-directive.cjs": `"use client";\n"use strict";\nmodule.exports = (function () { return this === undefined; })();\n`,
+    });
+    const { stdout, stderr, exitCode } = await runBun(["-p", `require("./strict-after-directive.cjs")`], String(dir));
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true\n");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -124,6 +124,42 @@ describe("transpiler cache", () => {
     expect(await bunRun(join(temp_dir, "b.js"), env)).toSpawn("b");
     expect(newCacheCount()).toBe(0);
   });
+  test("the stdin entry point does not share entries with a file of the same contents", async () => {
+    // A CommonJS file is cached wrapped in the module function. The stdin (and
+    // -e) entry point is printed without that wrapper and evaluated as a plain
+    // script, so an entry written for the file must not be served to stdin and
+    // the other way around. Stdin is parsed with the tsx loader, so a .tsx file
+    // is the one that hashes to the same features.
+    const source = dummyFile(50 * 1024, "stdin", { code: `"cjs", typeof module` });
+    writeFileSync(join(temp_dir, "a.tsx"), source);
+
+    async function runStdin() {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-"],
+        cwd: temp_dir,
+        env,
+        stdin: source,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout.trim();
+    }
+
+    expect(await bunRun(join(temp_dir, "a.tsx"), env)).toSpawn("cjs object");
+    expect(newCacheCount()).toBe(1);
+
+    // Same input hash, different features hash: the file's entry is replaced,
+    // not reused. If stdin were served the file's entry, it would evaluate the
+    // wrapper function without calling it and print nothing at all.
+    expect(await runStdin()).toBe("cjs object");
+    expect(newCacheCount()).toBe(0);
+    expect(await runStdin()).toBe("cjs object");
+
+    expect(await bunRun(join(temp_dir, "a.tsx"), env)).toSpawn("cjs object");
+  });
   test("doing 50 buns at once does not crash", async () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
     writeFileSync(join(temp_dir, "b.js"), dummyFile(50 * 1024, "2", "b"));

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -797,6 +797,17 @@ describe.concurrent("Bun REPL", () => {
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
+
+    test('"use strict" still applies when another directive comes first', async () => {
+      const { stdout, exitCode } = await runRepl([
+        `"use client"; "use strict"; (function () { return this === undefined; })()`,
+        ".exit",
+      ]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("true");
+      expect(output).not.toContain("false");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("async evaluation", () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -799,13 +799,14 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test('"use strict" still applies when another directive comes first', async () => {
-      const { stdout, exitCode } = await runRepl([
+      // The second line is the sloppy control: `this` is the global object.
+      const { outputs, stderr, exitCode } = await runRepl([
         `"use client"; "use strict"; (function () { return this === undefined; })()`,
+        `"use client"; (function () { return this === undefined; })()`,
         ".exit",
       ]);
-      const output = stripAnsi(stdout);
-      expect(output).toContain("true");
-      expect(output).not.toContain("false");
+      expect(outputs).toEqual(["true", "false"]);
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
   });


### PR DESCRIPTION
### Problem
- The parser dropped every `"use strict"` (`src/js_parser/parse/mod.rs`, the `skip = true` prologue branch) and the bundler restored only a module-level one. So `bun f.cjs` ran a function with `"use strict"` sloppy, `--minify` dropped `"use client"`, and `function f(a = 1) { "use strict" }` was accepted.
- A wrapped CommonJS file in the entry chunk lost its directive (the linker tested the chunk, not the file). The transpiler cache key lacked `remove_cjs_module_wrapper`.

### Fix
- Only a module, function, or TypeScript namespace body has a prologue. Every prologue string becomes an `S::Directive`. A bare, unescaped token is required: `("use strict")` and `"use\x20strict"` do not make code strict, as in node.
- The module-level prologue moves to `Ast.directives` and prints first on every path: `print_ast`, the runtime CommonJS wrapper, the entry chunk top, and inside a wrapped non-entry file's wrapper ahead of its `init_*()` calls. ESM output still omits `"use strict"`.
- `eval =` is an error only in strict code. A legacy octal in strict code is reported at the directive. `remove_cjs_module_wrapper` joins the cache key (version 28). The React Compiler's prologue scan skips a preserved legal comment.
- Supersedes #40831, #39943, #35473 and the directive half of #31807. Verified: `test/bundler/bundler_directive.test.ts`, `run-cjs`, `run-eval`, `transpiler-cache`, `transpiler.test.js`, `react-compiler`, all of `test/bundler`.

### Background
- A directive prologue is the run of string statements at the start of a script, module, or function body. Only `"use strict"` has semantics. `"use client"` marks a file for tools.
- The runtime wraps a CommonJS file in `(function(exports, require, module, ...) { ... })` (`to_ast`). `-e`, `-p` and stdin get the same output without the wrapper.
- The bundler wraps a CommonJS file in `__commonJS(function(exports, module) { ... })` and a required ES module in `__esm(() => { ... })`, with `init_x()` calls at `sync_dependencies_end` in that body.

<details><summary>Notes</summary>

Repros, all checked against bun 1.4.1 and esbuild 0.25.1:

1. `function f() { "use strict"; ... }` in a `.cjs`: `bun f.cjs` printed `sloppy false`, node `strict true`. Now `strict true`. `bun build --no-bundle` keeps both directives.
2. `"use strict"; function f() { return typeof this }` with `bun build --no-bundle`: the directive is printed first.
3. `a.cjs` with `"use strict"` required from `entry.js`, `--format=cjs`: the `__commonJS` wrapper body starts with `"use strict"` and the bundle prints `undefined`.
4. `"use client"; export const x = 1` with `--minify`: output is `"use client";var e=1;export{e as x};`.
5. `function f(a = 1) { "use strict" }` is a parse error. `function h(){ "use strict"; return 010 }` is a parse error with a note at the directive.
6. `{ 'use strict'; var eval = 1 }` and `if (1) { 'use strict'; eval = 1 }` parse and run.
7. `bun -e '"use strict"; console.log((function(){ return this === undefined })())'` printed `false`, node `true`. Now `true`. Same for `-p` and stdin.
8. A 50 KiB `.tsx` file run once, then the same bytes piped to `bun -`: the second run printed nothing (it got the cached wrapper function of the file and never called it). Now it prints the same output.
9. `namespace N { "use strict"; ... }` in a `.cts`: the body ran sloppy. tsc keeps the directive in the lowered IIFE, and so does bun now.
10. `/*! @license MIT */ "use no memo"; export function Hello() {...}` with `--react-compiler`: the opt-out was ignored because the legal comment ended the prologue scan. Same inside a function body.

Siblings covered by the tests: arrow, method, and static method bodies; `"use asm"` removed in both positions; duplicate directives removed; a comment before or between directives; a template literal and a late string are not directives; a class static block is not a prologue; directives stay ahead of the JSX runtime import that the transpiler injects; `--target=bun --format=cjs` puts the directive inside the `// @bun @bun-cjs` wrapper; `"use strict"` before `init_b()` in an `__esm` wrapper; two entry points where one requires the other (the wrapped copy keeps the directive inside its wrapper, its own chunk has it at the top); `"use client"; "use strict"` stays strict with the inspector attached and under `bun test --coverage` (both turn syntax minification off); the REPL prints `"use strict"` as a completion value.

Directive token rules, from ECMA-262 11.2.1: a directive is an expression statement that is a single string literal token, so `("use strict")` is not one and ends the prologue, and a Use Strict Directive has no escape sequence, so `"use\x20strict"` is a plain directive string. The parser checks that the statement starts at the string token and compares the raw source bytes for `"use strict"`. The escaped spelling is dropped like `"use asm"` (the printer cannot keep the escape), except in the REPL, where it stays the completion value. node follows both rules. esbuild 0.25.1 does not: it rejects `function f(a = 1) { ("first"); "use strict" }` and makes `function g() { "use\x20strict"; return this }` strict.

Dev server output (`--format=internal_bake_dev`) is a registry of module closures. Each closure opens with its own module's prologue (`InsideWrapperPrefix::append_directive`). The chunk top gets no copy, since the registry wrapper is not a module and a chunk-level `"use strict"` would apply to every module in it. The real dev server assembles its output in `finish_from_bake_dev_server`, so this only affects the `bun build` form of the format.

`test/bundler/bundler_bytecode_portable.test.ts` pins the bundler's output hashes. The corpus and the bundled libraries (react-dom, undici, svelte, happy-dom) contain function-level `"use strict"`, so their output and bytecode changed. The snapshot was regenerated with `--update-snapshots`; only the nine bundler builds that contain such directives moved, the `vm.Script` entries did not. The comment that said the bundler drops function-level directives is gone. The token rules and the namespace prologue did not move any hash.

`RuntimeTranspilerCache` is at version 28 because the printed output of cached CommonJS modules changes, and because the features hash gains `remove_cjs_module_wrapper`. Follow-up, not done here: `hash_for_runtime_transpiler` lists the hashed fields by hand, and #38683 and #38590 each add one more. An exhaustive destructure of `Features` would turn a missing field into a compile error.

Sibling PRs, with their tests run against this branch:

- #40831 (the per-file wrapper check and `append_directive`): 7 of 7 cases pass. Closed in favor of this PR.
- #35473 (module-level directives hoisted to the top of the output, fixes #6854): 13 of 14 `bundler_edgecase` cases and 4 of 4 `06854` cases passed as is. The dev server chunk top and the React Compiler legal comment scan are folded in. Closed in favor of this PR.
- #39943 (`"use strict"` in `-e`, `-p` and stdin, and the cache key): 15 of 16 cases passed as is. The cache key hash is folded in with that PR's tests (`run-eval.test.ts`, `preserve-use-strict-cjs.test.ts`, `transpiler-cache.test.ts`, `repl.test.ts`). Closed in favor of this PR.
- #31807 (function-body `"use strict"` in CommonJS, plus `X509Certificate.prototype` accessors made non-enumerable): 10 of 13 directive cases passed as is. The escaped and parenthesized forms and the TypeScript `namespace` body are folded in, so all 13 pass. The X509 half is separate and stays in that PR.
- #40827 (strict-mode early errors) and #35969 are handled separately.

`snapshotSourceMap.mappings` in `expectBundled.ts` used to compare positions with a matcher-less `expect(a === b)`. main fixed that in #34552, so the rebase drops this PR's copy of the fix. The ReactSSR `<html>` entry is the consumer's real answer (`100:19060:void`).

Not part of this change: `path_package_name` (`src/js_parser/p.rs`) returns `@scope` for a bare `require("@scope/pkg")`, so a configured bare scoped package is never unwrapped. Pre-existing, tracked separately.

Kept as is, on purpose: `"use strict"` is omitted from an `__commonJS` wrapper in ESM output (esbuild prints it there, an ES module is strict already). Bun still drops an unused string expression statement outside a prologue (`function f() { var x; "later" }`) with or without minification, where esbuild keeps it. Not in this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts, test/cli/run/run-eval.test.ts, test/bundler/transpiler/preserve-use-strict-cjs.test.ts, test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->
