### PR TITLE
sql: detach the stored socket in on_close/on_connect_error

### DIFF
--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -914,6 +914,11 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // Takes over the socket ref taken in on_open.
         // SAFETY: `this` is live and that ref is outstanding.
         let _guard = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
+        // usockets frees this socket at end-of-tick; drop the stored pointer
+        // now so nothing (timer callbacks, do_close) dereferences it after
+        // the free.
+        this.connection_mut()
+            .set_socket(AnySocket::SocketTcp(SocketTCP::detached()));
         // A close before the handshake finished means the server (or an
         // intermediary like a container port proxy) accepted the TCP
         // connection but went away before completing startup — e.g. the
@@ -943,6 +948,10 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_connect_error(this: &JSMySQLConnection, _: NewSocketHandler<SSL>, _: i32) {
+        // The dispatch trampoline already closed the connecting socket; it is
+        // freed at end-of-tick, so detach before any user-visible callback.
+        this.connection_mut()
+            .set_socket(AnySocket::SocketTcp(SocketTCP::detached()));
         this.fail(b"Failed to connect", AnyMySQLErrorT::ConnectionRefused);
     }
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1323,6 +1323,11 @@ impl<const SSL: bool> SocketHandler<SSL> {
         _: i32,
         _: Option<*mut c_void>,
     ) {
+        // usockets frees this socket at end-of-tick; drop the stored pointer
+        // now so nothing (timer callbacks, ref()/unref()) dereferences it
+        // after the free.
+        this.socket
+            .set(Socket::SocketTcp(uws::SocketTCP::detached()));
         this.on_close();
     }
 
@@ -1331,6 +1336,10 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_connect_error(this: &PostgresSQLConnection, _socket: SocketType<SSL>, _: i32) {
+        // The dispatch trampoline already closed the connecting socket; it is
+        // freed at end-of-tick, so detach before any user-visible callback.
+        this.socket
+            .set(Socket::SocketTcp(uws::SocketTCP::detached()));
         Self::guarded(this, |t| t.on_connect_error());
     }
 

