### PR TITLE
bun:ffi: compile cc() sources embedded in a standalone executable

### DIFF
--- a/docs/runtime/c-compiler.mdx
+++ b/docs/runtime/c-compiler.mdx
@@ -202,6 +202,39 @@ cc({
 });
 ```
 
+### Standalone executables
+
+`cc` works inside a `bun build --compile` executable. Import the C source `with { type: "file" }` so the bundler embeds it, and pass the imported path as `source`. TinyCC compiles the C code when `cc` is called, on the machine that runs the executable.
+
+```ts
+import { cc } from "bun:ffi";
+import source from "./hello.c" with { type: "file" };
+
+const { symbols } = cc({
+  source,
+  symbols: { hello: { args: [], returns: "int" } },
+});
+```
+
+TinyCC reads embedded files, so `#include "..."` and the `include` option also work for embedded headers. The bundler renames a file imported `with { type: "file" }` to `[name]-[hash].[ext]`, which does not match the name in an `#include`. Embed a directory with `--asset` instead. It keeps the relative paths of the files inside it, and the directory is available under `import.meta.dir` at runtime:
+
+```sh
+bun build --compile ./app.ts --asset ./csrc --outfile app
+```
+
+```ts
+import { cc } from "bun:ffi";
+import path from "path";
+
+const { symbols } = cc({
+  source: path.join(import.meta.dir, "csrc", "hello.c"), // #include "util.h" finds csrc/util.h
+  include: [path.join(import.meta.dir, "csrc", "vendor")],
+  symbols: { hello: { args: [], returns: "int" } },
+});
+```
+
+System headers and libraries still come from the machine that runs the executable.
+
 ### Disabling `cc`
 
 Pass `--no-ffi-cc` to disable the C compiler for a process. Any call to `cc()` then throws an error with the code `ERR_FFI_CC_DISABLED`. The `--no-addons` flag also disables `cc()`, in addition to `process.dlopen`.

