### PR TITLE
Output.err: print the errno description for libuv errors on Windows

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2451,8 +2451,7 @@ pub fn err_generic(fmt: &str, args: impl FmtTuple) {
 #[derive(Clone, Copy)]
 pub struct SysErrInfo {
     pub tag_name: &'static [u8],
-    /// The resolved `SystemErrno` discriminant that `tag_name` was derived
-    /// from, so `coreutils_error_map::get` finds the label for it.
+    /// The resolved `SystemErrno` discriminant, what `coreutils_error_map::get` takes.
     pub errno: i32,
     pub syscall: &'static str,
 }

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2451,6 +2451,8 @@ pub fn err_generic(fmt: &str, args: impl FmtTuple) {
 #[derive(Clone, Copy)]
 pub struct SysErrInfo {
     pub tag_name: &'static [u8],
+    /// The resolved `SystemErrno` discriminant that `tag_name` was derived
+    /// from, so `coreutils_error_map::get` finds the label for it.
     pub errno: i32,
     pub syscall: &'static str,
 }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -737,6 +737,12 @@ export const sysErrorNameFromLibuv: (errno: number) => string | undefined = $new
   1,
 );
 
+export const sysErrorOutputErr: (errno: number, fromLibuv: boolean) => undefined = $newRustFunction(
+  "sys/Error.rs",
+  "TestingAPIs.sysErrorOutputErr",
+  2,
+);
+
 export const sigactionLayout: () =>
   | undefined
   | {

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -53,6 +53,7 @@ pub use bun_sourcemap_jsc::internal_jsc::testing_to_vlq as sourcemap_internal_so
 
 pub use bun_sys_jsc::error_jsc::TestingAPIs::sigaction_layout as sys_sys_testing_ap_is_sigaction_layout;
 pub use bun_sys_jsc::error_jsc::TestingAPIs::sys_error_name_from_libuv as sys_error_testing_ap_is_sys_error_name_from_libuv;
+pub use bun_sys_jsc::error_jsc::TestingAPIs::sys_error_output_err as sys_error_testing_ap_is_sys_error_output_err;
 pub use bun_sys_jsc::error_jsc::TestingAPIs::translate_nt_status_to_e as sys_sys_testing_ap_is_translate_nt_status_to_e;
 pub use bun_sys_jsc::error_jsc::TestingAPIs::translate_uv_error_to_e as sys_sys_testing_ap_is_translate_uv_error_to_e;
 

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -21,6 +21,9 @@ const RETRY_ERRNO: Int = E::EAGAIN as Int;
 
 const TODO_ERRNO: Int = Int::MAX - 1;
 
+/// Printed in place of the errno tag when `errno` decodes to no `SystemErrno`.
+const UNKNOWN_TAG_NAME: &[u8] = b"UNKNOWN";
+
 pub(crate) type Int = u16;
 
 #[derive(Clone, Debug)]
@@ -318,8 +321,7 @@ impl Error {
 
     pub fn name(&self) -> &'static [u8] {
         self.get_error_code_tag_name()
-            .map(|(n, _)| n.as_bytes())
-            .unwrap_or(b"UNKNOWN")
+            .map_or(UNKNOWN_TAG_NAME, |(n, _)| n.as_bytes())
     }
 
     pub fn to_zig_err(&self) -> SystemErrno {
@@ -520,9 +522,16 @@ impl bun_core::output::ErrName for Error {
         Error::name(self)
     }
     fn as_sys_err_info(&self) -> Option<bun_core::output::SysErrInfo> {
+        // Resolve once and hand over the `SystemErrno` discriminant: with
+        // `from_libuv` the stored `errno` is a raw `UV_E*` magnitude, which the
+        // coreutils label table does not know.
+        let (tag_name, errno) = match self.get_error_code_tag_name() {
+            Some((name, e)) => (name.as_bytes(), e as i32),
+            None => (UNKNOWN_TAG_NAME, i32::from(self.errno)),
+        };
         Some(bun_core::output::SysErrInfo {
-            tag_name: Error::name(self),
-            errno: i32::from(self.errno),
+            tag_name,
+            errno,
             syscall: <&'static str>::from(self.syscall),
         })
     }

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -522,9 +522,7 @@ impl bun_core::output::ErrName for Error {
         Error::name(self)
     }
     fn as_sys_err_info(&self) -> Option<bun_core::output::SysErrInfo> {
-        // Resolve once and hand over the `SystemErrno` discriminant: with
-        // `from_libuv` the stored `errno` is a raw `UV_E*` magnitude, which the
-        // coreutils label table does not know.
+        // Not `self.errno`: with `from_libuv` that is a raw `UV_E*` magnitude.
         let (tag_name, errno) = match self.get_error_code_tag_name() {
             Some((name, e)) => (name.as_bytes(), e as i32),
             None => (UNKNOWN_TAG_NAME, i32::from(self.errno)),

--- a/src/sys_jsc/error_jsc.rs
+++ b/src/sys_jsc/error_jsc.rs
@@ -77,10 +77,8 @@ pub mod TestingAPIs {
         }
     }
 
-    /// Prints a `bun.sys.Error` through `Output.err` so tests can read the
-    /// `ENOENT: No such file or directory: ... (open)` line from stderr. With
-    /// `fromLibuv` the errno is the negated UV code as node_fs stores it
-    /// (Windows-only; prints nothing and returns `undefined` elsewhere).
+    /// Runs `Output.err` on a `bun.sys.Error` built from `(errno, fromLibuv)`;
+    /// tests read the line from stderr. `fromLibuv` is Windows-only (no-op elsewhere).
     #[bun_jsc::host_fn]
     pub fn sys_error_output_err(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         let arguments = frame.arguments();

--- a/src/sys_jsc/error_jsc.rs
+++ b/src/sys_jsc/error_jsc.rs
@@ -77,6 +77,38 @@ pub mod TestingAPIs {
         }
     }
 
+    /// Prints a `bun.sys.Error` through `Output.err` so tests can read the
+    /// `ENOENT: No such file or directory: ... (open)` line from stderr. With
+    /// `fromLibuv` the errno is the negated UV code as node_fs stores it
+    /// (Windows-only; prints nothing and returns `undefined` elsewhere).
+    #[bun_jsc::host_fn]
+    pub fn sys_error_output_err(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let arguments = frame.arguments();
+        if arguments.len() < 2 || !arguments[0].is_number() || !arguments[1].is_boolean() {
+            return Err(global.throw(format_args!(
+                "sysErrorOutputErr: expected (number, boolean) arguments"
+            )));
+        }
+        let Ok(errno) = u16::try_from(arguments[0].to_int32()) else {
+            return Err(global.throw(format_args!("sysErrorOutputErr: errno must fit in a u16")));
+        };
+        let from_libuv = arguments[1].as_boolean();
+        #[cfg(not(windows))]
+        if from_libuv {
+            return Ok(JSValue::UNDEFINED);
+        }
+        let err = Error {
+            errno,
+            syscall: bun_sys::Tag::open,
+            #[cfg(windows)]
+            from_libuv,
+            ..Default::default()
+        };
+        bun_core::output::err(err, "sysErrorOutputErr", ());
+        bun_core::output::flush();
+        Ok(JSValue::UNDEFINED)
+    }
+
     /// Exposes NTSTATUS -> `bun.sys.E` translation so tests can feed NTSTATUS
     /// values that filter drivers and cloud-sync placeholders return in the
     /// wild (STATUS_CANNOT_DELETE etc.) and verify they map to a sensible

--- a/src/sys_jsc/error_jsc.rs
+++ b/src/sys_jsc/error_jsc.rs
@@ -77,8 +77,7 @@ pub mod TestingAPIs {
         }
     }
 
-    /// Runs `Output.err` on a `bun.sys.Error` built from `(errno, fromLibuv)`;
-    /// tests read the line from stderr. `fromLibuv` is Windows-only (no-op elsewhere).
+    /// Runs `Output.err` on an `Error` built from `(errno, fromLibuv)`. Tests read stderr.
     #[bun_jsc::host_fn]
     pub fn sys_error_output_err(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         let arguments = frame.arguments();

--- a/test/js/bun/sys/error-name-from-libuv.test.ts
+++ b/test/js/bun/sys/error-name-from-libuv.test.ts
@@ -10,9 +10,9 @@ import { sysErrorNameFromLibuv } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
-// Runs `Output.err(sys_error, "sysErrorOutputErr", ())` in a child bun and
-// returns the stderr line it printed.
-async function outputErr(errno: number, fromLibuv: boolean): Promise<string> {
+// Runs `Output.err(sys_error, "sysErrorOutputErr", ())` in a child bun. The
+// line it prints is on stderr.
+async function outputErr(errno: number, fromLibuv: boolean) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `require("bun:internal-for-testing").sysErrorOutputErr(${errno}, ${fromLibuv})`],
     env: bunEnv,
@@ -20,21 +20,33 @@ async function outputErr(errno: number, fromLibuv: boolean): Promise<string> {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(exitCode).toBe(0);
-  return stderr;
+  return { stdout, stderr, exitCode };
 }
 
 test.concurrent("Output.err prints the errno label before the message", async () => {
-  expect(await outputErr(2, false)).toBe("ENOENT: No such file or directory: sysErrorOutputErr (open)\n");
+  expect(await outputErr(2, false)).toEqual({
+    stdout: "",
+    stderr: "ENOENT: No such file or directory: sysErrorOutputErr (open)\n",
+    exitCode: 0,
+  });
 });
 
 // The label lookup must use the translated errno. With from_libuv=true the
 // stored errno is the negated UV code, which names `UV_ENOENT` in the
 // SystemErrno table, and that has no coreutils label.
 test.concurrent.skipIf(!isWindows)("Output.err prints the errno label for a from_libuv error", async () => {
-  expect(await outputErr(4058, true)).toBe("ENOENT: No such file or directory: sysErrorOutputErr (open)\n"); // -UV_ENOENT
-  expect(await outputErr(4092, true)).toBe("EACCES: Permission denied: sysErrorOutputErr (open)\n"); // -UV_EACCES
+  // -UV_ENOENT
+  expect(await outputErr(4058, true)).toEqual({
+    stdout: "",
+    stderr: "ENOENT: No such file or directory: sysErrorOutputErr (open)\n",
+    exitCode: 0,
+  });
+  // -UV_EACCES
+  expect(await outputErr(4092, true)).toEqual({
+    stdout: "",
+    stderr: "EACCES: Permission denied: sysErrorOutputErr (open)\n",
+    exitCode: 0,
+  });
 });
 
 test.skipIf(!isWindows)("Error.name() with from_libuv=true does not overflow", () => {

--- a/test/js/bun/sys/error-name-from-libuv.test.ts
+++ b/test/js/bun/sys/error-name-from-libuv.test.ts
@@ -8,7 +8,34 @@
 
 import { sysErrorNameFromLibuv } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// Runs `Output.err(sys_error, "sysErrorOutputErr", ())` in a child bun and
+// returns the stderr line it printed.
+async function outputErr(errno: number, fromLibuv: boolean): Promise<string> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `require("bun:internal-for-testing").sysErrorOutputErr(${errno}, ${fromLibuv})`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+  return stderr;
+}
+
+test.concurrent("Output.err prints the errno label before the message", async () => {
+  expect(await outputErr(2, false)).toBe("ENOENT: No such file or directory: sysErrorOutputErr (open)\n");
+});
+
+// The label lookup must use the translated errno. With from_libuv=true the
+// stored errno is the negated UV code, which names `UV_ENOENT` in the
+// SystemErrno table, and that has no coreutils label.
+test.concurrent.skipIf(!isWindows)("Output.err prints the errno label for a from_libuv error", async () => {
+  expect(await outputErr(4058, true)).toBe("ENOENT: No such file or directory: sysErrorOutputErr (open)\n"); // -UV_ENOENT
+  expect(await outputErr(4092, true)).toBe("EACCES: Permission denied: sysErrorOutputErr (open)\n"); // -UV_EACCES
+});
 
 test.skipIf(!isWindows)("Error.name() with from_libuv=true does not overflow", () => {
   // errno values as stored by node_fs.zig: @intCast(-rc) where rc is the


### PR DESCRIPTION
### Problem
- On Windows, `Output::err(sys_error, ...)` for an error built with `from_libuv` prints `ENOENT: <msg> (open)` and drops the description (`No such file or directory`).
- The `ErrName` impl for `bun_sys::Error` (`src/sys/Error.rs:524`) resolves the tag name through the libuv-aware `resolve_system_errno()`, but puts the raw stored value (the `UV_E*` magnitude, 4058) in `SysErrInfo.errno`. `err_with_body` (`src/bun_core/output.rs:2403`) looks the label up with it. On Windows 4058 names `UV_ENOENT`, which has no coreutils label.

### Fix
- Resolve once with `get_error_code_tag_name()` and pass the resolved `SystemErrno` discriminant (2) in `SysErrInfo.errno`. The Zig `Output.err` did the same: `coreutils_error_map.get(sys_errno)` on the resolved errno.
- Off Windows, and for errors without `from_libuv` on Windows, the resolved discriminant equals the stored errno. Output does not change there.
- Adds the `bun:internal-for-testing` hook `sysErrorOutputErr(errno, fromLibuv)`. It runs `Output::err` on a constructed error, like `sysErrorNameFromLibuv` does for `name()`.
- Verified: `test/js/bun/sys/error-name-from-libuv.test.ts` on windows-x64. Without the `Error.rs` change the new test gets `ENOENT: sysErrorOutputErr (open)`, with it `ENOENT: No such file or directory: sysErrorOutputErr (open)`. Also passes on Linux (the `from_libuv` case skips).

### Background
- On Windows `bun_sys::Error.errno` holds either an `E` discriminant (the sync syscall wrappers translate eagerly) or, with `from_libuv` set (the node_fs async uv callbacks), the negated `UV_E*` code. `resolve_system_errno()` reads the flag to tell them apart.
- `SysErrInfo` is the view of a `bun_sys::Error` that `bun_core::output::err` consumes. `bun_core` cannot name `bun_sys::Error` (crate tiers), so `bun_sys` fills it.
- `bun_core::coreutils_error_map::get(i32)` maps a number to its `SystemErrno` name, then to the glibc text. The Windows `SystemErrno` enum has a `UV_*` tail, so 4058 names `UV_ENOENT`.

<details><summary>Notes</summary>

- In the current tree only the node_fs uv callbacks and `Fd::close` set `from_libuv`, and those errors go to JS, not to `Output::err`. So this is a latent inconsistency found by reading, not a user report. The hook is what makes it testable.
- `Error::name()` now shares the `UNKNOWN_TAG_NAME` constant with the `ErrName` impl instead of repeating the literal.
- A related but separate bug: `Error::from_uv_rc64` stores the raw `UV_E*` magnitude with `from_libuv` unset, so `ReturnCodeI64::to_error` errors get names like `UV_EBADF`. That is #37465.
- #39340 edits the same test file (the `EUNKNOWN` expectation). The two changes touch different lines.
- Clippy is clean for `bun_sys`, `bun_sys_jsc` and `bun_core` on Linux, and for `bun_sys_jsc` on Windows (`bun_sys` has pre-existing clippy errors on Windows unrelated to this change).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/sys/error-name-from-libuv.test.ts

<!-- robobun:evidence:end -->