### PR TITLE
test(cron): drive in-process-cron.test.ts from the fake clock, strengthen its assertions

### DIFF
--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, jest, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
+// Snippet prepended to subprocess/worker bodies so they can fire a cron
+// deterministically without waiting for a real minute boundary.
+const mockClock = `
+  const { jest } = require("bun:test");
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+`;
+
 describe("Bun.cron (in-process)", () => {
   test("validates cron expression", () => {
     expect(() => Bun.cron("invalid expr", () => {})).toThrow(/Invalid cron expression/);
@@ -80,47 +88,17 @@ describe("Bun.cron (in-process)", () => {
     expect(job.cron).toBe("0 9 * JAN-DEC MON-FRI");
   });
 
-  test("keeps process alive by default; unref() allows exit", async () => {
-    // ref'd: process stays alive (would block forever), so we spawn with timeout via cron
-    // unref'd: process exits immediately
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const job = Bun.cron("* * * * *", () => {});
-        job.unref();
-        console.log("scheduled");
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(normalizeBunSnapshot(stdout)).toBe("scheduled");
-    expect(exitCode).toBe(0);
+  test("distinguishes callback overload from OS-level overload", () => {
+    // Callable 2nd arg → in-process; 3-string-arg → OS-level.
+    // We only verify the callback path here; the string path is covered elsewhere.
+    using job = Bun.cron("* * * * *", () => {});
+    // CronJob has stop(); Promise would not
+    expect(typeof job.stop).toBe("function");
+    expect(job).not.toBeInstanceOf(Promise);
   });
+});
 
-  test("ref'd job prevents process exit", async () => {
-    // The cron keeps the loop alive; we stop it after a short delay to let the process exit.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const job = Bun.cron("* * * * *", () => {});
-        console.log("scheduled");
-        setTimeout(() => { job.stop(); console.log("stopped"); }, 50);
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(normalizeBunSnapshot(stdout)).toBe("scheduled\nstopped");
-    expect(exitCode).toBe(0);
-  });
-
+describe("Bun.cron (in-process) — firing under fake timers", () => {
   test("honors jest fake timers", () => {
     jest.useFakeTimers();
     try {
@@ -163,70 +141,112 @@ describe("Bun.cron (in-process)", () => {
     }
   });
 
-  test("distinguishes callback overload from OS-level overload", () => {
-    // Callable 2nd arg → in-process; 3-string-arg → OS-level.
-    // We only verify the callback path here; the string path is covered elsewhere.
-    using job = Bun.cron("* * * * *", () => {});
-    // CronJob has stop(); Promise would not
-    expect(typeof job.stop).toBe("function");
-    expect(job).not.toBeInstanceOf(Promise);
+  test("callback fires at minute boundary, this === job", () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+      let fired = 0;
+      let thisInCallback: unknown;
+      const job = Bun.cron("* * * * *", function () {
+        fired++;
+        thisInCallback = this;
+      });
+      jest.advanceTimersByTime(60_000);
+      expect(fired).toBe(1);
+      expect(thisInCallback).toBe(job);
+      job.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("async callback: stop() during await prevents reschedule", async () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+      let fires = 0;
+      const handler = Promise.withResolvers<void>();
+      const fire = Promise.withResolvers<void>();
+
+      const job = Bun.cron("* * * * *", async () => {
+        fires++;
+        fire.resolve();
+        await handler.promise;
+      });
+
+      jest.advanceTimersByTime(60_000);
+      await fire.promise;
+      expect(fires).toBe(1);
+      job.stop();
+      handler.resolve();
+      await Promise.resolve();
+      // After the async callback settles, stop() should have prevented the re-arm.
+      jest.advanceTimersByTime(120_000);
+      expect(fires).toBe(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("unreferenced running job survives GC", () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+      let fired = 0;
+      // No local binding: the JS wrapper is immediately unreachable.
+      Bun.cron("* * * * *", () => void fired++).unref();
+      Bun.gc(true);
+      Bun.gc(true);
+      jest.advanceTimersByTime(60_000);
+      expect(fired).toBe(1);
+      // jest.useRealTimers() drains the fake heap, cancelling the re-armed timer.
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 
-describe.concurrent("Bun.cron (in-process) — firing", () => {
-  test("callback fires at minute boundary, this === job", async () => {
-    let fired = 0;
-    let thisInCallback: unknown;
-    const { promise, resolve } = Promise.withResolvers<void>();
-
-    using job = Bun.cron("* * * * *", function () {
-      fired++;
-      thisInCallback = this;
-      resolve();
-    });
-
-    await promise;
-    expect(fired).toBe(1);
-    expect(thisInCallback).toBe(job);
-  }, 70_000);
-
-  test("async callback: stop() during await prevents reschedule", async () => {
-    let fires = 0;
-    const handler = Promise.withResolvers<void>();
-    const fire = Promise.withResolvers<void>();
-
-    using job = Bun.cron("* * * * *", async () => {
-      fires++;
-      fire.resolve();
-      await handler.promise;
-    });
-
-    await fire.promise;
-    expect(fires).toBe(1);
-    job.stop();
-    handler.resolve();
-    await Promise.resolve();
-    expect(fires).toBe(1);
-  }, 70_000);
-
-  test("unreferenced running job survives GC", async () => {
+describe.concurrent("Bun.cron (in-process) — subprocess", () => {
+  test("keeps process alive by default; unref() allows exit", async () => {
+    // ref'd: process stays alive (would block forever), so we spawn with timeout via cron
+    // unref'd: process exits immediately
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
-        Bun.cron("* * * * *", () => { console.log("fired"); process.exit(0); });
-        Bun.gc(true);
-        Bun.gc(true);
+        const job = Bun.cron("* * * * *", () => {});
+        job.unref();
+        console.log("scheduled");
       `,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
     const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("fired");
+    expect(normalizeBunSnapshot(stdout)).toBe("scheduled");
     expect(exitCode).toBe(0);
-  }, 70_000);
+  });
+
+  test("ref'd job prevents process exit", async () => {
+    // The cron keeps the loop alive; we stop it after a short delay to let the process exit.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const job = Bun.cron("* * * * *", () => {});
+        console.log("scheduled");
+        setTimeout(() => { job.stop(); console.log("stopped"); }, 50);
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stdout)).toBe("scheduled\nstopped");
+    expect(exitCode).toBe(0);
+  });
 
   test("ref() after stop() does not keep process alive", async () => {
     await using proc = Bun.spawn({
@@ -248,15 +268,128 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("sync throw in callback emits uncaughtException", async () => {
+    // Matches setTimeout: sync throw → uncaughtException. Process exits 1 without a handler.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        mockClock +
+          `
+        let caught;
+        process.on("uncaughtException", e => { caught = e.message; });
+        const job = Bun.cron("* * * * *", () => { throw new Error("sync-boom"); });
+        jest.advanceTimersByTime(60_000);
+        job.stop();
+        console.log("caught=" + caught);
+        process.exit(0);
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("caught=sync-boom");
+    expect(exitCode).toBe(0);
+  });
+
+  test("async throw in callback emits unhandledRejection", async () => {
+    // Matches setTimeout: rejected promise → unhandledRejection.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        mockClock +
+          `
+        process.on("unhandledRejection", (e, p) => {
+          console.log("caught=" + e.message + ":" + (p instanceof Promise));
+          process.exit(0);
+        });
+        const job = Bun.cron("* * * * *", async () => {
+          await Bun.sleep(1);
+          throw new Error("async-boom");
+        });
+        jest.advanceTimersByTime(60_000);
+        // Bun.sleep is itself a mocked timer; resolve it so the callback rejects
+        // after on_timer_fire has returned (exercises the pending .then() path).
+        jest.advanceTimersByTime(100);
+        job.stop();
+        jest.useRealTimers();
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("caught=async-boom:true");
+    expect(exitCode).toBe(0);
+  });
+
+  test("stop() while async callback pending still surfaces unhandledRejection with promise", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        mockClock +
+          `
+        process.on("unhandledRejection", (e, p) => {
+          console.log("caught=" + e.message + ":" + (p instanceof Promise));
+          process.exit(0);
+        });
+        let job = Bun.cron("* * * * *", async () => {
+          job.stop();
+          job = null;
+          Bun.gc(true);
+          Bun.gc(true);
+          await Bun.sleep(10);
+          throw new Error("after-stop");
+        });
+        jest.advanceTimersByTime(60_000);
+        // on_timer_fire has returned; the wrapper is now only kept alive by
+        // pending_ref. GC again, then resolve the Bun.sleep so the callback rejects.
+        Bun.gc(true);
+        jest.advanceTimersByTime(100);
+        jest.useRealTimers();
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("caught=after-stop:true");
+    expect(exitCode).toBe(0);
+  });
+
+  test("unhandled cron error exits process like setTimeout does", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        mockClock +
+          `
+        Bun.cron("* * * * *", () => { throw new Error("boom"); });
+        jest.advanceTimersByTime(60_000);
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("boom");
+    expect(exitCode).toBe(1);
+  });
+
   test("worker terminate while async callback pending releases cleanly", async () => {
     using dir = tempDir("cron-worker", {
-      "worker.ts": `
-        let fired = false;
+      "worker.ts":
+        mockClock +
+        `
         Bun.cron("* * * * *", async () => {
-          fired = true;
           self.postMessage("fired");
           await new Promise(() => {}); // never settles
         });
+        jest.advanceTimersByTime(60_000);
       `,
     });
     // Wait for "close" before forcing GC so main-VM destruct-on-exit (ASAN
@@ -283,7 +416,7 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     if (exitCode !== 0) console.error(stderr);
     expect(stdout.trim()).toBe("ok");
     expect(exitCode).toBe(0);
-  }, 130_000);
+  });
 
   test("worker terminate mid-callback does not report TerminationException as uncaught", async () => {
     // The callback busy-spins after postMessage so terminate() interrupts
@@ -291,17 +424,20 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     // When the VMEntryScope unwinds, JSC clears hasTerminationRequest but
     // leaves the exception pending; cron's catch block must not hand that to
     // uncaughtException(), or the lazy process-object init asserts in
-    // VMTraps::deferTerminationSlow. Use several workers so the timing lines
-    // up at least once per minute-boundary.
+    // VMTraps::deferTerminationSlow. Fake timers make the fire deterministic
+    // so a handful of workers is enough.
     using dir = tempDir("cron-worker-term", {
-      "worker.ts": `
+      "worker.ts":
+        mockClock +
+        `
         Bun.cron("* * * * *", () => {
           self.postMessage("fired");
           while (true) { for (let i = 0; i < 1e6; i++); }
         });
+        jest.advanceTimersByTime(60_000);
       `,
       "main.ts": `
-        const N = 20;
+        const N = 4;
         let closed = 0, errors = 0;
         for (let i = 0; i < N; i++) {
           const w = new Worker("./worker.ts");
@@ -327,101 +463,7 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     if (exitCode !== 0) console.error(stderr);
     expect(stdout.trim()).toBe("errors=0");
     expect(exitCode).toBe(0);
-  }, 130_000);
-
-  test("sync throw in callback emits uncaughtException", async () => {
-    // Matches setTimeout: sync throw → uncaughtException. Process exits 1 without a handler.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        let caught;
-        process.on("uncaughtException", e => { caught = e.message; });
-        const job = Bun.cron("* * * * *", () => {
-          setTimeout(() => { job.stop(); console.log("caught=" + caught); process.exit(0); }, 100);
-          throw new Error("sync-boom");
-        });
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("caught=sync-boom");
-    expect(exitCode).toBe(0);
-  }, 130_000);
-
-  test("async throw in callback emits unhandledRejection", async () => {
-    // Matches setTimeout: rejected promise → unhandledRejection.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        let caught;
-        process.on("unhandledRejection", (e, p) => { caught = e.message + ":" + (p instanceof Promise); });
-        const job = Bun.cron("* * * * *", async () => {
-          setTimeout(() => { job.stop(); console.log("caught=" + caught); process.exit(0); }, 100);
-          await Bun.sleep(1);
-          throw new Error("async-boom");
-        });
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("caught=async-boom:true");
-    expect(exitCode).toBe(0);
-  }, 130_000);
-
-  test("stop() while async callback pending still surfaces unhandledRejection with promise", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        process.on("unhandledRejection", (e, p) => {
-          console.log("caught=" + e.message + ":" + (p instanceof Promise));
-          process.exit(0);
-        });
-        let job = Bun.cron("* * * * *", async () => {
-          job.stop();
-          job = null;
-          Bun.gc(true);
-          Bun.gc(true);
-          await Bun.sleep(10);
-          throw new Error("after-stop");
-        });
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("caught=after-stop:true");
-    expect(exitCode).toBe(0);
-  }, 70_000);
-
-  test("unhandled cron error exits process like setTimeout does", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        Bun.cron("* * * * *", () => { throw new Error("boom"); });
-        setTimeout(() => console.log("still alive"), 61000);
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("");
-    expect(stderr).toContain("boom");
-    expect(exitCode).toBe(1);
-  }, 70_000);
+  });
 
   test("--hot reload clears jobs deleted from source", async () => {
     // Markers live OUTSIDE the --hot-watched dir so inotify doesn't deliver
@@ -429,15 +471,13 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     using markers = tempDir("cron-hot-markers", {});
     const m = (f: string) => join(String(markers), f);
     using dir = tempDir("cron-hot", {
-      "app.ts": `
+      "app.ts":
+        mockClock +
+        `
         import { writeFileSync, existsSync } from "node:fs";
         const m = process.env.MARKERS;
         writeFileSync(m + "/v1.evaluated", "");
-        // A fire before the v2 reload is legitimate (not a ghost) — only
-        // write the marker if v2 has already evaluated.
-        Bun.cron("* * * * *", () => {
-          if (existsSync(m + "/v2.evaluated")) writeFileSync(m + "/ghost.fired", "");
-        });
+        Bun.cron("* * * * *", () => writeFileSync(m + "/ghost.fired", ""));
       `,
     });
 
@@ -459,18 +499,19 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
 
     await waitFor("v1.evaluated");
 
-    // Delete the ghost cron; replace with a sentinel that fires on the same
-    // boundary. When the sentinel fires, ghost.fired must NOT exist.
+    // Delete the ghost cron; advance the fake clock past its fire time.
+    // If clear_all_for_vm(.reload) did not remove v1's cron from the fake
+    // heap, advanceTimersByTime would fire it and ghost.fired would exist.
     await Bun.write(
       join(String(dir), "app.ts"),
       `
         import { writeFileSync, existsSync } from "node:fs";
+        const { jest } = require("bun:test");
         const m = process.env.MARKERS;
         writeFileSync(m + "/v2.evaluated", "");
-        Bun.cron("* * * * *", () => {
-          writeFileSync(m + "/result", existsSync(m + "/ghost.fired") ? "GHOST_FIRED" : "ok");
-          process.exit(0);
-        });
+        jest.advanceTimersByTime(120_000);
+        writeFileSync(m + "/result", existsSync(m + "/ghost.fired") ? "GHOST_FIRED" : "ok");
+        process.exit(0);
       `,
     );
 
@@ -481,5 +522,5 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     expect(exitCode).toBe(0);
     expect(await Bun.file(m("result")).text()).toBe("ok");
     expect(await Bun.file(m("ghost.fired")).exists()).toBe(false);
-  }, 130_000);
+  });
 });

--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -1,328 +1,306 @@
-import { describe, expect, jest, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
-// Snippet prepended to subprocess/worker bodies so they can fire a cron
-// deterministically without waiting for a real minute boundary.
+// A cron schedule has one-minute resolution, so a job driven by the real clock
+// waits up to 60s for the next boundary. Bun.cron() anchors its schedule to the
+// jest fake clock when one is active, so every firing test below advances that
+// clock instead of waiting. Child processes drive their own fake clock: bun:test
+// loads outside the test runner too.
+const T0 = new Date("2026-01-01T12:00:00.000Z");
+const minute = (n: number) => new Date(T0.getTime() + n * 60_000).toISOString();
 const mockClock = `
   const { jest } = require("bun:test");
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+  jest.useFakeTimers({ now: new Date(${JSON.stringify(T0.toISOString())}) });
 `;
 
+async function output(proc: Bun.ReadableSubprocess) {
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
 describe("Bun.cron (in-process)", () => {
-  test("validates cron expression", () => {
-    expect(() => Bun.cron("invalid expr", () => {})).toThrow(/Invalid cron expression/);
-    expect(() => Bun.cron("* * * *", () => {})).toThrow(/Invalid cron expression/);
-    expect(() => Bun.cron("60 * * * *", () => {})).toThrow(/Invalid cron expression/);
+  test.each([
+    ["invalid expr", "Invalid cron expression: expected 5 space-separated fields (minute hour day month weekday)"],
+    ["* * * *", "Invalid cron expression: expected 5 space-separated fields (minute hour day month weekday)"],
+    ["60 * * * *", "Invalid cron expression: value out of range for field"],
+    // Feb 30 never exists
+    ["0 0 30 2 *", "Cron expression '0 0 30 2 *' has no future occurrences"],
+  ])("rejects %j", (expr, message) => {
+    expect(() => Bun.cron(expr, () => {})).toThrow(message);
   });
 
   test("validates schedule is a string", () => {
     // @ts-expect-error
-    expect(() => Bun.cron(123, () => {})).toThrow(/string cron expression/);
+    expect(() => Bun.cron(123, () => {})).toThrow("Bun.cron() expects a string cron expression");
   });
 
-  test("rejects expressions with no future occurrences", () => {
-    // Feb 30 never exists
-    expect(() => Bun.cron("0 0 30 2 *", () => {})).toThrow(/no future occurrences/);
-  });
+  test.each(["* * * * *", "@hourly", "0 9 * JAN-DEC MON-FRI"])(
+    "cron getter returns the schedule as written: %j",
+    expr => {
+      using job = Bun.cron(expr, () => {});
+      expect(job.cron).toBe(expr);
+    },
+  );
 
-  test("returns CronJob with cron getter", () => {
+  test("returns a CronJob handle, not a Promise", () => {
+    // Callable 2nd arg is the in-process overload; the OS-level overload returns a Promise.
     using job = Bun.cron("* * * * *", () => {});
-    expect(job.cron).toBe("* * * * *");
+    expect(job).not.toBeInstanceOf(Promise);
+    expect(Object.prototype.toString.call(job)).toBe("[object CronJob]");
+    expect(Bun.inspect(job)).toMatchInlineSnapshot(`
+      "CronJob {
+        cron: "* * * * *",
+        ref: [Function: ref],
+        stop: [Function: stop],
+        unref: [Function: unref],
+        [Symbol(Symbol.dispose)]: [Function: dispose],
+      }"
+    `);
   });
 
-  test("is Disposable", () => {
-    let j!: Bun.CronJob;
-    {
-      using job = Bun.cron("* * * * *", () => {});
-      j = job;
-      expect(typeof job[Symbol.dispose]).toBe("function");
-    }
-    // Disposed at scope exit; stop() is idempotent so this is just a smoke check
-    expect(() => j.stop()).not.toThrow();
-  });
-
-  test("stop() cancels before first fire", () => {
-    let called = false;
-    const job = Bun.cron("* * * * *", () => {
-      called = true;
-    });
-    job.stop();
-    // stop() returns immediately; callback was never scheduled to run
-    expect(called).toBe(false);
-  });
-
-  test("stop() is idempotent", () => {
+  test("stop(), ref() and unref() return the job; stop() is idempotent", () => {
     const job = Bun.cron("* * * * *", () => {});
-    expect(() => {
-      job.stop();
-      job.stop();
-      job.stop();
-    }).not.toThrow();
-  });
-
-  test("ref()/unref() are chainable", () => {
-    using job = Bun.cron("* * * * *", () => {});
     expect(job.unref()).toBe(job);
     expect(job.ref()).toBe(job);
     expect(job.stop()).toBe(job);
-  });
-
-  test("multiple jobs coexist independently", () => {
-    using a = Bun.cron("* * * * *", () => {});
-    using b = Bun.cron("* * * * *", () => {});
-    expect(a).not.toBe(b);
-    a.stop();
-    // b is still a valid handle after stopping a
-    expect(typeof b.stop).toBe("function");
-  });
-
-  test("accepts @nicknames", () => {
-    using job = Bun.cron("@hourly", () => {});
-    expect(job.cron).toBe("@hourly");
-  });
-
-  test("supports named weekdays and months", () => {
-    using job = Bun.cron("0 9 * JAN-DEC MON-FRI", () => {});
-    expect(job.cron).toBe("0 9 * JAN-DEC MON-FRI");
-  });
-
-  test("distinguishes callback overload from OS-level overload", () => {
-    // Callable 2nd arg → in-process; 3-string-arg → OS-level.
-    // We only verify the callback path here; the string path is covered elsewhere.
-    using job = Bun.cron("* * * * *", () => {});
-    // CronJob has stop(); Promise would not
-    expect(typeof job.stop).toBe("function");
-    expect(job).not.toBeInstanceOf(Promise);
+    expect(job.stop()).toBe(job);
   });
 });
 
-describe("Bun.cron (in-process) — firing under fake timers", () => {
-  test("honors jest fake timers", () => {
-    jest.useFakeTimers();
-    try {
-      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
-      const firedAt: number[] = [];
-      using job = Bun.cron("* * * * *", () => void firedAt.push(Date.now()));
-
-      jest.advanceTimersByTime(59_999);
-      expect(firedAt).toEqual([]);
-
-      jest.advanceTimersByTime(1);
-      expect(firedAt).toEqual([new Date("2026-01-01T12:01:00.000Z").getTime()]);
-
-      // Re-arms for the next minute; never double-fires at the same boundary
-      jest.advanceTimersByTime(60_000);
-      expect(firedAt).toEqual([
-        new Date("2026-01-01T12:01:00.000Z").getTime(),
-        new Date("2026-01-01T12:02:00.000Z").getTime(),
-      ]);
-    } finally {
-      jest.useRealTimers();
-    }
+describe("Bun.cron (in-process) firing under fake timers", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: T0 });
+  });
+  // useRealTimers() drops every job still in the fake heap and stops it.
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
-  test("stop() under fake timers prevents further fires", () => {
-    jest.useFakeTimers();
-    try {
-      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
-      let fires = 0;
-      const job = Bun.cron("* * * * *", () => void fires++);
+  test("fires at each minute boundary with this === job and no arguments", () => {
+    const fired: { at: string; self: boolean; args: number }[] = [];
+    using job = Bun.cron("* * * * *", function (...args) {
+      fired.push({ at: new Date().toISOString(), self: this === job, args: args.length });
+    });
 
-      jest.advanceTimersByTime(60_000);
-      expect(fires).toBe(1);
+    jest.advanceTimersByTime(59_999);
+    expect(fired).toEqual([]);
 
-      job.stop();
-      jest.advanceTimersByTime(120_000);
-      expect(fires).toBe(1);
-    } finally {
-      jest.useRealTimers();
-    }
+    jest.advanceTimersByTime(1);
+    expect(fired).toEqual([{ at: minute(1), self: true, args: 0 }]);
+
+    // Re-arms for the next minute; never double-fires at the same boundary
+    jest.advanceTimersByTime(60_000);
+    expect(fired).toEqual([
+      { at: minute(1), self: true, args: 0 },
+      { at: minute(2), self: true, args: 0 },
+    ]);
   });
 
-  test("callback fires at minute boundary, this === job", () => {
-    jest.useFakeTimers();
-    try {
-      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
-      let fired = 0;
-      let thisInCallback: unknown;
-      const job = Bun.cron("* * * * *", function () {
-        fired++;
-        thisInCallback = this;
-      });
-      jest.advanceTimersByTime(60_000);
-      expect(fired).toBe(1);
-      expect(thisInCallback).toBe(job);
-      job.stop();
-    } finally {
-      jest.useRealTimers();
+  test("@hourly fires at the top of the next hour", () => {
+    const firedAt: string[] = [];
+    using job = Bun.cron("@hourly", () => void firedAt.push(new Date().toISOString()), { tz: "UTC" });
+
+    jest.advanceTimersByTime(60 * 60_000 - 1);
+    expect(firedAt).toEqual([]);
+
+    jest.advanceTimersByTime(1);
+    expect(firedAt).toEqual(["2026-01-01T13:00:00.000Z"]);
+  });
+
+  test("stop() before the first fire cancels the job", () => {
+    let fires = 0;
+    const job = Bun.cron("* * * * *", () => void fires++);
+    job.stop();
+
+    jest.advanceTimersByTime(120_000);
+    expect(fires).toBe(0);
+  });
+
+  test("stop() after a fire prevents further fires", () => {
+    let fires = 0;
+    const job = Bun.cron("* * * * *", () => void fires++);
+
+    jest.advanceTimersByTime(60_000);
+    expect(fires).toBe(1);
+
+    job.stop();
+    jest.advanceTimersByTime(120_000);
+    expect(fires).toBe(1);
+  });
+
+  test("Symbol.dispose stops the job", () => {
+    let fires = 0;
+    let disposed!: Bun.CronJob;
+    {
+      using job = Bun.cron("* * * * *", () => void fires++);
+      disposed = job;
+      expect(typeof job[Symbol.dispose]).toBe("function");
     }
+
+    jest.advanceTimersByTime(120_000);
+    expect(fires).toBe(0);
+    // stop() after dispose is a no-op that still returns the job
+    expect(disposed.stop()).toBe(disposed);
+  });
+
+  test("stopping one job leaves another running", () => {
+    const fires = { a: 0, b: 0 };
+    using a = Bun.cron("* * * * *", () => void fires.a++);
+    using b = Bun.cron("* * * * *", () => void fires.b++);
+    expect(a).not.toBe(b);
+
+    a.stop();
+    jest.advanceTimersByTime(60_000);
+    expect(fires).toEqual({ a: 0, b: 1 });
+  });
+
+  test("a pending async tick is not overlapped; the job re-arms once it settles", async () => {
+    const gate = Promise.withResolvers<void>();
+    const firedAt: string[] = [];
+    using job = Bun.cron("* * * * *", async () => {
+      firedAt.push(new Date().toISOString());
+      await gate.promise;
+    });
+
+    jest.advanceTimersByTime(60_000);
+    expect(firedAt).toEqual([minute(1)]);
+
+    // Three more boundaries pass while the first tick is still pending.
+    jest.advanceTimersByTime(180_000);
+    expect(firedAt).toEqual([minute(1)]);
+
+    gate.resolve();
+    // setImmediate is not faked: one real turn lets the tick settle.
+    await new Promise(resolve => setImmediate(resolve));
+
+    // The next fire is the first boundary after the settle, not 60s after the first fire.
+    jest.advanceTimersByTime(59_999);
+    expect(firedAt).toEqual([minute(1)]);
+    jest.advanceTimersByTime(1);
+    expect(firedAt).toEqual([minute(1), minute(5)]);
   });
 
   test("async callback: stop() during await prevents reschedule", async () => {
-    jest.useFakeTimers();
-    try {
-      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
-      let fires = 0;
-      const handler = Promise.withResolvers<void>();
-      const fire = Promise.withResolvers<void>();
+    let fires = 0;
+    const gate = Promise.withResolvers<void>();
+    const job = Bun.cron("* * * * *", async () => {
+      fires++;
+      await gate.promise;
+    });
 
-      const job = Bun.cron("* * * * *", async () => {
-        fires++;
-        fire.resolve();
-        await handler.promise;
-      });
+    jest.advanceTimersByTime(60_000);
+    expect(fires).toBe(1);
 
-      jest.advanceTimersByTime(60_000);
-      await fire.promise;
-      expect(fires).toBe(1);
-      job.stop();
-      handler.resolve();
-      await Promise.resolve();
-      // After the async callback settles, stop() should have prevented the re-arm.
-      jest.advanceTimersByTime(120_000);
-      expect(fires).toBe(1);
-    } finally {
-      jest.useRealTimers();
-    }
+    job.stop();
+    gate.resolve();
+    await new Promise(resolve => setImmediate(resolve));
+
+    jest.advanceTimersByTime(120_000);
+    expect(fires).toBe(1);
   });
 
   test("unreferenced running job survives GC", () => {
-    jest.useFakeTimers();
-    try {
-      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
-      let fired = 0;
-      // No local binding: the JS wrapper is immediately unreachable.
-      Bun.cron("* * * * *", () => void fired++).unref();
-      Bun.gc(true);
-      Bun.gc(true);
-      jest.advanceTimersByTime(60_000);
-      expect(fired).toBe(1);
-      // jest.useRealTimers() drains the fake heap, cancelling the re-armed timer.
-    } finally {
-      jest.useRealTimers();
-    }
+    let fires = 0;
+    // Nothing in JS holds the handle; the native side keeps the wrapper alive while scheduled.
+    Bun.cron("* * * * *", () => void fires++).unref();
+    Bun.gc(true);
+    Bun.gc(true);
+
+    jest.advanceTimersByTime(60_000);
+    expect(fires).toBe(1);
   });
 });
 
-describe.concurrent("Bun.cron (in-process) — subprocess", () => {
-  test("keeps process alive by default; unref() allows exit", async () => {
-    // ref'd: process stays alive (would block forever), so we spawn with timeout via cron
-    // unref'd: process exits immediately
+describe.concurrent("Bun.cron (in-process) subprocess", () => {
+  // The unref'd 50ms timer never holds the event loop open on its own, so it
+  // runs, and logs "stopped", only while the job keeps the process alive.
+  test.each([
+    ["a ref'd job (the default) keeps the process alive", "", "scheduled\nstopped\n"],
+    ["unref() lets the process exit", "job.unref();", "scheduled\n"],
+    ["ref() after unref() keeps the process alive again", "job.unref().ref();", "scheduled\nstopped\n"],
+    ["ref() after stop() does not keep the process alive", "job.stop().ref();", "scheduled\n"],
+  ])("%s", async (_name, setup, stdout) => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
         const job = Bun.cron("* * * * *", () => {});
-        job.unref();
+        ${setup}
         console.log("scheduled");
+        setTimeout(() => { job.stop(); console.log("stopped"); }, 50).unref();
       `,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(normalizeBunSnapshot(stdout)).toBe("scheduled");
-    expect(exitCode).toBe(0);
+    expect(await output(proc)).toEqual({ stdout, stderr: "", exitCode: 0 });
   });
 
-  test("ref'd job prevents process exit", async () => {
-    // The cron keeps the loop alive; we stop it after a short delay to let the process exit.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const job = Bun.cron("* * * * *", () => {});
-        console.log("scheduled");
-        setTimeout(() => { job.stop(); console.log("stopped"); }, 50);
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(normalizeBunSnapshot(stdout)).toBe("scheduled\nstopped");
-    expect(exitCode).toBe(0);
-  });
-
-  test("ref() after stop() does not keep process alive", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const job = Bun.cron("* * * * *", () => {});
-        job.stop();
-        job.ref();
-        console.log("done");
-      `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("done");
-    expect(exitCode).toBe(0);
-  });
-
-  test("sync throw in callback emits uncaughtException", async () => {
-    // Matches setTimeout: sync throw → uncaughtException. Process exits 1 without a handler.
+  test("sync throw emits uncaughtException and the job keeps running", async () => {
+    // Matches setTimeout: a sync throw is an uncaughtException. With a listener
+    // installed the job is not stopped by the failure.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         mockClock +
           `
-        let caught;
-        process.on("uncaughtException", e => { caught = e.message; });
+        const events = [];
+        process.on("uncaughtException", e => events.push(e.message + "@" + new Date().toISOString()));
         const job = Bun.cron("* * * * *", () => { throw new Error("sync-boom"); });
-        jest.advanceTimersByTime(60_000);
+        jest.advanceTimersByTime(120_000);
         job.stop();
-        console.log("caught=" + caught);
-        process.exit(0);
+        console.log(JSON.stringify(events));
       `,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("caught=sync-boom");
-    expect(exitCode).toBe(0);
+    expect(await output(proc)).toEqual({
+      stdout: JSON.stringify([`sync-boom@${minute(1)}`, `sync-boom@${minute(2)}`]) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
-  test("async throw in callback emits unhandledRejection", async () => {
-    // Matches setTimeout: rejected promise → unhandledRejection.
+  test("async throw emits unhandledRejection with the promise and the job keeps running", async () => {
+    // Matches setTimeout: a rejected returned promise is an unhandledRejection.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         mockClock +
           `
+        const events = [];
         process.on("unhandledRejection", (e, p) => {
-          console.log("caught=" + e.message + ":" + (p instanceof Promise));
-          process.exit(0);
+          events.push(e.message + ":" + (p instanceof Promise) + "@" + new Date().toISOString());
         });
         const job = Bun.cron("* * * * *", async () => {
-          await Bun.sleep(1);
+          await Bun.sleep(1); // a fake timer as well
           throw new Error("async-boom");
         });
+        // Fires at 12:01:00 and resolves the sleep at 12:01:00.001. The
+        // rejection surfaces in the microtask drain of the next real turn,
+        // and only then does the job re-arm.
+        jest.advanceTimersByTime(60_001);
+        await new Promise(resolve => setImmediate(resolve));
         jest.advanceTimersByTime(60_000);
-        // Bun.sleep is itself a mocked timer; resolve it so the callback rejects
-        // after on_timer_fire has returned (exercises the pending .then() path).
-        jest.advanceTimersByTime(100);
+        await new Promise(resolve => setImmediate(resolve));
         job.stop();
-        jest.useRealTimers();
+        console.log(JSON.stringify(events));
       `,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("caught=async-boom:true");
-    expect(exitCode).toBe(0);
+    expect(await output(proc)).toEqual({
+      stdout:
+        JSON.stringify(["async-boom:true@2026-01-01T12:01:00.001Z", "async-boom:true@2026-01-01T12:02:00.001Z"]) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test("stop() while async callback pending still surfaces unhandledRejection with promise", async () => {
@@ -332,10 +310,8 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
         "-e",
         mockClock +
           `
-        process.on("unhandledRejection", (e, p) => {
-          console.log("caught=" + e.message + ":" + (p instanceof Promise));
-          process.exit(0);
-        });
+        const events = [];
+        process.on("unhandledRejection", (e, p) => events.push(e.message + ":" + (p instanceof Promise)));
         let job = Bun.cron("* * * * *", async () => {
           job.stop();
           job = null;
@@ -345,19 +321,18 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
           throw new Error("after-stop");
         });
         jest.advanceTimersByTime(60_000);
-        // on_timer_fire has returned; the wrapper is now only kept alive by
-        // pending_ref. GC again, then resolve the Bun.sleep so the callback rejects.
+        // The tick has returned; only the pending promise keeps the wrapper
+        // alive now. GC again, then resolve the sleep so the callback rejects.
         Bun.gc(true);
-        jest.advanceTimersByTime(100);
-        jest.useRealTimers();
+        jest.advanceTimersByTime(10);
+        await new Promise(resolve => setImmediate(resolve));
+        console.log(JSON.stringify(events));
       `,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("caught=after-stop:true");
-    expect(exitCode).toBe(0);
+    expect(await output(proc)).toEqual({ stdout: '["after-stop:true"]\n', stderr: "", exitCode: 0 });
   });
 
   test("unhandled cron error exits process like setTimeout does", async () => {
@@ -369,15 +344,17 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
           `
         Bun.cron("* * * * *", () => { throw new Error("boom"); });
         jest.advanceTimersByTime(60_000);
+        // The loop does not run on after an uncaught error: this real timer never fires.
+        jest.useRealTimers();
+        setTimeout(() => console.log("still alive"), 10);
       `,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("");
-    expect(stderr).toContain("boom");
-    expect(exitCode).toBe(1);
+    const { stdout, stderr, exitCode } = await output(proc);
+    expect(stderr).toContain("error: boom");
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 1 });
   });
 
   test("worker terminate while async callback pending releases cleanly", async () => {
@@ -394,7 +371,7 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
     });
     // Wait for "close" before forcing GC so main-VM destruct-on-exit (ASAN
     // CI sets BUN_DESTRUCT_VM_ON_EXIT=1) does not race the worker thread's
-    // own teardown — terminate() returns before the worker finishes.
+    // own teardown: terminate() returns before the worker finishes.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -412,21 +389,19 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) console.error(stderr);
-    expect(stdout.trim()).toBe("ok");
-    expect(exitCode).toBe(0);
+    expect(await output(proc)).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
   });
 
   test("worker terminate mid-callback does not report TerminationException as uncaught", async () => {
     // The callback busy-spins after postMessage so terminate() interrupts
-    // cb.call() with a TerminationException while it's still on the JS stack.
+    // cb.call() with a TerminationException while it is still on the JS stack.
     // When the VMEntryScope unwinds, JSC clears hasTerminationRequest but
     // leaves the exception pending; cron's catch block must not hand that to
     // uncaughtException(), or the lazy process-object init asserts in
-    // VMTraps::deferTerminationSlow. Fake timers make the fire deterministic,
-    // so one worker is enough. It also has to be one: the fake clock is
-    // process-wide, so several workers driving it race each other.
+    // VMTraps::deferTerminationSlow. A worker "error" event here means cron
+    // routed the TerminationException through uncaughtException, the
+    // regression this guards against. One worker per process: the fake clock
+    // is process-wide, so several workers driving it would race each other.
     using dir = tempDir("cron-worker-term", {
       "worker.ts":
         mockClock +
@@ -437,36 +412,27 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
         });
         jest.advanceTimersByTime(60_000);
       `,
-      "main.ts": `
-        const N = 1;
-        let closed = 0, errors = 0;
-        for (let i = 0; i < N; i++) {
-          const w = new Worker("./worker.ts");
-          w.addEventListener("message", () => w.terminate());
-          // Any worker 'error' here means cron routed the TerminationException
-          // through uncaughtException → WebWorker__dispatchError — the
-          // regression this test guards against, independent of whether
-          // VMTraps asserts are compiled in.
-          w.addEventListener("error", () => errors++);
-          w.addEventListener("close", () => {
-            if (++closed === N) console.log("errors=" + errors);
-          });
-        }
-      `,
     });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.ts"],
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const events = [];
+        const w = new Worker("./worker.ts");
+        w.addEventListener("message", e => { events.push("message:" + e.data); w.terminate(); });
+        w.addEventListener("error", e => events.push("error:" + e.message));
+        w.addEventListener("close", () => console.log(JSON.stringify(events)));
+      `,
+      ],
       env: bunEnv,
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) console.error(stderr);
-    expect(stdout.trim()).toBe("errors=0");
-    expect(exitCode).toBe(0);
+    expect(await output(proc)).toEqual({ stdout: '["message:fired"]\n', stderr: "", exitCode: 0 });
   });
 
-  test("--hot reload clears jobs deleted from source", async () => {
+  test("--hot reload clears jobs deleted from source and arms the ones that remain", async () => {
     // Markers live OUTSIDE the --hot-watched dir so inotify doesn't deliver
     // a write event that races process.exit() teardown (watcher/exit race).
     using markers = tempDir("cron-hot-markers", {});
@@ -475,7 +441,7 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
       "app.ts":
         mockClock +
         `
-        import { writeFileSync, existsSync } from "node:fs";
+        import { writeFileSync } from "node:fs";
         const m = process.env.MARKERS;
         writeFileSync(m + "/v1.evaluated", "");
         Bun.cron("* * * * *", () => writeFileSync(m + "/ghost.fired", ""));
@@ -502,9 +468,10 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
 
     await waitFor("v1.evaluated");
 
-    // Delete the ghost cron; advance the fake clock past its fire time.
-    // If clear_all_for_vm(.reload) did not remove v1's cron from the fake
-    // heap, advanceTimersByTime would fire it and ghost.fired would exist.
+    // Delete the ghost cron and register a new one. The fake clock is still
+    // the one v1 set up, so v2 sees how many timers survived the reload,
+    // then advances to the first boundary: its own job must fire, and v1's
+    // job would fire too were it still armed.
     await Bun.write(
       join(String(dir), "app.ts"),
       `
@@ -512,18 +479,26 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
         const { jest } = require("bun:test");
         const m = process.env.MARKERS;
         writeFileSync(m + "/v2.evaluated", "");
-        jest.advanceTimersByTime(120_000);
-        writeFileSync(m + "/result", existsSync(m + "/ghost.fired") ? "GHOST_FIRED" : "ok");
+        let result;
+        try {
+          const timers = jest.getTimerCount();
+          let fired = null;
+          Bun.cron("* * * * *", () => { fired = new Date().toISOString(); });
+          jest.advanceTimersByTime(60_000);
+          result = { timers, fired, ghost: existsSync(m + "/ghost.fired") };
+        } catch (e) {
+          result = { error: String(e) };
+        }
+        writeFileSync(m + "/result", JSON.stringify(result));
         process.exit(0);
       `,
     );
 
     await waitFor("v2.evaluated");
     const [exitCode, stderr] = await Promise.all([proc.exited, stderrP]);
-
+    // Debug builds log "DEBUG: Reloading..." here, so stderr is shown but not asserted on.
     if (exitCode !== 0) console.error(stderr);
-    expect(exitCode).toBe(0);
-    expect(await Bun.file(m("result")).text()).toBe("ok");
-    expect(await Bun.file(m("ghost.fired")).exists()).toBe(false);
+    const result = (await Bun.file(m("result")).exists()) ? await Bun.file(m("result")).json() : null;
+    expect({ exitCode, result }).toEqual({ exitCode: 0, result: { timers: 0, fired: minute(1), ghost: false } });
   });
 });

--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -424,8 +424,9 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
     // When the VMEntryScope unwinds, JSC clears hasTerminationRequest but
     // leaves the exception pending; cron's catch block must not hand that to
     // uncaughtException(), or the lazy process-object init asserts in
-    // VMTraps::deferTerminationSlow. Fake timers make the fire deterministic
-    // so a handful of workers is enough.
+    // VMTraps::deferTerminationSlow. Fake timers make the fire deterministic,
+    // so one worker is enough. It also has to be one: the fake clock is
+    // process-wide, so several workers driving it race each other.
     using dir = tempDir("cron-worker-term", {
       "worker.ts":
         mockClock +
@@ -437,7 +438,7 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
         jest.advanceTimersByTime(60_000);
       `,
       "main.ts": `
-        const N = 4;
+        const N = 1;
         let closed = 0, errors = 0;
         for (let i = 0; i < N; i++) {
           const w = new Worker("./worker.ts");
@@ -491,8 +492,10 @@ describe.concurrent("Bun.cron (in-process) — subprocess", () => {
     const stderrP = proc.stderr.text();
     const waitFor = async (file: string) => {
       while (!(await Bun.file(m(file)).exists())) {
-        if (proc.exitCode !== null)
-          throw new Error(`subprocess exited ${proc.exitCode} before ${file}: ${await stderrP}`);
+        // A crashed child (SIGABRT from a panic) has exitCode null and only
+        // signalCode set; without this check the loop spins to the test timeout.
+        if (proc.exitCode !== null || proc.signalCode !== null)
+          throw new Error(`subprocess exited ${proc.exitCode ?? proc.signalCode} before ${file}: ${await stderrP}`);
         await Bun.sleep(10);
       }
     };


### PR DESCRIPTION
### Problem
- `test/js/bun/cron/in-process-cron.test.ts` takes 88s on debian 13 x64-asan and 21s to 58s elsewhere (build #108217): ten tests wait for a real minute boundary.
- #33635 moved the file onto the jest fake clock. Its terminate test starts four workers that share one process-wide clock and fails about 1 run in 4.

### Fix
- Three commits: (1) #33635's fake-clock port, unchanged. (2) One worker per process in the terminate test, and #35218's `signalCode` check in `waitFor`. It alone delivers the speedup and the deflake. (3) Stronger assertions.
- Commit 3: exact error messages, an inline snapshot of the handle, keep-alive cases that can fail, a second fire after a handled error, the no-overlap guarantee, `Symbol.dispose` and `stop()` checked by advancing the clock, and a job that must fire after a `--hot` reload.
- Debug build: 85.5s before, 3.8s to 4.0s after, 5 of 5 runs green. Supersedes #33635 and #35218.
- Self-reviewed: 4 concerns raised, 3 addressed. Rejected a two-PR split: the commits separate the layers.

### Background
- Cron has one-minute resolution, so a job on the real clock fires 0 to 60s later. `jest.useFakeTimers()` puts `setTimeout`, `AbortSignal.timeout` and `Bun.cron` timers in a fake heap. `advanceTimersByTime(ms)` fires the due ones and moves `Date.now()`. `bun:test` loads in any bun process, so a child can drive its own clock.
- The fake clock is a process-wide static (`CURRENT_TIME`, `src/runtime/test_runner/timers/FakeTimers.rs`). Threads that advance it race. Per-VM clocks are in #38740.
- No test fires a job from a real timer tick. `CronJob::on_timer_fire` is shared with the real clock.

<details><summary>Notes</summary>

Measurements. 27 tests become 30. Same debug binary, same machine. `main` version of the file: 27 pass, 85.51s. This branch: 30 pass in 3.8s to 4.0s over 5 runs. The worker, hot-reload and error tests pass 20 of 20 when run alone. Four copies of the file in parallel all pass. The release build runs the file in 0.2s. The remaining time is subprocess spawn of the debug binary. All child tests are concurrent. The two worker tests and `--hot` are the long poles at 0.6s to 0.7s each.

New pins introduced by commit 3, each a deliberate choice:
- The four validation messages and the non-string schedule message, verbatim.
- `Bun.inspect(job)` as an inline snapshot: property names, order, and `Symbol.dispose`.
- `stderr: ""` for every `bun -e` child and both worker children. `bunEnv` silences debug logs. The `--hot` child is the exception: debug builds print `DEBUG: Reloading...`.
- `jest.getTimerCount() === 0` in the `--hot` child after the reload.
- Mocked timestamps: a sync throw is observed at `12:01:00.000Z` and `12:02:00.000Z`, an async rejection at `12:01:00.001Z` and `12:02:00.001Z` (`Bun.sleep(1)` is a fake timer too), and a tick pending across three boundaries re-arms for `12:05:00.000Z`.

Coverage. Arming from the real clock is still covered by the keep-alive cases, which put a job in the real heap and check whether it holds the process open. Not covered end to end any more: a fire from the real event loop drain. The `--hot` test covers both halves of the documented contract: the deleted job is gone from the heap and does not fire, and the job v2 registers fires at the next boundary. Dropped: `rejects an unknown time zone`, which `cron-local-time.test.ts` already checks for the callback overload.

Why one worker. `FakeTimers.rs` keeps `CURRENT_TIME` in a `static`. Each worker thread has its own timer heap, but all threads share the clock. With several workers, one worker's `advanceTimersByTime` moves the clock past another worker's armed job, and the debug assert in `FakeTimers::fire` (`now >= prev`) fails. A terminated worker also runs `stop_active_handles`, which calls `reset_for_isolation` and clears the shared clock, so a worker that has not reached `advanceTimersByTime` yet throws `Fake timers not initialized`. Under the fake clock the fire is deterministic, so one worker covers the case the old `N = 20` loop covered by chance.

Uncaught error semantics under the fake drain. With real timers an uncaught exception in a timer callback ends the process before later timers run. `advanceTimersByTime` reports the error and keeps draining the fake heap, and the process exits 1 once the script ends. The test switches back to real timers after the fire and arms a 10ms `setTimeout`. The loop does not run it, so stdout stays empty. The same fixture with `setTimeout` in place of `Bun.cron` behaves the same.

Microtasks do not run inside `advanceTimersByTime`. A rejected async tick surfaces in the next microtask drain, so the child awaits one `setImmediate` (not faked) between advances.

Keep-alive cases. A `setTimeout(..., 50).unref()` does not hold the loop open, and the loop does not run a due unref'd timer at exit. So `stopped` is printed only when the job keeps the process alive. With `job.unref()` or `job.stop()` the process exits after `scheduled`.

Suites run: `test/js/bun/cron/in-process-cron.test.ts` with the debug build (5 full runs, 20 filtered runs, 4 parallel copies, 12 runs of the reworked `--hot` test) and once with `USE_SYSTEM_BUN=1`.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/cron/in-process-cron.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/cron/in-process-cron.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/cron/in-process-cron.test.ts:
(pass) Bun.cron (in-process) > rejects "invalid expr" [6.11ms]
(pass) Bun.cron (in-process) > rejects "* * * *" [0.69ms]
(pass) Bun.cron (in-process) > rejects "60 * * * *" [0.50ms]
(pass) Bun.cron (in-process) > rejects "0 0 30 2 *" [158.57ms]
(pass) Bun.cron (in-process) > validates schedule is a string [3.91ms]
(pass) Bun.cron (in-process) > cron getter returns the schedule as written: "* * * * *" [5.29ms]
(pass) Bun.cron (in-process) > cron getter returns the schedule as written: "@hourly" [0.56ms]
(pass) Bun.cron (in-process) > cron getter returns the schedule as written: "0 9 * JAN-DEC MON-FRI" [0.35ms]
(pass) Bun.cron (in-process) > returns a CronJob handle, not a Promise [6.90ms]
(pass) Bun.cron (in-process) > stop(), ref() and unref() return the job; stop() is idempotent [3.20ms]
(pass) Bun.cron (in-process) firing under fake timers > fires at each minute boundary with this === job and no arguments [10.83ms]
(pass) Bun.cron (in-process) firing under fake timers > @hourly fires at the top of the next hour [5.11ms]
(pass) Bun.cron (in-process) firing under fake timers > stop() before the first fire cancels the job [2.41ms]
(pass) Bun.cron (in-process) firing under fake timers > stop() after a fire prevents further fires [3.56ms]
(pass) Bun.cron (in-process) firing under fake timers > Symbol.dispose stops the job [3.51ms]
(pass) Bun.cron (in-process) firing under fake timers > stopping one job leaves another running [4.81ms]
(pass) Bun.cron (in-process) firing under fake timers > a pending async tick is not overlapped; the job re-arms once it settles [24.66ms]
(pass) Bun.cron (in-process) firing under fake timers > async callback: stop() during await prevents reschedule [9.80ms]
(pass) Bun.cron (in-process) firing under fake timers > unreferenced running job su
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/cron/in-process-cron.test.ts | 647 ++++++++++++++++---------------
 1 file changed, 333 insertions(+), 314 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/bun/cron/in-process-cron.test.ts      5      8      0
```

</details>

<!-- robobun:evidence:end -->