### PR TITLE
test(tcp-server): count leaked sockets in a fresh process

### DIFF
--- a/test/js/bun/net/tcp-server-leak-fixture.ts
+++ b/test/js/bun/net/tcp-server-leak-fixture.ts
@@ -1,0 +1,82 @@
+// Spawned by tcp-server.test.ts "should not leak memory". The counts below are
+// heap-wide, and a `bun test --parallel` worker runs several files in one heap,
+// so the check has to run in a process of its own. It does not import
+// "harness": that costs over a second of startup in a debug build.
+import { heapStats } from "bun:jsc";
+import { expect } from "bun:test";
+
+const ROUND_TRIPS = 10;
+
+async function echoRoundTrip(hostname: string, port: number) {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  await Bun.connect({
+    hostname,
+    port,
+    socket: {
+      open(socket) {
+        socket.write("ping");
+      },
+      data(socket) {
+        socket.end();
+      },
+      close() {
+        resolve();
+      },
+      error(_, error) {
+        reject(error);
+      },
+      connectError(_, error) {
+        reject(error);
+      },
+    },
+  });
+  await promise;
+}
+
+// Everything that touches a Listener or a TCPSocket stays inside this function,
+// so no frame below the count still holds one.
+async function run() {
+  let closedOnServer = 0;
+  const allClosedOnServer = Promise.withResolvers<void>();
+  const server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open() {},
+      data(socket, data) {
+        socket.write(data);
+      },
+      close() {
+        if (++closedOnServer === ROUND_TRIPS) allClosedOnServer.resolve();
+      },
+    },
+  });
+  for (let i = 0; i < ROUND_TRIPS; i++) {
+    await echoRoundTrip(server.hostname, server.port);
+  }
+  await allClosedOnServer.promise;
+  server.stop();
+}
+
+function liveObjects(type: string): number {
+  Bun.gc(true);
+  return heapStats().objectTypeCounts[type] ?? 0;
+}
+
+// The native side releases a closed socket's wrapper one event loop turn after
+// the close callback, and a debug build keeps two more reachable for about a
+// second, so poll with a deadline like harness's expectMaxObjectTypeCount.
+async function expectAtMost(type: string, max: number) {
+  const deadline = performance.now() + 2000;
+  while (liveObjects(type) > max && performance.now() < deadline) {
+    await Bun.sleep(20);
+  }
+  expect(liveObjects(type)).toBeLessThanOrEqual(max);
+}
+
+await run();
+
+// 2 is the prototype and the constructor.
+await expectAtMost("Listener", 2);
+// The Windows slack for one more pair of sockets dates from #29538.
+await expectAtMost("TCPSocket", process.platform === "win32" ? 4 : 2);

--- a/test/js/bun/net/tcp-server-leak-fixture.ts
+++ b/test/js/bun/net/tcp-server-leak-fixture.ts
@@ -1,22 +1,29 @@
 // Spawned by tcp-server.test.ts "should not leak memory". The counts below are
 // heap-wide, and a `bun test --parallel` worker runs several files in one heap,
-// so the check has to run in a process of its own. It does not import
-// "harness": that costs over a second of startup in a debug build.
+// so the check has to run in a process of its own. It mirrors the echo tests
+// of that file: a `using` listener and a client per binaryType. It does not
+// import "harness": that costs over a second of startup in a debug build.
 import { heapStats } from "bun:jsc";
 import { expect } from "bun:test";
 
-const ROUND_TRIPS = 10;
+const BINARY_TYPES = ["arraybuffer", "uint8array", "buffer"] as const;
+const ROUND_TRIPS_PER_TYPE = 4;
+const DATA_CLASS = { arraybuffer: ArrayBuffer, uint8array: Uint8Array, buffer: Buffer };
 
