### PR TITLE
Bump WebKit (oven-sh/WebKit#540 preview): JSON.stringify fails fast on cyclic values

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "d71031a973e6f8838a1b10282dbe332ff012f04a";
+export const WEBKIT_VERSION = "autobuild-preview-pr-540-d48b6a68";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/json-stringify-cyclic-depth-limit.js
+++ b/test/js/bun/jsc-stress/fixtures/json-stringify-cyclic-depth-limit.js
@@ -1,0 +1,89 @@
+// The DynamicBuffer FastStringifier bails to the general Stringifier past a
+// depth limit, so a cyclic value is rejected after bounded work instead of
+// growing the buffer toward the 2GB string length limit. This test checks the
+// behavior around that limit: cycles still throw TypeError, and values nested
+// deeper than the limit still stringify correctly through the general path.
+
+function shouldThrowTypeError(fn) {
+    let threw = null;
+    try {
+        fn();
+    } catch (e) {
+        threw = e;
+    }
+    if (!(threw instanceof TypeError))
+        throw new Error("expected TypeError, got " + threw);
+}
+
+function makeCyclicObject(keys) {
+    const o = {};
+    for (let i = 0; i < keys; i++)
+        o["k" + i] = "y".repeat(50);
+    o.self = o;
+    return o;
+}
+
+// A payload large enough that the StaticBuffer attempt fails with BufferFull
+// and the DynamicBuffer attempt runs.
+const bigPayload = "y".repeat(10 * 1024);
+
+// Cyclic values throw, flat and with a gap, through objects and arrays, for
+// direct and indirect cycles.
+for (const space of [undefined, 2, "\t"]) {
+    for (const keys of [0, 8])
+        shouldThrowTypeError(() => JSON.stringify(makeCyclicObject(keys), null, space));
+
+    shouldThrowTypeError(() => JSON.stringify([makeCyclicObject(1)], null, space));
+
+    const selfArray = [1];
+    selfArray.push(selfArray);
+    shouldThrowTypeError(() => JSON.stringify(selfArray, null, space));
+}
+
+// Cycles that carry a large payload per revolution.
+for (const space of [undefined, 2]) {
+    const a = { payload: bigPayload };
+    const b = { a };
+    a.b = b;
+    shouldThrowTypeError(() => JSON.stringify(a, null, space));
+
+    const direct = { payload: bigPayload };
+    direct.self = direct;
+    shouldThrowTypeError(() => JSON.stringify(direct, null, space));
+}
+
+// Acyclic values nested deeper than any reasonable fast path depth limit
+// round-trip correctly, flat and with a gap, for objects and arrays, with
+// 8-bit and 16-bit content.
+for (const space of [undefined, 1]) {
+    for (const leafValue of ["eight-bit", "sixte\u00e9n-bit \u2603"]) {
+        const depth = 1000;
+
+        let root = {};
+        let node = root;
+        for (let i = 0; i < depth; i++)
+            node = node.x = {};
+        node.leaf = leafValue;
+        let parsed = JSON.parse(JSON.stringify(root, null, space));
+        let p = parsed;
+        for (let i = 0; i < depth; i++)
+            p = p.x;
+        if (p.leaf !== leafValue)
+            throw new Error("deep object round-trip broken for space=" + space);
+
+        let arrayRoot = [];
+        let arrayNode = arrayRoot;
+        for (let i = 0; i < depth; i++) {
+            const next = [];
+            arrayNode.push(next);
+            arrayNode = next;
+        }
+        arrayNode.push(leafValue);
+        parsed = JSON.parse(JSON.stringify(arrayRoot, null, space));
+        p = parsed;
+        for (let i = 0; i < depth; i++)
+            p = p[p.length - 1];
+        if (p[0] !== leafValue)
+            throw new Error("deep array round-trip broken for space=" + space);
+    }
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Runtime
+  "json-stringify-cyclic-depth-limit.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/jsc/json-stringify-cyclic.test.ts
+++ b/test/js/bun/jsc/json-stringify-cyclic.test.ts
@@ -61,7 +61,6 @@ test("JSON.stringify on a cyclic value throws with bounded memory (#40974)", asy
     for (let i = 0; i < 1000; i++) q = q[q.length - 1];
     results.deepArrayLeaf = q[0];
 
-    results.rssMB = Math.round(process.memoryUsage().rss / 1024 / 1024);
     console.log(JSON.stringify(results));
   `;
   await using proc = Bun.spawn({
@@ -71,7 +70,7 @@ test("JSON.stringify on a cyclic value throws with bounded memory (#40974)", asy
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const { rssMB, ...results } = JSON.parse(stdout);
+  const results = JSON.parse(stdout);
   expect(results).toEqual({
     objFlat: "TypeError",
     objIndent: "TypeError",
@@ -82,10 +81,11 @@ test("JSON.stringify on a cyclic value throws with bounded memory (#40974)", asy
     deepObjectLeaf: 1,
     deepArrayLeaf: "leaf",
   });
-  // Unfixed, the indented object call alone grows RSS past 2GB (the fast
-  // path's buffer doubles up to the 2GB string length limit before it gives
-  // up). Fixed, a debug ASAN build measures ~350MB and a release build far
-  // less, so both bounds keep plenty of margin on each side.
-  expect(rssMB).toBeLessThan(isASAN || isDebug ? 1024 : 512);
+  // Unfixed, the indented object call alone grows the child past 2GB (the
+  // fast path's buffer doubles up to the 2GB string length limit before it
+  // gives up). Fixed, a debug ASAN build peaks around 350MB and a release
+  // build far less, so both bounds keep plenty of margin on each side.
+  const maxRSSMB = proc.resourceUsage()!.maxRSS / 1024 / 1024;
+  expect(maxRSSMB).toBeLessThan(isASAN || isDebug ? 1024 : 512);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/json-stringify-cyclic.test.ts
+++ b/test/js/bun/jsc/json-stringify-cyclic.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/40974
+// JSON.stringify on a cyclic value must throw the TypeError after bounded
+// work. The JSC fast stringifier used to re-serialize the cycle until it hit
+// the 2GB string length limit when an indent is passed: about 2GB of RSS and
+// over a second of one thread per call. The fix (oven-sh/WebKit#540) bails the
+// fast path past a depth limit, so the general Stringifier detects the cycle
+// at once.
+test("JSON.stringify on a cyclic value throws with bounded memory (#40974)", async () => {
+  const code = `
+    const throwType = fn => {
+      try {
+        fn();
+        return null;
+      } catch (e) {
+        return e.constructor.name;
+      }
+    };
+
+    const o = {};
+    for (let i = 0; i < 8; i++) o["k" + i] = "y".repeat(50);
+    o.self = o;
+
+    const arr = [1];
+    arr.push(arr);
+
+    const a = { name: "a" };
+    const b = { a };
+    a.b = b; // indirect cycle a -> b -> a
+
+    const results = {
+      objFlat: throwType(() => JSON.stringify(o)),
+      objIndent: throwType(() => JSON.stringify(o, null, 2)),
+      arrFlat: throwType(() => JSON.stringify(arr)),
+      arrIndent: throwType(() => JSON.stringify(arr, null, 2)),
+      indirectIndent: throwType(() => JSON.stringify(a, null, "\\t")),
+      mixedIndent: throwType(() => JSON.stringify([{ wrap: o }], null, 2)),
+    };
+
+    // Deep acyclic values past any fast-path depth limit still round-trip.
+    let deep = {};
+    let node = deep;
+    for (let i = 0; i < 1000; i++) node = node.x = {};
+    node.leaf = 1;
+    let p = JSON.parse(JSON.stringify(deep, null, 2));
+    for (let i = 0; i < 1000; i++) p = p.x;
+    results.deepObjectLeaf = p.leaf;
+
+    let deepArray = [];
+    let arrayNode = deepArray;
+    for (let i = 0; i < 1000; i++) {
+      const next = [];
+      arrayNode.push(next);
+      arrayNode = next;
+    }
+    arrayNode.push("leaf");
+    let q = JSON.parse(JSON.stringify(deepArray, null, 2));
+    for (let i = 0; i < 1000; i++) q = q[q.length - 1];
+    results.deepArrayLeaf = q[0];
+
+    results.rssMB = Math.round(process.memoryUsage().rss / 1024 / 1024);
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { rssMB, ...results } = JSON.parse(stdout);
+  expect(results).toEqual({
+    objFlat: "TypeError",
+    objIndent: "TypeError",
+    arrFlat: "TypeError",
+    arrIndent: "TypeError",
+    indirectIndent: "TypeError",
+    mixedIndent: "TypeError",
+    deepObjectLeaf: 1,
+    deepArrayLeaf: "leaf",
+  });
+  // Unfixed, the indented object call alone grows RSS past 2GB (the fast
+  // path's buffer doubles up to the 2GB string length limit before it gives
+  // up). Fixed, the whole process stays far below this in every build config.
+  expect(rssMB).toBeLessThan(1024);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/jsc/json-stringify-cyclic.test.ts
+++ b/test/js/bun/jsc/json-stringify-cyclic.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
 // https://github.com/oven-sh/bun/issues/40974
 // JSON.stringify on a cyclic value must throw the TypeError after bounded
@@ -84,7 +84,8 @@ test("JSON.stringify on a cyclic value throws with bounded memory (#40974)", asy
   });
   // Unfixed, the indented object call alone grows RSS past 2GB (the fast
   // path's buffer doubles up to the 2GB string length limit before it gives
-  // up). Fixed, the whole process stays far below this in every build config.
-  expect(rssMB).toBeLessThan(1024);
+  // up). Fixed, a debug ASAN build measures ~350MB and a release build far
+  // less, so both bounds keep plenty of margin on each side.
+  expect(rssMB).toBeLessThan(isASAN || isDebug ? 1024 : 512);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/json-stringify-cyclic.test.ts
+++ b/test/js/bun/jsc/json-stringify-cyclic.test.ts
@@ -19,8 +19,9 @@ test("JSON.stringify on a cyclic value throws with bounded memory (#40974)", asy
       }
     };
 
+    const payload = Buffer.alloc(50, "y").toString();
     const o = {};
-    for (let i = 0; i < 8; i++) o["k" + i] = "y".repeat(50);
+    for (let i = 0; i < 8; i++) o["k" + i] = payload;
     o.self = o;
 
     const arr = [1];


### PR DESCRIPTION
### Problem
- `JSON.stringify` on a cyclic value throws the right `TypeError` but takes ~4 ms flat and ~1.5 s with an indent, with ~2 GB of RSS per call (#40974). Node takes microseconds. Acyclic values are unaffected.
- The cause is JSC's `FastStringifier` (`JSONObject.cpp`). It has no depth or cycle check and counts on its buffer limit to catch cycles. In dynamic-buffer mode that limit is the 2 GB string length cap, so an indented cyclic value doubles the buffer up to 2 GB before the general `Stringifier` runs and throws.

### Fix
- oven-sh/WebKit#540 makes the dynamic-buffer fast path fail past a depth limit of 512. Deeper values, including every cycle, bail to the general `Stringifier`, which detects cycles at once and serializes any depth iteratively. jsc shell, x64 release: cyclic flat 3.15 to 0.13 ms/op, cyclic indent-2 1464 to 1.5 ms/op, acyclic and large-document perf unchanged (min-of-9 A/B).
- This PR pins `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-540-d48b6a68`, based on the current `d71031a973` pin) so CI runs Bun against it. Before landing, oven-sh/WebKit#540 has to merge and the pin has to move to the resulting main sha.
- Tests: `test/js/bun/jsc/json-stringify-cyclic.test.ts` spawns a child that exercises object, array, indirect, and mixed cycles, flat and indented, plus 1000-deep acyclic round-trips, and asserts RSS stays under 1 GB. Unfixed it reaches 2083 MB. `test/js/bun/jsc-stress/fixtures/json-stringify-cyclic-depth-limit.js` is the JSTests file from the WebKit PR, run in CI by `jsc-stress.test.ts`.
- Verified: both tests pass with the debug ASAN build on the preview, fail with `USE_SYSTEM_BUN=1`. Also green: all 117 jsc-stress fixtures, `test/js/bun/jsc/`, `test/js/bun/util/inspect.test.js`.
- Self-reviewed: 5 concerns raised, 4 addressed (CI coverage for the array branch, fixture wiring, reference placeholders). Rejected one: exact cycle detection to also cover cycles that carry multiple MB per revolution. Three designs all cost 7 to 53% on large acyclic stringifies, details in Notes.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit. `scripts/build/deps/webkit.ts` pins which build. An engine fix lands as a WebKit PR plus a pin bump here, and `autobuild-preview-pr-*` tags let the bump PR run Bun's suite against the WebKit PR before it merges.
- `FastStringifier` is JSC's no-side-effect fast path for `JSON.stringify`. It tries an 8 KB static buffer, retries with a growable buffer on overflow, and falls back to the general `Stringifier` on any failure. The general path keeps a holder stack and throws `TypeError` on the first revisit.

<details><summary>Notes</summary>

Residual: a cycle that carries several MB of payload per revolution still reaches the 2 GB cap within the 512-level limit (a 3 MB payload self-cycle takes ~1.5 s). I prototyped exact detection three ways: a `WTF::Vector` visit stack, a flat array, and stack-frame-linked chain nodes gated behind a depth threshold. Measured on a 19 MB indented stringify of 200k objects (min of 9): baseline 24.5 ms, chain design 37 ms (gcc) and 21.5 to 29.2 ms (clang). Any per-container work in `append()` disturbs the hot path, so the free depth limit ships and the fat-payload corner stays on the slow-but-correct path.

Repro numbers, Linux x64, this container: issue's benchmark under `USE_SYSTEM_BUN=1` bun 1.4.1: cyclic flat 4.18 ms/op, cyclic indent 1516 ms/op. Under the preview debug build the new test's child (six cyclic stringifies plus two 1000-deep round-trips) completes in ~700 ms total with RSS ~350 MB.

The stress fixture runs in three places: oven-sh/WebKit JSTests (local `run-jsc-stress-tests`, fork CI does not execute JSTests), Bun's `jsc-stress.test.ts` in CI, and upstream if the patch is submitted there. Upstream WebKit `main` has the identical pathology.
</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-stress.test.ts' 'test/js/bun/jsc/json-stringify-cyclic.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-stress.test.ts test/js/bun/jsc/json-stringify-cyclic.test.ts
bun test v1.4.1 (d578a8c70)

test/js/bun/jsc/json-stringify-cyclic.test.ts:
(pass) JSON.stringify on a cyclic value throws with bounded memory (#40974) [811.94ms]

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [324.49ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [337.75ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [333.81ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [449.82ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [431.21ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [318.53ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [345.41ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [346.59ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [399.60ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [412.92ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [315.75ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength.js [433.91ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val.js [454.10ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined.js [465.71ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined-and-not-inlined.js [485.59ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception.js [371.87ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-varargs-exception.js [361.54ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 .../fixtures/json-stringify-cyclic-depth-limit.js  | 89 +++++++++++++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts          |  2 +
 test/js/bun/jsc/json-stringify-cyclic.test.ts      | 91 ++++++++++++++++++++++
 4 files changed, 183 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  1      3      0
…sc-stress/fixtures/json-stringify-cyclic-depth-limit.js      0      0      0
test/js/bun/jsc-stress/jsc-stress.test.ts                     1      2      0
test/js/bun/jsc/json-stringify-cyclic.test.ts                 0      5      0
```

</details>

<!-- robobun:evidence:end -->