### PR TITLE
compile: resolve run-time specifiers for embedded data entry points by their source spelling

### DIFF
--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -17,9 +17,15 @@ pub trait StandaloneModuleGraph: Send + Sync {
     fn has_module_info(&self, _name: &[u8]) -> bool {
         false
     }
+    /// The embedded module whose entry point was spelled `name` at build time (`/$bunfs/root/data.json` for the
+    /// module embedded as `/$bunfs/root/data.js`), when the executable recorded it.
+    fn find_entry_point_alias(&self, _name: &[u8]) -> Option<&'static [u8]> {
+        None
+    }
     /// The embedded module `specifier` names when imported from `source_dir`: an absolute embedded path (in either
-    /// path syntax), or a `./` / `../` specifier joined onto `source_dir`, looked up as spelled and then -- since every
-    /// entry point is embedded under a `.js` name -- under the `.js` name for a source extension or no extension
+    /// path syntax), or a `./` / `../` specifier joined onto `source_dir`, looked up as spelled, then as the source
+    /// spelling of an entry point (`./data.json` -> `/$bunfs/root/data.js`), and then -- since every entry point is
+    /// embedded under a `.js` name -- under the `.js` name for a source extension or no extension
     /// (`./w.ts` -> `/$bunfs/root/w.js`). Returns the graph's own name for the module, which is what the module
     /// loader keys on; `None` for anything else (bare specifiers, other absolute paths, misses).
     fn resolve(&self, source_dir: &[u8], specifier: &[u8]) -> Option<&'static [u8]> {
@@ -49,6 +55,9 @@ pub trait StandaloneModuleGraph: Send + Sync {
             .len()
         };
         if let Some(name) = self.find_assume_standalone_path(&buf[..path_len]) {
+            return Some(name);
+        }
+        if let Some(name) = self.find_entry_point_alias(&buf[..path_len]) {
             return Some(name);
         }
         // Entry points are embedded under a `.js` name whatever the (case-insensitive) source extension was.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -42,6 +42,9 @@ pub struct StandaloneModuleGraph {
     pub files: StringArrayHashMap<File>,
     /// Directory prefixes derived from `files` keys (no trailing `/`, always posix-separated).
     pub dirs: StringArrayHashMap<()>,
+    /// An entry point's source spelling (`/$bunfs/root/data.json`) -> the name of its module in `files`
+    /// (`/$bunfs/root/data.js`). Only module resolution consults it; the file system view does not.
+    pub entry_point_aliases: StringArrayHashMap<&'static [u8]>,
     pub entry_point_id: u32,
     pub compile_exec_argv: &'static [u8],
     pub flags: Flags,
@@ -311,6 +314,18 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
     }
     fn find_assume_standalone_path(&self, name: &[u8]) -> Option<&'static [u8]> {
         self.lookup_file(name).map(|f| f.name)
+    }
+    fn find_entry_point_alias(&self, name: &[u8]) -> Option<&'static [u8]> {
+        #[cfg(windows)]
+        {
+            let mut buf = PathBuffer::uninit();
+            return self
+                .entry_point_aliases
+                .get(normalize_file_key(name, &mut buf))
+                .copied();
+        }
+        #[cfg(not(windows))]
+        self.entry_point_aliases.get(name).copied()
     }
 
     fn base_public_path_with_default_suffix(&self) -> &'static [u8] {
@@ -818,7 +833,13 @@ bitflags::bitflags! {
         /// Built with `--compile --bytecode --target=<a different os/arch/libc than the bun that built it>`: the embedded
         /// bytecode was written by another platform's JavaScriptCore. Reported with crash reports.
         const CROSS_COMPILED_BYTECODE       = 1 << 10;
-        // _padding: u21
+        /// After the module-info string-table pointer: `u32 count`, then `count` × `{ StringPointer name, u32 module }`:
+        /// an entry point's source spelling under the virtual root (`/$bunfs/root/data.json`) and the index in the
+        /// module table of the module it was bundled into (`/$bunfs/root/data.js`). Only module resolution reads it.
+        /// Written for an entry point whose chunk name differs from its source name, unless the chunk is a path stub
+        /// over an embedded asset (`file`, `wasm`, `napi`, `sqlite`) or two entry points share the spelling.
+        const HAS_ENTRY_POINT_ALIASES       = 1 << 11;
+        // _padding: u20
     }
 }
 
