### PR TITLE
shell: throw instead of panicking when a ReadableStream is used as a redirect

### DIFF
--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -386,22 +386,10 @@ pub(crate) fn handle_template_value(
             return Ok(());
         }
 
-        if let Some(_rstream) = crate::webcore::ReadableStream::from_js(template_value, global)? {
-            let idx = out_jsobjs.len();
-            marked_argument_buffer.append(template_value);
-            out_jsobjs.push(template_value);
-            let mut cursor = std::io::Cursor::new(&mut jsobjref_buf[..]);
-            write!(
-                cursor,
-                "{}{}{}",
-                bstr::BStr::new(LEX_JS_OBJREF_PREFIX),
-                idx,
-                LEX_JS_REF_TERMINATOR as char
-            )
-            .map_err(|_| global.throw_out_of_memory())?;
-            let n = cursor.position() as usize;
-            out_script.extend_from_slice(&jsobjref_buf[..n]);
-            return Ok(());
+        if crate::webcore::ReadableStream::from_js(template_value, global)?.is_some() {
+            return Err(global.throw(format_args!(
+                "ReadableStream is not supported as a shell redirect yet. Buffer it first, e.g. `< ${{await new Response(stream).blob()}}`, or use Bun.spawn({{ stdin: stream }})"
+            )));
         }
 
         if let Some(_req) = template_value.as_::<crate::webcore::Response>() {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -767,8 +767,6 @@ impl Cmd {
                             STDERR_NO as i32,
                         )?;
                     }
-                } else if crate::webcore::ReadableStream::from_js(jsval, global)?.is_some() {
-                    panic!("TODO SHELL READABLE STREAM");
                 } else if let Some(req) = jsval.as_::<crate::webcore::Response>() {
                     // SAFETY: `as_` returns a live JSC-owned `*mut Response`;
                     // `get_body_value` is `&self`.

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -505,6 +505,25 @@ describe("bunshell", () => {
     expect(await file.text()).toEqual(thisFileText);
   });
 
+  test("redirect stdin from a ReadableStream throws instead of crashing", async () => {
+    // Streaming a ReadableStream into a shell command's stdin isn't implemented yet; it used to hit a
+    // `panic!("TODO SHELL READABLE STREAM")` and take the whole process down.
+    for (const cmd of ["cat", "echo", "true && cat", `${BUN} -e "process.stdin.pipe(process.stdout)"`]) {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("hello from a stream\n"));
+          controller.close();
+        },
+      });
+      expect(async () => await $`${{ raw: cmd }} < ${stream}`.env(bunEnv).quiet()).toThrow(
+        "ReadableStream is not supported as a shell redirect yet",
+      );
+    }
+    // The documented workaround keeps working.
+    const stream = new Response("hello from a stream\n").body!;
+    expect(await $`cat < ${await new Response(stream).blob()}`.text()).toBe("hello from a stream\n");
+  });
+
   // TODO This sometimes fails
   test("redirect stderr", async () => {
     const buffer = Buffer.alloc(128, 0);


### PR DESCRIPTION
### What

```js
await $`cat < ${new ReadableStream({...})}`;
```

crashed the process with `panic: TODO SHELL READABLE STREAM` (`src/runtime/shell/states/Cmd.rs`). The template parser explicitly accepted `ReadableStream` values into `jsobjs`, and the redirect setup then hit a TODO panic that has been there since the Zig shell.

Streaming a `ReadableStream` into a shell command's stdin (subprocess *and* builtins) isn't implemented, so this rejects it where the template is parsed: the `$` tag throws synchronously with

> ReadableStream is not supported as a shell redirect yet. Buffer it first, e.g. `< ${await new Response(stream).blob()}`, or use Bun.spawn({ stdin: stream })

Throwing at parse time (rather than from `Cmd`/`Builtin` redirect init) matters: a throw from redirect init only becomes a rejection when it happens synchronously under `run_from_js`; when the command starts from an async resume (`sleep 0.01; cat < ${stream}`) the exception would be stranded with no JS frame.

Blob / `Bun.file` / `Response` / ArrayBuffer redirects are unchanged.

### Test

`test/js/bun/shell/bunshell.test.ts` — "redirect stdin from a ReadableStream throws instead of crashing" covers a subprocess (`cat`, `bun -e`), a builtin (`echo`), and an async-resumed command (`true && cat`), plus the documented `Response.blob()` workaround. Crashes with `USE_SYSTEM_BUN=1`, passes on the debug build (also with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`).

Follow-up (not in this PR): actually plumb `Stdio::ReadableStream` through the shell's `Writable` (FileSink + `assign_to_stream`, as `Bun.spawn` does) and give builtins an async stdin source.