### PR TITLE
bundler: wrap the `await using` Symbol.dispose fallback in the `__using` helper

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -428,10 +428,14 @@ const RUNTIME_USING_BUN: &str = "\
 export var __using = (stack, value, async) => {
   if (value != null) {
     if (typeof value !== 'object' && typeof value !== 'function') throw TypeError('Object expected to be assigned to \"using\" declaration')
-    let dispose
+    let dispose, inner
     if (async) dispose = value[Symbol.asyncDispose]
-    if (dispose === void 0) dispose = value[Symbol.dispose]
+    if (dispose == null) {
+      dispose = value[Symbol.dispose]
+      if (async) inner = dispose
+    }
     if (typeof dispose !== 'function') throw TypeError('Object not disposable')
+    if (inner) dispose = function() { try { inner.call(this) } catch (e) { return Promise.reject(e) } }
     stack.push([async, dispose, value])
   } else if (async) {
     stack.push([async])
@@ -458,6 +462,7 @@ export var __callDispose = (stack, error, hasError) => {
 
 // Other platforms may or may not have the symbol or errors
 // The definitions of __dispose and __asyncDispose match what esbuild's __wellKnownSymbol() helper does
+// The `inner` wrapper is the spec's GetDisposeMethod step for an `await using` that falls back to Symbol.dispose
 const RUNTIME_USING_OTHER: &str = "\
 var __dispose = Symbol.dispose || /* @__PURE__ */ Symbol.for('Symbol.dispose');
 var __asyncDispose =  Symbol.asyncDispose || /* @__PURE__ */ Symbol.for('Symbol.asyncDispose');
@@ -465,10 +470,14 @@ var __asyncDispose =  Symbol.asyncDispose || /* @__PURE__ */ Symbol.for('Symbol.
 export var __using = (stack, value, async) => {
   if (value != null) {
     if (typeof value !== 'object' && typeof value !== 'function') throw TypeError('Object expected to be assigned to \"using\" declaration')
-    var dispose
+    var dispose, inner
     if (async) dispose = value[__asyncDispose]
-    if (dispose === void 0) dispose = value[__dispose]
+    if (dispose == null) {
+      dispose = value[__dispose]
+      if (async) inner = dispose
+    }
     if (typeof dispose !== 'function') throw TypeError('Object not disposable')
+    if (inner) dispose = function() { try { inner.call(this) } catch (e) { return Promise.reject(e) } }
     stack.push([async, dispose, value])
   } else if (async) {
     stack.push([async])

--- a/src/runtime.bun.js
+++ b/src/runtime.bun.js
@@ -5,10 +5,22 @@ export var __using = (stack, value, async) => {
   if (value != null) {
     if (typeof value !== "object" && typeof value !== "function")
       throw TypeError('Object expected to be assigned to "using" declaration');
-    let dispose;
+    let dispose, inner;
     if (async) dispose = value[Symbol.asyncDispose];
-    if (dispose === void 0) dispose = value[Symbol.dispose];
+    if (dispose == null) {
+      dispose = value[Symbol.dispose];
+      if (async) inner = dispose;
+    }
     if (typeof dispose !== "function") throw TypeError("Object not disposable");
+    // Spec GetDisposeMethod: the sync fallback's result is dropped and a throw becomes a rejection
+    if (inner)
+      dispose = function () {
+        try {
+          inner.call(this);
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
     stack.push([async, dispose, value]);
   } else if (async) {
     stack.push([async]);

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe } from "harness";
 import { itBundled } from "./expectBundled";
 
 // An `await using` whose value only has Symbol.dispose: a synchronous throw from
@@ -749,11 +749,9 @@ describe("bundler", () => {
 describe.concurrent("bun run", () => {
   for (const [name, { source, stdout }] of Object.entries(awaitUsingFallbackCases)) {
     test(name, async () => {
-      using dir = tempDir("await-using-fallback", { "entry.ts": source });
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "entry.ts"],
+        cmd: [bunExe(), "-e", source],
         env: bunEnv,
-        cwd: String(dir),
         stdout: "pipe",
         stderr: "pipe",
       });

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -1,6 +1,74 @@
 import assert from "assert";
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
+
+// An `await using` whose value only has Symbol.dispose: a synchronous throw from
+// the disposer must surface as a rejection, so a microtask that was already
+// queued ("interleave") runs before the catch block.
+const syncDisposeThrow = {
+  source: /* ts */ `
+    const out: string[] = [];
+    async function main() {
+      const interleave = Promise.resolve().then(() => { out.push("interleave") });
+      try {
+        await using x = { [Symbol.dispose]() { out.push("dispose"); throw null } };
+      } catch {
+        out.push("catch");
+      }
+      await interleave;
+      return out;
+    }
+    console.log((await main()).join());
+  `,
+  stdout: "dispose,interleave,catch",
+};
+
+// A Symbol.dispose fallback that returns a promise: the promise is not awaited.
+// Disposal of `x` proceeds after one tick, before `y`'s two-tick promise settles.
+const syncDisposeReturnsPromise = {
+  source: /* ts */ `
+    const out: string[] = [];
+    async function main() {
+      await using x = { async [Symbol.asyncDispose]() { out.push("x asyncDispose") } };
+      await using y = {
+        [Symbol.dispose]() {
+          out.push("y dispose");
+          return Promise.resolve().then(() => {}).then(() => { out.push("y promise settled") });
+        },
+      };
+      out.push("body");
+    }
+    await main();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    console.log(out.join());
+  `,
+  stdout: "body,y dispose,x asyncDispose,y promise settled",
+};
+
+// A null Symbol.asyncDispose falls back to Symbol.dispose (GetMethod treats null like undefined).
+const nullAsyncDisposeFallsBack = {
+  source: /* ts */ `
+    const out: string[] = [];
+    async function main() {
+      try {
+        await using x = { [Symbol.asyncDispose]: null, [Symbol.dispose]() { out.push("dispose") } };
+        out.push("body");
+      } catch (e) {
+        out.push("threw " + (e as Error).message);
+      }
+    }
+    await main();
+    console.log(out.join());
+  `,
+  stdout: "body,dispose",
+};
+
+const awaitUsingFallbackCases = {
+  AwaitUsingSyncDisposeThrowIsRejected: syncDisposeThrow,
+  AwaitUsingSyncDisposePromiseNotAwaited: syncDisposeReturnsPromise,
+  AwaitUsingNullAsyncDisposeFallsBack: nullAsyncDisposeFallsBack,
+};
 
 describe("bundler", () => {
   const nodePolyfillList = {
@@ -659,4 +727,40 @@ describe("bundler", () => {
       stdout: "Before!\nThe dispose function was called\n",
     },
   });
+
+  // The `__using` helper's Symbol.dispose fallback for `await using`. `--target=bun`
+  // keeps the syntax and JavaScriptCore runs it natively. Other targets lower it: a
+  // bundle inlines the helper, `--no-bundle` output imports it from `bun:wrap`. Every
+  // mode must agree with the spec (and with `bun run` of the source) on the order.
+  for (const [name, { source, stdout }] of Object.entries(awaitUsingFallbackCases)) {
+    for (const target of ["bun", "node", "browser"] as const) {
+      for (const bundling of [true, false]) {
+        itBundled(`browser/${name}/${target}${bundling ? "" : "-no-bundle"}`, {
+          files: { "/entry.ts": source },
+          target,
+          bundling,
+          run: { stdout },
+        });
+      }
+    }
+  }
+});
+
+describe.concurrent("bun run", () => {
+  for (const [name, { source, stdout }] of Object.entries(awaitUsingFallbackCases)) {
+    test(name, async () => {
+      using dir = tempDir("await-using-fallback", { "entry.ts": source });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(err).toBe("");
+      expect(out.trim()).toBe(stdout);
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -55,9 +55,9 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5623:at"],
+          ["react.development.js:524:'getContextName'", "1:5710:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
-          ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
+          ["react.development.js:696:''Component'", '1:7772:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18817:"Content-Type"'],
           ["entry.tsx:11:'<html>'", "100:19071:void"],
           ["entry.tsx:23:'await'", "100:19170:await"],
@@ -65,7 +65,7 @@ describe("bundler", () => {
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221995,
+      "out/entry.js": 222082,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",


### PR DESCRIPTION
### Problem
- An `await using` value that only has `Symbol.dispose` is disposed by the lowered `__using` helper without the spec's wrapper. `__callDispose` awaits the method's return value, and a synchronous throw escapes synchronously. `bun build` output prints `dispose,catch,interleave` where `bun file.ts`, node and the spec give `dispose,interleave,catch`.
- The fallback only ran when `Symbol.asyncDispose` was `undefined`. For `{ [Symbol.asyncDispose]: null, [Symbol.dispose]() {} }` the lowered output throws `Object not disposable` while JSC and V8 run the sync disposer.
- Cause: `RUNTIME_USING_BUN` / `RUNTIME_USING_OTHER` in `src/bundler/ParseTask.rs` and the `bun:wrap` copy in `src/runtime.bun.js` lack the wrapper esbuild has and test `dispose === void 0`.

### Fix
- `__using` wraps a `Symbol.dispose` fallback for `await using`: `function() { try { inner.call(this) } catch (e) { return Promise.reject(e) } }`. The return value is dropped and a throw becomes a rejection, like esbuild's helper. The fallback condition is `dispose == null`.
- Correct because this is the spec's `GetDisposeMethod`: `GetMethod` returns undefined for both `undefined` and `null`, and the fallback closure rejects on a sync throw. JSC (native `await using`) and node 26 give the same output as the lowered code now does.
- Verified: `test/bundler/bundler_browser.test.ts`, three fixtures × target bun/node/browser × bundle/no-bundle plus `bun run` of the source (12 of 22 fail on 1.4.1: every lowered mode). Also `bundler_npm` (source map pins move with the helper size), `explicit-resource-management`, `lower-using-bun-target`, `bake dev-and-prod (using)`.

### Background
- `await using x = v` disposes `v` with `Symbol.asyncDispose` when the block exits, and falls back to `Symbol.dispose`. The spec wraps that fallback so the sync method's result is never awaited and a throw becomes a rejected promise.
- `--target=bun` keeps the syntax and JSC runs it natively. Other targets lower it to `__using` / `__callDispose`. A bundle inlines the helpers, `--no-bundle` output imports them from `bun:wrap` (`src/runtime.bun.js`, also the bake HMR runtime).
- The helper text exists three times: `RUNTIME_USING_BUN` (target bun, unused since bun does not lower `using`), `RUNTIME_USING_OTHER` (node, browser) and the `bun:wrap` copy. All three change the same way.

<details><summary>Notes</summary>

This is the helper half of #40813, split out so the parser change there can land on its own. #38257 carries the same `__using` change with `== null` plus a tick-exact `__callDispose` rewrite and has merge conflicts. It can rebase onto this PR and keep only the `__callDispose` part.

Divergence from esbuild and TypeScript's `__addDisposableResource`: both test `=== void 0`, so a `null` `Symbol.asyncDispose` throws `Object not disposable` in their output. JSC, V8 and the spec fall back to `Symbol.dispose`. Bun's `--target=bun` output runs natively, so the lowered output follows the engines to keep both modes consistent.

Microtask count: esbuild's lowering takes one extra tick per awaited disposal compared to native code (`Promise.resolve(result).then(next)`). This PR keeps that behavior; only ordering relative to already-queued microtasks changes.

`RUNTIME_USING_BUN` is dead: `lower_using` is off for target bun (`src/bundler/ParseTask.rs`, `src/bundler/transpiler.rs`). Collapsing the three copies into one `include_str!` source is a separate refactor.

Suites run with this branch: `test/bundler/bundler_browser.test.ts` (44 pass), `test/bundler/bundler_npm.test.ts`, `test/js/web/explicit-resource-management.test.ts`, `test/js/bun/resolve/lower-using-bun-target.test.ts`, `test/bake/dev-and-prod.test.ts -t using`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_browser.test.ts test/bundler/bundler_npm.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1475.38ms]
(pass) bundler > browser/NodeBuffer#12272 [847.76ms]
(pass) bundler > browser/NodeFS [392.69ms]
(pass) bundler > browser/NodeTTY [344.52ms]
(pass) bundler > browser/NodeEventsOnce [562.14ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [444.50ms]
(pass) bundler > browser/NodePolyfills [7241.61ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [405.40ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [701.07ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [358.48ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [451.99ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [238.26ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [209.53ms]
(pass)
... (truncated)

release without fix: 13 failed, 2 skipped
bun test v1.4.1-canary.1 (a6c4cc276)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [33.60ms]
(pass) bundler > browser/NodeBuffer#12272 [18.41ms]
(pass) bundler > browser/NodeFS [11.73ms]
(pass) bundler > browser/NodeTTY [10.11ms]
(pass) bundler > browser/NodeEventsOnce [11.67ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [10.77ms]
(pass) bundler > browser/NodePolyfills [142.63ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [11.35ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [9.59ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [9.38ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [11.45ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [4.57ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [4.35ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldOnlyAppliesToBrowserTarget [9.70ms]
(pass) bundler > browser/EntryPointDisabledByPackageMainBrowserField [4.18ms]
(pass) bundler > browser/EntryPointIsNodeBuilti
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_browser.test.ts test/bundler/bundler_npm.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1408.44ms]
(pass) bundler > browser/NodeBuffer#12272 [719.93ms]
(pass) bundler > browser/NodeFS [343.00ms]
(pass) bundler > browser/NodeTTY [410.12ms]
(pass) bundler > browser/NodeEventsOnce [569.78ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [445.14ms]
(pass) bundler > browser/NodePolyfills [7325.27ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [404.94ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [768.77ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [352.00ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [523.89ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [313.48ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [214.10ms]
(pass)
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 568ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] esbuild runtime.out.js

  build/release/codegen/runtime.out.js  5.4kb

⚡ Done in 4ms
[2/7] cxx obj/src/jsc/bindings/bindings.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_js_printer
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ParseTask.rs             |  17 ++++--
 src/runtime.bun.js                   |  16 +++++-
 test/bundler/bundler_browser.test.ts | 104 ++++++++++++++++++++++++++++++++++-
 test/bundler/bundler_npm.test.ts     |   6 +-
 4 files changed, 133 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/bundler/ParseTask.rs                  0      0      0
src/runtime.bun.js                        0      0      0
test/bundler/bundler_browser.test.ts      2      3      0
test/bundler/bundler_npm.test.ts          0      0      0
```

</details>

<!-- robobun:evidence:end -->