### PR TITLE
test runner: stop the failure diff when rendering a value throws

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,23 +44,27 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            // An `Err` leaves a JS exception pending on the VM; the caller
+            // handles `fmt::Error` (see `JSGlobalObject::error_message`).
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(|_| fmt::Error)?;
 
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(|_| fmt::Error)?;
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,8 +44,6 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            // An `Err` leaves a JS exception pending on the VM; the caller
-            // handles `fmt::Error` (see `JSGlobalObject::error_message`).
             JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2872,7 +2872,14 @@ impl ExpectMatcherUtils {
         } else {
             bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", false)
         };
-        let buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n");
+        // `DiffFormatter` reports a JS exception thrown while rendering a value as `fmt::Error`.
+        use core::fmt::Write as _;
+        let mut buf = String::new();
+        if write!(buf, "{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n").is_err()
+            && global_this.has_exception()
+        {
+            return Err(JsError::Thrown);
+        }
         bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }
 }

--- a/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
+++ b/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
@@ -95,12 +95,12 @@ test("failure message diff stops at a value that throws while being rendered", a
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout: JSON.stringify({
+  expect(stdout).toBe(
+    `${JSON.stringify({
       toStrictEqual: "expect(received).toStrictEqual(expected)\n\n",
       matcherHint: "getter failed",
-    }),
-    stderr: "",
-    exitCode: 0,
-  });
+    })}\n`,
+  );
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
+++ b/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
@@ -49,3 +49,58 @@ test("matcher utils propagate exceptions thrown while inspecting the value", asy
     exitCode: 0,
   });
 });
+
+// A failure message diff renders `received` and then `expected`. Rendering
+// `received` can throw (the formatter reads `$$typeof` to detect React
+// elements), and the exception stayed pending while `expected` was rendered.
+// The unfixed build aborts on that pending exception, so the input runs in a
+// child. The matcher still fails with its own error, and `matcherHint` (which
+// renders the same diff) surfaces the exception to its caller.
+test("failure message diff stops at a value that throws while being rendered", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { expect } from "bun:test";
+        const received = {
+          get $$typeof() {
+            throw new Error("getter failed");
+          },
+        };
+        const caught = {};
+        try {
+          expect(received).toStrictEqual([1]);
+          caught.toStrictEqual = "did not throw";
+        } catch (e) {
+          caught.toStrictEqual = e.message;
+        }
+        expect.extend({
+          _matcherHintThrowingValue(received, expected) {
+            try {
+              caught.matcherHint = this.utils.matcherHint("_matcherHintThrowingValue", received, expected);
+            } catch (e) {
+              caught.matcherHint = e.message;
+            }
+            return { pass: true, message: () => "" };
+          },
+        });
+        expect(received)._matcherHintThrowingValue([1]);
+        console.log(JSON.stringify(caught));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      toStrictEqual: "expect(received).toStrictEqual(expected)\n\n",
+      matcherHint: "getter failed",
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a debug assertion in the `bun:test` failure message formatter. A fuzzer found it as `ASSERTION FAILED: Unexpected exception observed ... Maximum call stack size exceeded` in `ExceptionScope::assertNoExceptionExceptTermination`, raised from `JSC__JSValue__getOwn` (`ASSERT_NO_PENDING_EXCEPTION`).

`DiffFormatter::fmt` renders `received` and then `expected` with `JestPrettyFormat::format`. It ignored the `JsResult` of both calls (`let _ = ...; // TODO:`, the same `catch {}` as the old Zig code). When rendering `received` throws, the exception stays pending on the VM. The second `format` call then reads `$$typeof` on `expected` through `JSC__JSValue__getOwn`, which asserts on the pending exception.

Rendering `received` throws when it runs user code. Examples: a `$$typeof` getter that throws (the formatter reads `$$typeof` to detect React elements), a `FormData` whose `toJSON` throws, or any such call near the stack limit (the fuzzer case).

### Changes

`src/runtime/test_runner/diff_format.rs`: report a failed `format` as `fmt::Error` and return. This is what `ZigFormatter::fmt` does for `to_fmt`. The matcher error path (`JSGlobalObject::error_message`) handles `fmt::Error`: it clears the pending exception and uses the partial message.

`src/runtime/test_runner/expect.rs`: `matcherHint` built its string with `format!`, which panics when a `Display` impl fails. Write into a `String` instead. If the write fails and an exception is pending, return `JsError::Thrown` so the caller gets the exception, like `stringify`, `printExpected` and `printReceived` already do.

### Behavior change

Before, on a release build, a diff-based matcher (`toEqual`, `toStrictEqual`, `toMatchObject`) whose `received` value throws during rendering escaped with the getter's error, because `throw_value` saw the stale pending exception. Now it throws the matcher error with a partial message, the same as `toBe`, `toBeNull` and `toBeInstanceOf` do today for the same input:

```
expect(received).toStrictEqual(expected)

```

### Test

`test/js/bun/test/expect-extend-matcher-utils-throw.test.ts` gets a second test. A child process runs `expect(received).toStrictEqual([1])` and `this.utils.matcherHint(name, received, expected)` with a `received` whose `$$typeof` getter throws. It checks the two messages and exit code 0.

- Before the fix (debug): the child aborts with the assertion above.
- Before the fix (release, `USE_SYSTEM_BUN=1`): the test fails on the `toStrictEqual` message (`getter failed`).
- After the fix: passes. Also re-ran `expect.test.js`, `expect-extend.test.js`, `jest-extended.test.js`, `mock-fn.test.js`, `bun-test.test.ts` and the other `expect-*-crash` tests: all green.

The fuzzer input reaches the same code through a stack overflow: it recurses to the stack limit, then calls `expect(obj).toStrictEqual(arr)` where rendering `obj` calls into JS. With this change that input completes with a clean exit.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:
(pass) matcher utils propagate exceptions thrown while inspecting the value [696.13ms]
93 |     stdout: "pipe",
94 |     stderr: "pipe",
95 |   });
96 | 
97 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
98 |   expect(stdout).toBe(
                      ^
error: expect(received).toBe(expected)

- "{"toStrictEqual":"expect(received).toStrictEqual(expected)\n\n","matcherHint":"getter failed"}
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:98:18)
(fail) failure message diff stops at a value that throws while being rendered [468.50ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [3.22s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (d578a8c70)

test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:
(pass) matcher utils propagate exceptions thrown while inspecting the value [12.77ms]
93 |     stdout: "pipe",
94 |     stderr: "pipe",
95 |   });
96 | 
97 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
98 |   expect(stdout).toBe(
                      ^
error: expect(received).toBe(expected)

- "{"toStrictEqual":"expect(received).toStrictEqual(expected)\n\n","matcherHint":"getter failed"}
+ "{"toStrictEqual":"getter failed","matcherHint":"getter failed"}
  "

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:98:18)
(fail) failure message diff stops at a value that throws while being rendered [6.37ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [104.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:
(pass) matcher utils propagate exceptions thrown while inspecting the value [680.61ms]
(pass) failure message diff stops at a value that throws while being rendered [289.71ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [2.96s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 578ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/inst
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/diff_format.rs             | 10 ++--
 src/runtime/test_runner/expect.rs                  |  9 +++-
 .../test/expect-extend-matcher-utils-throw.test.ts | 55 ++++++++++++++++++++++
 3 files changed, 69 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/test_runner/diff_format.rs                        2      4      0
src/runtime/test_runner/expect.rs                             1      3      0
…t/js/bun/test/expect-extend-matcher-utils-throw.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->