### PR TITLE
js_parser: do not treat a static method named constructor as the class constructor in lower_class

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6390,9 +6390,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if let Some(prop_value) = prop.value {
                             match prop_value.data {
                                 js_ast::ExprData::EFunction(func) => {
-                                    // `static constructor() {}` and `["constructor"]() {}` are
-                                    // ordinary methods, the same rule as parse_property and
-                                    // visit_class.
                                     let is_constructor = !prop
                                         .flags
                                         .contains(Flags::Property::IsStatic)

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6390,7 +6390,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if let Some(prop_value) = prop.value {
                             match prop_value.data {
                                 js_ast::ExprData::EFunction(func) => {
-                                    let is_constructor = matches!(prop.key, Some(k) if matches!(k.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"constructor")));
+                                    // `static constructor() {}` and `["constructor"]() {}` are
+                                    // ordinary methods, the same rule as parse_property and
+                                    // visit_class.
+                                    let is_constructor = !prop
+                                        .flags
+                                        .contains(Flags::Property::IsStatic)
+                                        && !prop.flags.contains(Flags::Property::IsComputed)
+                                        && matches!(prop.key, Some(k) if matches!(k.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"constructor")));
 
                                     if is_constructor {
                                         constructor_function = Some(func);

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -226,8 +226,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 has_auto_accessor =
                     has_auto_accessor || prop_kind == js_ast::g::PropertyKind::AutoAccessor;
 
-                // Forbid decorators on class constructors. A static or computed
-                // "constructor" key is an ordinary method.
+                // Forbid decorators on class constructors
                 if opts.ts_decorators.len() > 0
                     && !prop_flags.contains(Flags::Property::IsStatic)
                     && !prop_flags.contains(Flags::Property::IsComputed)

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -221,12 +221,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // read fields before move (G::Property is not Copy).
                 let prop_kind = property.kind;
                 let prop_key = property.key;
+                let prop_flags = property.flags;
                 properties.push(property);
                 has_auto_accessor =
                     has_auto_accessor || prop_kind == js_ast::g::PropertyKind::AutoAccessor;
 
-                // Forbid decorators on class constructors
-                if opts.ts_decorators.len() > 0 {
+                // Forbid decorators on class constructors. A static or computed
+                // "constructor" key is an ordinary method.
+                if opts.ts_decorators.len() > 0
+                    && !prop_flags.contains(Flags::Property::IsStatic)
+                    && !prop_flags.contains(Flags::Property::IsComputed)
+                {
                     if let Some(key) = prop_key {
                         if let js_ast::expr::Data::EString(str_) = &key.data {
                             if str_.eql_comptime(b"constructor") {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,9 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: Legacy decorator lowering no longer treats a static method named
+/// `constructor` as the class constructor.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/decorator-metadata.test.ts
+++ b/test/bundler/transpiler/decorator-metadata.test.ts
@@ -439,6 +439,26 @@ describe("decorator metadata", () => {
     expect(Reflect.getMetadata("design:returntype", A)).toBeUndefined();
   });
 
+  test("static method named 'constructor' is not the class constructor", () => {
+    function d1() {}
+    class Dep {}
+    // @ts-ignore
+    @d1
+    class A {
+      // @ts-ignore
+      static constructor(@d1 arg1: Dep) {
+        return "static";
+      }
+    }
+
+    // The class has no constructor, so it has no design:paramtypes.
+    expect(Reflect.getMetadata("design:paramtypes", A)).toBeUndefined();
+
+    // The static method has its own metadata, like any other decorated static method.
+    expect(Reflect.getMetadata("design:type", A, "constructor")).toBe(Function);
+    expect(Reflect.getMetadata("design:paramtypes", A, "constructor")).toEqual([Dep]);
+  });
+
   test("more types", () => {
     type B = "hello" | "world";
     const b = 2;

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -698,6 +698,52 @@ test("decorated fields moving to constructor", () => {
   expect(a.c).toBe(5);
 });
 
+test("static method named 'constructor' is not treated as the constructor", () => {
+  const calls: any[] = [];
+  function dec(target, key?: string, index?: number) {
+    const name = target === A ? "A" : target === A.prototype ? "A.prototype" : "other";
+    calls.push({ target: name, key, index });
+  }
+
+  @dec
+  class A {
+    @dec x = 1;
+    static constructor(@dec d: string) {
+      return "static";
+    }
+  }
+
+  class Base {
+    args: any[];
+    constructor(...args: any[]) {
+      this.args = args;
+    }
+  }
+
+  function noop() {}
+  class B extends Base {
+    @noop y = 2;
+    static constructor() {
+      return "static B";
+    }
+  }
+
+  expect(new A().x).toBe(1);
+  expect(A.constructor()).toBe("static");
+  expect(new A().constructor).toBe(A);
+  // The parameter decorator belongs to the static method, not to the class.
+  expect(calls).toEqual([
+    { target: "A.prototype", key: "x", index: undefined },
+    { target: "A", key: "constructor", index: 0 },
+    { target: "A", key: undefined, index: undefined },
+  ]);
+
+  const b = new B(7, 8);
+  expect(b.y).toBe(2);
+  expect(b.args).toEqual([7, 8]);
+  expect(B.constructor()).toBe("static B");
+});
+
 test("only class decorator", () => {
   let a = 0;
   @d1

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import DecoratedClass from "./decorator-export-default-class-fixture";
 import DecoratedAnonClass from "./decorator-export-default-class-fixture-anon";
 
@@ -742,6 +742,50 @@ test("static method named 'constructor' is not treated as the constructor", () =
   expect(b.y).toBe(2);
   expect(b.args).toEqual([7, 8]);
   expect(B.constructor()).toBe("static B");
+});
+
+test("decorators on a static or computed 'constructor' key decorate an ordinary method", async () => {
+  const transpiler = new Bun.Transpiler({
+    loader: "ts",
+    tsconfig: { compilerOptions: { experimentalDecorators: true } },
+  });
+  // Only the real constructor rejects decorators.
+  expect(() => transpiler.transformSync("function dec() {}\nclass A { @dec constructor() {} }")).toThrow(
+    "TypeScript does not allow decorators on class constructors",
+  );
+
+  using dir = tempDir("decorators-static-ctor-key", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+    "index.ts": `
+      const calls: any[] = [];
+      function dec(target: any, key: string, desc: PropertyDescriptor) {
+        const name = target === A ? "A" : target === A.prototype ? "A.prototype" : "other";
+        calls.push([name, key, typeof desc.value]);
+      }
+      class A {
+        @dec static constructor() { return "static"; }
+        @dec ["constructor"]() { return "proto"; }
+      }
+      console.log(JSON.stringify({ s: A.constructor(), p: new A().constructor(), calls }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    s: "static",
+    p: "proto",
+    calls: [
+      ["A.prototype", "constructor", "function"],
+      ["A", "constructor", "function"],
+    ],
+  });
+  expect(exitCode).toBe(0);
 });
 
 test("only class decorator", () => {


### PR DESCRIPTION
### Problem
- With `experimentalDecorators`, a class that has a static method named `constructor` and a decorated instance field is miscompiled. The field initializer is injected into the static method: `static constructor(d) { this.x = 1; ... }`. `new A().x` is `undefined`. With `emitDecoratorMetadata`, the class also gets a `design:paramtypes` entry built from the static method's parameters, and a parameter decorator on that method is applied to the class.
- The cause is the constructor lookup in `lower_class` (`src/js_parser/p.rs:6393`). It accepts any method whose key is the string `constructor`. `parse_property` (`src/js_parser/parse/parse_property.rs:47`) and `visit_class` (`src/js_parser/visit/mod.rs:920`) both exclude static and computed keys. The parse-time error "TypeScript does not allow decorators on class constructors" (`src/js_parser/parse/mod.rs:229`) has the same key-only lookup, so `@dec static constructor() {}` was rejected.

### Fix
- `lower_class` and the parse-time error check skip static and computed keys. `static constructor()` and `["constructor"]()` are ordinary methods in JavaScript.
- With no real constructor found, the existing code path synthesizes one and puts the decorated field initializers there. No `design:paramtypes` is emitted, which is what tsc does for a class without a constructor. A decorator or parameter decorator on the static method receives `(A, "constructor", ...)`, like on any other static method.
- The transpiler cache version goes from 27 to 28. The lowering output changes for the same input, so entries written by an older build are stale.
- Verified: `test/bundler/transpiler/decorators.test.ts` (two new cases) and `test/bundler/transpiler/decorator-metadata.test.ts` (one new case), all fail on the released bun. Also `ts-use-define-for-class-fields.test.ts`, `es-decorators.test.ts`, `es-decorators-esbuild.test.ts`, `test/bundler/esbuild/ts.test.ts`, `transpiler.test.js`, `bundler_decorator_metadata.test.ts`, `test/cli/run/transpiler-cache.test.ts`.

### Background
- `lower_class` runs after `visit_class`. For TypeScript legacy decorators it moves decorated field initializers into the constructor and emits the `__legacyDecorateClassTS` calls after the class. It synthesizes a constructor when the class has none.
- `design:paramtypes` is the `Reflect.metadata` entry that records the constructor parameter types. Dependency injection frameworks read it. tsc emits it only when the class has a constructor with a body.
- In JavaScript, a class element is the constructor only when its name is the non-computed property name `constructor` and it is not static. `static constructor() {}` is a static method that shadows `Function.prototype.constructor` on the class.
- The runtime transpiler cache stores transpiled output on disk, keyed by source hash, parser options, and `EXPECTED_VERSION`. A new version makes every older entry a miss.

<details><summary>Notes</summary>

Repro, with `{ "compilerOptions": { "experimentalDecorators": true, "emitDecoratorMetadata": true } }`:

```ts
function Dec(): any { return () => {}; }
class Dep {}
@Dec() class A {
  @Dec() x = 1;
  static constructor(d: Dep) { return "static"; }
}
console.log(JSON.stringify({ x: new A().x }));
```

Before: `{}`. After: `{"x":1}`. The bundle before had `static constructor(d) { this.x = 1; return "static"; }` and `__legacyMetadataTS("design:paramtypes", [Object])`. After it has `constructor() { this.x = 1; }` next to the untouched static method, and no `design:paramtypes`.

TypeScript itself rejects `static constructor` with TS2699, so tsc has no reference output for this input. The JavaScript semantics are the reference. The parse pass already uses them: it decides `is_constructor` for `super()` and parameter properties with the same static and computed checks. `@dec ["constructor"]() {}` is valid TypeScript and tsc emits `__decorate([dec], A.prototype, "constructor", null)` for it. Bun rejected it before this change.

The cache version bump came out of testing. A release build of the first commit read the `decorators.test.ts` output that an unfixed release build had written to `~/.bun/install/cache/@t@/` moments earlier, and the new test failed on the fixed binary until the cache was disabled. A user who upgrades would see the same stale output for any cached file with this pattern.

The standard (TC39) decorator lowering in `src/js_parser/lower/lower_decorators.rs` has the same lookup. #40833 changes that code and adds the same exclusion there, so this PR leaves it alone.

Found while testing, not changed here: a method that has parameter decorators but no method decorator gets `design:returntype` `Object` instead of its annotated return type. tsc emits the annotated type. `parse_fn` only reads the return type metadata when the method itself is decorated.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/decorator-metadata.test.ts test/bundler/transpiler/decorators.test.ts
bun test v1.4.1 (d578a8c70)

test/bundler/transpiler/decorators.test.ts:
(pass) decorator order of evaluation [55.66ms]
(pass) decorator factories order of evaluation [38.65ms]
(pass) parameter decorators [29.92ms]
(pass) decorators random [64.90ms]
(pass) class field order [8.34ms]
(pass) changing static method [9.66ms]
(pass) class extending from another class [15.51ms]
(pass) decorated fields moving to constructor [9.51ms]
726 |     static constructor() {
727 |       return "static B";
728 |     }
729 |   }
730 | 
731 |   expect(new A().x).toBe(1);
                          ^
error: expect(received).toBe(expected)

Expected: 1
Received: undefined

      at <anonymous> (/workspace/bun/test/bundler/transpiler/decorators.test.ts:731:21)
(fail) static method named 'constructor' is not treated as the constructor [13.35ms]
774 |     env: bunEnv,
775 |     cwd: String(dir),
776 |     stderr: "pipe",
777 |   });
778 |   const [stdout, stderr, exitC
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (979a89962)

test/bundler/transpiler/decorators.test.ts:
(pass) decorator order of evaluation [0.39ms]
(pass) decorator factories order of evaluation [0.34ms]
(pass) parameter decorators [0.32ms]
(pass) decorators random [0.73ms]
(pass) class field order [0.09ms]
(pass) changing static method [0.10ms]
(pass) class extending from another class [0.14ms]
(pass) decorated fields moving to constructor [0.11ms]
(pass) static method named 'constructor' is not treated as the constructor [0.19ms]
774 |     env: bunEnv,
775 |     cwd: String(dir),
776 |     stderr: "pipe",
777 |   });
778 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
779 |   expect(stderr).toBe("");
                       ^
error: expect(received).toBe(expected)

- ""
+ "8 |         @dec static constructor() { return "static"; }
+             ^
+ error: TypeScript does not allow decorators on class constructors
+     at /tmp/decorators-static-ctor-key_5tbGel/index.ts:8:9
+ 
+ 9 |         @dec ["constructor"]() { return "proto"; }
+             ^
+ error: TypeScript does not allow decorators on class constructors
+     
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/decorator-metadata.test.ts test/bundler/transpiler/decorators.test.ts
bun test v1.4.1 (d578a8c70)

test/bundler/transpiler/decorators.test.ts:
(pass) decorator order of evaluation [56.25ms]
(pass) decorator factories order of evaluation [38.67ms]
(pass) parameter decorators [30.46ms]
(pass) decorators random [63.79ms]
(pass) class field order [8.17ms]
(pass) changing static method [9.73ms]
(pass) class extending from another class [15.46ms]
(pass) decorated fields moving to constructor [9.48ms]
(pass) static method named 'constructor' is not treated as the constructor [16.10ms]
(pass) decorators on a static or computed 'constructor' key decorate an ordinary method [327.83ms]
(pass) only class decorator [4.71ms]
(pass) decorators with different property key types [11.64ms]
(pass) only property decorators [10.73ms]
(pass) only argument decorators [5.21ms]
(pass) no decorators [4.25ms]
(pass) constructor statements > with parameter properties [11.89ms]
(pass) constructor statements > class expressions (no decorator
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 578ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_js
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                                 |  6 +-
 src/js_parser/parse/mod.rs                         |  6 +-
 src/jsc/RuntimeTranspilerCache.rs                  |  4 +-
 test/bundler/transpiler/decorator-metadata.test.ts | 20 +++++
 test/bundler/transpiler/decorators.test.ts         | 92 +++++++++++++++++++++-
 5 files changed, 124 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js_parser/p.rs                                      3      3      0
src/js_parser/parse/mod.rs                              2      3      0
src/jsc/RuntimeTranspilerCache.rs                       2      1      0
test/bundler/transpiler/decorator-metadata.test.ts      1      2      0
test/bundler/transpiler/decorators.test.ts              2      7      0
```

</details>

<!-- robobun:evidence:end -->