### PR TITLE
bun:test: wrap an indexed non-function spy in a GetterSetter

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1549,8 +1549,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
             } else if (auto index = parseIndex(propertyKey)) {
-                // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
+                object->putDirectIndex(globalObject, *index, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1157,6 +1157,54 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // A non-function index gets a getter/setter spy, like a named property does.
+    // The sparse entry used to hold the bare mock with the accessor attribute, so the
+    // next read or write of that index crashed the process.
+    test("spyOn works with indexed properties that are not functions", () => {
+      const arr = [];
+      arr[0] = 42;
+
+      const fn = spyOn(arr, 0);
+      expect(arr[0]).toBe(42);
+      expect(fn).toHaveBeenCalledTimes(1);
+      arr[0] = 7;
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(arr[0]).toBe(42);
+
+      fn.mockRestore();
+      expect(arr[0]).toBe(42);
+      arr[0] = 7;
+      expect(arr[0]).toBe(7);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("spyOn works with a large sparse index that is not a function", () => {
+      const obj = {};
+      obj[3221225473] = [1.5];
+
+      const fn = spyOn(obj, 3221225473);
+      expect(obj[3221225473]).toEqual([1.5]);
+      obj[3221225473] = 5;
+      expect(obj[3221225473]).toEqual([1.5]);
+      expect(fn).toHaveBeenCalledTimes(3);
+
+      fn.mockRestore();
+      expect(obj[3221225473]).toEqual([1.5]);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("spyOn works with an index that does not exist yet", () => {
+      const obj = {};
+
+      const fn = spyOn(obj, 5);
+      expect(obj[5]).toBeUndefined();
+      obj[5] = 1;
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      fn.mockRestore();
+      expect(obj[5]).toBeUndefined();
+    });
+
     // The engine serves a function's `prototype` property specially, so it cannot be
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found abort in `spyOn(target, index)`.

When the value at `target[index]` is not a function, `spyOn` sets the `Accessor` attribute and then stored the bare `JSMockFunction` at the index with `putDirectIndex`. JSC expects an entry with the `Accessor` attribute to hold a `GetterSetter`. The next access to that index then failed:

- A read hit `ASSERTION FAILED: !(attributes & PropertyAttribute::Accessor)` in `PropertySlot::setValue`.
- A write reached `SparseArrayEntry::put`, which downcasts the stored value to `GetterSetter`. In a debug build this aborts in `reportZappedCellAndCrash` with no output. In a release build the mock is read as a `GetterSetter` and the value leaks out as the mock function.

The fix stores `GetterSetter::create(vm, globalObject, mock, mock)` at the index. This is what the named property path one line below already does, so `target[index]` now calls the spy as a getter and `target[index] = v` calls it as a setter. `mockRestore()` is unchanged: it writes the original value and attributes back through `putDirectIndex`, which replaces the sparse entry.

The fuzzer saw this as a flaky crash. The crashing script only wrote to a large index on the `Bun.jest()` module object. That object is cached per global object, so a previous script in the same process had installed the broken spy on it. The crash did not reproduce in a fresh process.

Repro on an unfixed debug build:

```js
const o = {};
o[0] = 1;
Bun.jest().spyOn(o, 0);
o[0] = 5; // SIGABRT
```

### How did you verify your code works?

- The repro above and the fuzzer script (with the prior spy installed in the same process) run clean with the fixed debug build. Both abort with the unfixed build.
- Added three tests to `test/js/bun/test/mock-fn.test.js`: a non-function array index, a large sparse index on a plain object, and an index that does not exist yet. Each one reads and writes the index and then restores. They fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`.
- `mock-fn.test.js`, `mock-disposable.test.ts`, `spyMatchers.test.ts`, and `test/regression/issue/08794.test.ts` pass with the debug build.
