### PR TITLE
Retry pthread_create EAGAIN caused by an in-flight execve on Linux

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -1230,6 +1230,15 @@ export const linkerFlags: Flag[] = [
     desc: "Wrap glibc 2.18+ symbols (portable down to glibc 2.17)",
   },
   {
+    // c-bindings.cpp: __wrap_execve records that an exec of this process is in
+    // flight, and __wrap_pthread_create retries the EAGAIN the kernel returns
+    // for clone(CLONE_FS) during that window (the --watch reload). Behavioral,
+    // not a version pin, so it applies to every Linux libc.
+    flag: ["-Wl,--wrap=execve", "-Wl,--wrap=pthread_create"],
+    when: c => c.linux,
+    desc: "Retry pthread_create EAGAIN caused by an in-flight execve",
+  },
+  {
     flag: ["-static-libstdc++", "-static-libgcc"],
     when: c => c.linux && c.abi === "gnu",
     desc: "Static C++ runtime (don't depend on host libstdc++)",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -688,6 +688,14 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
   0,
 );
 
+// Runs `parallelism` threads that each spawn `iterations` no-op threads through
+// bun's own pthread_create. Every failure is written to `fd`. With `detach` the
+// loops run in the background and the call returns 0 at once; otherwise it
+// waits for them and returns the first failing errno (0 when every spawn
+// succeeded). Always 0 on Windows.
+export const spawnThreadsForTesting: (iterations: number, fd: number, parallelism: number, detach?: boolean) => number =
+  $newCppFunction("InternalForTesting.cpp", "jsFunction_spawnThreadsForTesting", 4);
+
 // True when the installed watcher registered a real OS source (a PSI trigger
 // on Linux). The watcher installs silently without one when the kernel
 // refuses the trigger, so isMemoryPressureWatcherInstalled() cannot tell.

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -688,11 +688,9 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
   0,
 );
 
-// Runs `parallelism` threads that each spawn `iterations` no-op threads through
-// bun's own pthread_create. Every failure is written to `fd`. With `detach` the
-// loops run in the background and the call returns 0 at once; otherwise it
-// waits for them and returns the first failing errno (0 when every spawn
-// succeeded). Always 0 on Windows.
+// `parallelism` threads each spawn `iterations` no-op threads through bun's own pthread_create,
+// writing every failure to `fd`. Returns the first failing errno, or with `detach` 0 as soon as
+// every loop runs; a detached loop also writes to `fd` when it runs out of iterations.
 export const spawnThreadsForTesting: (iterations: number, fd: number, parallelism: number, detach?: boolean) => number =
   $newCppFunction("InternalForTesting.cpp", "jsFunction_spawnThreadsForTesting", 4);
 

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -9,6 +9,11 @@
 #include <wtf/text/AtomStringImpl.h>
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/WTFString.h>
+#include <memory>
+#if !OS(WINDOWS)
+#include <pthread.h>
+#include <unistd.h>
+#endif
 
 extern "C" BunString BunString__threadIsolatedCopy(const BunString* str);
 extern "C" void BunString__makeThreadShareable(BunString* str);
