### PR TITLE
js_parser: give every standard decorator lowering temporary its own name

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -7,7 +7,7 @@ use bun_collections::{HashMap, VecExt};
 
 use crate::lexer as js_lexer;
 use crate::p::P;
-use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, is_eval_or_arguments};
+use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, TempRef, is_eval_or_arguments};
 use bun_ast::g::{DeclList, Property, PropertyKind};
 use bun_ast::{self as js_ast, B, E, Expr, ExprNodeList, Flags, G, S, Stmt};
 
@@ -396,24 +396,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Bump-format `_{prefix}{n}` (or just `_{prefix}` when n is omitted).
-    fn bump_name(&self, prefix: &[u8], n: Option<usize>) -> &'a [u8] {
-        let mut v = BumpVec::<u8>::new_in(self.arena);
-        v.extend_from_slice(prefix);
-        if let Some(n) = n {
-            // bumpalo Vec<u8> doesn't impl io::Write; format into a
-            // bump String and copy the bytes.
-            let s = bun_alloc::arena_format!(in self.arena, "{}", n);
-            v.extend_from_slice(s.as_bytes());
-        }
-        v.into_bump_slice()
-    }
-
     fn bump_name2(&self, a: &[u8], b: &[u8]) -> &'a [u8] {
         let mut v = BumpVec::<u8>::new_in(self.arena);
         v.extend_from_slice(a);
         v.extend_from_slice(b);
         v.into_bump_slice()
+    }
+
+    fn accessor_storage_name(&self, key: Option<Expr>) -> &'a [u8] {
+        if let Some(key) = key
+            && let js_ast::ExprData::EString(s) = &key.data
+            && s.is_utf8()
+            && js_lexer::is_identifier(&s.data)
+        {
+            return self.bump_name2(b"_", &s.data);
+        }
+        b"_accessor_storage"
     }
 
     // ── Generic tree rewriter ────────────────────────────
