### PR TITLE
Skip the synchronous getaddrinfo for a hostname that can never resolve

### DIFF
--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -826,12 +826,8 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
     Ok(instance)
 }
 
-/// `getaddrinfo ENOTFOUND <hostname>`, the error `Bun.connect` reports for a
-/// name that does not resolve. The bind paths (`Bun.serve`, `Bun.listen`,
-/// `Bun.udpSocket`) throw it for a hostname `bun_dns::is_valid_hostname`
-/// rejects, before the name reaches the synchronous `getaddrinfo` in uSockets:
-/// some resolvers never answer a query for such a name, and the libc call then
-/// blocks the JS thread until the resolver gives up (tens of seconds on macOS).
+/// Thrown for a name `is_valid_hostname` rejects, before uSockets' synchronous
+/// `getaddrinfo` can block on a query some resolvers never answer.
 pub(crate) fn not_a_hostname_error(global_this: &JSGlobalObject, hostname: &[u8]) -> JSValue {
     system_error_with_syscall_and_hostname(c_ares::Error::ENOTFOUND, b"getaddrinfo", hostname)
         .to_error_instance(global_this)

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -826,6 +826,17 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
     Ok(instance)
 }
 
+/// `getaddrinfo ENOTFOUND <hostname>`, the error `Bun.connect` reports for a
+/// name that does not resolve. The bind paths (`Bun.serve`, `Bun.listen`,
+/// `Bun.udpSocket`) throw it for a hostname `bun_dns::is_valid_hostname`
+/// rejects, before the name reaches the synchronous `getaddrinfo` in uSockets:
+/// some resolvers never answer a query for such a name, and the libc call then
+/// blocks the JS thread until the resolver gives up (tens of seconds on macOS).
+pub(crate) fn not_a_hostname_error(global_this: &JSGlobalObject, hostname: &[u8]) -> JSValue {
+    system_error_with_syscall_and_hostname(c_ares::Error::ENOTFOUND, b"getaddrinfo", hostname)
+        .to_error_instance(global_this)
+}
+
 // ── canonicalizeIP host fn ─────────────────────────────────────────────────
 // `#[bun_jsc::host_fn(export = ...)]` emits the C-ABI shim under that link name.
 #[bun_jsc::host_fn(export = "Bun__canonicalizeIP")]

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -826,8 +826,7 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
     Ok(instance)
 }
 
-/// Thrown for a name `is_valid_hostname` rejects, before uSockets' synchronous
-/// `getaddrinfo` can block on a query some resolvers never answer.
+/// Thrown before uSockets' synchronous `getaddrinfo` can block on a name that can never resolve.
 pub(crate) fn not_a_hostname_error(global_this: &JSGlobalObject, hostname: &[u8]) -> JSValue {
     system_error_with_syscall_and_hostname(c_ares::Error::ENOTFOUND, b"getaddrinfo", hostname)
         .to_error_instance(global_this)

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3582,9 +3582,7 @@ mod ffi {
     }
 }
 
