### PR TITLE
bundler: match defines through optional chains, string indexes, and this, and parse define values as member chains

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1152,7 +1152,9 @@ var logo = "https://cdn.example.com/logo-a7305bdef.svg";
 
 ### define
 
-A map of global identifiers to be replaced at build time. Keys of this object are identifiers or dotted property paths such as `process.env.NODE_ENV`, and values are JSON strings, identifiers, or property paths that are inlined.
+A map of global identifiers that Bun replaces at build time. A key is an identifier or a property path such as `process.env.NODE_ENV`. A path part can be a quoted string in brackets, as in `process.env["MY-VAR"]`. A key can also start with `this` or `import.meta`. A value is a JSON literal, a BigInt literal, an identifier, or a property path such as `globalThis.foo` or `import.meta.env`.
+
+A define matches every spelling of its key. `process.env.NODE_ENV`, `process.env["NODE_ENV"]`, and `process?.env?.NODE_ENV` are all replaced.
 
 <Tabs>
   <Tab title="JavaScript">

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2933,7 +2933,10 @@ declare module "bun" {
 
   interface TranspilerOptions {
     /**
-     * Replace key with value. Value must be a JSON string.
+     * Replace key with value. The key is an identifier or a property path
+     * such as `process.env.NODE_ENV` or `process.env["MY-VAR"]`. The value
+     * is a JSON literal, a BigInt literal, an identifier, or a property path
+     * such as `globalThis.foo`.
      * @example
      *  ```
      *  { "process.env.NODE_ENV": "\"production\"" }

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -21,8 +21,8 @@ use crate::defines_table::{
 // directly with no cross-crate hook.
 // ══════════════════════════════════════════════════════════════════════════
 pub use bun_js_parser::defines::{
-    Define, DefineData, DotDefine, Flags, IdentifierDefine, Options, RawDefines, UserDefines,
-    UserDefinesArray, are_parts_equal,
+    Define, DefineData, DefineKeyError, DotDefine, Flags, IdentifierDefine, Options, RawDefines,
+    UserDefines, UserDefinesArray, are_parts_equal, parse_define_key,
 };
 
 /// Alias for `Options` so `options.rs` can write `DefineData::init(DefineDataInit { .. })`.
@@ -253,6 +253,55 @@ fn const_default_define_value(value_str: &[u8]) -> Option<ExprData> {
     }
 }
 
+/// True when a define value names a member chain, as esbuild's
+/// `ParseDefineExpr` decides it: every `.`-separated part is an identifier,
+/// and the first part is not a keyword, except `null`, `this`, and `import`
+/// when `import.meta` follows. A keyword is a valid property name later in
+/// the chain (`a.if`).
+fn is_member_chain_define_value(value_str: &[u8]) -> bool {
+    let mut splitter = strings::split(value_str, b".");
+    let Some(first) = splitter.next() else {
+        return false;
+    };
+    if !js_lexer::is_identifier(first) {
+        return false;
+    }
+    match js_lexer::keyword(first) {
+        None | Some(js_lexer::T::TNull) | Some(js_lexer::T::TThis) => {}
+        Some(js_lexer::T::TImport) => {
+            let after_import = &value_str[first.len()..];
+            if !(after_import == b".meta" || after_import.starts_with(b".meta.")) {
+                return false;
+            }
+        }
+        Some(_) => return false,
+    }
+    while let Some(part) = splitter.next() {
+        if !js_lexer::is_identifier(part) {
+            return false;
+        }
+    }
+    true
+}
+
+/// The digits of a BigInt literal define value (`123n`, `0xffn`), without the
+/// `n` suffix. This is what `E::BigInt.value` stores.
+fn bigint_define_value(value_str: &[u8]) -> Option<&[u8]> {
+    let digits = value_str.strip_suffix(b"n")?;
+    let (radix, body): (u32, &[u8]) = match digits {
+        [b'0', b'x' | b'X', rest @ ..] => (16, rest),
+        [b'0', b'o' | b'O', rest @ ..] => (8, rest),
+        [b'0', b'b' | b'B', rest @ ..] => (2, rest),
+        // A decimal literal must not have a leading zero, except `0n`
+        [b'0', _, ..] => return None,
+        _ => (10, digits),
+    };
+    if body.is_empty() || !body.iter().all(|c| (*c as char).is_digit(radix)) {
+        return None;
+    }
+    Some(digits)
+}
+
 /// Extension surface for the canonical `DefineData` — `parse` / `from_input`
 /// need `bun_parsers::json_parser` / `js_lexer::Keywords`.
 pub trait DefineDataExt: Sized {
@@ -315,74 +364,85 @@ impl DefineDataExt for DefineData {
         log: &mut bun_ast::Log,
         bump: &bun_alloc::Arena,
     ) -> Result<DefineData, crate::Error> {
-        let mut key_splitter = strings::split(key, b".");
-        while let Some(part) = key_splitter.next() {
-            if !js_lexer::is_identifier(part) {
-                if strings::eql(part, key) {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::default(),
-                        format_args!(
-                            "define key \"{}\" must be a valid identifier",
-                            bstr::BStr::new(key)
-                        ),
-                    );
-                } else {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::default(),
-                        format_args!(
-                            "define key \"{}\" contains invalid identifier \"{}\"",
-                            bstr::BStr::new(part),
-                            bstr::BStr::new(value_str)
-                        ),
-                    );
-                }
-                break;
+        match parse_define_key(key) {
+            Ok(_) => {}
+            Err(DefineKeyError::InvalidIdentifier(part)) if strings::eql(part, key) => {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::default(),
+                    format_args!(
+                        "define key \"{}\" must be a valid identifier",
+                        bstr::BStr::new(key)
+                    ),
+                );
+            }
+            Err(DefineKeyError::InvalidIdentifier(part)) => {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::default(),
+                    format_args!(
+                        "define key \"{}\" contains invalid identifier \"{}\"",
+                        bstr::BStr::new(key),
+                        bstr::BStr::new(part)
+                    ),
+                );
+            }
+            Err(DefineKeyError::InvalidIndex) => {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::default(),
+                    format_args!(
+                        "define key \"{}\" must use a quoted string inside \"[]\", for example process.env[\"MY-VAR\"]",
+                        bstr::BStr::new(key)
+                    ),
+                );
             }
         }
 
-        // check for nested identifiers
-        let mut value_splitter = strings::split(value_str, b".");
-        let mut is_ident = true;
+        let finish = |value: ExprData, can_be_removed_if_unused: bool| DefineData {
+            value,
+            // Own the value bytes: these are tiny startup-time copies.
+            original_name: if !value_str.is_empty() {
+                Some(Box::<[u8]>::from(value_str))
+            } else {
+                None
+            },
+            flags: Flags::new(
+                /* valueless: */ value_is_undefined,
+                can_be_removed_if_unused,
+                /* call_can_be_unwrapped_if_unused: */ bun_ast::E::CallUnwrap::Never,
+                method_call_must_be_replaced_with_undefined_,
+            ),
+        };
 
