### PR TITLE
js_parser: point the fallback diagnostic for an unlogged parse failure at the lexer's range

### DIFF
--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -92,17 +92,10 @@ impl JavaScript {
                 debug_assert_eq!(temp_log.errors, 0);
                 r
             }
-            Err(err) => {
-                // `Parser::parse` consumes `self`, so `parser` is gone in this
-                // arm. The `&'a mut temp_log` it held is released, so read
-                // `temp_log.errors` directly. The lexer range is lost; fall
-                // back to `Range::None`.
-                // TODO: thread the failing token range through the `Err`
-                // payload (make `_parse` return a `(Error, Range)` pair) so the
-                // diagnostic points at the failing token.
-                if temp_log.errors == 0 {
-                    log.add_range_error(Some(source), bun_ast::Range::None, err.name().as_bytes());
-                }
+            Err(_) => {
+                // The parser logs every failure, at the failing token when
+                // nothing else described it.
+                debug_assert!(temp_log.errors > 0);
                 let _ = temp_log.append_to_maybe_recycled(log, source);
                 return Ok(None);
             }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -763,6 +763,23 @@ impl<'a> Parser<'a> {
         // SAFETY: `init_p!` only yields after `init` succeeded.
         let p: &mut P<'_, TS, false> = unsafe { __p.assume_init_mut() };
 
+        let result = Self::parse_with(p, source, orig_error_count);
+        if let Err(err) = &result {
+            // An `Err` with no new log entry has no diagnostic yet. The lexer
+            // still sits on the token that failed.
+            if p.log().errors == orig_error_count {
+                p.log()
+                    .add_range_error(Some(p.source), p.lexer.range(), err.name().as_bytes());
+            }
+        }
+        result
+    }
+
+    fn parse_with<const TS: bool>(
+        p: &mut P<'a, TS, false>,
+        source: &'a bun_ast::Source,
+        orig_error_count: u32,
+    ) -> Result<crate::Result<'a>, Error> {
         if p.options.features.hot_module_reloading {
             debug_assert!(!p.options.tree_shaking);
         }

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -40,6 +40,17 @@ test.concurrent("JS parse error after astral characters reports UTF-16 column", 
   });
 });
 
