### PR TITLE
js_parser: report delete of a bare identifier in strict mode

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4222,6 +4222,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         detail: &[u8],
     ) -> Result<(), crate::Error> {
         let text: &'a [u8] = match feature {
+            StrictModeFeature::DeleteBareName => b"\"delete\" of a bare identifier",
             StrictModeFeature::EvalOrArguments => bun_alloc::arena_format!(
                 in self.arena,
                 "Declarations with the name \"{}\"",

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1054,6 +1054,7 @@ pub struct ParsedPath<'a> {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum StrictModeFeature {
+    DeleteBareName,
     EvalOrArguments,
     ReservedWord,
 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1218,6 +1218,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             Op::UnDelete => {
+                if matches!(e_.value.data, Data::EIdentifier(..)) {
+                    p.mark_strict_mode_feature(
+                        StrictModeFeature::DeleteBareName,
+                        js_lexer::range_of_identifier(p.source, e_.value.loc),
+                        b"",
+                    )
+                    .expect("unreachable");
+                }
                 p.visit_expr_in_out(&mut e_.value, ExprIn::default());
             }
             _ => {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3275,6 +3275,103 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+  // `delete x` on a bare identifier is an early SyntaxError in strict mode, and
+  // every ES module is strict. Report it where the source is, like esbuild does,
+  // instead of emitting output that fails to parse.
+  itBundled("edgecase/DeleteBareIdentifierInESModuleIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        import { y } from "./y.js";
+        var x = 1;
+        delete x;
+        console.log(x, y);
+      `,
+      "/y.js": /* js */ `
+        export const y = 2;
+      `,
+    },
+    bundleErrors: {
+      "/entry.js": ['"delete" of a bare identifier cannot be used in strict mode'],
+    },
+  });
+  itBundled("edgecase/DeleteBareIdentifierInUseStrictFileIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        require("./lib.cjs");
+      `,
+      "/lib.cjs": /* js */ `
+        "use strict";
+        var x = 1;
+        delete x;
+      `,
+    },
+    format: "cjs",
+    bundleErrors: {
+      "/lib.cjs": ['"delete" of a bare identifier cannot be used in strict mode'],
+    },
+  });
+  itBundled("edgecase/SloppyDeleteBareIdentifierESMOutputIsAnError", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./lib.cjs";
+      `,
+      "/lib.cjs": /* js */ `
+        var x = 1;
+        delete x;
+        console.log("del", typeof x);
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/lib.cjs": ['"delete" of a bare identifier cannot be used with the ESM output format due to strict mode'],
+    },
+  });
+  // The cjs and iife output formats are sloppy, so the statement stays as written.
+  // Node runs the output: bun loads a script with no CommonJS marker as an ES module.
+  itBundled("edgecase/SloppyDeleteBareIdentifierCJSOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        var x = 1;
+        delete x;
+        console.log("del", typeof x);
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("delete x;");
+    },
+    run: { runtime: "node", stdout: "del number" },
+  });
+  itBundled("edgecase/SloppyDeleteBareIdentifierIIFEOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        var x = 1;
+        delete x;
+        console.log("del", typeof x);
+      `,
+    },
+    format: "iife",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("delete x;");
+    },
+    run: { runtime: "node", stdout: "del number" },
+  });
+  // Only a bare identifier is forbidden. A property access, a call, or a
+  // parenthesized comma expression is a value and stays valid in strict mode.
+  itBundled("edgecase/DeleteNonIdentifierOperandsESMOutput", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./lib.cjs";
+      `,
+      "/lib.cjs": /* js */ `
+        var o = { x: 1, y: 2 };
+        var z = 3;
+        console.log(delete o.x, delete o["y"], delete (0, z), delete (1 ? z : z), delete o?.x, typeof z);
+      `,
+    },
+    format: "esm",
+    run: { stdout: "true true true true true number" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/esbuild/lower.test.ts
+++ b/test/bundler/esbuild/lower.test.ts
@@ -1528,10 +1528,12 @@ describe.todo("bundler", () => {
       "/delete-3.js": `delete (1 ? z : z)`,
     },
     format: "esm",
-    /* TODO FIX expectedScanLog: `delete-1.js: ERROR: Delete of a bare identifier cannot be used with the "esm" output format due to strict mode
-  delete-2.js: ERROR: Delete of a bare identifier cannot be used with the "esm" output format due to strict mode
-  with.js: ERROR: With statements cannot be used with the "esm" output format due to strict mode
-  `, */
+    // esbuild also reports `with.js: With statements cannot be used with the "esm"
+    // output format due to strict mode`. Bun has no strict-mode check for `with`.
+    bundleErrors: {
+      "/delete-1.js": ['"delete" of a bare identifier cannot be used with the ESM output format due to strict mode'],
+      "/delete-2.js": ['"delete" of a bare identifier cannot be used with the ESM output format due to strict mode'],
+    },
   });
   itBundled("lower/LowerPrivateClassFieldOrder", {
     // GENERATED

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2676,7 +2676,9 @@ console.log(<div {...obj} key="after" />);`),
     });
 
     it("exponentiation", () => {
-      expectPrinted("(delete x) ** 0", "(delete x) ** 0");
+      // `expectPrinted` wraps the input in `export default (...)`, which is strict
+      // mode, where `delete x` is an error. Use the plain helper for that case.
+      expectPrinted_("(delete x) ** 0", "(delete x) ** 0");
       expectPrinted("(delete x.prop) ** 0", "(delete x.prop) ** 0");
       expectPrinted("(delete x[0]) ** 0", "(delete x[0]) ** 0");
 
@@ -2705,7 +2707,7 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted("(~1) ** 2", "(~1) ** 2");
       expectPrinted("(!1) ** 2", "false ** 2");
       expectPrinted("(void x) ** 2", "(void x) ** 2");
-      expectPrinted("(delete x) ** 2", "(delete x) ** 2");
+      expectPrinted_("(delete x) ** 2", "(delete x) ** 2");
       expectPrinted("(typeof x) ** 2", "(typeof x) ** 2");
       expectPrinted("undefined ** 2", "undefined ** 2");
 
@@ -2785,10 +2787,8 @@ console.log(<div {...obj} key="after" />);`),
 
       expectPrinted_("async function f() { await delete x }", "async function f() {\n  await delete x;\n}");
 
-      // expectParseError(
-      //   "await delete x",
-      //   "Delete of a bare identifier cannot be used in an ECMAScript module"
-      // );
+      // Top-level await makes the file a module, so this is strict mode.
+      expectParseError("await delete x", '"delete" of a bare identifier cannot be used in strict mode');
     });
 
     it("import assert", () => {
@@ -3555,6 +3555,31 @@ class Foo {
       "var arguments = 1; var package = 2; function eval() {}",
       "var arguments = 1;\nvar package = 2;\nfunction eval() {}",
     );
+  });
+
+  it("delete of a bare identifier in strict mode", () => {
+    const error = '"delete" of a bare identifier cannot be used in strict mode';
+    expectParseError('"use strict"; delete x', error);
+    expectParseError('"use strict"; delete (x)', error);
+    expectParseError('"use strict"; delete ((x))', error);
+    expectParseError("delete x; export {}", error);
+    expectParseError("import './a'; delete x", error);
+    expectParseError("await 1; delete x", error);
+    expectParseError("class A { m() { delete x } }", error);
+    expectParseError("function f() { 'use strict'; delete x }", error);
+
+    // Property access and other operands stay valid in strict mode. A parenthesized
+    // comma or conditional expression is a value, not a reference, so it is not a
+    // bare identifier even when it folds to one.
+    expectPrinted_(
+      "'use strict'; delete x.y; delete x[0]; delete x?.y; delete (0, x); delete (1 ? x : x); delete f()",
+      "delete x.y;\ndelete x[0];\ndelete x?.y;\ndelete (0, x);\ndelete (0, x);\ndelete f()",
+    );
+
+    // Sloppy mode allows it when the transpiler is not bundling.
+    expectPrinted_("var x = 1; delete x", "var x = 1;\ndelete x");
+    expectPrinted_("delete (x)", "delete x");
+    expectPrinted_("function f() { delete x }", "function f() {\n  delete x;\n}");
   });
 
   describe("simplification", () => {


### PR DESCRIPTION
### Problem
- `delete x` on a bare identifier is an early SyntaxError in strict mode, and ES modules are strict. Bun accepts it: `bun build` emits `delete x;` into ESM output, and node rejects the file with `SyntaxError: Delete of an unqualified identifier in strict mode`. esbuild errors.
- Cause: the `Op::UnDelete` arm (`src/js_parser/visit/visit_expr.rs:1220`) only visits the operand. The port lost esbuild's `markStrictModeFeature(deleteBareName)` call, and #39732 then removed the unused variant.

### Fix
- Restore `StrictModeFeature::DeleteBareName` and raise it from the `Op::UnDelete` arm when the operand is an `EIdentifier`, before the visit, as esbuild does.
- Correct because `mark_strict_mode_feature` already implements esbuild's two cases: strict source, and sloppy source bundled to ESM output. cjs and iife output, `--no-bundle`, and runtime CommonJS are unchanged.
- Only an identifier operand is reported, parenthesized too. `delete o.x`, `delete (0, x)` and `delete f()` stay valid.
- Verified: `test/bundler/transpiler/transpiler.test.js`, `test/bundler/bundler_edgecase.test.ts` (new cases fail on main). Self-reviewed: 9 concerns probed (notes), 0 needed a change.

### Background
- `Scope::strict_mode` records why a scope is strict: a `"use strict"` directive, or implicitly `import`, `export`, top-level `await`, or a class body. It is set after parsing (`p.rs:2717`), so the check belongs in the visit pass.
- `mark_strict_mode_feature` (`p.rs:4218`) reports sloppy-only syntax when the scope is strict, or when the bundler targets ESM output, since the bundle is then one strict module.
- ES2024 13.5.1.1 forbids `delete` on an identifier reference only. The operand is checked as parsed, so a later rewrite (`--define`, import binding) cannot change the result.

<details><summary>Notes</summary>

- Self-review, compared with node on each case: folded operands (`delete (1 ? x : x)`, handled by the printer's `(0, x)` wrap, `src/js_printer/lib.rs:4377`), synthesized deletes (the React compiler only emits property operands), caret placement for `delete ((x))`, identifier-like operands (`undefined`, `arguments`, `NaN`, `async`: all errors, as in node), non-identifier operands (`this`, `import.meta`, `new.target`, comma, assignment, call, template: all allowed), TypeScript assertions (`delete x!`, `delete (x as any)`: errors, TS2703 rejects them too), per-scope strictness (one error per strict scope, sloppy scopes untouched), sloppy CommonJS at runtime and in cjs/iife output (unchanged), and scan-only parses (the visitor is not reached).
- Suites run with the debug build, all green: `bundler_edgecase` (146), `transpiler.test.js` (198), `bundler_cjs2esm`, `bundler_cjs`, `bundler_minify`, `esbuild/default`, `esbuild/dce`, `esbuild/ts`, `esbuild/extra`, `transpiler/assign-to-import`, `transpiler/runtime-transpiler`, `transpiler/preserve-use-strict-cjs`, and `test/js/node/test/parallel/test-vm-not-strict.js` (sloppy CommonJS `delete a` at runtime).
- Messages: strict source gets `"delete" of a bare identifier cannot be used in strict mode` with a note at the directive or keyword. Sloppy source bundled to ESM gets `"delete" of a bare identifier cannot be used with the ESM output format due to strict mode`.
- The handoff that led to this PR also noted that the `UnDelete` arm never sets `p.delete_target`. That half is in #40804 (and #36734). This PR is independent of it: the strict-mode check reads the operand before the visit, so it does not use `delete_target`. Both add one statement to the same arm, so whichever lands second has a one-line conflict.
- #35962 proposed the same check in July against `StrictModeFeature::DeleteBareName`. #39732 removed that variant, so the branch no longer compiles. This PR supersedes it.
- The ESM bundler test deletes a local `var`, not an import binding. Once #40804 lands, `handle_identifier` also reports `Cannot assign to import "x"` for a delete of an import (esbuild reports both), and `bundleErrors` matches the exact error set.
- `test/bundler/esbuild/lower.test.ts` is `describe.todo`. The `LowerForbidStrictModeSyntax` entry carried a `TODO FIX expectedScanLog` comment for this case. It now has the real `bundleErrors` for `delete-1.js` and `delete-2.js`. I verified it passes with the describe enabled. `with.js` is not listed: bun has no strict-mode check for `with`.
- The note for an explicit `"use strict"` directive prints `because of the "" keyword here`. That is pre-existing (`"use strict"; var arguments = 1` on main prints the same) and not changed here.
- Runtime: `bun file.js` on an ES module with `delete x` now fails at transpile time with this error instead of JSC's `SyntaxError: Cannot delete unqualified property 'x' in strict mode`. Both are fatal. A dynamic `import()` of such a module rejects with a `BuildMessage` instead of a `SyntaxError`, like every other parse-time error.
- The runtime transpiler cache version is not bumped. The change adds a diagnostic and does not change emitted code.
- The two `expectPrinted("(delete x) ** N")` assertions in the exponentiation test now use `expectPrinted_`. `expectPrinted` wraps the input in `export default (...)`, which is strict. The parenthesization they assert is unchanged.

Repro before the fix:

```console
$ printf 'export const x = 1;\n' > x.js
$ printf 'import { x } from "./x.js";\nvar y = 1;\ndelete y;\n' > del.js
$ bun build del.js
// x.js
var x = 1;

// del.js
var y = 1;
delete y;

$ printf 'var x = 1; delete x; console.log("del", typeof x);\n' > d.cjs
$ printf "import './d.cjs';\n" > entry.mjs
$ bun build entry.mjs --format=esm --target=node --outfile=out.mjs && node out.mjs
SyntaxError: Delete of an unqualified identifier in strict mode.
```

After:

```console
$ bun build del.js
3 | delete y;
           ^
error: "delete" of a bare identifier cannot be used in strict mode
    at del.js:3:8

1 | import { x } from "./x.js";
    ^
note: This file is implicitly in strict mode because of the "import" keyword here

$ bun build entry.mjs --format=esm --target=node --outfile=out.mjs
1 | var x = 1; delete x; console.log("del", typeof x);
                      ^
error: "delete" of a bare identifier cannot be used with the ESM output format due to strict mode
    at d.cjs:1:19

$ bun build entry.mjs --format=cjs --target=node --outfile=out.cjs && node out.cjs
del number
```

</details>

