### PR TITLE
build: allow pointing the build at an explicit LLVM dir and Rust sysroot

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -1255,7 +1255,10 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     cargoHome: toolchain.cargoHome,
     rustupHome: toolchain.rustupHome,
     rustToolchain: toolchainOverride.rust !== undefined ? undefined : readRustToolchainChannel(cwd),
-    rustc: toolchainOverride.rust !== undefined ? join(toolchainOverride.rust, "bin", `rustc${host.os === "windows" ? ".exe" : ""}`) : undefined,
+    rustc:
+      toolchainOverride.rust !== undefined
+        ? join(toolchainOverride.rust, "bin", `rustc${host.os === "windows" ? ".exe" : ""}`)
+        : undefined,
     // Cargo-driven links (the bun_shim_impl.exe edge, any future target
     // cdylib) must keep using a real lld-link/link.exe, not the gcc-ld/
     // lld-link wrapper `ld` may have been swapped to above: rustc treats a

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -14,7 +14,7 @@ import { NODEJS_ABI_VERSION, NODEJS_V8_VERSION, NODEJS_VERSION } from "./deps/no
 import { WEBKIT_VERSION } from "./deps/webkit.ts";
 import { assert, BuildError } from "./error.ts";
 import { resolveMacosSdkPath } from "./macos-sdk.ts";
-import { clangTargetArch } from "./tools.ts";
+import { clangTargetArch, toolchainOverride } from "./tools.ts";
 import { cyan, dim, green } from "./tty.ts";
 
 export type OS = "linux" | "darwin" | "windows" | "freebsd";
