### PR TITLE
test: speed up bun-cryptohasher.test.ts and pin its digests

### DIFF
--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -1,20 +1,35 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe } from "harness";
 import { createHash, createHmac } from "node:crypto";
 
+// Every digest literal in this file was checked against python hashlib (openssl for md4).
+
 test("Bun.file in CryptoHasher is not supported yet", () => {
-  expect(() => Bun.SHA1.hash(Bun.file(import.meta.path))).toThrow();
-  expect(() => Bun.CryptoHasher.hash("sha1", Bun.file(import.meta.path))).toThrow();
-  expect(() => new Bun.CryptoHasher("sha1").update(Bun.file(import.meta.path))).toThrow();
-  expect(() => new Bun.SHA1().update(Bun.file(import.meta.path))).toThrow();
+  const file = Bun.file(import.meta.path);
+  const fileBlob = expect.objectContaining({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: "File blob cannot be used here",
+  });
+  expect(() => Bun.SHA1.hash(file)).toThrow(fileBlob);
+  expect(() => Bun.CryptoHasher.hash("sha1", file)).toThrow(fileBlob);
+  expect(() => new Bun.SHA1().update(file)).toThrow(fileBlob);
+  expect(() => new Bun.CryptoHasher("sha1").update(file)).toThrow(
+    "Bun.file() is not supported here yet (it needs an async version)",
+  );
 });
 test("CryptoHasher update should throw when no parameter/null/undefined is passed", () => {
+  const expected = expect.objectContaining({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: "expected blob, string or buffer",
+  });
   // @ts-expect-error
-  expect(() => new Bun.CryptoHasher("sha1").update()).toThrow();
+  expect(() => new Bun.CryptoHasher("sha1").update()).toThrow(expected);
   // @ts-expect-error
-  expect(() => new Bun.CryptoHasher("sha1").update(undefined)).toThrow();
+  expect(() => new Bun.CryptoHasher("sha1").update(undefined)).toThrow(expected);
   // @ts-expect-error
-  expect(() => new Bun.CryptoHasher("sha1").update(null)).toThrow();
+  expect(() => new Bun.CryptoHasher("sha1").update(null)).toThrow(expected);
 });
 test("CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto", () => {
   // Odd-length hex strings must throw instead of silently hashing the longest valid even prefix.
@@ -68,14 +83,18 @@ test("update(str, 'hex') decodes two-byte strings from the low byte of each code
   }
 });
 test("CryptoHasher throws on non-latin1 algorithm names instead of crashing", () => {
+  const unsupported = (message: string) =>
+    expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message });
   // @ts-expect-error
-  expect(() => Bun.CryptoHasher.hash("🚀", "hello")).toThrow(/Unsupported algorithm/);
+  expect(() => Bun.CryptoHasher.hash("🚀", "hello")).toThrow(unsupported('Unsupported algorithm "🚀"'));
   // @ts-expect-error
-  expect(() => Bun.CryptoHasher.hash("sha3-256\u{1F680}", "hello", "hex")).toThrow(/Unsupported algorithm/);
+  expect(() => Bun.CryptoHasher.hash("sha3-256\u{1F680}", "hello", "hex")).toThrow(
+    unsupported('Unsupported algorithm "sha3-256🚀"'),
+  );
   // @ts-expect-error
-  expect(() => new Bun.CryptoHasher("🚀")).toThrow(/Unsupported algorithm/);
+  expect(() => new Bun.CryptoHasher("🚀")).toThrow(unsupported("Unsupported algorithm 🚀"));
   // @ts-expect-error
