### PR TITLE
shell: report the full system error when the script runner cannot start

### DIFF
--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -733,10 +733,9 @@ impl Interpreter {
         // ── run ────────────────────────────────────────────────────────────
         interp.exit_code.set(Some(1));
         if let Err(e) = interp.run() {
-            let name = e.name();
             interp.deinit_from_exec();
             bun_core::output::err(
-                name,
+                e,
                 "Failed to run script <b>{}<r>",
                 (bstr::BStr::new(label),),
             );

--- a/test/cli/run/run-shell.test.ts
+++ b/test/cli/run/run-shell.test.ts
@@ -49,11 +49,16 @@ describe.concurrent("run-shell", () => {
     // build (event loop fds, the cwd fd, stdin), so scan upward. A lower
     // limit fails earlier with a different error, and a limit one above it
     // fails on the second dup, so the scan cannot step over the window.
+    //
+    // At startup bun walks the cwd's directory chain with one open fd per
+    // level. From a deep temp dir that walk needs more fds than the dup
+    // does, and no limit reaches the dup. Run from `/` so the walk is one
+    // directory.
     let stderr: string | undefined;
     for (let limit = 6; limit <= 16; limit++) {
       await using proc = Bun.spawn({
-        cmd: ["/bin/sh", "-c", `ulimit -n ${limit} && exec "$0" "$1"`, bunExe(), "hello.sh"],
-        cwd: String(dir),
+        cmd: ["/bin/sh", "-c", `ulimit -n ${limit} && exec "$0" "$1"`, bunExe(), join(String(dir), "hello.sh")],
+        cwd: "/",
         env: bunEnv,
         stdout: "pipe",
         stderr: "pipe",

--- a/test/cli/run/run-shell.test.ts
+++ b/test/cli/run/run-shell.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isMusl, isWindows, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 describe.concurrent("run-shell", () => {
@@ -36,6 +36,41 @@ describe.concurrent("run-shell", () => {
     });
     const stderr = await proc.stderr.text();
     expect(stderr).toBe("error: Failed to run script.sh due to error Unexpected ')'\n");
+  });
+
+  // Windows has no RLIMIT_NOFILE. On musl bun raises the hard fd limit at
+  // startup, which succeeds as root and defeats the limit set below.
+  test.skipIf(isWindows || isMusl)("a failure to start the interpreter reports the full system error", async () => {
+    using dir = tempDir("run-shell-emfile", { "hello.sh": "echo hello\n" });
+
+    // Before the shell runs a script it dups stdout and stderr. A hard
+    // RLIMIT_NOFILE equal to the number of fds bun holds at that point makes
+    // the dup fail with EMFILE. That number depends on the platform and the
+    // build (event loop fds, the cwd fd, stdin), so scan upward. A lower
+    // limit fails earlier with a different error, and a limit one above it
+    // fails on the second dup, so the scan cannot step over the window.
+    let stderr: string | undefined;
+    for (let limit = 6; limit <= 16; limit++) {
+      await using proc = Bun.spawn({
+        cmd: ["/bin/sh", "-c", `ulimit -n ${limit} && exec "$0" "$1"`, bunExe(), "hello.sh"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (err.includes("Failed to run script hello.sh")) {
+        expect(exitCode).toBe(1);
+        stderr = err;
+        break;
+      }
+      if (out === "hello\n") break;
+    }
+
+    expect(stderr, "no fd limit between 6 and 16 made the shell's dup fail").toBeDefined();
+    // `dup` is implemented with `fcntl(F_DUPFD_CLOEXEC)`, so that is the
+    // syscall the error names.
+    expect(stderr).toBe("EMFILE: Too many open files: Failed to run script hello.sh (fcntl)\n");
   });
 });
 


### PR DESCRIPTION
### Problem
- When `bun ./script.sh` fails to start the shell interpreter, the error names only the errno: `EMFILE: Failed to run script hello.sh`. The description and the syscall that `output::err` normally adds are missing.
- The cause is `init_and_run_impl` in `src/runtime/shell/interpreter.rs:736`. It passes `e.name()` (a `&[u8]`) to `bun_core::output::err`. The `ErrName` impl for `&[u8]` has no `as_sys_err_info`, so `err_with_body` (`src/bun_core/output.rs:2400`) takes the bare-name branch.

### Fix
- Pass the `bun_sys::Error` itself. Its `ErrName` impl (`src/sys/Error.rs:518`) returns the errno, the label, and the syscall tag, so the output becomes `EMFILE: Too many open files: Failed to run script hello.sh (fcntl)`.
- This matches the other call sites that print a `bun_sys::Error`, for example `src/runtime/cli/exec_command.rs:59`.
- The syscall reads `fcntl` because `bun_sys::dup` is `fcntl(F_DUPFD_CLOEXEC)` on POSIX. That tag is unchanged by this PR.
- Verified: `test/cli/run/run-shell.test.ts` (new test, the released bun prints the bare name and fails it). Also the rest of that file.

### Background
- `bun ./script.sh` runs the script with the built-in shell on a `MiniEventLoop`, without JSC. `Interpreter::run` first dups stdout and stderr so command output reaches the terminal. This is the only call in `run` that can fail.
- `output::err(name, fmt, args)` prints a red error whose prefix is the error name. When the name is a `bun_sys::Error`, it also prints the errno description and the syscall in parentheses.
- The test makes the dup fail with `EMFILE`. It spawns `sh -c 'ulimit -n N && exec bun /path/hello.sh'` from `/` and scans `N` from 6 up. A limit below the right value fails before the dup with a different message, and a limit one above it fails on the second dup (stderr), so the scan cannot miss the window. The right value is 7 on Linux and 6 on macOS.
- It runs from `/` because at startup bun opens one fd per directory in the cwd chain. From a deep temp dir that walk needs more fds than the dup, and no limit reaches the dup.

<details><summary>Notes</summary>

- Probe on Linux with the released bun, `ulimit -n N`: N=5 fails to read the script (`Failed to run script.sh due to error EMFILE`), N=6 fails in `Interpreter::init` (`bunsh: Too many open files`), N=7 and N=8 reach the dup (`EMFILE: Failed to run script script.sh`), N=9 runs the script.
- The debug ASAN build has the same fd footprint on Linux. With the fix, N=7 prints `EMFILE: Too many open files: Failed to run script script.sh (fcntl)`.
- The test is skipped on Windows (no `RLIMIT_NOFILE`) and on musl, where `RealFS::adjust_ulimit` raises the hard limit to 163840 at startup. That succeeds as root and would defeat the limit.
- The fd count at the dup: stdio (3), the mini event loop (epoll and eventfd on Linux, kqueue on macOS), the cwd fd, and the stdin dup from `Interpreter::init`.
- The first version of the test ran from the temp dir and failed on every macOS lane. `fs_usage` on a CI Mac shows the startup `read_dir_info` walk holding one fd per directory from `/` down to the cwd (`/private/var/folders/.../T/<dir>` is 8 levels), all closed afterwards. With cwd `/` the macOS window is N=6 and N=7, with a deep cwd there is none.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-shell.test.ts

<!-- robobun:evidence:end -->
