### PR TITLE
test: deflake h2 stream-release and CompressionStream backpressure tests

### DIFF
--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1289,6 +1289,33 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   });
 });
 
+// A stream nothing references any more can still survive a bounded number of collections: JSC scans
+// the machine stack conservatively and honors interior pointers, so a stale word left in a native
+// frame (seen on x64 as cell+0x84 in the microtask-drain frames; near-deterministic on aarch64) pins
+// one object until that slot is overwritten. The leaks these tests guard against retain every stream,
+// so they open many streams and tolerate a few stragglers instead of demanding exactly zero.
+const GC_STRAGGLERS = 3;
+
+/**
+ * Collects until every one of `refs` is gone, giving up after 50 passes or once the count has not
+ * moved for 10 passes, and resolves to how many survived.
+ */
+async function liveCount(refs: WeakRef<object>[]): Promise<number> {
+  const live = () => refs.filter(ref => ref.deref() !== undefined).length;
+  // A completed stream's JS teardown is spread over a few immediates (rstNextTick, deferred
+  // destroy), and a WeakRef target survives the job that dereferenced it, so every pass gets a
+  // fresh turn before collecting.
+  let last = live();
+  for (let pass = 0, stuck = 0; pass < 50 && last > 0 && stuck < 10; pass++) {
+    await new Promise(resolve => setImmediate(resolve));
+    await gcTick();
+    const now = live();
+    stuck = now === last ? stuck + 1 : 0;
+    last = now;
+  }
+  return last;
+}
+
 describe("inbound stream lifecycle", () => {
   test("releases server stream objects once the peer resets their streams", async () => {
     const total = 32;
@@ -1322,16 +1349,7 @@ describe("inbound stream lifecycle", () => {
         c.sendFrame(FrameType.RST_STREAM, 0, 1 + 2 * i, cancel);
       }
       await allClosed.promise;
-      // The streams' native release rides the deferred teardown chain
-      // (setImmediate: rstNextTick / delayed destroy), so drain an immediate
-      // turn before each GC pass - gcTick's Bun.sleep(0) alone leaves the
-      // release pending on slow FinalizationRegistry lanes (alpine/musl
-      // needed a retry at 20 passes; collection is late there, not stuck).
-      for (let i = 0; i < 50 && refs.some(ref => ref.deref() !== undefined); i++) {
-        await new Promise(resolve => setImmediate(resolve));
-        await gcTick();
-      }
-      expect(refs.filter(ref => ref.deref() !== undefined).length).toBe(0);
+      expect(await liveCount(refs)).toBeLessThanOrEqual(GC_STRAGGLERS);
     } finally {
       c.destroy();
       server.close();
@@ -1674,7 +1692,8 @@ describe("inbound stream lifecycle", () => {
 // (end() without a body, or the empty frame that follows a body once no trailers are coming); the
 // queue writes the two through different branches, so both shapes are covered below.
 describe("stream release after a queued END_STREAM", () => {
-  const STREAMS = 4;
+  // Well above GC_STRAGGLERS: without the release every one of these survives.
+  const STREAMS = 16;
   // The peer advertises a 1 KiB stream window: a 4 KiB body cannot be written in one go, so its
   // tail (the frame carrying END_STREAM) is queued and flushed as the peer's WINDOW_UPDATEs arrive.
   const WINDOW = 1024;
@@ -1687,17 +1706,6 @@ describe("stream release after a queued END_STREAM", () => {
     server.listen(0);
     await once(server, "listening");
     return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
-  }
-
-  async function liveCount(refs: WeakRef<object>[]): Promise<number> {
-    const live = () => refs.filter(ref => ref.deref() !== undefined).length;
-    // A completed stream's JS teardown is spread over a few immediates, and a WeakRef target
-    // survives the job that dereferenced it, so every pass gets a fresh turn before collecting.
-    for (let i = 0; i < 50 && live() > 0; i++) {
-      await new Promise(resolve => setImmediate(resolve));
-      await gcTick();
-    }
-    return live();
   }
 
   /**
@@ -1743,7 +1751,7 @@ describe("stream release after a queued END_STREAM", () => {
         tailQueued: Array(STREAMS).fill(true),
         received: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBe(0);
+      expect(await liveCount(refs)).toBeLessThanOrEqual(GC_STRAGGLERS);
     } finally {
       client.close();
       server.close();
@@ -1811,7 +1819,9 @@ describe("stream release after a queued END_STREAM", () => {
         finish(stream);
       });
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBe(0);
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThanOrEqual(
+      GC_STRAGGLERS,
+    );
   });
 
   // The compat API's responses wait for trailers, so after the body END_STREAM always goes out on an
@@ -1831,7 +1841,9 @@ describe("stream release after a queued END_STREAM", () => {
       req.resume();
       req.on("end", () => res.end("ok"));
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBe(0);
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThanOrEqual(
+      GC_STRAGGLERS,
+    );
   });
 
   test("client streams whose request body outgrew the server's window are released", async () => {
@@ -1872,7 +1884,7 @@ describe("stream release after a queued END_STREAM", () => {
         tailQueued: Array(STREAMS).fill(true),
         uploaded: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBe(0);
+      expect(await liveCount(refs)).toBeLessThanOrEqual(GC_STRAGGLERS);
     } finally {
       client.close();
       server.close();

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -558,21 +558,51 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
     },
   );
 
-  // Poll `get()` once per tick until it stays unchanged for 5 consecutive
-  // samples (parked on backpressure) or reaches `total` (ran away). The caller
-  // asserts the parked value is < total.
-  async function waitUntilStable(get: () => number, total: number) {
-    let last = get();
+  // 64 KiB chunks. A paused pipe holds whatever the socket buffers plus a few userland buffers
+  // absorb (Linux loopback autotunes to several MB per direction, so 100-250 chunks is normal);
+  // 32 MiB is beyond any of that, so a source that gets this far was never paused.
+  const RUNAWAY = 512;
+
+  /** A pull source of copies of `chunk` that keeps producing until `endAfter()` or RUNAWAY. */
+  function countingSource(chunk: Uint8Array) {
+    let pulls = 0;
+    let closeAt = RUNAWAY;
+    const stream = new ReadableStream({
+      pull(c) {
+        pulls++;
+        c.enqueue(chunk.slice());
+        if (pulls >= closeAt) c.close();
+      },
+    });
+    return {
+      stream,
+      get pulls() {
+        return pulls;
+      },
+      /** Ends the stream `n` pulls from now; returns the pull count it will end at. */
+      endAfter(n: number) {
+        closeAt = Math.min(closeAt, pulls + n);
+        return closeAt;
+      },
+    };
+  }
+
+  // Resolves once `source` has stopped pulling (no new pull across 50 consecutive 5 ms samples)
+  // or ran away to RUNAWAY. Where it parks depends on the kernel, so callers only assert that it
+  // parked below RUNAWAY, never at a specific count.
+  async function waitUntilParked(source: { readonly pulls: number }) {
+    let last = source.pulls;
     let stable = 0;
-    while (stable < 5 && get() < total) {
-      await Bun.sleep(1);
-      const now = get();
+    while (stable < 50 && source.pulls < RUNAWAY) {
+      await Bun.sleep(5);
+      const now = source.pulls;
       if (now === last) stable++;
       else {
         stable = 0;
         last = now;
       }
     }
+    return source.pulls;
   }
 
   // Native-sink backpressure: when the HTTP response sink's socket buffer fills
@@ -580,76 +610,54 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
   // the writable side parks on m_nativeSinkReadyPromise. Without that, a fast
   // source with a stalled client fills the sink buffer unboundedly.
   test("CompressionStream -> native HTTP sink applies backpressure to a stalled client", async () => {
-    let pulls = 0;
     // Incompressible data so the gzipped output is ~as large as the input.
     const chunk = crypto.getRandomValues(new Uint8Array(64 * 1024));
-    // Backpressure parks after ~tens of pulls (a few MB of socket+sink buffer /
-    // 64KB); 200 is enough headroom to distinguish "parked" from "ran away"
-    // without pushing ~32MB through gzip+HTTP under debug+ASAN.
-    const TOTAL = 200;
+    let source!: ReturnType<typeof countingSource>;
     await using server = Bun.serve({
       port: 0,
       fetch() {
-        const body = new ReadableStream({
-          pull(c) {
-            pulls++;
-            c.enqueue(chunk.slice());
-            if (pulls >= TOTAL) c.close();
-          },
-        });
-        return new Response(body.pipeThrough(new CompressionStream("gzip")));
+        source = countingSource(chunk);
+        return new Response(source.stream.pipeThrough(new CompressionStream("gzip")));
       },
     });
     const res = await fetch(server.url);
     const reader = res.body!.getReader();
     await reader.read();
-    // Let the server's pull loop run until it either parks on backpressure or
-    // runs away to TOTAL.
-    await waitUntilStable(() => pulls, TOTAL);
-    const pullsWhileStalled = pulls;
+    const pullsWhileStalled = await waitUntilParked(source);
+    if (pullsWhileStalled >= RUNAWAY) await reader.cancel();
+    expect(pullsWhileStalled).toBeGreaterThan(0);
+    expect(pullsWhileStalled).toBeLessThan(RUNAWAY);
+    // Reading again must resume the parked pull loop and run it to the end.
+    const closeAt = source.endAfter(8);
     while (!(await reader.read()).done) {}
-    // Without backpressure the pull loop reaches TOTAL while the client is
-    // stalled; with it, pulls stay bounded by the socket + sink buffer
-    // (~a few MB / 64KB ≈ tens of pulls).
-    expect(pullsWhileStalled).toBeLessThan(TOTAL);
-    expect(pulls).toBe(TOTAL);
+    expect(source.pulls).toBe(closeAt);
   });
 
   test("request body -> DecompressionStream propagates backpressure to the client", async () => {
-    let clientPulls = 0;
-    let clientPullsWhileServerStalled = -1;
     const chunk = crypto.getRandomValues(new Uint8Array(64 * 1024));
     const compressed = new Uint8Array(
       await new Response(new Blob([chunk]).stream().pipeThrough(new CompressionStream("gzip"))).arrayBuffer(),
     );
-    const TOTAL = 200;
-    const { promise: drain, resolve: startDrain } = Promise.withResolvers<void>();
+    const source = countingSource(compressed);
+    let clientPullsWhileServerStalled = -1;
+    let closeAt = -1;
     await using server = Bun.serve({
       port: 0,
       async fetch(req) {
         const reader = req.body!.pipeThrough(new DecompressionStream("gzip")).getReader();
         await reader.read();
-        // Stall: let the client's pull loop either park or run away.
-        await waitUntilStable(() => clientPulls, TOTAL);
-        clientPullsWhileServerStalled = clientPulls;
-        startDrain();
+        // Stall: the client's pull loop either parks on backpressure or runs away.
+        clientPullsWhileServerStalled = await waitUntilParked(source);
+        closeAt = source.endAfter(8);
         while (!(await reader.read()).done) {}
         return new Response("ok");
       },
     });
-    const body = new ReadableStream({
-      pull(c) {
-        clientPulls++;
-        c.enqueue(compressed.slice());
-        if (clientPulls >= TOTAL) c.close();
-      },
-    });
-    const res = await fetch(server.url, { method: "POST", body, duplex: "half" } as RequestInit);
-    await drain;
+    const res = await fetch(server.url, { method: "POST", body: source.stream, duplex: "half" } as RequestInit);
     expect(await res.text()).toBe("ok");
     expect(clientPullsWhileServerStalled).toBeGreaterThan(0);
-    expect(clientPullsWhileServerStalled).toBeLessThan(TOTAL);
-    expect(clientPulls).toBe(TOTAL);
+    expect(clientPullsWhileServerStalled).toBeLessThan(RUNAWAY);
+    expect(source.pulls).toBe(closeAt);
   });
 
   test("req.clone().textStream() -> TextEncoderStream -> CompressionStream -> Response round-trips", async () => {


### PR DESCRIPTION
### What was failing

**`test/js/node/http2/h2-conformance.test.ts`** — `stream release after a queued END_STREAM > … compat API …` (and occasionally the `end("ok")` variant) fails on the aarch64 lanes (darwin 14/26/27, "any aarch64", alpine 3.23 aarch64) in most main builds since #38044 added it, usually 4/4 attempts, always `Expected: 0, Received: 1|2` after ~58 ms.

**`test/js/web/streams/compression.test.ts`** — `CompressionStream -> native HTTP sink applies backpressure to a stalled client` fails intermittently on alpine (aarch64 and x64) with `Expected: < 200, Received: 200`.

Neither is a runtime bug; both tests assert something the environment doesn't guarantee.

### h2-conformance: 1–2 of 4 streams survive GC

The streams *are* released by the http2 code. I could not reproduce on Linux x64 with the test as written (200+ runs, tiny socket buffers, 30× parallel), but re-chunking the loopback traffic through a small TCP proxy (100-byte writes, 2 ms delay) reproduces it reliably with the release build: 1–2 of the 4 server streams survive the test's 50 GC passes and are then collected 50–580 passes later, while the proxy is still dribbling the stalled stream's body.

Per the repo rule on blaming the conservative scanner, both artifacts:

1. **Heap snapshot** (`bun:jsc` `generateHeapSnapshotForDebugging()`, taken on a fresh turn so the test's own `WeakRef.deref()` isn't marking): the surviving `ServerHttp2Stream` has no `roots` entry and its only incoming edges are the test's `WeakRef`, its bound `onwrite`, and its `Http2ServerRequest`/`Http2ServerResponse` (a dead cycle — a reverse BFS from them reaches no root and no `StrongRootBlock`). Its node id is ~39, i.e. it was marked during the very first constraint (the conservative scan), before any of its retainers.
   ```
   --- ServerHttp2Stream id=39 addr=0x7fe3ba319080 directRoots=[]
       <- Function#255 [Internal 0] roots=[]
       <- Http2ServerResponse#3406 [Property stream] roots=[]
       <- Http2ServerRequest#3407 [Property stream] roots=[]
       no rooted retainer found (excluding WeakRef)
   ```
   (the legitimately-alive stalled stream in the same snapshot shows `<- StrongRootBlock [StrongHandles]` as expected.)
2. **Debugger**, breakpoint on `JSC::ConservativeRoots::add(void*, void*, JITStubRoutineSet&, CodeBlockSet&)` during the `Bun.gc(true)` that fails to collect it (bun-profile, x64): the scanned main-thread span `[0x7fffffff9750, 0x7fffffffe250)` contains the value `0x7fffeb319104` = cell `0x7fffeb319080` + 0x84 at three slots (`0x7fffffff9c98`, `0x9d40`, `0x9ec8`). `vm.topCallFrame` is `0x7fffffff9950` (the `Bun.gc` host frame), its JS caller's frame is at `0x9a30` and the VM entry record at `0x9ae0`, so all three slots are above the entry record, in the native frames between `vmEntryToJavaScript` and `VM::drainMicrotasks` / `MicrotaskQueue::drainWithUseCallOnEachMicrotask` — not in any JS frame and not in the http2 code. The conservative scan honors interior pointers, so this pins the cell until those stack words are overwritten. With `BUN_JSC_useJIT=0` nothing survives; DFG/FTL/concurrent-JIT/concurrent-GC/generational-GC toggles make no difference.

So the test change: open 16 streams per case instead of 4 and assert `<= 3` survivors (shared `liveCount` helper, which still tries to reach 0 and stops once the count plateaus). With the one-line native release from #38044 reverted locally, all five cases fail with `Received: 16`, so the leak it was written for is still caught. The `releases server stream objects once the peer resets their streams` test uses the same helper/tolerance.

### compression.test.ts: kernel buffers decide where the pull loop parks

Backpressure works; the test's budget was wrong. It assumed "a few MB of socket+sink buffer ≈ tens of pulls" and allowed 200 × 64 KiB = 12.8 MB. On this Linux box the loop parks at 110–130 pulls, and `ss -tmi` during the stall shows where the bytes are:

```
client  Recv-Q 2185328   skmem rb2472427            (fetch side, receive paused)
server  Send-Q 4166528   skmem tb4194304 notsent:4166528
```

~6.3 MB in the kernel alone (loopback autotuning up to `tcp_wmem`/`tcp_rmem` max), before Bun's own 256 KB fetch buffer and the stream queues. A runner with larger limits fits all 200 chunks and the assertion fails with nothing wrong.

The two backpressure tests now use a source that keeps producing until it is observed parked (no pull for 250 ms) or reaches a runaway bound of 512 chunks (32 MiB, beyond any socket buffering), assert it parked below the bound, then end the source 8 pulls after the peer resumes and assert it ran to exactly that count. Against bun 1.3.14 (no native sink backpressure) both fail fast with `Expected: < 512, Received: 512`; on this branch they pass in ~3 s each on the debug+ASAN build.
