### PR TITLE
bun-release: stamp npm canary versions with the commit the assets were built from

### DIFF
--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -10,7 +10,7 @@ import { dirname } from "path";
 import { debug, error, log } from "../src/console";
 import { fetch } from "../src/fetch";
 import { chmod, copy, exists, join, write, writeJson } from "../src/fs";
-import { getRelease, getSemver, getShaForRelease } from "../src/github";
+import { getRelease, getSemverForRelease, getShaForRelease } from "../src/github";
 import type { Platform } from "../src/platform";
 import { platforms } from "../src/platform";
 import { binaryIncludesSha } from "../src/sha";
@@ -23,7 +23,7 @@ const [tag, action] = process.argv.slice(2);
 
 const release = await getRelease(tag);
 const revision = await getShaForRelease(release, "long");
-const version = await getSemver(release.tag_name);
+const version = await getSemverForRelease(release);
 
 if (action !== "test-only") await build();
 

--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -10,9 +10,10 @@ import { dirname } from "path";
 import { debug, error, log } from "../src/console";
 import { fetch } from "../src/fetch";
 import { chmod, copy, exists, join, write, writeJson } from "../src/fs";
-import { getRelease, getSemver } from "../src/github";
+import { getRelease, getSemver, getShaForRelease } from "../src/github";
 import type { Platform } from "../src/platform";
 import { platforms } from "../src/platform";
+import { binaryIncludesSha } from "../src/sha";
 import { spawn } from "../src/spawn";
 
 const module = "bun";
@@ -21,6 +22,7 @@ const owner = "@oven";
 const [tag, action] = process.argv.slice(2);
 
 const release = await getRelease(tag);
+const revision = await getShaForRelease(release, "long");
 const version = await getSemver(release.tag_name);
 
 if (action !== "test-only") await build();
@@ -152,9 +154,16 @@ async function buildModule(
     return;
   }
   const bun = await extractFromZip(asset.browser_download_url, `${bin}/bun`);
+  const buffer = await bun.async("nodebuffer");
+  // Abort the whole publish on a mismatch: stamping `version` (which carries
+  // `revision`) onto a binary built from another commit publishes metadata
+  // that lies about the binary (#40880).
+  if (!binaryIncludesSha(buffer, revision)) {
+    throw new Error(`Binary in ${bin}.zip was not built from the expected commit: ${revision}`);
+  }
   const cwd = join("npm", module);
   mkdirSync(dirname(join(cwd, exe)), { recursive: true });
