### PR TITLE
node:net: register the createServer callback as a 'connection' listener

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1003,10 +1003,6 @@ const ServerHandlers: SocketHandler<NetSocket> = {
       if (server) {
         // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1214-L1232
         if (!self.destroyed && self._releaseControl()) {
-          const connectionListener = server[bunSocketServerOptions]?.connectionListener;
-          if (typeof connectionListener === "function") {
-            server.prependOnceListener("secureConnection", connectionListener);
-          }
           server.emit("secureConnection", self);
         }
       }
@@ -1164,7 +1160,7 @@ function onconnection(err, clientHandle) {
   }
   clientHandle[kServerSocket] = handle;
   const options = self[bunSocketServerOptions];
-  const { connectionListener, [kSocketClass]: SClass } = options;
+  const { [kSocketClass]: SClass } = options;
   // Read per connection like node; the listener itself was created with the value listen() saw.
   const pauseOnConnect = self.pauseOnConnect;
   // Propagate the server's half-open/highWaterMark settings to the accepted
@@ -1239,9 +1235,6 @@ function onconnection(err, clientHandle) {
     pauseOnCreate(_socket, clientHandle);
   }
 
-  if (typeof connectionListener === "function" && !isTLS) {
-    self.prependOnceListener("connection", connectionListener);
-  }
   if (isTLS) initAcceptedTLSSocket(self, _socket);
 
   self.emit("connection", _socket);
@@ -3534,7 +3527,13 @@ function Server(options?, connectionListener?) {
   this.pauseOnConnect = Boolean(pauseOnConnect);
   this.noDelay = Boolean(noDelay);
 
-  options.connectionListener = connectionListener;
+  // Node registers the createServer callback as a plain "connection"
+  // listener in the constructor, so a manual emit("connection", socket)
+  // reaches it and listenerCount("connection") counts it.
+  // https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/net.js#L1837-L1846
+  if (typeof connectionListener === "function") {
+    this.on("connection", connectionListener);
+  }
   this[bunSocketServerOptions] = options;
 
   const optionsBlockList = options.blockList;
@@ -4232,10 +4231,6 @@ function onClusterConnection(err, clientHandle) {
   socket.server = self;
   socket._server = self;
   self._connections++;
-  const connectionListener = self[bunSocketServerOptions]?.connectionListener;
-  if (typeof connectionListener === "function" && typeof self[bunTlsSymbol] !== "function") {
-    self.prependOnceListener("connection", connectionListener);
-  }
   self.emit("connection", socket);
 }
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1172,7 +1172,10 @@ function Server(options, secureConnectionListener): void {
 
   // tls.createServer(options) requires an object (a function is the connection
   // listener); matches Node throwing ERR_INVALID_ARG_TYPE for e.g. a string.
-  if (options != null && typeof options !== "object" && typeof options !== "function") {
+  if (typeof options === "function") {
+    secureConnectionListener = options;
+    options = {};
+  } else if (options != null && typeof options !== "object") {
     throw $ERR_INVALID_ARG_TYPE("options", "object", options);
   }
   // A custom SNICallback must be a function.
@@ -1194,7 +1197,9 @@ function Server(options, secureConnectionListener): void {
     }
   }
 
-  NetServer.$apply(this, [options, secureConnectionListener]);
+  // The listener belongs on "secureConnection", not "connection": do not let
+  // the net.Server constructor register it.
+  NetServer.$apply(this, [options]);
 
   this.key = undefined;
   this.cert = undefined;
@@ -1514,6 +1519,13 @@ function Server(options, secureConnectionListener): void {
     wrapped._rejectUnauthorized = this._rejectUnauthorized;
     this[kArmHandshakeTimeout](wrapped);
   });
+
+  // Node registers the createServer callback as a plain "secureConnection"
+  // listener, so a manual emit("secureConnection", socket) reaches it.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1408-L1410
+  if (secureConnectionListener) {
+    this.on("secureConnection", secureConnectionListener);
+  }
 }
 $toClass(Server, "Server", NetServer);
 Server.prototype[kSharedCreds] = function () {

--- a/test/js/node/net/server.spec.ts
+++ b/test/js/node/net/server.spec.ts
@@ -20,6 +20,30 @@ describe("net.createServer(connectionListener)", () => {
     expect(server).toBeInstanceOf(net.Server);
   });
 
+  // https://github.com/oven-sh/bun/issues/40917
+  it("registers the callback as a regular 'connection' listener", () => {
+    expect(server.listenerCount("connection")).toBe(1);
+    expect(server.listeners("connection")).toContain(onListen);
+
+    const socket = new net.Socket();
+    server.emit("connection", socket);
+    expect(onListen).toHaveBeenCalledTimes(1);
+    expect(onListen).toHaveBeenCalledWith(socket);
+  });
+
+  it("stays a single 'connection' listener across accepted connections", async () => {
+    await new Promise<void>(resolve => server.listen(0, () => resolve()));
+    const address = server.address() as net.AddressInfo;
+    for (let i = 0; i < 2; i++) {
+      const { promise, resolve } = Promise.withResolvers<net.Socket>();
+      server.once("connection", resolve);
+      await using client = net.createConnection(address);
+      await promise;
+    }
+    expect(onListen).toHaveBeenCalledTimes(2);
+    expect(server.listenerCount("connection")).toBe(1);
+  });
+
   it("calls the connection listener when a socket connects", async () => {
     await new Promise<void>(resolve => server.listen(() => resolve()));
 

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -649,6 +649,20 @@ it("tls.rootCertificates should exists", () => {
   expect(typeof rootCertificates[0]).toBe("string");
 });
 
+// https://github.com/oven-sh/bun/issues/40917
+it("createServer registers the callback as a regular 'secureConnection' listener", () => {
+  const cb = () => {};
+  const withOptions = createServer(COMMON_CERT, cb);
+  expect(withOptions.listenerCount("secureConnection")).toBe(1);
+  expect(withOptions.listeners("secureConnection")).toContain(cb);
+  withOptions.close();
+
+  const withoutOptions = createServer(cb);
+  expect(withoutOptions.listenerCount("secureConnection")).toBe(1);
+  expect(withoutOptions.listeners("secureConnection")).toContain(cb);
+  withoutOptions.close();
+});
+
 it("connectionListener should emit the right amount of times, and with alpnProtocol available", async () => {
   let count = 0;
   const promises = [];


### PR DESCRIPTION
### Problem
- `net.createServer(cb)` does not register `cb` as a "connection" listener. `server.listenerCount("connection")` is 0 and a manual `server.emit("connection", socket)` never calls `cb`. Node returns 1 and calls it. This breaks Mockttp's CONNECT tunnel handoff, which re-emits a socket into its server (#40917).
- The cause: the `Server` constructor stashes the callback in the options bag (`src/js/node/net.ts:3537`) and each accept path calls `prependOnceListener` right before its own emit (net.ts:1242, net.ts:4235, and net.ts:1006 for TLS). The callback only exists as a listener during the internal emit.

### Fix
- Register the callback in the constructor, like Node: `this.on("connection", cb)` in `net.Server`, and `this.on("secureConnection", cb)` in `tls.Server` (which now stops passing it through to `net.Server`). Remove the three per-connection prepend sites and the options-bag stash.
- Listener ordering matches Node: the callback is registered first, so listeners added later run after it. `removeListener` now works on it, and each accepted connection still calls it exactly once (each accept path emits once).
- `Http2SecureServer` passes its internal listener through `tls.Server`, so it lands on "secureConnection" at construction, the same as Node.
- Verified: new tests in `test/js/node/net/server.spec.ts` and `test/js/node/tls/node-tls-server.test.ts` (fail on bun 1.4.1, pass with the fix). Also ran the net, tls, cluster, and http2 suites.

### Background
- Node's `net.Server` constructor runs `this.on('connection', connectionListener)` (nodejs/node lib/net.js). `tls.Server` keeps the listener for itself and registers it on `'secureConnection'` after the handshake path (lib/internal/tls/wrap.js).
- Bun has three accept paths that emit "connection": the native listener (`onconnection`), the cluster fd path (`onClusterConnection`), and the TLS handshake-done path, which emits "secureConnection". All three used the per-emit prepend.

<details><summary>Notes</summary>

- Repro from the issue passes after the fix: `listenerCount` is 1 and the manual emit reaches the callback.
- Fail-before: `USE_SYSTEM_BUN=1 bun test test/js/node/net/server.spec.ts` fails the two new tests, and the new tls test fails too. All pass under `bun bd test`.
- Suites run with the debug build: `test/js/node/net/server.spec.ts` (40 pass), `test/js/node/tls/node-tls-server.test.ts` (77 pass, 1 pre-existing host-dependent failure, see #35160), `node-net-server.test.ts`, `node-net.test.ts` (same pre-existing failures as the released bun), `node-http2.test.js` (364 pass), `node-http2-upgrade.test.mts`, `node-tls-context.test.ts`, `node-tls-connect.test.ts`, all upstream `test-net-server-*` and `test-tls-server-*` parallel tests, and the cluster net tests (`test-cluster-basic`, `test-cluster-http-pipe`, `test-cluster-net-server-drop-connection`, `test-cluster-send-socket-to-worker-http-server`, `test-net-listen-handle-in-cluster-1`, `test-cluster-child-index-net`, `test-cluster-net-send`).
- `tls.createServer(fn)` (function as first argument) now normalizes `options` to `{}` before `setSecureContext`. Before, the function object itself was read for option properties, which yielded the same undefined values.
- Self-reviewed: 3 concerns raised, 3 addressed (all were wrong line anchors in the two Node source links, now corrected).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-server.test.ts

<!-- robobun:evidence:end -->