@@ -778,7 +776,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     (obj_expr, self.new_expr(E::This {}, obj_expr.loc))
                                 }
                                 _ => {
-                                    let tmp_ref = self.generate_temp_ref(Some(b"_obj"));
+                                    let tmp_ref = self.generate_temp_var(b"_obj");
+                                    self.temp_refs_to_declare.push(TempRef { r#ref: tmp_ref });
                                     let write = self.assign_to(tmp_ref, obj_expr, expr_loc);
                                     let read = self.use_ref(tmp_ref, expr_loc);
                                     (write, read)
@@ -1130,7 +1129,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut expr_var_decls = BumpVec::<G::Decl>::new_in(bump);
 
         if is_expr {
-            let ecr = p.new_sym(js_ast::symbol::Kind::Other, b"_class");
+            let ecr = p.generate_temp_var(b"_class");
             expr_class_ref = Some(ecr);
             let binding = p.b(B::Identifier { r#ref: ecr }, loc);
             expr_var_decls.push(G::Decl {
@@ -1165,7 +1164,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .original_name
                 .slice();
             let name = p.bump_name2(b"_", cns);
-            inner_class_ref = p.new_sym(js_ast::symbol::Kind::Other, name);
+            inner_class_ref = p.generate_temp_var(name);
         }
 
         // `ExprNodeList = Vec<Expr>` owns its
@@ -1177,7 +1176,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
 
-        let init_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_init");
+        let init_ref = p.generate_temp_var(b"_init");
         if is_expr {
             let binding = p.b(B::Identifier { r#ref: init_ref }, loc);
             expr_var_decls.push(G::Decl {
@@ -1188,7 +1187,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut base_ref: Option<Ref> = None;
         if class.extends.is_some() {
-            let br = p.new_sym(js_ast::symbol::Kind::Other, b"_base");
+            let br = p.generate_temp_var(b"_base");
             base_ref = Some(br);
             if is_expr {
                 let binding = p.b(B::Identifier { r#ref: br }, loc);
@@ -1200,13 +1199,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // ── Phase 2: Pre-evaluate decorators/keys ────────
-        let mut dec_counter: usize = 0;
         let mut class_dec_ref: Option<Ref> = None;
         let mut class_dec_stmt: Stmt = Stmt::empty();
         let mut class_dec_assign_expr: Option<Expr> = None;
         if class_decorators_len > 0 {
-            dec_counter += 1;
-            let cdr = p.new_sym(js_ast::symbol::Kind::Other, b"_dec");
+            let cdr = p.generate_temp_var(b"_dec");
             class_dec_ref = Some(cdr);
             // Move ownership into the AST node — `class_decorators` is not read
             // again on this branch (Phase-5's else-arm only runs when
@@ -1234,7 +1231,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut prop_dec_refs: HashMap<usize, Ref> = HashMap::default();
         let mut computed_key_refs: HashMap<usize, Ref> = HashMap::default();
         let mut pre_eval_stmts = BumpVec::<Stmt>::new_in(bump);
-        let mut computed_key_counter: usize = 0;
 
         let props_slice: &mut [Property] = class.properties.slice_mut();
         for (prop_idx, prop) in props_slice.iter_mut().enumerate() {
@@ -1242,21 +1238,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
             if prop.ts_decorators.len_u32() > 0 {
-                dec_counter += 1;
-                let dec_name: &'a [u8] = if dec_counter == 1 {
-                    b"_dec"
-                } else {
-                    p.bump_name(b"_dec", Some(dec_counter))
-                };
-                let dec_ref = p.new_sym(js_ast::symbol::Kind::Other, dec_name);
+                let dec_ref = p.generate_temp_var(b"_dec");
                 prop_dec_refs.insert(prop_idx, dec_ref);
-                if is_expr {
-                    let binding = p.b(B::Identifier { r#ref: dec_ref }, loc);
-                    expr_var_decls.push(G::Decl {
-                        binding,
-                        value: None,
-                    });
-                }
                 // SAFETY: shallow-reborrow arena Vec.
                 let items: ExprNodeList = unsafe { core::ptr::read(&raw const prop.ts_decorators) };
                 let arr = p.new_expr(
@@ -1272,21 +1255,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && prop.key.is_some()
                 && prop.ts_decorators.len_u32() > 0
             {
-                computed_key_counter += 1;
-                let key_name: &'a [u8] = if computed_key_counter == 1 {
-                    b"_computedKey"
-                } else {
-                    p.bump_name(b"_computedKey", Some(computed_key_counter))
-                };
-                let key_ref = p.new_sym(js_ast::symbol::Kind::Other, key_name);
+                let key_ref = p.generate_temp_var(b"_computedKey");
                 computed_key_refs.insert(prop_idx, key_ref);
-                if is_expr {
-                    let binding = p.b(B::Identifier { r#ref: key_ref }, loc);
-                    expr_var_decls.push(G::Decl {
-                        binding,
-                        value: None,
-                    });
-                }
                 let key_loc = prop.key.expect("infallible: prop has key").loc;
                 pre_eval_stmts.push(p.var_decl(key_ref, prop.key, loc));
                 prop.key = Some(p.use_ref(key_ref, key_loc));
@@ -1391,7 +1361,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
-        let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
 
@@ -1458,7 +1427,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             ex.storage_ref
                         } else {
                             let nm = p.bump_name2(b"_", &npriv_orig[1..]);
-                            p.new_sym(js_ast::symbol::Kind::Other, nm)
+                            p.generate_temp_var(nm)
                         };
                         let fn_nm = {
                             let mut v = BumpVec::<u8>::new_in(bump);
@@ -1467,7 +1436,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             v.extend_from_slice(Self::fn_suffix(nk));
                             v.into_bump_slice()
                         };
-                        let fn_ref = p.new_sym(js_ast::symbol::Kind::Other, fn_nm);
+                        let fn_ref = p.generate_temp_var(fn_nm);
 
                         let mut new_info =
                             existing.unwrap_or_else(|| PrivateLoweredInfo::new(ws_ref));
@@ -1516,7 +1485,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     } else {
                         // Non-decorated private field → WeakMap
                         let wm_nm = p.bump_name2(b"_", &npriv_orig[1..]);
-                        let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, wm_nm);
+                        let wm_ref = p.generate_temp_var(wm_nm);
                         private_lowered_map.insert(npriv_inner, PrivateLoweredInfo::new(wm_ref));
                         let wme = p.new_weak_map_expr(loc);
                         prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
@@ -1543,20 +1512,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 // Undecorated auto-accessor → WeakMap + getter/setter
                 if prop.kind == PropertyKind::AutoAccessor {
-                    let accessor_name: &'a [u8] = 'brk: {
-                        if let Some(k) = prop.key {
-                            if let js_ast::ExprData::EString(s) = &k.data
-                                && s.is_utf8()
-                            {
-                                break 'brk p.bump_name2(b"_", &s.data);
-                            }
-                        }
-                        let name =
-                            p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                        accessor_storage_counter += 1;
-                        name
-                    };
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
+                    let accessor_name = p.accessor_storage_name(prop.key);
+                    let wm_ref = p.generate_temp_var(accessor_name);
                     let wme = p.new_weak_map_expr(loc);
                     prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
 
@@ -1726,7 +1683,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ex.storage_ref
                     } else {
                         let nm = p.bump_name2(b"_", &private_orig[1..]);
-                        p.new_sym(js_ast::symbol::Kind::Other, nm)
+                        p.generate_temp_var(nm)
                     };
                     private_storage_ref = Some(ws_ref);
                     let fn_nm = {
@@ -1736,7 +1693,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         v.extend_from_slice(Self::fn_suffix(k));
                         v.into_bump_slice()
                     };
-                    let fn_ref = p.new_sym(js_ast::symbol::Kind::Other, fn_nm);
+                    let fn_ref = p.generate_temp_var(fn_nm);
                     private_method_fn_ref = Some(fn_ref);
 
                     let mut new_info = existing.unwrap_or_else(|| PrivateLoweredInfo::new(ws_ref));
@@ -1758,7 +1715,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     dec_arg_count = 6;
                 } else if k == 5 {
                     let nm = p.bump_name2(b"_", &private_orig[1..]);
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, nm);
+                    let wm_ref = p.generate_temp_var(nm);
                     private_storage_ref = Some(wm_ref);
                     private_lowered_map.insert(priv_inner, PrivateLoweredInfo::new(wm_ref));
                     let wme = p.new_weak_map_expr(loc);
@@ -1766,7 +1723,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     dec_arg_count = 5;
                 } else if k == 4 {
                     let nm = p.bump_name2(b"_", &private_orig[1..]);
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, nm);
+                    let wm_ref = p.generate_temp_var(nm);
                     private_storage_ref = Some(wm_ref);
                     let acc_nm = {
                         let mut v = BumpVec::<u8>::new_in(bump);
@@ -1775,7 +1732,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         v.extend_from_slice(b"_acc");
                         v.into_bump_slice()
                     };
-                    let acc_ref = p.new_sym(js_ast::symbol::Kind::Other, acc_nm);
+                    let acc_ref = p.generate_temp_var(acc_nm);
                     private_method_fn_ref = Some(acc_ref);
                     private_lowered_map.insert(
                         priv_inner,
@@ -1793,17 +1750,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             } else if k == 4 {
                 // Decorated public auto-accessor → WeakMap
-                let accessor_name: &'a [u8] = 'brk: {
-                    if let js_ast::ExprData::EString(s) = &key_expr.data
-                        && s.is_utf8()
-                    {
-                        break 'brk p.bump_name2(b"_", &s.data);
-                    }
-                    let name = p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                    accessor_storage_counter += 1;
-                    name
-                };
-                let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
+                let accessor_name = p.accessor_storage_name(Some(key_expr));
+                let wm_ref = p.generate_temp_var(accessor_name);
                 private_extra_ref = Some(wm_ref);
                 let wme = p.new_weak_map_expr(loc);
                 prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8400,8 +8400,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         r#ref
     }
 
-    /// A `var` a lowering declares itself (`_init`, `_dec`). Without a renamer
-    /// the printer emits `name` verbatim, so it carries a per-file counter.
+    /// A lowering's own `var`. `bun run` prints names as they are, so there it gets a per-file counter.
     pub(crate) fn generate_temp_var(&mut self, name: &'a [u8]) -> Ref {
         let name: &'a [u8] = if self.will_use_renamer() {
             name
@@ -8416,8 +8415,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ref_
     }
 
-    /// Hands a generated `var` to the renamers: nested scopes are named from
-    /// `Scope::generated`, a file's top level from `Part::declared_symbols`.
+    /// Nested scopes are renamed from `Scope::generated`, a file's top level from `Part::declared_symbols`.
     pub(crate) fn declare_temp_var(&mut self, ref_: Ref) {
         let mut scope = self.current_scope_ref();
         // A parameter default has no statement list; its `var` goes outside the function.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8395,14 +8395,42 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         };
         let r#ref = self.new_symbol(js_ast::symbol::Kind::Other, name);
 
-        self.temp_refs_to_declare.push(TempRef {
-            r#ref,
-            ..Default::default()
-        });
-
         VecExt::append(&mut scope.generated, r#ref);
 
         r#ref
+    }
+
+    /// A `var` a lowering declares itself (`_init`, `_dec`). Without a renamer
+    /// the printer emits `name` verbatim, so it carries a per-file counter.
+    pub(crate) fn generate_temp_var(&mut self, name: &'a [u8]) -> Ref {
+        let name: &'a [u8] = if self.will_use_renamer() {
+            name
+        } else {
+            self.temp_ref_count += 1;
+            bun_alloc::arena_format!(in self.arena, "{}${}", bstr::BStr::new(name), self.temp_ref_count)
+                .into_bump_str()
+                .as_bytes()
+        };
+        let ref_ = self.new_symbol(js_ast::symbol::Kind::Other, name);
+        self.declare_temp_var(ref_);
+        ref_
+    }
+
+    /// Hands a generated `var` to the renamers: nested scopes are named from
+    /// `Scope::generated`, a file's top level from `Part::declared_symbols`.
+    pub(crate) fn declare_temp_var(&mut self, ref_: Ref) {
+        let mut scope = self.current_scope_ref();
+        // A parameter default has no statement list; its `var` goes outside the function.
+        while !scope.kind_stops_hoisting() || scope.kind == js_ast::scope::Kind::FunctionArgs {
+            scope = scope.parent.unwrap();
+        }
+        VecExt::append(&mut scope.generated, ref_);
+        self.declared_symbols
+            .append(DeclaredSymbol {
+                ref_,
+                is_top_level: scope == self.module_scope,
+            })
+            .expect("oom");
     }
 
     pub(crate) fn should_lower_using_declarations(&self, stmts: &[Stmt]) -> bool {
@@ -10065,40 +10093,9 @@ impl LowerUsingDeclarationsContext {
         let err_ref = p.generate_temp_ref(Some(b"_err"));
         let has_err_ref = p.generate_temp_ref(Some(b"_hasErr"));
 
-        // `StoreRef<Scope>` (Copy + safe `Deref`/`DerefMut`) lets the
-        // parent-chain walk and the `.generated` writes below run without
-        // raw-pointer `unsafe`, and does not borrow `p`.
-        let mut scope: js_ast::StoreRef<Scope> = p.current_scope_ref();
-        while !scope.kind_stops_hoisting() {
-            scope = scope.parent.unwrap();
+        for ref_ in [self.stack_ref, caught_ref, err_ref, has_err_ref] {
+            p.declare_temp_var(ref_);
         }
-
-        let is_top_level = scope == p.module_scope;
-        scope
-            .generated
-            .append_slice(&[self.stack_ref, caught_ref, err_ref, has_err_ref]);
-        p.declared_symbols
-            .ensure_unused_capacity(
-                // 5 to include the _promise decl later on:
-                if self.has_await_using { 5 } else { 4 },
-            )
-            .expect("oom");
-        p.declared_symbols.append_assume_capacity(DeclaredSymbol {
-            is_top_level,
-            ref_: self.stack_ref,
-        });
-        p.declared_symbols.append_assume_capacity(DeclaredSymbol {
-            is_top_level,
-            ref_: caught_ref,
-        });
-        p.declared_symbols.append_assume_capacity(DeclaredSymbol {
-            is_top_level,
-            ref_: err_ref,
-        });
-        p.declared_symbols.append_assume_capacity(DeclaredSymbol {
-            is_top_level,
-            ref_: has_err_ref,
-        });
 
         let loc = self.first_using_loc;
         let call_dispose = {
@@ -10133,11 +10130,7 @@ impl LowerUsingDeclarationsContext {
 
         let finally_stmts: &'a mut [Stmt] = if self.has_await_using {
             let promise_ref = p.generate_temp_ref(Some(b"_promise"));
-            VecExt::append(&mut scope.generated, promise_ref);
-            p.declared_symbols.append_assume_capacity(DeclaredSymbol {
-                is_top_level,
-                ref_: promise_ref,
-            });
+            p.declare_temp_var(promise_ref);
 
             let promise_ref_expr = p.new_expr(
                 E::Identifier {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -58,7 +58,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
-const EXPECTED_VERSION: u32 = 30;
+/// Version 31: Standard decorator lowering temporaries have a per-file counter in their name (`_init$1`).
+const EXPECTED_VERSION: u32 = 31;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -4137,6 +4137,111 @@ describe("bundler", () => {
     format: "cjs",
     run: { file: "/check.js", stdout: `{"x":1} true` },
   });
+
+  // Standard decorator lowering declares `var _init`, `var _dec` and a WeakMap per
+  // accessor or `#private` next to each class. Every class needs its own.
+  itBundled("edgecase/StandardDecoratorTemporariesPerClass", {
+    files: {
+      "/entry.js": /* js */ `
+        function Field(_, _c) {}
+        function AccessorDecorator(_, c) {
+          return { init: () => c.name, get: () => c.name };
+        }
+        class Entity { @Field id; }
+        class Action { @AccessorDecorator accessor success; }
+        console.log(new Entity().id);
+
+        const inject = target => (_, ctx) => v => target + ":" + ctx.name + "=" + v;
+        class Test1 { @inject("test1") field1 = "a"; }
+        class Test2 { @inject("test2") field2 = "b"; }
+        console.log(new Test1().field1, new Test2().field2);
+      `,
+    },
+    run: { stdout: "undefined\ntest1:field1=a test2:field2=b" },
+  });
+  // One decorated class per file: only the bundle puts them in one scope.
+  itBundled("edgecase/StandardDecoratorTemporariesAcrossFiles", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a";
+        import { B } from "./b";
+        import { Entity } from "./ent";
+        import { Action } from "./act";
+        new Action();
+        console.log(a.x, new B().x, a.read(), new B().read(), new Entity().id);
+      `,
+      "/a.js": /* js */ `
+        function dec(_, _c) {}
+        export class A { @dec accessor x = "A.x"; @dec #p = "A.#p"; read() { return this.#p; } }
+        export const a = new A();
+      `,
+      "/b.js": /* js */ `
+        function dec(_, _c) {}
+        export class B { @dec accessor x = "B.x"; @dec #p = "B.#p"; read() { return this.#p; } }
+      `,
+      "/ent.js": /* js */ `
+        function Field(_, _c) {}
+        export class Entity { @Field id; }
+      `,
+      "/act.js": /* js */ `
+        function Acc(_, _c) { return { init: () => "success" }; }
+        export class Action { @Acc accessor status; }
+      `,
+    },
+    run: { stdout: "A.x B.x A.#p B.#p undefined" },
+  });
+  // A `var` in a block belongs to the enclosing function.
+  for (const minifyIdentifiers of [false, true]) {
+    itBundled(`edgecase/StandardDecoratorTemporariesInSiblingBlocks${minifyIdentifiers ? "Minified" : ""}`, {
+      files: {
+        "/entry.js": /* js */ `
+          function dec(_, _c) {}
+          function make() {
+            let A, B;
+            { A = class { @dec accessor x = "a"; }; }
+            { B = class { @dec accessor x = "b"; }; }
+            return [new A().x, new B().x];
+          }
+          let C, D;
+          { C = class { @dec accessor x = "c"; }; }
+          { D = class { @dec accessor x = "d"; }; }
+          console.log(...make(), new C().x, new D().x);
+        `,
+      },
+      minifyIdentifiers,
+      run: { stdout: "a b c d" },
+    });
+  }
+  // The `var`s of a class in a parameter default are declared outside the function.
+  itBundled("edgecase/StandardDecoratorTemporariesInParameterDefaults", {
+    files: {
+      "/entry.js": /* js */ `
+        function dec(_, _c) {}
+        function f(C = class { @dec accessor x = "f"; }) { return C; }
+        function g(C = class { @dec accessor x = "g"; }) { return C; }
+        const F = f(), G = g();
+        console.log(new F().x, new G().x);
+      `,
+    },
+    run: { stdout: "f g" },
+  });
+  // `recv.#m()` on a lowered private method captures the receiver in a `var _obj`
+  // inside the calling method.
+  itBundled("edgecase/StandardDecoratorReceiverTemporaryVsUserBinding", {
+    files: {
+      "/entry.js": /* js */ `
+        const _obj = "user";
+        function dec(_, _c) {}
+        class A {
+          @dec #m() { return "m"; }
+          call(o) { return o.get().#m() + " " + _obj; }
+        }
+        const a = new A();
+        console.log(a.call({ get: () => a }));
+      `,
+    },
+    run: { stdout: "m user" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1154,6 +1154,151 @@ describe("ES Decorators", () => {
     });
   });
 
+  // `bun run` has no symbol renamer: the lowering's `var _init`, `var _dec` and the
+  // WeakMap behind each accessor or `#private` are printed under the name the
+  // parser gave them, so that name has to be unique in the file.
+  describe("lowering temporaries", () => {
+    test.concurrent("an accessor decorator's init does not leak into another class (#40761)", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function Field(_, _c) {}
+        function AccessorDecorator(_, c) {
+          return { init: () => c.name, get: () => c.name };
+        }
+        class Entity { @Field id; }
+        class Action { @AccessorDecorator accessor success; }
+        console.log(new Entity().id);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("undefined\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("field initializers run for their own class (#28316, #28010)", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        const d = name => (_, ctx) => v => (log.push(name + ":" + ctx.name + "=" + v), v);
+        class Parent { @d("Parent") foo = "p1"; @d("Parent") shared = "p2"; }
+        class Child extends Parent { @d("Child") foo = "c1"; @d("Child") own = "c2"; }
+        new Child();
+        class Test1 { @d("Test1") field1 = "t1"; }
+        class Test2 { @d("Test2") field2 = "t2"; }
+        new Test1();
+        console.log(log.join(" "));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("Parent:foo=p1 Parent:shared=p2 Child:foo=c1 Child:own=c2 Test1:field1=t1\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("two classes with an accessor of the same name keep separate storage", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(_, _c) {}
+        class A { @dec accessor x = "a"; }
+        class B { @dec accessor x = "b"; }
+        const a = new A();
+        const b = new B();
+        console.log(a.x, b.x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a b\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a subclass can redeclare an accessor of its base class (#29837)", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class A { accessor name = "A"; }
+        class B extends A {
+          accessor name = "B";
+          logName() { console.log(this.name, super.name); }
+        }
+        new B().logName();
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("B A\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("private members of the same name in two classes, and next to an accessor", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(_, _c) {}
+        class A {
+          accessor x = "A.x";
+          @dec #x = "A.#x";
+          #m() { return "A.#m"; }
+          read() { return [this.x, this.#x, this.#m()].join(" "); }
+        }
+        class B {
+          @dec #m() { return "B.#m"; }
+          read() { return this.#m(); }
+        }
+        console.log(new A().read(), new B().read());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("A.x A.#x A.#m B.#m\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("two decorated classes inside one function keep separate initializers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(_, ctx) {
+          ctx.addInitializer(function () { this.tag = ctx.name; });
+        }
+        function make() {
+          class A { @dec a() {} }
+          class B { @dec b() {} }
+          return [new A().tag, new B().tag];
+        }
+        console.log(make().join(" "));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a b\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class expressions in sibling blocks keep separate storage", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(_, _c) {}
+        let A, B;
+        { A = class { @dec accessor x = "a"; }; }
+        { B = class { @dec accessor x = "b"; }; }
+        console.log(new A().x, new B().x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a b\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("user bindings named like a temporary are left alone", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const _init = "init", _dec = "dec", _obj = "obj";
+        let _x = "x";
+        function dec(_, _c) {}
+        class A {
+          @dec accessor x = 1;
+          @dec #m() { return "m"; }
+          call(o) { return o.get().#m(); }
+        }
+        const a = new A();
+        console.log(_init, _dec, _obj, _x, a.x, a.call({ get: () => a }));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("init dec obj x 1 m\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("an accessor whose key is not an identifier gets a valid storage name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(_, _c) {}
+        class A { @dec accessor "x y" = 1; accessor "a-b" = 2; @dec accessor 3 = 3; }
+        const a = new A();
+        console.log(a["x y"], a["a-b"], a[3]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 2 3\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("accessor with TypeScript annotations", () => {
     test("accessor with definite assignment assertion (!)", async () => {
       using dir = tempDir("es-dec-accessor-bang", {


### PR DESCRIPTION
### What was wrong

Lowering a class with standard decorators (or a bare `accessor`) declares `var _init`, `var _dec`, and one WeakMap/WeakSet per accessor and `#private` member next to the class. **Every class used the same names.**

- **`bun run`** does not run the symbol renamer (on purpose, for speed) and prints those names as they are. Two classes in one scope shared one `var _init`, so a constructor that ran after a later class was evaluated read that class's initializers:

  ```js
  class Entity { @Field id }
  class Action { @AccessorDecorator accessor success }
  new Entity().id // "success"
  ```

  The same sharing made `class B extends A { accessor name }` throw `Cannot add the same private member more than once`, made two classes with `accessor x` throw `Cannot read from private field`, let `accessor x` and `#x` collide inside a single class, and turned a user's `const _init` next to a decorated class into a SyntaxError.
- **`bun build`** has a renamer, but it names a file's top level from `Part::declared_symbols`, and the temporaries were only in `Scope::generated`. Module-level classes collided inside one file and across files once the linker put them in one scope. Class expressions inside blocks registered their (function-hoisted) `var`s in the block scope, so sibling blocks got the same name, minified or not.

### The fix

`P::generate_temp_var(name)` in `src/js_parser/p.rs` creates every temporary the lowering declares:

- Without a renamer it appends the parser's existing per-file `temp_ref_count` to the name (`_init$1`, `_dec$2`), the same counter `generate_temp_ref` uses for `__bun_temp_ref_N$`. This is the line that fixes `bun run`.
- It registers the symbol in `generated` of the function/module scope that receives the `var`, and in `declared_symbols` (`declare_temp_var`). This is what fixes `bun build`, which then prints `_init`, `_init2` like esbuild. A class in a parameter default has its `var`s emitted outside the function, so registration skips the `FunctionArgs` scope.

In `lower_decorators.rs` every `new_sym(Kind::Other, …)` for a temporary becomes `generate_temp_var(…)`. Because names are unique by construction, the per-class `_dec2` / `_computedKey2` / `_accessor_storage0` counters and `bump_name` are deleted. `new_sym` remains for the three symbols whose printed name is observable or fixed: the class name inferred from context, the setter parameter `v`, and `arguments`.

Also in this PR, all in the touched code:

- The `using` lowering had its own copy of the "walk to the hoisting scope, append to `generated` and `declared_symbols`" sequence. It now calls `declare_temp_var`.
- `generate_temp_ref` pushed every ref onto `temp_refs_to_declare`. The only reader was the `_obj` receiver temporary of this lowering, which now pushes its own ref, so that push is deleted.
- `accessor "x y"` declared `var _x y`. The key is used for the storage name only when it is an identifier.
- A class expression listed each member's `_dec` / `_computedKey` twice in its `var` statement.
- `RuntimeTranspilerCache` version 30 → 31: cached output has the shared names.

### Tests

All new tests fail with `USE_SYSTEM_BUN=1` (1.4.1) and pass with the debug build.

- `test/bundler/transpiler/es-decorators.test.ts` → "lowering temporaries": 9 cases under `bun run`, including the repros from #40761, #28010, #28316, #29837.
- `test/bundler/bundler_edgecase.test.ts` → `edgecase/StandardDecorator*`: 6 cases under `bun build` (per class, across files, sibling blocks ± `minifyIdentifiers`, parameter defaults, `_obj` vs a user `_obj`). Each clause of `declare_temp_var` has a test that fails without it.

Also run: the rest of `es-decorators`, `es-decorators-esbuild`, `decorators`, `decorator-metadata`, `bundler_decorator_metadata`, `bundler_edgecase`, `transpiler.test.js`, `runtime-transpiler`, `lower-using-bun-target`, `explicit-resource-management`, `transpiler-cache`, and `regression/issue/{11100,14709,27526,27575}`.

### Not in this PR

- A class *expression* that is evaluated more than once (loop body, called function's parameter default) still shares its `var`s between evaluations. That needs a binding per evaluation, not a name per class: #38933, #38904.
- The class name inferred from context (`const Thing = class { @dec … }` → `class Thing`) is still created with `new_sym`. In a bundle it can capture a reference to an import that prints as `Thing`. Same behaviour as 1.4.1; renaming it like a temporary would change `.name` in every bundle, so it needs to be bound in the class's own scope instead.
- #40833 (rewrite of the lowering) uses the same `name$N` scheme and an equivalent of `declare_temp_var`; it can rebase onto this and drop those hunks.

Fixes #40761
Fixes #28010
Fixes #28316
Fixes #29837

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 6 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 failed, 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [592.49ms]
(pass) bundler > edgecase/EmptyCommonJSModule [420.69ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [440.35ms]
(pass) bundler > edgecase/ImportStarFunction [376.07ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [360.26ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [120.15ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [411.84ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [218.20ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [291.06ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [222.65ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [129.18ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [406.02ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/I
... (truncated)

release without fix: 15 failed, 11 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [15.00ms]
(pass) bundler > edgecase/EmptyCommonJSModule [12.54ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [12.31ms]
(pass) bundler > edgecase/ImportStarFunction [13.27ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [13.71ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [5.19ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [13.17ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [7.14ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [5.25ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [5.40ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [3.98ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [10.59ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [11.26ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [5.31ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [2.74ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDefaul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [779.81ms]
(pass) bundler > edgecase/EmptyCommonJSModule [592.14ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [669.46ms]
(pass) bundler > edgecase/ImportStarFunction [546.88ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [560.62ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [182.33ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [674.20ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [323.97ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [311.38ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [321.34ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [176.72ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [551.46ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/I
... (truncated)

release with fix: 11 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9e49008c0f
  features     baseline

23 deps, 131 codegen, 1172 objects in 781ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [7.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[8/1217] fetch zlib
[zlib] up to date
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lower/lower_decorators.rs       | 118 ++++++---------------
 src/js_parser/p.rs                            |  77 ++++++--------
 src/jsc/RuntimeTranspilerCache.rs             |   3 +-
 test/bundler/bundler_edgecase.test.ts         | 105 +++++++++++++++++++
 test/bundler/transpiler/es-decorators.test.ts | 145 ++++++++++++++++++++++++++
 5 files changed, 319 insertions(+), 129 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/lower/lower_decorators.rs           22     26     25
src/js_parser/p.rs                                13      7     24
src/jsc/RuntimeTranspilerCache.rs                  2      2     25
test/bundler/bundler_edgecase.test.ts              2      4     19
test/bundler/transpiler/es-decorators.test.ts      1      3     16
```

</details>

<!-- robobun:evidence:end -->