### PR TITLE
transpiler: parse json and jsonc data loaders into the classic tree directly

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1865,17 +1865,28 @@ fn parse_data_loader<'a>(
     // (`bun_ast::Expr`); lift into the full T4
     // `bun_ast::Expr` via the deep-convert `From` bridge
     // (Expr.rs:1265) so the StoreRef-backed accessors below work.
+    // The runtime module loader prints JSON rows; every other caller edits the classic tree.
     let value_expr: bun_ast::Expr = match loader {
         options::Loader::Jsonc => {
             // We allow importing tsconfig.*.json or jsconfig.*.json with comments
             // These files implicitly become JSONC files, which aligns with the behavior of text editors.
-            match bun_parsers::json::parse_jsonc_into_arena(source, log, arena) {
+            let parsed = if keep_json_and_toml_as_one_statement {
+                bun_parsers::json::parse_jsonc_into_arena(source, log, arena)
+            } else {
+                bun_parsers::json::parse_ts_config(source, log, arena)
+            };
+            match parsed {
                 Ok(e) => e,
                 Err(_) => return None,
             }
         }
         options::Loader::Json => {
-            match bun_parsers::json::parse_json_into_arena(source, log, arena) {
+            let parsed = if keep_json_and_toml_as_one_statement {
+                bun_parsers::json::parse_json_into_arena(source, log, arena)
+            } else {
+                bun_parsers::json::parse_utf8(source, log, arena)
+            };
+            match parsed {
                 Ok(e) => e,
                 Err(_) => return None,
             }
@@ -1915,6 +1926,7 @@ fn parse_data_loader<'a>(
     };
     let mut expr = value_expr;
 
+    // Only the XML parser still hands over rows here.
     if !keep_json_and_toml_as_one_statement
         && matches!(
             expr.data,

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -901,6 +901,7 @@ fn skip_json_value(contents: &[u8], p: usize) -> Option<usize> {
 }
 
 /// Deep-convert an immutable-AST document into the classic `E::Object` / `E::Array` tree.
+/// The rows must carry their value locations (`JSONOptions::record_value_locs`).
 pub fn materialize(
     root: &Expr,
     source: &bun_ast::Source,
@@ -951,7 +952,7 @@ impl Materializer<'_> {
     fn expr(&self, e: &Expr, loc: bun_ast::Loc) -> Expr {
         match &e.data {
             js_ast::expr::Data::EObjectJSON(o) => Expr::init(self.object(o.get()), loc),
-            js_ast::expr::Data::EArrayJSON(a) => Expr::init(self.array(a.get(), loc), loc),
+            js_ast::expr::Data::EArrayJSON(a) => Expr::init(self.array(a.get()), loc),
             js_ast::expr::Data::EString(s) => {
                 Expr::init(E::EString::init(self.rehome(s.get().data).slice()), loc)
             }
@@ -967,8 +968,10 @@ impl Materializer<'_> {
         let rows = o.properties();
         let mut properties: G::PropertyList =
             Vec::with_capacity_in(rows.len(), bun_alloc::AstAlloc);
-        let value_locs = o.value_locs();
-        for (i, row) in rows.iter().enumerate() {
+        let value_locs = o
+            .value_locs()
+            .expect("materialize needs rows parsed with record_value_locs");
+        for (row, &value_loc) in rows.iter().zip(value_locs) {
             let key = Expr::init(
                 E::String {
                     data: self.rehome(row.key),
@@ -976,10 +979,6 @@ impl Materializer<'_> {
                 },
                 row.key_loc,
             );
-            let value_loc = match value_locs {
-                Some(locs) => locs[i],
-                None => property_value_loc_or_key(self.contents, row.key_loc),
-            };
             properties.push(G::Property {
                 flags: E::own_key_property_flags(&key),
                 key: Some(key),
@@ -998,7 +997,7 @@ impl Materializer<'_> {
         }
     }
 
-    fn array(&self, a: &E::ArrayJSON, loc: bun_ast::Loc) -> E::Array {
+    fn array(&self, a: &E::ArrayJSON) -> E::Array {
         if !self.stack_check.is_safe_to_recurse() {
             self.overflowed.set(true);
             return E::Array::default();
@@ -1006,22 +1005,11 @@ impl Materializer<'_> {
         let rows = a.items();
         let mut items: js_ast::ExprNodeList =
             Vec::with_capacity_in(rows.len(), bun_alloc::AstAlloc);
-        let item_locs = a.item_locs();
-        let mut cursor = match item_locs {
-            Some(_) => None,
-            None => usize::try_from(loc.start)
-                .ok()
-                .and_then(|start| array_first_item(self.contents, start)),
-        };
-        for (i, item) in rows.iter().enumerate() {
-            let item_loc = match item_locs {
-                Some(locs) => locs[i],
-                None => cursor.map_or(loc, bun_ast::usize2loc),
-            };
+        let item_locs = a
+            .item_locs()
+            .expect("materialize needs rows parsed with record_value_locs");
+        for (item, &item_loc) in rows.iter().zip(item_locs) {
             items.push(self.json_value(item, item_loc));
-            if item_locs.is_none() {
-                cursor = cursor.and_then(|p| array_next_item(self.contents, p));
-            }
         }
         E::Array {
             items,
@@ -1035,7 +1023,7 @@ impl Materializer<'_> {
     fn json_value(&self, value: &E::JsonValue, loc: bun_ast::Loc) -> Expr {
         match value {
             E::JsonValue::Object(o) => Expr::init(self.object(o.get()), loc),
-            E::JsonValue::Array(a) => Expr::init(self.array(a.get(), loc), loc),
+            E::JsonValue::Array(a) => Expr::init(self.array(a.get()), loc),
             E::JsonValue::String(s) => Expr::init(E::EString::init(self.rehome(*s).slice()), loc),
             _ => Expr::from_json_value(value, loc),
         }
@@ -1088,6 +1076,16 @@ mod tests {
                     p.root
                 })
             }
+            Which::RowsWithLocs(opts) => {
+                let opts = JSONOptions {
+                    record_value_locs: true,
+                    ..opts
+                };
+                parse_to_rows(&source, &mut log, opts).map(|mut p| {
+                    tape = p.tape.take();
+                    p.root
+                })
+            }
         };
         let first_msg = log
             .msgs
@@ -1113,6 +1111,8 @@ mod tests {
         PackageJson,
         Jsonc,
         Immutable,
+        /// Rows with the value locations `materialize` needs.
+        RowsWithLocs(JSONOptions),
     }
 
     fn json_value_to_string(v: &E::JsonValue, out: &mut String) {
@@ -1661,38 +1661,40 @@ mod tests {
             ));
         }
         generated.push('}');
+        const ROWS: Which = Which::RowsWithLocs(JSONOptions::DEFAULT);
+        const JSONC_ROWS: Which = Which::RowsWithLocs(TSCONFIG_OPTS);
         let docs: Vec<(&str, Which, Which)> = vec![
-            ("{}", Which::Utf8, Which::Immutable),
-            ("[]", Which::Utf8, Which::Immutable),
-            ("\"leaf\"", Which::Utf8, Which::Immutable),
-            ("\"l\\u00e9af\\n\"", Which::Utf8, Which::Immutable),
-            ("-3.25e2", Which::Utf8, Which::Immutable),
+            ("{}", Which::Utf8, ROWS),
+            ("[]", Which::Utf8, ROWS),
+            ("\"leaf\"", Which::Utf8, ROWS),
+            ("\"l\\u00e9af\\n\"", Which::Utf8, ROWS),
+            ("-3.25e2", Which::Utf8, ROWS),
             (
                 r#"{"a": 1, "b": [true, null, "x", [], {}], "c": {"d": "é🚀", "e": ""}, "es\ncé": -0}"#,
                 Which::Utf8,
-                Which::Immutable,
+                ROWS,
             ),
             (
                 "[0, -1.5e3, \"s\", {\"n\": {\"deep\": [\"x\"]}},\n[\n1\n]\n]",
                 Which::Utf8,
-                Which::Immutable,
+                ROWS,
             ),
-            (&deep, Which::Utf8, Which::Immutable),
-            (&generated, Which::Utf8, Which::Immutable),
+            (&deep, Which::Utf8, ROWS),
+            (&generated, Which::Utf8, ROWS),
             (
                 "// c\n{\"a\": [1, 2,], /* x */ \"b\": 'sq', }",
                 Which::TsConfig,
-                Which::Jsonc,
+                JSONC_ROWS,
             ),
             (
                 "{\n  // line\n  \"a\" /* k */ : // v\n   42,\n  \"arr\": [ /* a */ 1,\n     [2], // b\n   {'z': 'q'},\n  ],\n}",
                 Which::TsConfig,
-                Which::Jsonc,
+                JSONC_ROWS,
             ),
             (
                 "{\"\u{e9}k\":\u{a0}\u{feff} 1,\"l\":\u{a0}[\u{a0}1\u{a0},\u{a0}2]}",
                 Which::TsConfig,
-                Which::Jsonc,
+                JSONC_ROWS,
             ),
         ];
         for (doc, full_which, immutable_which) in docs {

--- a/test/js/bun/transpiler/transpiler-json-nested-array.test.ts
+++ b/test/js/bun/transpiler/transpiler-json-nested-array.test.ts
@@ -1,0 +1,73 @@
+// The json and jsonc loaders of Bun.Transpiler parse into the immutable row AST
+// and then materialize it into the classic AST. The materializer used to get a
+// tape without recorded value locations, so for every array item it re-scanned
+// the source up to the item's closing bracket to recover the location. A nested
+// array therefore cost (depth x subtree size): 300 levels around a 4 MB string
+// took 0.9 s in a release build and 6 s in a debug build, against 4 ms for the
+// same bytes in a flat array.
+//
+// The fixture compares the nested document against a flat one of the same size
+// in one process, so the bound does not depend on machine speed. The depth stays
+// well below the debug build's stack limits (about 640 levels for transformSync).
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const script = `
+  const depth = 300;
+  const item = '"' + Buffer.alloc(4 * 1024 * 1024, "x").toString() + '"';
+  const nested = Buffer.alloc(depth, "[").toString() + item + Buffer.alloc(depth, "]").toString();
+  const flat = "[" + item + "]";
+  const transpiler = new Bun.Transpiler();
+
+  function best(fn) {
+    let min = Infinity;
+    for (let i = 0; i < 3; i++) {
+      const start = performance.now();
+      fn();
+      min = Math.min(min, performance.now() - start);
+    }
+    return min;
+  }
+
+  const ratios = {};
+  for (const loader of ["json", "jsonc"]) {
+    const result = transpiler.scan(nested, loader);
+    if (result.imports.length !== 0 || result.exports.length !== 0) {
+      throw new Error("unexpected scan result: " + JSON.stringify(result));
+    }
+    ratios["scan " + loader] =
+      best(() => transpiler.scan(nested, loader)) / best(() => transpiler.scan(flat, loader));
+  }
+  if (transpiler.transformSync(nested, "json") !== "export default " + nested + ";\\n") {
+    throw new Error("unexpected transformSync output");
+  }
+  ratios["transformSync json"] =
+    best(() => transpiler.transformSync(nested, "json")) / best(() => transpiler.transformSync(flat, "json"));
+  console.log(JSON.stringify(ratios));
+`;
+
+test("json loader: nesting depth does not multiply the cost of an array item", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
+    stdout: expect.stringMatching(/^\{"scan json":/),
+    stderr: "",
+    exitCode: 0,
+  });
+
+  // Nested costs about 2x flat with recorded locations (the extra array nodes)
+  // and 90x or more with the re-scan.
+  const ratios = JSON.parse(stdout);
+  expect(ratios).toEqual({
+    "scan json": expect.any(Number),
+    "scan jsonc": expect.any(Number),
+    "transformSync json": expect.any(Number),
+  });
+  const slow = Object.entries(ratios).filter(([, ratio]) => !(ratio < 20));
+  expect(slow).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `Bun.Transpiler` `scan`, `transform` and `transformSync` with the `json` or `jsonc` loader take time quadratic in the nesting depth of an array. Release build, `"[".repeat(d) + "]".repeat(d)`: 20 ms at d=4000, 300 ms at d=16000, 1.2 s at d=32000. `bun build --no-bundle` shares the path.
- `parse_data_loader` (`src/bundler/transpiler.rs:1868`) parsed into rows without value locations, then called `json::materialize`. `Materializer::array` (`src/parsers/json.rs:1001`) then recovered each item's location by a scan to the item's closing bracket, so each nesting level rescanned the rest of the document.

### Fix
- When `parse_data_loader` will edit the classic tree (`keep_json_and_toml_as_one_statement` is false), it parses with `parse_utf8` / `parse_ts_config`, the entry points the bundler's JSON loader uses. They record every value's location and materialize in one step. The runtime module loader keeps the row entry points and prints the rows.
- The materializer's rescan fallback now has no caller (the XML parser always records locations). It is removed, and `materialize` requires the location columns.
- Correct because the output is unchanged: the `materialize_matches_the_classic_entry_points` unit test compares recorded and recovered locations node for node, and `transformSync` / `bun build --no-bundle` outputs are byte-identical before and after.
- Verified: `test/js/bun/transpiler/transpiler-json-nested-array.test.ts` (new, fails on the unfixed build). Also `test/js/bun/transpiler/`, `jsonc.test.ts`, `bundler_loader.test.ts`, `xml.test.ts`.

### Background
- The JSON parser produces an immutable row AST: `E::ObjectJSON` / `E::ArrayJSON` nodes with spans into an `E::JsonTape`. A row stores a property's key location, not its value's. `record_value_locs` adds a tape column with every value's `Loc`.
- `json::materialize` converts the rows into the classic `E::Object` / `E::Array` tree that the named-exports rewrite edits. `parse_classic` (behind `parse_utf8` / `parse_ts_config`) is parse with locations plus materialize.

<details><summary>Notes</summary>

- Release build (linux-x64), `scan` on `"[".repeat(d) + "]".repeat(d)`: d=1000 1.6 ms, 2000 5.1 ms, 4000 20 ms, 8000 80 ms, 16000 310 ms, 32000 1.2 s. Four times per doubling. Nested objects were linear: `property_value_loc` only skips the key string and the colon. The bundler (`parse_classic`) was linear on both shapes.
- The materializer's cost without locations was the sum over all array items of the item's size in bytes, so depth times subtree size, not only a function of depth.
- The test cannot use a pure deep chain. The debug build's 8 MB stack limits the parser to about 1450 levels, the printer behind `transformSync` to about 640, and the async `transform` (thread pool stack) to about 310. The fixture nests 300 levels around a 4 MB string. Unfixed: 0.9 s in release and 6 s in debug, against 4 ms and 37 ms for the same bytes in a flat array. Fixed: nested costs 1.1 to 1.9 times flat (the extra array nodes). The assertion is on that ratio, so it does not depend on machine speed. On the unfixed debug build the fixture does not finish inside the test timeout.
- `bun build --no-bundle nested.json` (debug build): 6.1 s before, 0.27 s after, byte-identical output.
- Runtime `import data from "./nested.jsonc"` is unchanged: it still parses rows without locations.
- A too deep document that passes the parser but overflows the materializer now reports `JSON document is too deeply nested` (from `parse_classic`) instead of `Document is too deeply nested`, the same as the bundler. #40853 unifies these messages and touches adjacent lines in both files.
- An earlier revision added a `record_value_locs` flag to `parse_json_into_arena` / `parse_jsonc_into_arena` and kept the fallback. The self-review pointed out that the classic entry points already encode the contract and that the fallback would be dead, so this revision uses them instead.
- Separate pre-existing crash found while checking edge cases, not touched here: `new Bun.Transpiler().transformSync('{"default": 1}', "json")` panics in the printer (`print_decls`, `unreachable`) on main and on the release build.
- Also ran `cargo clippy -p bun_parsers -p bun_bundler` (clean) and `cargo check -p bun_parsers --tests`. The `bun_parsers` unit tests do not link standalone in this container.

</details>
