### PR TITLE
test: check process.versions.icu against the linked ICU

### DIFF
--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,4 +1,5 @@
 import { spawnSync, which } from "bun";
+import { CString, dlopen, ptr } from "bun:ffi";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
 import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
@@ -489,6 +490,41 @@ it("ICU version does not regress", () => {
     throw new Error(`Unknown platform/arch: ${process.platform}-${process.arch}`);
   }
   expect(parseFloat(process.versions.icu, 10) || 0).toBeGreaterThanOrEqual(parseFloat(min, 10));
+});
+
+it("process.versions.icu and process.versions.unicode describe the ICU the process runs with", () => {
+  // macOS links the system libicucore, so the ICU the build compiled against
+  // can differ from the one the process runs with. String.prototype.toUpperCase
+  // goes through ICU's case mapping, and U+10D70 GARAY SMALL LETTER A only has
+  // an uppercase (U+10D50) from Unicode 16 (ICU 76) on.
+  const hasUnicode16 = "\u{10D70}".toUpperCase() === "\u{10D50}";
+  expect({
+    unicode16: parseFloat(process.versions.unicode) >= 16,
+    icu76: parseInt(process.versions.icu) >= 76,
+  }).toEqual({ unicode16: hasUnicode16, icu76: hasUnicode16 });
+  expect(process.versions.icu).toMatch(/^\d+\.\d+(\.\d+)*$/);
+  expect(process.versions.unicode).toMatch(/^\d+\.\d+(\.\d+)*$/);
+});
+
+it.skipIf(!isMacOS)("process.versions.icu and process.versions.unicode match the system libicucore", () => {
+  // dlopen returns the image bun itself links (-licucore), so these are the
+  // versions of the ICU that does the work in this process.
+  const { symbols } = dlopen("/usr/lib/libicucore.A.dylib", {
+    u_getVersion: { args: ["ptr"], returns: "void" },
+    u_getUnicodeVersion: { args: ["ptr"], returns: "void" },
+    u_versionToString: { args: ["ptr", "ptr"], returns: "void" },
+  });
+  const version = new Uint8Array(4);
+  const string = new Uint8Array(20);
+  const read = getVersion => {
+    getVersion(ptr(version));
+    symbols.u_versionToString(ptr(version), ptr(string));
+    return new CString(ptr(string)).toString();
+  };
+  expect({ icu: process.versions.icu, unicode: process.versions.unicode }).toEqual({
+    icu: read(symbols.u_getVersion),
+    unicode: read(symbols.u_getUnicodeVersion),
+  });
 });
 
 it("process.env.TZ", () => {


### PR DESCRIPTION
### Problem
- #40943 reads the ICU and Unicode versions from the linked libicucore at run time on macOS. It has no test. Without the fix, `process.versions.icu` reports the header version (78) on a macOS 14 agent that runs ICU 74, and `test/js/web/url/url.test.ts` fails with `TypeError: Invalid URL`.
- #40183 carried the same fix with two tests. This PR moves those tests onto the #40943 branch. #40183 is closed.

### Fix
- Test 1 runs on every platform. `process.versions.unicode >= 16` and `process.versions.icu >= 76` must agree with a runtime probe: `"\u{10D70}".toUpperCase()`. U+10D70 GARAY SMALL LETTER A has an uppercase only from Unicode 16 (ICU 76) on, and `toUpperCase` goes through ICU. On macOS 14 without the fix, `process.versions` says 78 and the probe says no, so the test fails.
- Test 2 runs on macOS only. It reads `u_getVersion()` and `u_getUnicodeVersion()` from `/usr/lib/libicucore.A.dylib` through `bun:ffi` and requires the same strings as `process.versions`.
- Verified: `bun bd test test/js/node/process/process.test.js -t icu` on Linux with the #40943 branch. Test 1 passes, test 2 is skipped. Both passed on the macOS lanes of #40183 (build 104133), which had the same runtime lookup.

### Background
- On macOS bun links the system `libicucore` dynamically, so the `U_ICU_VERSION` header constant describes the SDK, not the library that runs. Linux and Windows link ICU statically, so header and library agree there.
- `u_getVersion()` and `u_getUnicodeVersion()` return the version of the loaded ICU. `u_versionToString()` formats them as `74.1` or `16.0`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->