### PR TITLE
Bun.Glob: scan the embedded directory tree of compiled executables

### DIFF
--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -233,11 +233,7 @@ pub(crate) mod standalone_accessor {
     }
 
     /// `path` resolved against the handle's directory when relative.
-    fn resolve<'a>(
-        handle: StandaloneHandle,
-        path: &'a [u8],
-        buf: &'a mut PathBuffer,
-    ) -> &'a [u8] {
+    fn resolve<'a>(handle: StandaloneHandle, path: &'a [u8], buf: &'a mut PathBuffer) -> &'a [u8] {
         if Platform::AUTO.is_absolute(path) {
             return path;
         }
@@ -508,9 +504,7 @@ impl Glob {
                 ),
             };
             match result.map_err(crate::Error::from)? {
-                bun_sys::Result::Err(err) => {
-                    Err(global_this.throw_value(err.to_js(global_this)))
-                }
+                bun_sys::Result::Err(err) => Err(global_this.throw_value(err.to_js(global_this))),
                 bun_sys::Result::Ok(gw) => Ok(Box::new(gw)),
             }
         }
@@ -536,14 +530,14 @@ impl Glob {
             return Ok(Some(AnyGlobWalker::Standalone(init_walker::<
                 StandaloneAccessor,
             >(
-                global_this, &self.pattern, &match_opts
+                global_this,
+                &self.pattern,
+                &match_opts,
             )?)));
         }
