### PR TITLE
Bump WebKit so `new Function` with a syntax error survives validateExceptionChecks

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-535-e6ad39a7";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/exception-checks.test.ts
+++ b/test/js/bun/jsc/exception-checks.test.ts
@@ -27,6 +27,33 @@ const snippets: Record<string, { code: string; stdout: string }> = {
     code: `const a = "SIG"; const b = "BOGUS"; try { process.kill(process.pid, a + b); } catch (e) { console.log(e.code); }`,
     stdout: "ERR_UNKNOWN_SIGNAL",
   },
+  // JSC builds a parse error's stack before it throws the error, which runs
+  // the Error.prepareStackTrace hook. eval is not affected: an eval parse
+  // error skips that step.
+  "new Function with a syntax error": {
+    code: `try { new Function("{"); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
+    stdout: "SyntaxError: Unexpected end of script",
+  },
+  "new Function with a syntax error and a custom Error.prepareStackTrace": {
+    code: `Error.prepareStackTrace = (err, sites) => "custom:" + err.message + ":" + (sites.length > 0); try { new Function("a", "{"); } catch (e) { console.log(e.constructor.name + " " + e.stack); }`,
+    stdout: "SyntaxError custom:Unexpected end of script:true",
+  },
+  "new Function with a syntax error and a throwing Error.prepareStackTrace": {
+    code: `Error.prepareStackTrace = () => { throw new Error("boom"); }; try { new Function("{"); } catch (e) { console.log(e.constructor.name + ": " + e.message + " " + typeof e.stack); }`,
+    stdout: "SyntaxError: Unexpected end of script string",
+  },
+  "GeneratorFunction with a syntax error": {
+    code: `const GeneratorFunction = Object.getPrototypeOf(function* () {}).constructor; try { GeneratorFunction("{"); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
+    stdout: "SyntaxError: Unexpected end of script",
+  },
+  "AsyncFunction with a syntax error": {
+    code: `const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor; try { new AsyncFunction("{"); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
+    stdout: "SyntaxError: Unexpected end of script",
+  },
+  "vm.SourceTextModule with a syntax error": {
+    code: `const { SourceTextModule } = require("node:vm"); try { new SourceTextModule("{"); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
+    stdout: "SyntaxError: Unexpected end of script",
+  },
 };
 
 for (const [name, { code, stdout: expected }] of Object.entries(snippets)) {

--- a/test/js/bun/jsc/exception-checks.test.ts
+++ b/test/js/bun/jsc/exception-checks.test.ts
@@ -51,7 +51,7 @@ const snippets: Record<string, { code: string; stdout: string }> = {
     stdout: "SyntaxError: Unexpected end of script",
   },
   "vm.SourceTextModule with a syntax error": {
-    code: `const { SourceTextModule } = require("node:vm"); try { new SourceTextModule("{"); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
+    code: `import { SourceTextModule } from "node:vm"; try { new SourceTextModule("{"); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
     stdout: "SyntaxError: Unexpected end of script",
   },
 };


### PR DESCRIPTION
### Problem
- With `BUN_JSC_validateExceptionChecks=1` (the debug and ASAN test lanes set it), any `new Function(source)` whose source has a syntax error aborts the process: `ERROR: Unchecked JS exception: This scope can throw a JS exception: computeErrorInfoToJSValueWithoutSkipping @ src/jsc/bindings/FormatStackTraceForJS.cpp:535 ... But the exception was unchecked as of this scope: constructFunctionSkippingEvalEnabledCheck @ FunctionConstructor.cpp:220`. `GeneratorFunction`, `AsyncFunction` and `vm.SourceTextModule` (`NodeVMSourceTextModule.cpp:167`) abort the same way. Seen on #40813 (`bundler_using.test.ts`, x64-asan).
- Cause: JSC's `ParserError::toErrorObject()` calls `addErrorInfo()`, which builds the new SyntaxError's stack at once. In Bun that runs the `Error.prepareStackTrace` hook (`computeErrorInfoToJSValueWithoutSkipping`), which declares a `ThrowScope` and can throw. Upstream's version cannot throw, so JSC throws the parse error with no exception check in between. `eval("{")` is not affected: an eval parse error is `ParserError::EvalError`, which skips `addErrorInfo()`.

### Fix
- oven-sh/WebKit#535: `addErrorInfo()` materializes under a `TopExceptionScope` and clears a hook exception there (a termination stays pending). `toErrorObject()` stays non-throwing, which is the contract every caller in JSC relies on.
- Correct because the parse error is what gets thrown, as in Node, where V8 does not run `prepareStackTrace` while it builds a SyntaxError. Release behavior does not change: there `VM::throwException` already replaced the hook exception with the parse error. Bun's `node:vm` callers of `toErrorObject()` clear that exception by hand (NodeVM.cpp:182, NodeVMScript.cpp:150). The WebKit change covers the callers inside JSC.
- `WEBKIT_VERSION` points at the preview build of oven-sh/WebKit#535. Move it to the merged `main` sha before this merges.
- Verified: `test/js/bun/jsc/exception-checks.test.ts` (six new snippets: `Function`, `GeneratorFunction`, `AsyncFunction`, a custom and a throwing `Error.prepareStackTrace`, `vm.SourceTextModule`; all six abort on the current pin). Also `test/js/node/vm/vm.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/js/bun/test/stack.test.ts` and `test/js/web/workers/structured-clone.test.ts` under `BUN_JSC_validateExceptionChecks=1`.

### Background
- `BUN_JSC_validateExceptionChecks=1` makes every `ThrowScope` destructor mark `VM::m_needExceptionCheck`. The next `ThrowScope` constructor, or a `throwException()` of a plain value, aborts if the bit is still set. Only `VM::exception()` and `clearException()` clear it. The check exists in debug and ASAN builds only.
- `TopExceptionScope` (the old `CatchScope`) only verifies in its destructor and does not mark the bit. It is the scope for code that must not propagate an exception, as `createTypeErrorCopy` in the same file uses it.
- `ErrorInstance` computes `stack`, `line`, `column` and `sourceURL` lazily from the captured frames. The Bun fork lets the embedder build them through `VM::onComputeErrorInfoJSValue`. That hook is where `Error.prepareStackTrace` runs.

<details><summary>Notes</summary>

Fail-before on the current pin (`ceb9f90fb7`, debug build), one of the six:

```
error: expect(received).toEqual(expected)
  {
-   "exitCode": 0,
-   "stdout": "SyntaxError: Unexpected end of script",
-   "unchecked": [],
+   "exitCode": 134,
+   "stdout": "",
+   "unchecked": [
+     "This scope can throw a JS exception: computeErrorInfoToJSValueWithoutSkipping @ unified/../../../src/jsc/bindings/FormatStackTraceForJS.cpp:535",
+     "But the exception was unchecked as of this scope: createModuleRecord @ unified/../../../src/jsc/bindings/NodeVMSourceTextModule.cpp:167",
+   ],
  }
(fail) vm.SourceTextModule with a syntax error
```

Why eval passes: `Parser::parse` reports an eval parse error as `ParserError::EvalError`, and `toErrorObject()` only calls `addErrorInfo()` for `ParserError::SyntaxError`. `gdb` on the old pin confirms `addErrorInfo` and `materializeErrorInfoIfNeeded` are never reached for `(0,eval)("{")` and are reached for `new Function("{")`.

Alternatives not taken:
- An exception check at each `toErrorObject()` call site in JSC (`FunctionConstructor.cpp:226`, `ModuleProgramExecutable.cpp:68`, `ScriptExecutable.cpp:320`, `UnlinkedFunctionExecutable.cpp:238`, `Interpreter::executeProgram`). The catch in `addErrorInfo()` covers all of them at once.
- Lazy materialization (drop the eager call in `addErrorInfo()`). `prepareStackTrace` would then run on the first `.stack` read like V8, but `decorateParseErrorStack` in NodeVM.cpp assumes the stack exists, the vm.test.ts test "a throwing Error.prepareStackTrace does not escape the compile-time SyntaxError" expects the arrow header to survive, and lazy parse errors would join #34398 (stack degraded by a GC before the first read).
- Swallowing the exception inside Bun's hook. That breaks the lazy path, where a throwing `prepareStackTrace` must propagate from `.stack` (test/js/node/v8/capture-stack-trace.test.js, structured-clone.test.ts).

NodeVM.cpp:182 and NodeVMScript.cpp:150 keep their `tryClearException()` after `toErrorObject()`. With this WebKit it is a no-op for anything but a termination. They stay so the bun side is correct on the old pin too.

Fail-before check: the fix is the WebKit pin in `scripts/build/deps/webkit.ts`, not `src/`. A check that stashes `src/` builds with the new WebKit in both arms and sees the new tests pass both ways. The evidence above is from a build on the old pin.

Suites run with the preview build and `BUN_JSC_validateExceptionChecks=1`: `test/js/bun/jsc/exception-checks.test.ts`, `test/js/node/vm/vm.test.ts`, `test/js/node/vm/vm-sourceUrl.test.ts`, `test/js/node/vm/sourcetextmodule-leak.test.ts`, `test/js/node/vm/sourcetextmodule-link-gc.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/js/bun/test/stack.test.ts`, `test/regression/issue/prepare-stack-trace-crash.test.ts`, `test/js/web/workers/structured-clone.test.ts`, `test/internal/source-lints/webkit-prebuilt-url.test.ts`, `test/js/node/test/parallel/test-vm-module-errors.js`, `test/js/node/test/parallel/test-error-prepare-stack-trace.js`.
</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/exception-checks.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/exception-checks.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/jsc/exception-checks.test.ts:
(pass) process.exitCode assigned a rope string [276.48ms]
(pass) Bun.deepEquals with one argument [356.13ms]
(pass) process.kill with an unknown rope signal name [352.55ms]
(pass) new Function with a syntax error [353.14ms]
(pass) process.umask with a rope string [372.60ms]
(pass) new Function with a syntax error and a throwing Error.prepareStackTrace [271.70ms]
(pass) new Function with a syntax error and a custom Error.prepareStackTrace [347.82ms]
(pass) AsyncFunction with a syntax error [268.26ms]
(pass) GeneratorFunction with a syntax error [318.95ms]
(pass) vm.SourceTextModule with a syntax error [419.15ms]

 10 pass
 0 fail
 10 expect() calls
Ran 10 tests across 1 file. [2.97s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts             |  2 +-
 test/js/bun/jsc/exception-checks.test.ts | 27 +++++++++++++++++++++++++++
 2 files changed, 28 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
scripts/build/deps/webkit.ts                  1      1      0
test/js/bun/jsc/exception-checks.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->