-/// `Bun.serve({ hostname: "[::1]" })` takes a bracketed IPv6 literal; uSockets
-/// wants it bare. Brackets around anything else stay, and the name then fails
-/// `is_valid_hostname` instead of resolving as its inside.
+/// `Bun.serve({ hostname: "[::1]" })`: uSockets wants the IPv6 literal bare.
 fn strip_ipv6_brackets(hostname: &[u8]) -> &[u8] {
     if let [b'[', inner @ .., b']'] = hostname {
         if bun_core::ip_address::to_ip_address(inner).is_some_and(|ip| ip.is_ipv6()) {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2815,6 +2815,22 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // not `*this`.
         let global = this_ref.global_this();
 
+        if let server_config::Address::Tcp {
+            hostname: Some(hostname),
+            ..
+        } = &this_ref.config.address
+        {
+            let hostname = hostname.as_bytes();
+            if !bun_dns::is_valid_hostname(strip_ipv6_brackets(hostname)) {
+                let _ = global.throw_value(crate::dns_jsc::cares_jsc::not_a_hostname_error(
+                    global, hostname,
+                ));
+                // SAFETY: caller contract — `this` is the live boxed server from `init()`.
+                Self::deinit(this);
+                return JSValue::ZERO;
+            }
+        }
+
         let app: *mut uws_sys::NewApp<SSL>;
         let route_list_value;
 
@@ -3057,14 +3073,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     let mut host: *const c_char = core::ptr::null();
                     if let Some(existing) = hostname.as_deref() {
                         let bytes = existing.as_bytes();
-                        if bytes.len() > 2 && bytes[0] == b'[' {
-                            // strip "[" and "]" from IPv6 literal
-                            host = stripped_hostname
-                                .insert(bun_core::ZBox::from_bytes(&bytes[1..bytes.len() - 1]))
-                                .as_ptr();
+                        let bare = strip_ipv6_brackets(bytes);
+                        host = if bare.len() == bytes.len() {
+                            existing.as_ptr()
                         } else {
-                            host = existing.as_ptr();
-                        }
+                            stripped_hostname
+                                .insert(bun_core::ZBox::from_bytes(bare))
+                                .as_ptr()
+                        };
                     }
                     Addr::Tcp { port: *port, host }
                 }
@@ -3563,6 +3579,16 @@ mod ffi {
             upgrade_ctx: *mut c_void,
             node_response_ptr: &mut *mut NodeHTTPResponse,
         ) -> jsc::JSValue;
+    }
+}
+
+/// `Bun.serve({ hostname: "[::1]" })` takes a bracketed IPv6 literal; uSockets
+/// wants it bare.
+fn strip_ipv6_brackets(hostname: &[u8]) -> &[u8] {
+    if hostname.len() > 2 && hostname[0] == b'[' {
+        &hostname[1..hostname.len() - 1]
+    } else {
+        hostname
     }
 }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3583,13 +3583,15 @@ mod ffi {
 }
 
 /// `Bun.serve({ hostname: "[::1]" })` takes a bracketed IPv6 literal; uSockets
