### PR TITLE
webview: share one WKProcessPool across all WebKit-backend views

### DIFF
--- a/src/runtime/webview/ObjCRuntime.cpp
+++ b/src/runtime/webview/ObjCRuntime.cpp
@@ -123,11 +123,9 @@ SEL WKWebViewConfiguration::s_initWithDirectory;
 SEL WKWebViewConfiguration::s_initWithConfiguration;
 SEL WKWebViewConfiguration::s_setProcessPool;
 
-// One pool for every view, retained for process lifetime. Without an
-// explicit pool each view gets a private WebProcessPool, which spends one
-// CVDisplayLink per display — CoreVideo allows 64 per process, so the
-// 65th lifetime view wedged (oven-sh/bun#40951). Cookies/storage are
-// per-configuration (WKWebsiteDataStore), not per-pool.
+// One pool shared by every view, retained for process lifetime. A private
+// pool per view spends one CVDisplayLink each (CoreVideo allows 64 per
+// process), so the 65th lifetime view wedged (oven-sh/bun#40951).
 id WKWebViewConfiguration::sharedProcessPool()
 {
     static id pool;

--- a/src/runtime/webview/ObjCRuntime.cpp
+++ b/src/runtime/webview/ObjCRuntime.cpp
@@ -117,9 +117,32 @@ SEL WKWebView::s_callAsyncJavaScript;
 Class WKWebViewConfiguration::cls;
 Class WKWebViewConfiguration::cls_WKWebsiteDataStore;
 Class WKWebViewConfiguration::cls_WKWebsiteDataStoreConfiguration;
+Class WKWebViewConfiguration::cls_WKProcessPool;
 SEL WKWebViewConfiguration::s_nonPersistentDataStore;
 SEL WKWebViewConfiguration::s_initWithDirectory;
 SEL WKWebViewConfiguration::s_initWithConfiguration;
+SEL WKWebViewConfiguration::s_setProcessPool;
+
+// One WKProcessPool for every view in this host process, created on first
+// use and retained for process lifetime. A configuration with no explicit
+// pool makes WKWebView allocate a private WebProcessPool per view, and
+// every pool owns per-process OS resources: DisplayLinkCollection is a
+// WebProcessPool member, and each DisplayLink wraps a CVDisplayLink, a
+// resource CoreVideo caps at 64 per process. A fresh pool per view spends
+// capped resources on every instantiation even when each view is closed
+// before the next is created; after exactly 64 lifetime views, the 65th
+// view's navigate() never completed (oven-sh/bun#40951). One shared pool
+// spends them once. Site isolation is unaffected: cookies/storage live in
+// the per-configuration WKWebsiteDataStore, not the pool.
+id WKWebViewConfiguration::sharedProcessPool()
+{
+    static id pool;
+    if (!pool) {
+        Ref p(msgCls<id>(cls_WKProcessPool, s_alloc));
+        pool = p.msg<id>(s_init);
+    }
+    return pool;
+}
 
 // Keyed by directory path. Stores live for the process: each WKWebsiteDataStore
 // runs its own NetworkProcess session, so two instances at the same path don't
@@ -448,6 +471,8 @@ bool ObjCRuntime::load()
     // _WKWebsiteDataStoreConfiguration is SPI but stable since macOS 10.13.
     // initWithDirectory: is 15.2+.
     CLS(WKWebViewConfiguration::cls_WKWebsiteDataStoreConfiguration, "_WKWebsiteDataStoreConfiguration");
+    CLS(WKWebViewConfiguration::cls_WKProcessPool, "WKProcessPool");
+    WKWebViewConfiguration::s_setProcessPool = sel("setProcessPool:");
     WKWebViewConfiguration::s_nonPersistentDataStore = sel("nonPersistentDataStore");
     WKWebViewConfiguration::s_initWithDirectory = sel("initWithDirectory:");
     WKWebViewConfiguration::s_initWithConfiguration = sel("_initWithConfiguration:");

--- a/src/runtime/webview/ObjCRuntime.cpp
+++ b/src/runtime/webview/ObjCRuntime.cpp
@@ -123,17 +123,11 @@ SEL WKWebViewConfiguration::s_initWithDirectory;
 SEL WKWebViewConfiguration::s_initWithConfiguration;
 SEL WKWebViewConfiguration::s_setProcessPool;
 
-// One WKProcessPool for every view in this host process, created on first
-// use and retained for process lifetime. A configuration with no explicit
-// pool makes WKWebView allocate a private WebProcessPool per view, and
-// every pool owns per-process OS resources: DisplayLinkCollection is a
-// WebProcessPool member, and each DisplayLink wraps a CVDisplayLink, a
-// resource CoreVideo caps at 64 per process. A fresh pool per view spends
-// capped resources on every instantiation even when each view is closed
-// before the next is created; after exactly 64 lifetime views, the 65th
-// view's navigate() never completed (oven-sh/bun#40951). One shared pool
-// spends them once. Site isolation is unaffected: cookies/storage live in
-// the per-configuration WKWebsiteDataStore, not the pool.
+// One pool for every view, retained for process lifetime. Without an
+// explicit pool each view gets a private WebProcessPool, which spends one
+// CVDisplayLink per display — CoreVideo allows 64 per process, so the
+// 65th lifetime view wedged (oven-sh/bun#40951). Cookies/storage are
+// per-configuration (WKWebsiteDataStore), not per-pool.
 id WKWebViewConfiguration::sharedProcessPool()
 {
     static id pool;

--- a/src/runtime/webview/ObjCRuntime.h
+++ b/src/runtime/webview/ObjCRuntime.h
@@ -478,16 +478,19 @@ struct WKWebViewConfiguration : Ref {
     static Class cls;
     static Class cls_WKWebsiteDataStore;
     static Class cls_WKWebsiteDataStoreConfiguration; // _WKWebsiteDataStoreConfiguration (SPI)
+    static Class cls_WKProcessPool;
     static SEL s_nonPersistentDataStore;
     static SEL s_initWithDirectory; // macOS 15.2+ (SPI)
     static SEL s_initWithConfiguration; // _initWithConfiguration: (SPI)
     static SEL s_setWebsiteDataStore;
+    static SEL s_setProcessPool;
 
     // +1 retained.
     static WKWebViewConfiguration createEphemeral()
     {
         WKWebViewConfiguration cfg(msgCls<id>(cls, s_alloc));
         cfg.m_id = cfg.msg<id>(s_init);
+        cfg.msg<void>(s_setProcessPool, sharedProcessPool());
         id store = msgCls<id>(cls_WKWebsiteDataStore, s_nonPersistentDataStore);
         cfg.msg<void>(s_setWebsiteDataStore, store);
         cfg.disableProcessSuppression();
@@ -504,6 +507,7 @@ struct WKWebViewConfiguration : Ref {
     {
         WKWebViewConfiguration cfg(msgCls<id>(cls, s_alloc));
         cfg.m_id = cfg.msg<id>(s_init);
+        cfg.msg<void>(s_setProcessPool, sharedProcessPool());
         cfg.msg<void>(s_setWebsiteDataStore, persistentStoreForDirectory(directory));
         cfg.disableProcessSuppression();
         return cfg;
@@ -533,6 +537,7 @@ struct WKWebViewConfiguration : Ref {
 
 private:
     static id persistentStoreForDirectory(const WTF::String &directory);
+    static id sharedProcessPool();
 };
 
 struct WKUserScript : Ref {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -152,9 +152,7 @@ it("navigate + evaluate round-trip", async () => {
 // CVDisplayLink per pool; CoreVideo allows 64 per process). After exactly
 // 64 create/close cycles, the 65th view's navigate() hung forever. The
 // host now shares one WKProcessPool across all views. Sequential on
-// purpose (the cap is on lifetime instances, not concurrent ones); the
-// per-test timeout exists because the regression needs more than 64 full
-// create/navigate/close cycles.
+// purpose: the cap is on lifetime instances, not concurrent ones.
 it("survives more than 64 lifetime create/navigate/close cycles", async () => {
   for (let i = 1; i <= 70; i++) {
     const view = new Bun.WebView({ width: 64, height: 64, backend: "webkit", dataStore: "ephemeral" });
@@ -172,7 +170,7 @@ it("survives more than 64 lifetime create/navigate/close cycles", async () => {
       view.close();
     }
   }
-}, 90_000);
+});
 
 it("url constructor option fires navigate()", async () => {
   // `url:` is sugar for navigate() right after Create. The promise lands in

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -147,6 +147,37 @@ it("navigate + evaluate round-trip", async () => {
   expect(result).toBe("hi");
 });
 
+// #40951: every view used to get its own implicit WKProcessPool, so each
+// lifetime instance spent capped per-process OS resources (one
+// CVDisplayLink per pool; CoreVideo allows 64 per process). After exactly
+// 64 create/close cycles, the 65th view's navigate() hung forever. The
+// host now shares one WKProcessPool across all views. Sequential on
+// purpose (the cap is on lifetime instances, not concurrent ones); the
+// per-test timeout exists because the regression needs more than 64 full
+// create/navigate/close cycles.
+it(
+  "survives more than 64 lifetime create/navigate/close cycles",
+  async () => {
+    for (let i = 1; i <= 70; i++) {
+      const view = new Bun.WebView({ width: 64, height: 64, backend: "webkit", dataStore: "ephemeral" });
+      let watchdog: ReturnType<typeof setTimeout> | undefined;
+      try {
+        // Watchdog so a regression fails with the iteration number instead
+        // of a bare test timeout. Cleared every iteration.
+        const hung = new Promise<never>((_, reject) => {
+          watchdog = setTimeout(() => reject(new Error(`navigate() hung at lifetime instance #${i}`)), 10_000);
+        });
+        await Promise.race([view.navigate(html(`<p>v${i}</p>`)), hung]);
+        expect(view.url).toStartWith("data:text/html");
+      } finally {
+        clearTimeout(watchdog);
+        view.close();
+      }
+    }
+  },
+  90_000,
+);
+
 it("url constructor option fires navigate()", async () => {
   // `url:` is sugar for navigate() right after Create. The promise lands in
   // m_pendingNavigate; the user's next await serializes behind it. Here

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -155,28 +155,24 @@ it("navigate + evaluate round-trip", async () => {
 // purpose (the cap is on lifetime instances, not concurrent ones); the
 // per-test timeout exists because the regression needs more than 64 full
 // create/navigate/close cycles.
-it(
-  "survives more than 64 lifetime create/navigate/close cycles",
-  async () => {
-    for (let i = 1; i <= 70; i++) {
-      const view = new Bun.WebView({ width: 64, height: 64, backend: "webkit", dataStore: "ephemeral" });
-      let watchdog: ReturnType<typeof setTimeout> | undefined;
-      try {
-        // Watchdog so a regression fails with the iteration number instead
-        // of a bare test timeout. Cleared every iteration.
-        const hung = new Promise<never>((_, reject) => {
-          watchdog = setTimeout(() => reject(new Error(`navigate() hung at lifetime instance #${i}`)), 10_000);
-        });
-        await Promise.race([view.navigate(html(`<p>v${i}</p>`)), hung]);
-        expect(view.url).toStartWith("data:text/html");
-      } finally {
-        clearTimeout(watchdog);
-        view.close();
-      }
+it("survives more than 64 lifetime create/navigate/close cycles", async () => {
+  for (let i = 1; i <= 70; i++) {
+    const view = new Bun.WebView({ width: 64, height: 64, backend: "webkit", dataStore: "ephemeral" });
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    try {
+      // Watchdog so a regression fails with the iteration number instead
+      // of a bare test timeout. Cleared every iteration.
+      const hung = new Promise<never>((_, reject) => {
+        watchdog = setTimeout(() => reject(new Error(`navigate() hung at lifetime instance #${i}`)), 10_000);
+      });
+      await Promise.race([view.navigate(html(`<p>v${i}</p>`)), hung]);
+      expect(view.url).toStartWith("data:text/html");
+    } finally {
+      clearTimeout(watchdog);
+      view.close();
     }
-  },
-  90_000,
-);
+  }
+}, 90_000);
 
 it("url constructor option fires navigate()", async () => {
   // `url:` is sugar for navigate() right after Create. The promise lands in


### PR DESCRIPTION
### Problem

- Fixes #40951. `Bun.WebView` (webkit backend) wedges after exactly 64 lifetime instances in one process. From the 65th view on, every `navigate()` hangs forever, `close()` reclaims nothing, and `com.apple.WebKit.WebContent` helpers accumulate. The cliff is deterministic and counts lifetime instances, not concurrent ones.
- Cause: `WebViewHost::createForIPC` builds a fresh `WKWebViewConfiguration` per view with no process pool set (src/runtime/webview/ObjCRuntime.h, `createEphemeral`/`createPersistent`). Each `WKWebView` then allocates a private `WebProcessPool`. Every pool owns per-process OS resources, among them one `CVDisplayLink` per display (`DisplayLinkCollection` is a `WebProcessPool` member, vendor/WebKit/Source/WebKit/UIProcess/WebProcessPool.h:934), and CoreVideo caps a process at 64 display links.

### Fix

- The host now creates one `WKProcessPool` on first use and sets it on every configuration (`setProcessPool:`, public API since macOS 10.10). Per-pool resources are spent once per process instead of once per view.
- Data isolation is unchanged. Cookies and storage belong to the per-configuration `WKWebsiteDataStore` (still one ephemeral store per view, persistent stores still cached by directory). One shared pool is also the standard WebKit embedding shape.
- Verified: `test/js/bun/webview/webview.test.ts` adds a sequential 70-cycle create/navigate/close test (macOS only). The full file passes on Linux (webkit tests skip there). This container has no macOS machine, so I could not run the fail-before locally; the macOS CI lanes compile and run this code.
- Self-reviewed: the review raised a docs rider and comment-calibration concerns, both addressed (the unverified sandbox note was dropped, the comments now separate what is proven from what is inferred). I rejected one claim that the per-view configuration leaks: `WKWebView::create` consumes the +1 via `cfg.release()` (ObjCRuntime.h).

### Background

- The webkit backend runs every `WKWebView` in one host subprocess (the bun binary re-executed, `host_main.cpp`). The JS process sends Create/Navigate/Close frames over a socketpair. So the 64 cap is on the host process, and it survives view churn.
- A `WKProcessPool` is the object that owns WebKit's UI-process machinery for a group of views: web process lifecycle, and per-display `DisplayLink`s that drive rendering callbacks. A configuration without an explicit pool gets a private one.
- `CVDisplayLink` is a CoreVideo vsync callback handle. The 64-per-process budget is a lifetime budget in practice: the reporter's trace shows 64 full create/close cycles succeed and the 65th instance wedges, with every earlier view closed.

<details><summary>Notes</summary>

- Reproduction evidence is the reporter's: two independent runs, three sites, 64 successes then 100% hangs, helpers accumulating 1:1 after the cliff. I audited the whole module and a wide sweep of the repo for an in-repo 64-cap first: viewIds are an unbounded u32, the parent keepalive refs are edge-triggered and balanced, every ObjC retain/release pair in `createForIPC` vs `close()` balances, and no `[64]`/bitmask pool exists in src/runtime/webview, bun-usockets, bun-uws, or the vendored WTF/JSC. The per-pool `DisplayLinkCollection` is the one per-view resource that is capped per process.
- What is proven vs inferred: per-pool display links and the CoreVideo cap are documented and visible in vendored WebKit source; that this specific cap (rather than another per-pool resource such as Mach/XPC plumbing) is what wedges navigate() is inferred, not observed with a spindump. The fix does not depend on which per-pool resource it is: one shared pool stops the per-view spend of all of them.
- The new test fails by watchdog with the iteration number if the cliff returns. On a machine where the capped resource is not consumed (for example some displayless CI configurations), it still exercises 70 full lifecycle churns.
- The test sets no per-test timeout (repo convention). The CI runner supplies 90s per test (270s under ASAN) via `scripts/runner.node.mjs`. The per-iteration watchdog is a hang detector that names the failing iteration, not a wait-for-time. A bare local `bun bd test` on macOS needs `--timeout` because the bun default is 5s.
- The issue's side note about sandbox profiles that deny Mach lookups is real as a report but unverified. I left it out of this PR on review advice. It can land separately once reproduced, ideally as an error path instead of a docs caveat.

</details>
