### PR TITLE
docs: fix TypeScript casing in transpiler docs

### DIFF
--- a/docs/runtime/transpiler.mdx
+++ b/docs/runtime/transpiler.mdx
@@ -182,7 +182,7 @@ const result = transpiler.scanImports(code);
 
 ## Reference
 
-```ts See Typescript Definitions expandable
+```ts See TypeScript Definitions expandable
 type Loader = "jsx" | "js" | "ts" | "tsx";
 
 interface TranspilerOptions {


### PR DESCRIPTION
Fix proper noun casing.