-/// wants it bare.
+/// wants it bare. Brackets around anything else stay, and the name then fails
+/// `is_valid_hostname` instead of resolving as its inside.
 fn strip_ipv6_brackets(hostname: &[u8]) -> &[u8] {
-    if hostname.len() > 2 && hostname[0] == b'[' {
-        &hostname[1..hostname.len() - 1]
-    } else {
-        hostname
+    if let [b'[', inner @ .., b']'] = hostname {
+        if bun_core::ip_address::to_ip_address(inner).is_some_and(|ip| ip.is_ipv6()) {
+            return inner;
+        }
     }
+    hostname
 }
 
 /// Drain the BoringSSL error queue; if non-empty, throw the top error on

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -191,6 +191,16 @@ impl Listener {
         let _cell_root = socket_config.handlers.root_cell(global);
 
         let port = socket_config.port;
+        if port.is_some() {
+            let hostname = socket_config.hostname_or_unix.slice();
+            if !bun_dns::is_valid_hostname(hostname) {
+                return Err(
+                    global.throw_value(crate::dns_jsc::cares_jsc::not_a_hostname_error(
+                        global, hostname,
+                    )),
+                );
+            }
+        }
         let ssl_enabled = socket_config.ssl.is_some();
         let socket_flags = socket_config.socket_flags();
         let pause_on_connect = socket_config.pause_on_connect;

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -638,6 +638,24 @@ impl UDPSocket {
 
         let config = this.config.get();
         let hostname_z = config.hostname.to_owned_slice_z();
+        // Both the bind and the connect below resolve their hostname with a
+        // synchronous getaddrinfo.
+        if config.fd.is_none() && !bun_dns::is_valid_hostname(hostname_z.as_bytes()) {
+            return Err(
+                global_this.throw_value(crate::dns_jsc::cares_jsc::not_a_hostname_error(
+                    global_this,
+                    hostname_z.as_bytes(),
+                )),
+            );
+        }
+        if let Some(connect) = &config.connect {
+            let address = connect.address.to_utf8();
+            if !bun_dns::is_valid_hostname(&address) {
+                return Err(global_this.throw_value(
+                    crate::dns_jsc::cares_jsc::not_a_hostname_error(global_this, &address),
+                ));
+            }
+        }
 
         // Reserve an adopted descriptor before creating the socket so a
         // concurrent adoption of the same number fails with EEXIST (like

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -638,8 +638,6 @@ impl UDPSocket {
 
         let config = this.config.get();
         let hostname_z = config.hostname.to_owned_slice_z();
-        // Both the bind and the connect below resolve their hostname with a
-        // synchronous getaddrinfo.
         if config.fd.is_none() && !bun_dns::is_valid_hostname(hostname_z.as_bytes()) {
             return Err(
                 global_this.throw_value(crate::dns_jsc::cares_jsc::not_a_hostname_error(

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1914,6 +1914,14 @@ impl UDPSocket {
 
         let str = args[0].to_bun_string(global_this)?;
         let connect_host = str.to_owned_slice_z();
+        if !bun_dns::is_valid_hostname(connect_host.as_bytes()) {
+            return Err(
+                global_this.throw_value(crate::dns_jsc::cares_jsc::not_a_hostname_error(
+                    global_this,
+                    connect_host.as_bytes(),
+                )),
+            );
+        }
 
         let connect_port_js = args[1];
 

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -161,6 +161,46 @@ describe.each([
   });
 });
 
+// A name that cannot be a host name (a space, a colon, an empty label) is
+// rejected in-process with the resolver's ENOTFOUND, the error Bun.connect
+// reports for the same name. The system resolver is never asked: some DNS
+// servers never answer a query for such a label, and the synchronous
+// getaddrinfo behind listen() then blocks startup for its full timeout.
+describe.each([
+  ["http", {}],
+  ["https", { tls }],
+] as const)("Bun.serve() %s with a hostname that is not a hostname", (_, options) => {
+  test.each(["this is not a hostname", "localhost:80", "a..b"])("%p throws getaddrinfo ENOTFOUND", hostname => {
+    let error: any;
+    try {
+      serve({ ...options, hostname, port: 0, fetch: () => new Response() }).stop(true);
+    } catch (e) {
+      error = e;
+    }
+    const { name, code, syscall, hostname: errHostname, message } = error ?? {};
+    expect({ name, code, syscall, hostname: errHostname, message }).toEqual({
+      name: "Error",
+      code: "ENOTFOUND",
+      syscall: "getaddrinfo",
+      hostname,
+      message: `getaddrinfo ENOTFOUND ${hostname}`,
+    });
+  });
+
+  test("a later Bun.serve() still binds", () => {
+    using server = serve({ ...options, port: 0, fetch: () => new Response() });
+    expect(server.port).toBeInteger();
+  });
+});
+
+test.skipIf(!hasIPv6)("Bun.serve() binds a bracketed IPv6 literal hostname", () => {
+  using server = serve({ hostname: "[::1]", port: 0, fetch: () => new Response() });
+  expect({ hostname: server.hostname, urlHostname: server.url.hostname }).toEqual({
+    hostname: "[::1]",
+    urlHostname: "[::1]",
+  });
+});
+
 // Linux-only: uses /proc/self/fd to find the listen socket and close it from
 // under the server so getsockname() fails with EBADF.
 test.skipIf(!isLinux)("server.address / server.port do not panic when getsockname() fails", async () => {

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -161,31 +161,35 @@ describe.each([
   });
 });
 
-// A name that cannot be a host name (a space, a colon, an empty label) is
-// rejected in-process with the resolver's ENOTFOUND, the error Bun.connect
-// reports for the same name. The system resolver is never asked: some DNS
-// servers never answer a query for such a label, and the synchronous
-// getaddrinfo behind listen() then blocks startup for its full timeout.
+// A name that cannot be a host name (a space, a colon, an empty label,
+// brackets around anything but an IPv6 literal) is rejected in-process with the
+// resolver's ENOTFOUND, the error Bun.connect reports for the same name. The
+// system resolver is never asked: some DNS servers never answer a query for
+// such a label, and the synchronous getaddrinfo behind listen() then blocks
+// startup for its full timeout.
 describe.each([
   ["http", {}],
   ["https", { tls }],
 ] as const)("Bun.serve() %s with a hostname that is not a hostname", (_, options) => {
-  test.each(["this is not a hostname", "localhost:80", "a..b"])("%p throws getaddrinfo ENOTFOUND", hostname => {
-    let error: any;
-    try {
-      serve({ ...options, hostname, port: 0, fetch: () => new Response() }).stop(true);
-    } catch (e) {
-      error = e;
-    }
-    const { name, code, syscall, hostname: errHostname, message } = error ?? {};
-    expect({ name, code, syscall, hostname: errHostname, message }).toEqual({
-      name: "Error",
-      code: "ENOTFOUND",
-      syscall: "getaddrinfo",
-      hostname,
-      message: `getaddrinfo ENOTFOUND ${hostname}`,
-    });
-  });
+  test.each(["this is not a hostname", "localhost:80", "a..b", "[not-an-ipv6]"])(
+    "%p throws getaddrinfo ENOTFOUND",
+    hostname => {
+      let error: any;
+      try {
+        serve({ ...options, hostname, port: 0, fetch: () => new Response() }).stop(true);
+      } catch (e) {
+        error = e;
+      }
+      const { name, code, syscall, hostname: errHostname, message } = error ?? {};
+      expect({ name, code, syscall, hostname: errHostname, message }).toEqual({
+        name: "Error",
+        code: "ENOTFOUND",
+        syscall: "getaddrinfo",
+        hostname,
+        message: `getaddrinfo ENOTFOUND ${hostname}`,
+      });
+    },
+  );
 
   test("a later Bun.serve() still binds", () => {
     using server = serve({ ...options, port: 0, fetch: () => new Response() });

--- a/test/js/bun/net/socket-dns-error.test.ts
+++ b/test/js/bun/net/socket-dns-error.test.ts
@@ -139,6 +139,22 @@ test.each(["this is not a hostname", "localhost:80", "a..b"])(
   },
 );
 
+// The listen side binds through a synchronous getaddrinfo, so a name the
+// resolver would sit on blocks the whole thread. The same names are rejected
+// before the call, with the same error the connect side reports.
+test.each(["this is not a hostname", "localhost:80", "a..b"])(
+  "Bun.listen on %p, which is not a hostname, throws ENOTFOUND without asking the resolver",
+  hostname => {
+    let error: any;
+    try {
+      Bun.listen({ hostname, port: 0, socket: { data() {} } }).stop(true);
+    } catch (e) {
+      error = e;
+    }
+    expect(pick(error ?? {})).toEqual({ ...EXPECTED, hostname, message: `getaddrinfo ENOTFOUND ${hostname}` });
+  },
+);
+
 // An answer that is already known when Bun.connect() is called (answered
 // in-process, or a cache hit) is delivered from the event loop, not inline.
 // When the connect is made from the callback that delivers the previous

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -467,6 +467,36 @@ test.skipIf(isWindows)("connected send() failure reports Node's error shape", as
   });
 });
 
+// The default lookup is dns.lookup, which already answers such a name with
+// ENOTFOUND. A custom lookup can hand the raw string to the native connect,
+// which resolves it synchronously: the same check runs there too, and the
+// socket does not end up marked connected.
+test("connect() with a custom lookup that yields a name that cannot be a hostname reports getaddrinfo ENOTFOUND", async () => {
+  const hostname = "this is not a hostname";
+  const socket = createSocket({ type: "udp4", lookup: (address, _family, callback) => callback(null, address, 4) });
+  const { promise: bound, resolve: onBound } = Promise.withResolvers<void>();
+  socket.bind(0, "127.0.0.1", onBound);
+  await bound;
+
+  const err: any = await new Promise(resolve => socket.connect(1234, hostname, resolve));
+  let connected = true;
+  try {
+    socket.remoteAddress();
+  } catch {
+    connected = false;
+  }
+  socket.close();
+  const { name, code, syscall, hostname: errHostname, message } = err ?? {};
+  expect({ name, code, syscall, hostname: errHostname, message, connected }).toEqual({
+    name: "Error",
+    code: "ENOTFOUND",
+    syscall: "getaddrinfo",
+    hostname,
+    message: `getaddrinfo ENOTFOUND ${hostname}`,
+    connected: false,
+  });
+});
+
 // Every send callback must fire with (null, byteLength) — never (null, 0) or
 // EAGAIN — even if the kernel refuses some writes (they queue and drain like
 // libuv's uv_udp_try_send → uv_udp_send fallback).

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -86,6 +86,44 @@ describe("udpSocket()", () => {
     ).toThrow();
   });
 
+  // The bind and the connect option both resolve their hostname with a
+  // synchronous getaddrinfo. A name that cannot be a host name is rejected
+  // before that call, with the resolver error node:dgram reports for it,
+  // instead of a stale errno named as the bind failure.
+  describe.each(["this is not a hostname", "localhost:80", "a..b"])("with %p, which is not a hostname", hostname => {
+    const resolverError = {
+      name: "Error",
+      code: "ENOTFOUND",
+      syscall: "getaddrinfo",
+      hostname,
+      message: `getaddrinfo ENOTFOUND ${hostname}`,
+    };
+    const pick = (e: any) => {
+      const { name, code, syscall, hostname, message } = e ?? {};
+      return { name, code, syscall, hostname, message };
+    };
+
+    test("bind fails with getaddrinfo ENOTFOUND", async () => {
+      let error: any;
+      try {
+        (await udpSocket({ hostname, port: 0 })).close();
+      } catch (e) {
+        error = e;
+      }
+      expect(pick(error)).toEqual(resolverError);
+    });
+
+    test("connect fails with getaddrinfo ENOTFOUND", async () => {
+      let error: any;
+      try {
+        (await udpSocket({ port: 0, connect: { hostname, port: 1234 } })).close();
+      } catch (e) {
+        error = e;
+      }
+      expect(pick(error)).toEqual(resolverError);
+    });
+  });
+
   // Out-of-range connect.port used to be silently rewritten to 0, so send()
   // returned true while every datagram was dropped. The bind path already
   // rejected the same values; connect must too. Values beyond the i32 range


### PR DESCRIPTION
### Problem
- `Bun.serve`, `Bun.listen` and `Bun.udpSocket` (bind and connect) resolve their hostname with a synchronous `getaddrinfo` in uSockets (`packages/bun-usockets/src/bsd.c:1340`, `:1733`, `:1818`), even for a name that can never be a hostname. Some resolvers never answer such a query, and the call blocks the JS thread (#40970 saw this on the connect side).
- Its error is also wrong: `Bun.serve({ hostname: "this is not a hostname" })` throws `ENOENT: no such file or directory, listen`, `Bun.listen` a bare `Failed to listen at <host>`, `Bun.udpSocket` `bind ENOENT <host>`, and `dgram`'s `connect()` reports success.

### Fix
- Each path checks the hostname with `bun_dns::is_valid_hostname` before it calls into uSockets. A rejected name throws `getaddrinfo ENOTFOUND <host>` with `code`, `syscall` and `hostname`: what `Bun.connect` reports for it and what Node emits from `server.listen()`.
- `Bun.serve` now strips brackets only around an IPv6 literal: `"[::1]"` still binds, `"[foo]"` no longer resolves as `foo`.
- A well-formed name that does not resolve (`nxdomain.invalid`) still gets the wrong errno. #37690 (serve/listen) and #37707 (udp) fix that. This PR does not touch `bsd.c` or fix #25765.
- Verified: 18 new cases in `test/js/bun/http/serve-listen.test.ts`, `test/js/bun/net/socket-dns-error.test.ts`, `test/js/bun/udp/udp_socket.test.ts` and `test/js/bun/udp/dgram.test.ts` fail on 1.4.1 and pass here. Also ran the serve, socket, net and dgram suites.

### Background
- `is_valid_hostname` (`src/dns/lib.rs`) accepts an IP literal or an RFC 1035 name (labels of 1 to 63 bytes from the c-ares set, 253 total).
- Node resolves with `dns.lookup` before it binds, so no name reaches a blocking call.
- Self-reviewed: 2 concerns, both addressed (an unchecked udp `connect` path; the framing is now the resolver skip).

<details><summary>Notes</summary>

What is and is not shown here:

- The blocking resolver is not observed in this PR. It is the same libc `getaddrinfo` call, on the same names, that #40970 measured on the connect side (`dns.lookup` waiting out the macOS resolver timeout for a label with a space). Linux glibc rejects these names locally, so on Linux the visible change is only the error.
- No user report exists for a malformed bind hostname. #25765 (`something.localhost` on macOS) is a well-formed name and is #37690's case.

Repro on 1.4.1 (Linux, no resolver needed for the first four names):

```
serve "this is not a hostname" => ENOENT listen "ENOENT: no such file or directory, listen"
listen "this is not a hostname" => (no code) "Failed to listen at this is not a hostname"
udpSocket "this is not a hostname" => ENOENT bind "bind ENOENT this is not a hostname"
udpSocket connect { hostname: "this is not a hostname" } => DNSException "connect ENOTFOUND this is not a hostname"
dgram socket.connect(1234, "this is not a hostname") via a custom lookup => no error, socket marked connected
serve "aaaa...(64).com" => EMSGSIZE listen
serve "nxdomain.invalid" => EAGAIN listen (left to #37690)
udpSocket "nxdomain.invalid" => ESRCH bind (left to #37707)
```

After this change the first six report `getaddrinfo ENOTFOUND <host>` (`name: "Error"`, `code: "ENOTFOUND"`, `syscall: "getaddrinfo"`, `hostname`). `node:net`, `node:http` and `node:dgram` (custom `lookup`) servers emit the same error object from `listen()` / `bind()`.

Where the check sits:

- `Bun.serve`: at the top of `NewServer::listen` (`src/runtime/server/mod.rs`), before the uws app is created. The existing `deinit` path frees the server and `Bun.serve` throws synchronously, as it does for `EADDRINUSE`. The bracket strip now lives in one function, `strip_ipv6_brackets`, used by the check and by the existing `Addr` code. It used to drop the first and last byte of any hostname that starts with `[`, so `[foo]` resolved as `foo` (`[localhost]`, `[127.0.0.1]` and `[example.com` were already rejected by the base URL parse). It now strips only when the inside is an IPv6 literal (`to_ip_address`, so a `%zone` still passes); anything else keeps its brackets and fails `is_valid_hostname`.
- `Bun.listen` (`src/runtime/socket/Listener.rs`): right after `SocketConfig::from_js`, only when a port is set (a unix path or an adopted fd has no hostname). `SocketConfig::from_js` itself is shared with `Bun.connect`, whose error is delivered asynchronously, so the check is not placed there.
- `Bun.udpSocket` (`src/runtime/socket/udp_socket.rs`): bind and `connect.hostname` are both checked right after the config parse, before the socket is created. Bind failures there throw synchronously today, and so does this. The `connect` option used to report these names as `connect ENOTFOUND <host>` (`DNSException`) from the `EAI_*` code; a well-formed unresolvable `connect.hostname` still does, that block is #38622's.
- The internal `UDPSocket.jsConnect` that `node:dgram`'s `socket.connect()` calls gets the same check. `dgram` resolves with `dns.lookup` first, so only a custom `lookup` can hand it a raw name. glibc rejected such a name with a code `jsConnect` never read (it checks for `-1` only), so the socket was marked connected with no error. #38622 reworks that return-code handling; the check here sits before the call and does not overlap it.

The error is built by `not_a_hostname_error` in `src/runtime/dns_jsc/cares_jsc.rs` from `system_error_with_syscall_and_hostname`, the helper `Bun.connect` uses.

For #37690 and #37707: their tests use a 64-byte label, which `is_valid_hostname` rejects, so once this lands that input is answered in-process and no longer exercises the `dns_error` plumbing. glibc rejects `a*b.com`, `a/b.com`, `-a.com` and `ünicode.com` locally (`EAI_NONAME`, no query sent) while `is_valid_hostname` accepts all four. Other platforms need checking in CI.

`Bun.listen({ hostname: "[::1]" })` and `Bun.udpSocket({ hostname: "[::1]" })` never stripped brackets and already fail on 1.4.1 (`Failed to listen at [::1]`, `bind ENOENT [::1]`). They now fail with `getaddrinfo ENOTFOUND [::1]`.

Suites run on the debug build: `serve-listen.test.ts` (37 pass), `socket-dns-error.test.ts` (11 pass), `udp_socket.test.ts` (214 pass), `dgram.test.ts` + `udp_socket_recv_flags.test.ts` (64 pass), `serve.test.ts` + `serve-http3.test.ts` + `server-url-invalid.test.ts` (349 pass, 2 environment failures: root can bind port 1003, egress proxy), `node-net-server.test.ts`, `serve-epoll-add-fail.test.ts`, `test/internal/source-lints/` (171 pass), node `test-dgram-bind*`, `test-dgram-connect*`, `test-dgram-custom-lookup`, `test-dgram-error-message-address`, `test-net-listen-error`, `test-http-listening`. `socket.test.ts` and `node-net.test.ts` have the same `localhost` dual-stack failures on the released bun in this container.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/udp/udp_socket.test.ts, test/js/bun/udp/dgram.test.ts, test/js/bun/http/serve-listen.test.ts

<!-- robobun:evidence:end -->