### PR TITLE
test: shrink the readdirSync recursive error leak test

### DIFF
--- a/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
+++ b/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
@@ -3,84 +3,101 @@
 // be fully released. Each Dirent owns a ref to both .name and .path; previously
 // only .name was dereferenced on the sync error path, leaking the .path string.
 //
-// This fixture builds a wide, shallow tree under a long path, with a
-// self-referential symlink two levels deep. The recursive walker is
-// breadth-first, so every depth-1 directory is fully scanned (allocating
-// distinct Dirent.path strings) before the depth-2 symlink is opened and fails
-// with ELOOP. It repeats the failing readdirSync many times and asserts RSS
-// growth between a warmed-up baseline and the end of the run stays bounded.
+// This fixture builds a tree of long directory names: root/mid/leaf_0..leaf_63,
+// with a self-referential symlink inside leaf_0. The recursive walker is
+// breadth-first, so it scans root, mid and every leaf (allocating one distinct
+// Dirent.path string of 500 to 800 bytes per directory) before it opens the
+// symlink and fails with ELOOP. It repeats the failing readdirSync and prints
+// the RSS growth between a warmed-up baseline and the end of the run as JSON.
+//
+// Usage: bun readdirSync-recursive-error-leak-fixture.js <iterations>
 
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
+const iterations = Number(process.argv[2]);
+if (!Number.isInteger(iterations) || iterations <= 0) {
+  throw new Error("usage: readdirSync-recursive-error-leak-fixture.js <iterations>");
+}
+
 const rss =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
+const toMB = bytes => Math.round((bytes / 1024 / 1024) * 100) / 100;
 
-const seg = (ch, n = 220) => Buffer.alloc(n, ch).toString();
+// Directory names are close to NAME_MAX so that every leaked path string is as
+// large as possible. Three levels of them put the longest absolute path at
+// TMPDIR + 785 bytes, under macOS's 1024-byte PATH_MAX for any TMPDIR shorter
+// than 230 bytes.
+const LEAF_COUNT = 64;
+const seg = i => Buffer.alloc(246, String.fromCharCode(97 + (i % 26))).toString() + String(i).padStart(4, "0");
 
 const base = fs.mkdtempSync(path.join(os.tmpdir(), "readdir-err-leak-"));
-const root = path.join(base, seg("r"));
-fs.mkdirSync(root);
+const root = path.join(base, seg(LEAF_COUNT));
+const mid = path.join(root, seg(LEAF_COUNT + 1));
+fs.mkdirSync(mid, { recursive: true });
 
