### PR TITLE
bun:test: cover the isArray() exception checks for Proxy values in expect matchers

### DIFF
--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -677,6 +677,39 @@ describe("expect()", () => {
         expect(p1).toStrictEqual(p2);
       }
     });
+
+    // JSC::isArray() can throw for a Proxy (revoked, or with a throwing trap), so
+    // expect.any(Array), toMatchObject, and toHaveProperty must check for an
+    // exception right after it. A missing check aborts a debug build under
+    // BUN_JSC_validateExceptionChecks=1 (a no-op on release builds).
+    test("expect.any(Array)/toMatchObject/toHaveProperty check the isArray() exception for Proxy values", async () => {
+      const { bunEnv, bunExe } = require("harness");
+      const src = `
+        const { expect } = require("bun:test");
+        try { expect(new Proxy({}, {})).toEqual(expect.any(Array)); } catch {}
+        try { expect(new Proxy([], {})).toEqual(expect.any(Array)); } catch {}
+        try { expect(new Proxy([], {})).toMatchObject([]); } catch {}
+        try { expect([]).toMatchObject(new Proxy([], {})); } catch {}
+        try { expect(new Proxy([], {})).toMatchObject(new Proxy([], {})); } catch {}
+        try { expect({ a: 1 }).toHaveProperty(new Proxy(["a"], {})); } catch {}
+        try { expect({ a: 1 }).toHaveProperty(new Proxy(new Set(["a"]), {})); } catch {}
+        const rp = Proxy.revocable({}, {}); rp.revoke();
+        try { expect(rp.proxy).toEqual(expect.any(Array)); } catch {}
+        console.log("ok");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toMatchObject({
+        stdout: "ok\n",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
   }
 
   test("deepEquals works with sets/maps/dates/strings", () => {


### PR DESCRIPTION
### Problem
- #40068 (3ee980151d) added exception checks after `JSC::isArray()` at three call sites in `src/jsc/bindings/bindings.cpp`: `expect.any(Array)` (`matchAsymmetricMatcherAndGetFlags`), `toMatchObject` (`Bun__deepMatch`), and `toHaveProperty` with an array path (`JSC__JSValue__getIfPropertyExistsFromPath`).
- That PR added a test only for `mockResolvedValue`. Nothing in the tree runs these three matchers with a Proxy under `BUN_JSC_validateExceptionChecks=1`. A future edit can drop one of the checks and no test fails.
- Without a check, a debug build aborts with `ERROR: Unchecked JS exception: This scope can throw a JS exception: isArraySlowInline @ JavaScriptCore/runtime/ArrayConstructor.cpp ... ASSERTION FAILED: exception check validation failed`.

### Fix
- Test only. It carries the test from #34753 into `test/js/bun/test/expect.test.js`. #34753 fixed the same three sites and is closed as superseded by #40068.
- The test spawns a child with `BUN_JSC_validateExceptionChecks=1`. The child runs each matcher with transparent and revoked Proxy values and prints `ok`. The test asserts `stdout`, `exitCode` 0, and no signal. On a release build the option is a no-op and the child exits 0.
- Verified: `bun bd test test/js/bun/test/expect.test.js -t isArray` passes on main. With the three checks removed from `bindings.cpp` and rebuilt, the same test fails with `exitCode: 134, signalCode: SIGABRT` and the abort message above. The full file passes (416 pass, 2 todo).

### Background
- `JSC::isArray()` follows the `Array.isArray` spec. For a Proxy it walks to the target and throws a `TypeError` if the Proxy is revoked. So it declares a throw scope, and the caller must check for an exception before the next JSC call.
- `BUN_JSC_validateExceptionChecks=1` makes a debug JSC assert when a throw scope is left unchecked. It is the tool that finds these sites. Release builds ignore it.
- The test lives inside the `if (isBun)` block and reads `harness` with `require` inside the test body. This file also runs under Jest and Vitest, and the existing `test("()")` uses the same pattern for that reason.

<details><summary>Notes</summary>

Fail-before run on main with the three `RETURN_IF_EXCEPTION` lines after `isArray()` removed from `bindings.cpp`:

```
error: expect(received).toMatchObject(expected)
+   "exitCode": 134,
+   "signalCode": "SIGABRT",
+   "stderr":
+ "ERROR: Unchecked JS exception:
+     This scope can throw a JS exception: isArraySlowInline @ vendor/WebKit/Source/JavaScriptCore/runtime/ArrayConstructor.cpp:130
+     But the exception was unchecked as of this scope: hasInstance @ vendor/WebKit/Source/JavaScriptCore/runtime/JSObject.cpp:2686
+ ASSERTION FAILED: exception check validation failed
```

Pass-after on main as is: `1 pass, 417 filtered out`.

The three repro snippets from #34753 also run without the abort on main under `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1`:

```js
expect(new Proxy({}, {})).toEqual(expect.any(Array));
expect(new Proxy([], {})).toMatchObject([]);
expect({ a: 1 }).toHaveProperty(new Proxy(new Set(["a"]), {}));
```

Each throws the normal matcher failure and the process exits 0.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/test/expect.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/test/expect.test.js
bun test v1.4.1 (d578a8c70)

test/js/bun/test/expect.test.js:
(pass) expect() > () [302.05ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [1.56ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.44ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.26ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.23ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.23ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.27ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [2.35ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.50ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.29ms]
(pass) expect() > toBe() > expect(1).toBe(2) == false [0.32ms]
(pass) expect() > toBe() > expect(1).toBe(true) == false [0.30ms]
(pass) expect() > toBe() > expect(1).toBe("1") == false [0.45ms]
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false [0.31ms]
(pass) expect() > toBe() > expect("foo").toBe("Foo") == false [0.30ms]
(pass) expect() > toBe() > expect("foo").toBe("bar") == false [0.29ms]
(pass) expect() > toBe() > expect("").toBe(" ") == false [0.33ms]
(pass) expect() > toBe() > expect("").toBe(" ") == false [0.29ms]
(pass) expect() > toBe() > expect("").toBe(true) == false [0.29ms]
(pass) expect() > toBe() > expect({}).toBe({}) == false [0.31ms]
(pass) expect() > toBe() > expect(Set {}).toBe(Set {}) == false [0.29ms]
(pass) expect() > toBe() > expect([Function: a]).toBe([Function: a]) == false [0.31ms]
(pass) expect() > toBe() > e
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/test/expect.test.js | 33 +++++++++++++++++++++++++++++++++
 1 file changed, 33 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
test/js/bun/test/expect.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->