### PR TITLE
test(fetch): speed up blob-oom.test.ts and assert the exact errors

### DIFF
--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -1,193 +1,204 @@
 import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { truncateSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { rmSync, truncateSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir, tempDirWithFiles } from "harness";
 import os from "node:os";
 import path from "path";
+
+const MiB = 1024 ** 2;
+const GiB = 1024 ** 3;
+
+// The in-process cases lower the synthetic allocation limit (1 MiB is the
+// smallest value the hook accepts) and read sources larger than it. Above the
+// limit .text(), .json() and .bytes() must reject the way they do at the real
+// limits (WTF::StringImpl::MaxLength for strings, 2^32 - 1 for typed arrays),
+// while .arrayBuffer() has no such limit.
+const ALLOCATION_LIMIT = 4 * MiB;
+const BLOB_SIZE = 9 * MiB;
+const FILE_SIZE = 8 * MiB;
+
+const stringTooLong = {
+  name: "Error",
+  code: "ERR_STRING_TOO_LONG",
+  message: "Cannot create a string longer than 2147483647 characters",
+};
+const jsonTooLong = {
+  name: "Error",
+  code: "ERR_STRING_TOO_LONG",
+  message: "Cannot parse a JSON string longer than 2147483647 characters",
+};
+const outOfMemory = { name: "RangeError", message: "Out of memory" };
+
+// The limit is process-wide, so put it back for whatever runs after this file.
+let previousLimit: number;
+beforeAll(() => {
+  previousLimit = setSyntheticAllocationLimitForTesting(ALLOCATION_LIMIT);
+});
+afterAll(() => {
+  setSyntheticAllocationLimitForTesting(previousLimit);
+});
+
 describe("Memory", () => {
+  // Nine 1 MiB parts of NUL bytes: larger than ALLOCATION_LIMIT and all ASCII.
+  const parts: ArrayBuffer[] = new Array(9).fill(new ArrayBuffer(MiB));
+  let blob: Blob;
   beforeAll(() => {
-    setSyntheticAllocationLimitForTesting(128 * 1024 * 1024);
-  });
-  afterEach(() => {
-    Bun.gc(true);
+    blob = new Blob(parts);
   });
 
   describe("Blob", () => {
-    let buf: ArrayBuffer;
-    beforeAll(() => {
-      buf = new ArrayBuffer(Math.floor(64 * 1024 * 1024));
+    // Each case builds its own Blob: Blob.prototype.bytes() detaches the blob
+    // it was called on when it throws.
+    test(".text() rejects with ERR_STRING_TOO_LONG", async () => {
+      await expect(new Blob(parts).text()).rejects.toMatchObject(stringTooLong);
     });
 
-    test(".json() should throw an OOM without crashing the process.", () => {
-      const array = [buf, buf, buf, buf, buf, buf, buf, buf, buf];
-      expect(async () => await new Blob(array).json()).toThrow(
-        "Cannot parse a JSON string longer than 2147483647 characters",
-      );
+    test(".json() rejects with ERR_STRING_TOO_LONG", async () => {
+      await expect(new Blob(parts).json()).rejects.toMatchObject(jsonTooLong);
     });
 
-    test(".text() should throw an OOM without crashing the process.", () => {
-      const array = [buf, buf, buf, buf, buf, buf, buf, buf, buf];
-      expect(async () => await new Blob(array).text()).toThrow(
-        "Cannot create a string longer than 2147483647 characters",
-      );
+    test(".bytes() rejects with RangeError: Out of memory", async () => {
+      await expect(new Blob(parts).bytes()).rejects.toMatchObject(outOfMemory);
     });
 
-    test(".bytes() should throw an OOM without crashing the process.", () => {
-      const array = [buf, buf, buf, buf, buf, buf, buf, buf, buf];
-      expect(async () => await new Blob(array).bytes()).toThrow("Out of memory");
-    });
-
-    test(".arrayBuffer() should NOT throw an OOM.", () => {
-      const array = [buf, buf, buf, buf, buf, buf, buf, buf, buf];
-      expect(async () => await new Blob(array).arrayBuffer()).not.toThrow();
+    test(".arrayBuffer() resolves with every byte", async () => {
+      const buffer = await new Blob(parts).arrayBuffer();
+      expect(buffer.byteLength).toBe(BLOB_SIZE);
     });
   });
 
+  // new Response(blob) and new Request(.., { body: blob }) share the blob's
+  // store instead of copying it, so one blob serves every case below.
   describe("Response", () => {
-    let blob: Blob;
-    beforeAll(() => {
-      const buf = new ArrayBuffer(Math.floor(64 * 1024 * 1024));
-      blob = new Blob([buf, buf, buf, buf, buf, buf, buf, buf, buf]);
-    });
-    afterAll(() => {
-      blob = undefined;
+    test(".text() rejects with ERR_STRING_TOO_LONG", async () => {
+      await expect(new Response(blob).text()).rejects.toMatchObject(stringTooLong);
     });
 
-    test(".text() should throw an OOM without crashing the process.", () => {
-      expect(async () => await new Response(blob).text()).toThrow(
-        "Cannot create a string longer than 2147483647 characters",
-      );
+    test(".json() rejects with ERR_STRING_TOO_LONG", async () => {
+      await expect(new Response(blob).json()).rejects.toMatchObject(jsonTooLong);
     });
 
-    test(".bytes() should throw an OOM without crashing the process.", async () => {
-      expect(async () => await new Response(blob).bytes()).toThrow("Out of memory");
+    test(".bytes() rejects with RangeError: Out of memory", async () => {
+      await expect(new Response(blob).bytes()).rejects.toMatchObject(outOfMemory);
     });
 
-    test(".arrayBuffer() should NOT throw an OOM.", async () => {
-      expect(async () => await new Response(blob).arrayBuffer()).not.toThrow();
-    });
-
-    test(".json() should throw an OOM without crashing the process.", async () => {
-      expect(async () => await new Response(blob).json()).toThrow(
-        "Cannot parse a JSON string longer than 2147483647 characters",
-      );
+    test(".arrayBuffer() resolves with every byte", async () => {
+      const buffer = await new Response(blob).arrayBuffer();
+      expect(buffer.byteLength).toBe(BLOB_SIZE);
     });
   });
 
   describe("Request", () => {
-    let blob: Blob;
-    beforeAll(() => {
-      const buf = new ArrayBuffer(Math.floor(64 * 1024 * 1024));
-      blob = new Blob([buf, buf, buf, buf, buf, buf, buf, buf, buf]);
-    });
-    afterAll(() => {
-      blob = undefined;
+    const request = () => new Request("http://localhost/", { method: "POST", body: blob });
+
+    test(".text() rejects with ERR_STRING_TOO_LONG", async () => {
+      await expect(request().text()).rejects.toMatchObject(stringTooLong);
     });
 
-    test(".text() should throw an OOM without crashing the process.", () => {
-      expect(async () => await new Request("http://localhost:3000", { body: blob }).text()).toThrow(
-        "Cannot create a string longer than 2147483647 characters",
-      );
+    test(".json() rejects with ERR_STRING_TOO_LONG", async () => {
+      await expect(request().json()).rejects.toMatchObject(jsonTooLong);
     });
 
-    test(".bytes() should throw an OOM without crashing the process.", async () => {
-      expect(async () => await new Request("http://localhost:3000", { body: blob }).bytes()).toThrow("Out of memory");
+    test(".bytes() rejects with RangeError: Out of memory", async () => {
+      await expect(request().bytes()).rejects.toMatchObject(outOfMemory);
     });
 
-    test(".arrayBuffer() should NOT throw an OOM.", async () => {
-      expect(async () => await new Request("http://localhost:3000", { body: blob }).arrayBuffer()).not.toThrow();
-    });
-
-    test(".json() should throw an OOM without crashing the process.", async () => {
-      expect(async () => await new Request("http://localhost:3000", { body: blob }).json()).toThrow(
-        "Cannot parse a JSON string longer than 2147483647 characters",
-      );
+    test(".arrayBuffer() resolves with every byte", async () => {
+      const buffer = await request().arrayBuffer();
+      expect(buffer.byteLength).toBe(BLOB_SIZE);
     });
   });
 });
 
 describe("Bun.file", () => {
-  let tmpFile;
-  beforeAll(async () => {
-    const buf = Buffer.allocUnsafe(8 * 1024 * 1024);
-    const tmpDir = tempDirWithFiles("file-oom", {
-      "file.txt": buf,
-    });
-    tmpFile = path.join(tmpDir, "file.txt");
-  });
-  beforeEach(() => {
-    setSyntheticAllocationLimitForTesting(4 * 1024 * 1024);
-  });
-  afterEach(() => {
-    setSyntheticAllocationLimitForTesting(128 * 1024 * 1024);
+  let dir: string;
+  let file: string;
+  beforeAll(() => {
+    dir = tempDirWithFiles("file-oom", { "file.txt": Buffer.alloc(FILE_SIZE, "x") });
+    file = path.join(dir, "file.txt");
   });
   afterAll(() => {
-    try {
-      unlinkSync(tmpFile);
-    } catch (err) {
-      console.error(err);
-    }
+    rmSync(dir, { recursive: true, force: true });
   });
 
-  test("text() should throw an OOM without crashing the process.", () => {
-    expect(async () => await Bun.file(tmpFile).text()).toThrow();
+  test(".text() rejects with ERR_STRING_TOO_LONG", async () => {
+    await expect(Bun.file(file).text()).rejects.toMatchObject(stringTooLong);
   });
 
-  test("bytes() should throw an OOM without crashing the process.", () => {
-    expect(async () => await Bun.file(tmpFile).bytes()).toThrow();
+  test(".json() rejects with ERR_STRING_TOO_LONG", async () => {
+    await expect(Bun.file(file).json()).rejects.toMatchObject(jsonTooLong);
   });
 
-  test("json() should throw an OOM without crashing the process.", () => {
-    expect(async () => await Bun.file(tmpFile).json()).toThrow();
+  test(".bytes() rejects with RangeError: Out of memory", async () => {
+    await expect(Bun.file(file).bytes()).rejects.toMatchObject(outOfMemory);
   });
 
-  test("arrayBuffer() should NOT throw an OOM.", () => {
-    expect(async () => await Bun.file(tmpFile).arrayBuffer()).not.toThrow();
+  test(".arrayBuffer() resolves with every byte", async () => {
+    const buffer = await Bun.file(file).arrayBuffer();
+    expect(buffer.byteLength).toBe(FILE_SIZE);
   });
 });
 
+// The cases below need real 2 GiB and 4 GiB buffers: the limits they hit are
+// WTF::StringImpl::MaxLength (2^31 - 1) and JSC's MAX_ARRAY_BUFFER_SIZE (2^32),
+// which the synthetic limit cannot stand in for. The Rust-side guards in front
+// of WTF string construction used to check only the synthetic limit, so a
+// smaller source behind a lower synthetic limit would pass the guard that the
+// real sizes get past. Each case runs in a child process so the buffer stays
+// out of the test runner, and the children carry their own timeouts because a
+// 4 GiB read takes several seconds in a debug build.
+//
+// Inside a container os.totalmem() reports the host's RAM;
+// process.constrainedMemory() reports the cgroup limit there.
+const memory = Math.min(os.totalmem(), process.constrainedMemory() || Infinity);
+// A child that reads N bytes from a file peaks near N of RSS, or 2N under ASAN
+// (measured: 8.5 GiB for the 4 GiB read). The 10 GiB gate, the same one as
+// buffer.test.js's 4 GiB case, covers one child at a time. Concurrent tests in
+// adjacent groups run as one batch, so when both groups below are concurrent
+// all four children run at once. That needs about 24 GiB under ASAN and 12 GiB
+// otherwise, and happens only where the machine holds twice that.
+const fitsOneChild = memory >= 10 * GiB;
+const fitsAllChildren = memory >= 2 * (isASAN ? 24 : 12) * GiB;
+
+interface ChildResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  signalCode: string | null;
+}
+
+// Everything the child produced goes into one assertion, so an abort shows its
+// signal, exit code and stderr next to the missing stdout.
+async function runChild(source: string): Promise<ChildResult> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+function childPrinted(output: unknown): ChildResult {
+  return { stdout: JSON.stringify(output) + "\n", stderr: "", exitCode: 0, signalCode: null };
+}
+
 // Byte lengths in [2^31, 2^32) used to abort the process instead of throwing:
-// the Rust-side guards in front of WTF string construction only checked the
-// synthetic allocation limit (2^32 - 1 by default) and missed
-// WTF::StringImpl::MaxLength (2^31 - 1), tripping
+// the guards missed WTF::StringImpl::MaxLength and tripped
 // "ASSERTION FAILED: data.size() <= MaxLength" / a RELEASE_ASSERT in
-// StringImplShape. Lengths >= 2^32 were already caught. These allocate a real
-// 2 GiB, so each case runs in a subprocess to keep the peak away from the
-// test runner, and the block skips on small machines (same gate as
-// buffer.test.js's 4 GiB case).
-describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB string limit", () => {
+// StringImplShape. Lengths >= 2^32 were already caught.
+describe.concurrent.skipIf(!fitsOneChild)("byte sources at the 2 GiB string limit", () => {
   test("Blob.text() and Blob.json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const results = [];
-          const report = e => ({ name: e.name, code: e.code, message: e.message });
-          const blob = new Blob([new Uint8Array(2 ** 31)]);
-          await blob.text().then(() => results.push("TEXT_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
-          await blob.json().then(() => results.push("JSON_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
-          console.log(JSON.stringify(results));
-          `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
-      {
-        name: "Error",
-        code: "ERR_STRING_TOO_LONG",
-        message: "Cannot create a string longer than 2147483647 characters",
-      },
-      {
-        name: "Error",
-        code: "ERR_STRING_TOO_LONG",
-        message: "Cannot parse a JSON string longer than 2147483647 characters",
-      },
-    ]);
-    expect(exitCode).toBe(0);
+    const result = await runChild(`
+      const results = [];
+      const report = e => ({ name: e.name, code: e.code, message: e.message });
+      const blob = new Blob([new Uint8Array(2 ** 31)]);
+      await blob.text().then(() => results.push("TEXT_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
+      await blob.json().then(() => results.push("JSON_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
+      console.log(JSON.stringify(results));
+    `);
+    expect(result).toEqual(childPrinted([stringTooLong, jsonTooLong]));
   }, 90_000);
 
   test("Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_LONG instead of aborting", async () => {
@@ -196,32 +207,12 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
     // Sparse where the filesystem supports it; reads back as 'x' + NUL bytes.
     writeFileSync(file, "x");
     truncateSync(file, 2 ** 31);
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const results = [];
-          const report = e => ({ name: e.name, code: e.code, message: e.message });
-          await Bun.file(${JSON.stringify(file)}).text().then(() => results.push("UNEXPECTED_SUCCESS"), e => results.push(report(e)));
-          console.log(JSON.stringify(results));
-          `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
-      {
-        name: "Error",
-        code: "ERR_STRING_TOO_LONG",
-        message: "Cannot create a string longer than 2147483647 characters",
-      },
-    ]);
-    expect(exitCode).toBe(0);
-    // Reads 2 GiB through the page cache; measured right at the default 5s
-    // ceiling under load.
+    const result = await runChild(`
+      const report = e => ({ name: e.name, code: e.code, message: e.message });
+      const result = await Bun.file(${JSON.stringify(file)}).text().then(() => "UNEXPECTED_SUCCESS", report);
+      console.log(JSON.stringify([result]));
+    `);
+    expect(result).toEqual(childPrinted([stringTooLong]));
   }, 90_000);
 });
 
@@ -229,54 +220,35 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
 // file path hands the bytes it read to JSC without a copy; converting the
 // length through u32 on the way panicked at exactly 2^32, and JSC aborts when
 // it is asked to adopt more than that. The file is sparse, but each case still
-// reads a real 4 GiB into the child (about 6 seconds in a debug build, all of
-// it page faults), so it runs in a subprocess, gets a long timeout, and skips
-// on small machines like the 2 GiB cases above. On Windows the file reader
-// itself rejects files of 2^32 bytes or more with ENOMEM (read_file.rs,
-// ReadFileUV), so neither case reaches the ArrayBuffer hand-off there.
-describe.skipIf(isWindows || os.totalmem() < 10 * 1024 ** 3)(
-  "Bun.file().arrayBuffer() at the 4 GiB ArrayBuffer limit",
-  () => {
-    async function readSparseFileAsArrayBuffer(size: number) {
-      using dir = tempDir("blob-4gib", {});
-      const file = path.join(String(dir), "big.bin");
-      // 'x' followed by a hole, which reads back as NUL bytes. Nothing is written
-      // after the truncate: on NTFS that would zero-fill the whole file on disk.
-      writeFileSync(file, "x");
-      truncateSync(file, size);
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
-          const report = buf => {
-            const view = new DataView(buf);
-            return { byteLength: buf.byteLength, first: view.getUint8(0), last: view.getUint8(buf.byteLength - 1) };
-          };
-          const result = await Bun.file(${JSON.stringify(file)}).arrayBuffer().then(report, e => ({ error: { name: e.name, message: e.message } }));
-          console.log(JSON.stringify(result));
-          `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode, signalCode: proc.signalCode }));
-    }
+// reads a real 4 GiB into the child. On Windows the file reader itself rejects
+// files of 2^32 bytes or more with ENOMEM (read_file.rs, ReadFileUV), so
+// neither case reaches the ArrayBuffer hand-off there.
+const describeFourGiB = fitsAllChildren ? describe.concurrent : describe;
+describeFourGiB.skipIf(isWindows || !fitsOneChild)("Bun.file().arrayBuffer() at the 4 GiB ArrayBuffer limit", () => {
+  async function readSparseFileAsArrayBuffer(size: number): Promise<ChildResult> {
+    using dir = tempDir("blob-4gib", {});
+    const file = path.join(String(dir), "big.bin");
+    // 'x' followed by a hole, which reads back as NUL bytes. Nothing is written
+    // after the truncate: on NTFS that would zero-fill the whole file on disk.
+    writeFileSync(file, "x");
+    truncateSync(file, size);
+    return await runChild(`
+      const report = buf => {
+        const view = new DataView(buf);
+        return { byteLength: buf.byteLength, first: view.getUint8(0), last: view.getUint8(buf.byteLength - 1) };
+      };
+      const result = await Bun.file(${JSON.stringify(file)}).arrayBuffer().then(report, e => ({ error: { name: e.name, message: e.message } }));
+      console.log(JSON.stringify(result));
+    `);
+  }
 
-    test("a file of exactly 2^32 bytes is returned whole", async () => {
-      expect(await readSparseFileAsArrayBuffer(2 ** 32)).toEqual({
-        byteLength: 2 ** 32,
-        first: "x".charCodeAt(0),
-        last: 0,
-      });
-    }, 120_000);
+  test("a file of exactly 2^32 bytes is returned whole", async () => {
+    expect(await readSparseFileAsArrayBuffer(2 ** 32)).toEqual(
+      childPrinted({ byteLength: 2 ** 32, first: "x".charCodeAt(0), last: 0 }),
+    );
+  }, 120_000);
 
-    test("a file of 2^32 + 1 bytes rejects with the RangeError that new ArrayBuffer() throws for that size", async () => {
-      expect(await readSparseFileAsArrayBuffer(2 ** 32 + 1)).toEqual({
-        error: { name: "RangeError", message: "Out of memory" },
-      });
-    }, 120_000);
-  },
-);
+  test("a file of 2^32 + 1 bytes rejects with the RangeError that new ArrayBuffer() throws for that size", async () => {
+    expect(await readSparseFileAsArrayBuffer(2 ** 32 + 1)).toEqual(childPrinted({ error: outOfMemory }));
+  }, 120_000);
+});


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/blob-oom.test.ts` took 11.8 s on the debian 13 x64-asan lane (build 108487). The in-process cases built 576 MiB Blobs behind a 128 MiB synthetic limit. The four children ran in sequence.
- The assertions were loose: message substrings, a bare `toThrow()` for `Bun.file`, `not.toThrow()` for `.arrayBuffer()`, nothing on a child's stderr or signal.

### Fix
- The in-process cases use a 4 MiB limit with 9 MiB blobs and an 8 MiB file. Response and Request share one blob. `afterAll` restores the previous limit.
- Every rejection is checked on `name`, `code` and `message`. `.arrayBuffer()` must resolve with the full `byteLength`. A child's `stdout`, `stderr`, `exitCode` and `signalCode` go into one `toEqual`.
- The 2 GiB children run concurrently. The 4 GiB children do too where the machine holds all four at once. Both gates read `process.constrainedMemory()`, so a cgroup limit counts.
- Verified: `bun bd test test/js/web/fetch/blob-oom.test.ts` (ASAN) 23.2 s before, 15.2 s to 16.2 s after. Release: 9.4 s before, 2.6 s after. With the limit at its default, the 12 OOM cases fail.

### Background
- `setSyntheticAllocationLimitForTesting(n)` sets a byte limit that `Blob.rs` checks before it hands a typed array to JSC, and a string limit that stands in for `WTF::StringImpl::MaxLength`. `.text()` and `.json()` throw `ERR_STRING_TOO_LONG`, `.bytes()` throws `RangeError: Out of memory`, `.arrayBuffer()` checks neither.
- The 2 GiB children cannot use the synthetic limit. The bug they cover was a guard that checked only that limit and missed `MaxLength`.
- `process.constrainedMemory()` is the cgroup limit on Linux. `os.totalmem()` reports the host's RAM inside a container.

<details><summary>Notes</summary>

Where the time went locally (debug ASAN, 12 vCPU, 32 GiB cgroup limit on a 247 GiB host). Before: 23.2 s and 22.2 s. After: 15.2 s, 16.2 s and 15.7 s. With `setSyntheticAllocationLimitForTesting` left at its default (4294967295), the 12 `.text()` / `.json()` / `.bytes()` cases fail and the 4 `.arrayBuffer()` cases pass, so the 9 MiB and 8 MiB sources do exercise the limit.

| part | before | after |
| --- | --- | --- |
| Blob / Response / Request in-process (12 tests) | 3.3 s | 0.2 s |
| Bun.file in-process (4 tests) | 0.1 s | 0.1 s |
| two 2 GiB children | 2.2 s + 3.5 s, serial | 3.0 s, concurrent |
| two 4 GiB children | 5.7 s + 5.6 s, serial | unchanged here |

The 4 GiB pair stays serial in this container because ASAN needs 2 x 24 GiB for all four children to overlap and the cgroup allows 32 GiB. The asan CI agents are r7i.2xlarge / r8g.2xlarge with 64 GiB (`.buildkite/ci.mjs`), so all four children overlap there. With the release binary (2 x 12 GiB needed, 32 GiB available) all four overlap locally too, which is where the 2.6 s comes from.

Measured peak RSS per child (`Bun.spawn(...).resourceUsage().maxRSS`): 4 GiB read 4.1 GiB release / 8.5 GiB ASAN, 2 GiB read 2.1 / 4.4 GiB, 2 GiB Blob 2.1 / 2.4 GiB. ASAN's allocator copies on realloc, which is why a read peaks at twice the file size there. Those numbers give the 24 GiB (ASAN) and 12 GiB figures in the gate, and the gate asks for twice that.

Adjacent concurrent groups run as one batch in `bun test` (checked with a small probe: four tests across two `describe.concurrent` blocks all started within 10 ms). That is why the 4 GiB gate counts all four children and not just its own two. When the gate is off, that `describe` is plain and its tests wait for the concurrent batch to finish.

The hook clamps the limit at 1 MiB (`virtual_machine_exports.rs`), so 4 MiB keeps a margin. The `Bun.file` describe already used 4 MiB. Both limits are process-wide atomics (`SYNTHETIC_ALLOCATION_LIMIT` in `VirtualMachine.rs`, `STRING_ALLOCATION_LIMIT` in `bun_core/string/mod.rs`), which is why `afterAll` restores the previous value: with `--parallel --isolate` the next file runs in the same process.

Why 9 x 1 MiB parts: a multi-part Blob concatenates into one store (`Blob.rs`, `from_js_without_defer_gc`), so the size only has to exceed the limit. The memfd copy-on-write path in the `Clone` arm applies only to single-ArrayBuffer blobs of 8 MiB or more, and the old 9-part blobs never took it either.

Why the 2 GiB children keep a real allocation: the guard in front of WTF string construction used to check only the synthetic limit. With a lower synthetic limit and a smaller source, that guard fires for the wrong reason and the `MaxLength` regression would go unnoticed.

Why the Blob `describe` does not share the blob: `Blob.prototype.bytes()` calls `self.detach()` before it throws the synthetic OOM (`Blob.rs`, `to_array_buffer_view_with_bytes`, `Clone` arm). After a failed `.bytes()` the blob still reports its size but `.text()` returns `""`. Each Blob case builds its own 9 MiB blob, which costs about 1 ms. Response and Request dupe the store into a body-owned Blob, so the detach hits that copy and the shared blob is safe. That detach looks like a bug in its own right, but it is out of scope here.

`expect(async () => ...).toThrow()` does wait for the returned promise in `bun test` (`get_value_as_to_throw` calls `wait_for_promise`), so the old tests were not broken. The `rejects.toMatchObject` form is the portable one and lets the assertion cover `name` and `code`.

`Buffer.alloc(FILE_SIZE, "x")` replaces `Buffer.allocUnsafe`, so the file's content no longer depends on uninitialized memory. The file cases hit the same three errors either way, because the length check runs before any decoding.

The `os.totalmem() < 10 GiB` skip keeps its threshold. With `process.constrainedMemory()` in the minimum, a container with a smaller cgroup limit now skips the children instead of having them OOM-killed. On macOS and Windows `constrainedMemory()` is the physical RAM, so nothing changes there.

Also ran `test/js/web/fetch/blob.test.ts` and `test/js/web/fetch/body.test.ts` with the debug build: 578 pass. Prettier and `tsc` (test project) report nothing for this file.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob-oom.test.ts

<!-- robobun:evidence:end -->