### PR TITLE
dns: reject names that are not hostnames before any resolver, report empty dns_sd answers as ENOTFOUND

### DIFF
--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -464,11 +464,8 @@ impl Order {
     }
 }
 
-/// Whether a getaddrinfo-style lookup could ever answer `name`: a numeric address,
-/// or a host name within the RFC 1035 limits (labels of 1 to 63 bytes, 253 in
-/// all, one optional trailing dot) made of the bytes c-ares allows in a host name
-/// (`ares_is_hostnamech`) or of non-ASCII bytes (UTF-8 mDNS names). Anything
-/// else is EAI_NONAME without a resolver round trip, as with glibc and c-ares.
+/// A numeric address, or a host name within the RFC 1035 limits made of the bytes
+/// c-ares allows in one (`ares_is_hostnamech`) or of non-ASCII bytes (UTF-8 mDNS names).
 pub fn is_valid_hostname(name: &[u8]) -> bool {
     fn is_hostname_byte(b: u8) -> bool {
         b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'/' | b'*') || !b.is_ascii()

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -464,16 +464,11 @@ impl Order {
     }
 }
 
-/// Whether a getaddrinfo-style lookup could ever answer `name`: a numeric
-/// address, or a host name within the RFC 1035 limits (labels of 1 to 63
-/// bytes, 253 in all, one optional trailing dot) whose labels hold the bytes
-/// c-ares allows in a host name (`ares_is_hostnamech`: letters, digits, `-`,
-/// `_`, `/`, `*`) or non-ASCII bytes, which mDNS names carry as UTF-8.
-///
-/// Callers answer EAI_NONAME for anything else without asking a resolver, as
-/// glibc (`res_hnok` in nss_dns) and c-ares do. libinfo does not: it hands such
-/// names to mDNSResponder, which puts them on the wire and, when the upstream
-/// server never answers for a label with a space in it, waits out its timeout.
+/// Whether a getaddrinfo-style lookup could ever answer `name`: a numeric address,
+/// or a host name within the RFC 1035 limits (labels of 1 to 63 bytes, 253 in
+/// all, one optional trailing dot) made of the bytes c-ares allows in a host name
+/// (`ares_is_hostnamech`) or of non-ASCII bytes (UTF-8 mDNS names). Anything
+/// else is EAI_NONAME without a resolver round trip, as with glibc and c-ares.
 pub fn is_valid_hostname(name: &[u8]) -> bool {
     fn is_hostname_byte(b: u8) -> bool {
         b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'/' | b'*') || !b.is_ascii()

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -464,6 +464,34 @@ impl Order {
     }
 }
 
