### PR TITLE
tls: read the Linux system CA store the way Node does, in Rust

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs_linux.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs_linux.cpp
@@ -6,191 +6,132 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
+#include <sys/stat.h>
+#include <algorithm>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include <openssl/evp.h>
 #include <openssl/x509.h>
-#include <openssl/x509_vfy.h>
 #include <openssl/pem.h>
 
-// Helper function to load certificates from a directory
-static void load_certs_from_directory(const char* dir_path, STACK_OF(X509)* cert_stack, bool accept_hashed) {
+// The same sources as Node's --use-system-ca (GetOpenSSLSystemCertificates in src/crypto/crypto_context.cc): the file
+// $SSL_CERT_FILE, else X509_get_default_cert_file() (/etc/ssl/cert.pem), and every regular file in $SSL_CERT_DIR, else
+// X509_get_default_cert_dir() (/etc/ssl/certs). Both are always read, symbolic links are followed, names are not
+// filtered, subdirectories are not entered. Distros alias these paths heavily (Debian's /etc/ssl/certs holds a <hash>.0
+// and a <name>.pem link to every root plus the ca-certificates.crt bundle, so Node reports each root three times there),
+// so a file is parsed once per inode and a certificate is kept once per SHA-256 fingerprint.
+struct us_system_cert_loader {
+  STACK_OF(X509)* certs;
+  std::set<std::pair<dev_t, ino_t>> files_read;
+  std::set<std::string> fingerprints;
+
+  // Takes ownership of cert. Frees it when the same certificate is already on the stack.
+  void add(X509* cert) {
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int digest_len = 0;
+    if (!X509_digest(cert, EVP_sha256(), digest, &digest_len) ||
+        !fingerprints.insert(std::string(reinterpret_cast<const char*>(digest), digest_len)).second ||
+        !sk_X509_push(certs, cert)) {
+      X509_free(cert);
+    }
+  }
+};
+
+// Reads every PEM certificate in a regular file. Stops at the first block that is not a certificate, as Node does.
+static void load_certs_from_file(us_system_cert_loader& loader, const char* path) {
+  struct stat st;
+  if (stat(path, &st) != 0 || !S_ISREG(st.st_mode)) {
+    return;
+  }
+  if (!loader.files_read.insert(std::make_pair(st.st_dev, st.st_ino)).second) {
+    return;
+  }
+
+  FILE* file = fopen(path, "r");
+  if (!file) {
+    return;
+  }
+
+  X509* cert;
+  while ((cert = PEM_read_X509(file, NULL, NULL, NULL)) != NULL) {
+    loader.add(cert);
+  }
+  ERR_clear_error();
+
+  fclose(file);
+}
+
+// Reads every regular file in the directory, in name order (the order Node gets from uv_fs_scandir).
+static void load_certs_from_directory(us_system_cert_loader& loader, const char* dir_path) {
   DIR* dir = opendir(dir_path);
   if (!dir) {
     return;
   }
 
+  std::vector<std::string> names;
   struct dirent* entry;
   while ((entry = readdir(dir)) != NULL) {
-    // Skip . and ..
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
       continue;
     }
-
-    // Accept .crt/.pem/.cer everywhere. Optionally also accept OpenSSL
-    // c_rehash-style names (^[0-9a-f]{8}\.[0-9]+$). accept_hashed is on for
-    // Android system stores (which use ONLY that format) and for SSL_CERT_DIR
-    // env-override directories (so a c_rehash-only dir works); it's off for
-    // the built-in /etc/ssl/certs fallback because Debian has both *.pem and
-    // <hash>.0 symlinks to the SAME files there and we'd double-load.
-    const char* ext = strrchr(entry->d_name, '.');
-    if (!ext) continue;
-    bool ok = strcmp(ext, ".crt") == 0 || strcmp(ext, ".pem") == 0 || strcmp(ext, ".cer") == 0;
-    if (!ok && accept_hashed) {
-      size_t prefix = (size_t)(ext - entry->d_name);
-      if (prefix == 8) {
-        ok = true;
-        for (size_t i = 0; i < 8; i++) {
-          char c = entry->d_name[i];
-          if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) { ok = false; break; }
-        }
-        for (const char* p = ext + 1; ok && *p; p++) if (*p < '0' || *p > '9') ok = false;
-        if (ext[1] == '\0') ok = false;
-      }
-    }
-    if (!ok) continue;
-    
-    // Build full path
-    char filepath[PATH_MAX];
-    snprintf(filepath, sizeof(filepath), "%s/%s", dir_path, entry->d_name);
-    
-    // Try to load certificate
-    FILE* file = fopen(filepath, "r");
-    if (file) {
-      X509* cert = PEM_read_X509(file, NULL, NULL, NULL);
-      fclose(file);
-      
-      if (cert) {
-        if (!sk_X509_push(cert_stack, cert)) {
-          X509_free(cert);
-        }
-      }
-    }
+    names.push_back(entry->d_name);
   }
-  
   closedir(dir);
+
+  std::sort(names.begin(), names.end());
+  for (const std::string& name : names) {
+    std::string filepath = std::string(dir_path) + "/" + name;
+    load_certs_from_file(loader, filepath.c_str());
+  }
 }
 
