### PR TITLE
json: use one depth-limit message for every parser path

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -914,7 +914,13 @@ pub mod parse_worker {
                             encoding: bun_parsers::xml::InputEncoding::File,
                         },
                     )?;
-                    let root = bun_parsers::json::materialize(&rows, source, &mut temp_log, bump)?;
+                    let root = bun_parsers::json::materialize(
+                        &rows,
+                        source,
+                        &mut temp_log,
+                        bump,
+                        "XML document",
+                    )?;
                     Ok(JSAst::init(
                         js_parser::new_lazy_export_ast(
                             bump,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1921,7 +1921,12 @@ fn parse_data_loader<'a>(
             bun_ast::ExprData::EObjectJSON(_) | bun_ast::ExprData::EArrayJSON(_)
         )
     {
-        expr = match bun_parsers::json::materialize(&expr, source, log, arena) {
+        // Only the JSON and XML parsers write tape rows.
+        let what = match loader {
+            options::Loader::Xml => "XML document",
+            _ => "JSON document",
+        };
+        expr = match bun_parsers::json::materialize(&expr, source, log, arena, what) {
             Ok(e) => e,
             Err(_) => return None,
         };

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -340,19 +340,36 @@ fn parse_classic(
     out.root = match materialize_impl(&out.root, source, bump, opts.was_originally_macro) {
         Ok(root) => root,
         Err(e) => {
-            log.add_error_fmt_opts(
-                format_args!("JSON document is too deeply nested"),
-                bun_ast::AddErrorOptions {
-                    source: Some(source),
+            add_too_deeply_nested_error(
+                log,
+                source,
+                bun_ast::Range {
                     loc: out.root.loc,
-                    ..Default::default()
+                    len: 0,
                 },
+                "JSON document",
             );
             return Err(e);
         }
     };
     out.tape = None;
     Ok(out)
+}
+
+/// Logs the depth-limit error at `range`. `what` names the document, as in
+/// `Source::check_parseable_len` ("JSON document", "XML document").
+#[cold]
+pub(crate) fn add_too_deeply_nested_error(
+    log: &mut bun_ast::Log,
+    source: &bun_ast::Source,
+    range: bun_ast::Range,
+    what: &str,
+) {
+    log.add_range_error_fmt(
+        Some(source),
+        range,
+        format_args!("{what} is too deeply nested"),
+    );
 }
 
 impl ParsedJson {
@@ -901,20 +918,25 @@ fn skip_json_value(contents: &[u8], p: usize) -> Option<usize> {
 }
 
 /// Deep-convert an immutable-AST document into the classic `E::Object` / `E::Array` tree.
+///
+/// `what` names the document in the depth-limit error ("JSON document",
+/// "XML document"): the XML parser writes the same tape rows.
 pub fn materialize(
     root: &Expr,
     source: &bun_ast::Source,
     log: &mut bun_ast::Log,
     bump: &Bump,
+    what: &str,
 ) -> crate::Result<Expr> {
     materialize_impl(root, source, bump, false).inspect_err(|_| {
-        log.add_error_fmt_opts(
-            format_args!("Document is too deeply nested"),
-            bun_ast::AddErrorOptions {
-                source: Some(source),
+        add_too_deeply_nested_error(
+            log,
+            source,
+            bun_ast::Range {
                 loc: root.loc,
-                ..Default::default()
+                len: 0,
             },
+            what,
         );
     })
 }
@@ -1706,8 +1728,14 @@ mod tests {
                 let source = bun_ast::Source::init_path_string("fixture.json", doc.as_bytes());
                 let bump = Bump::new();
                 let mut mlog = bun_ast::Log::init();
-                let root =
-                    materialize(p.root.as_ref().unwrap(), &source, &mut mlog, &bump).unwrap();
+                let root = materialize(
+                    p.root.as_ref().unwrap(),
+                    &source,
+                    &mut mlog,
+                    &bump,
+                    "JSON document",
+                )
+                .unwrap();
                 (root.loc, canon_full(&root))
             };
             assert_eq!(full, materialized, "materialized tree differs for {doc:?}");

--- a/src/parsers/json_stage2.rs
+++ b/src/parsers/json_stage2.rs
@@ -867,9 +867,11 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
 
     #[cold]
     fn too_deeply_nested(&mut self, loc: Loc) -> crate::Error {
-        let _ = self.add_range_error(
+        crate::json::add_too_deeply_nested_error(
+            self.log,
+            self.source,
             Range { loc, len: 1 },
-            format_args!("JSON document is too deeply nested"),
+            "JSON document",
         );
         crate::Error::StackOverflow
     }

--- a/test/js/bun/transpiler/too-deeply-nested.test.ts
+++ b/test/js/bun/transpiler/too-deeply-nested.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "node:path";
+
+// A JSON or XML document that nests deeper than the native stack allows is
+// rejected by the parser, or by the later pass that converts its tape rows
+// into the classic AST. That pass has larger frames, so it can trip on a
+// depth the parser accepted. Every site has to agree on the wording.
+// `scan` is used because `transformSync` also prints, and the printer has a
+// depth limit of its own.
+const repeat = (text: string, count: number) => Buffer.alloc(text.length * count, text).toString();
+const shapes = {
+  json: (depth: number) => repeat('{"a":', depth) + "1" + repeat("}", depth),
+  xml: (depth: number) => repeat("<a>", depth) + "x" + repeat("</a>", depth),
+};
+
+// Deep enough to trip the conversion pass on every build, and below the XML
+// parser's own element depth cap of 100_000, which has a different message.
+const deepEnough = 99_000;
+
+function scanError(transpiler: Bun.Transpiler, loader: keyof typeof shapes, depth: number): string | undefined {
+  try {
+    transpiler.scan(shapes[loader](depth), loader);
+  } catch (e: any) {
+    return `${e.name}: ${e.message}`;
+  }
+}
+
+test("Bun.Transpiler reports a too deeply nested JSON document with one message", () => {
+  // The depth at which each pass trips depends on the build, so sweep depths
+  // in small steps and collect every distinct message.
+  const transpiler = new Bun.Transpiler();
+  const messages = new Set<string>();
+  for (let depth = 256; depth <= 2 ** 18; depth = Math.ceil(depth * 1.05)) {
+    const message = scanError(transpiler, "json", depth);
+    if (message !== undefined) messages.add(message);
+  }
+  expect([...messages]).toEqual(["BuildMessage: JSON document is too deeply nested"]);
+});
+
+test("Bun.Transpiler names the format for a too deeply nested XML document", () => {
+  expect(scanError(new Bun.Transpiler(), "xml", deepEnough)).toBe("BuildMessage: XML document is too deeply nested");
+});
+
+test("Bun.build reports a too deeply nested document with the same messages", async () => {
+  using dir = tempDir("too-deeply-nested", {
+    "deep.json": shapes.json(deepEnough),
+    "deep.xml": shapes.xml(deepEnough),
+  });
+  const messages: Record<string, string[]> = {};
+  for (const name of ["deep.json", "deep.xml"]) {
+    const result = await Bun.build({ entrypoints: [join(String(dir), name)], throw: false });
+    messages[name] = result.logs.map(log => `${log.name}: ${log.message}`);
+  }
+  expect(messages).toEqual({
+    "deep.json": ["BuildMessage: JSON document is too deeply nested"],
+    "deep.xml": ["BuildMessage: XML document is too deeply nested"],
+  });
+});


### PR DESCRIPTION
### Problem
- A JSON document that nests past the stack limit gets one of two messages. The parser (`src/parsers/json_stage2.rs`, `too_deeply_nested`) and the bundler path (`src/parsers/json.rs`, `parse_classic`) say `JSON document is too deeply nested`. `json::materialize` says `Document is too deeply nested`.
- `materialize` runs after the parser and has larger frames, so it trips on a depth the parser accepted. On a release build, `new Bun.Transpiler().scan(src, "json")` reports `Document is too deeply nested` at depth 30235 and `JSON document is too deeply nested` at depth 35002.
- #37146 dropped "JSON" from the `materialize` message because the XML parser writes the same tape rows. So a too deep XML document from `bun build` also said only `Document`.

### Fix
- One helper, `json::add_too_deeply_nested_error(log, source, range, what)`, logs `{what} is too deeply nested`. All three sites call it. `what` names the document the way `Source::check_parseable_len` does.
- `materialize` takes `what` from the caller. The JSON callers pass `JSON document`. The two XML callers (`ParseTask.rs`, `transpiler.rs`) pass `XML document`.
- Verified: `test/js/bun/transpiler/too-deeply-nested.test.ts` (new, 3 tests). The JSON test sweeps depths and fails on the release build without the fix (both messages show up). The XML tests fail on release and debug builds without the fix. Also ran the `bun_parsers` unit tests, `jsonc.test.ts`, `xml.test.ts`, `source-too-large.test.ts`, `bundler_loader.test.ts`, and `toml.test.js`.

### Background
- The JSON parser writes immutable tape rows (`E::ObjectJSON` / `E::ArrayJSON`). `materialize` converts them into the classic `E::Object` / `E::Array` AST for the bundler and `Bun.Transpiler`. The runtime module loader hands JSON straight to JSC and never calls it.
- Every recursive step checks `StackCheck::is_safe_to_recurse` (128 KiB of headroom, 256 KiB on Windows). The depth at which a pass trips depends on its frame size, so the parser and `materialize` have different limits on every build.
- The XML parser is iterative and caps element depth at 100_000 with its own message (`Nesting is too deep`). Below that cap, `materialize` is the only depth limit an XML document meets.

<details><summary>Notes</summary>

- Release build, linux-x64 main thread, `Bun.Transpiler().scan`: nested arrays trip `materialize` at about 36k and the parser at about 48k. Nested objects: about 30k and 35k. XML elements: about 30k.
- Debug ASAN build: parser frames are larger than `materialize` frames, so the parser always trips first on JSON (arrays at about 1500, objects at about 1000) and the second message is unreachable. That is why the JSON test passes on a debug build with or without the fix, and why the XML tests carry the fail-before proof there.
- The test uses `scan` and not `transformSync`: the printer has a depth limit of its own (`StackOverflow Failed to print code`) that trips between the two parser limits.
- The test uses nested objects and not arrays for the JSON sweep: `parse_data_loader` parses with `record_value_locs: false`, and `materialize` then recovers array item locations by rescanning the source, which is quadratic in the depth for nested arrays (1.2 s at depth 32k). Handed off separately.
- `too_deeply_nested` in stage 2 no longer goes through `LexerLog::add_range_error`, so it does not update `prev_error_loc`. The parser returns `StackOverflow` right after, so nothing reads it. `warn_duplicate_key` in the same file already logs directly.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/too-deeply-nested.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/transpiler/too-deeply-nested.test.ts:
(pass) Bun.Transpiler reports a too deeply nested JSON document with one message [943.40ms]
37 |   }
38 |   expect([...messages]).toEqual(["BuildMessage: JSON document is too deeply nested"]);
39 | });
40 | 
41 | test("Bun.Transpiler names the format for a too deeply nested XML document", () => {
42 |   expect(scanError(new Bun.Transpiler(), "xml", deepEnough)).toBe("BuildMessage: XML document is too deeply nested");
                                                                  ^
error: expect(received).toBe(expected)

Expected: "BuildMessage: XML document is too deeply nested"
Received: "BuildMessage: Document is too deeply nested"

      at <anonymous> (/workspace/bun/test/js/bun/transpiler/too-deeply-nested.test.ts:42:62)
(fail) Bun.Transpiler names the format for a too deeply nested XML document [471.70ms]
50 |   const messages: Record<string, string[]> = {};
51 |   for (const name of ["deep.json", "de
... (truncated)

release without fix: 3 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/transpiler/too-deeply-nested.test.ts:
33 |   const messages = new Set<string>();
34 |   for (let depth = 256; depth <= 2 ** 18; depth = Math.ceil(depth * 1.05)) {
35 |     const message = scanError(transpiler, "json", depth);
36 |     if (message !== undefined) messages.add(message);
37 |   }
38 |   expect([...messages]).toEqual(["BuildMessage: JSON document is too deeply nested"]);
                             ^
error: expect(received).toEqual(expected)

  [
+   "BuildMessage: Document is too deeply nested",
    "BuildMessage: JSON document is too deeply nested",
  ]

- Expected  - 0
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/transpiler/too-deeply-nested.test.ts:38:25)
(fail) Bun.Transpiler reports a too deeply nested JSON document with one message [229.99ms]
37 |   }
38 |   expect([...messages]).toEqual(["BuildMessage: JSON document is too deeply nested"]);
39 | });
40 | 
41 | test("Bun.Transpiler names the format for a too deeply nested XML document", () => {
42 |   expect(scanError(new Bun.Transpiler(), "xml", deepEnough)).toBe("BuildMessage: XML document is too deeply nested");
           
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/too-deeply-nested.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/transpiler/too-deeply-nested.test.ts:
(pass) Bun.Transpiler reports a too deeply nested JSON document with one message [922.89ms]
(pass) Bun.Transpiler names the format for a too deeply nested XML document [449.61ms]
(pass) Bun.build reports a too deeply nested document with the same messages [640.61ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [3.94s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     036777814f
  features     baseline

23 deps, 131 codegen, 1172 objects in 847ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] fetch zlib
[zlib] up to date
[6/1243] gen ErrorCode+*.h
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[9/1243] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ParseTask.rs                         |  8 +++-
 src/bundler/transpiler.rs                        |  7 ++-
 src/parsers/json.rs                              | 52 ++++++++++++++++-----
 src/parsers/json_stage2.rs                       |  6 ++-
 test/js/bun/transpiler/too-deeply-nested.test.ts | 59 ++++++++++++++++++++++++
 5 files changed, 116 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/bundler/ParseTask.rs                              2      1      0
src/bundler/transpiler.rs                             3      1      0
src/parsers/json.rs                                   4      5      0
src/parsers/json_stage2.rs                            1      2      0
test/js/bun/transpiler/too-deeply-nested.test.ts      0      3      0
```

</details>

<!-- robobun:evidence:end -->