--- a/patches/tinycc/open-func.patch
+++ b/patches/tinycc/open-func.patch
@@ -1,0 +1,133 @@
+--- libtcc.c
++++ libtcc.c
+@@ -704,6 +704,20 @@ LIBTCCAPI void tcc_set_error_func(TCCState *s, void *error_opaque, TCCErrorFunc
+     s->error_func = error_func;
+ }
+ 
++LIBTCCAPI void tcc_set_open_func(TCCState *s, void *open_opaque, TCCOpenFunc *open_func)
++{
++    s->open_opaque = open_opaque;
++    s->open_func = open_func;
++}
++
++/* ask the open callback for 'filename'. Return 0 if it served the file */
++static int tcc_open_from_memory(TCCState *s1, const char *filename, const char **buf, unsigned long *len)
++{
++    if (!s1->open_func)
++        return -1;
++    return s1->open_func(s1->open_opaque, filename, buf, len);
++}
++
+ /* error without aborting current compilation */
+ PUB_FUNC int _tcc_error_noabort(const char *fmt, ...)
+ {
+@@ -789,7 +803,15 @@ static int _tcc_open(TCCState *s1, const char *filename)
+ 
+ ST_FUNC int tcc_open(TCCState *s1, const char *filename)
+ {
+-    int fd = _tcc_open(s1, filename);
++    const char *buf;
++    unsigned long len;
++    int fd;
++    if (tcc_open_from_memory(s1, filename, &buf, &len) == 0) {
++        tcc_open_bf(s1, filename, (int)len);
++        memcpy(file->buffer, buf, len);
++        return 0;
++    }
++    fd = _tcc_open(s1, filename);
+     if (fd < 0)
+         return -1;
+     tcc_open_bf(s1, filename, 0);
+@@ -797,8 +819,10 @@ ST_FUNC int tcc_open(TCCState *s1, const char *filename)
+     return 0;
+ }
+ 
+-/* compile the file opened in 'file'. Return non zero if errors. */
+-static int tcc_compile(TCCState *s1, int filetype, const char *str, int fd)
++/* compile 'filename'. The source is 'str' (len bytes) when it is non-NULL,
++   otherwise it is read from 'fd'. Return non zero if errors. */
++static int tcc_compile(TCCState *s1, int filetype, const char *filename,
++                       const char *str, unsigned long len, int fd)
+ {
+     /* Here we enter the code section where we use the global variables for
+        parsing and code generation (tccpp.c, tccgen.c, <target>-gen.c).
+@@ -812,12 +836,11 @@ static int tcc_compile(TCCState *s1, int filetype, const char *str, int fd)
+ 
+     if (setjmp(s1->error_jmp_buf) == 0) {
+ 
+-        if (fd == -1) {
+-            int len = strlen(str);
+-            tcc_open_bf(s1, "<string>", len);
++        if (str) {
++            tcc_open_bf(s1, filename, (int)len);
+             memcpy(file->buffer, str, len);
+         } else {
+-            tcc_open_bf(s1, str, 0);
++            tcc_open_bf(s1, filename, 0);
+             file->fd = fd;
+         }
+ 
+@@ -845,7 +868,7 @@ static int tcc_compile(TCCState *s1, int filetype, const char *str, int fd)
+ 
+ LIBTCCAPI int tcc_compile_string(TCCState *s, const char *str)
+ {
+-    return tcc_compile(s, s->filetype, str, -1);
++    return tcc_compile(s, s->filetype, "<string>", str, strlen(str), -1);
+ }
+ 
+ /* define a preprocessor symbol. value can be NULL, sym can be "sym=val" */
+@@ -1232,6 +1255,16 @@ ST_FUNC int tcc_add_file_internal(TCCState *s1, const char *filename, int flags)
+         && (flags & AFF_TYPE_BIN))
+         return 0;
+ 
++    /* sources may come from memory; binaries are always read from a fd */
++    if (0 == (flags & AFF_TYPE_BIN)) {
++        const char *buf;
++        unsigned long len;
++        if (tcc_open_from_memory(s1, filename, &buf, &len) == 0) {
++            dynarray_add(&s1->target_deps, &s1->nb_target_deps, tcc_strdup(filename));
++            return tcc_compile(s1, flags, filename, buf, len, -1);
++        }
++    }
++
+     /* open the file */
+     fd = _tcc_open(s1, filename);
+     if (fd < 0) {
+@@ -1244,7 +1277,7 @@ ST_FUNC int tcc_add_file_internal(TCCState *s1, const char *filename, int flags)
+         return tcc_add_binary(s1, flags, filename, fd);
+ 
+     dynarray_add(&s1->target_deps, &s1->nb_target_deps, tcc_strdup(filename));
+-    return tcc_compile(s1, flags, filename, fd);
++    return tcc_compile(s1, flags, filename, NULL, 0, fd);
+ }
+ 
+ LIBTCCAPI int tcc_add_file(TCCState *s, const char *filename)
+--- libtcc.h
++++ libtcc.h
+@@ -30,6 +30,13 @@ LIBTCCAPI void tcc_set_lib_path(TCCState *s, const char *path);
+ typedef void TCCErrorFunc(void *opaque, const char *msg);
+ LIBTCCAPI void tcc_set_error_func(TCCState *s, void *error_opaque, TCCErrorFunc *error_func);
+ 
++/* set a callback that serves source files from memory (optional). It is
++   asked before open(2) for every C source and #include. To serve 'filename',
++   set *buf and *len and return 0; tcc copies the bytes before it returns to
++   the caller. Return -1 to fall back to the file system. */
++typedef int TCCOpenFunc(void *opaque, const char *filename, const char **buf, unsigned long *len);
++LIBTCCAPI void tcc_set_open_func(TCCState *s, void *open_opaque, TCCOpenFunc *open_func);
++
+ /* set options as from command line (multiple supported) */
+ LIBTCCAPI int tcc_set_options(TCCState *s, const char *str);
+ 
+--- tcc.h
++++ tcc.h
+@@ -859,6 +859,10 @@ struct TCCState {
+     jmp_buf error_jmp_buf;
+     int nb_errors;
+ 
++    /* in-memory source files (see tcc_set_open_func) */
++    void *open_opaque;
++    int (*open_func)(void *opaque, const char *filename, const char **buf, unsigned long *len);
++
+     /* output file for preprocessing (-E) */
+     FILE *ppfp;
+ 

--- a/scripts/build/deps/tinycc.ts
+++ b/scripts/build/deps/tinycc.ts
@@ -27,7 +27,8 @@ export const tinycc: Dependency = {
     commit: TINYCC_COMMIT,
   }),
 
-  patches: ["patches/tinycc/tcc.h.patch"],
+  // open-func.patch adds tcc_set_open_func so bun:ffi cc() can serve embedded sources from memory.
+  patches: ["patches/tinycc/tcc.h.patch", "patches/tinycc/open-func.patch"],
 
   build: cfg => {
     const sources = ["libtcc.c", "tccpp.c", "tccgen.c", "tccdbg.c", "tccelf.c", "tccasm.c", "tccrun.c"];

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)] // `feature = "tinycc"` is a Phase-C placeholder; `bun_codegen_embed` is set via RUSTFLAGS in scripts/build/rust.ts.
 
 use core::cell::Cell;