-        while let Some(part) = value_splitter.next() {
-            if !js_lexer::is_identifier(part) || js_lexer::keyword(part).is_some() {
-                is_ident = false;
-                break;
-            }
+        // Special-case undefined. it's not an identifier here
+        // https://github.com/evanw/esbuild/issues/1407
+        if value_is_undefined || value_str == b"undefined" {
+            return Ok(finish(ExprData::EUndefined(bun_ast::E::Undefined), true));
         }
 
-        if is_ident {
-            // Special-case undefined. it's not an identifier here
-            // https://github.com/evanw/esbuild/issues/1407
-            let value = if value_is_undefined || value_str == b"undefined" {
-                ExprData::EUndefined(bun_ast::E::Undefined)
+        // `globalThis.foo`, `this.x`, `import.meta.env`, ... The parser builds
+        // the member chain from `original_name` when it substitutes the define.
+        if is_member_chain_define_value(value_str) {
+            // `null` alone is a constant. `null.x` stays a member chain.
+            let value = if value_str == b"null" {
+                ExprData::ENull(bun_ast::E::Null)
             } else {
                 ExprData::EIdentifier(
                     bun_ast::E::Identifier::init(Ref::NONE).with_can_be_removed_if_unused(true),
                 )
             };
+            return Ok(finish(value, true));
+        }
 
-            return Ok(DefineData {
-                value,
-                // upstream `DefineData` now owns `original_name:
-                // Option<Box<[u8]>>` (js_parser/lib.rs:1369) instead of a
-                // borrowed `ptr`/`len` pair. Dupe
-                // the value bytes — these are tiny startup-time copies.
-                original_name: if !value_str.is_empty() {
-                    Some(Box::<[u8]>::from(value_str))
-                } else {
-                    None
+        if let Some(digits) = bigint_define_value(value_str) {
+            let digits: &[u8] = bump.alloc_slice_copy(digits);
+            let value = ExprData::EBigInt(bun_ast::StoreRef::from_bump(bump.alloc(
+                bun_ast::E::BigInt {
+                    value: bun_ast::StoreStr::new(digits),
                 },
-                flags: Flags::new(
-                    /* valueless: */ value_is_undefined,
-                    /* can_be_removed_if_unused: */ true,
-                    /* call_can_be_unwrapped_if_unused: */ bun_ast::E::CallUnwrap::Never,
-                    /* method_call_must_be_replaced_with_undefined: */
-                    method_call_must_be_replaced_with_undefined_,
-                ),
-            });
+            )));
+            return Ok(finish(value, true));
         }
 
         // Fast path for the compile-time-constant literal define *values* that
@@ -396,21 +456,7 @@ impl DefineDataExt for DefineData {
         // (created lazily below only when a value really needs JSON parsing).
         if let Some(value) = const_default_define_value(value_str) {
             let can_be_removed_if_unused = bun_ast::expr::Tag::is_primitive_literal(value.tag());
-            return Ok(DefineData {
-                value,
-                original_name: if !value_str.is_empty() {
-                    Some(Box::<[u8]>::from(value_str))
-                } else {
-                    None
-                },
-                flags: Flags::new(
-                    /* valueless: */ value_is_undefined,
-                    /* can_be_removed_if_unused: */ can_be_removed_if_unused,
-                    /* call_can_be_unwrapped_if_unused: */ bun_ast::E::CallUnwrap::Never,
-                    /* method_call_must_be_replaced_with_undefined: */
-                    method_call_must_be_replaced_with_undefined_,
-                ),
-            });
+            return Ok(finish(value, can_be_removed_if_unused));
         }
 
         // `parse_env_json` builds `E::String`/`E::Object` nodes in the
@@ -442,21 +488,7 @@ impl DefineDataExt for DefineData {
         // into a freed slab and `process.env.NODE_ENV` reads garbage.
         let data: ExprData = expr.data.deep_clone(bump)?;
         let can_be_removed_if_unused = bun_ast::expr::Tag::is_primitive_literal(data.tag());
-        Ok(DefineData {
-            value: data,
-            original_name: if !value_str.is_empty() {
-                Some(Box::<[u8]>::from(value_str))
-            } else {
-                None
-            },
-            flags: Flags::new(
-                /* valueless: */ value_is_undefined,
-                /* can_be_removed_if_unused: */ can_be_removed_if_unused,
-                /* call_can_be_unwrapped_if_unused: */ bun_ast::E::CallUnwrap::Never,
-                /* method_call_must_be_replaced_with_undefined: */
-                method_call_must_be_replaced_with_undefined_,
-            ),
-        })
+        Ok(finish(data, can_be_removed_if_unused))
     }
 
     fn from_input(
@@ -480,7 +512,9 @@ impl DefineDataExt for DefineData {
         }
 
         for drop_item in drop {
-            if !drop_item.is_empty() {
+            // `--drop=debugger` removes a statement, not an identifier. The
+            // caller reads it into `Define.drop_debugger`.
+            if !drop_item.is_empty() && *drop_item != b"debugger" {
                 <Self as DefineDataExt>::from_mergeable_input_entry(
                     &mut user_defines,
                     drop_item,

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -253,11 +253,7 @@ fn const_default_define_value(value_str: &[u8]) -> Option<ExprData> {
     }
 }
 
-/// True when a define value names a member chain, as esbuild's
-/// `ParseDefineExpr` decides it: every `.`-separated part is an identifier,
-/// and the first part is not a keyword, except `null`, `this`, and `import`
-/// when `import.meta` follows. A keyword is a valid property name later in
-/// the chain (`a.if`).
+/// A member chain value such as `globalThis.foo`; only the first part is keyword-checked, as in esbuild.
 fn is_member_chain_define_value(value_str: &[u8]) -> bool {
     let mut splitter = strings::split(value_str, b".");
     let Some(first) = splitter.next() else {
@@ -284,8 +280,7 @@ fn is_member_chain_define_value(value_str: &[u8]) -> bool {
     true
 }
 
-/// The digits of a BigInt literal define value (`123n`, `0xffn`), without the
-/// `n` suffix. This is what `E::BigInt.value` stores.
+/// `123n` or `0xffn` without the `n` suffix, the form `E::BigInt.value` stores.
 fn bigint_define_value(value_str: &[u8]) -> Option<&[u8]> {
     let digits = value_str.strip_suffix(b"n")?;
     let (radix, body): (u32, &[u8]) = match digits {
@@ -415,14 +410,12 @@ impl DefineDataExt for DefineData {
             ),
         };
 
-        // Special-case undefined. it's not an identifier here
-        // https://github.com/evanw/esbuild/issues/1407
+        // Special-case undefined, it's not an identifier here: https://github.com/evanw/esbuild/issues/1407
         if value_is_undefined || value_str == b"undefined" {
             return Ok(finish(ExprData::EUndefined(bun_ast::E::Undefined), true));
         }
 
-        // `globalThis.foo`, `this.x`, `import.meta.env`, ... The parser builds
-        // the member chain from `original_name` when it substitutes the define.
+        // The parser builds the chain from `original_name` when it substitutes the define
         if is_member_chain_define_value(value_str) {
             // `null` alone is a constant. `null.x` stays a member chain.
             let value = if value_str == b"null" {
@@ -512,8 +505,7 @@ impl DefineDataExt for DefineData {
         }
 
         for drop_item in drop {
-            // `--drop=debugger` removes a statement, not an identifier. The
-            // caller reads it into `Define.drop_debugger`.
+            // `--drop=debugger` is a statement drop, the caller sets `Define.drop_debugger` for it
             if !drop_item.is_empty() && *drop_item != b"debugger" {
                 <Self as DefineDataExt>::from_mergeable_input_entry(
                     &mut user_defines,

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -518,36 +518,141 @@ pub mod defines {
             key: &[u8],
             value: DefineData,
         ) -> Result<(), bun_alloc::AllocError> {
-            // If it has a dot, then it's a DotDefine. e.g. process.env.NODE_ENV
-            if let Some(last_dot) = strings::last_index_of_char(key, b'.') {
-                let tail = &key[last_dot + 1..key.len()];
-                let remainder = &key[0..last_dot];
-                let count = strings::count_char(remainder, b'.') + 1;
-                let mut parts: Vec<Box<[u8]>> = Vec::with_capacity(count + 1);
-                for split in strings::split(remainder, b".") {
-                    parts.push(Box::from(split));
-                }
-                parts.push(Box::from(tail));
-
-                if let Some(existing) = self.dots.get_mut(tail) {
-                    for part in existing.iter_mut() {
-                        if are_parts_equal(&part.parts, &parts) {
-                            part.data = DefineData::merge(&part.data, value);
-                            return Ok(());
-                        }
+            // User keys were validated by `parse_define_key` already. Keys that
+            // fail it here come from the environment (`process.env.MY-VAR`), so
+            // fall back to a plain split on `.` for those.
+            let parts: Vec<Box<[u8]>> = match parse_define_key(key) {
+                Ok(parts) => parts,
+                Err(_) => {
+                    let mut parts = Vec::with_capacity(strings::count_char(key, b'.') + 1);
+                    for split in strings::split(key, b".") {
+                        parts.push(Box::from(split));
                     }
-                    existing.push(DotDefine { data: value, parts });
-                    return Ok(());
+                    parts
                 }
+            };
 
-                self.dots
-                    .put_assume_capacity(tail, vec![DotDefine { data: value, parts }]);
-            } else {
-                // e.g. IS_BROWSER
-                self.identifiers.put_assume_capacity(key, value);
+            // e.g. IS_BROWSER
+            if parts.len() == 1 {
+                self.identifiers.put_assume_capacity(&parts[0], value);
+                return Ok(());
             }
+
+            // e.g. process.env.NODE_ENV
+            let tail: Box<[u8]> = parts[parts.len() - 1].clone();
+            if let Some(existing) = self.dots.get_mut(&*tail) {
+                for part in existing.iter_mut() {
+                    if are_parts_equal(&part.parts, &parts) {
+                        part.data = DefineData::merge(&part.data, value);
+                        return Ok(());
+                    }
+                }
+                existing.push(DotDefine { data: value, parts });
+                return Ok(());
+            }
+
+            self.dots
+                .put_assume_capacity(&tail, vec![DotDefine { data: value, parts }]);
             Ok(())
         }
+    }
+
+    /// Why [`parse_define_key`] rejected a key.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum DefineKeyError<'a> {
+        /// This `.`-separated part is not an identifier. For the first part
+        /// this also covers keywords other than `this` and `import.meta`.
+        InvalidIdentifier(&'a [u8]),
+        /// A `[` is not followed by a quoted string and a `]`, or a `]` is not
+        /// followed by `.`, `[`, or the end of the key.
+        InvalidIndex,
+    }
+
+    /// Splits a define key into its property path, the same grammar esbuild
+    /// accepts for a define name: an identifier, `this`, or `import.meta`,
+    /// followed by any number of `.name` or `["quoted"]` parts. So
+    /// `process.env["NODE-ENV"]` becomes `["process", "env", "NODE-ENV"]`.
+    pub fn parse_define_key(key: &[u8]) -> Result<Vec<Box<[u8]>>, DefineKeyError<'_>> {
+        use crate::lexer::{is_identifier, keyword};
+
+        fn part_end(key: &[u8], start: usize) -> usize {
+            start + strings::index_of_any(&key[start..], b".[").unwrap_or(key.len() - start)
+        }
+
+        let mut parts: Vec<Box<[u8]>> = Vec::new();
+        let mut i = part_end(key, 0);
+        let first = &key[..i];
+        if !is_identifier(first) {
+            return Err(DefineKeyError::InvalidIdentifier(first));
+        }
+        match first {
+            b"this" => parts.push(Box::from(first)),
+            b"import" => {
+                // Only `import.meta` can start a key
+                if key.get(i) != Some(&b'.') {
+                    return Err(DefineKeyError::InvalidIdentifier(first));
+                }
+                let meta_end = part_end(key, i + 1);
+                if &key[i + 1..meta_end] != b"meta" {
+                    return Err(DefineKeyError::InvalidIdentifier(first));
+                }
+                parts.push(Box::from(first));
+                parts.push(Box::from(b"meta".as_slice()));
+                i = meta_end;
+            }
+            _ if keyword(first).is_some() => {
+                return Err(DefineKeyError::InvalidIdentifier(first));
+            }
+            _ => parts.push(Box::from(first)),
+        }
+
+        while i < key.len() {
+            match key[i] {
+                b'.' => {
+                    let end = part_end(key, i + 1);
+                    let part = &key[i + 1..end];
+                    // A keyword is a valid property name here (`a.if`)
+                    if !is_identifier(part) {
+                        return Err(DefineKeyError::InvalidIdentifier(part));
+                    }
+                    parts.push(Box::from(part));
+                    i = end;
+                }
+                b'[' => {
+                    let quote = match key.get(i + 1) {
+                        Some(&quote @ (b'"' | b'\'')) => quote,
+                        _ => return Err(DefineKeyError::InvalidIndex),
+                    };
+                    let mut part: Vec<u8> = Vec::new();
+                    let mut j = i + 2;
+                    loop {
+                        match key.get(j) {
+                            None => return Err(DefineKeyError::InvalidIndex),
+                            Some(&c) if c == quote => break,
+                            Some(b'\\') => match key.get(j + 1) {
+                                Some(&escaped @ (b'\\' | b'"' | b'\'')) => {
+                                    part.push(escaped);
+                                    j += 2;
+                                }
+                                _ => return Err(DefineKeyError::InvalidIndex),
+                            },
+                            Some(&c) => {
+                                part.push(c);
+                                j += 1;
+                            }
+                        }
+                    }
+                    if key.get(j + 1) != Some(&b']') {
+                        return Err(DefineKeyError::InvalidIndex);
+                    }
+                    parts.push(part.into_boxed_slice());
+                    i = j + 2;
+                }
+                _ => return Err(DefineKeyError::InvalidIndex),
+            }
+        }
+
+        Ok(parts)
     }
 
     pub fn are_parts_equal(a: &[Box<[u8]>], b: &[Box<[u8]>]) -> bool {

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -518,9 +518,7 @@ pub mod defines {
             key: &[u8],
             value: DefineData,
         ) -> Result<(), bun_alloc::AllocError> {
-            // User keys were validated by `parse_define_key` already. Keys that
-            // fail it here come from the environment (`process.env.MY-VAR`), so
-            // fall back to a plain split on `.` for those.
+            // An environment key such as `process.env.MY-VAR` fails the grammar, split it on `.` as before
             let parts: Vec<Box<[u8]>> = match parse_define_key(key) {
                 Ok(parts) => parts,
                 Err(_) => {
@@ -560,18 +558,13 @@ pub mod defines {
     /// Why [`parse_define_key`] rejected a key.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum DefineKeyError<'a> {
-        /// This `.`-separated part is not an identifier. For the first part
-        /// this also covers keywords other than `this` and `import.meta`.
+        /// A `.` part that is not an identifier, or a first part that is a keyword other than `this`/`import`.
         InvalidIdentifier(&'a [u8]),
-        /// A `[` is not followed by a quoted string and a `]`, or a `]` is not
-        /// followed by `.`, `[`, or the end of the key.
+        /// A `[` without a quoted string and `]`, or a `]` not followed by `.`, `[`, or the end of the key.
         InvalidIndex,
     }
 
-    /// Splits a define key into its property path, the same grammar esbuild
-    /// accepts for a define name: an identifier, `this`, or `import.meta`,
-    /// followed by any number of `.name` or `["quoted"]` parts. So
-    /// `process.env["NODE-ENV"]` becomes `["process", "env", "NODE-ENV"]`.
+    /// Splits a define key such as `process.env["NODE-ENV"]` into its parts, with esbuild's `ParseGlobalName` grammar.
     pub fn parse_define_key(key: &[u8]) -> Result<Vec<Box<[u8]>>, DefineKeyError<'_>> {
         use crate::lexer::{is_identifier, keyword};
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6303,13 +6303,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             _ => {
                 let result = self.find_symbol(loc, first).expect("unreachable");
+                // In `a.b = 1` the target is the chain, so the head `a` is only read
+                let head_opts = if rest.is_empty() {
+                    opts
+                } else {
+                    IdentifierOpts::new().with_was_originally_identifier(true)
+                };
                 self.handle_identifier(
                     loc,
                     E::Identifier::init(result.r#ref)
                         .with_must_keep_due_to_with_stmt(result.is_inside_with_scope)
                         .with_can_be_removed_if_unused(true),
                     None,
-                    opts,
+                    head_opts,
                 )
             }
         };

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4789,29 +4789,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             IdentifierOpts::new().with_was_originally_identifier(true),
         );
         if parts.len() > 1 {
-            return Ok(self.member_expression(loc, value, &parts[1..]));
+            return Ok(self.member_expression(loc, value, &parts[1..], IdentifierOpts::default()));
         }
 
         Ok(value)
     }
 
+    /// `last_link_opts` applies to the final property access only: in `a.b.c = 1` the
+    /// assignment target is `c`, and `a.b` is read.
     fn member_expression(
         &mut self,
         loc: bun_ast::Loc,
         initial_value: Expr,
         parts: &[&'a [u8]],
+        last_link_opts: IdentifierOpts,
     ) -> Expr {
         let mut value = initial_value;
 
-        for part in parts {
-            if let Some(rewrote) = self.maybe_rewrite_property_access(
-                loc,
-                value,
-                part,
-                loc,
-                // All defaults on the packed-u8 IdentifierOpts.
-                IdentifierOpts::default(),
-            ) {
+        for (i, part) in parts.iter().enumerate() {
+            let opts = if i + 1 == parts.len() {
+                last_link_opts
+            } else {
+                IdentifierOpts::default()
+            };
+            if let Some(rewrote) = self.maybe_rewrite_property_access(loc, value, part, loc, opts) {
                 value = rewrote;
             } else {
                 value = self.new_expr(
@@ -6323,7 +6324,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if rest.is_empty() {
             return value;
         }
-        self.member_expression(loc, value, &rest)
+        // The last link is the assignment or delete target, as `a.b.c = 1` written in source
+        // would be: an import namespace member is rejected and a CommonJS export is converted.
+        self.member_expression(
+            loc,
+            value,
+            &rest,
+            IdentifierOpts::new()
+                .with_assign_target(opts.assign_target())
+                .with_is_delete_target(opts.is_delete_target()),
+        )
     }
 
     // `parts` is `&[Box<[u8]>]` to match the active `DotDefine.parts:

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5137,43 +5137,66 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub(crate) fn value_for_this(&mut self, loc: bun_ast::Loc) -> Option<Expr> {
-        if !self.fn_only_data_visit.is_this_nested {
-            // In the REPL, top-level `this` must evaluate to the global object
-            // (matching Node's `> this` and `deno repl > this`). The REPL wraps
-            // user input in an arrow IIFE that has no `exports` binding, so the
-            // CommonJS substitution below would emit a reference to an
-            // undefined `exports`. Leaving `E::This` in place lets the arrow
-            // inherit `this` from the enclosing (global) scope at runtime.
-            if self.options.repl_mode {
-                return None;
-            }
-            if self.has_es_module_syntax && self.commonjs_named_exports.count() == 0 {
-                // In an ES6 module, "this" is supposed to be undefined. Instead of
-                // doing this at runtime using "fn.call(undefined)", we do it at
-                // compile time using expression substitution here.
-                return Some(Expr {
-                    loc,
-                    data: null_value_expr(),
-                });
-            } else {
-                // In a CommonJS module, "this" is supposed to be the same as "exports".
-                // Instead of doing this at runtime using "fn.call(module.exports)", we
-                // do it at compile time using expression substitution here.
-                let exports_ref = self.exports_ref;
-                self.record_usage(exports_ref);
-                self.deoptimize_common_js_named_exports();
-                return Some(self.new_expr(
-                    E::Identifier {
-                        ref_: exports_ref,
-                        ..Default::default()
-                    },
-                    loc,
-                ));
+    pub(crate) fn value_for_this(
+        &mut self,
+        loc: bun_ast::Loc,
+        assign_target: js_ast::AssignTarget,
+        is_delete_target: bool,
+    ) -> Option<Expr> {
+        if self.fn_only_data_visit.is_this_nested {
+            return None;
+        }
+
+        // Substitute a user-specified `--define this=...`
+        let defines = self.define;
+        if let Some(data) = defines.identifiers.get(b"this".as_slice()) {
+            if !data.valueless() {
+                return Some(self.value_for_define(loc, assign_target, is_delete_target, data));
             }
         }
 
-        None
+        self.value_for_top_level_this(loc)
+    }
+
+    /// The compile-time value of a top-level `this`: `exports` in CommonJS,
+    /// `null` in ESM. `None` keeps `this` as written (nested in a function, or
+    /// in the REPL). User defines are not consulted here.
+    fn value_for_top_level_this(&mut self, loc: bun_ast::Loc) -> Option<Expr> {
+        if self.fn_only_data_visit.is_this_nested {
+            return None;
+        }
+        // In the REPL, top-level `this` must evaluate to the global object
+        // (matching Node's `> this` and `deno repl > this`). The REPL wraps
+        // user input in an arrow IIFE that has no `exports` binding, so the
+        // CommonJS substitution below would emit a reference to an
+        // undefined `exports`. Leaving `E::This` in place lets the arrow
+        // inherit `this` from the enclosing (global) scope at runtime.
+        if self.options.repl_mode {
+            return None;
+        }
+        if self.has_es_module_syntax && self.commonjs_named_exports.count() == 0 {
+            // In an ES6 module, "this" is supposed to be undefined. Instead of
+            // doing this at runtime using "fn.call(undefined)", we do it at
+            // compile time using expression substitution here.
+            Some(Expr {
+                loc,
+                data: null_value_expr(),
+            })
+        } else {
+            // In a CommonJS module, "this" is supposed to be the same as "exports".
+            // Instead of doing this at runtime using "fn.call(module.exports)", we
+            // do it at compile time using expression substitution here.
+            let exports_ref = self.exports_ref;
+            self.record_usage(exports_ref);
+            self.deoptimize_common_js_named_exports();
+            Some(self.new_expr(
+                E::Identifier {
+                    ref_: exports_ref,
+                    ..Default::default()
+                },
+                loc,
+            ))
+        }
     }
 
     // PERF: takes `&Expr` — `Expr` inlines `ExprData`, so a by-value pass copies
@@ -6213,24 +6236,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // real Expr.Data by contract.
         let value = define_data.value;
         match value {
-            js_ast::ExprData::EIdentifier(id) => {
-                // Identifier defines always carry a name. Match the
-                // contract so `handle_identifier`'s trailing `find_symbol`
-                // rebind runs against the *resolved* scope ref, not the
-                // define-time ref silently passed through with `None`.
+            js_ast::ExprData::EIdentifier(_) => {
+                // An identifier define stores its member chain
+                // (`a.b.c`, `this.x`, `import.meta.env`) as `original_name`.
                 let original_name: &[u8] = define_data
                     .original_name()
                     .expect("identifier define must have original_name");
                 // SAFETY: `define_data` borrows `p.define: &'a Define`; the
                 // backing `original_name` bytes live for `'a`. Erase the local
-                // borrow lifetime to satisfy `handle_identifier`'s
-                // `Option<&'a [u8]>` param.
+                // borrow lifetime so the parts can be stored in the AST.
                 let original_name: &'a [u8] =
                     unsafe { bun_collections::detach_lifetime(original_name) };
-                return self.handle_identifier(
+                return self.instantiate_define_member_chain(
                     loc,
-                    id,
-                    Some(original_name),
+                    original_name,
                     IdentifierOpts::new()
                         .with_assign_target(assign_target)
                         .with_is_delete_target(is_delete_target)
@@ -6245,17 +6264,82 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Expr { data: value, loc }
     }
 
+    /// Builds the expression for a define value written as a member chain,
+    /// for example `--define A=globalThis.foo` or `--define B=import.meta.url`.
+    /// This is the port of esbuild's `instantiateDefineExpr`: the first part
+    /// resolves to a symbol (or `this` / `import.meta` / `null` / `undefined`),
+    /// and every later part becomes a property access on it.
+    fn instantiate_define_member_chain(
+        &mut self,
+        loc: bun_ast::Loc,
+        name: &'a [u8],
+        opts: IdentifierOpts,
+    ) -> Expr {
+        let mut splitter = strings::split(name, b".");
+        let first: &'a [u8] = splitter.next().unwrap_or(name);
+        let mut rest: Vec<&'a [u8]> = Vec::new();
+        while let Some(part) = splitter.next() {
+            rest.push(part);
+        }
+
+        let value: Expr = match first {
+            b"null" => Expr {
+                loc,
+                data: js_ast::ExprData::ENull(E::Null),
+            },
+            b"undefined" => Expr {
+                loc,
+                data: js_ast::ExprData::EUndefined(E::Undefined),
+            },
+            b"this" => {
+                // The define value is not matched against the `this` define
+                // again, so `--define this=this.x` cannot recurse.
+                match self.value_for_top_level_this(loc) {
+                    Some(value) => value,
+                    None => Expr {
+                        loc,
+                        data: js_ast::ExprData::EThis(E::This),
+                    },
+                }
+            }
+            b"import" if rest.first().is_some_and(|part| *part == b"meta") => {
+                rest.remove(0);
+                // The CommonJS wrapper passes `import.meta` in as a parameter
+                // when the module uses it, so count this use like a parsed one.
+                self.has_import_meta = true;
+                Expr {
+                    loc,
+                    data: js_ast::ExprData::EImportMeta(E::ImportMeta),
+                }
+            }
+            _ => {
+                let result = self.find_symbol(loc, first).expect("unreachable");
+                self.handle_identifier(
+                    loc,
+                    E::Identifier::init(result.r#ref)
+                        .with_must_keep_due_to_with_stmt(result.is_inside_with_scope)
+                        .with_can_be_removed_if_unused(true),
+                    None,
+                    opts,
+                )
+            }
+        };
+
+        if rest.is_empty() {
+            return value;
+        }
+        self.member_expression(loc, value, &rest)
+    }
+
     // `parts` is `&[Box<[u8]>]` to match the active `DotDefine.parts:
     // Vec<Box<[u8]>>` shape (auto-derefs at call sites). The full draft uses
     // `StoreSlice<StoreStr>`; both index to a `[u8]` so the body is unchanged.
     pub(crate) fn is_dot_define_match(&mut self, expr: Expr, parts: &[Box<[u8]>]) -> bool {
+        // An optional chain link (`a?.b`) matches like a plain `.`: the define
+        // for `a.b` replaces both spellings, as in esbuild.
         match expr.data {
             js_ast::ExprData::EDot(ex) => {
                 if parts.len() > 1 {
-                    if ex.optional_chain.is_some() {
-                        return false;
-                    }
-                    // Intermediates must be dot expressions
                     let last = parts.len() - 1;
                     let is_tail_match = strings::eql(&parts[last], &ex.name);
                     return is_tail_match && self.is_dot_define_match(ex.target, &parts[..last]);
@@ -6264,22 +6348,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ExprData::EImportMeta(_) => {
                 return parts.len() == 2 && &*parts[0] == b"import" && &*parts[1] == b"meta";
             }
-            // Note: this behavior differs from esbuild
-            // esbuild does not try to match index accessors
-            // we do, but only if it's a UTF8 string
-            // the intent is to handle people using this form instead of E.Dot. So we really only want to do this if the accessor can also be an identifier
+            js_ast::ExprData::EThis(_) => {
+                // Only a top-level "this" can match a define
+                if !self.fn_only_data_visit.is_this_nested {
+                    return parts.len() == 1 && &*parts[0] == b"this";
+                }
+            }
+            // `a["b"]` matches the same define as `a.b`
             js_ast::ExprData::EIndex(index) => {
                 if parts.len() > 1 {
                     if let js_ast::ExprData::EString(mut s) = index.index.data {
-                        if s.is_utf8() {
-                            if index.optional_chain.is_some() {
-                                return false;
-                            }
-                            let last = parts.len() - 1;
-                            let is_tail_match = strings::eql(&parts[last], s.slice(self.arena));
-                            return is_tail_match
-                                && self.is_dot_define_match(index.target, &parts[..last]);
-                        }
+                        let last = parts.len() - 1;
+                        let is_tail_match = strings::eql(&parts[last], s.slice(self.arena));
+                        return is_tail_match
+                            && self.is_dot_define_match(index.target, &parts[..last]);
                     }
                 }
             }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5137,7 +5137,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub(crate) fn value_for_this(
+    /// A top-level `this` with a user `--define this=...` applied first.
+    pub(crate) fn value_for_this_with_defines(
         &mut self,
         loc: bun_ast::Loc,
         assign_target: js_ast::AssignTarget,
@@ -5146,57 +5147,52 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if self.fn_only_data_visit.is_this_nested {
             return None;
         }
-
-        // Substitute a user-specified `--define this=...`
         let defines = self.define;
         if let Some(data) = defines.identifiers.get(b"this".as_slice()) {
             if !data.valueless() {
                 return Some(self.value_for_define(loc, assign_target, is_delete_target, data));
             }
         }
-
-        self.value_for_top_level_this(loc)
+        self.value_for_this(loc)
     }
 
-    /// The compile-time value of a top-level `this`: `exports` in CommonJS,
-    /// `null` in ESM. `None` keeps `this` as written (nested in a function, or
-    /// in the REPL). User defines are not consulted here.
-    fn value_for_top_level_this(&mut self, loc: bun_ast::Loc) -> Option<Expr> {
-        if self.fn_only_data_visit.is_this_nested {
-            return None;
+    pub(crate) fn value_for_this(&mut self, loc: bun_ast::Loc) -> Option<Expr> {
+        if !self.fn_only_data_visit.is_this_nested {
+            // In the REPL, top-level `this` must evaluate to the global object
+            // (matching Node's `> this` and `deno repl > this`). The REPL wraps
+            // user input in an arrow IIFE that has no `exports` binding, so the
+            // CommonJS substitution below would emit a reference to an
+            // undefined `exports`. Leaving `E::This` in place lets the arrow
+            // inherit `this` from the enclosing (global) scope at runtime.
+            if self.options.repl_mode {
+                return None;
+            }
+            if self.has_es_module_syntax && self.commonjs_named_exports.count() == 0 {
+                // In an ES6 module, "this" is supposed to be undefined. Instead of
+                // doing this at runtime using "fn.call(undefined)", we do it at
+                // compile time using expression substitution here.
+                return Some(Expr {
+                    loc,
+                    data: null_value_expr(),
+                });
+            } else {
+                // In a CommonJS module, "this" is supposed to be the same as "exports".
+                // Instead of doing this at runtime using "fn.call(module.exports)", we
+                // do it at compile time using expression substitution here.
+                let exports_ref = self.exports_ref;
+                self.record_usage(exports_ref);
+                self.deoptimize_common_js_named_exports();
+                return Some(self.new_expr(
+                    E::Identifier {
+                        ref_: exports_ref,
+                        ..Default::default()
+                    },
+                    loc,
+                ));
+            }
         }
-        // In the REPL, top-level `this` must evaluate to the global object
-        // (matching Node's `> this` and `deno repl > this`). The REPL wraps
-        // user input in an arrow IIFE that has no `exports` binding, so the
-        // CommonJS substitution below would emit a reference to an
-        // undefined `exports`. Leaving `E::This` in place lets the arrow
-        // inherit `this` from the enclosing (global) scope at runtime.
-        if self.options.repl_mode {
-            return None;
-        }
-        if self.has_es_module_syntax && self.commonjs_named_exports.count() == 0 {
-            // In an ES6 module, "this" is supposed to be undefined. Instead of
-            // doing this at runtime using "fn.call(undefined)", we do it at
-            // compile time using expression substitution here.
-            Some(Expr {
-                loc,
-                data: null_value_expr(),
-            })
-        } else {
-            // In a CommonJS module, "this" is supposed to be the same as "exports".
-            // Instead of doing this at runtime using "fn.call(module.exports)", we
-            // do it at compile time using expression substitution here.
-            let exports_ref = self.exports_ref;
-            self.record_usage(exports_ref);
-            self.deoptimize_common_js_named_exports();
-            Some(self.new_expr(
-                E::Identifier {
-                    ref_: exports_ref,
-                    ..Default::default()
-                },
-                loc,
-            ))
-        }
+
+        None
     }
 
     // PERF: takes `&Expr` — `Expr` inlines `ExprData`, so a by-value pass copies
@@ -6237,8 +6233,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let value = define_data.value;
         match value {
             js_ast::ExprData::EIdentifier(_) => {
-                // An identifier define stores its member chain
-                // (`a.b.c`, `this.x`, `import.meta.env`) as `original_name`.
+                // An identifier define stores its member chain (`a.b.c`) in `original_name`
                 let original_name: &[u8] = define_data
                     .original_name()
                     .expect("identifier define must have original_name");
@@ -6264,11 +6259,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Expr { data: value, loc }
     }
 
-    /// Builds the expression for a define value written as a member chain,
-    /// for example `--define A=globalThis.foo` or `--define B=import.meta.url`.
-    /// This is the port of esbuild's `instantiateDefineExpr`: the first part
-    /// resolves to a symbol (or `this` / `import.meta` / `null` / `undefined`),
-    /// and every later part becomes a property access on it.
+    /// esbuild's `instantiateDefineExpr`: resolves the first part of `name`, then builds property accesses.
     fn instantiate_define_member_chain(
         &mut self,
         loc: bun_ast::Loc,
@@ -6292,9 +6283,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 data: js_ast::ExprData::EUndefined(E::Undefined),
             },
             b"this" => {
-                // The define value is not matched against the `this` define
-                // again, so `--define this=this.x` cannot recurse.
-                match self.value_for_top_level_this(loc) {
+                // Not `value_for_this_with_defines`: `--define this=this.x` must not recurse
+                match self.value_for_this(loc) {
                     Some(value) => value,
                     None => Expr {
                         loc,
@@ -6304,8 +6294,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             b"import" if rest.first().is_some_and(|part| *part == b"meta") => {
                 rest.remove(0);
-                // The CommonJS wrapper passes `import.meta` in as a parameter
-                // when the module uses it, so count this use like a parsed one.
+                // The CommonJS wrapper takes an `import.meta` parameter when the module uses it
                 self.has_import_meta = true;
                 Expr {
                     loc,
@@ -6335,8 +6324,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // Vec<Box<[u8]>>` shape (auto-derefs at call sites). The full draft uses
     // `StoreSlice<StoreStr>`; both index to a `[u8]` so the body is unchanged.
     pub(crate) fn is_dot_define_match(&mut self, expr: Expr, parts: &[Box<[u8]>]) -> bool {
-        // An optional chain link (`a?.b`) matches like a plain `.`: the define
-        // for `a.b` replaces both spellings, as in esbuild.
+        // `a?.b` matches the define for `a.b`, as in esbuild
         match expr.data {
             js_ast::ExprData::EDot(ex) => {
                 if parts.len() > 1 {
@@ -6354,9 +6342,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return parts.len() == 1 && &*parts[0] == b"this";
                 }
             }
-            // `a["b"]` matches the same define as `a.b`. A UTF-16 literal
-            // (non-ASCII text) is skipped: comparing it would allocate a UTF-8
-            // copy on every visit, and define parts are ASCII in practice.
+            // `a["b"]` matches the define for `a.b`. A UTF-16 (non-ASCII) literal is skipped: comparing it allocates.
             js_ast::ExprData::EIndex(index) => {
                 if parts.len() > 1 {
                     if let js_ast::ExprData::EString(mut s) = index.index.data {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4795,8 +4795,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(value)
     }
 
-    /// `last_link_opts` applies to the final property access only: in `a.b.c = 1` the
-    /// assignment target is `c`, and `a.b` is read.
+    /// `last_link_opts` applies to the final property access only: in `a.b.c = 1` only `c` is the target.
     fn member_expression(
         &mut self,
         loc: bun_ast::Loc,
@@ -6324,8 +6323,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if rest.is_empty() {
             return value;
         }
-        // The last link is the assignment or delete target, as `a.b.c = 1` written in source
-        // would be: an import namespace member is rejected and a CommonJS export is converted.
+        // The last link is the assignment or delete target, as the literal `a.b.c = 1` would be
         self.member_expression(
             loc,
             value,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6354,14 +6354,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return parts.len() == 1 && &*parts[0] == b"this";
                 }
             }
-            // `a["b"]` matches the same define as `a.b`
+            // `a["b"]` matches the same define as `a.b`. A UTF-16 literal
+            // (non-ASCII text) is skipped: comparing it would allocate a UTF-8
+            // copy on every visit, and define parts are ASCII in practice.
             js_ast::ExprData::EIndex(index) => {
                 if parts.len() > 1 {
                     if let js_ast::ExprData::EString(mut s) = index.index.data {
-                        let last = parts.len() - 1;
-                        let is_tail_match = strings::eql(&parts[last], s.slice(self.arena));
-                        return is_tail_match
-                            && self.is_dot_define_match(index.target, &parts[..last]);
+                        if s.is_utf8() {
+                            let last = parts.len() - 1;
+                            // `slice` flattens a rope left by a folded `"b" + "c"`
+                            let is_tail_match = strings::eql(&parts[last], s.slice(self.arena));
+                            return is_tail_match
+                                && self.is_dot_define_match(index.target, &parts[..last]);
+                        }
                     }
                 }
             }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -103,7 +103,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn e_this(p: &mut Self, e: &mut Expr, in_: ExprIn) {
         let is_delete_target = matches!(p.delete_target, Data::EThis(..));
-        if let Some(exp) = p.value_for_this(e.loc, in_.assign_target, is_delete_target) {
+        if let Some(exp) = p.value_for_this_with_defines(e.loc, in_.assign_target, is_delete_target)
+        {
             *e = exp;
         }
     }
@@ -269,9 +270,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let newvalue: Expr =
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
-                    // Don't substitute a constant if this is an assignment
-                    // target, since "0 = 1" is a syntax error. An identifier or
-                    // a property access is still a valid target.
+                    // A constant is not a valid assignment target ("0 = 1"), an identifier or property access is
                     if in_.assign_target == js_ast::AssignTarget::None
                         || matches!(newvalue.data.tag(), Tag::EIdentifier | Tag::EDot)
                     {
@@ -884,8 +883,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let is_call_target = matches!(p.call_target, Data::EIndex(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
         let is_delete_target = matches!(p.delete_target, Data::EIndex(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
 
-        // Check user-specified defines and known globals: `a["b"]` matches the
-        // same define as `a.b`. See `is_dot_define_match` for the UTF-8 gate.
+        // `a["b"]` matches the same define as `a.b` (UTF-8 literals only, see `is_dot_define_match`)
         if let Some(mut s) = e_.index.data.e_string().filter(|s| s.is_utf8()) {
             let defines = p.define;
             if let Some(dot_defines) = defines.dots.get(s.slice(p.arena)) {
@@ -1034,9 +1032,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 };
             }
             _ => {
-                // The target visit sets this flag when the target is a `--drop`
-                // name. A call inside the index (`console[foo()]()`) must not
-                // consume it, so hide it while the index is visited.
+                // Hide the `--drop` flag from the target visit so a call in the index (`console[foo()]()`) does not consume it
                 let target_is_dropped_method_call =
                     core::mem::replace(&mut p.method_call_must_be_replaced_with_undefined, false);
                 p.visit_expr(&mut e_.index);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -26,7 +26,6 @@ use js_ast::OpCode as Op;
 // `visit_expr_in_out` are surfaced.
 
 /// A define value that can replace an assignment target: `FOO = 1` must not become `0 = 1`.
-/// A member chain value resolves to an import item or a CommonJS export when its last part is one.
 fn define_value_can_be_assign_target(value: &Expr) -> bool {
     matches!(
         value.data.tag(),

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -25,6 +25,11 @@ use js_ast::OpCode as Op;
 // The 25+ per-variant `e_*` helpers are private; only `visit_expr` /
 // `visit_expr_in_out` are surfaced.
 
+/// A define value that can replace an assignment target: `FOO = 1` must not become `0 = 1`.
+fn define_value_can_be_assign_target(value: &Expr) -> bool {
+    matches!(value.data.tag(), Tag::EIdentifier | Tag::EDot)
+}
+
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     // PERF(port:noalias): `e: &mut Expr` is lowered to a `noalias` LLVM param, so reads
     // through `e` can be cached in registers across child recursion. The by-value
@@ -270,9 +275,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let newvalue: Expr =
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
-                    // A constant is not a valid assignment target ("0 = 1"), an identifier or property access is
                     if in_.assign_target == js_ast::AssignTarget::None
-                        || matches!(newvalue.data.tag(), Tag::EIdentifier | Tag::EDot)
+                        || define_value_can_be_assign_target(&newvalue)
                     {
                         p.ignore_usage(e_.ref_);
                         *e = newvalue;
@@ -889,24 +893,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if let Some(dot_defines) = defines.dots.get(s.slice(p.arena)) {
                 for define in dot_defines.as_slice() {
                     if p.is_dot_define_match(expr, &define.parts) {
-                        if in_.assign_target == js_ast::AssignTarget::None {
-                            // Substitute user-specified defines
-                            if !define.data.valueless() {
-                                *e = p.value_for_define(
-                                    expr.loc,
-                                    in_.assign_target,
-                                    is_delete_target,
-                                    &define.data,
-                                );
+                        // Substitute user-specified defines
+                        if !define.data.valueless() {
+                            let replacement = p.value_for_define(
+                                expr.loc,
+                                in_.assign_target,
+                                is_delete_target,
+                                &define.data,
+                            );
+                            if in_.assign_target == js_ast::AssignTarget::None
+                                || define_value_can_be_assign_target(&replacement)
+                            {
+                                *e = replacement;
                                 return;
                             }
-
-                            if define.data.method_call_must_be_replaced_with_undefined()
-                                && in_
-                                    .property_access_for_method_call_maybe_should_replace_with_undefined
-                            {
-                                p.method_call_must_be_replaced_with_undefined = true;
-                            }
+                        } else if in_.assign_target == js_ast::AssignTarget::None
+                            && define.data.method_call_must_be_replaced_with_undefined()
+                            && in_
+                                .property_access_for_method_call_maybe_should_replace_with_undefined
+                        {
+                            p.method_call_must_be_replaced_with_undefined = true;
                         }
                         break;
                     }
@@ -1389,24 +1395,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if let Some(parts) = defines.dots.get(e_.name.slice()) {
             for define in parts.as_slice() {
                 if p.is_dot_define_match(expr, &define.parts) {
-                    if in_.assign_target == js_ast::AssignTarget::None {
-                        // Substitute user-specified defines
-                        if !define.data.valueless() {
-                            *e = p.value_for_define(
-                                expr.loc,
-                                in_.assign_target,
-                                is_delete_target,
-                                &define.data,
-                            );
+                    // Substitute user-specified defines
+                    if !define.data.valueless() {
+                        let replacement = p.value_for_define(
+                            expr.loc,
+                            in_.assign_target,
+                            is_delete_target,
+                            &define.data,
+                        );
+                        if in_.assign_target == js_ast::AssignTarget::None
+                            || define_value_can_be_assign_target(&replacement)
+                        {
+                            *e = replacement;
                             return;
                         }
-
-                        if define.data.method_call_must_be_replaced_with_undefined()
-                            && in_
-                                .property_access_for_method_call_maybe_should_replace_with_undefined
-                        {
-                            p.method_call_must_be_replaced_with_undefined = true;
-                        }
+                    } else if in_.assign_target == js_ast::AssignTarget::None
+                        && define.data.method_call_must_be_replaced_with_undefined()
+                        && in_.property_access_for_method_call_maybe_should_replace_with_undefined
+                    {
+                        p.method_call_must_be_replaced_with_undefined = true;
                     }
 
                     // Copy the side effect flags over in case this expression is unused

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -101,10 +101,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // idc about legacy octal loc
     }
 
-    fn e_this(p: &mut Self, e: &mut Expr, _: ExprIn) {
-        if let Some(exp) = p.value_for_this(e.loc) {
+    fn e_this(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+        let is_delete_target = matches!(p.delete_target, Data::EThis(..));
+        if let Some(exp) = p.value_for_this(e.loc, in_.assign_target, is_delete_target) {
             *e = exp;
-            return;
         }
     }
 
@@ -147,8 +147,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     continue;
                 }
                 // Substitute user-specified defines
-                *e =
-                    p.value_for_define(expr.loc, in_.assign_target, is_delete_target, &define.data);
+                if !define.data.valueless() {
+                    *e = p.value_for_define(
+                        expr.loc,
+                        in_.assign_target,
+                        is_delete_target,
+                        &define.data,
+                    );
+                }
                 return;
             }
         }
@@ -249,8 +255,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.symbols[result.r#ref.inner_index() as usize].set_has_been_assigned_to(true);
         }
 
-        let mut original_name: Option<&[u8]> = None;
-
         // Substitute user-specified defines for unbound symbols
         if p.symbols[e_.ref_.inner_index() as usize].kind == js_ast::symbol::Kind::Unbound
             && !result.is_inside_with_scope
@@ -265,17 +269,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let newvalue: Expr =
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
-                    // Don't substitute an identifier for a non-identifier if this is an
-                    // assignment target, since it'll cause a syntax error
-                    if matches!(newvalue.data.tag(), Tag::EIdentifier)
-                        || in_.assign_target == js_ast::AssignTarget::None
+                    // Don't substitute a constant if this is an assignment
+                    // target, since "0 = 1" is a syntax error. An identifier or
+                    // a property access is still a valid target.
+                    if in_.assign_target == js_ast::AssignTarget::None
+                        || matches!(newvalue.data.tag(), Tag::EIdentifier | Tag::EDot)
                     {
                         p.ignore_usage(e_.ref_);
                         *e = newvalue;
                         return;
                     }
-
-                    original_name = def.original_name();
                 }
 
                 // Copy the side effect flags over in case this expression is unused
@@ -320,7 +323,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         *e = p.handle_identifier(
             expr.loc,
             e_,
-            original_name,
+            None,
             IdentifierOpts::default()
                 .with_assign_target(in_.assign_target)
                 .with_is_delete_target(is_delete_target)
@@ -881,6 +884,38 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let is_call_target = matches!(p.call_target, Data::EIndex(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
         let is_delete_target = matches!(p.delete_target, Data::EIndex(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
 
+        // Check user-specified defines and known globals: `a["b"]` matches the
+        // same define as `a.b`.
+        if let Some(mut s) = e_.index.data.e_string() {
+            let defines = p.define;
+            if let Some(dot_defines) = defines.dots.get(s.slice(p.arena)) {
+                for define in dot_defines.as_slice() {
+                    if p.is_dot_define_match(expr, &define.parts) {
+                        if in_.assign_target == js_ast::AssignTarget::None {
+                            // Substitute user-specified defines
+                            if !define.data.valueless() {
+                                *e = p.value_for_define(
+                                    expr.loc,
+                                    in_.assign_target,
+                                    is_delete_target,
+                                    &define.data,
+                                );
+                                return;
+                            }
+
+                            if define.data.method_call_must_be_replaced_with_undefined()
+                                && in_
+                                    .property_access_for_method_call_maybe_should_replace_with_undefined
+                            {
+                                p.method_call_must_be_replaced_with_undefined = true;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         // "a['b']" => "a.b"
         if p.options.features.minify_syntax {
             if let Some(mut s) = e_.index.data.e_string() {
@@ -910,7 +945,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        p.visit_expr_in_out(&mut e_.target, ExprIn::default());
+        p.visit_expr_in_out(
+            &mut e_.target,
+            ExprIn {
+                property_access_for_method_call_maybe_should_replace_with_undefined: in_
+                    .property_access_for_method_call_maybe_should_replace_with_undefined,
+                ..Default::default()
+            },
+        );
 
         match e_.index.data {
             Data::EPrivateIdentifier(mut private) => {
@@ -992,7 +1034,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 };
             }
             _ => {
+                // The target visit sets this flag when the target is a `--drop`
+                // name. A call inside the index (`console[foo()]()`) must not
+                // consume it, so hide it while the index is visited.
+                let target_is_dropped_method_call =
+                    core::mem::replace(&mut p.method_call_must_be_replaced_with_undefined, false);
                 p.visit_expr(&mut e_.index);
+                if target_is_dropped_method_call {
+                    p.method_call_must_be_replaced_with_undefined = true;
+                }
 
                 let unwrapped = e_.index.unwrap_inlined();
                 if let Some(mut s) = unwrapped.data.e_string() {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -885,8 +885,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let is_delete_target = matches!(p.delete_target, Data::EIndex(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
 
         // Check user-specified defines and known globals: `a["b"]` matches the
-        // same define as `a.b`.
-        if let Some(mut s) = e_.index.data.e_string() {
+        // same define as `a.b`. See `is_dot_define_match` for the UTF-8 gate.
+        if let Some(mut s) = e_.index.data.e_string().filter(|s| s.is_utf8()) {
             let defines = p.define;
             if let Some(dot_defines) = defines.dots.get(s.slice(p.arena)) {
                 for define in dot_defines.as_slice() {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -26,8 +26,12 @@ use js_ast::OpCode as Op;
 // `visit_expr_in_out` are surfaced.
 
 /// A define value that can replace an assignment target: `FOO = 1` must not become `0 = 1`.
+/// A member chain value resolves to an import item or a CommonJS export when its last part is one.
 fn define_value_can_be_assign_target(value: &Expr) -> bool {
-    matches!(value.data.tag(), Tag::EIdentifier | Tag::EDot)
+    matches!(
+        value.data.tag(),
+        Tag::EIdentifier | Tag::EDot | Tag::EImportIdentifier | Tag::ECommonjsExportIdentifier
+    )
 }
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,8 +55,7 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-/// Version 28: Defines match through optional chains and `a["b"]` accesses, so
-/// the global side-effect table marks more property accesses as removable.
+/// Version 28: Defines match through optional chains, so more global property accesses are removable.
 const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,9 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: Defines match through optional chains and `a["b"]` accesses, so
+/// the global side-effect table marks more property accesses as removable.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1275,7 +1275,9 @@ impl Framework {
             }
 
             for drop_item in bundler_options.drop.keys() {
-                if !drop_item.is_empty() {
+                // `debugger` is a statement, not a define key. `configure_defines`
+                // already set `drop_debugger` for it.
+                if !drop_item.is_empty() && *drop_item != b"debugger" {
                     let parsed = bun_bundler::defines::DefineData::parse(
                         drop_item, b"", true, true, log, arena,
                     )?;

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1275,8 +1275,7 @@ impl Framework {
             }
 
             for drop_item in bundler_options.drop.keys() {
-                // `debugger` is a statement, not a define key. `configure_defines`
-                // already set `drop_debugger` for it.
+                // `debugger` is a statement drop, `configure_defines` already set `drop_debugger`
                 if !drop_item.is_empty() && *drop_item != b"debugger" {
                     let parsed = bun_bundler::defines::DefineData::parse(
                         drop_item, b"", true, true, log, arena,

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -309,7 +309,9 @@ impl Framework {
             }
 
             for drop_item in bundler_options.drop.keys() {
-                if !drop_item.is_empty() {
+                // `debugger` is a statement, not a define key. `configure_defines`
+                // already set `drop_debugger` for it.
+                if !drop_item.is_empty() && *drop_item != b"debugger" {
                     let parsed = bun_bundler::defines::DefineData::parse(
                         drop_item, b"", true, true, log, arena,
                     )?;

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -309,8 +309,7 @@ impl Framework {
             }
 
             for drop_item in bundler_options.drop.keys() {
-                // `debugger` is a statement, not a define key. `configure_defines`
-                // already set `drop_debugger` for it.
+                // `debugger` is a statement drop, `configure_defines` already set `drop_debugger`
                 if !drop_item.is_empty() && *drop_item != b"debugger" {
                     let parsed = bun_bundler::defines::DefineData::parse(
                         drop_item, b"", true, true, log, arena,

--- a/test/bundler/bundler_define.test.ts
+++ b/test/bundler/bundler_define.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// `define` key matching and value parsing, on every surface that takes a
+// define map: `bun build` (bundling and `--no-bundle`), `Bun.build`, and
+// `Bun.Transpiler`. The expected output follows esbuild, with one difference:
+// Bun rewrites a top-level `this` (to `exports` in CommonJS), so a define value
+// that starts with `this` gets the same rewrite at a top-level use site.
+
+type Defines = Record<string, string>;
+
+interface Surface {
+  name: string;
+  /** Transpile `source` with `defines`. Returns the output code. */
+  run(source: string, defines: Defines): Promise<string>;
+}
+
+/** Runs `bun build` with `--define` flags and returns stdout. Fails on stderr. */
+async function buildCli(source: string, defines: Defines, extraArgs: string[]): Promise<string> {
+  using dir = tempDir("bundler-define", { "entry.js": source });
+  const defineArgs = Object.entries(defines).flatMap(([key, value]) => ["--define", `${key}=${value}`]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", ...extraArgs, ...defineArgs, join(String(dir), "entry.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
+const surfaces: Surface[] = [
+  {
+    name: "bun build --no-bundle",
+    run: (source, defines) => buildCli(source, defines, ["--no-bundle"]),
+  },
+  {
+    name: "bun build",
+    run: (source, defines) => buildCli(source, defines, []),
+  },
+  {
+    name: "Bun.build",
+    async run(source, defines) {
+      using dir = tempDir("bundler-define-api", { "entry.js": source });
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "entry.js")],
+        define: defines,
+      });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+      return await result.outputs[0].text();
+    },
+  },
+  {
+    name: "Bun.Transpiler",
+    async run(source, defines) {
+      const transpiler = new Bun.Transpiler({ define: defines });
+      return transpiler.transformSync(source, "js");
+    },
+  },
+];
+
+/** One source statement and the statement the output must contain. */
+type Case = [input: string, output: string];
+
+interface Repro {
+  name: string;
+  defines: Defines;
+  cases: Case[];
+}
+
+const repros: Repro[] = [
+  {
+    name: "optional chains and string index keys match a dot define",
+    defines: {
+      "a.b": "c",
+      "a.b.c": "d",
+      "process.env.NODE_ENV": '"production"',
+    },
+    cases: [
+      ["console.log(a.b);", "console.log(c);"],
+      ["console.log(a?.b);", "console.log(c);"],
+      ["console.log(a?.b.c);", "console.log(d);"],
+      ["console.log(a.b?.c);", "console.log(d);"],
+      ['console.log(a?.["b"]);', "console.log(c);"],
+      ['console.log(a["b"]);', "console.log(c);"],
+      ["console.log(process?.env?.NODE_ENV);", 'console.log("production");'],
+      ['console.log(process.env["NODE_ENV"]);', 'console.log("production");'],
+      ['console.log(process["env"]["NODE_ENV"]);', 'console.log("production");'],
+      ['console.log(process["env"].NODE_ENV);', 'console.log("production");'],
+      // The rest of a partly replaced optional chain continues on the new value
+      ["console.log(a?.b.x);", "console.log(c.x);"],
+      ["console.log(a?.b());", "console.log(c());"],
+      ['console.log(a?.["b"].x);', "console.log(c.x);"],
+      ["console.log(a.b?.x);", "console.log(c?.x);"],
+    ],
+  },
+  {
+    name: "values are member chains, not strings",
+    defines: {
+      A: "import.meta",
+      B: "import.meta.url",
+      C: "this.foo",
+      F: "a.if",
+      "window.env": "import.meta.env",
+      N: "null",
+      U: "undefined",
+    },
+    cases: [
+      ["console.log(A);", "console.log(import.meta);"],
+      ["console.log(B);", "console.log(import.meta.url);"],
+      // A top-level `this` in a CommonJS file is `exports`
+      ["console.log(C);", "console.log(exports.foo);"],
+      // Inside a function `this` stays `this`
+      ["console.log(function () { return C; });", "return this.foo;"],
+      ["console.log(F);", "console.log(a.if);"],
+      ["console.log(window.env);", "console.log(import.meta.env);"],
+      ["console.log(N);", "console.log(null);"],
+      ["console.log(U);", "console.log(undefined);"],
+    ],
+  },
+  {
+    name: "this as a key, BigInt values, quoted key parts",
+    defines: {
+      this: "window",
+      FOO: "123n",
+      HEX: "0xffn",
+      'process.env["SOME-VAR"]': "3",
+      'process.env["dotted.name"]': "4",
+    },
+    cases: [
+      ["((g) => console.log(g))(this);", "((g) => console.log(g))(window);"],
+      ["console.log(FOO);", "console.log(123n);"],
+      ["console.log(HEX);", "console.log(0xffn);"],
+      ['console.log(process.env["SOME-VAR"]);', "console.log(3);"],
+      ["console.log(process.env['SOME-VAR']);", "console.log(3);"],
+      ['console.log(process?.env?.["SOME-VAR"]);', "console.log(3);"],
+      ['console.log(process.env["dotted.name"]);', "console.log(4);"],
+      // Only a top-level `this` is replaced
+      ["console.log(function () { return this; });", "return this;"],
+    ],
+  },
+  {
+    name: "a constant define is not substituted into an assignment target",
+    defines: {
+      FOO: "123",
+      BAR: "a.b",
+    },
+    cases: [
+      ["FOO = 1;", "FOO = 1;"],
+      ["console.log(FOO);", "console.log(123);"],
+      // An identifier or a member chain is a valid target
+      ["BAR = 2;", "a.b = 2;"],
+    ],
+  },
+];
+
+describe.each(surfaces)("$name", surface => {
+  for (const repro of repros) {
+    describe(repro.name, () => {
+      // One transpile per surface and repro. Every statement is its own line,
+      // so each case can assert on its own output line.
+      const source = repro.cases.map(([input]) => input).join("\n") + "\n";
+      let output: Promise<string> | undefined;
+      const getOutput = () => (output ??= surface.run(source, repro.defines));
+
+      test.each(repro.cases)("%s => %s", async (_input, expected) => {
+        const lines = (await getOutput()).split("\n").map(line => line.trim());
+        expect(lines).toContain(expected);
+      });
+    });
+  }
+});
+
+describe("define values are symbols, not text", () => {
+  test("a member chain follows a renamed local and a renamed import", async () => {
+    using dir = tempDir("bundler-define-link", {
+      "entry.js": `
+        import { x } from "./x.js";
+        const local = { b: { c: 1 } };
+        console.log(A, B.y);
+      `,
+      "x.js": `export const x = { y: 2 };`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      outdir: join(String(dir), "out"),
+      define: { A: "local.b.c", B: "x" },
+      minify: { identifiers: true },
+    });
+    expect(result.logs).toEqual([]);
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+    // `local` and `x` were renamed, so the define values must not print verbatim
+    expect(output).not.toContain("local.b.c");
+    expect(output).not.toContain("x.y");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), result.outputs[0].path],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1 2\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("define key errors", () => {
+  test.each([
+    ["a-b", 'define key "a-b" must be a valid identifier'],
+    ["a.b-c", 'define key "a.b-c" contains invalid identifier "b-c"'],
+    ["a.b.", 'define key "a.b." contains invalid identifier ""'],
+    ["null.x", 'define key "null.x" contains invalid identifier "null"'],
+    ["import.foo", 'define key "import.foo" contains invalid identifier "import"'],
+    ["a[b]", 'define key "a[b]" must use a quoted string inside "[]"'],
+    ['a["b"', 'define key "a["b"" must use a quoted string inside "[]"'],
+    ['a["b"]c', 'define key "a["b"]c" must use a quoted string inside "[]"'],
+  ])("%s is rejected", async (key, message) => {
+    using dir = tempDir("bundler-define-key-error", { "entry.js": "console.log(1);\n" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--define", `${key}=1`, join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(message);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("a keyword is a valid property name after the first part", async () => {
+    const transpiler = new Bun.Transpiler({ define: { "a.if": "1", "this.x": "2", "import.meta.env.MODE": '"test"' } });
+    expect(transpiler.transformSync("console.log(a.if, this.x, import.meta.env.MODE);", "js").trim()).toBe(
+      'console.log(1, 2, "test");',
+    );
+  });
+});

--- a/test/bundler/bundler_define.test.ts
+++ b/test/bundler/bundler_define.test.ts
@@ -177,26 +177,27 @@ describe.each(surfaces)("$name", surface => {
 
 describe("define values are symbols, not text", () => {
   test("a member chain follows a renamed local and a renamed import", async () => {
+    // Long names: the minifier generates short names, so these cannot come back.
     using dir = tempDir("bundler-define-link", {
       "entry.js": `
-        import { x } from "./x.js";
-        const local = { b: { c: 1 } };
+        import { importedObject } from "./imported.js";
+        const localObject = { b: { c: 1 } };
         console.log(A, B.y);
       `,
-      "x.js": `export const x = { y: 2 };`,
+      "imported.js": `export const importedObject = { y: 2 };`,
     });
     const result = await Bun.build({
       entrypoints: [join(String(dir), "entry.js")],
       outdir: join(String(dir), "out"),
-      define: { A: "local.b.c", B: "x" },
+      define: { A: "localObject.b.c", B: "importedObject" },
       minify: { identifiers: true },
     });
     expect(result.logs).toEqual([]);
     expect(result.success).toBe(true);
     const output = await result.outputs[0].text();
-    // `local` and `x` were renamed, so the define values must not print verbatim
-    expect(output).not.toContain("local.b.c");
-    expect(output).not.toContain("x.y");
+    // Both names were renamed, so the define values must not print verbatim
+    expect(output).not.toContain("localObject");
+    expect(output).not.toContain("importedObject");
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), result.outputs[0].path],

--- a/test/bundler/bundler_define.test.ts
+++ b/test/bundler/bundler_define.test.ts
@@ -247,6 +247,91 @@ describe("define values are symbols, not text", () => {
     expect(stdout).toBe("1\n");
     expect(exitCode).toBe(0);
   });
+
+  test("assigning through a member chain to an import namespace member is an error", async () => {
+    using dir = tempDir("bundler-define-assign-namespace", {
+      "entry.js": `
+        import * as ns from "./other.js";
+        FLAG = 1;
+        console.log(ns.member);
+      `,
+      "other.js": `export let member = 0;`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      outdir: join(String(dir), "out"),
+      define: { FLAG: "ns.member" },
+      throw: false,
+    });
+    // The same error as the literal `ns.member = 1`
+    expect(result.success).toBe(false);
+    expect(result.logs.map(log => log.message)).toEqual(['Cannot assign to import "member"']);
+  });
+
+  test("assigning through a member chain writes a property of an import namespace member", async () => {
+    using dir = tempDir("bundler-define-assign-namespace-property", {
+      "entry.js": `
+        import * as ns from "./settings.js";
+        FLAG = 1;
+        console.log(ns.settings.flag);
+      `,
+      "settings.js": `export const settings = { flag: 0 };`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      outdir: join(String(dir), "out"),
+      define: { FLAG: "ns.settings.flag" },
+    });
+    // Only the last link `flag` is the target. `ns.settings` is read, so the import is not reported.
+    expect(result.logs).toEqual([]);
+    expect(result.success).toBe(true);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), result.outputs[0].path],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("assigning through a member chain to a CommonJS export converts the export", async () => {
+    using dir = tempDir("bundler-define-assign-cjs-export", {
+      "entry.js": `
+        import * as lib from "./lib.cjs";
+        console.log(lib.foo, lib.bar);
+      `,
+      "lib.cjs": `
+        exports.bar = 1;
+        FOO = 2;
+      `,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      outdir: join(String(dir), "out"),
+      define: { FOO: "exports.foo" },
+    });
+    expect(result.logs).toEqual([]);
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+    // `$foo = 2` is a named export like the literal `exports.foo = 2`, so the module needs no wrapper
+    expect(output).not.toContain("__commonJS");
+    expect(output).not.toContain("FOO");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), result.outputs[0].path],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("2 1\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("define key errors", () => {

--- a/test/bundler/bundler_define.test.ts
+++ b/test/bundler/bundler_define.test.ts
@@ -148,12 +148,19 @@ const repros: Repro[] = [
     defines: {
       FOO: "123",
       BAR: "a.b",
+      "obj.key": "c.d",
+      "obj.num": "7",
     },
     cases: [
       ["FOO = 1;", "FOO = 1;"],
       ["console.log(FOO);", "console.log(123);"],
       // An identifier or a member chain is a valid target
       ["BAR = 2;", "a.b = 2;"],
+      ["obj.key = 3;", "c.d = 3;"],
+      ['obj["key"] = 4;', "c.d = 4;"],
+      ["obj.num = 5;", "obj.num = 5;"],
+      ['obj["num"] = 6;', 'obj["num"] = 6;'],
+      ["console.log(obj.num, obj.key);", "console.log(7, c.d);"],
     ],
   },
 ];

--- a/test/bundler/bundler_define.test.ts
+++ b/test/bundler/bundler_define.test.ts
@@ -63,7 +63,7 @@ const surfaces: Surface[] = [
   },
 ];
 
-/** One source statement and the statement the output must contain. */
+/** An expression and the expression it must transpile to. */
 type Case = [input: string, output: string];
 
 interface Repro {
@@ -81,21 +81,21 @@ const repros: Repro[] = [
       "process.env.NODE_ENV": '"production"',
     },
     cases: [
-      ["console.log(a.b);", "console.log(c);"],
-      ["console.log(a?.b);", "console.log(c);"],
-      ["console.log(a?.b.c);", "console.log(d);"],
-      ["console.log(a.b?.c);", "console.log(d);"],
-      ['console.log(a?.["b"]);', "console.log(c);"],
-      ['console.log(a["b"]);', "console.log(c);"],
-      ["console.log(process?.env?.NODE_ENV);", 'console.log("production");'],
-      ['console.log(process.env["NODE_ENV"]);', 'console.log("production");'],
-      ['console.log(process["env"]["NODE_ENV"]);', 'console.log("production");'],
-      ['console.log(process["env"].NODE_ENV);', 'console.log("production");'],
+      ["a.b", "c"],
+      ["a?.b", "c"],
+      ["a?.b.c", "d"],
+      ["a.b?.c", "d"],
+      ['a?.["b"]', "c"],
+      ['a["b"]', "c"],
+      ["process?.env?.NODE_ENV", '"production"'],
+      ['process.env["NODE_ENV"]', '"production"'],
+      ['process["env"]["NODE_ENV"]', '"production"'],
+      ['process["env"].NODE_ENV', '"production"'],
       // The rest of a partly replaced optional chain continues on the new value
-      ["console.log(a?.b.x);", "console.log(c.x);"],
-      ["console.log(a?.b());", "console.log(c());"],
-      ['console.log(a?.["b"].x);', "console.log(c.x);"],
-      ["console.log(a.b?.x);", "console.log(c?.x);"],
+      ["a?.b.x", "c.x"],
+      ["a?.b()", "c()"],
+      ['a?.["b"].x', "c.x"],
+      ["a.b?.x", "c?.x"],
     ],
   },
   {
@@ -110,16 +110,16 @@ const repros: Repro[] = [
       U: "undefined",
     },
     cases: [
-      ["console.log(A);", "console.log(import.meta);"],
-      ["console.log(B);", "console.log(import.meta.url);"],
+      ["A", "import.meta"],
+      ["B", "import.meta.url"],
       // A top-level `this` in a CommonJS file is `exports`
-      ["console.log(C);", "console.log(exports.foo);"],
+      ["C", "exports.foo"],
       // Inside a function `this` stays `this`
-      ["console.log(function () { return C; });", "return this.foo;"],
-      ["console.log(F);", "console.log(a.if);"],
-      ["console.log(window.env);", "console.log(import.meta.env);"],
-      ["console.log(N);", "console.log(null);"],
-      ["console.log(U);", "console.log(undefined);"],
+      ["function () { return C; }", "function() { return this.foo; }"],
+      ["F", "a.if"],
+      ["window.env", "import.meta.env"],
+      ["N", "null"],
+      ["U", "undefined"],
     ],
   },
   {
@@ -132,15 +132,15 @@ const repros: Repro[] = [
       'process.env["dotted.name"]': "4",
     },
     cases: [
-      ["((g) => console.log(g))(this);", "((g) => console.log(g))(window);"],
-      ["console.log(FOO);", "console.log(123n);"],
-      ["console.log(HEX);", "console.log(0xffn);"],
-      ['console.log(process.env["SOME-VAR"]);', "console.log(3);"],
-      ["console.log(process.env['SOME-VAR']);", "console.log(3);"],
-      ['console.log(process?.env?.["SOME-VAR"]);', "console.log(3);"],
-      ['console.log(process.env["dotted.name"]);', "console.log(4);"],
+      ["((g) => g)(this)", "((g) => g)(window)"],
+      ["FOO", "123n"],
+      ["HEX", "0xffn"],
+      ['process.env["SOME-VAR"]', "3"],
+      ["process.env['SOME-VAR']", "3"],
+      ['process?.env?.["SOME-VAR"]', "3"],
+      ['process.env["dotted.name"]', "4"],
       // Only a top-level `this` is replaced
-      ["console.log(function () { return this; });", "return this;"],
+      ["function () { return this; }", "function() { return this; }"],
     ],
   },
   {
@@ -152,15 +152,15 @@ const repros: Repro[] = [
       "obj.num": "7",
     },
     cases: [
-      ["FOO = 1;", "FOO = 1;"],
-      ["console.log(FOO);", "console.log(123);"],
+      ["FOO = 1", "FOO = 1"],
+      ["FOO", "123"],
       // An identifier or a member chain is a valid target
-      ["BAR = 2;", "a.b = 2;"],
-      ["obj.key = 3;", "c.d = 3;"],
-      ['obj["key"] = 4;', "c.d = 4;"],
-      ["obj.num = 5;", "obj.num = 5;"],
-      ['obj["num"] = 6;', 'obj["num"] = 6;'],
-      ["console.log(obj.num, obj.key);", "console.log(7, c.d);"],
+      ["BAR = 2", "a.b = 2"],
+      ["obj.key = 3", "c.d = 3"],
+      ['obj["key"] = 4', "c.d = 4"],
+      ["obj.num = 5", "obj.num = 5"],
+      ['obj["num"] = 6', 'obj["num"] = 6'],
+      ["[obj.num, obj.key]", "[7, c.d]"],
     ],
   },
 ];
@@ -168,15 +168,15 @@ const repros: Repro[] = [
 describe.each(surfaces)("$name", surface => {
   for (const repro of repros) {
     describe(repro.name, () => {
-      // One transpile per surface and repro. Every statement is its own line,
-      // so each case can assert on its own output line.
-      const source = repro.cases.map(([input]) => input).join("\n") + "\n";
+      // One transpile per surface and repro. Each expression is logged with its
+      // own index, so an assertion can only match its own statement.
+      const source = repro.cases.map(([input], i) => `console.log(${i}, ${input});`).join("\n") + "\n";
       let output: Promise<string> | undefined;
-      const getOutput = () => (output ??= surface.run(source, repro.defines));
+      const getOutput = async () => (await (output ??= surface.run(source, repro.defines))).replace(/\s+/g, " ");
+      const cases = repro.cases.map(([input, expected], i) => [input, expected, i] as const);
 
-      test.each(repro.cases)("%s => %s", async (_input, expected) => {
-        const lines = (await getOutput()).split("\n").map(line => line.trim());
-        expect(lines).toContain(expected);
+      test.each(cases)("%s => %s", async (_input, expected, i) => {
+        expect(await getOutput()).toContain(`console.log(${i}, ${expected});`);
       });
     });
   }
@@ -217,6 +217,36 @@ describe("define values are symbols, not text", () => {
     expect(stdout).toBe("1 2\n");
     expect(exitCode).toBe(0);
   });
+
+  test("assigning through a member chain does not assign to the import at its head", async () => {
+    using dir = tempDir("bundler-define-assign-import", {
+      "entry.js": `
+        import { settings } from "./settings.js";
+        FLAG = 1;
+        console.log(settings.flag);
+      `,
+      "settings.js": `export const settings = { flag: 0 };`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      outdir: join(String(dir), "out"),
+      define: { FLAG: "settings.flag" },
+    });
+    // `settings.flag = 1` writes a property. The bundler must not report an assignment to `settings`.
+    expect(result.logs).toEqual([]);
+    expect(result.success).toBe(true);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), result.outputs[0].path],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("define key errors", () => {
@@ -237,8 +267,9 @@ describe("define key errors", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain(message);
+    expect(stdout).toBe("");
     expect(exitCode).not.toBe(0);
   });
 

--- a/test/bundler/bundler_drop.test.ts
+++ b/test/bundler/bundler_drop.test.ts
@@ -29,6 +29,24 @@ describe("bundler", () => {
       api.expectFile("out.js").toIncludeRepeated("debugger", 4);
     },
   });
+  itBundled("drop/IndexAccess", {
+    files: {
+      "/a.js": `
+        console["log"]("hello");
+        console[method]("hello");
+        console[pick()]("hello");
+        console["log"].call(console, "hello");
+        var method = "log";
+        function pick() { return "log"; }
+      `,
+    },
+    run: { stdout: "" },
+    drop: ["console"],
+    backend: "api",
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude("console");
+    },
+  });
   itBundled("drop/RemovesSideEffects", {
     files: {
       "/a.js": `console.log(alert());`,

--- a/test/bundler/bundler_minify_symbol_for.test.ts
+++ b/test/bundler/bundler_minify_symbol_for.test.ts
@@ -119,7 +119,7 @@ describe("bundler", () => {
     itBundled("minify/SymbolForEdgeCases", {
       files: {
         "/entry.js": /* js */ `
-          // Optional chaining - these are preserved because optional chaining has observable behavior
+          // Optional chaining - Symbol?.for matches the same known global as Symbol.for
           Symbol?.for("optional1");
           Symbol?.for?.("optional2");
           
@@ -149,9 +149,10 @@ describe("bundler", () => {
       onAfterBundle(api) {
         const output = api.readFile("/out.js");
 
-        // Optional chaining preserves the call because it has observable behavior (checking if Symbol exists)
-        expect(output).toContain("optional1");
-        expect(output).toContain("optional2");
+        // An unused Symbol?.for(...) is removed like Symbol.for(...), as esbuild does.
+        // `Symbol?.for("x")` has no side effect whether or not Symbol exists.
+        expect(output).not.toContain("optional1");
+        expect(output).not.toContain("optional2");
 
         // All the conditional/ternary expressions were optimized away completely
         // because they evaluate to unused Symbol.for calls

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -4443,7 +4443,6 @@ describe.concurrent("bundler", () => {
   //   },
   // });
   itBundled("default/DefineThis", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         ok(
@@ -4521,7 +4520,6 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/DefineOptionalChain", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         log([

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2075,7 +2075,6 @@ describe("bundler", () => {
     ],
   });
   itBundled("ts/EnumDefine", {
-    todo: true,
     files: {
       "/entry.ts": `
       enum a { b = 123, c = d }


### PR DESCRIPTION
### Problem
- A define for `a.b` did not replace `a?.b` or `a["b"]`: `is_dot_define_match` (`src/js_parser/p.rs`) rejected optional chain links and `e_index` never looked up defines. `this` and `process.env["SOME-VAR"]` were rejected as keys.
- A value through a keyword (`import.meta.env`, `this.foo`, `a.if`) became a string literal and `123n` was rejected. A chain value was one symbol named `a.b.c`, so a renamed local left it dangling (#38533), and `FOO = 1` with `--define FOO=123` printed `123 = 1` (#21210).

### Fix
- Port esbuild's shape: `is_dot_define_match` treats `?.` like `.` and accepts a top-level `this`, `e_index` looks up defines like `e_dot`, and `value_for_this` consults the `this` define first.
- `parse_define_key` (`src/js_parser/lib.rs`) parses a key like esbuild's `ParseGlobalName`: an identifier, `this`, or `import.meta`, then `.name` or `["quoted"]` parts. `DefineData::parse` keyword-checks only the first part of a value and accepts BigInt literals.
- `instantiate_define_member_chain` ports `instantiateDefineExpr`: the first part resolves through `find_symbol`, later parts become `E::Dot` nodes. An assignment target takes an identifier or member-chain value, with the chain's last link as the target like the literal, and keeps a constant (`0 = 1` is a syntax error).
- Verified: `test/bundler/bundler_define.test.ts` (new, 166 cases on four surfaces, most fail on the released bun) and the suites in the notes.

### Background
- `Define.dots` holds dotted keys by their last part. `is_dot_define_match` walks an `E::Dot`/`E::Index` chain from the tail against the key parts, down to an unbound identifier, `import.meta`, or `this`.
- Bun rewrites a top-level `this` to `exports` (CommonJS) or `null` (ESM). A define value that starts with `this` gets the same rewrite, like esbuild's bundle mode.

Fixes #21210. Fixes the `?.` cases of #21084; `globalThis.process` stays a separate define, as in esbuild.

<details><summary>Notes</summary>

Repros from the request, on this branch (`bun build --no-bundle`):

```
// --define a.b=c --define a.b.c=d --define 'process.env.NODE_ENV="production"'
console.log(a.b, a?.b, a?.b.c, a.b?.c, a?.["b"], a["b"], process?.env?.NODE_ENV, process.env["NODE_ENV"], process["env"]["NODE_ENV"], process["env"].NODE_ENV);
// -> console.log(c, c, d, d, c, c, "production", "production", "production", "production");

// --define A=import.meta --define B=import.meta.url --define C=this.foo --define F=a.if --define window.env=import.meta.env
console.log(A, B, C, F, window.env);
// -> console.log(import.meta, import.meta.url, exports.foo, a.if, import.meta.env);

// --define this=window --define FOO=123n --define 'process.env["SOME-VAR"]=3'
((g) => console.log(g))(this); console.log(FOO, process.env["SOME-VAR"], process.env['SOME-VAR']);
// -> ((g) => console.log(g))(window);
//    console.log(123n, 3, 3);
```

esbuild prints `this.foo` for the second repro because its transform API is pass-through for `this`. Bun's `--no-bundle` and `Bun.Transpiler` rewrite a top-level `this` like a bundle does, so the define value follows that rewrite. `console.log(function () { return C })` prints `this.foo` on every surface.

Suites run on the debug build: `bundler_define`, `bundler_drop`, `transpiler/transpiler.test.js`, `esbuild/default`, `esbuild/dce`, `esbuild/ts`, `bundler_edgecase`, `bun-build-api`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_minify`, `bundler_jsx`, `bundler_env`, `bundler_bun`, `bundler_splitting`, `cli.test.ts`, `js/bun/transpiler`, `bake/dev-and-prod` (define case), and `test/internal/source-lints`. The ported esbuild tests `default/DefineThis`, `default/DefineOptionalChain`, and `ts/EnumDefine` pass now and lose their `todo`.

Other changes in the same pass:

- `--drop=console` now drops `console["log"]()`, `console[method]()`, and `console[pick()]()`. `e_index` passes the drop flag down to its target like `e_dot` does, and hides the flag while the index is visited so a call inside the index is not dropped instead.
- `--drop=debugger` is no longer also registered as an identifier define. The key parser rejects keywords, and `Define.drop_debugger` already carries it. The two bake call sites skip it the same way.
- `e_import_meta` checks `valueless()` before substituting, like the other visitors.
- `test/bundler/bundler_minify_symbol_for.test.ts` asserted that an unused `Symbol?.for("x")` is kept. `Symbol?.for` now matches the same known global as `Symbol.for`, so the minifier removes the unused call, the same as esbuild (`esbuild --minify-syntax` drops it). The assertion is flipped.
- A non-ASCII index string literal (`a["ключ"]`) is stored as UTF-16 and does not match a define part, as before. Comparing it would copy it to UTF-8 on every visit.
- A runtime `import.meta` define value sets `has_import_meta`, so the CommonJS wrapper receives the `$Bun_import_meta` parameter. Checked with a bunfig `[define]` on a `.cjs` file.
- The runtime transpiler cache is disabled whenever user defines are present (`Arguments.rs`). Without user defines the output changes only through the global side-effect table: an unused `Math?.floor` is now marked removable. Old cache entries stay valid, but `EXPECTED_VERSION` is bumped to 28 anyway, following the precedent of versions 14 and 15 for define table updates.

Open robobun PRs that each cover one slice of this: #28693 (optional chains, plus a `globalThis` base case that esbuild does not have), #33062 (string index access), #38563 (assignment to a constant define), #38533 (symbol resolution for dotted values). This PR supersedes them. Coverage check: the tests of #33062 and #38533 pass on this branch (the two assignment cases of #38533 needed the last-link commit), so both are closed. #28693 stays open for its `globalThis` base case, which this PR does not carry.

An unused define use whose value is a member chain (`FOO;` with `--define FOO=globalThis.config`) is removed, as before this change and as esbuild does: `instantiateDefineExpr` marks the chain `CanBeRemovedIfUnused`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_define.test.ts test/bundler/bundler_drop.test.ts test/bundler/bundler_minify_symbol_for.test.ts test/bundler/esbuild/default.test.ts test/bundler/esbuild/ts.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/176] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/176] gen cpp.rs (cppbind)
[3/176] gen JS modules (bundle-modules)
Preprocess modules (7828ms)
Bundle modules (65ms)
Postprocesss modules (31ms)
Bundle Functions (445ms)
Generate Code (25ms)

[8.40s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/176] cargo bun_runtime → libbun_runtime.a
[14/176] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
FAILED: obj/packages/bun-usockets/src/crypto/openssl.c.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-rtti -fno-omit-frame-pointe
... (truncated)

release without fix: 129 failed, 48 skipped
bun test v1.4.1-canary.1 (d578a8c70)

test/bundler/bundler_minify_symbol_for.test.ts:
(pass) bundler > minify/Symbol.for > minify/SymbolForUnused [11.88ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForNoMinifySyntax [2.96ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForWithWhitespace [2.75ms]
149 |       onAfterBundle(api) {
150 |         const output = api.readFile("/out.js");
151 | 
152 |         // An unused Symbol?.for(...) is removed like Symbol.for(...), as esbuild does.
153 |         // `Symbol?.for("x")` has no side effect whether or not Symbol exists.
154 |         expect(output).not.toContain("optional1");
                                 ^
error: expect(received).not.toContain(expected)

Expected to not contain: "optional1"
Received: "// entry.js\nSymbol?.for(\"optional1\");\nSymbol?.for?.(\"optional2\");\nvar arr = [Symbol.for(\"spread\")], obj = {\n  [Symbol.for(\"key\")]: \"value\"\n};\ncapture(arr, obj);\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_minify_symbol_for.test.ts:154:28)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1602:13)
(fail) bundler > minify/Symbol.for > minify/SymbolForEdgeCase
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 48 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_define.test.ts test/bundler/bundler_drop.test.ts test/bundler/bundler_minify_symbol_for.test.ts test/bundler/esbuild/default.test.ts test/bundler/esbuild/ts.test.ts
bun test v1.4.1 (d578a8c70)

test/bundler/bundler_minify_symbol_for.test.ts:
(pass) bundler > minify/Symbol.for > minify/SymbolForUnused [577.83ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForNoMinifySyntax [101.36ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForWithWhitespace [122.51ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForEdgeCases [129.99ms]
(pass) bundler > minify/Symbol.for > minify/SymbolKeyForNotAffected [105.87ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForProduction [352.30ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForTransformMode [152.06ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForTreeShaking [103.14ms]
(pass) bundler > minify/Symbol.for > minify/SymbolForRuntimeOverride [396.85ms]

test/bundler/bundler_drop.test.ts:
(pass) bundler > drop/FunctionCall [416.81ms]
(pass) bundler 
... (truncated)

release with fix: 48 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     256564262f
  features     baseline

23 deps, 131 codegen, 1172 objects in 609ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (d578a8c70)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (d578a8c70)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] gen bindgenv2
[5/1244] fetch zlib
[zlib] up to date
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (d578a8c70)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen .bind.ts → GeneratedBindings.cpp
[9/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 KB  (entry point)

[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/index.mdx                         |   4 +-
 packages/bun-types/bun.d.ts                    |   5 +-
 src/bundler/defines.rs                         | 202 ++++++++------
 src/js_parser/lib.rs                           | 144 ++++++++--
 src/js_parser/p.rs                             | 149 +++++++---
 src/js_parser/visit/visit_expr.rs              | 118 +++++---
 src/jsc/RuntimeTranspilerCache.rs              |   3 +-
 src/runtime/bake/bake_body.rs                  |   3 +-
 src/runtime/bake/mod.rs                        |   3 +-
 test/bundler/bundler_define.test.ts            | 367 +++++++++++++++++++++++++
 test/bundler/bundler_drop.test.ts              |  18 ++
 test/bundler/bundler_minify_symbol_for.test.ts |   9 +-
 test/bundler/esbuild/default.test.ts           |   2 -
 test/bundler/esbuild/ts.test.ts                |   1 -
 14 files changed, 843 insertions(+), 185 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
docs/bundler/index.mdx                              1      2      0
packages/bun-types/bun.d.ts                         1      1      0
src/bundler/defines.rs                              5      5      0
src/js_parser/lib.rs                                2      4      0
src/js_parser/p.rs                                  7      8      0
src/js_parser/visit/visit_expr.rs                  14     13      0
src/jsc/RuntimeTranspilerCache.rs                   1      1      0
src/runtime/bake/bake_body.rs                       1      2      0
src/runtime/bake/mod.rs                             1      1      0
test/bundler/bundler_define.test.ts                 4      9      0
test/bundler/bundler_drop.test.ts                   1      2      0
test/bundler/bundler_minify_symbol_for.test.ts      1      3      0
test/bundler/esbuild/default.test.ts                0      0      0
test/bundler/esbuild/ts.test.ts                     0      0      0
```

</details>

<!-- robobun:evidence:end -->