-// Helper function to load certificates from a bundle file
-// Returns how many certificates the bundle contributed.
-static size_t load_certs_from_bundle(const char* bundle_path, STACK_OF(X509)* cert_stack) {
-  FILE* file = fopen(bundle_path, "r");
-  if (!file) {
-    return 0;
-  }
-  
-  size_t loaded = 0;
-  X509* cert;
-  while ((cert = PEM_read_X509(file, NULL, NULL, NULL)) != NULL) {
-    if (!sk_X509_push(cert_stack, cert)) {
-      X509_free(cert);
-      break;
-    }
-    loaded++;
-  }
-  ERR_clear_error();
-  
-  fclose(file);
-  return loaded;
-}
-
-// Main function to load system certificates on Linux and other Unix-like systems
 extern "C" void us_load_system_certificates_linux(STACK_OF(X509) **system_certs) {
   *system_certs = sk_X509_new_null();
   if (*system_certs == NULL) {
     return;
   }
+  us_system_cert_loader loader = { *system_certs, {}, {} };
 
-  // First check environment variables (same as Node.js and OpenSSL)
-  const char* ssl_cert_file = getenv("SSL_CERT_FILE");
-  const char* ssl_cert_dir = getenv("SSL_CERT_DIR");
-  
-  // If SSL_CERT_FILE is set, load from it
-  if (ssl_cert_file && strlen(ssl_cert_file) > 0) {
-    load_certs_from_bundle(ssl_cert_file, *system_certs);
+  // A variable that is set but empty turns that source off, as it does in Node and OpenSSL.
+  const char* cert_file = getenv(X509_get_default_cert_file_env());
+  if (cert_file == NULL) {
+    cert_file = X509_get_default_cert_file();
   }
-  
-  // If SSL_CERT_DIR is set, load from each directory (colon-separated)
-  if (ssl_cert_dir && strlen(ssl_cert_dir) > 0) {
-    char* dir_copy = us_strdup(ssl_cert_dir);
+  if (cert_file[0]) {
+    load_certs_from_file(loader, cert_file);
+  }
+
+  const char* cert_dir = getenv(X509_get_default_cert_dir_env());
+  if (cert_dir != NULL) {
+    // OpenSSL accepts several directories separated by ':' here.
+    char* dir_copy = us_strdup(cert_dir);
     if (dir_copy) {
       char* token = strtok(dir_copy, ":");
       while (token != NULL) {
-        // Skip empty tokens
-        if (strlen(token) > 0) {
-          load_certs_from_directory(token, *system_certs, /*accept_hashed=*/true);
-        }
+        load_certs_from_directory(loader, token);
         token = strtok(NULL, ":");
       }
       us_free(dir_copy);
     }
-  }
-  
-  // If environment variables were set, use only those (even if they yield zero certs)
-  if (ssl_cert_file || ssl_cert_dir) {
     return;
   }
 
-  // Otherwise, load certificates from standard Linux/Unix paths
-  // These are the common locations for system certificates
 #ifdef __ANDROID__
-  // Android: no bundle files. System CAs are individual hashed PEM files.
-  static const char* bundle_paths[] = { NULL };
+  // Android has no OpenSSL layout. The system CAs are one hashed PEM file each in these directories.
   static const char* dir_paths[] = {
     "/apex/com.android.conscrypt/cacerts",  // API 30+ (mainline updatable)
     "/system/etc/security/cacerts",         // base system store
     "/data/misc/user/0/cacerts-added",      // user-installed
     NULL
   };
-#else
-  // Common certificate bundle locations (single file with multiple certs)
-  // These paths are based on common Linux distributions and OpenSSL defaults
-  static const char* bundle_paths[] = {
-    "/etc/ssl/certs/ca-certificates.crt",  // Debian/Ubuntu/Gentoo
-    "/etc/pki/tls/certs/ca-bundle.crt",    // Fedora/RHEL 6
-    "/etc/ssl/ca-bundle.pem",               // OpenSUSE
-    "/etc/pki/tls/cert.pem",                // Fedora/RHEL 7+
-    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  // CentOS/RHEL 7+
-    "/etc/ssl/cert.pem",                    // Alpine Linux, macOS OpenSSL
-    "/usr/local/etc/openssl/cert.pem",      // Homebrew OpenSSL on macOS
-    "/usr/local/share/ca-certificates/ca-certificates.crt", // Custom CA installs
-    NULL
-  };
-
-  // Common certificate directory locations (multiple files)
-  // Note: OpenSSL expects hashed symlinks in directories (c_rehash format)
-  static const char* dir_paths[] = {
-    "/etc/ssl/certs",           // Common location (Debian/Ubuntu with hashed links)
-    "/etc/pki/tls/certs",       // RHEL/Fedora
-    "/usr/share/ca-certificates", // Debian/Ubuntu (original certs, not hashed)
-    "/usr/local/share/certs",   // FreeBSD
-    "/etc/openssl/certs",       // NetBSD
-    "/var/ssl/certs",           // AIX
-    "/usr/local/etc/openssl/certs", // Homebrew OpenSSL on macOS
-    "/System/Library/OpenSSL/certs", // macOS system OpenSSL (older versions)
-    NULL
-  };
-#endif
-  
-  // The distro's bundle is one file that several of these paths usually alias (Fedora/Amazon Linux symlink four of them
-  // to the same tls-ca-bundle.pem, whose contents the hashed directory repeats again), so take the first bundle that
-  // yields certificates — as OpenSSL's default verify paths and Node's --use-system-ca do — and only walk the
-  // directories when no bundle did. The directories are distinct stores (Android: apex, system, user-added), not
-  // aliases, so all of them are read.
-  size_t loaded = 0;
-  for (const char** path = bundle_paths; *path != NULL && !loaded; path++) {
-    loaded = load_certs_from_bundle(*path, *system_certs);
-  }
-  if (loaded) {
-    return;
-  }
-  
-#ifdef __ANDROID__
-  const bool accept_hashed = true;
-#else
-  const bool accept_hashed = false;
-#endif
   for (const char** path = dir_paths; *path != NULL; path++) {
-    load_certs_from_directory(*path, *system_certs, accept_hashed);
+    load_certs_from_directory(loader, *path);
   }
+#else
+  load_certs_from_directory(loader, X509_get_default_cert_dir());
+#endif
 }
 
 #endif // !__APPLE__

--- a/packages/bun-usockets/src/crypto/root_certs_linux.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs_linux.cpp
@@ -2,89 +2,26 @@
 #ifndef __APPLE__
 
 #include "libusockets.h"
-#include <dirent.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <algorithm>
-#include <set>
-#include <string>
-#include <utility>
-#include <vector>
-#include <openssl/evp.h>
+#include <stdint.h>
+#include <openssl/err.h>
 #include <openssl/x509.h>
-#include <openssl/pem.h>
 
-// The same sources as Node's --use-system-ca (GetOpenSSLSystemCertificates in src/crypto/crypto_context.cc): the file
-// $SSL_CERT_FILE, else X509_get_default_cert_file() (/etc/ssl/cert.pem), and every regular file in $SSL_CERT_DIR, else
-// X509_get_default_cert_dir() (/etc/ssl/certs). Both are always read, symbolic links are followed, names are not
-// filtered, subdirectories are not entered. Distros alias these paths heavily (Debian's /etc/ssl/certs holds a <hash>.0
-// and a <name>.pem link to every root plus the ca-certificates.crt bundle, so Node reports each root three times there),
-// so a file is parsed once per inode and a certificate is kept once per SHA-256 fingerprint.
-struct us_system_cert_loader {
-  STACK_OF(X509)* certs;
-  std::set<std::pair<dev_t, ino_t>> files_read;
-  std::set<std::string> fingerprints;
+// src/runtime/socket/system_certs.rs reads the store (environment, directories, files, PEM, duplicates) and hands each
+// distinct certificate's DER encoding to the callback. Only the DER to X509 step needs BoringSSL.
+extern "C" void Bun__forEachSystemCertificate(const char* default_cert_file, const char* default_cert_dir, void* ctx,
+                                              bool (*add)(void* ctx, const uint8_t* der, size_t len));
 
-  // Takes ownership of cert. Frees it when the same certificate is already on the stack.
-  void add(X509* cert) {
-    unsigned char digest[EVP_MAX_MD_SIZE];
-    unsigned int digest_len = 0;
-    if (!X509_digest(cert, EVP_sha256(), digest, &digest_len) ||
-        !fingerprints.insert(std::string(reinterpret_cast<const char*>(digest), digest_len)).second ||
-        !sk_X509_push(certs, cert)) {
-      X509_free(cert);
-    }
+// Returns false when the bytes are not a certificate, which ends the file they came from.
+static bool us_push_system_certificate(void* ctx, const uint8_t* der, size_t len) {
+  X509* cert = d2i_X509(NULL, &der, len);
+  if (cert == NULL) {
+    ERR_clear_error();
+    return false;
   }
-};
-
-// Reads every PEM certificate in a regular file. Stops at the first block that is not a certificate, as Node does.
-static void load_certs_from_file(us_system_cert_loader& loader, const char* path) {
-  struct stat st;
-  if (stat(path, &st) != 0 || !S_ISREG(st.st_mode)) {
-    return;
+  if (!sk_X509_push(static_cast<STACK_OF(X509)*>(ctx), cert)) {
+    X509_free(cert);
   }
-  if (!loader.files_read.insert(std::make_pair(st.st_dev, st.st_ino)).second) {
-    return;
-  }
-
-  FILE* file = fopen(path, "r");
-  if (!file) {
-    return;
-  }
-
-  X509* cert;
-  while ((cert = PEM_read_X509(file, NULL, NULL, NULL)) != NULL) {
-    loader.add(cert);
-  }
-  ERR_clear_error();
-
-  fclose(file);
-}
-
-// Reads every regular file in the directory, in name order (the order Node gets from uv_fs_scandir).
-static void load_certs_from_directory(us_system_cert_loader& loader, const char* dir_path) {
-  DIR* dir = opendir(dir_path);
-  if (!dir) {
-    return;
-  }
-
-  std::vector<std::string> names;
-  struct dirent* entry;
-  while ((entry = readdir(dir)) != NULL) {
-    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
-      continue;
-    }
-    names.push_back(entry->d_name);
-  }
-  closedir(dir);
-
-  std::sort(names.begin(), names.end());
-  for (const std::string& name : names) {
-    std::string filepath = std::string(dir_path) + "/" + name;
-    load_certs_from_file(loader, filepath.c_str());
-  }
+  return true;
 }
 
 extern "C" void us_load_system_certificates_linux(STACK_OF(X509) **system_certs) {
@@ -92,46 +29,8 @@ extern "C" void us_load_system_certificates_linux(STACK_OF(X509) **system_certs)
   if (*system_certs == NULL) {
     return;
   }
-  us_system_cert_loader loader = { *system_certs, {}, {} };
-
-  // A variable that is set but empty turns that source off, as it does in Node and OpenSSL.
-  const char* cert_file = getenv(X509_get_default_cert_file_env());
-  if (cert_file == NULL) {
-    cert_file = X509_get_default_cert_file();
-  }
-  if (cert_file[0]) {
-    load_certs_from_file(loader, cert_file);
-  }
-
-  const char* cert_dir = getenv(X509_get_default_cert_dir_env());
-  if (cert_dir != NULL) {
-    // OpenSSL accepts several directories separated by ':' here.
-    char* dir_copy = us_strdup(cert_dir);
-    if (dir_copy) {
-      char* token = strtok(dir_copy, ":");
-      while (token != NULL) {
-        load_certs_from_directory(loader, token);
-        token = strtok(NULL, ":");
-      }
-      us_free(dir_copy);
-    }
-    return;
-  }
-
-#ifdef __ANDROID__
-  // Android has no OpenSSL layout. The system CAs are one hashed PEM file each in these directories.
-  static const char* dir_paths[] = {
-    "/apex/com.android.conscrypt/cacerts",  // API 30+ (mainline updatable)
-    "/system/etc/security/cacerts",         // base system store
-    "/data/misc/user/0/cacerts-added",      // user-installed
-    NULL
-  };
-  for (const char** path = dir_paths; *path != NULL; path++) {
-    load_certs_from_directory(loader, *path);
-  }
-#else
-  load_certs_from_directory(loader, X509_get_default_cert_dir());
-#endif
+  Bun__forEachSystemCertificate(X509_get_default_cert_file(), X509_get_default_cert_dir(), *system_certs,
+                                us_push_system_certificate);
 }
 
 #endif // !__APPLE__

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -175,6 +175,9 @@ new!(pub REPL_ID: boolean, "REPL_ID", { default: false });
 new!(pub RUNNER_DEBUG: boolean, "RUNNER_DEBUG", { default: false });
 platform_specific_new!(pub SDKROOT: string, posix = "SDKROOT", windows = None, {});
 platform_specific_new!(pub SHELL: string, posix = "SHELL", windows = None, {});
+// OpenSSL's overrides for its default certificate file and directory. Set but empty means none.
+new!(pub SSL_CERT_DIR: string, "SSL_CERT_DIR", {});
+new!(pub SSL_CERT_FILE: string, "SSL_CERT_FILE", {});
 // C:\Windows, for example.
 platform_specific_new!(pub SYSTEMROOT: string, posix = None, windows = "SYSTEMROOT", {});
 platform_specific_new!(pub TEMP: string, posix = "TEMP", windows = "TEMP", {});

--- a/src/runtime/socket/mod.rs
+++ b/src/runtime/socket/mod.rs
@@ -32,6 +32,9 @@ pub mod windows_named_pipe;
 #[path = "WindowsNamedPipeContext.rs"]
 pub mod windows_named_pipe_context;
 
+#[cfg(all(unix, not(target_vendor = "apple")))]
+mod system_certs;
+
 /// Re-export of the canonical `bun_uws::ssl_wrapper` plus the runtime-tier
 /// `init(&SSLConfig, ..)` constructor that the lower tier can't see (it would
 /// need to name `crate::server::server_config::SSLConfig`). The body is the

--- a/src/runtime/socket/system_certs.rs
+++ b/src/runtime/socket/system_certs.rs
@@ -1,23 +1,16 @@
-//! The system certificate store on Linux, read the way Node's `--use-system-ca` reads it
-//! (`GetOpenSSLSystemCertificates` in Node's `src/crypto/crypto_context.cc`): the file `$SSL_CERT_FILE`,
-//! else OpenSSL's default (`/etc/ssl/cert.pem`), then every regular file in `$SSL_CERT_DIR`, else OpenSSL's
-//! default (`/etc/ssl/certs`). Both are always read. A variable that is set but empty turns its source off.
-//! Symbolic links are followed, names are not filtered, subdirectories are not entered, entries are read in
-//! name order.
+//! The Linux system certificate store, read from the same places as Node's `--use-system-ca`
+//! (`GetOpenSSLSystemCertificates` in Node's `src/crypto/crypto_context.cc`): `$SSL_CERT_FILE` or
+//! `/etc/ssl/cert.pem`, plus every regular file in `$SSL_CERT_DIR` or `/etc/ssl/certs`.
 //!
-//! Distros alias these paths heavily. Debian's `/etc/ssl/certs` holds a `<hash>.0` and a `<name>.pem` link
-//! to every root plus the `ca-certificates.crt` bundle, so Node reports each root three times there. Here a
-//! file is read once per inode and a certificate is handed out once per DER encoding, so BoringSSL parses
-//! each root once. The C++ side (`packages/bun-usockets/src/crypto/root_certs_linux.cpp`) turns the DER into
-//! `X509` objects.
+//! Distros link every root several times under `/etc/ssl/certs` next to the bundle, so a file is read once
+//! per inode and a certificate is handed out once per DER encoding. `root_certs_linux.cpp` parses the DER.
 
 use core::ffi::{c_char, c_void};
 
 use bun_core::{ZBox, ZStr, env_var, strings};
 use bun_sys::O;
 
-/// Receives one DER-encoded certificate. Returns false when the bytes are not a certificate, which ends
-/// the file they came from, as a failed `PEM_read_bio_X509` would.
+/// Returns false when the bytes are not a certificate, which ends the file they came from.
 type AddCertificate = unsafe extern "C" fn(ctx: *mut c_void, der: *const u8, len: usize) -> bool;
 
 struct Loader {
@@ -37,8 +30,7 @@ impl Loader {
             .is_none()
     }
 
-    /// The file `$SSL_CERT_FILE` names, or OpenSSL's default file. Opened without a type check, as Node
-    /// does, so a pipe (`SSL_CERT_FILE=<(...)`) works.
+    /// No file type check, as in Node, so `SSL_CERT_FILE` can name a pipe.
     fn load_named_file(&mut self, path: &ZStr) {
         if let Ok(st) = bun_sys::stat(path)
             && !self.first_visit(&st)
@@ -81,11 +73,8 @@ impl Loader {
         }
     }
 
-    /// Hands every certificate block of a PEM file to `add`, with the rules of BoringSSL's PEM reader: a
-    /// block is `-----BEGIN <name>-----`, optional header lines closed by a blank line, base64 lines, and
-    /// `-----END <name>-----`. Blocks with another name are skipped. Reading stops, as `PEM_read_bio_X509`
-    /// would fail, at a bad END line, at a block with headers (an encrypted block), at bad base64, and at
-    /// bytes `add` rejects.
+    /// Follows BoringSSL's `PEM_read_bio_X509`: other block names are skipped, and the file ends at the
+    /// first block that would not parse (bad END line, headers, bad base64, rejected DER).
     fn load_pem(&mut self, bytes: &[u8]) {
         let mut lines = strings::split(bytes, b"\n").map(trim_trailing_space);
         loop {
@@ -161,8 +150,7 @@ fn trim_trailing_space(mut line: &[u8]) -> &[u8] {
 }
 
 /// # Safety
-/// `default_cert_file` and `default_cert_dir` must be valid NUL-terminated C strings. `add` is called with
-/// `ctx` for every distinct certificate, during this call only.
+/// `default_cert_file` and `default_cert_dir` must be valid NUL-terminated C strings.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Bun__forEachSystemCertificate(
     default_cert_file: *const c_char,
@@ -188,8 +176,7 @@ unsafe extern "C" fn Bun__forEachSystemCertificate(
         None => {
             #[cfg(target_os = "android")]
             {
-                // Android has no OpenSSL layout. The system CAs are one hashed PEM file each in these
-                // directories: the updatable mainline store (API 30+), the base system store, and the
+                // Android has no OpenSSL layout: the mainline store (API 30+), the base store, then the
                 // user-installed store.
                 let _ = default_cert_dir;
                 for dir in [

--- a/src/runtime/socket/system_certs.rs
+++ b/src/runtime/socket/system_certs.rs
@@ -88,8 +88,7 @@ impl Loader {
                 }
             };
 
-            // The body is decoded in place from the file buffer. A blank line right after BEGIN is an
-            // empty header. A blank line after other lines makes them a header, which fails as in BoringSSL.
+            // A blank line right after BEGIN is an empty header. One after other lines makes them a header.
             let mut body_start = lines.pos;
             let mut blank_seen = false;
             let body_end = loop {

--- a/src/runtime/socket/system_certs.rs
+++ b/src/runtime/socket/system_certs.rs
@@ -1,0 +1,216 @@
+//! The system certificate store on Linux, read the way Node's `--use-system-ca` reads it
+//! (`GetOpenSSLSystemCertificates` in Node's `src/crypto/crypto_context.cc`): the file `$SSL_CERT_FILE`,
+//! else OpenSSL's default (`/etc/ssl/cert.pem`), then every regular file in `$SSL_CERT_DIR`, else OpenSSL's
+//! default (`/etc/ssl/certs`). Both are always read. A variable that is set but empty turns its source off.
+//! Symbolic links are followed, names are not filtered, subdirectories are not entered, entries are read in
+//! name order.
+//!
+//! Distros alias these paths heavily. Debian's `/etc/ssl/certs` holds a `<hash>.0` and a `<name>.pem` link
+//! to every root plus the `ca-certificates.crt` bundle, so Node reports each root three times there. Here a
+//! file is read once per inode and a certificate is handed out once per DER encoding, so BoringSSL parses
+//! each root once. The C++ side (`packages/bun-usockets/src/crypto/root_certs_linux.cpp`) turns the DER into
+//! `X509` objects.
+
+use core::ffi::{c_char, c_void};
+
+use bun_core::{ZBox, ZStr, env_var, strings};
+use bun_sys::O;
+
+/// Receives one DER-encoded certificate. Returns false when the bytes are not a certificate, which ends
+/// the file they came from, as a failed `PEM_read_bio_X509` would.
+type AddCertificate = unsafe extern "C" fn(ctx: *mut c_void, der: *const u8, len: usize) -> bool;
+
+struct Loader {
+    ctx: *mut c_void,
+    add: AddCertificate,
+    /// `(st_dev, st_ino)` of every file already read.
+    files_read: bun_collections::HashMap<(u64, u64), ()>,
+    /// The DER encoding of every certificate already handed out.
+    certificates: bun_collections::HashMap<Vec<u8>, ()>,
+}
+
+impl Loader {
+    /// Marks the file as read. Returns false when it was read before under another name.
+    fn first_visit(&mut self, st: &bun_sys::Stat) -> bool {
+        self.files_read
+            .insert((st.st_dev as u64, st.st_ino as u64), ())
+            .is_none()
+    }
+
+    /// The file `$SSL_CERT_FILE` names, or OpenSSL's default file. Opened without a type check, as Node
+    /// does, so a pipe (`SSL_CERT_FILE=<(...)`) works.
+    fn load_named_file(&mut self, path: &ZStr) {
+        if let Ok(st) = bun_sys::stat(path)
+            && !self.first_visit(&st)
+        {
+            return;
+        }
+        let Ok(file) = bun_sys::File::open(path, O::RDONLY | O::CLOEXEC, 0) else {
+            return;
+        };
+        let mut bytes = Vec::new();
+        if file.read_to_end_into(&mut bytes).is_err() {
+            return;
+        }
+        self.load_pem(&bytes);
+    }
+
+    /// Every regular file in the directory, in name order.
+    fn load_directory(&mut self, dir_path: &[u8]) {
+        let Ok(dir) = bun_sys::Dir::open(dir_path) else {
+            return;
+        };
+        let mut names: Vec<ZBox> = Vec::new();
+        let mut entries = bun_sys::dir_iterator::iterate(dir.fd());
+        while let Ok(Some(entry)) = entries.next() {
+            names.push(ZBox::from_bytes(entry.name.slice_u8()));
+        }
+        names.sort_unstable_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+
+        for name in &names {
+            let Ok(st) = bun_sys::fstatat(dir.fd(), name) else {
+                continue;
+            };
+            if !bun_sys::is_regular_file(st.st_mode as bun_sys::Mode) || !self.first_visit(&st) {
+                continue;
+            }
+            let Ok(bytes) = bun_sys::File::read_from(dir.fd(), name.as_bytes()) else {
+                continue;
+            };
+            self.load_pem(&bytes);
+        }
+    }
+
+    /// Hands every certificate block of a PEM file to `add`, with the rules of BoringSSL's PEM reader: a
+    /// block is `-----BEGIN <name>-----`, optional header lines closed by a blank line, base64 lines, and
+    /// `-----END <name>-----`. Blocks with another name are skipped. Reading stops, as `PEM_read_bio_X509`
+    /// would fail, at a bad END line, at a block with headers (an encrypted block), at bad base64, and at
+    /// bytes `add` rejects.
+    fn load_pem(&mut self, bytes: &[u8]) {
+        let mut lines = strings::split(bytes, b"\n").map(trim_trailing_space);
+        loop {
+            let name = loop {
+                let Some(line) = lines.next() else {
+                    return;
+                };
+                if let Some(rest) = line.strip_prefix(b"-----BEGIN ")
+                    && let Some(name) = rest.strip_suffix(b"-----")
+                {
+                    break name;
+                }
+            };
+
+            let mut section: Vec<u8> = Vec::new();
+            let mut header_len: Option<usize> = None;
+            let end_line = loop {
+                let Some(line) = lines.next() else {
+                    return;
+                };
+                if line.starts_with(b"-----END ") {
+                    break line;
+                }
+                if line.is_empty() && header_len.is_none() {
+                    header_len = Some(section.len());
+                    continue;
+                }
+                section.extend_from_slice(line);
+                section.push(b'\n');
+            };
+            let end_ok = end_line
+                .strip_prefix(b"-----END ")
+                .and_then(|rest| rest.strip_prefix(name))
+                .is_some_and(|rest| rest == b"-----");
+            if !end_ok {
+                return;
+            }
+
+            if name != b"CERTIFICATE" && name != b"X509 CERTIFICATE" {
+                continue;
+            }
+            let (header, body) = match header_len {
+                Some(len) => section.split_at(len),
+                None => (&[][..], &section[..]),
+            };
+            if !header.is_empty() {
+                return;
+            }
+            let der = match bun_base64::decode_alloc(body) {
+                Ok(der) if !der.is_empty() => der,
+                _ => return,
+            };
+            if self.certificates.contains_key(der.as_slice()) {
+                continue;
+            }
+            // SAFETY: `add` and `ctx` come from the C++ caller, which keeps `ctx` alive for the whole call.
+            if !unsafe { (self.add)(self.ctx, der.as_ptr(), der.len()) } {
+                return;
+            }
+            self.certificates.insert(der, ());
+        }
+    }
+}
+
+/// BoringSSL's PEM reader drops every trailing byte that is not above ' '.
+fn trim_trailing_space(mut line: &[u8]) -> &[u8] {
+    while let [rest @ .., last] = line
+        && *last <= b' '
+    {
+        line = rest;
+    }
+    line
+}
+
+/// # Safety
+/// `default_cert_file` and `default_cert_dir` must be valid NUL-terminated C strings. `add` is called with
+/// `ctx` for every distinct certificate, during this call only.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Bun__forEachSystemCertificate(
+    default_cert_file: *const c_char,
+    default_cert_dir: *const c_char,
+    ctx: *mut c_void,
+    add: AddCertificate,
+) {
+    let mut loader = Loader {
+        ctx,
+        add,
+        files_read: bun_collections::HashMap::new(),
+        certificates: bun_collections::HashMap::new(),
+    };
+
+    match env_var::SSL_CERT_FILE::get() {
+        // SAFETY: caller contract guarantees a valid NUL-terminated string.
+        None => loader.load_named_file(unsafe { ZStr::from_c_ptr(default_cert_file) }),
+        Some(b"") => {}
+        Some(path) => loader.load_named_file(ZBox::from_bytes(path).as_zstr()),
+    }
+
+    match env_var::SSL_CERT_DIR::get() {
+        None => {
+            #[cfg(target_os = "android")]
+            {
+                // Android has no OpenSSL layout. The system CAs are one hashed PEM file each in these
+                // directories: the updatable mainline store (API 30+), the base system store, and the
+                // user-installed store.
+                let _ = default_cert_dir;
+                for dir in [
+                    &b"/apex/com.android.conscrypt/cacerts"[..],
+                    b"/system/etc/security/cacerts",
+                    b"/data/misc/user/0/cacerts-added",
+                ] {
+                    loader.load_directory(dir);
+                }
+            }
+            #[cfg(not(target_os = "android"))]
+            {
+                // SAFETY: caller contract guarantees a valid NUL-terminated string.
+                loader.load_directory(unsafe { ZStr::from_c_ptr(default_cert_dir) }.as_bytes());
+            }
+        }
+        // OpenSSL accepts several directories separated by ':' here.
+        Some(dirs) => {
+            for dir in strings::tokenize(dirs, b":") {
+                loader.load_directory(dir);
+            }
+        }
+    }
+}

--- a/src/runtime/socket/system_certs.rs
+++ b/src/runtime/socket/system_certs.rs
@@ -18,6 +18,8 @@ struct Loader {
     files_read: bun_collections::HashMap<(u64, u64), ()>,
     /// The DER encoding of every certificate already handed out.
     certificates: bun_collections::HashMap<Vec<u8>, ()>,
+    /// Decode buffer, reused across blocks.
+    der: Vec<u8>,
 }
 
 impl Loader {
@@ -73,10 +75,10 @@ impl Loader {
 
     /// As `PEM_read_bio_X509`: other block names are skipped, the file ends at the first block that fails.
     fn load_pem(&mut self, bytes: &[u8]) {
-        let mut lines = strings::split(bytes, b"\n").map(trim_trailing_space);
+        let mut lines = Lines { bytes, pos: 0 };
         loop {
             let name = loop {
-                let Some(line) = lines.next() else {
+                let Some((_, line)) = lines.next() else {
                     return;
                 };
                 if let Some(rest) = line.strip_prefix(b"-----BEGIN ")
@@ -86,64 +88,82 @@ impl Loader {
                 }
             };
 
-            let mut section: Vec<u8> = Vec::new();
-            let mut header_len: Option<usize> = None;
-            let end_line = loop {
-                let Some(line) = lines.next() else {
+            // The body is decoded in place from the file buffer. A blank line right after BEGIN is an
+            // empty header. A blank line after other lines makes them a header, which fails as in BoringSSL.
+            let mut body_start = lines.pos;
+            let mut blank_seen = false;
+            let body_end = loop {
+                let Some((start, line)) = lines.next() else {
                     return;
                 };
-                if line.starts_with(b"-----END ") {
-                    break line;
+                if let Some(rest) = line.strip_prefix(b"-----END ") {
+                    if rest.strip_prefix(name) != Some(b"-----") {
+                        return;
+                    }
+                    break start;
                 }
-                if line.is_empty() && header_len.is_none() {
-                    header_len = Some(section.len());
-                    continue;
+                if line.is_empty() && !blank_seen {
+                    blank_seen = true;
+                    if start != body_start {
+                        return;
+                    }
+                    body_start = lines.pos;
                 }
-                section.extend_from_slice(line);
-                section.push(b'\n');
             };
-            let end_ok = end_line
-                .strip_prefix(b"-----END ")
-                .and_then(|rest| rest.strip_prefix(name))
-                .is_some_and(|rest| rest == b"-----");
-            if !end_ok {
-                return;
-            }
 
             if name != b"CERTIFICATE" && name != b"X509 CERTIFICATE" {
                 continue;
             }
-            let (header, body) = match header_len {
-                Some(len) => section.split_at(len),
-                None => (&[][..], &section[..]),
-            };
-            if !header.is_empty() {
+            if !self.decode(&bytes[body_start..body_end]) {
                 return;
             }
-            let der = match bun_base64::decode_alloc(body) {
-                Ok(der) if !der.is_empty() => der,
-                _ => return,
-            };
-            if self.certificates.contains_key(der.as_slice()) {
+            if self.certificates.contains_key(self.der.as_slice()) {
                 continue;
             }
             // SAFETY: `add` and `ctx` come from the C++ caller, which keeps `ctx` alive for the whole call.
-            if !unsafe { (self.add)(self.ctx, der.as_ptr(), der.len()) } {
+            if !unsafe { (self.add)(self.ctx, self.der.as_ptr(), self.der.len()) } {
                 return;
             }
-            self.certificates.insert(der, ());
+            self.certificates.insert(self.der.clone(), ());
         }
+    }
+
+    /// Decodes one base64 body into `self.der`. The decoder skips whitespace, so the line breaks stay in.
+    fn decode(&mut self, body: &[u8]) -> bool {
+        self.der.clear();
+        self.der.resize(bun_base64::decode_len(body), 0);
+        let result = bun_base64::decode(&mut self.der, body);
+        if !result.is_successful() || result.count == 0 {
+            return false;
+        }
+        self.der.truncate(result.count);
+        true
     }
 }
 
-/// BoringSSL's PEM reader drops every trailing byte that is not above ' '.
-fn trim_trailing_space(mut line: &[u8]) -> &[u8] {
-    while let [rest @ .., last] = line
-        && *last <= b' '
-    {
-        line = rest;
+/// Lines of a file as `(offset, line)`, trailing bytes up to `' '` removed as BoringSSL's PEM reader does.
+struct Lines<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Lines<'a> {
+    fn next(&mut self) -> Option<(usize, &'a [u8])> {
+        let start = self.pos;
+        if start >= self.bytes.len() {
+            return None;
+        }
+        let end = strings::index_of_char_usize(&self.bytes[start..], b'\n')
+            .map_or(self.bytes.len(), |i| start + i);
+        self.pos = end + 1;
+        let mut line = &self.bytes[start..end];
+        while let [rest @ .., last] = line
+            && *last <= b' '
+        {
+            line = rest;
+        }
+        Some((start, line))
     }
-    line
 }
 
 /// Safety: `default_cert_file` and `default_cert_dir` must be valid NUL-terminated C strings.
@@ -159,6 +179,7 @@ unsafe extern "C" fn Bun__forEachSystemCertificate(
         add,
         files_read: bun_collections::HashMap::new(),
         certificates: bun_collections::HashMap::new(),
+        der: Vec::new(),
     };
 
     match env_var::SSL_CERT_FILE::get() {

--- a/src/runtime/socket/system_certs.rs
+++ b/src/runtime/socket/system_certs.rs
@@ -1,9 +1,7 @@
 //! The Linux system certificate store, read from the same places as Node's `--use-system-ca`
-//! (`GetOpenSSLSystemCertificates` in Node's `src/crypto/crypto_context.cc`): `$SSL_CERT_FILE` or
-//! `/etc/ssl/cert.pem`, plus every regular file in `$SSL_CERT_DIR` or `/etc/ssl/certs`.
-//!
-//! Distros link every root several times under `/etc/ssl/certs` next to the bundle, so a file is read once
-//! per inode and a certificate is handed out once per DER encoding. `root_certs_linux.cpp` parses the DER.
+//! (`GetOpenSSLSystemCertificates`): `$SSL_CERT_FILE` or `/etc/ssl/cert.pem`, plus every regular file in
+//! `$SSL_CERT_DIR` or `/etc/ssl/certs`. Each file is read once per inode and each certificate is handed to
+//! `root_certs_linux.cpp` once per DER encoding, because distros link every root several times there.
 
 use core::ffi::{c_char, c_void};
 
@@ -73,8 +71,7 @@ impl Loader {
         }
     }
 
-    /// Follows BoringSSL's `PEM_read_bio_X509`: other block names are skipped, and the file ends at the
-    /// first block that would not parse (bad END line, headers, bad base64, rejected DER).
+    /// As `PEM_read_bio_X509`: other block names are skipped, the file ends at the first block that fails.
     fn load_pem(&mut self, bytes: &[u8]) {
         let mut lines = strings::split(bytes, b"\n").map(trim_trailing_space);
         loop {
@@ -149,8 +146,7 @@ fn trim_trailing_space(mut line: &[u8]) -> &[u8] {
     line
 }
 
-/// # Safety
-/// `default_cert_file` and `default_cert_dir` must be valid NUL-terminated C strings.
+/// Safety: `default_cert_file` and `default_cert_dir` must be valid NUL-terminated C strings.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Bun__forEachSystemCertificate(
     default_cert_file: *const c_char,
@@ -176,8 +172,7 @@ unsafe extern "C" fn Bun__forEachSystemCertificate(
         None => {
             #[cfg(target_os = "android")]
             {
-                // Android has no OpenSSL layout: the mainline store (API 30+), the base store, then the
-                // user-installed store.
+                // Android has no OpenSSL layout: mainline store (API 30+), base store, user-installed store.
                 let _ = default_cert_dir;
                 for dir in [
                     &b"/apex/com.android.conscrypt/cacerts"[..],

--- a/src/runtime/socket/system_certs.rs
+++ b/src/runtime/socket/system_certs.rs
@@ -88,9 +88,9 @@ impl Loader {
                 }
             };
 
-            // A blank line right after BEGIN is an empty header. One after other lines makes them a header.
-            let mut body_start = lines.pos;
-            let mut blank_seen = false;
+            // The lines before the first blank line are the header, the rest up to END is the body.
+            let block_start = lines.pos;
+            let mut first_blank: Option<(usize, usize)> = None;
             let body_end = loop {
                 let Some((start, line)) = lines.next() else {
                     return;
@@ -101,19 +101,20 @@ impl Loader {
                     }
                     break start;
                 }
-                if line.is_empty() && !blank_seen {
-                    blank_seen = true;
-                    if start != body_start {
-                        return;
-                    }
-                    body_start = lines.pos;
+                if line.is_empty() && first_blank.is_none() {
+                    first_blank = Some((start, lines.pos));
                 }
             };
+            let body_start = first_blank.map_or(block_start, |(_, after_blank)| after_blank);
+            let has_header = first_blank.is_some_and(|(blank, _)| blank != block_start);
 
+            if !self.decode(&bytes[body_start..body_end]) {
+                return;
+            }
             if name != b"CERTIFICATE" && name != b"X509 CERTIFICATE" {
                 continue;
             }
-            if !self.decode(&bytes[body_start..body_end]) {
+            if has_header {
                 return;
             }
             if self.certificates.contains_key(self.der.as_slice()) {

--- a/test/js/node/tls/test-use-system-ca.test.ts
+++ b/test/js/node/tls/test-use-system-ca.test.ts
@@ -1,7 +1,9 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
-import { existsSync } from "node:fs";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { X509Certificate } from "node:crypto";
+import { existsSync, readFileSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 
 describe("--use-system-ca", () => {
   test("flag loads system certificates", async () => {
@@ -69,36 +71,75 @@ describe("--use-system-ca", () => {
   });
 });
 
-describe("tls.getCACertificates('system')", () => {
-  // Distros alias several well-known bundle paths (and the hashed cert directory) to one file; each system root must be
-  // reported once, not once per alias.
-  test.skipIf(process.platform !== "linux")("reports each system root once", async () => {
-    const knownBundles = [
-      "/etc/ssl/certs/ca-certificates.crt",
-      "/etc/pki/tls/certs/ca-bundle.crt",
-      "/etc/ssl/ca-bundle.pem",
-      "/etc/pki/tls/cert.pem",
-      "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
-      "/etc/ssl/cert.pem",
-    ];
-    const hasBundle = knownBundles.some(p => existsSync(p));
+// On Linux the loader reads what Node's --use-system-ca reads: $SSL_CERT_FILE (else /etc/ssl/cert.pem) and every
+// regular file in $SSL_CERT_DIR (else /etc/ssl/certs). Unlike Node it reports each certificate once.
+describe.skipIf(!isLinux)("tls.getCACertificates('system')", () => {
+  const fixtureCert = (name: string) =>
+    readFileSync(join(import.meta.dir, "../test/fixtures/keys", `${name}-cert.pem`), "utf8");
+  const fingerprint = (pem: string) => new X509Certificate(pem).fingerprint256;
+
+  async function systemFingerprints(env: Record<string, string | undefined>): Promise<string[]> {
     await using proc = spawn({
       cmd: [
         bunExe(),
         "-e",
-        `const certs = require("tls").getCACertificates("system");
-         const unique = new Set(certs);
-         console.log(JSON.stringify({ total: certs.length, unique: unique.size }));`,
+        `const { X509Certificate } = require("crypto");
+         const certs = require("tls").getCACertificates("system");
+         console.log(JSON.stringify(certs.map(pem => new X509Certificate(pem).fingerprint256)));`,
       ],
-      env: { ...bunEnv, SSL_CERT_FILE: undefined, SSL_CERT_DIR: undefined },
+      env: { ...bunEnv, SSL_CERT_FILE: undefined, SSL_CERT_DIR: undefined, ...env },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const { total, unique } = JSON.parse(stdout.trim());
-    if (hasBundle) expect(total).toBeGreaterThan(0);
-    expect(total).toBe(unique);
     expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  test("reports each system root once", async () => {
+    const hasDefaultStore = existsSync("/etc/ssl/cert.pem") || existsSync("/etc/ssl/certs");
+    const fingerprints = await systemFingerprints({});
+    if (hasDefaultStore) expect(fingerprints.length).toBeGreaterThan(0);
+    expect(new Set(fingerprints).size).toBe(fingerprints.length);
+  });
+
+  test("reads SSL_CERT_FILE and every regular file in SSL_CERT_DIR, each certificate once", async () => {
+    const [ca1, ca2, ca3, ca4, ca5, ca6, leaf] = ["ca1", "ca2", "ca3", "ca4", "ca5", "ca6", "agent1"].map(fixtureCert);
+    using dir = tempDir("system-ca", {
+      "bundle.pem": ca1 + ca2,
+      certs: {
+        "a-again.pem": ca1, // already in the bundle
+        "c.pem": ca3,
+        "multi.crt": ca5 + ca6, // every certificate in a file, not only the first
+        "noext": ca4, // names are not filtered
+        "README": "not a certificate\n",
+        sub: { "d.pem": leaf }, // subdirectories are not entered
+      },
+    });
+    // A second name for the same file.
+    symlinkSync("c.pem", join(String(dir), "certs", "c-alias.pem"));
+
+    const fingerprints = await systemFingerprints({
+      SSL_CERT_FILE: join(String(dir), "bundle.pem"),
+      SSL_CERT_DIR: join(String(dir), "certs"),
+    });
+    // The file first, then the directory in name order: a-again.pem (dropped), c-alias.pem, c.pem (same file,
+    // skipped), multi.crt, noext.
+    expect(fingerprints).toEqual([ca1, ca2, ca3, ca5, ca6, ca4].map(fingerprint));
+
+    // A variable that is set but empty turns that source off.
+    expect(await systemFingerprints({ SSL_CERT_FILE: join(String(dir), "bundle.pem"), SSL_CERT_DIR: "" })).toEqual(
+      [ca1, ca2].map(fingerprint),
+    );
+  });
+
+  test.skipIf(!existsSync("/etc/ssl/certs"))("SSL_CERT_FILE alone keeps the default directory", async () => {
+    using dir = tempDir("system-ca-file", { "bundle.pem": fixtureCert("ca1") });
+    const bundle = join(String(dir), "bundle.pem");
+    const withDefaultDir = await systemFingerprints({ SSL_CERT_FILE: bundle });
+    const withExplicitDir = await systemFingerprints({ SSL_CERT_FILE: bundle, SSL_CERT_DIR: "/etc/ssl/certs" });
+    expect(withDefaultDir[0]).toBe(fingerprint(fixtureCert("ca1")));
+    expect(withDefaultDir).toEqual(withExplicitDir);
   });
 });

--- a/test/js/node/tls/test-use-system-ca.test.ts
+++ b/test/js/node/tls/test-use-system-ca.test.ts
@@ -94,8 +94,9 @@ describe.skipIf(!isLinux)("tls.getCACertificates('system')", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
+    const fingerprints = JSON.parse(stdout);
     expect(exitCode).toBe(0);
-    return JSON.parse(stdout);
+    return fingerprints;
   }
 
   test("reports each system root once", async () => {

--- a/test/js/node/tls/test-use-system-ca.test.ts
+++ b/test/js/node/tls/test-use-system-ca.test.ts
@@ -78,7 +78,7 @@ describe.skipIf(!isLinux)("tls.getCACertificates('system')", () => {
     readFileSync(join(import.meta.dir, "../test/fixtures/keys", `${name}-cert.pem`), "utf8");
   const fingerprint = (pem: string) => new X509Certificate(pem).fingerprint256;
 
-  async function systemFingerprints(env: Record<string, string | undefined>): Promise<string[]> {
+  async function systemFingerprints(env: Record<string, string | undefined>, stdin?: Blob): Promise<string[]> {
     await using proc = spawn({
       cmd: [
         bunExe(),
@@ -88,6 +88,7 @@ describe.skipIf(!isLinux)("tls.getCACertificates('system')", () => {
          console.log(JSON.stringify(certs.map(pem => new X509Certificate(pem).fingerprint256)));`,
       ],
       env: { ...bunEnv, SSL_CERT_FILE: undefined, SSL_CERT_DIR: undefined, ...env },
+      stdin,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -132,6 +133,12 @@ describe.skipIf(!isLinux)("tls.getCACertificates('system')", () => {
     expect(await systemFingerprints({ SSL_CERT_FILE: join(String(dir), "bundle.pem"), SSL_CERT_DIR: "" })).toEqual(
       [ca1, ca2].map(fingerprint),
     );
+  });
+
+  test("SSL_CERT_FILE can be a pipe", async () => {
+    const ca1 = fixtureCert("ca1");
+    const fingerprints = await systemFingerprints({ SSL_CERT_FILE: "/dev/stdin", SSL_CERT_DIR: "" }, new Blob([ca1]));
+    expect(fingerprints).toEqual([fingerprint(ca1)]);
   });
 
   test.skipIf(!existsSync("/etc/ssl/certs"))("SSL_CERT_FILE alone keeps the default directory", async () => {

--- a/test/js/node/tls/test-use-system-ca.test.ts
+++ b/test/js/node/tls/test-use-system-ca.test.ts
@@ -107,16 +107,32 @@ describe.skipIf(!isLinux)("tls.getCACertificates('system')", () => {
   });
 
   test("reads SSL_CERT_FILE and every regular file in SSL_CERT_DIR, each certificate once", async () => {
-    const [ca1, ca2, ca3, ca4, ca5, ca6, leaf] = ["ca1", "ca2", "ca3", "ca4", "ca5", "ca6", "agent1"].map(fixtureCert);
+    const [ca1, ca2, ca3, ca4, ca5, ca6, leaf1, leaf2, leaf3] = [
+      "ca1",
+      "ca2",
+      "ca3",
+      "ca4",
+      "ca5",
+      "ca6",
+      "agent1",
+      "agent2",
+      "agent3",
+    ].map(fixtureCert);
+    // An encrypted key block carries header lines. PEM_read_bio_X509 decodes it, then skips it by name.
+    const encryptedKey =
+      "-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,00112233445566778899AABBCCDDEEFF\n\nQUJDREVGR0hJSktMTU5PUA==\n-----END RSA PRIVATE KEY-----\n";
+    const badBlock = "-----BEGIN PRIVATE KEY-----\n!!! not base64 !!!\n-----END PRIVATE KEY-----\n";
     using dir = tempDir("system-ca", {
       "bundle.pem": ca1 + ca2,
       certs: {
         "a-again.pem": ca1, // already in the bundle
+        "bad-block.pem": badBlock + leaf2, // a block that does not decode ends the file, whatever its name
         "c.pem": ca3,
+        "encrypted-key.pem": encryptedKey + leaf3, // a block with another name is skipped, headers and all
         "multi.crt": ca5 + ca6, // every certificate in a file, not only the first
         "noext": ca4, // names are not filtered
         "README": "not a certificate\n",
-        sub: { "d.pem": leaf }, // subdirectories are not entered
+        sub: { "d.pem": leaf1 }, // subdirectories are not entered
       },
     });
     // A second name for the same file.
@@ -126,9 +142,9 @@ describe.skipIf(!isLinux)("tls.getCACertificates('system')", () => {
       SSL_CERT_FILE: join(String(dir), "bundle.pem"),
       SSL_CERT_DIR: join(String(dir), "certs"),
     });
-    // The file first, then the directory in name order: a-again.pem (dropped), c-alias.pem, c.pem (same file,
-    // skipped), multi.crt, noext.
-    expect(fingerprints).toEqual([ca1, ca2, ca3, ca5, ca6, ca4].map(fingerprint));
+    // The file first, then the directory in name order: a-again.pem (dropped), bad-block.pem (nothing),
+    // c-alias.pem, c.pem (same file, skipped), encrypted-key.pem, multi.crt, noext.
+    expect(fingerprints).toEqual([ca1, ca2, ca3, leaf3, ca5, ca6, ca4].map(fingerprint));
 
     // A variable that is set but empty turns that source off.
     expect(await systemFingerprints({ SSL_CERT_FILE: join(String(dir), "bundle.pem"), SSL_CERT_DIR: "" })).toEqual(


### PR DESCRIPTION
### Problem
- #40825 made the Linux loader take the first well-known bundle and skip the directories, and called that Node's behavior. Node reads one file and one directory, always both (`GetOpenSSLSystemCertificates`, `src/crypto/crypto_context.cc`): `$SSL_CERT_FILE`, else `/etc/ssl/cert.pem`, and every regular file in `$SSL_CERT_DIR`, else `/etc/ssl/certs`.
- A certificate that is only in `/etc/ssl/certs` was a system CA for Node and not for Bun. Bun also treated either variable as "use only the variables".

### Fix
- The store is now read in Rust, `src/runtime/socket/system_certs.rs`, with `bun_sys`, under Node's rules: both sources, a set but empty variable turns its source off, no name filter, symbolic links followed, no recursion, name order.
- Each certificate is parsed once. A file is read once per inode, and each distinct DER encoding goes once to a 35 line C++ callback (`root_certs_linux.cpp`, `d2i_X509`). Node returns duplicates (453 entries for 152 roots on Debian 13). The distinct set and its order match Node's.
- `SSL_CERT_DIR` still takes several directories separated by `:`, as in OpenSSL. `SSL_CERT_FILE` can name a pipe, as in Node.
- Verified: `test/js/node/tls/test-use-system-ca.test.ts` (two new cases fail on main), the other TLS CA tests in `test/js/node/tls`, `regression/issue/24339`, Node's 10 `test-tls-get-ca-certificates*.js`.

### Background
- `tls.getCACertificates('system')` and `--use-system-ca` expose the OS trust store. On Linux, Node defines it as OpenSSL's default verify locations, `X509_get_default_cert_file()` and `X509_get_default_cert_dir()`, under `/etc/ssl` in both Node's OpenSSL and BoringSSL.
- Debian's `/etc/ssl/certs` holds a `<hash>.0` and a `<name>.pem` link to every root plus the `ca-certificates.crt` bundle, so a plain walk reads every root three times.
- Duplicates never changed what a connection trusts. `X509_STORE_add_cert` ignores a certificate it already holds.

<details><summary>Notes</summary>

Measured on this Debian 13 container, `tls.getCACertificates('system')`, no `SSL_CERT_*` variables set:

| | entries | distinct | X509 parses |
|---|---|---|---|
| Node v26.3.0 | 453 | 152 | 453 |
| Bun 1.4.1 (before #40825) | 303 | 152 | 303 |
| main (#40825) | 151 | 151 | 151 |
| this PR | 152 | 152 | 152 |

The 152nd certificate is `/etc/ssl/certs/ssl-cert-snakeoil.pem` (Debian's `ssl-cert` package, CN=localhost). It is a regular file in the directory and not in the bundle. Node reports it, #40825 did not. The SHA-256 fingerprints of this PR's output and Node's output are identical, in the same first-occurrence order.

Remaining cost over #40825 on Debian 13: one `stat` and one read per directory entry (303 entries, 152 distinct inodes), and a base64 decode per PEM block (453). In the debug (ASAN) build the call went from 53 ms to 66 ms. I did not measure a release build.

The PEM split follows BoringSSL's reader: `-----BEGIN <name>-----`, optional header lines closed by a blank line, base64, `-----END <name>-----`. Every block is decoded, then blocks with another name are skipped. A bad END line, bad base64, a certificate block with headers, or DER that `d2i_X509` rejects ends the file, as `PEM_read_bio_X509` would. Checked against Node on 14 crafted files.

Node behavior that is not copied: Node prints `Cannot open directory ... to load OpenSSL certificates.` to stderr when the directory cannot be opened. Bun stays silent, as before. Node also passes `SSL_CERT_DIR` through unsplit.

The Rust module lives in `bun_runtime`, which already depends on `bun_sys`, `bun_base64` and `bun_collections`, so `Cargo.lock` does not change.

Node source: `GetOpenSSLSystemCertificates` and `LoadCertsFromDir` in `src/crypto/crypto_context.cc` (nodejs/node@4215cc35e25c44f9f4fea5a4541afc862db7ef0a, lines 795-861).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/test-use-system-ca.test.ts

<!-- robobun:evidence:end -->