### PR TITLE
bundler: keep an ES module strict in cjs and iife output

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -353,6 +353,61 @@ impl<'a> LinkerContext<'a> {
                 .is_entry_point()
     }
 
+    /// The parser's verdict on a file: `ExplicitStrictMode` for a `"use strict"`
+    /// directive, an implicit kind for ES module syntax (`import`, `export`,
+    /// top-level `await`), `SloppyMode` otherwise.
+    fn module_strict_mode(&self, source_index: usize) -> bun_ast::StrictModeKind {
+        self.graph.ast.items_module_scope()[source_index].strict_mode
+    }
+
+    /// A file whose code is strict, or that has no code of its own to be sloppy
+    /// with: the runtime helpers (strict-safe, they run strict in esm output)
+    /// and data loaders such as JSON, whose code the bundler generates.
+    fn file_is_strict(&self, source_index: usize) -> bool {
+        source_index == Index::RUNTIME.value() as usize
+            || !self.parse_graph().input_files.items_loader()[source_index].is_javascript_like()
+            || self.module_strict_mode(source_index) != bun_ast::StrictModeKind::SloppyMode
+    }
+
+    /// Whether a wrapped file needs a `"use strict"` directive at the top of its
+    /// `__commonJS` or `__esm` closure body. The esm output is a module and is
+    /// strict already. The cjs and iife outputs are a CommonJS module and a
+    /// script: sloppy unless a directive says otherwise, so a strict file's code
+    /// keeps its strictness only through a directive in the closure.
+    pub(crate) fn wrapper_needs_use_strict(&self, source_index: usize) -> bool {
+        matches!(self.options.output_format, Format::Cjs | Format::Iife)
+            && self.module_strict_mode(source_index) != bun_ast::StrictModeKind::SloppyMode
+    }
+
+    /// Whether an entry point chunk needs a `"use strict"` directive at its top.
+    /// The entry point's statements are the chunk's top-level statements, so
+    /// the chunk's strictness is the entry point's. A directive the entry file
+    /// spelled out always applies to the output, as in esbuild. An ES module
+    /// entry file is strict with no directive to copy. Every other file in the
+    /// chunk is printed into the same scope, so its code is made strict only
+    /// when all of them are strict too: a sloppy CommonJS file must not turn
+    /// strict because of a directive it did not write.
+    pub(crate) fn entry_chunk_needs_use_strict(&self, chunk: &Chunk) -> bool {
+        let entry_strict_mode = self.module_strict_mode(chunk.entry_point.source_index() as usize);
+        match self.options.output_format {
+            Format::Esm => false,
+            // The dev server wraps every module in its own closure. A chunk-level
+            // directive would apply to all of them, so only a spelled-out one is kept.
+            Format::InternalBakeDev => {
+                entry_strict_mode == bun_ast::StrictModeKind::ExplicitStrictMode
+            }
+            Format::Cjs | Format::Iife => match entry_strict_mode {
+                bun_ast::StrictModeKind::SloppyMode => false,
+                bun_ast::StrictModeKind::ExplicitStrictMode => true,
+                _ => chunk
+                    .files_with_parts_in_chunk
+                    .keys()
+                    .iter()
+                    .all(|&source_index| self.file_is_strict(source_index as usize)),
+            },
+        }
+    }
+
     /// `"sideEffects": false` (or the resolver's equivalent), unless
     /// `--ignore-dce-annotations` says not to trust it.
     pub(crate) fn file_has_no_side_effects(&self, source_index: u32) -> bool {
@@ -4285,6 +4340,14 @@ impl InsideWrapperPrefix {
     pub(crate) fn append_non_dependency_slice(&mut self, stmts: &[Stmt]) -> Result<(), AllocError> {
         self.stmts.extend_from_slice(stmts);
         Ok(())
+    }
+
+    /// A directive is only a directive as the first statement of the wrapper
+    /// body, so it goes ahead of the `init_*()` dependency calls, which are
+    /// inserted at `sync_dependencies_end`.
+    pub(crate) fn append_directive(&mut self, stmt: Stmt) {
+        self.stmts.insert(0, stmt);
+        self.sync_dependencies_end += 1;
     }
 
     fn append_sync_dependency(&mut self, call_expr: Expr) -> Result<(), AllocError> {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -353,46 +353,30 @@ impl<'a> LinkerContext<'a> {
                 .is_entry_point()
     }
 
-    /// The parser's verdict on a file: `ExplicitStrictMode` for a `"use strict"`
-    /// directive, an implicit kind for ES module syntax (`import`, `export`,
-    /// top-level `await`), `SloppyMode` otherwise.
     fn module_strict_mode(&self, source_index: usize) -> bun_ast::StrictModeKind {
         self.graph.ast.items_module_scope()[source_index].strict_mode
     }
 
-    /// A file whose code is strict, or that has no code of its own to be sloppy
-    /// with: the runtime helpers (strict-safe, they run strict in esm output)
-    /// and data loaders such as JSON, whose code the bundler generates.
+    /// The runtime helpers and data loaders such as JSON have no code of their own to be sloppy.
     fn file_is_strict(&self, source_index: usize) -> bool {
         source_index == Index::RUNTIME.value() as usize
             || !self.parse_graph().input_files.items_loader()[source_index].is_javascript_like()
             || self.module_strict_mode(source_index) != bun_ast::StrictModeKind::SloppyMode
     }
 
-    /// Whether a wrapped file needs a `"use strict"` directive at the top of its
-    /// `__commonJS` or `__esm` closure body. The esm output is a module and is
-    /// strict already. The cjs and iife outputs are a CommonJS module and a
-    /// script: sloppy unless a directive says otherwise, so a strict file's code
-    /// keeps its strictness only through a directive in the closure.
+    /// Strict code in a `__commonJS` or `__esm` closure needs its own directive in cjs and iife output.
     pub(crate) fn wrapper_needs_use_strict(&self, source_index: usize) -> bool {
         matches!(self.options.output_format, Format::Cjs | Format::Iife)
             && self.module_strict_mode(source_index) != bun_ast::StrictModeKind::SloppyMode
     }
 
-    /// Whether an entry point chunk needs a `"use strict"` directive at its top.
-    /// The entry point's statements are the chunk's top-level statements, so
-    /// the chunk's strictness is the entry point's. A directive the entry file
-    /// spelled out always applies to the output, as in esbuild. An ES module
-    /// entry file is strict with no directive to copy. Every other file in the
-    /// chunk is printed into the same scope, so its code is made strict only
-    /// when all of them are strict too: a sloppy CommonJS file must not turn
-    /// strict because of a directive it did not write.
+    /// A chunk-top directive applies to every file in the chunk, so an ES module entry point
+    /// gets one only when all of them are strict. A spelled-out entry directive applies as before.
     pub(crate) fn entry_chunk_needs_use_strict(&self, chunk: &Chunk) -> bool {
         let entry_strict_mode = self.module_strict_mode(chunk.entry_point.source_index() as usize);
         match self.options.output_format {
             Format::Esm => false,
-            // The dev server wraps every module in its own closure. A chunk-level
-            // directive would apply to all of them, so only a spelled-out one is kept.
+            // The dev server's module closures share the chunk, so only a spelled-out directive is kept.
             Format::InternalBakeDev => {
                 entry_strict_mode == bun_ast::StrictModeKind::ExplicitStrictMode
             }
@@ -4342,9 +4326,7 @@ impl InsideWrapperPrefix {
         Ok(())
     }
 
-    /// A directive is only a directive as the first statement of the wrapper
-    /// body, so it goes ahead of the `init_*()` dependency calls, which are
-    /// inserted at `sync_dependencies_end`.
+    /// Inserted first: a directive has to precede the `init_*()` calls added at `sync_dependencies_end`.
     pub(crate) fn append_directive(&mut self, stmt: Stmt) {
         self.stmts.insert(0, stmt);
         self.sync_dependencies_end += 1;

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -370,8 +370,7 @@ impl<'a> LinkerContext<'a> {
             && self.module_strict_mode(source_index) != bun_ast::StrictModeKind::SloppyMode
     }
 
-    /// A chunk-top directive applies to every file in the chunk, so an ES module entry point
-    /// gets one only when all of them are strict. A spelled-out entry directive applies as before.
+    /// An ES module entry point gets the chunk-top directive only when every file in the chunk is strict.
     pub(crate) fn entry_chunk_needs_use_strict(&self, chunk: &Chunk) -> bool {
         let entry_strict_mode = self.module_strict_mode(chunk.entry_point.source_index() as usize);
         match self.options.output_format {

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -252,11 +252,12 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         u32::MAX
     };
 
-    // The chunk's own entry point gets the directive at the chunk top instead (`post_process_js_chunk`).
-    let is_chunk_entry_point =
-        chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
+    // Skipped when the chunk top carries the directive for this file (`post_process_js_chunk`).
+    let covered_by_chunk_top = chunk.is_entry_point()
+        && chunk.entry_point.source_index() as usize == source_index
+        && c.entry_chunk_needs_use_strict(chunk);
     if flags.wrap != WrapKind::None
-        && !is_chunk_entry_point
+        && !covered_by_chunk_top
         && c.wrapper_needs_use_strict(source_index)
     {
         stmts.inside_wrapper_prefix.append_directive(Stmt::alloc(

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -252,10 +252,13 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         u32::MAX
     };
 
-    // The top-level directive must come first (the non-wrapped case is handled
-    // by the chunk generation code, although only for the entry point)
+    // The top-level directive must come first. The chunk's own entry point gets
+    // it at the top of the chunk instead (`post_process_js_chunk`). A file that
+    // is an entry point of another chunk is an ordinary dependency here.
+    let is_chunk_entry_point =
+        chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
     if flags.wrap != WrapKind::None
-        && !c.graph.files.items_entry_point_kind()[source_index].is_entry_point()
+        && !is_chunk_entry_point
         && c.wrapper_needs_use_strict(source_index)
     {
         stmts.inside_wrapper_prefix.append_directive(Stmt::alloc(

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -252,26 +252,18 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         u32::MAX
     };
 
-    let output_format = c.options.output_format;
-
     // The top-level directive must come first (the non-wrapped case is handled
     // by the chunk generation code, although only for the entry point)
     if flags.wrap != WrapKind::None
-        && ast
-            .flags
-            .contains(AstFlags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
-        && !chunk.is_entry_point()
-        && !output_format.is_always_strict_mode()
+        && !c.graph.files.items_entry_point_kind()[source_index].is_entry_point()
+        && c.wrapper_needs_use_strict(source_index)
     {
-        stmts
-            .inside_wrapper_prefix
-            .append_non_dependency(Stmt::alloc(
-                S::Directive {
-                    value: bun_ast::StoreStr::new(b"use strict"),
-                },
-                bun_ast::Loc::EMPTY,
-            ))
-            .expect("unreachable");
+        stmts.inside_wrapper_prefix.append_directive(Stmt::alloc(
+            S::Directive {
+                value: bun_ast::StoreStr::new(b"use strict"),
+            },
+            bun_ast::Loc::EMPTY,
+        ));
     }
 
     // `convert_stmts_for_chunk` takes `&mut c` inside the loop body, so capture
@@ -779,6 +771,15 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                         // resized in this loop; `end <= i < len`.
                         inner_stmts.slice_mut()[end] = transformed;
                         end += 1;
+                    }
+                    // Directives alone are not a body. Everything else was hoisted,
+                    // so the closure stays empty, as the parser assumed when it
+                    // allocated no wrapper symbol (`needs_wrapper_ref`).
+                    if inner_stmts.slice()[..end]
+                        .iter()
+                        .all(|stmt| matches!(stmt.data, StmtData::SDirective(_)))
+                    {
+                        end = 0;
                     }
                     inner_stmts.truncate(end);
                 }

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -252,9 +252,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         u32::MAX
     };
 
-    // The top-level directive must come first. The chunk's own entry point gets
-    // it at the top of the chunk instead (`post_process_js_chunk`). A file that
-    // is an entry point of another chunk is an ordinary dependency here.
+    // The chunk's own entry point gets the directive at the chunk top instead (`post_process_js_chunk`).
     let is_chunk_entry_point =
         chunk.is_entry_point() && chunk.entry_point.source_index() as usize == source_index;
     if flags.wrap != WrapKind::None
@@ -775,9 +773,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                         inner_stmts.slice_mut()[end] = transformed;
                         end += 1;
                     }
-                    // Directives alone are not a body. Everything else was hoisted,
-                    // so the closure stays empty, as the parser assumed when it
-                    // allocated no wrapper symbol (`needs_wrapper_ref`).
+                    // A closure with only directives stays empty: `needs_wrapper_ref` allocated no symbol for it.
                     if inner_stmts.slice()[..end]
                         .iter()
                         .all(|stmt| matches!(stmt.data, StmtData::SDirective(_)))

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -410,9 +410,7 @@ pub(crate) fn post_process_js_chunk(
         newline_before_comment = true;
     }
 
-    // Add the top-level "use strict" directive (see `entry_chunk_needs_use_strict`).
-    // For iife it goes inside the wrapper below, so that it does not apply to
-    // other scripts the output is concatenated with.
+    // For iife the directive goes inside the wrapper below, so it does not leak into concatenated scripts.
     let use_strict_directive = chunk.is_entry_point() && c.entry_chunk_needs_use_strict(chunk);
     if use_strict_directive && output_format != options::OutputFormat::Iife {
         j.push_static(b"\"use strict\";\n");

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -410,16 +410,14 @@ pub(crate) fn post_process_js_chunk(
         newline_before_comment = true;
     }
 
-    // Add the top-level directive if present (but omit "use strict" in ES
-    // modules because all ES modules are automatically in strict mode)
-    if chunk.is_entry_point() && !output_format.is_always_strict_mode() {
-        let flags = c.graph.ast.items_flags()[chunk.entry_point.source_index() as usize];
-
-        if flags.contains(crate::bundled_ast::Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE) {
-            j.push_static(b"\"use strict\";\n");
-            line_offset.advance(b"\"use strict\";\n");
-            newline_before_comment = true;
-        }
+    // Add the top-level "use strict" directive (see `entry_chunk_needs_use_strict`).
+    // For iife it goes inside the wrapper below, so that it does not apply to
+    // other scripts the output is concatenated with.
+    let use_strict_directive = chunk.is_entry_point() && c.entry_chunk_needs_use_strict(chunk);
+    if use_strict_directive && output_format != options::OutputFormat::Iife {
+        j.push_static(b"\"use strict\";\n");
+        line_offset.advance(b"\"use strict\";\n");
+        newline_before_comment = true;
     }
 
     // For Kit, hoist runtime.js outside of the IIFE
@@ -447,13 +445,15 @@ pub(crate) fn post_process_js_chunk(
         }
         options::OutputFormat::Iife => {
             // Bun does not do arrow function lowering. So the wrapper can be an arrow.
-            let start: &[u8] = if c.options.minify_whitespace {
-                b"(()=>{"
-            } else {
-                b"(() => {\n"
+            let start: &[u8] = match (c.options.minify_whitespace, use_strict_directive) {
+                (true, false) => b"(()=>{",
+                (true, true) => b"(()=>{\"use strict\";",
+                (false, false) => b"(() => {\n",
+                (false, true) => b"(() => {\n  \"use strict\";\n",
             };
             j.push_static(start);
             line_offset.advance(start);
+            newline_before_comment |= use_strict_directive;
         }
         _ => {} // no wrapper
     }

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -460,10 +460,10 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "52c1e0868de8da5d8bf4b89d68afbd027f3c64fdce490cd46800674b0de3f0c1",
+          "js": "7cf9dd3d8bc03517a212eed923d3d3f8d856d53cd6d7fd915af776f50e645dd3",
           "jsc": {
-            "bytes": 1999232,
-            "sha256": "a6043ef5e8aaae25c9581e6802fc2508f0b7b2fb0681be536768f9d09ef4cac6",
+            "bytes": 2004632,
+            "sha256": "3bf715e72f2789878902f0d3bbaa6668d6f6fd0627cc15415ed16ee24235a6b5",
           },
         },
         "bun build --bytecode --minify features.js": {
@@ -481,17 +481,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode acorn/dist/acorn.mjs": {
-          "js": "2ed858fa1b38a20673cee13a857ccdaedb9da0a325ebc47e81c4851de77eef3c",
+          "js": "481e1c346358dc5c4d1f901ade95ecc569b8206e4394e070891ebb32e2c75d16",
           "jsc": {
-            "bytes": 266176,
-            "sha256": "9fec89f154cf2ae1593f52d49bb3ba6bae0634a56e4cc8fe76aabf6abb70bfe1",
+            "bytes": 266776,
+            "sha256": "02f137aae885055b35965959836f8bf0af1fa3cb2b69665fe2af91b4fa38a497",
           },
         },
         "bun build --bytecode all.js": {
-          "js": "46d723ea07e5e2d8db673a51fec52b3248edcd3e216029f243d8172244f7cd2c",
+          "js": "73f27a1414b26406c14a9d4c95cc8a5eb7271fad3792bfc020d39df02e7cf907",
           "jsc": {
-            "bytes": 2178792,
-            "sha256": "c5d1eaae5c4d198b1f8e0d768bb41502162081c75b67249032e66a2b95e26ec1",
+            "bytes": 2184416,
+            "sha256": "3d1f952144dcd37335b757b12b5a8cfa9497ad7d14cc8fbe37ff9cf5f822b088",
           },
         },
         "bun build --bytecode big.js": {
@@ -509,24 +509,24 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode happy-dom/lib/index.js": {
-          "js": "148f0d3e4baf485281725f859deb3e717a6da25a4a08de9af288d5ef54b6414b",
+          "js": "4172eb9d6db4c3f4d5eb2a5c009ba90f7db27530bdd032414b0c46fe0298bc96",
           "jsc": {
-            "bytes": 2528840,
-            "sha256": "d68b260282a74f545c15b5a3b812b69cb4e828972f85c5de60f8307b73c43e57",
+            "bytes": 2531968,
+            "sha256": "625cc4e89f74a2e82e62494501f2c3f889c3cb082a23692354a894603978acef",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
-          "js": "c9a2ba9f6b6a662e6bdfd44128bc66284276f5eac2a8875adb4578472328dc9f",
+          "js": "cab5a3ef2865aa8ee9518ac4082265b9cc1ce0ee5d2421b4ef53cbabf7a3e63d",
           "jsc": {
-            "bytes": 280016,
-            "sha256": "2a99c33a2516e2d41187bc322ddd4523318530b51c60c3d9a8bd566d4f2929a1",
+            "bytes": 281512,
+            "sha256": "d77950ed20795e6303e5f56d17a470ede464f8870a00aa74bb0e2b0a87708e97",
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "e685164a8316f60b665bc3d47e42b4623cfe7385f87310e655478a50ecd8f959",
+          "js": "96964ca12b5189cb7354e591f9c1ed2506357e9bf4201b6592d8b1fb487ef892",
           "jsc": {
-            "bytes": 23806352,
-            "sha256": "5f23309532d868e1c985d568207c92b77a7f3974e5c6c3f37b21accf7d429327",
+            "bytes": 23874600,
+            "sha256": "26e62f3ff317ff64680bc2ae9c2cd01e9f0558106d97ef938cd9ecfa2d9c6bd2",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -537,10 +537,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {
-          "js": "e2cf34c8eb6f5952a33ca91e3949b28786349cf97ea3fbf0b3b8500dbccd4860",
+          "js": "54451a126f78d48cafb01c7c3e9e459bf0f2821d084ed15d29adccfdf2d06875",
           "jsc": {
-            "bytes": 980080,
-            "sha256": "32fa8492ad9fdf3ea31395756898d556df9dc6bdfbac9bba07bcafa748ab38ca",
+            "bytes": 980088,
+            "sha256": "56e259fd06b1fba8ed7dcc1aef8d785a39b4190e45a67479851932c6bbef3b9a",
           },
         },
         "bun build --bytecode records.js": {
@@ -565,10 +565,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode undici/index.js": {
-          "js": "d0bd3791e7c8f77a06814429d5d95cb26a06baaa3c135502bcd3e984310f1d2c",
+          "js": "7ebc1a93fd924da1107ea2c12bc0a684686717fb6e382ba90d34bd3f1a9062c3",
           "jsc": {
-            "bytes": 937000,
-            "sha256": "d7cff4df84668b14987703bcd950a6753a574cf48e4372e4fe8779f747c0ed89",
+            "bytes": 937032,
+            "sha256": "ecb2f5eb5472bd2fbd8ab08cf64494afa66a5cb74f352cb26c543f0a32b96a79",
           },
         },
         "vm.Script big.js": {

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -924,4 +924,32 @@ describe("bundler", () => {
       { runtime: "node", file: "/out/b.js", stdout: "" },
     ],
   });
+
+  // An ES module entry point that a sloppy dependency requires back is wrapped
+  // in __esm. The sloppy file keeps the chunk top free of a directive, so the
+  // entry point's closure carries its own.
+  itBundled("cjs/StrictModeWrappedESMEntryWithSloppyDepFormatCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import dep from "./sloppy-dep.cjs";
+        export const strict = (function () { return this === undefined; })();
+        console.log("entry", strict, "dep", dep);
+      `,
+      "/sloppy-dep.cjs": /* js */ `
+        module.exports = (function () { return this === undefined; })();
+        require("./entry.js");
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toStartWith('"use strict"');
+      expect(out).toContain('__esm(() => {\n  "use strict";\n');
+    },
+    run: {
+      runtime: "node",
+      stdout: "entry true dep false",
+    },
+  });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
 
 // Tests for CommonJS <> ESM interop, specifically the __toESM helper behavior.
@@ -595,6 +595,301 @@ describe("bundler", () => {
     format: "cjs",
     run: {
       stdout: "loaded ok",
+    },
+  });
+
+  // ============================================================================
+  // An ES module is strict by construction. The cjs and iife outputs are a
+  // CommonJS module and a script, so they need a "use strict" directive for the
+  // module's code to stay strict. The esm output is a module and needs none.
+  // The chunk-top directive applies to every file in the chunk, so an ES module
+  // entry point gets one only when every other file in the chunk is strict too.
+  // ============================================================================
+
+  // Prints "true ReferenceError" in strict mode, "false assigned" in sloppy mode.
+  const strictProbe = /* js */ `
+    function thisIsUndefined() { return this === undefined; }
+    function assignUndeclared() {
+      try { undeclaredStrictProbe = 1; return "assigned"; } catch (e) { return e.constructor.name; }
+    }
+    console.log(thisIsUndefined(), assignUndeclared());
+  `;
+
+  itBundled("cjs/StrictModeESMEntryFormatCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        export {};
+        ${strictProbe}
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('"use strict";\n');
+    },
+    run: {
+      stdout: "true ReferenceError",
+    },
+  });
+
+  itBundled("cjs/StrictModeESMEntryFormatCJSTargetBun", {
+    files: {
+      "/entry.js": /* js */ `
+        import { value } from "./dep.js";
+        console.log(value);
+        ${strictProbe}
+      `,
+      "/dep.js": /* js */ `export const value = "dep";`,
+    },
+    target: "bun",
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith(
+        '// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {"use strict";\n',
+      );
+    },
+    run: {
+      stdout: "dep\ntrue ReferenceError",
+    },
+  });
+
+  // A sloppy CommonJS dependency must not turn strict because of a directive it
+  // did not write. The chunk stays sloppy, which also leaves the entry point's
+  // own code sloppy: the same trade-off esbuild makes.
+  itBundled("cjs/StrictModeESMEntryWithSloppyDepFormatCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import dep from "./sloppy-dep.cjs";
+        console.log("dep", dep, "entry", (function () { return this === undefined; })());
+      `,
+      "/sloppy-dep.cjs": /* js */ `
+        var scope = { fromWith: "with works" };
+        with (scope) module.exports = fromWith;
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("use strict");
+    },
+    run: {
+      stdout: "dep with works entry false",
+    },
+  });
+
+  // A CommonJS dependency with its own "use strict" is strict, so the chunk is.
+  itBundled("cjs/StrictModeESMEntryWithStrictDepFormatCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import dep from "./strict-dep.cjs";
+        console.log("dep", dep, "entry", (function () { return this === undefined; })());
+      `,
+      "/strict-dep.cjs": /* js */ `
+        "use strict";
+        module.exports = (function () { return this === undefined; })();
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('"use strict";\n');
+    },
+    run: {
+      stdout: "dep true entry true",
+    },
+  });
+
+  // Data files have no code of their own to be sloppy with.
+  itBundled("cjs/StrictModeESMEntryWithJSONFormatCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import data from "./data.json";
+        console.log(data.name, (function () { return this === undefined; })());
+      `,
+      "/data.json": `{ "name": "json" }`,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('"use strict";\n');
+    },
+    run: {
+      stdout: "json true",
+    },
+  });
+
+  // A directive the entry point spelled out applies to the whole output, with
+  // or without sloppy dependencies, as in esbuild and in earlier bun versions.
+  itBundled("cjs/StrictModeDirectiveEntryWithSloppyDepFormatCJS", {
+    files: {
+      "/entry.cjs": /* js */ `
+        "use strict";
+        console.log(require("./sloppy-dep.cjs"));
+      `,
+      "/sloppy-dep.cjs": /* js */ `
+        module.exports = "ok";
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('"use strict";\n');
+    },
+    run: {
+      stdout: "ok",
+    },
+  });
+
+  itBundled("cjs/StrictModeESMEntryBytecode", {
+    files: {
+      "/entry.js": /* js */ `
+        export {};
+        ${strictProbe}
+      `,
+    },
+    bytecode: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toStartWith(
+        '// @bun @bytecode @bun-cjs\n(function(exports, require, module, __filename, __dirname) {"use strict";\n',
+      );
+    },
+    run: {
+      stdout: "true ReferenceError",
+    },
+  });
+
+  itBundled("cjs/StrictModeESMEntryFormatIIFE", {
+    files: {
+      "/entry.js": /* js */ `
+        export {};
+        ${strictProbe}
+      `,
+    },
+    target: "browser",
+    format: "iife",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('(() => {\n  "use strict";\n');
+    },
+    run: {
+      stdout: "true ReferenceError",
+    },
+  });
+
+  itBundled("cjs/StrictModeESMEntryFormatIIFEMinified", {
+    files: {
+      "/entry.js": /* js */ `
+        export {};
+        ${strictProbe}
+      `,
+    },
+    target: "browser",
+    format: "iife",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('(()=>{"use strict";');
+    },
+    run: {
+      stdout: "true ReferenceError",
+    },
+  });
+
+  itBundled("cjs/StrictModeESMEntryFormatESMHasNoDirective", {
+    files: {
+      "/entry.js": /* js */ `
+        export {};
+        ${strictProbe}
+      `,
+    },
+    target: "node",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("use strict");
+    },
+    run: {
+      stdout: "true ReferenceError",
+    },
+  });
+
+  // A sloppy CommonJS entry point stays sloppy: `with` is only valid there, and
+  // the ES module it requires runs strict inside its own __esm wrapper. These
+  // two run under node because bun's runtime transpiler drops a directive that
+  // is inside a function body.
+  itBundled("cjs/StrictModeESMRequiredFromSloppyEntryFormatCJS", {
+    files: {
+      "/entry.cjs": /* js */ `
+        var scope = { fromWith: "with works" };
+        with (scope) console.log(fromWith);
+        console.log("entry", (function () { return this === undefined; })());
+        const esm = require("./esm.mjs");
+        console.log("esm", esm.strict);
+      `,
+      "/esm.mjs": /* js */ `
+        console.log("esm evaluated");
+        export const strict = (function () { return this === undefined; })();
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toStartWith('"use strict"');
+      expect(out).toContain('__esm(() => {\n  "use strict";\n');
+    },
+    run: {
+      runtime: "node",
+      stdout: "with works\nentry false\nesm evaluated\nesm true",
+    },
+  });
+
+  // An ES module whose statements are all hoisted out of the __esm closure gets
+  // no closure, so there is nothing to put a directive in.
+  itBundled("cjs/StrictModeESMDeclarationsOnlyRequiredFromSloppyEntryFormatCJS", {
+    files: {
+      "/entry.cjs": /* js */ `
+        const esm = require("./esm.mjs");
+        console.log(esm.value, esm.fn());
+      `,
+      "/esm.mjs": /* js */ `
+        export const value = "value";
+        export function fn() { return "fn"; }
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toContain("use strict");
+      expect(out).not.toContain("__esm(");
+    },
+    run: {
+      stdout: "value fn",
+    },
+  });
+
+  // The directive of a required CommonJS file goes inside its __commonJS wrapper,
+  // also when that file shares the chunk with the entry point.
+  itBundled("cjs/StrictModeDirectiveRequiredFromSloppyEntryFormatCJS", {
+    files: {
+      "/entry.cjs": /* js */ `
+        console.log("entry", (function () { return this === undefined; })());
+        console.log("dep", require("./dep.cjs"));
+      `,
+      "/dep.cjs": /* js */ `
+        "use strict";
+        module.exports = (function () { return this === undefined; })();
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toStartWith('"use strict"');
+      expect(out).toMatch(/__commonJS\(function\([^)]*\) \{\n  "use strict";\n/);
+    },
+    run: {
+      runtime: "node",
+      stdout: "entry false\ndep true",
     },
   });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -892,4 +892,36 @@ describe("bundler", () => {
       stdout: "entry false\ndep true",
     },
   });
+
+  // A required file that is also an entry point of its own is an ordinary
+  // dependency in the other entry point's chunk, so its directive goes inside
+  // its wrapper there. In its own chunk the directive is at the top.
+  itBundled("cjs/StrictModeDirectiveDepIsAnotherEntryPointFormatCJS", {
+    files: {
+      "/a.js": /* js */ `
+        console.log("a", (function () { return this === undefined; })());
+        console.log("b", require("./b.js"));
+      `,
+      "/b.js": /* js */ `
+        "use strict";
+        module.exports = (function () { return this === undefined; })();
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    outdir: "/out",
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      const a = api.readFile("/out/a.js");
+      expect(a).not.toStartWith('"use strict"');
+      expect(a).toMatch(/__commonJS\(function\([^)]*\) \{\n  "use strict";\n/);
+      const b = api.readFile("/out/b.js");
+      expect(b).toStartWith('"use strict";\n');
+      expect(b).not.toMatch(/__commonJS\(function\([^)]*\) \{\n  "use strict";\n/);
+    },
+    run: [
+      { runtime: "node", file: "/out/a.js", stdout: "a false\nb true" },
+      { runtime: "node", file: "/out/b.js", stdout: "" },
+    ],
+  });
 });


