### PR TITLE
Bun.serve: answer non-GET methods on { dir } routes with 405

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -222,7 +222,7 @@ Directory routes share the response path with file routes:
 - **Range requests** are supported with `Accept-Ranges: bytes` and `Content-Range`.
 - A request that resolves to a directory without a trailing `/` receives a `301` redirect to the trailing-slash URL. With the trailing slash, Bun serves `index.html` from that directory.
 - Missing files return `404`.
-- Only `GET` and `HEAD` serve the file. `OPTIONS` returns `204` and every other method returns `405`, both with `Allow: GET, HEAD, OPTIONS`. A method-scoped route (`"/static/*": { GET: { dir: "./public" } }`) registers only that method.
+- When `{ dir }` is the whole route value, only `GET` and `HEAD` serve the file. `OPTIONS` returns `204` and every other method returns `405`, both with `Allow: GET, HEAD, OPTIONS`. A method-scoped route (`"/static/*": { GET: { dir: "./public" } }`) serves its configured methods instead, and a `GET` route also answers `HEAD`.
 
 Pass `statCache: false` to disable the per-path `Last-Modified` cache (saves roughly 20 KB per route).
 

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -222,6 +222,7 @@ Directory routes share the response path with file routes:
 - **Range requests** are supported with `Accept-Ranges: bytes` and `Content-Range`.
 - A request that resolves to a directory without a trailing `/` receives a `301` redirect to the trailing-slash URL. With the trailing slash, Bun serves `index.html` from that directory.
 - Missing files return `404`.
