### PR TITLE
test: run bunfig preload tests concurrently and assert the preload markers

### DIFF
--- a/test/config/bunfig/fixtures/preload/many/preload1.ts
+++ b/test/config/bunfig/fixtures/preload/many/preload1.ts
@@ -1,1 +1,1 @@
-(globalThis.preload ??= []).push("multi/preload1.ts");
+(globalThis.preload ??= []).push("many/preload1.ts");

--- a/test/config/bunfig/fixtures/preload/many/preload2.ts
+++ b/test/config/bunfig/fixtures/preload/many/preload2.ts
@@ -1,1 +1,1 @@
-(globalThis.preload ??= []).push("multi/preload2.ts");
+(globalThis.preload ??= []).push("many/preload2.ts");

--- a/test/config/bunfig/fixtures/preload/many/preload3.ts
+++ b/test/config/bunfig/fixtures/preload/many/preload3.ts
@@ -1,1 +1,1 @@
-(globalThis.preload ??= []).push("multi/preload3.ts");
+(globalThis.preload ??= []).push("many/preload3.ts");

--- a/test/config/bunfig/fixtures/preload/mixed/index.fixture-test.ts
+++ b/test/config/bunfig/fixtures/preload/mixed/index.fixture-test.ts
@@ -1,5 +1,5 @@
+console.log(globalThis.preload);
+
 it("the correct file was preloaded", () => {
-  expect(globalThis.preload).toBeDefined();
-  expect(globalThis.preload).toBeArrayOfSize(1);
-  expect(globalThis.preload[0]).toEqual("mixed/preload-test.ts");
+  expect(globalThis.preload).toEqual(["mixed/preload-test.ts"]);
 });

--- a/test/config/bunfig/fixtures/preload/mixed/index.ts
+++ b/test/config/bunfig/fixtures/preload/mixed/index.ts
@@ -1,2 +1,1 @@
-import assert from "node:assert";
-assert.deepStrictEqual(globalThis.preload, ["mixed/preload-run.ts"]);
+console.log(globalThis.preload);

--- a/test/config/bunfig/fixtures/preload/multi/cli-merge.ts
+++ b/test/config/bunfig/fixtures/preload/multi/cli-merge.ts
@@ -1,2 +1,0 @@
-import assert from "node:assert";
-assert.deepStrictEqual(globalThis.preload, ["multi/preload1.ts", "multi/preload2.ts", "multi/preload3.ts"]);

--- a/test/config/bunfig/fixtures/preload/multi/empty.ts
+++ b/test/config/bunfig/fixtures/preload/multi/empty.ts
@@ -1,3 +1,0 @@
-// `bun --config=bunfig.empty.toml run index.ts`
-import assert from "node:assert";
-assert.strictEqual(globalThis.preload, undefined);

--- a/test/config/bunfig/fixtures/preload/multi/index.ts
+++ b/test/config/bunfig/fixtures/preload/multi/index.ts
@@ -1,2 +1,1 @@
-import assert from "node:assert";
-assert.deepStrictEqual(globalThis.preload, ["multi/preload1.ts", "multi/preload2.ts"]);
+console.log(globalThis.preload);

--- a/test/config/bunfig/fixtures/preload/parent/foo/index.ts
+++ b/test/config/bunfig/fixtures/preload/parent/foo/index.ts
@@ -1,2 +1,1 @@
-import assert from "node:assert";
-assert.equal(globalThis.preload, "parent/preload.ts");
+console.log(globalThis.preload);

--- a/test/config/bunfig/fixtures/preload/relative/index.fixture-test.ts
+++ b/test/config/bunfig/fixtures/preload/relative/index.fixture-test.ts
@@ -1,3 +1,3 @@
 it("the correct file was preloaded", () => {
-  expect(globalThis.preload).toBe("simple/preload.ts");
+  expect(globalThis.preload).toBe("relative/preload.ts");
 });