@@ -119,6 +124,105 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitMemoryPressure, (JSC::JSGlobalObject * g
 JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
+}
+
+#if !OS(WINDOWS)
+static void* spawnThreadsForTestingEntry(void* arg)
+{
+    return arg;
+}
+
+struct SpawnThreadsForTestingLoop {
+    int32_t iterations;
+    int fd;
+};
+
+// Spawns `iterations` detached no-op threads. Stops at the first failure:
+// writes the errno to `fd` right away (this thread may be killed a few
+// microseconds later by the exec it is racing) and returns it.
+static void* spawnThreadsForTestingLoop(void* arg)
+{
+    std::unique_ptr<SpawnThreadsForTestingLoop> loop(static_cast<SpawnThreadsForTestingLoop*>(arg));
+    // Detached threads with a small stack keep each spawn cheap (no join, and
+    // ASAN clears the shadow of the whole stack on thread start), so more
+    // spawns land in the exec window.
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setstacksize(&attr, 64 * 1024);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    intptr_t result = 0;
+    for (int32_t i = 0; i < loop->iterations; i++) {
+        pthread_t thread;
+        int rc = pthread_create(&thread, &attr, spawnThreadsForTestingEntry, nullptr);
+        if (rc != 0) {
+            char message[64];
+            int length = snprintf(message, sizeof message, "pthread_create failed: errno %d\n", rc);
+            if (loop->fd >= 0 && length > 0)
+                (void)write(loop->fd, message, static_cast<size_t>(length));
+            result = rc;
+            break;
+        }
+    }
+    pthread_attr_destroy(&attr);
+    return reinterpret_cast<void*>(result);
+}
+#endif
+
+// Runs `parallelism` threads that each spawn `iterations` no-op threads through
+// bun's own pthread_create, so a test can keep this process inside clone(2)
+// while an execve(2) runs on another thread. Each failure is written to `fd`
+// (a file, so the record survives the exec). With `detach` the loops run in
+// the background and the call returns 0 at once. Otherwise it waits for them
+// and returns the first failing errno, or 0 when every spawn succeeded.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+#if OS(WINDOWS)
+    UNUSED_PARAM(globalObject);
+    UNUSED_PARAM(callFrame);
+    return JSValue::encode(jsNumber(0));
+#else
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    int32_t iterations = callFrame->argument(0).toInt32(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    int32_t fd = callFrame->argument(1).toInt32(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    int32_t parallelism = callFrame->argument(2).toInt32(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    bool detach = callFrame->argument(3).toBoolean(globalObject);
+    if (parallelism < 1)
+        parallelism = 1;
+    if (parallelism > 64)
+        parallelism = 64;
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, detach ? PTHREAD_CREATE_DETACHED : PTHREAD_CREATE_JOINABLE);
+    pthread_t loops[64];
+    int32_t started = 0;
+    int firstError = 0;
+    for (; started < parallelism; started++) {
+        // Owned by the loop thread.
+        auto* loop = new SpawnThreadsForTestingLoop { iterations, fd };
+        int rc = pthread_create(&loops[started], &attr, spawnThreadsForTestingLoop, loop);
+        if (rc != 0) {
+            delete loop;
+            firstError = rc;
+            break;
+        }
+    }
+    pthread_attr_destroy(&attr);
+    if (!detach) {
+        for (int32_t i = 0; i < started; i++) {
+            void* result = nullptr;
+            pthread_join(loops[i], &result);
+            int rc = static_cast<int>(reinterpret_cast<intptr_t>(result));
+            if (rc != 0 && firstError == 0)
+                firstError = rc;
+        }
+    }
+    return JSValue::encode(jsNumber(firstError));
+#endif
 }
 
 }

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -137,9 +137,18 @@ struct SpawnThreadsForTestingLoop {
     int fd;
 };
 
