### PR TITLE
test(net): drive the TLS fault fixtures by events and assert their summaries

### DIFF
--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -13,7 +13,9 @@ const skip = !fault.available() || isWindows;
 // on success (or on a step deadline, with `error` set). `stderrTail` is only
 // populated when the fixture did not exit cleanly, so the abort/assertion
 // message shows up in the failure diff next to whatever summary it managed to
-// print.
+// print. Only the low-prio fixture needs fault injection; the sibling fixture
+// needs just `bun:internal-for-testing`, which `bunEnv` unlocks on every
+// build, so it runs on every lane like it did before.
 //
 // The explicit timeout is required: a bare `bun bd test <file>` applies Bun's
 // 5000ms default, and each fixture spawns two Bun processes and takes a few
@@ -98,7 +100,7 @@ test.concurrent.skipIf(skip)(
 // child's sockets received any bytes before the server closed them: none in
 // `walk` (every socket is paused), exactly the 5-per-iteration budget in
 // `parked`, which proves the other 59 were parked when stop(true) ran.
-test.concurrent.skipIf(skip)(
+test.concurrent(
   "TLS server.stop(true): a close handler that closes a sibling does not crash the teardown walk",
   async () => {
     const scenario = (kind: string, flightsReceived: number) => ({

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -288,8 +288,11 @@ test.concurrent.skipIf(!fault.available() || !isLinux)(
 // These run in the test process itself, and the send rule slot is process
 // global (one rule per syscall), so they must not overlap each other. They
 // are still `concurrent` so they overlap the fixture tests above, which only
-// wait on child processes; `serialized` chains them behind one another.
+// wait on child processes; `serialized` chains them behind one another. The
+// time a test spends waiting in that chain counts against its own timeout, so
+// each one gets an explicit timeout instead of Bun's 5000ms default.
 describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOTYPE)", () => {
+  const H2_TIMEOUT_MS = 30_000;
   let chain: Promise<unknown> = Promise.resolve();
   function serialized<T>(body: () => Promise<T>): Promise<T> {
     const run = chain.then(body, body);
@@ -351,7 +354,9 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
     client.on("goaway", code => events.push(`session-goaway:${code}`));
     client.on("connect", () => {
       const fd = (client.socket as any)?._handle?.fd ?? -1;
-      expect(fd).toBeGreaterThanOrEqual(0);
+      // Recorded rather than asserted here: a throw inside the listener would
+      // not reach the test body, while an unexpected event fails its toEqual.
+      if (fd < 0) events.push("connect:no-fd");
       fault.set({ syscall: "send", action: "errno", errno: "EPROTOTYPE", after: 0, repeat, fd });
     });
     const req = client.request({ ":path": "/" });
@@ -378,23 +383,26 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
     };
   }
 
-  test.concurrent("transient burst (x8) recovers: HEADERS, SETTINGS ACK and PING ACK all reach the server", () =>
-    serialized(async () => {
-      using h = await connectAndJam(8);
-      const pingAcked = new Promise<void>((resolve, reject) => {
-        h.setOnFrame(f => f === "t6a#0" && resolve());
-        h.client.on("close", () => reject(new Error(`session closed before PING ACK; tape: ${h.frames.join(",")}`)));
-      });
-      await pingAcked;
-      // Client SETTINGS, the request HEADERS (END_STREAM: no body), the ACK of
-      // the server's SETTINGS, then the PING ACK; nothing else, and no
-      // session or stream event.
-      expect({ frames: h.frames, events: h.events, destroyed: h.client.destroyed }).toEqual({
-        frames: ["t4#0", "t1a#1", "t4a#0", "t6a#0"],
-        events: [],
-        destroyed: false,
-      });
-    }),
+  test.concurrent(
+    "transient burst (x8) recovers: HEADERS, SETTINGS ACK and PING ACK all reach the server",
+    () =>
+      serialized(async () => {
+        using h = await connectAndJam(8);
+        const pingAcked = new Promise<void>((resolve, reject) => {
+          h.setOnFrame(f => f === "t6a#0" && resolve());
+          h.client.on("close", () => reject(new Error(`session closed before PING ACK; tape: ${h.frames.join(",")}`)));
+        });
+        await pingAcked;
+        // Client SETTINGS, the request HEADERS (END_STREAM: no body), the ACK of
+        // the server's SETTINGS, then the PING ACK; nothing else, and no
+        // session or stream event.
+        expect({ frames: h.frames, events: h.events, destroyed: h.client.destroyed }).toEqual({
+          frames: ["t4#0", "t1a#1", "t4a#0", "t6a#0"],
+          events: [],
+          destroyed: false,
+        });
+      }),
+    H2_TIMEOUT_MS,
   );
 
   // A fatal-classified errno (EPIPE) latches transport_write_fatal, but the
@@ -464,31 +472,35 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
           server.close();
         }
       }),
+    H2_TIMEOUT_MS,
   );
 
-  test.concurrent("sustained errno (forever) surfaces as session + stream close, not a silent half-alive jam", () =>
-    serialized(async () => {
-      using h = await connectAndJam(-1);
-      // No timers: the bounded retry exhausts within a handful of event-loop
-      // turns of writable retries, then the transport is torn down. A
-      // regression to the silent jam means these events never fire and the
-      // test times out. Manual listeners, not events.once(): that helper
-      // rejects when 'error' fires first, while here an unexpected 'error'
-      // should show up in the recorded event sequence instead.
-      await Promise.all([
-        new Promise<void>(resolve => h.client.once("close", () => resolve())),
-        new Promise<void>(resolve => h.req.once("close", () => resolve())),
-      ]);
-      // The session wrote its SETTINGS before 'connect' armed the rule, so that
-      // is the only frame on the wire. The stream is cancelled (RST_STREAM
-      // code 8) and the session destroyed without an 'error' event: the
-      // deferred close of a dead transport takes the same path as a peer
-      // disconnect.
-      expect({ frames: h.frames, events: h.events, destroyed: h.client.destroyed }).toEqual({
-        frames: ["t4#0"],
-        events: ["stream-close:8", "session-close"],
-        destroyed: true,
-      });
-    }),
+  test.concurrent(
+    "sustained errno (forever) surfaces as session + stream close, not a silent half-alive jam",
+    () =>
+      serialized(async () => {
+        using h = await connectAndJam(-1);
+        // No timers: the bounded retry exhausts within a handful of event-loop
+        // turns of writable retries, then the transport is torn down. A
+        // regression to the silent jam means these events never fire and the
+        // test times out. Manual listeners, not events.once(): that helper
+        // rejects when 'error' fires first, while here an unexpected 'error'
+        // should show up in the recorded event sequence instead.
+        await Promise.all([
+          new Promise<void>(resolve => h.client.once("close", () => resolve())),
+          new Promise<void>(resolve => h.req.once("close", () => resolve())),
+        ]);
+        // The session wrote its SETTINGS before 'connect' armed the rule, so that
+        // is the only frame on the wire. The stream is cancelled (RST_STREAM
+        // code 8) and the session destroyed without an 'error' event: the
+        // deferred close of a dead transport takes the same path as a peer
+        // disconnect.
+        expect({ frames: h.frames, events: h.events, destroyed: h.client.destroyed }).toEqual({
+          frames: ["t4#0"],
+          events: ["stream-close:8", "session-close"],
+          destroyed: true,
+        });
+      }),
+    H2_TIMEOUT_MS,
   );
 });

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -1,5 +1,5 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
@@ -7,6 +7,120 @@ import net from "node:net";
 import { join } from "node:path";
 
 const skip = !fault.available() || isWindows;
+
+// The two TLS fixtures below each run a server in a child Bun process and
+// drive raw TLS clients from a grandchild; they print one JSON summary line
+// on success (or on a step deadline, with `error` set). `stderrTail` is only
+// populated when the fixture did not exit cleanly, so the abort/assertion
+// message shows up in the failure diff next to whatever summary it managed to
+// print.
+//
+// The explicit timeout is required: a bare `bun bd test <file>` applies Bun's
+// 5000ms default, and each fixture spawns two Bun processes and takes a few
+// seconds on a debug+ASAN build.
+async function runFixture(name: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, name)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let summary: unknown = stdout.trim();
+  try {
+    summary = JSON.parse(stdout.trim().split("\n").pop()!);
+  } catch {}
+  return {
+    summary,
+    signalCode: proc.signalCode,
+    exitCode,
+    stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
+  };
+}
+
+// uSockets' TLS low-priority handshake queue (loop->data.low_prio_head)
+// shares its prev/next links with group->head_sockets. A socket already
+// parked in the queue used to be parked a SECOND time whenever a writable
+// dispatch re-enabled its readable poll bit (a backpressured handshake
+// flight retry does that), running us_internal_socket_group_unlink_socket on
+// low-prio-queue links and cross-wiring the two lists. In debug/ASAN builds
+// the double-incremented low_prio_count trips the group-deinit assertion; in
+// release builds freed sockets stay reachable from both lists
+// (heap-use-after-free in us_internal_socket_group_unlink_socket /
+// us_internal_handle_low_priority_sockets).
+//
+// Per wave of 32 sockets the fixture reports how many closed in the loop
+// iteration right after it made all 32 readable at once (`direct`: the
+// 5-per-iteration handshake budget) and how many closed in a later iteration
+// (`parked`: they sat in the queue and were re-enabled 5 per iteration, so
+// the last one closes ceil(27 / 5) + 1 = 7 iterations after the burst). A
+// fixture that stopped parking sockets would report direct: 32.
+test.concurrent.skipIf(skip)(
+  "TLS low-prio queue: a parked socket whose readable poll is re-enabled is not parked twice",
+  async () => {
+    const wave = { direct: 5, parked: 27, iterations: 7 };
+    expect(await runFixture("tls-low-prio-queue-fixture.ts")).toEqual({
+      summary: {
+        rounds: 2,
+        // 2 rounds x (1 primer + 2 waves x 32).
+        opened: 130,
+        closed: 130,
+        // Every wave socket is closed mid-handshake by the unread-ciphertext
+        // guard, which reports the handshake as failed; the primers are
+        // closed by stop(true) and report nothing.
+        handshakeFailed: 128,
+        handshakeOk: 0,
+        data: 0,
+        errors: 0,
+        waves: [wave, wave, wave, wave],
+      },
+      signalCode: null,
+      exitCode: 0,
+      stderrTail: "",
+    });
+  },
+  60_000,
+);
+
+// us_socket_group_close_all_ex walks group->head_sockets during
+// server.stop(true), closing each connection. Closing a socket dispatches its
+// JS close/handshake handler; if that handler closes a *sibling* connection,
+// the walk used to advance onto the freed sibling it had cached as `next` and
+// dereference its vtable (`panic: us_socket_t with kind=invalid`, a
+// use-after-free). The fixture's handlers close the sibling accepted right
+// before the socket being closed, which in the `walk` scenario is exactly the
+// walk's next entry, and in the `parked` scenario is one of the N - 5 sockets
+// sitting in the low-priority queue while stop(true) drains it.
+//
+// 64 sockets per scenario; each handler pair removes the socket being closed
+// plus two siblings, so 21 steps close 63 sockets and the last one has no
+// sibling left: 42 sibling closes. `flightsReceived` is how many of the
+// child's sockets received any bytes before the server closed them: none in
+// `walk` (every socket is paused), exactly the 5-per-iteration budget in
+// `parked`, which proves the other 59 were parked when stop(true) ran.
+test.concurrent.skipIf(skip)(
+  "TLS server.stop(true): a close handler that closes a sibling does not crash the teardown walk",
+  async () => {
+    const scenario = (kind: string, flightsReceived: number) => ({
+      kind,
+      opened: 64,
+      closed: 64,
+      handshakeFailed: 64,
+      handshakeOk: 0,
+      data: 0,
+      errors: 0,
+      siblingCloses: 42,
+      flightsReceived,
+    });
+    expect(await runFixture("tls-close-all-sibling-fixture.ts")).toEqual({
+      summary: { scenarios: [scenario("walk", 0), scenario("parked", 5)] },
+      signalCode: null,
+      exitCode: 0,
+      stderrTail: "",
+    });
+  },
+  60_000,
+);
 
 // us_poll_start_rc wraps uv_poll_init_socket on Windows and EPOLL_CTL_ADD /
 // kevent on posix. On Windows the return value was ignored, so an ioctlsocket
