### PR TITLE
net: server.listen() no longer loads node:cluster in the primary

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4025,6 +4025,7 @@ function emitListeningNextTick(self) {
   self.emit("listening");
 }
 
+const { isPrimary } = require("internal/cluster/isPrimary");
 let cluster;
 function listenInCluster(
   server,
@@ -4048,10 +4049,8 @@ function listenInCluster(
 ) {
   exclusive = !!exclusive;
 
-  if (cluster === undefined) cluster = require("node:cluster");
-
   if (
-    !cluster.isPrimary &&
+    !isPrimary &&
     !exclusive &&
     typeof address === "string" &&
     address.length > 0 &&
@@ -4092,7 +4091,7 @@ function listenInCluster(
     return;
   }
 
-  if (cluster.isPrimary || exclusive) {
+  if (isPrimary || exclusive) {
     server[kRealListen](
       path,
       port,
@@ -4124,6 +4123,7 @@ function listenInCluster(
   };
   const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);
   // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2080-L2102
+  if (cluster === undefined) cluster = require("node:cluster");
   cluster._getServer(server, serverQuery, function listenOnPrimaryHandle(err, handle, _reply) {
     if (listeningId !== server[kClusterListeningId]) {
       handle?.close();

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4049,6 +4049,10 @@ function listenInCluster(
 ) {
   exclusive = !!exclusive;
 
+  // A worker's first require of node:cluster runs its bootstrap (IPC handlers, 'online'); listen() has always been one
+  // of the places that happens, exclusive or not.
+  if (!isPrimary && cluster === undefined) cluster = require("node:cluster");
+
   if (
     !isPrimary &&
     !exclusive &&
@@ -4123,7 +4127,6 @@ function listenInCluster(
   };
   const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);
   // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2080-L2102
-  if (cluster === undefined) cluster = require("node:cluster");
   cluster._getServer(server, serverQuery, function listenOnPrimaryHandle(err, handle, _reply) {
     if (listeningId !== server[kClusterListeningId]) {
       handle?.close();


### PR DESCRIPTION
### What does this PR do?

`listenInCluster()` in `node:net` did `require("node:cluster")` on every `server.listen()` just to read `cluster.isPrimary`. In a primary (the normal case) that instantiates `node:cluster`, `internal/cluster/primary` and `internal/cluster/Worker` for nothing. It now reads the flag from the existing one-line `internal/cluster/isPrimary` module (which `_http_server` already uses for the same purpose) and loads `node:cluster` only on the worker path, right before `cluster._getServer`.

Found while tracing which internal modules a large compiled app instantiates before its first paint: it opens a local socket early, and `listen()` was pulling three cluster modules in.

### How did you verify your code works?

`test/js/node/test/parallel/test-cluster-*.js` (78/80 pass, same two fail on main), `test-net-server-*` / `test-net-listen-*` (30/30), `test/js/node/cluster` + `node-net-server.test.ts` (61 pass). After `net.createServer().listen()`, a first `require("node:cluster")` now costs its real load (~0.6 ms) instead of ~0 — i.e. `listen()` no longer paid it.