-// Spawns `iterations` detached no-op threads. Stops at the first failure:
-// writes the errno to `fd` right away (this thread may be killed a few
-// microseconds later by the exec it is racing) and returns it.
+// Written right away: the caller may be killed a few microseconds later by the
+// exec it is racing.
+static void recordSpawnThreadsForTestingFailure(int fd, int rc)
+{
+    char message[64];
+    int length = snprintf(message, sizeof message, "pthread_create failed: errno %d\n", rc);
+    if (fd >= 0 && length > 0)
+        (void)write(fd, message, static_cast<size_t>(length));
+}
+
+// Spawns `iterations` detached no-op threads. Stops at the first failure,
+// records it to `fd` and returns it.
 static void* spawnThreadsForTestingLoop(void* arg)
 {
     std::unique_ptr<SpawnThreadsForTestingLoop> loop(static_cast<SpawnThreadsForTestingLoop*>(arg));
@@ -155,10 +164,7 @@ static void* spawnThreadsForTestingLoop(void* arg)
         pthread_t thread;
         int rc = pthread_create(&thread, &attr, spawnThreadsForTestingEntry, nullptr);
         if (rc != 0) {
-            char message[64];
-            int length = snprintf(message, sizeof message, "pthread_create failed: errno %d\n", rc);
-            if (loop->fd >= 0 && length > 0)
-                (void)write(loop->fd, message, static_cast<size_t>(length));
+            recordSpawnThreadsForTestingFailure(loop->fd, rc);
             result = rc;
             break;
         }
@@ -207,6 +213,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting, (JSC::JSGlobalObject
         int rc = pthread_create(&loops[started], &attr, spawnThreadsForTestingLoop, loop);
         if (rc != 0) {
             delete loop;
+            recordSpawnThreadsForTestingFailure(fd, rc);
             firstError = rc;
             break;
         }

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -9,9 +9,11 @@
 #include <wtf/text/AtomStringImpl.h>
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/WTFString.h>
+#include <atomic>
 #include <memory>
 #if !OS(WINDOWS)
 #include <pthread.h>
+#include <sched.h>
 #include <unistd.h>
 #endif
 
@@ -135,26 +137,26 @@ static void* spawnThreadsForTestingEntry(void* arg)
 struct SpawnThreadsForTestingLoop {
     int32_t iterations;
     int fd;
+    bool detached;
+    // Lives on the caller's stack; each loop bumps it exactly once, before the caller returns.
+    std::atomic<int32_t>* runningLoops;
 };
 
-// Written right away: the caller may be killed a few microseconds later by the
-// exec it is racing.
-static void recordSpawnThreadsForTestingFailure(int fd, int rc)
+// Written at once: the exec this thread races may kill it microseconds later.
+static void recordSpawnThreadsForTesting(int fd, const char* what, int value)
 {
-    char message[64];
-    int length = snprintf(message, sizeof message, "pthread_create failed: errno %d\n", rc);
+    char message[96];
+    int length = snprintf(message, sizeof message, "%s %d\n", what, value);
     if (fd >= 0 && length > 0)
         (void)write(fd, message, static_cast<size_t>(length));
 }
 
-// Spawns `iterations` detached no-op threads. Stops at the first failure,
-// records it to `fd` and returns it.
+// Spawns `iterations` detached no-op threads; stops at and records the first failure.
 static void* spawnThreadsForTestingLoop(void* arg)
 {
     std::unique_ptr<SpawnThreadsForTestingLoop> loop(static_cast<SpawnThreadsForTestingLoop*>(arg));
-    // Detached threads with a small stack keep each spawn cheap (no join, and
-    // ASAN clears the shadow of the whole stack on thread start), so more
-    // spawns land in the exec window.
+    loop->runningLoops->fetch_add(1, std::memory_order_release);
+    // Small detached stacks keep each spawn cheap (ASAN clears a whole stack's shadow at start).
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setstacksize(&attr, 64 * 1024);
@@ -164,22 +166,21 @@ static void* spawnThreadsForTestingLoop(void* arg)
         pthread_t thread;
         int rc = pthread_create(&thread, &attr, spawnThreadsForTestingEntry, nullptr);
         if (rc != 0) {
-            recordSpawnThreadsForTestingFailure(loop->fd, rc);
+            recordSpawnThreadsForTesting(loop->fd, "pthread_create failed: errno", rc);
             result = rc;
             break;
         }
     }
     pthread_attr_destroy(&attr);
+    // A detached loop has no return value, so a test that expects the loop to outlive it
+    // can see in the file when it ran out of iterations instead.
+    if (loop->detached && result == 0)
+        recordSpawnThreadsForTesting(loop->fd, "loop finished after spawning", loop->iterations);
     return reinterpret_cast<void*>(result);
 }
 #endif
 
-// Runs `parallelism` threads that each spawn `iterations` no-op threads through
-// bun's own pthread_create, so a test can keep this process inside clone(2)
-// while an execve(2) runs on another thread. Each failure is written to `fd`
-// (a file, so the record survives the exec). With `detach` the loops run in
-// the background and the call returns 0 at once. Otherwise it waits for them
-// and returns the first failing errno, or 0 when every spawn succeeded.
+// (iterations, fd, parallelism, detach): see spawnThreadsForTesting in internal-for-testing.ts.
 JSC_DEFINE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
 #if OS(WINDOWS)
@@ -204,21 +205,25 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting, (JSC::JSGlobalObject
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, detach ? PTHREAD_CREATE_DETACHED : PTHREAD_CREATE_JOINABLE);
+    std::atomic<int32_t> runningLoops { 0 };
     pthread_t loops[64];
     int32_t started = 0;
     int firstError = 0;
     for (; started < parallelism; started++) {
         // Owned by the loop thread.
-        auto* loop = new SpawnThreadsForTestingLoop { iterations, fd };
+        auto* loop = new SpawnThreadsForTestingLoop { iterations, fd, detach, &runningLoops };
         int rc = pthread_create(&loops[started], &attr, spawnThreadsForTestingLoop, loop);
         if (rc != 0) {
             delete loop;
-            recordSpawnThreadsForTestingFailure(fd, rc);
+            recordSpawnThreadsForTesting(fd, "loop thread pthread_create failed: errno", rc);
             firstError = rc;
             break;
         }
     }
     pthread_attr_destroy(&attr);
+    // Every loop is spawning threads by the time this returns.
+    while (runningLoops.load(std::memory_order_acquire) < started)
+        sched_yield();
     if (!detach) {
         for (int32_t i = 0; i < started; i++) {
             void* result = nullptr;

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -138,7 +138,7 @@ struct SpawnThreadsForTestingLoop {
     int32_t iterations;
     int fd;
     bool detached;
-    // Lives on the caller's stack; each loop bumps it exactly once, before the caller returns.
+    // Lives on the caller's stack; each loop bumps it exactly once, after its first spawn attempt.
     std::atomic<int32_t>* runningLoops;
 };
 
@@ -155,22 +155,29 @@ static void recordSpawnThreadsForTesting(int fd, const char* what, int value)
 static void* spawnThreadsForTestingLoop(void* arg)
 {
     std::unique_ptr<SpawnThreadsForTestingLoop> loop(static_cast<SpawnThreadsForTestingLoop*>(arg));
-    loop->runningLoops->fetch_add(1, std::memory_order_release);
     // Small detached stacks keep each spawn cheap (ASAN clears a whole stack's shadow at start).
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setstacksize(&attr, 64 * 1024);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     intptr_t result = 0;
+    // The caller waits for this; it happens once the first spawn attempt has returned.
+    bool reportedRunning = false;
     for (int32_t i = 0; i < loop->iterations; i++) {
         pthread_t thread;
         int rc = pthread_create(&thread, &attr, spawnThreadsForTestingEntry, nullptr);
+        if (!reportedRunning) {
+            reportedRunning = true;
+            loop->runningLoops->fetch_add(1, std::memory_order_release);
+        }
         if (rc != 0) {
             recordSpawnThreadsForTesting(loop->fd, "pthread_create failed: errno", rc);
             result = rc;
             break;
         }
     }
+    if (!reportedRunning)
+        loop->runningLoops->fetch_add(1, std::memory_order_release);
     pthread_attr_destroy(&attr);
     // A detached loop has no return value, so a test that expects the loop to outlive it
     // can see in the file when it ran out of iterations instead.
@@ -221,7 +228,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting, (JSC::JSGlobalObject
         }
     }
     pthread_attr_destroy(&attr);
-    // Every loop is spawning threads by the time this returns.
+    // Every loop has made its first spawn attempt by the time this returns.
     while (runningLoops.load(std::memory_order_acquire) < started)
         sched_yield();
     if (!detach) {

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -13,5 +13,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_makeThreadShareableRefCountDelta)
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting);
 
 }

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -358,30 +358,18 @@ extern "C" void on_before_reload_process_posix()
 }
 
 #if OS(LINUX)