+/// Whether a getaddrinfo-style lookup could ever answer `name`: a numeric
+/// address, or a host name within the RFC 1035 limits (labels of 1 to 63
+/// bytes, 253 in all, one optional trailing dot) whose labels hold the bytes
+/// c-ares allows in a host name (`ares_is_hostnamech`: letters, digits, `-`,
+/// `_`, `/`, `*`) or non-ASCII bytes, which mDNS names carry as UTF-8.
+///
+/// Callers answer EAI_NONAME for anything else without asking a resolver, as
+/// glibc (`res_hnok` in nss_dns) and c-ares do. libinfo does not: it hands such
+/// names to mDNSResponder, which puts them on the wire and, when the upstream
+/// server never answers for a label with a space in it, waits out its timeout.
+pub fn is_valid_hostname(name: &[u8]) -> bool {
+    fn is_hostname_byte(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'/' | b'*') || !b.is_ascii()
+    }
+    if name.is_empty() || bun_core::strings::contains_char(name, 0) {
+        return false;
+    }
+    if bun_core::ip_address::to_ip_address(name).is_some() {
+        return true;
+    }
+    let name = name.strip_suffix(b".").unwrap_or(name);
+    if name.is_empty() || name.len() > 253 {
+        return false;
+    }
+    bun_core::strings::split(name, b".")
+        .all(|label| (1..=63).contains(&label.len()) && label.iter().all(|&b| is_hostname_byte(b)))
+}
+
 /// The process-wide DNS
 /// cache lives in `bun_runtime` (it owns libinfo/libuv worker threads + JSC
 /// stat counters). Lower-tier crates (`bun_http`, `bun_install`) reach it via

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3212,10 +3212,8 @@ pub mod internal {
         // touched under `global_cache().lock()`, which is held here.
         unsafe {
             if (*request).result.is_some() {
-                // Already answered (cache hit, or answered inline): the socket goes on
-                // the loop's dns_ready_head. Wake the loop too, as a worker would,
-                // because this may run inside that list's drain (a connect made from a
-                // connect-error callback) and nothing else would poll it again.
+                // Wakes the loop: this can run inside the dns_ready_head drain (a connect
+                // made from a connect-error callback), after the list was taken.
                 query.notify_threadsafe(request);
                 return;
             }
@@ -5175,9 +5173,6 @@ impl Resolver {
         options: GetAddrInfoOptions,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        // A name no resolver could answer is ENOTFOUND here, not after a round trip.
-        // This also keeps the name inside the fixed `PathBuffer` the system backends
-        // copy it into.
         if !bun_dns::is_valid_hostname(name) {
             let mut promise = JSPromiseStrong::init(global_this);
             let promise_value = promise.value();

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3212,8 +3212,7 @@ pub mod internal {
         // touched under `global_cache().lock()`, which is held here.
         unsafe {
             if (*request).result.is_some() {
-                // Wakes the loop: this can run inside the dns_ready_head drain (a connect
-                // made from a connect-error callback), after the list was taken.
+                // Also wakes the loop: this can run inside the dns_ready_head drain itself.
                 query.notify_threadsafe(request);
                 return;
             }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -27,7 +27,7 @@ use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromiseStrong, JSValue, JsCell, JsResult,
     SystemError, host_fn,
 };
-use bun_paths::{MAX_PATH_BYTES, PathBuffer};
+use bun_paths::PathBuffer;
 use bun_ptr::RefPtr;
 #[cfg(windows)]
 use bun_sys::windows::libuv;
@@ -59,6 +59,8 @@ pub(crate) mod netc {
         addrinfo, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage,
     };
     pub(crate) use bun_sys::windows::ws2_32::{AF_INET, AF_INET6, AF_UNSPEC, SOCK_STREAM};
+    /// The libuv spelling: `c_ares::Error::init_eai` reads UV_EAI_* codes on Windows.
+    pub(crate) const EAI_NONAME: core::ffi::c_int = bun_libuv_sys::UV_EAI_NONAME;
 }
 type SockaddrStorage = netc::sockaddr_storage;
 type AddrInfo = netc::addrinfo;
@@ -1222,7 +1224,7 @@ impl GetAddrInfoRequest {
             let status = if !results.is_empty() {
                 0
             } else {
-                query.empty_status()
+                dns_sd::EMPTY_STATUS
             };
             bun_output::scoped_log!(
                 GetAddrInfoRequest,
@@ -2790,8 +2792,7 @@ pub mod internal {
         let port = unsafe { (*req).key.port };
 
         if results.is_empty() {
-            let err = query.empty_status();
-            after_result_entries(req, None, err);
+            after_result_entries(req, None, dns_sd::EMPTY_STATUS);
             return;
         }
 
@@ -3037,6 +3038,19 @@ pub mod internal {
         DNS_CACHE_SIZE.store(guard.len, Ordering::Relaxed);
         drop(guard);
 
+        if host.is_some_and(|h| !bun_dns::is_valid_hostname(h.as_bytes())) {
+            bun_output::scoped_log!(
+                dns,
+                "getaddrinfo({}) = cache miss (not a hostname)",
+                bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
+            );
+            after_result_entries(req, None, netc::EAI_NONAME);
+            if let Some(is_cache_hit) = is_cache_hit {
+                *is_cache_hit = true;
+            }
+            return Some(req);
+        }
+
         if host.is_some_and(|h| is_localhost_name(h.as_bytes())) {
             bun_output::scoped_log!(
                 dns,
@@ -3198,7 +3212,11 @@ pub mod internal {
         // touched under `global_cache().lock()`, which is held here.
         unsafe {
             if (*request).result.is_some() {
-                query.notify(request);
+                // Already answered (cache hit, or answered inline): the socket goes on
+                // the loop's dns_ready_head. Wake the loop too, as a worker would,
+                // because this may run inside that list's drain (a connect made from a
+                // connect-error callback) and nothing else would poll it again.
+                query.notify_threadsafe(request);
                 return;
             }
             (*request).notify.push(DNSRequestOwner::Socket(socket));
@@ -5157,11 +5175,10 @@ impl Resolver {
         options: GetAddrInfoOptions,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        // The system backends copy the hostname into a fixed `bun.PathBuffer` on the
-        // stack before null-terminating it. Reject anything that cannot fit so we never
-        // index past that buffer. RFC 1035 caps hostnames at 253 octets and NI_MAXHOST
-        // is 1025, so this never rejects a name that could have resolved.
-        if name.len() >= MAX_PATH_BYTES || strings::contains_char(name, 0) {
+        // A name no resolver could answer is ENOTFOUND here, not after a round trip.
+        // This also keeps the name inside the fixed `PathBuffer` the system backends
+        // copy it into.
+        if !bun_dns::is_valid_hostname(name) {
             let mut promise = JSPromiseStrong::init(global_this);
             let promise_value = promise.value();
             error_to_deferred(

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -19,16 +19,9 @@ pub(crate) const PROTOCOL_IPV4: DNSServiceProtocol = 0x01;
 pub(crate) const PROTOCOL_IPV6: DNSServiceProtocol = 0x02;
 
 pub(crate) const ERR_NO_ERROR: DNSServiceErrorType = 0;
-const ERR_NO_SUCH_NAME: DNSServiceErrorType = -65538;
-const ERR_NO_MEMORY: DNSServiceErrorType = -65539;
-const ERR_REFUSED: DNSServiceErrorType = -65553;
 pub(crate) const ERR_NO_SUCH_RECORD: DNSServiceErrorType = -65554;
-const ERR_SERVICE_NOT_RUNNING: DNSServiceErrorType = -65563;
-const ERR_NO_ROUTER: DNSServiceErrorType = -65566;
 pub(crate) const ERR_TIMEOUT: DNSServiceErrorType = -65568;
 const ERR_DEFUNCT_CONNECTION: DNSServiceErrorType = -65569;
-const ERR_POLICY_DENIED: DNSServiceErrorType = -65570;
-const ERR_NOT_PERMITTED: DNSServiceErrorType = -65571;
 
 type GetAddrInfoReply = unsafe extern "C" fn(
     sd_ref: DNSServiceRef,
@@ -68,19 +61,11 @@ pub(crate) struct DNSServiceAttribute {
     _opaque: [u8; 0],
 }
 
-/// Map a DNSServiceErrorType to the EAI_* code the existing error paths expect.
-pub(crate) fn to_eai(err: DNSServiceErrorType) -> c_int {
-    match err {
-        ERR_NO_ERROR => 0,
-        ERR_NO_SUCH_NAME | ERR_NO_SUCH_RECORD => libc::EAI_NONAME,
-        ERR_TIMEOUT | ERR_NO_ROUTER | ERR_DEFUNCT_CONNECTION | ERR_SERVICE_NOT_RUNNING => {
-            libc::EAI_AGAIN
-        }
-        ERR_NO_MEMORY => libc::EAI_MEMORY,
-        ERR_POLICY_DENIED | ERR_NOT_PERMITTED | ERR_REFUSED => libc::EAI_FAIL,
-        _ => libc::EAI_FAIL,
-    }
-}
+/// Status of a query that ended with no address. libinfo's `getaddrinfo` reports
+/// every such lookup as EAI_NONAME (`mdns_addrinfo` in mdns_module.c), whether
+/// mDNSResponder said NoSuchRecord, Timeout, PolicyDenied, or the daemon went
+/// away. `dns.lookup()` promises getaddrinfo's contract, so this backend does too.
+pub(crate) const EMPTY_STATUS: c_int = libc::EAI_NONAME;
 
 pub(crate) fn protocol_for_family(family: bun_dns::Family) -> DNSServiceProtocol {
     match family {
@@ -151,7 +136,7 @@ pub(crate) struct QueryState {
     pub(crate) results: bun_dns::ResultList,
     /// First hard error (NoSuchRecord/Timeout are per-family negatives, not errors).
     pub(crate) sd_error: DNSServiceErrorType,
-    /// A family timed out: with no results this is EAI_AGAIN, not EAI_NONAME.
+    /// A family timed out: an unsuppressed reissue would only wait out the timeout again.
     saw_timeout: bool,
     /// Last reply had `MoreComing` and no other request's reply followed: more is queued daemon-side.
     awaiting_more: bool,
@@ -263,17 +248,6 @@ impl QueryState {
         match self.stragglers {
             Stragglers::Since(t) if self.only_stragglers_left() => Some(t + SECOND_FAMILY_EXTRA_MS),
             _ => None,
-        }
-    }
-
-    /// EAI_* status for a completed query with no results.
-    pub(crate) fn empty_status(&self) -> c_int {
-        if self.sd_error != 0 {
-            to_eai(self.sd_error)
-        } else if self.saw_timeout {
-            libc::EAI_AGAIN
-        } else {
-            libc::EAI_NONAME
         }
     }
 

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -61,8 +61,7 @@ pub(crate) struct DNSServiceAttribute {
     _opaque: [u8; 0],
 }
 
-/// Status of a query that ended with no address: libinfo's `getaddrinfo` reports every
-/// such lookup as EAI_NONAME (`mdns_addrinfo`), whatever mDNSResponder's error was.
+/// No address: libinfo's `getaddrinfo` reports this as EAI_NONAME whatever the daemon's error was.
 pub(crate) const EMPTY_STATUS: c_int = libc::EAI_NONAME;
 
 pub(crate) fn protocol_for_family(family: bun_dns::Family) -> DNSServiceProtocol {

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -61,10 +61,8 @@ pub(crate) struct DNSServiceAttribute {
     _opaque: [u8; 0],
 }
 
-/// Status of a query that ended with no address. libinfo's `getaddrinfo` reports
-/// every such lookup as EAI_NONAME (`mdns_addrinfo` in mdns_module.c), whether
-/// mDNSResponder said NoSuchRecord, Timeout, PolicyDenied, or the daemon went
-/// away. `dns.lookup()` promises getaddrinfo's contract, so this backend does too.
+/// Status of a query that ended with no address: libinfo's `getaddrinfo` reports every
+/// such lookup as EAI_NONAME (`mdns_addrinfo`), whatever mDNSResponder's error was.
 pub(crate) const EMPTY_STATUS: c_int = libc::EAI_NONAME;
 
 pub(crate) fn protocol_for_family(family: bun_dns::Family) -> DNSServiceProtocol {

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -7,7 +7,11 @@ import { join } from "node:path";
 const backends = ["system", "libc", "c-ares"];
 const validHostnames = ["localhost", "example.com"];
 const invalidHostnames = ["adsfa.asdfasdf.asdf.com"]; // known invalid
-const malformedHostnames = [" ", ".", " .", "localhost:80", "this is not a hostname"];
+// Not host names at all: rejected before any resolver is asked, so the answer
+// does not depend on what the network's DNS server does with a label that has
+// a space in it (some never answer, and mDNSResponder then waits out its 5s or
+// 30s timeout).
+const malformedHostnames = [" ", ".", " .", "localhost:80", "this is not a hostname", "a..b", "foo bar.example.com"];
 
 describe("dns", () => {
   describe.each(backends)("lookup() [backend: %s]", backend => {
@@ -111,8 +115,10 @@ describe("dns", () => {
     test.concurrent.each(malformedHostnames)("'%s'", async hostname => {
       // @ts-expect-error
       await expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
-        code: expect.stringMatching(/^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP$/),
+        code: "DNS_ENOTFOUND",
         name: "DNSException",
+        syscall: "getaddrinfo",
+        hostname,
       });
     });
   });
@@ -121,7 +127,8 @@ describe("dns", () => {
   // backends (bun.PathBuffer, which is MAX_PATH_BYTES: 1024 on macOS, 4096 on
   // Linux, ~98302 on Windows) previously overflowed when writing the NUL
   // terminator. They must reject cleanly on every backend. 100 000 bytes
-  // exceeds the buffer on every platform so the doLookup guard is what fires.
+  // exceeds the buffer on every platform so the doLookup guard (a host name is
+  // at most 253 bytes) is what fires.
   test.each(backends)("lookup() with oversized hostname rejects [backend: %s]", async backend => {
     const long = Buffer.alloc(100_000, "a").toString();
     // @ts-expect-error

--- a/test/js/bun/net/socket-dns-error.test.ts
+++ b/test/js/bun/net/socket-dns-error.test.ts
@@ -119,3 +119,53 @@ test("consecutive Bun.connect calls to the same unresolvable hostname all get th
   }
   expect(errors).toEqual([EXPECTED, EXPECTED, EXPECTED]);
 });
+
+// A name that cannot be a host name (a space, a colon, an empty label) is
+// answered ENOTFOUND in-process, without asking the system resolver. Some DNS
+// servers never answer a query for such a label, and the resolver then waits
+// out its own timeout (30s on macOS) before reporting anything.
+test("Bun.connect to a name that is not a hostname fails with ENOTFOUND without asking the resolver", async () => {
+  const errors = [];
+  for (const hostname of ["this is not a hostname", "localhost:80", "a..b"]) {
+    errors.push(
+      await Bun.connect({
+        hostname,
+        port: 80,
+        socket: { open() {}, data() {} },
+      }).then(
+        () => "resolved",
+        (e: Error) => pick(e),
+      ),
+    );
+  }
+  expect(errors).toEqual(
+    ["this is not a hostname", "localhost:80", "a..b"].map(hostname => ({
+      ...EXPECTED,
+      hostname,
+      message: `getaddrinfo ENOTFOUND ${hostname}`,
+    })),
+  );
+});
+
+// An answer that is already known when Bun.connect() is called (answered
+// in-process, or a cache hit) is delivered from the event loop, not inline.
+// When the connect is made from the callback that delivers the previous
+// answer, the loop has to be woken for it; otherwise each error waits for the
+// next unrelated wakeup (about a second), and 20 of them exceed the test
+// timeout.
+test("back-to-back Bun.connect calls whose names are rejected in-process do not wait for a loop wakeup", async () => {
+  const codes = [];
+  for (let i = 0; i < 20; i++) {
+    codes.push(
+      await Bun.connect({
+        hostname: `not a hostname ${i}`,
+        port: 80,
+        socket: { open() {}, data() {} },
+      }).then(
+        () => "resolved",
+        (e: Error) => e.code,
+      ),
+    );
+  }
+  expect(codes).toEqual(Array(20).fill("ENOTFOUND"));
+});

--- a/test/js/bun/net/socket-dns-error.test.ts
+++ b/test/js/bun/net/socket-dns-error.test.ts
@@ -124,28 +124,20 @@ test("consecutive Bun.connect calls to the same unresolvable hostname all get th
 // answered ENOTFOUND in-process, without asking the system resolver. Some DNS
 // servers never answer a query for such a label, and the resolver then waits
 // out its own timeout (30s on macOS) before reporting anything.
-test("Bun.connect to a name that is not a hostname fails with ENOTFOUND without asking the resolver", async () => {
-  const errors = [];
-  for (const hostname of ["this is not a hostname", "localhost:80", "a..b"]) {
-    errors.push(
-      await Bun.connect({
-        hostname,
-        port: 80,
-        socket: { open() {}, data() {} },
-      }).then(
-        () => "resolved",
-        (e: Error) => pick(e),
-      ),
-    );
-  }
-  expect(errors).toEqual(
-    ["this is not a hostname", "localhost:80", "a..b"].map(hostname => ({
-      ...EXPECTED,
+test.each(["this is not a hostname", "localhost:80", "a..b"])(
+  "Bun.connect to %p, which is not a hostname, fails with ENOTFOUND without asking the resolver",
+  async hostname => {
+    const error = await Bun.connect({
       hostname,
-      message: `getaddrinfo ENOTFOUND ${hostname}`,
-    })),
-  );
-});
+      port: 80,
+      socket: { open() {}, data() {} },
+    }).then(
+      () => "resolved",
+      (e: Error) => pick(e),
+    );
+    expect(error).toEqual({ ...EXPECTED, hostname, message: `getaddrinfo ENOTFOUND ${hostname}` });
+  },
+);
 
 // An answer that is already known when Bun.connect() is called (answered
 // in-process, or a cache hit) is delivered from the event loop, not inline.


### PR DESCRIPTION
### Problem
- `resolve-dns.test.ts` fails on darwin 14 x64: `dns.lookup(" ", { backend: "system" })` rejects with `getaddrinfo ETIMEOUT` after 5s, `" ."` after 30s. Google Public DNS drops a query whose top-level label has a space.
- `dns_sd.rs` mapped the daemon's `kDNSServiceErr_Timeout` to `EAI_AGAIN`. libinfo's `getaddrinfo` reports every lookup that ends without an address as `EAI_NONAME` (`mdns_addrinfo`, mdns_module.c). And names that can never be host names still went to the resolver.

### Fix
- `dns_sd::EMPTY_STATUS`: no address means `EAI_NONAME`, whatever mDNSResponder said. That is `getaddrinfo` on macOS, the `system` backend's contract.
- `bun_dns::is_valid_hostname`: IP literals pass; otherwise labels of 1 to 63 bytes, 253 in all, of the bytes c-ares accepts in a host name or non-ASCII bytes (UTF-8 mDNS names). `Bun.dns.lookup` and the connect-path resolver answer `ENOTFOUND` in-process for anything else. glibc's nss_dns and c-ares already do.
- `us_getaddrinfo_set` wakes the loop for an already-answered request. A connect issued from the previous connect-error callback otherwise waited about 950ms for an unrelated wakeup.
- Verified: `test/js/bun/dns/resolve-dns.test.ts` (malformed cases now assert `DNS_ENOTFOUND`, `syscall`, `hostname`) and `test/js/bun/net/socket-dns-error.test.ts` (two new tests). The other dns and net suites too.

### Background
- `dns.lookup` has three backends: `c-ares`, `libc` (`getaddrinfo` on the work pool), and `system`, which on macOS (#36619) talks to mDNSResponder directly, as libinfo does.
- mDNSResponder reports a negative answer as `NoSuchRecord` (NXDOMAIN) or `Timeout` (no server answered). libinfo folds both into `EAI_NONAME`, so Node on macOS only ever sees `ENOTFOUND`.
- The connect path (`Bun.connect`, `fetch`, SQL clients) caches answers process-wide and delivers a known answer from the loop's `dns_ready_head`, not inline.

<details><summary>Notes</summary>

- Failing hosts per job log: `darwin-x64-pita`, `-naan`, `-rye`, `-flatbread` (the batch added 2026-08-21, not on the tailnet). `darwin-x64-matzo`, `-cornbread`, `-bagel`, `-pretzel` run the file in about 300ms; pita takes 76s (the `libc` cases wait the same 5s and 30s but pass because `getaddrinfo` says `EAI_NONAME`).
- On cornbread, `dns-sd -G v4v6 " "`, `" ."`, `"this is not a hostname"` all return `No Such Record` in under 40ms, so the failure could not be reproduced there. #37668 measured the resolver side with dig: `@8.8.8.8 'this\032is\032not\032a\032hostname' A` times out, `@1.1.1.1` answers NXDOMAIN in 2ms.
- Bun 1.3.13 (libinfo's `getaddrinfo_async_start`) returns `ENOTFOUND` for these names, after the same wait on such a network.
- `to_eai` and the unused `kDNSServiceErr_*` constants are removed with the per-error mapping.
- The validator keeps c-ares's `/` and `*` (`ares_is_hostnamech`), so wildcard lookups still reach the resolver, and lets non-ASCII bytes through because RFC 6762 names are UTF-8 and `.local` names are routed to this backend on purpose. `.` and `a..b` are rejected as empty labels. It replaces the old `MAX_PATH_BYTES` and NUL guard in `do_lookup`, which it covers (a valid name is at most 253 bytes).
- The 950ms was measured with 8 sequential `Bun.connect` calls to names rejected in-process: 6ms, 951ms, 1ms, 47ms, 1ms, ... before the wakeup; 1ms each after. `us_internal_dns_callback` does not wake the loop, and the continuation runs inside the `dns_ready_head` drain, after the list was taken. Cached failures never hit this before because a failed connect evicts its cache entry.
- Suites run: `dns-interleave`, `dns-prefetch`, `dns-lookup-keepalive`, `dns-resolver-concurrent-timeout`, `node-net`, `node-dns` (the last two have the same network-dependent failures as main in this container), `socket.test.ts`, `byte-search` source lint, clippy and rustfmt.
- #37668 (test-only, accepts `DNS_ETIMEOUT`) is superseded by this change. #35591 also edits the malformed cases in `resolve-dns.test.ts` for `resolve*` (`EBADNAME`); it keeps `lookup` at `ENOTFOUND`, so the two do not conflict in behavior.
- Not tested: the dns_sd status change itself needs a resolver that drops queries; no lane has one on purpose.

</details>
