### PR TITLE
bun:test: settle thenables through their own then() in .resolves/.rejects

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -619,8 +619,6 @@ AsymmetricMatcherResult matchAsymmetricMatcher(JSGlobalObject* globalObject, JSV
 {
     ExpectFlags flags = ExpectFlags();
     AsymmetricMatcherResult result = matchAsymmetricMatcherAndGetFlags(globalObject, matcherProp, otherProp, throwScope, flags);
-    // A `.resolves`/`.rejects` flag runs user code (a `then` getter) and can throw.
-    // Propagate instead of flipping that FAIL to PASS on `.not`.
     RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
     if (result != AsymmetricMatcherResult::NOT_MATCHER && (flags & FLAG_NOT)) {
         result = (result == AsymmetricMatcherResult::PASS) ? AsymmetricMatcherResult::FAIL : AsymmetricMatcherResult::PASS;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -619,6 +619,9 @@ AsymmetricMatcherResult matchAsymmetricMatcher(JSGlobalObject* globalObject, JSV
 {
     ExpectFlags flags = ExpectFlags();
     AsymmetricMatcherResult result = matchAsymmetricMatcherAndGetFlags(globalObject, matcherProp, otherProp, throwScope, flags);
+    // A `.resolves`/`.rejects` flag runs user code (a `then` getter) and can throw.
+    // Propagate instead of flipping that FAIL to PASS on `.not`.
+    RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
     if (result != AsymmetricMatcherResult::NOT_MATCHER && (flags & FLAG_NOT)) {
         result = (result == AsymmetricMatcherResult::PASS) ? AsymmetricMatcherResult::FAIL : AsymmetricMatcherResult::PASS;
     }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use bun_core::Output;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{
-    CallFrame, JSGlobalObject, JSValue, JsError, JsResult,
+    AnyPromise, CallFrame, JSGlobalObject, JSValue, JsError, JsResult,
     ConsoleObject, JSFunction, JSPropertyIterator, JSString,
 };
 use bun_jsc::{JsClass as _, StringJsc as _};
@@ -471,6 +471,37 @@ impl Expect {
         }
     }
 
+    /// Returns the promise that `wait_for_promise` polls for `value`'s outcome, or `None`
+    /// when `value` is not a thenable.
+    ///
+    /// `wait_for_promise` reads a promise's internal state and never calls `then()`. A
+    /// `Promise` subclass that starts its work inside an overridden `then()` (Bun.SQL's
+    /// `Query`, `Bun.$`'s `ShellPromise`) never settles that way, and a plain thenable has no
+    /// internal state at all. A pending promise or a thenable is therefore adopted by a fresh
+    /// native promise through the spec resolve steps, which call the value's own `then()`,
+    /// the same as `await value`. JSC skips that call for a promise whose `then` is the
+    /// built-in one. A settled promise already holds its outcome and is returned as is.
+    ///
+    /// Nothing but the pending `then()` callbacks refer to the adopter, so the caller keeps
+    /// the returned promise on the stack across the wait.
+    fn thenable_to_wait_for(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Option<AnyPromise>> {
+        if let Some(promise) = value.as_any_promise() {
+            promise.set_handled(global_this.vm());
+            if promise.status() != js_promise::Status::Pending {
+                return Ok(Some(promise));
+            }
+        } else {
+            let then = if value.is_object() { value.get(global_this, "then")? } else { None };
+            if !then.is_some_and(JSValue::is_callable) {
+                return Ok(None);
+            }
+        }
+        let adopter = js_promise::JSPromise::create(global_this);
+        adopter.set_handled();
+        adopter.resolve(global_this, value)?;
+        Ok(Some(AnyPromise::Normal(core::ptr::from_mut(adopter))))
+    }
+
     /// Processes the async flags (resolves/rejects), waiting for the async value if needed.
     /// If no flags, returns the original value
     /// If either flag is set, waits for the result, and returns either it as a JSValue, or null if the expectation failed (in which case if silent is false, also throws a js exception)
@@ -485,9 +516,8 @@ impl Expect {
     ) -> JsResult<JSValue> {
         match flags.promise() {
             resolution @ (Promise::Resolves | Promise::Rejects) => {
-                if let Some(promise) = value.as_any_promise() {
+                if let Some(promise) = Self::thenable_to_wait_for(global_this, value)? {
                     let vm = global_this.vm();
-                    promise.set_handled(vm);
 
                     // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
             global_this
@@ -868,7 +898,14 @@ impl Expect {
             return_value = return_value_from_function;
         }
 
-        if let Some(promise) = return_value.as_any_promise() {
+        let promise = match Self::thenable_to_wait_for(global_this, return_value) {
+            Ok(promise) => promise,
+            Err(err) => {
+                scope.apply(vm);
+                return Err(err);
+            }
+        };
+        if let Some(promise) = promise {
             let waited = vm.wait_for_promise(promise);
             scope.apply(vm);
             waited.map_err(|stopped| stopped.throw(global_this))?;
@@ -1437,9 +1474,8 @@ impl Expect {
         // call the custom matcher implementation
         let mut result = matcher_fn.call(global_this, matcher_context_jsvalue, args)?;
         // support for async matcher results
-        if let Some(promise) = result.as_any_promise() {
+        if let Some(promise) = Self::thenable_to_wait_for(global_this, result)? {
             let vm = global_this.vm();
-            promise.set_handled(vm);
 
             // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
             global_this

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -471,19 +471,13 @@ impl Expect {
         }
     }
 
-    /// Returns the promise that `wait_for_promise` polls for `value`'s outcome, or `None`
-    /// when `value` is not a thenable.
+    /// The promise `wait_for_promise` polls for `value`'s outcome, or `None` for a non-thenable.
     ///
-    /// `wait_for_promise` reads a promise's internal state and never calls `then()`. A
-    /// `Promise` subclass that starts its work inside an overridden `then()` (Bun.SQL's
-    /// `Query`, `Bun.$`'s `ShellPromise`) never settles that way, and a plain thenable has no
-    /// internal state at all. A pending promise or a thenable is therefore adopted by a fresh
-    /// native promise through the spec resolve steps, which call the value's own `then()`,
-    /// the same as `await value`. JSC skips that call for a promise whose `then` is the
-    /// built-in one. A settled promise already holds its outcome and is returned as is.
-    ///
-    /// Nothing but the pending `then()` callbacks refer to the adopter, so the caller keeps
-    /// the returned promise on the stack across the wait.
+    /// `wait_for_promise` never calls `then()`, so a `Promise` subclass that starts its work
+    /// there (Bun.SQL's `Query`, `Bun.$`'s `ShellPromise`) would never settle. A pending promise
+    /// or a plain thenable is adopted by a fresh native promise, whose resolve steps call the
+    /// value's own `then()` as `await` does. The caller holds the result on the stack across
+    /// the wait: nothing else roots the adopter.
     fn thenable_to_wait_for(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Option<AnyPromise>> {
         if let Some(promise) = value.as_any_promise() {
             promise.set_handled(global_this.vm());

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -472,8 +472,7 @@ impl Expect {
     }
 
     /// The promise `wait_for_promise` polls for `value`'s outcome, or `None` for a non-thenable.
-    /// A pending promise or a plain thenable is adopted by a fresh native promise so that the
-    /// value's own `then()` runs, as under `await`. Bun.SQL's `Query` starts its work there.
+    /// A pending promise or a thenable is adopted through `resolve`, which calls its own `then()`.
     fn thenable_to_wait_for(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Option<AnyPromise>> {
         if let Some(promise) = value.as_any_promise() {
             promise.set_handled(global_this.vm());

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -472,12 +472,8 @@ impl Expect {
     }
 
     /// The promise `wait_for_promise` polls for `value`'s outcome, or `None` for a non-thenable.
-    ///
-    /// `wait_for_promise` never calls `then()`, so a `Promise` subclass that starts its work
-    /// there (Bun.SQL's `Query`, `Bun.$`'s `ShellPromise`) would never settle. A pending promise
-    /// or a plain thenable is adopted by a fresh native promise, whose resolve steps call the
-    /// value's own `then()` as `await` does. The caller holds the result on the stack across
-    /// the wait: nothing else roots the adopter.
+    /// A pending promise or a plain thenable is adopted by a fresh native promise so that the
+    /// value's own `then()` runs, as under `await`. Bun.SQL's `Query` starts its work there.
     fn thenable_to_wait_for(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Option<AnyPromise>> {
         if let Some(promise) = value.as_any_promise() {
             promise.set_handled(global_this.vm());

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -479,15 +479,17 @@ impl Expect {
             if promise.status() != js_promise::Status::Pending {
                 return Ok(Some(promise));
             }
-        } else {
-            let then = if value.is_object() { value.get(global_this, "then")? } else { None };
-            if !then.is_some_and(JSValue::is_callable) {
-                return Ok(None);
-            }
+        } else if !value.is_object() {
+            return Ok(None);
         }
         let adopter = js_promise::JSPromise::create(global_this);
         adopter.set_handled();
         adopter.resolve(global_this, value)?;
+        // A thenable's `then()` runs in a queued job, so the adopter is still pending here. An
+        // object without a callable `then` fulfilled it at once and is not a promise.
+        if adopter.status() == js_promise::Status::Fulfilled {
+            return Ok(None);
+        }
         Ok(Some(AnyPromise::Normal(core::ptr::from_mut(adopter))))
     }
 

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -131,14 +131,13 @@ test("expect(lazyPromiseSubclass).rejects settles instead of hanging the run", a
       });
 
       test("Bun.SQL Query", async () => {
-        const sql = new SQL("sqlite://:memory:");
+        await using sql = new SQL("sqlite://:memory:");
         await sql\`CREATE TABLE t (a INTEGER)\`;
         await sql\`INSERT INTO t VALUES (1)\`;
         await expect(sql\`SELECT a FROM t\`).resolves.toEqual([{ a: 1 }]);
         await expect(sql\`SELECT a FROM t\`.values()).resolves.toEqual([[1]]);
         await expect(sql\`SELECT * FROM no_such_table\`).rejects.toThrow(/no such table/);
         expect(() => sql\`SELECT * FROM no_such_table\`).toThrow(/no such table/);
-        await sql.close();
       });
     `,
   });

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -153,6 +153,8 @@ test("expect(lazyPromiseSubclass).rejects settles instead of hanging the run", a
 
   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  // A hang is reported as the timeout kill, not as missing output.
+  expect(proc.signalCode).toBeNull();
   expect(stderr).toContain("3 pass");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -83,3 +83,77 @@ test("toBeWithin() with missing or non-number arguments fails the test without c
   expect(stderr).toContain("4 fail");
   expect(exitCode).toBe(1);
 });
+
+// https://github.com/oven-sh/bun/issues/40949
+// https://github.com/oven-sh/bun/issues/14670
+// `.resolves` / `.rejects` used to wait on the internal promise state without
+// calling the value's own then(). A Promise subclass that starts its work in
+// then() (Bun.SQL's Query, Bun.$'s ShellPromise) never settled, and the test
+// timeout could not interrupt the wait. The child is killed by `timeout` if
+// that comes back.
+test("expect(lazyPromiseSubclass).rejects settles instead of hanging the run", async () => {
+  using dir = tempDir("expect-lazy-then", {
+    "lazy.test.ts": `
+      import { expect, test } from "bun:test";
+      import { $, SQL } from "bun";
+
+      class LazyQuery extends Promise<never> {
+        started = false;
+        #reject!: (e: Error) => void;
+        constructor() {
+          let reject!: (e: Error) => void;
+          super((_, rej) => {
+            reject = rej;
+          });
+          this.#reject = reject;
+        }
+        then(onFulfilled?: any, onRejected?: any): any {
+          if (!this.started) {
+            this.started = true;
+            queueMicrotask(() => this.#reject(new Error("boom")));
+          }
+          return super.then(onFulfilled, onRejected);
+        }
+        static get [Symbol.species]() {
+          return Promise;
+        }
+      }
+
+      test("expect(lazy).rejects settles", async () => {
+        await expect(new LazyQuery()).rejects.toThrow("boom");
+      });
+
+      test("Bun.$ ShellPromise", async () => {
+        $.throws(true);
+        await expect($\`exit 7\`.quiet()).rejects.toThrow(/exit code 7/);
+        await expect($\`echo hi\`.quiet()).resolves.toMatchObject({ exitCode: 0 });
+        expect(() => $\`exit 7\`.quiet()).toThrow(/exit code 7/);
+      });
+
+      test("Bun.SQL Query", async () => {
+        const sql = new SQL("sqlite://:memory:");
+        await sql\`CREATE TABLE t (a INTEGER)\`;
+        await sql\`INSERT INTO t VALUES (1)\`;
+        await expect(sql\`SELECT a FROM t\`).resolves.toEqual([{ a: 1 }]);
+        await expect(sql\`SELECT a FROM t\`.values()).resolves.toEqual([[1]]);
+        await expect(sql\`SELECT * FROM no_such_table\`).rejects.toThrow(/no such table/);
+        expect(() => sql\`SELECT * FROM no_such_table\`).toThrow(/no such table/);
+        await sql.close();
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "lazy.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 10_000,
+  });
+
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("3 pass");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -162,11 +162,14 @@ describe("expect()", () => {
     await expect(thenable("reject", 4)).rejects.toBe(4);
 
     if (isBun) {
-      // Should fail with "Received promise that resolved" / "Received promise that rejected"
-      await expectFailure(() => expect(thenable("resolve", 4)).rejects.toBe(4)).toThrow();
-      await expectFailure(() => expect(thenable("reject", 4)).resolves.toBe(4)).toThrow();
-      // A non-callable `then` does not make a thenable. Should fail with "Expected promise"
-      await expectFailure(() => expect({ then: 4 }).resolves.toBe(4)).toThrow();
+      await expectFailure(() => expect(thenable("resolve", 4)).rejects.toBe(4)).toThrow(
+        /Received promise that resolved/,
+      );
+      await expectFailure(() => expect(thenable("reject", 4)).resolves.toBe(4)).toThrow(
+        /Received promise that rejected/,
+      );
+      // A non-callable `then` does not make a thenable.
+      await expectFailure(() => expect({ then: 4 }).resolves.toBe(4)).toThrow(/Expected promise/);
     }
   });
 
@@ -211,8 +214,8 @@ describe("expect()", () => {
       await expect(lazy("reject", 7)).rejects.toBe(7);
 
       if (isBun) {
-        await expectFailure(() => expect(lazy("resolve", 1)).rejects.toBe(1)).toThrow();
-        await expectFailure(() => expect(lazy("reject", 1)).resolves.toBe(1)).toThrow();
+        await expectFailure(() => expect(lazy("resolve", 1)).rejects.toBe(1)).toThrow(/Received promise that resolved/);
+        await expectFailure(() => expect(lazy("reject", 1)).resolves.toBe(1)).toThrow(/Received promise that rejected/);
 
         // expect(fn).toThrow() awaits a promise returned by fn (Bun only)
         expect(() => lazy("reject", new Error("lazy boom"))).toThrow("lazy boom");

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -141,6 +141,99 @@ describe("expect()", () => {
     ).resolves.toBe(1);
   });
 
+  test("resolves/rejects on a thenable that is not a Promise", async () => {
+    /**
+     * @param {"resolve" | "reject"} how
+     * @param {unknown} value
+     */
+    const thenable = (how, value) => ({
+      /**
+       * @param {(value: unknown) => void} resolve
+       * @param {(reason: unknown) => void} reject
+       */
+      then(resolve, reject) {
+        (how === "resolve" ? resolve : reject)(value);
+      },
+    });
+
+    await expect(thenable("resolve", 4)).resolves.toBe(4);
+    await expect(thenable("resolve", 4)).resolves.not.toBe(5);
+    await expect(thenable("reject", new Error("thenable boom"))).rejects.toThrow("thenable boom");
+    await expect(thenable("reject", 4)).rejects.toBe(4);
+
+    if (isBun) {
+      // Should fail with "Received promise that resolved" / "Received promise that rejected"
+      await expectFailure(() => expect(thenable("resolve", 4)).rejects.toBe(4)).toThrow();
+      await expectFailure(() => expect(thenable("reject", 4)).resolves.toBe(4)).toThrow();
+      // A non-callable `then` does not make a thenable. Should fail with "Expected promise"
+      await expectFailure(() => expect({ then: 4 }).resolves.toBe(4)).toThrow();
+    }
+  });
+
+  // Bun.SQL's Query and Bun.$'s ShellPromise are Promise subclasses that start
+  // their work in an overridden then(). The matcher must call then(), as `await` does.
+  test("resolves/rejects on a Promise subclass whose then() starts the work", async () => {
+    /** @type {ReturnType<typeof setTimeout>[]} */
+    const fallbacks = [];
+    /**
+     * @param {"resolve" | "reject"} how
+     * @param {unknown} value
+     */
+    function lazy(how, value) {
+      /** @type {(value: unknown) => void} */
+      let settle = () => {};
+      /** @extends {Promise<unknown>} */
+      class Lazy extends Promise {
+        static get [Symbol.species]() {
+          return Promise;
+        }
+        /** @override */
+        // @ts-expect-error
+        then(onFulfilled, onRejected) {
+          queueMicrotask(() => settle(value));
+          return super.then(onFulfilled, onRejected);
+        }
+      }
+      const promise = new Lazy((resolve, reject) => {
+        settle = how === "resolve" ? resolve : reject;
+      });
+      // A matcher that never calls then() would wait forever. This timer makes
+      // such a regression fail the assertion instead. It never fires otherwise:
+      // then() runs in the first microtask drain, before any timer.
+      fallbacks.push(setTimeout(() => settle(new Error("then() was never called")), 1000));
+      return promise;
+    }
+
+    try {
+      await expect(lazy("resolve", 42)).resolves.toBe(42);
+      await expect(lazy("resolve", 42)).resolves.not.toBe(43);
+      await expect(lazy("reject", new Error("lazy boom"))).rejects.toThrow("lazy boom");
+      await expect(lazy("reject", 7)).rejects.toBe(7);
+
+      if (isBun) {
+        await expectFailure(() => expect(lazy("resolve", 1)).rejects.toBe(1)).toThrow();
+        await expectFailure(() => expect(lazy("reject", 1)).resolves.toBe(1)).toThrow();
+
+        // expect(fn).toThrow() awaits a promise returned by fn (Bun only)
+        expect(() => lazy("reject", new Error("lazy boom"))).toThrow("lazy boom");
+        expect(() => lazy("resolve", 1)).not.toThrow();
+
+        // a custom matcher may return the lazy subclass
+        expect.extend({
+          _toBeViaLazyThen(/** @type {unknown} */ received, /** @type {unknown} */ expected) {
+            return lazy("resolve", { pass: Object.is(received, expected), message: () => "_toBeViaLazyThen" });
+          },
+        });
+        // @ts-expect-error custom matcher
+        expect(1)._toBeViaLazyThen(1);
+        // @ts-expect-error custom matcher
+        expect(() => expect(1)._toBeViaLazyThen(2)).toThrow("_toBeViaLazyThen");
+      }
+    } finally {
+      for (const timer of fallbacks) clearTimeout(timer);
+    }
+  });
+
   test("can call without an argument", () => {
     expect().toBe(undefined);
   });


### PR DESCRIPTION
### Problem
- `expect(value).rejects` and `.resolves` hang forever when `value` is a `Promise` subclass whose overridden `then()` starts the work, as Bun.SQL's `Query` and `Bun.$`'s `ShellPromise` do. The test timeout cannot interrupt the wait. A plain thenable fails with `Expected promise`. Fixes #40949, fixes #14670, fixes #18857.
- Cause: `process_promise` (`src/runtime/test_runner/expect.rs:488`) waits with `wait_for_promise`, which polls the internal `JSPromise` state and never calls `then()`. `expect(fn).toThrow()` and async custom matchers wait the same way.

### Fix
- New `Expect::thenable_to_wait_for` at all three wait sites. A settled promise is read directly. A pending promise, or an object with a callable `then`, is adopted by a fresh native promise (`JSPromise::create` + `resolve(value)`), whose resolve steps call the value's own `then()`, as `await` does.
- Correct because Jest accepts any thenable and calls `actual.then(...)`. For a pending promise with the built-in `then`, JSC takes a fast path that calls no user code.
- `get_value_as_to_throw` restores the unhandled rejection scope on its new error path. `matchAsymmetricMatcher` no longer flips a FAIL with a pending exception to PASS under `.not`.
- Verified: `test/js/bun/test/expect.test.js` (two new tests), `test/js/bun/test/bun-test.test.ts` (child process: #40949 repro, real `Bun.$` and `Bun.SQL`). Also the other expect suites, bunshell, sqlite-sql.

### Background
- `wait_for_promise` (`src/jsc/event_loop.rs:1103`) runs event loop ticks until a promise's internal status leaves `Pending`.
- A thenable is any object with a callable `then`. `await` handles one through the spec's Promise Resolve Functions: read `then`, then queue a job that calls `then(resolveFn, rejectFn)` (`JSPromise::resolvePromise` in JSC).

<details><summary>Notes</summary>

- Supersedes #35951, which carried the same change but conflicts with main. The plain thenable part of #32944 is covered here. Its other part, calling a function passed to `.rejects` (#16144), is not part of this PR. #33289 replaces the synchronous wait with promise reactions and would remove this path when it lands.
- `Query` and `ShellPromise` are lazy: constructing one queues nothing, and the first `then()` call dispatches the work.
- The per-test timeout timer fires inside the `wait_for_promise` loop, so it cannot unwind the matcher that is still waiting.
- The adopter is marked handled because the matcher reads its result directly and attaches no handler.
- Settled promises keep the direct read, so a subclass with a constructor that does not forward the executor still passes `.resolves` when it is already settled, as on the released build. A pending instance of such a class now fails the same way `await` fails on it.
- `then` is read once, by the adopter's resolve steps, the same as `await`. A non-thenable object fulfills the adopter at once, which is the signal for the `Expected promise` error. A thenable whose `then` (or `then` getter) throws becomes a rejection of the adopter, so `.rejects` matches the thrown error, as `await` does. Jest propagates that throw synchronously.
- `expect.resolvesTo` / `expect.rejectsTo` go through the same `process_promise` and now accept thenables too.
- A test callback that returns a lazy Promise subclass (`test("q", () => sql\`...\`)`) has the same defect in `run_test_callback` (`bun_test.rs`), which attaches reactions to the internal promise. It is a separate change and not part of this PR.
- Fail before: on bun 1.4.1 the thenable test fails with `Expected promise`, the lazy subclass test fails through its 1 s fallback timer, and the child process test hangs until the outer test times out.
- Suites run on the debug build: `expect.test.js` 417 pass, `bun-test.test.ts` 5 pass, `expect-extend.test.js`, `jest-extended.test.js`, `spyMatchers.test.ts`, `expect-assertions.test.ts`, `bunshell.test.ts` 431 pass, `sqlite-sql.test.ts` 248 pass. `BUN_JSC_validateExceptionChecks=1` runs of the new tests report nothing.
- Self-reviewed: 15 concerns raised. Addressed: dropped a new `isThenFastAndNonObservable` FFI binding in favor of the `Pending` gate (the binding changed behavior for settled subclasses), added the `RETURN_IF_EXCEPTION` in `matchAsymmetricMatcher`, added real `Bun.$` and `Bun.SQL` coverage, closed the duplicate PR. Rejected: moving the helper into `bun_jsc` and reusing it in `run_test_callback` (different lifecycle, separate change) and absorbing the `.rejects(fn)` feature from #32944 (a feature, not this bug).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/bun-test.test.ts test/js/bun/test/expect.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/expect.test.js:
(pass) expect() > () [300.29ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [1.91ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.63ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.27ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.26ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.23ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.26ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.24ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.23ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.48ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) expect() > toBe() > expect(0).t
... (truncated)

release without fix: 3 failed, 2 skipped
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.69ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.02ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.01ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false [0.01ms]
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > ex
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/bun-test.test.ts test/js/bun/test/expect.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/expect.test.js:
(pass) expect() > () [298.79ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.69ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.47ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.24ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.23ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.23ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.23ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.27ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.43ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.33ms]
(pass) expect() > toBe() > expect(0).t
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c6a9b4bb03
  features     baseline

23 deps, 131 codegen, 1172 objects in 608ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch zlib
[zlib] up to date
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 K
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp     |  1 +
 src/runtime/test_runner/expect.rs | 39 +++++++++++++---
 test/js/bun/test/bun-test.test.ts | 75 ++++++++++++++++++++++++++++++
 test/js/bun/test/expect.test.js   | 96 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 205 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/bindings.cpp          6      4      0
src/runtime/test_runner/expect.rs     13     10      0
test/js/bun/test/bun-test.test.ts      4      6      0
test/js/bun/test/expect.test.js        2      3      0
```

</details>

<!-- robobun:evidence:end -->