### PR TITLE
docs: fix TypeScript casing in bundler reference

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1693,7 +1693,7 @@ if (result.logs.length > 0) {
 
 ## Reference
 
-```ts Typescript Definitions icon="/icons/typescript.svg" expandable
+```ts TypeScript Definitions icon="/icons/typescript.svg" expandable
 interface Bun {
   build(options: BuildOptions): Promise<BuildOutput>;
 }


### PR DESCRIPTION
Fix proper noun casing: Typescript -> TypeScript in bundler reference.