### PR DESCRIPTION
### Problem
- `bun build --format=cjs` (what `--bytecode` selects) and `--format=iife` print an ES module entry point with no `"use strict"`. Its code runs sloppy: `undeclared = 1` creates a global, `this` in a plain call is `globalThis`. Unbundled, and in esm output, it runs strict.
- Cause: `postProcessJSChunk.rs:415` emits the directive only for a spelled-out `"use strict"` in the entry file. The wrapper directive at `generateCodeForFileInChunkJS.rs:259` tests the chunk, not the file, so a required CommonJS file lost its directive in every single-chunk build.

### Fix
- `entry_chunk_needs_use_strict`: in cjs and iife output an ES module entry point gets a chunk-top `"use strict"` when every JavaScript file in the chunk is strict. A sloppy CommonJS dependency never turns strict from a directive it did not write: then the chunk stays sloppy, as in esbuild. A spelled-out entry directive applies as before.
- `wrapper_needs_use_strict`: a wrapped strict file gets `"use strict"` first in its closure, unless the chunk top already carries one for it. A closure with only directives stays empty (the parser's `needs_wrapper_ref` contract).
- For iife the directive goes inside the wrapper, as in esbuild.
- Verified: `test/bundler/bundler_cjs.test.ts` (15 new cases, 11 fail on 1.4.1), `bundler_bytecode_portable` (snapshot regenerated), 11 other bundler suites. Self-reviewed: 12 concerns, the chunk-wide rule became the all-strict rule, see Notes.

### Background
- An ES module is always strict. A CommonJS module and a classic script are sloppy unless a `"use strict"` directive starts them. The entry point's statements are the output's top-level statements, so a chunk-top directive covers every file in the chunk.
- A CommonJS file in the bundle is wrapped in `__commonJS(function(exports, module) { ... })`, a `require()`d ES module in `__esm(() => { ... })`.
- The parser sets `module_scope.strict_mode`: `ExplicitStrictMode` for a directive, an `Implicit*` kind for ES module syntax.

<details><summary>Notes</summary>

Repros, checked against bun 1.4.1 (all three print `false assigned` before and `true ReferenceError` after; `node` prints `true ReferenceError` for the cjs output):

```js
// esm.mjs
export {};
function thisIsUndefined() { return this === undefined; }
function assignUndeclared() { try { undeclared = 1; return "assigned"; } catch (e) { return e.constructor.name; } }
console.log(thisIsUndefined(), assignUndeclared());
```

1. `bun build --format=cjs --target=node esm.mjs --outfile=out.js && bun out.js`
2. `bun build --bytecode --target=bun esm.mjs --outdir=out && bun out/esm.js` (the `// @bun @bytecode @bun-cjs` wrapper now starts with `"use strict";`; the `.jsc` is a cache hit)
3. `bun build --compile --bytecode esm.mjs --outfile=exe && ./exe`

The same file with `--format=iife` now prints `(() => {\n  "use strict";\n ...`. Minified: `(()=>{"use strict";...`.

Why the all-strict rule. A chunk-top directive is chunk-wide. esbuild decided (evanw/esbuild#2264, #2381) that the choice is between false positives (a sloppy CommonJS dependency made strict: `with` becomes a `SyntaxError`, an implicit global a `ReferenceError`) and false negatives (ES module code left sloppy), and kept the directive tied to the entry file's own directive. This change takes the false negative only when a sloppy file is in the chunk, and fixes the pure case: a single-module program, an all-ESM graph, or ESM plus CommonJS files that have `"use strict"` (react, react-dom, undici, happy-dom's dependencies all do). A chunk-wide rule (strict whenever the entry is an ES module) was tried first: the 64 packages `bundler_bytecode_portable.test.ts` bundles together all load under it, but it breaks a dependency that uses `with` or an implicit global with no opt-out, so it was dropped. If bun wants the ESM code strict in a mixed chunk too, that needs either a warning plus an opt-out, or a per-module scope for the entry's code. Not decided here.

Wrapped files, `--format=cjs`, single chunk, run under node (bun's runtime transpiler drops a directive inside a function body, which #40838 fixes):

- `entry.cjs` with `with (o) ...` requires `esm.mjs` that has a side effect: the chunk has no top-level directive, `with` works, and the `__esm(() => { "use strict"; ... })` body is strict.
- `entry.cjs` requires `dep.cjs` that starts with `"use strict"`: the `__commonJS(function(exports2, module2) { "use strict"; ... })` body is strict. bun 1.4.1 dropped this directive (the chunk check), esbuild keeps it.
- `a.js` and `b.js` are both entry points, `a.js` requires `b.js` which starts with `"use strict"`: in `out/a.js` the directive is inside b's wrapper, in `out/b.js` at the top. The wrapper check compares the file with the chunk's own entry point, not with any entry point.
- `entry.js` (ES module) imports a sloppy `.cjs` file that requires it back, so the entry is wrapped in `__esm`: the chunk top has no directive (a sloppy file is in the chunk), the entry's closure has its own. The wrapper directive is skipped only when the chunk top carries one for that file.
- `entry.cjs` requires an ES module with only declarations: everything is hoisted, no `__esm` closure is printed, no directive. Without the guard a debug build hits `assertion failed: !ast.wrapper_ref.is_empty()` because the parser allocated no wrapper symbol for a file with no closure body.

Limits, kept on purpose:

- An ES module wrapped in `__esm` inside a sloppy chunk: its function declarations and movable initializers are hoisted out of the closure and stay sloppy. Only the closure body is strict. esbuild has the same shape for a spelled-out directive.
- A TypeScript file with only `import type` counts as strict, like any `import`. tsc emits `"use strict"` for such a file too.
- The dev server format is unchanged: a spelled-out directive in the entry file at the chunk top, nothing else.
- The runtime transpiler (`bun file.js`, the CommonJS wrapper in `to_ast`) is unchanged. #40838 covers directive prologues there and in the parser, and touches the same two emit sites (it adds an `append_directive` of its own). Whichever lands second needs a small rebase. #40827 covers the mirror case, a sloppy-only construct such as `with` in a file bundled to esm output.

`test/bundler/bundler_bytecode_portable.test.ts` pins the bundler output and bytecode hashes. Eight entries moved: `acorn/dist/acorn.mjs`, `immutable/dist/immutable.es.js` and `happy-dom/lib/index.js` are all-strict graphs and gain the chunk-top directive; `react-dom/cjs/react-dom.development.js`, `undici/index.js`, `libraries.js`, `all.js` and `--minify all.js` require CommonJS files that start with `'use strict'`, whose `__commonJS` wrapper bodies now keep it (4 in react-dom, 71 in undici). A `diff` of the old and new `react-dom.development.js` output is only those four `"use strict";` lines. The other entries (`features.js`, `records.js`, `big.js`, `shapes.js`, `lodash`, `svelte`, the `vm.Script` and `vm.SourceTextModule` rows) did not move. All 18 cache-load, compile and cache-miss cases in that file pass with the new output.

Self-review concerns not taken: "no user demand" (the request is a fuzz differential of `--bytecode` against the plain bundle, the strictness loss is a semantic divergence from the source); "let #40838 own both emit sites" (that PR is open, not merged, and does not synthesize a directive for ES module syntax). Not changed: `HAS_EXPLICIT_USE_STRICT_DIRECTIVE` still round-trips `Ast.directive` through `BundledAst`; the linker no longer reads it. The cjs directive keeps its trailing newline under `--minify`, as before.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->