### PR TITLE
compile: return module.exports from a run-time require() of an embedded CommonJS entry point

### DIFF
--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -126,8 +126,7 @@ pub mod js_meta {
         pub sorted_and_filtered_export_aliases: SortedAndFilteredExportAliases,
         pub top_level_symbol_to_parts_overlay: TopLevelSymbolToParts,
         pub cjs_export_copies: CjsExportCopies,
-        /// In a compile build, the top-level binding of a CommonJS entry point's
-        /// `module.exports` value (see `generate_entry_point_tail_js`), else `Ref::NONE`.
+        /// Compile builds: the entry point tail's `module.exports` binding, else `Ref::NONE`.
         pub module_exports_ref: Ref,
         pub wrapper_part_index: Index,
         pub flags: Flags,

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -126,10 +126,8 @@ pub mod js_meta {
         pub sorted_and_filtered_export_aliases: SortedAndFilteredExportAliases,
         pub top_level_symbol_to_parts_overlay: TopLevelSymbolToParts,
         pub cjs_export_copies: CjsExportCopies,
-        /// A CommonJS entry point of a `--compile` ESM build binds its
-        /// `module.exports` value to this top-level symbol so the chunk can
-        /// export it as both `default` and `"module.exports"`
-        /// (`generate_entry_point_tail_js`). `Ref::NONE` otherwise.
+        /// In a compile build, the top-level binding of a CommonJS entry point's
+        /// `module.exports` value (see `generate_entry_point_tail_js`), else `Ref::NONE`.
         pub module_exports_ref: Ref,
         pub wrapper_part_index: Index,
         pub flags: Flags,

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -126,6 +126,11 @@ pub mod js_meta {
         pub sorted_and_filtered_export_aliases: SortedAndFilteredExportAliases,
         pub top_level_symbol_to_parts_overlay: TopLevelSymbolToParts,
         pub cjs_export_copies: CjsExportCopies,
+        /// A CommonJS entry point of a `--compile` ESM build binds its
+        /// `module.exports` value to this top-level symbol so the chunk can
+        /// export it as both `default` and `"module.exports"`
+        /// (`generate_entry_point_tail_js`). `Ref::NONE` otherwise.
+        pub module_exports_ref: Ref,
         pub wrapper_part_index: Index,
         pub flags: Flags,
     }
@@ -140,6 +145,7 @@ pub mod js_meta {
                 sorted_and_filtered_export_aliases: AstAlloc::vec(),
                 top_level_symbol_to_parts_overlay: TopLevelSymbolToParts::default(),
                 cjs_export_copies: AstAlloc::vec(),
+                module_exports_ref: Ref::NONE,
                 wrapper_part_index: Index::default(),
                 flags: Flags::default(),
             }
@@ -155,6 +161,7 @@ pub mod js_meta {
             sorted_and_filtered_export_aliases: SortedAndFilteredExportAliases,
             top_level_symbol_to_parts_overlay: TopLevelSymbolToParts,
             cjs_export_copies: CjsExportCopies,
+            module_exports_ref: Ref,
             wrapper_part_index: Index,
             flags: Flags,
         }

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -1061,9 +1061,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                                     },
                                     bun_ast::Loc::EMPTY,
                                 ));
