### PR TITLE
process.versions: report the runtime ICU and Unicode versions on macOS

### DIFF
--- a/scripts/build/depVersionsHeader.ts
+++ b/scripts/build/depVersionsHeader.ts
@@ -102,7 +102,7 @@ export function generateDepVersionsHeader(cfg: Config): string {
     "#endif",
     "",
     "// C string constants for easy access",
-    ...versions.map(([name, val]) => `static const char* const BUN_VERSION_${name} = "${val}";`),
+    ...versions.map(([name, val]) => `static constexpr const char* BUN_VERSION_${name} = "${val}";`),
     "",
     "#ifdef __cplusplus",
     "}",

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -8,6 +8,7 @@
 
 // Include the CMake-generated dependency versions header
 #include "bun_dependency_versions.h"
+#include <node_version.h>
 #include <wtf/Scope.h>
 #include <JavaScriptCore/InternalFieldTuple.h>
 #include <JavaScriptCore/JSMicrotask.h>
@@ -103,6 +104,10 @@ typedef int mode_t;
 
 #if ASSERT_ENABLED
 #include <JavaScriptCore/IntegrityInlines.h>
+#endif
+
+#if OS(DARWIN)
+#include <unicode/uversion.h>
 #endif
 
 #pragma mark - Node.js Process
@@ -219,6 +224,33 @@ static JSValue constructPlatform(VM& vm, JSObject* processObject)
 #endif
 }
 
+// macOS links the system libicucore dynamically, so the compile-time U_ICU_VERSION can be newer than what actually runs.
+static inline String icuVersionString()
+{
+#if OS(DARWIN)
+    UVersionInfo version;
+    char buf[U_MAX_VERSION_STRING_LENGTH];
+    u_getVersion(version);
+    u_versionToString(version, buf);
+    return String::fromLatin1(buf);
+#else
+    return String(U_ICU_VERSION ""_s);
+#endif
+}
+
+static inline String unicodeVersionString()
+{
+#if OS(DARWIN)
+    UVersionInfo version;
+    char buf[U_MAX_VERSION_STRING_LENGTH];
+    u_getUnicodeVersion(version);
+    u_versionToString(version, buf);
+    return String::fromLatin1(buf);
+#else
+    return String(U_UNICODE_VERSION ""_s);
+#endif
+}
+
 static JSValue constructVersions(VM& vm, JSObject* processObject)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -234,7 +266,7 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
         const char* version;
     };
     // Use CMake-generated versions