--- a/test/js/sql/sql-connection-socket-uaf.test.ts
+++ b/test/js/sql/sql-connection-socket-uaf.test.ts
@@ -63,104 +63,102 @@ const drivers = [
 
 // The failure is a 1-byte heap-use-after-free; it is only observable under
 // ASAN (debug builds enable ASAN).
-for (const { name, touch, server } of drivers) {
-  test.skipIf(!isDebug && !isASAN)(
-    `${name}: touching the native connection after the socket is freed does not read freed memory`,
-    async () => {
-      using dir = tempDir(`sql-conn-socket-uaf-${name}`, {
-        "server.ts": server,
-        "fixture.ts": /* js */ `
-          import net from "node:net";
-          import { once } from "node:events";
-          import { SQL } from "bun";
-          import { onSocket, url } from "./server.ts";
+test.skipIf(!isDebug && !isASAN).each(drivers)(
+  "$name: touching the native connection after the socket is freed does not read freed memory",
+  async ({ name, touch, server }) => {
+    using dir = tempDir(`sql-conn-socket-uaf-${name}`, {
+      "server.ts": server,
+      "fixture.ts": /* js */ `
+        import net from "node:net";
+        import { once } from "node:events";
+        import { SQL } from "bun";
+        import { onSocket, url } from "./server.ts";
 
-          let socketRef;
-          const server = net.createServer(socket => {
-            socketRef = socket;
-            onSocket(socket);
-          });
-          server.listen(0, "127.0.0.1");
-          await once(server, "listening");
-          const { port } = server.address();
+        let socketRef;
+        const server = net.createServer(socket => {
+          socketRef = socket;
+          onSocket(socket);
+        });
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const { port } = server.address();
 
-          const sql = new SQL({ url: url(port), max: 1, connectionTimeout: 30 });
+        const sql = new SQL({ url: url(port), max: 1, connectionTimeout: 30 });
 
-          // Capture the native connection by shadowing the query handle's
-          // .run(connection, query) — the pool hands it the native handle.
-          let nativeConnection;
-          let runCount = 0;
-          const q = sql\`select 1\`;
-          q.values(); // force lazy creation of the native query handle
-          const handleSym = Object.getOwnPropertySymbols(q).find(s => s.description === "handle");
-          const handle = q[handleSym];
-          const protoRun = Object.getPrototypeOf(handle).run;
-          Object.defineProperty(handle, "run", {
-            configurable: true,
-            writable: true,
-            value(connection, query) {
-              nativeConnection = connection;
-              runCount++;
-              return protoRun.call(this, connection, query);
-            },
-          });
-          const settled = q.catch(err => err?.code ?? String(err));
+        // Capture the native connection by shadowing the query handle's
+        // .run(connection, query) — the pool hands it the native handle.
+        let nativeConnection;
+        let runCount = 0;
+        const q = sql\`select 1\`;
+        q.values(); // force lazy creation of the native query handle
+        const handleSym = Object.getOwnPropertySymbols(q).find(s => s.description === "handle");
+        const handle = q[handleSym];
+        const protoRun = Object.getPrototypeOf(handle).run;
+        Object.defineProperty(handle, "run", {
+          configurable: true,
+          writable: true,
+          value(connection, query) {
+            nativeConnection = connection;
+            runCount++;
+            return protoRun.call(this, connection, query);
+          },
+        });
+        const settled = q.catch(err => err?.code ?? String(err));
 
-          // Wait for the connection to establish and the query to enqueue.
-          while (runCount === 0) await new Promise(r => setImmediate(r));
+        // Wait for the connection to establish and the query to enqueue.
+        while (runCount === 0) await new Promise(r => setImmediate(r));
 
-          // Replace the pool's JS onclose so it does not pre-emptively drop
-          // our reference; we want the native connection to outlive the
-          // socket by at least one tick.
-          nativeConnection.onclose = () => {};
+        // Replace the pool's JS onclose so it does not pre-emptively drop
+        // our reference; we want the native connection to outlive the
+        // socket by at least one tick.
+        nativeConnection.onclose = () => {};
 
-          // Server drops the socket -> native on_close -> status=Failed. The
-          // us_socket_t goes onto closed_head and is freed at the end of the
-          // current usockets tick.
-          socketRef.destroy();
+        // Server drops the socket -> native on_close -> status=Failed. The
+        // us_socket_t goes onto closed_head and is freed at the end of the
+        // current usockets tick.
+        socketRef.destroy();
 
-          // Yield past us_internal_free_closed_sockets.
-          for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r));
+        // Yield past us_internal_free_closed_sockets.
+        for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r));
 
-          // Without the fix this reads s->flags.is_closed on a freed
-          // us_socket_t and ASAN aborts with heap-use-after-free.
-          ${touch}
+        // Without the fix this reads s->flags.is_closed on a freed
+        // us_socket_t and ASAN aborts with heap-use-after-free.
+        ${touch}
 
-          await settled;
-          // A second round of touches after the promise machinery has
-          // settled covers the re-entrant path the timer originally hit.
-          ${touch}
+        await settled;
+        // A second round of touches after the promise machinery has
+        // settled covers the re-entrant path the timer originally hit.
+        ${touch}
 
-          console.log("ok");
-          process.exit(0);
-        `,
-      });
+        console.log("ok");
+        process.exit(0);
+      `,
+    });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "fixture.ts"],
-        env: {
-          ...bunEnv,
-          // symbolize=0: the full symbolized report under debug+ASAN can
-          // take tens of seconds; we only need to see the crash, not the
-          // stack.
-          ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
-          BUN_ENABLE_CRASH_REPORTING: "0",
-        },
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-        timeout: 20_000,
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      env: {
+        ...bunEnv,
+        // symbolize=0: the full symbolized report under debug+ASAN can
+        // take tens of seconds; we only need to see the crash, not the
+        // stack.
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
+        BUN_ENABLE_CRASH_REPORTING: "0",
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+    });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // stderr is kept in the diff via expect.any(String); the failure
-      // signal is the missing "ok\n" and non-zero exitCode (ASAN aborts).
-      expect({ stdout, stderr, exitCode }).toEqual({
-        stdout: "ok\n",
-        stderr: expect.any(String),
-        exitCode: 0,
-      });
-    },
-  );
-}
+    // stderr is kept in the diff via expect.any(String); the failure
+    // signal is the missing "ok\n" and non-zero exitCode (ASAN aborts).
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "ok\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+);

--- a/test/js/sql/sql-connection-socket-uaf.test.ts
+++ b/test/js/sql/sql-connection-socket-uaf.test.ts
@@ -1,0 +1,166 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// The SQL drivers kept the raw us_socket_t* in self.socket after
+// on_close/on_connect_error; usockets frees it at end-of-tick, so later
+// reads (timer callbacks, ref()/unref()/close()) were heap-use-after-free.
+// Capture the native handle via the query handle's .run(connection, …),
+// drop the server socket, yield past the free, then touch the handle.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
+import path from "node:path";
+
+const wireFrames = path.join(import.meta.dir, "wire-frames.ts");
+
+const drivers = [
+  {
+    name: "postgres",
+    // .ref() calls update_has_pending_activity() which reads
+    // self.socket.is_closed() when the connection is in a terminal state.
+    touch: "nativeConnection.ref(); nativeConnection.unref();",
+    server: /* js */ `
+      import { pgAuthenticationOk, pgReadyForQuery } from ${JSON.stringify(wireFrames)};
+      export const url = port => \`postgres://postgres@127.0.0.1:\${port}/db\`;
+      export function onSocket(socket) {
+        socket.once("data", () => {
+          socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        });
+        socket.on("error", () => {});
+      }`,
+  },
+  {
+    name: "mysql",
+    // .close() on a failed connection calls clean_queue_and_close() which
+    // calls self.socket.close() and so reads the freed is_closed flag.
+    touch: "nativeConnection.close();",
+    server: /* js */ `
+      import { mysqlAckSessionSetup, mysqlHandshakeV10, mysqlOkPacket } from ${JSON.stringify(wireFrames)};
+      export const url = port => \`mysql://root@127.0.0.1:\${port}/db\`;
+      export function onSocket(socket) {
+        let buffered = Buffer.alloc(0), authed = false;
+        socket.write(mysqlHandshakeV10());
+        socket.on("data", chunk => {
+          buffered = Buffer.concat([buffered, chunk]);
+          while (buffered.length >= 4) {
+            const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+            if (buffered.length < 4 + len) break;
+            const seq = buffered[3];
+            const payload = buffered.subarray(4, 4 + len);
+            buffered = buffered.subarray(4 + len);
+            if (!authed) { authed = true; socket.write(mysqlOkPacket(seq + 1)); }
+            else mysqlAckSessionSetup(socket, payload);
+            // never respond to queries, so they stay in the native request queue
+          }
+        });
+        socket.on("error", () => {});
+      }`,
+  },
+] as const;
+
+// The failure is a 1-byte heap-use-after-free; it is only observable under
+// ASAN (debug builds enable ASAN).
+for (const { name, touch, server } of drivers) {
+  test.skipIf(!isDebug && !isASAN)(
+    `${name}: touching the native connection after the socket is freed does not read freed memory`,
+    async () => {
+      using dir = tempDir(`sql-conn-socket-uaf-${name}`, {
+        "server.ts": server,
+        "fixture.ts": /* js */ `
+          import net from "node:net";
+          import { once } from "node:events";
+          import { SQL } from "bun";
+          import { onSocket, url } from "./server.ts";
+
+          let socketRef;
+          const server = net.createServer(socket => {
+            socketRef = socket;
+            onSocket(socket);
+          });
+          server.listen(0, "127.0.0.1");
+          await once(server, "listening");
+          const { port } = server.address();
+
+          const sql = new SQL({ url: url(port), max: 1, connectionTimeout: 30 });
+
+          // Capture the native connection by shadowing the query handle's
+          // .run(connection, query) — the pool hands it the native handle.
+          let nativeConnection;
+          let runCount = 0;
+          const q = sql\`select 1\`;
+          q.values(); // force lazy creation of the native query handle
+          const handleSym = Object.getOwnPropertySymbols(q).find(s => s.description === "handle");
+          const handle = q[handleSym];
+          const protoRun = Object.getPrototypeOf(handle).run;
+          Object.defineProperty(handle, "run", {
+            configurable: true,
+            writable: true,
+            value(connection, query) {
+              nativeConnection = connection;
+              runCount++;
+              return protoRun.call(this, connection, query);
+            },
+          });
+          const settled = q.catch(err => err?.code ?? String(err));
+
+          // Wait for the connection to establish and the query to enqueue.
+          while (runCount === 0) await new Promise(r => setImmediate(r));
+
+          // Replace the pool's JS onclose so it does not pre-emptively drop
+          // our reference; we want the native connection to outlive the
+          // socket by at least one tick.
+          nativeConnection.onclose = () => {};
+
+          // Server drops the socket -> native on_close -> status=Failed. The
+          // us_socket_t goes onto closed_head and is freed at the end of the
+          // current usockets tick.
+          socketRef.destroy();
+
+          // Yield past us_internal_free_closed_sockets.
+          for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r));
+
+          // Without the fix this reads s->flags.is_closed on a freed
+          // us_socket_t and ASAN aborts with heap-use-after-free.
+          ${touch}
+
+          await settled;
+          // A second round of touches after the promise machinery has
+          // settled covers the re-entrant path the timer originally hit.
+          ${touch}
+
+          console.log("ok");
+          process.exit(0);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.ts"],
+        env: {
+          ...bunEnv,
+          // symbolize=0: the full symbolized report under debug+ASAN can
+          // take tens of seconds; we only need to see the crash, not the
+          // stack.
+          ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
+          BUN_ENABLE_CRASH_REPORTING: "0",
+        },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 20_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // stderr is kept in the diff via expect.any(String); the failure
+      // signal is the missing "ok\n" and non-zero exitCode (ASAN aborts).
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "ok\n",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
+    },
+  );
+}

--- a/test/js/sql/sql-connection-socket-uaf.test.ts
+++ b/test/js/sql/sql-connection-socket-uaf.test.ts
@@ -63,7 +63,7 @@ const drivers = [
 
 // The failure is a 1-byte heap-use-after-free; it is only observable under
 // ASAN (debug builds enable ASAN).
-test.skipIf(!isDebug && !isASAN).each(drivers)(
+test.concurrent.skipIf(!isDebug && !isASAN).each(drivers)(
   "$name: touching the native connection after the socket is freed does not read freed memory",
   async ({ name, touch, server }) => {
     using dir = tempDir(`sql-conn-socket-uaf-${name}`, {
@@ -109,17 +109,20 @@ test.skipIf(!isDebug && !isASAN).each(drivers)(
         while (runCount === 0) await new Promise(r => setImmediate(r));
 
         // Replace the pool's JS onclose so it does not pre-emptively drop
-        // our reference; we want the native connection to outlive the
-        // socket by at least one tick.
-        nativeConnection.onclose = () => {};
+        // our reference (we want the native connection to outlive the
+        // socket), and use it to observe the native on_close dispatch.
+        const { promise: closed, resolve: onNativeClose } = Promise.withResolvers();
+        nativeConnection.onclose = onNativeClose;
 
         // Server drops the socket -> native on_close -> status=Failed. The
         // us_socket_t goes onto closed_head and is freed at the end of the
         // current usockets tick.
         socketRef.destroy();
+        await closed;
 
-        // Yield past us_internal_free_closed_sockets.
-        for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r));
+        // One more tick: us_internal_free_closed_sockets runs at the end of
+        // the loop iteration that dispatched on_close.
+        await new Promise(r => setImmediate(r));
 
         // Without the fix this reads s->flags.is_closed on a freed
         // us_socket_t and ASAN aborts with heap-use-after-free.


### PR DESCRIPTION
### What does this PR do?

Fixes a use-after-free in `Bun.sql` for MySQL and Postgres: calling `sql.close()` (or `ref()`/`unref()`, or a connection-timeout timer firing) after the server had already dropped the connection could crash, e.g. a segfault at address 0x0 in `us_internal_ssl_close` on a plain-TCP MySQL connection.

Both drivers kept the raw `us_socket_t*` in `self.socket` after usockets dispatched `on_close` / `on_connect_error`. usockets frees closed sockets at the end of the loop iteration, so any later access through `self.socket` read freed memory; `us_socket_close` on the freed socket saw a garbage `s->ssl` and took the TLS close path. The stored socket is now reset to detached at the top of both callbacks in both drivers, matching what the Valkey client already does. A detached socket reports `is_closed()` and makes `close()`/`write()` no-ops.

This is #32861 rebased onto current main (that branch conflicts), with its mock server updated to ack the `SET time_zone` session-setup query the MySQL client now sends. Supersedes #32861.

### How did you verify your code works?

`test/js/sql/sql-connection-socket-uaf.test.ts` captures the native connection, has a mock server drop the socket, yields past the free, then calls `ref()` (Postgres) / `close()` (MySQL) on it. On a debug+ASan build without the change both cases abort with `heap-use-after-free`; with it both pass.
