### PR TITLE
test: cover the matcher diff path when formatting a value throws

### DIFF
--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -40,7 +40,7 @@ Identifier getFromIdentifierArray(VM& vm, Identifier* identifierArray, uint32_t 
 }
 
 extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject* globalObject, VM& vm, const Identifier& module_key, const SourceCode& source_code, bun_ModuleInfoDeserialized* module_info);
-extern "C" void zig__renderDiff(const char* expected_ptr, size_t expected_len, const char* received_ptr, size_t received_len, JSGlobalObject* globalObject);
+extern "C" void zig__renderDiff(const char* expected_ptr, size_t expected_len, const char* received_ptr, size_t received_len);
 
 extern "C" Identifier* JSC__IdentifierArray__create(size_t len)
 {
@@ -232,7 +232,7 @@ static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, const Identifi
             dataLog("  ------", "\n");
             dataLog("  BunAnalyzeTranspiledModule:", "\n");
 
-            zig__renderDiff(expected.utf8().data(), expected.utf8().length(), actual.utf8().data(), actual.utf8().length(), globalObject);
+            zig__renderDiff(expected.utf8().data(), expected.utf8().length(), actual.utf8().data(), actual.utf8().length());
 
             RELEASE_AND_RETURN(scope, JSValue::encode(rejectWithError(createError(globalObject, WTF::String::fromLatin1("Imports different between parseFromSourceCode and fallbackParse")))));
         }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1794,26 +1794,31 @@ JSC::EncodedJSValue Bun::throwInvalidThisCallError(JSC::JSGlobalObject* globalOb
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), typeName));
+    throwInvalidThisError(globalObject, scope, callFrame->thisValue(), typeName);
     return {};
 }
 
-JSC::JSObject* Bun::createInvalidThisError(JSC::JSGlobalObject* globalObject, JSC::JSValue thisValue, const ASCIILiteral typeName)
+void Bun::throwInvalidThisError(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, JSC::JSValue thisValue, const ASCIILiteral typeName)
 {
-    if (!thisValue.isEmpty())
+    auto& vm = JSC::getVM(globalObject);
+    if (!thisValue.isEmpty()) {
         thisValue = thisValue.toThis(globalObject, JSC::ECMAMode::strict());
-
-    if (thisValue.isEmpty() || thisValue.isUndefined()) {
-        return Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_THIS, makeString("Expected this to be instanceof "_s, typeName));
+        RETURN_IF_EXCEPTION(scope, );
     }
 
-    // Pathological case: the this value returns a string which is extremely long or causes an out of memory error.
+    if (thisValue.isEmpty() || thisValue.isUndefined()) {
+        scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_THIS, makeString("Expected this to be instanceof "_s, typeName)));
+        return;
+    }
+
     WTF::StringBuilder builder;
     builder.append("Expected this to be instanceof "_s);
     builder.append(typeName);
     builder.append(", but received "_s);
-    determineSpecificType(JSC::getVM(globalObject), globalObject, builder, thisValue);
-    return Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_THIS, builder.toString());
+    // Describing the receiver reads its `constructor.name`, which can throw; that error wins.
+    determineSpecificType(vm, globalObject, builder, thisValue);
+    RETURN_IF_EXCEPTION(scope, );
+    scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_THIS, builder.toString()));
 }
 
 JSC::EncodedJSValue Bun::throwError(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, Bun::ErrorCode code, const WTF::String& message)
@@ -2122,7 +2127,9 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Bun::jsFunctionMakeErrorWithCode, __att
         auto arg0 = callFrame->argument(1);
         auto arg1 = callFrame->argument(2);
         auto arg2 = callFrame->argument(3);
-        return JSC::JSValue::encode(createError(globalObject, error, Message::ERR_OUT_OF_RANGE(scope, globalObject, arg0, arg1, arg2)));
+        auto message = Message::ERR_OUT_OF_RANGE(scope, globalObject, arg0, arg1, arg2);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSC::JSValue::encode(createError(globalObject, error, message));
     }
 
     case Bun::ErrorCode::ERR_UNHANDLED_ERROR: {

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -60,8 +60,10 @@ JSC::JSObject* createError(Zig::GlobalObject* globalObject, ErrorCode code, cons
 JSC::JSObject* createError(JSC::JSGlobalObject* globalObject, ErrorCode code, const WTF::String& message);
 JSC::JSObject* createError(Zig::GlobalObject* globalObject, ErrorCode code, JSC::JSValue message);
 JSC::JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, JSValue message, JSValue options);
-JSObject* createInvalidThisError(JSGlobalObject* globalObject, JSValue thisValue, const ASCIILiteral typeName);
-// Throws createInvalidThisError(callFrame->thisValue()) and returns the empty value; one call at each generated host-function's invalid-this branch.
+// Throws ERR_INVALID_THIS describing `thisValue` ("…but received an instance of X"); if describing
+// the receiver itself throws (a `constructor`/`name` getter), that exception is left instead.
+void throwInvalidThisError(JSGlobalObject* globalObject, JSC::ThrowScope&, JSValue thisValue, const ASCIILiteral typeName);
+// throwInvalidThisError(callFrame->thisValue()) and returns the empty value; one call at each generated host-function's invalid-this branch.
 JSC::EncodedJSValue throwInvalidThisCallError(JSGlobalObject* globalObject, JSC::CallFrame* callFrame, const ASCIILiteral typeName);
 JSObject* createInvalidThisError(JSGlobalObject* globalObject, const String& message);
 

--- a/src/jsc/bindings/JSBunRequest.cpp
+++ b/src/jsc/bindings/JSBunRequest.cpp
@@ -279,8 +279,8 @@ JSC_DEFINE_HOST_FUNCTION(jsJSBunRequestClone, (JSC::JSGlobalObject * globalObjec
 
     auto* request = dynamicDowncast<JSBunRequest>(callFrame->thisValue());
     if (!request) {
-        throwScope.throwException(globalObject, Bun::createInvalidThisError(globalObject, request, "BunRequest"));
-        RETURN_IF_EXCEPTION(throwScope, {});
+        Bun::throwInvalidThisError(globalObject, throwScope, callFrame->thisValue(), "BunRequest"_s);
+        return {};
     }
 
     auto clone = request->clone(vm, globalObject);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -636,7 +636,6 @@ static void restoreAllMocks(Zig::GlobalObject* globalObject)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSValue spies = globalObject->mockModule.activeSpies.get();
-    globalObject->mockModule.activeSpies.clear();
     if (!spies)
         return;
     MarkedArgumentBuffer active;
@@ -647,6 +646,7 @@ static void restoreAllMocks(Zig::GlobalObject* globalObject)
             RETURN_IF_EXCEPTION(scope, );
         }
     }
+    globalObject->mockModule.activeSpies.clear();
 }
 
 extern "C" void JSMock__clearAllMocks(Zig::GlobalObject* globalObject)

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -37,10 +37,10 @@ BUN_DECLARE_HOST_FUNCTION(JSMock__jsResetAllMocks);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsSpyOn);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsMockFn);
 
