### PR TITLE
tls: resolve relative file paths at parse time and read them from Rust when the SSL_CTX is built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "bun_opaque",
  "bun_paths",
  "bun_ptr",
+ "bun_sys",
  "bun_windows_sys",
  "libc",
  "strum",

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1093,6 +1093,43 @@ static int us_install_ca_buffers(SSL_CTX *ctx, X509_STORE *store, STACK_OF(CRYPT
   return ok;
 }
 
+/* The bytes of a `caFile`, loaded as the file loaders load the path: the
+ * client-CA list the way SSL_load_client_CA_file builds it, then the trust
+ * store the way X509_STORE_load_locations fills it (PEM_X509_INFO_read_bio:
+ * CERTIFICATE, TRUSTED CERTIFICATE and X509 CRL blocks, any corrupt block
+ * fails the whole file). */
+static enum create_bun_socket_error_t us_ssl_ctx_use_ca_file_content(SSL_CTX *ctx, const char *content) {
+  BIO *in = BIO_new_mem_buf(content, -1);
+  STACK_OF(X509_NAME) *ca_list = in ? sk_X509_NAME_new_null() : NULL;
+  int ok = ca_list && SSL_add_bio_cert_subjects_to_stack(ca_list, in) && sk_X509_NAME_num(ca_list) > 0;
+  BIO_free(in);
+  if (!ok) {
+    sk_X509_NAME_pop_free(ca_list, X509_NAME_free);
+    return CREATE_BUN_SOCKET_ERROR_LOAD_CA_FILE;
+  }
+  SSL_CTX_set_client_CA_list(ctx, ca_list);
+
+  in = BIO_new_mem_buf(content, -1);
+  STACK_OF(X509_INFO) *inf = in ? PEM_X509_INFO_read_bio(in, NULL, NULL, NULL) : NULL;
+  BIO_free(in);
+  if (!inf) return CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE;
+  X509_STORE *store = SSL_CTX_get_cert_store(ctx);
+  int count = 0;
+  for (size_t i = 0; ok && i < sk_X509_INFO_num(inf); i++) {
+    X509_INFO *itmp = sk_X509_INFO_value(inf, i);
+    if (itmp->x509) {
+      ok = X509_STORE_add_cert(store, itmp->x509);
+      count++;
+    }
+    if (ok && itmp->crl) {
+      ok = X509_STORE_add_crl(store, itmp->crl);
+      count++;
+    }
+  }
+  sk_X509_INFO_pop_free(inf, X509_INFO_free);
+  return ok && count > 0 ? CREATE_BUN_SOCKET_ERROR_NONE : CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE;
+}
+
 static int add_ca_cert_to_ctx_store(SSL_CTX *ctx, const char *content, X509_STORE *store) {
   X509 *x = NULL;
   ERR_clear_error();
@@ -1348,24 +1385,33 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
    * everywhere downstream — no special "owner" path. */
   ssl_ctx_drop_passphrase(ssl_context);
 
-  if (options.ca_file_name) {
+  if (options.ca_file || options.ca_file_name) {
     /* An explicit CA replaces the default trust store (Node.js semantics):
      * chains must validate exclusively against the supplied CAs. The SSL_CTX
-     * already owns a fresh, empty X509_STORE from SSL_CTX_new(), so
-     * SSL_CTX_load_verify_locations below populates only the user's CAs. */
-    STACK_OF(X509_NAME) *ca_list = SSL_load_client_CA_file(options.ca_file_name);
-    if (ca_list == NULL) {
-      *err = CREATE_BUN_SOCKET_ERROR_LOAD_CA_FILE;
-      ssl_ctx_build_fail(ssl_context);
-      return NULL;
-    }
-    SSL_CTX_set_client_CA_list(ssl_context, ca_list);
+     * already owns a fresh, empty X509_STORE from SSL_CTX_new(), so the loaders
+     * below populate only the user's CAs. */
     us_ex_idx_ensure();
     SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_ex_idx, (void *)1);
-    if (SSL_CTX_load_verify_locations(ssl_context, options.ca_file_name, NULL) != 1) {
-      *err = CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE;
-      ssl_ctx_build_fail(ssl_context);
-      return NULL;
+    if (options.ca_file) {
+      enum create_bun_socket_error_t ca_err = us_ssl_ctx_use_ca_file_content(ssl_context, options.ca_file);
+      if (ca_err != CREATE_BUN_SOCKET_ERROR_NONE) {
+        *err = ca_err;
+        ssl_ctx_build_fail(ssl_context);
+        return NULL;
+      }
+    } else {
+      STACK_OF(X509_NAME) *ca_list = SSL_load_client_CA_file(options.ca_file_name);
+      if (ca_list == NULL) {
+        *err = CREATE_BUN_SOCKET_ERROR_LOAD_CA_FILE;
+        ssl_ctx_build_fail(ssl_context);
+        return NULL;
+      }
+      SSL_CTX_set_client_CA_list(ssl_context, ca_list);
+      if (SSL_CTX_load_verify_locations(ssl_context, options.ca_file_name, NULL) != 1) {
+        *err = CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE;
+        ssl_ctx_build_fail(ssl_context);
+        return NULL;
+      }
     }
     SSL_CTX_set_verify(ssl_context,
         options.reject_unauthorized ? (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT)

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1410,15 +1410,23 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
     }
   }
 
-  if (options.dh_params_file_name) {
+  if (options.dh_params || options.dh_params_file_name) {
     DH *dh_2048 = NULL;
-    FILE *paramfile = fopen(options.dh_params_file_name, "r");
-    if (paramfile) {
-      dh_2048 = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
-      fclose(paramfile);
+    if (options.dh_params) {
+      BIO *params = BIO_new_mem_buf(options.dh_params, -1);
+      if (params) {
+        dh_2048 = PEM_read_bio_DHparams(params, NULL, NULL, NULL);
+        BIO_free(params);
+      }
     } else {
-      ssl_ctx_build_fail(ssl_context);
-      return NULL;
+      FILE *paramfile = fopen(options.dh_params_file_name, "r");
+      if (paramfile) {
+        dh_2048 = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
+        fclose(paramfile);
+      } else {
+        ssl_ctx_build_fail(ssl_context);
+        return NULL;
+      }
     }
     if (dh_2048 == NULL) {
       ssl_ctx_build_fail(ssl_context);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1101,7 +1101,14 @@ static int us_install_ca_buffers(SSL_CTX *ctx, X509_STORE *store, STACK_OF(CRYPT
 static enum create_bun_socket_error_t us_ssl_ctx_use_ca_file_content(SSL_CTX *ctx, const char *content) {
   BIO *in = BIO_new_mem_buf(content, -1);
   STACK_OF(X509_NAME) *ca_list = in ? sk_X509_NAME_new_null() : NULL;
-  int ok = ca_list && SSL_add_bio_cert_subjects_to_stack(ca_list, in) && sk_X509_NAME_num(ca_list) > 0;
+  /* Like SSL_load_client_CA_file, the first block must be a certificate and its
+   * PEM error stays on the queue for the caller; later PEM errors end the list. */
+  X509 *first = ca_list ? PEM_read_bio_X509(in, NULL, NULL, NULL) : NULL;
+  X509_NAME *name = first ? X509_NAME_dup(X509_get_subject_name(first)) : NULL;
+  X509_free(first);
+  int ok = name && sk_X509_NAME_push(ca_list, name);
+  if (!ok) X509_NAME_free(name);
+  ok = ok && SSL_add_bio_cert_subjects_to_stack(ca_list, in);
   BIO_free(in);
   if (!ok) {
     sk_X509_NAME_pop_free(ca_list, X509_NAME_free);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1093,50 +1093,6 @@ static int us_install_ca_buffers(SSL_CTX *ctx, X509_STORE *store, STACK_OF(CRYPT
   return ok;
 }
 
-/* The bytes of a `caFile`, loaded as the file loaders load the path: the
- * client-CA list the way SSL_load_client_CA_file builds it, then the trust
- * store the way X509_STORE_load_locations fills it (PEM_X509_INFO_read_bio:
- * CERTIFICATE, TRUSTED CERTIFICATE and X509 CRL blocks, any corrupt block
- * fails the whole file). */
-static enum create_bun_socket_error_t us_ssl_ctx_use_ca_file_content(SSL_CTX *ctx, const char *content) {
-  BIO *in = BIO_new_mem_buf(content, -1);
-  STACK_OF(X509_NAME) *ca_list = in ? sk_X509_NAME_new_null() : NULL;
-  /* Like SSL_load_client_CA_file, the first block must be a certificate and its
-   * PEM error stays on the queue for the caller; later PEM errors end the list. */
-  X509 *first = ca_list ? PEM_read_bio_X509(in, NULL, NULL, NULL) : NULL;
-  X509_NAME *name = first ? X509_NAME_dup(X509_get_subject_name(first)) : NULL;
-  X509_free(first);
-  int ok = name && sk_X509_NAME_push(ca_list, name);
-  if (!ok) X509_NAME_free(name);
-  ok = ok && SSL_add_bio_cert_subjects_to_stack(ca_list, in);
-  BIO_free(in);
-  if (!ok) {
-    sk_X509_NAME_pop_free(ca_list, X509_NAME_free);
-    return CREATE_BUN_SOCKET_ERROR_LOAD_CA_FILE;
-  }
-  SSL_CTX_set_client_CA_list(ctx, ca_list);
-
-  in = BIO_new_mem_buf(content, -1);
-  STACK_OF(X509_INFO) *inf = in ? PEM_X509_INFO_read_bio(in, NULL, NULL, NULL) : NULL;
-  BIO_free(in);
-  if (!inf) return CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE;
-  X509_STORE *store = SSL_CTX_get_cert_store(ctx);
-  int count = 0;
-  for (size_t i = 0; ok && i < sk_X509_INFO_num(inf); i++) {
-    X509_INFO *itmp = sk_X509_INFO_value(inf, i);
-    if (itmp->x509) {
-      ok = X509_STORE_add_cert(store, itmp->x509);
-      count++;
-    }
-    if (ok && itmp->crl) {
-      ok = X509_STORE_add_crl(store, itmp->crl);
-      count++;
-    }
-  }
-  sk_X509_INFO_pop_free(inf, X509_INFO_free);
-  return ok && count > 0 ? CREATE_BUN_SOCKET_ERROR_NONE : CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE;
-}
-
 static int add_ca_cert_to_ctx_store(SSL_CTX *ctx, const char *content, X509_STORE *store) {
   X509 *x = NULL;
   ERR_clear_error();
@@ -1346,8 +1302,7 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
    * KEY_TYPE_MISMATCH on a mixed configuration. With pair-wise loading the
    * later identity replaces the earlier one in the legacy slot, which is the
    * documented BoringSSL behaviour the adapted tests expect. */
-  int interleave_identities = !options.cert_file_name && !options.key_file_name &&
-                              options.cert && options.key &&
+  int interleave_identities = options.cert && options.key &&
                               options.cert_count == options.key_count &&
                               options.cert_count > 1;
   if (interleave_identities) {
@@ -1359,12 +1314,7 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
       }
     }
   } else {
-    if (options.cert_file_name) {
-      if (SSL_CTX_use_certificate_chain_file(ssl_context, options.cert_file_name) != 1) {
-        ssl_ctx_build_fail(ssl_context);
-        return NULL;
-      }
-    } else if (options.cert && options.cert_count > 0) {
+    if (options.cert && options.cert_count > 0) {
       for (unsigned int i = 0; i < options.cert_count; i++) {
         if (us_ssl_ctx_use_certificate_chain(ssl_context, options.cert[i]) != 1) {
           ssl_ctx_build_fail(ssl_context);
@@ -1373,12 +1323,7 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
       }
     }
 
-    if (options.key_file_name) {
-      if (SSL_CTX_use_PrivateKey_file(ssl_context, options.key_file_name, SSL_FILETYPE_PEM) != 1) {
-        ssl_ctx_build_fail(ssl_context);
-        return NULL;
-      }
-    } else if (options.key && options.key_count > 0) {
+    if (options.key && options.key_count > 0) {
       for (unsigned int i = 0; i < options.key_count; i++) {
         if (us_ssl_ctx_use_privatekey_content(ssl_context, options.key[i], SSL_FILETYPE_PEM) != 1) {
           ssl_ctx_build_fail(ssl_context);
@@ -1392,45 +1337,13 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
    * everywhere downstream — no special "owner" path. */
   ssl_ctx_drop_passphrase(ssl_context);
 
-  if (options.ca_file || options.ca_file_name) {
+  if (options.ca && options.ca_count > 0) {
+    us_ex_idx_ensure();
+    SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_ex_idx, (void *)1);
     /* An explicit CA replaces the default trust store (Node.js semantics):
-     * chains must validate exclusively against the supplied CAs. The SSL_CTX
-     * already owns a fresh, empty X509_STORE from SSL_CTX_new(), so the loaders
-     * below populate only the user's CAs. */
-    us_ex_idx_ensure();
-    SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_ex_idx, (void *)1);
-    if (options.ca_file) {
-      enum create_bun_socket_error_t ca_err = us_ssl_ctx_use_ca_file_content(ssl_context, options.ca_file);
-      if (ca_err != CREATE_BUN_SOCKET_ERROR_NONE) {
-        *err = ca_err;
-        ssl_ctx_build_fail(ssl_context);
-        return NULL;
-      }
-    } else {
-      STACK_OF(X509_NAME) *ca_list = SSL_load_client_CA_file(options.ca_file_name);
-      if (ca_list == NULL) {
-        *err = CREATE_BUN_SOCKET_ERROR_LOAD_CA_FILE;
-        ssl_ctx_build_fail(ssl_context);
-        return NULL;
-      }
-      SSL_CTX_set_client_CA_list(ssl_context, ca_list);
-      if (SSL_CTX_load_verify_locations(ssl_context, options.ca_file_name, NULL) != 1) {
-        *err = CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE;
-        ssl_ctx_build_fail(ssl_context);
-        return NULL;
-      }
-    }
-    SSL_CTX_set_verify(ssl_context,
-        options.reject_unauthorized ? (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
-                                    : SSL_VERIFY_PEER,
-        us_verify_callback);
-
-  } else if (options.ca && options.ca_count > 0) {
-    us_ex_idx_ensure();
-    SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_ex_idx, (void *)1);
-    /* As above: user CAs only, into the SSL_CTX's own initially-empty store —
-     * otherwise a server doing mTLS with `ca: [internalCA]` would also accept
-     * any client certificate that chains to a public root. */
+     * user CAs only, into the SSL_CTX's own initially-empty store — otherwise
+     * a server doing mTLS with `ca: [internalCA]` would also accept any client
+     * certificate that chains to a public root. */
     X509_STORE *cert_store = SSL_CTX_get_cert_store(ssl_context);
     STACK_OF(CRYPTO_BUFFER) *ca_certs = sk_CRYPTO_BUFFER_new_null();
     for (unsigned int i = 0; ca_certs != NULL && i < options.ca_count; i++) {
@@ -1463,23 +1376,12 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
     }
   }
 
-  if (options.dh_params || options.dh_params_file_name) {
+  if (options.dh_params) {
     DH *dh_2048 = NULL;
-    if (options.dh_params) {
-      BIO *params = BIO_new_mem_buf(options.dh_params, -1);
-      if (params) {
-        dh_2048 = PEM_read_bio_DHparams(params, NULL, NULL, NULL);
-        BIO_free(params);
-      }
-    } else {
-      FILE *paramfile = fopen(options.dh_params_file_name, "r");
-      if (paramfile) {
-        dh_2048 = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
-        fclose(paramfile);
-      } else {
-        ssl_ctx_build_fail(ssl_context);
-        return NULL;
-      }
+    BIO *params = BIO_new_mem_buf(options.dh_params, -1);
+    if (params) {
+      dh_2048 = PEM_read_bio_DHparams(params, NULL, NULL, NULL);
+      BIO_free(params);
     }
     if (dh_2048 == NULL) {
       ssl_ctx_build_fail(ssl_context);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -485,12 +485,10 @@ const char *us_socket_sni_servername(struct us_socket_t *s);
  * from sockets entirely. Build once per SecureContext / config, share across
  * every connect/listen/upgrade. */
 
+/* TLS material arrives as PEM bytes; callers that take file paths read them
+ * before building the options. */
 struct us_bun_socket_context_options_t {
-    const char *key_file_name;
-    const char *cert_file_name;
     const char *passphrase;
-    const char *dh_params_file_name;
-    const char *ca_file_name;
     const char *ssl_ciphers;
     int ssl_prefer_low_memory_usage;
     const char * const *key;
@@ -519,12 +517,8 @@ struct us_bun_socket_context_options_t {
     const char *sigalgs;
     /* Colon-separated named-group list applied via SSL_CTX_set1_groups_list. */
     const char *ecdh_curve;
-    /* PEM-encoded DH parameters; takes precedence over dh_params_file_name. */
+    /* PEM-encoded DH parameters. */
     const char *dh_params;
-    /* The bytes of ca_file_name, loaded with the same rules as the file
-     * (CERTIFICATE, TRUSTED CERTIFICATE and CRL blocks); takes precedence
-     * over ca_file_name. */
-    const char *ca_file;
 };
 
 enum create_bun_socket_error_t {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -519,6 +519,8 @@ struct us_bun_socket_context_options_t {
     const char *sigalgs;
     /* Colon-separated named-group list applied via SSL_CTX_set1_groups_list. */
     const char *ecdh_curve;
+    /* PEM-encoded DH parameters; takes precedence over dh_params_file_name. */
+    const char *dh_params;
 };
 
 enum create_bun_socket_error_t {
@@ -529,6 +531,11 @@ enum create_bun_socket_error_t {
     CREATE_BUN_SOCKET_ERROR_INVALID_CIPHERS,
     CREATE_BUN_SOCKET_ERROR_INVALID_CRL,
     CREATE_BUN_SOCKET_ERROR_INVALID_ECDH_CURVE,
+    /* Set by the Rust caller when it cannot read a *_file_name option before
+     * handing the bytes over; us_ssl_ctx_from_options never produces these. */
+    CREATE_BUN_SOCKET_ERROR_LOAD_KEY_FILE,
+    CREATE_BUN_SOCKET_ERROR_LOAD_CERT_FILE,
+    CREATE_BUN_SOCKET_ERROR_LOAD_DH_PARAMS_FILE,
 };
 
 /* Build an SSL_CTX from options. Returns the BoringSSL SSL_CTX*; caller owns

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -521,6 +521,10 @@ struct us_bun_socket_context_options_t {
     const char *ecdh_curve;
     /* PEM-encoded DH parameters; takes precedence over dh_params_file_name. */
     const char *dh_params;
+    /* The bytes of ca_file_name, loaded with the same rules as the file
+     * (CERTIFICATE, TRUSTED CERTIFICATE and CRL blocks); takes precedence
+     * over ca_file_name. */
+    const char *ca_file;
 };
 
 enum create_bun_socket_error_t {

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -87,6 +87,7 @@ namespace uWS {
         int allow_partial_trust_chain = 0;
         const char *sigalgs = nullptr;
         const char *ecdh_curve = nullptr;
+        const char *dh_params = nullptr;
 
         /* Conversion operator used internally */
         operator struct us_bun_socket_context_options_t() const {

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -60,11 +60,7 @@ namespace uWS {
 
     /* This one matches us_socket_context_options_t but has default values */
     struct SocketContextOptions {
-        const char *key_file_name = nullptr;
-        const char *cert_file_name = nullptr;
         const char *passphrase = nullptr;
-        const char *dh_params_file_name = nullptr;
-        const char *ca_file_name = nullptr;
         const char *ssl_ciphers = nullptr;
         int ssl_prefer_low_memory_usage = 0;
 
@@ -88,7 +84,6 @@ namespace uWS {
         const char *sigalgs = nullptr;
         const char *ecdh_curve = nullptr;
         const char *dh_params = nullptr;
-        const char *ca_file = nullptr;
 
         /* Conversion operator used internally */
         operator struct us_bun_socket_context_options_t() const {

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -88,6 +88,7 @@ namespace uWS {
         const char *sigalgs = nullptr;
         const char *ecdh_curve = nullptr;
         const char *dh_params = nullptr;
+        const char *ca_file = nullptr;
 
         /* Conversion operator used internally */
         operator struct us_bun_socket_context_options_t() const {

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -583,7 +583,13 @@ impl<const SSL: bool> HTTPContext<SSL> {
             request_cert: 1,
             ..Default::default()
         };
-        self.init_with_opts(&opts)
+        match self.init_with_opts(&opts) {
+            // The file replaces the inline `ca`, so a rejected CA came from it.
+            Err(InitError::InvalidCA) if !opts.ca_file_name.is_null() => {
+                Err(InitError::InvalidCAFile)
+            }
+            result => result,
+        }
     }
 
     pub(crate) fn init(&mut self) {

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -546,7 +546,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     uws::create_bun_socket_error_t::invalid_crl => InitError::InvalidCRL,
                     uws::create_bun_socket_error_t::none
                     | uws::create_bun_socket_error_t::invalid_ciphers
-                    | uws::create_bun_socket_error_t::invalid_ecdh_curve => {
+                    | uws::create_bun_socket_error_t::invalid_ecdh_curve
+                    | uws::create_bun_socket_error_t::load_key_file
+                    | uws::create_bun_socket_error_t::load_cert_file
+                    | uws::create_bun_socket_error_t::load_dh_params_file => {
                         InitError::FailedToOpenSocket
                     }
                 });

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -32,7 +32,7 @@ use bun_uws as uws;
 use bun_uws_sys as uws_sys;
 use bun_uws_sys::app::c as uws_app_c;
 
-use bun_jsc::{JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{JSGlobalObject, JSValue, JsResult, SysErrorJsc as _};
 
 // ─── httplog ─────────────────────────────────────────────────────────────────
 // Output.scoped(.Server, .visible) — debug-build no-op until bun_output wires.
@@ -2830,6 +2830,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 Self::deinit(this);
                 return JSValue::ZERO;
             };
+            let ssl_options = match ssl_options.load_files() {
+                Ok(loaded) => loaded,
+                Err(err) => {
+                    let _ = err.err.throw(global);
+                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
+                    Self::deinit(this);
+                    return JSValue::ZERO;
+                }
+            };
 
             app = match uws_sys::NewApp::<SSL>::create(&ssl_options) {
                 Some(a) => a,
@@ -2953,6 +2962,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let sni_name = unsafe { bun_core::ffi::cstr(name_ptr) };
                 // SAFETY: sni_name is a CStr; NUL invariant holds for ZStr.
                 let z = unsafe { bun_core::ZStr::from_raw(name_ptr.cast(), name_len) };
+                let sni_opts = match sni_opts.load_files() {
+                    Ok(loaded) => loaded,
+                    Err(err) => {
+                        let _ = err.err.throw(global);
+                        // SAFETY: caller contract — `this` is the live boxed server from `init()`.
+                        Self::deinit(this);
+                        return JSValue::ZERO;
+                    }
+                };
 
                 if Self::HAS_H3 {
                     if let Some(h3_app) = this_ref.h3_app {
@@ -3000,8 +3018,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let _ = unsafe { (*this).set_routes() };
             }
         } else {
-            app = match uws_sys::NewApp::<SSL>::create(&uws_sys::BunSocketContextOptions::default())
-            {
+            app = match uws_sys::NewApp::<SSL>::create(&uws_sys::LoadedOptions::default()) {
                 Some(a) => a,
                 None => {
                     if !global.has_exception() {

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -298,9 +298,6 @@ fn handle_path(
     string: &bun_core::String,
 ) -> JsResult<*const c_char> {
     let name = string.to_owned_slice_z();
-    // The file is read when the SSL_CTX is built, which for fetch happens on the
-    // HTTP thread at connect time. Pin a relative path to the cwd of this call
-    // so a later `process.chdir()` cannot change which file is meant.
     let name = if name.is_empty() || bun_paths::is_absolute(name.as_bytes()) {
         name
     } else {

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -159,7 +159,7 @@ impl SSLConfigFromJs for SSLConfig {
             any = true;
         }
         if let Some(dh_params_file) = generated.dh_params_file.as_ref() {
-            result.dh_params_file_name = handle_path(vm, global, "dhParamsFile", dh_params_file)?;
+            result.dh_params_file_name = handle_path(global, "dhParamsFile", dh_params_file)?;
             any = true;
         }
         if let Some(server_name) = generated.server_name.as_ref() {
@@ -220,15 +220,15 @@ impl SSLConfigFromJs for SSLConfig {
             || result.allow_partial_trust_chain;
 
         if let Some(key_file) = generated.key_file.as_ref() {
-            result.key_file_name = handle_path(vm, global, "keyFile", key_file)?;
+            result.key_file_name = handle_path(global, "keyFile", key_file)?;
             result.requires_custom_request_ctx = true;
         }
         if let Some(cert_file) = generated.cert_file.as_ref() {
-            result.cert_file_name = handle_path(vm, global, "certFile", cert_file)?;
+            result.cert_file_name = handle_path(global, "certFile", cert_file)?;
             result.requires_custom_request_ctx = true;
         }
         if let Some(ca_file) = generated.ca_file.as_ref() {
-            result.ca_file_name = handle_path(vm, global, "caFile", ca_file)?;
+            result.ca_file_name = handle_path(global, "caFile", ca_file)?;
             result.requires_custom_request_ctx = true;
         }
 
@@ -292,7 +292,6 @@ pub fn resolve_reject_unauthorized(
 // `field` is a runtime &'static str (not monomorphized) since it is only
 // used in a cold error message.
 fn handle_path(
-    vm: &VirtualMachine,
     global: &JSGlobalObject,
     field: &'static str,
     string: &bun_core::String,
@@ -301,15 +300,13 @@ fn handle_path(
     let name = if name.is_empty() || bun_paths::is_absolute(name.as_bytes()) {
         name
     } else {
-        let mut buf = bun_paths::path_buffer_pool::get();
-        let Some(joined) = bun_paths::resolve_path::join_abs_string_buf_checked::<
-            bun_paths::resolve_path::platform::Auto,
-        >(vm.top_level_dir(), &mut buf[..], &[name.as_bytes()]) else {
+        let mut abs = bun_paths::AutoAbsPathChecked::init_top_level_dir();
+        if abs.join(&[name.as_bytes()]).is_err() {
             return Err(
                 global.throw_invalid_arguments(format_args!("Unable to access {} path", field))
             );
-        };
-        bun_core::ZBox::from_bytes(joined)
+        }
+        bun_core::ZBox::from_bytes(abs.slice())
     };
     // `bun_sys::access` routes to `access(2)` on POSIX and
     // `GetFileAttributesW` on Windows (via `sys_uv`), so this is the

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -159,7 +159,7 @@ impl SSLConfigFromJs for SSLConfig {
             any = true;
         }
         if let Some(dh_params_file) = generated.dh_params_file.as_ref() {
-            result.dh_params_file_name = handle_path(global, "dhParamsFile", dh_params_file)?;
+            result.dh_params_file_name = handle_path(vm, global, "dhParamsFile", dh_params_file)?;
             any = true;
         }
         if let Some(server_name) = generated.server_name.as_ref() {
@@ -220,15 +220,15 @@ impl SSLConfigFromJs for SSLConfig {
             || result.allow_partial_trust_chain;
 
         if let Some(key_file) = generated.key_file.as_ref() {
-            result.key_file_name = handle_path(global, "keyFile", key_file)?;
+            result.key_file_name = handle_path(vm, global, "keyFile", key_file)?;
             result.requires_custom_request_ctx = true;
         }
         if let Some(cert_file) = generated.cert_file.as_ref() {
-            result.cert_file_name = handle_path(global, "certFile", cert_file)?;
+            result.cert_file_name = handle_path(vm, global, "certFile", cert_file)?;
             result.requires_custom_request_ctx = true;
         }
         if let Some(ca_file) = generated.ca_file.as_ref() {
-            result.ca_file_name = handle_path(global, "caFile", ca_file)?;
+            result.ca_file_name = handle_path(vm, global, "caFile", ca_file)?;
             result.requires_custom_request_ctx = true;
         }
 
@@ -292,11 +292,28 @@ pub fn resolve_reject_unauthorized(
 // `field` is a runtime &'static str (not monomorphized) since it is only
 // used in a cold error message.
 fn handle_path(
+    vm: &VirtualMachine,
     global: &JSGlobalObject,
     field: &'static str,
     string: &bun_core::String,
 ) -> JsResult<*const c_char> {
     let name = string.to_owned_slice_z();
+    // The file is read when the SSL_CTX is built, which for fetch happens on the
+    // HTTP thread at connect time. Pin a relative path to the cwd of this call
+    // so a later `process.chdir()` cannot change which file is meant.
+    let name = if name.is_empty() || bun_paths::is_absolute(name.as_bytes()) {
+        name
+    } else {
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let Some(joined) = bun_paths::resolve_path::join_abs_string_buf_checked::<
+            bun_paths::resolve_path::platform::Auto,
+        >(vm.top_level_dir(), &mut buf[..], &[name.as_bytes()]) else {
+            return Err(
+                global.throw_invalid_arguments(format_args!("Unable to access {} path", field))
+            );
+        };
+        bun_core::ZBox::from_bytes(joined)
+    };
     // `bun_sys::access` routes to `access(2)` on POSIX and
     // `GetFileAttributesW` on Windows (via `sys_uv`), so this is the
     // cross-platform existence probe.

--- a/src/runtime/socket/uws_jsc.rs
+++ b/src/runtime/socket/uws_jsc.rs
@@ -83,6 +83,24 @@ pub(crate) fn create_bun_socket_error_to_js(
                 format_args!("Failed to set ECDH curve"),
             )
             .to_js(),
+        create_bun_socket_error_t::load_key_file => global_object
+            .err(
+                bun_jsc::ErrorCode::BORINGSSL,
+                format_args!("Failed to load key file"),
+            )
+            .to_js(),
+        create_bun_socket_error_t::load_cert_file => global_object
+            .err(
+                bun_jsc::ErrorCode::BORINGSSL,
+                format_args!("Failed to load certificate file"),
+            )
+            .to_js(),
+        create_bun_socket_error_t::load_dh_params_file => global_object
+            .err(
+                bun_jsc::ErrorCode::BORINGSSL,
+                format_args!("Failed to load DH params file"),
+            )
+            .to_js(),
     }
 }
 

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -151,6 +151,24 @@ pub(crate) fn create_bun_socket_error_to_js(
                 format_args!("Failed to set ECDH curve"),
             )
             .to_js(),
+        E::load_key_file => global
+            .err(
+                ErrorCode::BORINGSSL,
+                format_args!("Failed to load key file"),
+            )
+            .to_js(),
+        E::load_cert_file => global
+            .err(
+                ErrorCode::BORINGSSL,
+                format_args!("Failed to load certificate file"),
+            )
+            .to_js(),
+        E::load_dh_params_file => global
+            .err(
+                ErrorCode::BORINGSSL,
+                format_args!("Failed to load DH params file"),
+            )
+            .to_js(),
     }
 }
 

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1339,11 +1339,12 @@ pub use bun_uws_sys::{ConnectResult, SocketGroup};
 // SocketContext::BunSocketContextOptions
 // ═══════════════════════════════════════════════════════════════════════════
 pub mod SocketContext {
-    /// `#[repr(C)]` mirror of `us_bun_socket_context_options_t`. What
-    /// `SSLConfig.asUSockets()` produces and `us_ssl_ctx_from_options` consumes.
-    /// The struct body, `Default`, `digest()` and `create_ssl_context()` live in
-    /// `bun_uws_sys`; re-exported so this crate and `_sys` share one definition
-    /// (callers in higher tiers pass values to `_sys` constructors directly).
+    /// What `SSLConfig.asUSockets()` produces: TLS material as PEM bytes or as
+    /// the path of a file that holds them. `load_files()` reads the paths into
+    /// the `#[repr(C)]` `RawSocketContextOptions` that `us_ssl_ctx_from_options`
+    /// consumes. The struct body, `Default`, `digest()` and
+    /// `create_ssl_context()` live in `bun_uws_sys`; re-exported so this crate
+    /// and `_sys` share one definition.
     pub use bun_uws_sys::BunSocketContextOptions;
 }
 /// Snake-case module alias.

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1339,12 +1339,7 @@ pub use bun_uws_sys::{ConnectResult, SocketGroup};
 // SocketContext::BunSocketContextOptions
 // ═══════════════════════════════════════════════════════════════════════════
 pub mod SocketContext {
-    /// What `SSLConfig.asUSockets()` produces: TLS material as PEM bytes or as
-    /// the path of a file that holds them. `load_files()` reads the paths into
-    /// the `#[repr(C)]` `RawSocketContextOptions` that `us_ssl_ctx_from_options`
-    /// consumes. The struct body, `Default`, `digest()` and
-    /// `create_ssl_context()` live in `bun_uws_sys`; re-exported so this crate
-    /// and `_sys` share one definition.
+    /// What `SSLConfig.asUSockets()` produces; defined in `bun_uws_sys`.
     pub use bun_uws_sys::BunSocketContextOptions;
 }
 /// Snake-case module alias.

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -6,7 +6,7 @@ use bun_core::ZStr;
 use bun_http_types::Method::Method;
 
 use crate::response::Response;
-use crate::socket_context::BunSocketContextOptions;
+use crate::socket_context::{BunSocketContextOptions, LoadedOptions};
 use crate::web_socket::c::uws_ws;
 use crate::{
     AnyRequest, AnyResponse, ListenSocket as UwsListenSocket, Opcode, Request, SendStatus,
@@ -111,9 +111,10 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_close_idle(Self::SSL_FLAG, self.as_raw(), i32::from(close_when_idle))
     }
 
-    pub fn create(opts: &BunSocketContextOptions) -> Option<*mut Self> {
-        // SAFETY: FFI call; uws_create_app returns null on failure.
-        let app = unsafe { c::uws_create_app(Self::SSL_FLAG, *opts) };
+    pub fn create(opts: &LoadedOptions) -> Option<*mut Self> {
+        // SAFETY: FFI call; uws_create_app returns null on failure. `opts` keeps
+        // the buffers the options point at alive for the call.
+        let app = unsafe { c::uws_create_app(Self::SSL_FLAG, **opts) };
         if app.is_null() {
             None
         } else {
@@ -393,16 +394,17 @@ impl<const SSL: bool> App<SSL> {
     pub fn add_server_name_with_options(
         &mut self,
         hostname_pattern: &core::ffi::CStr,
-        opts: &BunSocketContextOptions,
+        opts: &LoadedOptions,
         apply_client_cert_policy: bool,
     ) -> Result<(), AddServerNameError> {
-        // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
+        // SAFETY: self is a valid app; hostname_pattern is NUL-terminated; `opts`
+        // keeps the buffers the options point at alive for the call.
         let rc = unsafe {
             c::uws_add_server_name_with_options(
                 Self::SSL_FLAG,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 hostname_pattern.as_ptr(),
-                *opts,
+                **opts,
                 i32::from(apply_client_cert_policy),
             )
         };

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -6,7 +6,7 @@ use bun_core::ZStr;
 use bun_http_types::Method::Method;
 
 use crate::response::Response;
-use crate::socket_context::{BunSocketContextOptions, LoadedOptions};
+use crate::socket_context::{LoadedOptions, RawSocketContextOptions};
 use crate::web_socket::c::uws_ws;
 use crate::{
     AnyRequest, AnyResponse, ListenSocket as UwsListenSocket, Opcode, Request, SendStatus,
@@ -535,7 +535,7 @@ pub mod c {
             handler: extern "C" fn(*mut c_void, c_int, *mut us_socket_t, u8, *mut u8, c_int),
             user_data: *mut c_void,
         );
-        pub(crate) fn uws_create_app(ssl: i32, options: BunSocketContextOptions) -> *mut uws_app_t;
+        pub(crate) fn uws_create_app(ssl: i32, options: RawSocketContextOptions) -> *mut uws_app_t;
         pub(crate) fn uws_app_destroy(ssl: i32, app: *mut uws_app_t);
         pub(crate) safe fn uws_app_set_flags(
             ssl: i32,
@@ -670,7 +670,7 @@ pub mod c {
             ssl: i32,
             app: *mut uws_app_t,
             hostname_pattern: *const c_char,
-            options: BunSocketContextOptions,
+            options: RawSocketContextOptions,
             apply_client_cert_policy: c_int,
         ) -> i32;
         pub(crate) safe fn uws_filter(

--- a/src/uws_sys/Cargo.toml
+++ b/src/uws_sys/Cargo.toml
@@ -22,6 +22,7 @@ bun_boringssl_sys.workspace = true
 bun_core.workspace = true
 bun_errno.workspace = true
 bun_http_types.workspace = true
+bun_sys.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 bun_windows_sys.workspace = true

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -124,6 +124,8 @@ pub struct BunSocketContextOptions {
     pub allow_partial_trust_chain: i32,
     pub sigalgs: *const c_char,
     pub ecdh_curve: *const c_char,
+    /// PEM-encoded DH parameters; takes precedence over `dh_params_file_name`.
+    pub dh_params: *const c_char,
 }
 
 impl Default for BunSocketContextOptions {
@@ -155,11 +157,99 @@ impl Default for BunSocketContextOptions {
             allow_partial_trust_chain: 0,
             sigalgs: ptr::null(),
             ecdh_curve: ptr::null(),
+            dh_params: ptr::null(),
         }
     }
 }
 
-impl BunSocketContextOptions {
+/// The `*_file_name` option a read failure belongs to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TlsFile {
+    Key,
+    Cert,
+    Ca,
+    DhParams,
+}
+
+/// A `*_file_name` option that could not be read.
+#[derive(Debug)]
+pub struct LoadFileError {
+    pub file: TlsFile,
+    pub err: bun_sys::Error,
+}
+
+impl LoadFileError {
+    pub fn code(&self) -> create_bun_socket_error_t {
+        match self.file {
+            TlsFile::Key => create_bun_socket_error_t::load_key_file,
+            TlsFile::Cert => create_bun_socket_error_t::load_cert_file,
+            TlsFile::Ca => create_bun_socket_error_t::load_ca_file,
+            TlsFile::DhParams => create_bun_socket_error_t::load_dh_params_file,
+        }
+    }
+}
+
+struct LoadedFile {
+    file: TlsFile,
+    bytes: bun_core::ZBox,
+    /// The one-element array `key` / `cert` / `ca` points at. Boxed so the
+    /// address survives moves of the `LoadedFile`.
+    array: Box<[*const c_char; 1]>,
+}
+
+impl LoadedFile {
+    fn read(file: TlsFile, path: *const c_char) -> Result<Self, LoadFileError> {
+        // SAFETY: `path` is a caller-provided NUL-terminated C string.
+        let len = unsafe { bun_core::ffi::cstr(path) }.to_bytes().len();
+        // SAFETY: `path[len] == 0` (CStr invariant) and `path[..len]` is readable.
+        let path = unsafe { bun_core::ZStr::from_raw(path.cast::<u8>(), len) };
+        let contents = bun_sys::File::open(path, bun_sys::O::RDONLY, 0)
+            .and_then(|f| f.read_to_end())
+            .map_err(|err| LoadFileError {
+                file,
+                err: err.with_path(path.as_bytes()),
+            })?;
+        let bytes = bun_core::ZBox::from_vec(contents);
+        let array = Box::new([bytes.as_ptr()]);
+        Ok(Self { file, bytes, array })
+    }
+}
+
+impl Drop for LoadedFile {
+    /// Key material: zero before the allocator reuses the pages, as
+    /// `SSLConfig` does for its own C strings.
+    fn drop(&mut self) {
+        bun_alloc::free_sensitive(core::mem::take(&mut self.bytes).into_boxed_slice_with_nul());
+    }
+}
+
+/// [`BunSocketContextOptions`] whose `*_file_name` fields have been read:
+/// `key`, `cert`, `ca` and `dh_params` carry the bytes, so the C side never
+/// opens a path. Derefs to the rewritten options.
+pub struct LoadedOptions {
+    options: BunSocketContextOptions,
+    files: Vec<LoadedFile>,
+}
+
+impl Default for LoadedOptions {
+    /// [`BunSocketContextOptions::default`]: no TLS material, nothing to read.
+    fn default() -> Self {
+        Self {
+            options: BunSocketContextOptions::default(),
+            files: Vec::new(),
+        }
+    }
+}
+
+impl core::ops::Deref for LoadedOptions {
+    type Target = BunSocketContextOptions;
+    #[inline]
+    fn deref(&self) -> &BunSocketContextOptions {
+        &self.options
+    }
+}
+
+impl LoadedOptions {
     /// Build a BoringSSL `SSL_CTX` from these options. The passphrase is freed
     /// inside this call once private-key load completes.
     ///
@@ -169,10 +259,69 @@ impl BunSocketContextOptions {
     /// chain validation, populate verify_error) is applied in
     /// `us_internal_ssl_attach`, so a server reusing this ctx never sends
     /// CertificateRequest unless these options asked it to.
+    pub fn create_ssl_context(&self, err: &mut create_bun_socket_error_t) -> Option<OwnedSslCtx> {
+        // SAFETY: FFI call; the options are `#[repr(C)]` and passed by value, `err`
+        // is a valid out-param, and `self.files` keeps every buffer the options
+        // point at alive for the call. A non-null return carries the +1 from
+        // `SSL_CTX_new`.
+        let ctx = unsafe { OwnedSslCtx::from_raw(c::us_ssl_ctx_from_options(self.options, err)) };
+        if ctx.is_none()
+            && *err == create_bun_socket_error_t::invalid_ca
+            && self.files.iter().any(|f| f.file == TlsFile::Ca)
+        {
+            *err = create_bun_socket_error_t::invalid_ca_file;
+        }
+        ctx
+    }
+}
+
+impl BunSocketContextOptions {
+    /// Read the `*_file_name` options into memory. A file option replaces the
+    /// inline value of the same field, as it did when usockets opened the path.
+    pub fn load_files(&self) -> Result<LoadedOptions, LoadFileError> {
+        let mut options = *self;
+        let mut files = Vec::new();
+        if !self.key_file_name.is_null() {
+            let file = LoadedFile::read(TlsFile::Key, self.key_file_name)?;
+            options.key = file.array.as_ptr();
+            options.key_count = 1;
+            options.key_file_name = ptr::null();
+            files.push(file);
+        }
+        if !self.cert_file_name.is_null() {
+            let file = LoadedFile::read(TlsFile::Cert, self.cert_file_name)?;
+            options.cert = file.array.as_ptr();
+            options.cert_count = 1;
+            options.cert_file_name = ptr::null();
+            files.push(file);
+        }
+        if !self.ca_file_name.is_null() {
+            let file = LoadedFile::read(TlsFile::Ca, self.ca_file_name)?;
+            options.ca = file.array.as_ptr();
+            options.ca_count = 1;
+            options.ca_file_name = ptr::null();
+            files.push(file);
+        }
+        if !self.dh_params_file_name.is_null() {
+            let file = LoadedFile::read(TlsFile::DhParams, self.dh_params_file_name)?;
+            options.dh_params = file.bytes.as_ptr();
+            options.dh_params_file_name = ptr::null();
+            files.push(file);
+        }
+        Ok(LoadedOptions { options, files })
+    }
+
+    /// [`Self::load_files`] then [`LoadedOptions::create_ssl_context`]. A file
+    /// that cannot be read reports through `err` and returns `None`.
     pub fn create_ssl_context(self, err: &mut create_bun_socket_error_t) -> Option<OwnedSslCtx> {
-        // SAFETY: FFI call; `self` is `#[repr(C)]` and passed by value, `err` is a valid out-param.
-        // A non-null return carries the +1 from `SSL_CTX_new`.
-        unsafe { OwnedSslCtx::from_raw(c::us_ssl_ctx_from_options(self, err)) }
+        let loaded = match self.load_files() {
+            Ok(loaded) => loaded,
+            Err(e) => {
+                *err = e.code();
+                return None;
+            }
+        };
+        loaded.create_ssl_context(err)
     }
 
     /// SHA-256 over every field this struct carries, dereferencing string
@@ -258,6 +407,7 @@ impl BunSocketContextOptions {
         h.update(bun_core::bytes_of(&self.allow_partial_trust_chain));
         feed_z(&mut h, self.sigalgs);
         feed_z(&mut h, self.ecdh_curve);
+        feed_z(&mut h, self.dh_params);
         let mut out = [0u8; 32];
         h.final_(&mut out);
         out

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -95,7 +95,9 @@ fn stat_for_digest(path: &bun_core::ZStr) -> Option<[i64; 3]> {
     ])
 }
 
-#[repr(C)]
+/// TLS options as the runtime holds them: PEM bytes or the path of a file
+/// that holds them. [`Self::load_files`] reads the paths and produces the
+/// [`RawSocketContextOptions`] usockets takes.
 #[derive(Clone, Copy)]
 pub struct BunSocketContextOptions {
     pub key_file_name: *const c_char,
@@ -124,10 +126,6 @@ pub struct BunSocketContextOptions {
     pub allow_partial_trust_chain: i32,
     pub sigalgs: *const c_char,
     pub ecdh_curve: *const c_char,
-    /// PEM-encoded DH parameters; takes precedence over `dh_params_file_name`.
-    pub dh_params: *const c_char,
-    /// The bytes of `ca_file_name`; takes precedence over it.
-    pub ca_file: *const c_char,
 }
 
 impl Default for BunSocketContextOptions {
@@ -159,14 +157,42 @@ impl Default for BunSocketContextOptions {
             allow_partial_trust_chain: 0,
             sigalgs: ptr::null(),
             ecdh_curve: ptr::null(),
-            dh_params: ptr::null(),
-            ca_file: ptr::null(),
         }
     }
 }
 
+/// `#[repr(C)]` mirror of `us_bun_socket_context_options_t`. TLS material is
+/// PEM bytes only; see [`BunSocketContextOptions::load_files`].
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct RawSocketContextOptions {
+    pub passphrase: *const c_char,
+    pub ssl_ciphers: *const c_char,
+    pub ssl_prefer_low_memory_usage: i32,
+    pub key: *const *const c_char,
+    pub key_count: u32,
+    pub cert: *const *const c_char,
+    pub cert_count: u32,
+    pub ca: *const *const c_char,
+    pub ca_count: u32,
+    pub secure_options: u32,
+    pub ssl_min_version: i32,
+    pub ssl_max_version: i32,
+    pub reject_unauthorized: i32,
+    pub request_cert: i32,
+    pub client_renegotiation_limit: u32,
+    pub client_renegotiation_window: u32,
+    pub session_timeout: i32,
+    pub crl: *const *const c_char,
+    pub crl_count: u32,
+    pub allow_partial_trust_chain: i32,
+    pub sigalgs: *const c_char,
+    pub ecdh_curve: *const c_char,
+    pub dh_params: *const c_char,
+}
+
 /// The `*_file_name` option a read failure belongs to.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 pub enum TlsFile {
     Key,
     Cert,
@@ -194,7 +220,7 @@ impl LoadFileError {
 
 struct LoadedFile {
     bytes: bun_core::ZBox,
-    /// What `key` / `cert` points at.
+    /// What `key` / `cert` / `ca` points at.
     array: Box<[*const c_char; 1]>,
 }
 
@@ -223,10 +249,9 @@ impl Drop for LoadedFile {
     }
 }
 
-/// [`BunSocketContextOptions`] with the `*_file_name` options read into memory.
+/// [`RawSocketContextOptions`] plus the buffers its pointers borrow.
 pub struct LoadedOptions {
-    options: BunSocketContextOptions,
-    /// Owns the buffers `options` points at.
+    raw: RawSocketContextOptions,
     _files: Vec<LoadedFile>,
 }
 
@@ -234,17 +259,17 @@ impl Default for LoadedOptions {
     /// [`BunSocketContextOptions::default`]: no TLS material, nothing to read.
     fn default() -> Self {
         Self {
-            options: BunSocketContextOptions::default(),
+            raw: BunSocketContextOptions::default().raw(),
             _files: Vec::new(),
         }
     }
 }
 
 impl core::ops::Deref for LoadedOptions {
-    type Target = BunSocketContextOptions;
+    type Target = RawSocketContextOptions;
     #[inline]
-    fn deref(&self) -> &BunSocketContextOptions {
-        &self.options
+    fn deref(&self) -> &RawSocketContextOptions {
+        &self.raw
     }
 }
 
@@ -263,45 +288,69 @@ impl LoadedOptions {
         // is a valid out-param, and `self._files` keeps every buffer the options
         // point at alive for the call. A non-null return carries the +1 from
         // `SSL_CTX_new`.
-        unsafe { OwnedSslCtx::from_raw(c::us_ssl_ctx_from_options(self.options, err)) }
+        unsafe { OwnedSslCtx::from_raw(c::us_ssl_ctx_from_options(self.raw, err)) }
     }
 }
 
 impl BunSocketContextOptions {
-    /// Read each `*_file_name` option into the matching bytes field.
+    /// The fields usockets takes, with no TLS material read yet.
+    fn raw(&self) -> RawSocketContextOptions {
+        RawSocketContextOptions {
+            passphrase: self.passphrase,
+            ssl_ciphers: self.ssl_ciphers,
+            ssl_prefer_low_memory_usage: self.ssl_prefer_low_memory_usage,
+            key: self.key,
+            key_count: self.key_count,
+            cert: self.cert,
+            cert_count: self.cert_count,
+            ca: self.ca,
+            ca_count: self.ca_count,
+            secure_options: self.secure_options,
+            ssl_min_version: self.ssl_min_version,
+            ssl_max_version: self.ssl_max_version,
+            reject_unauthorized: self.reject_unauthorized,
+            request_cert: self.request_cert,
+            client_renegotiation_limit: self.client_renegotiation_limit,
+            client_renegotiation_window: self.client_renegotiation_window,
+            session_timeout: self.session_timeout,
+            crl: self.crl,
+            crl_count: self.crl_count,
+            allow_partial_trust_chain: self.allow_partial_trust_chain,
+            sigalgs: self.sigalgs,
+            ecdh_curve: self.ecdh_curve,
+            dh_params: ptr::null(),
+        }
+    }
+
+    /// Read each `*_file_name` option into the matching bytes field. A file
+    /// replaces an inline value of the same field.
     pub fn load_files(&self) -> Result<LoadedOptions, LoadFileError> {
-        let mut options = *self;
+        let mut raw = self.raw();
         let mut files = Vec::new();
         if !self.key_file_name.is_null() {
             let file = LoadedFile::read(TlsFile::Key, self.key_file_name)?;
-            options.key = file.array.as_ptr();
-            options.key_count = 1;
-            options.key_file_name = ptr::null();
+            raw.key = file.array.as_ptr();
+            raw.key_count = 1;
             files.push(file);
         }
         if !self.cert_file_name.is_null() {
             let file = LoadedFile::read(TlsFile::Cert, self.cert_file_name)?;
-            options.cert = file.array.as_ptr();
-            options.cert_count = 1;
-            options.cert_file_name = ptr::null();
+            raw.cert = file.array.as_ptr();
+            raw.cert_count = 1;
             files.push(file);
         }
-        if self.ca_file.is_null() && !self.ca_file_name.is_null() {
+        if !self.ca_file_name.is_null() {
             let file = LoadedFile::read(TlsFile::Ca, self.ca_file_name)?;
-            options.ca_file = file.bytes.as_ptr();
-            options.ca_file_name = ptr::null();
+            raw.ca = file.array.as_ptr();
+            raw.ca_count = 1;
             files.push(file);
         }
-        if self.dh_params.is_null() && !self.dh_params_file_name.is_null() {
+        if !self.dh_params_file_name.is_null() {
             let file = LoadedFile::read(TlsFile::DhParams, self.dh_params_file_name)?;
-            options.dh_params = file.bytes.as_ptr();
-            options.dh_params_file_name = ptr::null();
+            raw.dh_params = file.bytes.as_ptr();
             files.push(file);
         }
-        Ok(LoadedOptions {
-            options,
-            _files: files,
-        })
+        Ok(LoadedOptions { raw, _files: files })
     }
 
     /// [`Self::load_files`] then [`LoadedOptions::create_ssl_context`].
@@ -399,8 +448,6 @@ impl BunSocketContextOptions {
         h.update(bun_core::bytes_of(&self.allow_partial_trust_chain));
         feed_z(&mut h, self.sigalgs);
         feed_z(&mut h, self.ecdh_curve);
-        feed_z(&mut h, self.dh_params);
-        feed_z(&mut h, self.ca_file);
         let mut out = [0u8; 32];
         h.final_(&mut out);
         out
@@ -464,7 +511,7 @@ pub mod c {
     use super::*;
     unsafe extern "C" {
         pub(crate) fn us_ssl_ctx_from_options(
-            options: BunSocketContextOptions,
+            options: RawSocketContextOptions,
             err: *mut create_bun_socket_error_t,
         ) -> *mut SSL_CTX;
         // safe: no args; reads a process-global counter — no preconditions.

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -126,6 +126,8 @@ pub struct BunSocketContextOptions {
     pub ecdh_curve: *const c_char,
     /// PEM-encoded DH parameters; takes precedence over `dh_params_file_name`.
     pub dh_params: *const c_char,
+    /// The bytes of `ca_file_name`; takes precedence over it.
+    pub ca_file: *const c_char,
 }
 
 impl Default for BunSocketContextOptions {
@@ -158,6 +160,7 @@ impl Default for BunSocketContextOptions {
             sigalgs: ptr::null(),
             ecdh_curve: ptr::null(),
             dh_params: ptr::null(),
+            ca_file: ptr::null(),
         }
     }
 }
@@ -190,9 +193,8 @@ impl LoadFileError {
 }
 
 struct LoadedFile {
-    file: TlsFile,
     bytes: bun_core::ZBox,
-    /// What `key` / `cert` / `ca` points at.
+    /// What `key` / `cert` points at.
     array: Box<[*const c_char; 1]>,
 }
 
@@ -202,15 +204,16 @@ impl LoadedFile {
         let len = unsafe { bun_core::ffi::cstr(path) }.to_bytes().len();
         // SAFETY: `path[len] == 0` (CStr invariant) and `path[..len]` is readable.
         let path = unsafe { bun_core::ZStr::from_raw(path.cast::<u8>(), len) };
-        let contents = bun_sys::File::open(path, bun_sys::O::RDONLY, 0)
-            .and_then(|f| f.read_to_end())
+        let mut contents = Vec::new();
+        bun_sys::File::open(path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)
+            .and_then(|f| f.read_to_end_into(&mut contents))
             .map_err(|err| LoadFileError {
                 file,
                 err: err.with_path(path.as_bytes()),
             })?;
         let bytes = bun_core::ZBox::from_vec(contents);
         let array = Box::new([bytes.as_ptr()]);
-        Ok(Self { file, bytes, array })
+        Ok(Self { bytes, array })
     }
 }
 
@@ -223,7 +226,8 @@ impl Drop for LoadedFile {
 /// [`BunSocketContextOptions`] with the `*_file_name` options read into memory.
 pub struct LoadedOptions {
     options: BunSocketContextOptions,
-    files: Vec<LoadedFile>,
+    /// Owns the buffers `options` points at.
+    _files: Vec<LoadedFile>,
 }
 
 impl Default for LoadedOptions {
@@ -231,7 +235,7 @@ impl Default for LoadedOptions {
     fn default() -> Self {
         Self {
             options: BunSocketContextOptions::default(),
-            files: Vec::new(),
+            _files: Vec::new(),
         }
     }
 }
@@ -256,17 +260,10 @@ impl LoadedOptions {
     /// CertificateRequest unless these options asked it to.
     pub fn create_ssl_context(&self, err: &mut create_bun_socket_error_t) -> Option<OwnedSslCtx> {
         // SAFETY: FFI call; the options are `#[repr(C)]` and passed by value, `err`
-        // is a valid out-param, and `self.files` keeps every buffer the options
+        // is a valid out-param, and `self._files` keeps every buffer the options
         // point at alive for the call. A non-null return carries the +1 from
         // `SSL_CTX_new`.
-        let ctx = unsafe { OwnedSslCtx::from_raw(c::us_ssl_ctx_from_options(self.options, err)) };
-        if ctx.is_none()
-            && *err == create_bun_socket_error_t::invalid_ca
-            && self.files.iter().any(|f| f.file == TlsFile::Ca)
-        {
-            *err = create_bun_socket_error_t::invalid_ca_file;
-        }
-        ctx
+        unsafe { OwnedSslCtx::from_raw(c::us_ssl_ctx_from_options(self.options, err)) }
     }
 }
 
@@ -289,10 +286,9 @@ impl BunSocketContextOptions {
             options.cert_file_name = ptr::null();
             files.push(file);
         }
-        if !self.ca_file_name.is_null() {
+        if self.ca_file.is_null() && !self.ca_file_name.is_null() {
             let file = LoadedFile::read(TlsFile::Ca, self.ca_file_name)?;
-            options.ca = file.array.as_ptr();
-            options.ca_count = 1;
+            options.ca_file = file.bytes.as_ptr();
             options.ca_file_name = ptr::null();
             files.push(file);
         }
@@ -302,7 +298,10 @@ impl BunSocketContextOptions {
             options.dh_params_file_name = ptr::null();
             files.push(file);
         }
-        Ok(LoadedOptions { options, files })
+        Ok(LoadedOptions {
+            options,
+            _files: files,
+        })
     }
 
     /// [`Self::load_files`] then [`LoadedOptions::create_ssl_context`].
@@ -401,6 +400,7 @@ impl BunSocketContextOptions {
         feed_z(&mut h, self.sigalgs);
         feed_z(&mut h, self.ecdh_curve);
         feed_z(&mut h, self.dh_params);
+        feed_z(&mut h, self.ca_file);
         let mut out = [0u8; 32];
         h.final_(&mut out);
         out

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -220,8 +220,7 @@ impl Drop for LoadedFile {
     }
 }
 
-/// [`BunSocketContextOptions`] with every `*_file_name` read into `key`,
-/// `cert`, `ca` or `dh_params`.
+/// [`BunSocketContextOptions`] with the `*_file_name` options read into memory.
 pub struct LoadedOptions {
     options: BunSocketContextOptions,
     files: Vec<LoadedFile>,
@@ -272,8 +271,7 @@ impl LoadedOptions {
 }
 
 impl BunSocketContextOptions {
-    /// Read each `*_file_name` option into the matching bytes field. A file
-    /// option replaces an inline value of the same field.
+    /// Read each `*_file_name` option into the matching bytes field.
     pub fn load_files(&self) -> Result<LoadedOptions, LoadFileError> {
         let mut options = *self;
         let mut files = Vec::new();

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -192,8 +192,7 @@ impl LoadFileError {
 struct LoadedFile {
     file: TlsFile,
     bytes: bun_core::ZBox,
-    /// The one-element array `key` / `cert` / `ca` points at. Boxed so the
-    /// address survives moves of the `LoadedFile`.
+    /// What `key` / `cert` / `ca` points at.
     array: Box<[*const c_char; 1]>,
 }
 
@@ -216,16 +215,13 @@ impl LoadedFile {
 }
 
 impl Drop for LoadedFile {
-    /// Key material: zero before the allocator reuses the pages, as
-    /// `SSLConfig` does for its own C strings.
     fn drop(&mut self) {
         bun_alloc::free_sensitive(core::mem::take(&mut self.bytes).into_boxed_slice_with_nul());
     }
 }
 
-/// [`BunSocketContextOptions`] whose `*_file_name` fields have been read:
-/// `key`, `cert`, `ca` and `dh_params` carry the bytes, so the C side never
-/// opens a path. Derefs to the rewritten options.
+/// [`BunSocketContextOptions`] with every `*_file_name` read into `key`,
+/// `cert`, `ca` or `dh_params`.
 pub struct LoadedOptions {
     options: BunSocketContextOptions,
     files: Vec<LoadedFile>,
@@ -276,8 +272,8 @@ impl LoadedOptions {
 }
 
 impl BunSocketContextOptions {
-    /// Read the `*_file_name` options into memory. A file option replaces the
-    /// inline value of the same field, as it did when usockets opened the path.
+    /// Read each `*_file_name` option into the matching bytes field. A file
+    /// option replaces an inline value of the same field.
     pub fn load_files(&self) -> Result<LoadedOptions, LoadFileError> {
         let mut options = *self;
         let mut files = Vec::new();
@@ -311,8 +307,7 @@ impl BunSocketContextOptions {
         Ok(LoadedOptions { options, files })
     }
 
-    /// [`Self::load_files`] then [`LoadedOptions::create_ssl_context`]. A file
-    /// that cannot be read reports through `err` and returns `None`.
+    /// [`Self::load_files`] then [`LoadedOptions::create_ssl_context`].
     pub fn create_ssl_context(self, err: &mut create_bun_socket_error_t) -> Option<OwnedSslCtx> {
         let loaded = match self.load_files() {
             Ok(loaded) => loaded,

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -296,7 +296,7 @@ impl BunSocketContextOptions {
             options.ca_file_name = ptr::null();
             files.push(file);
         }
-        if !self.dh_params_file_name.is_null() {
+        if self.dh_params.is_null() && !self.dh_params_file_name.is_null() {
             let file = LoadedFile::read(TlsFile::DhParams, self.dh_params_file_name)?;
             options.dh_params = file.bytes.as_ptr();
             options.dh_params_file_name = ptr::null();

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -216,7 +216,8 @@ impl LoadFileError {
 }
 
 struct LoadedFile {
-    bytes: bun_core::ZBox,
+    /// The file, NUL-terminated.
+    bytes: Vec<u8>,
     /// What `key` / `cert` / `ca` points at.
     array: Box<[*const c_char; 1]>,
 }
@@ -227,22 +228,33 @@ impl LoadedFile {
         let len = unsafe { bun_core::ffi::cstr(path) }.to_bytes().len();
         // SAFETY: `path[len] == 0` (CStr invariant) and `path[..len]` is readable.
         let path = unsafe { bun_core::ZStr::from_raw(path.cast::<u8>(), len) };
-        let mut contents = Vec::new();
-        bun_sys::File::open(path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)
-            .and_then(|f| f.read_to_end_into(&mut contents))
-            .map_err(|err| LoadFileError {
-                file,
-                err: err.with_path(path.as_bytes()),
-            })?;
-        let bytes = bun_core::ZBox::from_vec(contents);
-        let array = Box::new([bytes.as_ptr()]);
+        let bytes = Self::read_z(path).map_err(|err| LoadFileError {
+            file,
+            err: err.with_path(path.as_bytes()),
+        })?;
+        let array = Box::new([bytes.as_ptr().cast::<c_char>()]);
         Ok(Self { bytes, array })
+    }
+
+    /// One allocation: the `fstat` size plus the NUL; a pipe reports 0 and grows in the read loop.
+    fn read_z(path: &bun_core::ZStr) -> bun_sys::Maybe<Vec<u8>> {
+        let file = bun_sys::File::open(path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)?;
+        let mut bytes = Vec::new();
+        let size = file.get_end_pos()?;
+        if bytes.try_reserve_exact(size.saturating_add(1)).is_err() {
+            return Err(bun_sys::Error::oom());
+        }
+        file.read_to_end_into(&mut bytes)?;
+        // The read that hit EOF left spare capacity, so this does not grow.
+        bytes.push(0);
+        Ok(bytes)
     }
 }
 
 impl Drop for LoadedFile {
     fn drop(&mut self) {
-        bun_alloc::free_sensitive(core::mem::take(&mut self.bytes).into_boxed_slice_with_nul());
+        // SAFETY: `bytes` is exclusively owned; zeroing its `len` bytes is sound.
+        unsafe { bun_alloc::secure_zero(self.bytes.as_mut_ptr(), self.bytes.len()) };
     }
 }
 
@@ -343,7 +355,7 @@ impl BunSocketContextOptions {
         }
         if !self.dh_params_file_name.is_null() {
             let file = LoadedFile::read(TlsFile::DhParams, self.dh_params_file_name)?;
-            raw.dh_params = file.bytes.as_ptr();
+            raw.dh_params = file.bytes.as_ptr().cast::<c_char>();
             files.push(file);
         }
         Ok(LoadedOptions { raw, _files: files })

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -95,9 +95,7 @@ fn stat_for_digest(path: &bun_core::ZStr) -> Option<[i64; 3]> {
     ])
 }
 
-/// TLS options as the runtime holds them: PEM bytes or the path of a file
-/// that holds them. [`Self::load_files`] reads the paths and produces the
-/// [`RawSocketContextOptions`] usockets takes.
+/// TLS options: PEM bytes, or paths that [`Self::load_files`] reads into [`RawSocketContextOptions`].
 #[derive(Clone, Copy)]
 pub struct BunSocketContextOptions {
     pub key_file_name: *const c_char,
@@ -161,8 +159,7 @@ impl Default for BunSocketContextOptions {
     }
 }
 
-/// `#[repr(C)]` mirror of `us_bun_socket_context_options_t`. TLS material is
-/// PEM bytes only; see [`BunSocketContextOptions::load_files`].
+/// `#[repr(C)]` mirror of `us_bun_socket_context_options_t`; TLS material is PEM bytes only.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RawSocketContextOptions {
@@ -322,8 +319,7 @@ impl BunSocketContextOptions {
         }
     }
 
-    /// Read each `*_file_name` option into the matching bytes field. A file
-    /// replaces an inline value of the same field.
+    /// Read each `*_file_name` option into the matching bytes field.
     pub fn load_files(&self) -> Result<LoadedOptions, LoadFileError> {
         let mut raw = self.raw();
         let mut files = Vec::new();

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -7,7 +7,7 @@ use core::ptr;
 
 use crate::SocketAddress;
 use crate::response::{State, WriteResult};
-use crate::socket_context::{BunSocketContextOptions, LoadedOptions};
+use crate::socket_context::{LoadedOptions, RawSocketContextOptions};
 use crate::thunk;
 use crate::{AnyRequest, AnyResponse};
 use bun_ptr::ThisPtr;
@@ -592,7 +592,7 @@ mod c {
     // Shims with (ptr,len), nullable raw, *mut c_void ctx stay unsafe.
     unsafe extern "C" {
         pub(super) fn uws_h3_create_app(
-            opts: BunSocketContextOptions,
+            opts: RawSocketContextOptions,
             idle_timeout_s: u32,
         ) -> *mut App;
         pub(super) fn uws_h3_app_destroy(app: *mut App);
@@ -601,7 +601,7 @@ mod c {
         pub(super) fn uws_h3_app_add_server_name(
             app: *mut App,
             hostname: *const c_char,
-            opts: BunSocketContextOptions,
+            opts: RawSocketContextOptions,
         ) -> bool;
         pub(super) safe fn uws_h3_res_write_continue(res: &mut Response);
         pub(super) fn uws_h3_app_get(

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -7,7 +7,7 @@ use core::ptr;
 
 use crate::SocketAddress;
 use crate::response::{State, WriteResult};
-use crate::socket_context::BunSocketContextOptions;
+use crate::socket_context::{BunSocketContextOptions, LoadedOptions};
 use crate::thunk;
 use crate::{AnyRequest, AnyResponse};
 use bun_ptr::ThisPtr;
@@ -392,18 +392,20 @@ macro_rules! h3_route_methods {
 }
 
 impl App {
-    pub fn create(opts: &BunSocketContextOptions, idle_timeout_s: u32) -> Option<*mut App> {
-        // SAFETY: opts is `#[repr(C)]` passed by value; uws owns the returned handle
-        let p = unsafe { c::uws_h3_create_app(*opts, idle_timeout_s) };
+    pub fn create(opts: &LoadedOptions, idle_timeout_s: u32) -> Option<*mut App> {
+        // SAFETY: opts is `#[repr(C)]` passed by value and keeps the buffers it
+        // points at alive for the call; uws owns the returned handle
+        let p = unsafe { c::uws_h3_create_app(**opts, idle_timeout_s) };
         if p.is_null() { None } else { Some(p) }
     }
     pub fn add_server_name_with_options(
         &mut self,
         hostname: &bun_core::ZStr,
-        opts: &BunSocketContextOptions,
+        opts: &LoadedOptions,
     ) -> Result<(), AddServerNameError> {
-        // SAFETY: self is a live FFI handle; hostname is NUL-terminated; opts passed by value
-        if !unsafe { c::uws_h3_app_add_server_name(self, hostname.as_ptr().cast(), *opts) } {
+        // SAFETY: self is a live FFI handle; hostname is NUL-terminated; opts passed
+        // by value and keeps the buffers it points at alive for the call
+        if !unsafe { c::uws_h3_app_add_server_name(self, hostname.as_ptr().cast(), **opts) } {
             return Err(AddServerNameError::FailedToAddServerName);
         }
         Ok(())

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -496,7 +496,9 @@ pub use listen_socket::ListenSocket;
 pub use request::{AnyRequest, Request};
 pub use response::c::uws_res;
 pub use response::{AnyResponse, SocketAddress, WebSocketUpgradeContext};
-pub use socket_context::{BunSocketContextOptions, LoadFileError, LoadedOptions, TlsFile};
+pub use socket_context::{
+    BunSocketContextOptions, LoadFileError, LoadedOptions, RawSocketContextOptions, TlsFile,
+};
 pub use socket_group::ConnectResult;
 pub use socket_group::SocketGroup;
 pub use us_socket::{CloseCode, UsIoVec, us_socket_stream_buffer_t, us_socket_t};

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -110,8 +110,7 @@ pub enum create_bun_socket_error_t {
     invalid_ciphers,
     invalid_crl,
     invalid_ecdh_curve,
-    /// Set on this side when a `*_file_name` option cannot be read before
-    /// the bytes are handed over; C never produces these.
+    /// A `*_file_name` option could not be read. Set from Rust only.
     load_key_file,
     load_cert_file,
     load_dh_params_file,

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -110,6 +110,11 @@ pub enum create_bun_socket_error_t {
     invalid_ciphers,
     invalid_crl,
     invalid_ecdh_curve,
+    /// Set on this side when a `*_file_name` option cannot be read before
+    /// the bytes are handed over; C never produces these.
+    load_key_file,
+    load_cert_file,
+    load_dh_params_file,
 }
 
 impl create_bun_socket_error_t {
@@ -122,6 +127,9 @@ impl create_bun_socket_error_t {
             Self::invalid_ciphers => Some(b"Invalid ciphers"),
             Self::invalid_crl => Some(b"Invalid CRL"),
             Self::invalid_ecdh_curve => Some(b"Failed to set ECDH curve"),
+            Self::load_key_file => Some(b"Failed to load key file"),
+            Self::load_cert_file => Some(b"Failed to load certificate file"),
+            Self::load_dh_params_file => Some(b"Failed to load DH params file"),
         }
     }
 }
@@ -489,7 +497,7 @@ pub use listen_socket::ListenSocket;
 pub use request::{AnyRequest, Request};
 pub use response::c::uws_res;
 pub use response::{AnyResponse, SocketAddress, WebSocketUpgradeContext};
-pub use socket_context::BunSocketContextOptions;
+pub use socket_context::{BunSocketContextOptions, LoadFileError, LoadedOptions, TlsFile};
 pub use socket_group::ConnectResult;
 pub use socket_group::SocketGroup;
 pub use us_socket::{CloseCode, UsIoVec, us_socket_stream_buffer_t, us_socket_t};

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe, expiredTls, tempDir, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, expiredTls, isWindows, tempDir, tls as tlsCert } from "harness";
 import tls from "node:tls";
 import { join } from "path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
@@ -371,5 +371,85 @@ describe("keyFile / certFile / caFile / dhParamsFile", () => {
     };
     expect(listenWith(join(String(dir), "corrupt-second.pem"))).toThrow("Invalid CA file");
     expect(listenWith(join(String(dir), "no-certificate.pem"))).toThrow("Failed to load CA file");
+    // Bun.serve reports the BoringSSL error of the first PEM block instead.
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        tls: {
+          keyFile: join(String(dir), "key.pem"),
+          certFile: join(String(dir), "cert.pem"),
+          caFile: join(String(dir), "no-certificate.pem"),
+        },
+        fetch: () => new Response("unreachable"),
+      });
+    }).toThrow(expect.objectContaining({ code: "ERR_OSSL_PEM_NO_START_LINE" }));
+  });
+
+  test("serverName entries load their file options too", async () => {
+    using dir = tempDir("bun-serve-ssl-sni-files", {
+      "key.pem": tlsCert.key,
+      "cert.pem": tlsCert.cert,
+      "a-directory/.keep": "",
+    });
+    const keyFile = join(String(dir), "key.pem");
+    const certFile = join(String(dir), "cert.pem");
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: [
+        { keyFile, certFile },
+        { serverName: "localhost", keyFile, certFile },
+      ],
+      fetch: () => new Response("SNI-OK"),
+    });
+    const res = await fetch(`https://localhost:${server.port}/`, { keepalive: false, tls: { caFile: certFile } });
+    expect(await res.text()).toBe("SNI-OK");
+
+    const directory = join(String(dir), "a-directory");
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        tls: [
+          { keyFile, certFile },
+          { serverName: "localhost", keyFile: directory, certFile },
+        ],
+        fetch: () => new Response("unreachable"),
+      });
+    }).toThrow(expect.objectContaining({ code: "EISDIR", message: expect.stringContaining(directory) }));
+  });
+
+  test.skipIf(isWindows)("a FIFO works as a file option", async () => {
+    // The file is read with a cursor read(2) loop, as BoringSSL's fopen did, so
+    // a non-seekable file works.
+    using dir = tempDir("bun-serve-ssl-fifo", { "key.pem": tlsCert.key, "cert.pem": tlsCert.cert });
+    expect(Bun.spawnSync({ cmd: ["mkfifo", "key.fifo"], cwd: String(dir) }).exitCode).toBe(0);
+    // The writer blocks in open(2) until the server opens the FIFO for reading.
+    await using writer = Bun.spawn({ cmd: ["sh", "-c", "cat key.pem > key.fifo"], cwd: String(dir) });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const server = Bun.serve({
+            port: 0,
+            hostname: "127.0.0.1",
+            tls: { keyFile: "key.fifo", certFile: "cert.pem" },
+            fetch: () => new Response("FIFO-OK"),
+          });
+          const res = await fetch(server.url, { tls: { caFile: "cert.pem" } });
+          console.log(await res.text());
+          server.stop(true);
+        `,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("FIFO-OK\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(await writer.exited).toBe(0);
   });
 });

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe, tempDir, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, expiredTls, tempDir, tls as tlsCert } from "harness";
 import tls from "node:tls";
 import { join } from "path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
@@ -341,5 +341,35 @@ describe("keyFile / certFile / caFile / dhParamsFile", () => {
     expect(listenWith({ keyFile, certFile: directory })).toThrow("Failed to load certificate file");
     expect(listenWith({ keyFile, certFile, caFile: directory })).toThrow("Failed to load CA file");
     expect(listenWith({ keyFile, certFile, dhParamsFile: directory })).toThrow("Failed to load DH params file");
+  });
+
+  test("caFile keeps the PEM rules of the file loader", async () => {
+    using server = Bun.serve({ port: 0, hostname: "127.0.0.1", tls: tlsCert, fetch: () => new Response("OK") });
+    const asTrusted = tlsCert.cert.replaceAll("CERTIFICATE-----", "TRUSTED CERTIFICATE-----");
+    const crl = readFileSync(join(keysFixtures, "ca2-crl.pem"), "utf8");
+    using dir = tempDir("bun-serve-ssl-cafile-pem", {
+      "key.pem": tlsCert.key,
+      "cert.pem": tlsCert.cert,
+      "trusted-second.pem": `${expiredTls.cert}\n${asTrusted}`,
+      "with-crl.pem": `${tlsCert.cert}\n${crl}`,
+      "corrupt-second.pem": `${tlsCert.cert}\n-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n`,
+      "no-certificate.pem": tlsCert.key,
+    });
+    // TRUSTED CERTIFICATE and X509 CRL blocks are loaded into the trust store.
+    for (const name of ["trusted-second.pem", "with-crl.pem"]) {
+      const res = await fetch(server.url, { keepalive: false, tls: { caFile: join(String(dir), name) } });
+      expect(await res.text()).toBe("OK");
+    }
+    // A corrupt block fails the whole file. A file with no certificate is not a CA file.
+    const listenWith = (caFile: string) => () => {
+      Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: { keyFile: join(String(dir), "key.pem"), certFile: join(String(dir), "cert.pem"), caFile },
+        socket: { data() {} },
+      });
+    };
+    expect(listenWith(join(String(dir), "corrupt-second.pem"))).toThrow("Invalid CA file");
+    expect(listenWith(join(String(dir), "no-certificate.pem"))).toThrow("Failed to load CA file");
   });
 });

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -343,46 +343,45 @@ describe("keyFile / certFile / caFile / dhParamsFile", () => {
     expect(listenWith({ keyFile, certFile, dhParamsFile: directory })).toThrow("Failed to load DH params file");
   });
 
-  test("caFile keeps the PEM rules of the file loader", async () => {
+  test("caFile loads the file the way ca loads its bytes", async () => {
     using server = Bun.serve({ port: 0, hostname: "127.0.0.1", tls: tlsCert, fetch: () => new Response("OK") });
-    const asTrusted = tlsCert.cert.replaceAll("CERTIFICATE-----", "TRUSTED CERTIFICATE-----");
     const crl = readFileSync(join(keysFixtures, "ca2-crl.pem"), "utf8");
     using dir = tempDir("bun-serve-ssl-cafile-pem", {
-      "key.pem": tlsCert.key,
-      "cert.pem": tlsCert.cert,
-      "trusted-second.pem": `${expiredTls.cert}\n${asTrusted}`,
+      "trusts-server.pem": tlsCert.cert,
+      "other-ca.pem": expiredTls.cert,
       "with-crl.pem": `${tlsCert.cert}\n${crl}`,
       "corrupt-second.pem": `${tlsCert.cert}\n-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n`,
       "no-certificate.pem": tlsCert.key,
     });
-    // TRUSTED CERTIFICATE and X509 CRL blocks are loaded into the trust store.
-    for (const name of ["trusted-second.pem", "with-crl.pem"]) {
-      const res = await fetch(server.url, { keepalive: false, tls: { caFile: join(String(dir), name) } });
-      expect(await res.text()).toBe("OK");
-    }
-    // A corrupt block fails the whole file. A file with no certificate is not a CA file.
-    const listenWith = (caFile: string) => () => {
-      Bun.listen({
-        hostname: "127.0.0.1",
-        port: 0,
-        tls: { keyFile: join(String(dir), "key.pem"), certFile: join(String(dir), "cert.pem"), caFile },
-        socket: { data() {} },
-      });
+    const attempt = async (tls: Record<string, string>) => {
+      try {
+        const res = await fetch(server.url, { keepalive: false, tls });
+        return await res.text();
+      } catch (error) {
+        return (error as { code: string }).code;
+      }
     };
-    expect(listenWith(join(String(dir), "corrupt-second.pem"))).toThrow("Invalid CA file");
-    expect(listenWith(join(String(dir), "no-certificate.pem"))).toThrow("Failed to load CA file");
-    // Bun.serve reports the BoringSSL error of the first PEM block instead.
-    expect(() => {
-      Bun.serve({
-        port: 0,
-        tls: {
-          keyFile: join(String(dir), "key.pem"),
-          certFile: join(String(dir), "cert.pem"),
-          caFile: join(String(dir), "no-certificate.pem"),
-        },
-        fetch: () => new Response("unreachable"),
-      });
-    }).toThrow(expect.objectContaining({ code: "ERR_OSSL_PEM_NO_START_LINE" }));
+    const outcomes: Record<string, { caFile: string; ca: string }> = {};
+    for (const name of [
+      "trusts-server.pem",
+      "other-ca.pem",
+      "with-crl.pem",
+      "corrupt-second.pem",
+      "no-certificate.pem",
+    ]) {
+      const path = join(String(dir), name);
+      outcomes[name] = {
+        caFile: await attempt({ caFile: path }),
+        ca: await attempt({ ca: readFileSync(path, "utf8") }),
+      };
+    }
+    expect(outcomes).toEqual({
+      "trusts-server.pem": { caFile: "OK", ca: "OK" },
+      "other-ca.pem": { caFile: "DEPTH_ZERO_SELF_SIGNED_CERT", ca: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+      "with-crl.pem": { caFile: "OK", ca: "OK" },
+      "corrupt-second.pem": { caFile: "OK", ca: "OK" },
+      "no-certificate.pem": { caFile: "DEPTH_ZERO_SELF_SIGNED_CERT", ca: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+    });
   });
 
   test("serverName entries load their file options too", async () => {

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -256,19 +256,22 @@ describe("Bun.serve per-serverName client certificate policy", () => {
   });
 });
 
-describe("keyFile / certFile / caFile", () => {
+describe("keyFile / certFile / caFile / dhParamsFile", () => {
+  const keysFixtures = join(import.meta.dir, "..", "..", "node", "test", "fixtures", "keys");
+
   test("relative paths resolve against the cwd and non-ASCII paths load", async () => {
     // The directory name is not ASCII: the files are opened from Rust with a
     // wide open on Windows, not by BoringSSL's narrow fopen.
     using dir = tempDir("bun-serve-ssl-ünïcødé", {
       "key.pem": tlsCert.key,
       "cert.pem": tlsCert.cert,
+      "dh.pem": readFileSync(join(keysFixtures, "dh2048.pem"), "utf8"),
       "server.ts": `
         import { join } from "node:path";
         const server = Bun.serve({
           port: 0,
           hostname: "127.0.0.1",
-          tls: { keyFile: "key.pem", certFile: join(process.cwd(), "cert.pem") },
+          tls: { keyFile: "key.pem", certFile: join(process.cwd(), "cert.pem"), dhParamsFile: "dh.pem" },
           fetch: () => new Response("TLS-OK"),
         });
         const res = await fetch(server.url, { tls: { caFile: "cert.pem" } });
@@ -298,5 +301,45 @@ describe("keyFile / certFile / caFile", () => {
         fetch: () => new Response("unreachable"),
       });
     }).toThrow("Unable to access keyFile path");
+  });
+
+  test("a malformed dhParamsFile is rejected by the PEM parser", () => {
+    using dir = tempDir("bun-serve-ssl-dh-malformed", { "key.pem": tlsCert.key, "cert.pem": tlsCert.cert });
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        tls: {
+          keyFile: join(String(dir), "key.pem"),
+          certFile: join(String(dir), "cert.pem"),
+          dhParamsFile: join(keysFixtures, "dherror.pem"),
+        },
+        fetch: () => new Response("unreachable"),
+      });
+    }).toThrow(expect.objectContaining({ code: "ERR_OSSL_PEM_BAD_BASE64_DECODE" }));
+  });
+
+  // A directory passes the parse-time access() probe and fails when the file
+  // is read for the SSL_CTX.
+  test("a file that cannot be read reports which option failed", () => {
+    using dir = tempDir("bun-serve-ssl-unreadable", {
+      "key.pem": tlsCert.key,
+      "cert.pem": tlsCert.cert,
+      "a-directory/.keep": "",
+    });
+    const keyFile = join(String(dir), "key.pem");
+    const certFile = join(String(dir), "cert.pem");
+    const directory = join(String(dir), "a-directory");
+
+    expect(() => {
+      Bun.serve({ port: 0, tls: { keyFile: directory, certFile }, fetch: () => new Response("unreachable") });
+    }).toThrow(expect.objectContaining({ code: "EISDIR", message: expect.stringContaining(directory) }));
+
+    const listenWith = (tls: Record<string, string>) => () => {
+      Bun.listen({ hostname: "127.0.0.1", port: 0, tls, socket: { data() {} } });
+    };
+    expect(listenWith({ keyFile: directory, certFile })).toThrow("Failed to load key file");
+    expect(listenWith({ keyFile, certFile: directory })).toThrow("Failed to load certificate file");
+    expect(listenWith({ keyFile, certFile, caFile: directory })).toThrow("Failed to load CA file");
+    expect(listenWith({ keyFile, certFile, dhParamsFile: directory })).toThrow("Failed to load DH params file");
   });
 });

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir, tls as tlsCert } from "harness";
 import tls from "node:tls";
 import { join } from "path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
@@ -252,5 +253,50 @@ describe("Bun.serve per-serverName client certificate policy", () => {
       defaultResumed: "HTTP/1.1 200 OK",
       gatedResumed: "connection closed without a response",
     });
+  });
+});
+
+describe("keyFile / certFile / caFile", () => {
+  test("relative paths resolve against the cwd and non-ASCII paths load", async () => {
+    // The directory name is not ASCII: the files are opened from Rust with a
+    // wide open on Windows, not by BoringSSL's narrow fopen.
+    using dir = tempDir("bun-serve-ssl-ünïcødé", {
+      "key.pem": tlsCert.key,
+      "cert.pem": tlsCert.cert,
+      "server.ts": `
+        import { join } from "node:path";
+        const server = Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          tls: { keyFile: "key.pem", certFile: join(process.cwd(), "cert.pem") },
+          fetch: () => new Response("TLS-OK"),
+        });
+        const res = await fetch(server.url, { tls: { caFile: "cert.pem" } });
+        console.log(await res.text());
+        server.stop(true);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "server.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("TLS-OK\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a missing file is rejected when the options are parsed", () => {
+    using dir = tempDir("bun-serve-ssl-missing", { "cert.pem": tlsCert.cert });
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        tls: { keyFile: join(String(dir), "missing.pem"), certFile: join(String(dir), "cert.pem") },
+        fetch: () => new Response("unreachable"),
+      });
+    }).toThrow("Unable to access keyFile path");
   });
 });

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -8,8 +8,8 @@ import { once } from "node:events";
 import tls from "node:tls";
 // @ts-expect-error - debug-only export
 import { sslCtxLiveCount } from "bun:internal-for-testing";
-import { tempDir, tls as tlsCerts } from "harness";
-import { readFileSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, expiredTls, tempDir, tls as tlsCerts } from "harness";
+import { readFileSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 async function withServer(fn: (port: number) => Promise<void>) {
@@ -209,6 +209,81 @@ test("file-backed config: in-place rotation invalidates cache (mtime+size in dig
     expect(sslCtxLiveCount()).toBe(after1 + 1);
     pin.length = 0;
   });
+});
+
+test("file-backed config: a relative caFile is keyed on the cwd at connect() time", async () => {
+  // Two `ca.pem` files of equal size and mtime, so only the resolved path
+  // tells them apart in the digest. Only the first one signs the server.
+  let trusted = tlsCerts.cert;
+  let other = expiredTls.cert;
+  while (Buffer.byteLength(trusted) < Buffer.byteLength(other)) trusted += "\n";
+  while (Buffer.byteLength(other) < Buffer.byteLength(trusted)) other += "\n";
+  using dir = tempDir("ssl-ctx-cafile-cwd", {
+    "trusts-server/ca.pem": trusted,
+    "other-ca/ca.pem": other,
+  });
+  const mtime = 1_700_000_000;
+  utimesSync(join(String(dir), "trusts-server", "ca.pem"), mtime, mtime);
+  utimesSync(join(String(dir), "other-ca", "ca.pem"), mtime, mtime);
+
+  using server = Bun.serve({ port: 0, hostname: "127.0.0.1", tls: tlsCerts, fetch: () => new Response("OK") });
+  const script = `
+    import tls from "node:tls";
+    const pinned = [];
+    function viaBunConnect() {
+      return new Promise(resolve => {
+        Bun.connect({
+          hostname: "127.0.0.1",
+          port: ${server.port},
+          tls: { caFile: "ca.pem" },
+          socket: {
+            open(s) { pinned.push(s); },
+            handshake(s, ok, err) { resolve(ok ? "OK" : err.code); },
+            error(s, err) { resolve(err.code); },
+            connectError(s, err) { resolve(err.code); },
+            data() {},
+            close() {},
+          },
+        }).catch(err => resolve(err.code));
+      });
+    }
+    function viaNodeTls() {
+      return new Promise(resolve => {
+        const s = tls.connect({ host: "127.0.0.1", port: ${server.port}, caFile: "ca.pem", servername: "localhost" });
+        pinned.push(s);
+        s.once("secureConnect", () => resolve("OK"));
+        s.once("error", err => resolve(err.code));
+      });
+    }
+    const out = {};
+    for (const [name, attempt] of [["connect", viaBunConnect], ["tls", viaNodeTls]]) {
+      out[name] = [];
+      for (const cwd of [process.env.DIR_TRUSTED, process.env.DIR_OTHER, process.env.DIR_TRUSTED]) {
+        process.chdir(cwd);
+        out[name].push(await attempt());
+      }
+    }
+    console.log(JSON.stringify(out));
+    for (const s of pinned) s.end?.();
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      DIR_TRUSTED: join(String(dir), "trusts-server"),
+      DIR_OTHER: join(String(dir), "other-ca"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout ? JSON.parse(stdout) : stderr).toEqual({
+    connect: ["OK", "DEPTH_ZERO_SELF_SIGNED_CERT", "OK"],
+    tls: ["OK", "DEPTH_ZERO_SELF_SIGNED_CERT", "OK"],
+  });
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 test("addCACert on one user-facing context does not affect another with identical options", () => {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir, tmpdirSync } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import tls from "node:tls";
@@ -1099,5 +1099,55 @@ describe.concurrent("fetch-tls", () => {
       expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
       expect(stderr).toContain("ignoring extra certs");
     }
+  });
+
+  it("resolves a relative tls.caFile against the cwd at fetch() time", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: validTls,
+      fetch() {
+        return new Response("OK", { headers: { Connection: "close" } });
+      },
+    });
+    // Both directories hold a `ca.pem`. Only the one in `trusts-server`
+    // signs the server certificate.
+    using dir = tempDir("fetch-tls-cafile-cwd", {
+      "trusts-server/ca.pem": validTls.cert,
+      "other-ca/ca.pem": expiredTls.cert,
+    });
+    const script = `
+      async function attempt() {
+        try {
+          const res = await fetch(process.env.SERVER, { keepalive: false, tls: { caFile: "ca.pem" } });
+          return await res.text();
+        } catch (e) {
+          return e.code;
+        }
+      }
+      const out = [];
+      process.chdir(process.env.DIR_TRUSTED);
+      out.push(await attempt());
+      process.chdir(process.env.DIR_OTHER);
+      out.push(await attempt());
+      process.chdir(process.env.DIR_TRUSTED);
+      out.push(await attempt());
+      console.log(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        SERVER: `https://127.0.0.1:${server.port}`,
+        DIR_TRUSTED: join(String(dir), "trusts-server"),
+        DIR_OTHER: join(String(dir), "other-ca"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout ? JSON.parse(stdout) : stderr).toEqual(["OK", "DEPTH_ZERO_SELF_SIGNED_CERT", "OK"]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `fetch(url, { tls: { caFile: "ca.pem" } })`, then `process.chdir()` to a directory with a different `ca.pem`, then the same `fetch()`: the second request verifies the server with the first directory's CA. A fresh process there fails with `DEPTH_ZERO_SELF_SIGNED_CERT`. `Bun.connect`, `tls.connect`, `certFile`, `keyFile` and `dhParamsFile` behave the same.
- `handle_path` (`src/runtime/socket/SSLConfig.rs`) stores the raw path. usockets opens it at connect time against the process cwd, and the `SSL_CTX` caches key on the raw string (`src/http/HTTPThread.rs`, `SSLContextCache`).

### Fix
- `handle_path` joins a relative path onto the cached cwd (`AutoAbsPathChecked::init_top_level_dir().join()`) before the `access(2)` probe. No new syscall.
- A cache hit costs what it did: a pointer compare for fetch, a `stat()` for the node:tls digest. Nothing is read on a hit.
- usockets takes TLS material one way, as PEM bytes: `key`, `cert`, `ca` and the new `dh_params`. The `*_file_name` fields and the `fopen` loaders are gone from the C struct and `openssl.c`. The paths live in the Rust `BunSocketContextOptions`. On a miss, `load_files()` (`src/uws_sys/SocketContext.rs`) reads each file with one allocation into the `#[repr(C)]` `RawSocketContextOptions`. No path reaches BoringSSL's narrow `fopen`, so non-ASCII paths work on Windows.
- Verified: chdir tests in `fetch.tls.test.ts` and `ssl-ctx-cache.test.ts` (both fail on stock bun), seven tests in `bun-serve-ssl.test.ts`. Also `test/js/node/tls`, `serve-http3`, `proxy`, `bun-install-registry` CA tests.

### Background
- `SSLConfig` is the parsed `tls` object. `as_usockets()` turns it into `BunSocketContextOptions`. Bun.serve hands the loaded form to C++. Other consumers call `create_ssl_context`, which loads and builds.
- bun caches the cwd at startup and updates it on `process.chdir()`.

<details><summary>Notes</summary>

Control run on stock bun, one fresh process per directory, `caFile: "ca.pem"`:

```
/tmp/cafile-ctl/A "OK"
/tmp/cafile-ctl/B "DEPTH_ZERO_SELF_SIGNED_CERT"
```

The same two fetches in one process (chdir A, fetch, chdir B, fetch) both return `"OK"` on stock bun. The `ssl-ctx-cache.test.ts` chdir test gives the two files equal size and mtime, so only the resolved path separates them in the digest. Stock bun returns `["OK", "OK", "OK"]` for `Bun.connect` and for `tls.connect`.

History of this PR: the first version pinned the path only. Self-review found that a relative path in a non-ASCII cwd on Windows would then reach BoringSSL's narrow `fopen` as UTF-8 and fail. The second version read the files at parse time, which added a file read to every `fetch()` and `tls.connect()` that passes a file option, even on a cache hit (review above). The third kept a separate `ca_file` loader in C to preserve the file loader's PEM rules; the review above asked for one way, so the `caFile` bytes go through `ca`.

User-visible changes:
- `caFile` follows the PEM rules of `ca`, since both go through the same loader: CERTIFICATE blocks count, other blocks (CRL, TRUSTED CERTIFICATE) and a corrupt later block are skipped, and a file with no certificate is an empty trust store instead of `Failed to load CA file`. `bun-serve-ssl.test.ts` asserts that `caFile: path` and `ca: readFileSync(path)` give the same result for five inputs.
- A file that exists at parse time but cannot be read when the context is built: Bun.serve throws the node_fs error (for example `EISDIR: illegal operation on a directory, read '/x/adir'`). `Bun.listen`, `Bun.connect`, `node:tls` and `Bun.sql` report `Failed to load key file` / `Failed to load certificate file` / `Failed to load DH params file`, or the existing `Failed to load CA file`. Before, these surfaced as the BoringSSL queue error of the failed `fopen` (`NO_START_LINE` for a directory). fetch is unchanged: it reports `FailedToOpenSocket` for an unreadable file, as before.
- `..` in a relative path is resolved lexically, as `path.resolve()` and the other cwd-anchoring sites in bun (`Bun.mmapFile`, `fs.watch`, `--cafile`) do.
- A FIFO or `/dev/fd/N` as a file option still works: the Rust read is a cursor `read(2)` loop (`File::read_to_end_into`), as `cert_files.rs` uses for `NODE_EXTRA_CA_CERTS`.

`bun install --cafile` (`HTTPThread` `abs_ca_file_name`) goes through the same `load_files()` on the HTTP thread at init. A missing file still reports `LoadCAFile`, and `init_with_thread_opts` maps a rejected CA back to `InvalidCAFile` so the `HTTPThread: invalid CA file: '<path>'` message is unchanged. The proxied-origin path from #42661 calls `create_ssl_context`, so it loads files the same way.

`LoadedFile::read_z` reserves the `fstat` size plus one byte before the cursor read loop and keeps the `Vec`, so a regular file costs one allocation and the NUL lands in the spare byte. A pipe reports size 0 and grows in the read loop.

Precedence is unchanged from main: a file option replaces the inline value of the same field (`caFile` over `ca`), as usockets did with `if (ca_file_name) ... else if (ca)`.

The branch is merged with main (through #42661 and #42693). The merged build passes the suites below.

Parity checks run by hand on the debug build and on stock bun, same output on both: mTLS with `caFile` plus `requestCert` on the server and `certFile`/`keyFile` on the fetch side (trusted client OK, untrusted client and no client cert rejected), an encrypted `keyFile` with a right and a wrong `passphrase`, `dhParamsFile` relative and absolute, a key file passed as `dhParamsFile` (`NO_START_LINE` on both), a missing `dhParamsFile`, and a FIFO as `keyFile`.

Suites run: all of `fetch.tls.test.ts`, `bun-serve-ssl.test.ts`, `serve-http3.test.ts`, `test/js/node/tls/{node-tls-server,node-tls-context,node-tls-cert,node-tls-connect,node-tls-create-secure-context-args,fetch-tls-cert,test-node-extra-ca-certs,ssl-ctx-cache,node-tls-connect-hostname-verification}.test.ts`, `test/js/bun/net/{tcp-server,socket}.test.ts`, `bun-connect-x509.test.ts`, `proxy.test.ts`, `websocket-proxy.test.ts`, `test/js/sql/adapter-env-var-precedence.test.ts`. Failures seen and unrelated: one `node-tls-server.test.ts` test (`SNICallback runs even when the requested servername matches the bind hostname`) fails in this container on stock bun too (`localhost` binds `::1`, the client dials `127.0.0.1`), and the tests that dial `example.com` or `ws.postman-echo.com` have no internet here.

Self-review: 11 concerns raised across two rounds, 9 addressed (cursor read for FIFOs, the JS-thread chdir test, `serverName` and FIFO tests, `dhParamsFile` coverage, the `AutoAbsPathChecked` helper, a wrong fetch error claim in this body, and the CA loader question, settled by the maintainer's direction to use one loader). Two not taken: replacing the `create_bun_socket_error_t` out-param with a typed `Result` that carries the `bun_sys::Error` to every caller (`SSLContextCache`, the runtime and sql hook function pointers, `VirtualMachine::ssl_ctx_cache_get_or_create`) touches a dozen call sites across six crates for a message on a rare path, and a follow-up can do it since `LoadFileError` already carries the error with the path. A Windows rooted path without a drive (`\\certs\\ca.pem`) counts as absolute and is not pinned, the same as the other cwd-anchoring sites.

Open PR #37005 adds a NUL-byte check to `handle_path`, before the join added here. No overlap in logic.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.tls.test.ts, test/js/bun/http/bun-serve-ssl.test.ts

<!-- robobun:evidence:end -->
