### PR TITLE
test runner: undo a file's process.env side effects when --isolate swaps the global

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -370,6 +370,14 @@ pub struct VirtualMachine {
 #[derive(Default)]
 pub struct TestIsolationState {
     pub saved_cwd: Option<Box<[u8]>>,
+    /// The time zone the test runner applied at startup (`TZ`, default
+    /// `Etc/UTC`). Empty means no override (local time). Re-applied after
+    /// every file so a `process.env.TZ` write stays with the file that made it.
+    /// `Option` keeps the zero-initialized VM valid (a `Box` has no null niche).
+    pub time_zone: Option<Box<[u8]>>,
+    /// The proxy env keys as the env map held them at startup, restored after
+    /// every file. See [`crate::rare_data::ProxyEnvSnapshot`].
+    pub proxy_env: Option<crate::rare_data::ProxyEnvSnapshot>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -5221,6 +5229,28 @@ impl VirtualMachine {
                     hook.global_this = new_global;
                 }
             }
+        }
+
+        self.undo_process_env_side_effects();
+    }
+
+    /// The `process.env` keys with a custom setter (`applySharedEnvSideEffects`
+    /// in JSEnvironmentVariableMap.cpp) write past the env object: TZ into the
+    /// WTF time zone override, NODE_TLS_REJECT_UNAUTHORIZED and
+    /// BUN_CONFIG_VERBOSE_FETCH into per-VM caches, and the proxy keys into the
+    /// env map that seeds the next global's `process.env`. Put each back to
+    /// its startup state so a file's write does not reach the files after it.
+    fn undo_process_env_side_effects(&mut self) {
+        self.default_tls_reject_unauthorized = None;
+        self.default_verbose_fetch.set(None);
+        if let Some(tz) = self.test_isolation_state.time_zone.as_deref() {
+            let _ = self
+                .global()
+                .set_time_zone(&bun_core::EncodedSlice::from_bytes(tz));
+        }
+        if let Some(snapshot) = self.test_isolation_state.proxy_env.as_ref() {
+            let mut slots = self.proxy_env_storage.lock();
+            slots.restore(&mut self.transpiler.env_mut().map, snapshot);
         }
     }
 

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -526,6 +526,46 @@ impl ProxyEnvSlots {
         sync_one!(b"NO_PROXY", NO_PROXY);
         sync_one!(b"no_proxy", no_proxy);
     }