@@ -103,7 +217,7 @@ describe.skipIf(!fault.available())("poll_start failure is reported, not a crash
 // plain filter/poll change with nothing for the hook to fail. onread mode, because
 // like in node only that mode's pause() stops the handle (a plain pause() keeps
 // reading into the stream's buffer, which would deliver the reply as data here).
-test.skipIf(!fault.available() || !isLinux)(
+test.concurrent.skipIf(!fault.available() || !isLinux)(
   "resume() of a parked socket that cannot be registered again fails the socket instead of leaving it deaf",
   async () => {
     await using proc = Bun.spawn({
@@ -158,71 +272,6 @@ test.skipIf(!fault.available() || !isLinux)(
   },
 );
 
-// uSockets' TLS low-priority handshake queue (loop->data.low_prio_head)
-// shares its prev/next links with group->head_sockets. A socket already
-// parked in the queue used to be parked a SECOND time whenever a writable
-// dispatch re-enabled its readable poll bit (a backpressured handshake
-// flight retry does that), running us_internal_socket_group_unlink_socket on
-// low-prio-queue links and cross-wiring the two lists. In debug/ASAN builds
-// the double-incremented low_prio_count trips the group-deinit assertion; in
-// release builds freed sockets stay reachable from both lists
-// (heap-use-after-free in us_internal_socket_group_unlink_socket /
-// us_internal_handle_low_priority_sockets).
-//
-// The explicit timeout is required: a bare `bun bd test <file>` applies Bun's
-// 5000ms default, and this fixture spawns two Bun processes and has to hold
-// 32 concurrent TLS handshakes across several event-loop ticks, which takes
-// ~25s on a debug+ASAN build. 180s keeps comfortable headroom over the
-// CI runner's ASAN per-test budget instead of capping below it.
-test.skipIf(skip)(
-  "TLS low-prio queue: a parked socket whose readable poll is re-enabled is not parked twice",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "tls-low-prio-queue-fixture.ts")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // `stderrTail` is only populated when the fixture did not exit cleanly, so
-    // the abort/assertion message shows up in the failure diff.
-    expect({
-      stdout: stdout.trim(),
-      signalCode: proc.signalCode,
-      exitCode,
-      stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
-    }).toEqual({ stdout: "OK", signalCode: null, exitCode: 0, stderrTail: "" });
-  },
-  180_000,
-);
-
-// us_socket_group_close_all_ex walks group->head_sockets during
-// server.stop(true), closing each connection. Closing a socket dispatches its
-// JS close/handshake handler; if that handler closes a *sibling* connection,
-// the walk used to advance onto the freed sibling it had cached as `next` and
-// dereference its vtable (`panic: us_socket_t with kind=invalid`, a
-// use-after-free). The fixture reproduces it with a burst of TLS connections
-// torn down mid-handshake while the handlers close siblings.
-//
-// The explicit timeout matches the low-prio fixture above: this spawns child
-// Bun processes and drives hundreds of concurrent TLS handshakes across
-// several rounds, which runs long on a debug+ASAN build.
-test("TLS server.stop(true): a close handler that closes a sibling does not crash the teardown walk", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "tls-close-all-sibling-fixture.ts")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({
-    stdout: stdout.trim(),
-    signalCode: proc.signalCode,
-    exitCode,
-    stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
-  }).toEqual({ stdout: "OK", signalCode: null, exitCode: 0, stderrTail: "" });
-}, 180_000);
-
 // An injected send() errno that is neither would-block/transient
 // (EAGAIN/ENOBUFS/ENOMEM) nor a known peer-gone error (EPIPE/ECONNRESET/...)
 // exercises the bounded unclassified-errno retry in
@@ -235,11 +284,22 @@ test("TLS server.stop(true): a close handler that closes a sibling does not cras
 //     machinery with no observable hiccup, and
 //   - a sustained errno must surface as session teardown, never a silent
 //     half-alive jam with the bytes parked forever.
+//
+// These run in the test process itself, and the send rule slot is process
+// global (one rule per syscall), so they must not overlap each other. They
+// are still `concurrent` so they overlap the fixture tests above, which only
+// wait on child processes; `serialized` chains them behind one another.
 describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOTYPE)", () => {
-  afterEach(() => fault.clear());
+  let chain: Promise<unknown> = Promise.resolve();
+  function serialized<T>(body: () => Promise<T>): Promise<T> {
+    const run = chain.then(body, body);
+    chain = run.catch(() => {});
+    return run;
+  }
 
   /** Raw TCP server speaking just enough h2: tapes every client frame as
-   * "t<type><a if ACK flag>#<streamId>" and reports them via onFrame. */
+   * "t<type><a if flag 0x1: ACK, or END_STREAM on HEADERS>#<streamId>" and
+   * reports them via onFrame. */
   function rawH2Server(
     onFrame: (frame: string) => void,
     opts: { sendPing?: boolean; onSocket?: (socket: net.Socket) => void } = {},
@@ -276,24 +336,31 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
   }
 
   /** Connects an http2 client and arms the send-errno rule on its socket fd
-   * as soon as the session is connected (before the SETTINGS ACK window). */
+   * as soon as the session is connected (before the SETTINGS ACK window).
+   * Every session and stream lifecycle event is recorded in `events`. */
   async function connectAndJam(repeat: number) {
     const frames: string[] = [];
+    const events: string[] = [];
     let onFrame: (f: string) => void = f => frames.push(f);
     const server = rawH2Server(f => onFrame(f));
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
-    client.on("error", () => {});
+    client.on("error", e => events.push(`session-error:${(e as any).code ?? e.message}`));
+    client.on("close", () => events.push("session-close"));
+    client.on("goaway", code => events.push(`session-goaway:${code}`));
     client.on("connect", () => {
       const fd = (client.socket as any)?._handle?.fd ?? -1;
       expect(fd).toBeGreaterThanOrEqual(0);
       fault.set({ syscall: "send", action: "errno", errno: "EPROTOTYPE", after: 0, repeat, fd });
     });
     const req = client.request({ ":path": "/" });
-    req.on("error", () => {});
+    req.on("error", e => events.push(`stream-error:${(e as any).code ?? e.message}`));
+    req.on("aborted", () => events.push("stream-aborted"));
+    req.on("close", () => events.push(`stream-close:${req.rstCode}`));
     return {
       frames,
+      events,
       setOnFrame(f: (frame: string) => void) {
         onFrame = frame => {
           frames.push(frame);
@@ -311,92 +378,117 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
     };
   }
 
-  test("transient burst (x8) recovers: HEADERS, SETTINGS ACK and PING ACK all reach the server", async () => {
-    using h = await connectAndJam(8);
-    const pingAcked = new Promise<void>((resolve, reject) => {
-      h.setOnFrame(f => f === "t6a#0" && resolve());
-      h.client.on("close", () => reject(new Error(`session closed before PING ACK; tape: ${h.frames.join(",")}`)));
-    });
-    await pingAcked;
-    // type 1 = HEADERS (the request), t4a = client's SETTINGS ACK.
-    expect(h.frames.some(f => f.startsWith("t1"))).toBe(true);
-    expect(h.frames).toContain("t4a#0");
-  });
+  test.concurrent("transient burst (x8) recovers: HEADERS, SETTINGS ACK and PING ACK all reach the server", () =>
+    serialized(async () => {
+      using h = await connectAndJam(8);
+      const pingAcked = new Promise<void>((resolve, reject) => {
+        h.setOnFrame(f => f === "t6a#0" && resolve());
+        h.client.on("close", () => reject(new Error(`session closed before PING ACK; tape: ${h.frames.join(",")}`)));
+      });
+      await pingAcked;
+      // Client SETTINGS, the request HEADERS (END_STREAM: no body), the ACK of
+      // the server's SETTINGS, then the PING ACK; nothing else, and no
+      // session or stream event.
+      expect({ frames: h.frames, events: h.events, destroyed: h.client.destroyed }).toEqual({
+        frames: ["t4#0", "t1a#1", "t4a#0", "t6a#0"],
+        events: [],
+        destroyed: false,
+      });
+    }),
+  );
 
   // A fatal-classified errno (EPIPE) latches transport_write_fatal, but the
   // same flush() cycle retries the buffered bytes (_generic_flush after the
   // failed uncork write) and can drain them - kernels return racy one-off
   // send errnos on healthy sockets (macOS EPROTOTYPE->EPIPE class). The
   // deferred close must re-verify instead of killing the recovered session.
-  test("one-off fatal errno (EPIPE) whose bytes drain in the same flush cycle leaves the session alive", async () => {
-    const frames: string[] = [];
-    const waiters: Array<{ want: string; count: number; resolve: () => void }> = [];
-    const seen = (want: string) => frames.filter(f => f === want).length;
-    function frameSeen(want: string, count = 1) {
-      return new Promise<void>(resolve => {
-        if (seen(want) >= count) return resolve();
-        waiters.push({ want, count, resolve });
-      });
-    }
-    let rawSocket: net.Socket | undefined;
-    const server = rawH2Server(
-      f => {
-        frames.push(f);
-        for (let i = waiters.length - 1; i >= 0; i--) {
-          if (seen(waiters[i].want) >= waiters[i].count) waiters.splice(i, 1)[0].resolve();
+  test.concurrent(
+    "one-off fatal errno (EPIPE) whose bytes drain in the same flush cycle leaves the session alive",
+    () =>
+      serialized(async () => {
+        const frames: string[] = [];
+        const waiters: Array<{ want: string; count: number; resolve: () => void }> = [];
+        const seen = (want: string) => frames.filter(f => f === want).length;
+        function frameSeen(want: string, count = 1) {
+          return new Promise<void>(resolve => {
+            if (seen(want) >= count) return resolve();
+            waiters.push({ want, count, resolve });
+          });
         }
-      },
-      { sendPing: false, onSocket: s => (rawSocket = s) },
-    );
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
-    let terminal: string | null = null;
-    client.on("error", e => (terminal ??= `session-error:${(e as any).code ?? (e as Error).message}`));
-    client.on("close", () => (terminal ??= "session-close"));
-    const req = client.request({ ":path": "/" });
-    req.on("error", () => {});
-    try {
-      // The client's SETTINGS ACK on the wire means its write path is idle:
-      // the next client send is the PING ACK triggered below.
-      await frameSeen("t4a#0");
-      const fd = (client.socket as any)?._handle?.fd ?? -1;
-      expect(fd).toBeGreaterThanOrEqual(0);
-      fault.set({ syscall: "send", action: "errno", errno: "EPIPE", after: 0, repeat: 1, fd });
-      const acked = frameSeen("t6a#0");
-      rawSocket!.write(Buffer.concat([Buffer.from([0, 0, 8, 6, 0, 0, 0, 0, 0]), Buffer.alloc(8, 5)]));
-      await acked;
-      // The ACK reached the server, so the transport recovered. Bounded window
-      // for the stale-latch deferred close to fire (it runs from the deferred
-      // task queue within a few macrotask turns).
-      for (let i = 0; i < 20 && terminal === null; i++) {
-        await new Promise(r => setTimeout(r, 10));
-      }
-      expect(terminal).toBeNull();
-      // Second round-trip proves the session stayed fully alive.
-      const acked2 = frameSeen("t6a#0", 2);
-      rawSocket!.write(Buffer.concat([Buffer.from([0, 0, 8, 6, 0, 0, 0, 0, 0]), Buffer.alloc(8, 6)]));
-      await acked2;
-      expect({ terminal, destroyed: client.destroyed }).toEqual({ terminal: null, destroyed: false });
-    } finally {
-      fault.clear();
-      client.destroy();
-      server.close();
-    }
-  });
+        let rawSocket: net.Socket | undefined;
+        const server = rawH2Server(
+          f => {
+            frames.push(f);
+            for (let i = waiters.length - 1; i >= 0; i--) {
+              if (seen(waiters[i].want) >= waiters[i].count) waiters.splice(i, 1)[0].resolve();
+            }
+          },
+          { sendPing: false, onSocket: s => (rawSocket = s) },
+        );
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+        const events: string[] = [];
+        client.on("error", e => events.push(`session-error:${(e as any).code ?? e.message}`));
+        client.on("close", () => events.push("session-close"));
+        const req = client.request({ ":path": "/" });
+        req.on("error", e => events.push(`stream-error:${(e as any).code ?? e.message}`));
+        req.on("close", () => events.push(`stream-close:${req.rstCode}`));
+        try {
+          // The client's SETTINGS ACK on the wire means its write path is idle:
+          // the next client send is the PING ACK triggered below.
+          await frameSeen("t4a#0");
+          const fd = (client.socket as any)?._handle?.fd ?? -1;
+          expect(fd).toBeGreaterThanOrEqual(0);
+          fault.set({ syscall: "send", action: "errno", errno: "EPIPE", after: 0, repeat: 1, fd });
+          const acked = frameSeen("t6a#0");
+          rawSocket!.write(Buffer.concat([Buffer.from([0, 0, 8, 6, 0, 0, 0, 0, 0]), Buffer.alloc(8, 5)]));
+          await acked;
+          // The ACK reached the server, so the transport recovered. The
+          // stale-latch deferred close runs from the deferred task queue, once
+          // per loop iteration; give it several iterations to (wrongly) fire.
+          for (let i = 0; i < 10; i++) await new Promise(r => setImmediate(r));
+          expect(events).toEqual([]);
+          // Second round-trip proves the session stayed fully alive.
+          const acked2 = frameSeen("t6a#0", 2);
+          rawSocket!.write(Buffer.concat([Buffer.from([0, 0, 8, 6, 0, 0, 0, 0, 0]), Buffer.alloc(8, 6)]));
+          await acked2;
+          expect({ frames, events, destroyed: client.destroyed }).toEqual({
+            frames: ["t4#0", "t1a#1", "t4a#0", "t6a#0", "t6a#0"],
+            events: [],
+            destroyed: false,
+          });
+        } finally {
+          fault.clear();
+          client.destroy();
+          server.close();
+        }
+      }),
+  );
 
-  test("sustained errno (forever) surfaces as session + stream close, not a silent half-alive jam", async () => {
-    using h = await connectAndJam(-1);
-    // No timers: the bounded retry exhausts within a handful of event-loop
-    // turns of writable retries, then the transport is torn down. A
-    // regression to the silent jam means these events never fire and the
-    // test times out. Manual listeners, not events.once(): that helper
-    // rejects when 'error' fires first, and an 'error' preceding 'close' is
-    // an acceptable teardown ordering here.
-    await Promise.all([
-      new Promise<void>(resolve => h.client.once("close", () => resolve())),
-      new Promise<void>(resolve => h.req.once("close", () => resolve())),
-    ]);
-    expect(h.client.closed || h.client.destroyed).toBe(true);
-  });
+  test.concurrent("sustained errno (forever) surfaces as session + stream close, not a silent half-alive jam", () =>
+    serialized(async () => {
+      using h = await connectAndJam(-1);
+      // No timers: the bounded retry exhausts within a handful of event-loop
+      // turns of writable retries, then the transport is torn down. A
+      // regression to the silent jam means these events never fire and the
+      // test times out. Manual listeners, not events.once(): that helper
+      // rejects when 'error' fires first, while here an unexpected 'error'
+      // should show up in the recorded event sequence instead.
+      await Promise.all([
+        new Promise<void>(resolve => h.client.once("close", () => resolve())),
+        new Promise<void>(resolve => h.req.once("close", () => resolve())),
+      ]);
+      // The session wrote its SETTINGS before 'connect' armed the rule, so that
+      // is the only frame on the wire. The stream is cancelled (RST_STREAM
+      // code 8) and the session destroyed without an 'error' event: the
+      // deferred close of a dead transport takes the same path as a peer
+      // disconnect.
+      expect({ frames: h.frames, events: h.events, destroyed: h.client.destroyed }).toEqual({
+        frames: ["t4#0"],
+        events: ["stream-close:8", "session-close"],
+        destroyed: true,
+      });
+    }),
+  );
 });

--- a/test/js/bun/net/tls-close-all-sibling-fixture.ts
+++ b/test/js/bun/net/tls-close-all-sibling-fixture.ts
@@ -39,7 +39,9 @@ import tls from "node:tls";
 import { tls as certs, bunEnv, bunExe } from "harness";
 
 const N = 64;
-const STEP_DEADLINE_MS = 30_000;
+// Well inside the test's own timeout, so a stalled step still gets to print
+// the summary with `error` set instead of being killed silently.
+const STEP_DEADLINE_MS = 20_000;
 
 type Scenario = {
   kind: "walk" | "parked";
@@ -182,7 +184,7 @@ const lineWaiters: Array<(line: string) => void> = [];
       else lines.push(line);
     }
   }
-})();
+})().catch(e => report({ error: `child stdout reader failed: ${e}` }));
 function send(cmd: string) {
   child.stdin.write(cmd + "\n");
   child.stdin.flush();

--- a/test/js/bun/net/tls-close-all-sibling-fixture.ts
+++ b/test/js/bun/net/tls-close-all-sibling-fixture.ts
@@ -3,19 +3,71 @@
 //
 // us_socket_group_close_all_ex walks group->head_sockets to close every
 // connection during teardown. It used to cache `next = s->next` and then call
-// us_socket_close(s), which dispatches the JS close/handshake handler. If that
+// us_socket_close(s), which dispatches the JS handshake/close handlers. If a
 // handler closes a *sibling* connection (the one cached as `next`), the walk
-// then advanced onto freed memory. With a burst of a few hundred TLS
-// connections mid-handshake (overflowing the 5-per-tick handshake budget) the
-// crash is reliable: the event loop dispatches through a freed socket's vtable
-// and aborts with `panic: us_socket_t with kind=invalid`.
+// then advanced onto freed memory: the event loop dispatched through a freed
+// socket's vtable and aborted with `panic: us_socket_t with kind=invalid`.
+// Sockets parked in the loop-wide low-priority handshake queue are not in
+// head_sockets at all; close_all drains those separately and a handler may
+// close another parked socket while that drain runs.
 //
-// This fixture is the server: it closes a sibling from both the handshake and
-// close handlers, then floods itself from a CHILD process and tears down with
-// server.stop(true) while connections are still mid-handshake.
+// This fixture is the server. Its handshake and close handlers each close one
+// more live connection while the teardown runs, and a CHILD process supplies
+// the connections (raw TLS 1.2 ClientHellos, so every socket is mid-handshake
+// and a close dispatches handshake(false) and then close). Two scenarios, each
+// on a fresh listener:
+//
+//   walk:   every accepted socket is paused in `open`, so nothing is read and
+//           head_sockets keeps its link order (newest first). stop(true) then
+//           walks that list. The handlers close the live socket that was
+//           accepted right before the one being closed, which is exactly the
+//           walk's next entry, so every step of the walk lands on the path the
+//           fix guards.
+//   parked: the server resumes all N paused sockets at once. In the next loop
+//           iteration the 5-per-iteration handshake budget processes 5
+//           ClientHellos (their flights reach the child) and parks the rest in
+//           the low-priority queue. stop(true) runs in that same iteration, so
+//           it walks 5 sockets and then drains N - 5 parked ones while the
+//           handlers close parked siblings.
+//
+// The child reports how many of its sockets received any bytes before the
+// server closed them: 0 in `walk` and exactly 5 (the budget) in `parked`,
+// which is the proof that N - 5 sockets were parked when stop(true) ran.
+import { getEventLoopStats } from "bun:internal-for-testing";
 import net from "node:net";
 import tls from "node:tls";
 import { tls as certs, bunEnv, bunExe } from "harness";
+
+const N = 64;
+const STEP_DEADLINE_MS = 30_000;
+
+type Scenario = {
+  kind: "walk" | "parked";
+  opened: number;
+  closed: number;
+  handshakeFailed: number;
+  handshakeOk: number;
+  data: number;
+  errors: number;
+  siblingCloses: number;
+  flightsReceived: number;
+};
+const summary = { scenarios: [] as Scenario[] };
+
+function report(extra: Record<string, unknown> = {}): never {
+  console.log(JSON.stringify({ ...summary, ...extra }));
+  process.exit(extra.error ? 1 : 0);
+}
+
+function withDeadline<T>(promise: Promise<T>, step: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out waiting for ${step}`)), STEP_DEADLINE_MS);
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
+
+const iteration = () => getEventLoopStats().iteration;
 
 // Capture one real TLS 1.2 ClientHello record so raw net clients can replay it
 // without doing a full handshake. TLS 1.2 keeps the server waiting for the
@@ -47,7 +99,13 @@ async function captureClientHello(): Promise<Buffer> {
   const port = (srv.address() as net.AddressInfo).port;
   let c: tls.TLSSocket | undefined;
   try {
-    c = tls.connect({ port, host: "127.0.0.1", maxVersion: "TLSv1.2", minVersion: "TLSv1.2", rejectUnauthorized: false });
+    c = tls.connect({
+      port,
+      host: "127.0.0.1",
+      maxVersion: "TLSv1.2",
+      minVersion: "TLSv1.2",
+      rejectUnauthorized: false,
+    });
     c.on("error", reject);
     c.on("close", () => reject(new Error("tls.connect closed before the ClientHello was captured")));
     return await promise;
@@ -58,44 +116,121 @@ async function captureClientHello(): Promise<Buffer> {
 }
 
 const clientHello = await captureClientHello();
-const N = Number(process.env.REPRO_N || 240);
-const ROUNDS = Number(process.env.REPRO_ROUNDS || 3);
 
-// Child floods `N` raw TLS ClientHellos, staggered so they sit mid-handshake,
-// then fires a one-byte burst at all of them in a single tick and prints BURST.
+// The child reads one command per line on stdin:
+//   connect <n> <port> -> connects n sockets, writes ONLY the ClientHello to
+//                         each, answers `hellos <n>` once every write callback
+//                         has fired, and later `closed <n> <flights>` once all
+//                         n sockets have closed, where <flights> is how many
+//                         of them received any bytes first
+//   exit               -> exits 0
 const clientSrc = `
 const net = require("node:net");
-const port = Number(process.env.REPRO_PORT);
-const N = Number(process.env.REPRO_N);
+const readline = require("node:readline");
 const hello = Buffer.from(process.env.REPRO_HELLO, "hex");
-const socks = [];
-for (let i = 0; i < N; i++) {
-  const c = net.connect(port, "127.0.0.1");
-  c.setNoDelay(true);
-  c.on("error", () => {});
-  socks.push(c);
-  c.on("connect", () => setTimeout(() => { try { c.write(hello); } catch {} }, 30 + Math.floor(i / 4) * 40));
-}
-setTimeout(() => {
-  for (const c of socks) if (!c.destroyed) { try { c.write(Buffer.from([0])); } catch {} }
-  process.stdout.write("BURST\\n");
-}, 30 + Math.ceil(N / 4) * 40 + 300);
-setTimeout(() => process.exit(0), 60000);
+const say = line => process.stdout.write(line + "\\n");
+readline.createInterface({ input: process.stdin }).on("line", line => {
+  const [cmd, arg, arg2] = line.split(" ");
+  if (cmd === "connect") {
+    const n = Number(arg);
+    let connected = 0;
+    let written = 0;
+    let closed = 0;
+    let flights = 0;
+    const socks = [];
+    for (let i = 0; i < n; i++) {
+      const c = net.connect(Number(arg2), "127.0.0.1");
+      c.setNoDelay(true);
+      let gotData = false;
+      c.on("error", () => {});
+      c.on("data", () => { gotData = true; });
+      c.on("close", () => {
+        if (gotData) flights++;
+        if (++closed === n) say("closed " + n + " " + flights);
+      });
+      socks.push(c);
+      c.on("connect", () => {
+        if (++connected < n) return;
+        for (const s of socks) s.write(hello, () => { if (++written === n) say("hellos " + n); });
+      });
+    }
+  } else if (cmd === "exit") {
+    process.exit(0);
+  }
+});
 `;
 
-async function round() {
-  const socks: any[] = [];
-  let tearing = false;
-  function closeSibling(self: any) {
-    if (!tearing) return;
-    const i = socks.indexOf(self);
-    if (i < 0) return;
-    const other = socks[(i + (socks.length >> 1)) % socks.length];
-    if (other && other !== self) {
-      try {
-        other.end();
-      } catch {}
+const child = Bun.spawn({
+  cmd: [bunExe(), "-e", clientSrc],
+  env: { ...bunEnv, REPRO_HELLO: clientHello.toString("hex") },
+  stdin: "pipe",
+  stdout: "pipe",
+  stderr: "inherit",
+});
+const lines: string[] = [];
+const lineWaiters: Array<(line: string) => void> = [];
+(async () => {
+  let rest = "";
+  for await (const chunk of child.stdout.pipeThrough(new TextDecoderStream())) {
+    rest += chunk;
+    let nl;
+    while ((nl = rest.indexOf("\n")) >= 0) {
+      const line = rest.slice(0, nl);
+      rest = rest.slice(nl + 1);
+      const waiter = lineWaiters.shift();
+      if (waiter) waiter(line);
+      else lines.push(line);
     }
+  }
+})();
+function send(cmd: string) {
+  child.stdin.write(cmd + "\n");
+  child.stdin.flush();
+}
+async function nextLine(step: string): Promise<string> {
+  return withDeadline(
+    lines.length ? Promise.resolve(lines.shift()!) : new Promise<string>(r => lineWaiters.push(r)),
+    step,
+  );
+}
+async function expectLine(want: string) {
+  const got = await nextLine(`child to answer "${want}"`);
+  if (got !== want) report({ error: `child answered "${got}", expected "${want}"` });
+}
+
+async function scenario(kind: Scenario["kind"]) {
+  const stats: Scenario = {
+    kind,
+    opened: 0,
+    closed: 0,
+    handshakeFailed: 0,
+    handshakeOk: 0,
+    data: 0,
+    errors: 0,
+    siblingCloses: 0,
+    flightsReceived: -1,
+  };
+  const socks: Bun.Socket<undefined>[] = [];
+  const live = new Set<Bun.Socket<undefined>>();
+  const allOpen = Promise.withResolvers<void>();
+  let tearing = false;
+  // Only a handler running for the socket that close_all itself is closing
+  // picks a sibling; the sibling's own handlers (depth 2) do not, so the
+  // teardown never recurses more than one level.
+  let depth = 0;
+
+  // The live socket accepted right before `self`, or the one accepted right
+  // after it when `self` is the oldest one left. In `walk` the former is the
+  // entry close_all visits next.
+  function closeSibling(self: Bun.Socket<undefined>) {
+    if (!tearing || depth !== 1) return;
+    const i = socks.indexOf(self);
+    let other: Bun.Socket<undefined> | undefined;
+    for (let j = i - 1; j >= 0 && !other; j--) if (live.has(socks[j])) other = socks[j];
+    for (let j = i + 1; j < socks.length && !other; j++) if (live.has(socks[j])) other = socks[j];
+    if (!other) return;
+    stats.siblingCloses++;
+    other.end();
   }
 
   const server = Bun.listen({
@@ -104,58 +239,82 @@ async function round() {
     tls: { key: certs.key, cert: certs.cert },
     socket: {
       open(s) {
+        stats.opened++;
+        s.pause();
         socks.push(s);
+        live.add(s);
+        if (socks.length === N) allOpen.resolve();
       },
-      handshake(s) {
-        closeSibling(s);
+      handshake(s, success) {
+        if (success) stats.handshakeOk++;
+        else stats.handshakeFailed++;
+        depth++;
+        try {
+          closeSibling(s);
+        } finally {
+          depth--;
+        }
       },
-      data() {},
+      data() {
+        stats.data++;
+      },
       close(s) {
-        closeSibling(s);
+        stats.closed++;
+        live.delete(s);
+        depth++;
+        try {
+          closeSibling(s);
+        } finally {
+          depth--;
+        }
       },
-      error() {},
+      error() {
+        stats.errors++;
+      },
     },
   });
 
-  // The finally keeps a failed round (child crashed before BURST, spawn threw)
-  // from leaking the listener and hanging the fixture until the test timeout;
-  // stop(true) on an already-stopped listener is a no-op.
   try {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", clientSrc],
-      env: { ...bunEnv, REPRO_PORT: String(server.port), REPRO_N: String(N), REPRO_HELLO: clientHello.toString("hex") },
-      stdout: "pipe",
-      stderr: "ignore",
-    });
-
-    const reader = proc.stdout.getReader();
-    const dec = new TextDecoder();
-    let buf = "";
-    let sawBurst = false;
-    for (;;) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buf += dec.decode(value);
-      if (buf.includes("BURST")) {
-        // The stop must land HERE, while the burst holds connections
-        // mid-handshake, or the round doesn't exercise the teardown walk.
-        sawBurst = true;
-        tearing = true;
-        server.stop(true);
-        break;
-      }
+    send(`connect ${N} ${server.port}`);
+    await withDeadline(allOpen.promise, `${N} opens`);
+    await expectLine(`hellos ${N}`);
+    if (kind === "parked") {
+      for (const s of socks) s.resume();
+      // The resumed sockets are dispatched in the next loop iteration.
+      // Immediates run after an iteration's dispatch, so the first one that
+      // sees the counter advance runs with the budget spent and N - 5 sockets
+      // parked. (getEventLoopStats().iteration is us_internal_loop_pre's
+      // counter.)
+      const target = iteration() + 1;
+      while (iteration() < target) await new Promise(r => setImmediate(r));
     }
-    reader.cancel().catch(() => {});
-    proc.kill();
-    await proc.exited;
-    if (!sawBurst) throw new Error("flood child exited before printing BURST");
+    // The stop must land HERE, while every connection is mid-handshake, or the
+    // scenario does not exercise the teardown walk.
+    tearing = true;
+    server.stop(true);
+    tearing = false;
+    const closedLine = await nextLine("child to report its closes");
+    const m = /^closed (\d+) (\d+)$/.exec(closedLine);
+    if (!m || Number(m[1]) !== N) report({ error: `child answered "${closedLine}", expected "closed ${N} <flights>"` });
+    stats.flightsReceived = Number(m![2]);
   } finally {
     server.stop(true);
   }
+  summary.scenarios.push(stats);
 }
 
-for (let i = 0; i < ROUNDS; i++) {
-  await round();
+try {
+  await scenario("walk");
+  await scenario("parked");
+  // Finalize both Listeners while the process is still alive so their socket
+  // groups deinit (and assert that nothing is left parked).
   Bun.gc(true);
+  send("exit");
+  const exitCode = await withDeadline(child.exited, "child exit");
+  if (exitCode !== 0) report({ error: `client exited with ${exitCode}` });
+} catch (e) {
+  report({ error: String(e) });
+} finally {
+  child.kill();
 }
-console.log("OK");
+report();

--- a/test/js/bun/net/tls-close-all-sibling-fixture.ts
+++ b/test/js/bun/net/tls-close-all-sibling-fixture.ts
@@ -61,12 +61,18 @@ function report(extra: Record<string, unknown> = {}): never {
   process.exit(extra.error ? 1 : 0);
 }
 
+// Rejects when the child exits (set once it is spawned): a step still waiting
+// on it then fails at once with the exit status instead of at its deadline.
+let childGone: Promise<never> | null = null;
+
 function withDeadline<T>(promise: Promise<T>, step: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new Error(`timed out waiting for ${step}`)), STEP_DEADLINE_MS);
   });
-  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+  return Promise.race(childGone ? [promise, deadline, childGone] : [promise, deadline]).finally(() =>
+    clearTimeout(timer),
+  );
 }
 
 const iteration = () => getEventLoopStats().iteration;
@@ -169,6 +175,11 @@ const child = Bun.spawn({
   stdout: "pipe",
   stderr: "inherit",
 });
+childGone = child.exited.then(code => {
+  throw new Error(`child exited (code ${code}, signal ${child.signalCode}) before the fixture finished`);
+});
+// Only the races in withDeadline consume the rejection.
+childGone.catch(() => {});
 const lines: string[] = [];
 const lineWaiters: Array<(line: string) => void> = [];
 (async () => {

--- a/test/js/bun/net/tls-low-prio-queue-fixture.ts
+++ b/test/js/bun/net/tls-low-prio-queue-fixture.ts
@@ -1,10 +1,11 @@
 // Regression fixture for the TLS low-priority handshake queue.
 //
-// uSockets throttles concurrent TLS handshakes: when the per-tick budget (5)
-// is exhausted, the readable dispatch PARKS the socket in the loop-wide
+// uSockets throttles concurrent TLS handshakes: when the per-iteration budget
+// (5) is exhausted, the readable dispatch PARKS the socket in the loop-wide
 // low-priority queue (loop->data.low_prio_head), unlinking it from
 // group->head_sockets (the two lists share the prev/next fields) and
-// disabling READABLE on its poll.
+// disabling READABLE on its poll. Every later loop iteration re-enables 5
+// parked sockets.
 //
 // A parked socket can still get a WRITABLE dispatch. If its handshake flight
 // is backpressured, us_internal_ssl_on_writable retries the BIO write, and
@@ -21,8 +22,41 @@
 // This fixture is the server: it arms a process-wide `send -> 0` fault so
 // every handshake flight is permanently backpressured, and drives N raw TLS
 // clients from a CHILD process (the fault is process-global, and the clients'
-// ClientHello delivery must not be affected).
-import { socketFaultInjection as fault } from "bun:internal-for-testing";
+// ClientHello delivery must not be affected). Server and child talk over the
+// child's stdio, one line per step, so no step waits for a timer.
+//
+// One wave:
+//   1. The child connects N sockets. The server pauses each accepted socket in
+//      `open`, so the ClientHellos the child then writes stay unread in the
+//      kernel buffers. The child reports `hellos` once every write callback
+//      has fired.
+//   2. The server resumes all N at once: N readables land in one loop
+//      iteration, the budget processes 5 ClientHellos (flight -> send() -> 0
+//      -> WANT_WRITE) and parks the rest at the ClientHello stage. Each later
+//      iteration re-enables 5 more, so after ceil(N / 5) + 1 iterations every
+//      socket has a backpressured flight. The server counts iterations
+//      (getEventLoopStats().iteration is us_internal_loop_pre's counter) and
+//      then pauses all N again.
+//   3. The child writes one byte to each socket and reports `bursted`. The
+//      server resumes all N at once: N readables in one iteration again. The
+//      budget processes 5 (the byte is unread ciphertext after WANT_WRITE, so
+//      on_data closes them in that same iteration) and parks N - 5 with their
+//      flight still pending. Every iteration after that re-enables 5 parked
+//      sockets (each then closes the same way), while the still-parked ones
+//      get their WRITABLE retry, which re-enables READABLE, and then a
+//      READABLE dispatch with the budget exhausted: the guarded path.
+//
+// The parked count is observable without a native counter: a socket that
+// closes in the iteration right after the resume was processed directly; one
+// that closes later was parked and re-enabled. The summary reports both per
+// wave and the test asserts the exact split.
+//
+// One extra "primer" connection per round takes the first handshake flight:
+// that flight is batched and its ciphertext occupies the loop's single spill
+// slot (ssl_spill_owner), and a spill owner never hits the unread-ciphertext
+// close in step 3. With the slot taken, all N wave sockets take the same
+// per-record WANT_WRITE path and the per-wave numbers are exact.
+import { socketFaultInjection as fault, getEventLoopStats } from "bun:internal-for-testing";
 import net from "node:net";
 import tls from "node:tls";
 import { tls as certs, bunEnv, bunExe } from "harness";
@@ -31,6 +65,44 @@ if (!fault.available()) throw new Error("socket fault injection is not available
 
 const N = 32;
 const ROUNDS = 2;
+const WAVES = 2;
+// MAX_LOW_PRIO_SOCKETS_PER_LOOP_ITERATION in packages/bun-usockets/src/loop.c.
+const BUDGET = 5;
+const STEP_DEADLINE_MS = 30_000;
+
+type Wave = { direct: number; parked: number; iterations: number };
+const summary = {
+  rounds: 0,
+  opened: 0,
+  closed: 0,
+  handshakeFailed: 0,
+  handshakeOk: 0,
+  data: 0,
+  errors: 0,
+  waves: [] as Wave[],
+};
+
+function report(extra: Record<string, unknown> = {}): never {
+  console.log(JSON.stringify({ ...summary, ...extra }));
+  process.exit(extra.error ? 1 : 0);
+}
+
+function withDeadline<T>(promise: Promise<T>, step: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out waiting for ${step}`)), STEP_DEADLINE_MS);
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
+
+const iteration = () => getEventLoopStats().iteration;
+
+// Each setImmediate turn is one us_internal_loop_pre, but count the loop's own
+// iterations rather than the turns so the wait is exact.
+async function afterIterations(n: number) {
+  const target = iteration() + n;
+  while (iteration() < target) await new Promise(r => setImmediate(r));
+}
 
 // Capture one real TLS 1.2 ClientHello record so raw net clients can replay
 // it. TLS 1.2 keeps the server waiting for the client's second flight after
