### PR TITLE
fetch: anchor a relative unix socket path to the cwd at call time

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -90,20 +90,10 @@ fn ssl_config_intern_for_http(config: SSLConfig) -> http::ssl_config::SharedPtr 
     http::ssl_config::global_registry::intern(config)
 }
 
-/// The HTTP thread connects to the `unix` path later, and the keep-alive pool
-/// keys the connection on that path. A relative path is anchored to `cwd`
-/// here, on the JS thread, so it names one socket: a `process.chdir()` after
-/// this `fetch()` neither moves the connect target nor lets the pool hand back
-/// a connection to a same-named socket in another directory.
-///
-/// The join does not normalize. `connect(2)` resolves `..` after following a
-/// symlink, `path.resolve` collapses it first, and the socket must stay the one
-/// the kernel would have picked from `cwd`.
-///
-/// Windows keeps the path as given: `sun_path` holds 108 bytes and, unlike the
-/// Linux and macOS paths in `bsd.c`, Windows has no fallback for a longer one.
+/// The HTTP thread connects to the `unix` path later and the keep-alive pool
+/// keys on it, so a relative path is anchored to `cwd` at call time, unnormalized.
 fn absolute_unix_socket_path(cwd: &[u8], path: Vec<u8>) -> Box<[u8]> {
-    // Linux abstract-namespace sockets start with NUL and are not paths.
+    // Windows: bsd.c has no long-path fallback. Leading NUL: Linux abstract socket.
     if cfg!(windows) || path.first() == Some(&0) || bun_paths::is_absolute(&path) {
         return path.into_boxed_slice();
     }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -99,9 +99,12 @@ fn ssl_config_intern_for_http(config: SSLConfig) -> http::ssl_config::SharedPtr 
 /// The join does not normalize. `connect(2)` resolves `..` after following a
 /// symlink, `path.resolve` collapses it first, and the socket must stay the one
 /// the kernel would have picked from `cwd`.
+///
+/// Windows keeps the path as given: `sun_path` holds 108 bytes and, unlike the
+/// Linux and macOS paths in `bsd.c`, Windows has no fallback for a longer one.
 fn absolute_unix_socket_path(cwd: &[u8], path: Vec<u8>) -> Box<[u8]> {
     // Linux abstract-namespace sockets start with NUL and are not paths.
-    if path.first() == Some(&0) || bun_paths::is_absolute(&path) {
+    if cfg!(windows) || path.first() == Some(&0) || bun_paths::is_absolute(&path) {
         return path.into_boxed_slice();
     }
     bun_paths::join_sep_maybe_z::<false>(&[cwd, &path])

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -90,6 +90,23 @@ fn ssl_config_intern_for_http(config: SSLConfig) -> http::ssl_config::SharedPtr 
     http::ssl_config::global_registry::intern(config)
 }
 
+/// The HTTP thread connects to the `unix` path later, and the keep-alive pool
+/// keys the connection on that path. A relative path is anchored to `cwd`
+/// here, on the JS thread, so it names one socket: a `process.chdir()` after
+/// this `fetch()` neither moves the connect target nor lets the pool hand back
+/// a connection to a same-named socket in another directory.
+///
+/// The join does not normalize. `connect(2)` resolves `..` after following a
+/// symlink, `path.resolve` collapses it first, and the socket must stay the one
+/// the kernel would have picked from `cwd`.
+fn absolute_unix_socket_path(cwd: &[u8], path: Vec<u8>) -> Box<[u8]> {
+    // Linux abstract-namespace sockets start with NUL and are not paths.
+    if path.first() == Some(&0) || bun_paths::is_absolute(&path) {
+        return path.into_boxed_slice();
+    }
+    bun_paths::join_sep_maybe_z::<false>(&[cwd, &path])
+}
+
 /// Build the refcounted `bun_s3_signing::S3Credentials` from the lower-tier
 /// `bun_dotenv::S3Credentials` POD mirror. The dotenv crate (T2) cannot name
 /// `bun_s3_signing` types (would be an upward dep), so the conversion lives at
@@ -688,10 +705,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             if !obj.is_empty() {
                 if let Some(socket_path) = obj.get(global_this, "unix")? {
                     if socket_path.is_string() && socket_path.get_length(ctx)? > 0 {
-                        break 'extract_unix_socket_path socket_path
-                            .to_bun_string(global_this)?
-                            .to_owned_slice()
-                            .into_boxed_slice();
+                        break 'extract_unix_socket_path absolute_unix_socket_path(
+                            vm.top_level_dir(),
+                            socket_path.to_bun_string(global_this)?.to_owned_slice(),
+                        );
                     }
                 }
             }

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -327,6 +327,49 @@ it.skipIf(isWindows)("keep-alive pool is keyed by socket path", async () => {
   }
 });
 
