### PR TITLE
Resolve file:// parent URLs in import.meta.resolve(specifier, parent)

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4674,26 +4674,26 @@ impl VirtualMachine {
             }
         }
 
-        let specifier_utf8 = specifier.to_utf8();
-        let source_utf8 = source.to_utf8();
-
         // A `file:` source (the parent URL in two-arg `import.meta.resolve`)
         // must become a filesystem path before the resolver walks
         // `node_modules` from it: percent escapes decode, and on Windows
-        // `file:///C:/x` becomes `C:\x`.
+        // `file:///C:/x` becomes `C:\x`. If the URL does not parse,
+        // `normalize_source` below strips the prefix as before.
         let decoded_source;
-        let decoded_source_utf8;
-        let normalized_source: &[u8] = if source_utf8.slice().starts_with(b"file:/") {
+        let resolve_source = if source.starts_with_ascii(b"file:/") {
             decoded_source = bun_url::path_from_file_url(source);
             if decoded_source.is_dead() {
-                normalize_source(source_utf8.slice())
+                source
             } else {
-                decoded_source_utf8 = decoded_source.to_utf8();
-                decoded_source_utf8.slice()
+                &decoded_source
             }
         } else {
-            source_utf8.slice()
+            source
         };
+
+        let specifier_utf8 = specifier.to_utf8();
+        let source_utf8 = resolve_source.to_utf8();
+        let normalized_source = normalize_source(source_utf8.slice());
 
         if jsc_vm.plugin_runner.is_some() {
             use bun_bundler::transpiler::PluginRunner;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4677,14 +4677,10 @@ impl VirtualMachine {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
 
-        // A `file:` source (e.g. the parent URL in
-        // `import.meta.resolve(specifier, parent)`) must become a filesystem
-        // path before the resolver walks `node_modules` from it: percent
-        // escapes decode, single-slash `file:/x` normalizes, and on Windows
-        // `file:///C:/x` becomes `C:\x`. A bare prefix strip gets all of
-        // these wrong, and the resolver then falls back to auto-install or
-        // fails. The guard stays at `file:/` (not `file:`) because this
-        // function also serves callers that pass plain paths.
+        // A `file:` source (the parent URL in two-arg `import.meta.resolve`)
+        // must become a filesystem path before the resolver walks
+        // `node_modules` from it: percent escapes decode, and on Windows
+        // `file:///C:/x` becomes `C:\x`.
         let decoded_source;
         let decoded_source_utf8;
         let normalized_source: &[u8] = if source_utf8.slice().starts_with(b"file:/") {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4677,15 +4677,17 @@ impl VirtualMachine {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
 
-        // A `file://` source (e.g. the parent URL in
+        // A `file:` source (e.g. the parent URL in
         // `import.meta.resolve(specifier, parent)`) must become a filesystem
         // path before the resolver walks `node_modules` from it: percent
-        // escapes decode, and on Windows `file:///C:/x` becomes `C:\x`. A
-        // bare prefix strip gets both wrong, and the resolver then falls
-        // back to auto-install or fails.
+        // escapes decode, single-slash `file:/x` normalizes, and on Windows
+        // `file:///C:/x` becomes `C:\x`. A bare prefix strip gets all of
+        // these wrong, and the resolver then falls back to auto-install or
+        // fails. The guard stays at `file:/` (not `file:`) because this
+        // function also serves callers that pass plain paths.
         let decoded_source;
         let decoded_source_utf8;
-        let normalized_source: &[u8] = if source_utf8.slice().starts_with(b"file://") {
+        let normalized_source: &[u8] = if source_utf8.slice().starts_with(b"file:/") {
             decoded_source = bun_url::path_from_file_url(source);
             if decoded_source.is_dead() {
                 normalize_source(source_utf8.slice())
@@ -4815,7 +4817,7 @@ impl VirtualMachine {
                 .unwrap_or_else(|| {
                     let printed = crate::ResolveMessage::fmt(
                         specifier_utf8.slice(),
-                        source_utf8.slice(),
+                        normalized_source,
                         err,
                         import_kind,
                     );
@@ -4832,7 +4834,7 @@ impl VirtualMachine {
             return Ok(Err(crate::ResolveMessage::create(
                 global,
                 &msg,
-                source_utf8.slice(),
+                normalized_source,
             )?));
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4677,6 +4677,26 @@ impl VirtualMachine {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
 
+        // A `file://` source (e.g. the parent URL in
+        // `import.meta.resolve(specifier, parent)`) must become a filesystem
+        // path before the resolver walks `node_modules` from it: percent
+        // escapes decode, and on Windows `file:///C:/x` becomes `C:\x`. A
+        // bare prefix strip gets both wrong, and the resolver then falls
+        // back to auto-install or fails.
+        let decoded_source;
+        let decoded_source_utf8;
+        let normalized_source: &[u8] = if source_utf8.slice().starts_with(b"file://") {
+            decoded_source = bun_url::path_from_file_url(source);
+            if decoded_source.is_dead() {
+                normalize_source(source_utf8.slice())
+            } else {
+                decoded_source_utf8 = decoded_source.to_utf8();
+                decoded_source_utf8.slice()
+            }
+        } else {
+            source_utf8.slice()
+        };
+
         if jsc_vm.plugin_runner.is_some() {
             use bun_bundler::transpiler::PluginRunner;
             let spec = specifier_utf8.slice();
@@ -4774,7 +4794,7 @@ impl VirtualMachine {
         let resolve_result = jsc_vm._resolve(
             &mut result,
             specifier_utf8.slice(),
-            normalize_source(source_utf8.slice()),
+            normalized_source,
             mode.is_esm(),
             IS_A_FILE_PATH,
         );

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1704,6 +1704,13 @@ it("import.meta.resolve with a file:// parent URL resolves bare package names", 
     "node_modules/mypkg/dist/core/probe.mjs": [
       `console.log(import.meta.resolve("mypkg"));`,
       `console.log(import.meta.resolve("mypkg", import.meta.url));`,
+      // Single-slash file URL: the WHATWG parser normalizes file:/p to file:///p.
+      `console.log(import.meta.resolve("mypkg", import.meta.url.replace("file:///", "file:/")));`,
+      `try {
+        import.meta.resolve("does-not-exist-xyz", import.meta.url);
+      } catch (e) {
+        console.log(e.message);
+      }`,
     ].join("\n"),
   });
   await using proc = Bun.spawn({
@@ -1715,8 +1722,13 @@ it("import.meta.resolve with a file:// parent URL resolves bare package names", 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const [oneArg, twoArg] = stdout.trim().split("\n");
+  const [oneArg, twoArg, singleSlash, errMessage] = stdout.trim().split("\n");
   expect(oneArg).toEndWith("/node_modules/mypkg/dist/index.mjs");
   expect(twoArg).toBe(oneArg);
+  expect(singleSlash).toBe(oneArg);
+  // The failure message prints the decoded referrer path, like Node.
+  expect(errMessage).toContain("does-not-exist-xyz");
+  expect(errMessage).toContain("imr space");
+  expect(errMessage).not.toContain("%20");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1701,11 +1701,20 @@ it("import.meta.resolve with a file:// parent URL resolves bare package names", 
       exports: { ".": "./dist/index.mjs" },
     }),
     "node_modules/mypkg/dist/index.mjs": "export default 1;\n",
+    "other/node_modules/otherpkg/package.json": JSON.stringify({
+      name: "otherpkg",
+      version: "1.0.0",
+      exports: { ".": "./index.mjs" },
+    }),
+    "other/node_modules/otherpkg/index.mjs": "export default 2;\n",
     "node_modules/mypkg/dist/core/probe.mjs": [
       `console.log(import.meta.resolve("mypkg"));`,
       `console.log(import.meta.resolve("mypkg", import.meta.url));`,
       // Single-slash file URL: the WHATWG parser normalizes file:/p to file:///p.
       `console.log(import.meta.resolve("mypkg", import.meta.url.replace("file:///", "file:/")));`,
+      // A synthetic parent in a different tree: otherpkg only exists under
+      // other/node_modules, so this passes only if the parent is honored.
+      `console.log(import.meta.resolve("otherpkg", new URL("../../../../other/app.mjs", import.meta.url).href));`,
       `try {
         import.meta.resolve("does-not-exist-xyz", import.meta.url);
       } catch (e) {
@@ -1722,10 +1731,11 @@ it("import.meta.resolve with a file:// parent URL resolves bare package names", 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const [oneArg, twoArg, singleSlash, errMessage] = stdout.trim().split("\n");
+  const [oneArg, twoArg, singleSlash, otherTree, errMessage] = stdout.trim().split("\n");
   expect(oneArg).toEndWith("/node_modules/mypkg/dist/index.mjs");
   expect(twoArg).toBe(oneArg);
   expect(singleSlash).toBe(oneArg);
+  expect(otherTree).toEndWith("/other/node_modules/otherpkg/index.mjs");
   // The failure message prints the decoded referrer path, like Node.
   expect(errMessage).toContain("does-not-exist-xyz");
   expect(errMessage).toContain("imr space");

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1689,3 +1689,34 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
     expect(exitCode).toBe(0);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/40931
+it("import.meta.resolve with a file:// parent URL resolves bare package names", async () => {
+  // The space in the directory name makes import.meta.url percent-encoded,
+  // which reproduces the Windows failure (file:///C:/...) on every platform.
+  await using dir = tempDir("imr space", {
+    "node_modules/mypkg/package.json": JSON.stringify({
+      name: "mypkg",
+      version: "1.0.0",
+      exports: { ".": "./dist/index.mjs" },
+    }),
+    "node_modules/mypkg/dist/index.mjs": "export default 1;\n",
+    "node_modules/mypkg/dist/core/probe.mjs": [
+      `console.log(import.meta.resolve("mypkg"));`,
+      `console.log(import.meta.resolve("mypkg", import.meta.url));`,
+    ].join("\n"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--no-install", join("node_modules", "mypkg", "dist", "core", "probe.mjs")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [oneArg, twoArg] = stdout.trim().split("\n");
+  expect(oneArg).toEndWith("/node_modules/mypkg/dist/index.mjs");
+  expect(twoArg).toBe(oneArg);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- The two-arg form `import.meta.resolve(specifier, parent)` fails for bare package names with `Cannot find package 'wxt' imported from file:///...`, while the one-arg form works. Node accepts both. This breaks WXT under `bun --bun` (#40931).
- The resolver turns the parent URL into a path with a bare `file://` prefix strip (`normalize_source`, src/jsc/VirtualMachine.rs:3501). Percent escapes stay encoded, and on Windows `file:///C:/x` becomes `/C:/x`. The resolver finds no `node_modules` above that path and falls back to auto-install, which fetches the same name from npm or throws.

### Fix
- Convert a `file:/` parent to a filesystem path with the WHATWG parser (`bun_url::path_from_file_url`) before resolving, the same way `Bun.resolveSync` already converts `file://` specifiers (src/runtime/api/BunObject.rs:1115). The old strip stays as a fallback for a URL that does not parse.
- The guard matches `file:/`, so single-slash `file:/p` parents normalize too. It does not match bare `file:` because this function also serves callers that pass plain paths.
- The resolve failure message now prints the decoded referrer path, like Node.
- Verified: the new test in test/js/bun/resolve/resolve.test.ts fails on stock bun and passes with the fix on Linux and Windows. The full test/js/bun/resolve/ suite passes. Self-reviewed: the review raised sequencing with #39782, the guard width, and the error referrer. All three are addressed. The same class of bug in the `--preload` path (src/runtime/jsc_hooks.rs:777) is left to #39782, which already owns the non-resolver call sites.

### Background
- `Bun.resolveSync`, `require.resolve`, and two-arg `import.meta.resolve` all route through `VirtualMachine::resolve_maybe_needs_trailing_slash`. The parent (the "source") is the path the resolver walks `node_modules` from.
- The one-arg form passes `import.meta.path`, a plain filesystem path, so it never hit the bug.
- When the parent path is invalid, the resolver falls back to auto-install. It fetches the package from npm into the install cache instead of using the local `node_modules`. That is why the bug shows as a hard failure only for names that are not on npm.

<details><summary>Notes</summary>

- Linux repro: a project dir with a space (`/tmp/imr space`) makes `import.meta.url` percent-encoded, so the same failure reproduces without Windows. Stock bun resolves the two-arg form to `~/.bun/install/cache/mypkg@1.0.0@@@1/index.js` instead of the local package.
- Windows repro (debug build, before the fix): `two-arg FAIL Cannot find package 'notonnpm-xyz987' imported from file:///C:/temp/...`. After the fix, both forms return the same local `node_modules` URL, including self-resolution from a file inside the package.
- Sequencing with #39782: that PR rewrites the same call site with a byte-level `strip_file_url_prefix` that does not percent-decode. This PR should land first. #39782 can then drop its VirtualMachine.rs hunk (the WHATWG conversion here covers its single-slash case at this seam) and keep its non-resolver sites (Worker, dlopen, preloads, C++ sites).
- `path_from_file_url` is backed by `WTF::URL::fileSystemPath()` (`URL__pathFromFileURL`, src/jsc/bindings/BunString.cpp:594). It returns a dead string for an unparseable URL, in which case the old prefix strip runs, so behavior for garbage input is unchanged.
- The early ENAMETOOLONG message (VirtualMachine.rs:4640) still formats the raw source. It fires only for specifiers over 1.5x MAX_PATH and is cosmetic.
- `test/js/bun/resolve/load-same-js-file-a-lot.test.ts` ("load the same empty JS file 2000 times") times out at its 5s default in this debug+ASAN container, with or without this diff. The diff adds one 6-byte prefix check to that path.
- Suites run: test/js/bun/resolve/ (full), import-meta.test.js, import-meta-resolve.test.mjs, resolve-bad-parent.test.mjs, on Linux debug+ASAN. resolve.test.ts also on Windows x64 debug.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->