-use core::ffi::{c_char, c_int, c_long, c_void};
+use core::ffi::{c_char, c_int, c_long, c_ulong, c_void};
 use core::ptr::NonNull;
 use std::io::Write as _;
 use std::sync::{Once, OnceLock};
@@ -308,6 +308,50 @@ impl Source {
         }
         Ok(())
     }
+}
+
+/// `TCCOpenFunc` that serves `/$bunfs/` sources and headers from the standalone module graph.
+unsafe extern "C" fn open_embedded_file(
+    _opaque: *mut c_void,
+    filename: *const c_char,
+    buf: *mut *const c_char,
+    len: *mut c_ulong,
+) -> c_int {
+    // SAFETY: TinyCC passes a NUL-terminated path.
+    let path = unsafe { ZStr::from_c_ptr(filename) }.as_bytes();
+    if !bun_standalone_graph::is_bun_standalone_file_path(path) {
+        return -1;
+    }
+    let Some(graph) = bun_standalone_graph::Graph::get_ref() else {
+        return -1;
+    };
+    // An embedded key can keep `..` verbatim (#32728), so the exact path goes first.
+    let mut normalized = bun_paths::path_buffer_pool::get();
+    let file = match graph.find_ref(path) {
+        Some(file) => file,
+        None => {
+            // TinyCC builds `/$bunfs/root/dir/../x.h` for `#include "../x.h"`.
+            let key = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+                b"/",
+                &mut normalized[..],
+                &[path],
+            );
+            match graph.find_ref(key) {
+                Some(file) => file,
+                None => return -1,
+            }
+        }
+    };
+    let contents = file.utf8_contents();
+    let Ok(contents_len) = c_ulong::try_from(contents.len()) else {
+        return -1;
+    };
+    // SAFETY: TinyCC passes valid out-pointers.
+    unsafe {
+        *buf = contents.as_ptr().cast::<c_char>();
+        *len = contents_len;
+    }
+    0
 }
 
 // ─── stdarg ─────────────────────────────────────────────────────────────────
