### PR TITLE
sql: deliver onconnect before onclose so a connection killed right after connecting can't strand a query

### DIFF
--- a/src/sql/shared/ConnectionFlags.rs
+++ b/src/sql/shared/ConnectionFlags.rs
@@ -10,6 +10,10 @@ bitflags! {
         const HAS_BACKPRESSURE                = 1 << 4;
         /// `ref()` was called; `on_data` must not unref the idle connection.
         const KEEP_ALIVE_REQUESTED            = 1 << 5;
+        /// The connection became established during the current read; the
+        /// `onconnect` callback is delivered when that read has been fully
+        /// processed, and only if the connection is still established then.
+        const ON_CONNECT_PENDING              = 1 << 6;
     }
 }
 

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -714,7 +714,12 @@ impl JSMySQLConnection {
     /// fails later in the same read reports `onclose` alone, never `onclose`
     /// followed by a stale `onconnect` for an already-dead connection.
     fn notify_connected(&self) {
-        if !self.connection.get().flags.contains(ConnectionFlags::ON_CONNECT_PENDING) {
+        if !self
+            .connection
+            .get()
+            .flags
+            .contains(ConnectionFlags::ON_CONNECT_PENDING)
+        {
             return;
         }
         self.connection_mut()

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -18,6 +18,7 @@ use bun_sql::mysql::protocol::error_packet::ErrorPacket;
 use bun_sql::mysql::protocol::new_reader::NewReader;
 use bun_sql::mysql::protocol::new_writer::NewWriter;
 use bun_sql::mysql::ssl_mode::SSLMode;
+use bun_sql::shared::connection_flags::ConnectionFlags;
 use bun_uws::{self as uws, AnySocket, NewSocketHandler, SocketTCP};
 
 use super::js_mysql_query::JSMySQLQuery;
@@ -706,15 +707,34 @@ impl JSMySQLConnection {
         self.fail_with_js_value(instance);
     }
 
-    pub(crate) fn on_connection_estabilished(&self) {
+    /// Delivers `onconnect` once the read that established the connection has
+    /// been fully processed. Running it from here rather than from inside the
+    /// packet parser keeps JS out of the parser, and running it synchronously
+    /// (like `onclose`) keeps the two callbacks ordered: a connection that
+    /// fails later in the same read reports `onclose` alone, never `onclose`
+    /// followed by a stale `onconnect` for an already-dead connection.
+    fn notify_connected(&self) {
+        if !self.connection.get().flags.contains(ConnectionFlags::ON_CONNECT_PENDING) {
+            return;
+        }
+        self.connection_mut()
+            .flags
+            .remove(ConnectionFlags::ON_CONNECT_PENDING);
+        if self.connection.get().status != my_sql_connection::Status::Connected {
+            return;
+        }
         let Some(on_connect) = self.consume_on_connect_callback(&self.global_object) else {
             return;
         };
         on_connect.ensure_still_alive();
         let js_value = self.js_value.get().try_get().unwrap_or(JSValue::UNDEFINED);
         js_value.ensure_still_alive();
-        self.global_object
-            .queue_microtask(on_connect, &[JSValue::NULL, js_value]);
+        self.event_loop().run_callback(
+            on_connect,
+            &self.global_object,
+            JSValue::UNDEFINED,
+            &[JSValue::NULL, js_value],
+        );
     }
 
     pub(crate) fn on_query_result(&self, request: &JSMySQLQuery, result: &MySQLQueryResult) {
@@ -973,6 +993,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         if let Err(e) = this.connection_mut().read_and_process_data(data) {
             this.on_error(None, e);
         }
+        this.notify_connected();
     }
 
     pub fn on_writable(this: &JSMySQLConnection, _: NewSocketHandler<SSL>) {

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -86,7 +86,7 @@ pub struct MySQLConnection {
     tls_status: TLSStatus,
     ssl_mode: SSLMode,
     allow_public_key_retrieval: bool,
-    flags: ConnectionFlags,
+    pub(crate) flags: ConnectionFlags,
 }
 
 impl Default for MySQLConnection {
@@ -747,12 +747,8 @@ impl MySQLConnection {
 
         self.status = status;
 
-        match status {
-            ConnectionState::Connected => {
-                // `on_connection_estabilished` spelling is intentional (sic).
-                self.js_connection_ref().on_connection_estabilished();
-            }
-            _ => {}
+        if status == ConnectionState::Connected {
+            self.flags.insert(ConnectionFlags::ON_CONNECT_PENDING);
         }
     }
 
@@ -988,8 +984,17 @@ impl MySQLConnection {
         reader: NewReader<C>,
         header_length: u32, // u24 on the wire
     ) -> Result<(), AnyMySQLError> {
-        // Get the current request if any
         let Some(request) = self.queue.current() else {
+            // No query in flight. The only packet a server sends on its own is
+            // an ERR right before it drops the connection (shutdown, KILL,
+            // wait_timeout / ER_CLIENT_INTERACTION_TIMEOUT); surface that
+            // error instead of a generic unexpected-packet failure.
+            if PacketType(reader.peek().first().copied().unwrap_or(0)) == PacketType::ERROR {
+                let mut err = ErrorPacket::default();
+                err.decode_internal(reader)?;
+                self.js_connection_ref().on_error_packet(None, &err);
+                return Err(AnyMySQLError::ConnectionClosed);
+            }
             debug!("Received unexpected command response");
             return Err(AnyMySQLError::UnexpectedPacket);
         };

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -647,21 +647,42 @@ impl PostgresSQLConnection {
 
         self.status.set(status);
         self.reset_connection_timeout();
-        match status {
-            Status::Connected => {
-                let Some(on_connect) = self.consume_on_connect_callback(self.global()) else {
-                    self.update_has_pending_activity();
-                    return;
-                };
-                let js_value = self.js_value.get().get();
-                js_value.ensure_still_alive();
-                self.global()
-                    .queue_microtask(on_connect, &[JSValue::NULL, js_value]);
-                self.poll_ref.with_mut(|r| r.unref(self.vm_ctx()));
-            }
-            _ => {}
+        if status == Status::Connected {
+            self.update_flags(|f| f.insert(ConnectionFlags::ON_CONNECT_PENDING));
+            self.poll_ref.with_mut(|r| r.unref(self.vm_ctx()));
         }
         self.update_has_pending_activity();
+    }
+
+    /// Delivers `onconnect` once the read that established the connection has
+    /// been fully processed. Running it from here rather than from inside the
+    /// message parser keeps JS out of the parser, and running it synchronously
+    /// (like `onclose`) keeps the two callbacks ordered: a connection that
+    /// fails later in the same read reports `onclose` alone, never `onclose`
+    /// followed by a stale `onconnect` for an already-dead connection.
+    fn notify_connected(&self) {
+        if !self
+            .flags
+            .get()
+            .contains(ConnectionFlags::ON_CONNECT_PENDING)
+        {
+            return;
+        }
+        self.update_flags(|f| f.remove(ConnectionFlags::ON_CONNECT_PENDING));
+        if self.status.get() != Status::Connected {
+            return;
+        }
+        let Some(on_connect) = self.consume_on_connect_callback(self.global()) else {
+            return;
+        };
+        let js_value = self.js_value.get().get();
+        js_value.ensure_still_alive();
+        self.event_loop().run_callback(
+            on_connect,
+            self.global(),
+            JSValue::UNDEFINED,
+            &[JSValue::NULL, js_value],
+        );
     }
 
     pub fn finalize(&self) {
@@ -1033,6 +1054,7 @@ impl PostgresSQLConnection {
             }
         }
 
+        self.notify_connected();
         event_loop.exit();
         // === defer block ===
         if self.status.get() == Status::Connected
@@ -2920,8 +2942,13 @@ impl PostgresSQLConnection {
                 }
 
                 let Some(request) = self.current() else {
-                    debug!("ErrorResponse: {}", err);
-                    return Err(AnyPostgresError::ExpectedRequest);
+                    // No query in flight: the server is terminating the
+                    // session (admin shutdown, idle_session_timeout, ...).
+                    let v =
+                        crate::postgres::protocol::error_response_jsc::to_js(&err, self.global());
+                    drop(err);
+                    self.fail_with_js_value(v);
+                    return Ok(());
                 };
                 // Convert to JS while we still own `err` — materialize the JS value once and route through
                 // `on_js_error` to avoid double-ownership of the non-Clone ErrorResponse.

--- a/test/js/sql/sql-connect-error-reporting.test.ts
+++ b/test/js/sql/sql-connect-error-reporting.test.ts
@@ -437,9 +437,7 @@ test("mysql: a connection killed in the same read that established it is not han
   const onconnect = mock();
   const onclose = mock();
   const { port, server } = await mysqlServerUpToAuthOk(socket => {
-    socket.write(
-      Buffer.concat([mysqlOkPacket(1), mysqlErrPacket(0, 1053, "08S01", "Server shutdown in progress")]),
-    );
+    socket.write(Buffer.concat([mysqlOkPacket(1), mysqlErrPacket(0, 1053, "08S01", "Server shutdown in progress")]));
     socket.end();
   });
   const db = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 0.25, onconnect, onclose });

--- a/test/js/sql/sql-connect-error-reporting.test.ts
+++ b/test/js/sql/sql-connect-error-reporting.test.ts
@@ -179,6 +179,52 @@ test("postgres: established connection that closes keeps the plain message", asy
   }
 });
 
+// The server establishes the connection and kills it in the same write
+// (ReadyForQuery immediately followed by a FATAL ErrorResponse, e.g. an
+// admin shutdown or too-many-connections check that runs after auth). The
+// driver used to report onconnect via a microtask but onclose synchronously,
+// so the pool saw onclose first, then a stale onconnect that handed the dead
+// connection to the waiting query, which then never settled.
+test("postgres: a connection killed in the same read that established it is not handed to a query", async () => {
+  const onconnect = mock();
+  const onclose = mock();
+  const { port, server } = await listeningServer(socket => {
+    socket.once("data", () => {
+      socket.write(
+        Buffer.concat([
+          pgAuthenticationOk(),
+          pgReadyForQuery(),
+          pgErrorResponse({ S: "FATAL", C: "57P01", M: "terminating connection due to administrator command" }),
+        ]),
+      );
+      socket.end();
+    });
+    socket.on("error", () => {});
+  });
+  const db = new SQL({
+    url: `postgres://postgres@127.0.0.1:${port}/postgres`,
+    max: 1,
+    connectionTimeout: 0.25,
+    onconnect,
+    onclose,
+  });
+  try {
+    const err: any = await db`SELECT 1`.then(
+      () => {
+        throw new Error("expected the query to reject");
+      },
+      e => e,
+    );
+    expect(err.code).toBe("ERR_POSTGRES_SERVER_ERROR");
+    expect(err.message).toBe("terminating connection due to administrator command");
+    expect(onconnect).not.toHaveBeenCalled();
+    expect(onclose).toHaveBeenCalledTimes(1);
+  } finally {
+    await db.close({ timeout: 0 });
+    server.close();
+  }
+});
+
 test("mysql: connection refused is reported distinctly and fails fast", async () => {
   const port = await closedPort();
   const start = Date.now();
@@ -379,6 +425,35 @@ test("mysql: a socket close during session setup is a connect failure", async ()
     expect(err.message).toBe("Connection closed before the connection was established");
     expect(err.code).toBe("ERR_MYSQL_CONNECTION_FAILED");
     expect(onconnect).not.toHaveBeenCalled();
+  } finally {
+    await db.close({ timeout: 0 });
+    server.close();
+  }
+});
+
+// MySQL flavour of the postgres test above: the session-setup OK establishes
+// the connection and an ERR packet in the same write kills it.
+test("mysql: a connection killed in the same read that established it is not handed to a query", async () => {
+  const onconnect = mock();
+  const onclose = mock();
+  const { port, server } = await mysqlServerUpToAuthOk(socket => {
+    socket.write(
+      Buffer.concat([mysqlOkPacket(1), mysqlErrPacket(0, 1053, "08S01", "Server shutdown in progress")]),
+    );
+    socket.end();
+  });
+  const db = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 0.25, onconnect, onclose });
+  try {
+    const err: any = await db`SELECT 1`.then(
+      () => {
+        throw new Error("expected the query to reject");
+      },
+      e => e,
+    );
+    expect(err.code).toBe("ERR_MYSQL_SERVER_ERROR");
+    expect(err.message).toBe("Server shutdown in progress");
+    expect(onconnect).not.toHaveBeenCalled();
+    expect(onclose).toHaveBeenCalledTimes(1);
   } finally {
     await db.close({ timeout: 0 });
     server.close();


### PR DESCRIPTION
### What does this PR do?

Fixes a `Bun.sql` query hanging forever when the server establishes a connection and kills it within the same socket read — e.g. MySQL answering the session-setup `SET time_zone` with OK and then an ERR (shutdown / `KILL` / a proxy dropping the backend), or Postgres sending `ReadyForQuery` followed by a FATAL `ErrorResponse` (57P01 admin shutdown, too-many-connections checks that run after auth).

Both drivers reported `onconnect` to the JS pool through a queued microtask but `onclose` synchronously. When the failure was processed later in the same read, the pool saw `onclose` first and then a stale `onconnect`, which marked the dead connection as connected again; the waiting query was enqueued on a native connection that would never run or reject it.

`onconnect` is now delivered synchronously, once the read that established the connection has been fully processed and only if the connection is still established then. A connection that dies in the same read reports `onclose` alone, which the pool already handles as closed-before-connect. JS still never runs from inside the packet parser.

Also: an ERR packet / `ErrorResponse` that arrives with no query in flight (server shutdown, `KILL`, `wait_timeout` / `idle_session_timeout`) now fails the connection with the server's own error instead of `ERR_MYSQL_UNEXPECTED_PACKET` / `ERR_POSTGRES_EXPECTED_REQUEST`.

### How did you verify your code works?

Two new cases in `test/js/sql/sql-connect-error-reporting.test.ts` use a mock server that writes the establishing packet and a fatal error in one write, then assert the first query rejects with the server error, `onconnect` is not called and `onclose` is called once. On 1.4.0 the Postgres case times out (the hang) and the MySQL case reports the generic code; with this change both pass, along with the rest of that file and the other mock-server SQL tests (`sql-onconnect-onclose-throw`, `sql-close-pending-connection`, `sql-mysql-clean-reentry`, `postgres-failed-connection-resurrection`). The container suites are left to CI.
