### PR TITLE
ast: keep a class with a static accessor initializer in place

### DIFF
--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -101,7 +101,10 @@ impl Class {
                 return false;
             }
 
-            if property.kind == PropertyKind::Normal && f.contains(flags::Property::IsStatic) {
+            if (property.kind == PropertyKind::Normal
+                || property.kind == PropertyKind::AutoAccessor)
+                && f.contains(flags::Property::IsStatic)
+            {
                 for val in [property.value, property.initializer].into_iter().flatten() {
                     match val.data {
                         ExprData::EArrow(..) | ExprData::EFunction(..) => {}

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1754,6 +1754,33 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  describe("class statement placement", () => {
+    // The runtime hoists a class statement to the top of the module when the
+    // class has no side effects. A static auto-accessor initializer is a side
+    // effect like a static field initializer, so the class must stay where it
+    // was written or the initializer runs before the bindings it reads exist.
+    test("static accessor initializer keeps the class in place", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        let order = [];
+        order.push("top");
+        function sideEffect(name, value) {
+          order.push(name);
+          return value;
+        }
+        class C {
+          accessor m = sideEffect("m", 1);
+          static accessor s = sideEffect("s", 2);
+        }
+        order.push("after class");
+        const c = new C();
+        console.log(order.join(","), C.s, c.m);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("top,s,after class,m 2 1\n");
+      expect(exitCode).toBe(0);
+    });
+  });
 });
 
 // One fixture holds a matrix of decorated members and prints one JSON object;


### PR DESCRIPTION
### Problem
- `bun run` moves a side-effect-free class statement to the top of the module (`src/js_parser/parse/parse_entry.rs:1070`, cyclic import relief). `Class::can_be_moved` (`src/ast/g.rs:104`) checks static field initializers for side effects but skips static `accessor` initializers. So `class C { static accessor s = f() }` is hoisted and `f()` runs before the bindings above the class exist: `ReferenceError: Cannot access 'order' before initialization`.
- The bundler uses the same predicate to move a class out of a lazy `__esm` wrapper, so the initializer can run at the wrong time there too.

### Fix
- `Class::can_be_moved` treats `PropertyKind::AutoAccessor` like `PropertyKind::Normal`. A static auto-accessor initializer that is not a literal or a function keeps the class where it was written.
- Verified: `test/bundler/transpiler/es-decorators.test.ts` (new "class statement placement" test; it fails on 1.4.3 and on main a22b2aa90e with the `ReferenceError` above). Also `es-decorators-esbuild.test.ts`.

### Background
- An auto-accessor (`accessor x = v`) is a field with a generated getter and setter. Its storage is initialized like a field: during class evaluation for a static one, during construction for an instance one.
- `parse_entry.rs` asks `can_be_moved` before the class is visited and lowered, so it sees the `AutoAccessor` property as written. The lowering (#40833) then emits the static initializer as a `static { __privateAdd(this, _s, v) }` block in the class body, which moves with the class.

<details><summary>Notes</summary>

Found with a differential run of the standard-decorator lowering against tsc and esbuild. The other findings of that run were covered by #40833, which is merged. This branch is rebased on it; the bug is independent of the lowering shape because the hoist decision is made on the parsed class.

Repro (1.4.3 and main a22b2aa90e):

```js
let order = [];
order.push("top");
function sideEffect(name, value) { order.push(name); return value; }
class C {
  accessor m = sideEffect("m", 1);
  static accessor s = sideEffect("s", 2);
}
order.push("after class");
const c = new C();
console.log(order.join(","), C.s, c.m);
```

`bun run` throws the `ReferenceError` inside `sideEffect` (the class runs before line 1). With the fix it prints `top,s,after class,m 2 1`. `bun build --no-bundle` output evaluated directly is correct, because the hoist only happens in the runtime path.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (b99371011)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [301.15ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [285.52ms]
(pass) ES Decorators > class decorators > class decorator can replace class [377.16ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [368.03ms]
(pass) ES Decorators > method decorators > instance method decorator [395.74ms]
(pass) ES Decorators > method decorators > static method decorator [325.33ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [368.88ms]
(pass) ES Decorators > getter decorators > getter decorator [377.00ms]
(pass) ES Decorators > setter decorators > setter decorator [292.97ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [292.86ms]
(pass) ES Decorators > field decorators > multiple field decorators [330.06ms]
(
... (truncated)

release without fix: 353 FAILED
bun test v1.4.3-canary.1 (b99371011)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [8.85ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [6.16ms]
(pass) ES Decorators > class decorators > class decorator can replace class [8.57ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [7.54ms]
(pass) ES Decorators > method decorators > instance method decorator [5.35ms]
(pass) ES Decorators > method decorators > static method decorator [8.87ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [6.23ms]
(pass) ES Decorators > getter decorators > getter decorator [6.63ms]
(pass) ES Decorators > setter decorators > setter decorator [6.21ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [10.22ms]
(pass) ES Decorators > field decorators > multiple field decorators [6.63ms]
(pass) ES Decorators > field decorators > static field decorator [5.77ms]
(pass) ES Decorators > non-ASCII string-literal keys > Bun.Transpiler output preserves the key [0.64ms]
(pass) ES Dec
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (b99371011)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [460.28ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [300.51ms]
(pass) ES Decorators > class decorators > class decorator can replace class [308.31ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [330.49ms]
(pass) ES Decorators > method decorators > instance method decorator [444.20ms]
(pass) ES Decorators > method decorators > static method decorator [296.98ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [450.84ms]
(pass) ES Decorators > getter decorators > getter decorator [386.15ms]
(pass) ES Decorators > setter decorators > setter decorator [375.01ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [301.52ms]
(pass) ES Decorators > field decorators > multiple field decorators [309.12ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 792ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/g.rs                                  |  5 ++++-
 test/bundler/transpiler/es-decorators.test.ts | 27 +++++++++++++++++++++++++++
 2 files changed, 31 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/ast/g.rs                                       1      1     15
test/bundler/transpiler/es-decorators.test.ts      2      1     14
```

</details>

**root cause** · written by the author bot

The hoisting check in `Class::can_be_moved` only examined static initializers on `PropertyKind::Normal` properties, so a class whose only side effect was a static `accessor x = expr` initializer was treated as side-effect free and moved to the top of the module, where the initializer ran before the bindings it reads existed. The fix widens that check so `PropertyKind::AutoAccessor` is inspected the same way as a normal static field, which keeps such classes where they were written. A new test in the ES decorators suite asserts the correct evaluation order for a static accessor initializer.

<!-- robobun:evidence:end -->