### PR TITLE
server.fetch: copy a Headers argument instead of adopting the wrapper's pointer

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2311,22 +2311,15 @@ where
 
                 if let Some(headers_) = opts.fast_get(ctx, jsc::BuiltinName::Headers)? {
                     if let Some(headers__) = FetchHeaders::cast_(headers_, ctx.vm()) {
-                        // NOTE: `cast_` returns the `FetchHeaders*` held by the
-                        // JS `Headers` wrapper (`JSFetchHeaders`'s internal
-                        // `Ref<FetchHeaders>`) without bumping the refcount —
-                        // the FFI surface has `WebCore__FetchHeaders__deref` but
-                        // no `ref()`, so a +1 cannot be taken here. Adopting
-                        // hands that wrapper-held ref to the constructed
-                        // `Request` (via `Request::init2` below): the eventual
-                        // single deref happens when the Request's finalizer
-                        // drops its `headers` field (`HeadersRef::Drop`,
-                        // Response.rs), pairing with the wrapper's +1.
-                        // SAFETY: `headers__` is live (rooted by `headers_`),
-                        // and ownership of one ref transfers as described above.
-                        headers = Some(unsafe { HeadersRef::adopt(headers__) });
-                    } else if let Some(headers__) = FetchHeaders::create_from_js(ctx, headers_)? {
-                        // SAFETY: create_from_js returns a +1 ref.
-                        headers = Some(unsafe { HeadersRef::adopt(headers__) });
+                        // The JS `Headers` keeps its own reference; the Request
+                        // gets a copy, as `new Request(url, { headers })` does.
+                        // S008: `FetchHeaders` is an opaque ZST FFI handle — safe deref.
+                        headers = bun_opaque::opaque_deref_mut(headers__.as_ptr())
+                            .clone_this(ctx)?
+                            // SAFETY: `clone_this` returns a +1 ref.
+                            .map(|p| unsafe { HeadersRef::adopt(p) });
+                    } else {
+                        headers = HeadersRef::create_from_js(ctx, headers_)?;
                     }
                 }
 

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -374,38 +374,6 @@ describe.concurrent("Server", () => {
     expect(kept.map(h => h.get("x-i"))).toEqual(kept.map((_, i) => String(i * 2)));
   });
 
-  test("server.upgrade(req, { headers }) with a Headers object and with a plain object, across GC", async () => {
-    for (const makeHeaders of [() => new Headers({ "x-up": "1" }), () => ({ "x-up": "1" })]) {
-      let upgraded = 0;
-      using server = Bun.serve({
-        port: 0,
-        fetch(req, srv) {
-          if (srv.upgrade(req, { headers: makeHeaders() })) {
-            upgraded++;
-            return;
-          }
-          return new Response("no upgrade", { status: 400 });
-        },
-        websocket: {
-          open(ws) {
-            ws.close();
-          },
-          message() {},
-        },
-      });
-      for (let i = 0; i < 100; i++) {
-        const ws = new WebSocket(`ws://${server.hostname}:${server.port}/`);
-        const { promise, resolve } = Promise.withResolvers<void>();
-        ws.onclose = () => resolve();
-        ws.onerror = () => resolve();
-        await promise;
-        if (i % 25 === 0) Bun.gc(true);
-      }
-      Bun.gc(true);
-      expect(upgraded).toBe(100);
-    }
-  });
-
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -352,6 +352,60 @@ describe.concurrent("Server", () => {
     }
   });
 
+  test("server.fetch(url, { headers: Headers }) copies the headers; the Headers object stays usable across GC", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response(req.headers.get("x-i") ?? "none");
+      },
+    });
+    const url = `http://${server.hostname}:${server.port}/`;
+    const kept: Headers[] = [];
+    for (let i = 0; i < 200; i++) {
+      const headers = new Headers({ "x-i": String(i) });
+      const response = await server.fetch(url, { headers });
+      expect(await response.text()).toBe(String(i));
+      if (i % 2 === 0) kept.push(headers);
+      if (i % 50 === 0) Bun.gc(true);
+    }
+    Bun.gc(true);
+    // The Request built by server.fetch() has been collected; the Headers we
+    // kept must still own their list.
+    expect(kept.map(h => h.get("x-i"))).toEqual(kept.map((_, i) => String(i * 2)));
+  });
+
+  test("server.upgrade(req, { headers }) with a Headers object and with a plain object, across GC", async () => {
+    for (const makeHeaders of [() => new Headers({ "x-up": "1" }), () => ({ "x-up": "1" })]) {
+      let upgraded = 0;
+      using server = Bun.serve({
+        port: 0,
+        fetch(req, srv) {
+          if (srv.upgrade(req, { headers: makeHeaders() })) {
+            upgraded++;
+            return;
+          }
+          return new Response("no upgrade", { status: 400 });
+        },
+        websocket: {
+          open(ws) {
+            ws.close();
+          },
+          message() {},
+        },
+      });
+      for (let i = 0; i < 100; i++) {
+        const ws = new WebSocket(`ws://${server.hostname}:${server.port}/`);
+        const { promise, resolve } = Promise.withResolvers<void>();
+        ws.onclose = () => resolve();
+        ws.onerror = () => resolve();
+        await promise;
+        if (i % 25 === 0) Bun.gc(true);
+      }
+      Bun.gc(true);
+      expect(upgraded).toBe(100);
+    }
+  });
+
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### Bug

On main and in 1.4.1, `server.fetch(url, { headers: new Headers({...}) })` followed by a GC segfaults. A debug build reports UBSAN "member call on null pointer of type HTTPHeaderMap::UncommonHeader"; a release build crashes with a segfault at address 0x0.

```js
using server = Bun.serve({ port: 0, fetch: req => new Response(req.headers.get("x-i") ?? "none") });
const headers = new Headers({ "x-i": "1" });
await server.fetch(`http://${server.hostname}:${server.port}/`, { headers });
Bun.gc(true);
headers.get("x-i"); // crash
```

### Cause

`src/runtime/server/server_body.rs` did `HeadersRef::adopt(FetchHeaders::cast_(value))` — adopting the `FetchHeaders*` owned by the JS `Headers` wrapper without taking a reference. The wrapper's finalizer and the constructed `Request`'s `HeadersRef::drop` then both release the same object.

### Fix

Deep-copy the headers via `clone_this`, the same way `new Request(url, { headers })` and `Response` init handle a `Headers` argument. The `HeadersInit` (plain object / array) arm now uses `HeadersRef::create_from_js`.

This change also lives in #40202; this PR lands it on its own.

### Test

Added to `test/js/bun/http/bun-server.test.ts`:
- `server.fetch(url, { headers: Headers }) copies the headers; the Headers object stays usable across GC` — segfaults with 1.4.1 (`USE_SYSTEM_BUN=1`), passes with this change.
- `server.upgrade(req, { headers })` with a `Headers` object and with a plain object, across GC.

`bun-server.test.ts`, `serve.test.ts` and `bun-serve-routes` pass with a debug build.