+- Only `GET` and `HEAD` serve the file. `OPTIONS` returns `204` and every other method returns `405`, both with `Allow: GET, HEAD, OPTIONS`. A method-scoped route (`"/static/*": { GET: { dir: "./public" } }`) registers only that method.
 
 Pass `statCache: false` to disable the per-path `Last-Modified` cache (saves roughly 20 KB per route).
 

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -610,7 +610,9 @@ declare module "bun" {
      * requests. A request that resolves to a directory without a trailing
      * `/` is redirected (`301`) to the trailing-slash URL; with the trailing
      * slash, `index.html` from that directory is served. Missing files
-     * return `404`.
+     * return `404`. Only `GET` and `HEAD` serve the file: `OPTIONS` returns
+     * `204` and every other method returns `405`, both with
+     * `Allow: GET, HEAD, OPTIONS`.
      *
      * @example
      * ```ts

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -640,7 +640,12 @@ declare module "bun" {
       [Path in R]:
         | BaseRouteValue
         | Handler<BunRequest<Path>, Server<WebSocketData>, Response>
-        | Partial<Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Response>>;
+        | Partial<
+            Record<
+              HTTPMethod,
+              Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Exclude<BaseRouteValue, false>
+            >
+          >;
     };
 
     type RoutesWithUpgrade<WebSocketData, R extends string> = {
@@ -648,7 +653,11 @@ declare module "bun" {
         | BaseRouteValue
         | Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void>
         | Partial<
-            Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void> | Response>
+            Record<
+              HTTPMethod,
+              | Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void>
+              | Exclude<BaseRouteValue, false>
+            >
           >;
     };
 

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -610,9 +610,11 @@ declare module "bun" {
      * requests. A request that resolves to a directory without a trailing
      * `/` is redirected (`301`) to the trailing-slash URL; with the trailing
      * slash, `index.html` from that directory is served. Missing files
-     * return `404`. Only `GET` and `HEAD` serve the file: `OPTIONS` returns
-     * `204` and every other method returns `405`, both with
-     * `Allow: GET, HEAD, OPTIONS`.
+     * return `404`. When `{ dir }` is the whole route value, only `GET` and
+     * `HEAD` serve the file: `OPTIONS` returns `204` and every other method
+     * returns `405`, both with `Allow: GET, HEAD, OPTIONS`. Under a method
+     * key (`{ POST: { dir } }`), the route serves its configured methods
+     * instead.
      *
      * @example
      * ```ts

--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -38,8 +38,7 @@ pub struct DirectoryRoute {
     stat_cache: Box<[Cell<StatCacheEntry>]>,
     /// Sum of `StatCacheEntry.path` capacities, for `memory_cost()`.
     stat_cache_path_bytes: Cell<usize>,
-    /// Registered for every method (a plain `{ dir }` route value), so
-    /// `on_request` gates non-GET/HEAD. Method-scoped values serve as-is.
+    /// Registered via `any_this` (plain `{ dir }`): `on_request` gates non-GET/HEAD.
     any_method: Cell<bool>,
 }
 

--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -38,10 +38,8 @@ pub struct DirectoryRoute {
     stat_cache: Box<[Cell<StatCacheEntry>]>,
     /// Sum of `StatCacheEntry.path` capacities, for `memory_cost()`.
     stat_cache_path_bytes: Cell<usize>,
-    /// True when registered for every method (a plain `{ dir }` route value):
-    /// only GET and HEAD serve the file; OPTIONS answers 204 and the rest 405,
-    /// both with an `Allow` list. A method-scoped value (`{ POST: { dir } }`)
-    /// registers only its methods and serves them as-is.
+    /// Registered for every method (a plain `{ dir }` route value), so
+    /// `on_request` gates non-GET/HEAD. Method-scoped values serve as-is.
     any_method: Cell<bool>,
 }
 
@@ -119,8 +117,7 @@ impl DirectoryRoute {
         Self::on(this, req, resp, method.unwrap_or(Method::GET));
     }
 
-    /// A directory tree implements GET and HEAD only (nginx and Caddy do the
-    /// same): 405 with `Allow`, and 204 with `Allow` for OPTIONS.
+    /// 405 (204 for OPTIONS) with `Allow: GET, HEAD, OPTIONS`, like nginx.
     fn on_method_not_allowed(
         this: ThisPtr<DirectoryRoute>,
         mut req: AnyRequest,

--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -38,12 +38,22 @@ pub struct DirectoryRoute {
     stat_cache: Box<[Cell<StatCacheEntry>]>,
     /// Sum of `StatCacheEntry.path` capacities, for `memory_cost()`.
     stat_cache_path_bytes: Cell<usize>,
+    /// True when registered for every method (a plain `{ dir }` route value):
+    /// only GET and HEAD serve the file; OPTIONS answers 204 and the rest 405,
+    /// both with an `Allow` list. A method-scoped value (`{ POST: { dir } }`)
+    /// registers only its methods and serves them as-is.
+    any_method: Cell<bool>,
 }
 
 impl DirectoryRoute {
     #[inline]
     pub fn set_server(&self, server: Option<AnyServer>) {
         self.server.set(server);
+    }
+
+    #[inline]
+    pub(crate) fn set_registered_for_any_method(&self, any: bool) {
+        self.any_method.set(any);
     }
 
     pub fn memory_cost(&self) -> usize {
@@ -92,6 +102,7 @@ impl DirectoryRoute {
             url_prefix: url_prefix.to_vec().into_boxed_slice(),
             stat_cache: stat_cache.into_boxed_slice(),
             stat_cache_path_bytes: Cell::new(0),
+            any_method: Cell::new(false),
         }))
     }
 
@@ -100,8 +111,40 @@ impl DirectoryRoute {
     }
 
     pub fn on_request(this: ThisPtr<DirectoryRoute>, req: AnyRequest, resp: AnyResponse) {
-        let method = Method::find(req.method()).unwrap_or(Method::GET);
-        Self::on(this, req, resp, method);
+        let method = Method::find(req.method());
+        if this.any_method.get() && !matches!(method, Some(Method::GET | Method::HEAD)) {
+            Self::on_method_not_allowed(this, req, resp, method == Some(Method::OPTIONS));
+            return;
+        }
+        Self::on(this, req, resp, method.unwrap_or(Method::GET));
+    }
+
+    /// A directory tree implements GET and HEAD only (nginx and Caddy do the
+    /// same): 405 with `Allow`, and 204 with `Allow` for OPTIONS.
+    fn on_method_not_allowed(
+        this: ThisPtr<DirectoryRoute>,
+        mut req: AnyRequest,
+        resp: AnyResponse,
+        is_options: bool,
+    ) {
+        debug_assert!(this.server.get().is_some());
+        let _guard = ResponseGuard {
+            route: Some(RefPtr::from_this(this)),
+            resp,
+        };
+        if let Some(mut server) = this.server.get() {
+            server.on_pending_request();
+            resp.timeout(server.config().idle_timeout);
+        }
+        req.set_yield(false);
+        write_any_status(resp, if is_options { 204 } else { 405 });
+        resp.write_mark();
+        resp.write_header(b"allow", b"GET, HEAD, OPTIONS");
+        if is_options {
+            resp.end_without_body(resp.should_close_connection());
+        } else {
+            resp.end(b"", resp.should_close_connection());
+        }
     }
 
     fn on(this: ThisPtr<DirectoryRoute>, mut req: AnyRequest, resp: AnyResponse, method: Method) {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -424,8 +424,7 @@ pub(crate) fn apply_static_route_mux<T: StaticRouteLike, A: MuxApp>(
 /// it is registered.
 pub(crate) trait StaticRouteLike: Sized + 'static {
     fn set_server(&self, server: AnyServer);
-    /// Registration reports whether the route answers every method
-    /// (`any_this`) or an explicit method set. Only `DirectoryRoute` cares.
+    /// Whether the route registers via `any_this` or an explicit method set.
     fn set_registered_for_any_method(&self, _any: bool) {}
     fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse);
     fn on_head_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse);

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -328,6 +328,7 @@ pub(crate) fn apply_static_route<const SSL: bool, T: StaticRouteLike>(
     path_has_user_head_route: bool,
 ) {
     entry.set_server(server);
+    entry.set_registered_for_any_method(method == http_method::Optional::Any);
 
     // Only answer HEAD from an entry that serves GET (HEAD must mirror GET,
     // RFC 9110 section 9.3.2) or HEAD itself, and never displace an explicit HEAD
@@ -401,6 +402,7 @@ pub(crate) fn apply_static_route_mux<T: StaticRouteLike, A: MuxApp>(
     path_has_user_head_route: bool,
 ) {
     entry.set_server(server);
+    entry.set_registered_for_any_method(method == http_method::Optional::Any);
 
     if !path_has_user_head_route && serves_head(&method) {
         app.method_this(Method::HEAD, path, T::on_head_request, entry);
@@ -422,6 +424,9 @@ pub(crate) fn apply_static_route_mux<T: StaticRouteLike, A: MuxApp>(
 /// it is registered.
 pub(crate) trait StaticRouteLike: Sized + 'static {
     fn set_server(&self, server: AnyServer);
+    /// Registration reports whether the route answers every method
+    /// (`any_this`) or an explicit method set. Only `DirectoryRoute` cares.
+    fn set_registered_for_any_method(&self, _any: bool) {}
     fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse);
     fn on_head_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse);
 }
@@ -453,6 +458,9 @@ impl StaticRouteLike for super::FileRoute {
 impl StaticRouteLike for super::DirectoryRoute {
     fn set_server(&self, server: AnyServer) {
         self.set_server(Some(server));
+    }
+    fn set_registered_for_any_method(&self, any: bool) {
+        super::DirectoryRoute::set_registered_for_any_method(self, any);
     }
     fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
         Self::on_request(this, req, resp)

--- a/test/integration/bun-types/fixture/serve.ts
+++ b/test/integration/bun-types/fixture/serve.ts
@@ -1,6 +1,21 @@
 // This file is merely types only, you (probably) want to put the tests in ./serve-types.test.ts instead
 
+import type { HTMLBundle } from "bun";
 import { expectType } from "./utilities";
+
+// Method-scoped routes accept every static route value the runtime accepts:
+// Response, HTMLBundle, BunFile, and { dir }. `false` disables a route at the
+// top level only.
+declare const appHtml: HTMLBundle;
+Bun.serve({
+  routes: {
+    "/assets/*": { GET: { dir: "./public" } },
+    "/file": { POST: Bun.file("./a.txt"), GET: new Response("ok") },
+    "/app": { GET: appHtml },
+    // @ts-expect-error `false` is only valid as a whole-route value
+    "/nope": { POST: false },
+  },
+});
 
 Bun.serve({
   routes: {

--- a/test/js/bun/http/serve-directory-routes.test.ts
+++ b/test/js/bun/http/serve-directory-routes.test.ts
@@ -240,21 +240,23 @@ describe("Bun.serve() directory routes", () => {
   });
 
   describe("method handling", () => {
-    it.each(["DELETE", "POST", "PUT", "PATCH", "PROPFIND"])("%s gets 405 with Allow", async method => {
-      using dir = tempDir("serve-dir-405", {
-        "public/app.js": "console.log(1)",
-      });
+    describe.each(["DELETE", "POST", "PUT", "PATCH", "PROPFIND"])("%s", method => {
+      it("gets 405 with Allow", async () => {
+        using dir = tempDir("serve-dir-405", {
+          "public/app.js": "console.log(1)",
+        });
 
-      server = serve({
-        port: 0,
-        routes: { "/assets/*": { dir: join(String(dir), "public") } },
-        fetch: () => new Response("fallback"),
-      });
+        server = serve({
+          port: 0,
+          routes: { "/assets/*": { dir: join(String(dir), "public") } },
+          fetch: () => new Response("fallback"),
+        });
 
-      const res = await fetch(`${server.url}assets/app.js`, { method });
-      expect(res.headers.get("allow")).toBe("GET, HEAD, OPTIONS");
-      expect(await res.text()).toBe("");
-      expect(res.status).toBe(405);
+        const res = await fetch(`${server.url}assets/app.js`, { method });
+        expect(res.headers.get("allow")).toBe("GET, HEAD, OPTIONS");
+        expect(await res.text()).toBe("");
+        expect(res.status).toBe(405);
+      });
     });
 
     it("OPTIONS gets 204 with Allow and no body", async () => {

--- a/test/js/bun/http/serve-directory-routes.test.ts
+++ b/test/js/bun/http/serve-directory-routes.test.ts
@@ -239,6 +239,82 @@ describe("Bun.serve() directory routes", () => {
     expect(await res.text()).toBe("");
   });
 
+  describe("method handling", () => {
+    it.each(["DELETE", "POST", "PUT", "PATCH", "PROPFIND"])("%s gets 405 with Allow", async method => {
+      using dir = tempDir("serve-dir-405", {
+        "public/app.js": "console.log(1)",
+      });
+
+      server = serve({
+        port: 0,
+        routes: { "/assets/*": { dir: join(String(dir), "public") } },
+        fetch: () => new Response("fallback"),
+      });
+
+      const res = await fetch(`${server.url}assets/app.js`, { method });
+      expect(res.headers.get("allow")).toBe("GET, HEAD, OPTIONS");
+      expect(await res.text()).toBe("");
+      expect(res.status).toBe(405);
+    });
+
+    it("OPTIONS gets 204 with Allow and no body", async () => {
+      using dir = tempDir("serve-dir-options", {
+        "public/app.js": "console.log(1)",
+      });
+
+      server = serve({
+        port: 0,
+        routes: { "/assets/*": { dir: join(String(dir), "public") } },
+      });
+
+      const res = await fetch(`${server.url}assets/app.js`, { method: "OPTIONS" });
+      expect(res.headers.get("allow")).toBe("GET, HEAD, OPTIONS");
+      expect(await res.text()).toBe("");
+      expect(res.status).toBe(204);
+    });
+
+    it("GET and HEAD still serve the file", async () => {
+      using dir = tempDir("serve-dir-get-head", {
+        "public/app.js": "console.log(1)",
+      });
+
+      server = serve({
+        port: 0,
+        routes: { "/assets/*": { dir: join(String(dir), "public") } },
+      });
+
+      const get = await fetch(`${server.url}assets/app.js`);
+      expect(await get.text()).toBe("console.log(1)");
+      expect(get.status).toBe(200);
+
+      const head = await fetch(`${server.url}assets/app.js`, { method: "HEAD" });
+      expect(await head.text()).toBe("");
+      expect(head.status).toBe(200);
+    });
+
+    it("a method-scoped dir route serves only that method", async () => {
+      using dir = tempDir("serve-dir-scoped", {
+        "public/app.js": "console.log(1)",
+      });
+
+      server = serve({
+        port: 0,
+        routes: { "/assets/*": { POST: { dir: join(String(dir), "public") } } as any },
+        fetch: () => new Response("fallback", { status: 418 }),
+      });
+
+      // The explicit POST registration serves the file for POST.
+      const post = await fetch(`${server.url}assets/app.js`, { method: "POST" });
+      expect(await post.text()).toBe("console.log(1)");
+      expect(post.status).toBe(200);
+
+      // GET is not registered, so it falls through to fetch.
+      const get = await fetch(`${server.url}assets/app.js`);
+      expect(await get.text()).toBe("fallback");
+      expect(get.status).toBe(418);
+    });
+  });
+
   it("sends Last-Modified and a weak ETag", async () => {
     using dir = tempDir("serve-dir-lm", {
       "public/data.json": '{"key":"value"}',

--- a/test/js/bun/http/serve-directory-routes.test.ts
+++ b/test/js/bun/http/serve-directory-routes.test.ts
@@ -299,7 +299,7 @@ describe("Bun.serve() directory routes", () => {
 
       server = serve({
         port: 0,
-        routes: { "/assets/*": { POST: { dir: join(String(dir), "public") } } as any },
+        routes: { "/assets/*": { POST: { dir: join(String(dir), "public") } } },
         fetch: () => new Response("fallback", { status: 418 }),
       });
 


### PR DESCRIPTION
### Problem

- A plain `{ dir }` route value answers every HTTP method with the file body. `DELETE /assets/app.js` returns `200` plus the file, and `OPTIONS` returns the file instead of `Allow`, which breaks CORS preflight. Fixes #40893.
- The cause: `{ dir }` registers with `any` on the uWS router (src/runtime/server/ServerConfig.rs:340), and `DirectoryRoute::on_request` mapped every method to GET (src/runtime/server/DirectoryRoute.rs:103).

### Fix

- Registration now tells the route when it answers every method (a new `StaticRouteLike` default method). A `DirectoryRoute` registered that way serves only GET and HEAD. OPTIONS returns `204` and every other method `405`, both with `Allow: GET, HEAD, OPTIONS`. nginx and Caddy's file servers behave the same way.
- A method-scoped value (`{ POST: { dir } }`) still serves exactly its registered methods. `Response`, `Bun.file`, and HTML bundle routes are unchanged: they carry a user-provided value, and their any-method behavior is a deliberate shipped choice (StaticRoute.rs says so in a comment).
- The route types now accept static values under a method key (`{ GET: { dir } }`, `{ POST: Bun.file(x) }`). The runtime already accepted them. The docs in this PR use that form, so the types had to follow.
- Verified: test/js/bun/http/serve-directory-routes.test.ts (8 new tests, 6 fail on 1.4.0). Also bun-serve-routes, bun-serve-file, bun-serve-static, and the bun-types integration test.
- Self-reviewed: 5 concerns raised, 2 addressed (the per-method types gap), 3 recorded in the notes.

### Background

- A `routes` value registers on the uWS router per method. A handler object (`{ GET(){} }`) registers each method separately. Every other value (a `Response`, a file, `{ dir }`) registers with `any`, which matches all methods.
- `DirectoryRoute` is the native handler behind `{ dir }`. It resolves the URL suffix under an opened root fd and streams the file.
- HEAD has its own registration (RFC 9110 section 9.3.2) and still serves headers without a body.

<details><summary>Notes</summary>

- A non-GET request for a path that does not exist now gets `405`, not `404`. The method gate runs before path resolution. nginx orders the checks the same way.
- Follow-up candidates, out of scope here because each changes shipped behavior and needs its own decision:
  - `FileRoute` (`Bun.file` values) has the same serve-any-method pattern (FileRoute.rs:232).
  - HTML bundle routes answer unknown methods with `405` while the bundle builds (HTMLBundle.rs:276) but `200` once loaded (HTMLBundle.rs:310). The two states disagree.
- The gate flag travels through `StaticRouteLike::set_registered_for_any_method`, a default no-op. Extending the policy to a sibling route type is a two-line change if that decision lands.
- `false` stays out of the per-method type union: the runtime parses negative routes only at the top level, so `{ POST: false }` is a silent no-op and the types reject it.
- Suites run locally: serve-directory-routes (38 pass), bun-serve-routes, bun-serve-file, bun-serve-static (228 pass), test/integration/bun-types (19 pass).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve-directory-routes.test.ts

<!-- robobun:evidence:end -->