### PR TITLE
test runner: propagate a formatting error out of DiffFormatter

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use bun_core::Output;
-use bun_jsc::{JSGlobalObject, JSValue};
+use bun_jsc::{js_error_to_write_error, JSGlobalObject, JSValue};
 
 use super::diff::print_diff::{print_diff_main, DiffConfig};
 use super::pretty_format::{FormatOptions, JestPrettyFormat, MessageLevel};
@@ -44,23 +44,25 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(js_error_to_write_error)?;
 
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(js_error_to_write_error)?;
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -17,9 +17,7 @@ pub struct DiffFormatter<'a> {
 }
 
 impl<'a> DiffFormatter<'a> {
-    /// Renders the diff into `out`. A JS exception raised while a value is
-    /// pretty-printed is returned as the outer `Err`, so a `JsResult` caller
-    /// can propagate it. The `Display` impl collapses it into `fmt::Error`.
+    /// The outer `Err` is a JS exception raised while a value was pretty-printed.
     pub(crate) fn write_to<W: fmt::Write>(&self, out: &mut W) -> JsResult<fmt::Result> {
         let diff_config =
             DiffConfig::default(Output::is_ai_agent(), Output::enable_ansi_colors_stderr());

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use bun_core::Output;
-use bun_jsc::{js_error_to_write_error, JSGlobalObject, JSValue};
+use bun_jsc::{js_error_to_write_error, JSGlobalObject, JSValue, JsResult};
 
 use super::diff::print_diff::{print_diff_main, DiffConfig};
 use super::pretty_format::{FormatOptions, JestPrettyFormat, MessageLevel};
@@ -16,18 +16,20 @@ pub struct DiffFormatter<'a> {
     pub(crate) not: bool,
 }
 
-impl<'a> fmt::Display for DiffFormatter<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<'a> DiffFormatter<'a> {
+    /// Renders the diff into `out`. A JS exception raised while a value is
+    /// pretty-printed is returned as the outer `Err`, so a `JsResult` caller
+    /// can propagate it. The `Display` impl collapses it into `fmt::Error`.
+    pub(crate) fn write_to<W: fmt::Write>(&self, out: &mut W) -> JsResult<fmt::Result> {
         let diff_config =
             DiffConfig::default(Output::is_ai_agent(), Output::enable_ansi_colors_stderr());
 
         if let (Some(expected), Some(received)) = (self.expected_string, self.received_string) {
-            print_diff_main(self.not, received, expected, f, &diff_config)?;
-            return Ok(());
+            return Ok(print_diff_main(self.not, received, expected, out, &diff_config));
         }
 
         if self.received.is_none() || self.expected.is_none() {
-            return Ok(());
+            return Ok(Ok(()));
         }
 
         let global_this = self.global_this.expect("DiffFormatter.global_this not set");
@@ -51,8 +53,7 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 1,
                 &mut received_buf,
                 fmt_options,
-            )
-            .map_err(js_error_to_write_error)?;
+            )?;
 
             JestPrettyFormat::format(
                 MessageLevel::Debug,
@@ -61,8 +62,7 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 1,
                 &mut expected_buf,
                 fmt_options,
-            )
-            .map_err(js_error_to_write_error)?;
+            )?;
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();
@@ -80,8 +80,13 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
             expected_slice = &expected_slice[..expected_slice.len() - 1];
         }
 
-        print_diff_main(self.not, received_slice, expected_slice, f, &diff_config)?;
-        Ok(())
+        Ok(print_diff_main(self.not, received_slice, expected_slice, out, &diff_config))
+    }
+}
+
+impl<'a> fmt::Display for DiffFormatter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.write_to(f).map_err(js_error_to_write_error)?
     }
 }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2872,7 +2872,10 @@ impl ExpectMatcherUtils {
         } else {
             bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", false)
         };
-        let buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n");
+        let mut buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n");
+        // Writing to a `String` cannot fail. The outer error is a JS exception.
+        let _ = diff_formatter.write_to(&mut buf)?;
+        buf.push('\n');
         bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }
 }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2873,8 +2873,7 @@ impl ExpectMatcherUtils {
             bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", false)
         };
         let mut buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n");
-        // Writing to a `String` cannot fail. The outer error is a JS exception.
-        let _ = diff_formatter.write_to(&mut buf)?;
+        diff_formatter.write_to(&mut buf)?.expect("writing to a String cannot fail");
         buf.push('\n');
         bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }

--- a/test/js/bun/test/expect-diff-format-throw-crash.test.ts
+++ b/test/js/bun/test/expect-diff-format-throw-crash.test.ts
@@ -5,7 +5,7 @@ import { bunEnv, bunExe } from "harness";
 // pretty-printing the received value throws, the error must not stay pending on
 // the VM while the expected value is formatted. The matcher reports its own
 // failure instead.
