### PR TITLE
bundler: import.meta.main is false for an entry point copied into another entry's bundle

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1305,6 +1305,8 @@ pub struct LinkerOptions {
     pub(crate) source_maps: SourceMapOption,
     pub(crate) target: Target,
     pub(crate) compile_mode: CompileMode,
+    /// `--compile`: an entry point's own bundle is a main module (`import.meta.main` is `true`).
+    pub(crate) inline_entrypoint_import_meta_main: bool,
     pub(crate) metafile: bool,
     /// Path to write JSON metafile (for Bun.build API)
     pub(crate) metafile_json_path: &'static [u8],
@@ -1348,6 +1350,7 @@ impl Default for LinkerOptions {
             source_maps: SourceMapOption::None,
             target: Target::Browser,
             compile_mode: CompileMode::None,
+            inline_entrypoint_import_meta_main: false,
             metafile: false,
             metafile_json_path: b"",
             metafile_markdown_path: b"",
@@ -2218,6 +2221,7 @@ impl<'a> LinkerContext<'a> {
         source_index: Index,
         source: &Source,
         module_info: Option<&mut crate::analyze_transpiled_module::ModuleInfo>,
+        import_meta_main_value: Option<bool>,
     ) -> js_printer::PrintResult {
         let parts_to_print = &[Part {
             stmts: bun_ast::StoreSlice::new_mut(out_stmts),
@@ -2273,6 +2277,7 @@ impl<'a> LinkerContext<'a> {
             module_type: self.options.output_format,
             print_dce_annotations: self.options.emit_dce_annotations,
             has_run_symbol_renamer: true,
+            import_meta_main_value,
 
             to_esm_ref,
             to_commonjs_ref,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -116,6 +116,8 @@ pub struct ParseTask {
     pub(crate) package_version: ast::StoreStr,
     pub(crate) package_name: ast::StoreStr,
     pub(crate) is_entry_point: bool,
+    /// The first user entry point: the main module of a `--compile` executable.
+    pub(crate) is_primary_entry_point: bool,
 }
 
 pub enum ParseTaskStage {
@@ -289,6 +291,7 @@ impl ParseTask {
             },
             stage: ParseTaskStage::NeedsSourceCode,
             is_entry_point: false,
+            is_primary_entry_point: false,
         }
     }
 
@@ -329,6 +332,7 @@ impl Default for ParseTask {
             package_version: ast::StoreStr::EMPTY,
             package_name: ast::StoreStr::EMPTY,
             is_entry_point: false,
+            is_primary_entry_point: false,
         }
     }
 }
@@ -569,6 +573,7 @@ pub mod parse_worker {
             package_version: ast::StoreStr::EMPTY,
             package_name: ast::StoreStr::EMPTY,
             is_entry_point: false,
+            is_primary_entry_point: false,
         };
         let source = Source {
             // `bun_ast::Source.path` is `bun_paths::fs::Path<'static>`, distinct
@@ -2591,11 +2596,19 @@ pub mod parse_worker {
         opts.ignore_dce_annotations =
             topts.ignore_dce_annotations && !task.source_index.is_runtime();
 
-        // For files that are not user-specified entrypoints, set `import.meta.main` to `false`.
-        // Entrypoints will have `import.meta.main` set as "unknown", unless we use `--compile`,
-        // in which we inline `true`.
-        if topts.inline_entrypoint_import_meta_main || !task.is_entry_point {
-            opts.import_meta_main_value = Some(task.is_entry_point && !topts.has_dev_server());
+        // A file that is not a user entry point is never the main module. An entry point is
+        // "unknown" (decided at run time), except under `--compile`, where it is inlined as `true`
+        // so the dead branch folds. An executable's other entry points are also copied into every
+        // entry's bundle that imports them, as dependencies. Only the printer can tell a copy from
+        // the entry's own bundle (`generate_code_for_file_in_chunk_js`), so they stay unknown.
+        let entry_point_may_be_dependency =
+            topts.compile_mode.is_executable() && !task.is_primary_entry_point;
+        if !task.is_entry_point {
+            opts.import_meta_main_value = Some(false);
+        } else if topts.inline_entrypoint_import_meta_main {
+            if !entry_point_may_be_dependency {
+                opts.import_meta_main_value = Some(!topts.has_dev_server());
+            }
         } else if target == options::Target::Node {
             opts.lower_import_meta_main_for_node_js = true;
         }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2872,6 +2872,7 @@ pub mod bv2_impl {
             task.loader = Some(loader);
             task.task.node.next = core::ptr::null_mut();
             task.is_entry_point = is_entry_point;
+            task.is_primary_entry_point = is_entry_point && self.graph.entry_points.is_empty();
             task.known_target = target;
             task.jsx.development = self
                 .transpiler_for_target(target)
@@ -3063,6 +3064,8 @@ pub mod bv2_impl {
                 };
             this.linker.options.bytecode_depth = this.transpiler.options.bytecode_depth;
             this.linker.options.compile_mode = this.transpiler.options.compile_mode;
+            this.linker.options.inline_entrypoint_import_meta_main =
+                this.transpiler.options.inline_entrypoint_import_meta_main;
             this.linker.options.metafile = this.transpiler.options.metafile;
             // SAFETY: same `'a`-owned `Transpiler` field as `banner` above.
             this.linker.options.metafile_json_path =

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -229,6 +229,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 part_range.source_index,
                 source,
                 module_info,
+                None,
             );
         }
     }
@@ -919,6 +920,18 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         });
     }
 
+    // An entry point's module printed into another entry point's bundle is a dependency there.
+    // Under `--compile`, an entry point's own bundle is a main module (see `ParseTask`).
+    let import_meta_main_value = if !chunk.entry_point.is_entry_point() {
+        None
+    } else if chunk.entry_point.source_index() as usize != source_index {
+        Some(false)
+    } else if c.options.inline_entrypoint_import_meta_main {
+        Some(true)
+    } else {
+        None
+    };
+
     // `get_source` returns `&'static Source` (parse_graph SoA is append-only and
     // outlives the link step), so it does not borrow `c` — no split-borrow needed
     // across the `&mut self` call below.
@@ -936,6 +949,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         part_range.source_index,
         source,
         module_info,
+        import_meta_main_value,
     )
 }
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1350,6 +1350,9 @@ pub struct Options<'a> {
     pub inline_require_and_import_errors: bool,
     pub has_run_symbol_renamer: bool,
 