-        Ok(Some(AnyGlobWalker::Fs(init_walker::<walk::SyscallAccessor>(
-            global_this,
-            &self.pattern,
-            &match_opts,
-        )?)))
+        Ok(Some(AnyGlobWalker::Fs(
+            init_walker::<walk::SyscallAccessor>(global_this, &self.pattern, &match_opts)?,
+        )))
     }
 
     // No `#[bun_jsc::host_fn]` here — the `#[bun_jsc::JsClass]` derive on

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -192,13 +192,9 @@ impl ScanOpts {
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// StandaloneAccessor — `bun_glob::walk::Accessor` impl backed by the
-// standalone-executable module graph, so `Glob.scan` can walk the embedded
-// `/$bunfs/` (`B:\~BUN\` on Windows) virtual directory tree. Lives here, not
-// in `bun_glob`: the low-tier crate owns the trait, the high-tier crate owns
-// the impl (same split as `bun_resolver::DirEntryAccessor`).
-// ─────────────────────────────────────────────────────────────────────────────
+/// `bun_glob::walk::Accessor` over the standalone module graph, so `Glob.scan`
+/// can walk the embedded `/$bunfs/` tree. Up-tier from the trait on purpose,
+/// like `bun_resolver::DirEntryAccessor`.
 pub(crate) mod standalone_accessor {
     use bun_core::ZStr;
     use bun_glob::walk::{Accessor, AccessorDirEntry, AccessorDirIter, AccessorHandle};
@@ -210,9 +206,8 @@ pub(crate) mod standalone_accessor {
 
     #[derive(Clone, Copy)]
     pub(crate) struct StandaloneHandle {
-        /// The canonical `dirs` key of the opened directory. The borrow is
-        /// `'static` because the graph is the process-lifetime singleton
-        /// (`Graph::get_ref`) and its keys are never mutated after startup.
+        /// The opened directory's `Graph::dir_key` (`'static`: the graph is
+        /// the immortal process singleton).
         dir: Option<&'static [u8]>,
     }
 
@@ -285,8 +280,8 @@ pub(crate) mod standalone_accessor {
         }
 
         fn iterate(dir: StandaloneHandle) -> Self {
-            // `dir` came from `open_resolved`, so `readdir` only misses when
-            // the handle is EMPTY (never handed out for a live directory).
+            // `readdir` only misses for the EMPTY handle: `open_resolved`
+            // proved the directory.
             let entries = dir
                 .dir
                 .and_then(|key| Graph::get_ref()?.readdir(key, false))
@@ -310,8 +305,7 @@ pub(crate) mod standalone_accessor {
             handle: StandaloneHandle,
             path: &ZStr,
         ) -> Result<Maybe<StandaloneHandle>, bun_core::Error> {
-            // Pool, not a stack `PathBuffer` (~64 KB on Windows): this runs
-            // inside the walker's iteration on worker-thread stacks.
+            // Pooled: a stack `PathBuffer` is ~64 KB on Windows.
             let mut buf = bun_paths::path_buffer_pool::get();
             Ok(open_resolved(resolve(handle, path.as_bytes(), &mut buf)))
         }
@@ -509,11 +503,9 @@ impl Glob {
             }
         }
 
-        // In a standalone executable, a scan rooted inside the embedded module
-        // graph walks the graph instead of the real filesystem. Mirror the
-        // walker's root choice (`Iterator::init`): an absolute pattern roots
-        // at the pattern's literal prefix and ignores the cwd, a relative
-        // pattern roots at the cwd.
+        // Match the walker's root choice (`Iterator::init`): an absolute
+        // pattern roots at its literal prefix and ignores the cwd, a relative
+        // pattern roots at the cwd. A `/$bunfs/` root walks the graph.
         let pattern_is_absolute = resolve_path::is_absolute(&self.pattern)
             || (cfg!(windows) && resolve_path::is_absolute_posix(&self.pattern));
         let in_standalone_graph = bun_standalone_graph::Graph::get_ref().is_some()

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -249,15 +249,10 @@ pub(crate) mod standalone_accessor {
         let Some(graph) = Graph::get_ref() else {
             return Err(SysError::from_code(E::ENOENT, Tag::open));
         };
-        if let Some(key) = graph.dir_key(path) {
-            return Ok(StandaloneHandle { dir: Some(key) });
+        match graph.dir_key(path) {
+            Ok(key) => Ok(StandaloneHandle { dir: Some(key) }),
+            Err(code) => Err(SysError::from_code(code, Tag::open)),
         }
-        let code = if graph.contains_file(path) {
-            E::ENOTDIR
-        } else {
-            E::ENOENT
-        };
-        Err(SysError::from_code(code, Tag::open))
     }
 
     pub(crate) struct StandaloneDirEntry {
@@ -319,12 +314,14 @@ pub(crate) mod standalone_accessor {
             handle: StandaloneHandle,
             path: &ZStr,
         ) -> Result<Maybe<StandaloneHandle>, bun_core::Error> {
-            let mut buf = PathBuffer::uninit();
+            // Pool, not a stack `PathBuffer` (~64 KB on Windows): this runs
+            // inside the walker's iteration on worker-thread stacks.
+            let mut buf = bun_paths::path_buffer_pool::get();
             Ok(open_resolved(resolve(handle, path.as_bytes(), &mut buf)))
         }
 
         fn statat(handle: StandaloneHandle, path: &ZStr) -> Maybe<Stat> {
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let resolved = resolve(handle, path.as_bytes(), &mut buf);
             Graph::get_ref()
                 .and_then(|graph| graph.stat(resolved))
@@ -519,13 +516,21 @@ impl Glob {
         }
 
         // In a standalone executable, a scan rooted inside the embedded module
-        // graph walks the graph instead of the real filesystem.
+        // graph walks the graph instead of the real filesystem. Mirror the
+        // walker's root choice (`Iterator::init`): an absolute pattern roots
+        // at the pattern's literal prefix and ignores the cwd, a relative
+        // pattern roots at the cwd.
+        let pattern_is_absolute = resolve_path::is_absolute(&self.pattern)
+            || (cfg!(windows) && resolve_path::is_absolute_posix(&self.pattern));
         let in_standalone_graph = bun_standalone_graph::Graph::get_ref().is_some()
-            && (match_opts
-                .cwd
-                .as_deref()
-                .is_some_and(bun_standalone_graph::is_bun_standalone_file_path)
-                || bun_standalone_graph::is_bun_standalone_file_path(&self.pattern));
+            && if pattern_is_absolute {
+                bun_standalone_graph::is_bun_standalone_file_path(&self.pattern)
+            } else {
+                match_opts
+                    .cwd
+                    .as_deref()
+                    .is_some_and(bun_standalone_graph::is_bun_standalone_file_path)
+            };
 
         if in_standalone_graph {
             return Ok(Some(AnyGlobWalker::Standalone(init_walker::<

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -3,6 +3,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use bun_alloc::Arena;
 use bun_core::String as BunString;
 use bun_glob::BunGlobWalker as GlobWalker;
+use bun_glob::walk;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{
     ArgumentsSlice, CallFrame, JSGlobalObject, JSPromiseStrong, JSValue, Job, JobContext, JsPtr,
@@ -191,10 +192,186 @@ impl ScanOpts {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// StandaloneAccessor — `bun_glob::walk::Accessor` impl backed by the
+// standalone-executable module graph, so `Glob.scan` can walk the embedded
+// `/$bunfs/` (`B:\~BUN\` on Windows) virtual directory tree. Lives here, not
+// in `bun_glob`: the low-tier crate owns the trait, the high-tier crate owns
+// the impl (same split as `bun_resolver::DirEntryAccessor`).
+// ─────────────────────────────────────────────────────────────────────────────
+pub(crate) mod standalone_accessor {
+    use bun_core::ZStr;
+    use bun_glob::walk::{Accessor, AccessorDirEntry, AccessorDirIter, AccessorHandle};
+    use bun_paths::{PathBuffer, Platform, platform, resolve_path};
+    use bun_standalone_graph::Graph;
+    use bun_sys::{E, Error as SysError, FileKind, Result as Maybe, Stat, Tag};
+
+    pub(crate) struct StandaloneAccessor;
+
+    #[derive(Clone, Copy)]
+    pub(crate) struct StandaloneHandle {
+        /// The canonical `dirs` key of the opened directory. The borrow is
+        /// `'static` because the graph is the process-lifetime singleton
+        /// (`Graph::get_ref`) and its keys are never mutated after startup.
+        dir: Option<&'static [u8]>,
+    }
+
+    impl AccessorHandle for StandaloneHandle {
+        const EMPTY: Self = StandaloneHandle { dir: None };
+
+        fn is_empty(self) -> bool {
+            self.dir.is_none()
+        }
+
+        fn eql(self, other: Self) -> bool {
+            match (self.dir, other.dir) {
+                (Some(a), Some(b)) => a == b,
+                (None, None) => true,
+                _ => false,
+            }
+        }
+    }
+
+    /// `path` resolved against the handle's directory when relative.
+    fn resolve<'a>(
+        handle: StandaloneHandle,
+        path: &'a [u8],
+        buf: &'a mut PathBuffer,
+    ) -> &'a [u8] {
+        if Platform::AUTO.is_absolute(path) {
+            return path;
+        }
+        let Some(dir) = handle.dir else { return path };
+        resolve_path::join_string_buf::<platform::Auto>(buf, &[dir, path])
+    }
+
+    fn open_resolved(path: &[u8]) -> Maybe<StandaloneHandle> {
+        let Some(graph) = Graph::get_ref() else {
+            return Err(SysError::from_code(E::ENOENT, Tag::open));
+        };
+        if let Some(key) = graph.dir_key(path) {
+            return Ok(StandaloneHandle { dir: Some(key) });
+        }
+        let code = if graph.contains_file(path) {
+            E::ENOTDIR
+        } else {
+            E::ENOENT
+        };
+        Err(SysError::from_code(code, Tag::open))
+    }
+
+    pub(crate) struct StandaloneDirEntry {
+        name: Box<[u8]>,
+        is_dir: bool,
+    }
+
+    impl AccessorDirEntry for StandaloneDirEntry {
+        fn name_slice(&self) -> &[u8] {
+            &self.name
+        }
+        fn kind(&self) -> FileKind {
+            if self.is_dir {
+                FileKind::Directory
+            } else {
+                FileKind::File
+            }
+        }
+    }
+
+    pub(crate) struct StandaloneDirIter {
+        entries: std::vec::IntoIter<(Box<[u8]>, bool)>,
+    }
+
+    impl AccessorDirIter for StandaloneDirIter {
+        type Handle = StandaloneHandle;
+        type Entry = StandaloneDirEntry;
+
+        fn next(&mut self) -> Maybe<Option<StandaloneDirEntry>> {
+            Ok(self
+                .entries
+                .next()
+                .map(|(name, is_dir)| StandaloneDirEntry { name, is_dir }))
+        }
+
+        fn iterate(dir: StandaloneHandle) -> Self {
+            // `dir` came from `open_resolved`, so `readdir` only misses when
+            // the handle is EMPTY (never handed out for a live directory).
+            let entries = dir
+                .dir
+                .and_then(|key| Graph::get_ref()?.readdir(key, false))
+                .unwrap_or_default();
+            StandaloneDirIter {
+                entries: entries.into_iter(),
+            }
+        }
+    }
+
+    impl Accessor for StandaloneAccessor {
+        const COUNT_FDS: bool = false;
+        type Handle = StandaloneHandle;
+        type DirIter = StandaloneDirIter;
+
+        fn open(path: &ZStr) -> Result<Maybe<StandaloneHandle>, bun_core::Error> {
+            Ok(open_resolved(path.as_bytes()))
+        }
+
+        fn openat(
+            handle: StandaloneHandle,
+            path: &ZStr,
+        ) -> Result<Maybe<StandaloneHandle>, bun_core::Error> {
+            let mut buf = PathBuffer::uninit();
+            Ok(open_resolved(resolve(handle, path.as_bytes(), &mut buf)))
+        }
+
+        fn statat(handle: StandaloneHandle, path: &ZStr) -> Maybe<Stat> {
+            let mut buf = PathBuffer::uninit();
+            let resolved = resolve(handle, path.as_bytes(), &mut buf);
+            Graph::get_ref()
+                .and_then(|graph| graph.stat(resolved))
+                .ok_or_else(|| SysError::from_code(E::ENOENT, Tag::fstatat))
+        }
+
+        fn lstatat(handle: StandaloneHandle, path: &ZStr) -> Maybe<Stat> {
+            // The embedded graph has no symlinks, so lstat == stat.
+            Self::statat(handle, path)
+        }
+
+        fn close(_handle: StandaloneHandle) -> Option<SysError> {
+            None
+        }
+    }
+}
+use standalone_accessor::StandaloneAccessor;
+
+type StandaloneGlobWalker = walk::GlobWalker<StandaloneAccessor, false>;
+
+/// The accessor is picked at init time: embedded-graph walks for a cwd or
+/// pattern under the standalone virtual path, syscalls for everything else.
+pub(crate) enum AnyGlobWalker {
+    Fs(Box<GlobWalker>),
+    Standalone(Box<StandaloneGlobWalker>),
+}
+
+impl AnyGlobWalker {
+    fn walk(&mut self) -> Result<bun_sys::Result<()>, bun_core::Error> {
+        match self {
+            AnyGlobWalker::Fs(walker) => walker.walk(),
+            AnyGlobWalker::Standalone(walker) => walker.walk(),
+        }
+    }
+
+    fn result_to_js(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+        match self {
+            AnyGlobWalker::Fs(walker) => glob_walk_result_to_js(walker, global_this),
+            AnyGlobWalker::Standalone(walker) => glob_walk_result_to_js(walker, global_this),
+        }
+    }
+}
+
 /// `Glob.scan()` off the JS thread.
 pub(crate) struct WalkTask {
-    // `Box<GlobWalker>` drop runs `GlobWalker::Drop` then frees the box.
-    walker: Box<GlobWalker>,
+    // Dropping the enum runs `GlobWalker::Drop` then frees the box.
+    walker: AnyGlobWalker,
     err: Option<WalkTaskErr>,
 }
 // SAFETY: the walker owns its pattern/arena; nothing in it is thread-affine.
@@ -261,14 +438,14 @@ impl JobContext for WalkTask {
         Some(done)
     }
 
-    fn then(mut this: Self, mut js: WalkJs, cx: &JsThread<'_>) -> JsResult<()> {
+    fn then(this: Self, mut js: WalkJs, cx: &JsThread<'_>) -> JsResult<()> {
         let global = cx.global();
         let promise = js.promise.swap();
         if let Some(err) = &this.err {
             promise.reject_with_async_stack(global, err.to_js(global))?;
             return Ok(());
         }
-        let js_strings = match glob_walk_result_to_js(&mut this.walker, global) {
+        let js_strings = match this.walker.result_to_js(global) {
             Ok(v) => v,
             Err(e) => return promise.reject(global, Err(e)),
         };
@@ -276,8 +453,8 @@ impl JobContext for WalkTask {
     }
 }
 
-fn glob_walk_result_to_js(
-    glob_walk: &mut GlobWalker,
+fn glob_walk_result_to_js<A: walk::Accessor>(
+    glob_walk: &walk::GlobWalker<A, false>,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
     let keys = glob_walk.matched_paths.keys();
@@ -300,57 +477,68 @@ impl Glob {
         arguments: &mut ArgumentsSlice,
         fn_name: &'static str,
         arena: &mut Arena,
-    ) -> JsResult<Option<Box<GlobWalker>>> {
+    ) -> JsResult<Option<AnyGlobWalker>> {
         let Some(match_opts) = ScanOpts::from_js(global_this, arguments, fn_name, arena)? else {
             return Ok(None);
         };
-        let cwd = match_opts.cwd;
-        let dot = match_opts.dot;
-        let absolute = match_opts.absolute;
-        let follow_symlinks = match_opts.follow_symlinks;
-        let error_on_broken_symlinks = match_opts.error_on_broken_symlinks;
-        let only_files = match_opts.only_files;
 
         let _ = arena; // arena ownership is no longer threaded through GlobWalker init.
 
-        if let Some(cwd) = cwd {
-            let glob_walker = match GlobWalker::init_with_cwd(
-                &self.pattern,
-                &cwd,
-                dot,
-                absolute,
-                follow_symlinks,
-                error_on_broken_symlinks,
-                only_files,
-                None,
-            )
-            .map_err(crate::Error::from)?
-            {
-                bun_sys::Result::Err(err) => {
-                    return Err(global_this.throw_value(err.to_js(global_this)));
-                }
-                bun_sys::Result::Ok(gw) => Box::new(gw),
+        fn init_walker<A: walk::Accessor>(
+            global_this: &JSGlobalObject,
+            pattern: &[u8],
+            opts: &ScanOpts,
+        ) -> JsResult<Box<walk::GlobWalker<A, false>>> {
+            let result = match &opts.cwd {
+                Some(cwd) => walk::GlobWalker::<A, false>::init_with_cwd(
+                    pattern,
+                    cwd,
+                    opts.dot,
+                    opts.absolute,
+                    opts.follow_symlinks,
+                    opts.error_on_broken_symlinks,
+                    opts.only_files,
+                    None,
+                ),
+                None => walk::GlobWalker::<A, false>::init(
+                    pattern,
+                    opts.dot,
+                    opts.absolute,
+                    opts.follow_symlinks,
+                    opts.error_on_broken_symlinks,
+                    opts.only_files,
+                    None,
+                ),
             };
-            return Ok(Some(glob_walker));
+            match result.map_err(crate::Error::from)? {
+                bun_sys::Result::Err(err) => {
+                    Err(global_this.throw_value(err.to_js(global_this)))
+                }
+                bun_sys::Result::Ok(gw) => Ok(Box::new(gw)),
+            }
         }
 
-        let glob_walker = match GlobWalker::init(
+        // In a standalone executable, a scan rooted inside the embedded module
+        // graph walks the graph instead of the real filesystem.
+        let in_standalone_graph = bun_standalone_graph::Graph::get_ref().is_some()
+            && (match_opts
+                .cwd
+                .as_deref()
+                .is_some_and(bun_standalone_graph::is_bun_standalone_file_path)
+                || bun_standalone_graph::is_bun_standalone_file_path(&self.pattern));
+
+        if in_standalone_graph {
+            return Ok(Some(AnyGlobWalker::Standalone(init_walker::<
+                StandaloneAccessor,
+            >(
+                global_this, &self.pattern, &match_opts
+            )?)));
+        }
+        Ok(Some(AnyGlobWalker::Fs(init_walker::<walk::SyscallAccessor>(
+            global_this,
             &self.pattern,
-            dot,
-            absolute,
-            follow_symlinks,
-            error_on_broken_symlinks,
-            only_files,
-            None,
-        )
-        .map_err(crate::Error::from)?
-        {
-            bun_sys::Result::Err(err) => {
-                return Err(global_this.throw_value(err.to_js(global_this)));
-            }
-            bun_sys::Result::Ok(gw) => Box::new(gw),
-        };
-        Ok(Some(glob_walker))
+            &match_opts,
+        )?)))
     }
 
     // No `#[bun_jsc::host_fn]` here — the `#[bun_jsc::JsClass]` derive on
@@ -476,7 +664,7 @@ impl Glob {
             bun_sys::Result::Ok(()) => {}
         }
 
-        glob_walk_result_to_js(&mut glob_walker, global_this)
+        glob_walker.result_to_js(global_this)
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -228,9 +228,7 @@ impl StandaloneModuleGraph {
     }
 
     /// Directory `name`'s stored key (posix-separated, no trailing `/`), or
-    /// the errno an `open(O_DIRECTORY)` of it would produce: `ENOTDIR` for an
-    /// embedded file, `ENOENT` otherwise. Through `get_ref()` the key borrow
-    /// is `'static` (the graph is the process-lifetime singleton).
+    /// the errno an `open(O_DIRECTORY)` of it would produce.
     pub fn dir_key(&self, name: &[u8]) -> Result<&[u8], E> {
         if !is_bun_standalone_file_path(name) {
             return Err(E::ENOENT);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -227,6 +227,20 @@ impl StandaloneModuleGraph {
         self.dirs.contains_key(name)
     }
 
+    /// The stored `dirs` key for `name` (normalized, posix-separated, no
+    /// trailing `/`), or `None` when `name` is not an embedded directory.
+    /// Through `get_ref()` the key borrow is `'static` (the graph is the
+    /// process-lifetime singleton).
+    pub fn dir_key(&self, name: &[u8]) -> Option<&[u8]> {
+        if !is_bun_standalone_file_path(name) {
+            return None;
+        }
+        let mut buf = PathBuffer::uninit();
+        let name = Self::normalize_dir_path(name, &mut buf);
+        let index = self.dirs.get_index(name)?;
+        Some(&self.dirs.keys()[index])
+    }
+
     /// `(entry, is_dir)`; `entry` is the basename, or the `name`-relative path when `recursive`.
     pub fn readdir(&self, name: &[u8], recursive: bool) -> Option<Vec<(Box<[u8]>, bool)>> {
         if !is_bun_standalone_file_path(name) {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -21,7 +21,7 @@ use bun_paths::{self as path, PathBuffer, strings};
 #[cfg(windows)]
 use bun_paths::{OSPathBuffer, WPathBuffer};
 use bun_sourcemap as SourceMap;
-use bun_sys::{self as Syscall, Fd, FdExt as _, Stat};
+use bun_sys::{self as Syscall, E, Fd, FdExt as _, Stat};
 
 bun_core::declare_scope!(StandaloneModuleGraph, hidden);
 
@@ -227,18 +227,24 @@ impl StandaloneModuleGraph {
         self.dirs.contains_key(name)
     }
 
-    /// The stored `dirs` key for `name` (normalized, posix-separated, no
-    /// trailing `/`), or `None` when `name` is not an embedded directory.
-    /// Through `get_ref()` the key borrow is `'static` (the graph is the
-    /// process-lifetime singleton).
-    pub fn dir_key(&self, name: &[u8]) -> Option<&[u8]> {
+    /// Directory `name`'s stored key (posix-separated, no trailing `/`), or
+    /// the errno an `open(O_DIRECTORY)` of it would produce: `ENOTDIR` for an
+    /// embedded file, `ENOENT` otherwise. Through `get_ref()` the key borrow
+    /// is `'static` (the graph is the process-lifetime singleton).
+    pub fn dir_key(&self, name: &[u8]) -> Result<&[u8], E> {
         if !is_bun_standalone_file_path(name) {
-            return None;
+            return Err(E::ENOENT);
         }
         let mut buf = PathBuffer::uninit();
         let name = Self::normalize_dir_path(name, &mut buf);
-        let index = self.dirs.get_index(name)?;
-        Some(&self.dirs.keys()[index])
+        if let Some(index) = self.dirs.get_index(name) {
+            return Ok(&self.dirs.keys()[index]);
+        }
+        Err(if self.lookup_file(name).is_some() {
+            E::ENOTDIR
+        } else {
+            E::ENOENT
+        })
     }
 
     /// `(entry, is_dir)`; `entry` is the basename, or the `name`-relative path when `recursive`.

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -114,7 +114,22 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           readdirCode: errcode(() => fs.readdirSync(cfg)),
         };
 
-        console.log(JSON.stringify({ fileLoader, client, enoent, missing, singleFile }));
+        // Bun.Glob over the embedded tree (issue #40932)
+        const rootPosix = root.split(path.sep).join("/");
+        const glob = {
+          scanSync: [...new Bun.Glob("*").scanSync(root)].sort(),
+          scanAsync: (await Array.fromAsync(new Bun.Glob("*").scan(root))).sort(),
+          recursive: [...new Bun.Glob("**/*").scanSync(root)].sort(),
+          onlyFilesFalse: [...new Bun.Glob("*").scanSync({ cwd: root, onlyFiles: false })].sort(),
+          nestedWildcard: [...new Bun.Glob("_app/immutable/*.css").scanSync(root)].sort(),
+          literalFile: [...new Bun.Glob("_app/immutable/app.css").scanSync(root)].sort(),
+          absoluteOpt: [...new Bun.Glob("*").scanSync({ cwd: root, absolute: true })].sort(),
+          absolutePattern: [...new Bun.Glob(rootPosix + "/*").scanSync({})].sort(),
+          enoentCode: errcode(() => [...new Bun.Glob("*").scanSync(missing)]),
+          enotdirCode: errcode(() => [...new Bun.Glob("*").scanSync(indexHtml)]),
+        };
+
+        console.log(JSON.stringify({ fileLoader, client, enoent, missing, singleFile, glob }));
       `,
         "data.txt": "hello",
         "client/index.html": "<!doctype html><h1>hi</h1>",
@@ -182,6 +197,27 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         enoent: { code: "ENOENT", path: r.missing, exists: false },
         missing: expect.stringMatching(/[/\\]root[/\\]does-not-exist$/),
         singleFile: { exists: true, content: `{"ok":true}`, readdirCode: "ENOTDIR" },
+        glob: {
+          scanSync: ["empty.txt", "favicon.svg", "index.html"],
+          scanAsync: ["empty.txt", "favicon.svg", "index.html"],
+          recursive: [
+            join("_app", "immutable", "app.css"),
+            join("_app", "immutable", "chunks", "entry.js"),
+            "empty.txt",
+            "favicon.svg",
+            "index.html",
+          ].sort(),
+          onlyFilesFalse: ["_app", "empty.txt", "favicon.svg", "index.html"],
+          nestedWildcard: [join("_app", "immutable", "app.css")],
+          literalFile: [join("_app", "immutable", "app.css")],
+          absoluteOpt: ["empty.txt", "favicon.svg", "index.html"].map(n => join(r.client.root, n)).sort(),
+          // An absolute pattern keeps its prefix verbatim; entries append with the platform separator.
+          absolutePattern: ["empty.txt", "favicon.svg", "index.html"]
+            .map(n => r.client.root.replaceAll(sep, "/") + sep + n)
+            .sort(),
+          enoentCode: "ENOENT",
+          enotdirCode: "ENOTDIR",
+        },
       });
       // recursive uses the platform path separator (same as Node's real-fs recursive readdir)
       expect(r.client.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -45,6 +45,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         "index.ts": /* ts */ `
         import asset from "./data.txt" with { type: "file" };
         import fs from "node:fs";
+        import os from "node:os";
         import path from "node:path";
 
         function errcode(fn: () => unknown): string {
@@ -115,6 +116,9 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         };
 
         // Bun.Glob over the embedded tree (issue #40932)
+        const realDir = fs.mkdtempSync(path.join(os.tmpdir(), "bunfs-glob-real-"));
+        fs.writeFileSync(path.join(realDir, "real.txt"), "x");
+        const realDirPosix = realDir.split(path.sep).join("/");
         const rootPosix = root.split(path.sep).join("/");
         const glob = {
           scanSync: [...new Bun.Glob("*").scanSync(root)].sort(),
@@ -125,11 +129,21 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           literalFile: [...new Bun.Glob("_app/immutable/app.css").scanSync(root)].sort(),
           absoluteOpt: [...new Bun.Glob("*").scanSync({ cwd: root, absolute: true })].sort(),
           absolutePattern: [...new Bun.Glob(rootPosix + "/*").scanSync({})].sort(),
+          // A bunfs cwd with an absolute real-fs pattern walks the real filesystem
+          // (an absolute pattern ignores the cwd).
+          mixedRealAbsolute: [...new Bun.Glob(realDirPosix + "/*").scanSync({ cwd: import.meta.dir })],
+          // A real-fs cwd inside a compiled executable still walks the real filesystem.
+          realCwdRelative: [...new Bun.Glob("*").scanSync(realDir)],
+          // Pins the current walker behavior for a fully-literal absolute pattern:
+          // the match is dropped ([]), on the real filesystem and in the embedded
+          // graph alike. If a walker fix changes this, both must change together.
+          absoluteLiteralFile: [...new Bun.Glob(rootPosix + "/index.html").scanSync({})],
           enoentCode: errcode(() => [...new Bun.Glob("*").scanSync(missing)]),
           enotdirCode: errcode(() => [...new Bun.Glob("*").scanSync(indexHtml)]),
         };
+        fs.rmSync(realDir, { recursive: true, force: true });
 
-        console.log(JSON.stringify({ fileLoader, client, enoent, missing, singleFile, glob }));
+        console.log(JSON.stringify({ fileLoader, client, enoent, missing, singleFile, glob, realDirPosix }));
       `,
         "data.txt": "hello",
         "client/index.html": "<!doctype html><h1>hi</h1>",
@@ -215,9 +229,13 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           absolutePattern: ["empty.txt", "favicon.svg", "index.html"]
             .map(n => r.client.root.replaceAll(sep, "/") + "/" + n)
             .sort(),
+          mixedRealAbsolute: [r.realDirPosix + "/real.txt"],
+          realCwdRelative: ["real.txt"],
+          absoluteLiteralFile: [],
           enoentCode: "ENOENT",
           enotdirCode: "ENOTDIR",
         },
+        realDirPosix: expect.any(String),
       });
       // recursive uses the platform path separator (same as Node's real-fs recursive readdir)
       expect(r.client.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -211,9 +211,9 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           nestedWildcard: [join("_app", "immutable", "app.css")],
           literalFile: [join("_app", "immutable", "app.css")],
           absoluteOpt: ["empty.txt", "favicon.svg", "index.html"].map(n => join(r.client.root, n)).sort(),
-          // An absolute pattern keeps its prefix verbatim; entries append with the platform separator.
+          // An absolute pattern keeps its literal prefix verbatim, including its separator style.
           absolutePattern: ["empty.txt", "favicon.svg", "index.html"]
-            .map(n => r.client.root.replaceAll(sep, "/") + sep + n)
+            .map(n => r.client.root.replaceAll(sep, "/") + "/" + n)
             .sort(),
           enoentCode: "ENOENT",
           enotdirCode: "ENOTDIR",


### PR DESCRIPTION
Fixes #40932.

### Problem
- In a compiled executable, `Glob.scan` and `Glob.scanSync` fail with `ENOENT: no such file or directory, open '/$bunfs/root/build'` (`B:\~BUN\root\build` on Windows), while `fs.readdir` lists the same embedded directory.
- The glob walker's only accessor is `SyscallAccessor` (src/glob/GlobWalker.rs:170). It opens the scan root with `open(2)`, and the virtual path does not exist on disk.

### Fix
- Add a walker accessor backed by the standalone module graph (src/runtime/api/glob.rs). It serves directory handles, entries, and stats from the embedded file table, with the same ENOENT and ENOTDIR semantics as `fs.readdir`.
- `Glob.scan` picks the accessor at init time and mirrors the walker's root choice. An absolute pattern roots at its literal prefix, a relative pattern roots at the cwd. So a bunfs cwd with an absolute real-filesystem pattern still walks the real filesystem.
- The new `Graph::dir_key` (src/standalone_graph/StandaloneModuleGraph.rs) returns the stored directory key, or the errno an `open(O_DIRECTORY)` would produce. Open PR #40875 adds the same helper for `Bun.serve` directory routes. The signature and body here are identical, so either PR rebases cleanly on the other.
- Verified: test/bundler/compile-asset-bunfs.test.ts (new `glob` block, stock bun fails it with the issue's ENOENT), on Linux and Windows. Also test/js/bun/glob/ (no new failures).
- Self-reviewed: 3 concerns raised, 3 addressed (the `dir_key` shape, a mixed-root selection regression, and a pre-existing literal-pattern bug, now filed as #40936 and pinned by a test case).

### Background
- A compiled executable embeds its assets in the standalone module graph: a process-lifetime table of files and directory prefixes keyed by virtual posix paths under `/$bunfs/root/` (`B:/~BUN/root/` on Windows). `fs.readdir`, `fs.stat`, and `Bun.file` already consult it.
- The glob walker is generic over an `Accessor` trait (open, openat, statat, directory iteration). `bun_resolver::DirEntryAccessor` already uses this split: the low-tier crate owns the trait, a higher crate owns the impl.
- The graph has no symlinks, so the accessor's `lstatat` equals `statat` and entries are only files or directories.

<details><summary>Notes</summary>

- Accessor selection: the first version chose the embedded accessor when the cwd or the pattern was a bunfs path. Review found a regression: for an absolute pattern the walker ignores the cwd (src/glob/GlobWalker.rs:386-401), so a bunfs cwd plus an absolute real-filesystem pattern must use syscalls. The selection now branches on pattern absoluteness first. The test's `mixedRealAbsolute` and `realCwdRelative` cases cover both directions.
- A fully literal absolute pattern (`new Bun.Glob("/tmp/f.txt").scanSync({})`) returns `[]` on the real filesystem today: the stat fast path never inserts into `matched_paths`. That bug predates this PR (reproduces on 1.4.0) and is filed as #40936. The embedded accessor reproduces the same behavior through the same walker branch. The test pins it in `absoluteLiteralFile` so a walker fix updates both together.
- An absolute pattern's matches keep the literal prefix verbatim, including its separator style: `B:/~BUN/root/client/empty.txt` on Windows. The relative join uses the platform separator. The test encodes both.
- Handle paths borrow the graph's stored `dirs` keys (`&'static`, the graph is the process-lifetime singleton). Join buffers come from `bun_paths::path_buffer_pool`, not the stack: a `PathBuffer` is about 64 KB on Windows and `openat`/`statat` run inside the walker's iteration.
- Suites run: test/bundler/compile-asset-bunfs.test.ts (Linux + Windows), test/js/bun/glob/ (224 pass; the failures are pre-existing debug-build timeouts that also fail on main in this environment, verified by stashing the diff).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/compile-asset-bunfs.test.ts

<!-- robobun:evidence:end -->