-                                items.extend(
-                                    module_exports_clause_items(module_exports_ref).into_iter(),
-                                );
+                                items.extend(module_exports_clause_items(module_exports_ref));
                             }
                         }
 

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -772,7 +772,6 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                         c.graph.meta.items_module_exports_ref()[source_index as usize];
                     if module_exports_ref.is_valid() {
                         // "var foo_default = require_foo();"
-                        // "export { foo_default as default, foo_default as "module.exports" };"
                         stmts.push(Stmt::alloc(
                             S::Local {
                                 decls: G::DeclList::from_slice(&[G::Decl {
@@ -789,6 +788,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                             },
                             bun_ast::Loc::EMPTY,
                         ));
+                        // "export { foo_default as default, foo_default as "module.exports" };"
                         let items: &mut [bun_ast::ClauseItem] = arena
                             .alloc_slice_fill_iter(module_exports_clause_items(module_exports_ref));
                         stmts.push(Stmt::alloc(
@@ -1027,7 +1027,6 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
 
                         if module_exports_ref.is_valid() {
                             // "var foo_default = { get a() { return a; } };"
-                            // "export { a, foo_default as default, foo_default as "module.exports" };"
                             debug_assert!(synthetic_default.is_some());
                             if let Some(value) = synthetic_default.take() {
                                 stmts.push(Stmt::alloc(
@@ -1207,8 +1206,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
     }
 }
 
-/// `foo_default as default, foo_default as "module.exports"`. Bun's `require()`
-/// of an ES module returns its `"module.exports"` export when there is one.
+/// `foo_default as default, foo_default as "module.exports"`, the names `require(esm)` reads.
 fn module_exports_clause_items(module_exports_ref: Ref) -> [bun_ast::ClauseItem; 2] {
     let aliases: [&[u8]; 2] = [b"default", b"module.exports"];
     aliases.map(|alias| bun_ast::ClauseItem {
@@ -1222,8 +1220,7 @@ fn module_exports_clause_items(module_exports_ref: Ref) -> [bun_ast::ClauseItem;
     })
 }
 
-/// `{ get a() { return a; }, ... }`, one getter per export clause item: what
-/// `module.exports` would have been for a CommonJS module converted to ESM.
+/// `{ get a() { return a; }, ... }`: the `module.exports` a CommonJS module converted to ESM lacks.
 fn synthetic_default_export_object(arena: &Arena, items: &[bun_ast::ClauseItem]) -> Expr {
     let mut properties = G::PropertyList::init_capacity(items.len());
     let getter_fn_body: &mut [Stmt] = arena.alloc_slice_fill_default(items.len());

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -761,26 +761,61 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
         options::OutputFormat::Esm => {
             match flags.wrap {
                 crate::WrapKind::Cjs => {
-                    stmts.push(Stmt::alloc(
-                        // "export default require_foo();"
-                        S::ExportDefault {
-                            default_name: bun_ast::LocRef {
-                                loc: bun_ast::Loc::EMPTY,
-                                ref_: ast.wrapper_ref,
-                            },
-                            value: StmtOrExpr::Expr(Expr::init(
-                                E::Call {
-                                    target: Expr::init_identifier(
-                                        ast.wrapper_ref,
-                                        bun_ast::Loc::EMPTY,
-                                    ),
-                                    ..Default::default()
-                                },
-                                bun_ast::Loc::EMPTY,
-                            )),
+                    let require_call = Expr::init(
+                        E::Call {
+                            target: Expr::init_identifier(ast.wrapper_ref, bun_ast::Loc::EMPTY),
+                            ..Default::default()
                         },
                         bun_ast::Loc::EMPTY,
-                    ));
+                    );
+                    let module_exports_ref =
+                        c.graph.meta.items_module_exports_ref()[source_index as usize];
+                    if module_exports_ref.is_valid() {
+                        // A compiled executable evaluates this chunk as ESM. Its
+                        // `require()` returns the `"module.exports"` export when
+                        // there is one, so a run-time `require()` of this entry
+                        // point gets `module.exports` instead of the namespace.
+                        //
+                        //   var foo_default = require_foo();
+                        //   export { foo_default as default, foo_default as "module.exports" };
+                        stmts.push(Stmt::alloc(
+                            S::Local {
+                                decls: G::DeclList::from_slice(&[G::Decl {
+                                    binding: Binding::alloc(
+                                        temp_arena,
+                                        B::Identifier {
+                                            r#ref: module_exports_ref,
+                                        },
+                                        bun_ast::Loc::EMPTY,
+                                    ),
+                                    value: Some(require_call),
+                                }]),
+                                ..Default::default()
+                            },
+                            bun_ast::Loc::EMPTY,
+                        ));
+                        let items: &mut [bun_ast::ClauseItem] = arena
+                            .alloc_slice_fill_iter(module_exports_clause_items(module_exports_ref));
+                        stmts.push(Stmt::alloc(
+                            S::ExportClause {
+                                items: bun_ast::StoreSlice::new_mut(items),
+                                is_single_line: false,
+                            },
+                            bun_ast::Loc::EMPTY,
+                        ));
+                    } else {
+                        // "export default require_foo();"
+                        stmts.push(Stmt::alloc(
+                            S::ExportDefault {
+                                default_name: bun_ast::LocRef {
+                                    loc: bun_ast::Loc::EMPTY,
+                                    ref_: ast.wrapper_ref,
+                                },
+                                value: StmtOrExpr::Expr(require_call),
+                            },
+                            bun_ast::Loc::EMPTY,
+                        ));
+                    }
                 }
                 _ => {
                     if flags.wrap == crate::WrapKind::Esm && ast.wrapper_ref.is_valid() {
@@ -986,6 +1021,52 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                         }
 
                         let own_len = items.len();
+
+                        // A CommonJS module that the bundler converted to ESM exports
+                        // has no `module.exports` object. Code that `import()`s or
+                        // `require()`s it may expect one, so build an object with a
+                        // getter per statically known export. This is kind of similar
+                        // to what Node.js does.
+                        let module_exports_ref =
+                            c.graph.meta.items_module_exports_ref()[source_index as usize];
+                        let mut synthetic_default: Option<Expr> = (!had_default_export
+                            && own_len > 0
+                            && (module_exports_ref.is_valid()
+                                || flags.needs_synthetic_default_export))
+                            .then(|| synthetic_default_export_object(arena, &items[..own_len]));
+
+                        if module_exports_ref.is_valid() {
+                            // In a compiled executable, `require()` of this chunk
+                            // returns the `"module.exports"` export and `import()`
+                            // reads `default`, so the object gets a binding that is
+                            // exported under both names.
+                            //
+                            //   var foo_default = { get a() { return a; } };
+                            //   export { a, foo_default as default, foo_default as "module.exports" };
+                            debug_assert!(synthetic_default.is_some());
+                            if let Some(value) = synthetic_default.take() {
+                                stmts.push(Stmt::alloc(
+                                    S::Local {
+                                        decls: G::DeclList::from_slice(&[G::Decl {
+                                            binding: Binding::alloc(
+                                                temp_arena,
+                                                B::Identifier {
+                                                    r#ref: module_exports_ref,
+                                                },
+                                                bun_ast::Loc::EMPTY,
+                                            ),
+                                            value: Some(value),
+                                        }]),
+                                        ..Default::default()
+                                    },
+                                    bun_ast::Loc::EMPTY,
+                                ));
+                                items.extend(
+                                    module_exports_clause_items(module_exports_ref).into_iter(),
+                                );
+                            }
+                        }
+
                         items.extend(cross_chunk_exports.iter().map(|item| bun_ast::ClauseItem {
                             alias: item.alias,
                             alias_loc: item.alias_loc,
@@ -993,8 +1074,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                             original_name: item.original_name,
                         }));
                         // arena-owned `*mut [ClauseItem]` — move the
-                        // collected Vec into the linker arena. The arena slice is also iterated
-                        // below for the synthetic-default-export path.
+                        // collected Vec into the linker arena.
                         let items: &mut [bun_ast::ClauseItem] = arena.alloc_slice_fill_iter(items);
                         stmts.push(Stmt::alloc(
                             S::ExportClause {
@@ -1003,76 +1083,15 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                             },
                             bun_ast::Loc::EMPTY,
                         ));
-                        let items = &items[..own_len];
 
-                        if flags.needs_synthetic_default_export
-                            && !had_default_export
-                            && !items.is_empty()
-                        {
-                            let mut properties = G::PropertyList::init_capacity(items.len());
-                            let getter_fn_body: &mut [Stmt] =
-                                arena.alloc_slice_fill_default(items.len());
-                            let mut remain_getter_fn_body = &mut getter_fn_body[..];
-                            for export_item in items.iter() {
-                                let (fn_body, rest) = remain_getter_fn_body.split_at_mut(1);
-                                remain_getter_fn_body = rest;
-                                fn_body[0] = Stmt::alloc(
-                                    S::Return {
-                                        value: Some(Expr::init(
-                                            E::Identifier {
-                                                ref_: export_item.name.ref_,
-                                                ..Default::default()
-                                            },
-                                            export_item.name.loc,
-                                        )),
-                                    },
-                                    bun_ast::Loc::EMPTY,
-                                );
-                                VecExt::append(
-                                    &mut properties,
-                                    G::Property {
-                                        key: Some(Expr::init(
-                                            E::String {
-                                                // SAFETY: alias is an arena `*const [u8]`; never null.
-                                                data: export_item.alias.slice().into(),
-                                                is_utf16: false,
-                                                ..Default::default()
-                                            },
-                                            export_item.alias_loc,
-                                        )),
-                                        value: Some(Expr::init(
-                                            E::Function {
-                                                func: G::Fn {
-                                                    body: G::FnBody {
-                                                        loc: bun_ast::Loc::EMPTY,
-                                                        stmts: bun_ast::StoreSlice::new_mut(
-                                                            fn_body,
-                                                        ),
-                                                    },
-                                                    ..Default::default()
-                                                },
-                                            },
-                                            export_item.alias_loc,
-                                        )),
-                                        kind: G::PropertyKind::Get,
-                                        flags: bun_ast::Flags::Property::IsMethod.into(),
-                                        ..Default::default()
-                                    },
-                                );
-                            }
+                        if let Some(value) = synthetic_default {
                             stmts.push(Stmt::alloc(
                                 S::ExportDefault {
                                     default_name: bun_ast::LocRef {
                                         ref_: Ref::NONE,
                                         loc: bun_ast::Loc::EMPTY,
                                     },
-                                    value: StmtOrExpr::Expr(Expr::init(
-                                        E::Object {
-                                            properties,
-                                            ..Default::default()
-                                        },
-                                        bun_ast::Loc::EMPTY,
-                                    )),
+                                    value: StmtOrExpr::Expr(value),
                                 },
                                 bun_ast::Loc::EMPTY,
                             ));
@@ -1203,4 +1222,81 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
         // The exports were recorded straight into the chunk's ModuleInfo above.
         module_info: None,
     }
+}
+
+/// `foo_default as default, foo_default as "module.exports"`: the two export
+/// names under which a compiled executable's entry point tail exposes the
+/// `module.exports` value of a CommonJS entry point (`js_meta.module_exports_ref`).
+fn module_exports_clause_items(module_exports_ref: Ref) -> [bun_ast::ClauseItem; 2] {
+    let aliases: [&[u8]; 2] = [b"default", b"module.exports"];
+    aliases.map(|alias| bun_ast::ClauseItem {
+        name: bun_ast::LocRef {
+            ref_: module_exports_ref,
+            loc: bun_ast::Loc::EMPTY,
+        },
+        alias: bun_ast::StoreStr::new(alias),
+        alias_loc: bun_ast::Loc::EMPTY,
+        ..Default::default()
+    })
+}
+
+/// `{ get a() { return a; }, ... }`: one getter per export clause item, the shape
+/// `module.exports` would have had for a CommonJS module that the bundler
+/// converted to ESM exports.
+fn synthetic_default_export_object(arena: &Arena, items: &[bun_ast::ClauseItem]) -> Expr {
+    let mut properties = G::PropertyList::init_capacity(items.len());
+    let getter_fn_body: &mut [Stmt] = arena.alloc_slice_fill_default(items.len());
+    let mut remain_getter_fn_body = &mut getter_fn_body[..];
+    for export_item in items.iter() {
+        let (fn_body, rest) = remain_getter_fn_body.split_at_mut(1);
+        remain_getter_fn_body = rest;
+        fn_body[0] = Stmt::alloc(
+            S::Return {
+                value: Some(Expr::init(
+                    E::Identifier {
+                        ref_: export_item.name.ref_,
+                        ..Default::default()
+                    },
+                    export_item.name.loc,
+                )),
+            },
+            bun_ast::Loc::EMPTY,
+        );
+        VecExt::append(
+            &mut properties,
+            G::Property {
+                key: Some(Expr::init(
+                    E::String {
+                        // SAFETY: alias is an arena `*const [u8]`; never null.
+                        data: export_item.alias.slice().into(),
+                        is_utf16: false,
+                        ..Default::default()
+                    },
+                    export_item.alias_loc,
+                )),
+                value: Some(Expr::init(
+                    E::Function {
+                        func: G::Fn {
+                            body: G::FnBody {
+                                loc: bun_ast::Loc::EMPTY,
+                                stmts: bun_ast::StoreSlice::new_mut(fn_body),
+                            },
+                            ..Default::default()
+                        },
+                    },
+                    export_item.alias_loc,
+                )),
+                kind: G::PropertyKind::Get,
+                flags: bun_ast::Flags::Property::IsMethod.into(),
+                ..Default::default()
+            },
+        );
+    }
+    Expr::init(
+        E::Object {
+            properties,
+            ..Default::default()
+        },
+        bun_ast::Loc::EMPTY,
+    )
 }

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -771,13 +771,8 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                     let module_exports_ref =
                         c.graph.meta.items_module_exports_ref()[source_index as usize];
                     if module_exports_ref.is_valid() {
-                        // A compiled executable evaluates this chunk as ESM. Its
-                        // `require()` returns the `"module.exports"` export when
-                        // there is one, so a run-time `require()` of this entry
-                        // point gets `module.exports` instead of the namespace.
-                        //
-                        //   var foo_default = require_foo();
-                        //   export { foo_default as default, foo_default as "module.exports" };
+                        // "var foo_default = require_foo();"
+                        // "export { foo_default as default, foo_default as "module.exports" };"
                         stmts.push(Stmt::alloc(
                             S::Local {
                                 decls: G::DeclList::from_slice(&[G::Decl {
@@ -1022,11 +1017,6 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
 
                         let own_len = items.len();
 
-                        // A CommonJS module that the bundler converted to ESM exports
-                        // has no `module.exports` object. Code that `import()`s or
-                        // `require()`s it may expect one, so build an object with a
-                        // getter per statically known export. This is kind of similar
-                        // to what Node.js does.
                         let module_exports_ref =
                             c.graph.meta.items_module_exports_ref()[source_index as usize];
                         let mut synthetic_default: Option<Expr> = (!had_default_export
@@ -1036,13 +1026,8 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                             .then(|| synthetic_default_export_object(arena, &items[..own_len]));
 
                         if module_exports_ref.is_valid() {
-                            // In a compiled executable, `require()` of this chunk
-                            // returns the `"module.exports"` export and `import()`
-                            // reads `default`, so the object gets a binding that is
-                            // exported under both names.
-                            //
-                            //   var foo_default = { get a() { return a; } };
-                            //   export { a, foo_default as default, foo_default as "module.exports" };
+                            // "var foo_default = { get a() { return a; } };"
+                            // "export { a, foo_default as default, foo_default as "module.exports" };"
                             debug_assert!(synthetic_default.is_some());
                             if let Some(value) = synthetic_default.take() {
                                 stmts.push(Stmt::alloc(
@@ -1222,9 +1207,8 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
     }
 }
 
-/// `foo_default as default, foo_default as "module.exports"`: the two export
-/// names under which a compiled executable's entry point tail exposes the
-/// `module.exports` value of a CommonJS entry point (`js_meta.module_exports_ref`).
+/// `foo_default as default, foo_default as "module.exports"`. Bun's `require()`
+/// of an ES module returns its `"module.exports"` export when there is one.
 fn module_exports_clause_items(module_exports_ref: Ref) -> [bun_ast::ClauseItem; 2] {
     let aliases: [&[u8]; 2] = [b"default", b"module.exports"];
     aliases.map(|alias| bun_ast::ClauseItem {
@@ -1238,9 +1222,8 @@ fn module_exports_clause_items(module_exports_ref: Ref) -> [bun_ast::ClauseItem;
     })
 }
 
-/// `{ get a() { return a; }, ... }`: one getter per export clause item, the shape
-/// `module.exports` would have had for a CommonJS module that the bundler
-/// converted to ESM exports.
+/// `{ get a() { return a; }, ... }`, one getter per export clause item: what
+/// `module.exports` would have been for a CommonJS module converted to ESM.
 fn synthetic_default_export_object(arena: &Arena, items: &[bun_ast::ClauseItem]) -> Expr {
     let mut properties = G::PropertyList::init_capacity(items.len());
     let getter_fn_body: &mut [Stmt] = arena.alloc_slice_fill_default(items.len());

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -72,7 +72,7 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
     // elements; the lists do not reallocate during this function. Read-only
     // columns are deref'd to `&[T]`; the two written columns
     // (`module_scope`, `parts`) are deref'd to `&mut [T]` — see CONCURRENCY
-    // note above re: code-splitting overlap. All ten derefs share the same
+    // note above re: code-splitting overlap. All eleven derefs share the same
     // invariant, so they are grouped under one `unsafe` block.
     let (
         all_module_scopes,
@@ -85,7 +85,8 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         exports_ref_col,
         module_ref_col,
         nested_slot_counts_col,
-    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _) = unsafe {
+        module_exports_ref_col,
+    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _, _) = unsafe {
         (
             &mut *ast.module_scope,
             &*meta.flags,
@@ -97,7 +98,21 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             &*ast.exports_ref,
             &*ast.module_ref,
             &*ast.nested_scope_slot_counts,
+            &*meta.module_exports_ref,
         )
+    };
+
+    // In a compiled executable the entry point tail declares the entry point's
+    // `module.exports` binding at the top level of the chunk
+    // (`generate_entry_point_tail_js`). The per-file loops below never name it
+    // there: a CommonJS closure's generated symbols are named inside the
+    // closure's scope, a plain ESM entry's are not walked at all, and under
+    // code splitting the entry file may not even be in this chunk. So it is
+    // registered with the other chunk-level names.
+    let entry_module_exports_ref: bun_ast::Ref = if chunk.is_entry_point() {
+        module_exports_ref_col[chunk.entry_point.source_index() as usize]
+    } else {
+        bun_ast::Ref::NONE
     };
 
     // `symbol::Map` is not `Clone`/`Copy`. Build a non-owning shallow view via
@@ -260,6 +275,14 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
                 stable_source_indices,
             )?;
         }
+        if entry_module_exports_ref.is_valid() {
+            minify_renamer.accumulate_symbol_use_count(
+                &mut top_level_symbols,
+                entry_module_exports_ref,
+                1,
+                stable_source_indices,
+            )?;
+        }
         top_level_symbols_all.extend_from_slice(&top_level_symbols);
         minify_renamer.allocate_top_level_symbol_slots(&top_level_symbols_all)?;
 
@@ -292,6 +315,9 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
     for stable_ref in &sorted_imports_from_other_chunks {
         // `StableRef` is `repr(packed)`; copy the field to avoid an unaligned ref.
         r.add_top_level_symbol(stable_ref.r#ref);
+    }
+    if entry_module_exports_ref.is_valid() {
+        r.add_top_level_symbol(entry_module_exports_ref);
     }
 
     let mut sorted: Vec<u32> = Vec::new();

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -102,10 +102,8 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         )
     };
 
-    // Declared by the entry point tail at chunk top level, so it is named with the
-    // chunk-level symbols: the per-file loops below name a CommonJS closure's
-    // generated symbols inside the closure, and with code splitting the entry
-    // file may not be in this chunk at all.
+    // Named with the chunk-level symbols: the per-file loops below would name it inside the
+    // entry's CommonJS closure, or not at all when splitting puts the entry file in another chunk.
     let entry_module_exports_ref: bun_ast::Ref = if chunk.is_entry_point() {
         module_exports_ref_col[chunk.entry_point.source_index() as usize]
     } else {

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -102,13 +102,10 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         )
     };
 
-    // In a compiled executable the entry point tail declares the entry point's
-    // `module.exports` binding at the top level of the chunk
-    // (`generate_entry_point_tail_js`). The per-file loops below never name it
-    // there: a CommonJS closure's generated symbols are named inside the
-    // closure's scope, a plain ESM entry's are not walked at all, and under
-    // code splitting the entry file may not even be in this chunk. So it is
-    // registered with the other chunk-level names.
+    // Declared by the entry point tail at chunk top level, so it is named with the
+    // chunk-level symbols: the per-file loops below name a CommonJS closure's
+    // generated symbols inside the closure, and with code splitting the entry
+    // file may not be in this chunk at all.
     let entry_module_exports_ref: bun_ast::Ref = if chunk.is_entry_point() {
         module_exports_ref_col[chunk.entry_point.source_index() as usize]
     } else {

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -539,7 +539,9 @@ pub(crate) fn scan_imports_and_exports(
                     _ => {
                         col_ref!(ast_flags_list)[id].contains(AstFlags::FORCE_CJS_TO_ESM)
                             && !aliases.is_empty()
-                            && !aliases.iter().any(|alias| **alias == *b"default")
+                            && !aliases.iter().any(|alias| {
+                                **alias == *b"default" || **alias == *b"module.exports"
+                            })
                     }
                 };
 

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -125,6 +125,7 @@ pub(crate) fn scan_imports_and_exports(
     let sorted_aliases: *mut [js_meta::SortedAndFilteredExportAliases] =
         meta.sorted_and_filtered_export_aliases;
     let cjs_export_copies: *mut [js_meta::CjsExportCopies] = meta.cjs_export_copies;
+    let module_exports_refs: *mut [Ref] = meta.module_exports_ref;
 
     {
         // Step 1: Figure out what modules must be CommonJS
@@ -529,6 +530,26 @@ pub(crate) fn scan_imports_and_exports(
             let exports_ref = col_ref!(exports_refs)[id];
             let module_ref = col_ref!(module_refs)[id];
 
+            // A compiled executable evaluates every embedded chunk as ESM, and a
+            // run-time `require()` of one returns its `"module.exports"` export
+            // when there is one. So the `module.exports` value of a CommonJS
+            // entry point gets a top-level binding that the entry point tail
+            // exports as `default` and `"module.exports"`
+            // (`generate_entry_point_tail_js`). For a CommonJS module converted
+            // to ESM exports that value is an object of getters, built only when
+            // there are exports and none of them is already `default`.
+            let binds_module_exports = is_entry_point
+                && output_format == Format::Esm
+                && this.options.compile_mode.is_executable()
+                && match wrap {
+                    WrapKind::Cjs => true,
+                    _ => {
+                        col_ref!(ast_flags_list)[id].contains(AstFlags::FORCE_CJS_TO_ESM)
+                            && !aliases.is_empty()
+                            && !aliases.iter().any(|alias| **alias == *b"default")
+                    }
+                };
+
             // Format the source identifier once into a reusable scratch so the
             // per-file `init_/exports_/module_` writes below are plain memcpys
             // instead of three trips through `core::fmt::write`.
@@ -567,6 +588,10 @@ pub(crate) fn scan_imports_and_exports(
                 {
                     count += "exports_".len() + ident_fmt_len;
                     count += "module_".len() + ident_fmt_len;
+                }
+
+                if binds_module_exports {
+                    count += ident_fmt_len + "_default".len();
                 }
 
                 break 'brk count;
@@ -612,6 +637,17 @@ pub(crate) fn scan_imports_and_exports(
                     );
                 }
                 col!(cjs_export_copies)[id] = copies;
+            }
+
+            if binds_module_exports {
+                let start = builder.len;
+                builder.append(ident);
+                builder.append(b"_default");
+                let end = builder.len;
+                let original_name = &builder.allocated_slice()[start..end];
+                col!(module_exports_refs)[id] =
+                    this.graph
+                        .generate_new_symbol(source_index, SymbolKind::Other, original_name);
             }
 
             // Use "init_*" for ESM wrappers instead of "require_*"

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -530,9 +530,7 @@ pub(crate) fn scan_imports_and_exports(
             let exports_ref = col_ref!(exports_refs)[id];
             let module_ref = col_ref!(module_refs)[id];
 
-            // A compiled executable `require()`s this entry point as an ES module, so
-            // its `module.exports` value gets a top-level binding that the entry point
-            // tail exports as `default` and `"module.exports"` (`generate_entry_point_tail_js`).
+            // A compiled executable's `require()` of the chunk reads its `"module.exports"` export.
             let binds_module_exports = is_entry_point
                 && output_format == Format::Esm
                 && this.options.compile_mode.is_executable()

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -530,14 +530,9 @@ pub(crate) fn scan_imports_and_exports(
             let exports_ref = col_ref!(exports_refs)[id];
             let module_ref = col_ref!(module_refs)[id];
 
-            // A compiled executable evaluates every embedded chunk as ESM, and a
-            // run-time `require()` of one returns its `"module.exports"` export
-            // when there is one. So the `module.exports` value of a CommonJS
-            // entry point gets a top-level binding that the entry point tail
-            // exports as `default` and `"module.exports"`
-            // (`generate_entry_point_tail_js`). For a CommonJS module converted
-            // to ESM exports that value is an object of getters, built only when
-            // there are exports and none of them is already `default`.
+            // A compiled executable `require()`s this entry point as an ES module, so
+            // its `module.exports` value gets a top-level binding that the entry point
+            // tail exports as `default` and `"module.exports"` (`generate_entry_point_tail_js`).
             let binds_module_exports = is_entry_point
                 && output_format == Format::Esm
                 && this.options.compile_mode.is_executable()

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -497,6 +497,62 @@ describe("bundler", () => {
     outfile: "dist/out",
     run: { stdout: "mod mod\nmod mod\nmod mod\nmod mod\nResolveMessage\n", file: "dist/out", setCwd: true },
   });
+  // A CommonJS entry point reached only through a run-time require()/import() is embedded as an ESM chunk. require()
+  // must still return `module.exports` (not a namespace around it) and import() must have it as `default`, as when the
+  // same files run from disk: for `module.exports = value` (an object, a function) and for `exports.x = ...`, which the
+  // bundler turns into named exports. The main entry also imports one of them statically, so under --splitting that
+  // entry point's own chunk is only the tail that re-exports the shared code.
+  for (const [suffix, options] of [
+    ["", {}],
+    ["+bytecode", { bytecode: true }],
+    ["+minify", { minifyIdentifiers: true, minifySyntax: true, minifyWhitespace: true }],
+    ["+splitting", { splitting: true }],
+  ] as const) {
+    itBundled("compile/RuntimeRequireEmbeddedCJSExportsShape" + suffix, {
+      backend: "cli",
+      compile: true,
+      format: "esm",
+      ...options,
+      files: {
+        "/entry.ts": /* js */ `
+          import { rmSync } from "fs";
+          import { tmpdir } from "os";
+          import staticObject from "./object.cjs";
+          rmSync("./object.cjs", { force: true });
+          rmSync("./fn.cjs", { force: true });
+          rmSync("./named.cjs", { force: true });
+          process.chdir(tmpdir());
+          const s = (x: string) => x; // keeps the bundler from resolving the specifier at build time
+          const obj = require(s("./object.cjs"));
+          console.log(JSON.stringify(obj), obj === require(s("./object.cjs")), JSON.stringify(staticObject));
+          const fn = require(s("./fn.cjs"));
+          console.log(typeof fn, fn(), fn.extra);
+          const named = require(s("./named.cjs"));
+          console.log(JSON.stringify(named), named.fn());
+          const ns = await import(s("./named.cjs"));
+          console.log(ns.default === named, ns.kind, typeof ns.fn, JSON.stringify(ns.default));
+          console.log((await import(s("./object.cjs"))).default === obj, (await import(s("./fn.cjs"))).default === fn);
+        `,
+        "/object.cjs": `module.exports = { hello: "world", nested: { n: 1 } };`,
+        "/fn.cjs": `module.exports = function hello() { return "called"; }; module.exports.extra = 2;`,
+        "/named.cjs": `exports.kind = "named"; module.exports.fn = function () { return "fn"; };`,
+      },
+      entryPointsRaw: ["./entry.ts", "./object.cjs", "./fn.cjs", "./named.cjs"],
+      outfile: "dist/out",
+      run: {
+        stdout: [
+          '{"hello":"world","nested":{"n":1}} true {"hello":"world","nested":{"n":1}}',
+          "function called 2",
+          '{"kind":"named"} fn',
+          'true named function {"kind":"named"}',
+          "true true",
+          "",
+        ].join("\n"),
+        file: "dist/out",
+        setCwd: true,
+      },
+    });
+  }
   // Nested embedded entry points, from the entry and from inside the subdirectory (`../`), by every spelling.
   itBundled("compile/EmbeddedResolveNested", {
     backend: "cli",

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -501,7 +501,8 @@ describe("bundler", () => {
   // must still return `module.exports` (not a namespace around it) and import() must have it as `default`, as when the
   // same files run from disk: for `module.exports = value` (an object, a function) and for `exports.x = ...`, which the
   // bundler turns into named exports. The main entry also imports one of them statically, so under --splitting that
-  // entry point's own chunk is only the tail that re-exports the shared code.
+  // entry point's own chunk is only the tail that re-exports the shared code. A module that already exports the
+  // `module.exports` name keeps its own export (a second one would be a syntax error).
   for (const [suffix, options] of [
     ["", {}],
     ["+bytecode", { bytecode: true }],
@@ -521,6 +522,7 @@ describe("bundler", () => {
           rmSync("./object.cjs", { force: true });
           rmSync("./fn.cjs", { force: true });
           rmSync("./named.cjs", { force: true });
+          rmSync("./taken.cjs", { force: true });
           process.chdir(tmpdir());
           const s = (x: string) => x; // keeps the bundler from resolving the specifier at build time
           const obj = require(s("./object.cjs"));
@@ -532,12 +534,14 @@ describe("bundler", () => {
           const ns = await import(s("./named.cjs"));
           console.log(ns.default === named, ns.kind, typeof ns.fn, JSON.stringify(ns.default));
           console.log((await import(s("./object.cjs"))).default === obj, (await import(s("./fn.cjs"))).default === fn);
+          console.log(Object.keys(await import(s("./taken.cjs"))).join(","));
         `,
         "/object.cjs": `module.exports = { hello: "world", nested: { n: 1 } };`,
         "/fn.cjs": `module.exports = function hello() { return "called"; }; module.exports.extra = 2;`,
         "/named.cjs": `exports.kind = "named"; module.exports.fn = function () { return "fn"; };`,
+        "/taken.cjs": `exports["module.exports"] = 1; exports.a = 2;`,
       },
-      entryPointsRaw: ["./entry.ts", "./object.cjs", "./fn.cjs", "./named.cjs"],
+      entryPointsRaw: ["./entry.ts", "./object.cjs", "./fn.cjs", "./named.cjs", "./taken.cjs"],
       outfile: "dist/out",
       run: {
         stdout: [
@@ -546,6 +550,7 @@ describe("bundler", () => {
           '{"kind":"named"} fn',
           'true named function {"kind":"named"}',
           "true true",
+          "a,module.exports",
           "",
         ].join("\n"),
         file: "dist/out",


### PR DESCRIPTION
### Problem
- In a `bun build --compile` executable, a run-time `require()` of an embedded CommonJS entry point returns the ESM namespace `{ default: module.exports, __esModule: true }` instead of `module.exports`, and for `exports.kind = "x"` style modules `(await import(name)).default` is `undefined`. From disk both behave as CommonJS.
- Every embedded chunk is evaluated as ESM. The bundler emits a CommonJS entry point as `export default require_plugin();`, or as named exports with no `default` when it converted `exports.x = ...` (`generate_entry_point_tail_js`, `src/bundler/linker_context/postProcessJSChunk.rs`).

### Fix
- In a compile build with ESM output, the tail binds the `module.exports` value (for converted CommonJS, an object with a getter per export) and exports it twice: `var plugin_default = require_plugin(); export { plugin_default as default, plugin_default as "module.exports" };`. Bun's `require()` of an ES module already returns its `"module.exports"` export (`overridableRequire`, `src/js/builtins/CommonJS.ts:123`). Neither the runtime nor on-disk `bun build` output changes.
- `scan_imports_and_exports` generates the symbol into a new `js_meta.module_exports_ref` column. Both renamers register it at chunk level: a dependency's own `plugin_default` keeps its name, and the symbol is named even when `--splitting` leaves only the tail in the entry point's chunk.
- Verified: `test/bundler/bundler_compile.test.ts`, `compile/RuntimeRequireEmbeddedCJSExportsShape` plain, `+bytecode`, `+minify`, `+splitting` (all fail on main). Other suites in Notes.

### Background
- A compiled executable stores each entry point as a file of a standalone module graph (`src/runtime/jsc_hooks.rs`). The file's `module_format` is the build's global `--format`, so by default every chunk is an ES module.
- `require()` of an ES module returns the namespace, except when it has a `"module.exports"` export. Then it returns that value. Node does the same.
- `require_foo()`, the bundler's `__commonJS` wrapper call, returns a CommonJS file's `module.exports`. A file whose exports are all `exports.x = ...` is converted to ESM named exports instead.

<details><summary>Notes</summary>

- #40619 made a run-time `require()` of an embedded entry point resolve at all. Before it the call failed with `Cannot find module './plugin.cjs'`, so this is not a regression of that PR. It made a pre-existing output shape reachable.
- `import()` of a `module.exports = value` chunk now yields a namespace with `default` and `module.exports`. From disk, Bun also synthesizes named exports from the `module.exports` keys. Node's `import()` of a CommonJS module whose exports it cannot analyze gives `default` and `module.exports`, the same shape as the compiled chunk. Closing this gap means evaluating the chunk as CommonJS, which needs the bundler to emit one entry point in CommonJS format while the rest of the build is ESM. `output_format` is a per-build setting consulted in about 80 places, including parse-time decisions, so that is a separate, larger change. For converted CommonJS (`exports.x = ...`) the namespace already has the named exports, so `import()` matches disk except for the extra `module.exports` key and the key order of `require()`'s result (sorted).
- A converted CommonJS entry point gets the getter object only when it has exports and none of them is already named `default` or `module.exports`. Otherwise its own exports stand, as before (`taken.cjs` in the test, `exports["module.exports"] = 1`, loads as `a,module.exports`).
- `--compile --format cjs` already returned `module.exports`, because every chunk is then evaluated as CommonJS (`compile/RuntimeRequireEmbeddedCJS` covers it). The default ESM format did not.
- The `"module.exports"` export is emitted only in compile mode. Emitting it for every ESM build would change the public namespace shape of every CommonJS entry point bundled to ESM. That is a separate decision.
- `js_meta` (`src/bundler/LinkerGraph.rs`) holds per-file linker data. It is filled in `scan_imports_and_exports` (step 6, where `cjs_export_copies` symbols are minted for the same reason: the symbol map cannot grow once chunks print in parallel).
- Known gaps left for separate fixes: the `cjs_export_copies` tail bindings (`export_<alias>`) are still not registered with the renamer and can collide with a user binding of the same name (pre-existing, also in esbuild). Data-loader entry points (`data.json`, `note.txt`) do not resolve at run time in an executable at all (`Cannot find module`), which is a resolution gap in `StandaloneModuleGraph::resolve`.
- Also checked by hand on the debug build: the JS API (`Bun.build({ compile: ... })`), `--splitting --minify --bytecode --format esm`, and a CommonJS entry point that the main entry also imports statically.
- Suites run: `bundler_compile`, `bundler_compile_splitting`, `bundler_splitting`, `bun-build-compile`, `standalone`, `bundler_compile_autoload`, `bundler_cjs2esm`, `bundler_edgecase`, `bundler_npm`, `esbuild/default`, `esbuild/splitting`. Three tests in `bun-build-compile.test.ts` (`--compile --bytecode for ...`, `bytecode from a compiled executable is not copied into private memory`) time out on this debug build with or without the change (`bun build --compile --bytecode` alone takes 10 s to 44 s here against 5 s and 60 s test timeouts), and `compile/HelloWorldWithProcessVersionsBun` fails on any debug build (`process.versions.bun` is `1.4.1-debug`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->