-  write(join(cwd, exe), await bun.async("arraybuffer"));
+  write(join(cwd, exe), buffer);
   chmod(join(cwd, exe), 0o755);
   writeJson(join(cwd, "package.json"), {
     name: module,

--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -9,11 +9,11 @@ import { tmpdir } from "os";
 import { dirname } from "path";
 import { debug, error, log } from "../src/console";
 import { fetch } from "../src/fetch";
-import { chmod, copy, exists, join, write, writeJson } from "../src/fs";
-import { getRelease, getSemverForRelease, getShaForRelease } from "../src/github";
+import { basename, chmod, copy, exists, join, tmp, write, writeJson } from "../src/fs";
+import { getRelease, getSemver } from "../src/github";
 import type { Platform } from "../src/platform";
-import { platforms } from "../src/platform";
-import { binaryIncludesSha } from "../src/sha";
+import { abi, arch, os, platforms } from "../src/platform";
+import { binaryIncludesSha, binaryRevision } from "../src/sha";
 import { spawn } from "../src/spawn";
 
 const module = "bun";
@@ -22,8 +22,27 @@ const owner = "@oven";
 const [tag, action] = process.argv.slice(2);
 
 const release = await getRelease(tag);
-const revision = await getShaForRelease(release, "long");
-const version = await getSemverForRelease(release);
+const revision = await getRevisionOfAssets();
+const version = await getSemver(release.tag_name, undefined, revision);
+
+// The commit the release's assets were built from, read out of the binary
+// for the platform this script runs on. git has no ref for it: the rolling
+// canary release's tag never moves while its assets are replaced in place.
+async function getRevisionOfAssets(): Promise<string> {
+  const platform = platforms.find(p => !p.alias && p.os === os && p.arch === arch && p.abi === abi);
+  if (!platform) {
+    throw new Error(`No platform entry matches this machine: ${os}-${arch}`);
+  }
+  const asset = release.assets.find(({ name }) => name === `${platform.bin}.zip`);
+  if (!asset) {
+    throw new Error(`Release "${release.tag_name}" has no asset: ${platform.bin}.zip`);
+  }
+  const bun = await extractFromZip(asset.browser_download_url, `${platform.bin}/bun`);
+  const exe = join(tmp(), basename(platform.exe));
+  write(exe, await bun.async("nodebuffer"));
+  chmod(exe, 0o755);
+  return binaryRevision(exe);
+}
 
 if (action !== "test-only") await build();
 

--- a/packages/bun-release/scripts/upload-s3.ts
+++ b/packages/bun-release/scripts/upload-s3.ts
@@ -1,6 +1,6 @@
 import { AwsClient } from "aws4fetch";
 import { join, tmp } from "../src/fs";
-import { getBuild, getRelease, getSemver, getShaForRelease } from "../src/github";
+import { getBuild, getRelease, getSemver } from "../src/github";
 
 // The source of truth for the git sha is what's in the local build, extracted from features.json
 // NOT the git tag revision.
@@ -45,13 +45,12 @@ try {
 
 const latest = await getRelease();
 const release = await getRelease(tag);
-// For canary this is the commit the release's assets were built from, not
-// heads/main, so the bun.report purge-cache call below names the commit that
-// was actually uploaded.
-const full_commit_hash = await getShaForRelease(release, "long");
-console.log("Found release:", release.tag_name, "with commit hash:", full_commit_hash);
+console.log("Found release:", release.tag_name);
 
-console.log("Found build:", full_commit_hash);
+// The commit the assets were built from, read out of the local build's
+// features.json below. git has no ref for it on canary, so the bun.report
+// purge-cache call at the end waits for this instead of resolving heads/main.
+let full_commit_hash: string | undefined;
 const isCanary = release.tag_name === "canary";
 
 let paths: string[] = [];
@@ -61,7 +60,7 @@ async function setPaths(revision: string, isCanary: boolean) {
     paths = ["releases/latest", `releases/${release.tag_name}`, releaseSha];
   } else if (isCanary) {
     try {
-      const build = await getSemver("canary", await getBuild());
+      const build = await getSemver("canary", await getBuild(), revision);
       paths = ["releases/canary", `releases/${build}`, releaseSha];
     } catch (error) {
       console.warn(error);
@@ -142,6 +141,8 @@ for (const asset of release.assets) {
     const text = await getFeaturesJSON(body);
     const features = JSON.parse(text);
     const sha = features.revision;
+    full_commit_hash = sha;
+    console.log("Found build:", full_commit_hash);
     if (features.is_canary && !isCanary) {
       console.warn("Local build is a canary but release is not tagged as canary.");
     }
@@ -176,7 +177,7 @@ for (const asset of release.assets) {
   }
 }
 
-if (!dryRun && process.env.BUN_REPORT_TOKEN) {
+if (!dryRun && process.env.BUN_REPORT_TOKEN && full_commit_hash) {
   await fetch(`https://bun.report/purge-cache/${full_commit_hash}`, {
     method: "POST",
     headers: {

--- a/packages/bun-release/scripts/upload-s3.ts
+++ b/packages/bun-release/scripts/upload-s3.ts
@@ -1,6 +1,6 @@
 import { AwsClient } from "aws4fetch";
 import { join, tmp } from "../src/fs";
-import { getBuild, getRelease, getSemver, getSha } from "../src/github";
+import { getBuild, getRelease, getSemver, getShaForRelease } from "../src/github";
 
 // The source of truth for the git sha is what's in the local build, extracted from features.json
 // NOT the git tag revision.
@@ -45,7 +45,10 @@ try {
 
 const latest = await getRelease();
 const release = await getRelease(tag);
-const full_commit_hash = await getSha(tag, "long");
+// For canary this is the commit the release's assets were built from, not
+// heads/main, so the bun.report purge-cache call below names the commit that
+// was actually uploaded.
+const full_commit_hash = await getShaForRelease(release, "long");
 console.log("Found release:", release.tag_name, "with commit hash:", full_commit_hash);
 
 console.log("Found build:", full_commit_hash);

--- a/packages/bun-release/src/github.ts
+++ b/packages/bun-release/src/github.ts
@@ -117,9 +117,18 @@ export async function getBuild(): Promise<number> {
 }
 
 export async function getSemver(tag?: string, build?: number): Promise<string> {
+  return getSemverForRelease(await getRelease(tag), build);
+}
+
+// Takes the release object instead of a tag so that the caller and the
+// version share one snapshot of the rolling canary release: a re-fetch could
+// see different assets and notes if an upload replaces them in between.
+export async function getSemverForRelease(
+  release: { tag_name: string; body?: string | null },
+  build?: number,
+): Promise<string> {
   const { tag_name: latest_tag_name } = await getRelease();
   const version = latest_tag_name.replace("bun-v", "");
-  const release = await getRelease(tag);
   if (release.tag_name !== "canary") {
     return release.tag_name.replace("bun-v", "");
   }

--- a/packages/bun-release/src/github.ts
+++ b/packages/bun-release/src/github.ts
@@ -2,7 +2,6 @@ import type { Endpoints, RequestParameters, Route } from "@octokit/types";
 import { Octokit } from "octokit";
 import { debug, error, log, warn } from "./console";
 import { fetch } from "./fetch";
-import { getShaFromReleaseBody } from "./sha";
 
 const [owner, repo] = process.env["GITHUB_REPOSITORY"]?.split("/") ?? ["oven-sh", "bun"];
 
@@ -86,25 +85,6 @@ export async function getSha(tag: string, format?: "short" | "long") {
   return format === "short" ? sha.substring(0, 7) : sha;
 }
 
-// The sha of the commit that a release's assets were built from. For the
-// rolling canary release this comes from the release notes, which the upload
-// step rewrites whenever it replaces the assets. heads/main is only a
-// fallback: it can be ahead of the assets when a canary upload fails or lags.
-export async function getShaForRelease(
-  release: { tag_name: string; body?: string | null },
-  format?: "short" | "long",
-): Promise<string> {
-  let sha: string | undefined;
-  if (release.tag_name === "canary") {
-    sha = getShaFromReleaseBody(release.body);
-    if (!sha) {
-      warn("Canary release notes do not record the built commit, falling back to heads/main");
-    }
-  }
-  sha ??= await getSha(release.tag_name, "long");
-  return format === "short" ? sha.substring(0, 7) : sha;
-}
-
 export async function getBuild(): Promise<number> {
   const date = new Date().toISOString().split("T")[0].replace(/-/g, "");
   const response = await fetch("https://registry.npmjs.org/-/package/bun/dist-tags");
@@ -116,28 +96,25 @@ export async function getBuild(): Promise<number> {
   return match ? 1 + parseInt(match[1]) : 1;
 }
 
-export async function getSemver(tag?: string, build?: number): Promise<string> {
-  return getSemverForRelease(await getRelease(tag), build);
-}
-
-// Takes the release object instead of a tag so that the caller and the
-// version share one snapshot of the rolling canary release: a re-fetch could
-// see different assets and notes if an upload replaces them in between.
-export async function getSemverForRelease(
-  release: { tag_name: string; body?: string | null },
-  build?: number,
-): Promise<string> {
+// For a canary version, `sha` names the commit the release's binaries were
+// built from. The publish scripts derive it from the binaries themselves
+// (src/sha.ts binaryRevision): the rolling canary release's tag never moves,
+// so git has no ref for what its assets contain. Without `sha` this falls
+// back to heads/main, which can be ahead of the assets when a canary upload
+// fails or lags (#40880).
+export async function getSemver(tag?: string, build?: number, sha?: string): Promise<string> {
   const { tag_name: latest_tag_name } = await getRelease();
   const version = latest_tag_name.replace("bun-v", "");
-  if (release.tag_name !== "canary") {
-    return release.tag_name.replace("bun-v", "");
+  const { tag_name } = await getRelease(tag);
+  if (tag_name !== "canary") {
+    return tag_name.replace("bun-v", "");
   }
   if (build === undefined) {
     build = await getBuild();
   }
-  const sha = await getShaForRelease(release, "short");
+  sha ??= await getSha(tag_name);
   const date = new Date().toISOString().split("T")[0].replace(/-/g, "");
-  return `${version}-canary.${date}.${build}+${sha}`;
+  return `${version}-canary.${date}.${build}+${sha.substring(0, 7)}`;
 }
 
 export function formatTag(tag: string): string {

--- a/packages/bun-release/src/github.ts
+++ b/packages/bun-release/src/github.ts
@@ -2,6 +2,7 @@ import type { Endpoints, RequestParameters, Route } from "@octokit/types";
 import { Octokit } from "octokit";
 import { debug, error, log, warn } from "./console";
 import { fetch } from "./fetch";
+import { getShaFromReleaseBody } from "./sha";
 
 const [owner, repo] = process.env["GITHUB_REPOSITORY"]?.split("/") ?? ["oven-sh", "bun"];
 
@@ -85,6 +86,25 @@ export async function getSha(tag: string, format?: "short" | "long") {
   return format === "short" ? sha.substring(0, 7) : sha;
 }
 
+// The sha of the commit that a release's assets were built from. For the
+// rolling canary release this comes from the release notes, which the upload
+// step rewrites whenever it replaces the assets. heads/main is only a
+// fallback: it can be ahead of the assets when a canary upload fails or lags.
+export async function getShaForRelease(
+  release: { tag_name: string; body?: string | null },
+  format?: "short" | "long",
+): Promise<string> {
+  let sha: string | undefined;
+  if (release.tag_name === "canary") {
+    sha = getShaFromReleaseBody(release.body);
+    if (!sha) {
+      warn("Canary release notes do not record the built commit, falling back to heads/main");
+    }
+  }
+  sha ??= await getSha(release.tag_name, "long");
+  return format === "short" ? sha.substring(0, 7) : sha;
+}
+
 export async function getBuild(): Promise<number> {
   const date = new Date().toISOString().split("T")[0].replace(/-/g, "");
   const response = await fetch("https://registry.npmjs.org/-/package/bun/dist-tags");
@@ -99,14 +119,14 @@ export async function getBuild(): Promise<number> {
 export async function getSemver(tag?: string, build?: number): Promise<string> {
   const { tag_name: latest_tag_name } = await getRelease();
   const version = latest_tag_name.replace("bun-v", "");
-  const { tag_name } = await getRelease(tag);
-  if (tag_name !== "canary") {
-    return tag_name.replace("bun-v", "");
+  const release = await getRelease(tag);
+  if (release.tag_name !== "canary") {
+    return release.tag_name.replace("bun-v", "");
   }
   if (build === undefined) {
     build = await getBuild();
   }
-  const sha = await getSha(tag_name, "short");
+  const sha = await getShaForRelease(release, "short");
   const date = new Date().toISOString().split("T")[0].replace(/-/g, "");
   return `${version}-canary.${date}.${build}+${sha}`;
 }

--- a/packages/bun-release/src/sha.ts
+++ b/packages/bun-release/src/sha.ts
@@ -9,9 +9,11 @@ export function binaryRevision(exe: string): string {
   const { exitCode, stdout, stderr } = spawn(exe, ["--print", "Bun.revision"], {
     env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1" },
   });
-  const revision = stdout.trim();
+  // spawnSync leaves stdout and stderr null when the binary cannot launch at
+  // all (missing file, wrong architecture), and spawn() passes that through.
+  const revision = (stdout ?? "").trim();
   if (exitCode !== 0 || !/^[0-9a-f]{40}$/.test(revision)) {
-    throw new Error(`Could not read the build commit from ${exe}: ${stderr || stdout}`);
+    throw new Error(`Could not read the build commit from ${exe}: ${stderr || stdout || "the binary did not run"}`);
   }
   return revision;
 }

--- a/packages/bun-release/src/sha.ts
+++ b/packages/bun-release/src/sha.ts
@@ -1,0 +1,18 @@
+// The rolling "canary" GitHub release is re-used for every canary upload: the
+// tag never moves, so the only record of which commit its assets were built
+// from is the release notes line that .buildkite/scripts/upload-release.sh
+// writes after uploading ("This release of Bun corresponds to the commit: ...").
+// Resolving heads/main instead is wrong whenever an upload fails or lags,
+// because main keeps moving while the assets stay behind (#40880).
+export function getShaFromReleaseBody(body: string | null | undefined): string | undefined {
+  const match = /corresponds to the commit:\s*([0-9a-f]{40})\b/.exec(body ?? "");
+  return match?.[1];
+}
+
+// Bun embeds its build commit verbatim (it is what `Bun.revision` returns),
+// so the bytes of a released binary always contain the full sha it was built
+// from. This is how a downloaded binary is checked against the sha that will
+// be stamped into package metadata.
+export function binaryIncludesSha(binary: Buffer, sha: string): boolean {
+  return binary.includes(sha, 0, "utf8");
+}

--- a/packages/bun-release/src/sha.ts
+++ b/packages/bun-release/src/sha.ts
@@ -1,18 +1,25 @@
-// The rolling "canary" GitHub release is re-used for every canary upload: the
-// tag never moves, so the only record of which commit its assets were built
-// from is the release notes line that .buildkite/scripts/upload-release.sh
-// writes after uploading ("This release of Bun corresponds to the commit: ...").
-// Resolving heads/main instead is wrong whenever an upload fails or lags,
-// because main keeps moving while the assets stay behind (#40880).
-export function getShaFromReleaseBody(body: string | null | undefined): string | undefined {
-  const match = /corresponds to the commit:\s*([0-9a-f]{40})\b/.exec(body ?? "");
-  return match?.[1];
+import { spawn } from "./spawn";
+
+// Bun embeds the full commit it was built from (it is what `Bun.revision`
+// returns), so a released binary is itself the canonical record of the commit
+// its release assets were built from. The rolling "canary" release has no
+// other trustworthy record: its tag never moves, and heads/main advances past
+// the assets whenever an upload fails or lags (#40880).
+export function binaryRevision(exe: string): string {
+  const { exitCode, stdout, stderr } = spawn(exe, ["--print", "Bun.revision"], {
+    env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1" },
+  });
+  const revision = stdout.trim();
+  if (exitCode !== 0 || !/^[0-9a-f]{40}$/.test(revision)) {
+    throw new Error(`Could not read the build commit from ${exe}: ${stderr || stdout}`);
+  }
+  return revision;
 }
 
-// Bun embeds its build commit verbatim (it is what `Bun.revision` returns),
-// so the bytes of a released binary always contain the full sha it was built
-// from. This is how a downloaded binary is checked against the sha that will
-// be stamped into package metadata.
+// The embedded sha makes the bytes of every released binary contain the full
+// commit it was built from. This is how binaries for platforms that cannot
+// run on this machine are checked against the sha stamped into package
+// metadata.
 export function binaryIncludesSha(binary: Buffer, sha: string): boolean {
   return binary.includes(sha, 0, "utf8");
 }

--- a/test/integration/bun-release/sha.test.ts
+++ b/test/integration/bun-release/sha.test.ts
@@ -19,7 +19,7 @@ const SHA = "d578a8c70d103dd11c75cf3c8b681d4a015a66df";
 
 test("binaryRevision reads the embedded build commit out of a binary", () => {
   expect(binaryRevision(bunExe())).toBe(Bun.revision);
-  expect(() => binaryRevision("/does/not/exist")).toThrow();
+  expect(() => binaryRevision("/does/not/exist")).toThrow(/Could not read the build commit from/);
 });
 
 test("binaryIncludesSha finds the embedded revision among binary bytes", () => {

--- a/test/integration/bun-release/sha.test.ts
+++ b/test/integration/bun-release/sha.test.ts
@@ -2,41 +2,24 @@
  * The npm canary publish (packages/bun-release/scripts/upload-npm.ts) stamps a
  * commit sha into each package version. That sha must describe the binaries it
  * packages, which come from the assets of the rolling GitHub "canary" release.
- * The record of what those assets were built from is the release notes line
- * that .buildkite/scripts/upload-release.sh writes after every upload.
+ * The release's tag never moves, so the binaries themselves are the only
+ * record of the commit they were built from: Bun embeds it as Bun.revision.
  *
- * These tests pin the parser in packages/bun-release/src/sha.ts to the exact
- * template in the upload script, and cover the byte check that upload-npm.ts
- * runs on every downloaded binary before it is packaged.
+ * These tests cover the helpers in packages/bun-release/src/sha.ts that read
+ * and verify that embedded commit, and pin getSemver to stamp the sha of the
+ * assets instead of heads/main.
  */
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { cpSync, readFileSync } from "node:fs";
+import { cpSync } from "node:fs";
 import { join } from "node:path";
-import { binaryIncludesSha, getShaFromReleaseBody } from "../../../packages/bun-release/src/sha";
+import { binaryIncludesSha, binaryRevision } from "../../../packages/bun-release/src/sha";
 
 const SHA = "d578a8c70d103dd11c75cf3c8b681d4a015a66df";
 
-test("getShaFromReleaseBody parses the notes template in upload-release.sh", () => {
-  const script = readFileSync(join(import.meta.dir, "../../../.buildkite/scripts/upload-release.sh"), "utf8");
-  const template = /--notes "([^"]*corresponds to the commit[^"]*)"/.exec(script)?.[1];
-  expect(template).toBeDefined();
-  const body = template!.replace("$BUILDKITE_COMMIT", SHA);
-  expect(getShaFromReleaseBody(body)).toBe(SHA);
-});
-
-test("getShaFromReleaseBody parses the live canary release body format", () => {
-  expect(getShaFromReleaseBody(`This release of Bun corresponds to the commit: ${SHA}`)).toBe(SHA);
-  expect(getShaFromReleaseBody(`This release of Bun corresponds to the commit: ${SHA}\n\nmore notes`)).toBe(SHA);
-});
-
-test("getShaFromReleaseBody rejects bodies without a full commit sha", () => {
-  expect(getShaFromReleaseBody(undefined)).toBeUndefined();
-  expect(getShaFromReleaseBody(null)).toBeUndefined();
-  expect(getShaFromReleaseBody("")).toBeUndefined();
-  expect(getShaFromReleaseBody("Bun is a fast all-in-one JavaScript runtime.")).toBeUndefined();
-  // A short sha is not enough to identify the build.
-  expect(getShaFromReleaseBody("This release of Bun corresponds to the commit: d578a8c")).toBeUndefined();
+test("binaryRevision reads the embedded build commit out of a binary", () => {
+  expect(binaryRevision(bunExe())).toBe(Bun.revision);
+  expect(() => binaryRevision("/does/not/exist")).toThrow();
 });
 
 test("binaryIncludesSha finds the embedded revision among binary bytes", () => {
@@ -52,11 +35,12 @@ test("binaryIncludesSha finds the embedded revision among binary bytes", () => {
   expect(binaryIncludesSha(junk, SHA)).toBe(false);
 });
 
-test("getSemver stamps the canary version with the sha from the release notes, not heads/main", async () => {
+test("getSemver stamps the canary version with the sha of the assets, not heads/main", async () => {
   // The shas from oven-sh/bun#40880: the rolling release held binaries built
-  // from ASSET_SHA while heads/main had moved on to MAIN_SHA. The version
-  // must carry the sha of the assets, so the mocked GitHub API answers with a
-  // canary release whose notes name ASSET_SHA and a main ref at MAIN_SHA.
+  // from ASSET_SHA while heads/main had moved on to MAIN_SHA. The publish
+  // scripts read ASSET_SHA out of a downloaded binary and pass it in, and the
+  // version must carry it. The mocked GitHub API serves a main ref at
+  // MAIN_SHA, which is what the version must not fall back to.
   const ASSET_SHA = "731aa92dad3777448920b40a4c2d3efe7e776c4e";
   const MAIN_SHA = SHA;
   using dir = tempDir("bun-release-semver", {
@@ -69,13 +53,7 @@ test("getSemver stamps the canary version with the sha from the release notes, n
             case "GET /repos/{owner}/{repo}/releases/latest":
               return { data: { tag_name: "bun-v1.4.1" } };
             case "GET /repos/{owner}/{repo}/releases/tags/{tag}":
-              return {
-                data: {
-                  tag_name: params.tag,
-                  body: "This release of Bun corresponds to the commit: ${ASSET_SHA}",
-                  assets: [],
-                },
-              };
+              return { data: { tag_name: params.tag, assets: [] } };
             case "GET /repos/{owner}/{repo}/git/ref/{ref}":
               return { data: { object: { sha: "${MAIN_SHA}" } } };
             default:
@@ -87,7 +65,7 @@ test("getSemver stamps the canary version with the sha from the release notes, n
     // Passing the build number skips getBuild's npm registry request.
     "run-semver.fixture.ts": `
       import { getSemver } from "./src/github";
-      console.log(await getSemver("canary", 1));
+      console.log(await getSemver("canary", 1, "${ASSET_SHA}"));
     `,
   });
   // Copy the sources at test time, so this runs whatever state the release

--- a/test/integration/bun-release/sha.test.ts
+++ b/test/integration/bun-release/sha.test.ts
@@ -10,7 +10,8 @@
  * runs on every downloaded binary before it is packaged.
  */
 import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { cpSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { binaryIncludesSha, getShaFromReleaseBody } from "../../../packages/bun-release/src/sha";
 
@@ -49,4 +50,60 @@ test("binaryIncludesSha finds the embedded revision among binary bytes", () => {
   expect(binaryIncludesSha(binary, SHA)).toBe(true);
   expect(binaryIncludesSha(binary, Buffer.alloc(40, "f").toString())).toBe(false);
   expect(binaryIncludesSha(junk, SHA)).toBe(false);
+});
+
+test("getSemver stamps the canary version with the sha from the release notes, not heads/main", async () => {
+  // The shas from oven-sh/bun#40880: the rolling release held binaries built
+  // from ASSET_SHA while heads/main had moved on to MAIN_SHA. The version
+  // must carry the sha of the assets, so the mocked GitHub API answers with a
+  // canary release whose notes name ASSET_SHA and a main ref at MAIN_SHA.
+  const ASSET_SHA = "731aa92dad3777448920b40a4c2d3efe7e776c4e";
+  const MAIN_SHA = SHA;
+  using dir = tempDir("bun-release-semver", {
+    "node_modules/octokit/package.json": `{ "name": "octokit", "version": "0.0.0", "main": "index.js" }`,
+    "node_modules/octokit/index.js": `
+      exports.Octokit = class Octokit {
+        constructor() {}
+        async request(route, params = {}) {
+          switch (route) {
+            case "GET /repos/{owner}/{repo}/releases/latest":
+              return { data: { tag_name: "bun-v1.4.1" } };
+            case "GET /repos/{owner}/{repo}/releases/tags/{tag}":
+              return {
+                data: {
+                  tag_name: params.tag,
+                  body: "This release of Bun corresponds to the commit: ${ASSET_SHA}",
+                  assets: [],
+                },
+              };
+            case "GET /repos/{owner}/{repo}/git/ref/{ref}":
+              return { data: { object: { sha: "${MAIN_SHA}" } } };
+            default:
+              throw new Error("Unexpected request: " + route);
+          }
+        }
+      };
+    `,
+    // Passing the build number skips getBuild's npm registry request.
+    "run-semver.fixture.ts": `
+      import { getSemver } from "./src/github";
+      console.log(await getSemver("canary", 1));
+    `,
+  });
+  // Copy the sources at test time, so this runs whatever state the release
+  // scripts are in, with only the octokit dependency mocked.
+  cpSync(join(import.meta.dir, "../../../packages/bun-release/src"), join(String(dir), "src"), { recursive: true });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run-semver.fixture.ts"],
+    env: { ...bunEnv, GITHUB_REPOSITORY: "oven-sh/bun" },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ version: stdout.trim(), stderr }).toEqual({
+    version: expect.stringMatching(new RegExp(`^1\\.4\\.1-canary\\.\\d{8}\\.1\\+${ASSET_SHA.substring(0, 7)}$`)),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
 });

--- a/test/integration/bun-release/sha.test.ts
+++ b/test/integration/bun-release/sha.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The npm canary publish (packages/bun-release/scripts/upload-npm.ts) stamps a
+ * commit sha into each package version. That sha must describe the binaries it
+ * packages, which come from the assets of the rolling GitHub "canary" release.
+ * The record of what those assets were built from is the release notes line
+ * that .buildkite/scripts/upload-release.sh writes after every upload.
+ *
+ * These tests pin the parser in packages/bun-release/src/sha.ts to the exact
+ * template in the upload script, and cover the byte check that upload-npm.ts
+ * runs on every downloaded binary before it is packaged.
+ */
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { binaryIncludesSha, getShaFromReleaseBody } from "../../../packages/bun-release/src/sha";
+
+const SHA = "d578a8c70d103dd11c75cf3c8b681d4a015a66df";
+
+test("getShaFromReleaseBody parses the notes template in upload-release.sh", () => {
+  const script = readFileSync(join(import.meta.dir, "../../../.buildkite/scripts/upload-release.sh"), "utf8");
+  const template = /--notes "([^"]*corresponds to the commit[^"]*)"/.exec(script)?.[1];
+  expect(template).toBeDefined();
+  const body = template!.replace("$BUILDKITE_COMMIT", SHA);
+  expect(getShaFromReleaseBody(body)).toBe(SHA);
+});
+
+test("getShaFromReleaseBody parses the live canary release body format", () => {
+  expect(getShaFromReleaseBody(`This release of Bun corresponds to the commit: ${SHA}`)).toBe(SHA);
+  expect(getShaFromReleaseBody(`This release of Bun corresponds to the commit: ${SHA}\n\nmore notes`)).toBe(SHA);
+});
+
+test("getShaFromReleaseBody rejects bodies without a full commit sha", () => {
+  expect(getShaFromReleaseBody(undefined)).toBeUndefined();
+  expect(getShaFromReleaseBody(null)).toBeUndefined();
+  expect(getShaFromReleaseBody("")).toBeUndefined();
+  expect(getShaFromReleaseBody("Bun is a fast all-in-one JavaScript runtime.")).toBeUndefined();
+  // A short sha is not enough to identify the build.
+  expect(getShaFromReleaseBody("This release of Bun corresponds to the commit: d578a8c")).toBeUndefined();
+});
+
+test("binaryIncludesSha finds the embedded revision among binary bytes", () => {
+  // Bun.revision is the embedded full build sha that binaryIncludesSha
+  // searches for in released binaries.
+  expect(Bun.revision).toMatch(/^[0-9a-f]{40}$/);
+
+  const junk = Buffer.alloc(1 << 16);
+  for (let i = 0; i < junk.length; i++) junk[i] = i * 31;
+  const binary = Buffer.concat([junk, Buffer.from(SHA, "utf8"), junk]);
+  expect(binaryIncludesSha(binary, SHA)).toBe(true);
+  expect(binaryIncludesSha(binary, "f".repeat(40))).toBe(false);
+  expect(binaryIncludesSha(junk, SHA)).toBe(false);
+});

--- a/test/integration/bun-release/sha.test.ts
+++ b/test/integration/bun-release/sha.test.ts
@@ -47,6 +47,6 @@ test("binaryIncludesSha finds the embedded revision among binary bytes", () => {
   for (let i = 0; i < junk.length; i++) junk[i] = i * 31;
   const binary = Buffer.concat([junk, Buffer.from(SHA, "utf8"), junk]);
   expect(binaryIncludesSha(binary, SHA)).toBe(true);
-  expect(binaryIncludesSha(binary, "f".repeat(40))).toBe(false);
+  expect(binaryIncludesSha(binary, Buffer.alloc(40, "f").toString())).toBe(false);
   expect(binaryIncludesSha(junk, SHA)).toBe(false);
 });


### PR DESCRIPTION
### Problem

- npm canary packages can claim one commit and ship another. `@oven/bun-darwin-aarch64@1.4.0-canary.20260828.1` reports `1.4.0-canary.20260828.1+d578a8c` in package.json, but `bun --revision` on its binary prints `1.4.1-canary.1+731aa92da` (#40880).
- The cause: `upload-npm.ts` downloads binaries from the assets of the rolling GitHub `canary` release, but `getSha` (`packages/bun-release/src/github.ts:83`) resolves `heads/main` at publish time. The two drift when the rolling release is stale. It is stale right now: its assets are still the Aug 26 `731aa92da` build.

### Fix

- Derive the sha from the binaries themselves. Bun embeds the full commit it was built from (`Bun.revision`), so `upload-npm.ts` runs the downloaded binary for its own platform with `--print Bun.revision` and stamps that commit into the version. `upload-s3.ts` already works this way (`features.revision`).
- Verify every other platform's binary before it is packaged: the embedded commit makes the binary bytes contain the full sha, so `upload-npm.ts` requires it and aborts the whole publish on a mismatch. This catches a mixed asset set.
- `upload-s3.ts` now also uses the binary-derived sha for its canary version path and for the `bun.report/purge-cache` call, which used to purge the `heads/main` commit.
- Verified: `test/integration/bun-release/sha.test.ts` drives the real `getSemver` through a mocked GitHub API and fails on main. Smoke-tested against the live stale release: the `bun-linux-x64` binary reports `731aa92dad...`, the version stamps `+731aa92`, and the darwin asset passes the byte check. `tsc --noEmit` error count is unchanged from main.

### Background

- The `canary` GitHub release is re-used for every canary upload. A Buildkite step replaces its assets with `gh release upload --clobber`. The `canary` tag never moves, so git has no ref for what the assets contain.
- A separate scheduled workflow (`release.yml`, job `npm`) repackages those assets for npm once a day and computes the version with `getSemver`, which included the `heads/main` sha.
- An earlier revision of this PR parsed the commit out of the release notes that the Buildkite step writes. Review called that brittle, so the sha now comes from the binaries.

<details><summary>Notes</summary>

- The stale packages already on npm (`*@1.4.0-canary.20260828.1` and later) cannot be fixed from this repo. They need a deprecate or a republish once the rolling release catches up. The rolling release being stuck since Aug 26 is a separate upload failure, not addressed here.
- Executing a downloaded release binary on the runner is existing practice: `upload-s3.ts` spawns it for `features.json`.
- `getSemver` keeps a `heads/main` fallback for calls without a sha (the manual `get-version` helper). Both publish scripts always pass the binary-derived sha.
- The byte check searches for the full 40-char sha, so a false positive needs 20 specific bytes to appear by chance in a binary.
- Stable release tags (`bun-v*`) are lightweight and their assets match the tagged commit, so the derivation and byte check hold for them too.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-release/sha.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/46] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/46] gen cpp.rs (cppbind)
[3/46] gen JS modules (bundle-modules)
Preprocess modules (7888ms)
Bundle modules (43ms)
Postprocesss modules (44ms)
Bundle Functions (432ms)
Generate Code (26ms)

[8.44s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/30] cargo bun_runtime → libbun_runtime.a
[24/30] cc obj/packages/bun-usockets/src/quic.c.o
FAILED: obj/packages/bun-usockets/src/quic.c.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (0b81522d9)

test/integration/bun-release/sha.test.ts:
(pass) binaryRevision reads the embedded build commit out of a binary [6.45ms]
(pass) binaryIncludesSha finds the embedded revision among binary bytes [1.14ms]
77 |     env: { ...bunEnv, GITHUB_REPOSITORY: "oven-sh/bun" },
78 |     cwd: String(dir),
79 |     stderr: "pipe",
80 |   });
81 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
82 |   expect({ version: stdout.trim(), stderr }).toEqual({
                                                  ^
error: expect(received).toEqual(expected)

  {
    "stderr": "",
-   "version": StringMatching /^1\.4\.1-canary\.\d{8}\.1\+731aa92$/,
+   "version": "1.4.1-canary.20260829.1+d578a8c",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/integration/bun-release/sha.test.ts:82:46)
(fail) getSemver stamps the canary version with the sha of the assets, not heads/main [31.90ms]

 2 pass
 1 fail
 7 expect() calls
Ran 3 tests across 1 file. [117.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-release/sha.test.ts
bun test v1.4.1 (d578a8c70)

test/integration/bun-release/sha.test.ts:
(pass) binaryRevision reads the embedded build commit out of a binary [402.17ms]
(pass) binaryIncludesSha finds the embedded revision among binary bytes [29.40ms]
(pass) getSemver stamps the canary version with the sha of the assets, not heads/main [1235.86ms]

 3 pass
 0 fail
 8 expect() calls
Ran 3 tests across 1 file. [3.85s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 598ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/40] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/40] gen cpp.rs (cppbind)
[3/40] gen JS modules (bundle-modules)
Preprocess modules (8133ms)
Bundle modules (68ms)
Postprocesss modules (43ms)
Bundle Functions (535ms)
Generate Code (23ms)

[8.81s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/30] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-release/scripts/upload-npm.ts | 36 +++++++++++--
 packages/bun-release/scripts/upload-s3.ts  | 16 +++---
 packages/bun-release/src/github.ts         | 12 +++--
 packages/bun-release/src/sha.ts            | 27 ++++++++++
 test/integration/bun-release/sha.test.ts   | 87 ++++++++++++++++++++++++++++++
 5 files changed, 165 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-release/scripts/upload-npm.ts      4      7      0
packages/bun-release/scripts/upload-s3.ts       4      5      0
packages/bun-release/src/github.ts              4      7      0
packages/bun-release/src/sha.ts                 1      4      0
test/integration/bun-release/sha.test.ts        1      6      0
```

</details>

<!-- robobun:evidence:end -->