-for (let i = 0; i < 4; i++) fs.writeFileSync(path.join(root, "f" + i), "x");
-
-// Eight subdirectories with long names. Each one visited before the error
-// contributes a distinct ~500-byte Dirent.path string.
-const subdirs = [];
-for (let i = 0; i < 8; i++) {
-  const d = path.join(root, seg(String.fromCharCode(97 + i)));
+// Each leaf holds one file so that the walker creates a Dirent.path string for
+// it (an empty directory yields no Dirent and no path string).
+const leaves = [];
+for (let i = 0; i < LEAF_COUNT; i++) {
+  const d = path.join(mid, seg(i));
   fs.mkdirSync(d);
-  for (let j = 0; j < 2; j++) fs.writeFileSync(path.join(d, "f" + j), "x");
-  subdirs.push(d);
+  fs.writeFileSync(path.join(d, "f"), "x");
+  leaves.push(d);
 }
 
-// Self-referential symlink at depth 2. Opened last (BFS), yields ELOOP, which
-// is not in the silently-skipped set (NOENT/NOTDIR/PERM) and so propagates as
-// an error after all the Dirents above have been collected.
-const loop = path.join(subdirs[0], "zzloop");
-fs.symlinkSync("zzloop", loop);
+// Self-referential symlink inside a leaf. It is queued while that leaf is
+// scanned, after every leaf was queued, so BFS opens it last. ELOOP is not in
+// the silently-skipped set (NOENT/NOTDIR/PERM) and so propagates as an error
+// after all the Dirents above have been collected.
+fs.symlinkSync("zzloop", path.join(leaves[0], "zzloop"));
 
-// Sanity: confirm the error path actually fires.
-let threw = false;
-try {
-  fs.readdirSync(root, { recursive: true, withFileTypes: true });
-} catch {
-  threw = true;
-}
-if (!threw) throw new Error("expected readdirSync to throw (symlink loop not triggering error path)");
-
-// Warmup: saturate allocator working set / ASAN quarantine so the baseline
-// measurement is taken after steady state is reached.
-for (let i = 0; i < 10000; i++) {
+// Every error code seen across all calls. A call that does not throw records null.
+const codes = new Set();
+function failingReaddir() {
   try {
     fs.readdirSync(root, { recursive: true, withFileTypes: true });
-  } catch {}
+    codes.add(null);
+  } catch (e) {
+    codes.add(e.code);
+  }
 }
+
+// Warmup: run chunks of calls until RSS stops growing between two samples, so
+// that the baseline is taken from the allocator's steady state (the first
+// calls grow RSS by a few MB without any leak). A real leak grows RSS on every
+// chunk, so the cap is what ends the warmup in that case.
+const WARMUP_CHUNK = 50;
+const WARMUP_MAX = 1000;
+let warmup = 0;
 Bun.gc(true);
-const before = rss();
+let before = rss();
+do {
+  for (let i = 0; i < WARMUP_CHUNK; i++) failingReaddir();
+  warmup += WARMUP_CHUNK;
+  Bun.gc(true);
+  const now = rss();
+  const grew = now - before >= 1024 * 1024;
+  before = now;
+  if (!grew) break;
+} while (warmup < WARMUP_MAX);
 
-for (let i = 0; i < 20000; i++) {
-  try {
-    fs.readdirSync(root, { recursive: true, withFileTypes: true });
-  } catch {}
-}
+for (let i = 0; i < iterations; i++) failingReaddir();
 Bun.gc(true);
 const after = rss();
 
-const deltaMB = Math.round((after - before) / 1024 / 1024);
-console.log("RSS delta", deltaMB, "MB");
+fs.rmSync(base, { recursive: true, force: true });
 
-try {
-  fs.rmSync(base, { recursive: true, force: true });
-} catch {}
-
-// With the leak, each failing call retains ~9 path strings (~5 KB). 20k
-// iterations is ~100+ MB of unreclaimable growth on top of the warmed-up
-// baseline (observed: ~124-130 MB). Without the leak the delta is allocator /
-// ASAN-quarantine noise (observed: ~26 MB in debug+ASAN, ~0 in release).
-if (deltaMB > 64) {
-  throw new Error("Dirent.path leak: RSS grew " + deltaMB + " MB over 20000 failing readdirSync calls");
-}
+console.log(
+  JSON.stringify({
+    iterations,
+    warmup,
+    codes: [...codes],
+    rssBeforeMB: toMB(before),
+    rssAfterMB: toMB(after),
+    deltaMB: toMB(after - before),
+  }),
+);

--- a/test/js/node/fs/readdirSync-recursive-error-leak.test.ts
+++ b/test/js/node/fs/readdirSync-recursive-error-leak.test.ts
@@ -1,6 +1,14 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows } from "harness";
 import path from "path";
+
+// Each failing call scans 66 directories before it hits the ELOOP, so the
+// original bug leaked 66 path strings (~50 KB) per call: ~20 MB over 400
+// calls, ~15 MB over 300. Without the leak the delta is allocator slack,
+// within 3 MB on every build measured. Debug+ASAN builds take ~12 ms per
+// call, so they run fewer of them.
+const iterations = isASAN || isDebug ? 300 : 400;
+const maxDeltaMB = 8;
 
 // Windows: self-referential symlinks behave differently and the recursive
 // walker takes a different open path there; this leak is posix-specific.
@@ -8,27 +16,39 @@ test.skipIf(isWindows)(
   "readdirSync({recursive:true, withFileTypes:true}) error path does not leak Dirent.path",
   async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "readdirSync-recursive-error-leak-fixture.js")],
+      cmd: [bunExe(), path.join(import.meta.dir, "readdirSync-recursive-error-leak-fixture.js"), String(iterations)],
       env: {
         ...bunEnv,
-        // The fixture distinguishes the leak (~5 KB/call retained) from
-        // allocator/redzone noise by an RSS delta. ASAN's quarantine holds
-        // every *freed* allocation poisoned-but-resident until it exceeds
-        // quarantine_size_mb (default 256 MB); 20 000 readdirSync error paths
-        // free ~100 MB of Dirent.path strings, all of which sit in the
-        // quarantine and inflate RSS by exactly the amount the test is trying
-        // to detect — even when nothing leaks. Disable the quarantine for
-        // this measurement subprocess only; the test still flags the original
-        // ~5 KB/call leak.
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+        // The DFG tier-up of the fixture's loop allocates ~4 MB (~8 MB in
+        // debug builds) of compiler and code memory a few hundred calls in,
+        // which an RSS delta this small cannot tell apart from a leak. The
+        // leak under test is in native code, so the JIT adds nothing here.
+        BUN_JSC_useJIT: "0",
+        // ASAN's quarantine keeps every freed allocation resident until it
+        // exceeds quarantine_size_mb (default 256 MB), which would inflate the
+        // RSS delta by exactly the amount this test measures. Disable it for
+        // the measurement subprocess only.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+          .filter(Boolean)
+          .join(":"),
       },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout).toContain("RSS delta");
