### PR TITLE
bundler: register the entry point's CommonJS re-export copies with the chunk renamer

### DIFF
--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -5,7 +5,7 @@ use core::cmp::Ordering;
 use crate::bundled_ast::Flags as AstFlags;
 use bun_ast::StmtData;
 use bun_ast::symbol;
-use bun_ast::{Part, SlotCounts};
+use bun_ast::{Part, Ref, SlotCounts};
 
 use crate::bun_renamer as renamer;
 use crate::bun_renamer::{ChunkRenamer, MinifyRenamer, NumberRenamer, StableSymbolCount};
@@ -72,7 +72,7 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
     // elements; the lists do not reallocate during this function. Read-only
     // columns are deref'd to `&[T]`; the two written columns
     // (`module_scope`, `parts`) are deref'd to `&mut [T]` — see CONCURRENCY
-    // note above re: code-splitting overlap. All ten derefs share the same
+    // note above re: code-splitting overlap. All eleven derefs share the same
     // invariant, so they are grouped under one `unsafe` block.
     let (
         all_module_scopes,
@@ -85,7 +85,8 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         exports_ref_col,
         module_ref_col,
         nested_slot_counts_col,
-    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _) = unsafe {
+        cjs_export_copies_col,
+    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _, _) = unsafe {
         (
             &mut *ast.module_scope,
             &*meta.flags,
@@ -97,7 +98,22 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             &*ast.exports_ref,
             &*ast.module_ref,
             &*ast.nested_scope_slot_counts,
+            &*meta.cjs_export_copies,
         )
+    };
+
+    // An entry point chunk ends with `generate_entry_point_tail_js`, which
+    // declares a copy binding (`var export_foo = import_cjs.foo`) for each
+    // re-export that resolves to a CommonJS property. The tail is printed with
+    // this chunk's renamer, so those bindings are numbered like the chunk's
+    // other top-level symbols. Otherwise the copy prints under its original
+    // name and can redeclare another binding with that name: a user binding,
+    // an unbound global, or another copy whose alias formats to the same
+    // identifier (`"x-y"` and `"x.y"` both give `export_x_y`).
+    let entry_point_cjs_export_copies: &[Ref] = if chunk.entry_point.is_entry_point() {
+        &cjs_export_copies_col[chunk.entry_point.source_index() as usize]
+    } else {
+        &[]
     };
 
     // `symbol::Map` is not `Clone`/`Copy`. Build a non-owning shallow view via
@@ -256,6 +272,14 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             minify_renamer.accumulate_symbol_use_count(
                 &mut top_level_symbols,
                 ref_,
+                1,
+                stable_source_indices,
+            )?;
+        }
+        for &copy in entry_point_cjs_export_copies {
+            minify_renamer.accumulate_symbol_use_count(
+                &mut top_level_symbols,
+                copy,
                 1,
                 stable_source_indices,
             )?;
@@ -428,6 +452,12 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             }
             r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
         }
+    }
+
+    // After the files, so a user binding with the same name keeps it and the
+    // copy takes the numbered one.
+    for &copy in entry_point_cjs_export_copies {
+        r.add_top_level_symbol(copy);
     }
 
     Ok(ChunkRenamer::Number(r))

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -667,4 +667,134 @@ describe("bundler", () => {
     cjs2esm: true,
     run: { stdout: "[1,2]" },
   });
