### PR TITLE
test: make request-method-getter.test.ts faster and stricter

### DIFF
--- a/test/js/web/request/request-method-getter.test.ts
+++ b/test/js/web/request/request-method-getter.test.ts
@@ -1,56 +1,55 @@
 import { heapStats } from "bun:jsc";
 import { expect, test } from "bun:test";
+import { isASAN, isDebug } from "harness";
 
-const requestOptions = [
-  ["http://localhost:3000/"],
-  [
-    "http://localhost:3000/",
-    {
-      method: "GET",
-    },
-  ],
-  [
-    "http://localhost:3000/",
-    {
-      method: "POST",
-    },
-  ],
-] as const;
-test.each(requestOptions)("new Request(%s).clone().method doesnt create a new JSString every time", function () {
-  // Start at a clean state.
+// A getter that allocates one JSString per call leaves `iterations` live
+// strings behind, 8x the budget. The cached string adds none (a handful of
+// unrelated strings is the observed noise).
+const iterations = isASAN || isDebug ? 1024 : 8192;
+const budget = iterations / 8;
+
+// [constructor arguments after the URL, expected `method`]
+const cases: [[] | [RequestInit], string][] = [
+  [[], "GET"],
+  [[{ method: "GET" }], "GET"],
+  [[{ method: "POST" }], "POST"],
+  // The constructor normalizes a lowercase method to the uppercase form.
+  [[{ method: "post" }], "POST"],
+];
+
+function liveStrings(): number {
   Bun.gc(true);
+  return heapStats().objectTypeCounts.string;
+}
 
-  // @ts-expect-error
-  const request = new Request(...arguments);
-
-  const {
-    objectTypeCounts: { string: initialStrings },
-  } = heapStats();
-  for (let i = 0; i < 1024 * 512; i++) {
-    request.clone().method;
+// Keeping every returned string alive makes the count independent of GC
+// timing: a per-call allocation stays live until the final reading.
+function measure(read: () => string) {
+  const samples: string[] = [];
+  const before = liveStrings();
+  for (let i = 0; i < iterations; i++) {
+    samples.push(read());
   }
-  const {
-    objectTypeCounts: { string: finalStrings },
-  } = heapStats();
+  const growth = liveStrings() - before;
+  return { distinct: [...new Set(samples)], growth };
+}
 
-  expect(finalStrings - initialStrings).toBeLessThan(512);
-});
+test.each(cases)(
+  "new Request(url, ...%j).clone().method is %s and does not allocate a JSString per call",
+  (init, method) => {
+    const request = new Request("http://localhost:3000/", ...init);
+    expect(request.method).toBe(method);
 
-test.each(requestOptions)("new Request(%s).method doesnt create a new JSString every time", function () {
-  // Start at a clean state.
-  Bun.gc(true);
+    const { distinct, growth } = measure(() => request.clone().method);
 
-  const {
-    objectTypeCounts: { string: initialStrings },
-  } = heapStats();
-  for (let i = 0; i < 1024 * 128; i++) {
-    // @ts-expect-error
-    const request = new Request(...arguments);
-    request.method;
-  }
-  const {
-    objectTypeCounts: { string: finalStrings },
-  } = heapStats();
+    expect(distinct).toEqual([request.method]);
+    expect(growth, `${growth} new JSStrings after ${iterations} clone().method reads`).toBeLessThan(budget);
+  },
+);
 
-  expect(finalStrings - initialStrings).toBeLessThan(512);
+test.each(cases)("new Request(url, ...%j).method is %s and does not allocate a JSString per call", (init, method) => {
+  const { distinct, growth } = measure(() => new Request("http://localhost:3000/", ...init).method);
+
+  expect(distinct).toEqual([method]);
+  expect(growth, `${growth} new JSStrings after ${iterations} new Request().method reads`).toBeLessThan(budget);
 });


### PR DESCRIPTION
### Problem
- `test/js/web/request/request-method-getter.test.ts` takes 19.3s on the debian 13 x64-asan lane (build #108217) and under 3s on release lanes. A local debug ASAN build takes 124s, and every test exceeds the 5s timeout.
- Each row runs 512K `clone().method` reads and 128K `new Request().method` reads against a fixed budget of 512 new JSStrings. A few thousand reads detect a per-call allocation.

### Fix
- Size the loops by the assertion: 1024 reads under ASAN or debug, 8192 in release. The budget is `iterations / 8`, so a per-call allocation overshoots it by 8x.
- Keep every returned string alive and run `Bun.gc(true)` before both `heapStats()` readings. A leaked string stays live until the final reading, so the count does not depend on when the GC runs.
- Assert the value (`"GET"` or `"POST"`), that every clone reports its source's method, and that `method: "post"` normalizes to `"POST"` on the same cached string. The failure message reports the measured growth.
- Verified: debug ASAN file time 124.4s before, 4.9s after, stable over 6 debug and 10 release runs. On the debian 13 x64-asan lane the file takes 362ms (build 108294). Reading `.url` instead of `.method` fails all 8 cases with growth 1022 of 1024 (debug) and 8190 of 8192 (release).

### Background
- `heapStats().objectTypeCounts.string` (`bun:jsc`) counts JSString cells on the heap without a GC, so dead strings count until a collection sweeps them.
- `request.method` returns one cell from the common strings table (`Bun__HTTPMethod__toJS`) on every call. #18961 made it so, and this test guards that.

<details><summary>Notes</summary>

- Release build (`USE_SYSTEM_BUN=1`): 486ms before, 147ms after.
- Noise in the passing case: growth between -3 and +2 strings, in both builds, for loop sizes from 256 to 16384.
- Without retention, a full GC before the final reading hides a per-call allocation (growth -1 when reading `.url`). Retention is what makes the final GC safe. Without the final GC the old test counted dead strings, which works until an Eden collection runs inside the loop.
- The tests stay serial. The string count is process wide, and the test bodies are synchronous, so `test.concurrent` would not overlap them anyway.
- #33704 (open, 54 files, conflicting) scales this file's loops down 8x under ASAN and keeps the constant 512 budget. This PR replaces that change for this file.
- Observed but not touched: `new Request(url, { method: "Post" })` and `{ method: "BREW" }` both return `"GET"` in Bun. Node returns `"POST"` and `"BREW"`. The new row uses the all-lowercase form, which Bun accepts.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/request/request-method-getter.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/request/request-method-getter.test.ts
bun test v1.4.1 (d578a8c70)

test/js/web/request/request-method-getter.test.ts:
(pass) new Request(url, ...[]).clone().method is GET and does not allocate a JSString per call [325.99ms]
(pass) new Request(url, ...[{"method":"GET"}]).clone().method is GET and does not allocate a JSString per call [288.28ms]
(pass) new Request(url, ...[{"method":"POST"}]).clone().method is POST and does not allocate a JSString per call [304.56ms]
(pass) new Request(url, ...[{"method":"post"}]).clone().method is POST and does not allocate a JSString per call [280.68ms]
(pass) new Request(url, ...[]).method is GET and does not allocate a JSString per call [338.96ms]
(pass) new Request(url, ...[{"method":"GET"}]).method is GET and does not allocate a JSString per call [414.88ms]
(pass) new Request(url, ...[{"method":"POST"}]).method is POST and does not allocate a JSString per call [405.94ms]
(pass) new Request(url, ...[{"method":"post"}]).method is POST and does not allocate a JSString per call [408.47ms]

 8 pass
 0 fail
 20 expect() calls
Ran 8 tests across 1 file. [4.75s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/request/request-method-getter.test.ts | 89 +++++++++++------------
 1 file changed, 44 insertions(+), 45 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
test/js/web/request/request-method-getter.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->
