### PR TITLE
Key the runtime transpiler cache on remove_cjs_module_wrapper

### DIFF
--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -355,7 +355,7 @@ pub mod Runtime {
         pub(crate) fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 17] = [
+            let bools: [bool; 18] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -373,6 +373,7 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
+                self.remove_cjs_module_wrapper,
                 // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
             ];
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,11 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: `remove_cjs_module_wrapper` participates in the features hash. The
+/// `bun -` and `bun -e` entry point is printed without the CommonJS wrapper, and
+/// entries written before this shared a key with the wrapped output of the same
+/// bytes run as a file.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -320,6 +320,58 @@ describe("transpiler cache", () => {
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
 
+  // `bun -` prints the entry point without the CommonJS wrapper and evaluates
+  // it as a script. The same bytes run as a file are printed wrapped in
+  // `(function(exports, require, module, __filename, __dirname) {})` and the
+  // loader calls that function. The two transpiles must not share an entry.
+  describe("a CommonJS entry point from stdin does not share an entry with the same file", () => {
+    // stdin is transpiled with the tsx loader, so only a .tsx file agrees with
+    // it on the rest of the cache key.
+    const filler = "\n//" + Buffer.alloc(5 * 1024, "f").toString();
+    const cjs = `console.log("ran", typeof module.exports);\nmodule.exports = { a: 1 };${filler}`;
+
+    async function bunRunStdin(code: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-"],
+        cwd: temp_dir,
+        env,
+        stdin: Buffer.from(code),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signalCode: proc.signalCode };
+    }
+
+    test("file first, then stdin", async () => {
+      writeFileSync(join(temp_dir, "a.tsx"), cjs);
+      expect(await bunRun(join(temp_dir, "a.tsx"), env)).toSpawn("ran object");
+      expect(newCacheCount()).toBe(1);
+
+      // Served the wrapped output, the script evaluates to a function that is
+      // never called and prints nothing.
+      expect(await bunRunStdin(cjs)).toSpawn("ran object");
+      expect(newCacheCount()).toBe(0); // different features hash: deleted + written
+
+      expect(await bunRunStdin(cjs)).toSpawn("ran object");
+      expect(newCacheCount()).toBe(0); // cache hit
+    });
+
+    test("stdin first, then file", async () => {
+      writeFileSync(join(temp_dir, "a.tsx"), cjs);
+      expect(await bunRunStdin(cjs)).toSpawn("ran object");
+      expect(newCacheCount()).toBe(1);
+
+      // Served the unwrapped output, the file run has no `module` binding and
+      // fails with "ReferenceError: module is not defined".
+      expect(await bunRun(join(temp_dir, "a.tsx"), env)).toSpawn("ran object");
+      expect(newCacheCount()).toBe(0);
+
+      expect(await bunRun(join(temp_dir, "a.tsx"), env)).toSpawn("ran object");
+      expect(newCacheCount()).toBe(0);
+    });
+  });
+
   // Serving the entry point from the cache must not change how the modules it
   // loads are resolved. Both of these are gated on the `has_loaded` flag, which
   // used to be set only on the path that runs the printer.


### PR DESCRIPTION
### Problem
- With the transpiler cache on, `bun a.tsx` then `bun - < a.tsx` (same CommonJS bytes, 4 KiB or more) prints nothing and exits 0. In the other order `bun a.tsx` fails with `ReferenceError: module is not defined`. Reproduces on 1.4.1 and main.
- The stdin and `-e` entry point is transpiled with `remove_cjs_module_wrapper` (`src/jsc/RuntimeTranspilerStore.rs:826`), which drops the CommonJS wrapper (`src/js_parser/p.rs:8209`). `Features::hash_for_runtime_transpiler` (`src/js_parser/parser.rs:355`) skips the flag, so both transpiles share one cache key.

### Fix
- `remove_cjs_module_wrapper` joins the hashed feature bools, and `EXPECTED_VERSION` moves from 27 to 28 as with every earlier change to the hash inputs.
- Cost: one re-transpile when the same bytes switch modes, the same delete-and-rewrite as a `--feature` change.
- Verified: two new tests in `test/cli/run/transpiler-cache.test.ts` (both orders), both fail on the released binary. The rest of that file, `run-eval.test.ts` and regression tests 28159, 30887, 32686 pass.

### Background
- The runtime transpiler cache (`src/jsc/RuntimeTranspilerCache.rs`) keys transpiled output by a hash of the source bytes plus a features hash of the options that change the output. A features hash mismatch deletes the entry and re-transpiles.
- A CommonJS file is printed as `(function(exports, require, module, __filename, __dirname) {...})` and the loader calls that function. The eval entry point gets `module`, `exports` and `require` as globals and runs as a plain script, so the wrapper must be absent.
- stdin and `-e` use the `tsx` loader (`src/bundler/options.rs:508`), which is part of the key. Only a `.tsx` file of the same bytes collides.

<details><summary>Notes</summary>

Repro on the released binary (`cjsbig.tsx` is `console.log("ran", typeof module); module.exports = {}` plus 5 KiB of comments):

```
export BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/tc
bun cjsbig.tsx          # ran object
bun - < cjsbig.tsx      # (nothing), exit 0
rm -rf tc
bun - < cjsbig.tsx      # ran object
bun cjsbig.tsx          # ran undefined, then ReferenceError: module is not defined
```

Both runs write the same `.pile` file name (same input hash) with the same features hash. The second run reads the first run's output. In the first order the wrapper function is evaluated and never called. In the second order the unwrapped statements run without a `module` binding.

The evaluation paths are both in `evaluateCommonJSModuleOnce` (`src/jsc/bindings/JSCommonJSModule.cpp`). The eval entry branch is selected by `Bun__VM__specifierIsEvalEntryPoint`. The sync transpile path sets the same flag in `src/runtime/jsc_hooks.rs:2666`.

A `.js` file does not collide: stdin is transpiled as `tsx`, and `ParserOptions::hash_for_runtime_transpiler` hashes the `ts` flag and the JSX options, so the `.js` entry already had another features hash and was replaced, not served.

Debug build sequence with the fix (`BUN_DEBUG_cache=1`): file run writes, file run again `restored`, stdin run `MismatchedFeatureHash` then write, stdin run again `restored`, file run `MismatchedFeatureHash` then write.

Why key the flag and not disable the cache for the eval entry: the features hash is where every other output-affecting switch is keyed, and a large piped script still benefits from a hit on a repeat run.

Related open PRs that touch the same list or the version constant:

- #40838 carries the same one-line change and the same version bump as a side change of a larger directive-prologue change. Whichever lands first, the other drops its copy on rebase.
- #40971 (define table) also moves the version to 28. The second to land renumbers to 29.
- #38683 adds `is_macro_runtime` to the same list for the macro-mode collision. It is not included here.

`hash_for_runtime_transpiler` lists the hashed fields by hand. An exhaustive destructure of `Features` would turn a missing field into a compile error. Not done here, since three open PRs add a line to this list.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->