### PR TITLE
node:vm: do not report a top-level-await dependency's rejection as unhandled

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -284,9 +284,14 @@ void NodeVMModule::evaluateDependencies(JSGlobalObject* globalObject, AbstractMo
                 // promise means the dependency uses top-level await; the
                 // root record's evaluate() drives the async machinery to
                 // completion and the wrapper status reconciles lazily
-                // (reconcileEvaluationState), so a pending result is fine
-                // here.
-                UNUSED_PARAM(dependencyResult);
+                // (reconcileEvaluationState). Nothing observes this promise
+                // afterwards: a later evaluate() on the dependency re-throws
+                // the stored error, and AsyncModuleExecutionRejected delivers
+                // the same error through the importer's own capability. Mark
+                // it handled so a top-level-await rejection in the dependency
+                // is not reported as unhandled.
+                if (auto* promise = dynamicDowncast<JSPromise>(dependencyResult))
+                    promise->markAsHandled();
             }
         }
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1631,6 +1631,88 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
   });
 });
 
+describe("node:vm SourceTextModule top-level await rejection in a dependency", () => {
+  // Evaluating an importer runs Evaluate() on each dependency too, which gives the
+  // dependency its own capability promise. For a top-level-await dependency that
+  // promise is still pending when it is handed back and nothing ever observes it,
+  // so its later rejection used to be reported as unhandled (exit code 1) even
+  // though every evaluate() the user awaited rejected and was caught.
+  const evaluateAll = `
+    const results = [];
+    for (const [name, m] of modules) {
+      try {
+        await m.evaluate();
+        results.push(name + ": fulfilled");
+      } catch (e) {
+        results.push(name + ": " + e.constructor.name + " " + e.message + " " + m.status + " " + (m.error === e));
+      }
+    }
+    console.log(JSON.stringify(results));
+  `;
+
+  test.concurrent("a dependency shared by two importers", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const M = (src, id) => new vm.SourceTextModule(src, { identifier: id });
+      const leaf = M("await 0; throw new URIError('tla');", "leaf");
+      const a = M("import 'leaf'; export const x = 1;", "a");
+      const b = M("import 'leaf'; export const y = 1;", "b");
+      await a.link(() => leaf);
+      await b.link(() => leaf);
+      const modules = [["a", a], ["b", b], ["leaf", leaf]];
+      ${evaluateAll}
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([
+      "a: URIError tla errored true",
+      "b: URIError tla errored true",
+      "leaf: URIError tla errored true",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a dependency two imports deep", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const M = (src, id) => new vm.SourceTextModule(src, { identifier: id });
+      const leaf = M("await 0; throw new URIError('tla');", "leaf");
+      const mid = M("import 'leaf'; export const m = 1;", "mid");
+      const root = M("import 'mid'; export const r = 1;", "root");
+      const graph = { mid, leaf };
+      await root.link(spec => graph[spec]);
+      const modules = [["root", root], ["mid", mid], ["leaf", leaf]];
+      ${evaluateAll}
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([
+      "root: URIError tla errored true",
+      "mid: URIError tla errored true",
+      "leaf: URIError tla errored true",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});
+
 test("node:vm Object.defineProperty on the context global when the sandbox is an uncacheable dictionary holding an accessor for a built-in", async () => {
   // Regression: NodeVMGlobalObject::defineOwnProperty used a single PropertySlot
   // for both the global-object lookup and the sandbox lookup. When the first


### PR DESCRIPTION
### Problem
- `bun` exits 1 with an unhandled rejection report when a `vm.SourceTextModule` graph has a top-level-await dependency that throws, even though the user catches every `evaluate()`. Node exits 0 for the same script.
- Cause: `NodeVMModule::evaluateDependencies()` (`src/jsc/bindings/NodeVMModule.cpp:280`) calls `evaluate()` on each dependency before the importer, which creates a capability promise on the dependency. For a top-level-await dependency that promise is still pending and nothing observes it. When the dependency rejects, `CyclicModuleRecord::asyncExecutionRejected` rejects the orphan too and JSC reports it.

### Fix
- Mark the dependency's capability promise as handled right after the nested `evaluate()` call.
- Correct because nothing else observes that promise. A later `evaluate()` on the dependency re-throws the stored error, and the importer's own capability carries the same error to the caller. The synchronous error path already marks its capability handled.
- A promise from the user's own `evaluate()` call is untouched. A discarded one is still reported, as in Node.
- Verified: two new tests in `test/js/node/vm/vm.test.ts`, both fail on main. Also `test/js/node/vm/` and the 22 `test-vm-module-*` Node tests.

### Background
- A module with top-level await evaluates asynchronously. `Evaluate()` returns a capability promise that settles when the graph finishes. A rejection walks up `[[AsyncParentModules]]` and rejects each parent's capability too.
- V8 creates that capability only for a module `evaluate()` is called on directly. Bun's wrapper pre-walks the graph and calls `evaluate()` on each dependency (for `initializeImportMeta` and synthetic module steps), so every dependency gets one.
- `JSPromise::rejectPromise` reports a rejection when the promise's `isHandled` flag is clear. `markAsHandled()` sets that flag without a reaction job.

<details><summary>Notes</summary>

Minimal repro (one importer is enough):

```js
import * as vm from "node:vm";
const M = (src, id) => new vm.SourceTextModule(src, { identifier: id });
const leaf = M("await 0; throw new URIError('tla');", "leaf");
const a = M("import 'l'; export const x = 1;", "a");
await a.link(() => leaf);
try { await a.evaluate(); } catch (e) { console.log("a rejected:", e.message); }
try { await leaf.evaluate(); } catch (e) { console.log("leaf rejected:", e.message); }
```

Before: both lines print, then `URIError: tla` is reported as unhandled and the exit code is 1. After: exit code 0, same as `node --experimental-vm-modules`.

One report per nested level: a `root -> mid -> leaf` chain reports two (leaf's and mid's capabilities). The "two imports deep" test covers that.

`markAsHandled()` sets a flag only. A `.then` reaction instead would enqueue a job on the dependency's context queue, which is not drained automatically for `microtaskMode: "afterEvaluate"` contexts (the same reason `drainAfterEvaluate` uses it).

Paths probed against Node with the fix, all identical output and exit code:
- the user evaluates the leaf first, so no nested call happens
- a dependency that throws synchronously (the existing throw path)
- a top-level-await dependency that throws before its first `await`
- a dependency in a `microtaskMode: "afterEvaluate"` context (the inner queue drains inside the nested call, so the rejection was already a throw)
- a fire-and-forget `leaf.evaluate()` whose promise the user discards: still reported, as in Node

#33346 restructures the pre-walk so dependencies no longer evaluate themselves. If it lands, it removes this nested call and this line with it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->