-// Linux builds link with -Wl,--wrap=execve -Wl,--wrap=pthread_create
-// (scripts/build/flags.ts), so every execve and pthread_create in the binary
-// lands in the two wrappers below.
-//
-// While one thread is inside execve(2), from check_unsafe_exec() until
-// de_thread() has killed the other threads or the exec has failed, the kernel
-// fails every clone(CLONE_FS) in the process with EAGAIN (fs/exec.c,
-// kernel/fork.c copy_fs). pthread_create is such a clone. The --watch reload
-// execs on the watcher thread, so a GC marker or worker thread that the JS
-// thread started at that moment failed, and WTF::Thread::create aborted the
-// process. Such an EAGAIN is transient: the exec either replaces the process,
-// which ends the failing thread too, or fails and clears the kernel flag.
-//
-// `threads_in_execve` counts the threads inside execve(2) right now.
-// `execve_generation` counts every exec ever started, so an exec that began and
-// ended during one pthread_create is still visible. __wrap_execve bumps the
-// count before the generation and __wrap_pthread_create reads them in the
-// opposite order, so an exec that overlaps an attempt shows up in at least one.
+// Linked in with -Wl,--wrap=execve -Wl,--wrap=pthread_create (scripts/build/flags.ts).
+// While a thread is inside execve(2), until de_thread() has killed the other threads or the
+// exec has failed, the kernel fails every clone(CLONE_FS) in the process with EAGAIN
+// (fs/exec.c check_unsafe_exec, kernel/fork.c copy_fs). WTF::Thread::create aborts on a
+// failed pthread_create, which killed --watch reloads. A pthread_create EAGAIN that overlaps
+// an exec of this process is retried instead. `execve_generation` counts execs ever started
+// so one that began and ended inside a single pthread_create is still seen; it is bumped
+// after `threads_in_execve` and read before it.
 static std::atomic<int> threads_in_execve { 0 };
 static std::atomic<unsigned> execve_generation { 0 };
