### PR TITLE
parser: keep legal comments across the speculative arrow parse in a conditional

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -167,6 +167,7 @@ impl<'a> core::ops::DerefMut for NamedImportsType<'a> {
 /// See [`P::parser_snapshot`].
 pub(crate) struct ParserSnapshot<'a> {
     lexer: js_lexer::LexerSnapshot<'a>,
+    comments_to_preserve_before: Vec<js_ast::G::Comment>,
     log_msgs_len: usize,
     log_errors: u32,
     log_warnings: u32,
@@ -7377,10 +7378,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// dynamic imports and logs through `P::log()`, which ignores
     /// `lexer.is_log_disabled`. Lists are captured as lengths and truncated
     /// on restore; the attempt's arena allocations just become unreachable.
-    pub(crate) fn parser_snapshot(&self) -> ParserSnapshot<'a> {
+    /// The legal comments waiting for the next statement are moved out
+    /// instead: a block body or `import()` drains them, so a length cannot
+    /// restore them.
+    pub(crate) fn parser_snapshot(&mut self) -> ParserSnapshot<'a> {
+        let comments_to_preserve_before =
+            core::mem::take(&mut self.lexer.comments_to_preserve_before);
         let log = self.log();
         ParserSnapshot {
             lexer: self.lexer.snapshot(),
+            comments_to_preserve_before,
             log_msgs_len: log.msgs.len(),
             log_errors: log.errors,
             log_warnings: log.warnings,
@@ -7411,6 +7418,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// Undo every parse-pass mutation made since [`Self::parser_snapshot`].
     pub(crate) fn restore_parser_snapshot(&mut self, snapshot: ParserSnapshot<'a>) {
         self.lexer.restore(&snapshot.lexer);
+        self.lexer.comments_to_preserve_before = snapshot.comments_to_preserve_before;
 
         let log = self.log();
         log.msgs.truncate(snapshot.log_msgs_len);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -377,6 +377,13 @@ describe("Bun.Transpiler", () => {
         "x = a ? (b) => {\n  return a ? (b) => d : e;\n} : f;\n",
       );
 
+      // A legal comment scanned between "?" and "(" waits in the lexer for the
+      // next statement. The attempt's block body or import() takes it. The real
+      // parse must still get it.
+      exp("x = a ? /*! L */ (b) : T => { let y = 1 } : c", "x = a ? (b) => {\n  /*! L */\n  let y = 1;\n} : c;\n");
+      exp("x = a ? /*! L */ (b) : c => { return d }", "x = a ? b : (c) => {\n  /*! L */\n  return d;\n};\n");
+      exp('x = a ? /*! L */ (b) : T => import("m") : c', 'x = a ? (b) => import("m") : c;\n');
+
       // The attempt parses the body, so an attempt nested in the body must not
       // run again when the body is parsed for real: 2^40 parses would hang.
       let kept = "d";


### PR DESCRIPTION
### Problem
- `x = a ? /*! L */ (b) : T => { let y = 1 } : c` aborts a debug build: `panic: assertion failed: self.comments_to_preserve_before.len() >= original.comments_to_preserve_before_len` in `Lexer::restore` (`src/js_parser/lexer.rs:396`). A release build drops the legal comment from the output.
- The cause is the speculative parse from #40818 (`src/js_parser/parse/parse_skip_typescript.rs:1598`). It parses the arrow body, then restores a snapshot that records `comments_to_preserve_before` as a length. A block body (`src/js_parser/parse/mod.rs:1473`) or an `import()` drains that buffer. A length cannot restore it.

### Fix
- `P::parser_snapshot` moves the buffer out of the lexer with `core::mem::take`. The attempt runs with an empty buffer. `restore_parser_snapshot` puts the original back.
- Correct because the attempt's output is discarded. The real parse scans the same tokens again and attaches the comment to the first statement of the arrow body.
- Verified: `test/bundler/transpiler/transpiler.test.js` (three new cases, each aborts the debug build without the fix). Also `bundler_comments`, `bundler_edgecase`, `esbuild/ts`.

### Background
- A legal comment is `/*! ... */`, `//! ...`, or a comment with `@license` or `@preserve`. The lexer collects them in `comments_to_preserve_before`. The next statement takes them and prints them before itself.
- In TypeScript, `(b) : c => d` after `a ?` is an arrow function with return type `c` only when another `:` follows its body. Otherwise the `:` pairs with the `?`. #40818 decides this with a speculative parse: snapshot, parse the body, restore.
- `ParserSnapshot` (`src/js_parser/p.rs`) holds everything a parse of an expression mutates. Lists are stored as lengths and truncated on restore.

<details><summary>Notes</summary>

- Found while I checked whether #34252 is superseded by #40818. The test block of #34252 has these three cases. With this change, all 32 of its assertions pass on main.
- The `import()` case loses the comment with and without this change, because `import()` parsing (`parse_import_export.rs:49`) clears the buffer. That case covers only the assertion.
- Release output without this change: `x = a ? (b) => {\n  let y = 1;\n} : c;` (the comment is gone).
- `parser_snapshot` has one caller. It now takes `&mut self`.
</details>