--- a/test/config/bunfig/fixtures/preload/relative/index.ts
+++ b/test/config/bunfig/fixtures/preload/relative/index.ts
@@ -1,2 +1,1 @@
-import assert from "node:assert";
-assert.strictEqual(globalThis.preload, "simple/preload.ts");
+console.log(globalThis.preload);

--- a/test/config/bunfig/fixtures/preload/relative/preload.ts
+++ b/test/config/bunfig/fixtures/preload/relative/preload.ts
@@ -1,2 +1,2 @@
 // this file's name so we know the right file was loaded
-globalThis.preload = "simple/preload.ts";
+globalThis.preload = "relative/preload.ts";

--- a/test/config/bunfig/fixtures/preload/simple/index.ts
+++ b/test/config/bunfig/fixtures/preload/simple/index.ts
@@ -1,2 +1,1 @@
-import assert from "node:assert";
-assert.strictEqual(globalThis.preload, "simple/preload.ts");
+console.log(globalThis.preload);

--- a/test/config/bunfig/preload.test.ts
+++ b/test/config/bunfig/preload.test.ts
@@ -21,10 +21,7 @@ async function run(file: string, { args = [], cwd, env = {} }: Opts = {}): Promi
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
-    env: {
-      ...env,
-      ...bunEnv,
-    },
+    env: { ...bunEnv, ...env },
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/config/bunfig/preload.test.ts
+++ b/test/config/bunfig/preload.test.ts
@@ -1,5 +1,5 @@
-import type { SpawnOptions } from "bun";
-import { bunEnv, bunExe } from "harness";
+import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 import { join, resolve } from "path";
 
 const fixturePath = (...segs: string[]) => resolve(import.meta.dirname, "fixtures", "preload", ...segs);
@@ -10,32 +10,36 @@ type Opts = {
   env?: Record<string, string>;
 };
 type Out = [stdout: string, stderr: string, exitCode: number];
-const run = (file: string, { args = [], cwd, env = {} }: Opts = {}): Promise<Out> => {
-  const res = Bun.spawn([bunExe(), ...args, file], {
+
+// Every preload fixture records its own path in `globalThis.preload`, and every
+// entry file prints that value. So `stdout` says exactly which preloads ran,
+// and in what order.
+async function run(file: string, { args = [], cwd, env = {} }: Opts = {}): Promise<Out> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args, file],
     cwd,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
     env: {
       ...env,
       ...bunEnv,
     },
-  } satisfies SpawnOptions.OptionsObject<"ignore", "pipe", "pipe">);
+  });
 
-  return Promise.all([
-    new Response(res.stdout).text().then(s => s.trim()),
-    new Response(res.stderr).text().then(s => s.trim()),
-    res.exited,
-  ]);
-};
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return [normalizeBunSnapshot(stdout, cwd), normalizeBunSnapshot(stderr, cwd), exitCode];
+}
 