@@ -845,6 +866,7 @@ impl StandaloneModuleGraph {
                 bytes: core::ptr::slice_from_raw_parts(NonNull::<u8>::dangling().as_ptr(), 0),
                 files: StringArrayHashMap::new(),
                 dirs: StringArrayHashMap::new(),
+                entry_point_aliases: StringArrayHashMap::new(),
                 entry_point_id: 0,
                 compile_exec_argv: b"",
                 flags: Flags::default(),
@@ -956,6 +978,7 @@ impl StandaloneModuleGraph {
                     offset: read_u32(record_at),
                     length: read_u32(record_at + 4),
                 };
+                record_at += 2 * size_of::<u32>();
                 if (ptr.offset as usize).saturating_add(ptr.length as usize) > raw_len {
                     &[]
                 } else {
@@ -966,6 +989,37 @@ impl StandaloneModuleGraph {
             } else {
                 &[]
             };
+
+        // `(name, module index)` pairs; the map is built once the module table below gives the names their targets.
+        let mut alias_records: Vec<(StringPointer, u32)> = Vec::new();
+        if offsets.flags.contains(Flags::HAS_ENTRY_POINT_ALIASES)
+            && record_at + size_of::<u32>() <= raw_len
+        {
+            let count = read_u32(record_at) as usize;
+            record_at += size_of::<u32>();
+            let record_size = 3 * size_of::<u32>();
+            let count = count.min(raw_len.saturating_sub(record_at) / record_size);
+            alias_records.reserve(count);
+            for _ in 0..count {
+                let name = StringPointer {
+                    offset: read_u32(record_at),
+                    length: read_u32(record_at + 4),
+                };
+                let module_index = read_u32(record_at + 8);
+                record_at += record_size;
+                // The NUL after the name must be inside the section too.
+                if (name.offset as usize).saturating_add(name.length as usize) < raw_len
+                    && (module_index as usize) < modules_list_count
+                {
+                    alias_records.push((name, module_index));
+                }
+            }
+        }
+        // The argv string follows the last record, so a graph this version wrote (no unknown flag bits) has been
+        // read exactly to it.
+        if offsets.flags.bits() & !Flags::all().bits() == 0 {
+            debug_assert_eq!(record_at, offsets.compile_exec_argv_ptr.offset as usize);
+        }
 
         let mut modules = StringArrayHashMap::<File>::new();
         modules.reserve(modules_list_count);
@@ -1056,12 +1110,37 @@ impl StandaloneModuleGraph {
         }
         dirs.lock_pointers();
 
+        let mut entry_point_aliases = StringArrayHashMap::<&'static [u8]>::new();
+        entry_point_aliases.reserve(alias_records.len());
+        for (alias, module_index) in alias_records {
+            // SAFETY: `module_index < modules_list_count` was checked when the record was read; same read as above.
+            let module: CompiledModuleGraphFile = unsafe {
+                core::ptr::read_unaligned(
+                    modules_list_base
+                        .add(module_index as usize * size_of::<CompiledModuleGraphFile>())
+                        .cast::<CompiledModuleGraphFile>(),
+                )
+            };
+            // SAFETY: both are read-only name subranges `to_bytes` wrote with a NUL; the alias was bounds checked
+            // when its record was read.
+            let (alias, target) = unsafe {
+                (
+                    slice_to_z(raw_const, raw_len, alias),
+                    slice_to_z(raw_const, raw_len, module.name),
+                )
+            };
+            if let Some(file) = modules.get(target.as_bytes()) {
+                let _ = entry_point_aliases.put(alias.as_bytes(), file.name);
+            }
+        }
+
         Ok(StandaloneModuleGraph {
             // Stored as a raw fat pointer — `byte_count` covers the writable
             // bytecode/module_info regions, so a `&'static [u8]` here would alias them.
             bytes: core::ptr::slice_from_raw_parts(raw_const, offsets.byte_count),
             files: modules,
             dirs,
+            entry_point_aliases,
             entry_point_id: offsets.entry_point_id,
             // SAFETY: read-only argv string subrange, disjoint from writable regions.
             compile_exec_argv: unsafe {
@@ -1234,7 +1313,15 @@ pub(crate) fn to_bytes(
             } else if output_file.output_kind == options::OutputKind::ModuleInfoStringTable {
                 string_builder.cap += bytes.len() + 2 * size_of::<u32>();
             } else {
-                has_entry_point |= is_entry_point(output_file);
+                if is_entry_point(output_file) {
+                    has_entry_point = true;
+                    // Its source-spelling alias: the prefix, the directory of `dest_path`, the source basename,
+                    // and a `{ StringPointer, u32 }` record.
+                    string_builder.count_z(prefix);
+                    string_builder.count_z(&output_file.dest_path);
+                    string_builder.count_z(path::basename(output_file.src_path.text));
+                    string_builder.cap += 3 * size_of::<u32>();
+                }
 
                 string_builder.count_z(bytes);
                 if is_stored_as_string(output_file) {
@@ -1253,7 +1340,7 @@ pub(crate) fn to_bytes(
     string_builder.cap +=
         (size_of::<CompiledModuleGraphFile>() + size_of::<u32>()) * output_files.len();
     string_builder.cap += TRAILER.len();
-    string_builder.cap += 16 + 2 * size_of::<u32>();
+    string_builder.cap += 16 + 3 * size_of::<u32>();
     string_builder.cap += size_of::<Offsets>();
     string_builder.count_z(compile_exec_argv);
 
@@ -1491,6 +1578,54 @@ pub(crate) fn to_bytes(
         }
     }
 
+    // `Flags::HAS_ENTRY_POINT_ALIASES`: an entry point whose chunk name differs from its source name
+    // (`data.json` -> `data.js`, `entry.ts` -> the outfile) is also resolvable by the source spelling, in the
+    // chunk's directory. Not when the chunk is a path stub over an embedded asset (`file`, `wasm`, `napi`,
+    // `sqlite`): `require.resolve("./yoga.wasm")` must not name the stub. A spelling two entry points share
+    // (`--entry-naming` without `[dir]`) is ambiguous and gets no alias; a file's own name always wins.
+    let mut alias_candidates: StringArrayHashMap<Option<u32>> = StringArrayHashMap::new();
+    let mut alias_rel_path: Vec<u8> = Vec::new();
+    for (module_index, output_file) in module_files.iter().enumerate() {
+        if !is_entry_point(output_file) || output_file.input_loader.should_copy_for_bundling() {
+            continue;
+        }
+        let dest_path = module_dest_path(output_file);
+        let dest_dir_len =
+            strings::last_index_of_char(dest_path, b'/').map_or(0, |i| i as usize + 1);
+        let src_basename = path::basename(output_file.src_path.text);
+        if src_basename.is_empty() || src_basename == &dest_path[dest_dir_len..] {
+            continue;
+        }
+        alias_rel_path.clear();
+        alias_rel_path.extend_from_slice(&dest_path[..dest_dir_len]);
+        alias_rel_path.extend_from_slice(src_basename);
+        let candidate = alias_candidates.get_or_put(&alias_rel_path)?;
+        *candidate.value_ptr = if candidate.found_existing {
+            None
+        } else {
+            Some(module_index as u32)
+        };
+    }
+    let mut alias_records: Vec<u8> = Vec::new();
+    let mut alias_count: u32 = 0;
+    for (alias_rel_path, module_index) in alias_candidates.iter() {
+        let Some(module_index) = *module_index else {
+            continue;
+        };
+        if seen_paths.contains_key(alias_rel_path) {
+            continue;
+        }
+        let alias = string_builder.fmt_append_count_z(format_args!(
+            "{}{}",
+            bstr::BStr::new(prefix),
+            bstr::BStr::new(&alias_rel_path[..])
+        ));
+        alias_records.extend_from_slice(&alias.offset.to_le_bytes());
+        alias_records.extend_from_slice(&alias.length.to_le_bytes());
+        alias_records.extend_from_slice(&module_index.to_le_bytes());
+        alias_count += 1;
+    }
+
     // SAFETY: `CompiledModuleGraphFile` is `#[repr(C)]` POD with no padding-dependent
     // invariants; reinterpreting its backing storage as bytes is sound.
     let modules_as_bytes: &[u8] = unsafe {
@@ -1526,6 +1661,11 @@ pub(crate) fn to_bytes(
         record[4..8].copy_from_slice(&module_info_string_table_ptr.length.to_le_bytes());
         let _ = string_builder.append_count(&record);
         flags |= Flags::HAS_MODULE_INFO_STRING_TABLE;
+    }
+    if alias_count != 0 {
+        let _ = string_builder.append_count(&alias_count.to_le_bytes());
+        let _ = string_builder.append_count(&alias_records);
+        flags |= Flags::HAS_ENTRY_POINT_ALIASES;
     }
     if !target.is_host_platform()
         && output_files
@@ -1563,6 +1703,7 @@ pub(crate) fn to_bytes(
             offsets,
         )?;
         debug_assert_eq!(graph.files.count(), modules.len());
+        debug_assert_eq!(graph.entry_point_aliases.count(), alias_count as usize);
         graph.files.unlock_pointers();
         graph.dirs.unlock_pointers();
 

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -497,6 +497,92 @@ describe("bundler", () => {
     outfile: "dist/out",
     run: { stdout: "mod mod\nmod mod\nmod mod\nmod mod\nResolveMessage\n", file: "dist/out", setCwd: true },
   });
+  // An entry point with a data loader is embedded under a `.js` name too (`data.json` -> `data.js`). The executable
+  // records the source spelling of such an entry point, so that spelling resolves to the module; the spelling is
+  // exact (`./UP.JSON`, not `./UP.json`). A `file` entry point's chunk is only a stub over the embedded asset
+  // (`export default "/$bunfs/root/blob-<hash>.bin"`), so its source spelling stays unresolved.
+  itBundled("compile/DynamicImportEmbeddedDataEntryPoint", {
+    backend: "cli",
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import { rmSync } from "fs";
+        import { tmpdir } from "os";
+        for (const f of ["./data.json", "./note.txt", "./conf.toml", "./blob.bin", "./UP.JSON"]) rmSync(f, { force: true });
+        process.chdir(tmpdir());
+        const s = (x: string) => x; // keeps the bundler from resolving the specifier at build time
+        const outcome = async (spec: string) => {
+          try {
+            return (await import(spec)).default;
+          } catch (e: any) {
+            return e?.constructor?.name ?? String(e);
+          }
+        };
+        console.log(require(s("./data.json")).b, (await import(s("./data.json"))).default.a);
+        console.log((await import(s("./note.txt"))).default, require(s("./note.txt")).default);
+        console.log((await import(s("./conf.toml"))).y.z, require(s("./conf.toml")).default.x);
+        const root = process.platform === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/";
+        console.log(require.resolve(s("./data.json")) === root + "data.js", Bun.resolveSync("./data.json", import.meta.dir) === root + "data.js");
+        console.log((await outcome(s("./UP.JSON"))).up, await outcome(s("./UP.json")), await outcome(s("./nope.json")));
+        console.log(await outcome(s("./blob.bin")), (await outcome(s("./blob.js"))).startsWith(root));
+      `,
+      "/data.json": `{ "a": 1, "b": "two" }`,
+      "/note.txt": `hello text`,
+      "/conf.toml": `x = 1\n[y]\nz = "w"\n`,
+      "/blob.bin": `blob bytes`,
+      "/UP.JSON": `{ "up": true }`,
+    },
+    entryPointsRaw: ["./entry.ts", "./data.json", "./note.txt", "./conf.toml", "./blob.bin", "./UP.JSON"],
+    outfile: "dist/out",
+    run: {
+      stdout: "two 1\nhello text hello text\nw 1\ntrue true\ntrue ResolveMessage ResolveMessage\nResolveMessage true\n",
+      file: "dist/out",
+      setCwd: true,
+    },
+  });
+  // With `--entry-naming` the chunk name is not the source name with `.js` swapped in, so only the recorded source
+  // spelling finds the module: `data.json` -> `data-<hash>.js`, `sub/inner.ts` -> `inner-<hash>.js` (no `[dir]`).
+  // A spelling two entry points share (`a/dup.json` and `b/dup.json` both land at the root) is ambiguous: neither
+  // gets it, and it still resolves against the cwd instead.
+  itBundled("compile/EmbeddedResolveEntryNaming", {
+    backend: "cli",
+    compile: true,
+    entryNaming: "[name]-[hash].[ext]",
+    files: {
+      "/entry.ts": /* js */ `
+        import { rmSync } from "fs";
+        import { tmpdir } from "os";
+        rmSync("./data.json", { force: true });
+        for (const dir of ["./sub", "./a", "./b"]) rmSync(dir, { recursive: true, force: true });
+        const s = (x: string) => x;
+        const outcome = async (spec: string) => {
+          try {
+            return (await import(spec)).default;
+          } catch (e: any) {
+            return e?.constructor?.name ?? String(e);
+          }
+        };
+        console.log((await outcome(s("./dup.json"))).from);
+        process.chdir(tmpdir());
+        console.log((await outcome(s("./data.json"))).a, await outcome(s("./inner.ts")), require(s("./inner.ts")).default);
+        console.log(await outcome(s("./sub/inner.ts")), await outcome(s("./inner")), await outcome(s("./dup.json")));
+      `,
+      "/data.json": `{ "a": 1 }`,
+      "/sub/inner.ts": `export default "inner" as string;`,
+      "/a/dup.json": `{ "from": "a" }`,
+      "/b/dup.json": `{ "from": "b" }`,
+    },
+    runtimeFiles: {
+      "/dup.json": `{ "from": "cwd" }`,
+    },
+    entryPointsRaw: ["./entry.ts", "./data.json", "./sub/inner.ts", "./a/dup.json", "./b/dup.json"],
+    outfile: "dist/out",
+    run: {
+      stdout: "cwd\n1 inner inner\nResolveMessage ResolveMessage ResolveMessage\n",
+      file: "dist/out",
+      setCwd: true,
+    },
+  });
   // Nested embedded entry points, from the entry and from inside the subdirectory (`../`), by every spelling.
   itBundled("compile/EmbeddedResolveNested", {
     backend: "cli",
@@ -535,7 +621,8 @@ describe("bundler", () => {
     run: { stdout: "inner\ninner\ninner\nsibling,top\ntop,top,sibling\n", file: "dist/out", setCwd: true },
   });
   // What resolves where: an embedded module wins over a file of the same name in the cwd; a relative specifier that
-  // is not embedded still resolves against the cwd; the resolved name of an embedded module is the graph's own.
+  // is not embedded still resolves against the cwd (a `config.json` there is not captured by an embedded `config.ts`);
+  // the resolved name of an embedded module is the graph's own.
   itBundled("compile/EmbeddedResolvePrecedence", {
     backend: "cli",
     compile: true,
@@ -544,6 +631,7 @@ describe("bundler", () => {
         const s = (x: string) => x;
         console.log(require(s("./both.js")).default);
         console.log(require(s("./disk-only.js")).default);
+        console.log(require(s("./config.json")).from, require(s("./config.ts")).default);
         const w1 = new Worker("./both.js");
         console.log(await new Promise(r => { w1.onmessage = e => r(e.data); w1.onerror = e => r("error: " + e.message); }));
         w1.terminate();
@@ -555,16 +643,19 @@ describe("bundler", () => {
         console.log(import.meta.path.replaceAll("\\\\", "/") === root + "out");
       `,
       "/both.js": `export default "both:embedded"; if (!Bun.isMainThread) postMessage("both:embedded worker");`,
+      "/config.ts": `export default "config:embedded" as string;`,
     },
     runtimeFiles: {
       "/both.js": `export default "both:disk"; if (!Bun.isMainThread) postMessage("both:disk worker");`,
       "/disk-only.js": `export default "disk-only";`,
       "/disk-only-worker.js": `postMessage("disk-only worker");`,
+      "/config.json": `{ "from": "disk" }`,
     },
-    entryPointsRaw: ["./entry.ts", "./both.js"],
+    entryPointsRaw: ["./entry.ts", "./both.js", "./config.ts"],
     outfile: "dist/out",
     run: {
-      stdout: "both:embedded\ndisk-only\nboth:embedded worker\ndisk-only worker\ntrue true\ntrue\n",
+      stdout:
+        "both:embedded\ndisk-only\ndisk config:embedded\nboth:embedded worker\ndisk-only worker\ntrue true\ntrue\n",
       file: "dist/out",
       setCwd: true,
     },


### PR DESCRIPTION
### Problem
- In a compiled executable, a run-time `require()` or `import()` of an embedded data entry point fails: `Cannot find module './data.json' from '/$bunfs/root/app'`. Only JS and TS spellings resolve (#40619).
- The bundler embeds the entry point under its `.js` chunk name (`data.json` -> `/$bunfs/root/data.js`). `StandaloneModuleGraph::resolve` (`src/resolver/standalone_module_graph.rs:54`) guesses that name only for a JS or TS extension. A wider guess would let an embedded `config.ts` capture a run-time `require("./config.json")` that reads the cwd today.

### Fix
- `to_bytes` records the source spelling of every entry point whose chunk name differs from it, as an alias of that module. The record sits behind a new flag bit (`HAS_ENTRY_POINT_ALIASES`), so an older runtime ignores it.
- `from_bytes` reads the aliases into their own map. `resolve()` tries the exact name, then the alias, then the unchanged `.js` retry. `readdir`, `stat` and `Bun.embeddedFiles` never see an alias.
- No alias for a `file`, `wasm`, `napi` or `sqlite` entry point: its chunk is a path stub, so `require.resolve("./yoga.wasm")` keeps missing instead of naming the stub. A spelling two entry points share (`--entry-naming` without `[dir]`) is ambiguous and gets none.
- Verified: `test/bundler/bundler_compile.test.ts`: new `compile/DynamicImportEmbeddedDataEntryPoint` and `compile/EmbeddedResolveEntryNaming` (both fail on 1.4.1), and a cwd-wins guard in `compile/EmbeddedResolvePrecedence`. Also the whole file and the other compile suites.

### Background
- A compiled executable carries a serialized module graph: a module table, then optional records chained in flag-bit order. Each record's presence is one bit in `Flags`.
- Each extra CLI entry point is one module, keyed by its output path under a virtual root (`/$bunfs/root/`). A JSON or text entry becomes a small ES module. A `file` asset becomes a module whose default export is the asset's embedded path.
- A run-time specifier is a computed string the bundler could not rewrite at build time. The resolver consults the graph first, then the file system relative to the cwd.

<details><summary>Notes</summary>

- The `HAS_MODULE_INFO_STRING_TABLE` reader never advanced the record cursor. It was the last record, so nothing noticed. The alias record follows it, and the debug round-trip assertion in `to_bytes` caught the misread on a `--bytecode` build. The cursor now advances, and `from_bytes` asserts (debug only) that the chain ends exactly at the argv string.
- The alias is `prefix + dirname(dest_path) + basename(src_path)`, so it lives in the chunk's directory. With `--entry-naming "[name]-[hash].[ext]"`, `sub/inner.ts` embeds as `inner-<hash>.js` at the root and its alias is `./inner.ts` at the root too.
- Not changed: a main entry point in a subdirectory (`src/entry.ts`) is still hoisted to `/$bunfs/root/<outfile>`, so `./helper.ts` and `../data/x.json` from it miss, as they do today for every spelling. That is a separate fix in `build_command.rs` / `js_bundle_completion_task.rs`.
- The main entry point gets an alias too (`entry.ts` -> the main module), so `new Worker(new URL("./entry.ts", import.meta.url))` works as it does from disk. A self `import()` during top-level await hangs, the same as `bun entry.ts` from disk does.
- `require()` of the embedded JSON entry returns the ES module namespace (`a`, `b`, `default`). From disk it returns the parsed object. That is the shape of every bundled ESM entry under `require()`, unchanged here (see #40914 for the CommonJS counterpart). `import()` matches the disk result.
- The `.js` retry stays unconditional: existing tests pin `./both.ts` -> `both.js` for a `.js` source and extensionless `./mod` -> `mod.js`.
- Self-reviewed twice. The first pass rejected a wider extension guess for the `config.json` shadowing above and proposed the recorded alias. The second pass found the path-stub and shared-spelling cases, now handled, and questioned whether a format record is warranted without a user report. I left that call to a maintainer: the record is 12 bytes per aliased entry point behind one flag bit, and it is the only exact fix.
- Other suites run on the debug build: `standalone`, `bundler_compile_splitting`, `compile-asset-bunfs`, `bundler_compile_autoload`, `bundler_bytecode_portable`, `compile-node-compile-cache`, `bun-build-compile-sourcemap`, `compile-sourcemap-internal`, `bun-build-compile`. Failures with and without this diff: three `bun-build-compile` tests and five `bundler_bytecode_portable` tests that time out at 5 s or 60 s under ASAN, and `compile/HelloWorldWithProcessVersionsBun` (#37373).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->