-#define CHECK_IS_MOCK_FUNCTION(thisValue)                                                              \
-    if (!thisObject) [[unlikely]] {                                                                    \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, thisValue, "Mock"_s)); \
-        return {};                                                                                     \
+#define CHECK_IS_MOCK_FUNCTION(thisValue)                                \
+    if (!thisObject) [[unlikely]] {                                      \
+        throwInvalidThisError(globalObject, scope, thisValue, "Mock"_s); \
+        return {};                                                       \
     }
 
 namespace Bun {
@@ -357,32 +357,38 @@ public:
         this->tail.clear();
     }
 
-    void clearSpy()
+    // Puts the original value back on the spied-on object; that put can throw (a module namespace
+    // export, an indexed slot).
+    void clearSpy(JSGlobalObject* globalObject)
     {
+        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
         this->reset();
 
-        if (auto* target = this->spyTarget.get()) {
-            JSValue implValue = this->spyOriginal.get();
-            if (!implValue) {
-                implValue = jsUndefined();
-            }
-
-            // Reset the spy back to the original value.
-            if (this->spyAttributes & SpyAttributeESModuleNamespace) {
-                if (auto* moduleNamespaceObject = tryJSDynamicCast<JSModuleNamespaceObject*>(target)) {
-                    moduleNamespaceObject->overrideExportValue(moduleNamespaceObject->globalObject(), this->spyIdentifier, implValue);
-                }
-            } else if (auto index = parseIndex(this->spyIdentifier)) {
-                // Use putDirectIndex for numeric property keys (e.g., spyOn(arr, 0))
-                target->putDirectIndex(globalObject(), *index, implValue, this->spyAttributes, PutDirectIndexLikePutDirect);
-            } else {
-                target->putDirect(this->vm(), this->spyIdentifier, implValue, this->spyAttributes);
-            }
+        auto* target = this->spyTarget.get();
+        JSValue implValue = this->spyOriginal.get();
+        if (!implValue) {
+            implValue = jsUndefined();
         }
-
+        JSC::Identifier identifier = this->spyIdentifier;
+        unsigned attributes = this->spyAttributes;
         this->spyTarget.clear();
         this->spyIdentifier = JSC::Identifier();
         this->spyAttributes = 0;
+        if (!target)
+            return;
+
+        if (attributes & SpyAttributeESModuleNamespace) {
+            if (auto* moduleNamespaceObject = tryJSDynamicCast<JSModuleNamespaceObject*>(target)) {
+                moduleNamespaceObject->overrideExportValue(globalObject, identifier, implValue);
+                RETURN_IF_EXCEPTION(scope, );
+            }
+        } else if (auto index = parseIndex(identifier)) {
+            // Use putDirectIndex for numeric property keys (e.g., spyOn(arr, 0))
+            target->putDirectIndex(globalObject, *index, implValue, attributes, PutDirectIndexLikePutDirect);
+            RETURN_IF_EXCEPTION(scope, );
+        } else {
+            target->putDirect(this->vm(), identifier, implValue, attributes);
+        }
     }
 
     JSArray* getCalls() const
@@ -626,10 +632,21 @@ static void forEachMockInSet(JSC::WriteBarrier<JSC::Unknown>& mockSet, const Fun
     }
 }
 
-extern "C" void JSMock__resetSpies(Zig::GlobalObject* globalObject)
+static void restoreAllMocks(Zig::GlobalObject* globalObject)
 {
-    forEachMockInSet(globalObject->mockModule.activeSpies, [](JSMockFunction* spy) { spy->clearSpy(); });
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    JSValue spies = globalObject->mockModule.activeSpies.get();
     globalObject->mockModule.activeSpies.clear();
+    if (!spies)
+        return;
+    MarkedArgumentBuffer active;
+    uncheckedDowncast<ActiveSpySet>(spies)->takeSnapshot(active);
+    for (size_t i = 0; i < active.size(); ++i) {
+        if (auto* spy = dynamicDowncast<JSMockFunction>(active.at(i))) {
+            spy->clearSpy(globalObject);
+            RETURN_IF_EXCEPTION(scope, );
+        }
+    }
 }
 
 extern "C" void JSMock__clearAllMocks(Zig::GlobalObject* globalObject)