-async function echoRoundTrip(hostname: string, port: number) {
+type BinaryType = (typeof BINARY_TYPES)[number];
+
+async function echoRoundTrip(hostname: string, port: number, binaryType: BinaryType) {
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   await Bun.connect({
     hostname,
     port,
     socket: {
+      binaryType,
       open(socket) {
         socket.write("ping");
       },
-      data(socket) {
+      data(socket, data) {
+        expect(data).toBeInstanceOf(DATA_CLASS[binaryType]);
         socket.end();
       },
       close() {
@@ -35,27 +42,27 @@ async function echoRoundTrip(hostname: string, port: number) {
 
 // Everything that touches a Listener or a TCPSocket stays inside this function,
 // so no frame below the count still holds one.
-async function run() {
+async function run(binaryType: BinaryType) {
   let closedOnServer = 0;
   const allClosedOnServer = Promise.withResolvers<void>();
-  const server = Bun.listen({
+  using server = Bun.listen({
     hostname: "127.0.0.1",
     port: 0,
     socket: {
+      binaryType,
       open() {},
       data(socket, data) {
         socket.write(data);
       },
       close() {
-        if (++closedOnServer === ROUND_TRIPS) allClosedOnServer.resolve();
+        if (++closedOnServer === ROUND_TRIPS_PER_TYPE) allClosedOnServer.resolve();
       },
     },
   });
-  for (let i = 0; i < ROUND_TRIPS; i++) {
-    await echoRoundTrip(server.hostname, server.port);
+  for (let i = 0; i < ROUND_TRIPS_PER_TYPE; i++) {
+    await echoRoundTrip(server.hostname, server.port, binaryType);
   }
   await allClosedOnServer.promise;
-  server.stop();
 }
 
 function liveObjects(type: string): number {
@@ -74,7 +81,9 @@ async function expectAtMost(type: string, max: number) {
   expect(liveObjects(type)).toBeLessThanOrEqual(max);
 }
 
-await run();
+for (const binaryType of BINARY_TYPES) {
+  await run(binaryType);
+}
 
 // 2 is the prototype and the constructor.
 await expectAtMost("Listener", 2);

--- a/test/js/bun/net/tcp-server-leak-fixture.ts
+++ b/test/js/bun/net/tcp-server-leak-fixture.ts
@@ -23,7 +23,8 @@ async function echoRoundTrip(hostname: string, port: number, binaryType: BinaryT
         socket.write("ping");
       },
       data(socket, data) {
-        expect(data).toBeInstanceOf(DATA_CLASS[binaryType]);
+        // Not toBeInstanceOf: a Buffer is also a Uint8Array.
+        expect(data.constructor).toBe(DATA_CLASS[binaryType]);
         socket.end();
       },
       close() {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -1,6 +1,7 @@
 import { connect, listen, SocketHandler, TCPSocketListener } from "bun";
 import { describe, expect, it } from "bun:test";
-import { expectMaxObjectTypeCount, isWindows } from "harness";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 
 type Resolve = (value?: unknown) => void;
 type Reject = (reason?: any) => void;
@@ -296,17 +297,18 @@ describe("tcp socket binaryType", () => {
 });
 
 it("should not leak memory", async () => {
-  // assert we don't leak the sockets
-  // we expect 1 or 2 because that's the prototype / structure
-  await expectMaxObjectTypeCount(expect, "Listener", 2);
-  // JSC's native `using` implementation keeps the disposed value in a
-  // bytecode register for the lifetime of the enclosing function frame
-  // (emitUsingBodyScope does not clear `slot.value` after calling dispose),
-  // whereas Bun's previous lowered `__callDispose` polyfill released the
-  // reference via `stack.pop()` immediately. On Windows this can leave one
-  // extra accepted socket reachable for one more GC cycle. Disposal still
-  // happens correctly; this is purely a GC-observable register-lifetime
-  // difference. The JSC-side fix (clearing the value register after dispose)
-  // requires a WebKit rebuild and is tracked separately.
-  await expectMaxObjectTypeCount(expect, "TCPSocket", isWindows ? 4 : 2);
+  // The fixture counts live Listener and TCPSocket objects after the sockets
+  // close. The count is heap-wide, and under `bun test --parallel` this
+  // process also holds the previous file's global (its own TCPSocket
+  // prototype, and any sockets it left behind), so the fixture runs alone.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "tcp-server-leak-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -166,7 +166,7 @@ it("echo server 1 on 1", async () => {
 
     using server: TCPSocketListener<any> | undefined = listen({
       socket: handlers,
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: 0,
 
       data: {
@@ -176,7 +176,7 @@ it("echo server 1 on 1", async () => {
     });
     const clientProm = connect({
       socket: handlers,
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: server.port,
       data: {
         counter: 0,
@@ -273,7 +273,7 @@ describe("tcp socket binaryType", () => {
 
         using server: TCPSocketListener<any> | undefined = listen({
           socket: handlers,
-          hostname: "localhost",
+          hostname: "127.0.0.1",
           port: 0,
           data: {
             isServer: true,
@@ -283,7 +283,7 @@ describe("tcp socket binaryType", () => {
 
         const clientProm = connect({
           socket: handlers,
-          hostname: "localhost",
+          hostname: "127.0.0.1",
           port: server.port,
           data: {
             counter: 0,


### PR DESCRIPTION
### Problem
- `test/js/bun/net/tcp-server.test.ts` "should not leak memory" fails in the parallel batch on alpine, darwin and others: `expect(received).toBeLessThanOrEqual(expected)`, `Expected: <= 2`, `Received: 4`. It passes when the file runs alone.
- The test asserts a heap-wide count of live `Listener` and `TCPSocket` objects (2 is the prototype and the constructor). A `bun test --parallel` worker runs several files in one process and one JSC heap. The previous file's global stays reachable until the next swap, with its own `TCPSocket` prototype and any sockets it left behind. So the count includes objects this file never created.

### Fix
- The check moves to `test/js/bun/net/tcp-server-leak-fixture.ts`, which the test spawns with `bunExe()`. The fixture mirrors the echo tests of the file: for each binaryType it opens a `using` listener, runs four echo round trips, waits for both sides of every connection to close, and lets `Symbol.dispose` stop the listener. Then it asserts the same bounds with a poll-and-deadline like `expectMaxObjectTypeCount`.
- A fresh process has nothing in its heap but the fixture's own objects, so the absolute bound is valid again, and the file can stay in the parallel batch. The fixture does not import `harness`: that import costs over a second of startup in a debug build.
- The four echo tests now listen and connect on `127.0.0.1` instead of `localhost`, like the `remoteAddress` test. On a host where `localhost` resolves to `::1` first and no global IPv6 address exists, `Bun.listen` binds `::1` and `Bun.connect` tries `127.0.0.1` alone, so they failed with `ECONNREFUSED`. They test the data path, not name resolution. The listen/connect mismatch itself is a separate bug.
- Verified: `bun bd test test/js/bun/net/tcp-server.test.ts` passes alone and in a shared worker after a file that leaves `node:net` sockets open (`bun test --parallel=2 --parallel-delay=100000 leaky.test.ts tcp-server.test.ts`). The old test fails in that setup with `Received: 3`. A fixture variant that keeps the client sockets in a global array fails with `Received: 13`.

### Background
- `bun test --parallel` implies `--isolate`: each file gets a new global object, but the worker process and its heap are shared. `test/cli/test/isolation.test.ts` documents that one lagging global is expected after a swap.
- `heapStats().objectTypeCounts` (from `bun:jsc`) counts every live cell in the heap by class name. It cannot tell which global an object belongs to.
- #40593 takes this file out of the parallel batch instead. With this change that denylist entry is not needed for `tcp-server.test.ts`.

<details><summary>Notes</summary>

- Reproduction: in one worker, run a file that uses `node:net` before this file. `bun test --parallel=2 --parallel-delay=100000 a.test.ts tcp-server.test.ts` with `a.test.ts` leaving a `net.createServer` and a `net.connect` open gives `Expected: <= 2, Received: 3` on the old test, every run. A clean `node:net` file gives a count of 3 for about a second, so the old 1000 ms poll usually recovered locally. Under CI load it did not.
- A heap snapshot after such a swap shows the old global reachable only through its `process` object's `warning` listener (root reason `DOMGCOutput`), with no `Strong` or protected handle on it. The isolation tests tolerate this lagging global, so the test has to tolerate it too.
- `TCPSocketListener[Symbol.dispose]` is `stop(true)`: it also closes accepted connections. The fixture waits for every server-side close before the listener goes out of scope, so nothing is open at that point.
- In a debug build, two closed sockets of the last round trip stay reachable for about a second after their close callbacks, with no heap path and no strong handle. The fixture's poll deadline covers that. Release builds collect them on the next event loop turn.
- The `localhost` failure: `bsd_create_listen_socket` (packages/bun-usockets/src/bsd.c) resolves without `AI_ADDRCONFIG` and prefers an `AF_INET6` result, while the connect path resolves through `Bun__addrinfo_get` with `AI_ADDRCONFIG`, which drops `::1` on a host with no global IPv6 address. `BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG=1` makes the old tests pass on such a host. Reported separately.
- Runtime of the new test: about 60 ms in release, about 1.4 s in a debug build.
- Also ran: `test/js/bun/net/tcp-server.test.ts` (all 8 tests) with the debug build and with the system bun.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/net/tcp-server.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/net/tcp-server.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/net/tcp-server.test.ts:
(pass) remoteAddress works [42.39ms]
(pass) should not allow invalid tls option [11.73ms]
(pass) should allow using false, null or undefined tls option [7.91ms]
(pass) echo server 1 on 1 [38.46ms]
(pass) tcp socket binaryType > arraybuffer [44.49ms]
(pass) tcp socket binaryType > uint8array [21.03ms]
(pass) tcp socket binaryType > buffer [17.61ms]
(pass) should not leak memory [1367.68ms]

 8 pass
 0 fail
 151 expect() calls
Ran 8 tests across 1 file. [3.50s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/net/tcp-server-leak-fixture.ts | 92 ++++++++++++++++++++++++++++++
 test/js/bun/net/tcp-server.test.ts         | 38 ++++++------
 2 files changed, 112 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
test/js/bun/net/tcp-server-leak-fixture.ts      2      8      0
test/js/bun/net/tcp-server.test.ts              2      4      0
```

</details>

<!-- robobun:evidence:end -->