### PR TITLE
build: toolchain overrides — exe suffix on Windows host, drop dead guard

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -1256,9 +1256,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     rustupHome: toolchain.rustupHome,
     rustToolchain: toolchainOverride.rust !== undefined ? undefined : readRustToolchainChannel(cwd),
     rustc:
-      toolchainOverride.rust !== undefined
-        ? join(toolchainOverride.rust, "bin", `rustc${host.exeSuffix}`)
-        : undefined,
+      toolchainOverride.rust !== undefined ? join(toolchainOverride.rust, "bin", `rustc${host.exeSuffix}`) : undefined,
     // Cargo-driven links (the bun_shim_impl.exe edge, any future target
     // cdylib) must keep using a real lld-link/link.exe, not the gcc-ld/
     // lld-link wrapper `ld` may have been swapped to above: rustc treats a

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -1257,7 +1257,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     rustToolchain: toolchainOverride.rust !== undefined ? undefined : readRustToolchainChannel(cwd),
     rustc:
       toolchainOverride.rust !== undefined
-        ? join(toolchainOverride.rust, "bin", `rustc${host.os === "windows" ? ".exe" : ""}`)
+        ? join(toolchainOverride.rust, "bin", `rustc${host.exeSuffix}`)
         : undefined,
     // Cargo-driven links (the bun_shim_impl.exe edge, any future target
     // cdylib) must keep using a real lld-link/link.exe, not the gcc-ld/

--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -670,7 +670,7 @@ export function findRustLld(os: OS): {
   const cargoHome = process.env.CARGO_HOME ?? join(homedir(), ".cargo");
   const rustc =
     toolchainOverride.rust !== undefined
-      ? join(toolchainOverride.rust, "bin", "rustc")
+      ? join(toolchainOverride.rust, "bin", os === "windows" ? "rustc.exe" : "rustc")
       : findTool({ names: ["rustc"], paths: [join(cargoHome, "bin")], required: false })?.path;
   if (rustc === undefined) return none;
 
@@ -690,7 +690,7 @@ export function findRustLld(os: OS): {
   // whatever's there.
   const rustup = findTool({ names: ["rustup"], paths: [join(cargoHome, "bin")], required: false })?.path;
   const channel = readRustToolchainChannel();
-  if (rustup !== undefined && channel !== undefined && toolchainOverride.rust === undefined) {
+  if (rustup !== undefined && channel !== undefined) {
     const started = performance.now();
     spawnSync(
       rustup,
@@ -786,13 +786,9 @@ export function findCargo(hostOs: OS): CargoToolchain | undefined {
   const cargo =
     toolchainOverride.cargo ??
     (toolchainOverride.rust !== undefined
-      ? join(toolchainOverride.rust, "bin", "cargo")
+      ? join(toolchainOverride.rust, "bin", hostOs === "windows" ? "cargo.exe" : "cargo")
       : findTool({ names: ["cargo"], paths: [join(cargoHome, "bin")], required: false })?.path);
   if (cargo === undefined) return undefined;
-
-  // Suppress unused warning for hostOs — kept in signature for future
-  // host-specific path resolution (e.g. %PROGRAMFILES% probing on win32).
-  void hostOs;
 
   return { cargo, cargoHome, rustupHome };
 }


### PR DESCRIPTION
Follow-up to #40884 (post-merge review comments):

- `BUN_TOOLCHAIN_RUST`: the `bin/rustc` / `bin/cargo` paths get the host's `.exe` suffix (the non-override path got it from `findTool`); `config.ts` uses `host.exeSuffix` instead of an inline ternary.
- `findRustLld`: drop `&& toolchainOverride.rust === undefined` — unreachable, since `readRustToolchainChannel()` already returns `undefined` under the override.
- removes the `void hostOs` placeholder in `findCargo` now that `hostOs` is used.

No behavior change on non-Windows hosts.