+
+  // When an ESM entry point re-exports a name from a CommonJS module that is
+  // not converted to ESM, the linker declares a copy binding named
+  // `export_<alias>` in the entry point tail and exports that. The copy must be
+  // renamed around every other binding of that name in the chunk.
+  const printNamespace = {
+    "/test.js": /* js */ `
+      import * as ns from './out.js';
+      console.log(JSON.stringify(ns));
+    `,
+  };
+  itBundled("cjs2esm/ReExportCJSCopyKeepsUserBinding", {
+    files: {
+      "/entry.js": /* js */ `
+        export { foo } from './cjs.cjs';
+        export { bar } from './esm.js';
+        export const export_foo = "user-foo";
+        export const export_bar = "user-bar";
+      `,
+      "/cjs.cjs": /* js */ `
+        Object.defineProperty(exports, "foo", { enumerable: true, get: () => 42 });
+      `,
+      "/esm.js": /* js */ `
+        export const bar = 1;
+      `,
+    },
+    format: "esm",
+    runtimeFiles: printNamespace,
+    onAfterBundle(api) {
+      // The user bindings keep their names. The copy is the numbered one.
+      api.expectFile("/out.js").toContain('var export_foo = "user-foo"');
+      api.expectFile("/out.js").toContain('var export_bar = "user-bar"');
+      api.expectFile("/out.js").toContain("var export_foo2 = ");
+    },
+    run: {
+      file: "/test.js",
+      stdout: '{"bar":1,"export_bar":"user-bar","export_foo":"user-foo","foo":42}',
+    },
+  });
+  itBundled("cjs2esm/ReExportCJSCopyKeepsClassBinding", {
+    // `module.exports = {...}` is not converted either, so it takes the same
+    // path. A `class` with the copy's name used to make the output a
+    // SyntaxError at load: `var` cannot redeclare a class binding.
+    files: {
+      "/entry.js": /* js */ `
+        export { foo } from './cjs.cjs';
+        export class export_foo {}
+      `,
+      "/cjs.cjs": /* js */ `
+        module.exports = { foo: 42 };
+      `,
+    },
+    format: "esm",
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        import * as ns from './out.js';
+        console.log(typeof ns.export_foo, ns.foo);
+      `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: "function 42",
+    },
+  });
+  itBundled("cjs2esm/ReExportCJSCopiesWithSameMangledName", {
+    // The copy's name is built from the alias with every run of non-identifier
+    // characters folded into "_", so distinct aliases can collide with each
+    // other even when the entry point declares nothing else.
+    files: {
+      "/entry.js": /* js */ `
+        export { "x-y", "x.y" } from './cjs.cjs';
+      `,
+      "/cjs.cjs": /* js */ `
+        Object.defineProperty(exports, "x-y", { enumerable: true, get: () => "dash" });
+        Object.defineProperty(exports, "x.y", { enumerable: true, get: () => "dot" });
+      `,
+    },
+    format: "esm",
+    runtimeFiles: printNamespace,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('var export_x_y = import_cjs["x-y"]');
+      api.expectFile("/out.js").toContain('var export_x_y2 = import_cjs["x.y"]');
+    },
+    run: {
+      file: "/test.js",
+      stdout: '{"x-y":"dash","x.y":"dot"}',
+    },
+  });
+  // An unbound global is a reserved name for the chunk. The copy must be
+  // numbered around it in both renamers: with minified identifiers the user
+  // bindings are short, so this is the collision that remains.
+  const unboundGlobalFiles = {
+    "/entry.js": /* js */ `
+      import './side.js';
+      export { foo } from './cjs.cjs';
+    `,
+    "/side.js": /* js */ `
+      globalThis.export_foo = "global";
+      console.log("side sees", export_foo);
+    `,
+    "/cjs.cjs": /* js */ `
+      Object.defineProperty(exports, "foo", { enumerable: true, get: () => 42 });
+    `,
+  };
+  itBundled("cjs2esm/ReExportCJSCopyKeepsUnboundGlobal", {
+    files: unboundGlobalFiles,
+    format: "esm",
+    runtimeFiles: printNamespace,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var export_foo2 = import_cjs.foo");
+    },
+    run: {
+      file: "/test.js",
+      stdout: 'side sees global\n{"foo":42}',
+    },
+  });
+  itBundled("cjs2esm/ReExportCJSCopyKeepsUnboundGlobalMinified", {
+    files: unboundGlobalFiles,
+    format: "esm",
+    minifyIdentifiers: true,
+    runtimeFiles: printNamespace,
+    onAfterBundle(api) {
+      // The copy gets a short name like every other top-level symbol.
+      api.expectFile("/out.js").not.toContain("var export_foo");
+    },
+    run: {
+      file: "/test.js",
+      stdout: 'side sees global\n{"foo":42}',
+    },
+  });
 });


### PR DESCRIPTION
### Problem
- With `--format=esm`, an entry point that re-exports a name from a CommonJS module gets a copy binding `export_<alias>` in its tail. The copy prints under its original name, so it redeclares any other `export_foo` in the chunk: a user binding (the copy wins, a `class` is a SyntaxError), an unbound global, or a second copy whose alias formats to the same identifier (`"x-y"`, `"x.y"`).
- The copy symbol is minted in `scan_imports_and_exports` step 6 but never registered with the chunk renamer (`src/bundler/linker_context/renameSymbolsInChunk.rs`). esbuild has the same defect.

### Fix
- `rename_symbols_in_chunk` registers the copies of the chunk's entry point in both renamers: `add_top_level_symbol` (numbering), `accumulate_symbol_use_count` (minifying).
- The numbering path adds them after the files, so the other binding keeps its name and the copy becomes `export_foo2`. The minifying path gives the copy a short name.
- The copies are read through `chunk.entry_point.source_index()`: with code splitting the entry file's parts can live in a shared chunk while the tail stays in the entry chunk.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (five new cases, all fail on bun 1.4.1). Other suites in the notes.

### Background
- The linker prints each chunk with a renamer (`src/js_printer/renamer.rs`). `NumberRenamer` gives a registered top-level symbol its original name, or a numbered one when taken. `MinifyRenamer` assigns short names by use count. An unregistered symbol prints under its `original_name`.
- A CommonJS export can be a getter, so an ESM entry point cannot re-export it live. The tail (`generate_entry_point_tail_js`) snapshots it: `var export_foo = import_cjs.foo; export { export_foo as foo }`. `cjs_export_copies` holds one symbol per export alias of an ESM entry point.

<details><summary>Notes</summary>

Repro (`bun build --format=esm --target=bun lib.js --outdir out`):

```js
// lib.js
export { foo } from "./cjs.cjs";
export const export_foo = "user-binding";
// cjs.cjs
Object.defineProperty(exports, "foo", { enumerable: true, get: () => 42 });
```

bun 1.4.1 output tail:

```js
var export_foo = "user-binding";
var export_foo = import_cjs.foo;
export { export_foo, export_foo as foo };
```

With this change:

```js
var export_foo = "user-binding";
var export_foo2 = import_cjs.foo;
export { export_foo, export_foo2 as foo };
```

The copy appears for any CommonJS module the bundler does not convert to ESM. `module.exports = { foo: 42 }` takes the same path as the getter.

Unbound globals are reserved names for the chunk, so both renamers already step around them for registered symbols. With `--minify-identifiers` the copy used to print as `var export_foo = O.foo` (unminified). User bindings are short in that mode, so the only collider was an unbound global `export_foo`. The copy now gets a short name.

Every export alias of an ESM entry point gets a copy symbol, so copies for ESM re-exports are registered too. In the numbering path they come after the files and nothing prints them, so they change no emitted name. In the minifying path they take slots at the end of the frequency order, after every printed symbol, so they change no emitted name either.

Checked by hand with `--splitting` and two entry points that both re-export the getter: each entry chunk numbers its own copy, and `--splitting --minify-identifiers` assigns short names through the deferred `finish()` path.

Suites run with the debug build, all green: `test/bundler/{bundler_cjs2esm,bundler_cjs,bundler_splitting,bundler_compile_splitting,bundler_edgecase,bundler_minify,bundler_minify_symbol_for,bundler_naming,bundler_regressions,bundler_bun}.test.ts` and `test/bundler/esbuild/{extra,splitting,importstar,importstar_ts,default,dce,ts,loader,lower}.test.ts`.

In `bun-build-api.test.ts`, two bytecode tests hit the 5 s timeout in this debug ASAN container (a 128-build sweep and a 3000-function build). They build CJS output, which this change does not touch.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (d578a8c70)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [998.35ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [499.01ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [469.91ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [362.78ms]
(pass) bundler > cjs2esm/ExportsFunction [483.38ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [407.81ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [405.99ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [444.95ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [565.49ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [486.32ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [513.98ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [953.42ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [65
... (truncated)

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (d578a8c70)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [20.85ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [14.08ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [9.66ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [8.57ms]
(pass) bundler > cjs2esm/ExportsFunction [9.42ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [9.23ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [9.13ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [12.90ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [12.94ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [12.13ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [10.75ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [13.28ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [11.79ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [10.31ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [10.75ms]
(pass) bundler > cjs2esm/UnwrappedMo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (d578a8c70)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [845.50ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [434.38ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [403.42ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [455.16ms]
(pass) bundler > cjs2esm/ExportsFunction [440.70ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [429.64ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [427.44ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [442.83ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [447.90ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [497.71ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [500.96ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [755.75ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [60
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 688ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/83] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/linker_context/renameSymbolsInChunk.rs |  36 +++++-
 test/bundler/bundler_cjs2esm.test.ts               | 130 +++++++++++++++++++++
 2 files changed, 163 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/bundler/linker_context/renameSymbolsInChunk.rs      2      8      0
test/bundler/bundler_cjs2esm.test.ts                    2      2      0
```

</details>

<!-- robobun:evidence:end -->