### PR TITLE
bun:sqlite: throw instead of crashing when prepare() gets SQL with no statement

### DIFF
--- a/src/jsc/bindings/InspectorBunFrontendDevServerAgent.cpp
+++ b/src/jsc/bindings/InspectorBunFrontendDevServerAgent.cpp
@@ -35,7 +35,7 @@ void InspectorBunFrontendDevServerAgent::didCreateFrontendAndBackend()
 
 void InspectorBunFrontendDevServerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    disable();
+    (void)disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorBunFrontendDevServerAgent::enable()

--- a/src/jsc/bindings/InspectorHTTPServerAgent.cpp
+++ b/src/jsc/bindings/InspectorHTTPServerAgent.cpp
@@ -39,7 +39,7 @@ void InspectorHTTPServerAgent::didCreateFrontendAndBackend()
 
 void InspectorHTTPServerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    disable();
+    (void)disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorHTTPServerAgent::enable()

--- a/src/jsc/bindings/InspectorLifecycleAgent.cpp
+++ b/src/jsc/bindings/InspectorLifecycleAgent.cpp
@@ -62,7 +62,7 @@ void InspectorLifecycleAgent::didCreateFrontendAndBackend()
 
 void InspectorLifecycleAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    disable();
+    (void)disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorLifecycleAgent::enable()

--- a/src/jsc/bindings/InspectorTestReporterAgent.cpp
+++ b/src/jsc/bindings/InspectorTestReporterAgent.cpp
@@ -136,7 +136,7 @@ void InspectorTestReporterAgent::didCreateFrontendAndBackend()
 
 void InspectorTestReporterAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    disable();
+    (void)disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorTestReporterAgent::enable()

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1709,6 +1709,12 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
         return {};
     }
 
+    // nullptr with SQLITE_OK: the input contained no SQL (only whitespace and/or comments)
+    if (!statement) {
+        throwException(lexicalGlobalObject, scope, createRangeError(lexicalGlobalObject, "Invalid SQL statement"_s));
+        return {};
+    }
+
     int64_t memoryChange = sqlite_malloc_amount - currentMemoryUsage;
 
     JSSQLStatement* sqlStatement = JSSQLStatement::create(

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1181,6 +1181,20 @@ describe("Database.run", () => {
   });
 });
 
+describe("Database.prepare", () => {
+  // sqlite3_prepare_v3 returns SQLITE_OK with a NULL statement when the input
+  // has no SQL (only whitespace/comments). That must be rejected up front, not
+  // wrapped in a Statement that later derefs the NULL (crashed when params were
+  // passed, threw "Statement has finalized" otherwise).
+  it.each([" ", "\n", ";", " ; ", "-- comment", "/* block */"])("throws on SQL with no statement: %p", sql => {
+    const db = new Database(":memory:");
+    expect(() => db.prepare(sql)).toThrow("Invalid SQL statement");
+    expect(() => db.prepare(sql, {})).toThrow("Invalid SQL statement");
+    expect(() => db.prepare(sql, [])).toThrow("Invalid SQL statement");
+    expect(() => db.query(sql)).toThrow("Invalid SQL statement");
+  });
+});
+
 it("#3991", () => {
   const db = new Database(":memory:");
   db.prepare(

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1188,10 +1188,10 @@ describe("Database.prepare", () => {
   // passed, threw "Statement has finalized" otherwise).
   it.each([" ", "\n", ";", " ; ", "-- comment", "/* block */"])("throws on SQL with no statement: %p", sql => {
     const db = new Database(":memory:");
-    expect(() => db.prepare(sql)).toThrow("Invalid SQL statement");
-    expect(() => db.prepare(sql, {})).toThrow("Invalid SQL statement");
-    expect(() => db.prepare(sql, [])).toThrow("Invalid SQL statement");
-    expect(() => db.query(sql)).toThrow("Invalid SQL statement");
+    for (const call of [() => db.prepare(sql), () => db.prepare(sql, {}), () => db.prepare(sql, []), () => db.query(sql)]) {
+      expect(call).toThrow(RangeError);
+      expect(call).toThrow("Invalid SQL statement");
+    }
   });
 });
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1188,7 +1188,12 @@ describe("Database.prepare", () => {
   // passed, threw "Statement has finalized" otherwise).
   it.each([" ", "\n", ";", " ; ", "-- comment", "/* block */"])("throws on SQL with no statement: %p", sql => {
     const db = new Database(":memory:");
-    for (const call of [() => db.prepare(sql), () => db.prepare(sql, {}), () => db.prepare(sql, []), () => db.query(sql)]) {
+    for (const call of [
+      () => db.prepare(sql),
+      () => db.prepare(sql, {}),
+      () => db.prepare(sql, []),
+      () => db.query(sql),
+    ]) {
       expect(call).toThrow(RangeError);
       expect(call).toThrow("Invalid SQL statement");
     }


### PR DESCRIPTION
### What does this PR do?

`db.prepare(" ", [])` (or any SQL that is only whitespace, comments, or `;`, with a params argument) segfaulted, and `db.prepare(" ")` without params threw a misleading "Statement has finalized".

`sqlite3_prepare_v3` returns `SQLITE_OK` with a NULL statement handle when the input contains no SQL. `prepare()` only checked the return code, so it wrapped the NULL handle in a `Statement`; binding params then dereferenced it, and without params the first property read hit the "finalized" guard. This rejects the NULL handle up front with the same `Invalid SQL statement` RangeError the empty-string case already throws. `db.run()`/`exec()` already handled this case and are unchanged.

```js
new (require("bun:sqlite").Database)(":memory:").prepare(" ", {})
// before: Segmentation fault at address 0x0
// after:  RangeError: Invalid SQL statement
```

### How did you verify your code works?

Added `Database.prepare > throws on SQL with no statement` in `test/js/bun/sqlite/sqlite.test.js` covering `prepare`/`query` with and without params for `" "`, `"\n"`, `";"`, `" ; "`, `"-- comment"`, `"/* block */"`. Fails on 1.4.0 (crash / wrong error), passes on a debug build with this change.

Also included: libstdc++ 16 declares `std::expected` as `class [[nodiscard]]`, and `Protocol::ErrorStringOr<void>` is `std::expected<void, String>`, so the bare `disable();` calls in the four Bun inspector agents' `willDestroyFrontendAndBackend` failed the build under `-Werror=unused-value`. Those now discard the result explicitly; no behavior change.