@@ -646,6 +690,10 @@ impl CompileC {
         // SAFETY: `state_ptr` was just returned non-null by `TCC::State::init`;
         // we hold the only reference for the rest of this function.
         let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
+
+        if bun_standalone_graph::Graph::get_ref().is_some() {
+            state.set_open_func(Some(open_embedded_file));
+        }
 
         if let Some(compiler_rt_dir) = CompilerRT::dir() {
             if state.add_sys_include_path(compiler_rt_dir).is_err() {

--- a/src/tcc_sys/tcc.rs
+++ b/src/tcc_sys/tcc.rs
@@ -1,4 +1,4 @@
-use core::ffi::{c_char, c_int, c_void};
+use core::ffi::{c_char, c_int, c_ulong, c_void};
 use core::ptr::NonNull;
 
 use bun_core::ZStr;
@@ -10,6 +10,16 @@ pub type TCCErrorFunc = Option<unsafe extern "C" fn(opaque: *mut c_void, msg: *c
 
 /// Typed error callback signature for a given context type.
 pub type ErrorFunc<Ctx> = unsafe extern "C" fn(ctx: *mut Ctx, msg: *const c_char);
+
+/// Raw C open callback signature; the contract is documented at `TCCOpenFunc` in libtcc.h.
+pub type TCCOpenFunc = Option<
+    unsafe extern "C" fn(
+        opaque: *mut c_void,
+        filename: *const c_char,
+        buf: *mut *const c_char,
+        len: *mut c_ulong,
+    ) -> c_int,
+>;
 
 // `libtcc.a` is only built where `cfg.tinycc` is true (`scripts/build/config.ts`):
 // not Android, not FreeBSD (the vendored fork doesn't support those targets).
@@ -49,6 +59,7 @@ tcc_externs! {
     fn tcc_new() -> *mut TCCState;
     fn tcc_delete(s: *mut TCCState);
     fn tcc_set_error_func(s: *mut TCCState, error_opaque: *mut c_void, error_func: TCCErrorFunc);
+    fn tcc_set_open_func(s: *mut TCCState, open_opaque: *mut c_void, open_func: TCCOpenFunc);
     // NOTE: tcc_get_error_func / tcc_get_error_opaque were removed from the libtcc public API
     // (not present in vendor/tinycc/libtcc.h). Do not declare them here —
     // referencing them would fail to link.
@@ -236,6 +247,12 @@ impl State {
         let opaque = error_opaque.map_or(core::ptr::null_mut(), |p| p.cast::<c_void>());
         // SAFETY: self is a valid *mut TCCState.
         unsafe { tcc_set_error_func(self, opaque, erased) }
+    }
+
+    /// Set the callback that serves source files and headers from memory (no opaque context).
+    pub fn set_open_func(&mut self, open_func: TCCOpenFunc) {
+        // SAFETY: self is a valid *mut TCCState.
+        unsafe { tcc_set_open_func(self, core::ptr::null_mut(), open_func) }
     }
 
     // NOTE: get_error_func / get_error_opaque wrappers removed — the underlying

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -462,6 +462,244 @@ describe.skipIf(isASAN)("GC liveness of compiled symbols and callbacks", () => {
   });
 });
 
+// A C source imported `with { type: "file" }` or embedded with `--asset` and
+// shipped through `bun build --compile` lives in the embedded file system,
+// which TinyCC's open(2) cannot see. cc() serves those paths to TinyCC itself.
+describe.concurrent("cc() inside a bun build --compile executable", () => {
+  // The executable runs from an empty directory, so a header that TinyCC finds
+  // comes from the embedded file system and not from the source tree.
+  async function compileAndRun(dir: string, entry: string, ...buildArgs: string[]) {
+    const exe = path.join(dir, isWindows ? "app.exe" : "app");
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", entry, "--outfile", exe, ...buildArgs],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    expect({ buildStdout, buildStderr, buildExitCode }).toMatchObject({ buildExitCode: 0 });
+
+    const runDir = path.join(dir, "run");
+    mkdirSync(runDir);
+    await using proc = Bun.spawn({
+      cmd: [exe],
+      env: bunEnv,
+      cwd: runDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  it("compiles an embedded source file", async () => {
+    using dir = tempDir("bun-ffi-cc-compile", {
+      "hello.c": /* c */ `
+        int hello() {
+          return 42;
+        }
+      `,
+      "hello.ts": /* ts */ `
+        import { cc } from "bun:ffi";
+        import source from "./hello.c" with { type: "file" };
+
+        const { symbols } = cc({
+          source,
+          symbols: { hello: { args: [], returns: "int" } },
+        });
+        console.log(symbols.hello());
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await compileAndRun(String(dir), "hello.ts");
+
+    expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "42\n", exitCode: 0 });
+  });
+
+  it("compiles several embedded source files and keeps their paths in __FILE__", async () => {
+    using dir = tempDir("bun-ffi-cc-compile-many", {
+      "add.c": /* c */ `
+        int add(int a, int b) {
+          return a + b;
+        }
+      `,
+      "where.c": /* c */ `
+        const char* where(void) {
+          return __FILE__;
+        }
+      `,
+      "main.ts": /* ts */ `
+        import { cc } from "bun:ffi";
+        import add from "./add.c" with { type: "file" };
+        import where from "./where.c" with { type: "file" };
+
+        const { symbols } = cc({
+          source: [add, where],
+          symbols: {
+            add: { args: ["int", "int"], returns: "int" },
+            where: { args: [], returns: "cstring" },
+          },
+        });
+        console.log(JSON.stringify({
+          sum: symbols.add(1, 2),
+          where: symbols.where().toString(),
+          embedded: where,
+        }));
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await compileAndRun(String(dir), "main.ts");
+
+    const result = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ result, stderr, exitCode }).toMatchObject({ result: { sum: 3 }, exitCode: 0 });
+    // TinyCC normalizes Windows separators to "/" in __FILE__.
+    expect(result.where).toBe(result.embedded.replaceAll("\\", "/"));
+    expect(result.embedded).toMatch(/where-[a-z0-9]+\.c$/);
+  });
+
+  // `--asset ./csrc` keeps the tree's relative paths, so quoted includes resolve
+  // next to the embedded source, including `..` segments.
+  it('resolves #include "..." between files embedded with --asset', async () => {
+    using dir = tempDir("bun-ffi-cc-compile-include", {
+      "csrc/hello.c": /* c */ `
+        #include "sibling.h"
+        #include "sub/deep.h"
+        int hello() {
+          return ANSWER + DEEP;
+        }
+        int has_sibling(void) {
+        #if __has_include("sibling.h") && !__has_include("missing.h")
+          return 1;
+        #else
+          return 0;
+        #endif
+        }
+      `,
+      "csrc/sibling.h": /* c */ `
+        #define ANSWER 40
+      `,
+      "csrc/sub/deep.h": /* c */ `
+        #include "../sibling.h"
+        #define DEEP 2
+      `,
+      "main.ts": /* ts */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "csrc", "hello.c"),
+          symbols: {
+            hello: { args: [], returns: "int" },
+            has_sibling: { args: [], returns: "int" },
+          },
+        });
+        console.log(symbols.hello(), symbols.has_sibling());
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await compileAndRun(String(dir), "main.ts", "--asset", "./csrc");
+
+    expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "42 1\n", exitCode: 0 });
+  });
+
+  it("searches include directories embedded with --asset", async () => {
+    using dir = tempDir("bun-ffi-cc-compile-include-dir", {
+      "hello.c": /* c */ `
+        #include <answer.h>
+        int hello() {
+          return ANSWER;
+        }
+      `,
+      "headers/answer.h": /* c */ `
+        #define ANSWER 42
+      `,
+      "main.ts": /* ts */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+        import source from "./hello.c" with { type: "file" };
+
+        const { symbols } = cc({
+          source,
+          include: [path.join(import.meta.dir, "headers")],
+          symbols: { hello: { args: [], returns: "int" } },
+        });
+        console.log(symbols.hello());
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await compileAndRun(String(dir), "main.ts", "--asset", "./headers");
+
+    expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "42\n", exitCode: 0 });
+  });
+
+  // An out-of-root entry point keeps its `..` in the embedded name (#32728),
+  // and the lookup has to match that name byte for byte.
+  it("finds an embedded source whose path keeps a parent segment", async () => {
+    using dir = tempDir("bun-ffi-cc-compile-parent", {
+      "hello.c": /* c */ `
+        int hello() {
+          return 42;
+        }
+      `,
+      "app/index.ts": /* ts */ `
+        import { cc } from "bun:ffi";
+
+        const source = import.meta.dir + "/../hello.c";
+        const { symbols } = cc({
+          source,
+          symbols: { hello: { args: [], returns: "int" } },
+        });
+        console.log(symbols.hello(), source);
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await compileAndRun(
+      path.join(String(dir), "app"),
+      "./index.ts",
+      "../hello.c",
+      "--asset-naming=[dir]/[name].[ext]",
+    );
+
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    // import.meta.dir is `/$bunfs/root` (`B:\~BUN\root` on Windows) and the `..` stays in the path.
+    expect(stdout.replaceAll("\\", "/")).toMatch(/^42 .*\/root\/\.\.\/hello\.c\n$/);
+  });
+
+  // TinyCC's setjmp/longjmp error handling conflicts with ASan.
+  it.skipIf(isASAN)("reports errors against the embedded path", async () => {
+    using dir = tempDir("bun-ffi-cc-compile-error", {
+      "broken.c": /* c */ `
+        int broken() {
+          return 1 +;
+        }
+      `,
+      "main.ts": /* ts */ `
+        import { cc } from "bun:ffi";
+        import source from "./broken.c" with { type: "file" };
+
+        try {
+          cc({ source, symbols: { broken: { args: [], returns: "int" } } });
+          console.log("no error");
+        } catch (e) {
+          console.log(JSON.stringify({ message: e.message, source }));
+        }
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await compileAndRun(String(dir), "main.ts");
+
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    const result = JSON.parse(stdout);
+    expect(result.source).toMatch(/broken-[a-z0-9]+\.c$/);
+    expect(result.message).toStartWith(`1 errors while compiling ${result.source}\n`);
+    expect(result.message).toContain(`${result.source.replaceAll("\\", "/")}:3: error:`);
+  });
+});
+
 // va_arg on x86_64 SysV lowers to a call to __va_arg, which TinyCC expects
 // libtcc1 to provide; Bun replaces libtcc1 with src/runtime/ffi/libtcc1.c.
 // TinyCC's setjmp/longjmp error handling conflicts with ASan.


### PR DESCRIPTION
Fixes #24752. Supersedes #25149.

### Problem
- `cc({ source })` fails inside a `bun build --compile` executable when `source` is a C file imported `with { type: "file" }`: `tcc: error: file '/$bunfs/root/hello-c4hqht5f.c' not found`.
- The file lives in the standalone module graph, not on disk. TinyCC opens sources and headers with `open(2)`, so `tcc_add_file` (`Source::add`, `src/runtime/ffi/ffi_body.rs`) cannot find it, nor any `#include` of an embedded header.

### Fix
- TinyCC gains an open callback, `tcc_set_open_func`, next to `tcc_set_error_func` (`patches/tinycc/open-func.patch`, also proposed upstream as oven-sh/tinycc#4). TinyCC asks it before `open(2)` for every C source and `#include`, and copies the bytes it gets.
- `CompileC::compile` installs `open_embedded_file` when a standalone graph exists. It serves `/$bunfs/` paths from the graph, exact path first (a key can keep `..`, #32728), then normalized (`#include "../x.h"` arrives as `dir/../x.h`). Other paths return -1, so TinyCC reads them from disk as before.
- TinyCC opens the file under its real name, so `__FILE__`, diagnostics, `#include "sibling.h"`, `include: [dir]`, and `__has_include` behave like a file on disk.
- Verified: `test/js/bun/ffi/cc.test.ts`, six new cases under "cc() inside a bun build --compile executable" (all fail on bun 1.4.1). The rest of the file passes. Docs gain a "Standalone executables" section.

### Background
- `bun build --compile` packs modules and assets into the executable. At runtime they appear under `/$bunfs/root/` (`B:/~BUN/root/` on Windows). `Graph::get_ref()` is their table, `None` outside a compiled executable.
- `with { type: "file" }` renames an asset to `[name]-[hash].[ext]`, which no `#include` matches. `--asset ./dir` keeps relative paths; the include tests use it.
- The tinycc dependency is fetched from oven-sh/tinycc and patched at build time (`scripts/build/deps/tinycc.ts`). When oven-sh/tinycc#4 lands, the patch becomes a `TINYCC_COMMIT` bump.

<details><summary>Notes</summary>

- Alternative considered: `resolve_embedded_file_to_buf` (`src/runtime/jsc_hooks.rs`) extracts embedded `.node`/`.so` files to a temp file for `dlopen`. For C it would leave `.c` files in the temp directory and still not resolve an `#include` of another embedded header, so the hook was chosen instead.
- The first version of this PR fed embedded sources to `tcc_compile_string` with a `#line` prefix. That compiled the source but left TinyCC's `true_filename` as `<string>`, so `#include "x.h"` resolved against the process cwd and embedded headers could never be found. The hook replaces it.
- Follow-up, not in this PR: the same hook can serve the compiler runtime headers (`CompilerRT`, `ffi_body.rs`) from memory and retire the temp directory they are staged in today.
- Example diagnostic with the hook: `1 errors while compiling /$bunfs/root/broken-kt71z00s.c` then `/$bunfs/root/broken-kt71z00s.c:3: error: expression expected before ';'`.
- `unsigned long` for the length matches `TCCReallocFunc` in libtcc.h, which includes no headers on purpose. TinyCC's own `make test` passes with the change (it now serves a header and a source from memory in `tests/libtcc_test.c`).
- The error-path test is skipped under ASAN like the other compile-error tests in this file, although it passed locally under the ASAN debug build.
- While writing the tests I found that `toMatchObject` replaces matched properties of the received object with the asymmetric matcher (`expect.any(String)`). That bug is handed off separately; the tests here avoid the pattern.
- Fails before: `USE_SYSTEM_BUN=1 bun test test/js/bun/ffi/cc.test.ts -t "compile executable"` (6 fail). Passes after: `bun bd test test/js/bun/ffi/cc.test.ts` (19 pass, 34 skip under ASAN, 0 fail).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->