### PR TITLE
tsconfig: derive the useDefineForClassFields default from target

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2961,9 +2961,7 @@ pub mod flags {
         /// this function's body close. The React Compiler skips such functions.
         HasReactHooksSuppression,
 
-        /// A class constructor the TypeScript lowering added to hold field
-        /// assignments. The source has no constructor, so tsc emits no
-        /// `design:paramtypes` for the class.
+        /// A constructor the TypeScript lowering added; it never gets `design:paramtypes`.
         IsSynthesizedConstructor,
     }
     pub type FunctionSet = EnumSet<Function>;

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2960,6 +2960,11 @@ pub mod flags {
         /// A `// eslint-disable… react-hooks/…` comment was scanned at or before
         /// this function's body close. The React Compiler skips such functions.
         HasReactHooksSuppression,
+
+        /// A class constructor the TypeScript lowering added to hold field
+        /// assignments. The source has no constructor, so tsc emits no
+        /// `design:paramtypes` for the class.
+        IsSynthesizedConstructor,
     }
     pub type FunctionSet = EnumSet<Function>;
     pub const FUNCTION_NONE: FunctionSet = EnumSet::empty();

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -726,7 +726,7 @@ impl<'a> Transpiler<'a> {
                     }
                     self.options.emit_decorator_metadata = tsconfig.emit_decorator_metadata;
                     self.options.experimental_decorators = tsconfig.experimental_decorators;
-                    if let Some(v) = tsconfig.use_define_for_class_fields {
+                    if let Some(v) = tsconfig.use_define_for_class_fields_or_target_default() {
                         self.options.use_define_for_class_fields = v;
                     }
                 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6702,8 +6702,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let mut array: Vec<Expr> = s_class.class.ts_decorators.move_to_list_managed();
 
                     if self.options.features.emit_decorator_metadata {
-                        // Only a constructor the source declares gets `design:paramtypes`,
-                        // like tsc. A synthesized one would shadow the parent's metadata.
+                        // tsc emits `design:paramtypes` only for a constructor with a body in the source.
                         let declared_constructor = constructor_function.filter(|cf| {
                             !cf.func
                                 .flags

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6664,7 +6664,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             constructor_stmts.into_bump_slice_mut(),
                                         ),
                                     },
-                                    flags: Flags::FUNCTION_NONE,
+                                    flags: Flags::Function::IsSynthesizedConstructor.into(),
                                     ..Default::default()
                                 },
                             },
