### PR TITLE
watch: name the errno when the process reload fails

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2400,18 +2400,18 @@ pub fn err(error_name: impl ErrName, fmt: &str, args: impl FmtTuple) {
 fn err_with_body(error_name: &dyn ErrName, body: &dyn fmt::Display) {
     if let Some(e) = error_name.as_sys_err_info() {
         // MOVE_DOWN: bun_sys::coreutils_error_map → bun_core (move-in pass).
-        if let Some(label) = crate::coreutils_error_map::get(e.errno) {
+        if let Some(label) = crate::coreutils_error_map::get_by_name(e.tag_name) {
             pretty_errorln!(
                 "<r><red>{}<r><d>:<r> {}: {} <d>({})<r>",
-                bstr::BStr::new(e.tag_name),
-                bstr::BStr::new(label),
+                e.tag_name,
+                label,
                 body,
                 e.syscall,
             );
         } else {
             pretty_errorln!(
                 "<r><red>{}<r><d>:<r> {} <d>({})<r>",
-                bstr::BStr::new(e.tag_name),
+                e.tag_name,
                 body,
                 e.syscall,
             );
@@ -2446,13 +2446,24 @@ pub fn err_generic(fmt: &str, args: impl FmtTuple) {
     );
 }
 
-/// What `err()` needs from a `bun_sys::Error` without naming the type.
-/// Populated by bun_sys's `ErrName` impl (move-in pass).
+/// What `err()` needs from a failed syscall without naming `bun_sys::Error`:
+/// the `SystemErrno` tag (`"ENOENT"`, or `"UNKNOWN"` when the code has no
+/// tag) and the syscall. bun_sys's `ErrName` impl projects its `Error` onto
+/// this; code in bun_core that holds only a raw OS error code (`reload_process`)
+/// builds one from the `ErrnoNames` hook.
 #[derive(Clone, Copy)]
 pub struct SysErrInfo {
-    pub tag_name: &'static [u8],
-    pub errno: i32,
+    pub tag_name: &'static str,
     pub syscall: &'static str,
+}
+
+impl ErrName for SysErrInfo {
+    fn name(&self) -> &[u8] {
+        self.tag_name.as_bytes()
+    }
+    fn as_sys_err_info(&self) -> Option<SysErrInfo> {
+        Some(*self)
+    }
 }
 
 /// Trait abstracting the error-name shapes accepted by `err()`.

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2447,10 +2447,7 @@ pub fn err_generic(fmt: &str, args: impl FmtTuple) {
 }
 
 /// What `err()` needs from a failed syscall without naming `bun_sys::Error`:
-/// the `SystemErrno` tag (`"ENOENT"`, or `"UNKNOWN"` when the code has no
-/// tag) and the syscall. bun_sys's `ErrName` impl projects its `Error` onto
-/// this; code in bun_core that holds only a raw OS error code (`reload_process`)
-/// builds one from the `ErrnoNames` hook.
+/// the `SystemErrno` tag (`"ENOENT"`, or `"UNKNOWN"`) and the syscall name.
 #[derive(Clone, Copy)]
 pub struct SysErrInfo {
     pub tag_name: &'static str,

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2446,8 +2446,7 @@ pub fn err_generic(fmt: &str, args: impl FmtTuple) {
     );
 }
 
-/// What `err()` needs from a failed syscall without naming `bun_sys::Error`:
-/// the `SystemErrno` tag (`"ENOENT"`, or `"UNKNOWN"`) and the syscall name.
+/// What `err()` needs from a failed syscall without naming `bun_sys::Error`.
 #[derive(Clone, Copy)]
 pub struct SysErrInfo {
     pub tag_name: &'static str,

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4396,12 +4396,15 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         const WATCHER_RELOAD_EXIT: u32 = 0xC031_EF32;
         let rc = TerminateProcess(GetCurrentProcess(), WATCHER_RELOAD_EXIT);
         if rc == 0 {
-            let err = GetLastError();
+            let code = GetLastError();
+            let tag_name = crate::ErrnoNames::SYS.win32_name(code).unwrap_or("UNKNOWN");
             if may_return {
-                crate::output::err_generic("Failed to reload process: {}", (err,));
+                report_reload_failure(tag_name, "TerminateProcess");
                 return;
             }
-            panic!("Error while reloading process: {}", err);
+            panic!(
+                "Error while reloading process: {tag_name} (TerminateProcess, GetLastError {code})"
+            );
         } else {
             if may_return {
                 crate::output::err_generic("Failed to reload process", ());
@@ -4450,14 +4453,12 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         libc::execve(exec_path, newargv.as_ptr().cast(), envp.as_ptr().cast());
         // execve only returns on error.
         let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+        let tag_name = crate::ErrnoNames::SYS.name(errno).unwrap_or("UNKNOWN");
         if may_return {
-            crate::output::pretty_errorln(format_args!(
-                "error: Failed to reload process: errno {}",
-                errno
-            ));
+            report_reload_failure(tag_name, "execve");
             return;
         }
-        panic!("Unexpected error while reloading: errno {}", errno);
+        panic!("Unexpected error while reloading: {tag_name} (execve, errno {errno})");
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -4467,6 +4468,18 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         let _ = (clear_terminal, may_return);
         compile_error!("unsupported platform for reload_process");
     }
+}
+
+/// `EACCES: Permission denied: Failed to reload process (execve)`. Flushed
+/// here: the `may_return` caller is the crash handler, which re-raises the
+/// fatal signal without a flush, so a buffered line would never be seen.
+fn report_reload_failure(tag_name: &'static str, syscall: &'static str) {
+    crate::output::err(
+        crate::output::SysErrInfo { tag_name, syscall },
+        "Failed to reload process",
+        (),
+    );
+    crate::output::flush();
 }
 
 // ── spawn_sync_inherit ────────────────────────────────────────────────────

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4470,15 +4470,14 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
     }
 }
 
-/// `EACCES: Permission denied: Failed to reload process (execve)`. Flushed
-/// here: the `may_return` caller is the crash handler, which re-raises the
-/// fatal signal without a flush, so a buffered line would never be seen.
+/// `EACCES: Permission denied: Failed to reload process (execve)`
 fn report_reload_failure(tag_name: &'static str, syscall: &'static str) {
     crate::output::err(
         crate::output::SysErrInfo { tag_name, syscall },
         "Failed to reload process",
         (),
     );
+    // The crash handler re-raises the fatal signal right after this returns, without a flush.
     crate::output::flush();
 }
 

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -317,9 +317,14 @@ impl Error {
     }
 
     pub fn name(&self) -> &'static [u8] {
+        self.tag_name().as_bytes()
+    }
+
+    /// The `SystemErrno` tag (`"ENOENT"`), or `"UNKNOWN"` when `errno` has no tag.
+    pub fn tag_name(&self) -> &'static str {
         self.get_error_code_tag_name()
-            .map(|(n, _)| n.as_bytes())
-            .unwrap_or(b"UNKNOWN")
+            .map(|(n, _)| n)
+            .unwrap_or("UNKNOWN")
     }
 
     pub fn to_zig_err(&self) -> SystemErrno {
@@ -521,8 +526,7 @@ impl bun_core::output::ErrName for Error {
     }
     fn as_sys_err_info(&self) -> Option<bun_core::output::SysErrInfo> {
         Some(bun_core::output::SysErrInfo {
-            tag_name: Error::name(self),
-            errno: i32::from(self.errno),
+            tag_name: self.tag_name(),
             syscall: <&'static str>::from(self.syscall),
         })
     }

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -221,6 +221,11 @@ function linkBunExe(dir: string): string {
 // deliberate crashes below must not upload there.
 const noCrashReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" };
 
+// The children below die from a deliberate crash. On the coredump-upload CI
+// lane the runner flags a leaked core file as a failure, so run them with core
+// dumps disabled. RLIMIT_CORE is inherited across exec.
+const noCoreCmd = (argv: string[]) => ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
+
 it.skipIf(isWindows)(
   "--watch names the errno when the re-exec of the binary fails",
   async () => {
@@ -232,7 +237,7 @@ it.skipIf(isWindows)(
     const proc = spawn({
       // --debug-crash-handler-use-trace-string skips the debug build's slow
       // backtrace symbolication so the child exits promptly.
-      cmd: [exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"],
+      cmd: noCoreCmd([exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"]),
       cwd: String(dir),
       env: noCrashReportEnv,
       stdout: "pipe",
@@ -272,7 +277,7 @@ it.skipIf(isWindows)(
     const exe = linkBunExe(String(dir));
 
     const proc = spawn({
-      cmd: [exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"],
+      cmd: noCoreCmd([exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"]),
       cwd: String(dir),
       env: noCrashReportEnv,
       stdin: "pipe",

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -226,83 +226,75 @@ const noCrashReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH
 // dumps disabled. RLIMIT_CORE is inherited across exec.
 const noCoreCmd = (argv: string[]) => ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
 
-it.skipIf(isWindows)(
-  "--watch names the errno when the re-exec of the binary fails",
-  async () => {
-    using dir = tempDir("watch-reexec-fails", {
-      "app.js": `console.log("iter first"); setInterval(() => {}, 1000);`,
-    });
-    const exe = linkBunExe(String(dir));
+it.skipIf(isWindows)("--watch names the errno when the re-exec of the binary fails", async () => {
+  using dir = tempDir("watch-reexec-fails", {
+    "app.js": `console.log("iter first"); setInterval(() => {}, 1000);`,
+  });
+  const exe = linkBunExe(String(dir));
 
-    const proc = spawn({
-      // --debug-crash-handler-use-trace-string skips the debug build's slow
-      // backtrace symbolication so the child exits promptly.
-      cmd: noCoreCmd([exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"]),
-      cwd: String(dir),
-      env: noCrashReportEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    watchee = proc;
-    const stderr = proc.stderr.text();
-    const { waitFor, release } = stdoutWaiter(proc);
+  const proc = spawn({
+    // --debug-crash-handler-use-trace-string skips the debug build's slow
+    // backtrace symbolication so the child exits promptly.
+    cmd: noCoreCmd([exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"]),
+    cwd: String(dir),
+    env: noCrashReportEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  watchee = proc;
+  const stderr = proc.stderr.text();
+  const { waitFor, release } = stdoutWaiter(proc);
 
-    await waitFor("iter first");
-    release();
+  await waitFor("iter first");
+  release();
 
-    // The path the reload will execve() no longer exists.
-    rmSync(exe);
-    await Bun.write(join(String(dir), "app.js"), `console.log("iter second");`);
+  // The path the reload will execve() no longer exists.
+  rmSync(exe);
+  await Bun.write(join(String(dir), "app.js"), `console.log("iter second");`);
 
-    const [err, exitCode] = await Promise.all([stderr, proc.exited]);
-    expect(err).toContain("Unexpected error while reloading: ENOENT");
-    expect(exitCode).not.toBe(0);
-  },
-  30000,
-);
+  const [err, exitCode] = await Promise.all([stderr, proc.exited]);
+  expect(err).toContain("Unexpected error while reloading: ENOENT");
+  expect(exitCode).not.toBe(0);
+});
 
 // A crash under --watch restarts the process from the crash handler. When that
 // execve() fails as well, the error line must name the errno and must reach
 // stderr before the handler re-raises the fatal signal.
-it.skipIf(isWindows)(
-  "--watch crash auto-restart reports a failed re-exec by errno name",
-  async () => {
-    using dir = tempDir("watch-crash-reexec-fails", {
-      "app.js": `
+it.skipIf(isWindows)("--watch crash auto-restart reports a failed re-exec by errno name", async () => {
+  using dir = tempDir("watch-crash-reexec-fails", {
+    "app.js": `
         import { crash_handler } from "bun:internal-for-testing";
         console.log("iter first");
         process.stdin.on("data", () => crash_handler.segfault());
       `,
-    });
-    const exe = linkBunExe(String(dir));
+  });
+  const exe = linkBunExe(String(dir));
 
-    const proc = spawn({
-      cmd: noCoreCmd([exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"]),
-      cwd: String(dir),
-      env: noCrashReportEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    watchee = proc;
-    const stderr = proc.stderr.text();
-    const { waitFor, release } = stdoutWaiter(proc);
+  const proc = spawn({
+    cmd: noCoreCmd([exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"]),
+    cwd: String(dir),
+    env: noCrashReportEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  watchee = proc;
+  const stderr = proc.stderr.text();
+  const { waitFor, release } = stdoutWaiter(proc);
 
-    await waitFor("iter first");
-    release();
+  await waitFor("iter first");
+  release();
 
-    // Crash only after the path the restart will execve() is gone.
-    rmSync(exe);
-    proc.stdin.write("crash\n");
-    await proc.stdin.end();
+  // Crash only after the path the restart will execve() is gone.
+  rmSync(exe);
+  proc.stdin.write("crash\n");
+  await proc.stdin.end();
 
-    const [err, exitCode] = await Promise.all([stderr, proc.exited]);
-    expect(err).toContain("Bun is auto-restarting due to crash");
-    expect(err).toContain("ENOENT: No such file or directory: Failed to reload process (execve)");
-    expect(exitCode).not.toBe(0);
-  },
-  30000,
-);
+  const [err, exitCode] = await Promise.all([stderr, proc.exited]);
+  expect(err).toContain("Bun is auto-restarting due to crash");
+  expect(err).toContain("ENOENT: No such file or directory: Failed to reload process (execve)");
+  expect(exitCode).not.toBe(0);
+});
 
 // A script that registers a SIGTERM handler and then spins in synchronous
 // code must still restart on file change: the watcher thread posts the reload

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -269,7 +269,7 @@ it.skipIf(isWindows)(
   async () => {
     using dir = tempDir("watch-crash-reexec-fails", {
       "app.js": `
-        const { crash_handler } = require("bun:internal-for-testing");
+        import { crash_handler } from "bun:internal-for-testing";
         console.log("iter first");
         process.stdin.on("data", () => crash_handler.segfault());
       `,

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -2,7 +2,7 @@ import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
-import { readdirSync, rmSync } from "node:fs";
+import { copyFileSync, linkSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 let watchee: Subprocess;
@@ -202,6 +202,102 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
   expect(stdout).not.toContain("unreachable");
   expect(exitCode).not.toBe(0);
 });
+
+// The reload execve()s the running binary by path. That fails when the binary
+// is gone, for example after an upgrade replaced it. The tests below run a
+// second link to the binary so removing it leaves the build alone. A hard link
+// needs the same filesystem; fall back to a copy.
+function linkBunExe(dir: string): string {
+  const exe = join(dir, "bun-link");
+  try {
+    linkSync(bunExe(), exe);
+  } catch {
+    copyFileSync(bunExe(), exe);
+  }
+  return exe;
+}
+
+// CI sets BUN_CRASH_REPORT_URL so unexpected crashes are captured; the
+// deliberate crashes below must not upload there.
+const noCrashReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" };
+
+it.skipIf(isWindows)(
+  "--watch names the errno when the re-exec of the binary fails",
+  async () => {
+    using dir = tempDir("watch-reexec-fails", {
+      "app.js": `console.log("iter first"); setInterval(() => {}, 1000);`,
+    });
+    const exe = linkBunExe(String(dir));
+
+    const proc = spawn({
+      // --debug-crash-handler-use-trace-string skips the debug build's slow
+      // backtrace symbolication so the child exits promptly.
+      cmd: [exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"],
+      cwd: String(dir),
+      env: noCrashReportEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    watchee = proc;
+    const stderr = proc.stderr.text();
+    const { waitFor, release } = stdoutWaiter(proc);
+
+    await waitFor("iter first");
+    release();
+
+    // The path the reload will execve() no longer exists.
+    rmSync(exe);
+    await Bun.write(join(String(dir), "app.js"), `console.log("iter second");`);
+
+    const [err, exitCode] = await Promise.all([stderr, proc.exited]);
+    expect(err).toContain("Unexpected error while reloading: ENOENT");
+    expect(exitCode).not.toBe(0);
+  },
+  30000,
+);
+
+// A crash under --watch restarts the process from the crash handler. When that
+// execve() fails as well, the error line must name the errno and must reach
+// stderr before the handler re-raises the fatal signal.
+it.skipIf(isWindows)(
+  "--watch crash auto-restart reports a failed re-exec by errno name",
+  async () => {
+    using dir = tempDir("watch-crash-reexec-fails", {
+      "app.js": `
+        const { crash_handler } = require("bun:internal-for-testing");
+        console.log("iter first");
+        process.stdin.on("data", () => crash_handler.segfault());
+      `,
+    });
+    const exe = linkBunExe(String(dir));
+
+    const proc = spawn({
+      cmd: [exe, "--debug-crash-handler-use-trace-string", "--watch", "app.js"],
+      cwd: String(dir),
+      env: noCrashReportEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    watchee = proc;
+    const stderr = proc.stderr.text();
+    const { waitFor, release } = stdoutWaiter(proc);
+
+    await waitFor("iter first");
+    release();
+
+    // Crash only after the path the restart will execve() is gone.
+    rmSync(exe);
+    proc.stdin.write("crash\n");
+    await proc.stdin.end();
+
+    const [err, exitCode] = await Promise.all([stderr, proc.exited]);
+    expect(err).toContain("Bun is auto-restarting due to crash");
+    expect(err).toContain("ENOENT: No such file or directory: Failed to reload process (execve)");
+    expect(exitCode).not.toBe(0);
+  },
+  30000,
+);
 
 // A script that registers a SIGTERM handler and then spins in synchronous
 // code must still restart on file change: the watcher thread posts the reload


### PR DESCRIPTION
### Problem
- When `--watch` or `--hot` cannot re-exec the process, the message shows a raw number: `panic: Unexpected error while reloading: errno 2` on POSIX, a bare `GetLastError()` integer on Windows. Other syscall failures in bun print the errno name.
- The cause is `reload_process` in `src/bun_core/util.rs`. It formats `raw_os_error()` and the Win32 code directly instead of resolving them through the `ErrnoNames` hook.
- The crash handler's auto-restart path (`may_return == true`) prints its line through the buffered stderr writer and returns. The handler then re-raises the fatal signal without a flush, so that line was never written at all.

### Fix
- Resolve the code to its `SystemErrno` tag (`ErrnoNames::SYS.name` on POSIX, `win32_name` on Windows) and print it with `Output::err`: `ENOENT: No such file or directory: Failed to reload process (execve)`. The panic path reads `Unexpected error while reloading: ENOENT (execve, errno 2)`.
- `report_reload_failure` flushes after the print, so the auto-restart report reaches stderr before the re-raise.
- `Output::err` now looks the coreutils label up by the errno tag instead of the raw errno. `SysErrInfo` loses its `errno` field and implements `ErrName` itself, so code that holds only a tag (here, and a Win32 code in bun_core) can use the same format as `bun_sys::Error`. For `bun_sys::Error` the result is unchanged: the tag was derived from the same errno.
- Verified: `test/cli/watch/watch.test.ts`, two new tests (the watcher reload, and the crash auto-restart). Both fail on the released bun. Also the rest of that file, and `cargo test -p bun_errno`.

### Background
- `bun --watch` does not reload modules in place. On a file change the watcher calls `reload_process`, which `execve`s the running binary with the same argv. The reload fails when that path is gone, for example after an upgrade replaced the binary.
- `bun_core` cannot depend on `bun_errno` (cycle). `ErrnoNames` is a link interface in `bun_core` that `bun_errno` implements. It maps an errno or a Win32 code to the tag name string.
- `Output::err(sys_error, body)` is the standard format for a failed syscall: `<tag>: <coreutils label>: <body> (<syscall>)`. `SysErrInfo` is the projection of a `bun_sys::Error` that `err` consumes, since `bun_core` cannot name that type.

<details><summary>Notes</summary>

- #39975 (open, CI red) changes the same POSIX arm more broadly: the panic becomes `exit(1)`, and Linux retries the `<path> (deleted)` case. This PR is text only and covers both arms. If #39975 lands first, its message already carries the errno name.
- On Windows the label lookup by tag also fixes a gap: a libuv-origin `bun_sys::Error` has a `UV_*` discriminant as its raw errno, which has no coreutils entry, while its tag is the translated `ENOENT`. The label now resolves.
- The tests run a hard link to the binary from a temp dir, unlink it after the first iteration, then trigger the reload. A hard link needs the same filesystem, so they fall back to a copy. The second test crashes the child through `bun:internal-for-testing` on stdin input, so the watched file is not modified and the crash handler's restart is what calls `reload_process`.
- The Windows arm (`TerminateProcess` on the current process) cannot be made to fail from a test. It was checked with `cargo check` and `clippy` for `x86_64-pc-windows-msvc`, and for `aarch64-apple-darwin`.
- `SysErrInfo` had no other users (`src/bun_core/output.rs`, `src/sys/Error.rs`). `bun_core::coreutils_error_map::get(errno)` keeps its unit tests and is no longer called at runtime.
- Manual check that the existing format is unchanged: `bun ./missing.lockb --hash` prints `ENOENT: No such file or directory: failed to open lockfile (open)` before and after.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->