-describe("Given a single universal preload", () => {
+describe.concurrent("Given a single universal preload", () => {
   const dir = fixturePath("simple");
 
   // `bun run` looks for a `bunfig.toml` in the current directory by default
   it("When `bun run` is run and `bunfig.toml` is implicitly loaded, preloads are run", async () => {
     // `bun run index.ts`
     const [out, err, code] = await run("index.ts", { cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"simple/preload.ts"`);
     expect(code).toBe(0);
   });
 
@@ -46,44 +50,55 @@ describe("Given a single universal preload", () => {
       args: [`--config=${join(dir, "bunfig.toml")}`],
       cwd: process.cwd(),
     });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"simple/preload.ts"`);
     expect(code).toBe(0);
   });
 }); // </given a single universal preload>
 
-describe("Given a bunfig.toml with both universal and test-only preloads", () => {
+describe.concurrent("Given a bunfig.toml with both universal and test-only preloads", () => {
   const dir = fixturePath("mixed");
 
   it("`bun run index.ts` only loads the universal preload", async () => {
     const [out, err, code] = await run("index.ts", { cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"[ "mixed/preload-run.ts" ]"`);
     expect(code).toBe(0);
   });
 
   it("`bun test` only loads test-only preloads, clobbering the universal ones", async () => {
     const [out, err, code] = await run("./index.fixture-test.ts", { args: ["test"], cwd: dir });
-    // note: err has test report, out has "bun test <version>"
+    expect(err).toMatchInlineSnapshot(`
+      "index.fixture-test.ts:
+      (pass) the correct file was preloaded
 
+       1 pass
+       0 fail
+       1 expect() calls
+      Ran 1 test across 1 file."
+    `);
+    expect(out).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      [ "mixed/preload-test.ts" ]"
+    `);
     expect(code).toBe(0);
   });
 }); // </given a bunfig.toml with both universal and test-only preloads>
 
-describe("Given a `bunfig.toml` with a list of preloads", () => {
+describe.concurrent("Given a `bunfig.toml` with a list of preloads", () => {
   const dir = fixturePath("multi");
 
   it("When `bun run` is run, preloads are run", async () => {
     const [out, err, code] = await run("index.ts", { cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"[ "multi/preload1.ts", "multi/preload2.ts" ]"`);
     expect(code).toBe(0);
   });
 
   it("when passed `--config=bunfig.empty.toml`, preloads are not run", async () => {
-    const [out, err, code] = await run("empty.ts", { args: ["--config=bunfig.empty.toml"], cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+    const [out, err, code] = await run("index.ts", { args: ["--config=bunfig.empty.toml"], cwd: dir });
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"undefined"`);
     expect(code).toBe(0);
   });
 
@@ -96,15 +111,15 @@ describe("Given a `bunfig.toml` with a list of preloads", () => {
     // "--preload=./preload3.ts run",
     // "run --preload ./preload3.ts",
     // "run --preload=./preload3.ts",
-  ])("When `bun %s cli-merge.ts` is run, `--preload` adds the target file to the list of preloads", async args => {
-    const [out, err, code] = await run("cli-merge.ts", { args: args.split(" "), cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+  ])("When `bun %s index.ts` is run, `--preload` adds the target file to the list of preloads", async args => {
+    const [out, err, code] = await run("index.ts", { args: args.split(" "), cwd: dir });
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"[ "multi/preload1.ts", "multi/preload2.ts", "multi/preload3.ts" ]"`);
     expect(code).toBe(0);
   });
 }); // </given a `bunfig.toml` with a list of preloads>
 
-describe("Given a `bunfig.toml` with a plugin preload", () => {
+describe.concurrent("Given a `bunfig.toml` with a plugin preload", () => {
   const dir = fixturePath("plugin");
 
   it.todo("When `bun run` is run, preloads are run", async () => {
@@ -115,54 +130,53 @@ describe("Given a `bunfig.toml` with a plugin preload", () => {
   });
 }); // </given a `bunfig.toml` with a plugin preload>
 
-describe("Given a `bunfig.toml` file with a relative path to a preload in a parent directory", () => {
+describe.concurrent("Given a `bunfig.toml` file with a relative path to a preload in a parent directory", () => {
   const dir = fixturePath("parent", "foo");
 
-  // FIXME
   it("When `bun run` is run, preloads are run", async () => {
     const [out, err, code] = await run("index.ts", { cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"parent/preload.ts"`);
     expect(code).toBe(0);
   });
 }); // </given a `bunfit.toml` file with a relative path to a preload in a parent directory>
 
-describe("Given a `bunfig.toml` file with a relative path without a leading './'", () => {
+describe.concurrent("Given a `bunfig.toml` file with a relative path without a leading './'", () => {
   const dir = fixturePath("relative");
 
   // FIXME: currently treaded as an import to an external package
   it.skip("preload = 'preload.ts' is treated like a relative path and loaded", async () => {
     const [out, err, code] = await run("index.ts", { cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBeEmpty();
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"relative/preload.ts"`);
     expect(code).toBe(0);
   });
 }); // </given a `bunfig.toml` file with a relative path without a leading './'>
 
-describe("Test that all the aliases for --preload work", () => {
+describe.concurrent("Test that all the aliases for --preload work", () => {
   const dir = fixturePath("many");
 
   it.each(["--preload=./preload1.ts", "--require=./preload1.ts", "--import=./preload1.ts"])(
     "When `bun run` is run with %s, the preload is executed",
     async flag => {
       const [out, err, code] = await run("index.ts", { args: [flag], cwd: dir });
-      expect(err).toBeEmpty();
-      expect(out).toBe('[ "multi/preload1.ts" ]');
+      expect(err).toBe("");
+      expect(out).toMatchInlineSnapshot(`"[ "many/preload1.ts" ]"`);
       expect(code).toBe(0);
     },
   );
 
-  it.each(["1", "2", "3", "4"])(
-    "When multiple preload flags are used, they execute in order: --preload, --require, --import (#%s)",
-    async i => {
-      let args: string[] = [];
-      if (i === "1") args = ["--preload", "./preload1.ts", "--require", "./preload2.ts", "--import", "./preload3.ts"];
-      if (i === "2") args = ["--import", "./preload3.ts", "--preload=./preload1.ts", "--require", "./preload2.ts"];
-      if (i === "3") args = ["--require", "./preload2.ts", "--import", "./preload3.ts", "--preload", "./preload1.ts"];
-      if (i === "4") args = ["--require", "./preload1.ts", "--import", "./preload3.ts", "--require", "./preload2.ts"];
-      const [out, err, code] = await run("index.ts", { args, cwd: dir });
-      expect(err).toBeEmpty();
-      expect(out).toBe('[ "multi/preload1.ts", "multi/preload2.ts", "multi/preload3.ts" ]');
+  it.each([
+    "--preload ./preload1.ts --require ./preload2.ts --import ./preload3.ts",
+    "--import ./preload3.ts --preload=./preload1.ts --require ./preload2.ts",
+    "--require ./preload2.ts --import ./preload3.ts --preload ./preload1.ts",
+    "--require ./preload1.ts --import ./preload3.ts --require ./preload2.ts",
+  ])(
+    "When multiple preload flags are used, they execute in order: --preload, --require, --import (`bun %s index.ts`)",
+    async flags => {
+      const [out, err, code] = await run("index.ts", { args: flags.split(" "), cwd: dir });
+      expect(err).toBe("");
+      expect(out).toMatchInlineSnapshot(`"[ "many/preload1.ts", "many/preload2.ts", "many/preload3.ts" ]"`);
       expect(code).toBe(0);
     },
   );
@@ -170,13 +184,12 @@ describe("Test that all the aliases for --preload work", () => {
   it("Duplicate preload flags are only executed once", async () => {
     const args = ["--preload", "./preload1.ts", "--require", "./preload1.ts", "--import", "./preload1.ts"];
     const [out, err, code] = await run("index.ts", { args, cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toBe('[ "multi/preload1.ts" ]');
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"[ "many/preload1.ts" ]"`);
     expect(code).toBe(0);
   });
 
   it("Test double preload flags", async () => {
-    const dir = fixturePath("many");
     const args = [
       "--preload",
       "./preload1.ts",
@@ -187,16 +200,16 @@ describe("Test that all the aliases for --preload work", () => {
       "./preload3.ts",
     ];
     const [out, err, code] = await run("index.ts", { args, cwd: dir });
-    expect(err).toBeEmpty();
-    expect(out).toMatchInlineSnapshot(`"[ "multi/preload1.ts", "multi/preload2.ts", "multi/preload3.ts" ]"`);
+    expect(err).toBe("");
+    expect(out).toMatchInlineSnapshot(`"[ "many/preload1.ts", "many/preload2.ts", "many/preload3.ts" ]"`);
     expect(code).toBe(0);
   });
 }); // </Test that all the aliases for --preload work>
 
-test("Test BUN_INSPECT_PRELOAD is used to set preloads", async () => {
+test.concurrent("Test BUN_INSPECT_PRELOAD is used to set preloads", async () => {
   const dir = fixturePath("many");
   const [out, err, code] = await run("index.ts", { args: [], cwd: dir, env: { BUN_INSPECT_PRELOAD: "./preload1.ts" } });
-  expect(err).toBeEmpty();
-  expect(out).toMatchInlineSnapshot(`"[ "multi/preload1.ts" ]"`);
+  expect(err).toBe("");
+  expect(out).toMatchInlineSnapshot(`"[ "many/preload1.ts" ]"`);
   expect(code).toBe(0);
 }); // </Test BUN_INSPECT_PRELOAD is used to set preloads>


### PR DESCRIPTION
### Problem
- `test/config/bunfig/preload.test.ts` took 42.28s on the windows 2019 x64 lane of build #108217. It runs 18 `bun` child processes one after the other, so its wall time is the sum of 18 process starts.
- Most tests asserted `expect(out).toBeEmpty()`. The fixture entry files did the real check with `node:assert`, so the test only proved that the child printed nothing and exited 0.

### Fix
- Every `describe` is `describe.concurrent` and the last test is `test.concurrent`. With no hooks, all 18 spawns form one concurrent group. No test writes to a fixture directory.
- Every entry fixture prints `globalThis.preload`, the marker each preload pushes. Each test matches the exact stdout with `toMatchInlineSnapshot` and asserts `stderr` is `""` before the exit code. The `bun test` case also snapshots its report.
- `multi/empty.ts` and `multi/cli-merge.ts` are gone (`index.ts` prints the list). The `many` and `relative` markers name their own directory.
- Verified: `bun bd test test/config/bunfig/preload.test.ts`, 3 runs each. Linux debug (ASAN): 8.2 to 8.5s before, 3.3s after. Windows Server 2019 debug: 6.2s before, 1.9s after. Windows release: 0.33s before, 0.10s after.

### Background
- The 42s did not reproduce on a Windows Server 2019 machine. CI runs this file in a `bun test --parallel` batch of 167 files, so the per-file timer includes contention.
- `--max-concurrency` is 20 by default and 5 under ASAN, hence 3.3s on the Linux debug build.
- The `it.skip` and FIXME cases still fail on main and stay as they are. PR #39058 enables the plugin `it.todo`. The merge with it is clean and the merged file passes.

<details><summary>Notes</summary>

Probes of the FIXME cases with the debug build at 1ab272b:

- `bun --config=<abs>/simple/bunfig.toml <abs>/simple/index.ts` from another cwd: `error: preload not found "./preload.ts"`.
- `relative` fixture (`preload = "preload.ts"`): `globalThis.preload` is `undefined`.
- `bun --preload=./preload3.ts run index.ts`, `bun run --preload ./preload3.ts index.ts`, `bun run --preload=./preload3.ts index.ts`: preload3 is missing from the list (#38599 covers this).
- `bun --preload ./preload3.ts run index.ts`: prints the `bun run` usage text and exits 0.

Per-test times on Windows debug are still 0.4 to 0.6s each. The file total of 1.9s is 1.2s of fixed cost (a test file that only imports `harness` takes 1.22s on that build) plus one round of overlapping spawns. Spawning itself is cheap there: 18 `Bun.spawn` calls of the debug binary complete in 81ms.

`bun test` in the `simple` fixture does not load the top-level `preload` (only `[test].preload` applies to `bun test`, see `src/bunfig/bunfig.rs`). `simple/index.fixture-test.ts` and `relative/index.fixture-test.ts` are unreferenced and left alone.

CI timings for this file in build #108300 (release builds, the file runs alone as a modified test): windows 2019 x64 161ms (median before this PR: 290ms in `test/expected-durations.json`), x64-asan 733ms (before: 1550ms), linux lanes 57 to 133ms, darwin 85 to 168ms. 18 pass on every lane.

Merge check: `git merge-tree --write-tree HEAD pr-39058` is clean. The merged `preload.test.ts` with the plugin test enabled passes (19 pass) with the `bun-plugin-yaml` fixture dependency installed.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 14 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/config/bunfig/preload.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/config/bunfig/preload.test.ts
bun test v1.4.1 (d578a8c70)

test/config/bunfig/preload.test.ts:
(skip) Given a single universal preload > When `bun run` is run from a different directory but bunfig.toml is explicitly used, preloads are run
(pass) Given a single universal preload > When `bun run` is run and `bunfig.toml` is implicitly loaded, preloads are run [308.06ms]
(pass) Given a bunfig.toml with both universal and test-only preloads > `bun run index.ts` only loads the universal preload [291.20ms]
(pass) Given a `bunfig.toml` with a list of preloads > When `bun run` is run, preloads are run [285.80ms]
(todo) Given a `bunfig.toml` with a plugin preload > When `bun run` is run, preloads are run
(pass) Given a `bunfig.toml` with a list of preloads > when passed `--config=bunfig.empty.toml`, preloads are not run [285.38ms]
(skip) Given a `bunfig.toml` file with a relative path without a leading './' > preload = 'preload.ts' is treated like a relative path and loaded
(pass) Given a bunfig.toml with both universal and test-only preloads > `bun test` only loads test-only preloads, clobbering the universal ones [320.57ms]
(pass) Given a `bunfig.toml` with a list of preloads > When `bun --preload ./preload3.ts index.ts` is run, `--preload` adds the target file to the list of preloads [295.79ms]
(pass) Given a `bunfig.toml` file with a relative path to a preload in a parent directory > When `bun run` is run, preloads are run [281.08ms]
(pass) Test that all the aliases for --preload work > When `bun run` is run with --preload=./preload1.ts, the preload is executed [286.61ms]
(pass) Test that all the aliases for --preload work > When `bun run` is run with --require=./preload1.ts, the preload is executed [281.16ms]
(pass) Given a `bunfig.toml` with a list of preloads > When `bun --preload=./preload3.ts index.ts` is run, `--preload` adds the target file to the list of preloads [402.
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../bunfig/fixtures/preload/many/preload1.ts       |   2 +-
 .../bunfig/fixtures/preload/many/preload2.ts       |   2 +-
 .../bunfig/fixtures/preload/many/preload3.ts       |   2 +-
 .../fixtures/preload/mixed/index.fixture-test.ts   |   6 +-
 test/config/bunfig/fixtures/preload/mixed/index.ts |   3 +-
 .../bunfig/fixtures/preload/multi/cli-merge.ts     |   2 -
 test/config/bunfig/fixtures/preload/multi/empty.ts |   3 -
 test/config/bunfig/fixtures/preload/multi/index.ts |   3 +-
 .../bunfig/fixtures/preload/parent/foo/index.ts    |   3 +-
 .../preload/relative/index.fixture-test.ts         |   2 +-
 .../bunfig/fixtures/preload/relative/index.ts      |   3 +-
 .../bunfig/fixtures/preload/relative/preload.ts    |   2 +-
 .../config/bunfig/fixtures/preload/simple/index.ts |   3 +-
 test/config/bunfig/preload.test.ts                 | 142 +++++++++++----------
 14 files changed, 89 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/config/bunfig/fixtures/preload/many/preload1.ts          0      0      0
test/config/bunfig/fixtures/preload/many/preload2.ts          0      0      0
test/config/bunfig/fixtures/preload/many/preload3.ts          0      0      0
…fig/bunfig/fixtures/preload/mixed/index.fixture-test.ts      1      1      0
test/config/bunfig/fixtures/preload/mixed/index.ts            1      1      0
test/config/bunfig/fixtures/preload/multi/cli-merge.ts        0      0      0
test/config/bunfig/fixtures/preload/multi/empty.ts            0      0      0
test/config/bunfig/fixtures/preload/multi/index.ts            1      1      0
test/config/bunfig/fixtures/preload/parent/foo/index.ts       1      1      0
…/bunfig/fixtures/preload/relative/index.fixture-test.ts      1      1      0
test/config/bunfig/fixtures/preload/relative/index.ts         1      1      0
test/config/bunfig/fixtures/preload/relative/preload.ts       1      1      0
test/config/bunfig/fixtures/preload/simple/index.ts           1      3      0
test/config/bunfig/preload.test.ts                            2      3      0
```

</details>

<!-- robobun:evidence:end -->