@@ -276,6 +276,8 @@ export interface Config {
    * would otherwise pick up that worktree's pin).
    */
   rustToolchain: string | undefined;
+  /** Explicit rustc for cargo to drive (BUN_TOOLCHAIN_RUST); undefined = cargo's own resolution (rustup proxy). */
+  rustc: string | undefined;
   /** Windows: MSVC link.exe path (to avoid Git's /usr/bin/link shadowing). */
   msvcLinker: string | undefined;
   /** Windows: llvm-rc for nested cmake (CMAKE_RC_COMPILER). */
@@ -1252,7 +1254,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     cargo: toolchain.cargo,
     cargoHome: toolchain.cargoHome,
     rustupHome: toolchain.rustupHome,
-    rustToolchain: readRustToolchainChannel(cwd),
+    rustToolchain: toolchainOverride.rust !== undefined ? undefined : readRustToolchainChannel(cwd),
+    rustc: toolchainOverride.rust !== undefined ? join(toolchainOverride.rust, "bin", `rustc${host.os === "windows" ? ".exe" : ""}`) : undefined,
     // Cargo-driven links (the bun_shim_impl.exe edge, any future target
     // cdylib) must keep using a real lld-link/link.exe, not the gcc-ld/
     // lld-link wrapper `ld` may have been swapped to above: rustc treats a

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -642,6 +642,7 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
   // across worktrees; rustup's directory walk could otherwise resolve a
   // different worktree's `rust-toolchain.toml`.
   if (cfg.rustToolchain !== undefined) env.RUSTUP_TOOLCHAIN = cfg.rustToolchain;
+  if (cfg.rustc !== undefined) env.RUSTC = cfg.rustc;
   // Darwin cross-compile from a non-darwin host: point anything in the dep
   // graph that cares about the Apple SDK at the extracted sysroot. rustc
   // itself doesn't need it for a staticlib, but cc-rs (build scripts

--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -84,6 +84,8 @@ export interface ToolSpec {
   names: string[];
   /** Extra search paths beyond $PATH. Tried FIRST (more specific). */
   paths?: string[];
+  /** Search only `paths`, never $PATH. */
+  pathsOnly?: boolean;
   /** Version constraint, e.g. `">=21.1.0 <22.0.0"`. */
   version?: string;
   /** How to get the version. `"--version"` (default) or `"version"` (go/zig style). */
@@ -211,7 +213,9 @@ export function clangTargetArch(clang: string): Arch | undefined {
  */
 export function findTool(spec: ToolSpec): FoundTool | undefined {
   const exeSuffix = process.platform === "win32" ? ".exe" : "";
-  const searchPaths = [...(spec.paths ?? []), ...(process.env.PATH ?? "").split(delimiter).filter(p => p.length > 0)];
+  const searchPaths = spec.pathsOnly
+    ? [...(spec.paths ?? [])]
+    : [...(spec.paths ?? []), ...(process.env.PATH ?? "").split(delimiter).filter(p => p.length > 0)];
   const versionArg = spec.versionArg ?? "--version";
   const rejections: Rejection[] = [];
 
@@ -270,12 +274,29 @@ const LLVM_MINOR = "1";
 const LLVM_VERSION_RANGE = `>=${LLVM_MAJOR}.${LLVM_MINOR}.0 <${LLVM_MAJOR}.${LLVM_MINOR}.99`;
 
 /**
+ * Explicit toolchain directories, for building Bun with a self-built LLVM /
+ * Rust (the oven-sh/rust toolchain build trains its PGO profiles this way).
+ * When set they are the ONLY place the corresponding tools are taken from,
+ * and the LLVM version pin above is not enforced — the directory is the pin.
+ *
+ *   BUN_TOOLCHAIN_LLVM   dir containing bin/clang, bin/ld.lld, bin/llvm-ar, …
+ *   BUN_TOOLCHAIN_RUST   rustc sysroot dir containing bin/rustc (and bin/cargo)
+ *   BUN_TOOLCHAIN_CARGO  cargo binary, if not <BUN_TOOLCHAIN_RUST>/bin/cargo
+ */
+export const toolchainOverride = {
+  llvm: process.env.BUN_TOOLCHAIN_LLVM,
+  rust: process.env.BUN_TOOLCHAIN_RUST,
+  cargo: process.env.BUN_TOOLCHAIN_CARGO,
+};
+
+/**
  * Known LLVM install locations per platform. Call ONCE from
  * resolveLlvmToolchain — it contains a spawn on macOS (brew --prefix as
  * fallback) which takes ~100ms, so calling it per-tool would dominate
  * configure time.
  */
 function llvmSearchPaths(os: OS, arch: Arch): string[] {
+  if (toolchainOverride.llvm !== undefined) return [join(toolchainOverride.llvm, "bin")];
   const paths: string[] = [];
 
   if (os === "darwin") {
@@ -352,7 +373,8 @@ function findLlvmTool(
     required: opts.required,
     hint: llvmInstallHint(os),
   };
-  if (opts.checkVersion) spec.version = LLVM_VERSION_RANGE;
+  if (toolchainOverride.llvm !== undefined) spec.pathsOnly = true;
+  else if (opts.checkVersion) spec.version = LLVM_VERSION_RANGE;
   return findTool(spec);
 }
 
@@ -646,7 +668,10 @@ export function findRustLld(os: OS): {
   const none = { rustLld: undefined, rustLlvmVersion: undefined, rustSysroot: undefined, rustHostTriple: undefined };
   // Look up rustc the same way findCargo does cargo: $CARGO_HOME/bin first.
   const cargoHome = process.env.CARGO_HOME ?? join(homedir(), ".cargo");
-  const rustc = findTool({ names: ["rustc"], paths: [join(cargoHome, "bin")], required: false })?.path;
+  const rustc =
+    toolchainOverride.rust !== undefined
+      ? join(toolchainOverride.rust, "bin", "rustc")
+      : findTool({ names: ["rustc"], paths: [join(cargoHome, "bin")], required: false })?.path;
   if (rustc === undefined) return none;
 
   // The link-only CI mode runs `findRustLld()` on an agent that downloads
@@ -665,7 +690,7 @@ export function findRustLld(os: OS): {
   // whatever's there.
   const rustup = findTool({ names: ["rustup"], paths: [join(cargoHome, "bin")], required: false })?.path;
   const channel = readRustToolchainChannel();
-  if (rustup !== undefined && channel !== undefined) {
+  if (rustup !== undefined && channel !== undefined && toolchainOverride.rust === undefined) {
     const started = performance.now();
     spawnSync(
       rustup,
@@ -735,6 +760,7 @@ export function findRustLld(os: OS): {
  * same file; keeping the parse local avoids an import cycle.
  */
 function readRustToolchainChannel(): string | undefined {
+  if (toolchainOverride.rust !== undefined) return undefined; // not a rustup toolchain
   // tools.ts lives at `scripts/build/`; the toolchain file is two levels up.
   const path = join(import.meta.dirname, "..", "..", "rust-toolchain.toml");
   if (!existsSync(path)) return undefined;
@@ -757,11 +783,11 @@ export function findCargo(hostOs: OS): CargoToolchain | undefined {
 
   // Search $CARGO_HOME/bin BEFORE $PATH. Some systems have an outdated
   // distro cargo in /usr/bin that shadows rustup's — we want rustup's.
-  const cargo = findTool({
-    names: ["cargo"],
-    paths: [join(cargoHome, "bin")],
-    required: false,
-  })?.path;
+  const cargo =
+    toolchainOverride.cargo ??
+    (toolchainOverride.rust !== undefined
+      ? join(toolchainOverride.rust, "bin", "cargo")
+      : findTool({ names: ["cargo"], paths: [join(cargoHome, "bin")], required: false })?.path);
   if (cargo === undefined) return undefined;
 
   // Suppress unused warning for hostOs — kept in signature for future

--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -373,8 +373,8 @@ function findLlvmTool(
     required: opts.required,
     hint: llvmInstallHint(os),
   };
+  if (opts.checkVersion) spec.version = toolchainOverride.llvm !== undefined ? "ignore" : LLVM_VERSION_RANGE;
   if (toolchainOverride.llvm !== undefined) spec.pathsOnly = true;
-  else if (opts.checkVersion) spec.version = LLVM_VERSION_RANGE;
   return findTool(spec);
 }
 

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -233,20 +233,24 @@ export const workarounds: Workaround[] = [
  * Call from configure.ts after Config is fully resolved.
  */
 export function checkWorkarounds(cfg: Config): void {
-  // Expiry thresholds are written against the pinned toolchain; an explicitly
-  // supplied one (BUN_TOOLCHAIN_LLVM) may be newer without the tree having
-  // dropped the workaround yet.
-  if (toolchainOverride.llvm !== undefined) return;
+  // Expiry thresholds are written against the pinned toolchains. With an
+  // explicitly supplied one (BUN_TOOLCHAIN_LLVM / BUN_TOOLCHAIN_RUST), which may
+  // be newer than the pin, an expired workaround is reported, not fatal.
+  const overridden = toolchainOverride.llvm !== undefined || toolchainOverride.rust !== undefined;
   for (const w of workarounds) {
     if (!w.applies(cfg)) continue;
     if (!w.expectedToBeFixed(cfg)) continue;
 
-    throw new BuildError(`Workaround '${w.id}' is obsolete — upstream fix is available`, {
-      hint:
-        `${w.description}\n` +
-        `  Tracked: ${w.issue}\n\n` +
-        `${w.cleanup}\n\n` +
-        `If the issue still reproduces, bump the threshold in expectedToBeFixed() in scripts/build/workarounds.ts instead.`,
-    });
+    const title = `Workaround '${w.id}' is obsolete — upstream fix is available`;
+    const hint =
+      `${w.description}\n` +
+      `  Tracked: ${w.issue}\n\n` +
+      `${w.cleanup}\n\n` +
+      `If the issue still reproduces, bump the threshold in expectedToBeFixed() in scripts/build/workarounds.ts instead.`;
+    if (overridden) {
+      console.warn(`note: ${title} (with the overridden toolchain)\n${hint}\n`);
+      continue;
+    }
+    throw new BuildError(title, { hint });
   }
 }

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -33,7 +33,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Config } from "./config.ts";
 import { BuildError } from "./error.ts";
-import { satisfiesRange } from "./tools.ts";
+import { satisfiesRange, toolchainOverride } from "./tools.ts";
 
 /** Read a crate's locked version out of the repo's Cargo.lock. */
 function lockedCrateVersion(cfg: Config, name: string): string | undefined {
@@ -233,6 +233,10 @@ export const workarounds: Workaround[] = [
  * Call from configure.ts after Config is fully resolved.
  */
 export function checkWorkarounds(cfg: Config): void {
+  // Expiry thresholds are written against the pinned toolchain; an explicitly
+  // supplied one (BUN_TOOLCHAIN_LLVM) may be newer without the tree having
+  // dropped the workaround yet.
+  if (toolchainOverride.llvm !== undefined) return;
   for (const w of workarounds) {
     if (!w.applies(cfg)) continue;
     if (!w.expectedToBeFixed(cfg)) continue;


### PR DESCRIPTION
### What

Three environment overrides for `scripts/build`:

| var | meaning |
|---|---|
| `BUN_TOOLCHAIN_LLVM` | directory with `bin/clang`, `bin/ld.lld`, `bin/llvm-ar`, … — used as the *only* LLVM search path, and the pinned-version check is skipped (the directory is the pin) |
| `BUN_TOOLCHAIN_RUST` | a rustc sysroot (`bin/rustc`, `bin/cargo`) — cargo is taken from it and driven with `RUSTC=` pointing into it; rustup and `rust-toolchain.toml` are bypassed |
| `BUN_TOOLCHAIN_CARGO` | cargo binary, when it is not `$BUN_TOOLCHAIN_RUST/bin/cargo` |

Unset, nothing changes.

### Why

[oven-sh/rust](https://github.com/oven-sh/rust/tree/nightly-2026-07-20-bun/bun) builds a rustc/cargo + clang/lld toolchain for compiling Bun using the upstream release recipes with PGO/BOLT profiles trained on Bun's own build. Training means "build Bun with this half-built compiler", which needs a way to hand the build an arbitrary clang and rustc. The same knobs are how a developer can try a self-built toolchain locally.

Workaround expiry checks (`workarounds.ts`) are skipped under `BUN_TOOLCHAIN_LLVM`, since their thresholds are written against the pinned LLVM version.