### PR TITLE
node:fs: access returns undefined, and callbacks of operations with no result get (null) alone

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -62,7 +62,7 @@ var access = function access(path, mode, callback) {
     }
 
     callback = ensureCallback(callback);
-    fs.access(path, mode).then(callback, callback);
+    fs.access(path, mode).then(callOnceWithNull.bind(null, callback), callback);
   },
   appendFile = function appendFile(path, data, options, callback) {
     if (!$isCallable(callback)) {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -62,7 +62,7 @@ var access = function access(path, mode, callback) {
     }
 
     callback = ensureCallback(callback);
-    fs.access(path, mode).then(callOnceWithNull.bind(null, callback), callback);
+    fs.access(path, mode).then(FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback), callback);
   },
   appendFile = function appendFile(path, data, options, callback) {
     if (!$isCallable(callback)) {
@@ -425,7 +425,10 @@ var access = function access(path, mode, callback) {
       callback = wrapFsCallback(callback);
     }
 
-    fs.symlink(target, path, type).then(callback, callback);
+    fs.symlink(target, path, type).then(
+      $isCallable(callback) ? FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback) : callback,
+      callback,
+    );
   },
   truncate = function truncate(path, len, callback) {
     if (typeof path === "number") {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -40,14 +40,16 @@ function ensureCallback(callback) {
   return wrapFsCallback(callback);
 }
 
-// Micro-optimization: avoid creating a new function for every call
-// bind() is slightly more optimized in JSC
-// This code is equivalent to:
-//
-// function () { callback(null); }
-//
+// The fulfillment handler for an operation with no result. It is bound, not a
+// closure, because bind() is slightly more optimized in JSC.
 function nullcallback(callback) {
-  return FunctionPrototypeBind.$call(callback, undefined, null);
+  return FunctionPrototypeBind.$call(callbackWithResult, undefined, callback);
+}
+// Same rule as node's FSReqCallback::Resolve: `null` alone when the result is
+// undefined. Only a recursive mkdir that created a directory has a result.
+function callbackWithResult(callback, result) {
+  if (result === undefined) callback(null);
+  else callback(null, result);
 }
 const FunctionPrototypeBind = nullcallback.bind;
 
@@ -62,7 +64,7 @@ var access = function access(path, mode, callback) {
     }
 
     callback = ensureCallback(callback);
-    fs.access(path, mode).then(FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback), callback);
+    fs.access(path, mode).then(nullcallback(callback), callback);
   },
   appendFile = function appendFile(path, data, options, callback) {
     if (!$isCallable(callback)) {
@@ -425,10 +427,7 @@ var access = function access(path, mode, callback) {
       callback = wrapFsCallback(callback);
     }
 
-    fs.symlink(target, path, type).then(
-      $isCallable(callback) ? FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback) : callback,
-      callback,
-    );
+    fs.symlink(target, path, type).then($isCallable(callback) ? nullcallback(callback) : callback, callback);
   },
   truncate = function truncate(path, len, callback) {
     if (typeof path === "number") {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1130,12 +1130,6 @@ mod _async_tasks {
             Ok(JSValue::js_boolean(self))
         }
     }
-    impl FsReturn for Null {
-        #[inline]
-        fn fs_to_js(self, _global: &JSGlobalObject) -> JsResult<JSValue> {
-            Ok(JSValue::NULL)
-        }
-    }
     impl FsReturn for Stats {
         #[inline]
         fn fs_to_js(self, global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -4273,13 +4267,10 @@ impl StringOrUndefined {
     }
 }
 
-/// For use in `Return`'s definitions to act as `void` while returning `null` to JavaScript
-pub struct Null;
-
 pub mod ret {
     use super::*;
 
-    pub(crate) type Access = Null;
+    pub(crate) type Access = ();
     pub(crate) type AppendFile = ();
     pub type Close = ();
     pub(crate) type CopyFile = ();
@@ -4443,7 +4434,7 @@ impl NodeFS {
                 if (mode & sys::posix::W_OK) != 0 || ((mode & sys::posix::X_OK) != 0 && !is_dir) {
                     return Err(sys::Error::from_code(E::EACCES, sys::Tag::access).with_path(p));
                 }
-                return Ok(Null);
+                return Ok(());
             }
         }
         // The `bun_sys::access` Windows
@@ -4457,7 +4448,7 @@ impl NodeFS {
         };
         match Syscall::access(path, args.mode.as_int()) {
             Err(err) => Err(err.with_path(args.path.slice())),
-            Ok(_) => Ok(Null),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -61,6 +61,9 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           dirStatIsDir: fs.statSync(assetDir).isDirectory(),
           dirLstatIsDir: fs.lstatSync(assetDir).isDirectory(),
           accessOk: errcode(() => fs.accessSync(assetDir)) === "",
+          // JSON.stringify drops undefined values, so compare here and ship a boolean
+          accessReturnsUndefined: fs.accessSync(asset) === undefined,
+          accessPromiseResolvesUndefined: (await fs.promises.access(asset)) === undefined,
           accessWriteErr: errcode(() => fs.accessSync(asset, fs.constants.W_OK)),
           readdir: fs.readdirSync(assetDir).sort(),
           readdirHasAsset: fs.readdirSync(assetDir).includes(path.basename(asset)),
@@ -178,6 +181,8 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           dirStatIsDir: true,
           dirLstatIsDir: true,
           accessOk: true,
+          accessReturnsUndefined: true,
+          accessPromiseResolvesUndefined: true,
           accessWriteErr: "EACCES",
           // the hashed file-loader name is covered by readdirHasAsset
           readdir: expect.arrayContaining(["client", "config.json"]),

--- a/test/js/bun/bun-object/write.spec.ts
+++ b/test/js/bun/bun-object/write.spec.ts
@@ -127,9 +127,8 @@ describe("Bun.write() on file paths", () => {
           await Bun.write(filepath, content);
         });
         it("Recursively creates the directory", async () => {
-          // FIXME: should be undefined, not null
-          expect(await fs.access(rootdir, constants.F_OK)).toBeFalsy();
-          expect(await fs.access(path.dirname(filepath), constants.F_OK)).toBeFalsy();
+          expect(await fs.access(rootdir, constants.F_OK)).toBeUndefined();
+          expect(await fs.access(path.dirname(filepath), constants.F_OK)).toBeUndefined();
         });
 
         it("Creates a file with the provided content", async () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -123,7 +123,7 @@ it.skipIf(isWindows)("fs.chmodSync applies mode bits above 0o777", () => {
   expect(statSync(dirPath).mode & 0o7777).toBe(0o1755);
 });
 
-describe("fs.access success values match node", () => {
+describe("fs.access and fs.symlink success values match node", () => {
   it("accessSync returns undefined", () => {
     using dir = tempDir("fs-access-success", { "file.txt": "" });
     const file = join(String(dir), "file.txt");
@@ -160,6 +160,30 @@ describe("fs.access success values match node", () => {
     const args = await promise;
     expect(args).toHaveLength(1);
     expect(args[0]).toMatchObject({ code: "ENOENT", syscall: "access" });
+  });
+
+  // symlink was the other wrapper that handed the native promise's resolution
+  // value straight to the callback.
+  it("symlink callback is called with exactly (null) in both overloads", async () => {
+    using dir = tempDir("fs-symlink-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+
+    const threeArgs = Promise.withResolvers<unknown[]>();
+    fs.symlink(file, join(String(dir), "link-3"), (...args) => threeArgs.resolve(args));
+    expect(await threeArgs.promise).toStrictEqual([null]);
+
+    const fourArgs = Promise.withResolvers<unknown[]>();
+    fs.symlink(file, join(String(dir), "link-4"), "file", (...args) => fourArgs.resolve(args));
+    expect(await fourArgs.promise).toStrictEqual([null]);
+  });
+
+  it("symlink callback receives the error on failure", async () => {
+    using dir = tempDir("fs-symlink-failure", { "file.txt": "", "taken": "" });
+    const { promise, resolve } = Promise.withResolvers<unknown[]>();
+    fs.symlink(join(String(dir), "file.txt"), join(String(dir), "taken"), (...args) => resolve(args));
+    const args = await promise;
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatchObject({ code: "EEXIST", syscall: "symlink" });
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -123,6 +123,46 @@ it.skipIf(isWindows)("fs.chmodSync applies mode bits above 0o777", () => {
   expect(statSync(dirPath).mode & 0o7777).toBe(0o1755);
 });
 
+describe("fs.access success values match node", () => {
+  it("accessSync returns undefined", () => {
+    using dir = tempDir("fs-access-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+    expect(fs.accessSync(file)).toBeUndefined();
+    expect(fs.accessSync(file, constants.R_OK)).toBeUndefined();
+    expect(fs.accessSync(String(dir))).toBeUndefined();
+  });
+
+  it("promises.access resolves to undefined", async () => {
+    using dir = tempDir("fs-access-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+    expect(await promises.access(file)).toBeUndefined();
+    expect(await promises.access(file, constants.R_OK)).toBeUndefined();
+    expect(await promises.access(String(dir))).toBeUndefined();
+  });
+
+  it("access callback is called with exactly (null)", async () => {
+    using dir = tempDir("fs-access-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+
+    const withoutMode = Promise.withResolvers<unknown[]>();
+    fs.access(file, (...args) => withoutMode.resolve(args));
+    expect(await withoutMode.promise).toStrictEqual([null]);
+
+    const withMode = Promise.withResolvers<unknown[]>();
+    fs.access(file, constants.R_OK, (...args) => withMode.resolve(args));
+    expect(await withMode.promise).toStrictEqual([null]);
+  });
+
+  it("access callback receives the error on failure", async () => {
+    using dir = tempDir("fs-access-success", {});
+    const { promise, resolve } = Promise.withResolvers<unknown[]>();
+    fs.access(join(String(dir), "missing.txt"), (...args) => resolve(args));
+    const args = await promise;
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatchObject({ code: "ENOENT", syscall: "access" });
+  });
+});
+
 it.concurrent("fs.writeFile(1, data) should work when its inherited", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "fs-writeFile-1-fixture.js"), "1"],
@@ -6400,7 +6440,7 @@ describe('kernel32 long path conversion does not mangle "../../path" into "path"
   ];
   const existTests = [
     ["existsSync", 'assert.strictEqual(fs.existsSync("../../config"), true)'],
-    ["accessSync", 'assert.strictEqual(fs.accessSync("../../config"), null)'],
+    ["accessSync", 'assert.strictEqual(fs.accessSync("../../config"), undefined)'],
   ];
 
   for (const [name, code] of nonExistTests) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -123,7 +123,7 @@ it.skipIf(isWindows)("fs.chmodSync applies mode bits above 0o777", () => {
   expect(statSync(dirPath).mode & 0o7777).toBe(0o1755);
 });
 
-describe("fs.access and fs.symlink success values match node", () => {
+describe("fs.access success values match node", () => {
   it("accessSync returns undefined", () => {
     using dir = tempDir("fs-access-success", { "file.txt": "" });
     const file = join(String(dir), "file.txt");
@@ -139,49 +139,91 @@ describe("fs.access and fs.symlink success values match node", () => {
     expect(await promises.access(file, constants.R_OK)).toBeUndefined();
     expect(await promises.access(String(dir))).toBeUndefined();
   });
+});
 
-  it("access callback is called with exactly (null)", async () => {
-    using dir = tempDir("fs-access-success", { "file.txt": "" });
-    const file = join(String(dir), "file.txt");
+// On success node calls the callback of an operation with no result with exactly
+// one argument, `null`. Rest parameters and arguments.length see a trailing
+// `undefined`: async's waterfall passes it to the next task as its first argument.
+// toStrictEqual is what tells [null] apart from [null, undefined].
+describe("the callback of an operation with no result receives the same arguments as in node", () => {
+  type Callback = (...args: unknown[]) => void;
+  function argumentsPassedTo(run: (cb: Callback) => void): Promise<unknown[]> {
+    const { promise, resolve } = Promise.withResolvers<unknown[]>();
+    run((...args) => resolve(args));
+    return promise;
+  }
+  async function withFd(dir: string, run: (fd: number, cb: Callback) => void): Promise<unknown[]> {
+    const fd = openSync(join(dir, "file.txt"), "r+");
+    try {
+      return await argumentsPassedTo(cb => run(fd, cb));
+    } finally {
+      closeSync(fd);
+    }
+  }
 
-    const withoutMode = Promise.withResolvers<unknown[]>();
-    fs.access(file, (...args) => withoutMode.resolve(args));
-    expect(await withoutMode.promise).toStrictEqual([null]);
+  // Every case runs in a fresh directory holding file.txt and an empty subdir/.
+  const voidOps: Record<string, (dir: string) => Promise<unknown[]>> = {
+    access: dir => argumentsPassedTo(cb => fs.access(join(dir, "file.txt"), cb)),
+    "access (with mode)": dir => argumentsPassedTo(cb => fs.access(join(dir, "file.txt"), constants.R_OK, cb)),
+    "symlink (3 arguments)": dir => argumentsPassedTo(cb => fs.symlink(join(dir, "file.txt"), join(dir, "link-3"), cb)),
+    "symlink (4 arguments)": dir =>
+      argumentsPassedTo(cb => fs.symlink(join(dir, "file.txt"), join(dir, "link-4"), "file", cb)),
+    appendFile: dir => argumentsPassedTo(cb => fs.appendFile(join(dir, "file.txt"), "more", cb)),
+    writeFile: dir => argumentsPassedTo(cb => fs.writeFile(join(dir, "written.txt"), "data", cb)),
+    copyFile: dir => argumentsPassedTo(cb => fs.copyFile(join(dir, "file.txt"), join(dir, "copy.txt"), cb)),
+    rename: dir => argumentsPassedTo(cb => fs.rename(join(dir, "file.txt"), join(dir, "renamed.txt"), cb)),
+    link: dir => argumentsPassedTo(cb => fs.link(join(dir, "file.txt"), join(dir, "hardlink.txt"), cb)),
+    unlink: dir => argumentsPassedTo(cb => fs.unlink(join(dir, "file.txt"), cb)),
+    rm: dir => argumentsPassedTo(cb => fs.rm(join(dir, "file.txt"), cb)),
+    "rm (recursive)": dir => argumentsPassedTo(cb => fs.rm(join(dir, "subdir"), { recursive: true }, cb)),
+    rmdir: dir => argumentsPassedTo(cb => fs.rmdir(join(dir, "subdir"), cb)),
+    mkdir: dir => argumentsPassedTo(cb => fs.mkdir(join(dir, "created"), cb)),
+    "mkdir (recursive, directory already exists)": dir =>
+      argumentsPassedTo(cb => fs.mkdir(join(dir, "subdir"), { recursive: true }, cb)),
+    truncate: dir => argumentsPassedTo(cb => fs.truncate(join(dir, "file.txt"), cb)),
+    chmod: dir => argumentsPassedTo(cb => fs.chmod(join(dir, "file.txt"), 0o644, cb)),
+    // uid/gid -1 leaves ownership unchanged, so these succeed unprivileged.
+    chown: dir => argumentsPassedTo(cb => fs.chown(join(dir, "file.txt"), -1, -1, cb)),
+    lchown: dir => argumentsPassedTo(cb => fs.lchown(join(dir, "file.txt"), -1, -1, cb)),
+    utimes: dir => argumentsPassedTo(cb => fs.utimes(join(dir, "file.txt"), 1, 1, cb)),
+    lutimes: dir => argumentsPassedTo(cb => fs.lutimes(join(dir, "file.txt"), 1, 1, cb)),
+    fchmod: dir => withFd(dir, (fd, cb) => fs.fchmod(fd, 0o644, cb)),
+    fchown: dir => withFd(dir, (fd, cb) => fs.fchown(fd, -1, -1, cb)),
+    fsync: dir => withFd(dir, (fd, cb) => fs.fsync(fd, cb)),
+    fdatasync: dir => withFd(dir, (fd, cb) => fs.fdatasync(fd, cb)),
+    ftruncate: dir => withFd(dir, (fd, cb) => fs.ftruncate(fd, cb)),
+    futimes: dir => withFd(dir, (fd, cb) => fs.futimes(fd, 1, 1, cb)),
+    close: dir => argumentsPassedTo(cb => fs.close(openSync(join(dir, "file.txt"), "r"), cb)),
+  };
+  if (fs.lchmod) {
+    voidOps.lchmod = dir => argumentsPassedTo(cb => fs.lchmod(join(dir, "file.txt"), 0o644, cb));
+  }
 
-    const withMode = Promise.withResolvers<unknown[]>();
-    fs.access(file, constants.R_OK, (...args) => withMode.resolve(args));
-    expect(await withMode.promise).toStrictEqual([null]);
+  it.each(Object.entries(voidOps))("%s calls back with [null]", async (_name, run) => {
+    using dir = tempDir("fs-callback-arguments", { "file.txt": "data" });
+    mkdirSync(join(String(dir), "subdir"));
+    expect(await run(String(dir))).toStrictEqual([null]);
+  });
+
+  it("mkdir (recursive) still passes the first directory it created", async () => {
+    using dir = tempDir("fs-callback-arguments-mkdir", {});
+    const first = join(String(dir), "a");
+    const args = await argumentsPassedTo(cb => fs.mkdir(join(first, "b", "c"), { recursive: true }, cb));
+    expect(args).toStrictEqual([null, path.toNamespacedPath(first)]);
   });
 
   it("access callback receives the error on failure", async () => {
-    using dir = tempDir("fs-access-success", {});
-    const { promise, resolve } = Promise.withResolvers<unknown[]>();
-    fs.access(join(String(dir), "missing.txt"), (...args) => resolve(args));
-    const args = await promise;
+    using dir = tempDir("fs-access-failure", {});
+    const args = await argumentsPassedTo(cb => fs.access(join(String(dir), "missing.txt"), cb));
     expect(args).toHaveLength(1);
     expect(args[0]).toMatchObject({ code: "ENOENT", syscall: "access" });
   });
 
-  // symlink was the other wrapper that handed the native promise's resolution
-  // value straight to the callback.
-  it("symlink callback is called with exactly (null) in both overloads", async () => {
-    using dir = tempDir("fs-symlink-success", { "file.txt": "" });
-    const file = join(String(dir), "file.txt");
-
-    const threeArgs = Promise.withResolvers<unknown[]>();
-    fs.symlink(file, join(String(dir), "link-3"), (...args) => threeArgs.resolve(args));
-    expect(await threeArgs.promise).toStrictEqual([null]);
-
-    const fourArgs = Promise.withResolvers<unknown[]>();
-    fs.symlink(file, join(String(dir), "link-4"), "file", (...args) => fourArgs.resolve(args));
-    expect(await fourArgs.promise).toStrictEqual([null]);
-  });
-
   it("symlink callback receives the error on failure", async () => {
     using dir = tempDir("fs-symlink-failure", { "file.txt": "", "taken": "" });
-    const { promise, resolve } = Promise.withResolvers<unknown[]>();
-    fs.symlink(join(String(dir), "file.txt"), join(String(dir), "taken"), (...args) => resolve(args));
-    const args = await promise;
+    const args = await argumentsPassedTo(cb =>
+      fs.symlink(join(String(dir), "file.txt"), join(String(dir), "taken"), cb),
+    );
     expect(args).toHaveLength(1);
     expect(args[0]).toMatchObject({ code: "EEXIST", syscall: "symlink" });
   });
@@ -7121,6 +7163,12 @@ describe("a throw from a node-style callback is an uncaughtException", () => {
     ["fs.readdir", `require("fs").readdir(${dirLit}, () => { throw new Error("boom"); })`],
     ["fs.open", `require("fs").open("/definitely/not/here", "r", () => { throw new Error("boom"); })`],
     ["fs.access", `require("fs").access(${file}, () => { throw new Error("boom"); })`],
+    // Both arms of the handler that operations with no result share: no result, and mkdir's created path.
+    ["fs.chmod", `require("fs").chmod(${file}, 0o644, () => { throw new Error("boom"); })`],
+    [
+      "fs.mkdir (recursive)",
+      `require("fs").mkdir(${dirLit} + "/mk/a", { recursive: true }, () => { throw new Error("boom"); })`,
+    ],
     ["fs.realpath", `require("fs").realpath(${file}, () => { throw new Error("boom"); })`],
     [
       "fs.close",

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -88,7 +88,7 @@ it("should be enumerable", () => {
 
 describe("access", () => {
   it("should work", async () => {
-    await access(__filename, 0);
+    expect(await access(__filename, 0)).toBeUndefined();
   });
 
   it("should fail on non-existant files", async () => {


### PR DESCRIPTION
Supersedes #38065, #42279 and #38085 (see Notes).

### Problem
- `fs.accessSync(path)` returns `null` and `fs.promises.access(path)` resolves to `null`. Node gives `undefined`. The cause is `ret::Access` in `src/runtime/node/node_fs.rs`: the `Null` marker type, which converts to `JSValue::NULL`.
- On success, the callback of an operation with no result gets wrong arguments: `symlink` calls `cb(undefined)`. The 22 operations built on `nullcallback()` in `src/js/node/fs.ts` call `cb(null, undefined)`. Node calls `cb(null)`.
- The extra `undefined` breaks `async.waterfall([cb => fs.writeFile(f, "x", cb), cb => fs.chmod(f, 0o644, cb)])`. It throws `ERR_INVALID_ARG_TYPE`: `The "cb" argument must be of type function. Received undefined`.

### Fix
- `ret::Access` becomes `()`, like the other void operations. The unused `Null` marker is deleted.
- `nullcallback()` now binds a handler with node's rule: `cb(null)` when the result is `undefined`, `cb(null, result)` otherwise (only a recursive `mkdir`). `access` and `symlink` use it.
- With the Rust half alone, `fs.access(path, cb)` changes from `cb(null)` to `cb(undefined)`, and node's `test-fs-access.js:72` fails.
- Verified: `test/js/node/fs/fs.test.ts` (33 new cases, 27 fail on bun 1.4.3-canary.1), `promises.test.js`, `write.spec.ts`, `compile-asset-bunfs.test.ts`. Also 129 node `test-fs-*` files.

### Background
- `ret::*` in `node_fs.rs` are the result types of `NodeFS::<op>`. The type decides what `xSync()` returns and what `fs.promises.x()` resolves with. `()` converts to `undefined`.
- The callback API in `fs.ts` attaches handlers to the same native promises. The old `nullcallback` was `callback.bind(undefined, null)`, so the promise's resolution value arrived as a second argument.
- Node completes these operations in `FSReqCallback::Resolve` (`src/node_file.cc:736`, v26.3.0). It passes one argument when the result is `undefined`, two otherwise.

<details><summary>Notes</summary>

Superseded PRs: #38065 is the original of this branch. #42279 (closed) made only the `ret::Access` change. Its `promises.test.js` assertion is here, and the commit credits its author. #38085 had the `nullcallback` fix and the `voidOps` test table. Both are here. The paragraph on #38085 below says what is not taken.

History of this branch:
- 2026-08-29: rebased from #38065 onto main. Main had changed `FsReturn::fs_to_js(&mut self, ...)` to `fs_to_js(self, ...)` and removed `Null::to_js`, which conflicted with this branch's deletion of `Null`. The resolution takes the deletion.
- 2026-09-11: rebased onto main at 158ff6c. One commit added: `test/js/node/fs/promises.test.js` asserts that `access(__filename, 0)` resolves to `undefined`. The assertion is taken from #42279, and the commit credits its author. CI build #114393 passed on that head (5268ccf).
- 2026-09-12: commit 8ed7483 moves the callback rule into `nullcallback()`. Before it, `access` and `symlink` each inlined `FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback)`, and the helper stayed wrong for the other 22 operations until #38085. The self-review objected to that shape (fix the helper, not two call sites), so the helper fix is folded in here.

What is taken from #38085 and what is not: the `voidOps` test table is taken as it was, with rows added for `access` with a mode and both `symlink` overloads. Its helper was `callOnceWithNull` plus a separate `mkdir` handler. Here one handler follows `FSReqCallback::Resolve`, so `mkdir` needs no special case. Its `fs.cp` change is not taken: node's `fs.cp` is `util.callbackify(cpFn)` and calls back with `(null, undefined)`, bun calls back with `(null)`. That is a different helper and the opposite direction. It can be its own change.

Probe, node v26.3.0 against this branch (argument lists on success):

```
op                     node                this branch         bun 1.4.3-canary.1
accessSync             undefined           undefined           null
promises.access        undefined           undefined           null
access                 [null]              [null]              [null]
symlink (3 and 4 arg)  [null]              [null]              [undefined]
chmod, unlink, ...     [null]              [null]              [null, undefined]
mkdir                  [null]              [null]              [null, undefined]
mkdir (rec, exists)    [null]              [null]              [null, undefined]
mkdir (rec, created)   [null, "<dir>"]     [null, "<dir>"]     [null, "<dir>"]
close, Dir#close       [null]              [null]              [null]
cp                     [null, undefined]   [null]              [null]
```

`async@3.2.6` `waterfall` and `seq` over `writeFile`, `chmod`, `unlink`: ok on node and on this branch. They throw `ERR_INVALID_ARG_TYPE` on bun 1.4.3-canary.1 and on the previous head of this branch.

Why the `fs.ts` half is needed with the Rust half: the `access` wrapper on main is `fs.access(path, mode).then(callback, callback)`. `callback` is the user function wrapped by `guardCallback` (`src/js/internal/shared.ts:161`), which forwards its arguments unchanged. When the native promise resolves with `undefined` and not `null`, the user function receives `(undefined)`. The `access` rows of the new table cover this. They pass on bun 1.4.3-canary.1 and fail if only the Rust half is applied.

Both the `access(2)` path and the compiled executable (`/$bunfs/`) branch of `NodeFS::access` return `Ok(())`. `test/bundler/compile-asset-bunfs.test.ts` reports the `accessSync` and `promises.access` return values for an embedded asset, which covers the `/$bunfs/` branch.

Two in-tree tests had been written around the old value. `fs.test.ts` asserted `accessSync(...) === null` in the kernel32 long-path case, and `write.spec.ts` had loosened `await fs.promises.access(...)` to `toBeFalsy()` under a FIXME. Both now assert `undefined`.

A throw from the user callback still surfaces as an `uncaughtException`: the callback that the handler calls is the `guardCallback` wrapper. The callback-throw table in `fs.test.ts` has new rows for `chmod` and a recursive `mkdir`, one for each arm of the handler. `symlink`'s non-callable 4-argument case is left as it was (handler ignored, gated on `$isCallable`).

Also untouched: the `.bind(null, ...)` handler sites elsewhere in `fs.ts` (`cp`, `Dir#close`, `Dir#read`, `opendir`, `glob`).

Suites run on 8ed7483 with `bun bd test`: full `fs.test.ts` (601 pass), `promises.test.js`, `fs-mkdir.test.ts`, `cp.test.ts`, `dir.test.ts`, `write.spec.ts`, `compile-asset-bunfs.test.ts`, `AsyncLocalStorage-tracking.test.ts` (the 22 `fs-*` cases). Node's vendored tests: 129 `test-fs-*` files for the touched operations, as root and as an unprivileged user (`test-fs-access.js` skips itself as root), plus the two `test-trace-events-fs-*.js`. Two fail, and they fail the same way on bun 1.4.3-canary.1: `test-fs-cp-async-file-url.mjs` (needs a different working directory) and `test-fs-error-messages.js` as the unprivileged user (`EACCES` against `EPERM` on a root-owned fixture directory).

Self-reviewed: the review raised no concern about correctness. Its one standing concern was the shape of the `fs.ts` half (two call sites patched, shared helper left wrong). Commit 8ed7483 addresses it.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts, test/bundler/compile-asset-bunfs.test.ts

<!-- robobun:evidence:end -->