-// Set in bun_initialize_process. The exec of a child that posix_spawn_bun made
-// with clone(CLONE_VM) runs in this address space too; it must not touch the
-// counters, because it never returns to undo them and the kernel flag it sets
-// lives in the child's own fs_struct.
+// The clone(CLONE_VM) child of posix_spawn_bun execs in this address space and never returns
+// to undo a count, so only the pid recorded in bun_initialize_process counts its execs.
 static pid_t execve_counting_pid = 0;
 
 extern "C" int __real_execve(const char*, char* const[], char* const[]);
@@ -399,9 +387,7 @@ extern "C" int __wrap_execve(const char* path, char* const argv[], char* const e
     return rc;
 }
 
-// Retries an EAGAIN that overlaps an exec of this process. Any other EAGAIN is
-// returned unchanged. The bound keeps a real limit, hit while an exec never
-// completes, from looping forever.
+// The attempt bound keeps a real limit, hit while an exec never completes, from looping forever.
 extern "C" int __wrap_pthread_create(pthread_t* thread, const pthread_attr_t* attr, void* (*start_routine)(void*), void* arg)
 {
     for (int attempt = 0;; attempt++) {

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -9,10 +9,13 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <unistd.h>
+#include <atomic>
+#include <cerrno>
 #include <cstring>
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
+#include <pthread.h>
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
@@ -354,6 +357,69 @@ extern "C" void on_before_reload_process_posix()
     sigprocmask(SIG_SETMASK, &signal_set, nullptr);
 }
 
+#if OS(LINUX)
+// Linux builds link with -Wl,--wrap=execve -Wl,--wrap=pthread_create
+// (scripts/build/flags.ts), so every execve and pthread_create in the binary
+// lands in the two wrappers below.
+//
+// While one thread is inside execve(2), from check_unsafe_exec() until
+// de_thread() has killed the other threads or the exec has failed, the kernel
+// fails every clone(CLONE_FS) in the process with EAGAIN (fs/exec.c,
+// kernel/fork.c copy_fs). pthread_create is such a clone. The --watch reload
+// execs on the watcher thread, so a GC marker or worker thread that the JS
+// thread started at that moment failed, and WTF::Thread::create aborted the
+// process. Such an EAGAIN is transient: the exec either replaces the process,
+// which ends the failing thread too, or fails and clears the kernel flag.
+//
+// `threads_in_execve` counts the threads inside execve(2) right now.
+// `execve_generation` counts every exec ever started, so an exec that began and
+// ended during one pthread_create is still visible. __wrap_execve bumps the
+// count before the generation and __wrap_pthread_create reads them in the
+// opposite order, so an exec that overlaps an attempt shows up in at least one.
+static std::atomic<int> threads_in_execve { 0 };
+static std::atomic<unsigned> execve_generation { 0 };
+// Set in bun_initialize_process. The exec of a child that posix_spawn_bun made
+// with clone(CLONE_VM) runs in this address space too; it must not touch the
+// counters, because it never returns to undo them and the kernel flag it sets
+// lives in the child's own fs_struct.
+static pid_t execve_counting_pid = 0;
+
+extern "C" int __real_execve(const char*, char* const[], char* const[]);
+extern "C" int __real_pthread_create(pthread_t*, const pthread_attr_t*, void* (*)(void*), void*);
+
+extern "C" int __wrap_execve(const char* path, char* const argv[], char* const envp[])
+{
+    if (getpid() != execve_counting_pid)
+        return __real_execve(path, argv, envp);
+    threads_in_execve.fetch_add(1, std::memory_order_seq_cst);
+    execve_generation.fetch_add(1, std::memory_order_seq_cst);
+    int rc = __real_execve(path, argv, envp);
+    // Only reached when execve failed and the old image keeps running.
+    threads_in_execve.fetch_sub(1, std::memory_order_seq_cst);
+    return rc;
+}
+
+// Retries an EAGAIN that overlaps an exec of this process. Any other EAGAIN is
+// returned unchanged. The bound keeps a real limit, hit while an exec never
+// completes, from looping forever.
+extern "C" int __wrap_pthread_create(pthread_t* thread, const pthread_attr_t* attr, void* (*start_routine)(void*), void* arg)
+{
+    for (int attempt = 0;; attempt++) {
+        unsigned generation = execve_generation.load(std::memory_order_seq_cst);
+        bool execInFlight = threads_in_execve.load(std::memory_order_seq_cst) > 0;
+        int rc = __real_pthread_create(thread, attr, start_routine, arg);
+        if (rc != EAGAIN || attempt >= 1000)
+            return rc;
+        if (!execInFlight && threads_in_execve.load(std::memory_order_seq_cst) == 0
+            && execve_generation.load(std::memory_order_seq_cst) == generation) {
+            // No exec overlapped this attempt: a real limit.
+            return rc;
+        }
+        usleep(1000);
+    }
+}
+#endif // OS(LINUX)
+
 #endif // !OS(WINDOWS)
 
 #define LSHPACK_MAX_HEADER_SIZE 65536
@@ -652,6 +718,8 @@ extern "C" void bun_initialize_process()
     // This is best effort, not all linux kernels support close_range or CLOSE_RANGE_CLOEXEC
     // To avoid breaking --watch, we skip stdin, stdout, stderr and IPC.
     bun_close_range(4, ~0U, CLOSE_RANGE_CLOEXEC);
+
+    execve_counting_pid = getpid();
 #endif
 
 #if OS(LINUX) || OS(DARWIN) || OS(FREEBSD)

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -129,6 +129,63 @@ setInterval(() => {}, 1000);
   10000,
 );
 