+
+    /// Undo every `Bun__setEnvValue` since `snapshot` was captured: drop the
+    /// slot refs and put the captured values back into `map`. Caller holds
+    /// the `ProxyEnvStorage` lock, like the setter.
+    pub(crate) fn restore(&mut self, map: &mut bun_dotenv::Map, snapshot: &ProxyEnvSnapshot) {
+        for_each_proxy_field!(self, |_name, field| {
+            *field = None;
+        });
+        for (key, value) in &snapshot.entries {
+            match value {
+                Some(value) => bun_core::handle_oom(map.put(key, value)),
+                None => map.remove(key),
+            }
+        }
+    }
+}
+
+const PROXY_ENV_KEYS: [&[u8]; 6] = [
+    b"HTTP_PROXY",
+    b"http_proxy",
+    b"HTTPS_PROXY",
+    b"https_proxy",
+    b"NO_PROXY",
+    b"no_proxy",
+];
+
+/// The six proxy keys as the env map held them when the test runner started.
+/// `process.env` writes to these keys go through `Bun__setEnvValue` into the
+/// per-VM env map, which seeds every later global's `process.env`, so
+/// `--isolate` restores them from this between files.
+pub struct ProxyEnvSnapshot {
+    entries: [(&'static [u8], Option<Box<[u8]>>); 6],
+}
+
+impl ProxyEnvSnapshot {
+    pub fn capture(map: &bun_dotenv::Map) -> Self {
+        Self {
+            entries: PROXY_ENV_KEYS.map(|key| (key, map.get(key).map(Box::from))),
+        }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1990,6 +1990,12 @@ impl TestCommand {
                 .global()
                 .set_time_zone(&EncodedSlice::from_bytes(tz_name));
         }
+        if vm.test_isolation_enabled {
+            vm.test_isolation_state.time_zone = Some(Box::from(tz_name));
+            vm.test_isolation_state.proxy_env = Some(
+                bun_jsc::rare_data::ProxyEnvSnapshot::capture(&vm.env_loader().map),
+            );
+        }
 
         if ctx.test_options.test_worker {
             // Worker mode: skip discovery; files arrive over stdin and

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir, tls } from "harness";
 import fs from "node:fs";
 import net from "node:net";
 import { join } from "node:path";
@@ -39,10 +39,15 @@ const fixtures = {
   `,
 };
 
-async function runTests(dir: string, extraArgs: string[], files = ["./a-leaker.test.ts", "./b-observer.test.ts"]) {
+async function runTests(
+  dir: string,
+  extraArgs: string[],
+  files = ["./a-leaker.test.ts", "./b-observer.test.ts"],
+  env: Record<string, string | undefined> = bunEnv,
+) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", ...extraArgs, ...files],
-    env: bunEnv,
+    env,
     cwd: dir,
     stderr: "pipe",
     stdout: "pipe",
@@ -104,6 +109,81 @@ describe.concurrent("bun test --isolate", () => {
     });
     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(normalizeBunSnapshot(stderr, parallel)).toContain("2 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  // TZ, NODE_TLS_REJECT_UNAUTHORIZED, BUN_CONFIG_VERBOSE_FETCH and the proxy
+  // keys have process.env setters with a native side effect outside the global
+  // (the WTF time zone override, per-VM caches, the env map the next
+  // process.env is seeded from). The next file reads the original values, so
+  // the side effects must be rolled back with the global.
+  test("with --isolate, a file's process.env writes with native side effects are undone before the next file", async () => {
+    const envFixtures = {
+      "a-env.test.ts": `
+        import { test, expect } from "bun:test";
+        process.env.TZ = "America/New_York";
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+        process.env.BUN_CONFIG_VERBOSE_FETCH = "curl";
+        process.env.HTTP_PROXY = "http://127.0.0.1:9/";
+        test("the writes apply to this file", () => {
+          expect(new Date(0).getTimezoneOffset()).toBe(300);
+          expect(process.env.HTTP_PROXY).toBe("http://127.0.0.1:9/");
+        });
+      `,
+      "b-env.test.ts": `
+        import { test, expect } from "bun:test";
+        const tls = ${JSON.stringify(tls)};
+        test("Date is back on the runner's TZ", () => {
+          expect(process.env.TZ).toBe("Etc/UTC");
+          expect(new Date(0).getTimezoneOffset()).toBe(0);
+        });
+        test("fetch() verifies certificates again", async () => {
+          expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+          using server = Bun.serve({ port: 0, tls, fetch: () => new Response("ok") });
+          // Self-signed and not in any CA store: only a lax fetch() can connect.
+          await expect(fetch(\`https://localhost:\${server.port}/\`, { keepalive: false })).rejects.toMatchObject({
+            code: "DEPTH_ZERO_SELF_SIGNED_CERT",
+          });
+        });
+        test("fetch() no longer goes through the previous file's proxy", async () => {
+          expect(process.env.HTTP_PROXY).toBeUndefined();
+          using server = Bun.serve({ port: 0, fetch: () => new Response("direct") });
+          expect(await fetch(\`http://127.0.0.1:\${server.port}/\`, { keepalive: false }).then(r => r.text())).toBe("direct");
+        });
+      `,
+    };
+    const files = ["./a-env.test.ts", "./b-env.test.ts"];
+    // The second file expects the proxy key to be unset, so the runner must
+    // start without one even on a machine that routes through a proxy.
+    const env = {
+      ...bunEnv,
+      HTTP_PROXY: undefined,
+      http_proxy: undefined,
+      HTTPS_PROXY: undefined,
+      https_proxy: undefined,
+      NO_PROXY: undefined,
+      no_proxy: undefined,
+    };
+
+    using isolated = tempDir("isolate-env", envFixtures);
+    const serial = await runTests(String(isolated), ["--isolate"], files, env);
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("4 pass");
+    // Verbose fetch logging was left on by the first file: the second file's
+    // fetch() must not print its curl transcript.
+    expect(serial.stderr).not.toContain("curl --http1.1");
+    expect(serial.exitCode).toBe(0);
+
+    using parallel = tempDir("isolate-env-parallel", envFixtures);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", ...files],
+      env: { ...env, BUN_TEST_PARALLEL_SCALE_MS: "60000" },
+      cwd: String(parallel),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("4 pass");
+    expect(stderr).not.toContain("curl --http1.1");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Problem
- Under `bun test --isolate` (how every `bun test --parallel` worker runs), a `process.env` write to `TZ`, `NODE_TLS_REJECT_UNAUTHORIZED`, `BUN_CONFIG_VERBOSE_FETCH` or a proxy key leaks into every later file. That file reads the first three as unset while `Date`, `fetch()` certificate checks and verbose logging keep the old value. The proxy keys leak in full, and its `fetch()` dials the proxy.
- Their custom setters (`src/jsc/bindings/JSEnvironmentVariableMap.cpp:694`) write past the env object: per-VM caches, the WTF time zone override, and the per-VM env map that seeds the next `process.env`. `swap_global_for_test_isolation` (`src/jsc/VirtualMachine.rs:5099`) never reset them.
- In CI, `test/js/third_party/undici-h2/run.test.ts:10` sets `NODE_TLS_REJECT_UNAUTHORIZED="0"` at module scope. `test/js/web/fetch/fetch.tls.wildcard.test.ts` then sees `fetch()` accept a mismatched `serverName`: flaky in 339 of the last 400 builds.

### Fix
- `undo_process_env_side_effects` runs at the end of the swap. It resets `default_tls_reject_unauthorized` and `default_verbose_fetch` to `None` (both fall back to the real environment), re-applies the startup time zone, and restores the six proxy keys in the env map from a startup snapshot (`ProxyEnvSnapshot`, `src/jsc/rare_data.rs`) under the setter's lock.
- The runner records the time zone (`TZ`, default `Etc/UTC`, empty means local time) and the proxy snapshot in `TestIsolationState`, next to the cwd restore.
- Verified: `test/cli/test/isolation.test.ts` (new case, fails on stock bun, 32 pass), `test/cli/test/parallel.test.ts` (41 pass).

### Background
- `--isolate` gives each test file a fresh global in one process. The swap is the only per-file boundary, so anything a file changes outside its global is undone there.
- Each `bun test --parallel` worker runs a sorted, contiguous range of files with `--isolate`. The platform's file list decides which files share a worker, hence darwin only.

<details><summary>Notes</summary>

Reproduction with a stock bun, two files under `bun test --isolate`:

```ts
// a.test.ts
process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
process.env.TZ = "America/New_York";
process.env.HTTP_PROXY = "http://127.0.0.1:9/";
// b.test.ts
console.log(process.env.NODE_TLS_REJECT_UNAUTHORIZED, process.env.TZ, new Date(0).getTimezoneOffset(), process.env.HTTP_PROXY);
// prints: undefined undefined 300 http://127.0.0.1:9/
// a strict fetch() to a self-signed server resolves, a fetch() to a local server fails with ConnectionRefused
```

The new test fails on stock bun with offset 300, a resolved fetch and a curl transcript in stderr. The test clears the proxy keys from the child's environment, so it also holds on a machine that routes through a proxy.

CI data (400 builds, 2026-08-28 to 2026-08-29): `fetch.tls.wildcard.test.ts` appeared in the flaky annotation of 339 builds, all darwin (x64 and aarch64), all "passed alone" after failing in the parallel batch. Every negative row failed with `fetch: { ok: true }` while `checkServerIdentity` and `checkHost` stayed correct, which points at the request-level verification switch rather than the matcher.

Self-review raised the proxy keys as a missed fourth mechanism in the same setter list, reproduced it on the first version of this branch, and that is now covered. It also noted the SHARE_ENV store carry-over at `ZigGlobalObject.cpp:697`. That is left as is: it is a separate design question about worker trees, not a leak between files.

`undici-h2/run.test.ts` is left as is. Its write is now contained to its own file, which is what a test author expects from `--isolate`.
</details>