@@ -6702,7 +6702,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let mut array: Vec<Expr> = s_class.class.ts_decorators.move_to_list_managed();
 
                     if self.options.features.emit_decorator_metadata {
-                        if let Some(cf) = constructor_function {
+                        // Only a constructor the source declares gets `design:paramtypes`,
+                        // like tsc. A synthesized one would shadow the parent's metadata.
+                        let declared_constructor = constructor_function.filter(|cf| {
+                            !cf.func
+                                .flags
+                                .contains(Flags::Function::IsSynthesizedConstructor)
+                        });
+                        if let Some(cf) = declared_constructor {
                             // design:paramtypes
                             let constructor_args: &[G::Arg] = cf.func.args.slice();
                             let args1 = if !constructor_args.is_empty() {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1142,7 +1142,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                     }
 
-                    if let Some(mut cf) = constructor_function {
+                    if injected.is_empty() {
+                        // Only declared-only fields were removed. tsc emits no constructor for them.
+                    } else if let Some(mut cf) = constructor_function {
                         let old_body: &[Stmt] = cf.func.body.stmts.slice();
                         let super_end = if class.extends.is_some() {
                             old_body
@@ -1212,7 +1214,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         loc,
                                         stmts: bun_ast::StoreSlice::from_bump(ctor_stmts),
                                     },
-                                    flags: flags::FUNCTION_NONE,
+                                    flags: flags::Function::IsSynthesizedConstructor.into(),
                                     ..Default::default()
                                 },
                             },

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -258,7 +258,7 @@ use crate::fs as Fs;
 use crate::fs::FilenameStoreAppender;
 use crate::node_fallbacks as NodeFallbackModules;
 use crate::package_json::{BrowserMap, ESModule, PackageJSON};
-use crate::tsconfig_json::TSConfigJSON;
+use crate::tsconfig_json::{TSConfigJSON, TSTarget};
 
 pub use crate::data_url::DataURL;
 pub use crate::dir_info as DirInfo;
@@ -1566,7 +1566,7 @@ impl<'a> Resolver<'a> {
                 result.flags.set_experimental_decorators(
                     result.flags.experimental_decorators() || tsconfig.experimental_decorators,
                 );
-                if let Some(v) = tsconfig.use_define_for_class_fields {
+                if let Some(v) = tsconfig.use_define_for_class_fields_or_target_default() {
                     result.flags.set_use_define_for_class_fields(v);
                 }
             }
@@ -6552,6 +6552,9 @@ impl<'a> Resolver<'a> {
                             mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
                         if let Some(v) = parent_config.use_define_for_class_fields {
                             mc.use_define_for_class_fields = Some(v);
+                        }
+                        if parent_config.target != TSTarget::Unspecified {
+                            mc.target = parent_config.target;
                         }
                         if !parent_config.base_url.is_empty() {
                             mc.base_url = core::mem::take(&mut parent_config.base_url);

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -161,28 +161,22 @@ pub struct TSConfigJSON {
 
     pub emit_decorator_metadata: bool,
     pub experimental_decorators: bool,
-    /// The explicit `compilerOptions.useDefineForClassFields` flag. `None` =
-    /// unset. Use [`Self::use_define_for_class_fields_or_target_default`]
-    /// for the value tsc applies.
+    /// The explicit flag only; [`Self::use_define_for_class_fields_or_target_default`] applies the `target` default.
     pub use_define_for_class_fields: Option<bool>,
     pub target: TSTarget,
 }
 
-/// `compilerOptions.target`. Bun reads it only for the default of
-/// `useDefineForClassFields`, so only the ES2022 boundary is kept.
+/// `compilerOptions.target`, reduced to the ES2022 boundary that decides the `useDefineForClassFields` default.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum TSTarget {
     #[default]
     Unspecified,
-    /// `useDefineForClassFields` defaults to `false` ([[Set]] assignments).
     BelowES2022,
-    /// `useDefineForClassFields` defaults to `true` ([[Define]] fields).
     AtOrAboveES2022,
 }
 
 impl TSTarget {
-    /// Case-insensitive, same table as tsc and esbuild. An unknown name stays
-    /// `Unspecified`.
+    /// Same name table as tsc and esbuild, case-insensitive.
     fn parse(value: &[u8]) -> TSTarget {
         let Some((lower, len)) = strings::ascii_lowercase_buf::<6>(value) else {
             return TSTarget::Unspecified;
@@ -258,9 +252,7 @@ impl TSConfigJSON {
         !self.base_url.is_empty()
     }
 
-    /// `useDefineForClassFields` as tsc resolves it: the explicit flag wins,
-    /// otherwise `target` decides (`false` below ES2022). `None` when neither
-    /// is set, so the caller keeps its own default.
+    /// `useDefineForClassFields` as tsc resolves it; `None` when neither the flag nor `target` is set.
     pub fn use_define_for_class_fields_or_target_default(&self) -> Option<bool> {
         self.use_define_for_class_fields.or(match self.target {
             TSTarget::Unspecified => None,

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -161,8 +161,39 @@ pub struct TSConfigJSON {
 
     pub emit_decorator_metadata: bool,
     pub experimental_decorators: bool,
-    /// `None` = unset (keeps native [[Define]] class-field semantics).
+    /// The explicit `compilerOptions.useDefineForClassFields` flag. `None` =
+    /// unset. Use [`Self::use_define_for_class_fields_or_target_default`]
+    /// for the value tsc applies.
     pub use_define_for_class_fields: Option<bool>,
+    pub target: TSTarget,
+}
+
+/// `compilerOptions.target`. Bun reads it only for the default of
+/// `useDefineForClassFields`, so only the ES2022 boundary is kept.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum TSTarget {
+    #[default]
+    Unspecified,
+    /// `useDefineForClassFields` defaults to `false` ([[Set]] assignments).
+    BelowES2022,
+    /// `useDefineForClassFields` defaults to `true` ([[Define]] fields).
+    AtOrAboveES2022,
+}
+
+impl TSTarget {
+    /// Case-insensitive, same table as tsc and esbuild. An unknown name stays
+    /// `Unspecified`.
+    fn parse(value: &[u8]) -> TSTarget {
+        let Some((lower, len)) = strings::ascii_lowercase_buf::<6>(value) else {
+            return TSTarget::Unspecified;
+        };
+        match &lower[..len] {
+            b"es3" | b"es5" | b"es6" | b"es2015" | b"es2016" | b"es2017" | b"es2018"
+            | b"es2019" | b"es2020" | b"es2021" => TSTarget::BelowES2022,
+            b"es2022" | b"es2023" | b"es2024" | b"es2025" | b"esnext" => TSTarget::AtOrAboveES2022,
+            _ => TSTarget::Unspecified,
+        }
+    }
 }
 
 impl Default for TSConfigJSON {
@@ -179,6 +210,7 @@ impl Default for TSConfigJSON {
             emit_decorator_metadata: false,
             experimental_decorators: false,
             use_define_for_class_fields: None,
+            target: TSTarget::Unspecified,
         }
     }
 }
@@ -224,6 +256,17 @@ impl TSConfigJSON {
 
     pub(crate) fn has_base_url(&self) -> bool {
         !self.base_url.is_empty()
+    }
+
+    /// `useDefineForClassFields` as tsc resolves it: the explicit flag wins,
+    /// otherwise `target` decides (`false` below ES2022). `None` when neither
+    /// is set, so the caller keeps its own default.
+    pub fn use_define_for_class_fields_or_target_default(&self) -> Option<bool> {
+        self.use_define_for_class_fields.or(match self.target {
+            TSTarget::Unspecified => None,
+            TSTarget::BelowES2022 => Some(false),
+            TSTarget::AtOrAboveES2022 => Some(true),
+        })
     }
 
     pub fn merge_jsx(&self, current: options::jsx::Pragma) -> options::jsx::Pragma {
@@ -375,6 +418,7 @@ impl TSConfigJSON {
             let mut emit_decorator_metadata_v: Option<&bun_ast::E::JsonValue> = None;
             let mut experimental_decorators_v: Option<&bun_ast::E::JsonValue> = None;
             let mut use_define_for_class_fields_v: Option<&bun_ast::E::JsonValue> = None;
+            let mut target_v: Option<&bun_ast::E::JsonValue> = None;
             let mut jsx_factory_v: Option<(&bun_ast::E::JsonValue, bun_ast::Loc)> = None;
             let mut jsx_fragment_factory_v: Option<(&bun_ast::E::JsonValue, bun_ast::Loc)> = None;
             let mut jsx_v: Option<&bun_ast::E::JsonValue> = None;
@@ -398,6 +442,7 @@ impl TSConfigJSON {
                         b"useDefineForClassFields" if use_define_for_class_fields_v.is_none() => {
                             use_define_for_class_fields_v = Some(value)
                         }
+                        b"target" if target_v.is_none() => target_v = Some(value),
                         b"jsxFactory" if jsx_factory_v.is_none() => {
                             jsx_factory_v = Some((value, loc))
                         }
@@ -445,6 +490,11 @@ impl TSConfigJSON {
             // Parse "useDefineForClassFields"
             if let Some(&bun_ast::E::JsonValue::Boolean(val)) = use_define_for_class_fields_v {
                 result.use_define_for_class_fields = Some(val);
+            }
+
+            // Parse "target"
+            if let Some(target) = target_v.and_then(|v| v.as_str()) {
+                result.target = TSTarget::parse(target);
             }
 
             // Parse "jsxFactory"

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -778,7 +778,7 @@ impl TransformTask {
             experimental_decorators: tsconfig.is_some_and(|ts| ts.experimental_decorators),
             emit_decorator_metadata: tsconfig.is_some_and(|ts| ts.emit_decorator_metadata),
             use_define_for_class_fields: tsconfig
-                .and_then(|ts| ts.use_define_for_class_fields)
+                .and_then(|ts| ts.use_define_for_class_fields_or_target_default())
                 .unwrap_or(true),
             macro_js_ctx: MacroJSCtx::ZERO,
             file_fd_ptr: None,
@@ -1242,7 +1242,7 @@ impl JSTranspiler {
             use_define_for_class_fields: config
                 .tsconfig
                 .as_deref()
-                .and_then(|ts| ts.use_define_for_class_fields)
+                .and_then(|ts| ts.use_define_for_class_fields_or_target_default())
                 .unwrap_or(true),
             file_fd_ptr: None,
             inject_jest_globals: false,

--- a/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
+++ b/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
@@ -335,6 +335,63 @@ describe("tsconfig compilerOptions.target implies useDefineForClassFields", () =
     expect(exitCode).toBe(0);
   });
 
+  // tsc emits `design:paramtypes` only for a constructor written in the source.
+  // The constructor synthesized for lowered fields must not shadow the parent's
+  // metadata, or dependency injection (NestJS) loses the inherited types.
+  for (const compilerOptions of [{ target: "ES2021" }, { useDefineForClassFields: false }]) {
+    test.concurrent(
+      `${JSON.stringify(compilerOptions)}: synthesized constructor has no design:paramtypes`,
+      async () => {
+        using dir = tempDir("udfcf-target-metadata", {
+          "tsconfig.json": JSON.stringify({
+            compilerOptions: { ...compilerOptions, experimentalDecorators: true, emitDecoratorMetadata: true },
+          }),
+          "index.ts": `
+          const store = new WeakMap<object, Map<string, unknown>>();
+          (Reflect as any).metadata = (key: string, value: unknown) => (target: object) => {
+            if (!store.has(target)) store.set(target, new Map());
+            store.get(target)!.set(key, value);
+          };
+          const own = (target: object) => store.get(target)?.get("design:paramtypes") as Function[] | undefined;
+          const inherited = (target: object) => {
+            for (let t: object | null = target; t; t = Object.getPrototypeOf(t)) {
+              const types = own(t);
+              if (types) return types;
+            }
+          };
+          const names = (types?: Function[]) => types?.map(t => t.name) ?? null;
+
+          function Injectable(): ClassDecorator { return () => {}; }
+          class Dep {}
+          @Injectable() class Base { constructor(public dep: Dep) {} }
+          @Injectable() class Declared extends Base { label: string; }
+          @Injectable() class Initialized extends Base { name = "x"; }
+          @Injectable() class Explicit extends Base { constructor(d: Dep, n: number) { super(d); } }
+
+          const report = (cls: any) => ({
+            own: names(own(cls)),
+            inherited: names(inherited(cls)),
+            keys: Object.getOwnPropertyNames(new cls(new Dep(), 1)),
+          });
+          process.stdout.write(JSON.stringify({
+            Declared: report(Declared),
+            Initialized: report(Initialized),
+            Explicit: report(Explicit),
+          }));
+        `,
+        });
+        const { stdout, stderr, exitCode } = await run(String(dir));
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual({
+          Declared: { own: null, inherited: ["Dep"], keys: ["dep"] },
+          Initialized: { own: null, inherited: ["Dep"], keys: ["dep", "name"] },
+          Explicit: { own: ["Dep", "Number"], inherited: ["Dep", "Number"], keys: ["dep"] },
+        });
+        expect(exitCode).toBe(0);
+      },
+    );
+  }
+
   test.concurrent("Bun.Transpiler derives the default from target", () => {
     const source = `
       class A {

--- a/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
+++ b/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
@@ -246,3 +246,106 @@ describe("tsconfig compilerOptions.useDefineForClassFields", () => {
     expect(out).not.toMatch(/^\s*x;\s*$/m);
   });
 });
+
+// When `useDefineForClassFields` is not set, tsc (and esbuild) derive it from
+// `target`: `false` below ES2022, `true` from ES2022 on.
+describe("tsconfig compilerOptions.target implies useDefineForClassFields", () => {
+  const probe = `
+    let setterCalled = false;
+    class Base { set p(v: any) { setterCalled = true; } get p() { return "getter"; } }
+    class C extends Base { p: any = "field"; b: number; }
+    const c = new C();
+    process.stdout.write(JSON.stringify({
+      setterCalled,
+      p: c.p,
+      ownP: Object.prototype.hasOwnProperty.call(c, "p"),
+      hasB: "b" in c,
+    }));
+  `;
+  const setSemantics = { setterCalled: true, p: "getter", ownP: false, hasB: false };
+  const defineSemantics = { setterCalled: false, p: "field", ownP: true, hasB: true };
+
+  const cases: [compilerOptions: Record<string, unknown>, expected: typeof setSemantics][] = [
+    [{ target: "ES2021" }, setSemantics],
+    [{ target: "es5" }, setSemantics],
+    [{ target: "ES2022" }, defineSemantics],
+    [{ target: "ESNext" }, defineSemantics],
+    [{ target: "ES2017", useDefineForClassFields: true }, defineSemantics],
+    [{ target: "ES2022", useDefineForClassFields: false }, setSemantics],
+  ];
+
+  for (const [compilerOptions, expected] of cases) {
+    const name = JSON.stringify(compilerOptions);
+    const semantics = expected === setSemantics ? "[[Set]]" : "[[Define]]";
+
+    test.concurrent(`${name}: bun run uses ${semantics}`, async () => {
+      using dir = tempDir("udfcf-target", {
+        "tsconfig.json": JSON.stringify({ compilerOptions }),
+        "index.ts": probe,
+      });
+      const { stdout, stderr, exitCode } = await run(String(dir));
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(expected);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent(`${name}: bun build uses ${semantics}`, async () => {
+      using dir = tempDir("udfcf-target-build", {
+        "tsconfig.json": JSON.stringify({ compilerOptions }),
+        "index.ts": probe,
+      });
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "index.ts", "--outfile", "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [buildStderr, buildExitCode] = await Promise.all([build.stderr.text(), build.exited]);
+      expect(buildStderr).toBe("");
+      expect(buildExitCode).toBe(0);
+
+      const { stdout, stderr, exitCode } = await run(String(dir), "out.js");
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(expected);
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test.concurrent("target below ES2022 is inherited through extends", async () => {
+    using dir = tempDir("udfcf-target-extends", {
+      "base.json": JSON.stringify({ compilerOptions: { target: "ES2017" } }),
+      "tsconfig.json": JSON.stringify({ extends: "./base.json", compilerOptions: { strict: true } }),
+      "index.ts": probe,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(setSemantics);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an inherited explicit useDefineForClassFields wins over the child's target", async () => {
+    using dir = tempDir("udfcf-target-extends-explicit", {
+      "base.json": JSON.stringify({ compilerOptions: { useDefineForClassFields: true } }),
+      "tsconfig.json": JSON.stringify({ extends: "./base.json", compilerOptions: { target: "ES2017" } }),
+      "index.ts": probe,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(defineSemantics);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("Bun.Transpiler derives the default from target", () => {
+    const source = `
+      class A {
+        v = this.x + 1;
+        constructor(public x: number) {}
+      }
+    `;
+    const below = new Bun.Transpiler({ loader: "ts", tsconfig: { compilerOptions: { target: "ES2021" } } });
+    expect(below.transformSync(source)).toContain("this.v = this.x + 1");
+
+    const atOrAbove = new Bun.Transpiler({ loader: "ts", tsconfig: { compilerOptions: { target: "ES2022" } } });
+    expect(atOrAbove.transformSync(source)).not.toContain("this.v = this.x + 1");
+  });
+});

--- a/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
+++ b/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
@@ -300,7 +300,11 @@ describe("tsconfig compilerOptions.target implies useDefineForClassFields", () =
         cwd: String(dir),
         stderr: "pipe",
       });
-      const [buildStderr, buildExitCode] = await Promise.all([build.stderr.text(), build.exited]);
+      const [, buildStderr, buildExitCode] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
       expect(buildStderr).toBe("");
       expect(buildExitCode).toBe(0);
 


### PR DESCRIPTION
### Problem
- With `"target"` below ES2022 and no `useDefineForClassFields`, Bun keeps [[Define]] class fields where tsc and esbuild use [[Set]]. For `class D extends B { x = 5 }` with a setter `x` on `B`, they print `setter 5` then `[] 99`. Bun prints `["x"] 5`.
- `TSConfigJSON::parse` (`src/resolver/tsconfig_json.rs`) never read `compilerOptions.target`. #36664 wired up the explicit flag only.
- The [[Set]] lowering also breaks NestJS (Nest CLI default: `target: ES2021`). A decorated `class Child extends Base { name = "x" }` gets a synthesized constructor, and `lower_class` emits `design:paramtypes: []` for it. That shadows `Base`'s paramtypes, so Nest injects nothing into `Child`.

### Fix
- Parse `target` into a `TSTarget` tri-state (tsc and esbuild name table, case-insensitive), inherit it through `extends`, and derive the flag's default from it: `false` below ES2022, `true` from ES2022 on. An explicit flag still wins. An unspecified target keeps Bun's [[Define]] default.
- Flag a synthesized constructor and emit `design:paramtypes` only for a declared one, as tsc does. Emit no constructor when every lowered field is declared-only.
- Verified: `test/bundler/transpiler/ts-use-define-for-class-fields.test.ts` (14 new cases, 8 fail on 1.4.1). Also `test/bundler/transpiler/`, the decorator and tsconfig suites, and `test/integration/nest/`.

### Background
- [[Define]] creates an own property for `x = 5` and ignores an inherited setter. [[Set]] runs `this.x = 5` in the constructor, so the setter runs and a declared-only field emits nothing. Code older than TypeScript 4 relies on [[Set]].
- `design:paramtypes` is legacy decorator metadata with a constructor's parameter types. `Reflect.getMetadata` walks the prototype chain, so a subclass without own metadata inherits its parent's.

<details><summary>Notes</summary>

Self-review: 1 blocker (the `design:paramtypes` shadowing above, fixed here) and 1 should-fix raised. The should-fix is that `experimentalDecorators` is not inherited through `extends` in the same merge loop. That is pre-existing and #40823 already fixes it with a tri-state, so it is left to that PR.

Oracles, all with the report's `main.ts` and `{ "compilerOptions": { "target": "ES2021" } }`:

```
bun 1.4.1:        ["x"] 5
esbuild 0.21.5:   setter 5 / [] 99
tsc 6.0.2:        setter 5 / [] 99
bun (this PR):    setter 5 / [] 99   (bun run, bun build -> bun, bun build --minify -> node)
```

Edge cases checked against esbuild 0.21.5 and tsc 6.0.2:

- `Es2021` (mixed case): [[Set]] everywhere.
- `es2025`, `ESNext`: [[Define]] everywhere.
- `ES4` (unknown): stays `Unspecified`, [[Define]], same as esbuild and tsc.
- `es3`: [[Set]] here and in esbuild. tsc 6.0 removed ES3 and maps it to the latest target, so tsc 6.0 gives [[Define]]. tsc 5.x gives [[Set]]. Bun follows esbuild and tsc 5.x: a project that still says `es3` expects the old assignment semantics.
- Unspecified target: [[Define]]. esbuild gives [[Define]] too (it falls back to its own `--target`, which defaults to esnext). tsc 6.0 defaults `target` to ES2025, so [[Define]] as well.

tsc 6.0.2 resolution (`lib/_tsc.js`):

```js
useDefineForClassFields: computeValue: (o) =>
  o.useDefineForClassFields === void 0 ? target(o) >= 9 /* ES2022 */ : o.useDefineForClassFields
target: computeValue: (o) => (o.target === 0 /* ES3 */ ? void 0 : o.target) ?? 12 /* LatestStandard */
```

`extends` precedence follows tsc: compilerOptions merge per key, so an inherited explicit flag beats the child's `target`, and a child's `target` beats the parent's.

Decorator metadata, tsconfig `{ target: ES2021, experimentalDecorators, emitDecoratorMetadata }`, `@Injectable() class Base { constructor(public dep: Dep) {} }`, own and inherited `design:paramtypes` per subclass. tsc 6.0.2 and this PR agree on every row. Before this PR the first two rows were `own: []`, `inherited: []`.

```
class Declared extends Base { label: string; }             own: none        inherited: [Dep]
class Initialized extends Base { name = "x"; }             own: none        inherited: [Dep]
class Explicit extends Base { constructor() { ... } }      own: []          inherited: []
class ExplicitArgs extends Base { constructor(d: Dep, n: number) }  own: [Dep, Number]
class ParamProp extends Base { constructor(public n: number) }      own: [Number]
```

The same shadowing happens today with an explicit `useDefineForClassFields: false`, so the new test runs both spellings.

The lowering is in `src/js_parser/visit/mod.rs` and is gated on the TypeScript parser variant, so `.js` files are not affected. esbuild also keeps [[Define]] for an unspecified target.

The runtime transpiler reads only the root (cwd) tsconfig. That is pre-existing behavior (#38719 tracks per-file tsconfig at runtime).

Suites run with the debug build: `test/bundler/transpiler/` plus `test/bundler/bundler_decorator_metadata.test.ts`, `test/bundler/esbuild/ts.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`, `test/regression/issue/27526.test.ts` (3994 pass, 321 skip), `test/integration/nest/nest_metadata.test.ts`, `test/integration/typegraphql/`, `test/js/bun/resolve/tsconfig-extends-leak.test.ts`, `test/js/bun/resolve/jsonc.test.ts`, `test/js/bun/resolve/resolve-error.test.ts`, `test/cli/run/tsconfig-override.test.ts`, `test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts` (45 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
bun test v1.4.1 (d578a8c70)

test/bundler/transpiler/ts-use-define-for-class-fields.test.ts:
(pass) tsconfig compilerOptions.useDefineForClassFields > false: field initializers see parameter properties (#10961) [316.60ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: synthesizes constructor when none is declared [925.62ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: matches tsc/esbuild ordering and [[Set]] semantics [957.14ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: computed non-literal key keeps the class native [1101.75ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: computed literal keys use [[Set]] semantics [1188.99ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > true: keeps native class-field ([[Define]]) semantics [1089.83ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: Bun.Transpiler honors the option [15.28ms]
(pass) tsconfig compilerOptions.useDefi
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (34bff0f0f)

test/bundler/transpiler/ts-use-define-for-class-fields.test.ts:
(pass) tsconfig compilerOptions.useDefineForClassFields > false: Bun.Transpiler honors the option [0.30ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: field initializers see parameter properties (#10961) [27.29ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: synthesizes constructor when none is declared [25.45ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: computed literal keys use [[Set]] semantics [24.74ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: computed non-literal key keeps the class native [25.65ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > true: keeps native class-field ([[Define]]) semantics [25.52ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: static method named 'constructor' is not treated as the constructor [28.17ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: matches tsc/esbuild ordering and [[Set]] semantics [33.72ms]
(pass) tsconfig compilerOptions.target implies useDefineForClassFields > Bun.Transpiler deriv
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
bun test v1.4.1 (d578a8c70)

test/bundler/transpiler/ts-use-define-for-class-fields.test.ts:
(pass) tsconfig compilerOptions.useDefineForClassFields > false: field initializers see parameter properties (#10961) [419.62ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: synthesizes constructor when none is declared [988.90ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: computed literal keys use [[Set]] semantics [992.24ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: computed non-literal key keeps the class native [1008.87ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: matches tsc/esbuild ordering and [[Set]] semantics [1176.22ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > true: keeps native class-field ([[Define]]) semantics [970.68ms]
(pass) tsconfig compilerOptions.useDefineForClassFields > false: Bun.Transpiler honors the option [9.57ms]
(pass) tsconfig compilerOptions.useDefine
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 723ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/lib.rs                                     |   3 +
 src/bundler/transpiler.rs                          |   2 +-
 src/js_parser/p.rs                                 |  10 +-
 src/js_parser/visit/mod.rs                         |   6 +-
 src/resolver/resolver.rs                           |   7 +-
 src/resolver/tsconfig_json.rs                      |  44 +++++-
 src/runtime/api/JSTranspiler.rs                    |   4 +-
 .../ts-use-define-for-class-fields.test.ts         | 164 +++++++++++++++++++++
 8 files changed, 230 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/ast/lib.rs                                                2      3      0
src/bundler/transpiler.rs                                     1      2      0
src/js_parser/p.rs                                            3      3      0
src/js_parser/visit/mod.rs                                    1      2      0
src/resolver/resolver.rs                                      2      3      0
src/resolver/tsconfig_json.rs                                 4     10      0
src/runtime/api/JSTranspiler.rs                               2      2      0
…ndler/transpiler/ts-use-define-for-class-fields.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->