### PR TITLE
test/internal: make fifo.test.ts fast and assert exact Dequeue state

### DIFF
--- a/test/internal/fifo.test.ts
+++ b/test/internal/fifo.test.ts
@@ -1,54 +1,91 @@
 import { Dequeue } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, it } from "bun:test";
 
-/**
- * Implements the same API as {@link Dequeue} but uses a simple list as the
- * backing store.
- *
- * Used to check expected behavior.
- */
-class DequeueList<T> {
-  private _list: T[];
+// Dequeue is a ring buffer. `_list.length` is its capacity, a power of two
+// that starts at 4, and `_capacityMask` is `capacity - 1`. The push that
+// fills the list doubles it. shift() only halves the list when the new head
+// is 0 or 1, the tail is past 10000 and the items left fit in a quarter of
+// the list, so a list shorter than 65536 never shrinks.
+//
+// The tests below avoid expect() calls inside loops. Each expect() is slow in
+// debug builds and runs a GC in CI, so per-iteration checks are collected
+// into arrays and compared once.
 
-  constructor() {
-    this._list = [];
-  }
+/** The Dequeue API the tests use. `Dequeue` itself has no type declaration. */
+interface Queue {
+  size(): number;
+  isEmpty(): boolean;
+  isNotEmpty(): boolean;
+  peek(): number | undefined;
+  shift(): number | undefined;
+  push(item: number): void;
+  toArray(): number[];
+  _list: (number | undefined)[];
+  _capacityMask: number;
+}
 
-  size(): number {
-    return this._list.length;
-  }
+/** `[start, start + 1, ..., end - 1]` */
+function range(start: number, end: number): number[] {
+  const result = new Array<number>(end - start);
+  for (let i = start; i < end; i++) result[i - start] = i;
+  return result;
+}
 
-  isEmpty(): boolean {
-    return this.size() == 0;
-  }
+/** The capacity of a queue that held at most `maxSize` items at once and never shrank. */
+function capacityFor(maxSize: number): number {
+  let capacity = 4;
+  while (capacity <= maxSize) capacity *= 2;
+  return capacity;
+}
 
-  isNotEmpty(): boolean {
-    return this.size() > 0;
-  }
+/** Everything observable about `queue`, so that one toEqual() checks all of it. */
+function stateOf(queue: Queue) {
+  return {
+    size: queue.size(),
+    isEmpty: queue.isEmpty(),
+    isNotEmpty: queue.isNotEmpty(),
+    peek: queue.peek(),
+    items: queue.toArray(),
+    capacity: queue._list.length,
+    capacityMask: queue._capacityMask,
+  };
+}
 
-  shift(): T | undefined {
-    return this._list.shift();
-  }
+/** The state of a queue that holds `items` in a backing list of length `capacity`. */
+function stateWith(items: number[], capacity: number) {
+  return {
+    size: items.length,
+    isEmpty: items.length === 0,
+    isNotEmpty: items.length > 0,
+    peek: items[0],
+    items,
+    capacity,
+    capacityMask: capacity - 1,
+  };
+}
 
-  peek(): T | undefined {
-    return this._list[0];
-  }
+function pushRange(queue: Queue, start: number, end: number): void {
+  for (let i = start; i < end; i++) queue.push(i);
+}
 
-  push(item: T): void {
-    this._list.push(item);
+/** Calls peek() and then shift() `count` times. Returns what each call returned, in order. */
+function shiftMany(queue: Queue, count: number) {
+  const peeked = new Array<number | undefined>(count);
+  const shifted = new Array<number | undefined>(count);
+  for (let i = 0; i < count; i++) {
+    peeked[i] = queue.peek();
+    shifted[i] = queue.shift();
   }
+  return { peeked, shifted };
+}
 
-  toArray(fullCopy: boolean): T[] {
-    return fullCopy ? this._list.slice() : this._list;
-  }
-
-  clear(): void {
-    this._list = [];
-  }
+/** What shiftMany() returns when it takes `items` out in order. */
+function shiftedInOrder(items: number[]) {
+  return { peeked: items, shifted: items };
 }
 
 describe("Given an empty queue", () => {
-  let queue: Dequeue<number>;
+  let queue: Queue;
 
   beforeEach(() => {
     queue = new Dequeue();
@@ -65,6 +102,11 @@ describe("Given an empty queue", () => {
 
   it("shift() returns undefined", () => {
     expect(queue.shift()).toBe(undefined);
+    expect(queue.size()).toBe(0);
+  });
+
+  it("peek() returns undefined", () => {
+    expect(queue.peek()).toBe(undefined);
     expect(queue.size()).toBe(0);
   });
 
@@ -88,7 +130,7 @@ describe("Given an empty queue", () => {
 
     it("can be peeked without removing it", () => {
       expect(queue.peek()).toBe(42);
-      expect(queue.size()).toBe(1);
+      expect(stateOf(queue)).toEqual(stateWith([42], 4));
     });
 
     it("is not empty", () => {
@@ -97,23 +139,28 @@ describe("Given an empty queue", () => {
     });
 
     it("can be shifted out", () => {
-      const el = queue.shift();
-      expect(el).toBe(42);
-      expect(queue.size()).toBe(0);
-      expect(queue.isEmpty()).toBe(true);
+      expect(queue.shift()).toBe(42);
+      expect(stateOf(queue)).toEqual(stateWith([], 4));
     });
   }); // </When an element is pushed>
 }); // </Given an empty queue>
 
 describe("grow boundary conditions", () => {
-  describe.each([3, 4, 16])("when %d items are pushed", n => {
-    let queue: Dequeue<number>;
+  // 3 and 7 items are one push short of a grow. The 4th, 8th and 16th push
+  // fill the list and grow it. 1000 items cross eight grows.
+  describe.each([
+    [3, 4],
+    [4, 8],
+    [7, 8],
+    [8, 16],
+    [16, 32],
+    [1000, 1024],
+  ])("when %d items are pushed", (n, capacity) => {
+    let queue: Queue;
 
     beforeEach(() => {
       queue = new Dequeue();
-      for (let i = 0; i < n; i++) {
-        queue.push(i);
-      }
+      pushRange(queue, 0, n);
     });
 
     it(`has a size of ${n}`, () => {
@@ -125,121 +172,182 @@ describe("grow boundary conditions", () => {
       expect(queue.isNotEmpty()).toBe(true);
     });
 
-    it(`can shift() ${n} times`, () => {
-      for (let i = 0; i < n; i++) {
-        expect(queue.peek()).toBe(i);
-        expect(queue.shift()).toBe(i);
-      }
-      expect(queue.size()).toBe(0);
-      expect(queue.shift()).toBe(undefined);
+    it(`has a capacity of ${capacity}`, () => {
+      expect(queue._list.length).toBe(capacity);
+      expect(queue._capacityMask).toBe(capacity - 1);
     });
 
     it("toArray() returns [0..n-1]", () => {
-      // same as repeated push() but only allocates once
-      var expected = new Array<number>(n);
-      for (let i = 0; i < n; i++) {
-        expected[i] = i;
-      }
-      expect(queue.toArray()).toEqual(expected);
+      expect(queue.toArray()).toEqual(range(0, n));
     });
+
+    it(`can shift() ${n} times`, () => {
+      expect(shiftMany(queue, n)).toEqual(shiftedInOrder(range(0, n)));
+      // empty again, but shift() does not shrink a list this small
+      expect(stateOf(queue)).toEqual(stateWith([], capacity));
+      expect(queue.shift()).toBe(undefined);
+    });
+  });
+
+  it("the push that fills the list doubles it", () => {
+    const queue: Queue = new Dequeue();
+    const capacities: number[] = [];
+    for (let i = 0; i < 20; i++) {
+      queue.push(i);
+      capacities.push(queue._list.length);
+    }
+    expect(capacities).toEqual([4, 4, 4, 8, 8, 8, 8, 16, 16, 16, 16, 16, 16, 16, 16, 32, 32, 32, 32, 32]);
+    expect(queue._capacityMask).toBe(31);
   });
 }); // </grow boundary conditions>
 
 describe("adding and removing items", () => {
-  let queue: Dequeue<number>;
-  let expected: DequeueList<number>;
+  let queue: Queue;
 
   describe("when 10k items are pushed", () => {
     beforeEach(() => {
       queue = new Dequeue();
-      expected = new DequeueList();
-
-      for (let i = 0; i < 10_000; i++) {
-        queue.push(i);
-        expected.push(i);
-      }
+      pushRange(queue, 0, 10_000);
     });
 
     it("has a size of 10000", () => {
-      expect(queue.size()).toBe(10_000);
-      expect(expected.size()).toBe(10_000);
+      expect(stateOf(queue)).toEqual(stateWith(range(0, 10_000), 16384));
     });
 
     describe("when 10 items are shifted", () => {
+      let taken: ReturnType<typeof shiftMany>;
+
       beforeEach(() => {
-        for (let i = 0; i < 10; i++) {
-          expect(queue.shift()).toBe(expected.shift());
-        }
+        taken = shiftMany(queue, 10);
       });
 
       it("has a size of 9990", () => {
-        expect(queue.size()).toBe(9990);
-        expect(expected.size()).toBe(9990);
+        expect(taken).toEqual(shiftedInOrder(range(0, 10)));
+        expect(stateOf(queue)).toEqual(stateWith(range(10, 10_000), 16384));
       });
     });
   }); // </when 10k items are pushed>
 
   describe("when 1k items are pushed, then removed", () => {
+    let taken: ReturnType<typeof shiftMany>;
+
     beforeEach(() => {
       queue = new Dequeue();
-      expected = new DequeueList();
-
-      for (let i = 0; i < 1_000; i++) {
-        queue.push(i);
-        expected.push(i);
-      }
-      expect(queue.size()).toBe(1_000);
-
-      while (queue.isNotEmpty()) {
-        expect(queue.shift()).toBe(expected.shift());
-      }
+      pushRange(queue, 0, 1_000);
+      taken = shiftMany(queue, 1_000);
     });
 
     it("is now empty", () => {
-      expect(queue.size()).toBe(0);
-      expect(queue.isEmpty()).toBeTrue();
-      expect(queue.isNotEmpty()).toBeFalse();
+      expect(taken).toEqual(shiftedInOrder(range(0, 1_000)));
+      // shift() does not shrink a list this small
+      expect(stateOf(queue)).toEqual(stateWith([], 1024));
+      expect(queue.shift()).toBe(undefined);
     });
 
     it("when new items are added, the backing list is resized", () => {
-      for (let i = 0; i < 10_000; i++) {
+      // head and tail both sit at slot 1000 of the 1024-slot list, so the
+      // 24th push wraps tail around to slot 0.
+      pushRange(queue, 0, 500);
+      expect(stateOf(queue)).toEqual(stateWith(range(0, 500), 1024));
+
+      // The 1024th push fills the list. Growing it moves the wrapped items so
+      // that head is back at slot 0. The 2048th push grows it again.
+      const capacities: number[] = [];
+      for (let i = 500; i < 3_000; i++) {
         queue.push(i);
-        expected.push(i);
-        expect(queue.size()).toBe(expected.size());
-        expect(queue.peek()).toBe(expected.peek());
-        expect(queue.isEmpty()).toBeFalse();
-        expect(queue.isNotEmpty()).toBeTrue();
+        capacities.push(queue._list.length);
       }
+      // The list never shrank below the 1024 slots the first 1000 items needed.
+      expect(capacities).toEqual(range(501, 3_001).map(size => capacityFor(Math.max(size, 1_000))));
+      expect(stateOf(queue)).toEqual(stateWith(range(0, 3_000), 4096));
     });
   }); // </when 1k items are pushed, then removed>
 
   it("pushing and shifting a lot of items affects the size and backing list correctly", () => {
     queue = new Dequeue();
-    expected = new DequeueList();
 
-    for (let i = 0; i < 15_000; i++) {
-      queue.push(i);
-      expected.push(i);
-      expect(queue.size()).toBe(expected.size());
-      expect(queue.peek()).toBe(expected.peek());
-      expect(queue.isEmpty()).toBeFalse();
-      expect(queue.isNotEmpty()).toBeTrue();
-    }
+    pushRange(queue, 0, 1_500);
+    expect(stateOf(queue)).toEqual(stateWith(range(0, 1_500), 2048));
 
-    // shift() shrinks the backing array when tail > 10,000 and the list is
-    // shrunk too far (tail <= list.length >>> 2)
-    for (let i = 0; i < 10_000; i++) {
-      expect(queue.shift()).toBe(expected.shift());
-      expect(queue.size()).toBe(expected.size());
-    }
+    // shift() does not shrink the list
+    expect(shiftMany(queue, 1_000)).toEqual(shiftedInOrder(range(0, 1_000)));
+    expect(stateOf(queue)).toEqual(stateWith(range(1_000, 1_500), 2048));
 
-    for (let i = 0; i < 5_000; i++) {
-      queue.push(i);
-      expected.push(i);
-      expect(queue.size()).toBe(expected.size());
-      expect(queue.peek()).toBe(expected.peek());
-      expect(queue.isEmpty()).toBeFalse();
-      expect(queue.isNotEmpty()).toBeTrue();
+    // tail wraps around to slot 452 while head stays at slot 1000
+    pushRange(queue, 1_500, 2_500);
+    expect(stateOf(queue)).toEqual(stateWith(range(1_000, 2_500), 2048));
+
+    // the items come back out in order across the wrap
+    expect(shiftMany(queue, 1_500)).toEqual(shiftedInOrder(range(1_000, 2_500)));
+    expect(stateOf(queue)).toEqual(stateWith([], 2048));
+    expect(queue.shift()).toBe(undefined);
+  }); // </pushing and shifting a lot of items affects the size and backing list correctly>
+
+  it("wraps around the ring many times without growing", () => {
+    queue = new Dequeue();
+    pushRange(queue, 0, 12);
+    expect(stateOf(queue)).toEqual(stateWith(range(0, 12), 16));
+
+    // 12 items in 16 slots: head and tail each go around the ring 62 times
+    const shifted: (number | undefined)[] = [];
+    const sizeAndCapacity: number[][] = [];
+    for (let i = 0; i < 1_000; i++) {
+      shifted.push(queue.shift());
+      queue.push(12 + i);
+      sizeAndCapacity.push([queue.size(), queue._list.length]);
     }
-  }); // </pushing a lot of items affects the size and backing list correctly>
+    expect(shifted).toEqual(range(0, 1_000));
+    expect(sizeAndCapacity).toEqual(new Array(1_000).fill([12, 16]));
+    expect(stateOf(queue)).toEqual(stateWith(range(1_000, 1_012), 16));
+  });
+
+  it("grows while wrapped when each round pushes two items and shifts one", () => {
+    queue = new Dequeue();
+    const shifted: (number | undefined)[] = [];
+    const capacities: number[] = [];
+    for (let i = 0; i < 2_000; i++) {
+      queue.push(2 * i);
+      shifted.push(queue.shift());
+      queue.push(2 * i + 1);
+      capacities.push(queue._list.length);
+    }
+    // Round i leaves i + 1 items behind. Every grow happens while head is
+    // past slot 0, so each one copies the wrapped items to the front.
+    expect(shifted).toEqual(range(0, 2_000));
+    expect(capacities).toEqual(range(1, 2_001).map(capacityFor));
+    expect(stateOf(queue)).toEqual(stateWith(range(2_000, 4_000), 2048));
+  });
+
+  it("shift() halves the list once the items left fit in a quarter of it", () => {
+    // shift() shrinks only when the new head is 0 or 1, tail > 10000 and
+    // tail <= capacity / 4. That needs a list of at least 65536 slots.
+    queue = new Dequeue();
+    pushRange(queue, 0, 32_768);
+    expect(stateOf(queue)).toEqual(stateWith(range(0, 32_768), 65536));
+
+    // head moves to slot 22768. tail stays at 32768, more than a quarter.
+    expect(shiftMany(queue, 22_768)).toEqual(shiftedInOrder(range(0, 22_768)));
+    expect(stateOf(queue)).toEqual(stateWith(range(22_768, 32_768), 65536));
+
+    // tail wraps around to slot 10001
+    pushRange(queue, 32_768, 75_537);
+    expect(stateOf(queue)).toEqual(stateWith(range(22_768, 75_537), 65536));
+
+    // head moves to slot 65535, the last one. No shrink yet.
+    expect(shiftMany(queue, 42_767)).toEqual(shiftedInOrder(range(22_768, 65_535)));
+    expect(stateOf(queue)).toEqual(stateWith(range(65_535, 75_537), 65536));
+
+    // This shift wraps head to slot 0 and halves the list. The 10001 items
+    // left sit in slots 0..10000 and survive the cut.
+    expect(queue.shift()).toBe(65_535);
+    expect(stateOf(queue)).toEqual(stateWith(range(65_536, 75_537), 32768));
+
+    // 10001 items do not fit in a quarter of 32768 slots, so no second cut.
+    expect(queue.shift()).toBe(65_536);
+    expect(stateOf(queue)).toEqual(stateWith(range(65_537, 75_537), 32768));
+
+    expect(shiftMany(queue, 10_000)).toEqual(shiftedInOrder(range(65_537, 75_537)));
+    expect(stateOf(queue)).toEqual(stateWith([], 32768));
+    expect(queue.shift()).toBe(undefined);
+  });
 }); // </adding and removing items>


### PR DESCRIPTION
### Problem
- `test/internal/fifo.test.ts` took 11.9s on debian 13 x64-asan and 9.9s on darwin aarch64 (release) in build 108487. Under ASAN locally, the last test ran past the 5s default timeout.
- The cost is 142,099 `expect()` calls inside 10k and 15k iteration loops. One costs about 100us in a debug build. In CI, `BUN_GARBAGE_COLLECTOR_LEVEL=1` makes each one run `auto_garbage_collect` (`src/runtime/test_runner/expect.rs:1390`), so a release lane is as slow as ASAN. `Dequeue` itself is fast: 100k pushes and 100k shifts take 55ms under ASAN.

### Fix
- Collect per-iteration values into arrays and compare them once: 109 `expect()` calls over 49 tests. No scenario was removed.
- Assert the full queue state after each phase (contents, size, peek, capacity and mask) against a generated `range()` array. Pin the capacity before and after each push that grows the list. Check that `shift()` does not shrink it.
- Add a ring that wraps 62 times at a fixed size, a pattern that grows while wrapped, and the `shift()` shrink path. Shrink needs a 65536-slot list. The old 15k case stopped at 16384 slots and never reached it.
- Verified: `bun bd test test/internal/fifo.test.ts`. ASAN: 16.0s before, 2.5s after (44.2s and 3.5s with the CI env). Release with the CI env: 1.1s before, 130ms after.

### Background
- `Dequeue` (`src/js/internal/fifo.ts`) is the JS ring buffer behind `createFIFO()`. `_list` is the backing array, a power of two long, starting at 4. `_capacityMask` is `length - 1`.
- The push that fills the list doubles it. If `head` is not 0 at that point, the items are copied to the front first. `shift()` halves the list only when the new head is 0 or 1, `tail > 10000` and `tail <= length / 4`.
- `BUN_GARBAGE_COLLECTOR_LEVEL=1` is the mild GC mode. The test runner then requests a collection after every matcher.

<details><summary>Notes</summary>

Timings on this container (slower than the CI machines). "CI env" means `BUN_GARBAGE_COLLECTOR_LEVEL=1 BUN_JSC_randomIntegrityAuditRate=1.0`, which `scripts/runner.node.mjs` sets.

| build | env | before | after |
| --- | --- | --- | --- |
| debug ASAN (`bun bd test`) | default | 15.97s | 2.54s |
| debug ASAN | CI env | 44.17s | 3.46s |
| release (system bun 1.4.1) | default | 120ms | 120ms |
| release | CI env | 1.10s | 130ms |

The remaining 2.5s under ASAN is mostly fixed cost: process startup, the per-test GC under the CI env (about 15ms per test), and the shrink case (283ms for 151k operations and a 52k element `toArray()` compare).

Mutation checks. I ported `fifo.ts` to plain TypeScript and broke it in five ways: wrong `size()` when wrapped, no shrink, shrink at half instead of a quarter, reversed `toArray()` when wrapped, head at 1 after the grow copy. The new file fails on every one (5, 1, 1, 4 and 2 tests). The old file passes both shrink mutations and catches the other three with 1 or 2 tests each.

Iteration counts. The named counts stay (10k pushed, 1k pushed then removed). The unnamed 10k loop became 3000 pushes, which still crosses the wrap at push 24, the copying grow at 1024 and the plain grow at 2048. The 15k/10k/5k case became 1500/1000/1000, which still wraps the tail around the 2048-slot ring. The shrink case is the one large run (32768 pushes and up), because the shrink condition needs it.

`describe.concurrent` does not help here. Every test is synchronous, so nothing can interleave.

Also seen, not changed: `toArray(true)` returns garbage when the queue is not wrapped. `total = len - head + tail` is only right when the list is full or `head > tail`. For `[1, 2, 3]` in a 4-slot list it returns `[1, 2, 3, undefined, 1, 2, 3]`. The only caller is `_growArray`, which calls it on a full list, so nothing hits this today. The new tests call `toArray()` without the flag.

Typing. `Dequeue` has no type declaration in the test tsconfig (it resolves to `any`), so the old `Dequeue<number>` annotations were tsc errors. The file now declares a small `Queue` interface and tsc reports no errors for it.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/fifo.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/fifo.test.ts
bun test v1.4.1 (d578a8c70)

test/internal/fifo.test.ts:
(pass) Given an empty queue > has a size of 0 [25.08ms]
(pass) Given an empty queue > is empty [3.81ms]
(pass) Given an empty queue > shift() returns undefined [5.41ms]
(pass) Given an empty queue > peek() returns undefined [3.43ms]
(pass) Given an empty queue > has an initial capacity of 4 [1.56ms]
(pass) Given an empty queue > toArray() returns an empty array [3.49ms]
(pass) Given an empty queue > When an element is pushed > has a size of 1 [3.41ms]
(pass) Given an empty queue > When an element is pushed > can be peeked without removing it [5.27ms]
(pass) Given an empty queue > When an element is pushed > is not empty [1.45ms]
(pass) Given an empty queue > When an element is pushed > can be shifted out [2.27ms]
(pass) grow boundary conditions > when 3 items are pushed > has a size of 3 [4.14ms]
(pass) grow boundary conditions > when 3 items are pushed > is not empty [1.59ms]
(pass) grow boundary conditions > when 3 items are pushed > has a capacity of 4 [2.01ms]
(pass) grow boundary conditions > when 3 items are pushed > toArray() returns [0..n-1] [3.31ms]
(pass) grow boundary conditions > when 3 items are pushed > can shift() 3 times [6.32ms]
(pass) grow boundary conditions > when 4 items are pushed > has a size of 4 [2.06ms]
(pass) grow boundary conditions > when 4 items are pushed > is not empty [1.40ms]
(pass) grow boundary conditions > when 4 items are pushed > has a capacity of 8 [0.50ms]
(pass) grow boundary conditions > when 4 items are pushed > toArray() returns [0..n-1] [1.04ms]
(pass) grow boundary conditions > when 4 items are pushed > can shift() 4 times [1.11ms]
(pass) grow boundary conditions > when 7 items are pushed > has a size of 7 [0.34ms]
(pass) grow boundary conditions > when 7 items are pushed > is not empty [0.40ms]
(pass) grow boundary conditions > when 7 items are pu
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/internal/fifo.test.ts | 342 +++++++++++++++++++++++++++++----------------
 1 file changed, 225 insertions(+), 117 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                        reads  edits  tests
test/internal/fifo.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->