### PR TITLE
upgrade: name the JSON type when the release API returns a non-object

### DIFF
--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -341,8 +341,8 @@ impl UpgradeCommand {
                 refresher.expect("infallible: progress active").refresh();
 
                 bun_core::pretty_errorln!(
-                    "JSON error - expected an object but received {:?}",
-                    core::mem::discriminant(&expr.data)
+                    "JSON error - expected an object but received {}",
+                    expr.data.tag_name()
                 );
                 Global::exit(1);
             }

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -124,6 +124,8 @@ function startReleaseServer(opts: {
   zipPath?: string;
   zipBody?: string;
   digest?: string;
+  /** Raw body for the release endpoint. Replaces the generated release object. */
+  releaseBody?: string;
 }): ReleaseServer {
   const assetNames = opts.assetNames ?? allAssetNames();
   const server = Bun.serve({
@@ -134,6 +136,9 @@ function startReleaseServer(opts: {
       if (pathname.startsWith("/download/")) {
         if (opts.zipPath) return new Response(Bun.file(opts.zipPath));
         return new Response(opts.zipBody ?? "this is not a real zip archive");
+      }
+      if (opts.releaseBody !== undefined) {
+        return new Response(opts.releaseBody, { headers: { "content-type": "application/json" } });
       }
       return new Response(
         JSON.stringify({
@@ -255,6 +260,29 @@ describe.concurrent(() => {
     );
     expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --stable --profile` instead.");
     await proc.exited;
+  });
+});
+
+describe.concurrent("non-object release JSON", () => {
+  it.each([
+    ["[]", "array"],
+    ['"bun-v9.9.9"', "string"],
+    ["42", "number"],
+    ["null", "null"],
+  ])("names the JSON type in the error for %s", async (releaseBody, typeName) => {
+    using server = startReleaseServer({ tagName: "bun-v9.9.9", releaseBody });
+    await using proc = spawn({
+      cmd: [bunExe(), "upgrade", "--stable"],
+      cwd: tmpdirSync(),
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: server.env,
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(`JSON error - expected an object but received ${typeName}`);
+    expect(exitCode).toBe(1);
   });
 });
 


### PR DESCRIPTION
### Problem
- When the GitHub release API returns JSON that is not an object, `bun upgrade` prints `JSON error - expected an object but received Discriminant(7)`. The number is the enum variant index, not the JSON type.
- The cause is `src/runtime/cli/upgrade_command.rs:343`. It formats `core::mem::discriminant(&expr.data)` with `{:?}`. `Discriminant` has an opaque `Debug` output.

### Fix
- Print `expr.data.tag_name()` instead. It maps the AST variant to a readable name: `array`, `string`, `number`, `null`, `boolean`.
- This is the same idiom that `create_command.rs` and `bunfig.rs` use for the same check.
- Verified: `test/cli/install/bun-upgrade.test.ts` (4 new cases, all fail on 1.4.1 with `Discriminant(N)`). The full file passes (12 tests).

### Background
- `bun upgrade --stable` fetches `releases/latest` from the GitHub API and parses the body with the JSON parser into a `bun_ast::Expr`.
- `Expr::data` is the `Data` enum, one variant per expression kind (`EArray`, `EString`, `ENull`, and so on). `Data::tag_name()` returns the human readable name of the active variant.
- The test points `GITHUB_API_DOMAIN` at a local TLS server and serves `[]`, a string, a number, and `null`. `startReleaseServer` gained a `releaseBody` option for this.