-    static const VersionEntry versions[] = {
+    static constexpr VersionEntry versions[] = {
         { "boringssl", BUN_VERSION_BORINGSSL },
         // https://github.com/oven-sh/bun/issues/7921
         // BoringSSL is a fork of OpenSSL 1.1.0, so we can report OpenSSL 1.1.0
@@ -263,22 +295,21 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
         { "uv", "1.48.0" },
 #endif
     };
-    auto putVersion = [&](const char* name, const char* version) {
-        object->putDirect(vm, JSC::Identifier::fromString(vm, ASCIILiteral::fromLiteralUnsafe(name)), JSC::jsOwnedString(vm, String(ASCIILiteral::fromLiteralUnsafe(version))), 0);
+    auto putVersion = [&](const char* name, String&& version) {
+        object->putDirect(vm, JSC::Identifier::fromString(vm, ASCIILiteral::fromLiteralUnsafe(name)), JSC::jsOwnedString(vm, version), 0);
     };
     for (auto& entry : versions)
-        putVersion(entry.name, entry.version);
+        putVersion(entry.name, String(ASCIILiteral::fromLiteralUnsafe(entry.version)));
 #if OS(WINDOWS)
     putDirectNamed(vm, object, "uv"_s, JSValue(JSC::jsOwnedString(vm, String::fromLatin1(uv_version_string()))));
 #endif
-    putVersion("napi", "10");
-    putVersion("icu", U_ICU_VERSION);
-    putVersion("unicode", U_UNICODE_VERSION);
-    putVersion("sqlite", Bun__sqlite3_version());
-
 #define STRINGIFY_IMPL(x) #x
 #define STRINGIFY(x) STRINGIFY_IMPL(x)
-    putDirectNamed(vm, object, "modules"_s, JSC::jsOwnedString(vm, String(ASCIILiteral::fromLiteralUnsafe(STRINGIFY(REPORTED_NODEJS_ABI_VERSION)))));
+    putVersion("napi", STRINGIFY(NODE_API_SUPPORTED_VERSION_MAX) ""_s);
+    putVersion("icu", icuVersionString());
+    putVersion("unicode", unicodeVersionString());
+    putVersion("sqlite", String::fromLatin1(Bun__sqlite3_version()));
+    putVersion("modules", STRINGIFY(REPORTED_NODEJS_ABI_VERSION) ""_s);
 #undef STRINGIFY
 #undef STRINGIFY_IMPL
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,4 +1,5 @@
 import { spawnSync, which } from "bun";
+import { CString, dlopen, ptr } from "bun:ffi";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
 import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
@@ -489,6 +490,41 @@ it("ICU version does not regress", () => {
     throw new Error(`Unknown platform/arch: ${process.platform}-${process.arch}`);
   }
   expect(parseFloat(process.versions.icu, 10) || 0).toBeGreaterThanOrEqual(parseFloat(min, 10));
+});
+
+it("process.versions.icu and process.versions.unicode describe the ICU the process runs with", () => {
+  // macOS links the system libicucore, so the ICU the build compiled against
+  // can differ from the one the process runs with. String.prototype.toUpperCase
+  // goes through ICU's case mapping, and U+10D70 GARAY SMALL LETTER A only has
+  // an uppercase (U+10D50) from Unicode 16 (ICU 76) on.
+  const hasUnicode16 = "\u{10D70}".toUpperCase() === "\u{10D50}";
+  expect({
+    unicode16: parseFloat(process.versions.unicode) >= 16,
+    icu76: parseInt(process.versions.icu) >= 76,
+  }).toEqual({ unicode16: hasUnicode16, icu76: hasUnicode16 });
+  expect(process.versions.icu).toMatch(/^\d+\.\d+(\.\d+)*$/);
+  expect(process.versions.unicode).toMatch(/^\d+\.\d+(\.\d+)*$/);
+});
+
+it.skipIf(!isMacOS)("process.versions.icu and process.versions.unicode match the system libicucore", () => {
+  // dlopen returns the image bun itself links (-licucore), so these are the
+  // versions of the ICU that does the work in this process.
+  const { symbols } = dlopen("/usr/lib/libicucore.A.dylib", {
+    u_getVersion: { args: ["ptr"], returns: "void" },
+    u_getUnicodeVersion: { args: ["ptr"], returns: "void" },
+    u_versionToString: { args: ["ptr", "ptr"], returns: "void" },
+  });
+  const version = new Uint8Array(4);
+  const string = new Uint8Array(20);
+  const read = getVersion => {
+    getVersion(ptr(version));
+    symbols.u_versionToString(ptr(version), ptr(string));
+    return new CString(ptr(string)).toString();
+  };
+  expect({ icu: process.versions.icu, unicode: process.versions.unicode }).toEqual({
+    icu: read(symbols.u_getVersion),
+    unicode: read(symbols.u_getUnicodeVersion),
+  });
 });
 
 it("process.env.TZ", () => {


### PR DESCRIPTION


### What does this PR do?

macOS links the system libicucore dynamically, so U_ICU_VERSION from the bundled headers (78) can be newer than the ICU that actually runs (74 on macOS 14). Tests that gate on process.versions.icu, like the Unicode 16 IDNA cases in url.test.ts, never skipped on those machines and failed. Linux and Windows link ICU statically and keep the compile-time constants.

Also derive process.versions.napi from NODE_API_SUPPORTED_VERSION_MAX in the Node headers instead of a hardcoded string, and make the generated dependency version table constexpr.

### How did you verify your code works?