@@ -87,44 +159,125 @@ async function captureClientHello(): Promise<Buffer> {
 
 const clientHello = await captureClientHello();
 
-// One "wave": connect N clients, stagger their ClientHellos so the server
-// processes each without parking, then hit all N server sockets with a byte
-// in one synchronous burst so N readables land in one server tick and the
-// budget exhausts. The parked sockets never recv the byte (the low-prio gate
-// breaks before the recv loop) so it stays buffered, keeping them
-// level-readable on every subsequent tick.
+// The child reads one command per line on stdin and answers one line on
+// stdout once the command's effect has reached the kernel (write callbacks)
+// or the sockets are gone (close events).
+//   connect <n> <port> -> connects n sockets and writes ONLY the ClientHello
+//                         to each (trailing bytes in the same segment would
+//                         trip the unread-ciphertext close in on_data before
+//                         the socket can be parked); answers `hellos <n>`
+//   burst              -> writes one byte to each socket of the last batch;
+//                         answers `bursted <n>`
+//   reset              -> destroys every socket; answers `reset` once all of
+//                         them have closed
+//   exit               -> exits 0
 const clientSrc = `
 const net = require("node:net");
-const port = Number(process.env.REPRO_PORT);
-const N = Number(process.env.REPRO_N);
+const readline = require("node:readline");
 const hello = Buffer.from(process.env.REPRO_HELLO, "hex");
-function wave() {
-  const socks = [];
-  for (let i = 0; i < N; i++) {
-    const c = net.connect(port, "127.0.0.1");
-    c.setNoDelay(true);
-    c.on("error", () => {});
-    socks.push(c);
-    // ONLY the ClientHello. Trailing bytes in the same segment would trip the
-    // "unread ciphertext after WANT_WRITE" close guard in on_data and destroy
-    // the socket before it can be parked.
-    c.on("connect", () => setTimeout(() => c.write(hello), 40 + Math.floor(i / 3) * 70));
-  }
-  setTimeout(() => {
-    for (let i = 0; i < N; i++) if (!socks[i].destroyed) socks[i].write(Buffer.from([0]));
-    // Mixed staggered teardown so closes land while peers sit in the queue.
-    setTimeout(() => {
-      for (let i = 0; i < N; i++) {
-        const c = socks[i];
-        setTimeout(() => (i % 3 === 0 ? c.resetAndDestroy() : c.destroy()), (i % 9) * 30);
-      }
-    }, 900);
-  }, 40 + Math.ceil(N / 3) * 70 + 500);
+const say = line => process.stdout.write(line + "\\n");
+let all = [];
+let batch = [];
+function writeAll(socks, data, done) {
+  let pending = socks.length;
+  if (!pending) return done();
+  for (const c of socks) c.write(data, () => { if (--pending === 0) done(); });
 }
-let off = 0;
-for (let w = 0; w < 3; w++) { setTimeout(wave, off); off += 40 + Math.ceil(N / 3) * 70 + 1900; }
-setTimeout(() => process.exit(0), off + 2000);
+readline.createInterface({ input: process.stdin }).on("line", line => {
+  const [cmd, arg, arg2] = line.split(" ");
+  if (cmd === "connect") {
+    const n = Number(arg);
+    batch = [];
+    let connected = 0;
+    for (let i = 0; i < n; i++) {
+      const c = net.connect(Number(arg2), "127.0.0.1");
+      c.setNoDelay(true);
+      c.on("error", () => {});
+      batch.push(c);
+      all.push(c);
+      c.on("connect", () => {
+        if (++connected === n) writeAll(batch, hello, () => say("hellos " + n));
+      });
+    }
+  } else if (cmd === "burst") {
+    const live = batch.filter(c => !c.destroyed);
+    writeAll(live, Buffer.from([0]), () => say("bursted " + live.length));
+  } else if (cmd === "reset") {
+    const open = all.filter(c => !c.closed);
+    all = [];
+    batch = [];
+    let pending = open.length;
+    if (!pending) return say("reset");
+    for (const c of open) {
+      c.once("close", () => { if (--pending === 0) say("reset"); });
+      c.destroy();
+    }
+  } else if (cmd === "exit") {
+    process.exit(0);
+  }
+});
 `;
+
+const child = Bun.spawn({
+  cmd: [bunExe(), "-e", clientSrc],
+  env: { ...bunEnv, REPRO_HELLO: clientHello.toString("hex") },
+  stdin: "pipe",
+  stdout: "pipe",
+  stderr: "inherit",
+});
+const lines: string[] = [];
+const lineWaiters: Array<(line: string) => void> = [];
+(async () => {
+  let rest = "";
+  for await (const chunk of child.stdout.pipeThrough(new TextDecoderStream())) {
+    rest += chunk;
+    let nl;
+    while ((nl = rest.indexOf("\n")) >= 0) {
+      const line = rest.slice(0, nl);
+      rest = rest.slice(nl + 1);
+      const waiter = lineWaiters.shift();
+      if (waiter) waiter(line);
+      else lines.push(line);
+    }
+  }
+})();
+function send(cmd: string) {
+  child.stdin.write(cmd + "\n");
+  child.stdin.flush();
+}
+async function expectLine(want: string) {
+  const got = await withDeadline(
+    lines.length ? Promise.resolve(lines.shift()!) : new Promise<string>(r => lineWaiters.push(r)),
+    `child to answer "${want}"`,
+  );
+  if (got !== want) report({ error: `child answered "${got}", expected "${want}"` });
+}
+
+type Batch = {
+  socks: Bun.Socket<undefined>[];
+  allOpen: PromiseWithResolvers<void>;
+  allClosed: PromiseWithResolvers<void>;
+  expected: number;
+  burstIteration: number;
+  direct: number;
+  late: number;
+  lastCloseIteration: number;
+};
+
+function newBatch(expected: number): Batch {
+  return {
+    socks: [],
+    allOpen: Promise.withResolvers<void>(),
+    allClosed: Promise.withResolvers<void>(),
+    expected,
+    burstIteration: -1,
+    direct: 0,
+    late: 0,
+    lastCloseIteration: -1,
+  };
+}
+
+let current: Batch | null = null;
 
 async function round() {
   // Bun.listen({tls}) is the native SSL listen path: us_internal_ssl_attach()
@@ -132,16 +285,40 @@ async function round() {
   // gate on its very first readable dispatch. `server` is local so each
   // round's Listener can be finalized (which is where the group deinit
   // asserts low_prio_count == 0).
-  let server: ReturnType<typeof Bun.listen> | null = Bun.listen({
+  const server = Bun.listen({
     hostname: "127.0.0.1",
     port: 0,
     tls: { key: certs.key, cert: certs.cert },
     socket: {
-      open() {},
-      data() {},
-      close() {},
-      error() {},
-      handshake() {},
+      open(s) {
+        summary.opened++;
+        // Reads stay off until the server resumes the whole batch at once.
+        s.pause();
+        const batch = current!;
+        batch.socks.push(s);
+        if (batch.socks.length === batch.expected) batch.allOpen.resolve();
+      },
+      close() {
+        summary.closed++;
+        const batch = current;
+        if (!batch || batch.burstIteration < 0) return;
+        const it = iteration();
+        batch.lastCloseIteration = it;
+        if (it === batch.burstIteration + 1) batch.direct++;
+        else batch.late++;
+        if (batch.direct + batch.late === batch.expected) batch.allClosed.resolve();
+      },
+      data() {
+        summary.data++;
+      },
+      error() {
+        summary.errors++;
+      },
+      // A socket closed mid-handshake reports the handshake as failed.
+      handshake(_s, success) {
+        if (success) summary.handshakeOk++;
+        else summary.handshakeFailed++;
+      },
     },
   });
 
@@ -149,43 +326,72 @@ async function round() {
   // stay WANT_WRITE forever and every writable retry re-issues
   // us_poll_change(READABLE|WRITABLE), including on already-parked sockets.
   // The faults are process-wide, so clear them even if the child fails.
-  try {
-    // fault.set returns false if the rule could not be armed; without the
-    // forced backpressure nothing ever parks, so that must fail the fixture.
-    if (!fault.set({ syscall: "send", action: "zero", repeat: -1 })) {
-      throw new Error("failed to arm the send socket fault");
-    }
-    if (!fault.set({ syscall: "writev", action: "zero", repeat: -1 })) {
-      throw new Error("failed to arm the writev socket fault");
-    }
+  // fault.set returns false if the rule could not be armed; without the
+  // forced backpressure nothing ever parks, so that must fail the fixture.
+  if (!fault.set({ syscall: "send", action: "zero", repeat: -1 })) {
+    report({ error: "failed to arm the send socket fault" });
+  }
+  if (!fault.set({ syscall: "writev", action: "zero", repeat: -1 })) {
+    report({ error: "failed to arm the writev socket fault" });
+  }
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", clientSrc],
-      env: {
-        ...bunEnv,
-        REPRO_PORT: String(server.port),
-        REPRO_N: String(N),
-        REPRO_HELLO: clientHello.toString("hex"),
-      },
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    const clientExitCode = await proc.exited;
-    // Without the clients the server sockets never park, so a broken client
-    // script must fail the fixture rather than let it still print OK.
-    if (clientExitCode !== 0) throw new Error(`client fixture exited with ${clientExitCode}`);
+  try {
+    // Primer: see the header comment. Its ClientHello is processed alone and
+    // its flight becomes the spill owner.
+    current = newBatch(1);
+    send(`connect 1 ${server.port}`);
+    await withDeadline(current.allOpen.promise, "primer open");
+    await expectLine("hellos 1");
+    for (const s of current.socks) s.resume();
+    await afterIterations(2);
+
+    for (let w = 0; w < WAVES; w++) {
+      const batch = (current = newBatch(N));
+      send(`connect ${N} ${server.port}`);
+      await withDeadline(batch.allOpen.promise, `${N} opens`);
+      await expectLine(`hellos ${N}`);
+      // Step 2: every ClientHello becomes readable in the next iteration.
+      for (const s of batch.socks) s.resume();
+      await afterIterations(Math.ceil(N / BUDGET) + 2);
+      for (const s of batch.socks) s.pause();
+      // Step 3.
+      send("burst");
+      await expectLine(`bursted ${N}`);
+      batch.burstIteration = iteration();
+      for (const s of batch.socks) s.resume();
+      await withDeadline(batch.allClosed.promise, `${N} closes after the burst`);
+      summary.waves.push({
+        direct: batch.direct,
+        parked: batch.late,
+        iterations: batch.lastCloseIteration - batch.burstIteration,
+      });
+    }
+    current = null;
+    send("reset");
+    await expectLine("reset");
+  } catch (e) {
+    report({ error: String(e) });
   } finally {
     fault.clear();
     server.stop(true);
-    server = null;
   }
+  summary.rounds++;
 }
 
-for (let i = 0; i < ROUNDS; i++) {
-  await round();
-  // Finalize the round's Listener so its socket group deinits.
-  Bun.gc(true);
-  await Bun.sleep(30);
-  Bun.gc(true);
+try {
+  for (let i = 0; i < ROUNDS; i++) {
+    await round();
+    // Finalize the round's Listener so its socket group deinits.
+    Bun.gc(true);
+    await afterIterations(2);
+    Bun.gc(true);
+  }
+  send("exit");
+  const exitCode = await withDeadline(child.exited, "child exit");
+  if (exitCode !== 0) report({ error: `child exited with ${exitCode}` });
+} catch (e) {
+  report({ error: String(e) });
+} finally {
+  child.kill();
 }
-console.log("OK");
+report();

--- a/test/js/bun/net/tls-low-prio-queue-fixture.ts
+++ b/test/js/bun/net/tls-low-prio-queue-fixture.ts
@@ -68,7 +68,9 @@ const ROUNDS = 2;
 const WAVES = 2;
 // MAX_LOW_PRIO_SOCKETS_PER_LOOP_ITERATION in packages/bun-usockets/src/loop.c.
 const BUDGET = 5;
-const STEP_DEADLINE_MS = 30_000;
+// Well inside the test's own timeout, so a stalled step still gets to print
+// the summary with `error` set instead of being killed silently.
+const STEP_DEADLINE_MS = 20_000;
 
 type Wave = { direct: number; parked: number; iterations: number };
 const summary = {
@@ -240,7 +242,7 @@ const lineWaiters: Array<(line: string) => void> = [];
       else lines.push(line);
     }
   }
-})();
+})().catch(e => report({ error: `child stdout reader failed: ${e}` }));
 function send(cmd: string) {
   child.stdin.write(cmd + "\n");
   child.stdin.flush();
@@ -298,10 +300,12 @@ async function round() {
         batch.socks.push(s);
         if (batch.socks.length === batch.expected) batch.allOpen.resolve();
       },
-      close() {
+      close(s) {
         summary.closed++;
         const batch = current;
-        if (!batch || batch.burstIteration < 0) return;
+        // Only the current wave's sockets count toward its split; the primer
+        // and any other socket just land in the total above.
+        if (!batch || batch.burstIteration < 0 || !batch.socks.includes(s)) return;
         const it = iteration();
         batch.lastCloseIteration = it;
         if (it === batch.burstIteration + 1) batch.direct++;

--- a/test/js/bun/net/tls-low-prio-queue-fixture.ts
+++ b/test/js/bun/net/tls-low-prio-queue-fixture.ts
@@ -89,12 +89,18 @@ function report(extra: Record<string, unknown> = {}): never {
   process.exit(extra.error ? 1 : 0);
 }
 
+// Rejects when the child exits (set once it is spawned): a step still waiting
+// on it then fails at once with the exit status instead of at its deadline.
+let childGone: Promise<never> | null = null;
+
 function withDeadline<T>(promise: Promise<T>, step: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new Error(`timed out waiting for ${step}`)), STEP_DEADLINE_MS);
   });
-  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+  return Promise.race(childGone ? [promise, deadline, childGone] : [promise, deadline]).finally(() =>
+    clearTimeout(timer),
+  );
 }
 
 const iteration = () => getEventLoopStats().iteration;
@@ -227,6 +233,11 @@ const child = Bun.spawn({
   stdout: "pipe",
   stderr: "inherit",
 });
+childGone = child.exited.then(code => {
+  throw new Error(`child exited (code ${code}, signal ${child.signalCode}) before the fixture finished`);
+});
+// Only the races in withDeadline consume the rejection.
+childGone.catch(() => {});
 const lines: string[] = [];
 const lineWaiters: Array<(line: string) => void> = [];
 (async () => {


### PR DESCRIPTION
### Problem
- `test/js/bun/net/socket-syscall-fault.test.ts` took 8.4s on every release lane and 31s on the ASAN lane (build #108217). Its two TLS fixtures ran on fixed timers: 2.7s per wave plus 2s of padding in the low-prio fixture, 240 staggered ClientHellos per round in the sibling fixture.
- The timers also made the low-prio fixture weak. Traced locally, its 32 one-byte writes spread over several loop iterations: 6 waves hit the double-park guard 5 times in total, and 4 waves never hit it.

### Fix
- The fixtures drive their client child over stdio, one line per step. The server pauses accepted sockets in `open` and resumes them all at once, so N readables land in one loop iteration: 27 of 32 sockets park per wave, and the sibling fixture stops the server with 59 of 64 sockets parked. Its `walk` scenario closes exactly the walk's next entry at every step.
- Each fixture prints a JSON summary (opened, closed, handshake results, direct/parked split per wave, sibling closes, flights the child received) that the test checks with `toEqual`. All tests in the file run concurrently. The h2 tests chain behind one another (one process-global send rule slot) and assert exact frame tapes and event sequences. The sibling test keeps running on every lane, Windows included: its fixture needs no fault injection.
- Verified: 9.1 to 9.6s over 5 runs of `bun bd test` (debug+ASAN), down from 49.2s. With the low-prio fix reverted, the fixture aborts at the `low_prio_count == 0` deinit assertion. With the pre-fix close_all walk restored, the sibling fixture panics with `us_socket_t with kind=invalid`.

### Background
- uSockets processes at most 5 mid-handshake TLS reads per loop iteration. The rest are unlinked from `group->head_sockets` and parked in `loop->data.low_prio_head` with READABLE off. Each later iteration re-enables 5.
- The guarded path in `loop.c`: a parked socket whose writable retry re-enabled READABLE must not be parked again. A process-wide `send -> 0` fault keeps every handshake flight backpressured, so that retry runs every iteration.
- `getEventLoopStats().iteration` is `us_internal_loop_pre`'s counter. The fixtures use it to wait an exact number of iterations, and to tell a socket processed in the burst iteration from a parked one.

<details><summary>Notes</summary>

**Timing (local debug+ASAN, linux x64).** Before: whole file 49.2s (low-prio test 24.3s, sibling test 17.5s, everything else sequential). After, 5 runs of the whole file: 9.06s, 9.13s, 9.19s, 9.32s, 9.60s. The two fixture tests take 6.1 to 7.0s each and overlap. `USE_SYSTEM_BUN=1 bun test` skips all 9 tests (the release binary has no fault injection), as before.

**How the guarded paths were confirmed.** Local-only `fprintf` probes in `loop.c` (park, unpark, the `low_prio_state == 1` break) and `context.c` (an unlink of `group->iterator` during close_all), not part of this PR:

- Old low-prio fixture: 94 parks in 6 waves, 5 guard hits, 4 waves with 0 hits. The loop spins at about 65us per iteration because of the EPOLLOUT retries, so the client's 32 writes rarely coalesce.
- New low-prio fixture: per wave, 27 parks at the ClientHello stage, 27 parks at the burst, then 17 + 7 guard hits (iterations burst+2 and burst+4). 96 hits per run, identical over 5 runs. With `if (flags->low_prio_state == 1) break;` disabled the run aborts at `context.c:61 us_socket_group_deinit: Assertion 'group->low_prio_count == 0' failed` after 48 double parks.
- Old sibling fixture: the handler closed the walk's next socket 3 times in 3 rounds, and `low_prio_count` was 0 when the head_sockets walk ended in every round, so the low-prio drain in close_all never ran.
- New sibling fixture: `walk` scenario 42 next-entry closes (one per sibling close); `parked` scenario ends the head_sockets walk with `low_prio_count == 58` and drains those through the low-prio loop. With the cached-`next` walk and the old drain loop from `529adec09e^` restored, the `walk` scenario panics with `us_socket_t with kind=invalid (group=0x...)`.

**Why the numbers are exact.** `direct: 5` is the per-iteration budget, `parked: 27` is N - 5, `iterations: 7` is ceil(27 / 5) + 1. One primer connection per round takes the first handshake flight: that flight is batched and its ciphertext owns the loop's spill slot, and a spill owner never hits the unread-ciphertext close in the burst. Without it one socket per round would close at a different time. In the sibling fixture each depth-1 close removes the socket plus two siblings, so 64 sockets give 21 steps and 42 sibling closes; `flightsReceived` is 0 in `walk` (all paused) and exactly the budget (5) in `parked`.

**Assertions added.** Low-prio: `{rounds, opened, closed, handshakeFailed, handshakeOk, data, errors, waves[4]}` with exact values (was `stdout: "OK"`). Sibling: two scenarios with `{opened, closed, handshakeFailed, handshakeOk, data, errors, siblingCloses, flightsReceived}` (was `stdout: "OK"`). h2 transient: exact tape `t4#0, t1a#1, t4a#0, t6a#0`, no session or stream events. h2 EPIPE: exact tape with both PING ACKs, no events, replaces the 20 x 10ms `setTimeout` poll with 10 loop iterations. h2 sustained: tape `t4#0`, events `stream-close:8, session-close`, `destroyed: true`. The `{summary, signalCode, exitCode, stderrTail}` shape is kept so a crash still shows its stderr tail in the diff. The per-test timeouts drop from 180s to 60s; each fixture step has its own 30s deadline and reports a partial summary with `error` when it fires.

**Windows.** The sibling fixture ran on Windows x64 with a release build (the canary): five runs print the same summary in about 130ms each, so the pause/resume iteration counting also holds under libuv. The low-prio fixture and the h2 tests stay gated on fault injection and not-Windows, as before.

**Other suites run.** `test/js/bun/net/socket-syscall-fault.test.ts` only (5 full runs plus single-fixture runs). The change touches no other file.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket-syscall-fault.test.ts

<!-- robobun:evidence:end -->