### PR TITLE
install.sh: detect musl on non-Alpine distros

### DIFF
--- a/src/runtime/cli/install.sh
+++ b/src/runtime/cli/install.sh
@@ -86,7 +86,15 @@ esac
 
 case "$target" in
 'linux'*)
+    # Non-Alpine musl distros (Gentoo musl, Void, Chimera) have no
+    # /etc/alpine-release, so also probe for the musl dynamic loader and
+    # ask ldd. Checking for a glibc-style loader instead would misfire:
+    # gcompat provides one on musl systems too.
     if [ -f /etc/alpine-release ]; then
+        target="$target-musl"
+    elif ls /lib/ld-musl-*.so.1 >/dev/null 2>&1; then
+        target="$target-musl"
+    elif [[ $(ldd --version 2>&1 || true) == *musl* ]]; then
         target="$target-musl"
     fi
     ;;

--- a/test/cli/install-script.test.ts
+++ b/test/cli/install-script.test.ts
@@ -61,9 +61,7 @@ async function requestedReleasePath(lddStub: string): Promise<string | undefined
 describe.skipIf(isWindows)("install.sh target detection", () => {
   // musl's ldd prints its banner to stderr and exits non-zero.
   test.concurrent("selects the musl build when ldd reports musl", async () => {
-    const path = await requestedReleasePath(
-      `#!/bin/sh\nprintf 'musl libc (aarch64)\\nVersion 1.2.5\\n' >&2\nexit 1\n`,
-    );
+    const path = await requestedReleasePath(`#!/bin/sh\nprintf 'musl libc (aarch64)\\nVersion 1.2.5\\n' >&2\nexit 1\n`);
     expect(path).toBe("/oven-sh/bun/releases/latest/download/bun-linux-aarch64-musl.zip");
   });
 

--- a/test/cli/install-script.test.ts
+++ b/test/cli/install-script.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, existsSync } from "fs";
+import { bunEnv, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// Tests for the curl | bash installer (src/runtime/cli/install.sh), not the
+// package manager. The script picks a release target from `uname -ms` plus a
+// libc probe, then downloads bun-<target>.zip from $GITHUB. We stub uname and
+// ldd on PATH, point $GITHUB at a local server, and assert which target the
+// script asks for.
+
+const installSh = join(import.meta.dir, "../../src/runtime/cli/install.sh");
+
+// On a real musl host the script detects musl from the filesystem, so the
+// glibc expectation below cannot hold there.
+function hostLooksMusl(): boolean {
+  if (existsSync("/etc/alpine-release")) return true;
+  try {
+    for (const _ of new Bun.Glob("ld-musl-*.so.1").scanSync("/lib")) return true;
+  } catch {}
+  return false;
+}
+
+async function requestedReleasePath(lddStub: string): Promise<string | undefined> {
+  let requested: string | undefined;
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      requested = new URL(req.url).pathname;
+      return new Response("not a real zip");
+    },
+  });
+
+  using dir = tempDir("install-sh", {
+    "bin/uname": `#!/bin/sh\necho "Linux aarch64"\n`,
+    "bin/ldd": lddStub,
+    "bin/unzip": `#!/bin/sh\nexit 0\n`,
+    "install/.keep": "",
+  });
+  for (const stub of ["uname", "ldd", "unzip"]) {
+    chmodSync(join(String(dir), "bin", stub), 0o755);
+  }
+
+  await using proc = Bun.spawn({
+    cmd: ["bash", installSh],
+    env: {
+      ...bunEnv,
+      PATH: `${join(String(dir), "bin")}:${bunEnv.PATH}`,
+      BUN_INSTALL: join(String(dir), "install"),
+      GITHUB: `http://localhost:${server.port}`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // The stub unzip extracts nothing, so the script fails after the download.
+  // The download request is all this test needs.
+  await proc.exited;
+  return requested;
+}
+
+describe.skipIf(isWindows)("install.sh target detection", () => {
+  // musl's ldd prints its banner to stderr and exits non-zero.
+  test.concurrent("selects the musl build when ldd reports musl", async () => {
+    const path = await requestedReleasePath(
+      `#!/bin/sh\nprintf 'musl libc (aarch64)\\nVersion 1.2.5\\n' >&2\nexit 1\n`,
+    );
+    expect(path).toBe("/oven-sh/bun/releases/latest/download/bun-linux-aarch64-musl.zip");
+  });
+
+  test.concurrent.skipIf(hostLooksMusl())("selects the glibc build when ldd reports glibc", async () => {
+    const path = await requestedReleasePath(`#!/bin/sh\necho "ldd (GNU libc) 2.39"\n`);
+    expect(path).toBe("/oven-sh/bun/releases/latest/download/bun-linux-aarch64.zip");
+  });
+});


### PR DESCRIPTION
### Problem

- `curl -fsSL https://bun.com/install | bash` installs the glibc build on non-Alpine musl systems. The binary then fails to load: `Error relocating /root/.bun/bin/bun: gnu_get_libc_version: symbol not found`.
- The cause is the musl check in `src/runtime/cli/install.sh:89`. It only tests for `/etc/alpine-release`. Gentoo musl, Void musl, and Chimera do not have that file, so the script picks `bun-linux-aarch64.zip` instead of `bun-linux-aarch64-musl.zip`.

### Fix

- Add two fallback probes after the Alpine check: a `/lib/ld-musl-*.so.1` loader file, and `ldd --version` output that contains `musl`.
- The loader file check cannot use the glibc loader path in reverse. gcompat provides a glibc-style loader on musl systems, as the reporter's `ldd` output shows.
- The `ldd` probe uses a command substitution with `|| true`, not a pipe into `grep`. musl's `ldd --version` exits non-zero, and the script runs under `set -o pipefail`.
- Verified: `test/cli/install-script.test.ts` (new). It runs the real script with stub `uname` and `ldd` binaries and a local server in place of GitHub, and asserts which release asset the script requests. The musl test fails on the unpatched script.

### Background

- The install script maps `uname -ms` to a release target, then appends `-musl` for musl systems. The musl zip exists for both x64 and aarch64 (`.buildkite/scripts/upload-release.sh`).
- The npm installer is not affected. `packages/bun-release/src/platform.ts` detects musl from `process.report`, which is distro independent. That is why `npm install -g bun` works on the reporter's system.

Fixes #40975

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install-script.test.ts

<!-- robobun:evidence:end -->