+    const report = JSON.parse(stdout);
+    expect(report).toEqual({
+      iterations,
+      warmup: expect.any(Number),
+      codes: ["ELOOP"],
+      rssBeforeMB: expect.any(Number),
+      rssAfterMB: expect.any(Number),
+      deltaMB: expect.any(Number),
+    });
+    expect(report.deltaMB).toBeLessThan(maxDeltaMB);
     expect(exitCode).toBe(0);
   },
-  90_000,
+  // ~0.3 s in release, ~6 s in a debug+ASAN build.
+  isASAN || isDebug ? 30_000 : 15_000,
 );


### PR DESCRIPTION
### Problem
- `test/js/node/fs/readdirSync-recursive-error-leak.test.ts` took 16.3 s on darwin x64 in CI (build #108487) and 41 s under a debug+ASAN build. The fixture ran 30 000 failing `readdirSync` calls over 9 directories to detect a leak of one `Dirent.path` string per scanned directory.
- The assertions were weak: `stdout` contains "RSS delta", exit code 0. A regression showed no numbers.

### Fix
- The tree is now root/mid/64 leaves with 250-byte names: 66 path strings (~50 KB) per failing call. 400 calls (300 under debug or ASAN) give a 15 to 20 MB leak signal from 10x fewer directory scans.
- The fixture prints a JSON report (iterations, warmup, error codes, RSS before and after, delta). The test asserts it with `toEqual`, codes exactly `["ELOOP"]`, then `deltaMB < 8`.
- The fixture runs with `BUN_JSC_useJIT=0` and warms up until RSS is flat. The DFG tier-up of its loop added 4 MB (8 MB in debug) of RSS a few hundred calls in.
- Verified on linux x64: release 2.1 s to 0.3 s, debug+ASAN 41 s to 5.7 s. With the leak put back in `node_fs.rs` (forget `Dirent.path` on the error path) the test fails: `deltaMB` 16 against the 8 MB bound.

### Background
- `readdirSync({ recursive: true, withFileTypes: true })` walks breadth-first. All entries of one directory share one refcounted `Dirent.path` string. #30167 fixed the sync error path, which released `.name` but not `.path`.
- An RSS delta is the only observable for a leaked native string. `heapStats()` counts JS cells only.
- The per-test timeout drops from 90 s to 15 s (30 s under debug or ASAN).

<details><summary>Notes</summary>

Timings, linux x64 in this container:

| build | before | after |
|---|---|---|
| release (`USE_SYSTEM_BUN=1 bun test`) | 2.1 s | 0.3 s |
| debug+ASAN (`bun bd test`) | 41.1 s | 5.1 to 6.5 s |

Per call cost: release ~0.5 ms, debug+ASAN ~12 ms. The cost is per directory scan (openat, getdents, close, one Dirent per entry), so the leak signal per unit of time is fixed at roughly 4 KB per ms in debug. Fewer, larger path strings is the only lever: the tree went from 9 directories with 220-byte names to 66 with 250-byte names, three levels deep.

Noise: without a leak, RSS grew by 4 MB (release) or 8 MB (debug) between call 100 and call 300, then stayed flat. `BUN_JSC_useDFGJIT=0` removed it, `BUN_JSC_useFTLJIT=0` did not, so it is the DFG compile of the loop. With the JIT off the no-leak delta is 0 to 2 MB (release 0 to 1 MB, debug 0 to 3 MB over 10 runs). The warmup loop runs 50-call chunks until a chunk grows RSS by less than 1 MB, capped at 1000 calls. With the leak present every chunk grows by ~2.5 MB, so the cap ends the warmup and the measured window still shows the leak (observed `warmup: 1000, deltaMB: 17`).

Leak check: added a temporary `leak_path_for_test` to `ReaddirEntry` that runs `std::mem::forget` on `Dirent.path` when `readdir_with_entries_recursive_sync` returns an error. Result under debug+ASAN: `Expected: < 8, Received: 16`. The patch is not part of this PR.

darwin x64: I could not measure it here. The cost is per directory scan, so the 10x cut in scans should bring the 16.3 s down to about 2 s. The gap to darwin aarch64 (4.6 s) is most likely syscall cost on the Intel CI hosts plus the 3-wide batch, not the RSS sampling (`Bun.unsafe.memoryFootprint` is called only three to four times per run).

No `src/` change. The test ran 3 times under the release build and 3 times under debug+ASAN, all green.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/readdirSync-recursive-error-leak.test.ts

<!-- robobun:evidence:end -->