### PR TITLE
windows: unwrap FACILITY_WIN32 HRESULTs in Win32Error::get() instead of saturating

### DIFF
--- a/src/errno/windows_errno.rs
+++ b/src/errno/windows_errno.rs
@@ -577,11 +577,13 @@ impl SystemErrnoInit for i32 {
 impl SystemErrnoInit for u32 {
     #[inline]
     fn into_system_errno(self) -> Option<SystemErrno> {
-        // GetLastError()/WSAGetLastError() return DWORD; HRESULT-shaped facility
-        // codes and some installer/WinHTTP errors exceed 0xFFFF. Those are
-        // intentionally unmapped → None. Codes that DO fit u16 route via
-        // the Win32Error→errno table.
-        u16::try_from(self).ok().and_then(SystemErrno::init_numeric)
+        // A DWORD from GetLastError() and friends: values above 0xFFFF are
+        // unmapped unless they are a `FACILITY_WIN32` HRESULT wrapping a Win32
+        // code (see `Win32Error::from_u32`).
+        match Win32Error::from_u32(self) {
+            Win32Error(u16::MAX) => None,
+            code => SystemErrno::init_numeric(code.0),
+        }
     }
 }
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -2076,6 +2076,10 @@ mod tests {
         assert_eq!(Win32Error::FILE_NOT_FOUND.to_e(), E::NOENT);
         assert_eq!(UNMAPPED.to_e(), E::UNKNOWN);
         assert_eq!(Win32Error::SUCCESS.to_e(), E::UNKNOWN);
+        // `HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED)` unwraps; other HRESULTs do not.
+        assert_eq!(Win32Error::from_u32(0x8007_0005).to_e(), E::PERM);
+        assert_eq!(Win32Error::from_u32(0x8000_4005).to_e(), E::UNKNOWN);
+        assert_eq!(Win32Error::from_u32(5), Win32Error::ACCESS_DENIED);
         assert_eq!(
             Error::from_win32(UNMAPPED, Tag::open).get_errno(),
             E::UNKNOWN

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -1273,11 +1273,22 @@ impl Win32Error {
     pub const WSANO_DATA: Win32Error = Win32Error(11004);
     pub const WSA_QOS_RESERVED_PETYPE: Win32Error = Win32Error(11031);
 
-    /// `GetLastError()`. Win32 error codes fit in 16 bits; a larger
-    /// (HRESULT-shaped) value saturates to `0xFFFF`, which no code uses.
+    /// `GetLastError()` (see [`from_u32`](Self::from_u32)).
     #[inline]
     pub fn get() -> Win32Error {
-        Win32Error(u16::try_from(kernel32::GetLastError()).unwrap_or(u16::MAX))
+        Self::from_u32(kernel32::GetLastError() as u32)
+    }
+
+    /// Win32 error codes fit in 16 bits. An `HRESULT` that wraps one
+    /// (`FACILITY_WIN32`, `0x8007xxxx`) is unwrapped to it; any other larger
+    /// value saturates to `0xFFFF`, which no code uses.
+    #[inline]
+    pub const fn from_u32(code: u32) -> Win32Error {
+        if code <= u16::MAX as u32 || code & 0xFFFF_0000 == 0x8007_0000 {
+            Win32Error(code as u16)
+        } else {
+            Win32Error(u16::MAX)
+        }
     }
 
     #[inline]
@@ -1292,7 +1303,7 @@ impl Win32Error {
 
     #[inline]
     pub fn from_ntstatus(status: NTSTATUS) -> Win32Error {
-        Win32Error(u16::try_from(RtlNtStatusToDosError(status)).unwrap_or(u16::MAX))
+        Self::from_u32(RtlNtStatusToDosError(status) as u32)
     }
     /// Snake-cased alias for [`from_ntstatus`] (matches `bun_sys::windows`
     /// callers — `from_nt_status`).


### PR DESCRIPTION
### What does this PR do?

Follow-up to #40860. `GetLastError()` occasionally holds an `HRESULT` rather than a plain Win32 code (shell/COM/filter-driver paths). #40860 made `Win32Error::get()` saturate any value above `0xFFFF` to an unmapped code, so e.g. `0x80070005` (`HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED)`) became `EUNKNOWN`; before #40860 the low word was taken, which was right for `FACILITY_WIN32` (`0x8007xxxx`) values by accident and wrong for every other facility.

`Win32Error::from_u32` now unwraps the `FACILITY_WIN32` case to its Win32 code and saturates everything else; `Win32Error::get()`, `Win32Error::from_ntstatus()` and `SystemErrno::init(u32)` all go through it.

### How did you verify your code works?

Unit assertions in `src/sys/windows/mod.rs` (`from_u32(0x80070005)` → EPERM, `from_u32(0x80004005)` → EUNKNOWN, `from_u32(5)` == `ACCESS_DENIED`); `cargo check --workspace --tests` for x86_64-pc-windows-msvc and the Linux host. None of the Win32 APIs Bun calls on these paths are documented to set an HRESULT last-error, so there is no JS-level repro.