### PR TITLE
docs: fix TypeScript casing in websockets docs

### DIFF
--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -360,7 +360,7 @@ socket.addEventListener("message", event => {
 
 ## Reference
 
-```ts See Typescript Definitions expandable
+```ts See TypeScript Definitions expandable
 namespace Bun {
   export function serve(params: {
     fetch: (req: Request, server: Server) => Response | Promise<Response>;


### PR DESCRIPTION
Fix proper noun casing.