@@ -1074,9 +1091,9 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRestore, (JSC::JSGlobalObject * globa
     auto scope = DECLARE_THROW_SCOPE(vm);
     CHECK_IS_MOCK_FUNCTION(thisValue);
 
-    thisObject->clearSpy();
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+    thisObject->clearSpy(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(thisObject);
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockImplementation, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callframe))
 {
@@ -1190,9 +1207,11 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValue, (JSC::JSGlobalObject *
     auto scope = DECLARE_THROW_SCOPE(vm);
     CHECK_IS_MOCK_FUNCTION(thisValue);
 
-    pushImpl(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, JSC::JSPromise::resolvedPromise(globalObject, callframe->argument(0)));
+    auto* promise = JSC::JSPromise::resolvedPromise(globalObject, callframe->argument(0));
+    RETURN_IF_EXCEPTION(scope, {});
+    pushImpl(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, promise);
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+    return JSValue::encode(thisObject);
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValueOnce, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
@@ -1203,9 +1222,11 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValueOnce, (JSC::JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     CHECK_IS_MOCK_FUNCTION(thisValue);
 
-    pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, JSC::JSPromise::resolvedPromise(globalObject, callframe->argument(0)));
+    auto* promise = JSC::JSPromise::resolvedPromise(globalObject, callframe->argument(0));
+    RETURN_IF_EXCEPTION(scope, {});
+    pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, promise);
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+    return JSValue::encode(thisObject);
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRejectedValue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
@@ -1432,7 +1453,9 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsRestoreAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
-    JSMock__resetSpies(uncheckedDowncast<Zig::GlobalObject>(globalObject));
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    restoreAllMocks(uncheckedDowncast<Zig::GlobalObject>(globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -407,7 +407,9 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
         }
 
         case AsymmetricMatcherConstructorType::Array: {
-            if (JSC::isArray(globalObject, otherProp)) {
+            bool otherIsArray = JSC::isArray(globalObject, otherProp);
+            RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
+            if (otherIsArray) {
                 return AsymmetricMatcherResult::PASS;
             }
             break;
@@ -476,7 +478,10 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                 }
             } else if (auto* regex = dynamicDowncast<RegExpObject>(expectedTestValue)) {
                 JSString* otherString = otherProp.toString(globalObject);
-                if (regex->match(globalObject, otherString)) {
+                RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
+                bool matched = !!regex->match(globalObject, otherString);
+                RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
+                if (matched) {
                     return AsymmetricMatcherResult::PASS;
                 }
             }
@@ -504,10 +509,12 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
             // O(m*n) but works for now
             for (unsigned m = 0; m < expectedLength; m++) {
                 JSValue expectedValue = expectedArray->getIndex(globalObject, m);
+                RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                 bool found = false;
 
                 for (unsigned n = 0; n < otherLength; n++) {
                     JSValue otherValue = otherArray->getIndex(globalObject, n);
+                    RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                     Vector<std::pair<JSValue, JSValue>, 16> stack;
                     MarkedArgumentBuffer gcBuffer;
                     bool foundNow = Bun__deepEquals<false, true, false>(globalObject, expectedValue, otherValue, gcBuffer, stack, throwScope, true);
@@ -559,8 +566,9 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
         JSValue expectedValue = expectCloseTo->m_numberValue.get();
         JSValue digitsValue = expectCloseTo->m_digitsValue.get();
 
-        double received = otherProp.toNumber(globalObject);
-        double expected = expectedValue.toNumber(globalObject);
+        // expect.closeTo() validated both as numbers when it was constructed.
+        double received = otherProp.asNumber();
+        double expected = expectedValue.asNumber();
 
         constexpr double infinity = std::numeric_limits<double>::infinity();
 
@@ -569,6 +577,7 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
             return AsymmetricMatcherResult::PASS;
         } else {
             int32_t digits = digitsValue.toInt32(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
 
             double threshold = 0.5 * std::pow(10.0, -digits);
             bool isClose = std::abs(expected - received) < threshold;
@@ -2089,7 +2098,11 @@ bool Bun__deepMatch(
     // similar to what is done in deepEquals (canPerformFastPropertyEnumerationForIterationBun)
 
     // arrays should match exactly
-    if (isArray(globalObject, objValue) && isArray(globalObject, subsetValue)) {
+    bool objIsArray = isArray(globalObject, objValue);
+    RETURN_IF_EXCEPTION(throwScope, false);
+    bool subsetIsArray = objIsArray && isArray(globalObject, subsetValue);
+    RETURN_IF_EXCEPTION(throwScope, false);
+    if (subsetIsArray) {
         if (obj->getArrayLength() != subsetObj->getArrayLength()) {
             return false;
         }
@@ -4832,7 +4845,9 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
         return JSValue::encode(currProp);
     }
 
-    if (isArray(globalObject, path)) {
+    bool pathIsArray = isArray(globalObject, path);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (pathIsArray) {
         // each item in array is property name, ignore dot/bracket notation
         JSValue currProp = value;
         auto* pathObject = path.toObject(globalObject);

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -1220,13 +1220,13 @@ JSC_DECLARE_HOST_FUNCTION(jsDatabaseSyncDeserialize);
 JSC_DECLARE_HOST_FUNCTION(jsDatabaseSyncCreateTagStore);
 JSC_DECLARE_HOST_FUNCTION(jsDatabaseSyncDispose);
 
-#define THIS_DATABASE()                                                                                                     \
-    auto& vm = JSC::getVM(globalObject);                                                                                    \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                                   \
-    JSDatabaseSync* self = dynamicDowncast<JSDatabaseSync>(callFrame->thisValue());                                         \
-    if (!self) [[unlikely]] {                                                                                               \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "DatabaseSync"_s)); \
-        return {};                                                                                                          \
+#define THIS_DATABASE()                                                                       \
+    auto& vm = JSC::getVM(globalObject);                                                      \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                                     \
+    JSDatabaseSync* self = dynamicDowncast<JSDatabaseSync>(callFrame->thisValue());           \
+    if (!self) [[unlikely]] {                                                                 \
+        throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "DatabaseSync"_s); \
+        return {};                                                                            \
     }
 
 JSC_DEFINE_HOST_FUNCTION(jsDatabaseSyncOpen, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -2737,13 +2737,13 @@ JSC_DECLARE_HOST_FUNCTION(jsStatementSyncSetReturnArrays);
 JSC_DECLARE_HOST_FUNCTION(jsStatementSyncSetAllowBareNamedParameters);
 JSC_DECLARE_HOST_FUNCTION(jsStatementSyncSetAllowUnknownNamedParameters);
 
-#define THIS_STATEMENT()                                                                                                     \
-    auto& vm = JSC::getVM(globalObject);                                                                                     \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                                    \
-    JSStatementSync* self = dynamicDowncast<JSStatementSync>(callFrame->thisValue());                                        \
-    if (!self) [[unlikely]] {                                                                                                \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "StatementSync"_s)); \
-        return {};                                                                                                           \
+#define THIS_STATEMENT()                                                                       \
+    auto& vm = JSC::getVM(globalObject);                                                       \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                                      \
+    JSStatementSync* self = dynamicDowncast<JSStatementSync>(callFrame->thisValue());          \
+    if (!self) [[unlikely]] {                                                                  \
+        throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "StatementSync"_s); \
+        return {};                                                                             \
     }
 
 struct StatementResetter {
@@ -3076,7 +3076,7 @@ JSC_DEFINE_HOST_FUNCTION(jsStatementSyncIteratorNext, (JSGlobalObject * globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* self = dynamicDowncast<JSStatementSyncIterator>(callFrame->thisValue());
     if (!self) [[unlikely]] {
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "StatementSyncIterator"_s));
+        throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "StatementSyncIterator"_s);
         return {};
     }
     // Once exhausted, next() doesn't touch the statement — so keep
@@ -3131,7 +3131,7 @@ JSC_DEFINE_HOST_FUNCTION(jsStatementSyncIteratorReturn, (JSGlobalObject * global
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* self = dynamicDowncast<JSStatementSyncIterator>(callFrame->thisValue());
     if (!self) [[unlikely]] {
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "StatementSyncIterator"_s));
+        throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "StatementSyncIterator"_s);
         return {};
     }
     // return() is the iterator-protocol cleanup hook (called implicitly by
@@ -3245,13 +3245,13 @@ GCClient::IsoSubspace* JSNodeSqliteSession::subspaceForImpl(VM& vm)
     return WebCore::subspaceForImpl<JSNodeSqliteSession, UseCustomHeapCellType::No>(vm, BUN_SUBSPACE_SLOTS(m_clientSubspaceForNodeSqliteSession, m_subspaceForNodeSqliteSession));
 }
 
-#define THIS_SESSION()                                                                                                 \
-    auto& vm = JSC::getVM(globalObject);                                                                               \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                              \
-    JSNodeSqliteSession* self = dynamicDowncast<JSNodeSqliteSession>(callFrame->thisValue());                          \
-    if (!self) [[unlikely]] {                                                                                          \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "Session"_s)); \
-        return {};                                                                                                     \
+#define THIS_SESSION()                                                                        \
+    auto& vm = JSC::getVM(globalObject);                                                      \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                                     \
+    JSNodeSqliteSession* self = dynamicDowncast<JSNodeSqliteSession>(callFrame->thisValue()); \
+    if (!self) [[unlikely]] {                                                                 \
+        throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "Session"_s);      \
+        return {};                                                                            \
     }
 
 static EncodedJSValue sessionChangesetCommon(JSGlobalObject* globalObject, CallFrame* callFrame,
@@ -3712,13 +3712,13 @@ JSStatementSync* JSNodeSqliteTagStore::prepare(JSGlobalObject* globalObject, Thr
     return stmtObj;
 }
 
-#define THIS_TAGSTORE()                                                                                                    \
-    auto& vm = JSC::getVM(globalObject);                                                                                   \
-    auto scope = DECLARE_THROW_SCOPE(vm);                                                                                  \
-    JSNodeSqliteTagStore* self = dynamicDowncast<JSNodeSqliteTagStore>(callFrame->thisValue());                            \
-    if (!self) [[unlikely]] {                                                                                              \
-        scope.throwException(globalObject, createInvalidThisError(globalObject, callFrame->thisValue(), "SQLTagStore"_s)); \
-        return {};                                                                                                         \
+#define THIS_TAGSTORE()                                                                         \
+    auto& vm = JSC::getVM(globalObject);                                                        \
+    auto scope = DECLARE_THROW_SCOPE(vm);                                                       \
+    JSNodeSqliteTagStore* self = dynamicDowncast<JSNodeSqliteTagStore>(callFrame->thisValue()); \
+    if (!self) [[unlikely]] {                                                                   \
+        throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "SQLTagStore"_s);    \
+        return {};                                                                              \
     }
 
 // Shared tag execution: prepare/reset/bind then delegate to the same

--- a/src/jsc/bindings/webcore/JSMIMEParams.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEParams.cpp
@@ -395,8 +395,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncGet, (JSGlobalObject * globalObjec
     // 1. Get this value
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
 
     // 2. Get argument
@@ -425,8 +425,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncHas, (JSGlobalObject * globalObjec
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
 
     JSValue nameValue = callFrame->argument(0);
@@ -447,8 +447,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncSet, (JSGlobalObject * globalObjec
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
 
     // 1. Validate Arguments
@@ -489,8 +489,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncDelete, (JSGlobalObject * globalOb
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
 
     JSValue nameValue = callFrame->argument(0);
@@ -511,8 +511,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncToString, (JSGlobalObject * global
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
 
     JSMap* map = thisObject->jsMap();
@@ -557,8 +557,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncEntries, (JSGlobalObject * globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(JSMapIterator::create(vm, globalObject->mapIteratorStructure(), thisObject->jsMap(), IterationKind::Entries)));
 }
@@ -569,8 +569,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncKeys, (JSGlobalObject * globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(JSMapIterator::create(vm, globalObject->mapIteratorStructure(), thisObject->jsMap(), IterationKind::Keys)));
 }
@@ -581,8 +581,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncValues, (JSGlobalObject * globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEParams"_s);
+        return {};
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(JSMapIterator::create(vm, globalObject->mapIteratorStructure(), thisObject->jsMap(), IterationKind::Values)));
 }

--- a/src/jsc/bindings/webcore/JSMIMEType.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEType.cpp
@@ -342,7 +342,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterType, (JSGlobalObject * globalObje
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        Bun::throwInvalidThisError(globalObject, scope, JSC::JSValue::decode(thisValue), "MIMEType"_s);
         return {};
     }
 
@@ -356,7 +356,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsMIMETypeProtoSetterType, (JSGlobalObject * globalObje
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        Bun::throwInvalidThisError(globalObject, scope, JSC::JSValue::decode(thisValue), "MIMEType"_s);
         return {};
     }
 
@@ -382,7 +382,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterSubtype, (JSGlobalObject * globalO
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        Bun::throwInvalidThisError(globalObject, scope, JSC::JSValue::decode(thisValue), "MIMEType"_s);
         return {};
     }
 
@@ -396,7 +396,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsMIMETypeProtoSetterSubtype, (JSGlobalObject * globalO
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        Bun::throwInvalidThisError(globalObject, scope, JSC::JSValue::decode(thisValue), "MIMEType"_s);
         return {};
     }
 
@@ -422,7 +422,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterEssence, (JSGlobalObject * globalO
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        Bun::throwInvalidThisError(globalObject, scope, JSC::JSValue::decode(thisValue), "MIMEType"_s);
         return {};
     }
 
@@ -437,7 +437,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterParams, (JSGlobalObject * globalOb
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        Bun::throwInvalidThisError(globalObject, scope, JSC::JSValue::decode(thisValue), "MIMEType"_s);
         return {};
     }
 
@@ -451,7 +451,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMETypeProtoFuncToString, (JSGlobalObject * globalOb
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        Bun::throwInvalidThisError(globalObject, scope, callFrame->thisValue(), "MIMEType"_s);
         return {};
     }
 

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -1,85 +1,89 @@
 use core::fmt;
+use std::borrow::Cow;
 
 use bun_core::Output;
-use bun_jsc::{JSGlobalObject, JSValue};
+use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
 use super::diff::print_diff::{print_diff_main, DiffConfig};
 use super::pretty_format::{FormatOptions, JestPrettyFormat, MessageLevel};
 
-#[derive(Default)]
+/// Renders a Jest-style diff of two already-formatted values. Formatting a JS value runs user code
+/// (getters, Proxy traps) and can throw, so it happens up front in [`DiffFormatter::new`], never
+/// inside `Display::fmt`.
 pub struct DiffFormatter<'a> {
-    pub(crate) received_string: Option<&'a [u8]>,
-    pub(crate) expected_string: Option<&'a [u8]>,
-    pub(crate) received: Option<JSValue>,
-    pub(crate) expected: Option<JSValue>,
-    pub global_this: Option<&'a JSGlobalObject>,
+    pub(crate) received_string: Cow<'a, [u8]>,
+    pub(crate) expected_string: Cow<'a, [u8]>,
     pub(crate) not: bool,
+}
+
+impl<'a> DiffFormatter<'a> {
+    pub fn new(
+        global_this: &JSGlobalObject,
+        received: JSValue,
+        expected: JSValue,
+        not: bool,
+    ) -> JsResult<DiffFormatter<'static>> {
+        let fmt_options = FormatOptions {
+            enable_colors: false,
+            add_newline: false,
+            flush: false,
+            quote_strings: true,
+        };
+        let mut received_buf: Vec<u8> = Vec::new();
+        JestPrettyFormat::format(
+            MessageLevel::Debug,
+            global_this,
+            core::slice::from_ref(&received),
+            1,
+            &mut received_buf,
+            fmt_options,
+        )?;
+        let mut expected_buf: Vec<u8> = Vec::new();
+        JestPrettyFormat::format(
+            MessageLevel::Debug,
+            global_this,
+            core::slice::from_ref(&expected),
+            1,
+            &mut expected_buf,
+            fmt_options,
+        )?;
+        Ok(DiffFormatter {
+            received_string: Cow::Owned(trim_one_newline(received_buf)),
+            expected_string: Cow::Owned(trim_one_newline(expected_buf)),
+            not,
+        })
+    }
+
+    pub fn from_strings(received: &'a [u8], expected: &'a [u8], not: bool) -> Self {
+        DiffFormatter {
+            received_string: Cow::Borrowed(received),
+            expected_string: Cow::Borrowed(expected),
+            not,
+        }
+    }
+}
+
+fn trim_one_newline(mut buf: Vec<u8>) -> Vec<u8> {
+    if buf.ends_with(b"\n") {
+        buf.pop();
+    }
+    if buf.starts_with(b"\n") {
+        buf.remove(0);
+    }
+    buf
 }
 
 impl<'a> fmt::Display for DiffFormatter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let diff_config =
             DiffConfig::default(Output::is_ai_agent(), Output::enable_ansi_colors_stderr());
-
-        if let (Some(expected), Some(received)) = (self.expected_string, self.received_string) {
-            print_diff_main(self.not, received, expected, f, &diff_config)?;
-            return Ok(());
-        }
-
-        if self.received.is_none() || self.expected.is_none() {
-            return Ok(());
-        }
-
-        let global_this = self.global_this.expect("DiffFormatter.global_this not set");
-
-        let received = self.received.unwrap();
-        let expected = self.expected.unwrap();
-        let mut received_buf: Vec<u8> = Vec::new();
-        let mut expected_buf: Vec<u8> = Vec::new();
-
-        {
-            let fmt_options = FormatOptions {
-                enable_colors: false,
-                add_newline: false,
-                flush: false,
-                quote_strings: true,
-            };
-            let _ = JestPrettyFormat::format(
-                MessageLevel::Debug,
-                global_this,
-                core::slice::from_ref(&received),
-                1,
-                &mut received_buf,
-                fmt_options,
-            ); // TODO:
-
-            let _ = JestPrettyFormat::format(
-                MessageLevel::Debug,
-                global_this,
-                core::slice::from_ref(&expected),
-                1,
-                &mut expected_buf,
-                fmt_options,
-            ); // TODO:
-        }
-
-        let mut received_slice: &[u8] = received_buf.as_slice();
-        let mut expected_slice: &[u8] = expected_buf.as_slice();
-        if received_slice.starts_with(b"\n") {
-            received_slice = &received_slice[1..];
-        }
-        if expected_slice.starts_with(b"\n") {
-            expected_slice = &expected_slice[1..];
-        }
-        if received_slice.ends_with(b"\n") {
-            received_slice = &received_slice[..received_slice.len() - 1];
-        }
-        if expected_slice.ends_with(b"\n") {
-            expected_slice = &expected_slice[..expected_slice.len() - 1];
-        }
-
-        print_diff_main(self.not, received_slice, expected_slice, f, &diff_config)?;
-        Ok(())
+        print_diff_main(
+            self.not,
+            &self.received_string,
+            &self.expected_string,
+            f,
+            &diff_config,
+        )
     }
 }
 
@@ -97,7 +101,7 @@ extern "C" fn zig__renderDiff(
     expected_len: usize,
     received_ptr: *const core::ffi::c_char,
     received_len: usize,
-    global_this: &JSGlobalObject,
+    _global_this: &JSGlobalObject,
 ) {
     // SAFETY: caller (BunAnalyzeTranspiledModule.cpp) passes a valid UTF-8 buffer
     // of length `expected_len` that outlives this call.
@@ -105,11 +109,6 @@ extern "C" fn zig__renderDiff(
     // SAFETY: caller (BunAnalyzeTranspiledModule.cpp) passes a valid UTF-8 buffer
     // of length `received_len` that outlives this call.
     let received = unsafe { bun_core::ffi::slice(received_ptr.cast::<u8>(), received_len) };
-    let formatter = DiffFormatter {
-        received_string: Some(received),
-        expected_string: Some(expected),
-        global_this: Some(global_this),
-        ..Default::default()
-    };
+    let formatter = DiffFormatter::from_strings(received, expected, false);
     let _ = bun_core::output::error_writer().print(format_args!("DIFF:\n{}\n", formatter));
 }

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -101,7 +101,6 @@ extern "C" fn zig__renderDiff(
     expected_len: usize,
     received_ptr: *const core::ffi::c_char,
     received_len: usize,
-    _global_this: &JSGlobalObject,
 ) {
     // SAFETY: caller (BunAnalyzeTranspiledModule.cpp) passes a valid UTF-8 buffer
     // of length `expected_len` that outlives this call.

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1089,12 +1089,7 @@ impl Expect {
             } else {
                 runner.snapshots.failed += 1;
                 let signature = Self::get_signature(fn_name, "<green>expected<r>", false);
-                let diff_format = DiffFormatter {
-                    received_string: Some(&pretty_value),
-                    expected_string: Some(trim_res.trimmed),
-                    global_this: Some(global_this),
-                    ..Default::default()
-                };
+                let diff_format = DiffFormatter::from_strings(&pretty_value, trim_res.trimmed, false);
                 return throw!(this, global_this, signature, "\n\n{}\n", diff_format);
             }
         } else {
@@ -1186,14 +1181,7 @@ impl Expect {
             }
         }
 
-        if value.jest_snapshot_pretty_format(pretty_value, global_this).is_err() {
-            let mut formatter = ConsoleObject::Formatter::new(global_this);
-            return Err(global_this.throw(format_args!(
-                "Failed to pretty format value: {}",
-                value.to_fmt(&mut formatter),
-            )));
-        }
-        Ok(())
+        value.jest_snapshot_pretty_format(pretty_value, global_this)
     }
 
     pub(crate) fn snapshot(
@@ -1272,12 +1260,7 @@ impl Expect {
 
             runner.snapshots.failed += 1;
             let signature = Self::get_signature(fn_name, "<green>expected<r>", false);
-            let diff_format = DiffFormatter {
-                received_string: Some(&pretty_value),
-                expected_string: Some(&saved_value),
-                global_this: Some(global_this),
-                ..Default::default()
-            };
+            let diff_format = DiffFormatter::from_strings(&pretty_value, &saved_value, false);
             return throw!(self, global_this, signature, "\n\n{}\n", diff_format);
         }
 
@@ -2877,14 +2860,7 @@ impl ExpectMatcherUtils {
         }
         let _ = (comment, promise, second_argument);
 
-        let diff_formatter = DiffFormatter {
-            received_string: None,
-            expected_string: None,
-            received: Some(received),
-            expected: Some(expected),
-            global_this: Some(global_this),
-            not: is_not,
-        };
+        let diff_formatter = DiffFormatter::new(global_this, received, expected, is_not)?;
 
         // Builds `getSignature("{f}", "<green>expected<r>", is_not) ++ "\n\n{f}\n"`
         // and substitutes `(matcher_name, diff_formatter)` into the two `{f}`

--- a/src/runtime/test_runner/expect/toBe.rs
+++ b/src/runtime/test_runner/expect/toBe.rs
@@ -80,7 +80,7 @@ impl Expect {
         }
 
         if right.is_string() && left.is_string() {
-            let diff_format = DiffFormatter { expected: Some(right), received: Some(left), expected_string: None, received_string: None, global_this: Some(global_this), not };
+            let diff_format = DiffFormatter::new(global_this, left, right, not)?;
             return throw!(this, global_this, signature, "\n\n{}\n", diff_format);
         }
 

--- a/src/runtime/test_runner/expect/toEqual.rs
+++ b/src/runtime/test_runner/expect/toEqual.rs
@@ -31,14 +31,7 @@ impl Expect {
         }
 
         // handle failure
-        let diff_formatter = DiffFormatter {
-            received: Some(value),
-            expected: Some(expected),
-            received_string: None,
-            expected_string: None,
-            global_this: Some(global),
-            not,
-        };
+        let diff_formatter = DiffFormatter::new(global, value, expected, not)?;
 
         if not {
             let signature: &str = Expect::get_signature("toEqual", "<green>expected<r>", true);

--- a/src/runtime/test_runner/expect/toHaveBeenCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledWith.rs
@@ -88,14 +88,7 @@ pub(crate) fn to_have_been_called_with(
     // If there's only one call, provide a nice diff.
     if calls_count == 1 {
         let received_call_args = calls.get_index(global, 0)?;
-        let diff_format = DiffFormatter {
-            received_string: None,
-            expected_string: None,
-            expected: Some(expected_args_js_array),
-            received: Some(received_call_args),
-            global_this: Some(global),
-            not: false,
-        };
+        let diff_format = DiffFormatter::new(global, received_call_args, expected_args_js_array, false)?;
         return throw!(this, global, signature, "\n\n{}\n", diff_format);
     }
 

--- a/src/runtime/test_runner/expect/toHaveBeenLastCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenLastCalledWith.rs
@@ -80,13 +80,6 @@ pub(crate) fn to_have_been_last_called_with(
         );
     }
 
-    let diff_format = DiffFormatter {
-        expected: Some(expected_args_js_array),
-        received: Some(last_call_value),
-        expected_string: None,
-        received_string: None,
-        global_this: Some(global),
-        not: false,
-    };
+    let diff_format = DiffFormatter::new(global, last_call_value, expected_args_js_array, false)?;
     throw!(this, global, signature, "\n\n{}\n", diff_format)
 }

--- a/src/runtime/test_runner/expect/toHaveBeenNthCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenNthCalledWith.rs
@@ -96,14 +96,7 @@ pub(crate) fn to_have_been_nth_called_with(
     }
 
     // The call existed but didn't match. Show a diff.
-    let diff_format = DiffFormatter {
-        expected: Some(expected_args_js_array),
-        received: Some(nth_call_value),
-        expected_string: None,
-        received_string: None,
-        global_this: Some(global),
-        not: false,
-    };
+    let diff_format = DiffFormatter::new(global, nth_call_value, expected_args_js_array, false)?;
     throw!(
         this,
         global,

--- a/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
@@ -95,14 +95,7 @@ pub(crate) fn to_have_last_returned_with(
 
     // Diff if possible
     if expected.is_string() && last_return_value.is_string() {
-        let diff_format = DiffFormatter {
-            received_string: None,
-            expected_string: None,
-            expected: Some(expected),
-            received: Some(last_return_value),
-            global_this: Some(global_this),
-            not: false,
-        };
+        let diff_format = DiffFormatter::new(global_this, last_return_value, expected, false)?;
         return throw!(this, global_this, signature, "\n\n{}\n", diff_format);
     }
 

--- a/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
@@ -107,14 +107,7 @@ pub(crate) fn to_have_nth_returned_with(
 
     // Diff if possible
     if expected.is_string() && nth_return_value.is_string() {
-        let diff_format = DiffFormatter {
-            expected: Some(expected),
-            received: Some(nth_return_value),
-            expected_string: None,
-            received_string: None,
-            global_this: Some(global),
-            not: false,
-        };
+        let diff_format = DiffFormatter::new(global, nth_return_value, expected, false)?;
         return throw!(
             this,
             global,

--- a/src/runtime/test_runner/expect/toHaveProperty.rs
+++ b/src/runtime/test_runner/expect/toHaveProperty.rs
@@ -105,12 +105,7 @@ pub(crate) fn to_have_property(
             Expect::get_signature("toHaveProperty", "<green>path<r><d>, <r><green>value<r>", false);
         if !received_property.is_empty() {
             // deep equal case
-            let diff_format = DiffFormatter {
-                received: Some(received_property),
-                expected: Some(expected_property_value),
-                global_this: Some(global),
-                ..Default::default()
-            };
+            let diff_format = DiffFormatter::new(global, received_property, expected_property_value, false)?;
 
             return throw!(this, global, signature, "\n\n{}\n", diff_format);
         }

--- a/src/runtime/test_runner/expect/toHaveReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveReturnedWith.rs
@@ -82,14 +82,7 @@ pub(crate) fn to_have_returned_with(
     if calls_count == 1 && successful_returns_count == 1 {
         let received = successful_returns[0];
         if expected.is_string() && received.is_string() {
-            let diff_format = DiffFormatter {
-                expected: Some(expected),
-                received: Some(received),
-                expected_string: None,
-                received_string: None,
-                global_this: Some(global),
-                not: false,
-            };
+            let diff_format = DiffFormatter::new(global, received, expected, false)?;
             return throw!(this, global, signature, "\n\n{}\n", diff_format);
         }
 

--- a/src/runtime/test_runner/expect/toMatchObject.rs
+++ b/src/runtime/test_runner/expect/toMatchObject.rs
@@ -40,14 +40,7 @@ pub(crate) fn to_match_object(
     }
 
     // handle failure
-    let diff_formatter = DiffFormatter {
-        received_string: None,
-        expected_string: None,
-        received: Some(received_object),
-        expected: Some(property_matchers),
-        global_this: Some(global),
-        not,
-    };
+    let diff_formatter = DiffFormatter::new(global, received_object, property_matchers, not)?;
 
     if not {
         let signature: &str = get_signature("toMatchObject", "<green>expected<r>", true);

--- a/src/runtime/test_runner/expect/toStrictEqual.rs
+++ b/src/runtime/test_runner/expect/toStrictEqual.rs
@@ -33,14 +33,7 @@ impl Expect {
         }
 
         // handle failure
-        let diff_formatter = DiffFormatter {
-            received: Some(value),
-            expected: Some(expected),
-            received_string: None,
-            expected_string: None,
-            global_this: Some(global),
-            not,
-        };
+        let diff_formatter = DiffFormatter::new(global, value, expected, not)?;
 
         if not {
             let signature = Expect::get_signature("toStrictEqual", "<green>expected<r>", true);

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -237,9 +237,7 @@ pub mod expect {
             )?;
             // `FormatOptions.flush` is false, so the formatter does not flush
             // internally; a buffered `out` would otherwise drop trailing
-            // snapshot bytes. Propagate the writer error as a thrown JS error
-            // so the caller's `.is_err()` branch
-            // (expect.rs `to_match_snapshot_value_kind`) fires.
+            // snapshot bytes.
             out.flush().map_err(|e| global.throw_error(e, "snapshot writer flush failed"))?;
             Ok(())
         }

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -474,14 +474,7 @@ impl Snapshots {
                             },
                             format_args!(
                                 "Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value:\n{}",
-                                DiffFormatter {
-                                    received_string: Some(&ils.value),
-                                    expected_string: Some(last_value),
-                                    global_this: Some(vm.global()),
-                                    received: None,
-                                    expected: None,
-                                    not: false,
-                                },
+                                DiffFormatter::from_strings(&ils.value, last_value, false),
                             ),
                         );
                     }

--- a/test/js/bun/test/expect-diff-format-throw.test.ts
+++ b/test/js/bun/test/expect-diff-format-throw.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A failing matcher formats the received and the expected value for its diff.
+// Formatting runs user code (getters, Proxy traps, toString), which can throw.
+// That error propagates to the caller. DiffFormatter used to format both values
+// inside Display::fmt and drop the result, so the exception stayed pending on
+// the VM while the other value was formatted, and a debug build aborted on the
+// next native call. Every input runs in a child process for that reason.
+
+async function run(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+}
+
+// Each setup defines `value`. The comparison itself never reaches the throwing
+// code, so only the formatting of the failure message throws.
+const throwingValues: Record<string, { setup: string; error: string }> = {
+  "an object whose $$typeof getter throws": {
+    setup: `
+      const value = {};
+      Object.defineProperty(value, "$$typeof", { get() { throw new Error("boom"); } });
+    `,
+    error: "Error: boom",
+  },
+  "an object whose Symbol.toStringTag getter throws": {
+    setup: `
+      const value = { a: 1 };
+      Object.defineProperty(value, Symbol.toStringTag, { get() { throw new Error("boom"); } });
+    `,
+    error: "Error: boom",
+  },
+  "a function whose Symbol.toStringTag getter throws": {
+    setup: `
+      const value = function named() {};
+      Object.defineProperty(value, Symbol.toStringTag, { get() { throw new Error("boom"); } });
+    `,
+    error: "Error: boom",
+  },
+  "a function whose prototype is a Proxy with a throwing has trap": {
+    setup: `
+      const value = function named() {};
+      Object.setPrototypeOf(value, new Proxy(Function.prototype, { has() { throw new Error("boom"); } }));
+    `,
+    error: "Error: boom",
+  },
+  "an array Proxy whose get trap throws": {
+    setup: `
+      const value = new Proxy([1], {
+        get(target, key, receiver) {
+          if (key === "0") throw new Error("boom");
+          return Reflect.get(target, key, receiver);
+        },
+      });
+    `,
+    error: "Error: boom",
+  },
+  "a RegExp whose toString throws": {
+    setup: `
+      const value = /abc/;
+      Object.defineProperty(value, "toString", { value() { throw new Error("boom"); } });
+    `,
+    error: "Error: boom",
+  },
+  "a RegExp whose toString returns a Symbol": {
+    setup: `
+      const value = /u/i;
+      value.toString = Symbol;
+    `,
+    error: "TypeError: Cannot convert a symbol to a string",
+  },
+  "an object whose $$typeof getter overflows the stack": {
+    setup: `
+      const value = {};
+      Object.defineProperty(value, "$$typeof", { get() { return this.$$typeof; } });
+    `,
+    error: "RangeError: Maximum call stack size exceeded.",
+  },
+};
+
+describe.concurrent("a failing matcher propagates the error thrown while its diff is formatted", () => {
+  test.each(Object.entries(throwingValues))("%s on either side of the diff", async (_, { setup, error }) => {
+    const result = await run(`
+      ${setup}
+      const { expect } = Bun.jest();
+      const results = {};
+      const record = (name, fn) => {
+        try {
+          fn();
+          results[name] = "did not throw";
+        } catch (e) {
+          results[name] = e.constructor.name + ": " + e.message.split("\\n")[0];
+        }
+      };
+      record("toEqual received", () => expect(value).toEqual({ z: 9 }));
+      record("toEqual expected", () => expect({ z: 9 }).toEqual(value));
+      record("toStrictEqual received", () => expect(value).toStrictEqual({ z: 9 }));
+      record("toStrictEqual expected", () => expect({ z: 9 }).toStrictEqual(value));
+      record("toMatchObject received", () => expect({ a: value }).toMatchObject({ a: 1 }));
+      record("toMatchObject expected", () => expect({ a: 1 }).toMatchObject({ a: value }));
+      console.log(JSON.stringify(results));
+    `);
+    expect(result).toEqual({
+      stdout: JSON.stringify({
+        "toEqual received": error,
+        "toEqual expected": error,
+        "toStrictEqual received": error,
+        "toStrictEqual expected": error,
+        "toMatchObject received": error,
+        "toMatchObject expected": error,
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // matcherHint renders the same diff for a custom matcher and returns it as a
+  // string, so the custom matcher can catch the error.
+  test("matcherHint throws the error to the custom matcher", async () => {
+    const result = await run(`
+      ${throwingValues["an object whose Symbol.toStringTag getter throws"].setup}
+      const { expect } = Bun.jest();
+      let caught;
+      expect.extend({
+        toBeHinted(received, expected) {
+          try {
+            this.utils.matcherHint("toBeHinted", received, expected);
+            caught = "did not throw";
+          } catch (e) {
+            caught = e.constructor.name + ": " + e.message;
+          }
+          return { pass: true, message: () => "" };
+        },
+      });
+      expect(value).toBeHinted({ z: 9 });
+      console.log(caught);
+    `);
+    expect(result).toEqual({ stdout: "Error: boom", stderr: "", exitCode: 0 });
+  });
+
+  // The error also propagates when matcherHint runs inside the message callback
+  // of a failing custom matcher.
+  test("matcherHint inside the message of a failing custom matcher", async () => {
+    const result = await run(`
+      ${throwingValues["a function whose Symbol.toStringTag getter throws"].setup}
+      const { expect } = Bun.jest();
+      expect.extend({
+        toBeHinted(received, expected) {
+          return { pass: false, message: () => this.utils.matcherHint("toBeHinted", received, expected) };
+        },
+      });
+      try {
+        expect({ fn: value }).toBeHinted({ b: 16 });
+        console.log("did not throw");
+      } catch (e) {
+        console.log(e.constructor.name + ": " + e.message.split("\\n")[0]);
+      }
+    `);
+    expect(result).toEqual({ stdout: "Error: boom", stderr: "", exitCode: 0 });
+  });
+});

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -725,6 +725,20 @@ describe("mock()", () => {
     );
     expect(fn()).toBe("1");
   });
+  test("mockResolvedValue propagates an error thrown while wrapping the value in a promise", () => {
+    const boom = new Error("boom");
+    const value = Promise.resolve(1);
+    Object.defineProperty(value, "constructor", {
+      get() {
+        throw boom;
+      },
+    });
+    const fn = jest.fn();
+    expect(() => fn.mockResolvedValue(value)).toThrow(boom);
+    expect(() => fn.mockResolvedValueOnce(value)).toThrow(boom);
+    // nothing was queued
+    expect(fn()).toBeUndefined();
+  });
   test("withImplementation (callback throws)", () => {
     const fn = jest.fn(() => "1");
     expect(() =>

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -725,20 +725,23 @@ describe("mock()", () => {
     );
     expect(fn()).toBe("1");
   });
-  test("mockResolvedValue propagates an error thrown while wrapping the value in a promise", () => {
-    const boom = new Error("boom");
-    const value = Promise.resolve(1);
-    Object.defineProperty(value, "constructor", {
-      get() {
-        throw boom;
-      },
+  if (isBun) {
+    // Bun wraps the value in a promise when mockResolvedValue is called, not when the mock is.
+    test("mockResolvedValue propagates an error thrown while wrapping the value in a promise", () => {
+      const boom = new Error("boom");
+      const value = Promise.resolve(1);
+      Object.defineProperty(value, "constructor", {
+        get() {
+          throw boom;
+        },
+      });
+      const fn = jest.fn();
+      expect(() => fn.mockResolvedValue(value)).toThrow(boom);
+      expect(() => fn.mockResolvedValueOnce(value)).toThrow(boom);
+      // nothing was queued
+      expect(fn()).toBeUndefined();
     });
-    const fn = jest.fn();
-    expect(() => fn.mockResolvedValue(value)).toThrow(boom);
-    expect(() => fn.mockResolvedValueOnce(value)).toThrow(boom);
-    // nothing was queued
-    expect(fn()).toBeUndefined();
-  });
+  }
   test("withImplementation (callback throws)", () => {
     const fn = jest.fn(() => "1");
     expect(() =>


### PR DESCRIPTION
### Problem
- #40068 fixes the pending exception in `DiffFormatter` but adds no test for the diff path. Four open PRs fix the same lines, each with one test: #40883, #40390, #40555 and #39565. This PR keeps their coverage so those PRs can close.
- On main, a failing `toEqual`, `toStrictEqual` or `toMatchObject` whose received value throws while it is formatted aborts a debug build: `ASSERTION FAILED: Unexpected exception observed on thread` in `ExceptionScope::assertNoExceptionExceptTermination`.

### Fix
- Adds `test/js/bun/test/expect-diff-format-throw.test.ts`: eight values whose formatting throws (getters, Proxy traps, `toString`, a stack overflow), each on both sides of the diff, plus two `matcherHint` cases.
- The expectations follow #40068: the error from the user code propagates. The four source PRs asserted the matcher's own error. That is the only difference.
- This PR targets the #40068 branch, so the diff is the test file only. Retarget it to main if #40068 merges first.
- Verified: 10 pass on main with #40068 merged, 10 fail on main without it (each child exits 134 with the assertion above). `expect.test.js`, `mock-fn.test.js` and the existing `expect-*` crash tests pass on the merged tree.

### Background
- `DiffFormatter` (`src/runtime/test_runner/diff_format.rs`) renders the `- Expected / + Received` block. It pretty-prints both values with `JestPrettyFormat`, which reads `$$typeof`, `Symbol.toStringTag`, array elements and `toString`. Each read can run user code.
- On main, `Display::fmt` formats both values and drops both results. When the first throws, the exception stays pending and the next binding that asserts a clean VM aborts. A release build keeps the pending error, so the user sees the same error there. The test fails on debug builds only.
- #40068 moves the formatting into `DiffFormatter::new(...) -> JsResult<_>`. Every caller propagates the error with `?`.

<details><summary>Notes</summary>

Triggers: a `$$typeof` getter that throws, a `$$typeof` getter that overflows the stack, a `Symbol.toStringTag` getter on an object and on a function, a function whose prototype is a Proxy with a throwing `has` trap, an array Proxy with a throwing `get` trap, a RegExp whose `toString` throws, a RegExp whose `toString` returns a Symbol.

Per-assertion probe on the unfixed debug build (main at f189103280): every received-side assertion exits 134, every expected-side assertion exits 0 with the propagated error, because nothing formats after the expected value. The expected-side cases stay in the test to pin the behavior.

The stack-overflow trigger uses `get $$typeof() { return this.$$typeof; }`. A `function r() { return r(); }` version never throws: JSC applies proper tail calls in strict mode.

Source test files: `expect-diff-format-throw-crash.test.ts` (#40883), `expect-extend-matcher-utils-throw.test.ts` (#40390), `expect-symbol-toPrimitive-crash.test.ts` (#40555), `expect-stack-overflow-crash.test.ts` (#39565).
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/test/expect-diff-format-throw.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/test/expect-diff-format-throw.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/test/expect-diff-format-throw.test.ts:
(pass) a failing matcher propagates the error thrown while its diff is formatted > an object whose $$typeof getter throws on either side of the diff [337.62ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > an object whose Symbol.toStringTag getter throws on either side of the diff [298.84ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > a function whose Symbol.toStringTag getter throws on either side of the diff [300.74ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > a function whose prototype is a Proxy with a throwing has trap on either side of the diff [299.94ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > an array Proxy whose get trap throws on either side of the diff [305.90ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > a RegExp whose toString throws on either side of the diff [294.13ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > a RegExp whose toString returns a Symbol on either side of the diff [287.30ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > matcherHint throws the error to the custom matcher [279.49ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > matcherHint inside the message of a failing custom matcher [279.24ms]
(pass) a failing matcher propagates the error thrown while its diff is formatted > an object whose $$typeof getter overflows the stack on either side of the diff [1802.27ms]

 10 pass
 0 fail
 10 expect() calls
Ran 10 tests across 1 file. [4.16s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/test/expect-diff-format-throw.test.ts | 167 ++++++++++++++++++++++
 1 file changed, 167 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
test/js/bun/test/expect-diff-format-throw.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->