### PR TITLE
test(fs): restore the synthetic allocation limit after fs-oom.test.ts

### DIFF
--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -1,10 +1,19 @@
 import { memfd_create, setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { closeSync, readFileSync, truncateSync, writeFileSync, writeSync } from "fs";
 import { bunEnv, bunExe, isASAN, isLinux, isPosix, tempDir } from "harness";
 import os from "node:os";
 import { join } from "path";
-setSyntheticAllocationLimitForTesting(128 * 1024 * 1024);
+
+// The limit is process-wide and a `--parallel` worker runs many files in one
+// process, so put it back for whatever runs after this file. A later file in
+// the same worker would otherwise fail to build any string over the lowered
+// limit with ERR_STRING_TOO_LONG.
+const FILE_LIMIT = 128 * 1024 * 1024;
+const previousLimit = setSyntheticAllocationLimitForTesting(FILE_LIMIT);
+afterAll(() => {
+  setSyntheticAllocationLimitForTesting(previousLimit);
+});
 
 // /dev/zero reports a size of 0. So we need a separate test for reDgular files that are huge.
 if (isPosix) {
@@ -42,6 +51,7 @@ if (isLinux) {
           "ENOMEM: not enough memory",
         );
       } finally {
+        setSyntheticAllocationLimitForTesting(FILE_LIMIT);
         Bun.gc(true);
         closeSync(memfd);
       }


### PR DESCRIPTION
### Problem
- `test/js/bun/http/bun-serve-file.test.ts` fails in the CI parallel batch on the Linux lanes (ubuntu 25.04 x64 and aarch64, debian 13 x64) and passes alone. Three cases that read the 8 MiB `large.txt` body reject with `Cannot create a string longer than 2147483647 characters` (`ERR_STRING_TOO_LONG`).
- The cause is a cross-file leak. `test/js/node/fs/fs-oom.test.ts:7` sets `setSyntheticAllocationLimitForTesting(128 MiB)` and `fs-oom.test.ts:38` sets it to 2 MiB inside the Linux memfd cases. Neither call is undone. The limit is the process-wide atomic `STRING_ALLOCATION_LIMIT` (`src/bun_core/string/mod.rs:1732`), and `EncodedSlice::to_external_value` (`src/jsc/EncodedSlice.rs:109`) throws `STRING_TOO_LONG` for any string over it.
- A `bun test --parallel` worker runs many files in one process (`src/cli/test/parallel/Coordinator.rs:294`, `assign_work`). Work stealing can hand `bun-serve-file.test.ts` to the worker that ran `fs-oom.test.ts`. Every string over 2 MiB then fails for the rest of that worker's life.

### Fix
- `fs-oom.test.ts` saves the value returned by the file-scope `setSyntheticAllocationLimitForTesting` call and restores it in `afterAll`. This is the pattern `test/js/web/fetch/blob-oom.test.ts:33` already uses.
- The memfd cases restore the file baseline (128 MiB) in their `finally` block, so the 2 MiB value never outlives the case that needs it.
- Verified: `bun test --parallel=1 test/js/node/fs/fs-oom.test.ts <probe>` where the probe does `fetch().text()` on an 8 MiB body. Before the fix the probe fails with the exact CI error. After the fix both files pass (3 of 3 runs under the debug build, and with the released binary). `fs-oom.test.ts` alone passes under `bun bd test`.

### Background
- `setSyntheticAllocationLimitForTesting` (`bun:internal-for-testing`, `src/jsc/virtual_machine_exports.rs:297`) caps the size of strings and buffers bun will allocate. OOM tests lower it so a 16 MiB read fails like a 4 GiB one would. It returns the previous value so a caller can restore it.
- The 2 MiB call sits inside an `isLinux` block, which is why only the Linux lanes failed.
- The error text names the WTF hard limit (2^31 - 1) and not the synthetic one, so the message looked like a bug in the 8 MiB response path. It is not.

<details><summary>Notes</summary>

Minimal repro, two files under one worker:

```ts
// a-leak.test.ts
import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
import { test } from "bun:test";
test("lowers the limit", () => {
  setSyntheticAllocationLimitForTesting(2 * 1024 * 1024);
});
```

```ts
// b-serve.test.ts
import { expect, test } from "bun:test";
test("fetch().text() of an 8 MiB body", async () => {
  using server = Bun.serve({ port: 0, fetch: () => new Response(Buffer.alloc(8 * 1024 * 1024, "bun")) });
  const text = await (await fetch(server.url)).text();
  expect(text).toHaveLength(8 * 1024 * 1024);
});
```

```
$ BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun test --parallel=1 ./a-leak.test.ts ./b-serve.test.ts
b-serve.test.ts:
error: Cannot create a string longer than 2147483647 characters
 code: "ERR_STRING_TOO_LONG"
(fail) fetch().text() of an 8 MiB body
```

Why the file order can put fs-oom first: the parallel runner sorts files lexicographically and gives each worker a contiguous range. `js/bun/http/...` sorts before `js/node/fs/...`, so within one range the serve test runs first. But a worker that drains its own range steals the back half of the largest remaining range. A worker that has already run `fs-oom.test.ts` can steal a block that contains `bun-serve-file.test.ts`.

Other in-process users of the hook already restore it: `blob-oom.test.ts` (afterAll) and `FormData.test.ts:371` (finally). `streams.test.js:2395` sets it in a subprocess.

The `.text()` path that throws: `Body::resolve` -> `AnyBlob::to_string` -> `Internal::to_string_owned` -> `owned_utf8_into_js` -> `owned_latin1_into_js` -> `EncodedSlice::to_external_value`, which compares the length against `String::max_length()` (the synthetic limit clamped to the WTF limit).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs-oom.test.ts

<!-- robobun:evidence:end -->