-  expect(() => new Bun.CryptoHasher("ünïcode")).toThrow(/Unsupported algorithm/);
+  expect(() => new Bun.CryptoHasher("ünïcode")).toThrow(unsupported("Unsupported algorithm ünïcode"));
 });
 
 test("static hash requires the algorithm to be a string primitive", () => {
@@ -108,25 +127,62 @@ test("static hash requires the algorithm to be a string primitive", () => {
   );
 });
 
-test("update rejects a hasher that was digested while its input was being converted", async () => {
+test("hash functions read their buffers and hasher state only after every argument has been coerced", async () => {
+  // A toString() hook on one argument detaches the buffer behind another argument, or digests the
+  // hasher, before the hash runs. transfer(0) frees the old backing store at once, so no GC is
+  // needed to expose a stale pointer. One child process runs every case, so a fault there does not
+  // take down the test runner.
   const source = /* js */ `
-    const results = {};
+    const caught = fn => {
+      try {
+        return fn();
+      } catch (e) {
+        return { code: e.code, message: e.message };
+      }
+    };
+    const detachedInput = hash => {
+      const buf = new Uint8Array(64 * 1024).fill(7);
+      const encoding = new String("hex");
+      encoding.toString = () => {
+        buf.buffer.transfer(0);
+        return "hex";
+      };
+      return { digest: hash(buf, encoding), detached: buf.byteLength === 0 };
+    };
+    const detachedOutput = hash => {
+      const out = new Uint8Array(32);
+      const input = new String("hello");
+      input.toString = () => {
+        out.buffer.transfer(0);
+        return "hello";
+      };
+      return { result: caught(() => hash(input, out)), detached: out.byteLength === 0 };
+    };
+    const digestedDuringUpdate = {};
     for (const name of ["SHA1", "SHA224", "SHA256", "SHA384", "SHA512", "SHA512_256", "MD4", "MD5"]) {
-      const hasher = new Bun[name]();
-      hasher.update("hello");
+      const hasher = new Bun[name]().update("hello");
       const input = new String("world");
       input.toString = () => {
         hasher.digest();
         return "world";
       };
-      try {
-        hasher.update(input);
-        results[name] = "no throw";
-      } catch (e) {
-        results[name] = { code: e.code, message: e.message };
-      }
+      digestedDuringUpdate[name] = caught(() => hasher.update(input));
     }
-    console.log(JSON.stringify(results));
+    console.log(
+      JSON.stringify({
+        detachedInput: {
+          cryptoHasher: detachedInput((buf, encoding) => Bun.CryptoHasher.hash("sha256", buf, encoding)),
+          sha256: detachedInput((buf, encoding) => Bun.SHA256.hash(buf, encoding)),
+          sha: detachedInput((buf, encoding) => Bun.sha(buf, encoding)),
+        },
+        detachedOutput: {
+          cryptoHasher: detachedOutput((input, out) => Bun.CryptoHasher.hash("sha256", input, out)),
+          sha256: detachedOutput((input, out) => Bun.SHA256.hash(input, out)),
+          sha: detachedOutput((input, out) => Bun.sha(input, out)),
+        },
+        digestedDuringUpdate,
+      }),
+    );
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", source],
@@ -135,137 +191,37 @@ test("update rejects a hasher that was digested while its input was being conver
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const expected: Record<string, { code: string; message: string }> = {};
-  for (const name of ["SHA1", "SHA224", "SHA256", "SHA384", "SHA512", "SHA512_256", "MD4", "MD5"]) {
-    expected[name] = {
-      code: "ERR_INVALID_STATE",
-      message: `${name} hasher already digested, create a new instance to update`,
-    };
-  }
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual(expected);
-  expect(exitCode).toBe(0);
-});
 
-test("static hash reads the input buffer only after every argument has been coerced", async () => {
-  const source = /* js */ `
-    const emptyDigest = Bun.CryptoHasher.hash("sha256", new Uint8Array(0), "hex");
-    const results = {};
-    {
-      const buf = new Uint8Array(1024 * 1024).fill(7);
-      const enc = new String("hex");
-      enc.toString = () => {
-        structuredClone(buf.buffer, { transfer: [buf.buffer] });
-        Bun.gc(true);
-        return "hex";
-      };
-      const digest = Bun.CryptoHasher.hash("sha256", buf, enc);
-      results.hashEncoding = { digest, detached: buf.byteLength === 0 };
-    }
-    {
-      const buf = new Uint8Array(1024 * 1024).fill(7);
-      const enc = new String("hex");
-      enc.toString = () => {
-        structuredClone(buf.buffer, { transfer: [buf.buffer] });
-        Bun.gc(true);
-        return "hex";
-      };
-      const digest = Bun.SHA256.hash(buf, enc);
-      results.staticHashEncoding = { digest, detached: buf.byteLength === 0 };
-    }
-    {
-      const out = new Uint8Array(32);
-      const input = new String("hello");
-      input.toString = () => {
-        structuredClone(out.buffer, { transfer: [out.buffer] });
-        Bun.gc(true);
-        return "hello";
-      };
-      try {
-        Bun.CryptoHasher.hash("sha256", input, out);
-        results.hashOutput = "no throw";
-      } catch (e) {
-        results.hashOutput = e.message;
-      }
-    }
-    {
-      const out = new Uint8Array(32);
-      const input = new String("hello");
-      input.toString = () => {
-        structuredClone(out.buffer, { transfer: [out.buffer] });
-        Bun.gc(true);
-        return "hello";
-      };
-      try {
-        Bun.SHA256.hash(input, out);
-        results.staticHashOutput = "no throw";
-      } catch (e) {
-        results.staticHashOutput = e.message;
-      }
-    }
-    console.log(JSON.stringify({ emptyDigest, results }));
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", source],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+  // The input is read after it was detached, so the digest is the digest of zero bytes.
+  const sha256Empty = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  const sha512_256Empty = "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a";
+  // The output buffer is checked after it was detached, so it is too small.
+  const tooSmall = {
+    result: { code: "ERR_INVALID_ARG_TYPE", message: "TypedArray must be at least 32 bytes" },
+    detached: true,
+  };
+  const digested = (name: string) => ({
+    code: "ERR_INVALID_STATE",
+    message: `${name} hasher already digested, create a new instance to update`,
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const { emptyDigest, results } = JSON.parse(stdout.trim());
-  expect(emptyDigest).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-  expect(results).toEqual({
-    hashEncoding: { digest: emptyDigest, detached: true },
-    staticHashEncoding: { digest: emptyDigest, detached: true },
-    hashOutput: "TypedArray must be at least 32 bytes",
-    staticHashOutput: "TypedArray must be at least 32 bytes",
-  });
-  expect(exitCode).toBe(0);
-});
-
-test("Bun.sha reads its buffers only after every argument has been coerced", async () => {
-  const source = /* js */ `
-    const emptyDigest = Buffer.from(Bun.sha(new Uint8Array(0))).toString("hex");
-    const results = {};
-    {
-      const buf = new Uint8Array(1024 * 1024).fill(7);
-      const enc = new String("hex");
-      enc.toString = () => {
-        structuredClone(buf.buffer, { transfer: [buf.buffer] });
-        Bun.gc(true);
-        return "hex";
-      };
-      const digest = Bun.sha(buf, enc);
-      results.encoding = { digest, detached: buf.byteLength === 0 };
-    }
-    {
-      const out = new Uint8Array(32);
-      const input = new String("hello");
-      input.toString = () => {
-        structuredClone(out.buffer, { transfer: [out.buffer] });
-        Bun.gc(true);
-        return "hello";
-      };
-      try {
-        Bun.sha(input, out);
-        results.output = "no throw";
-      } catch (e) {
-        results.output = e.message;
-      }
-    }
-    console.log(JSON.stringify({ emptyDigest, results }));
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", source],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const { emptyDigest, results } = JSON.parse(stdout.trim());
-  expect(results).toEqual({
-    encoding: { digest: emptyDigest, detached: true },
-    output: "TypedArray must be at least 32 bytes",
+  expect(JSON.parse(stdout)).toEqual({
+    detachedInput: {
+      cryptoHasher: { digest: sha256Empty, detached: true },
+      sha256: { digest: sha256Empty, detached: true },
+      sha: { digest: sha512_256Empty, detached: true },
+    },
+    detachedOutput: { cryptoHasher: tooSmall, sha256: tooSmall, sha: tooSmall },
+    digestedDuringUpdate: {
+      SHA1: digested("SHA1"),
+      SHA224: digested("SHA224"),
+      SHA256: digested("SHA256"),
+      SHA384: digested("SHA384"),
+      SHA512: digested("SHA512"),
+      SHA512_256: digested("SHA512_256"),
+      MD4: digested("MD4"),
+      MD5: digested("MD5"),
+    },
   });
   expect(exitCode).toBe(0);
 });
@@ -331,27 +287,42 @@ describe("HMAC", () => {
       "b15ed8373f1b493ccd417a7591745fdefbb4aa7b85c6937284de678e1a7b73b31e4da07561d358fefa30c6b1cf1a4b19a4c0d2f4f6e90ddfadc3a12367cb1a3c",
     "ripemd160": "5291464ec22d15e61190b00b81b87c1a9dcb966f",
   };
+  const consumed = "HMAC has been consumed and is no longer usable";
+  const throws = (fn: () => unknown) => {
+    try {
+      fn();
+      return "no throw";
+    } catch (e) {
+      return (e as Error).message;
+    }
+  };
+  const afterDigest = (hmac: Bun.CryptoHasher) => ({
+    digest: throws(() => hmac.digest()),
+    byteLength: throws(() => hmac.byteLength),
+    copy: throws(() => hmac.copy()),
+    update: throws(() => hmac.update("more")),
+  });
+  const allConsumed = { digest: consumed, byteLength: consumed, copy: consumed, update: consumed };
+
   for (let key of ["key", Buffer.from("key"), Buffer.from("key").buffer]) {
     test.each(Object.entries(hashes))("%s (key: " + key.constructor.name + ")", (algorithm, expected) => {
       const hmac = new Bun.CryptoHasher(algorithm, key);
       hmac.update("data\n");
       const copied = hmac.copy();
-      expect(hmac.algorithm).toEqual(algorithm);
-      expect(hmac.byteLength).toEqual(hashes[algorithm].length / 2);
       expect(copied.copy()).toBeInstanceOf(Bun.CryptoHasher);
 
-      expect(hmac.digest("hex")).toEqual(expected);
+      const state = { algorithm, byteLength: expected.length / 2, digest: expected };
+      expect({ algorithm: hmac.algorithm, byteLength: hmac.byteLength, digest: hmac.digest("hex") }).toEqual(state);
+      // The copy is still usable after the original was digested.
+      expect({ algorithm: copied.algorithm, byteLength: copied.byteLength, digest: copied.digest("hex") }).toEqual(
+        state,
+      );
 
-      expect(copied.algorithm).toEqual(algorithm);
-      expect(copied.byteLength).toEqual(hashes[algorithm].length / 2);
-
-      expect(copied.digest("hex")).toEqual(expected);
-      expect(() => hmac.digest()).toThrow();
-      expect(() => copied.digest()).toThrow();
-      expect(() => hmac.byteLength).toThrow();
-      expect(() => copied.byteLength).toThrow();
-      expect(() => copied.copy()).toThrow();
-      expect(() => hmac.copy()).toThrow();
+      // digest() consumes an HMAC: every later operation throws.
+      expect({ hmac: afterDigest(hmac), copied: afterDigest(copied) }).toEqual({
+        hmac: allConsumed,
+        copied: allConsumed,
+      });
 
       // Note that algorithm may throw if the first time the property was accessed is after it was already consumed.
       // This is a property caching edgecase that it does not always throw.
@@ -361,33 +332,12 @@ describe("HMAC", () => {
 
   const unsupported = [["shake128"], ["shake256"]] as const;
   test.each(unsupported)("%s is not supported", algorithm => {
-    expect(() => new Bun.CryptoHasher(algorithm, "key")).toThrow();
-    expect(() => new Bun.CryptoHasher(algorithm)).not.toThrow();
+    expect(() => new Bun.CryptoHasher(algorithm, "key")).toThrow("HMAC is not supported for this algorithm yet");
+    expect(new Bun.CryptoHasher(algorithm).algorithm).toBe(algorithm);
   });
 });
 
-describe("Hash is consistent", () => {
-  const sourceInputs = [
-    Buffer.from([
-      103, 87, 129, 242, 154, 82, 159, 206, 176, 124, 10, 39, 235, 214, 121, 13, 34, 155, 131, 178, 40, 34, 252, 134, 7,
-      203, 130, 187, 207, 49, 26, 59,
-    ]),
-    Buffer.from([
-      68, 19, 111, 163, 85, 179, 103, 138, 17, 70, 173, 22, 247, 232, 100, 158, 148, 251, 79, 194, 31, 231, 126, 131,
-      16, 192, 96, 246, 28, 170, 255, 138,
-    ]),
-    Buffer.from([
-      219, 133, 5, 84, 59, 236, 191, 241, 104, 167, 186, 223, 204, 158, 177, 43, 205, 52, 120, 28, 60, 233, 156, 159,
-      125, 64, 171, 91, 240, 17, 71, 210,
-    ]),
-    Buffer.from([
-      34, 93, 2, 87, 76, 190, 175, 238, 185, 96, 201, 38, 104, 215, 236, 99, 223, 134, 157, 237, 254, 36, 49, 242, 100,
-      135, 198, 114, 49, 71, 220, 79,
-    ]),
-  ];
-
-  const inputs = [...sourceInputs, ...sourceInputs.map(x => new Blob([x]))];
-
+describe("static hashers", () => {
   for (let algorithm of [
     Bun.SHA1,
     Bun.SHA224,
@@ -409,128 +359,178 @@ describe("Hash is consistent", () => {
       );
     });
   }
+});
+
+describe("Hash matches reference digests", () => {
+  const sourceInputs = [
+    Buffer.from([
+      103, 87, 129, 242, 154, 82, 159, 206, 176, 124, 10, 39, 235, 214, 121, 13, 34, 155, 131, 178, 40, 34, 252, 134, 7,
+      203, 130, 187, 207, 49, 26, 59,
+    ]),
+    Buffer.from([
+      68, 19, 111, 163, 85, 179, 103, 138, 17, 70, 173, 22, 247, 232, 100, 158, 148, 251, 79, 194, 31, 231, 126, 131,
+      16, 192, 96, 246, 28, 170, 255, 138,
+    ]),
+    Buffer.from([
+      219, 133, 5, 84, 59, 236, 191, 241, 104, 167, 186, 223, 204, 158, 177, 43, 205, 52, 120, 28, 60, 233, 156, 159,
+      125, 64, 171, 91, 240, 17, 71, 210,
+    ]),
+    Buffer.from([
+      34, 93, 2, 87, 76, 190, 175, 238, 185, 96, 201, 38, 104, 215, 236, 99, 223, 134, 157, 237, 254, 36, 49, 242, 100,
+      135, 198, 114, 49, 71, 220, 79,
+    ]),
+  ];
+
+  // A Blob input takes a different path into the hasher than a Buffer.
+  const inputs = [...sourceInputs, ...sourceInputs.map(x => new Blob([x]))];
+
+  // Hex digests of sourceInputs, in order.
+  const digests = {
+    sha1: [
+      "25b8cb4ac0499acdaecb5c5bcd72bf7b4af17599",
+      "1b21e09040dbb5bed7727c34f45e0c0705821ec7",
+      "7c35c0a288ac36a54fe0559406f7cd8c74d6401f",
+      "7e8f0a60442dde14079982f981ff51ccc8fc721f",
+    ],
+    sha256: [
+      "71bcc56fa3fa8f2e1d2fcf06a8e4a95337c286cb68a57a8da69386e4e02c5f6a",
+      "c74f3008fdd2f7c5ae5446ab2e522629f63346f68a4026b4f72b91b393475ff6",
+      "9801a682688feb689613ffaed72165d2e42d0daa918de81125c10baea032acf7",
+      "324c27b84dab9870a399c4a3b86101a3e01dbaf96d4605501fcb405a7be2a89f",
+    ],
+    sha512: [
+      "a9c638c774125fa19db1574709641f3923f3471d44da1715422e85dd04db49edddbd660dd77e7bf01bd6b5d597540295a76be4840a03a58b3857a0b43351552d",
+      "a5ff0017e5faebbb18563dfc39fbb3e2db4a8ccca2e029e124dd472623e179b621772f3dac4210598f68d31cc4c3a6005e2940c55298a4fb8314f6b7f3e22292",
+      "c8f3e36e89a223717d96f55abd44836a499b6c2ea5fc7d93bf2fa2df72b5ee86925b37f93396b2a2a442d163fc6dca77eb63209206ebfb0847dec84f506db889",
+      "287b698c06a8b6b5af3d3e4b966b7898d1f5d675457854950ba5bae9877c66ff7859ffb27c013064f0246379b56f08c871cb7c65f48856703ad650f7f6548b68",
+    ],
+    md5: [
+      "3b3579e416de5d7775a4e92b0c30e4b9",
+      "dde82ade99f87dd7cab686ad0f3283a7",
+      "4cf897b53dbc3fac0433c6cc911eef5c",
+      "dfcd12014d97b4e1d97a2e16b8e1ca5f",
+    ],
+  };
 
   for (let algorithm of ["sha1", "sha256", "sha512", "md5"] as const) {
     describe(algorithm, () => {
       const Class = globalThis.Bun[algorithm.toUpperCase() as "SHA1" | "SHA256" | "SHA512" | "MD5"];
-      test("base64", () => {
-        for (let buffer of inputs) {
-          for (let i = 0; i < 100; i++) {
-            const hasher = new Bun.CryptoHasher(algorithm);
-            expect(hasher.update(buffer, "base64")).toBeInstanceOf(Bun.CryptoHasher);
-            expect(Bun.CryptoHasher.hash(algorithm, buffer, "base64")).toEqual(
-              Bun.CryptoHasher.hash(algorithm, buffer, "base64"),
-            );
-
-            const instance1 = new Class();
-            instance1.update(buffer);
-            const instance2 = new Class();
-            instance2.update(buffer);
-
-            expect(instance1.digest("base64")).toEqual(instance2.digest("base64"));
-            expect(Class.hash(buffer, "base64")).toEqual(Class.hash(buffer, "base64"));
-          }
-        }
-      });
-
-      test("hex", () => {
-        for (let buffer of inputs) {
-          for (let i = 0; i < 100; i++) {
-            const hasher = new Bun.CryptoHasher(algorithm);
-            expect(hasher.update(buffer, "hex")).toBeInstanceOf(Bun.CryptoHasher);
-            expect(Bun.CryptoHasher.hash(algorithm, buffer, "hex")).toEqual(
-              Bun.CryptoHasher.hash(algorithm, buffer, "hex"),
-            );
-
-            const instance1 = new Class();
-            instance1.update(buffer);
-            const instance2 = new Class();
-            instance2.update(buffer);
-
-            expect(instance1.digest("hex")).toEqual(instance2.digest("hex"));
-            expect(Class.hash(buffer, "hex")).toEqual(Class.hash(buffer, "hex"));
-          }
-        }
-      });
-
-      test("blob", () => {
-        for (let buffer of inputs) {
-          for (let i = 0; i < 100; i++) {
-            const hasher = new Bun.CryptoHasher(algorithm);
-            expect(hasher.update(buffer)).toBeInstanceOf(Bun.CryptoHasher);
-            expect(Bun.CryptoHasher.hash(algorithm, buffer)).toEqual(Bun.CryptoHasher.hash(algorithm, buffer));
-
-            const instance1 = new Class();
-            instance1.update(buffer);
-            const instance2 = new Class();
-            instance2.update(buffer);
-
-            expect(instance1.digest()).toEqual(instance2.digest());
-            expect(Class.hash(buffer)).toEqual(Class.hash(buffer));
-          }
-        }
-      });
-    });
-  }
-});
-
-describe("CryptoHasher", () => {
-  const algorithms = [
-    "blake2b256",
-    "blake2b512",
-    "blake2s256",
-    "ripemd160",
-    "rmd160",
-    "md4",
-    "md5",
-    "sha1",
-    "sha128",
-    "sha224",
-    "sha256",
-    "sha384",
-    "sha512",
-    "sha-1",
-    "sha-224",
-    "sha-256",
-    "sha-384",
-    "sha-512",
-    "sha-512/224",
-    "sha-512_224",
-    "sha-512224",
-    "sha512-224",
-    "sha-512/256",
-    "sha-512_256",
-    "sha-512256",
-    "sha512-256",
-    "sha384",
-    "sha3-224",
-    "sha3-256",
-    "sha3-384",
-    "sha3-512",
-    "shake128",
-    "shake256",
-  ] as const;
-
-  for (let algorithm of algorithms) {
-    describe(algorithm, () => {
-      for (let encoding of ["hex", "base64", "buffer", undefined, "base64url"] as const) {
-        describe(encoding || "default", () => {
-          test("instance", () => {
-            const hasher = new Bun.CryptoHasher(algorithm || undefined);
-            hasher.update("hello");
-            expect(hasher.digest(encoding)).toEqual(Bun.CryptoHasher.hash(algorithm, "hello", encoding));
+      // With no encoding, digest() and hash() return the raw bytes.
+      for (const [name, encoding] of [
+        ["hex", "hex"],
+        ["base64", "base64"],
+        ["bytes", undefined],
+      ] as const) {
+        test(name, () => {
+          const expected = inputs.map((_, i) => {
+            const bytes = Buffer.from(digests[algorithm][i % sourceInputs.length], "hex");
+            return encoding === undefined ? bytes : bytes.toString(encoding);
           });
-
-          test("consistent", () => {
-            const first = Bun.CryptoHasher.hash(algorithm, "hello", encoding);
-            withoutAggressiveGC(() => {
-              for (let i = 0; i < 100; i++) {
-                expect(Bun.CryptoHasher.hash(algorithm, "hello", encoding)).toStrictEqual(first);
-              }
-            });
+          const results = {
+            instance: inputs.map(input => {
+              const hasher = new Bun.CryptoHasher(algorithm);
+              // The input encoding argument has no effect on a Buffer or Blob input.
+              expect(hasher.update(input, encoding)).toBe(hasher);
+              return hasher.digest(encoding);
+            }),
+            static: inputs.map(input => Bun.CryptoHasher.hash(algorithm, input, encoding)),
+            classInstance: inputs.map(input => new Class().update(input).digest(encoding)),
+            classStatic: inputs.map(input => Class.hash(input, encoding)),
+          };
+          expect(results).toEqual({
+            instance: expected,
+            static: expected,
+            classInstance: expected,
+            classStatic: expected,
           });
         });
       }
     });
   }
+});
+
+describe("CryptoHasher", () => {
+  // Hex digests of "hello" for every accepted algorithm name.
+  const hello = {
+    "blake2b256": "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf",
+    "blake2b512":
+      "e4cfa39a3d37be31c59609e807970799caa68a19bfaa15135f165085e01d41a65ba1e1b146aeb6bd0092b49eac214c103ccfa3a365954bbbe52f74a2b3620c94",
+    "blake2s256": "19213bacc58dee6dbde3ceb9a47cbb330b3d86f8cca8997eb00be456f140ca25",
+    "ripemd160": "108f07b8382412612c048d07d13f814118445acd",
+    "rmd160": "108f07b8382412612c048d07d13f814118445acd",
+    "md4": "866437cb7a794bce2b727acc0362ee27",
+    "md5": "5d41402abc4b2a76b9719d911017c592",
+    "sha1": "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d",
+    "sha128": "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d",
+    "sha224": "ea09ae9cc6768c50fcee903ed054556e5bfc8347907f12598aa24193",
+    "sha256": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    "sha384": "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f",
+    "sha512":
+      "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+    "sha-1": "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d",
+    "sha-224": "ea09ae9cc6768c50fcee903ed054556e5bfc8347907f12598aa24193",
+    "sha-256": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    "sha-384": "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f",
+    "sha-512":
+      "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+    "sha-512/224": "fe8509ed1fb7dcefc27e6ac1a80eddbec4cb3d2c6fe565244374061c",
+    "sha-512_224": "fe8509ed1fb7dcefc27e6ac1a80eddbec4cb3d2c6fe565244374061c",
+    "sha-512224": "fe8509ed1fb7dcefc27e6ac1a80eddbec4cb3d2c6fe565244374061c",
+    "sha512-224": "fe8509ed1fb7dcefc27e6ac1a80eddbec4cb3d2c6fe565244374061c",
+    "sha-512/256": "e30d87cfa2a75db545eac4d61baf970366a8357c7f72fa95b52d0accb698f13a",
+    "sha-512_256": "e30d87cfa2a75db545eac4d61baf970366a8357c7f72fa95b52d0accb698f13a",
+    "sha-512256": "e30d87cfa2a75db545eac4d61baf970366a8357c7f72fa95b52d0accb698f13a",
+    "sha512-256": "e30d87cfa2a75db545eac4d61baf970366a8357c7f72fa95b52d0accb698f13a",
+    "sha3-224": "b87f88c72702fff1748e58b87e9141a42c0dbedc29a78cb0d4a5cd81",
+    "sha3-256": "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392",
+    "sha3-384": "720aea11019ef06440fbf05d87aa24680a2153df3907b23631e7177ce620fa1330ff07c0fddee54699a4c3ee0ee9d887",
+    "sha3-512":
+      "75d527c368f2efe848ecf6b073a36767800805e9eef2b1857d5f984f036eb6df891d75f72d9b154518c1cd58835286d1da9a38deba3de98b5a53e5ed78a84976",
+    "shake128": "8eb4b6a932f280335ee1a279f8c208a3",
+    "shake256": "1234075ae4a1e77316cf2d8000974581a343b9ebbca7e3d1db83394c30f22162",
+  };
+
+  // The algorithm getter reports the canonical name of an alias.
+  const canonical: Record<string, string> = {
+    "rmd160": "ripemd160",
+    "sha128": "sha1",
+    "sha-1": "sha1",
+    "sha-224": "sha224",
+    "sha-256": "sha256",
+    "sha-384": "sha384",
+    "sha-512": "sha512",
+    "sha-512/224": "sha512-224",
+    "sha-512_224": "sha512-224",
+    "sha-512224": "sha512-224",
+    "sha-512/256": "sha512-256",
+    "sha-512_256": "sha512-256",
+    "sha-512256": "sha512-256",
+  };
+
+  const encodings = ["hex", "base64", "base64url", "buffer", undefined] as const;
+
+  test.each(Object.entries(hello))("%s", (algorithm, hex) => {
+    const bytes = Buffer.from(hex, "hex");
+    // "buffer" and no encoding both return the raw bytes.
+    const expected = {
+      hex,
+      base64: bytes.toString("base64"),
+      base64url: bytes.toString("base64url"),
+      buffer: bytes,
+      default: bytes,
+    };
+
+    const collect = (run: (encoding: (typeof encodings)[number]) => unknown) =>
+      Object.fromEntries(encodings.map(encoding => [encoding ?? "default", run(encoding)]));
+
+    const hasher = new Bun.CryptoHasher(algorithm);
+    expect({ algorithm: hasher.algorithm, byteLength: hasher.byteLength }).toEqual({
+      algorithm: canonical[algorithm] ?? algorithm,
+      byteLength: bytes.length,
+    });
+    expect({
+      instance: collect(encoding => new Bun.CryptoHasher(algorithm).update("hello").digest(encoding)),
+      static: collect(encoding => Bun.CryptoHasher.hash(algorithm, "hello", encoding)),
+    }).toEqual({ instance: expected, static: expected });
+  });
 });


### PR DESCRIPTION
### Problem
- `test/js/bun/util/bun-cryptohasher.test.ts` took 42s on the debian 13 x64-asan lane (build #108217). It ran 55,719 `expect()` calls, most in 100-iteration loops that compared a hash result with itself. At the GC level CI sets (`GCLevel::Mild`), every matcher call runs a collection (`post_match` in `src/runtime/test_runner/expect.rs`).
- Three tests each spawned a child `bun -e`. The coercion fixtures ran `Bun.gc(true)` eight times over 1 MiB buffers.

### Fix
- Replace each self-comparison loop with one pass against a literal digest, checked against python hashlib and openssl. Buffer and Blob inputs, four API paths, and every encoding stay covered.
- Collapse the three child processes into one fixture that prints one JSON object. Detach with `ArrayBuffer.prototype.transfer(0)`, which frees the backing store at once, so no `Bun.gc(true)` is needed.
- Pin the error codes and messages that a bare `toThrow()` covered before.
- Verified: `bun bd test test/js/bun/util/bun-cryptohasher.test.ts` (debug ASAN build). Before: 17.4s, 404 tests, 55,719 expects. After: 2.9s, 104 tests, 443 expects. With `BUN_GARBAGE_COLLECTOR_LEVEL=1` as CI sets it: 209.8s with 12 timeouts before, 6.3s and green after. 3 runs each way, no flakes. On the debian 13 x64-asan lane in CI (build #108295): 569ms.

### Background
- `Bun.CryptoHasher` wraps BoringSSL EVP digests. `Bun.SHA256` and the other static hashers are fixed-algorithm classes with the same surface. `Bun.sha` is `Bun.SHA512_256.hash`.
- The coercion fixture tests argument order. A `toString()` hook on one argument detaches the buffer behind another, or digests the hasher, before the hash runs. A correct hash then sees zero input bytes, or an output buffer that is too small.

<details><summary>Notes</summary>

Baseline per-group times (local debug ASAN, default env): "Hash is consistent" 12 tests 10.1s, "CryptoHasher" 330 tests 3.0s, three spawn tests 1.2s, HMAC 44 tests 0.16s. With `BUN_GARBAGE_COLLECTOR_LEVEL=1` each "Hash is consistent" test took about 16s and hit the 5s per-test timeout.

After: the single spawn test 0.33s, HMAC 0.13s, reference digests 0.10s, CryptoHasher 0.09s. With GC level 1: HMAC 1.6s, CryptoHasher 0.68s, reference digests 0.54s, spawn 0.35s. Four runs each: 2.86s to 3.03s and 6.14s to 6.48s. The file also passes on the release build (95ms).

Digest literals: 32 algorithm names (including the aliases `sha128`, `rmd160`, `sha-1`, `sha-512/224`, and so on) hashing "hello", and four 32-byte inputs under sha1, sha256, sha512, and md5. All were checked against python hashlib, md4 against `openssl dgst -provider legacy -md4`. The `algorithm` getter is now checked to report the canonical name of an alias, and `byteLength` to match the digest length.

Why one pass is enough: the original loops came from #7757, where `encodeWithMaxSize` encoded bytes past the digest, so repeated calls disagreed. A literal digest catches that on the first call. A pinned value also catches a wrong algorithm mapping, which the self-comparison never could.

Why `transfer(0)` instead of `structuredClone` plus `Bun.gc(true)`: `arrayBufferCopyAndDetach` copies into a new zero-length buffer and drops the old contents at once, so a stale pointer is a use-after-free immediately, and the digest assertion fails whether or not ASAN is on. Buffers are 64 KiB instead of 1 MiB. The fixture stays in a child process so that fault cannot take down the runner.

Pinned messages that were bare `toThrow()` before: HMAC consumed state (`digest`, `byteLength`, `copy`, and now `update`), `Bun.file` input, missing `update` argument, unsupported HMAC algorithms, non-latin1 algorithm names.

Unchanged tests: odd-length hex, two-byte hex decode, `Bun.sha` argument validation, `static hash requires the algorithm to be a string primitive`.

Related: #33704 also touches this file (it lowers the loop count to 10 on ASAN). That PR predates the spawn tests and is conflicting with main. This PR removes those loops.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/util/bun-cryptohasher.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/util/bun-cryptohasher.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [10.69ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [6.66ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [33.29ms]
(pass) update(str, 'hex') decodes two-byte strings from the low byte of each code unit like node [15.43ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [9.29ms]
(pass) static hash requires the algorithm to be a string primitive [10.11ms]
(pass) hash functions read their buffers and hasher state only after every argument has been coerced [315.66ms]
(pass) Bun.sha validates its arguments like Bun.SHA512_256.hash [22.79ms]
(pass) HMAC > sha1 (key: String) [13.68ms]
(pass) HMAC > sha256 (key: String) [3.23ms]
(pass) HMAC > sha384 (key: String) [2.51ms]
(pass) HMAC > sha512 (key: String) [2.87ms]
(pass) HMAC > blake2b512 (key: String) [3.29ms]
(pass) HMAC > md5 (key: String) [2.75ms]
(pass) HMAC > sha224 (key: String) [2.44ms]
(pass) HMAC > sha512-224 (key: String) [2.46ms]
(pass) HMAC > sha512-256 (key: String) [2.42ms]
(pass) HMAC > sha3-224 (key: String) [2.85ms]
(pass) HMAC > sha3-256 (key: String) [2.52ms]
(pass) HMAC > sha3-384 (key: String) [2.53ms]
(pass) HMAC > sha3-512 (key: String) [2.46ms]
(pass) HMAC > ripemd160 (key: String) [3.12ms]
(pass) HMAC > sha1 (key: Buffer) [2.47ms]
(pass) HMAC > sha256 (key: Buffer) [2.42ms]
(pass) HMAC > sha384 (key: Buffer) [2.93ms]
(pass) HMAC > sha512 (key: Buffer) [3.53ms]
(pass) HMAC > blake2b512 (key: Buffer) [3.18ms]
(pass) HMAC > md5 (key: Buffer) [2.93ms]
(pass) HMAC > sha224 (key: Buffer) [2.40ms]
(pass) HMAC > sha512-224 (key: Buffer) [2.37ms]
(pass) HMAC > sha512-256 (key: Buffer) [2.37ms]
(pass) HMAC > sha3-224 (key: Buffer) [2.45ms]
(pass) HMAC
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/util/bun-cryptohasher.test.ts | 588 +++++++++++++++---------------
 1 file changed, 294 insertions(+), 294 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
test/js/bun/util/bun-cryptohasher.test.ts      7      9      0
```

</details>

<!-- robobun:evidence:end -->
