### PR TITLE
test(intl): run the locale children concurrently and assert the sweep once per tree

### DIFF
--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -111,54 +111,6 @@ describe("Intl.DateTimeFormat", () => {
 // ---------------------------------------------------------------------------
 
 describe("Intl.Collator", () => {
-  // The default locale must not be ICU's en_US_POSIX fallback (what an invalid
-  // platform language tag degrades to; bionic's default "C.UTF-8" used to
-  // produce exactly that): its case-first collation gives "a".localeCompare("B") === 1.
-  test("default locale is a real locale, not en-US-u-va-posix", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `console.log(JSON.stringify([new Intl.Collator().resolvedOptions().locale, "a".localeCompare("B")]))`,
-      ],
-      // whatever the environment says, including nothing at all
-      env: { ...bunEnv, LANG: undefined, LC_ALL: undefined, LC_CTYPE: undefined },
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    const [locale, order] = JSON.parse(stdout);
-    expect(locale).not.toContain("posix");
-    expect(order).toBe(-1);
-    expect(exitCode).toBe(0);
-  });
-
-  // Same path with the C locale spelled "C.UTF-8" (glibc/musl name for it, and
-  // what bionic reports by default): WTF must still treat it as C -> "en-US".
-  test.skipIf(!isLinux)("default locale under C.UTF-8 is not en-US-u-va-posix", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const { dlopen } = require("bun:ffi");
-         const libc = dlopen(${JSON.stringify(libcPathForDlopen())}, { setlocale: { args: ["i32", "cstring"], returns: "cstring" } });
-         const LC_CTYPE = 0; // glibc, musl and bionic; the category platformLanguage() reads
-         const set = String(libc.symbols.setlocale(LC_CTYPE, Buffer.from("C.UTF-8\\0")));
-         console.log(JSON.stringify([set, new Intl.Collator().resolvedOptions().locale, "a".localeCompare("B"), (12345.5).toLocaleString()]));`,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    const [set, locale, order, grouped] = JSON.parse(stdout);
-    // a libc without a C.UTF-8 locale keeps "C", which is the case above
-    if (set === "C.UTF-8") {
-      expect(locale).toBe("en-US");
-      expect(order).toBe(-1);
-      expect(grouped).toBe("12,345.5");
-    }
-    expect(exitCode).toBe(0);
-  });
-
   snapshotIf("sort order across locales", () => {
     const out: Record<string, string[]> = {};
     for (const loc of LOCALES) out[loc] = ["z", "a", "ä", "ö", "Z", "A"].sort(new Intl.Collator(loc).compare);
@@ -182,9 +134,58 @@ describe("Intl.Collator", () => {
 
   test("sensitivity:'base' equates case and diacritics", () => {
     const c = new Intl.Collator("en", { sensitivity: "base" });
-    expect(c.compare("a", "A")).toBe(0);
-    expect(c.compare("a", "á")).toBe(0);
-    expect(c.compare("a", "b")).toBeLessThan(0);
+    expect([c.compare("a", "A"), c.compare("a", "á"), c.compare("a", "b"), c.compare("b", "a")]).toEqual([0, 0, -1, 1]);
+  });
+
+  // The default locale must not be ICU's en_US_POSIX fallback (what an invalid
+  // platform language tag degrades to; bionic's default "C.UTF-8" used to
+  // produce exactly that): its case-first collation gives "a".localeCompare("B") === 1.
+  // Unix WTF maps the C locale to en-US. macOS and Windows report the UI
+  // language of the machine, the same one this test process sees.
+  // Concurrent: the children here run alongside the "locale variables" children below.
+  test.concurrent("default locale is a real locale, not en-US-u-va-posix", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `console.log(JSON.stringify([new Intl.Collator().resolvedOptions().locale, "a".localeCompare("B")]))`,
+      ],
+      // whatever the environment says, including nothing at all
+      env: { ...bunEnv, LANG: undefined, LC_ALL: undefined, LC_CTYPE: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const locale = isMacOS || isWindows ? new Intl.Collator().resolvedOptions().locale : "en-US";
+    expect(stdout).toBe(JSON.stringify([locale, -1]) + "\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  // Same path with the C locale spelled "C.UTF-8" (glibc/musl name for it, and
+  // what bionic reports by default): WTF must still treat it as C -> "en-US".
+  test.concurrent.skipIf(!isLinux)("default locale under C.UTF-8 is not en-US-u-va-posix", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { dlopen } = require("bun:ffi");
+         const libc = dlopen(${JSON.stringify(libcPathForDlopen())}, { setlocale: { args: ["i32", "cstring"], returns: "cstring" } });
+         const LC_CTYPE = 0; // glibc, musl and bionic; the category platformLanguage() reads
+         const set = libc.symbols.setlocale(LC_CTYPE, Buffer.from("C.UTF-8\\0"));
+         console.log(JSON.stringify([set, new Intl.Collator().resolvedOptions().locale, "a".localeCompare("B"), (12345.5).toLocaleString()]));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // setlocale returns null on a libc without a C.UTF-8 locale. The locale then
+    // stays "C", which must give the same en-US output as the test above.
+    const out = (set: string | null) => JSON.stringify([set, "en-US", -1, "12,345.5"]) + "\n";
+    expect(stdout).toBeOneOf([out("C.UTF-8"), out(null)]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });
 
@@ -224,13 +225,10 @@ describe.skipIf(isWindows).concurrent("locale variables in the environment", () 
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(
+      JSON.stringify(["Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)", -1, "1,234.5", "en-US"]) + "\n",
+    );
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual([
-      "Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)",
-      -1,
-      "1,234.5",
-      "en-US",
-    ]);
     expect(exitCode).toBe(0);
   });
 });
@@ -382,12 +380,16 @@ describe("exhaustive locale sweep (every compressed item)", () => {
   for (const tree of Object.keys(probe) as Tree[]) {
     test(`${tree}/ — ${locales.length} locales, non-empty + locale-varying`, () => {
       const seen = new Set<string>();
+      // One assertion per tree: two expect() calls per locale cost 0.6 s across
+      // the five trees on a debug build, and a failure should name every broken
+      // locale at once.
+      const empty: string[] = [];
       for (const loc of locales) {
         const v = probe[tree](loc);
-        expect(typeof v).toBe("string");
-        expect(v!.length).toBeGreaterThan(0);
-        seen.add(v!);
+        if (typeof v !== "string" || v.length === 0) empty.push(loc);
+        else seen.add(v);
       }
+      expect(empty).toEqual([]);
       // Regional variants (en-GB, ar-AE, …) legitimately share strings with
       // their base locale, so the bar is "many distinct", not "all distinct".
       expect(seen.size).toBeGreaterThan(50);


### PR DESCRIPTION
### Problem
- `test/js/web/intl/intl.test.ts` takes 11.6 s on the debian 13 x64-asan lane (build #108487) and 9.9 s locally on a debug ASAN build. The file has 41 tests. Most of its time is not in the Intl calls it pins.
- Profile of the 9.9 s: 3.4 s in 10 spawned children (2 serial, then 8 concurrent in batches of 5, the ASAN default for `--max-concurrency`). 3.2 s in the exhaustive sweep, of which 0.6 s is 6200 `expect()` calls. 0.43 s in the first `new Intl.Collator`, which is JSC's debug-only `checkICULocaleInvariants` over every collator locale. 2.2 s is `bun test` startup plus the harness import.

### Fix
- The two `Intl.Collator` default-locale children are `test.concurrent` and sit at the end of their describe. They now share one concurrent group with the eight "locale variables" children, so the 10 children run in two batches instead of 2 serial runs plus two batches.
- The sweep collects the empty results per tree and asserts once with `toEqual([])`. Coverage is the same (every locale, every tree). A failure now lists every broken locale instead of stopping at the first one.
- Stronger assertions: every child asserts `stdout` and `stderr` exactly, then the exit code. The default-locale test pins the locale (`en-US` on Unix, the test process's own default on macOS and Windows) instead of `not.toContain("posix")`. The C.UTF-8 test asserts the full output whether `setlocale` succeeds or returns null. The sensitivity test asserts the exact `compare()` sign for each pair, including the reversed one.
- Verified: `bun bd test test/js/web/intl/intl.test.ts`, 41 pass, 20 snapshots unchanged. Before: 9.86 s, 9.88 s, 9.87 s. After: 7.38 s, 7.41 s, 7.44 s. Release build (`USE_SYSTEM_BUN=1`): 0.45 s.

### Background
- `bun test` runs consecutive `test.concurrent` tests as one group, across describe boundaries when no hooks sit between them. A sequential test in between splits the group. Under ASAN the default group width is 5 (`src/options_types/context.rs`).
- Snapshot matchers are not allowed in concurrent tests, so the four Collator snapshot tests stay sequential. That is why the two children moved below them instead of the whole describe going concurrent.
- The `LOCALES` list is unchanged. Each extra locale costs 1 to 3 ms in the snapshot loops. The 450 ms of the "sort order" test is the one-time debug invariant check, not the CJK tailorings (zh, ja, ko each open in under 2 ms once it ran). Trimming locales would drop pinned `region/ lang/ curr/ unit/ zone/` items for no measurable gain.

<details><summary>Notes</summary>

Per-phase measurements on the debug ASAN build (linux x64, 12 CPU quota):

- Trivial test file: 1.63 s. This file with no test matched (`-t` filter): 2.19 s. The difference is the harness import and the describe bodies (the 638-tag `getCanonicalLocales` filter is 100 ms, `supportedLocalesOf` 78 ms).
- One child `bun -e ''`: 100 ms. `new Intl.Collator()`: 680 ms. `new Date(0).toString()`: 406 ms. `new Intl.DateTimeFormat()`: 428 ms. `Intl.Collator.supportedLocalesOf(["en"])` alone is 429 ms, so the collator cost is `intlCollatorAvailableLocales()` -> `IntlCollator::checkICULocaleInvariants` (ASSERT_ENABLED only, 128x128 `ucol_strcoll` per locale). Release children take about 30 ms.
- 10 children started from a shell at once finish in 935 ms, the same as one. Inside `bun test` the 8 "locale variables" children took 1.9 s because the ASAN concurrency default is 5, so they ran as 5 + 3.
- Sweep per tree, first pass vs second pass with all ICU caches warm: region 367/162 ms, lang 194/182, curr 245/155, unit 553/424, zone 1258/960. Most of the cost is ICU constructor work (`udat_open`, `unumf_openForSkeletonAndLocale`, `uldn_open`), not data loading or decompression. 620 `new Intl.DateTimeFormat("en", ...)` with one fixed locale still cost 500 ms.
- 6200 `expect()` calls (the old sweep) cost 612 ms. The collect-then-`toEqual` form of the same checks costs 6 ms.
- `timeStyle: "full"` gives the same 620 zone names 20 percent faster than `timeZoneName: "long"` but relies on every CLDR full time pattern containing `zzzz`. Not taken.
- #33491 and #33205 also touch this file. Neither adds to the lines this PR changes, except that #33205 inserts two snapshot tests in the middle of the Collator describe. The two children moved past that spot, so a rebase places those tests in the same describe with no rewrite.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/intl/intl.test.ts

<!-- robobun:evidence:end -->