### PR TITLE
postgres: send a string parameter bound to json/jsonb verbatim

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -158,11 +158,9 @@ pub(crate) fn write_bind<Context: WriterContext>(
         // convert it to the binary representation. This minimizes the room
         // for mistakes on our end, such as stripping the timezone
         // differently than what Postgres does when given a timestamp with
-        // timezone. A string bound to json/jsonb already carries the JSON
-        // text, so send it verbatim (like node-postgres and postgres.js);
-        // stringifying it again would turn the document into a JSON string
-        // scalar. json/jsonb are text-format either way, so the format code
-        // written above does not change.
+        // timezone. A string bound to json/jsonb is the JSON text itself:
+        // send it verbatim, like node-postgres, instead of stringifying it
+        // into a JSON string scalar.
         let effective_tag = if value.is_string()
             && (tag.is_binary_format_supported()
                 || matches!(tag, types::Tag::json | types::Tag::jsonb))

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -166,10 +166,21 @@ pub(crate) fn write_bind<Context: WriterContext>(
         };
         match effective_tag {
             types::Tag::jsonb | types::Tag::json => {
-                // Use jsonStringifyFast for SIMD-optimized serialization
-                let str = value
-                    .json_stringify_fast(global)
-                    .map_err(js_error_to_postgres)?;
+                // A string parameter already carries the JSON text. Send it
+                // verbatim (like node-postgres and postgres.js); stringifying
+                // it again would turn the document into a JSON string scalar.
+                let str = if value.is_string() {
+                    let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
+                    if str.tag() == bun_core::Tag::Dead {
+                        return Err(AnyPostgresError::OutOfMemory);
+                    }
+                    str
+                } else {
+                    // Use jsonStringifyFast for SIMD-optimized serialization
+                    value
+                        .json_stringify_fast(global)
+                        .map_err(js_error_to_postgres)?
+                };
                 let slice = str.to_utf8();
                 let l = writer.length()?;
                 writer.write(slice.slice())?;

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -158,29 +158,25 @@ pub(crate) fn write_bind<Context: WriterContext>(
         // convert it to the binary representation. This minimizes the room
         // for mistakes on our end, such as stripping the timezone
         // differently than what Postgres does when given a timestamp with
-        // timezone.
-        let effective_tag = if tag.is_binary_format_supported() && value.is_string() {
+        // timezone. A string bound to json/jsonb already carries the JSON
+        // text, so send it verbatim (like node-postgres and postgres.js);
+        // stringifying it again would turn the document into a JSON string
+        // scalar. json/jsonb are text-format either way, so the format code
+        // written above does not change.
+        let effective_tag = if value.is_string()
+            && (tag.is_binary_format_supported()
+                || matches!(tag, types::Tag::json | types::Tag::jsonb))
+        {
             types::Tag::text
         } else {
             tag
         };
         match effective_tag {
             types::Tag::jsonb | types::Tag::json => {
-                // A string parameter already carries the JSON text. Send it
-                // verbatim (like node-postgres and postgres.js); stringifying
-                // it again would turn the document into a JSON string scalar.
-                let str = if value.is_string() {
-                    let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
-                    if str.tag() == bun_core::Tag::Dead {
-                        return Err(AnyPostgresError::OutOfMemory);
-                    }
-                    str
-                } else {
-                    // Use jsonStringifyFast for SIMD-optimized serialization
-                    value
-                        .json_stringify_fast(global)
-                        .map_err(js_error_to_postgres)?
-                };
+                // Use jsonStringifyFast for SIMD-optimized serialization
+                let str = value
+                    .json_stringify_fast(global)
+                    .map_err(js_error_to_postgres)?;
                 let slice = str.to_utf8();
                 let l = writer.length()?;
                 writer.write(slice.slice())?;

--- a/test/js/sql/postgres-json-string-param.test.ts
+++ b/test/js/sql/postgres-json-string-param.test.ts
@@ -77,8 +77,6 @@ describeWithContainer("postgres json string parameters", { image: "postgres_plai
     await using sql = new SQL(options());
     // .execute() because `expect(query).rejects` on the lazy Query hangs:
     // https://github.com/oven-sh/bun/issues/40949
-    await expect(sql`select ${"not json"}::json as x`.execute()).rejects.toThrow(
-      /invalid input syntax for type json/,
-    );
+    await expect(sql`select ${"not json"}::json as x`.execute()).rejects.toThrow(/invalid input syntax for type json/);
   });
 });

--- a/test/js/sql/postgres-json-string-param.test.ts
+++ b/test/js/sql/postgres-json-string-param.test.ts
@@ -32,18 +32,17 @@ describeWithContainer("postgres json string parameters", { image: "postgres_plai
     expect(row).toEqual({ kind: "object", value: { a: "hello", b: 42 } });
   });
 
-  test("non-ASCII JSON text round-trips through the verbatim path", async () => {
+  // A JS string is 8-bit or 16-bit as a whole, so two documents cover both
+  // transcode arms: "café" stays Latin-1, the emoji/CJK one forces UTF-16.
+  test.each([
+    ["Latin-1", { name: "caf\u00e9" }],
+    ["UTF-16", { name: "\u{1F680}", text: "\u4e16\u754c" }],
+  ])("non-ASCII JSON text (%s) round-trips through the verbatim path", async (_label, doc) => {
     await container.ready;
     await using sql = new SQL(options());
-    // A JS string is 8-bit or 16-bit as a whole, so two documents cover both
-    // transcode arms: "café" stays Latin-1, the emoji/CJK one forces UTF-16.
-    const latin1Doc = { name: "caf\u00e9" };
-    const utf16Doc = { name: "\u{1F680}", text: "\u4e16\u754c" };
-    for (const doc of [latin1Doc, utf16Doc]) {
-      const payload = JSON.stringify(doc);
-      const [row] = await sql`select jsonb_typeof(${payload}::jsonb) as kind, ${payload}::jsonb as value`;
-      expect(row).toEqual({ kind: "object", value: doc });
-    }
+    const payload = JSON.stringify(doc);
+    const [row] = await sql`select jsonb_typeof(${payload}::jsonb) as kind, ${payload}::jsonb as value`;
+    expect(row).toEqual({ kind: "object", value: doc });
   });
 
   test("json_to_recordset accepts a stringified array parameter", async () => {

--- a/test/js/sql/postgres-json-string-param.test.ts
+++ b/test/js/sql/postgres-json-string-param.test.ts
@@ -35,12 +35,15 @@ describeWithContainer("postgres json string parameters", { image: "postgres_plai
   test("non-ASCII JSON text round-trips through the verbatim path", async () => {
     await container.ready;
     await using sql = new SQL(options());
-    // "café" is Latin-1 in JSC's 8-bit representation, "🚀"/"世界" force
-    // UTF-16, so one payload covers both transcode arms of the verbatim path.
-    const doc = { name: "caf\u00e9\u{1F680}", text: "\u4e16\u754c" };
-    const payload = JSON.stringify(doc);
-    const [row] = await sql`select jsonb_typeof(${payload}::jsonb) as kind, ${payload}::jsonb as value`;
-    expect(row).toEqual({ kind: "object", value: doc });
+    // A JS string is 8-bit or 16-bit as a whole, so two documents cover both
+    // transcode arms: "café" stays Latin-1, the emoji/CJK one forces UTF-16.
+    const latin1Doc = { name: "caf\u00e9" };
+    const utf16Doc = { name: "\u{1F680}", text: "\u4e16\u754c" };
+    for (const doc of [latin1Doc, utf16Doc]) {
+      const payload = JSON.stringify(doc);
+      const [row] = await sql`select jsonb_typeof(${payload}::jsonb) as kind, ${payload}::jsonb as value`;
+      expect(row).toEqual({ kind: "object", value: doc });
+    }
   });
 
   test("json_to_recordset accepts a stringified array parameter", async () => {

--- a/test/js/sql/postgres-json-string-param.test.ts
+++ b/test/js/sql/postgres-json-string-param.test.ts
@@ -32,6 +32,17 @@ describeWithContainer("postgres json string parameters", { image: "postgres_plai
     expect(row).toEqual({ kind: "object", value: { a: "hello", b: 42 } });
   });
 
+  test("non-ASCII JSON text round-trips through the verbatim path", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    // "café" is Latin-1 in JSC's 8-bit representation, "🚀"/"世界" force
+    // UTF-16, so one payload covers both transcode arms of the verbatim path.
+    const doc = { name: "caf\u00e9\u{1F680}", text: "\u4e16\u754c" };
+    const payload = JSON.stringify(doc);
+    const [row] = await sql`select jsonb_typeof(${payload}::jsonb) as kind, ${payload}::jsonb as value`;
+    expect(row).toEqual({ kind: "object", value: doc });
+  });
+
   test("json_to_recordset accepts a stringified array parameter", async () => {
     await container.ready;
     await using sql = new SQL(options());
@@ -64,12 +75,10 @@ describeWithContainer("postgres json string parameters", { image: "postgres_plai
   test("non-JSON string bound to ::json fails on the server", async () => {
     await container.ready;
     await using sql = new SQL(options());
-    let error: Error | undefined;
-    try {
-      await sql`select ${"not json"}::json as x`;
-    } catch (e) {
-      error = e as Error;
-    }
-    expect(error?.message).toMatch(/invalid input syntax for type json/);
+    // .execute() because `expect(query).rejects` on the lazy Query hangs:
+    // https://github.com/oven-sh/bun/issues/40949
+    await expect(sql`select ${"not json"}::json as x`.execute()).rejects.toThrow(
+      /invalid input syntax for type json/,
+    );
   });
 });

--- a/test/js/sql/postgres-json-string-param.test.ts
+++ b/test/js/sql/postgres-json-string-param.test.ts
@@ -1,0 +1,75 @@
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+// https://github.com/oven-sh/bun/issues/40942
+// A string parameter bound to a json/jsonb placeholder carries the JSON text
+// itself and must be sent verbatim, not re-stringified into a JSON string
+// scalar. This matches node-postgres and postgres.js.
+describeWithContainer("postgres json string parameters", { image: "postgres_plain" }, container => {
+  const options = () =>
+    ({
+      db: "bun_sql_test",
+      username: "bun_sql_test",
+      host: container.host,
+      port: container.port,
+      max: 1,
+    }) as const;
+
+  test("string parameter bound to ::json is sent as the JSON text itself", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    const payload = JSON.stringify([{ id: 1, name: "a" }]);
+    const [row] = await sql`select json_typeof(${payload}::json) as kind, ${payload}::json as value`;
+    expect(row).toEqual({ kind: "array", value: [{ id: 1, name: "a" }] });
+  });
+
+  test("string parameter bound to ::jsonb is sent as the JSON text itself", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    const payload = JSON.stringify({ a: "hello", b: 42 });
+    const [row] = await sql`select jsonb_typeof(${payload}::jsonb) as kind, ${payload}::jsonb as value`;
+    expect(row).toEqual({ kind: "object", value: { a: "hello", b: 42 } });
+  });
+
+  test("json_to_recordset accepts a stringified array parameter", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    const payload = JSON.stringify([
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+    ]);
+    const rows = await sql.unsafe("select * from json_to_recordset($1::json) as x(id int, name text)", [payload]);
+    expect(rows).toEqual([
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+    ]);
+  });
+
+  test("object parameter bound to ::json is still stringified", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    const [row] = await sql`select json_typeof(${{ a: 1 }}::json) as kind, ${{ a: 1 }}::json as value`;
+    expect(row).toEqual({ kind: "object", value: { a: 1 } });
+  });
+
+  test("string parameter bound to ::json with prepare: false", async () => {
+    await container.ready;
+    await using sql = new SQL({ ...options(), prepare: false });
+    const payload = JSON.stringify([{ id: 1 }]);
+    const [row] = await sql`select json_typeof(${payload}::json) as kind`;
+    expect(row).toEqual({ kind: "array" });
+  });
+
+  test("non-JSON string bound to ::json fails on the server", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    let error: Error | undefined;
+    try {
+      await sql`select ${"not json"}::json as x`;
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error?.message).toMatch(/invalid input syntax for type json/);
+  });
+});


### PR DESCRIPTION
Fixes #28819

### Problem

- A string bound to a `json` or `jsonb` parameter is serialized twice. `JSON.stringify({hello: "world"})` is stored as a JSON string scalar: `json_typeof` reports `string`, and `json_to_recordset($1::json)` fails with `cannot call json_to_recordset on a scalar`. `drizzle-orm/bun-sql` and pg-boss stringify before they bind, so both break.
- The cause is `write_bind` (`src/sql_jsc/postgres/PostgresRequest.rs:173`): the json/jsonb arm calls `json_stringify_fast` on every value, strings included.

### Fix

- A string bound to json/jsonb now takes the generic text arm, which writes its UTF-8 bytes verbatim. Objects and arrays keep `json_stringify_fast`.
- node-postgres does the same for a string. postgres.js does not: it stringifies the string again, as Bun did.
- **Behavior change:** a bare string is now JSON text. `${"hello"}::json` stored the JSON string `"hello"` and now fails with `22P02 invalid input syntax for type json`. `${"42"}::jsonb` stored a string and now stores the number `42`, with no error. To store a JSON string, pass `JSON.stringify(str)`. `docs/runtime/sql.mdx` states the rule.
- Verified: `test/js/sql/postgres-json-string-param.test.ts` (10 tests, 8 fail without the fix). Also ran `postgres-bytea-bind.test.ts`, `sql-prepare-false.test.ts`, and the 40 json tests of `sql.test.ts` (results in Notes). Self-reviewed: 3 concerns raised, 3 addressed.

### Background

- After Parse, the server's ParameterDescription message reports the type OID of each parameter. For OID 114 (`json`) or 3802 (`jsonb`) the driver formats the value itself.
- json and jsonb use the text wire format, so the Bind payload is the JSON text. That does not change.
- MySQL is not affected. That driver selects `MYSQL_TYPE_JSON` only for an object.

<details><summary>Notes</summary>

Repro from the issue:

```ts
const payload = JSON.stringify([{ id: 1, name: "a" }]);
const [row] = await sql.unsafe("SELECT json_typeof($1::json) AS kind", [payload]);
// before: { kind: "string" }   after: { kind: "array" }
```

Other drivers, measured on the same server with `SELECT json_typeof($1::json)`:

| input | pg 8.11.1 | postgres 3.3.5 | Bun before | Bun after |
| --- | --- | --- | --- | --- |
| `JSON.stringify({hello:"world"})` | object | string | string | object |
| `JSON.stringify([1,2,3])` | array | string | string | array |
| `JSON.stringify(42)` | number | string | string | number |
| `JSON.stringify("hello")` | string | string | string | string |
| plain `"hello"` | ERROR 22P02 | string | string | ERROR 22P02 |
| plain `"42"` | number | string | string | number |
| raw object | object | object | object | object |
| raw array `[1,2,3]` | ERROR 22P02 | array | array | array |

- The last row is a difference from node-postgres that stays. node-postgres sends a JS array as a Postgres array literal. Bun serializes it as JSON, before and after this change.
- postgres.js lets a caller replace the serializers for OID 114 and 3802, and drizzle does that. `Bun.SQL` has no such hook, so `drizzle-orm/bun-sql` cannot work around the double encoding.
- A heuristic (send verbatim only if the string parses as JSON) is not used. The result would depend on the data: `"42"`, `"null"`, and `"true"` would change type with no error.
- Entry points covered by tests: tagged template with a cast, insert into `json` and `jsonb` columns with no cast, `sql.unsafe(query, [param])`, the `sql({...})` insert helper, and `prepare: false`.
- The non-ASCII tests cover both transcode arms of `to_utf8` (Latin-1 and UTF-16 source strings).
- No existing test in `test/js/sql/` binds a string to a json or jsonb parameter. The existing binds pass objects or arrays.

Test runs on a debug build against a local PostgreSQL 17:

- `postgres-json-string-param.test.ts`: 10 pass. On `1.4.3-canary.1+09bb54630` without the fix: 8 fail. The 2 that pass both ways are controls (an object is still stringified, and `prepare: false` was already correct).
- `postgres-bytea-bind.test.ts`: 6 pass. `sql-prepare-false.test.ts`: 8 pass.
- `sql.test.ts -t json`: 38 pass, 2 fail. The 2 failures (`jsonb[] - unicode escape sequences` and `jsonb[] - mixed unicode and escape sequences`) fail the same way without the fix. They bind no parameter. My local database uses the `SQL_ASCII` encoding, which rejects `\u` escapes above ASCII. The rest of the Postgres block in `sql.test.ts` needs docker, so I did not run it locally.
- `postgres-json-bind-leak.fixture.ts`, run directly: RSS delta 12 MiB (bound 80). It binds an object, so it stays on the `json_stringify_fast` path.

History:

- #28821 had the same fix for the Zig sources. It was closed unmerged when the Zig files were removed.
- #40942 is a duplicate report of #28819.
- While writing the error-case test I hit an unrelated hang: `await expect(sqlQuery).rejects.toThrow(...)` never settles, because the lazy Query only dispatches inside its overridden `then()`. Filed as #40949. The test calls `.execute()` first, the same workaround as `sql-mysql-bigint-out-of-range.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-json-string-param.test.ts
bun test v1.4.3 (09bb54630)

test/js/sql/postgres-json-string-param.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
19 |   test("string parameter bound to ::json is sent as the JSON text itself", async () => {
20 |     await container.ready;
21 |     await using sql = new SQL(options());
22 |     const payload = JSON.stringify([{ id: 1, name: "a" }]);
23 |     const [row] = await sql`select json_typeof(${payload}::json) as kind, ${payload}::json as value`;
24 |     expect(row).toEqual({ kind: "array", value: [{ id: 1, name: "a" }] });
                     ^
error: expect(received).toEqual(expected)

  {
-   "kind": "array",
-   "value": [
-     {
-       "id": 1,
-       "name": "a",
-     },
-   ],
+   "kind": "string",
+   "value": "[{"id":1,"name":"a"}]",
  }

- Expected  - 7
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/postgres-json-string-param.test.ts:24:17)
(fail) postgres json string parameters > string parameter bound to ::json is 
... (truncated)

release without fix: 8 FAILED
bun test v1.4.3-canary.1 (09bb54630)

test/js/sql/postgres-json-string-param.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
19 |   test("string parameter bound to ::json is sent as the JSON text itself", async () => {
20 |     await container.ready;
21 |     await using sql = new SQL(options());
22 |     const payload = JSON.stringify([{ id: 1, name: "a" }]);
23 |     const [row] = await sql`select json_typeof(${payload}::json) as kind, ${payload}::json as value`;
24 |     expect(row).toEqual({ kind: "array", value: [{ id: 1, name: "a" }] });
                     ^
error: expect(received).toEqual(expected)

  {
-   "kind": "array",
-   "value": [
-     {
-       "id": 1,
-       "name": "a",
-     },
-   ],
+   "kind": "string",
+   "value": "[{"id":1,"name":"a"}]",
  }

- Expected  - 7
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/postgres-json-string-param.test.ts:24:17)
(fail) postgres json string parameters > string parameter bound to ::json is sent as the JSON text itself [7.79ms]
27 |   test("string parameter bound to ::jsonb is sent as the JSON text itself", async () => {
28 |     await container.ready;
29 | 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-json-string-param.test.ts
bun test v1.4.3 (09bb54630)

test/js/sql/postgres-json-string-param.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres json string parameters > string parameter bound to ::json is sent as the JSON text itself [252.16ms]
(pass) postgres json string parameters > string parameter bound to ::jsonb is sent as the JSON text itself [28.72ms]
(pass) postgres json string parameters > non-ASCII JSON text (Latin-1) round-trips through the verbatim path [23.22ms]
(pass) postgres json string parameters > non-ASCII JSON text (UTF-16) round-trips through the verbatim path [12.43ms]
(pass) postgres json string parameters > json_to_recordset accepts a stringified array parameter [24.14ms]
(pass) postgres json string parameters > stringified values inserted into json and jsonb columns keep their JSON type [59.26ms]
(pass) postgres json string parameters > sql() insert helper sends stringified values verbatim [46.79ms]
(pass) postgres json string parameters > object 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 657ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 32s
[2/6] link bun-profile
rust-lld: warning: Linking two modules of different target triples: 'obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o' is 'x86_64-pc-linux-gnu' whereas '../../../../root/.bun/build-cache/webkit-65513e295c73416a-lto/lib/libJavaScriptCore.a(UnifiedSource-inspector-2.cpp.o at 97577272)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o' is 'x86_64-pc-linux-gnu' whereas '../../../../root/.bun/build-cache/webkit-65513e295c73416a-lto/lib/libJavaScriptCore.a(UnifiedSource-inspector-2.cpp.o at 97577272)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/vendor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sql.mdx                           |  17 ++++
 src/sql_jsc/postgres/PostgresRequest.rs        |   9 +-
 test/js/sql/postgres-json-string-param.test.ts | 115 +++++++++++++++++++++++++
 3 files changed, 139 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
docs/runtime/sql.mdx                                0      0     18
src/sql_jsc/postgres/PostgresRequest.rs             2      4     18
test/js/sql/postgres-json-string-param.test.ts      3      9     18
```

</details>

**root cause** · written by the author bot

When a parameter was typed json or jsonb, the Postgres bind path passed every value through JSON serialization, so a string that already contained JSON text was encoded a second time and reached the server as a JSON string scalar rather than the document it spelled out. The fix checks whether the bound value is a JavaScript string and, if so, sends it as text unchanged while still serializing objects and arrays, so the server parses the string as JSON and `$1::json` yields the array or object the caller intended. This matches the behavior of node-postgres and lets libraries that serialize t…

<!-- robobun:evidence:end -->
