### PR TITLE
ci: log a host health snapshot when the artifact download stalls and on the bare-metal darwin agents

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -65,6 +65,7 @@ import {
   markBuildkiteStepReported,
   parseJunitFileSuites,
   printEnvironment,
+  printHostHealth,
   reportAnnotationToBuildKite,
   startGroup,
   tmpdir,
@@ -2742,6 +2743,11 @@ async function getExecPathFromBuildKite(target, buildId) {
       timeout: 120000,
     });
     if (error === "timeout") {
+      // The agent had just listed the artifacts over the Buildkite API, and
+      // nothing of the job has run yet, so a zip that does not arrive in two
+      // minutes points at the host. Record what it looks like before failing;
+      // on the bare-metal darwin agents this is the only view of the host.
+      printHostHealth();
       throw new Error(
         `buildkite-agent artifact download timed out after 120s for step '${target}'. ` +
           `Refusing to continue with a partial download (would silently fall back to the wrong binary).`,

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -2832,6 +2832,9 @@ export function printEnvironment() {
           spawnSync([shell, "-c", "df"], { stdio: "inherit" });
         }
       });
+      if (isBareMetalAgent()) {
+        printHostHealth();
+      }
     }
     if (isLinux) {
       startGroup("Memory", () => {
@@ -2938,6 +2941,172 @@ export function getLoggedInUserCountOrDetails() {
 
     return message;
   }
+}
+
+/**
+ * Whether this Buildkite job runs on a bare-metal box that serves the next job
+ * from the same kernel: the macOS minis scripts/agent.mjs registers, tagged
+ * `ephemeral=false`. Cloud agents are `ephemeral=true` and leave after one job,
+ * and the darwin tart agents (`tart=true`) boot a fresh guest for every job.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {boolean}
+ */
+export function isBareMetalAgent(env = process.env) {
+  return env["BUILDKITE_AGENT_META_DATA_EPHEMERAL"] === "false" && env["BUILDKITE_AGENT_META_DATA_TART"] !== "true";
+}
+
+/**
+ * A few lines about the host for the job log: uptime and load, memory and swap,
+ * the process table, and on macOS the kernel's network buffer and TCP retransmit
+ * counters. Every probe is best effort.
+ *
+ * This is what #33728 needed from a darwin mini whose artifact downloads had
+ * started to time out: `bun-profile` processes from earlier jobs parked in an
+ * uninterruptible `sendfile(2)` sleep (state `U`, or `E` once exit() hung on
+ * their sockets), each pinning kernel socket buffers until the mbuf pool was
+ * empty and every transfer on the box crawled. SIGKILL pends on such a
+ * process, so it survives the end of its job and only a reboot clears it.
+ * Two things in the output point at that: processes in those states, and a
+ * binary under the agent's build directory with an `etime` older than this job.
+ *
+ * @returns {string[]}
+ */
+export function getHostHealthSnapshot() {
+  if (isWindows) {
+    return [];
+  }
+  const run = command => {
+    const { error, stdout } = spawnSync(command, { timeout: 5_000 });
+    return error ? undefined : stdout.trim();
+  };
+  const read = path => {
+    try {
+      return readFileSync(path, "utf-8");
+    } catch {
+      return undefined;
+    }
+  };
+  const gib = bytes => `${(bytes / 1024 ** 3).toFixed(1)}G`;
+  const lines = [];
+
+  let upSeconds;
+  let load;
+  if (isMacOS) {
+    const bootSeconds = parseInt(/sec = (\d+)/.exec(run(["sysctl", "-n", "kern.boottime"]) || "")?.[1] || "");
+    if (bootSeconds) upSeconds = Date.now() / 1000 - bootSeconds;
+    load = run(["sysctl", "-n", "vm.loadavg"])?.replace(/[{}]/g, "").trim();
+  } else {
+    upSeconds = parseFloat(read("/proc/uptime") || "");
+    load = read("/proc/loadavg")?.split(" ").slice(0, 3).join(" ");
+  }
+  if (upSeconds || load) {
+    lines.push(`up ${upSeconds ? (upSeconds / 3600).toFixed(1) : "?"} h, load average: ${load || "?"}`);
+  }
+
+  if (isMacOS) {
+    const memsize = parseInt(run(["sysctl", "-n", "hw.memsize"]) || "");
+    const vmStat = run(["vm_stat"]) || "";
+    const pageSize = parseInt(/page size of (\d+) bytes/.exec(vmStat)?.[1] || "") || 16384;
+    const pages = name => parseInt(new RegExp(`^Pages ${name}:\\s+(\\d+)`, "m").exec(vmStat)?.[1] || "") || 0;
+    if (memsize && vmStat) {
+      lines.push(
+        `memory: ${gib(memsize)} total, ${gib(pages("free") * pageSize)} free, ` +
+          `${gib(pages("inactive") * pageSize)} inactive, ${gib(pages("wired down") * pageSize)} wired, ` +
+          `${gib(pages("occupied by compressor") * pageSize)} compressed`,
+      );
+    }
+    const swap = run(["sysctl", "-n", "vm.swapusage"]);
+    if (swap) lines.push(`swap: ${swap.replace(/\s+/g, " ")}`);
+  } else {
+    const meminfo = read("/proc/meminfo") || "";
+    const kib = name => parseInt(new RegExp(`^${name}:\\s+(\\d+)`, "m").exec(meminfo)?.[1] || "") || 0;
+    if (meminfo) {
+      lines.push(
+        `memory: ${gib(kib("MemTotal") * 1024)} total, ${gib(kib("MemAvailable") * 1024)} available, ` +
+          `swap ${gib((kib("SwapTotal") - kib("SwapFree")) * 1024)} used of ${gib(kib("SwapTotal") * 1024)}`,
+      );
+    }
+  }
+
+  // `-e`, not `-ax`: busybox ps (alpine) has no `-x`. `comm` is the executable
+  // as exec'd, a full path on macOS.
+  const ps = run(["ps", "-eo", "pid=,ppid=,user=,stat=,etime=,rss=,comm="]) || "";
+  const procs = ps
+    .split("\n")
+    .map(line => /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(.*)$/.exec(line))
+    .filter(Boolean)
+    .map(([, pid, ppid, user, stat, etime, rss, comm]) => ({
+      pid: parseInt(pid),
+      ppid: parseInt(ppid),
+      user,
+      stat,
+      etime,
+      rss: parseInt(rss),
+      comm: comm.trim(),
+    }));
+  if (procs.length) {
+    const describe = ({ pid, stat, etime, rss, comm }) =>
+      `  pid ${pid} stat ${stat} up ${etime} rss ${Math.round(rss / 1024)}M ${comm}`;
+    const me = getUsername();
+    const mine = procs.filter(({ user }) => user === me);
+    lines.push(`processes: ${procs.length} total, ${mine.length} for ${me}`);
+
+    // macOS: U is an uninterruptible wait, E is a process stuck in exit(). Linux:
+    // D is an uninterruptible wait, Z a zombie nobody reaped. Our own zombies are
+    // children we killed a moment ago and have not reaped yet.
+    const stuck = procs.filter(
+      ({ stat, ppid }) =>
+        (isMacOS ? /^U|E/.test(stat) : /^[DZ]/.test(stat)) && !(/^Z/.test(stat) && ppid === process.pid),
+    );
+    lines.push(`processes in an uninterruptible wait or stuck exiting: ${stuck.length}`);
+    lines.push(...stuck.slice(0, 20).map(describe));
+
+    const buildPath = getEnv("BUILDKITE_BUILD_PATH", false);
+    if (buildPath) {
+      const leftovers = procs.filter(({ comm }) => comm.startsWith(buildPath));
+      lines.push(`processes running a binary under ${buildPath}: ${leftovers.length}`);
+      lines.push(
+        ...leftovers
+          .filter(p => !stuck.includes(p))
+          .slice(0, 20)
+          .map(describe),
+      );
+    }
+  }
+
+  if (isMacOS) {
+    const mbufs = run(["netstat", "-m"]) || "";
+    for (const line of mbufs.split("\n")) {
+      if (/mbufs in use|clusters in use|requests for memory/.test(line)) lines.push(`netstat -m: ${line.trim()}`);
+    }
+    const tcp = run(["netstat", "-s", "-p", "tcp"]) || "";
+    for (const line of tcp.split("\n")) {
+      if (/retransmit|rexmit|connections dropped|completely duplicate/.test(line)) {
+        lines.push(`netstat -s -p tcp: ${line.trim()}`);
+      }
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * One `--- Host health` group with getHostHealthSnapshot(). The runner prints it
+ * in every job's header on a bare-metal agent, where the state of the kernel
+ * carries over from job to job, and from any agent when the artifact download
+ * stalls.
+ */
+export function printHostHealth() {
+  const lines = getHostHealthSnapshot();
+  if (!lines.length) {
+    return;
+  }
+  startGroup("Host health", () => {
+    for (const line of lines) {
+      console.log(line);
+    }
+  });
 }
 
 /** @typedef {keyof typeof emojiMap} Emoji */

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3030,18 +3030,24 @@ export function getHostHealthSnapshot() {
   }
 
   // `-e`, not `-ax`: busybox ps (alpine) has no `-x`. `comm` is the executable
-  // as exec'd, a full path on macOS.
-  const ps = run(["ps", "-eo", "pid=,ppid=,user=,stat=,etime=,rss=,comm="]) || "";
-  const procs = ps
+  // as exec'd, a full path on macOS. A busybox built without FEATURE_PS_TIME
+  // rejects `etime`; the process rows matter more than that column.
+  let ps = run(["ps", "-eo", "pid=,ppid=,user=,stat=,etime=,rss=,comm="]);
+  let rowPattern = /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(.*)$/;
+  if (ps === undefined) {
+    ps = run(["ps", "-eo", "pid=,ppid=,user=,stat=,rss=,comm="]);
+    rowPattern = /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\S+)()\s+(\d+)\s+(.*)$/;
+  }
+  const procs = (ps || "")
     .split("\n")
-    .map(line => /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(.*)$/.exec(line))
+    .map(line => rowPattern.exec(line))
     .filter(Boolean)
     .map(([, pid, ppid, user, stat, etime, rss, comm]) => ({
       pid: parseInt(pid),
       ppid: parseInt(ppid),
       user,
       stat,
-      etime,
+      etime: etime || "?",
       rss: parseInt(rss),
       comm: comm.trim(),
     }));

--- a/test/internal/runner-host-health.test.ts
+++ b/test/internal/runner-host-health.test.ts
@@ -1,0 +1,52 @@
+/**
+ * scripts/runner.node.mjs prints a "Host health" group when the build artifact
+ * download stalls, and in every job's header on a bare-metal agent.
+ * getHostHealthSnapshot() in scripts/utils.mjs is the content of that group and
+ * isBareMetalAgent() decides which agents get it in the header.
+ */
+import { describe, expect, test } from "bun:test";
+import { isWindows } from "harness";
+import { getHostHealthSnapshot, isBareMetalAgent } from "../../scripts/utils.mjs";
+
+describe("isBareMetalAgent", () => {
+  test("a box registered by scripts/agent.mjs", () => {
+    expect(isBareMetalAgent({ BUILDKITE_AGENT_META_DATA_EPHEMERAL: "false" })).toBe(true);
+    expect(
+      isBareMetalAgent({
+        BUILDKITE_AGENT_META_DATA_EPHEMERAL: "false",
+        BUILDKITE_AGENT_META_DATA_RELEASE_TIER: "latest",
+        BUILDKITE_AGENT_META_DATA_OS: "darwin",
+      }),
+    ).toBe(true);
+  });
+
+  test("a cloud agent that disconnects after its job", () => {
+    expect(isBareMetalAgent({ BUILDKITE_AGENT_META_DATA_EPHEMERAL: "true" })).toBe(false);
+  });
+
+  test("a darwin tart agent, which boots a fresh guest for every job", () => {
+    expect(isBareMetalAgent({ BUILDKITE_AGENT_META_DATA_TART: "true" })).toBe(false);
+    expect(
+      isBareMetalAgent({ BUILDKITE_AGENT_META_DATA_EPHEMERAL: "false", BUILDKITE_AGENT_META_DATA_TART: "true" }),
+    ).toBe(false);
+  });
+
+  test("outside Buildkite", () => {
+    expect(isBareMetalAgent({})).toBe(false);
+  });
+});
+
+describe("getHostHealthSnapshot", () => {
+  test.skipIf(isWindows)("describes load, memory, and the process table", () => {
+    const lines = getHostHealthSnapshot();
+    expect(lines.length).toBeGreaterThanOrEqual(4);
+    expect(lines[0]).toMatch(/^up [\d.]+ h, load average: [\d.]+ [\d.]+ [\d.]+$/);
+    expect(lines.find(line => line.startsWith("memory: "))).toMatch(/^memory: [\d.]+G total, /);
+    expect(lines.find(line => line.startsWith("processes: "))).toMatch(/^processes: \d+ total, \d+ for \S+$/);
+    expect(lines.find(line => line.startsWith("processes in an uninterruptible"))).toMatch(/: \d+$/);
+  });
+
+  test.skipIf(!isWindows)("has nothing to say on Windows", () => {
+    expect(getHostHealthSnapshot()).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Problem
- `:darwin: any aarch64 - test-bun` fails with `Error: buildkite-agent artifact download timed out after 120s for step 'darwin-aarch64-build-bun'. Refusing to continue with a partial download (would silently fall back to the wrong binary).` at `getExecPathFromBuildKite` (`scripts/runner.node.mjs:2745`). A manual retry on another box passes.
- All 62 such failures in 3 days (builds 107078 to 108064) are on the two bare-metal 16 GB minis, `biscuit` and `hardtack`. Each box goes bad 15 to 18 hours after its daily 06:27 reboot. From then on every job on it fails here or crawls into the 45 minute job timeout, until the next reboot. The other minis and the Tart guests never fail here.
- The job log says nothing about the host at that moment. The last time this happened (#33116), the cause was found on the box itself: `bun-profile` processes from earlier jobs wedged in `sendfile(2)`, pinning kernel socket buffers until the mbuf pool was empty (#33728). The fleet ssh route is not reachable from this session, so the log has to carry that evidence.

### Fix
- `getHostHealthSnapshot()` in `scripts/utils.mjs` returns a few lines: uptime and load, memory and swap, processes in an uninterruptible wait or stuck exiting (`stat` U or E on macOS, D or Z on Linux), processes that run a binary under the agent's build directory (only a CI job starts those, so at job start they are leftovers), and on macOS the `netstat -m` mbuf pool and TCP retransmit counters.
- The runner prints it as a `--- Host health` group in the header of every job on an agent tagged `ephemeral=false` (the bare-metal minis), and from any agent right before it fails on the download timeout. Healthy runs add about eight lines and a few `ps`/`sysctl` calls; the header of the minis then shows the mbuf pool and the stuck process count drift over the day, and the first failed job shows the state at the stall.
- No policy change. A first version of this PR paused the agent and exited a status the pipeline retried. #33117 proposed the same retry for the same symptom and was closed after #33728 fixed the host cause and #34684 narrowed automatic retries to agent loss. That half waits for one episode's snapshot, and for #40500, which edits the same timeout branch.
- Verified: `test/internal/runner-host-health.test.ts` covers the agent tag check and the snapshot format. The runner was run against a fake `buildkite-agent` whose `artifact download` hangs: the group appears in the header with `ephemeral=false`, and before the error on every agent. `ps -eo` was checked against the busybox source (alpine has no `-x`).

### Background
- `scripts/runner.node.mjs` is the test step's command. It downloads the build step's zips with `buildkite-agent artifact download` before it runs any test. #29039 made a timeout fatal so a truncated zip is never used.
- `scripts/agent.mjs` registers the bare-metal macOS agents with the tag `ephemeral=false` and reboots them daily at 06:27 local. Cloud agents are `ephemeral=true` and leave after one job. The darwin Tart agents boot a fresh guest per job and carry `tart=true`. Only the bare-metal kernels carry state from one job to the next.
- XNU's `sendfile(2)` allocates its mbuf chain with an uninterruptible wait. When the pool is empty the process cannot be killed, and it keeps what it holds. #33728 removed the server-side `sendfile` on macOS for that reason. `fetch()` with a `Bun.file()` body over plain HTTP still uses it (`src/http/SendFile.rs`), and `test/js/bun/http/fetch-file-upload.test.ts` pushes a 128 MiB file through that path on every darwin job.
- macOS derives `kern.maxprocperuid` from physical memory. The job header's `max user processes` is 1333 on `biscuit` and `hardtack` and 2666 on the other minis, so these two are the 16 GB boxes with the smallest mbuf pool.

<details><summary>Notes</summary>

Data from the Buildkite API over builds 107078 to 108064 (2026-08-27T22:56Z to 2026-08-29T01:36Z), `:darwin: any aarch64 - test-bun` jobs, retried jobs included:

- Download timeouts per host: biscuit 28 (agent `darwin-aarch64-26.6.1-1`), hardtack 34 (`darwin-aarch64-26.6.2-1`), crouton 0, breadstick 0, bingus 0, every Tart agent 0. The one other `exit 1` under 250 s on breadstick was a job cut by the 06:27 reboot, with a 3 s download.
- biscuit episode 1: 23:52Z on 08-27 to the 05:27Z reboot. Episode 2: from 21:20Z on 08-28, still going at the end of the window. hardtack: 03:53Z to about 10:18Z on 08-28, ended by an agent restart at 11:30Z. In an episode, jobs are only download timeouts (exit 1, 124 to 204 s), 45 minute timeouts, or long failures (1191 to 2520 s). Job durations creep up before an episode: 450 s, 510 s, 585 s, 748 s, 2520 s.
- Downloads inside an episode are intermittent: build 107185 took 41 s for the 24 MiB zip and 2 s for the 120 MiB zip, build 107190 took 4 s for both, build 107956 (20:02Z, before the episode) took 41 s and 85 s. Normal is 2 to 4 s.
- The tests that fail inside an episode all move bytes over loopback or the network: `The socket connection was closed unexpectedly`, `ConnectionClosed downloading tarball` from a local registry, `test/package.json` (`bun install`) hitting its timeout, `Failed to install dependencies: SIGTERM`, and `uploads roundtrip with sendfile()` in `fetch-file-upload.test.ts`. `curl https://checkip.amazonaws.com` in the runner's own header took 257 ms ten seconds before the stalled download in build 108064.
- The agent runs jobs in a PTY, so the job shell's exit sends SIGHUP to the job's process group and ordinary leftovers die (checked on Linux with `pty.fork()`). That does not reach a process in an uninterruptible wait, which is the case #33728 describes.
- If the snapshot shows stuck `bun-profile` processes and a full pool, the product fix is the one #33728 left open: stop `SendFile::is_eligible` from choosing `sendfile` on macOS, which needs the fallback at `fetch.rs:1566` (a synchronous whole-file read on the JS thread) to become asynchronous first. Shrinking the 128 MiB upload in `fetch-file-upload.test.ts` would lower the pressure from that one test but not remove the hazard.
- Related: #40500 retries the download three times before it fails, for a Tart guest whose NAT stalled for two minutes. It edits the same timeout branch; the snapshot call belongs before its `rmSync` of the release directory.
- Not done: the on-host check the handoff asked for. The fleet ssh route (`farm-tailscale` SOCKS proxy) does not resolve from this session's container.

</details>
