### PR TITLE
js_parser: keep a function declared in a switch case clause as a declaration

### DIFF
--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -24,7 +24,7 @@ use bun_ast::scope::{Kind as ScopeKind, Member as ScopeMember};
 use bun_ast::symbol::Kind as SymbolKind;
 use bun_ast::{
     AssignTarget, B, Binding, BindingNodeIndex, E, Expr, ExprData, ExprNodeList, G, LocRef, S,
-    Stmt, StmtData, Symbol,
+    Stmt, StmtData, StmtNodeList, Symbol,
 };
 use bun_collections::VecExt;
 // `parser::SideEffects` is a stub enum without the assoc fns; the real
@@ -1257,6 +1257,92 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         shadow_ref
     }
 
+    /// In sloppy mode a block-level function declaration also assigns the
+    /// function to a `var` of the same name in the enclosing function scope
+    /// (Annex B). `hoist_symbols` split that `var` off into its own symbol. A
+    /// declaration directly in a case body stays in place instead of becoming
+    /// a `let` (see `visit_stmts`), so this adds the assignment right after it,
+    /// which is where the spec performs it. Run it on every case body of a
+    /// switch only after all of them have been visited: a direct `eval` in a
+    /// later clause still forbids renaming the two symbols apart.
+    pub(crate) fn append_sloppy_mode_case_fn_assignments(&mut self, body: &mut StmtNodeList) {
+        let p = self;
+        if p.hoisted_ref_for_sloppy_mode_block_fn.is_empty() {
+            return;
+        }
+
+        let hoisted_for = |p: &Self, stmt: &Stmt| -> Option<(LocRef, Ref)> {
+            let StmtData::SFunction(data) = stmt.data else {
+                return None;
+            };
+            let name = data.func.name?;
+            let hoisted_ref = *p.hoisted_ref_for_sloppy_mode_block_fn.get(&name.ref_)?;
+            Some((name, hoisted_ref))
+        };
+
+        let stmts: &'a [Stmt] = body.slice();
+        let count = stmts
+            .iter()
+            .filter(|stmt| hoisted_for(p, stmt).is_some())
+            .count();
+        if count == 0 {
+            return;
+        }
+
+        // Direct "eval" means neither identifier can be renamed, so the two
+        // symbols have to be one again. See the `before` handling in `visit_stmts`.
+        // SAFETY: current_scope is a valid arena ptr for the parse.
+        if p.current_scope().contains_direct_eval {
+            for stmt in stmts {
+                if let Some((name, hoisted_ref)) = hoisted_for(p, stmt) {
+                    p.symbols[hoisted_ref.inner_index() as usize]
+                        .link
+                        .set(name.ref_);
+                }
+            }
+            return;
+        }
+
+        let mut out: ListManaged<'a, Stmt> =
+            ListManaged::with_capacity_in(stmts.len() + count, p.arena);
+        for stmt in stmts {
+            out.push(*stmt);
+            let Some((name, hoisted_ref)) = hoisted_for(p, stmt) else {
+                continue;
+            };
+
+            p.record_usage(name.ref_);
+            let value = p.new_expr(
+                E::Identifier {
+                    ref_: name.ref_,
+                    ..Default::default()
+                },
+                name.loc,
+            );
+            let decls = [G::Decl {
+                binding: p.b(B::Identifier { r#ref: hoisted_ref }, name.loc),
+                value: Some(value),
+            }];
+
+            let relocated = p.maybe_relocate_vars_to_top_level(&decls, RelocateVarsMode::Normal);
+            if relocated.ok {
+                if let Some(new) = relocated.stmt {
+                    out.push(new);
+                }
+            } else {
+                out.push(p.s(
+                    S::Local {
+                        kind: LocalKind::KVar,
+                        decls: G::DeclList::from_slice(&decls),
+                        ..Default::default()
+                    },
+                    name.loc,
+                ));
+            }
+        }
+        *body = StmtNodeList::from_bump(out);
+    }
+
     // Try separating the list for appending, so that it's not a pointer.
     pub(crate) fn visit_stmts(
         &mut self,
@@ -1348,7 +1434,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // or async functions, since this is a backwards-compatibility hack from
                             // Annex B of the JavaScript standard.
                             // SAFETY: current_scope is a valid arena ptr for the parse.
-                            if !p.current_scope().kind_stops_hoisting()
+                            //
+                            // A case body is one slice of the switch block scope. The binding
+                            // is created when the switch is entered, so any clause can call it.
+                            // A `let` at the top of this clause would be in its TDZ from every
+                            // other clause, and nothing in a switch precedes the first case, so
+                            // the declaration stays where it is. `s_switch` adds the Annex B
+                            // `var` assignment once every clause has been visited.
+                            if kind != StmtsKind::SwitchStmt
+                                && !p.current_scope().kind_stops_hoisting()
                                 && p.symbols[data.func.name.unwrap().ref_.inner_index() as usize]
                                     .kind
                                     == SymbolKind::HoistedFunction

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2107,6 +2107,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             p.fn_or_arrow_data_visit.is_inside_switch = old_is_inside_switch;
 
+            // Function declarations directly in a case body stay in place. Now
+            // that every clause is visited, add their sloppy-mode `var` aliases.
+            for i in 0..cases.len() {
+                p.append_sloppy_mode_case_fn_assignments(&mut cases[i].body);
+            }
+
             for i in 0..cases.len() {
                 if p.should_lower_using_declarations(cases[i].body.slice()) {
                     lowered_using = true;

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,9 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: A function declared directly in a switch case clause stays a
+/// declaration instead of becoming a `let` scoped to that one clause.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3275,6 +3275,47 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+  // A function declared directly in a case clause is a binding of the whole
+  // switch block, so every clause can call it. Lowering it to a `let` at the
+  // top of its own clause left it in TDZ for the other clauses. In sloppy mode
+  // the declaration also assigns a `var` of the same name in the enclosing
+  // function (Annex B). The bundler keeps that `var` as its own renamed symbol
+  // and assigns it where the declaration is.
+  for (const minifySyntax of [false, true]) {
+    itBundled(`edgecase/SwitchCaseFunctionDeclaration${minifySyntax ? "MinifySyntax" : ""}`, {
+      files: {
+        "/entry.cjs": /* js */ `
+          function h(v) {
+            let r;
+            switch (v) {
+              case 1: function g() { return 4 } break;
+              case 2: r = [typeof g, g()]; break;
+            }
+            return [r, typeof g];
+          }
+          function strict(v) {
+            "use strict";
+            switch (v) {
+              default: return [typeof g, g()];
+              case 1: function g() { return "d" }
+            }
+          }
+          console.log(JSON.stringify([h(1), h(2), h(3), strict(0), strict(1)]));
+        `,
+      },
+      format: "esm",
+      target: "bun",
+      minifySyntax,
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out).toMatch(/case 1:\s*function g\d*\(\)/);
+        expect(out).not.toMatch(/let g\d* = function/);
+      },
+      run: {
+        stdout: '[[null,"function"],[["function",4],"undefined"],[null,"undefined"],["function","d"],null]',
+      },
+    });
+  }
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5347,6 +5347,145 @@ describe("using declarations in switch statements", () => {
   });
 });
 
+// A function declared directly in a case clause is a binding of the whole
+// switch block, created when the switch is entered. It used to be lowered to
+// a `let` at the top of its own clause, which every other clause saw in TDZ.
+describe("function declarations in switch case clauses", () => {
+  const faces = /* js */ `
+    function crossClause(v) {
+      switch (v) {
+        case 1: function g() { return 4 } break;
+        case 2: return [typeof g, g()];
+      }
+      return "no match";
+    }
+    function fromDefault(v) {
+      switch (v) {
+        default: return [typeof g, g()];
+        case 1: function g() { return "d" }
+      }
+    }
+    function fallthrough(v) {
+      switch (v) {
+        case 1: function g() { return "f" }
+        case 2: return g();
+      }
+    }
+    function switchTrue(x) {
+      switch (true) {
+        case x > 0: function g() { return "pos" }
+        case x < 0: return g();
+      }
+    }
+    function nestedBlock(v) {
+      switch (v) {
+        case 1: { function g() { return "nested" } return g(); }
+        case 2: return typeof g;
+      }
+    }
+    function closesOverCaseLet(v) {
+      switch (v) {
+        case 1: let x = "x1"; function g() { return x } return g();
+        case 2: try { return g(); } catch (e) { return [typeof g, e.constructor.name]; }
+      }
+    }
+    console.log(JSON.stringify([
+      crossClause(1), crossClause(2), crossClause(3),
+      fromDefault(0), fromDefault(1),
+      fallthrough(1), fallthrough(2),
+      switchTrue(1), switchTrue(-1),
+      nestedBlock(1), nestedBlock(2),
+      closesOverCaseLet(1), closesOverCaseLet(2),
+    ]));
+  `;
+  const expected = [
+    "no match",
+    ["function", 4],
+    "no match",
+    ["function", "d"],
+    null,
+    "f",
+    "f",
+    "pos",
+    "pos",
+    "nested",
+    "undefined",
+    "x1",
+    ["function", "ReferenceError"],
+  ];
+
+  it("keeps the declaration in the clause", () => {
+    const out = new Bun.Transpiler({ loader: "js" }).transformSync(
+      "function f(v) {\n switch (v) {\n case 1: function g() {} break;\n case 2: g();\n }\n}",
+    );
+    expect(out).toMatch(/case 1:\s*function g\(\)/);
+    expect(out).not.toContain("let g");
+  });
+
+  it("can be called from every clause in a strict mode module", async () => {
+    using dir = tempDir("switch-case-fn-strict", { "faces.mjs": faces + "\nexport {};\n" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "faces.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  it("can be called from every clause in a sloppy mode script", async () => {
+    using dir = tempDir("switch-case-fn-sloppy", { "faces.cjs": faces });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "faces.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  // Annex B: in sloppy mode the declaration also assigns a `var` of the same
+  // name in the enclosing function when the clause runs.
+  it("is visible after the switch in sloppy mode", async () => {
+    using dir = tempDir("switch-case-fn-annex-b", {
+      "annex-b.cjs": /* js */ `
+        function h(v) {
+          let r;
+          switch (v) {
+            case 1: function g() { return 4 } break;
+            case 2: r = [typeof g, g()]; break;
+          }
+          return [r, typeof g];
+        }
+        console.log(JSON.stringify([h(1), h(2), h(3)]));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "annex-b.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([
+      [null, "function"],
+      [["function", 4], "undefined"],
+      [null, "undefined"],
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("minifyWhitespace keeps the space before keyword operators", () => {
   const minifier = new Bun.Transpiler({ loader: "js", minifyWhitespace: true });
 


### PR DESCRIPTION
### Problem
- A `function` declared in one `switch` case clause cannot be called from another clause. `case 1: function g() {} break; case 2: g()` throws `ReferenceError: Cannot access 'g' before initialization`. Node prints `function 4` for the same code. Every mode is affected: `bun run`, `bun build` with and without `--no-bundle`, and all minify flags. Under `--minify-syntax` the single-use `let` is also inlined away, so `typeof g` becomes `"undefined"`.
- The cause is the block-level function hoist in `visit_stmts` (`src/js_parser/visit/mod.rs:1430`). It rewrites every block-level declaration to `let g = function () {}` at the top of the statement list it sits in. A switch visits each case body as its own list, so the `let` lands at the top of one clause, while the binding belongs to the whole switch block. From every other clause that `let` is in its TDZ.

### Fix
- `visit_stmts` leaves the declaration in place when the list is a case body (`StmtsKind::SwitchStmt`). The engine creates the binding when it enters the switch, which is what the spec requires, in strict and sloppy mode alike.
- The `let` form cannot be made correct for a switch. Nothing precedes the first case, and a `let` hoisted out of the switch would separate the function from `let`/`const` bindings of the case block that its body closes over.
- In sloppy mode the bundler also keeps the Annex B `var` alias as its own renamed symbol (`hoisted_ref_for_sloppy_mode_block_fn`). `s_switch` now emits `var g = g2` right after each kept declaration, once every clause has been visited. A direct `eval` in a later clause still forbids renaming, so the two symbols are merged in that case, as the block path already does.
- Verified: `test/bundler/transpiler/transpiler.test.js` (4 new tests, strict `.mjs` and sloppy `.cjs`) and `test/bundler/bundler_edgecase.test.ts` (2 new `itBundled` cases, sloppy CJS bundled to ESM, plain and `minifySyntax`). Also ran `bundler_minify.test.ts` and `esbuild/default.test.ts`.

### Background
- The hoist exists so that the output does not depend on the strictness of the output format. In strict mode a block-level function is block scoped. In sloppy mode (Annex B) it is also assigned to a `var` of the same name in the enclosing function when the declaration runs. The parser emulates this with a `let` for the block binding plus a `var` for the alias.
- Generators and async functions are never hoisted this way. They stay declarations today, so a declaration inside a case clause is not a new shape for the printer or the bundler.
- `bun run` prints with a `NoOpRenamer` (names are kept), so it never creates the Annex B `var` symbol. The kept declaration makes the engine apply Annex B itself there, which matches node.
- The runtime transpiler cache version moves to 28 because the transpiled output changes.

<details><summary>Notes</summary>

Repro (`node` prints `function 4`, bun printed `ReferenceError` in every mode):

```js
function f(v) { switch (v) {
  case 1: function g() { return 4 } break;
  case 2: try { console.log(typeof g, g()) } catch (e) { console.log(e.constructor.name) } } }
f(1); f(2);
export {}
```

esbuild 0.25.1 emits the same `let` inside the clause, so there is no upstream fix to port.

Faces checked against node with the debug build: fallthrough, reference from `default`, `default` placed first, `switch (true)`, a nested block inside a case (still lowered to `let`, correct), a function closing over a `let` of the case block (TDZ `ReferenceError` from the other clause, same as node), TypeScript overload signatures in a clause, a switch at module top level of a sloppy script (the alias relocates to a top-level `var`), a switch inside a `for` loop, and a direct `eval` in the same clause after the declaration (bundled output keeps `function q()` with no `var q = q`).

Bundled output for a sloppy file now reads:

```js
case 1:
  function g2() { return 4; }
  var g = g2;
  break;
case 2:
  console.log(typeof g2, g2());
```

Pre-existing and out of scope: two declarations of the same name in different clauses of a sloppy switch. The parser drops the overwritten one, so the alias is only assigned by the surviving clause. Node assigns it from either clause.

`RuntimeTranspilerCache::EXPECTED_VERSION` bumps to 28. #40791 also bumps it to 28 for the minify inliner change in the same area. Whichever lands second needs 29.
</details>