+// While one thread is inside execve(2), Linux fails every clone(CLONE_FS) in
+// the process with EAGAIN until the exec has killed the other threads
+// (fs/exec.c check_unsafe_exec, kernel/fork.c copy_fs). The --watch reload
+// runs execve on the watcher thread, so a GC marker or worker thread that the
+// JS thread spawned at that moment failed, and WTF::Thread::create aborted the
+// process. The fixture keeps the JS thread inside pthread_create for the whole
+// run and records the first failure in a file that outlives each exec'd image.
+it.skipIf(!isLinux)(
+  "a --watch reload does not fail pthread_create on the other threads",
+  async () => {
+    using dir = tempDir("watch-reload-pthread-create", {
+      "spinner.js": `import { spawnThreadsForTesting } from "bun:internal-for-testing";
+import { openSync } from "node:fs";
+const fd = openSync("failures.txt", "a");
+console.log("started");
+for (;;) spawnThreadsForTesting(1000, fd, 2);
+`,
+    });
+    const cwd = String(dir);
+    const path = join(cwd, "spinner.js");
+    const proc = spawn({
+      cwd,
+      cmd: [bunExe(), "--watch", "--no-clear-screen", "spinner.js"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+    watchee = proc;
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let output = "";
+    const waitForStarts = async (count: number) => {
+      while (output.split("started\n").length - 1 < count) {
+        const { value, done } = await reader.read();
+        // stdout survives the exec, so a closed pipe means the process died
+        // instead of reloading.
+        if (done) throw new Error(`watchee exited after ${count - 1} reload(s): ${JSON.stringify(output)}`);
+        output += decoder.decode(value, { stream: true });
+      }
+    };
+
+    const reloads = 8;
+    await waitForStarts(1);
+    for (let i = 1; i <= reloads; i++) {
+      await Bun.write(path, (await Bun.file(path).text()) + `// touch ${i}\n`);
+      await waitForStarts(i + 1);
+    }
+    reader.releaseLock();
+    proc.kill("SIGKILL");
+    await proc.exited;
+
+    expect(await Bun.file(join(cwd, "failures.txt")).text()).toBe("");
+  },
+  30000,
+);
+
 // Watcher::start() must propagate a failed thread spawn as an Err through its
 // Result return instead of aborting inside start() with `.expect()`. An
 // LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux

--- a/test/js/node/process/process-execve.test.ts
+++ b/test/js/node/process/process-execve.test.ts
@@ -183,7 +183,8 @@ describe.concurrent("process.execve", () => {
         import { openSync, writeFileSync } from "node:fs";
         writeFileSync("not-a-binary", "not an ELF file\\n", { mode: 0o755 });
         const fd = openSync("failures.txt", "a");
-        spawnThreadsForTesting(1_000_000, fd, 2, true);
+        const rc = spawnThreadsForTesting(1_000_000, fd, 2, true);
+        if (rc !== 0) throw new Error("could not start the spinner threads: errno " + rc);
         let attempts = 0;
         for (; attempts < 3000; attempts++) {
           try {

--- a/test/js/node/process/process-execve.test.ts
+++ b/test/js/node/process/process-execve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { join } from "node:path";
 
 describe.concurrent("process.execve", () => {
   test("is a function", () => {
@@ -165,6 +166,51 @@ describe.concurrent("process.execve", () => {
 
     expect(stderr).not.toContain("second execve returned unexpectedly");
     expect(stdout.trim()).toBe("REPLACED_AFTER:ENOENT");
+    expect(exitCode).toBe(0);
+  });
+
+  // While a thread is inside execve(2), Linux fails every clone(CLONE_FS) in
+  // the process with EAGAIN until the exec has killed the other threads or has
+  // failed (fs/exec.c check_unsafe_exec, kernel/fork.c copy_fs). An exec of a
+  // file that is executable but not a valid binary opens that window and then
+  // fails with ENOEXEC, so the fixture can open it thousands of times while
+  // background threads keep calling pthread_create. Every failure they see is
+  // recorded in a file.
+  test.skipIf(!isLinux)("does not make pthread_create fail on other threads while the exec runs", async () => {
+    using dir = tempDir("process-execve-pthread-create", {
+      "index.js": `
+        import { spawnThreadsForTesting } from "bun:internal-for-testing";
+        import { openSync, writeFileSync } from "node:fs";
+        writeFileSync("not-a-binary", "not an ELF file\\n", { mode: 0o755 });
+        const fd = openSync("failures.txt", "a");
+        spawnThreadsForTesting(1_000_000, fd, 2, true);
+        let attempts = 0;
+        for (; attempts < 3000; attempts++) {
+          try {
+            process.execve("./not-a-binary", ["not-a-binary"], {});
+            throw new Error("execve returned without an error");
+          } catch (e) {
+            if (e.code !== "ENOEXEC") throw e;
+          }
+        }
+        console.log("attempts:" + attempts);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(await Bun.file(join(String(dir), "failures.txt")).text()).toBe("");
+    // stderr carries the ExperimentalWarning for process.execve.
+    expect(stderr).not.toContain("error");
+    expect(stdout.trim()).toBe("attempts:3000");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/node/process/process-execve.test.ts
+++ b/test/js/node/process/process-execve.test.ts
@@ -174,8 +174,10 @@ describe.concurrent("process.execve", () => {
   // failed (fs/exec.c check_unsafe_exec, kernel/fork.c copy_fs). An exec of a
   // file that is executable but not a valid binary opens that window and then
   // fails with ENOEXEC, so the fixture can open it thousands of times while
-  // background threads keep calling pthread_create. Every failure they see is
-  // recorded in a file.
+  // background threads keep calling pthread_create. The threads are spawning
+  // before the first exec (the call returns once they run) and record both a
+  // failed spawn and running out of iterations, so an empty file means they
+  // spawned without failure for the whole exec loop.
   test.skipIf(!isLinux)("does not make pthread_create fail on other threads while the exec runs", async () => {
     using dir = tempDir("process-execve-pthread-create", {
       "index.js": `


### PR DESCRIPTION
### Problem
- A `bun --watch` reload can end the process with a core dump instead of a restart. CI: `test-changed.test.ts`, alpine aarch64, `SIGABRT` in `WTF::Thread::create` (`Threading.cpp:328`, `RELEASE_ASSERT(success)`) under `Bun__JSC_onBeforeWait` (builds 108462, 108292; earlier 102050, 102111 and 13 flaky glibc hits listed in #39868).
- The reload calls `execve` on the watcher thread. Until `de_thread()` kills the other threads, Linux fails every `clone(CLONE_FS)` in the process with `EAGAIN` (`check_unsafe_exec` sets `fs->in_exec`, `copy_fs` refuses). The JS thread was starting the GC marker threads right then, and WTF aborts on a failed `pthread_create`.

### Fix
- Linux builds link with `-Wl,--wrap=execve -Wl,--wrap=pthread_create`. `__wrap_execve` (`c-bindings.cpp`) records that an exec of this process is in flight. The `clone(CLONE_VM)` child of `posix_spawn_bun` skips the counters: it never returns to undo them, and its kernel flag is on its own `fs_struct`.
- `__wrap_pthread_create` retries an `EAGAIN` that overlaps such an exec (1 ms sleeps, at most 1000). Any other `EAGAIN` returns unchanged, so the call-site retries for real limits (`Watcher.rs`, #39864) still see real failures.
- Correct because that `EAGAIN` is transient: the exec either replaces the process, which ends the retrying thread, or fails, which clears the flag. The wrap covers every `pthread_create` and `execve` in the binary, so `process.execve` and any future exec site need no routing.
- Verified: `test/js/node/process/process-execve.test.ts` (deterministic, fails every run without the retry) and `test/cli/watch/watch.test.ts` (8 reloads).

### Background
- `--watch` restarts by calling `execve` on bun's own binary from the watcher thread. The other threads run until the kernel kills them inside that `execve`.
- JSC starts its GC marker threads on the thread that runs the collection, the first time one needs them (#39541 moved that to the first collection). Here that is the JS thread, right after the run summary.
- `--wrap=SYMBOL` sends every reference to `SYMBOL` to `__wrap_SYMBOL`; `__real_SYMBOL` is the original. Bun already uses it on glibc for version pins.
- #39868 parks a thread that crashes during the reload. This PR removes the failure instead, also for `process.execve` and for failures that do not crash (a `Worker` that fails to start). It supersedes #39868 for this crash.

<details><summary>Notes</summary>

- Other suites run with the fix: `test/cli/watch/`, `test/cli/hot/`, `test/cli/test/test-changed.test.ts`, the node `test-process-execve-*` tests. All pass.
- The cores show a plain `abort()` with no crash handler frames: `on_before_reload_process_posix` (#34660) resets `SIGABRT` to `SIG_DFL` before the exec, so the abort ended the process instead of one thread.
- Kernel source (6.12 and 6.17), `fs/exec.c` `check_unsafe_exec`: "Otherwise we set fs->in_exec = 1 to deny clone(CLONE_FS) from another sub-thread until de_thread() succeeds". `copy_fs` returns `-EAGAIN` while it is set. musl maps every clone failure to `EAGAIN`, glibc passes the errno through.
- Reproduced outside bun with a C program: one thread calls `execve(bun)`, another loops `pthread_create`. 56 to 110 of 200 execs saw `EAGAIN` on this x64 glibc host (kernel 6.17). Same with `bun --watch` and an FFI spinner on the JS thread: 5 of 5 reloads.
- `unshare(CLONE_FS)` before `execve` also removes the window (the exec then marks a private `fs_struct`), but Docker's default seccomp profile answers `unshare` with `EPERM` unless the container has `CAP_SYS_ADMIN`, so it would silently not apply in containers. Not used.
- The child check in `__wrap_execve` compares `getpid()` with the pid recorded in `bun_initialize_process`. Verified by spawning five children and then forcing a real `EAGAIN` (`RLIMIT_NPROC=1` as an unprivileged user): it came back in 0 ms, so the counters were not left raised.
- The window is short when the binary is in the page cache (about 10 to 60 us). The `--watch` test hits it in roughly 1 of 5 reloads in an ASAN build without the fix, so its 8 reloads catch a regression most but not all of the time. The `process.execve` test opens the window 3000 times per run (an executable file that is not a valid binary fails with `ENOEXEC` after `check_unsafe_exec`), so it is deterministic: every run failed without the retry, 8 of 8 passed with it.
- A first version retried once more when the exec had already finished and returned that result. With back-to-back execs the second attempt landed in the next window, so the test failed about half the time. The generation counter fixes that: an `EAGAIN` is retried while any exec has started since the attempt began.
- `spawnThreadsForTesting` in `bun:internal-for-testing` is the only way a test can reach bun's own `pthread_create` at a high rate. `bun:ffi` resolves `pthread_create` from libc directly, which the wrap does not cover.
- On glibc, `__real_pthread_create` and `__real_execve` bind to the same `GLIBC_2.2.5` (or `2.17`) versions the references used before, so the version floor does not move. In ASAN builds `__real_pthread_create` binds to the ASAN interceptor.
- Layering with the other thread-spawn work: `src/watcher/Watcher.rs` retries its one spawn once after 10 ms, and #39864 proposes `spawn_with_retry` for the HTTP, bundle, IO and waiter threads. Both handle real resource limits at the call site. The wrapper handles only the exec window, at the libc boundary, and hands every other `EAGAIN` through to them.
- #40706 moves the reload exec into `bun_reload_process_exec` in `c-bindings.cpp`. Its non-Darwin branch calls `execve`, which the wrap covers, so the two PRs do not depend on each other.
- Other platforms: the wrap is Linux only (lld and GNU ld). Darwin's `process.execve` keeps `posix_spawn(POSIX_SPAWN_SETEXEC)`. Windows has no in-place exec.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process-execve.test.ts, test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->