-async function run(setup: string) {
+async function run(setup: string, assertion: string) {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -14,7 +14,7 @@ async function run(setup: string) {
       const { expect } = Bun.jest();
       ${setup}
       try {
-        expect({ fn }).toMatchObject({ b: 16 });
+        ${assertion}
         console.log("no error");
       } catch (e) {
         console.log(String(e).split("\\n")[0]);
@@ -26,24 +26,49 @@ async function run(setup: string) {
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  return { stdout, exitCode };
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
 }
 
+const throwingToStringTag = `
+  const fn = function named() {};
+  Object.defineProperty(fn, Symbol.toStringTag, { get() { throw new Error("getter threw"); } });
+`;
+
+const throwingHasTrap = `
+  const fn = function named() {};
+  Object.setPrototypeOf(fn, new Proxy(Function.prototype, { has() { throw new Error("has trap threw"); } }));
+`;
+
 test.concurrent("failing matcher when Symbol.toStringTag getter on a function throws", async () => {
-  const { stdout, exitCode } = await run(`
-    const fn = function named() {};
-    Object.defineProperty(fn, Symbol.toStringTag, { get() { throw new Error("getter threw"); } });
-  `);
+  const { stdout, stderr, exitCode } = await run(throwingToStringTag, `expect({ fn }).toMatchObject({ b: 16 });`);
   expect(stdout).toBe("Error: expect(received).toMatchObject(expected)\n");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
 
 test.concurrent("failing matcher when a Proxy has trap in the prototype chain throws", async () => {
-  const { stdout, exitCode } = await run(`
-    const fn = function named() {};
-    Object.setPrototypeOf(fn, new Proxy(Function.prototype, { has() { throw new Error("has trap threw"); } }));
-  `);
+  const { stdout, stderr, exitCode } = await run(throwingHasTrap, `expect({ fn }).toMatchObject({ b: 16 });`);
   expect(stdout).toBe("Error: expect(received).toMatchObject(expected)\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+// matcherHint returns the rendered hint to the custom matcher, so the error
+// from pretty-printing is thrown to the caller instead of being dropped.
+test.concurrent("matcherHint throws the formatting error instead of aborting", async () => {
+  const { stdout, stderr, exitCode } = await run(
+    throwingToStringTag +
+      `
+      expect.extend({
+        toHint(received, expected) {
+          return { pass: false, message: () => this.utils.matcherHint("toHint", received, expected) };
+        },
+      });
+    `,
+    `expect({ fn }).toHint({ b: 16 });`,
+  );
+  expect(stdout).toBe("Error: getter threw\n");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/expect-diff-format-throw-crash.test.ts
+++ b/test/js/bun/test/expect-diff-format-throw-crash.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A failing matcher renders a diff of the received and expected values. If
+// pretty-printing the received value throws, the error must not stay pending on
+// the VM while the expected value is formatted. The matcher reports its own
+// failure instead.
+async function run(setup: string) {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { expect } = Bun.jest();
+      ${setup}
+      try {
+        expect({ fn }).toMatchObject({ b: 16 });
+        console.log("no error");
+      } catch (e) {
+        console.log(String(e).split("\\n")[0]);
+      }
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  return { stdout, exitCode };
+}
+
+test.concurrent("failing matcher when Symbol.toStringTag getter on a function throws", async () => {
+  const { stdout, exitCode } = await run(`
+    const fn = function named() {};
+    Object.defineProperty(fn, Symbol.toStringTag, { get() { throw new Error("getter threw"); } });
+  `);
+  expect(stdout).toBe("Error: expect(received).toMatchObject(expected)\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("failing matcher when a Proxy has trap in the prototype chain throws", async () => {
+  const { stdout, exitCode } = await run(`
+    const fn = function named() {};
+    Object.setPrototypeOf(fn, new Proxy(Function.prototype, { has() { throw new Error("has trap threw"); } }));
+  `);
+  expect(stdout).toBe("Error: expect(received).toMatchObject(expected)\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion failure in `bun:test` (fingerprint `e6d79e50c001e7ee`).

`DiffFormatter::fmt` renders the received and expected values of a failed matcher. It called `JestPrettyFormat::format` twice and discarded both results with `let _ =`. When the received value could not be formatted (a getter or a Proxy trap threw), the JS exception stayed pending on the VM. The second `format` call then ran `Tag::get` on the expected value. That reached `JSC__JSValue__getOwn`, whose `ASSERT_NO_PENDING_EXCEPTION` aborted the process:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: ReflectHas is not a function. (In 'ReflectHas(target, key)', 'ReflectHas' is undefined)
!exception() || m_vm.hasPendingTerminationException()
ExceptionScope.h(63) : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

In the fuzzer, the exception came from a Proxy `has` trap placed on the prototype of the `expect` function. Bun's `getNameProperty` reads `Symbol.toStringTag` through `getIfPropertyExists`, which uses `[[HasProperty]]`, so the trap fired while the `expect` function was pretty-printed. A release build did not abort. It threw the trap's error in place of the matcher error, because `throw_value` does not override a pending exception.

The fix adds `DiffFormatter::write_to`, which returns the `JsError` from pretty-printing to the caller, and stops before the second value is formatted. The `Display` impl delegates to it and maps the error to `fmt::Error`, the same pattern the other `Display` impls in the test runner use (`js_error_to_write_error`). `JSGlobalObject::error_message` clears the pending exception when the write fails, so the matcher throws its own error.

`ExpectMatcherUtils::matcher_hint` is the one consumer that did not go through `error_message`. It rendered the formatter with `format!`, which panics when a `Display` impl returns `fmt::Error`. It now calls `write_to` and throws the formatting error to the custom matcher, the same way `printReceived` does.

### Reproduction

```js
const { expect } = Bun.jest();
const fn = function named() {};
Object.defineProperty(fn, Symbol.toStringTag, { get() { throw new Error("getter threw"); } });
expect({ fn }).toMatchObject({ b: 16 });
```

Before: a debug build aborts with the assertion above. A release build throws `Error: getter threw`.
After: both throw `Error: expect(received).toMatchObject(expected)`.

### How did you verify your code works?

- Replayed the Fuzzilli script with the Probe prelude and a clobbered `Reflect.has` against the fuzz build. It aborts before the fix and exits 0 after.
- Added `test/js/bun/test/expect-diff-format-throw-crash.test.ts` with three cases. The two `toMatchObject` cases (a throwing `Symbol.toStringTag` getter, a throwing Proxy `has` trap) fail with `USE_SYSTEM_BUN=1 bun test` (wrong error reported) and pass with `bun bd test`, also under `BUN_JSC_validateExceptionChecks=1`. The `matcherHint` case passes on main and on this branch. It fails on a release build of the first commit of this PR (db6ac2d4), where `format!` panicked with `a formatting trait implementation returned an error when the underlying stream did not`.
- `bun bd test` on `test/js/bun/test/expect.test.js`, `expect-extend.test.js`, `expect-extend-matcher-utils-throw.test.ts`, `expect-extend-asymmetric-match-throw.test.ts`, `expect-label.test.ts`, the other `expect-*-crash.test.ts` files, `test/js/bun/test/expect/` and `test/js/bun/test/snapshot-tests/`: all pass. The one exception is `snapshot.test.ts > error snapshots`, which also fails with the unmodified system bun in this non-TTY container and passes with `FORCE_COLOR=1`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-diff-format-throw-crash.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[0/7] cargo bun_runtime → libbun_runtime.a
[1/7] cc obj/packages/bun-usockets/src/quic.c.o
FAILED: obj/packages/bun-usockets/src/quic.c.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections -fdata-sections -faddrsig -fno-semantic-interposition -fno-delete-null-pointer-checks -fdiagnostics-color=always -ferror-limit=100 -std=gnu17 -fsanitize=null -fno-sanitize-recover=all -fsanitize=bounds -fsanitize=return -fsanitize=nullability-arg -fsanitize=nullability-assign -fsanitize=nullability-return -fsanitize=returns-nonnull-attribute -fsanitize=unreachable -fno-pic -fno-pie -Werror=return-type -Werror=return-stack-address -Werror=implicit-functio
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (b39d4bfb2)

test/js/bun/test/expect-diff-format-throw-crash.test.ts:
(pass) failing matcher when Symbol.toStringTag getter on a function throws [5.68ms]
(pass) failing matcher when a Proxy has trap in the prototype chain throws [4.91ms]
(pass) matcherHint throws the formatting error instead of aborting [5.03ms]

 3 pass
 0 fail
 9 expect() calls
Ran 3 tests across 1 file. [88.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-diff-format-throw-crash.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/test/expect-diff-format-throw-crash.test.ts:
(pass) failing matcher when Symbol.toStringTag getter on a function throws [380.61ms]
(pass) failing matcher when a Proxy has trap in the prototype chain throws [339.22ms]
(pass) matcherHint throws the formatting error instead of aborting [345.54ms]

 3 pass
 0 fail
 9 expect() calls
Ran 3 tests across 1 file. [2.31s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 791ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/40] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/40] gen cpp.rs (cppbind)
[3/40] gen JS modules (bundle-modules)
Preprocess modules (7348ms)
Bundle modules (43ms)
Postprocesss modules (25ms)
Bundle Functions (458ms)
Generate Code (26ms)

[7.91s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/30] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/diff_format.rs             | 29 +++++----
 src/runtime/test_runner/expect.rs                  |  4 +-
 .../test/expect-diff-format-throw-crash.test.ts    | 74 ++++++++++++++++++++++
 3 files changed, 94 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/runtime/test_runner/diff_format.rs                       3      7      0
src/runtime/test_runner/expect.rs                            3      3      0
test/js/bun/test/expect-diff-format-throw-crash.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->