+test.concurrent("parser failure with no message of its own points at the token the lexer stopped on", async () => {
+  // A method-signature parameter that is not a binding makes the parser fail
+  // without logging anything. The fallback diagnostic carried no position
+  // (line -1, column -1); it must point at the `1` the lexer stopped on.
+  expect(await buildPosition("in.ts", "const a = 1;\n\ntype T = { foo(1): void };\n")).toEqual({
+    stdout: `{"line":3,"column":16}`,
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 test.concurrent("JS parse error column agrees for BMP vs astral lines of equal UTF-16 width", async () => {
   // Four one-unit BMP characters and two two-unit astral characters both put
   // `]` at column 19.


### PR DESCRIPTION
### Problem
- When `Parser::parse` fails without a logged message, the runtime transpiler path added the fallback diagnostic with `Range::None` (`src/bundler/cache.rs:103`). The user saw the bare error name with no position: `error: Backtrack` followed by `at /path/file.ts`. `Bun.build` reported `position: { line: -1, column: -1, lineText: "" }`.
- `cache.rs` could not do better. `Parser::parse` consumes the parser, so the lexer and its range were gone when the `Err` came back.

### Fix
- `Parser::_parse` (`src/js_parser/parse/parse_entry.rs`) now runs the parse body through a new `parse_with` helper. If that returns an `Err` and the log has no new error, `_parse` logs the error name at `p.lexer.range()`. The lexer still sits on the token that failed, and the `P` that owns it is still alive at that point.
- `cache.rs` drops the `Range::None` fallback. Its `Err` arm now matches the `Parser::init` failure arm and asserts (debug) that the parser logged something.
- Correct because every logged error halts the parser, so `log.errors == orig_error_count` on an `Err` means no diagnostic exists yet. Other `Parser::parse` callers (REPL, snapshot file parser, `pm diff`) use a local log and ignore its contents on failure, so the extra entry does not change their behavior.
- Verified: `test/js/bun/transpiler/parse-error-column.test.ts` (new test, stock bun reports `line -1, column -1`, the fix reports `line 3, column 16`). Also `test/js/bun/transpiler/`, `test/bundler/bundler_edgecase.test.ts`, `test/bundler/transpiler/transpiler.test.js`, `bun-pragma`, `jsx-deep-nesting-stack-overflow`, and `cargo clippy` on `bun_js_parser` and `bun_bundler`.

### Background
- The parser logs syntax errors itself, with a range, and then returns `Err(SyntaxError)`. A stack overflow is logged at `lexer.loc()` before the return. So an `Err` that reaches `_parse` with no new log entry is an internal failure (an out-of-memory error, or a `Backtrack` that escaped a backtracking region).
- `Parser` is a thin wrapper. `parse(self)` destructures it and moves the lexer into `P`, the real parser state. `P` is dropped at the end of `_parse`, which is why the range has to be read there.
- The test uses such an escaped `Backtrack`: `type T = { foo(1): void }` makes `skip_type_script_binding` return `Error::Backtrack` outside any backtracking helper, so nothing is logged. That the message says `Backtrack` instead of `Unexpected 1` is a separate parser bug and is not changed here. The test asserts only the position, which stays the same once that message is fixed.

<details><summary>Notes</summary>

Before, with the released bun:

```
$ bun bt.ts
error: Backtrack
    at /tmp/probe/bt.ts
```

After, with this change:

```
$ bun bt.ts
4 | type T = { foo(1): void };
                   ^
error: Backtrack
    at /tmp/probe/bt.ts:4:16
```

`bun build`, `Bun.build({ throw: false }).logs[0].position`, and `new Bun.Transpiler({ loader: "ts" }).transformSync(...)` show the same change. `interface I { foo(1): void }` and `let x: { foo(1): void }` hit the same path.

The scan path (`Parser::scan_imports`, used by `Bun.Transpiler.scanImports`) is not touched. It does not log a fallback at all. `JSTranspiler` throws `Failed to scan imports` with the error name when the log is empty.

`P::init` returns a `Result` but has no failing path today, so every `Err` from `parse` now carries a logged message. The `debug_assert!(temp_log.errors > 0)` in `cache.rs` makes a future unlogged path visible in debug builds.

The `snapshot.test.ts` "error snapshots" test fails in this container with and without the change. It expects ANSI color codes that this environment does not emit.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/parse-error-column.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/transpiler/parse-error-column.test.ts:
(pass) JS parse error after astral characters reports UTF-16 column [388.61ms]
42 | 
43 | test.concurrent("parser failure with no message of its own points at the token the lexer stopped on", async () => {
44 |   // A method-signature parameter that is not a binding makes the parser fail
45 |   // without logging anything. The fallback diagnostic carried no position
46 |   // (line -1, column -1); it must point at the `1` the lexer stopped on.
47 |   expect(await buildPosition("in.ts", "const a = 1;\n\ntype T = { foo(1): void };\n")).toEqual({
                                                                                            ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "{"line":3,"column":16}",
+   "stdout": "{"line":-1,"column":-1}",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/transpiler/parse-error-co
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/transpiler/parse-error-column.test.ts:
42 | 
43 | test.concurrent("parser failure with no message of its own points at the token the lexer stopped on", async () => {
44 |   // A method-signature parameter that is not a binding makes the parser fail
45 |   // without logging anything. The fallback diagnostic carried no position
46 |   // (line -1, column -1); it must point at the `1` the lexer stopped on.
47 |   expect(await buildPosition("in.ts", "const a = 1;\n\ntype T = { foo(1): void };\n")).toEqual({
                                                                                            ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "{"line":3,"column":16}",
+   "stdout": "{"line":-1,"column":-1}",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/transpiler/parse-error-column.test.ts:47:88)
(pass) JS parse error after astral characters reports UTF-16 column [12.83ms]
(fail) parser failure with no message of its own points at the token the lexer stopped on [10.98ms]
(pass) CLI caret stays under the token for an error at 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/parse-error-column.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/transpiler/parse-error-column.test.ts:
(pass) JS parse error after astral characters reports UTF-16 column [396.55ms]
(pass) JS parse error column matches JSC runtime column for the same line [390.02ms]
(pass) parser failure with no message of its own points at the token the lexer stopped on [421.22ms]
(pass) CLI caret stays under the token for an error at the end of a long line [220.84ms]
(pass) TOML parse error after astral characters reports UTF-16 column [642.71ms]
(pass) long non-ASCII line's lineText window covers the error token [364.36ms]
(pass) JS parse error column agrees for BMP vs astral lines of equal UTF-16 width [728.89ms]
(pass) long non-ASCII line's lineText window does not split a UTF-8 sequence [334.93ms]

 8 pass
 0 fail
 8 expect() calls
Ran 8 tests across 1 file. [2.79s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 598ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/cache.rs                              | 15 ++++-----------
 src/js_parser/parse/parse_entry.rs                | 17 +++++++++++++++++
 test/js/bun/transpiler/parse-error-column.test.ts | 11 +++++++++++
 3 files changed, 32 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/bundler/cache.rs                                   2      1      0
src/js_parser/parse/parse_entry.rs                     4      2      0
test/js/bun/transpiler/parse-error-column.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->