### PR TITLE
test: cover over-long relative specifiers in compiled executables

### DIFF
--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -616,6 +616,45 @@ describe("bundler", () => {
       setCwd: true,
     },
   });
+  // A "./" specifier imported at runtime from an embedded module is joined onto
+  // /$bunfs/root/ in a fixed-size path buffer and looked up in the standalone
+  // module graph. A specifier that does not fit must fall through to the regular
+  // resolver, not abort the process. Specifiers longer than 1.5x PATH_MAX (1024
+  // on macOS, 4096 on Linux, 98302 on Windows) are rejected before resolution
+  // starts, so the lengths below sit between PATH_MAX and that cap. Both probes
+  // must report "not found" like a non-compiled `bun run` does, and the graph
+  // must still serve a "./" specifier of normal length afterwards.
+  itBundled("compile/RelativeSpecifierLongerThanPathMax", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        const req = (x) => require(x);
+        const imp = (x) => import(x);
+        const len = process.platform === "win32" ? 100_000 : process.platform === "linux" ? 5000 : 1200;
+        const tooLong = "./" + Buffer.alloc(len, "w").toString();
+        const out = [];
+        try { req(tooLong); out.push("require resolved"); } catch (e) { out.push("require: " + e.code); }
+        try { await imp(tooLong); out.push("import resolved"); } catch (e) { out.push("import: " + e.code); }
+        out.push(req("./embedded-sibling.js").value);
+        out.push((await imp("./embedded-sibling.js")).value);
+        console.log(out.join("\\n"));
+      `,
+      "/embedded-sibling.ts": /* js */ `
+        export const value = "embedded sibling resolved from the graph";
+      `,
+    },
+    entryPointsRaw: ["./entry.ts", "./embedded-sibling.ts"],
+    outfile: "dist/out",
+    run: {
+      file: "dist/out",
+      stdout: [
+        "require: MODULE_NOT_FOUND",
+        "import: ERR_MODULE_NOT_FOUND",
+        "embedded sibling resolved from the graph",
+        "embedded sibling resolved from the graph",
+      ].join("\n"),
+    },
+  });
   itBundled("compile/WorkerRelativePathTSExtension", {
     backend: "cli",
     compile: true,
@@ -678,6 +717,68 @@ describe("bundler", () => {
         ]);
       },
     },
+  });
+  // A relative Worker specifier is joined onto the embedded root ("./worker" ->
+  // "/$bunfs/root/worker.js") in a fixed-size path buffer before the graph
+  // lookup. A specifier that does not fit must fall through to the regular
+  // resolver and fire the worker's error event, not abort the process.
+  itBundled("compile/WorkerRelativePathLongerThanPathBuffer", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        const w = (length) => Buffer.alloc(length, "w").toString();
+        // The specifier is joined onto import.meta.dir ("/$bunfs/root") plus a slash.
+        const joinedPrefixLength = import.meta.dir.length + 1;
+        const specifiers = [
+          ["./ past the buffer", "./" + w(100_000)],
+          ["../ past the buffer", "../" + w(100_000)],
+          // Path buffer sizes on macOS, Linux and Windows. The joined path
+          // stops one byte short of filling the buffer, so the join fits and
+          // only the ".js" appended by the remap does not.
+          ...[1024, 4096, 98302].map(size => [
+            "./ one byte short of a " + size + " byte buffer",
+            "./" + w(size - 1 - joinedPrefixLength),
+          ]),
+        ];
+        for (const [label, specifier] of specifiers) {
+          const { promise, resolve } = Promise.withResolvers();
+          const worker = new Worker(specifier);
+          worker.onerror = resolve;
+          await promise;
+          console.log(label + ": error event");
+        }
+      `,
+    },
+    run: {
+      stdout: `
+        ./ past the buffer: error event
+        ../ past the buffer: error event
+        ./ one byte short of a 1024 byte buffer: error event
+        ./ one byte short of a 4096 byte buffer: error event
+        ./ one byte short of a 98302 byte buffer: error event
+      `,
+      setCwd: true,
+    },
+  });
+  // Preloads go through the same join, on the parent thread.
+  itBundled("compile/WorkerPreloadLongerThanPathBuffer", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        try {
+          new Worker("./worker.ts", { preload: ["./" + Buffer.alloc(100_000, "p").toString()] });
+          console.log("constructed");
+        } catch (e) {
+          console.log("constructor threw an Error:", e instanceof Error);
+        }
+      `,
+      "/worker.ts": /* js */ `
+        console.log("Worker loaded!");
+      `.trim(),
+    },
+    entryPointsRaw: ["./entry.ts", "./worker.ts"],
+    outfile: "dist/out",
+    run: { stdout: "constructor threw an Error: true", file: "dist/out", setCwd: true },
   });
   itBundled("compile/Bun.embeddedFiles", {
     compile: true,


### PR DESCRIPTION
### Problem
- In a `bun build --compile` executable, a `./` specifier longer than the path buffer aborted the process in `new Worker`, a Worker `preload`, `import()` and `require()`: `panic: range end index 5012 out of range for slice of length 4095`. #38422 and #38428 fixed the two code paths separately.
- #40619 (b49398c4ad) moved both lookups into `StandaloneModuleGraph::resolve` (`src/resolver/standalone_module_graph.rs:25`). It joins with `join_abs_string_buf_checked` and checks `stem_len + 3 > buf.len()` before it appends `.js`. Both panics are gone on main.
- No test on main exercises an over-long specifier. The 70000 byte probe in `compile/EmbeddedResolveMisses` hits the 1.5x `PATH_MAX` cap before the resolver.

### Fix
- Test only. This adds the three tests from #38422 and #38428 to `test/bundler/bundler_compile.test.ts`: `compile/WorkerRelativePathLongerThanPathBuffer`, `compile/WorkerPreloadLongerThanPathBuffer` and `compile/RelativeSpecifierLongerThanPathMax`. The comments describe the code after #40619.
- On the build before #40619 (1.4.1-canary d578a8c70) all three fail with `Runtime failed with SIGABRT` and the panic above. On main at f189103280 (debug build) all three pass.
- Both PRs passed CI on all platforms with these tests. Their per-platform lengths are kept.

### Background
- A compiled executable embeds its modules under a virtual root (`/$bunfs/root/`, `B:/~BUN/root/` on Windows). A relative specifier is joined onto that root and looked up in the graph, as spelled and under its `.js` name.
- `PathBuffer` is a fixed scratch buffer of `MAX_PATH_BYTES` (1024 on macOS, 4096 on Linux, 98302 on Windows). The old join wrote into it unchecked.
- `import()` and `require()` specifiers longer than 1.5x `MAX_PATH_BYTES` are rejected before resolution. Worker specifiers have no cap. The test lengths sit between the two bounds on each platform.

<details><summary>Notes</summary>

Hand probes on main with a compiled two-file app from a cwd 71 bytes deep. `./` specifiers of 4081 to 4085 bytes (the `.js` append window on Linux), 5000, 6145, 98288 and 100000 bytes: the worker fires `error`, the preload constructor throws, `require` reports `MODULE_NOT_FOUND`, `import` reports `ERR_MODULE_NOT_FOUND` (or the ENAMETOOLONG cap past 6144 bytes). No abort.

One neighbouring abort remains and is out of scope here. From a short cwd (`/tmp/probe`), a `./` specifier of 4081 to 4085 bytes panics in `Resolver::load_extension` (`src/resolver/resolver.rs:6012`) with `range end index 4097 out of range for slice of length 4096`. That is the regular resolver's extension probe. It reproduces with plain `bun main.js` as well, before and after #40619. #39626 fixes it.

Test runs:
- `USE_SYSTEM_BUN=1 bun test test/bundler/bundler_compile.test.ts -t "LongerThanPathBuffer|LongerThanPathMax"` on 1.4.1-canary d578a8c70: 0 pass, 3 fail (SIGABRT).
- `bun bd test test/bundler/bundler_compile.test.ts -t "LongerThanPathBuffer|LongerThanPathMax"` on main f189103280: 3 pass.
- `bun bd test test/bundler/bundler_compile.test.ts`: 85 pass, 1 fail (`compile/HelloWorldWithProcessVersionsBun`, which also fails on main without this change).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->