+    /// Prints `EImportMetaMain` as this literal (an entry point's module inside another entry's bundle).
+    pub import_meta_main_value: Option<bool>,
+
     pub require_or_import_meta_for_source_callback: RequireOrImportMetaCallback,
 
     /// The module type of the importing file (after linking), used to determine interop helper behavior.
@@ -1418,6 +1421,7 @@ impl<'a> Default for Options<'a> {
             print_dce_annotations: true,
             inline_require_and_import_errors: true,
             has_run_symbol_renamer: false,
+            import_meta_main_value: None,
             require_or_import_meta_for_source_callback: RequireOrImportMetaCallback::default(),
             input_module_type: bundle_opts::ModuleType::Unknown,
             module_type: bundle_opts::Format::Esm,
@@ -3213,7 +3217,24 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 ExprData::EImportMetaMain(data) => {
-                    if self.options.module_type == bundle_opts::Format::Esm
+                    if let Some(value) = self.options.import_meta_main_value {
+                        let value = value != data.inverted;
+                        self.add_source_mapping(expr.loc);
+                        if self.options.minify_syntax {
+                            if level.gte(Level::Prefix) {
+                                self.print(if value { b"(!0)" } else { b"(!1)" });
+                            } else {
+                                self.print(if value { b"!0" } else { b"!1" });
+                            }
+                        } else {
+                            self.print_space_before_identifier();
+                            self.print(if value {
+                                b"true".as_slice()
+                            } else {
+                                b"false".as_slice()
+                            });
+                        }
+                    } else if self.options.module_type == bundle_opts::Format::Esm
                         && self.options.target != bun_ast::Target::Node
                     {
                         // Node.js doesn't support import.meta.main

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1304,6 +1304,37 @@ describe("bundler", () => {
     },
     run: { stdout: new Array(7).fill("true").join("\n") },
   });
+  // An entry point that another entry point imports is copied into that
+  // entry's bundle. The copy is a dependency there, so its `require.main ===
+  // module` (lowered to `import.meta.main`) is false, as when the files run
+  // unbundled. The first entry point is the executable's main module and
+  // keeps the inlined `true` (observed through toString, as above).
+  for (const format of ["esm", "cjs"] as const) {
+    itBundled("compile/ImportMetaMainEntryImportedByOtherEntry+" + format, {
+      backend: "cli",
+      compile: true,
+      format,
+      files: {
+        "/entry.ts": /* js */ `
+          import lib from "./lib.cjs";
+          console.log(JSON.stringify(lib), (() => import.meta.main).toString().includes("true"));
+        `,
+        "/lib.cjs": /* js */ `
+          module.exports = {
+            isMain: require.main === module,
+            cli: (function () { if (require.main === module) return "CLI-RAN"; return "lib"; })(),
+          };
+        `,
+      },
+      entryPointsRaw: ["./entry.ts", "./lib.cjs"],
+      outfile: "dist/out",
+      run: {
+        stdout: '{"isMain":false,"cli":"lib"} true',
+        file: "dist/out",
+        setCwd: true,
+      },
+    });
+  }
   itBundled("compile/SourceMap", {
     target: "bun",
     compile: true,


### PR DESCRIPTION
### Problem
- `bun build --compile app.ts lib.cjs`, where `app.ts` imports `lib.cjs` and `lib.cjs` has `if (require.main === module) cli()`: the executable runs `cli()` when it imports `lib.cjs`. `bun run app.ts` does not. The same happens to `import.meta.main` in an imported entry point, in every format and with `--bytecode` or `--minify`.
- Cause: the parser lowers `require.main === module` to an `EImportMetaMain` node and, under `--compile`, inlines `true` for every entry point (`src/bundler/ParseTask.rs:2597`). Without code splitting, each entry point's bundle holds a copy of every file it reaches, so an entry point that another entry point imports is printed twice: as its own bundle's entry, and as a dependency of the other bundle.

### Fix
- The first entry point is the executable's main module. It keeps the parse-time `true`, so its dead branch still folds and the modules only that branch requires stay out of the binary. `ParseTask` gets `is_primary_entry_point` for this.
- The other entry points keep the node. The printer gets `Options::import_meta_main_value`, and `generate_code_for_file_in_chunk_js` sets it per chunk: `false` when the file is not the chunk's entry point (a copy), `true` in the entry point's own bundle under `--compile`. A shared chunk under `--splitting` stays a run-time read.
- Correct because a copy is a dependency of the bundle it is printed into, as it is when the files run unbundled. An entry point's own bundle prints the same `true` as before, so nothing in an executable depends on the run-time `import.meta.main` getter, and a `__commonJS`-wrapped entry never compares `require.main` with the wrapper's `module`.
- Verified: `test/bundler/bundler_compile.test.ts` (2 new tests, both fail on main with `isMain: true`). Also `bundler_compile`, `bundler_edgecase`, `bundler_minify`, `bundler_splitting`, `bundler_compile_splitting`, `bundler_cjs`, `bundler_bun`, `bun-build-api`, `esbuild/default -t ImportMeta`, `bake/dev-and-prod`, `cli/run/run-importmetamain`.

### Background
- `import.meta.main` is `true` in the module Bun started with. The bundler lowers `require.main === module` to the same node, so both idioms get the same treatment in every output format.
- `inline_entrypoint_import_meta_main` is set by the CLI for `--compile` (#12867). The executable's entry is its main module, so the parser inlines `true`, which lets it drop the other branch and the imports only that branch uses.
- A chunk's `entry_point` names the file the chunk is the output of. When the file being printed is not that file, the printer is printing a dependency.

<details><summary>Notes</summary>

Reported in a fuzz ledger note in Slack (#18968 there). Reproduces on 1.3.14, 1.4.0, 1.4.1 and main. `--splitting` was not affected: the imported entry point lands in a shared chunk, which reads `import.meta.main` at run time.

Repro on main and on this branch:

```
$ cat lib.cjs
module.exports = {
  isMain: require.main === module,
  cli: (function () { if (require.main === module) return "CLI-RAN"; return "lib"; })(),
};
$ cat app.ts
import m from "./lib.cjs"; console.log(JSON.stringify(m));
$ bun run app.ts
{"isMain":false,"cli":"lib"}
$ bun build --compile app.ts lib.cjs --outfile app && ./app
# main:   {"isMain":true,"cli":"CLI-RAN"}
# fixed:  {"isMain":false,"cli":"lib"}
```

The printer option and the `Some(false)` branch are the same hunks as #40601, which fixes the `--outdir` form of this bug (`bun build app.ts lib.cjs --outdir out && bun out/app.js`) inside a splitting PR. Whichever lands second drops them. The test here covers only `--compile`, so it does not duplicate that PR's test.

What stays as before:
- The first entry point's output is byte-identical to main, with one or with several entry points (`compile/ImportMetaMain` still passes, and a module behind `if (!import.meta.main) require(...)` is still absent from the binary of the documented `bun build --compile ./index.ts ./my-worker.ts` recipe).
- Another entry point's own bundle still prints `true`, also when the executable loads it at run time with `import()` or `require()`.
- The first entry point, when another entry point imports it, is still copied with `true`. That needs the linker to drop the parse-time inlining for it as well, at the cost of the folding above.

Bake also sets `inline_entrypoint_import_meta_main`. The deferral is gated on `compile_mode.is_executable()`, so Bake output is unchanged. `Bun.build({compile})` does not set the flag, so only the `false` copy applies to it; its entry points keep the run-time read they have today.

`compile/HelloWorldWithProcessVersionsBun` fails on every debug build independent of this change (it compares `process.versions.bun` of the debug binary with the version string of the test runner). Two `bun-build-api` bytecode tests need more than the 5 s default on the debug build and pass with `--timeout 120000`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->