### PR TITLE
test(fetch): deflake the textStream() drop-after-empty-decode case

### DIFF
--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -696,17 +696,29 @@ for (const { body, fn } of bodyTypes) {
           },
         );
         test("rejects a fetch textStream() when the connection drops after an empty decode", async () => {
+          // The client must consume "A" before the drop reaches the HTTP
+          // thread: a failure that arrives in the same progress update as
+          // unread body bytes errors the body and discards those bytes.
+          const consumedFirstChunk = Promise.withResolvers<void>();
           await using server = await rawChunkedServer(async sock => {
-            for (const p of [[0x41], [0xf0], [0x9f]]) await writeChunk(sock, p);
+            await writeChunk(sock, [0x41]);
+            await consumedFirstChunk.promise;
+            for (const p of [[0xf0], [0x9f]]) await writeChunk(sock, p);
             sock.destroy();
           });
           const res = await fetch(`http://127.0.0.1:${server.port}/`);
           let received = "";
           let error: any;
           try {
-            for await (const ch of res.textStream()) received += ch;
+            for await (const ch of res.textStream()) {
+              received += ch;
+              consumedFirstChunk.resolve();
+            }
           } catch (e) {
             error = e;
+          } finally {
+            // Let the server finish (and close the socket) if the stream ended early.
+            consumedFirstChunk.resolve();
           }
           expect({ code: error?.code, received }).toEqual({ code: "ECONNRESET", received: "A" });
         });


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/body.test.ts` > "rejects a fetch textStream() when the connection drops after an empty decode" fails in the parallel CI batch with `received: ""` instead of `"A"`. The error code is the expected `ECONNRESET`. It passes when it runs alone.
- The test server writes `"A"`, `0xF0`, `0x9F` (one `setImmediate` apart) and then destroys the socket. Under load, the HTTP thread sees all of that before the JS thread has read anything. `FetchTasklet::callback` coalesces the updates into one progress update with `fail` set, and `to_body_value` (`src/runtime/webcore/fetch/FetchTasklet.rs:1707`) or `on_body_received` (`:740`) turns the body into an errored stream. The buffered `"A"` is discarded by design.

### Fix
- The server now waits until the client has consumed the first chunk before it writes the incomplete UTF-8 tail and drops the socket. A `Promise.withResolvers` resolved from the `for await` body is the handshake. A `finally` resolves it too, so the server still closes the socket if the stream ends early.
- The drop still lands after the empty decodes (`0xF0`, `0x9F` decode to nothing), which is what the test guards: the stall fixed in #36180 surfaced as a hang, not a rejection.
- Verified: 24 parallel loops of the old test body failed 1400 of 3600 iterations. The new body: 0 of 3600. With `bun test` under the same load: old 32 of 192 failures, new 0 of 192 (release) and 0 of 60 (debug build). The whole file passes with `bun bd test`.

### Background
- `res.textStream()` on a fetch response is a native `ByteStream` source in text mode. The HTTP thread delivers body bytes and the terminal result to the JS thread through `FetchTasklet`.
- `FetchTasklet::callback` posts at most one task at a time (`has_schedule_callback`). Results that arrive before the JS thread runs that task are merged: body bytes are appended to `scheduled_response_buffer`, and the latest `fail` or `has_more` wins.
- When the merged update carries the response head and a failure, the body is `BodyValue::Error` and the bytes are dropped. When it carries a failure after the head was already delivered, `ByteStream::on_data(Err)` rejects the pending pull or, with no pull pending, `append(Err)` clears the buffer (#32662). Whether the consumer sees the bytes before the error depends on timing.

<details><summary>Notes</summary>

- Repro: `/tmp/repro-textstream.ts` style loop (the test body, 150 iterations) run 24 times in parallel on a 16-core box. Failure rate 24% to 59% per process, all with `received: ""` and `code: "ECONNRESET"`. The same loop with the handshake: 0 failures in 3600 iterations.
- The single-process loop (no load) passes 300 of 300 with the old body, which is why the test passes alone.
- The other cases in the same `test.each` table end with a clean `0\r\n\r\n`. A coalesced successful end delivers the bytes (`TemporaryAndDone`), so they are not affected.
- The data-then-error order is timing dependent in bun for any streaming fetch that fails mid-body. Browsers deliver the bytes received before the error first. This PR does not change that behavior. It only removes the dependence from the test.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->