### PR TITLE
Key the runtime transpiler cache on the define table and --drop

### DIFF
--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -167,6 +167,7 @@ impl DefineExt for Define {
             identifiers: StringHashMap::default(),
             dots: StringHashMap::default(),
             drop_debugger,
+            user_hash: None,
         });
         define.dots.reserve(124);
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -946,12 +946,38 @@ pub(crate) fn defines_from_transform_options(
 
     let drop_debugger = drop.iter().any(|item| *item == b"debugger");
 
-    Ok(defines::Define::init(
+    // Everything above this line that is not a constant table: the resolved
+    // define map, the inlined env entries (strings only, `window` has none)
+    // and the drop list.
+    let user_hash = defines::Define::hash_user_inputs(
+        user_defines
+            .keys()
+            .iter()
+            .zip(user_defines.values().iter())
+            .map(|(k, v)| (k.as_ref(), v.as_ref()))
+            .chain(
+                environment_defines
+                    .keys()
+                    .iter()
+                    .zip(environment_defines.values().iter())
+                    .filter_map(|(k, v)| match &v.value {
+                        defines::DefineValue::EString(s) if s.is_utf8() => {
+                            Some((k.as_ref(), s.slice8()))
+                        }
+                        _ => None,
+                    }),
+            ),
+        drop.iter().copied(),
+    );
+
+    let mut define = defines::Define::init(
         Some(resolved_defines),
         Some(environment_defines),
         drop_debugger,
         omit_unused_global_calls,
-    )?)
+    )?;
+    define.user_hash = user_hash;
+    Ok(define)
 }
 
 const DEFAULT_LOADER_EXT_BUN: &[&[u8]] = &[b".node", b".html"];
@@ -1414,6 +1440,7 @@ impl<'a> BundleOptions<'a> {
                 identifiers: self.define.identifiers.clone(),
                 dots: self.define.dots.clone(),
                 drop_debugger: self.define.drop_debugger,
+                user_hash: self.define.user_hash,
             }),
             drop: self.drop.clone(),
             bundler_feature_flags: self