+it.skipIf(isWindows)("a relative socket path is resolved against the cwd at fetch() time", async () => {
+  // Two servers listen on `x.sock` in different directories. The child starts
+  // in `a`. The first fetch is still in flight when the cwd moves to `b`, so
+  // its answer shows which cwd the connect used. The later fetches show the
+  // pool key: keyed on the bare string, `x.sock` in `b` would reuse the
+  // connection to `a`.
+  using dir = tempDir("fetch-unix-relative", { a: {}, b: {} });
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const base = process.env.FETCH_UNIX_BASE;
+      const servers = ["a", "b"].map(name =>
+        Bun.serve({ unix: base + "/" + name + "/x.sock", fetch: () => new Response(name) }),
+      );
+      const get = unix => fetch("http://localhost/x", { unix }).then(res => res.text());
+      const bodies = [];
+      const inflight = get("x.sock");
+      process.chdir(base + "/b");
+      bodies.push(await inflight);
+      bodies.push(await get("x.sock"));
+      bodies.push(await get("./x.sock"));
+      bodies.push(await get("../a/x.sock"));
+      for (const name of ["a", "b"]) {
+        process.chdir(base + "/" + name);
+        bodies.push(await get("x.sock"));
+      }
+      console.log(JSON.stringify(bodies));
+      for (const server of servers) server.stop(true);
+      `,
+    ],
+    env: { ...bunEnv, FETCH_UNIX_BASE: String(dir) },
+    cwd: join(String(dir), "a"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual(["a", "b", "b", "a", "a", "b"]);
+  expect(exitCode).toBe(0);
+});
+
 it.skipIf(isWindows)("TLS over a unix socket is only reused for the hostname the handshake verified", async () => {
   using dir = tempDir("fetch-unix-tls", { "ca.pem": tls.cert });
   // The harness cert is valid for "localhost". A pooled connection verified


### PR DESCRIPTION
### Problem
- `fetch(url, { unix: "x.sock" })`, `process.chdir()` to a directory with its own `x.sock`, the same `fetch()` again: the second request rides the pooled connection to the first server. Main prints `A`, `A`. bun 1.4.1 prints `A`, `B`. The unix pool is new since #34079 and in no release.
- The pool keys a unix entry on the path bytes as passed (`src/http/HTTPContext.rs:640`). `fetch.rs` copies the `unix` string verbatim and the HTTP thread calls `connect(2)` with it later, against the cwd of that moment. A `chdir()` right after `fetch()` also moves the connect target, in every release.

### Fix
- `absolute_unix_socket_path` (`src/runtime/webcore/fetch.rs`) joins a relative `unix` path onto the cached cwd (`vm.top_level_dir()`, updated by `process.chdir()`) inside `fetch()`. No syscall. Absolute paths and Linux abstract names (leading NUL) pass through.
- The join is a plain concatenation with the native separator and no lexical `..` collapse, so `connect(2)` reaches the socket the kernel would pick from that cwd.
- Cost: a longer path. Linux and macOS connect it through the `bsd.c` long-path workarounds. Windows has none, so on Windows the path stays as given and this change is a no-op there (Notes).
- Verified: `test/js/web/fetch/fetch.unix.test.ts`, new test `a relative socket path is resolved against the cwd at fetch() time`: fails on main and on 1.4.1, passes with the fix (13 of 13 runs). Also `fetch-keepalive`, `fetch-tcp-keepalive`, `fetch-args`, `fetch.tls`, regression 23621, 24385, 28159.

### Background
- A unix socket address is a filesystem path. `connect(2)` resolves a relative one against the process cwd at the moment of the call. In bun that call runs on the HTTP thread, after `fetch()` has returned.
- The keep-alive pool (`HTTPContext::release_socket`, `existing_socket`) parks an idle connection after a response and reuses it for the next request with an equal key. For unix that key is the path plus TLS state, for TCP `host:port`.

<details><summary>Notes</summary>

Repro (from the fuzz report):

```js
import net from "node:net";
import fs from "node:fs";
import os from "node:os";
const base = fs.mkdtempSync(os.tmpdir() + "/unixpool-");
const mk = (dir, name) => new Promise(ok => { fs.mkdirSync(dir);
  const srv = net.createServer(c => { let b = ""; c.on("data", d => { b += d;
    if (b.includes("\r\n\r\n")) { b = ""; c.write(`HTTP/1.1 200 OK\r\nContent-Length: ${name.length}\r\n\r\n${name}`); } }); });
  srv.listen(dir + "/x.sock", () => ok(srv)); });
await mk(base + "/a", "A"); await mk(base + "/b", "B");
process.chdir(base + "/a");
console.log("cwd=a:", await (await fetch("http://h/", { unix: "x.sock" })).text());
process.chdir(base + "/b");
console.log("cwd=b:", await (await fetch("http://h/", { unix: "x.sock" })).text());
```

Main debug build: `cwd=a: A`, `cwd=b: A`. With this change: `cwd=a: A`, `cwd=b: B`.

What the test covers:

- The first fetch of the child is still in flight when the cwd moves from `a` to `b`. It answers `a` with the fix. Without it the HTTP thread connects after the `chdir()` and answers `b` (20 of 20 runs on a pre-fix build).
- The startup cwd (no trailing separator in the cached value) and the cwd after `process.chdir()` (trailing separator) both feed the join.
- `./x.sock` and `../a/x.sock` connect to the right socket. They are distinct pool keys from `x.sock`. That is the same over-splitting as `/./` and `//` spellings of an absolute path today, and it is the safe direction.

Design notes:

- `fetch()` is the only producer of `unix_socket_path` for the pooled client. `Bun.connect`, `Bun.serve` and the WebSocket client take a unix path verbatim, but they connect on the JS thread with no pool, so they are unchanged.
- Resolving on the JS thread, instead of adding the cwd to the pool key on the HTTP thread, leaves the pool code untouched and also fixes the connect target. The HTTP thread only sees the cwd at connect time.
- The cwd is the cached `top_level_dir` of the resolver `FileSystem`. `VirtualMachine::set_process_cwd` (the `process.chdir()` path) rewrites it after each successful `chdir`. `Bun.mmap`, `fs.watch` and `fetch("file:...")` resolve relative paths against the same value.
- No lexical normalization. `path.resolve` semantics would collapse `link/../x.sock` to `x.sock`, while the kernel follows `link` first.

Path length:

- `sun_path` is 108 bytes on Linux and Windows, 104 on macOS. `packages/bun-usockets/src/bsd.c` connects a longer path on Linux through `/proc/self/fd/N/<basename>` (one `open(O_PATH)` and `close` per new connection) and on macOS through `__pthread_fchdir` into the parent directory. Both need the basename to fit. On Linux the `/proc` prefix leaves about 88 bytes for it, so a relative basename of 89 to 107 bytes that connected before now fails with `FailedToOpenSocket`. Measured: 95, 100 and 107 byte names fail on this branch and connect on 1.4.1.
- Windows has no workaround, and a joined path of 108 bytes or more would fail with `ENAMETOOLONG` where the relative spelling connected before. So `absolute_unix_socket_path` returns the path as given on Windows (`cfg!(windows)`). The pool key stays the relative string there, with the cwd behavior this PR fixes on POSIX. A length-based fallback to the relative spelling on all platforms was considered and rejected: on Linux and macOS the workarounds make the joined path connect, so such a fallback would silently disable this fix for deep cwds on the platforms where unix sockets are common. The new test is `skipIf(isWindows)` like the other keep-alive tests in the file, because `net.createServer(path)` on Windows is a named pipe.
- The pool key has its own ceiling. `PooledSocket` stores the key in a 128 byte inline buffer (`MAX_KEEPALIVE_HOSTNAME`, `src/http/HTTPContext.rs:23`), and `release_socket` closes instead of parks a socket whose key is longer. A joined path over 128 bytes therefore connects (through the workarounds above) but is not pooled. Absolute unix paths over 128 bytes behave the same on main today. A heap-allocated key for `Transport::Unix` would lift this. It is a pool change and is left out of this PR.

Related, not in this PR:

- `tls.caFile`, `tls.certFile`, `tls.keyFile` have the same shape. `SSLConfig::handle_path` (`src/runtime/socket/SSLConfig.rs:294`) stores the relative string after an `access()` probe, BoringSSL opens it on the HTTP thread against the cwd at connect time, and the SSL_CTX cache (`src/http/HTTPThread.rs:403`) keys on the interned string for 30 minutes. A relative `caFile` after `process.chdir()` can reuse an SSL_CTX built from another directory's CA. That path predates #34079 and serves every TLS option parser, so it is left for a separate PR.
- #37002 rejects interior NUL bytes in unix paths and touches the same lines in `fetch.rs`. The abstract-name check here (leading NUL) and its helper should be shared by whichever lands second.
- The repro script keeps running after the second fetch: the pooled connection to server A keeps `net.Server.close()` waiting until the 5 minute idle timeout. TCP keep-alive behaves the same.
- `test/js/web/fetch/fetch.test.ts` has failures in this container on both main and this branch (`[::]` IPv6 listeners, public HTTPS hosts, permission tests as root, utf16 GC tests). None involve unix sockets.

Self-review: 4 concerns raised, 3 addressed (test coverage of the in-flight connect, both cwd shapes and dot segments; the TLS sibling and the #37002 overlap written up above). Rejected: a relative-path fallback for the `sun_path` limit, for the reason given under Path length.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.unix.test.ts

<!-- robobun:evidence:end -->