### PR TITLE
napi: accept duplicate napi_define_class instance descriptors

### DIFF
--- a/src/jsc/bindings/NapiClass.cpp
+++ b/src/jsc/bindings/NapiClass.cpp
@@ -122,8 +122,10 @@ napi_status NapiClass::finishCreation(VM& vm, const String& name, napi_callback 
     for (size_t i = 0; i < property_count; i++) {
         const napi_property_descriptor& property = properties[i];
 
-        JSC::JSObject* target = (property.attributes & napi_static) ? static_cast<JSC::JSObject*>(this) : prototype;
-        napi_status status = Napi::defineProperty(env, target, property, throwScope);
+        bool isStatic = property.attributes & napi_static;
+        JSC::JSObject* target = isStatic ? static_cast<JSC::JSObject*>(this) : prototype;
+        auto mode = isStatic ? Napi::PropertyDefinitionMode::Ordinary : Napi::PropertyDefinitionMode::ClassInstance;
+        napi_status status = Napi::defineProperty(env, target, property, throwScope, mode);
 
         if (throwScope.exception()) {
             result = napi_pending_exception;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -337,7 +337,7 @@ void NAPICallFrame::extract(size_t* argc, napi_value* argv, napi_value* this_arg
     }
 }
 
-napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ExceptionScope& scope)
+napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ExceptionScope& scope, PropertyDefinitionMode mode)
 {
     Zig::GlobalObject* globalObject = env->globalObject();
     JSC::VM& vm = JSC::getVM(globalObject);
@@ -405,6 +405,11 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
     bool success = to->methodTable()->defineOwnProperty(to, globalObject, propertyName, descriptor, false);
     RETURN_IF_EXCEPTION(scope, napi_pending_exception);
     if (!success) {
+        // Node stages instance descriptors on a PrototypeTemplate, where duplicates do not fail napi_define_class.
+        if (mode == PropertyDefinitionMode::ClassInstance && to->hasOwnProperty(globalObject, propertyName)) {
+            RETURN_IF_EXCEPTION(scope, napi_pending_exception);
+            return napi_ok;
+        }
         return failureStatus;
     }
     return napi_ok;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/ExceptionScope.h>
 #include <JavaScriptCore/FunctionConstructor.h>
+#include <JavaScriptCore/GetterSetter.h>
 #include <JavaScriptCore/Heap.h>
 #include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/InitializeThreading.h>
@@ -366,17 +367,19 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
 
     PropertyDescriptor descriptor;
     napi_status failureStatus = napi_invalid_arg;
+    JSC::JSObject* getter = nullptr;
+    JSC::JSObject* setter = nullptr;
 
     if (property.getter != nullptr || property.setter != nullptr) {
         if (property.getter) {
             auto name = makeString("get "_s, propertyName.isSymbol() ? String() : propertyName.string());
-            auto* getter = NapiClass::create(vm, env, name, property.getter, dataPtr, 0, nullptr);
+            getter = NapiClass::create(vm, env, name, property.getter, dataPtr, 0, nullptr);
             RETURN_IF_EXCEPTION(scope, napi_pending_exception);
             descriptor.setGetter(getter);
         }
         if (property.setter) {
             auto name = makeString("set "_s, propertyName.isSymbol() ? String() : propertyName.string());
-            auto* setter = NapiClass::create(vm, env, name, property.setter, dataPtr, 0, nullptr);
+            setter = NapiClass::create(vm, env, name, property.setter, dataPtr, 0, nullptr);
             RETURN_IF_EXCEPTION(scope, napi_pending_exception);
             descriptor.setSetter(setter);
         }
@@ -408,6 +411,17 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
         // Node stages instance descriptors on a PrototypeTemplate, where duplicates do not fail napi_define_class.
         if (mode == PropertyDefinitionMode::ClassInstance && to->hasOwnProperty(globalObject, propertyName)) {
             RETURN_IF_EXCEPTION(scope, napi_pending_exception);
+            if (getter || setter) {
+                unsigned accessorAttributes = 0;
+                if (!enumerable)
+                    accessorAttributes |= JSC::PropertyAttribute::DontEnum;
+                if (!configurable)
+                    accessorAttributes |= JSC::PropertyAttribute::DontDelete;
+                auto* getterSetter = JSC::GetterSetter::create(vm, globalObject, getter, setter);
+                to->putDirectAccessor(globalObject, propertyName, getterSetter,
+                    accessorAttributes | JSC::PropertyAttribute::Accessor);
+                RETURN_IF_EXCEPTION(scope, napi_pending_exception);
+            }
             return napi_ok;
         }
         return failureStatus;

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -116,7 +116,12 @@ private:
 
 using HookSet = std::unordered_set<EitherCleanupHook, EitherCleanupHook::Hash>;
 
-napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ExceptionScope& scope);
+enum class PropertyDefinitionMode : uint8_t {
+    Ordinary,
+    ClassInstance,
+};
+
+napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ExceptionScope& scope, PropertyDefinitionMode mode = PropertyDefinitionMode::Ordinary);
 }
 
 // Owned by the addon: allocated by napi_add_async_cleanup_hook and freed only

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -211,8 +211,13 @@ static napi_value perform_get(const Napi::CallbackInfo &info) {
 
 static napi_value define_properties_getter(napi_env env,
                                            napi_callback_info info) {
+  size_t argc = 0;
+  void *data = nullptr;
+  napi_get_cb_info(env, info, &argc, nullptr, nullptr, &data);
   napi_value result;
-  napi_create_int32(env, 123, &result);
+  napi_create_int32(
+      env, data ? static_cast<int32_t>(reinterpret_cast<intptr_t>(data)) : 123,
+      &result);
   return result;
 }
 
@@ -223,8 +228,13 @@ static napi_value define_properties_setter(napi_env env,
 
 static napi_value define_properties_method(napi_env env,
                                            napi_callback_info info) {
+  size_t argc = 0;
+  void *data = nullptr;
+  napi_get_cb_info(env, info, &argc, nullptr, nullptr, &data);
   napi_value result;
-  napi_create_int32(env, 456, &result);
+  napi_create_int32(
+      env, data ? static_cast<int32_t>(reinterpret_cast<intptr_t>(data)) : 456,
+      &result);
   return result;
 }
 
@@ -278,10 +288,16 @@ static napi_value define_properties(const Napi::CallbackInfo &info) {
   napi_status status;
   bool is_class = false;
   napi_get_value_bool(env, info[3], &is_class);
+  napi_value cls = nullptr;
   if (is_class) {
     bool duplicate = info.Length() > 4 && info[4].As<Napi::Boolean>();
-    napi_property_descriptor properties[] = {desc, desc};
-    napi_value cls = nullptr;
+    desc.data = reinterpret_cast<void *>(1);
+    napi_property_descriptor second = desc;
+    second.data = reinterpret_cast<void *>(2);
+    if (kind == "value") {
+      NODE_API_CALL(env, napi_create_int32(env, 84, &second.value));
+    }
+    napi_property_descriptor properties[] = {desc, second};
     status = napi_define_class(env, "C", NAPI_AUTO_LENGTH,
                                define_properties_method, nullptr,
                                duplicate ? 2 : 1, properties, &cls);
@@ -303,6 +319,9 @@ static napi_value define_properties(const Napi::CallbackInfo &info) {
   NODE_API_CALL(env, napi_set_named_property(env, result, "status", js_status));
   NODE_API_CALL(env,
                 napi_set_named_property(env, result, "pending", js_pending));
+  if (cls != nullptr) {
+    NODE_API_CALL(env, napi_set_named_property(env, result, "class", cls));
+  }
   return result;
 }
 

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -228,12 +228,14 @@ static napi_value define_properties_method(napi_env env,
   return result;
 }
 
-// define_properties(target, kind, name, isClass)
+// define_properties(target, kind, name, isClass, duplicate, isStatic)
 // kind: "value" | "getter" | "setter" | "accessor" | "method"
 // name: if undefined, utf8name "k" is used; otherwise the napi_value itself is
 //       passed as the descriptor's name (any type).
 // isClass: if true, passes the descriptor to napi_define_class instead of
 //          napi_define_properties (target is ignored).
+// duplicate: if true, passes the descriptor twice.
+// isStatic: if true, adds napi_static to the descriptor attributes.
 // Returns { status, pending } where status is the napi_status returned and
 // pending is whether an exception was left pending.
 static napi_value define_properties(const Napi::CallbackInfo &info) {
@@ -247,6 +249,9 @@ static napi_value define_properties(const Napi::CallbackInfo &info) {
 
   napi_property_descriptor desc = {};
   desc.attributes = napi_default;
+  if (info.Length() > 5 && info[5].As<Napi::Boolean>()) {
+    desc.attributes = static_cast<napi_property_attributes>(napi_static);
+  }
   if (name_arg.IsUndefined()) {
     desc.utf8name = "k";
   } else if (name_arg.IsNull()) {
@@ -274,10 +279,12 @@ static napi_value define_properties(const Napi::CallbackInfo &info) {
   bool is_class = false;
   napi_get_value_bool(env, info[3], &is_class);
   if (is_class) {
+    bool duplicate = info.Length() > 4 && info[4].As<Napi::Boolean>();
+    napi_property_descriptor properties[] = {desc, desc};
     napi_value cls = nullptr;
     status = napi_define_class(env, "C", NAPI_AUTO_LENGTH,
-                               define_properties_method, nullptr, 1, &desc,
-                               &cls);
+                               define_properties_method, nullptr,
+                               duplicate ? 2 : 1, properties, &cls);
   } else {
     status = napi_define_properties(env, target, 1, &desc);
   }

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -561,6 +561,31 @@ nativeTests.test_define_properties = () => {
   }
 };
 
+nativeTests.test_define_class_duplicate_properties = () => {
+  const statusNames = [
+    "napi_ok",
+    "napi_invalid_arg",
+    "napi_object_expected",
+    "napi_string_expected",
+    "napi_name_expected",
+    "napi_function_expected",
+    "napi_number_expected",
+    "napi_boolean_expected",
+    "napi_array_expected",
+    "napi_generic_failure",
+    "napi_pending_exception",
+  ];
+  const fmtStatus = status => statusNames[status] ?? String(status);
+
+  for (const kind of ["getter", "setter", "accessor", "method"]) {
+    const result = nativeTests.define_properties({}, kind, undefined, true, true, false);
+    console.log(`${kind}: status=${fmtStatus(result.status)} pending=${result.pending}`);
+  }
+
+  const staticResult = nativeTests.define_properties({}, "method", undefined, true, true, true);
+  console.log(`static method: status=${fmtStatus(staticResult.status)} pending=${staticResult.pending}`);
+};
+
 nativeTests.test_property_names_cache_poisoning = () => {
   // napi_key_include_prototypes = 0, napi_key_own_only = 1
   // napi_key_all_properties = 0, napi_key_skip_symbols = 16

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -577,9 +577,14 @@ nativeTests.test_define_class_duplicate_properties = () => {
   ];
   const fmtStatus = status => statusNames[status] ?? String(status);
 
-  for (const kind of ["getter", "setter", "accessor", "method"]) {
+  for (const kind of ["value", "getter", "setter", "accessor", "method"]) {
     const result = nativeTests.define_properties({}, kind, undefined, true, true, false);
-    console.log(`${kind}: status=${fmtStatus(result.status)} pending=${result.pending}`);
+    let value = "";
+    if (result.class && kind !== "setter") {
+      const instance = new result.class();
+      value = ` value=${kind === "method" ? instance.k() : instance.k}`;
+    }
+    console.log(`${kind}: status=${fmtStatus(result.status)} pending=${result.pending}${value}`);
   }
 
   const staticResult = nativeTests.define_properties({}, "method", undefined, true, true, true);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1252,6 +1252,10 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   });
 
   describe("napi_define_class", () => {
+    it("accepts duplicate instance descriptors like Node", async () => {
+      await checkSameOutput("test_define_class_duplicate_properties", []);
+    });
+
     it("handles edge cases in the constructor", async () => {
       await Promise.all([
         checkSameOutput("test_napi_class", []),


### PR DESCRIPTION
### What does this PR do?

Allow duplicate instance descriptors passed to `napi_define_class` to return `napi_ok`, matching Node.js and Bun 1.3. Static class descriptors and `napi_define_properties` remain strict.

The regression came from #34134. That change correctly routed property creation through `[[DefineOwnProperty]]` and propagated failures, but it also applied that behavior to class instance descriptors. Since `napi_default` methods and accessors are non-configurable, the second descriptor with the same key failed.

Node stages instance descriptors on a V8 `PrototypeTemplate`, where duplicates do not make `napi_define_class` fail. This change distinguishes class instance definitions and only accepts a failed definition when the fresh prototype already owns that property. Normal property definitions do not add an extra lookup.

This fixes native addons such as `openvino-node` that loaded on Node and Bun 1.3 but fail on Bun 1.4.

Fixes #40906

### How did you verify your code works?

Added a Node comparison test covering duplicate getter, setter, accessor, and method descriptors, plus a duplicate static method as a negative control.

- `USE_SYSTEM_BUN=1 npx --yes bun@1.4.0 test test/napi/napi.test.ts -t "accepts duplicate instance descriptors like Node"` fails before the fix with the expected status mismatch.
- `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1 bun bd test test/napi/napi.test.ts -t "accepts duplicate instance descriptors like Node"` passes.
- `bun bd test test/napi/napi.test.ts -t "napi_define_class"` passes all 3 focused tests.
