### PR TITLE
Bump WebKit (oven-sh/WebKit#534 preview): call the tag of (a?.b)`...` with this = a

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-534-bc9542d2";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-534-bc9542d2";
+export const WEBKIT_VERSION = "autobuild-preview-pr-534-492e8dd6";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -463,7 +463,7 @@ describe("bytecode cache portability", () => {
           "js": "52c1e0868de8da5d8bf4b89d68afbd027f3c64fdce490cd46800674b0de3f0c1",
           "jsc": {
             "bytes": 1999232,
-            "sha256": "a6043ef5e8aaae25c9581e6802fc2508f0b7b2fb0681be536768f9d09ef4cac6",
+            "sha256": "655b2364d21871e6043a35b3ba0a0a419f036810c1427f59a83d675c32f9403d",
           },
         },
         "bun build --bytecode --minify features.js": {
@@ -477,7 +477,7 @@ describe("bytecode cache portability", () => {
           "js": "889cbb2c9525ff69a2676a6e81d97bb87760bdee65178b836c9c1d6808ac7c6e",
           "jsc": {
             "bytes": 89144,
-            "sha256": "3c3e86151fe78e6d56d7e7033dfa0e97b062af3b86d7ad75b723d91c77b11cba",
+            "sha256": "d6e5429e29a78fb5ecfc9adb79c7bb062748dffb5bdf02930060985b6c2f59e2",
           },
         },
         "bun build --bytecode acorn/dist/acorn.mjs": {
@@ -490,8 +490,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode all.js": {
           "js": "46d723ea07e5e2d8db673a51fec52b3248edcd3e216029f243d8172244f7cd2c",
           "jsc": {
-            "bytes": 2178792,
-            "sha256": "c5d1eaae5c4d198b1f8e0d768bb41502162081c75b67249032e66a2b95e26ec1",
+            "bytes": 2178800,
+            "sha256": "e378926a6779e35643ae1359d9700430fa6bb831f0a31c011af330e9263c432e",
           },
         },
         "bun build --bytecode big.js": {
@@ -526,7 +526,7 @@ describe("bytecode cache portability", () => {
           "js": "e685164a8316f60b665bc3d47e42b4623cfe7385f87310e655478a50ecd8f959",
           "jsc": {
             "bytes": 23806352,
-            "sha256": "5f23309532d868e1c985d568207c92b77a7f3974e5c6c3f37b21accf7d429327",
+            "sha256": "3b02b1a3ee511ab0cc9d1ffc35626fcf0cc94fca8630e33f1a4726bb0a8a4b39",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -547,7 +547,7 @@ describe("bytecode cache portability", () => {
           "js": "c87ea35df4ad6b2063402c9901ef4775a82f12594f280db76f50695f4b0eba13",
           "jsc": {
             "bytes": 91800,
-            "sha256": "e58b77a8ed116cb6d48d82496d214eb11f8cc6b821049851b60c1f2fb27ebeea",
+            "sha256": "18f03953a82ce7138e98c39b1e5d19db047100b882c1a064bbe128379d64c2c9",
           },
         },
         "bun build --bytecode shapes.js": {
@@ -585,7 +585,7 @@ describe("bytecode cache portability", () => {
         },
         "vm.Script records.js": {
           "bytes": 92928,
-          "sha256": "82ee58ee4885a96f8e2b55f9716d7782914d7212957b44f2109b63d3372ffcf3",
+          "sha256": "0eed0e79d2422b972ba80ade1926912a034048aaf005fa0f5904ce7202c10e2b",
         },
         "vm.Script shapes.js": {
           "bytes": 286632,
@@ -593,7 +593,7 @@ describe("bytecode cache portability", () => {
         },
         "vm.Script source-forms.js": {
           "bytes": 4976,
-          "sha256": "01418094926f5c168db7a01da064308b376fe796a3d8c96aef0719dbe1db4081",
+          "sha256": "04d45d3db4b4c523931ad105f19dfc56ed1b0f31da572f18b06d72b67d71853c",
         },
         "vm.Script typescript.js": {
           "bytes": 12094104,

--- a/test/js/bun/jsc-stress/fixtures/tagged-templates-optional-chain-this.js
+++ b/test/js/bun/jsc-stress/fixtures/tagged-templates-optional-chain-this.js
@@ -1,0 +1,225 @@
+// @bun
+// A tagged template whose tag is a parenthesized optional chain, (a?.b)`...` or (a?.[k])`...`, must call the
+// tag with |this| = a, the same |this| that (a?.b)(...) and a.b`...` get. The parentheses end the optional
+// chain, but the expression they wrap is still the property reference a?.b, so EvaluateCall
+// (https://tc39.es/ecma262/#sec-evaluatecall, step 1.a.i) uses GetThisValue of that reference. The tag used to
+// be called with |this| = undefined, as if the chain had produced a plain value.
+//
+// Only the lookup of the tag short-circuits. When a is nullish, (a?.b)`...` is a call of undefined: the template
+// object and the substitutions are still evaluated (ArgumentListEvaluation comes before the IsCallable check),
+// and then a TypeError is thrown.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: got ${String(actual)}, expected ${String(expected)}`);
+}
+
+function shouldThrowTypeError(func, message) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof TypeError))
+        throw new Error(`${message}: expected a TypeError, got ${String(error)}`);
+}
+
+// The tag is strict so it sees exactly the |this| it was called with, and it records the call.
+function tag(strings) {
+    "use strict";
+    tag.lastCall = { thisValue: this, strings, values: Array.prototype.slice.call(arguments, 1) };
+    return this;
+}
+
+const key = "tag";
+const symbolKey = Symbol("tag");
+const inner = { tag, [symbolKey]: tag, 0: tag };
+const object = {
+    tag,
+    [symbolKey]: tag,
+    0: tag,
+    inner,
+    get getterTag() {
+        object.lastGetterReceiver = this;
+        return tag;
+    },
+    getTag() {
+        return tag;
+    },
+    method() {
+        return (this?.tag)`x`;
+    },
+};
+
+shouldBe((object?.tag)`x`, object, "(object?.tag)`x`");
+shouldBe((object?.["tag"])`x`, object, "(object?.[\"tag\"])`x`");
+shouldBe((object?.[key])`x`, object, "(object?.[key])`x`");
+shouldBe((object?.[symbolKey])`x`, object, "(object?.[symbolKey])`x`");
+shouldBe((object?.[0])`x`, object, "(object?.[0])`x`");
+shouldBe(((object?.tag))`x`, object, "((object?.tag))`x`");
+shouldBe(object.method(), object, "(this?.tag)`x` in a method");
+
+// Longer chains: |this| is the base of the last property access.
+shouldBe((object?.inner.tag)`x`, inner, "(object?.inner.tag)`x`");
+shouldBe((object?.inner?.tag)`x`, inner, "(object?.inner?.tag)`x`");
+shouldBe((object.inner?.tag)`x`, inner, "(object.inner?.tag)`x`");
+shouldBe((object?.inner?.[key])`x`, inner, "(object?.inner?.[key])`x`");
+shouldBe((object?.inner[symbolKey])`x`, inner, "(object?.inner[symbolKey])`x`");
+
+// A getter on the base runs with the base as receiver, and the tag it returns is called with the base too.
+shouldBe((object?.getterTag)`x`, object, "(object?.getterTag)`x`");
+shouldBe(object.lastGetterReceiver, object, "the getter's receiver");
+
+// The base of the chain can be any expression; it is evaluated once.
+let getObjectCalls = 0;
+function getObject() {
+    getObjectCalls++;
+    return object;
+}
+shouldBe((getObject()?.tag)`x`, object, "(getObject()?.tag)`x`");
+shouldBe(getObjectCalls, 1, "the base is evaluated once");
+
+// The template object, its raw strings and the substitutions are passed as for any tagged template, and the
+// template object is cached per call site.
+function withSubstitutions(a, b) {
+    return (object?.tag)`a${a}b${b}c`;
+}
+shouldBe(withSubstitutions(1, 2), object, "(object?.tag)`a${a}b${b}c`");
+{
+    const { strings, values } = tag.lastCall;
+    shouldBe(strings.length, 3, "strings.length");
+    shouldBe(strings.join(","), "a,b,c", "strings");
+    shouldBe(strings.raw.join(","), "a,b,c", "strings.raw");
+    shouldBe(values.length, 2, "values.length");
+    shouldBe(values[0], 1, "values[0]");
+    shouldBe(values[1], 2, "values[1]");
+    withSubstitutions(3, 4);
+    shouldBe(tag.lastCall.strings, strings, "the template object is cached per call site");
+    shouldBe(tag.lastCall.values[0], 3, "values[0] of the second call");
+}
+
+// Substitutions are evaluated after the tag is looked up, and see the same |this| as the enclosing code.
+{
+    const log = [];
+    const probe = {
+        get tag() { log.push("tag"); return tag; },
+        m() { return (this?.tag)`${log.push("first")}${this}`; },
+    };
+    shouldBe(probe.m(), probe, "(this?.tag)`${...}` with substitutions");
+    shouldBe(log.join(), "tag,first", "evaluation order");
+    shouldBe(tag.lastCall.values[1], probe, "the substitution saw the enclosing this");
+}
+
+// Primitive receivers: a strict tag sees the primitive itself.
+String.prototype.tag = tag;
+Number.prototype.tag = tag;
+shouldBe(("str"?.tag)`x`, "str", "(\"str\"?.tag)`x`");
+shouldBe(((1)?.tag)`x`, 1, "((1)?.tag)`x`");
+shouldBe(("str"?.["tag"])`x`, "str", "(\"str\"?.[\"tag\"])`x`");
+delete String.prototype.tag;
+delete Number.prototype.tag;
+
+// Private names in the chain.
+class WithPrivate {
+    #tag = tag;
+    #method(strings) { "use strict"; return this; }
+    static #staticTag = tag;
+    field() { return (this?.#tag)`x`; }
+    method() { return (this?.#method)`x`; }
+    static staticField() { return (WithPrivate?.#staticTag)`x`; }
+    static onInstance(instance) { return (instance?.#tag)`x`; }
+}
+{
+    const instance = new WithPrivate;
+    shouldBe(instance.field(), instance, "(this?.#tag)`x`");
+    shouldBe(instance.method(), instance, "(this?.#method)`x`");
+    shouldBe(WithPrivate.staticField(), WithPrivate, "(WithPrivate?.#staticTag)`x`");
+    shouldBe(WithPrivate.onInstance(instance), instance, "(instance?.#tag)`x`");
+}
+
+// A super property can be the base of the chain, but not the chain itself.
+class Base {
+    get inner() { return inner; }
+}
+class Derived extends Base {
+    m() { return (super.inner?.tag)`x`; }
+}
+shouldBe(new Derived().m(), inner, "(super.inner?.tag)`x`");
+
+// Other contexts that compile the same node.
+function* generator() {
+    yield (object?.tag)`x`;
+}
+shouldBe(generator().next().value, object, "(object?.tag)`x` in a generator");
+globalThis.taggedTemplateThisObject = object;
+shouldBe((0, eval)("(taggedTemplateThisObject?.tag)`x`"), object, "(object?.tag)`x` in indirect eval");
+shouldBe(eval("(object?.tag)`x`"), object, "(object?.tag)`x` in direct eval");
+shouldBe(new Function("object", "return (object?.tag)`x`")(object), object, "(object?.tag)`x` in new Function");
+shouldBe((() => (object?.tag)`x`)(), object, "(object?.tag)`x` in an arrow function");
+shouldBe([1].map(() => (object?.tag)`x`)[0], object, "(object?.tag)`x` in a callback");
+{
+    let result;
+    if ((object?.tag)`x`)
+        result = "truthy";
+    shouldBe(result, "truthy", "(object?.tag)`x` in a condition");
+}
+shouldBe((object?.tag)`x`.tag, tag, "a property of the result");
+
+// Tags that are not parenthesized optional chains keep their |this|.
+shouldBe((object?.inner).tag`x`, inner, "(object?.inner).tag`x`");
+shouldBe((object?.inner)[key]`x`, inner, "(object?.inner)[key]`x`");
+shouldBe((object?.getTag())`x`, undefined, "(object?.getTag())`x` is a call of a plain value");
+shouldBe((object?.tag ?? tag)`x`, undefined, "(object?.tag ?? tag)`x` is a call of a plain value");
+shouldBe((object?.tag, tag)`x`, undefined, "(object?.tag, tag)`x` is a call of a plain value");
+shouldBe(object.tag`x`, object, "object.tag`x`");
+shouldBe(tag`x`, undefined, "tag`x`");
+
+// A nullish base: the tag is undefined and the call throws a TypeError. The key and the rest of the chain are
+// skipped, the substitutions are still evaluated, and the tag function is never called.
+{
+    const log = [];
+    tag.lastCall = null;
+    const nullish = null;
+    shouldThrowTypeError(() => (nullish?.tag)`x`, "(null?.tag)`x`");
+    shouldThrowTypeError(() => (undefined?.tag)`x`, "(undefined?.tag)`x`");
+    shouldThrowTypeError(() => (nullish?.[log.push("key")])`${log.push("substitution")}`, "(null?.[key])`${...}`");
+    shouldBe(log.join(), "substitution", "the key is skipped, the substitution is evaluated");
+    shouldThrowTypeError(() => (nullish?.inner.tag)`x`, "(null?.inner.tag)`x`");
+    shouldThrowTypeError(() => (object?.missing?.tag)`x`, "(object?.missing?.tag)`x`");
+    shouldThrowTypeError(() => (object?.missing.tag)`x`, "(object?.missing.tag)`x` throws on the plain access");
+    shouldBe(tag.lastCall, null, "the tag is never called");
+}
+
+// A missing tag on a present base is a call of undefined too.
+shouldThrowTypeError(() => (object?.missing)`x`, "(object?.missing)`x`");
+shouldThrowTypeError(() => (object?.[Symbol("missing")])`x`, "(object?.[missing symbol])`x`");
+
+// Through the JIT tiers.
+function dot(o) {
+    return (o?.tag)`x`;
+}
+noInline(dot);
+function bracket(o, k) {
+    return (o?.[k])`x`;
+}
+noInline(bracket);
+function chain(o) {
+    return (o?.inner?.tag)`x`;
+}
+noInline(chain);
+function nullishBase(o) {
+    try {
+        (o?.tag)`x`;
+    } catch (e) {
+        return e instanceof TypeError;
+    }
+    return false;
+}
+noInline(nullishBase);
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(dot(object), object, `dot, iteration ${i}`);
+    shouldBe(bracket(object, key), object, `bracket, iteration ${i}`);
+    shouldBe(chain(object), inner, `chain, iteration ${i}`);
+    shouldBe(nullishBase(i & 1 ? null : undefined), true, `nullish base, iteration ${i}`);
+}

--- a/test/js/bun/jsc-stress/fixtures/tagged-templates-super-this.js
+++ b/test/js/bun/jsc-stress/fixtures/tagged-templates-super-this.js
@@ -1,0 +1,347 @@
+// @bun
+// A tagged template whose tag is a super property reference, super.tag`...` or super[key]`...`, must call
+// the tag with the same |this| as super.tag(...) would: the |this| of the method containing it
+// (EvaluateCall, https://tc39.es/ecma262/#sec-evaluatecall, step 1.a.i: GetThisValue of a Super Reference).
+// It used to be called with the object the tag was found on, the home object's prototype, as if it were
+// written Base.prototype.tag`...`.
+
+function describe(value) {
+    if (typeof value === "function")
+        return `function ${value.name}`;
+    if (typeof value === "object" && value !== null)
+        return `[object ${value.constructor ? value.constructor.name : "?"}]`;
+    return `${typeof value} ${String(value)}`;
+}
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: got ${describe(actual)}, expected ${describe(expected)}`);
+}
+
+function shouldThrowReferenceError(func, message) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof ReferenceError))
+        throw new Error(`${message}: expected a ReferenceError, got ${String(error)}`);
+}
+
+const failures = [];
+function test(name, func) {
+    try {
+        func();
+    } catch (e) {
+        failures.push(`${name}: ${e.message}`);
+    }
+}
+
+// Every tag records the |this| it was called with and returns it, so callers can compare it with `===`.
+// All of them are strict, so they see exactly the value they were passed.
+function tagStrict(strings) {
+    "use strict";
+    tagStrict.lastCall = { thisValue: this, strings, values: Array.prototype.slice.call(arguments, 1) };
+    return this;
+}
+
+class Base {
+    tag(strings, ...values) {
+        Base.lastCall = { thisValue: this, strings, values };
+        return this;
+    }
+    get getterTag() {
+        Base.lastGetterReceiver = this;
+        return tagStrict;
+    }
+    static tag() {
+        return this;
+    }
+}
+const key = "tag";
+const symbolKey = Symbol("tag");
+Base.prototype[symbolKey] = tagStrict;
+Base.prototype[0] = tagStrict;
+
+test("super.tag in a method", () => {
+    class C extends Base {
+        m() { return super.tag`x`; }
+        call() { return super.tag(); }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "super.tag`x` is called with the receiver as this");
+    shouldBe(Base.lastCall.strings.length, 1, "the template object is still passed");
+    shouldBe(Base.lastCall.strings[0], "x", "the template strings are still passed");
+    shouldBe(c.call(), c, "super.tag() is called with the receiver as this");
+});
+
+test("super.tag is still looked up on the super base, not on this", () => {
+    class C extends Base {
+        tag() { throw new Error("C.prototype.tag must not be called by super.tag`x`"); }
+        m() { return super.tag`x`; }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "super.tag`x` resolves to Base.prototype.tag and is called with the receiver");
+});
+
+test("super.tag two levels up", () => {
+    class Middle extends Base { }
+    class C extends Middle {
+        m() { return super.tag`x`; }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "a tag inherited through an intermediate class is called with the receiver");
+});
+
+test("super[key] with a variable, a string literal, a symbol and an index", () => {
+    class C extends Base {
+        variable() { return super[key]`x`; }
+        literal() { return super["tag"]`x`; }
+        symbol() { return super[symbolKey]`x`; }
+        index() { return super[0]`x`; }
+    }
+    const c = new C;
+    shouldBe(c.variable(), c, "super[key]`x`");
+    shouldBe(c.literal(), c, "super[\"tag\"]`x`");
+    shouldBe(c.symbol(), c, "super[symbolKey]`x`");
+    shouldBe(c.index(), c, "super[0]`x`");
+});
+
+test("template object and substitutions", () => {
+    class C extends Base {
+        dot(a, b) { return super.tag`a${a}b${b}c`; }
+        bracket(a, b) { return super[key]`a${a}b${b}c`; }
+    }
+    const c = new C;
+    for (const [name, method] of [["super.tag", c.dot], ["super[key]", c.bracket]]) {
+        shouldBe(method.call(c, 1, 2), c, `${name} with substitutions is called with the receiver`);
+        const { strings, values } = Base.lastCall;
+        shouldBe(strings.length, 3, `${name}: strings.length`);
+        shouldBe(strings.join(","), "a,b,c", `${name}: strings`);
+        shouldBe(strings.raw.join(","), "a,b,c", `${name}: strings.raw`);
+        shouldBe(values.length, 2, `${name}: values.length`);
+        shouldBe(values[0], 1, `${name}: values[0]`);
+        shouldBe(values[1], 2, `${name}: values[1]`);
+        method.call(c, 3, 4);
+        shouldBe(Base.lastCall.strings, strings, `${name}: the template object is cached per call site`);
+    }
+});
+
+test("substitutions are evaluated after the tag is looked up and see the same this", () => {
+    const log = [];
+    class C extends Base {
+        get probe() { log.push("substitution"); return this; }
+        m() { return super.tag`${this.probe}${log.push("second")}`; }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "this value");
+    shouldBe(log.join(), "substitution,second", "substitution order");
+    shouldBe(Base.lastCall.values[0], c, "the substitution saw the receiver");
+    shouldBe(Base.lastCall.values[1], 2, "the second substitution");
+});
+
+test("getter on the super base", () => {
+    class C extends Base {
+        dot() { return super.getterTag`x`; }
+        bracket() { return super["getterTag"]`x`; }
+    }
+    const c = new C;
+    shouldBe(c.dot(), c, "the function a super getter returns is called with the receiver");
+    shouldBe(Base.lastGetterReceiver, c, "super.getterTag invokes the getter with the receiver");
+    Base.lastGetterReceiver = null;
+    shouldBe(c.bracket(), c, "the same through super[\"getterTag\"]");
+    shouldBe(Base.lastGetterReceiver, c, "super[\"getterTag\"] invokes the getter with the receiver");
+});
+
+test("static method", () => {
+    class C extends Base {
+        static dot() { return super.tag`x`; }
+        static bracket() { return super[key]`x`; }
+    }
+    shouldBe(C.dot(), C, "static super.tag`x` is called with the class as this");
+    shouldBe(C.bracket(), C, "static super[key]`x` is called with the class as this");
+});
+
+test("object literal method", () => {
+    const proto = { tag: tagStrict, [symbolKey]: tagStrict };
+    const object = {
+        __proto__: proto,
+        dot() { return super.tag`x`; },
+        bracket() { return super[symbolKey]`x`; },
+    };
+    shouldBe(object.dot(), object, "super.tag`x` in an object literal method");
+    shouldBe(object.bracket(), object, "super[key]`x` in an object literal method");
+
+    const inheriting = { __proto__: object };
+    shouldBe(inheriting.dot(), inheriting, "the receiver, not the home object, when the method is called through an inheriting object");
+    shouldBe(inheriting.bracket(), inheriting, "the same for super[key]");
+});
+
+test("primitive receivers are passed through like super.tag() passes them", () => {
+    class C extends Base {
+        dot() { return super.tag`x`; }
+        bracket() { return super[key]`x`; }
+        call() { return super.tag(); }
+    }
+    // Class code is strict, so the primitive reaches the method unconverted and is passed on as is.
+    shouldBe(C.prototype.call.call(5), 5, "sanity: super.tag() from a strict method passes the primitive through");
+    shouldBe(C.prototype.dot.call(5), 5, "super.tag`x` from a strict method passes the primitive through");
+    shouldBe(C.prototype.bracket.call(5), 5, "super[key]`x` from a strict method passes the primitive through");
+
+    // A sloppy method (made with Function so that it is sloppy whatever mode this file runs in) boxes its
+    // receiver on entry; the tag has to be called with that box.
+    const proto = { tag: tagStrict };
+    const sloppy = Function("proto", "return { __proto__: proto, dot() { return super.tag`x`; }, call() { return super.tag(); } };")(proto);
+    const boxedByCall = sloppy.call.call(5);
+    shouldBe(typeof boxedByCall, "object", "sanity: super.tag() from a sloppy method passes the boxed receiver");
+    const boxed = sloppy.dot.call(5);
+    shouldBe(typeof boxed, "object", "super.tag`x` from a sloppy method passes the boxed receiver");
+    shouldBe(boxed instanceof Number, true, "the box is a Number object");
+    shouldBe(boxed.valueOf(), 5, "the box holds the receiver");
+});
+
+test("super base replaced after the class was defined", () => {
+    class C extends Base {
+        m() { return super.tag`x`; }
+    }
+    Object.setPrototypeOf(C.prototype, { tag: tagStrict });
+    const c = new C;
+    tagStrict.lastCall = null;
+    shouldBe(c.m(), c, "this is still the receiver when the tag comes from the replacement super base");
+    shouldBe(tagStrict.lastCall.thisValue, c, "the replacement tag is the one that was called");
+});
+
+test("arrow functions inside a method", () => {
+    class C extends Base {
+        dot() { return (() => super.tag`x`)(); }
+        bracket() { return (() => (() => super[key]`x`)())(); }
+    }
+    const c = new C;
+    shouldBe(c.dot(), c, "super.tag`x` inside an arrow function uses the method's this");
+    shouldBe(c.bracket(), c, "super[key]`x` inside nested arrow functions uses the method's this");
+});
+
+test("direct eval inside a method", () => {
+    class C extends Base {
+        dot() { return eval("super.tag`x`"); }
+        bracket() { return eval("super[key]`x`"); }
+    }
+    const c = new C;
+    shouldBe(c.dot(), c, "super.tag`x` in eval code");
+    shouldBe(c.bracket(), c, "super[key]`x` in eval code");
+});
+
+test("class field initializers", () => {
+    class C extends Base {
+        dot = super.tag`x`;
+        bracket = super[key]`x`;
+        static staticDot = super.tag`x`;
+        static staticBracket = super[key]`x`;
+    }
+    const c = new C;
+    shouldBe(c.dot, c, "instance field initializer, super.tag");
+    shouldBe(c.bracket, c, "instance field initializer, super[key]");
+    shouldBe(C.staticDot, C, "static field initializer, super.tag");
+    shouldBe(C.staticBracket, C, "static field initializer, super[key]");
+});
+
+test("generator and async methods", () => {
+    class C extends Base {
+        *generator() { yield super.tag`x`; yield super[key]`x`; }
+        async asyncMethod() { return [super.tag`x`, await null, super[key]`x`]; }
+    }
+    const c = new C;
+    const results = Array.from(c.generator());
+    shouldBe(results[0], c, "generator method, super.tag");
+    shouldBe(results[1], c, "generator method, super[key]");
+
+    let asyncResult;
+    let asyncError;
+    c.asyncMethod().then((value) => { asyncResult = value; }, (error) => { asyncError = error; });
+    drainMicrotasks();
+    if (asyncError)
+        throw asyncError;
+    shouldBe(asyncResult[0], c, "async method, super.tag before an await");
+    shouldBe(asyncResult[2], c, "async method, super[key] after an await");
+});
+
+test("derived constructor after super()", () => {
+    let seen;
+    class C extends Base {
+        constructor() {
+            super();
+            seen = [super.tag`x`, super[key]`x`, this];
+        }
+    }
+    const c = new C;
+    shouldBe(seen[2], c, "sanity: this is the constructed object");
+    shouldBe(seen[0], c, "super.tag`x` after super() is called with the new object");
+    shouldBe(seen[1], c, "super[key]`x` after super() is called with the new object");
+});
+
+test("derived constructor before super(): this is in its TDZ", () => {
+    // Nothing belonging to the tagged template may run before the uninitialized |this| is detected: neither the
+    // key of super[key] nor the substitutions. This is the order super[key]() and a plain super[key] read already use.
+    const log = [];
+    const evaluatedKey = () => { log.push("key"); return "tag"; };
+    const substitution = () => { log.push("substitution"); return 1; };
+    Base.lastCall = null;
+
+    class Dot extends Base {
+        constructor() { super.tag`${substitution()}`; super(); }
+    }
+    shouldThrowReferenceError(() => new Dot, "super.tag`...` before super()");
+
+    class Bracket extends Base {
+        constructor() { super[evaluatedKey()]`${substitution()}`; super(); }
+    }
+    shouldThrowReferenceError(() => new Bracket, "super[key]`...` before super()");
+
+    class InArrow extends Base {
+        constructor() { (() => super[evaluatedKey()]`${substitution()}`)(); super(); }
+    }
+    shouldThrowReferenceError(() => new InArrow, "super[key]`...` in an arrow function before super()");
+
+    shouldBe(log.length, 0, `neither the key nor the substitutions were evaluated (evaluated: ${log.join()})`);
+    shouldBe(Base.lastCall, null, "the tag was never called");
+});
+
+test("tags that are not super references keep their this", () => {
+    const object = { tag: tagStrict, 0: tagStrict };
+    const log = [];
+    function base() { log.push("base"); return object; }
+    function property() { log.push("key"); return "tag"; }
+    shouldBe(object.tag`x`, object, "object.tag`x`");
+    shouldBe(object["tag"]`x`, object, "object[\"tag\"]`x`");
+    shouldBe(object[0]`x`, object, "object[0]`x`");
+    shouldBe(base()[property()]`x`, object, "base()[key()]`x` is called with the base");
+    shouldBe(log.join(), "base,key", "base()[key()]`x` evaluates the base before the key");
+    shouldBe(tagStrict`x`, undefined, "tag`x` through a binding is called with undefined");
+    class C extends Base {
+        other() { return object.tag`x`; }
+        own() { return this.tag`x`; }
+    }
+    const c = new C;
+    shouldBe(c.other(), object, "object.tag`x` inside a method is called with the object");
+    shouldBe(c.own(), c, "this.tag`x` is called with this");
+});
+
+test("optimized tiers", () => {
+    class C extends Base {
+        dot() { return super.tag`x`; }
+        bracket() { return super[key]`x`; }
+    }
+    noInline(C.prototype.dot);
+    noInline(C.prototype.bracket);
+    const c = new C;
+    for (let i = 0; i < testLoopCount; ++i) {
+        if (c.dot() !== c)
+            throw new Error(`super.tag\`x\` was called with the wrong this on iteration ${i}`);
+        if (c.bracket() !== c)
+            throw new Error(`super[key]\`x\` was called with the wrong this on iteration ${i}`);
+    }
+});
+
+if (failures.length)
+    throw new Error(`FAIL:\n${failures.join("\n")}`);

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -123,6 +123,7 @@ const jsFixtures = [
   "licm-no-pre-header.js",
   // Bytecode generator
   "tagged-templates-optional-chain-this.js",
+  "tagged-templates-super-this.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Bytecode generator
+  "tagged-templates-optional-chain-this.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/jsc-stress/preload.js
+++ b/test/js/bun/jsc-stress/preload.js
@@ -32,3 +32,6 @@ globalThis.fullGC = jsc.fullGC;
 globalThis.edenGC = jsc.edenGC;
 globalThis.numberOfDFGCompiles = jsc.numberOfDFGCompiles;
 globalThis.noDFG = jsc.noFTL;
+
+// drainMicrotasks: the jsc shell's way of settling promises synchronously.
+globalThis.drainMicrotasks = jsc.drainMicrotasks;


### PR DESCRIPTION
### Problem
- JavaScriptCore calls the tag of `(y?.z)\`x\`` with `this` = `undefined`, while `(y?.z)()` and `y.z\`x\`` pass `y`, as node does for all three. Same for `(y?.["z"])\`x\`` and `(w?.v.z)\`x\``. It also calls the tag of `super.tag\`x\`` with the home object's prototype instead of the method's `this` (oven-sh/WebKit#438, #38920).
- Both are in `TaggedTemplateNode::emitBytecode` (`bytecompiler/NodesCodegen.cpp`), which reuses the lookup base as the receiver and never sees through an `OptionalChainNode`. `FunctionCallDotNode` gets both right for calls.
- Reach today: eval, `new Function`, `vm` and `// @bun` files. For a plain file Bun's printer drops the parentheses (`src/js_printer/lib.rs:4131` tests `expr.data`, not `tag.data`), so the result is a SyntaxError. #40829 and #40793 fix the printer. Once either lands, every file reaches the engine, so this bump has to land first.

### Fix
- oven-sh/WebKit#534 (#438's commit, then the optional chain fix) computes the receiver the way the call nodes do. For a parenthesized optional chain it compiles the inner property access with the bracket/dot branches, so the base becomes `this`. The short-circuit target wraps only the lookup, so a nullish base still throws a TypeError, as in node.
- Correct because parentheses yield the Reference of their contents (EvaluateCall step 1.a.i) and a short-circuited chain is the plain value `undefined`. Other tags emit the same instructions as before.
- Pins the preview `autobuild-preview-pr-534-492e8dd6` and absorbs #38920's fixture. Before landing, oven-sh/WebKit#534 must merge and `WEBKIT_VERSION` must move to the merged sha.
- Verified: both `jsc-stress` fixtures fail on the `ceb9f90f` pin and pass on the preview, with the other 116. Full `JSTests/stress` on both `jsc` shells differs only in the new tests. The bytecode portability snapshot moves by the new expression info entry.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit, pinned in `scripts/build/deps/webkit.ts`. A preview tag lets a bump PR test a WebKit PR before it merges.
- `test/js/bun/jsc-stress/` runs WebKit `JSTests/stress` files under `bun`. The `// @bun` line hands the source to JSC verbatim, past the printer.
- A tagged template is a call with a call's `this`: `o` for `o.f`. JSC temporaries start uninitialized, so the base register is also written at the short-circuit target.

<details><summary>Notes</summary>

Repro (bun 1.4.1, WebKit `ceb9f90f`):

```js
const y = { z() { return this === y ? "y" : String(this); } };
console.log(new Function("y", "return [(y?.z)``, (y?.z)(), (y.z)``].join(' ')")(y));
// bun:  [object Object] y y    (sloppy mode, so this = globalThis)
// node: y y y
```

- Found while #40829 taught the printer to keep these parentheses: its end-to-end test avoids asserting `this` for `(y?.z)\`\`` because the engine loses it. After this bump that assertion can be added there.
- The spec: ParenthesizedExpression returns the Reference of its contents. `OptionalChain : ?. IdentifierName` returns a property Reference with base `y`. When `y` is nullish the OptionalExpression returns the value `undefined`. EvaluateCall evaluates the arguments (template object, substitutions) before the IsCallable check, so `(null?.z)\`${f()}\`` calls `f` and then throws. The fix keeps that order, and the skipped subscript of `(null?.[k()])\`x\``.
- `(n?.z)()` with `n` nullish returns `undefined` in JSC and throws in node. That is a separate, pre-existing JSC deviation in the call path (`makeFunctionCallNode` pushes the call inside the chain). Out of scope. This fix does not copy that approach, so `(n?.z)\`x\`` keeps throwing. Also out of scope: `arguments.length\`x\`` throws a ReferenceError instead of a TypeError (the `arguments.length` fast path has no tagged template branch).
- Why one WebKit PR: #438 and the optional chain fix rewrite the same two branches and conflicted in three hunks. #534 now carries #438's commit underneath its own, and the combined function computes the receiver for a super base, an optional chain base and a plain base the way `FunctionCallDotNode` does. This PR therefore also absorbs #38920 (fixture, registration, `drainMicrotasks` preload line), which can close when this lands.
- The WebKit PR also emits the expression info of the tag's property access before the lookup, as `DotAccessorNode` does. Without it, the TypeError of a failing lookup used stale info: `a.b.c\`x\`` with `a.b` undefined said `evaluating 'a.b'`, and the unwrapped `(a?.b[k])\`x\`` would have said `evaluating 'k'`. Both now name the whole access. This changes only the error-message side table, which is why the bytecode portability snapshot moves for the corpus files with a `String.raw\`...\`` tag (records.js, all.js, libraries.js, source-forms); CI produced the same new hashes on all 11 platforms.
- The first version of the fix read the base register on the short-circuit path without writing it. On a debug `jsc` that crashed in `llint_op_call` with stack garbage in the `this` slot. Only `numVars` slots are initialized by `op_enter`. Loading the base at the target fixes it.
- Local Debug (non-ASAN) `jsc` of the WebKit branch: both new tests pass with the default options and with `--useJIT=false`, `--useLLInt=false`, the DFG-eager and FTL-eager thresholds, each with `--validateGraph=true --validateBytecode=true`. 168 existing `optional-chaining*`, `tagged-template*`, `*optional*`, `*template*`, `*super*`, `*this*` stress files give the same results as the unfixed release `jsc`.

- Full `JSTests/stress` comparison: default options plus `--useDollarVM=true`, 120s per file, 14 in parallel, release `jsc` shells of `autobuild-ceb9f90f` (unfixed) and of this preview. 5746 files (one new). 132 non-zero exits before, 129 after. The differing files:

| file | before | after | reason |
| --- | --- | --- | --- |
| `tagged-templates-optional-chain-this.js` | exception | pass | new test |
| `tagged-templates-super-this.js` | exception (run alone on the unfixed shell) | pass | new test, from #438 |
| `big-int-spec-to-this.js` | pass | exception | `skip if not $jitTests`. Alone, fails on both |
| `big-int-strict-spec-to-this.js` | pass | exception | needs `--useConcurrentJIT=false`. Alone, fails on both |
| `int8-repeat-in-then-out-of-bounds.js` | exception | pass | alone, fails on both |
| `math-pow-coherency.js` | pass | exception | `//@ skip`. FTL timing check, flaky on both (8 and 12 of 12 runs alone, 11 of 12 each under load) |
| `ffi-pointers-and-buffers.js` | exception | pass | alone, passes on both |
| `array-prototype-flat-reentrant-mutation.js`, `regress-84402043.js` | timeout | pass | `memoryHog!`. Alone, pass on both |
| `deep-StructureStubClearingWatchpoint-destructor-recursion.js` | timeout | pass | `//@ skip`. Alone, passes on both |
| `get-own-property-descriptors-oom.js`, `re-enter-resolve-rope-string.js` | timeout / killed | killed / timeout | `memoryHog!` with a watchdog. Which limit hits first depends on load |

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->