### PR TITLE
js_parser: record one use of the classic JSX factory per element

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4780,12 +4780,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<Expr, crate::Error> {
         let result = self.find_symbol(loc, parts[0])?;
 
+        // `find_symbol` recorded the use. A name here would make `handle_identifier`
+        // resolve it again and count a second use per JSX element.
         let value = self.handle_identifier(
             loc,
             E::Identifier::init(result.r#ref)
                 .with_must_keep_due_to_with_stmt(result.is_inside_with_scope)
                 .with_can_be_removed_if_unused(true),
-            Some(parts[0]),
+            None,
             IdentifierOpts::new().with_was_originally_identifier(true),
         );
         if parts.len() > 1 {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -506,6 +506,32 @@ describe("bundler", () => {
       expect(file).toContain('import * as React from "react"');
     },
   });
+  // A factory reached through a namespace import only uses the factory export,
+  // the same as writing `H.h(...)` by hand. Counting it as a use of `H` itself
+  // would make the bundle build the namespace object and keep every sibling.
+  itBundled("jsx/FactoryThroughNamespaceImportOnlyUsesFactory", {
+    files: {
+      "/index.jsx": /* jsx */ `
+        import * as H from "hyper";
+        console.log(JSON.stringify([<div id="x">hi</div>, <>frag</>]));
+      `,
+      "/node_modules/hyper/index.js": /* js */ `
+        export function h(tag, props, ...children) { return [tag, props, children]; }
+        export function Fragment() {}
+        export const unusedSibling = "REMOVE";
+      `,
+    },
+    jsx: {
+      runtime: "classic",
+      factory: "H.h",
+      fragment: "H.Fragment",
+    },
+    dce: true,
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toContain("__export(");
+    },
+    run: { stdout: '[["div",{"id":"x"},["hi"]],[null,null,["frag"]]]' },
+  });
   itBundled("jsx/jsxImportSource pragma works", {
     files: {
       "/index.jsx": /* jsx */ `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2197,6 +2197,26 @@ export default <>hi</>
     expect(exitCode).toBe(0);
   });
 
+  // Each JSX element is one use of its factory, so a factory that is a
+  // single-use local is inlined exactly like the equivalent hand-written call.
+  it("a JSX element counts as one use of a classic factory", () => {
+    const minifier = new Bun.Transpiler({ loader: "jsx", minify: { syntax: true } });
+    const code = minifier.transformSync(`
+      /* @jsxRuntime classic */
+      /* @jsx h */
+      export function render(mk) {
+        const h = mk();
+        return <div id="x">hi</div>;
+      }
+    `);
+    expect(code).toBe(`export function render(mk) {
+  return mk()("div", {
+    id: "x"
+  }, "hi");
+}
+`);
+  });
+
   it("JSX keys", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",


### PR DESCRIPTION
### Problem
- With the classic JSX runtime, each JSX element counts as two uses of its factory. `jsx_strings_to_member_expression` (`src/js_parser/p.rs`) resolves the factory name with `find_symbol`, then passes the same name to `handle_identifier`, which resolves it a second time.
- A factory through a namespace import (`import * as H from "hyper"`, factory `H.h`) keeps one use of `H` after the member rewrite takes one back. The bundler treats `H` as captured, builds the namespace object with `__export(...)`, and keeps every sibling export. Under `minify: { syntax: true }` a single-use local factory is not inlined, while the hand-written `h(...)` call is.

### Fix
- Pass `None` as the name to `handle_identifier`. The reference keeps the resolved ref and its flags. Only the extra `find_symbol` call goes away, so the use count is one per element, as in esbuild's `jsxStringsToMemberExpression`.
- Verified: `test/bundler/bundler_jsx.test.ts` (`jsx/FactoryThroughNamespaceImportOnlyUsesFactory`) and `test/bundler/transpiler/transpiler.test.js` (`a JSX element counts as one use of a classic factory`). Both fail on the released bun. Also green: `bundler_jsx`, `transpiler.test.js`, `esbuild/default`, `esbuild/dce`, `bundler_minify`, `bundler_edgecase`, `test/js/bun/transpiler`.

### Background
- `find_symbol` looks a name up through the scope chain and records one use of the symbol. Use counts drive tree shaking, single-use inlining under minify-syntax, and namespace capture.
- `handle_identifier` is the last step for an identifier reference. Its optional name argument makes it resolve the name again. That path exists for synthesized identifiers and is not needed here.
- A namespace import is "captured" when its symbol has a use of its own, not only `ns.prop` reads. `maybe_rewrite_property_access` takes one use back from the namespace for each `ns.prop` it rewrites. Only a captured namespace gets an `__export(...)` object in the bundle.

<details><summary>Notes</summary>

This change was part of #38533, which is superseded by #40857 for its define work. The JSX part is separate from defines and moves here with its two tests.

Output for the namespace case before this change (`bun build`, `dce`): the `hyper` module keeps `unusedSibling` and an `__export(exports_hyper, { Fragment, h, unusedSibling })` block. After: `h` and `Fragment` are referenced directly and `unusedSibling` is removed.

The `fold.rs` caller of `handle_identifier` still passes a name for a namespace import item, and returns earlier as an import item. `value_for_define` on main also passes a name. The parameter stays.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 27 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (d578a8c70)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1108.84ms]
(pass) bundler > jsx/AutomaticProd [693.30ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [615.23ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [599.74ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [622.25ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [603.07ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [311.97ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [348.02ms]
(pass) bundler > jsx/ImportSourceDev [621.13ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [635.83ms]
(pass) bundler > jsx/ClassicProd [635.37ms]
(pass) bundler > jsx/ClassicPragmaDev [735.25ms]
(pass) bundler > jsx/ClassicPragmaProd [598.27ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultiple
... (truncated)

release without fix: 2 failed, 27 skipped
bun test v1.4.1-canary.1 (d578a8c70)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [21.13ms]
(pass) bundler > jsx/AutomaticProd [11.49ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [11.42ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [11.20ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [11.30ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [10.68ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [5.73ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [5.22ms]
(pass) bundler > jsx/ImportSourceDev [11.10ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [10.85ms]
(pass) bundler > jsx/ClassicProd [11.46ms]
(pass) bundler > jsx/ClassicPragmaDev [10.67ms]
(pass) bundler > jsx/ClassicPragmaProd [11.76ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [11.51ms]
(pass) bundler > jsx/FactoryProd [10.80ms]
(pass) bundler > jsx/FactoryImportDev [10.78ms]
(pass) bundler > jsx/FactoryImportProd [11.28ms]
(pass) bundler > jsx/FactoryI
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 27 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (d578a8c70)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [978.75ms]
(pass) bundler > jsx/AutomaticProd [619.27ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [603.54ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [725.81ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [623.61ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [677.22ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [385.62ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [345.35ms]
(pass) bundler > jsx/ImportSourceDev [707.26ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [639.88ms]
(pass) bundler > jsx/ClassicProd [672.47ms]
(pass) bundler > jsx/ClassicPragmaDev [601.05ms]
(pass) bundler > jsx/ClassicPragmaProd [603.64ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleP
... (truncated)

release with fix: 27 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 834ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         |  4 +++-
 test/bundler/bundler_jsx.test.ts           | 26 ++++++++++++++++++++++++++
 test/bundler/transpiler/transpiler.test.js | 20 ++++++++++++++++++++
 3 files changed, 49 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              4      4      0
test/bundler/bundler_jsx.test.ts                1      1      0
test/bundler/transpiler/transpiler.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->