@@ -1663,11 +1690,7 @@ impl<'a> BundleOptions<'a> {
             log,
             // `define` is filled by `load_defines` later;
             // initialize empty so the struct is well-formed before `load_defines` runs.
-            define: Box::new(defines::Define {
-                identifiers: Default::default(),
-                dots: Default::default(),
-                drop_debugger: false,
-            }),
+            define: Box::new(defines::Define::default()),
             loaders,
             output_dir: Box::from(transform.output_dir.as_deref().unwrap_or(b"out")),
             target,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -946,9 +946,6 @@ pub(crate) fn defines_from_transform_options(
 
     let drop_debugger = drop.iter().any(|item| *item == b"debugger");
 
-    // Everything above this line that is not a constant table: the resolved
-    // define map, the inlined env entries (strings only, `window` has none)
-    // and the drop list.
     let user_hash = defines::Define::hash_user_inputs(
         user_defines
             .keys()

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -954,19 +954,15 @@ pub(crate) fn defines_from_transform_options(
             .keys()
             .iter()
             .zip(user_defines.values().iter())
-            .map(|(k, v)| (k.as_ref(), v.as_ref()))
-            .chain(
-                environment_defines
-                    .keys()
-                    .iter()
-                    .zip(environment_defines.values().iter())
-                    .filter_map(|(k, v)| match &v.value {
-                        defines::DefineValue::EString(s) if s.is_utf8() => {
-                            Some((k.as_ref(), s.slice8()))
-                        }
-                        _ => None,
-                    }),
-            ),
+            .map(|(k, v)| (k.as_ref(), v.as_ref())),
+        environment_defines
+            .keys()
+            .iter()
+            .zip(environment_defines.values().iter())
+            .filter_map(|(k, v)| match &v.value {
+                defines::DefineValue::EString(s) if s.is_utf8() => Some((k.as_ref(), s.slice8())),
+                _ => None,
+            }),
         drop.iter().copied(),
     );
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1644,6 +1644,7 @@ impl<'a> Transpiler<'a> {
                     .bundler_feature_flags
                     .as_deref()
                     .and_then(|s| s.clone().ok().map(Box::new));
+                opts.features.define_hash = self.options.define.user_hash;
                 opts.features.repl_mode = self.options.repl_mode;
 
                 // we'll just always enable top-level await

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -502,36 +502,48 @@ pub mod defines {
     }
 
     impl Define {
-        /// Hash define `(key, value)` pairs and `--drop` entries. Both lists
-        /// are sorted first, so the order they were given in does not matter,
-        /// and every entry is length-prefixed, so two different inputs cannot
-        /// produce the same byte stream. Returns `None` when there is nothing
-        /// to hash, so a configuration without them adds nothing to the
-        /// runtime transpiler cache key.
+        /// Hash the user define `(key, value)` pairs, the inlined env define
+        /// pairs and the `--drop` entries. The three lists stay separate
+        /// sections: `init` inserts the env pairs after the user pairs and
+        /// `DefineData::merge` keeps the later value, so the same pair means a
+        /// different table depending on its source. Each list is sorted, so
+        /// the order the entries were given in does not matter, and each
+        /// section is prefixed with its length and each entry with its byte
+        /// length, so two different inputs cannot produce the same byte
+        /// stream. Returns `None` when there is nothing to hash, so a
+        /// configuration without them adds nothing to the runtime transpiler
+        /// cache key.
         pub fn hash_user_inputs<'i>(
             defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
+            env_defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
             drop: impl IntoIterator<Item = &'i [u8]>,
         ) -> Option<u64> {
             let mut defines: Vec<(&[u8], &[u8])> = defines.into_iter().collect();
+            let mut env_defines: Vec<(&[u8], &[u8])> = env_defines.into_iter().collect();
             let mut drop: Vec<&[u8]> = drop.into_iter().filter(|item| !item.is_empty()).collect();
-            if defines.is_empty() && drop.is_empty() {
+            if defines.is_empty() && env_defines.is_empty() && drop.is_empty() {
                 return None;
             }
             defines.sort_unstable();
+            env_defines.sort_unstable();
             drop.sort_unstable();
             drop.dedup();
 
             let mut hasher = bun_wyhash::Wyhash::init(0);
-            for (key, value) in defines {
-                hasher.update(&(key.len() as u64).to_le_bytes());
-                hasher.update(key);
-                hasher.update(&(value.len() as u64).to_le_bytes());
-                hasher.update(value);
+            let mut update = |bytes: &[u8]| {
+                hasher.update(&(bytes.len() as u64).to_le_bytes());
+                hasher.update(bytes);
+            };
+            for pairs in [defines, env_defines] {
+                update(&(pairs.len() as u64).to_le_bytes());
+                for (key, value) in pairs {
+                    update(key);
+                    update(value);
+                }
             }
-            hasher.update(b"drop");
+            update(&(drop.len() as u64).to_le_bytes());
             for item in drop {
-                hasher.update(&(item.len() as u64).to_le_bytes());
-                hasher.update(item);
+                update(item);
             }
             Some(hasher.final_())
         }

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -493,26 +493,15 @@ pub mod defines {
         pub identifiers: StringHashMap<IdentifierDefine>,
         pub dots: StringHashMap<Vec<DotDefine>>,
         pub drop_debugger: bool,
-        /// Hash of the non-constant inputs this table was built from: the
-        /// define pairs (`--define`, bunfig `[define]`, inlined env) and the
-        /// `--drop` entries (see `hash_user_inputs`). The runtime transpiler
-        /// cache keys on it, because those inputs change the transpiled
-        /// output. `None` when there are none.
+        /// `hash_user_inputs` of the define pairs and `--drop` entries this
+        /// table was built from. Part of the runtime transpiler cache key.
         pub user_hash: Option<u64>,
     }
 
     impl Define {
-        /// Hash the user define `(key, value)` pairs, the inlined env define
-        /// pairs and the `--drop` entries. The three lists stay separate
-        /// sections: `init` inserts the env pairs after the user pairs and
-        /// `DefineData::merge` keeps the later value, so the same pair means a
-        /// different table depending on its source. Each list is sorted, so
-        /// the order the entries were given in does not matter, and each
-        /// section is prefixed with its length and each entry with its byte
-        /// length, so two different inputs cannot produce the same byte
-        /// stream. Returns `None` when there is nothing to hash, so a
-        /// configuration without them adds nothing to the runtime transpiler
-        /// cache key.
+        /// Order-independent, length-prefixed hash of the three inputs. User
+        /// and env pairs are separate sections because `init` lets a later env
+        /// pair override a user pair. `None` when all three are empty.
         pub fn hash_user_inputs<'i>(
             defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
             env_defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -493,9 +493,49 @@ pub mod defines {
         pub identifiers: StringHashMap<IdentifierDefine>,
         pub dots: StringHashMap<Vec<DotDefine>>,
         pub drop_debugger: bool,
+        /// Hash of the non-constant inputs this table was built from: the
+        /// define pairs (`--define`, bunfig `[define]`, inlined env) and the
+        /// `--drop` entries (see `hash_user_inputs`). The runtime transpiler
+        /// cache keys on it, because those inputs change the transpiled
+        /// output. `None` when there are none.
+        pub user_hash: Option<u64>,
     }
 
     impl Define {
+        /// Hash define `(key, value)` pairs and `--drop` entries. Both lists
+        /// are sorted first, so the order they were given in does not matter,
+        /// and every entry is length-prefixed, so two different inputs cannot
+        /// produce the same byte stream. Returns `None` when there is nothing
+        /// to hash, so a configuration without them adds nothing to the
+        /// runtime transpiler cache key.
+        pub fn hash_user_inputs<'i>(
+            defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
+            drop: impl IntoIterator<Item = &'i [u8]>,
+        ) -> Option<u64> {
+            let mut defines: Vec<(&[u8], &[u8])> = defines.into_iter().collect();
+            let mut drop: Vec<&[u8]> = drop.into_iter().filter(|item| !item.is_empty()).collect();
+            if defines.is_empty() && drop.is_empty() {
+                return None;
+            }
+            defines.sort_unstable();
+            drop.sort_unstable();
+            drop.dedup();
+
+            let mut hasher = bun_wyhash::Wyhash::init(0);
+            for (key, value) in defines {
+                hasher.update(&(key.len() as u64).to_le_bytes());
+                hasher.update(key);
+                hasher.update(&(value.len() as u64).to_le_bytes());
+                hasher.update(value);
+            }
+            hasher.update(b"drop");
+            for item in drop {
+                hasher.update(&(item.len() as u64).to_le_bytes());
+                hasher.update(item);
+            }
+            Some(hasher.final_())
+        }
+
         pub(crate) fn for_identifier(&self, name: &[u8]) -> Option<&IdentifierDefine> {
             if let Some(data) = self.identifiers.get(name) {
                 return Some(data);

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -493,15 +493,12 @@ pub mod defines {
         pub identifiers: StringHashMap<IdentifierDefine>,
         pub dots: StringHashMap<Vec<DotDefine>>,
         pub drop_debugger: bool,
-        /// `hash_user_inputs` of the define pairs and `--drop` entries this
-        /// table was built from. Part of the runtime transpiler cache key.
+        /// `hash_user_inputs` of this table's inputs, for the runtime transpiler cache key.
         pub user_hash: Option<u64>,
     }
 
     impl Define {
-        /// Order-independent, length-prefixed hash of the three inputs. User
-        /// and env pairs are separate sections because `init` lets a later env
-        /// pair override a user pair. `None` when all three are empty.
+        /// Order-independent, length-prefixed hash of the three inputs. `None` when all are empty.
         pub fn hash_user_inputs<'i>(
             defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
             env_defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
@@ -523,6 +520,7 @@ pub mod defines {
                 hasher.update(&(bytes.len() as u64).to_le_bytes());
                 hasher.update(bytes);
             };
+            // Separate sections: `init` lets a later env pair override a user pair.
             for pairs in [defines, env_defines] {
                 update(&(pairs.len() as u64).to_le_bytes());
                 for (key, value) in pairs {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -212,6 +212,7 @@ impl<'a> Options<'a> {
                 runtime_transpiler_cache: None,
                 lower_using: f.lower_using,
                 bundler_feature_flags: None,
+                define_hash: f.define_hash,
                 repl_mode: f.repl_mode,
                 jsx_optimization_inline: f.jsx_optimization_inline,
             },

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -257,9 +257,8 @@ pub mod Runtime {
         /// in watch/dev-server mode.
         pub bundler_feature_flags: Option<Box<StringSet>>,
 
-        /// `Define::user_hash` of the define table this parse runs with: the
-        /// define pairs and `--drop` entries it was built from. Part of the
-        /// runtime transpiler cache key. `None` when there are none.
+        /// `Define::user_hash` of the table this parse runs with, for the
+        /// runtime transpiler cache key.
         pub define_hash: Option<u64>,
 
         /// REPL mode: transforms code for interactive evaluation
@@ -398,9 +397,7 @@ pub mod Runtime {
                 }
             }
 
-            // Hash the define table's inputs (define pairs, `--drop` entries).
-            // Both change the transpiled output (identifier substitution,
-            // removed calls). `None` adds nothing, like an empty flag set.
+            // Define pairs and `--drop` entries. `None` adds nothing, like an empty flag set.
             if let Some(define_hash) = self.define_hash {
                 hasher.update(b"define");
                 hasher.update(&define_hash.to_le_bytes());

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -257,6 +257,11 @@ pub mod Runtime {
         /// in watch/dev-server mode.
         pub bundler_feature_flags: Option<Box<StringSet>>,
 
+        /// `Define::user_hash` of the define table this parse runs with: the
+        /// define pairs and `--drop` entries it was built from. Part of the
+        /// runtime transpiler cache key. `None` when there are none.
+        pub define_hash: Option<u64>,
+
         /// REPL mode: transforms code for interactive evaluation
         /// - Wraps lone object literals `{...}` in parentheses
         /// - Hoists variable declarations for REPL persistence
@@ -304,6 +309,7 @@ pub mod Runtime {
                 runtime_transpiler_cache: None,
                 lower_using: true,
                 bundler_feature_flags: None,
+                define_hash: None,
                 repl_mode: false,
                 jsx_optimization_inline: false,
             }
@@ -390,6 +396,14 @@ pub mod Runtime {
                     hasher.update(flag);
                     hasher.update(b"\x00");
                 }
+            }
+
+            // Hash the define table's inputs (define pairs, `--drop` entries).
+            // Both change the transpiled output (identifier substitution,
+            // removed calls). `None` adds nothing, like an empty flag set.
+            if let Some(define_hash) = self.define_hash {
+                hasher.update(b"define");
+                hasher.update(&define_hash.to_le_bytes());
             }
         }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -257,8 +257,7 @@ pub mod Runtime {
         /// in watch/dev-server mode.
         pub bundler_feature_flags: Option<Box<StringSet>>,
 
-        /// `Define::user_hash` of the table this parse runs with, for the
-        /// runtime transpiler cache key.
+        /// `Define::user_hash` of this parse's define table (runtime transpiler cache key).
         pub define_hash: Option<u64>,
 
         /// REPL mode: transforms code for interactive evaluation

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,10 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: user `define` pairs (CLI and bunfig) and `--drop` entries participate
+/// in the features hash. Older entries can hold output transpiled with a bunfig
+/// `[define]` under the hash of a configuration that has none.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -56,7 +56,6 @@ bun_core::declare_scope!(cache, visible);
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
-/// Older entries can hold define-substituted output under a define-free hash.
 const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,9 +55,8 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-/// Version 28: user `define` pairs (CLI and bunfig) and `--drop` entries participate
-/// in the features hash. Older entries can hold output transpiled with a bunfig
-/// `[define]` under the hash of a configuration that has none.
+/// Version 28: the define table and `--drop` entries participate in the features hash.
+/// Older entries can hold define-substituted output under a define-free hash.
 const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1569,13 +1569,6 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 };
             }
         }
-
-        if let Some(define) = &opts.define {
-            if !define.keys.is_empty() {
-                bun_jsc::runtime_transpiler_cache::IS_DISABLED
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-        }
     }
 
     if matches!(

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -407,6 +407,32 @@ describe("transpiler cache", () => {
       expect(newCacheCount()).toBe(0);
     });
 
+    test("--define passed to bun test invalidates cache", () => {
+      // `bun test` builds its define table on its own boot path. The test file
+      // is below the minimum cache size; the module it imports is not, and
+      // `bun a.js` loads that same module.
+      writeFileSync(join(temp_dir, "a.js"), code + "\n//" + filler);
+      writeFileSync(
+        join(temp_dir, "a.test.js"),
+        `import "./a.js";\nimport { test } from "bun:test";\ntest("x", () => {});\n`,
+      );
+      // `bun test` prints its version banner to stdout ahead of the module's output.
+      const lastLine = (args: string[]) => run(temp_dir, args).split("\n").at(-1);
+
+      expect(lastLine(["test", "--define", 'BVAL:"cli"', "./a.test.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(1);
+
+      expect(lastLine(["test", "./a.test.js"])).toBe("undefined");
+      expect(newCacheCount()).toBe(0);
+      expect(run(temp_dir, ["a.js"])).toBe("undefined");
+      expect(newCacheCount()).toBe(0);
+
+      expect(lastLine(["test", "--define", 'BVAL:"cli"', "./a.test.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+      expect(run(temp_dir, ["a.js"])).toBe("undefined");
+      expect(newCacheCount()).toBe(0);
+    });
+
     test("--drop invalidates cache", () => {
       writeFileSync(
         join(temp_dir, "a.js"),

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -320,6 +320,113 @@ describe("transpiler cache", () => {
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
 
+  // A define replaces an identifier at parse time, so the define table is part
+  // of the cache key. The cache is shared by every project of the user, and
+  // keyed by source bytes, so two projects with the same file must not see
+  // each other's values.
+  describe("defines are part of the cache key", () => {
+    const code = `console.log(typeof BVAL === "undefined" ? "undefined" : BVAL);`;
+    const filler = Buffer.alloc((50 * 1024 * 1.5) | 0, "/").toString();
+
+    const run = (cwd: string, args: string[]) => {
+      const result = Bun.spawnSync({ cmd: [bunExe(), ...args], cwd, env });
+      if (!result.success) throw new Error(result.stderr.toString());
+      return result.stdout.toString().trim();
+    };
+
+    test("bunfig [define] invalidates cache", () => {
+      // `bun run <file>` loads bunfig.toml after the command line is parsed,
+      // so the define table only exists once the runtime is up.
+      const projectA = join(temp_dir, "a");
+      const projectB = join(temp_dir, "b");
+      for (const dir of [projectA, projectB]) {
+        mkdirSync(dir);
+        writeFileSync(join(dir, "a.js"), code + "\n//" + filler);
+      }
+      const setDefine = (dir: string, value: string | null) => {
+        if (value === null) rmSync(join(dir, "bunfig.toml"), { force: true });
+        else writeFileSync(join(dir, "bunfig.toml"), `[define]\nBVAL = '${JSON.stringify(value)}'\n`);
+      };
+
+      setDefine(projectA, "one");
+      expect(run(projectA, ["run", "./a.js"])).toBe("one");
+      expect(newCacheCount()).toBe(1);
+      expect(run(projectA, ["run", "./a.js"])).toBe("one");
+      expect(newCacheCount()).toBe(0);
+
+      // A new value: features_hash differs -> old entry deleted, new entry written
+      setDefine(projectA, "two");
+      expect(run(projectA, ["run", "./a.js"])).toBe("two");
+      expect(newCacheCount()).toBe(0);
+
+      setDefine(projectA, null);
+      expect(run(projectA, ["run", "./a.js"])).toBe("undefined");
+      expect(newCacheCount()).toBe(0);
+
+      // The same source bytes in another project, with its own define
+      setDefine(projectB, "mine");
+      expect(run(projectB, ["run", "./a.js"])).toBe("mine");
+      expect(newCacheCount()).toBe(0);
+      expect(run(projectB, ["./a.js"])).toBe("mine");
+      expect(newCacheCount()).toBe(0);
+    });
+
+    test("--define invalidates cache", () => {
+      writeFileSync(join(temp_dir, "a.js"), code + "\n//" + filler);
+
+      expect(run(temp_dir, ["--define", 'BVAL:"cli"', "a.js"])).toBe("cli");
+      expect(existsSync(cache_dir)).toBeTrue();
+      expect(newCacheCount()).toBe(1);
+      expect(run(temp_dir, ["--define", 'BVAL:"cli"', "a.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(temp_dir, ["--define", 'BVAL:"other"', "a.js"])).toBe("other");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(temp_dir, ["a.js"])).toBe("undefined");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(temp_dir, ["run", "--define", 'BVAL:"cli"', "./a.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+
+      // The key is built from the resolved map: flag order does not matter,
+      // and a key given twice keeps its last value, so `x` then `cli` is
+      // served the entry that `--define BVAL:"cli"` alone wrote above.
+      expect(run(temp_dir, ["--define", 'BVAL:"cli"', "--define", "OTHER:1", "a.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+      const entry = join(cache_dir, readdirSync(cache_dir)[0]);
+      const written = readFileSync(entry);
+      expect(run(temp_dir, ["--define", "OTHER:1", "--define", 'BVAL:"cli"', "a.js"])).toBe("cli");
+      expect(readFileSync(entry).equals(written)).toBeTrue();
+
+      expect(run(temp_dir, ["--define", 'BVAL:"cli"', "a.js"])).toBe("cli");
+      const alone = readFileSync(entry);
+      expect(alone.equals(written)).toBeFalse();
+      expect(run(temp_dir, ["--define", 'BVAL:"x"', "--define", 'BVAL:"cli"', "a.js"])).toBe("cli");
+      expect(readFileSync(entry).equals(alone)).toBeTrue();
+      expect(newCacheCount()).toBe(0);
+    });
+
+    test("--drop invalidates cache", () => {
+      writeFileSync(
+        join(temp_dir, "a.js"),
+        `console.log("logged");\nprocess.stdout.write("written\\n");` + "\n//" + filler,
+      );
+
+      expect(run(temp_dir, ["a.js"])).toBe("logged\nwritten");
+      expect(newCacheCount()).toBe(1);
+
+      expect(run(temp_dir, ["--drop=console", "a.js"])).toBe("written");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(temp_dir, ["--drop=console", "a.js"])).toBe("written");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(temp_dir, ["a.js"])).toBe("logged\nwritten");
+      expect(newCacheCount()).toBe(0);
+    });
+  });
+
   // Serving the entry point from the cache must not change how the modules it
   // loads are resolved. Both of these are gated on the `has_loaded` flag, which
   // used to be set only on the path that runs the printer.


### PR DESCRIPTION
### Problem
- `bun run ./a.ts` with a bunfig `[define]` serves stale output after the value changes. A second project with the same source bytes (4 KiB or more) gets the first project's values on its first run. `--drop=console` has the same hole. Reproduces on 1.4.1 and main.
- Cause: the cache key is the source bytes plus a features hash (`Features::hash_for_runtime_transpiler`, `src/js_parser/parser.rs`) that never covered the define table. CLI `--define` was safe only because `Arguments.rs:1573` disabled the cache, and `bun run <file>` loads bunfig.toml after that check (`RunCommand::boot`, `run_command.rs:931`).

### Fix
- `defines_from_transform_options` (`src/bundler/options.rs`) hashes what it adds to the `Define` table beyond the constant tables: the resolved define map, the inlined env string entries and the `--drop` list, each sorted, length-prefixed and in its own section (`Define::hash_user_inputs`). `None` when there are none.
- `Define::user_hash` is copied into `Features::define_hash` per parse (`src/bundler/transpiler.rs`) and folded into the features hash like `--feature` flags.
- Cache version 27 to 28, because old entries can hold define-substituted output under a define-free hash. The `--define` cache disable is removed: the key covers it now.
- Self-reviewed: 3 concerns raised, 1 addressed (user and env pairs hash as separate sections). Rejected: fold this into #38590 so the cache version bump is spent once (the maintainer asked for this smaller PR), and add `remove_cjs_module_wrapper` and `is_macro_runtime` to the hashed bools here (out of scope, tracked separately, the second is #38683).
- Verified: four new tests in `test/cli/run/transpiler-cache.test.ts` (bunfig define across two projects through `bun run`, `--define` with flag order and a repeated key, `--define` on `bun test`, `--drop`). Each fails on the released binary. The rest of that file, `bundler_drop.test.ts` and regression tests 28159, 30887, 32686 pass.

### Background
- The runtime transpiler cache stores the transpiled output of every source file of 4 KiB or more in a per-user directory (`.pile` files) and reuses it across processes and projects. The file name is a hash of the source bytes. The entry header carries a features hash of the options that change the output.
- The define table (`Define`, `src/js_parser/lib.rs`) makes the parser replace an expression such as `BVAL` with a constant. `--define`, bunfig `[define]` and `--drop` all feed it through `defines_from_transform_options`, once per VM.
- At runtime every boot path disables env inlining, so the inlined env entries hold only the `window` placeholder, which has no string value.

<details><summary>Notes</summary>

Repro on the released binary, with the cache in an empty directory:

```
mkdir tc pA pB
# big.ts: 'declare const BVAL: string; console.log("bval:", BVAL);' plus 5 KiB of comments
cp big.ts pA/; cp big.ts pB/
printf '[define]\nBVAL = "\\"one\\""\n' > pA/bunfig.toml
(cd pA; BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/../tc bun run ./big.ts)   # bval: one
printf '[define]\nBVAL = "\\"two\\""\n' > pA/bunfig.toml
(cd pA; BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/../tc bun run ./big.ts)   # bval: one   (expected two)
printf '[define]\nBVAL = "\\"mine\\""\n' > pB/bunfig.toml
(cd pB; BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/../tc bun run ./big.ts)   # bval: one   (expected mine)
```

`bun ./big.ts` (no `run`) was already safe: `bun file.ts` loads bunfig.toml inside `Arguments::parse`, before the `IS_DISABLED` check, so a bunfig define turned the cache off on that path.

Why the resolved map and not the raw flag list: the table keeps one value per key, so `--define X=1 --define X=2` must key like `--define X=2`, and sorting a raw list with repeated keys would make `X=1 X=2` and `X=2 X=1` collide. A map has unique keys, so sorting by key is unambiguous.

Why the user and env pairs are separate sections: `Define::init` inserts the env pairs after the user pairs and `DefineData::merge` keeps the later value, so the same pair gives a different table depending on its source. One pooled list would key `--define process.env.FLAG='"a"'` with `FLAG=b` like `--define process.env.FLAG='"b"'` with `FLAG=a`.

Why the env entries are hashed although the runtime never inlines them: the hash is taken from the same inputs the table is built from, so the key and the table cannot disagree if a boot path ever runs with env inlining on.

On a features hash mismatch the cache entry is deleted and rewritten, so the tests count entries (net zero on a rewrite) and compare entry bytes to tell a hit from a rewrite.

Found while testing, not part of this change: under `bun run <file>` a bunfig `[define]` overrides a CLI `--define`, because the lazy bunfig load replaces `ctx.args.define`. `bun <file>` lets the CLI win. This is the precedence problem of #12216.

#38590 is a wider change for the same cache key (it also adds the module type and `--jsx-side-effects`). This PR is the smaller one.
</details>
