### PR TITLE
bun:test: fill vitest shim gaps (suite, vitest, onTestFailed, vi members, async timers, modifier aliases)

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -100,6 +100,10 @@ declare module "bun:test" {
     function advanceTimersToNextTimer(): typeof vi;
     function runAllTimers(): typeof vi;
     function runOnlyPendingTimers(): typeof vi;
+    function advanceTimersByTimeAsync(milliseconds: number): Promise<typeof vi>;
+    function advanceTimersToNextTimerAsync(): Promise<typeof vi>;
+    function runAllTimersAsync(): Promise<typeof vi>;
+    function runOnlyPendingTimersAsync(): Promise<typeof vi>;
     function getTimerCount(): number;
     function clearAllTimers(): void;
     function isFakeTimers(): boolean;
@@ -193,10 +197,63 @@ declare module "bun:test" {
     advanceTimersToNextTimer: typeof jest.advanceTimersToNextTimer;
     runAllTimers: typeof jest.runAllTimers;
     runOnlyPendingTimers: typeof jest.runOnlyPendingTimers;
+    advanceTimersByTimeAsync: typeof jest.advanceTimersByTimeAsync;
+    advanceTimersToNextTimerAsync: typeof jest.advanceTimersToNextTimerAsync;
+    runAllTimersAsync: typeof jest.runAllTimersAsync;
+    runOnlyPendingTimersAsync: typeof jest.runOnlyPendingTimersAsync;
     getTimerCount: typeof jest.getTimerCount;
     clearAllTimers: typeof jest.clearAllTimers;
     isFakeTimers: typeof jest.isFakeTimers;
+    /**
+     * Sets the current system time used by `Date.now()` and `new Date()`.
+     * Call with no argument to restore the real clock.
+     */
+    setSystemTime: typeof setSystemTime;
+    /**
+     * Returns the mocked system time as a `Date`, or `null` when the clock is
+     * not mocked.
+     */
+    getMockedSystemTime(): Date | null;
+    /**
+     * Returns the real system time in milliseconds, even when the clock is
+     * mocked.
+     */
+    getRealSystemTime(): number;
+    /**
+     * Returns `true` if the given value is a mock function created by
+     * `vi.fn()` or `vi.spyOn()`.
+     */
+    isMockFunction(value: unknown): value is Mock<(...args: any[]) => any>;
+    /**
+     * Type helper for mocked modules. At runtime it returns its argument
+     * unchanged.
+     */
+    mocked<T>(item: T, deep?: boolean): T;
+    /**
+     * Sets an environment variable on `process.env` and remembers the
+     * original value. Pass `undefined` to remove the variable.
+     * Restore with `vi.unstubAllEnvs()`.
+     */
+    stubEnv(name: string, value: string | undefined): void;
+    /**
+     * Restores every environment variable changed with `vi.stubEnv()`.
+     */
+    unstubAllEnvs(): void;
+    /**
+     * Sets a property on `globalThis` and remembers the original value.
+     * Restore with `vi.unstubAllGlobals()`.
+     */
+    stubGlobal(name: string, value: unknown): void;
+    /**
+     * Restores every global changed with `vi.stubGlobal()`.
+     */
+    unstubAllGlobals(): void;
   };
+
+  /**
+   * Alias of {@link vi}, matching the `vitest` export of the vitest module.
+   */
+  export const vitest: typeof vi;
 
   interface FunctionLike {
     readonly name: string;
@@ -250,6 +307,10 @@ declare module "bun:test" {
      */
     serial: Describe<T>;
     /**
+     * Alias of {@link Describe.serial}, matching vitest's `describe.sequential`.
+     */
+    sequential: Describe<T>;
+    /**
      * Runs this group of tests, only if `condition` is true.
      *
      * This is the opposite of `describe.skipIf()`.
@@ -257,6 +318,12 @@ declare module "bun:test" {
      * @param condition if these tests should run
      */
     if(condition: boolean): Describe<T>;
+    /**
+     * Alias of {@link Describe.if}, matching vitest's `describe.runIf`.
+     *
+     * @param condition if these tests should run
+     */
+    runIf(condition: boolean): Describe<T>;
     /**
      * Skips this group of tests, if `condition` is true.
      *
@@ -297,6 +364,15 @@ declare module "bun:test" {
    * @param fn the function that defines the tests
    */
   export const describe: Describe<[]>;
+  /**
+   * Alias of {@link describe}, matching vitest's `suite` export.
+   */
+  export const suite: Describe<[]>;
+  /**
+   * Accepts a benchmark declaration for vitest compatibility. Bun's test
+   * runner does not execute benchmarks: the callback never runs.
+   */
+  export function bench(label: string, fn: () => void | Promise<unknown>, options?: object): void;
   /**
    * Skips a group of related tests.
    *
@@ -396,6 +472,17 @@ declare module "bun:test" {
    * @param fn the function to run
    */
   export function onTestFinished(
+    fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
+    options?: HookOptions,
+  ): void;
+  /**
+   * Runs a function after the test finishes, but only if the test failed.
+   *
+   * Can only be called inside a test, not in `describe` blocks.
+   *
+   * @param fn the function to run
+   */
+  export function onTestFailed(
     fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
     options?: HookOptions,
   ): void;
@@ -518,6 +605,10 @@ declare module "bun:test" {
      */
     failing: Test<T>;
     /**
+     * Alias of {@link Test.failing}, matching vitest's `test.fails`.
+     */
+    fails: Test<T>;
+    /**
      * Runs the test concurrently with other concurrent tests.
      */
     concurrent: Test<T>;
@@ -527,6 +618,10 @@ declare module "bun:test" {
      */
     serial: Test<T>;
     /**
+     * Alias of {@link Test.serial}, matching vitest's `test.sequential`.
+     */
+    sequential: Test<T>;
+    /**
      * Runs this test, if `condition` is true.
      *
      * This is the opposite of `test.skipIf()`.
@@ -534,6 +629,12 @@ declare module "bun:test" {
      * @param condition if the test should run
      */
     if(condition: boolean): Test<T>;
+    /**
+     * Alias of {@link Test.if}, matching vitest's `test.runIf`.
+     *
+     * @param condition if the test should run
+     */
+    runIf(condition: boolean): Test<T>;
     /**
      * Skips this test, if `condition` is true.
      *

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -169,7 +169,7 @@ declare module "bun:test" {
   /**
    * Vitest-compatible mocking utilities, for migrating tests from Vitest to Bun.
    */
-  export const vi: {
+  export interface VitestUtils {
     /**
      * Create a mock function
      */
@@ -225,35 +225,44 @@ declare module "bun:test" {
      */
     isMockFunction(value: unknown): value is Mock<(...args: any[]) => any>;
     /**
-     * Type helper for mocked modules. At runtime it returns its argument
-     * unchanged.
+     * Type helper for mocked functions and modules. At runtime it returns its
+     * argument unchanged.
      */
-    mocked<T>(item: T, deep?: boolean): T;
+    mocked<T extends (...args: any[]) => any>(
+      item: T,
+      options?: boolean | { partial?: boolean; deep?: boolean },
+    ): Mock<T>;
+    mocked<T>(item: T, options?: boolean | { partial?: boolean; deep?: boolean }): T;
     /**
      * Sets an environment variable on `process.env` and remembers the
      * original value. Pass `undefined` to remove the variable.
      * Restore with `vi.unstubAllEnvs()`.
      */
-    stubEnv(name: string, value: string | undefined): void;
+    stubEnv(name: string, value: string | undefined): VitestUtils;
     /**
      * Restores every environment variable changed with `vi.stubEnv()`.
      */
-    unstubAllEnvs(): void;
+    unstubAllEnvs(): VitestUtils;
     /**
      * Sets a property on `globalThis` and remembers the original value.
      * Restore with `vi.unstubAllGlobals()`.
      */
-    stubGlobal(name: string, value: unknown): void;
+    stubGlobal(name: string, value: unknown): VitestUtils;
     /**
      * Restores every global changed with `vi.stubGlobal()`.
      */
-    unstubAllGlobals(): void;
-  };
+    unstubAllGlobals(): VitestUtils;
+  }
+
+  /**
+   * Vitest-compatible mocking utilities, for migrating tests from Vitest to Bun.
+   */
+  export const vi: VitestUtils;
 
   /**
    * Alias of {@link vi}, matching the `vitest` export of the vitest module.
    */
-  export const vitest: typeof vi;
+  export const vitest: VitestUtils;
 
   interface FunctionLike {
     readonly name: string;

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1494,6 +1494,8 @@ impl JSValue {
     }
     /// [`Self::get`] with an explicit key encoding. The byte-slice [`Self::get`]
     /// reads the key as Latin-1, so non-ASCII UTF-8 key bytes need this one.
+    /// Unlike [`Self::get`], a property that exists with the value `undefined`
+    /// returns `Some(undefined)`, not `None`.
     pub fn get_encoded(
         self,
         global: &JSGlobalObject,
@@ -1501,7 +1503,7 @@ impl JSValue {
     ) -> JsResult<Option<JSValue>> {
         // SAFETY: `key` is valid for the duration of the call.
         let v = unsafe { crate::cpp::JSC__JSValue__getIfPropertyExistsEncoded(self, global, key) }?;
-        if v.0 == JSValue::PROPERTY_DOES_NOT_EXIST.0 || v.is_undefined() {
+        if v.0 == JSValue::PROPERTY_DOES_NOT_EXIST.0 {
             Ok(None)
         } else {
             Ok(Some(v))

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1492,17 +1492,18 @@ impl JSValue {
             JSC__JSValue__putMayBeIndex(self, global, key, value)
         })
     }
-    /// [`Self::get`] with an explicit key encoding. The byte-slice [`Self::get`]
-    /// reads the key as Latin-1, so non-ASCII UTF-8 key bytes need this one.
-    /// Unlike [`Self::get`], a property that exists with the value `undefined`
-    /// returns `Some(undefined)`, not `None`.
-    pub fn get_encoded(
+    /// Own-property read with an explicit key encoding: the prototype chain
+    /// is not consulted, non-ASCII UTF-8 key bytes are read as UTF-8 (the
+    /// byte-slice [`Self::get`] reads Latin-1), and an own property that
+    /// exists with the value `undefined` returns `Some(undefined)`, not
+    /// `None`.
+    pub fn get_own_encoded(
         self,
         global: &JSGlobalObject,
         key: &bun_core::EncodedSlice,
     ) -> JsResult<Option<JSValue>> {
         // SAFETY: `key` is valid for the duration of the call.
-        let v = unsafe { crate::cpp::JSC__JSValue__getIfPropertyExistsEncoded(self, global, key) }?;
+        let v = unsafe { crate::cpp::JSC__JSValue__getOwnEncoded(self, global, key) }?;
         if v.0 == JSValue::PROPERTY_DOES_NOT_EXIST.0 {
             Ok(None)
         } else {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1492,6 +1492,29 @@ impl JSValue {
             JSC__JSValue__putMayBeIndex(self, global, key, value)
         })
     }
+    /// [`Self::get`] with an explicit key encoding. The byte-slice [`Self::get`]
+    /// reads the key as Latin-1, so non-ASCII UTF-8 key bytes need this one.
+    pub fn get_encoded(
+        self,
+        global: &JSGlobalObject,
+        key: &bun_core::EncodedSlice,
+    ) -> JsResult<Option<JSValue>> {
+        // SAFETY: `key` is valid for the duration of the call.
+        let v = unsafe { crate::cpp::JSC__JSValue__getIfPropertyExistsEncoded(self, global, key) }?;
+        if v.0 == JSValue::PROPERTY_DOES_NOT_EXIST.0 || v.is_undefined() {
+            Ok(None)
+        } else {
+            Ok(Some(v))
+        }
+    }
+    /// [`Self::delete_property`] with an explicit key encoding.
+    pub fn delete_property_encoded(
+        self,
+        global: &JSGlobalObject,
+        key: &bun_core::EncodedSlice,
+    ) -> JsResult<bool> {
+        crate::call_check_slow(global, || JSC__JSValue__deleteProperty(self, global, key))
+    }
     /// Method-table put: runs custom `put` overrides (for example
     /// `process.env`'s setter). [`Self::put`] is a `putDirect` and bypasses
     /// them.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1492,6 +1492,20 @@ impl JSValue {
             JSC__JSValue__putMayBeIndex(self, global, key, value)
         })
     }
+    /// Method-table put: runs custom `put` overrides (for example
+    /// `process.env`'s setter). [`Self::put`] is a `putDirect` and bypasses
+    /// them.
+    pub fn put_generic(
+        self,
+        global: &JSGlobalObject,
+        key: impl AsRef<[u8]>,
+        value: JSValue,
+    ) -> JsResult<()> {
+        let key = bun_core::EncodedSlice::from_bytes(key.as_ref());
+        host_fn::from_js_host_call_generic(global, || {
+            JSC__JSValue__putGeneric(self, global, &key, value)
+        })
+    }
     pub fn put_to_property_key(
         target: JSValue,
         global: &JSGlobalObject,
@@ -2075,6 +2089,12 @@ unsafe extern "C" {
         this: JSValue,
         global: &JSGlobalObject,
         key: &bun_core::String,
+        value: JSValue,
+    );
+    safe fn JSC__JSValue__putGeneric(
+        this: JSValue,
+        global: &JSGlobalObject,
+        key: &bun_core::EncodedSlice,
         value: JSValue,
     );
     safe fn JSC__JSValue__putIndex(this: JSValue, global: &JSGlobalObject, i: u32, value: JSValue);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1423,8 +1423,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] double JSMock__getCurrentUnixTimeMs()
     return WTF::WallTime::now().secondsSinceEpoch().milliseconds();
 }
 
-// Helper function for native code to read the overriden Date.now() time.
-// NaN is the "no override" sentinel (see JSGlobalObject::jsDateNow()).
+// Helper function for native code to read the overriden Date.now() time (NaN = no override)
 extern "C" [[ZIG_EXPORT(nothrow)]] double JSMock__getOverridenDateNow(JSC::JSGlobalObject* globalObject)
 {
     return globalObject->overridenDateNow;

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1423,6 +1423,18 @@ extern "C" [[ZIG_EXPORT(nothrow)]] double JSMock__getCurrentUnixTimeMs()
     return WTF::WallTime::now().secondsSinceEpoch().milliseconds();
 }
 
+// Helper function for native code to read the overriden Date.now() time.
+// NaN is the "no override" sentinel (see JSGlobalObject::jsDateNow()).
+extern "C" [[ZIG_EXPORT(nothrow)]] double JSMock__getOverridenDateNow(JSC::JSGlobalObject* globalObject)
+{
+    return globalObject->overridenDateNow;
+}
+
+extern "C" [[ZIG_EXPORT(nothrow)]] bool JSMock__isMockFunction(JSC::EncodedJSValue encodedValue)
+{
+    return !!dynamicDowncast<JSMockFunction>(JSC::JSValue::decode(encodedValue));
+}
+
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsNow, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
     return JSValue::encode(jsNumber(globalObject->jsDateNow()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4166,7 +4166,8 @@ void JSC__JSValue__putNonEnumerable(JSC::EncodedJSValue JSValue0, JSC::JSGlobalO
 }
 
 // Encoding-aware variant of JSC__JSValue__getIfPropertyExistsImpl: the key's
-// EncodedSlice bits decide Latin-1 vs UTF-8 vs UTF-16.
+// EncodedSlice bits decide Latin-1 vs UTF-8 vs UTF-16, and integer-index
+// names ("0") are safe. Returns deleted if the property does not exist.
 extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsEncoded(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const EncodedSlice* key)
 {
     ASSERT_NO_PENDING_EXCEPTION(globalObject);
@@ -4182,7 +4183,18 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getIf
     const auto identifier = Zig::toIdentifier(*key, globalObject);
     const auto property = JSC::PropertyName(identifier);
 
-    return JSC::JSValue::encode(Bun::getIfPropertyExistsPrototypePollutionMitigationUnsafe(vm, globalObject, object, property));
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
+    if (!object->getPropertySlot(globalObject, property, slot)) {
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(JSValue::decode(JSC::JSValue::ValueDeleted));
+    }
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue result = slot.getValue(globalObject, property);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(result);
 }
 
 // Generic (method-table) put: runs custom `put` overrides such as

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4165,31 +4165,27 @@ void JSC__JSValue__putNonEnumerable(JSC::EncodedJSValue JSValue0, JSC::JSGlobalO
     object->putDirect(arg1->vm(), Zig::toIdentifier(*arg2, arg1), JSC::JSValue::decode(JSValue3), JSC::PropertyAttribute::DontEnum | 0);
 }
 
-// Encoding-aware variant of JSC__JSValue__getIfPropertyExistsImpl: the key's
-// EncodedSlice bits decide Latin-1 vs UTF-8 vs UTF-16, and integer-index
-// names ("0") are safe. Returns deleted if the property does not exist.
-extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsEncoded(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const EncodedSlice* key)
+// Encoding-aware own-property read: the key's EncodedSlice bits decide
+// Latin-1 vs UTF-8 vs UTF-16, integer-index names ("0") are safe, and the
+// prototype chain is not consulted. Returns deleted if the own property
+// does not exist.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getOwnEncoded(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const EncodedSlice* key)
 {
     ASSERT_NO_PENDING_EXCEPTION(globalObject);
     JSValue value = JSC::JSValue::decode(target);
-    ASSERT_WITH_MESSAGE(!value.isEmpty(), "get() must not be called on empty value");
+    ASSERT_WITH_MESSAGE(!value.isEmpty(), "getOwn() must not be called on empty value");
 
     auto& vm = JSC::getVM(globalObject);
-    JSC::JSObject* object = value.getObject();
-    if (!object) [[unlikely]] {
-        return JSValue::encode(JSValue::decode(JSC::JSValue::ValueDeleted));
-    }
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     const auto identifier = Zig::toIdentifier(*key, globalObject);
     const auto property = JSC::PropertyName(identifier);
 
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-    if (!object->getPropertySlot(globalObject, property, slot)) {
-        RETURN_IF_EXCEPTION(scope, {});
-        return JSValue::encode(JSValue::decode(JSC::JSValue::ValueDeleted));
-    }
+    PropertySlot slot(value, PropertySlot::InternalMethodType::GetOwnProperty);
+    bool hasSlot = value.getOwnPropertySlot(globalObject, property, slot);
     RETURN_IF_EXCEPTION(scope, {});
+    if (!hasSlot)
+        return JSValue::encode(JSValue::decode(JSC::JSValue::ValueDeleted));
 
     JSValue result = slot.getValue(globalObject, property);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4165,6 +4165,26 @@ void JSC__JSValue__putNonEnumerable(JSC::EncodedJSValue JSValue0, JSC::JSGlobalO
     object->putDirect(arg1->vm(), Zig::toIdentifier(*arg2, arg1), JSC::JSValue::decode(JSValue3), JSC::PropertyAttribute::DontEnum | 0);
 }
 
+// Encoding-aware variant of JSC__JSValue__getIfPropertyExistsImpl: the key's
+// EncodedSlice bits decide Latin-1 vs UTF-8 vs UTF-16.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsEncoded(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const EncodedSlice* key)
+{
+    ASSERT_NO_PENDING_EXCEPTION(globalObject);
+    JSValue value = JSC::JSValue::decode(target);
+    ASSERT_WITH_MESSAGE(!value.isEmpty(), "get() must not be called on empty value");
+
+    auto& vm = JSC::getVM(globalObject);
+    JSC::JSObject* object = value.getObject();
+    if (!object) [[unlikely]] {
+        return JSValue::encode(JSValue::decode(JSC::JSValue::ValueDeleted));
+    }
+
+    const auto identifier = Zig::toIdentifier(*key, globalObject);
+    const auto property = JSC::PropertyName(identifier);
+
+    return JSC::JSValue::encode(Bun::getIfPropertyExistsPrototypePollutionMitigationUnsafe(vm, globalObject, object, property));
+}
+
 // Generic (method-table) put: runs custom `put` overrides such as
 // JSEnvironmentVariableMap's, which JSC__JSValue__put (a putDirect) bypasses.
 extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__putGeneric(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const EncodedSlice* key, JSC::EncodedJSValue value)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4165,6 +4165,21 @@ void JSC__JSValue__putNonEnumerable(JSC::EncodedJSValue JSValue0, JSC::JSGlobalO
     object->putDirect(arg1->vm(), Zig::toIdentifier(*arg2, arg1), JSC::JSValue::decode(JSValue3), JSC::PropertyAttribute::DontEnum | 0);
 }
 
+// Generic (method-table) put: runs custom `put` overrides such as
+// JSEnvironmentVariableMap's, which JSC__JSValue__put (a putDirect) bypasses.
+extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__putGeneric(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const EncodedSlice* key, JSC::EncodedJSValue value)
+{
+    auto& vm = JSC::getVM(globalObject);
+    ThrowScope scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSObject* object = JSC::JSValue::decode(target).getObject();
+    if (!object)
+        return;
+    JSC::Identifier identifier = Zig::toIdentifier(*key, globalObject);
+    JSC::PutPropertySlot slot(object, false);
+    object->methodTable()->put(object, globalObject, identifier, JSC::JSValue::decode(value), slot);
+    RETURN_IF_EXCEPTION(scope, );
+}
+
 void JSC__JSValue__putToPropertyKey(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue arg2, JSC::EncodedJSValue arg3)
 {
     auto& vm = JSC::getVM(arg1);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1868,6 +1868,8 @@ impl TestCommand {
                 unhandled_errors_between_tests: 0,
                 summary: Summary::default(),
                 node_test_used: false,
+                stubbed_envs: Vec::new(),
+                stubbed_globals: Vec::new(),
             },
             repeat_count: 1,
             last_printed_dot: core::cell::Cell::new(false),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1760,9 +1760,7 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             unsafe { (*all).event_loop_delay.disable() };
         }
     }
-    // vi.stubEnv / vi.stubGlobal state is per-thread, not per-global: restore
-    // the env vars and drop the stored originals so they cannot leak into the
-    // next file or pin the outgoing realm.
+    // vi.stubEnv / vi.stubGlobal state is per-thread, not per-global.
     if reason == StopReason::TestIsolation {
         crate::test_runner::jest::Jest::reset_stubs_for_isolation(vm.global());
     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1760,6 +1760,12 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             unsafe { (*all).event_loop_delay.disable() };
         }
     }
+    // vi.stubEnv / vi.stubGlobal state is per-thread, not per-global: restore
+    // the env vars and drop the stored originals so they cannot leak into the
+    // next file or pin the outgoing realm.
+    if reason == StopReason::TestIsolation {
+        crate::test_runner::jest::Jest::reset_stubs_for_isolation(vm.global());
+    }
     // Entries that stay registered across a test-isolation swap.
     let mut kept: Vec<ActiveHandle> = Vec::new();
     loop {

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -628,36 +628,44 @@ impl Execution {
         }
     }
 
+    /// The result this sequence gets when it completes. Pure so the
+    /// `onTestFailed` gate can ask for the outcome before the deferred
+    /// failure modes (assertion counts, failing/todo inversion) are applied
+    /// to `sequence.result` by `on_sequence_completed`.
+    fn resolve_final_result(sequence: &ExecutionSequence) -> Result {
+        let mut result = sequence.result;
+        match sequence.expect_assertions {
+            ExpectAssertions::NotSet => {}
+            ExpectAssertions::AtLeastOne => {
+                if sequence.expect_call_count == 0 && result.is_pass(PendingIs::PendingIsPass) {
+                    result = Result::FailBecauseExpectedHasAssertions;
+                }
+            }
+            ExpectAssertions::Exact(expected) => {
+                if sequence.expect_call_count != expected
+                    && result.is_pass(PendingIs::PendingIsPass)
+                {
+                    result = Result::FailBecauseExpectedAssertionCount;
+                }
+            }
+        }
+        if result == Result::Pending {
+            result = match sequence.entry_mode() {
+                ScopeMode::Failing => Result::FailBecauseFailingTestPassed,
+                ScopeMode::Todo => Result::FailBecauseTodoPassed,
+                _ => Result::Pass,
+            };
+        }
+        result
+    }
+
     fn on_sequence_completed(buntest: NonNull<BunTest>, sequence: &mut ExecutionSequence) {
         let elapsed_ns: u64 = if sequence.started_at.eql(&Timespec::EPOCH) {
             0
         } else {
             sequence.started_at.since_now_force_real_time()
         };
-        match sequence.expect_assertions {
-            ExpectAssertions::NotSet => {}
-            ExpectAssertions::AtLeastOne => {
-                if sequence.expect_call_count == 0
-                    && sequence.result.is_pass(PendingIs::PendingIsPass)
-                {
-                    sequence.result = Result::FailBecauseExpectedHasAssertions;
-                }
-            }
-            ExpectAssertions::Exact(expected) => {
-                if sequence.expect_call_count != expected
-                    && sequence.result.is_pass(PendingIs::PendingIsPass)
-                {
-                    sequence.result = Result::FailBecauseExpectedAssertionCount;
-                }
-            }
-        }
-        if sequence.result == Result::Pending {
-            sequence.result = match sequence.entry_mode() {
-                ScopeMode::Failing => Result::FailBecauseFailingTestPassed,
-                ScopeMode::Todo => Result::FailBecauseTodoPassed,
-                _ => Result::Pass,
-            };
-        }
+        sequence.result = Self::resolve_final_result(sequence);
         if let Some(first_entry) = sequence.first_entry {
             if sequence.test_entry.is_some() || sequence.result != Result::Pass {
                 // SAFETY: deref parent BunTest at point-of-use. `sequence` aliases
@@ -1004,8 +1012,8 @@ fn step_sequence_one(
     Execution::on_entry_started(next_item);
 
     if let Some(cb) = next_item.callback.as_ref() {
-        if next_item.only_on_failure && !sequence.result.is_fail() {
-            // onTestFailed() callback on a sequence that did not fail: skip it.
+        if next_item.only_on_failure && !Execution::resolve_final_result(sequence).is_fail() {
+            // onTestFailed() callback on a sequence that is not failing: skip it.
             Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
             return Ok(None); // run again
         }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -1004,6 +1004,11 @@ fn step_sequence_one(
     Execution::on_entry_started(next_item);
 
     if let Some(cb) = next_item.callback.as_ref() {
+        if next_item.only_on_failure && !sequence.result.is_fail() {
+            // onTestFailed() callback on a sequence that did not fail: skip it.
+            Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
+            return Ok(None); // run again
+        }
         group_log::log(format_args!("runSequence queued callback"));
 
         let entry_data = EntryData {

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -77,6 +77,11 @@ impl ScopeFunctions {
     pub(crate) fn get_failing(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         this.generic_extend(global, BaseScopeCfg { self_mode: SelfMode::Failing, ..Default::default() }, b"get .failing", "failing")
     }
+    /// vitest spells `.failing` as `.fails`.
+    #[bun_jsc::host_fn(getter)]
+    pub(crate) fn get_fails(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        this.generic_extend(global, BaseScopeCfg { self_mode: SelfMode::Failing, ..Default::default() }, b"get .fails", "fails")
+    }
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_concurrent(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         this.generic_extend(global, BaseScopeCfg { self_concurrent: SelfConcurrent::Yes, ..Default::default() }, b"get .concurrent", "concurrent")
@@ -85,6 +90,11 @@ impl ScopeFunctions {
     pub(crate) fn get_serial(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         this.generic_extend(global, BaseScopeCfg { self_concurrent: SelfConcurrent::No, ..Default::default() }, b"get .serial", "serial")
     }
+    /// vitest spells `.serial` as `.sequential`.
+    #[bun_jsc::host_fn(getter)]
+    pub(crate) fn get_sequential(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        this.generic_extend(global, BaseScopeCfg { self_concurrent: SelfConcurrent::No, ..Default::default() }, b"get .sequential", "sequential")
+    }
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_only(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         this.generic_extend(global, BaseScopeCfg { self_only: true, ..Default::default() }, b"get .only", "only")
@@ -92,6 +102,11 @@ impl ScopeFunctions {
     #[bun_jsc::host_fn(method)]
     pub(crate) fn fn_if(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         this.generic_if(global, frame, BaseScopeCfg { self_mode: SelfMode::Skip, ..Default::default() }, b"call .if()", true, "if")
+    }
+    /// vitest spells `.if` as `.runIf`.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn fn_run_if(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        this.generic_if(global, frame, BaseScopeCfg { self_mode: SelfMode::Skip, ..Default::default() }, b"call .runIf()", true, "runIf")
     }
     #[bun_jsc::host_fn(method)]
     pub(crate) fn fn_skip_if(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
@@ -426,6 +441,7 @@ impl ScopeFunctions {
                         timeout: options.timeout,
                         retry_count: options.retry.unwrap_or(0),
                         repeat_count: options.repeats,
+                        ..Default::default()
                     },
                     base,
                     bun_test::AddedInPhase::Collection,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -115,7 +115,7 @@ pub mod js_fns {
     }
 
     /// Tags accepted by `generic_hook`. Superset of `DescribeScope::HookTag`
-    /// (adds `OnTestFinished`).
+    /// (adds `OnTestFinished` and `OnTestFailed`).
     // was a const-generic param (`adt_const_params` is unstable);
     // reshaped to runtime dispatch with per-tag thin host_fn wrappers below.
     #[derive(Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]
@@ -130,6 +130,8 @@ pub mod js_fns {
         AfterAll,
         #[strum(serialize = "onTestFinished")]
         OnTestFinished,
+        #[strum(serialize = "onTestFailed")]
+        OnTestFailed,
     }
     impl GenericHookTag {
         const fn as_hook_tag(self) -> Option<HookTag> {
@@ -138,8 +140,13 @@ pub mod js_fns {
                 Self::BeforeEach => Some(HookTag::BeforeEach),
                 Self::AfterEach => Some(HookTag::AfterEach),
                 Self::AfterAll => Some(HookTag::AfterAll),
-                Self::OnTestFinished => None,
+                Self::OnTestFinished | Self::OnTestFailed => None,
             }
+        }
+        /// `onTestFinished`/`onTestFailed` register inside a running test only;
+        /// the describe-scope hooks register during preload or collection.
+        const fn is_test_scoped(self) -> bool {
+            matches!(self, Self::OnTestFinished | Self::OnTestFailed)
         }
         /// Per-variant signature string: the tag name plus `"()"`.
         const fn sig(self) -> &'static [u8] {
@@ -149,6 +156,7 @@ pub mod js_fns {
                 Self::AfterEach => b"afterEach()",
                 Self::AfterAll => b"afterAll()",
                 Self::OnTestFinished => b"onTestFinished()",
+                Self::OnTestFailed => b"onTestFailed()",
             }
         }
     }
@@ -187,11 +195,12 @@ pub mod js_fns {
             let cfg = ExecutionEntryCfg {
                 has_done_parameter,
                 timeout: args.options.timeout,
+                only_on_failure: tag == GenericHookTag::OnTestFailed,
                 ..Default::default()
             };
 
             let Some(bun_test) = bun_test_root.get_active_file_unless_in_preload(global_this.bun_vm()) else {
-                if tag == GenericHookTag::OnTestFinished {
+                if tag.is_test_scoped() {
                     return Err(global_this.throw(format_args!(
                         "Cannot call {}() in preload. It can only be called inside a test.",
                         tag_name
@@ -211,7 +220,7 @@ pub mod js_fns {
 
             match bun_test.phase {
                 Phase::Collection => {
-                    if tag == GenericHookTag::OnTestFinished {
+                    if tag.is_test_scoped() {
                         return Err(global_this.throw(format_args!(
                             "Cannot call {}() outside of a test. It can only be called inside a test.",
                             tag_name
@@ -229,7 +238,7 @@ pub mod js_fns {
                 Phase::Execution => {
                     let active = bun_test.get_current_state_data();
                     let Some((sequence, _)) = bun_test.execution.get_current_and_valid_execution_sequence(&active) else {
-                        return Err(if tag == GenericHookTag::OnTestFinished {
+                        return Err(if tag.is_test_scoped() {
                             global_this.throw(format_args!(
                                 "Cannot call {}() here. It cannot be called inside a concurrent test. Use test.serial or remove test.concurrent.",
                                 tag_name
@@ -266,7 +275,7 @@ pub mod js_fns {
                                 }
                             }
                         }
-                        GenericHookTag::OnTestFinished => 'blk: {
+                        GenericHookTag::OnTestFinished | GenericHookTag::OnTestFailed => 'blk: {
                             // Find the last entry in the sequence
                             let Some(mut last_entry) = sequence_ref.active_entry.map(|p| p.as_ptr()) else {
                                 return Err(global_this.throw(format_args!(
@@ -340,6 +349,7 @@ pub mod js_fns {
         hook!(after_each, AfterEach);
         hook!(after_all, AfterAll);
         hook!(on_test_finished, OnTestFinished);
+        hook!(on_test_failed, OnTestFailed);
     }
 }
 
@@ -1861,6 +1871,8 @@ pub struct ExecutionEntryCfg {
     pub(crate) retry_count: u32,
     /// Number of times to repeat a test (0 = run once, 1 = run twice, etc.)
     pub(crate) repeat_count: u32,
+    /// `onTestFailed()`: run the callback only when the sequence has failed.
+    pub(crate) only_on_failure: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -1884,6 +1896,8 @@ pub struct ExecutionEntry {
     pub(crate) retry_count: u32,
     /// Number of times to repeat a test (0 = run once, 1 = run twice, etc.)
     pub(crate) repeat_count: u32,
+    /// `onTestFailed()`: run the callback only when the sequence has failed.
+    pub(crate) only_on_failure: bool,
 
     pub(crate) next: Option<*mut ExecutionEntry>,
     /// if this entry fails, go to the entry 'failure_skip_past.next'
@@ -1907,6 +1921,7 @@ impl ExecutionEntry {
             added_in_phase: phase,
             retry_count: cfg.retry_count,
             repeat_count: cfg.repeat_count,
+            only_on_failure: cfg.only_on_failure,
             timespec: Timespec::EPOCH,
             next: None,
             failure_skip_past: None,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -143,8 +143,7 @@ pub mod js_fns {
                 Self::OnTestFinished | Self::OnTestFailed => None,
             }
         }
-        /// `onTestFinished`/`onTestFailed` register inside a running test only;
-        /// the describe-scope hooks register during preload or collection.
+        /// True for the hooks that only register inside a running test.
         const fn is_test_scoped(self) -> bool {
             matches!(self, Self::OnTestFinished | Self::OnTestFailed)
         }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -275,20 +275,29 @@ pub mod js_fns {
                             }
                         }
                         GenericHookTag::OnTestFinished | GenericHookTag::OnTestFailed => 'blk: {
-                            // Find the last entry in the sequence
-                            let Some(mut last_entry) = sequence_ref.active_entry.map(|p| p.as_ptr()) else {
+                            let Some(mut append_point) = sequence_ref.active_entry.map(|p| p.as_ptr()) else {
                                 return Err(global_this.throw(format_args!(
                                     "Cannot call {}() here. Call it inside a test instead.",
                                     tag_name
                                 )));
                             };
+                            // onTestFailed entries append at the tail.
+                            // onTestFinished entries splice before that gated
+                            // tail, whatever the registration order, so every
+                            // finished callback runs (and can still fail the
+                            // test) before the failure gate is evaluated.
+                            let keep_before_gated = tag == GenericHookTag::OnTestFinished;
                             // SAFETY: intrusive linked-list traversal
                             unsafe {
-                                while let Some(next_entry) = (*last_entry).next {
-                                    last_entry = next_entry;
+                                let mut cursor = (*append_point).next;
+                                while let Some(entry) = cursor {
+                                    if !(keep_before_gated && (*entry).only_on_failure) {
+                                        append_point = entry;
+                                    }
+                                    cursor = (*entry).next;
                                 }
                             }
-                            break 'blk last_entry;
+                            break 'blk append_point;
                         }
                         _ => {
                             return Err(global_this.throw(format_args!(
@@ -309,6 +318,10 @@ pub mod js_fns {
                     let new_item_ptr = bun_core::heap::into_raw(new_item);
                     // SAFETY: append_point is a valid linked-list node; new_item_ptr just allocated
                     unsafe {
+                        // A hook entry that fails skips only itself, so the
+                        // remaining onTestFinished/onTestFailed entries still
+                        // run (and the failure gate sees the failed result).
+                        (*new_item_ptr).failure_skip_past = Some(new_item_ptr);
                         (*new_item_ptr).next = (*append_point).next;
                         (*append_point).next = Some(new_item_ptr);
                     }

--- a/src/runtime/test_runner/jest.classes.ts
+++ b/src/runtime/test_runner/jest.classes.ts
@@ -826,6 +826,10 @@ export default [
         getter: "getFailing",
         cache: true,
       },
+      fails: {
+        getter: "getFails",
+        cache: true,
+      },
       concurrent: {
         getter: "getConcurrent",
         cache: true,
@@ -834,12 +838,20 @@ export default [
         getter: "getSerial",
         cache: true,
       },
+      sequential: {
+        getter: "getSequential",
+        cache: true,
+      },
       only: {
         getter: "getOnly",
         cache: true,
       },
       if: {
         fn: "fnIf",
+        length: 1,
+      },
+      runIf: {
+        fn: "fnRunIf",
         length: 1,
       },
       skipIf: {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -1,4 +1,5 @@
 use core::ptr::NonNull;
+use std::cell::RefCell;
 use std::io::Write as _;
 
 use crate::cli::command::TestOptions;
@@ -331,7 +332,7 @@ pub mod Jest {
     }
 
     fn create_test_module(global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let module = JSValue::create_empty_object(global_object, 23);
+        let module = JSValue::create_empty_object(global_object, 44);
 
         let test_scope_functions = create_bound(
             global_object,
@@ -361,6 +362,8 @@ pub mod Jest {
             "describe",
         )?;
         module.put(global_object, b"describe", describe_scope_functions);
+        // vitest alias for `describe`.
+        module.put(global_object, b"suite", describe_scope_functions);
 
         let xdescribe_scope_functions = create_bound(
             global_object,
@@ -400,13 +403,19 @@ pub mod Jest {
         );
         module.put(
             global_object,
+            b"onTestFailed",
+            jsc::JSFunction::create(global_object, "onTestFailed", generic_hook::__jsc_host_on_test_failed, 1, Default::default()),
+        );
+        module.put(
+            global_object,
             b"setDefaultTimeout",
             jsc::JSFunction::create(global_object, "setDefaultTimeout", __jsc_host_js_set_default_timeout, 1, Default::default()),
         );
         module.put(global_object, b"expect", jsc::codegen::js::get_constructor::<Expect>(global_object));
         module.put(global_object, b"expectTypeOf", jsc::codegen::js::get_constructor::<ExpectTypeOf>(global_object));
 
-        // will add more 9 properties in the module here so we need to allocate 23 properties
+        // create_mock_objects adds the rest of the properties; the inline
+        // capacity hint above covers both.
         create_mock_objects(global_object, module);
 
         Ok(module)
@@ -442,20 +451,221 @@ pub mod Jest {
         module.put(global_object, b"spyOn", spy_on);
         module.put(global_object, b"expect", jsc::codegen::js::get_constructor::<Expect>(global_object));
 
-        let vi = JSValue::create_empty_object(global_object, 6 + fake_timers::TIMER_FNS_COUNT);
+        let vi = JSValue::create_empty_object(global_object, 15 + fake_timers::TIMER_FNS_COUNT);
         vi.put(global_object, b"fn", mock_fn);
         vi.put(global_object, b"mock", mock_module_fn);
         vi.put(global_object, b"spyOn", spy_on);
         vi.put(global_object, b"restoreAllMocks", restore_all_mocks);
         vi.put(global_object, b"resetAllMocks", reset_all_mocks);
         vi.put(global_object, b"clearAllMocks", clear_all_mocks);
+        vi.put(global_object, b"setSystemTime", set_system_time);
+        for &(name, arity, func) in VI_FNS {
+            vi.put(global_object, name.as_bytes(), jsc::JSFunction::create(global_object, name, func, arity, Default::default()));
+        }
         module.put(global_object, b"vi", vi);
+        // vitest also exports `vi` under the name `vitest`.
+        module.put(global_object, b"vitest", vi);
+
+        // `vitest run` collects bench() entries but does not execute them;
+        // match that by registering nothing.
+        module.put(global_object, b"bench", jsc::JSFunction::create(global_object, "bench", __jsc_host_js_bench_noop, 2, Default::default()));
+
+        // vitest exports that bun:test does not implement. A missing named
+        // export fails the whole file at load with a SyntaxError, so export a
+        // function that throws on call instead: only the tests that use the
+        // member fail, with an error that names it.
+        const UNIMPLEMENTED_VITEST_EXPORTS: &[&str] = &[
+            "assert",
+            "assertType",
+            "aroundAll",
+            "aroundEach",
+            "BenchmarkRunner",
+            "chai",
+            "createExpect",
+            "EvaluatedModules",
+            "inject",
+            "recordArtifact",
+            "should",
+            "Snapshots",
+            "TestRunner",
+        ];
+        for &name in UNIMPLEMENTED_VITEST_EXPORTS {
+            let stub = jsc::JSFunction::create(global_object, name, __jsc_host_js_vitest_unimplemented, 0, Default::default());
+            module.put(global_object, name.as_bytes(), stub);
+        }
 
         fake_timers::put_timers_fns(global_object, jest, vi);
     }
 
+    // `#[bun_jsc::host_fn]` emits a `__jsc_host_{name}` shim with the raw
+    // `JSHostFn` ABI, which is what `JSFunction::create` expects.
+    const VI_FNS: &[(&str, u32, jsc::JSHostFn)] = &[
+        ("isMockFunction", 1, __jsc_host_js_is_mock_function),
+        ("mocked", 1, __jsc_host_js_vi_mocked),
+        ("stubEnv", 2, __jsc_host_js_stub_env),
+        ("unstubAllEnvs", 0, __jsc_host_js_unstub_all_envs),
+        ("stubGlobal", 2, __jsc_host_js_stub_global),
+        ("unstubAllGlobals", 0, __jsc_host_js_unstub_all_globals),
+        ("getMockedSystemTime", 0, __jsc_host_js_get_mocked_system_time),
+        ("getRealSystemTime", 0, __jsc_host_js_get_real_system_time),
+    ];
+
+    #[bun_jsc::host_fn]
+    fn js_vitest_unimplemented(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let name = callframe
+            .callee()
+            .get(global_object, "name")?
+            .unwrap_or(JSValue::UNDEFINED);
+        let name_utf8 = name.to_utf8(global_object)?;
+        Err(global_object.throw(format_args!(
+            "{}() is not yet implemented in bun:test",
+            bstr::BStr::new(name_utf8.slice())
+        )))
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_bench_noop(_global_object: &JSGlobalObject, _callframe: &CallFrame) -> JsResult<JSValue> {
+        Ok(JSValue::UNDEFINED)
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_is_mock_function(_global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let [value] = callframe.arguments_as_array::<1>();
+        Ok(JSValue::from(JSMock__isMockFunction(value)))
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_vi_mocked(_global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        // vi.mocked() is a TypeScript-level cast; at runtime it returns its argument.
+        Ok(callframe.arguments_as_array::<1>()[0])
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_get_mocked_system_time(global_object: &JSGlobalObject, _callframe: &CallFrame) -> JsResult<JSValue> {
+        // NaN is `JSGlobalObject::overridenDateNow`'s "no override" sentinel.
+        let ms = JSMock__getOverridenDateNow(global_object);
+        if ms.is_nan() {
+            return Ok(JSValue::NULL);
+        }
+        Ok(JSValue::from_date_number(global_object, ms))
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_get_real_system_time(_global_object: &JSGlobalObject, _callframe: &CallFrame) -> JsResult<JSValue> {
+        Ok(JSValue::js_number(JSMock__getCurrentUnixTimeMs()))
+    }
+
+    thread_local! {
+        // Stub registries for vi.stubEnv / vi.stubGlobal: the key bytes plus
+        // the original value. `None` = the property did not exist (or was
+        // undefined), so restore deletes it. Only the first stub of a key
+        // records an original, matching vitest.
+        static STUBBED_ENVS: RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>> = const { RefCell::new(Vec::new()) };
+        static STUBBED_GLOBALS: RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>> = const { RefCell::new(Vec::new()) };
+    }
+    type StubStore = std::thread::LocalKey<RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>>>;
+
+    fn get_process_env(global_object: &JSGlobalObject) -> JsResult<JSValue> {
+        let global_this = global_object.to_js_value();
+        let Some(process) = global_this.get(global_object, "process")? else {
+            return Err(global_object.throw(format_args!("process is not available")));
+        };
+        let Some(env) = process.get(global_object, "env")? else {
+            return Err(global_object.throw(format_args!("process.env is not available")));
+        };
+        Ok(env)
+    }
+
+    fn stub_value(
+        global_object: &JSGlobalObject,
+        target: JSValue,
+        store: &'static StubStore,
+        key: JSValue,
+        value: JSValue,
+        signature: &str,
+    ) -> JsResult<()> {
+        if !key.is_string() {
+            return Err(global_object.throw(format_args!("{}() expects a string name", signature)));
+        }
+        let key_utf8 = key.to_utf8(global_object)?;
+        let key_bytes = key_utf8.slice();
+
+        let original = target.get(global_object, key_bytes)?;
+        store.with(|cell| {
+            let mut stubbed = cell.borrow_mut();
+            if !stubbed.iter().any(|(k, _)| &**k == key_bytes) {
+                stubbed.push((
+                    Box::<[u8]>::from(key_bytes),
+                    original.map(|v| jsc::Strong::create(v, global_object)),
+                ));
+            }
+        });
+
+        if value.is_undefined() {
+            target.delete_property(global_object, key_bytes)?;
+        } else {
+            target.put(global_object, key_bytes, value);
+        }
+        Ok(())
+    }
+
+    fn unstub_all(
+        global_object: &JSGlobalObject,
+        target: JSValue,
+        store: &'static StubStore,
+    ) -> JsResult<()> {
+        let stubbed = store.with(|cell| core::mem::take(&mut *cell.borrow_mut()));
+        for (key, original) in stubbed {
+            match original {
+                Some(strong) => target.put(global_object, &*key, strong.get()),
+                None => {
+                    target.delete_property(global_object, &*key)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_stub_env(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let [key, value] = callframe.arguments_as_array::<2>();
+        let env = get_process_env(global_object)?;
+        // process.env values are strings; coerce like an env assignment does.
+        let value = if value.is_undefined() {
+            value
+        } else {
+            let utf8 = value.to_utf8(global_object)?;
+            bun_string_jsc::create_utf8_for_js(global_object, utf8.slice())?
+        };
+        stub_value(global_object, env, &STUBBED_ENVS, key, value, "vi.stubEnv")?;
+        Ok(callframe.this())
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_unstub_all_envs(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let env = get_process_env(global_object)?;
+        unstub_all(global_object, env, &STUBBED_ENVS)?;
+        Ok(callframe.this())
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_stub_global(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let [key, value] = callframe.arguments_as_array::<2>();
+        stub_value(global_object, global_object.to_js_value(), &STUBBED_GLOBALS, key, value, "vi.stubGlobal")?;
+        Ok(callframe.this())
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_unstub_all_globals(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        unstub_all(global_object, global_object.to_js_value(), &STUBBED_GLOBALS)?;
+        Ok(callframe.this())
+    }
+
     unsafe extern "C" {
         pub(crate) safe fn Bun__Jest__testModuleObject(global: &JSGlobalObject) -> JSValue;
+        safe fn JSMock__isMockFunction(value: JSValue) -> bool;
+        safe fn JSMock__getOverridenDateNow(global: &JSGlobalObject) -> f64;
+        safe fn JSMock__getCurrentUnixTimeMs() -> f64;
     }
     bun_jsc::jsc_abi_extern! {
         pub(crate) fn JSMock__jsMockFn(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -608,9 +608,18 @@ pub mod Jest {
         // Read the original before the borrow of the runner: the property
         // access can run user JS (a getter), which may re-enter these fns.
         let original = target.get(global_object, key_bytes)?;
+        // Windows env names are ASCII-case-insensitive: PATH and Path are one
+        // variable, so they must share one registry entry.
+        let same_key = |k: &[u8]| -> bool {
+            if cfg!(windows) && matches!(kind, StubKind::Env) {
+                k.eq_ignore_ascii_case(key_bytes)
+            } else {
+                k == key_bytes
+            }
+        };
         if let Some(runner) = runner() {
             let registry = kind.registry(runner);
-            if !registry.iter().any(|(k, _)| &**k == key_bytes) {
+            if !registry.iter().any(|(k, _)| same_key(k)) {
                 registry.push((
                     Box::<[u8]>::from(key_bytes),
                     original.map(|v| jsc::Strong::create(v, global_object)),

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -626,6 +626,21 @@ pub mod Jest {
         Ok(())
     }
 
+    /// `bun test --isolate` file boundary: restore env vars stubbed with
+    /// `vi.stubEnv` and drop every stored original. The `vi.stubGlobal`
+    /// originals belong to the outgoing realm, which is discarded whole, so
+    /// they are dropped without a restore. Dropping the `Strong`s here also
+    /// keeps them from pinning the outgoing realm.
+    pub(crate) fn reset_stubs_for_isolation(global_object: &JSGlobalObject) {
+        let restored =
+            get_process_env(global_object).and_then(|env| unstub_all(global_object, env, &STUBBED_ENVS));
+        if restored.is_err() {
+            global_object.clear_exception_except_termination();
+            STUBBED_ENVS.with(|cell| cell.borrow_mut().clear());
+        }
+        STUBBED_GLOBALS.with(|cell| cell.borrow_mut().clear());
+    }
+
     #[bun_jsc::host_fn]
     fn js_stub_env(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let [key, value] = callframe.arguments_as_array::<2>();

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -608,7 +608,7 @@ pub mod Jest {
 
         // Read the original before the borrow of the runner: the property
         // access can run user JS (a getter), which may re-enter these fns.
-        let mut original = target.get_encoded(global_object, &key_slice)?;
+        let mut original = target.get_own_encoded(global_object, &key_slice)?;
         if matches!(kind, StubKind::Env) {
             // Env values are strings, and the Windows env map reports a missing
             // name as `undefined`: treat `undefined` as absent so restore

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -604,10 +604,11 @@ pub mod Jest {
         }
         let key_utf8 = key.to_utf8(global_object)?;
         let key_bytes = key_utf8.slice();
+        let key_slice = bun_core::EncodedSlice::from_bytes(key_bytes);
 
         // Read the original before the borrow of the runner: the property
         // access can run user JS (a getter), which may re-enter these fns.
-        let original = target.get(global_object, key_bytes)?;
+        let original = target.get_encoded(global_object, &key_slice)?;
         // Windows env names are ASCII-case-insensitive: PATH and Path are one
         // variable, so they must share one registry entry.
         let same_key = |k: &[u8]| -> bool {
@@ -627,8 +628,10 @@ pub mod Jest {
             }
         }
 
-        if value.is_undefined() {
-            target.delete_property(global_object, key_bytes)?;
+        if value.is_undefined() && matches!(kind, StubKind::Env) {
+            // vitest: stubEnv(name, undefined) removes the variable, while
+            // stubGlobal(name, undefined) defines the global as undefined.
+            target.delete_property_encoded(global_object, &key_slice)?;
         } else {
             // Method-table put: process.env has a custom `put` (value
             // coercion, Windows case handling) that a putDirect bypasses.
@@ -654,7 +657,10 @@ pub mod Jest {
                     target.put_generic(global_object, &*key, strong.get())?;
                 }
                 None => {
-                    target.delete_property(global_object, &*key)?;
+                    target.delete_property_encoded(
+                        global_object,
+                        &bun_core::EncodedSlice::from_bytes(&key),
+                    )?;
                 }
             }
         }

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -414,8 +414,6 @@ pub mod Jest {
         module.put(global_object, b"expect", jsc::codegen::js::get_constructor::<Expect>(global_object));
         module.put(global_object, b"expectTypeOf", jsc::codegen::js::get_constructor::<ExpectTypeOf>(global_object));
 
-        // create_mock_objects adds the rest of the properties; the inline
-        // capacity hint above covers both.
         create_mock_objects(global_object, module);
 
         Ok(module)
@@ -463,17 +461,13 @@ pub mod Jest {
             vi.put(global_object, name.as_bytes(), jsc::JSFunction::create(global_object, name, func, arity, Default::default()));
         }
         module.put(global_object, b"vi", vi);
-        // vitest also exports `vi` under the name `vitest`.
         module.put(global_object, b"vitest", vi);
 
-        // `vitest run` collects bench() entries but does not execute them;
-        // match that by registering nothing.
+        // `vitest run` collects bench() entries but never executes them.
         module.put(global_object, b"bench", jsc::JSFunction::create(global_object, "bench", __jsc_host_js_bench_noop, 2, Default::default()));
 
-        // vitest exports that bun:test does not implement. A missing named
-        // export fails the whole file at load with a SyntaxError, so export a
-        // function that throws on call instead: only the tests that use the
-        // member fail, with an error that names it.
+        // Unimplemented vitest exports throw on call. A missing named export
+        // would fail the whole file at load with a SyntaxError instead.
         const UNIMPLEMENTED_VITEST_EXPORTS: &[&str] = &[
             "assert",
             "assertType",
@@ -556,10 +550,8 @@ pub mod Jest {
     }
 
     thread_local! {
-        // Stub registries for vi.stubEnv / vi.stubGlobal: the key bytes plus
-        // the original value. `None` = the property did not exist (or was
-        // undefined), so restore deletes it. Only the first stub of a key
-        // records an original, matching vitest.
+        // vi.stubEnv / vi.stubGlobal registries: key bytes plus the original
+        // value (`None` = absent, so restore deletes). First stub of a key wins.
         static STUBBED_ENVS: RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>> = const { RefCell::new(Vec::new()) };
         static STUBBED_GLOBALS: RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>> = const { RefCell::new(Vec::new()) };
     }
@@ -626,11 +618,9 @@ pub mod Jest {
         Ok(())
     }
 
-    /// `bun test --isolate` file boundary: restore env vars stubbed with
-    /// `vi.stubEnv` and drop every stored original. The `vi.stubGlobal`
-    /// originals belong to the outgoing realm, which is discarded whole, so
-    /// they are dropped without a restore. Dropping the `Strong`s here also
-    /// keeps them from pinning the outgoing realm.
+    /// `bun test --isolate` file boundary: restore stubbed env vars, and drop
+    /// the stored originals so they cannot pin the outgoing realm. Global-stub
+    /// originals belong to that discarded realm, so they get no restore.
     pub(crate) fn reset_stubs_for_isolation(global_object: &JSGlobalObject) {
         let restored =
             get_process_env(global_object).and_then(|env| unstub_all(global_object, env, &STUBBED_ENVS));

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -1,5 +1,4 @@
 use core::ptr::NonNull;
-use std::cell::RefCell;
 use std::io::Write as _;
 
 use crate::cli::command::TestOptions;
@@ -149,8 +148,15 @@ pub struct TestRunner<'a> {
     /// Set once any `node:test` registration API is called; gates `process.on('exit')` dispatch at the end of the run.
     pub(crate) node_test_used: bool,
 
+    /// vi.stubEnv / vi.stubGlobal registries: key bytes plus the original
+    /// value (`None` = absent, so restore deletes). First stub of a key wins.
+    pub(crate) stubbed_envs: StubRegistry,
+    pub(crate) stubbed_globals: StubRegistry,
+
     pub(crate) bun_test_root: bun_test::BunTestRoot,
 }
+
+pub(crate) type StubRegistry = Vec<(Box<[u8]>, Option<jsc::Strong>)>;
 
 impl<'a> TestRunner<'a> {
     pub(crate) fn get_active_timeout(&self) -> bun_core::Timespec {
@@ -549,13 +555,28 @@ pub mod Jest {
         Ok(JSValue::js_number(JSMock__getCurrentUnixTimeMs()))
     }
 
-    thread_local! {
-        // vi.stubEnv / vi.stubGlobal registries: key bytes plus the original
-        // value (`None` = absent, so restore deletes). First stub of a key wins.
-        static STUBBED_ENVS: RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>> = const { RefCell::new(Vec::new()) };
-        static STUBBED_GLOBALS: RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>> = const { RefCell::new(Vec::new()) };
+    /// Which `TestRunner` stub registry a `vi.stubEnv`/`vi.stubGlobal` call
+    /// uses. The registries live on the runner (per-run state, dropped with
+    /// it on the JS thread), not in a thread-local or process global.
+    #[derive(Copy, Clone)]
+    enum StubKind {
+        Env,
+        Global,
     }
-    type StubStore = std::thread::LocalKey<RefCell<Vec<(Box<[u8]>, Option<jsc::Strong>)>>>;
+    impl StubKind {
+        fn signature(self) -> &'static str {
+            match self {
+                StubKind::Env => "vi.stubEnv",
+                StubKind::Global => "vi.stubGlobal",
+            }
+        }
+        fn registry<'r>(self, runner: &'r mut TestRunner<'static>) -> &'r mut StubRegistry {
+            match self {
+                StubKind::Env => &mut runner.stubbed_envs,
+                StubKind::Global => &mut runner.stubbed_globals,
+            }
+        }
+    }
 
     fn get_process_env(global_object: &JSGlobalObject) -> JsResult<JSValue> {
         let global_this = global_object.to_js_value();
@@ -571,32 +592,38 @@ pub mod Jest {
     fn stub_value(
         global_object: &JSGlobalObject,
         target: JSValue,
-        store: &'static StubStore,
+        kind: StubKind,
         key: JSValue,
         value: JSValue,
-        signature: &str,
     ) -> JsResult<()> {
         if !key.is_string() {
-            return Err(global_object.throw(format_args!("{}() expects a string name", signature)));
+            return Err(global_object.throw(format_args!("{}() expects a string name", kind.signature())));
+        }
+        if runner().is_none() {
+            return Err(global_object.throw(format_args!("{}() can only be used in bun test", kind.signature())));
         }
         let key_utf8 = key.to_utf8(global_object)?;
         let key_bytes = key_utf8.slice();
 
+        // Read the original before the borrow of the runner: the property
+        // access can run user JS (a getter), which may re-enter these fns.
         let original = target.get(global_object, key_bytes)?;
-        store.with(|cell| {
-            let mut stubbed = cell.borrow_mut();
-            if !stubbed.iter().any(|(k, _)| &**k == key_bytes) {
-                stubbed.push((
+        if let Some(runner) = runner() {
+            let registry = kind.registry(runner);
+            if !registry.iter().any(|(k, _)| &**k == key_bytes) {
+                registry.push((
                     Box::<[u8]>::from(key_bytes),
                     original.map(|v| jsc::Strong::create(v, global_object)),
                 ));
             }
-        });
+        }
 
         if value.is_undefined() {
             target.delete_property(global_object, key_bytes)?;
         } else {
-            target.put(global_object, key_bytes, value);
+            // Method-table put: process.env has a custom `put` (value
+            // coercion, Windows case handling) that a putDirect bypasses.
+            target.put_generic(global_object, key_bytes, value)?;
         }
         Ok(())
     }
@@ -604,12 +631,19 @@ pub mod Jest {
     fn unstub_all(
         global_object: &JSGlobalObject,
         target: JSValue,
-        store: &'static StubStore,
+        kind: StubKind,
     ) -> JsResult<()> {
-        let stubbed = store.with(|cell| core::mem::take(&mut *cell.borrow_mut()));
+        // Take the entries out before the restore puts run: a put can run
+        // user JS (a setter), which may re-enter these fns.
+        let stubbed = match runner() {
+            Some(runner) => core::mem::take(kind.registry(runner)),
+            None => return Ok(()),
+        };
         for (key, original) in stubbed {
             match original {
-                Some(strong) => target.put(global_object, &*key, strong.get()),
+                Some(strong) => {
+                    target.put_generic(global_object, &*key, strong.get())?;
+                }
                 None => {
                     target.delete_property(global_object, &*key)?;
                 }
@@ -622,13 +656,15 @@ pub mod Jest {
     /// the stored originals so they cannot pin the outgoing realm. Global-stub
     /// originals belong to that discarded realm, so they get no restore.
     pub(crate) fn reset_stubs_for_isolation(global_object: &JSGlobalObject) {
-        let restored =
-            get_process_env(global_object).and_then(|env| unstub_all(global_object, env, &STUBBED_ENVS));
+        let restored = get_process_env(global_object)
+            .and_then(|env| unstub_all(global_object, env, StubKind::Env));
         if restored.is_err() {
             global_object.clear_exception_except_termination();
-            STUBBED_ENVS.with(|cell| cell.borrow_mut().clear());
         }
-        STUBBED_GLOBALS.with(|cell| cell.borrow_mut().clear());
+        if let Some(runner) = runner() {
+            runner.stubbed_envs.clear();
+            runner.stubbed_globals.clear();
+        }
     }
 
     #[bun_jsc::host_fn]
@@ -642,27 +678,27 @@ pub mod Jest {
             let utf8 = value.to_utf8(global_object)?;
             bun_string_jsc::create_utf8_for_js(global_object, utf8.slice())?
         };
-        stub_value(global_object, env, &STUBBED_ENVS, key, value, "vi.stubEnv")?;
+        stub_value(global_object, env, StubKind::Env, key, value)?;
         Ok(callframe.this())
     }
 
     #[bun_jsc::host_fn]
     fn js_unstub_all_envs(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let env = get_process_env(global_object)?;
-        unstub_all(global_object, env, &STUBBED_ENVS)?;
+        unstub_all(global_object, env, StubKind::Env)?;
         Ok(callframe.this())
     }
 
     #[bun_jsc::host_fn]
     fn js_stub_global(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let [key, value] = callframe.arguments_as_array::<2>();
-        stub_value(global_object, global_object.to_js_value(), &STUBBED_GLOBALS, key, value, "vi.stubGlobal")?;
+        stub_value(global_object, global_object.to_js_value(), StubKind::Global, key, value)?;
         Ok(callframe.this())
     }
 
     #[bun_jsc::host_fn]
     fn js_unstub_all_globals(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        unstub_all(global_object, global_object.to_js_value(), &STUBBED_GLOBALS)?;
+        unstub_all(global_object, global_object.to_js_value(), StubKind::Global)?;
         Ok(callframe.this())
     }
 

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -608,7 +608,13 @@ pub mod Jest {
 
         // Read the original before the borrow of the runner: the property
         // access can run user JS (a getter), which may re-enter these fns.
-        let original = target.get_encoded(global_object, &key_slice)?;
+        let mut original = target.get_encoded(global_object, &key_slice)?;
+        if matches!(kind, StubKind::Env) {
+            // Env values are strings, and the Windows env map reports a missing
+            // name as `undefined`: treat `undefined` as absent so restore
+            // deletes instead of writing the string "undefined".
+            original = original.filter(|v| !v.is_undefined());
+        }
         // Windows env names are ASCII-case-insensitive: PATH and Path are one
         // variable, so they must share one registry entry.
         let same_key = |k: &[u8]| -> bool {

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -474,11 +474,14 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
     Ok(frame.this())
 }
 
-// The `*Async` variants run the timers synchronously like their sync
-// counterparts, then resolve. The value of the promise shape: a caller that
-// `await`s gets a microtask checkpoint, so continuations of async timer
-// callbacks (the part after their first `await`) run before the test resumes.
-// They do not yet interleave a microtask flush between individual timers.
+// The `*Async` variants run the timers like their sync counterparts, then
+// resolve. A microtask flush happens between individual fired timers either
+// way: `EventLoopTimer::fire` wraps each callback in the event-loop
+// enter/exit pair, and the exit drains microtasks. The async variants must
+// keep that between-timer flush (vitest semantics, pinned by the chained
+// timer test in test/js/bun/test/vitest-compat.test.ts), so any future
+// change that suppresses microtask drains for the sync jest APIs belongs in
+// the four sync host functions, not in the shared execute paths.
 
 #[bun_jsc::host_fn]
 fn advance_timers_by_time_async(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -475,13 +475,11 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
 }
 
 // The `*Async` variants run the timers like their sync counterparts, then
-// resolve. A microtask flush happens between individual fired timers either
-// way: `EventLoopTimer::fire` wraps each callback in the event-loop
-// enter/exit pair, and the exit drains microtasks. The async variants must
-// keep that between-timer flush (vitest semantics, pinned by the chained
-// timer test in test/js/bun/test/vitest-compat.test.ts), so any future
-// change that suppresses microtask drains for the sync jest APIs belongs in
-// the four sync host functions, not in the shared execute paths.
+// resolve. Microtasks already flush between fired timers (each timer's
+// event-loop exit drains them); the async variants must keep that flush
+// (vitest semantics, pinned by the chained-timer test in
+// vitest-compat.test.ts), so a future sync-API drain suppression belongs in
+// the four sync host fns above, not in the shared execute paths.
 
 #[bun_jsc::host_fn]
 fn advance_timers_by_time_async(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -4,7 +4,7 @@ use bun_threading::RwLock;
 
 use bun_core::Environment;
 use bun_core::Timespec;
-use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
+use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSPromise, JSValue, JsResult};
 use crate::api::cron::CronJob;
 use crate::jsc::virtual_machine::VirtualMachine;
 use crate::timer::{
@@ -415,8 +415,7 @@ fn advance_timers_to_next_timer(global: &JSGlobalObject, frame: &CallFrame) -> J
     Ok(frame.this())
 }
 
-#[bun_jsc::host_fn]
-fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+fn advance_timers_by_time_impl(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<()> {
     error_unless_fake_timers(global)?;
 
     let arg = frame.arguments_as_array::<1>()[0];
@@ -448,6 +447,12 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     CURRENT_TIME.set(global, &target, None);
     advanced?;
 
+    Ok(())
+}
+
+#[bun_jsc::host_fn]
+fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    advance_timers_by_time_impl(global, frame)?;
     Ok(frame.this())
 }
 
@@ -467,6 +472,39 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
     FakeTimers::execute_all_timers(global)?;
 
     Ok(frame.this())
+}
+
+// The `*Async` variants run the timers synchronously like their sync
+// counterparts, then resolve. The value of the promise shape: a caller that
+// `await`s gets a microtask checkpoint, so continuations of async timer
+// callbacks (the part after their first `await`) run before the test resumes.
+// They do not yet interleave a microtask flush between individual timers.
+
+#[bun_jsc::host_fn]
+fn advance_timers_by_time_async(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    advance_timers_by_time_impl(global, frame)?;
+    Ok(JSPromise::resolved_promise_value(global, frame.this()))
+}
+
+#[bun_jsc::host_fn]
+fn advance_timers_to_next_timer_async(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    error_unless_fake_timers(global)?;
+    FakeTimers::execute_next(global)?;
+    Ok(JSPromise::resolved_promise_value(global, frame.this()))
+}
+
+#[bun_jsc::host_fn]
+fn run_only_pending_timers_async(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    error_unless_fake_timers(global)?;
+    FakeTimers::execute_only_pending_timers(global)?;
+    Ok(JSPromise::resolved_promise_value(global, frame.this()))
+}
+
+#[bun_jsc::host_fn]
+fn run_all_timers_async(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    error_unless_fake_timers(global)?;
+    FakeTimers::execute_all_timers(global)?;
+    Ok(JSPromise::resolved_promise_value(global, frame.this()))
 }
 
 #[bun_jsc::host_fn]
@@ -508,6 +546,10 @@ const FAKE_TIMERS_FNS: &[(&str, u32, JSHostFn)] = &[
     ("advanceTimersByTime", 1, __jsc_host_advance_timers_by_time),
     ("runOnlyPendingTimers", 0, __jsc_host_run_only_pending_timers),
     ("runAllTimers", 0, __jsc_host_run_all_timers),
+    ("advanceTimersToNextTimerAsync", 0, __jsc_host_advance_timers_to_next_timer_async),
+    ("advanceTimersByTimeAsync", 1, __jsc_host_advance_timers_by_time_async),
+    ("runOnlyPendingTimersAsync", 0, __jsc_host_run_only_pending_timers_async),
+    ("runAllTimersAsync", 0, __jsc_host_run_all_timers_async),
     ("getTimerCount", 0, __jsc_host_get_timer_count),
     ("clearAllTimers", 0, __jsc_host_clear_all_timers),
     ("isFakeTimers", 0, __jsc_host_is_fake_timers),

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -161,6 +161,53 @@ describe("vi members", () => {
     }
   });
 
+  test("vi.stubEnv('TZ', ...) fires the timezone side effect", () => {
+    process.env.TZ = "Etc/UTC";
+    try {
+      vi.stubEnv("TZ", "Etc/GMT-2");
+      expect(new Date(0).getTimezoneOffset()).toBe(-120);
+      vi.unstubAllEnvs();
+      expect(new Date(0).getTimezoneOffset()).toBe(0);
+    } finally {
+      vi.unstubAllEnvs();
+      process.env.TZ = "Etc/UTC";
+    }
+  });
+
+  test("vi.stubGlobal(name, undefined) defines undefined instead of deleting", () => {
+    const original = globalThis.structuredClone;
+    try {
+      vi.stubGlobal("structuredClone", undefined);
+      expect(globalThis.structuredClone).toBeUndefined();
+      expect("structuredClone" in globalThis).toBe(true);
+      vi.unstubAllGlobals();
+      expect(globalThis.structuredClone).toBe(original);
+    } finally {
+      vi.unstubAllGlobals();
+      globalThis.structuredClone = original;
+    }
+  });
+
+  test("non-ASCII names stub and restore correctly", () => {
+    const g = globalThis as Record<string, unknown>;
+    try {
+      vi.stubGlobal("π", 3.14);
+      expect(g["π"]).toBe(3.14);
+      vi.stubEnv("ÜBER_COMPAT", "ja");
+      expect(process.env["ÜBER_COMPAT"]).toBe("ja");
+
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+      expect("π" in g).toBe(false);
+      expect(process.env["ÜBER_COMPAT"]).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+      delete g["π"];
+      delete process.env["ÜBER_COMPAT"];
+    }
+  });
+
   test("stub calls chain like vitest's utils object", () => {
     try {
       expect(vi.stubEnv("VITEST_COMPAT_CHAIN", "1").stubGlobal("__vitest_compat_chain__", 2)).toBe(vi);

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -38,13 +38,11 @@ describe("unimplemented exports are throwing stubs, not missing", () => {
     "TestRunner",
   ] as const;
 
-  for (const name of stubNames) {
-    test(`${name} is exported and throws on call with its own name`, () => {
-      const member = (vitestModule as Record<string, unknown>)[name];
-      expect(typeof member).toBe("function");
-      expect(() => (member as () => void)()).toThrow(`${name}() is not yet implemented in bun:test`);
-    });
-  }
+  test.each([...stubNames])("%s is exported and throws on call with its own name", name => {
+    const member = (vitestModule as Record<string, unknown>)[name];
+    expect(typeof member).toBe("function");
+    expect(() => (member as () => void)()).toThrow(`${name}() is not yet implemented in bun:test`);
+  });
 });
 
 test("bench is a no-op that never runs its callback", () => {
@@ -100,39 +98,63 @@ describe("vi members", () => {
   test("vi.stubEnv and vi.unstubAllEnvs", () => {
     process.env.VITEST_COMPAT_EXISTING = "original";
     delete process.env.VITEST_COMPAT_ADDED;
+    try {
+      vi.stubEnv("VITEST_COMPAT_EXISTING", "stubbed");
+      vi.stubEnv("VITEST_COMPAT_EXISTING", "stubbed-twice");
+      vi.stubEnv("VITEST_COMPAT_ADDED", "added");
+      expect(process.env.VITEST_COMPAT_EXISTING).toBe("stubbed-twice");
+      expect(process.env.VITEST_COMPAT_ADDED).toBe("added");
 
-    vi.stubEnv("VITEST_COMPAT_EXISTING", "stubbed");
-    vi.stubEnv("VITEST_COMPAT_EXISTING", "stubbed-twice");
-    vi.stubEnv("VITEST_COMPAT_ADDED", "added");
-    expect(process.env.VITEST_COMPAT_EXISTING).toBe("stubbed-twice");
-    expect(process.env.VITEST_COMPAT_ADDED).toBe("added");
-
-    vi.unstubAllEnvs();
-    expect(process.env.VITEST_COMPAT_EXISTING).toBe("original");
-    expect(process.env.VITEST_COMPAT_ADDED).toBeUndefined();
-    delete process.env.VITEST_COMPAT_EXISTING;
+      vi.unstubAllEnvs();
+      expect(process.env.VITEST_COMPAT_EXISTING).toBe("original");
+      expect(process.env.VITEST_COMPAT_ADDED).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+      delete process.env.VITEST_COMPAT_EXISTING;
+      delete process.env.VITEST_COMPAT_ADDED;
+    }
   });
 
   test("vi.stubEnv(name, undefined) removes the variable", () => {
     process.env.VITEST_COMPAT_REMOVE = "here";
-    vi.stubEnv("VITEST_COMPAT_REMOVE", undefined);
-    expect(process.env.VITEST_COMPAT_REMOVE).toBeUndefined();
-    vi.unstubAllEnvs();
-    expect(process.env.VITEST_COMPAT_REMOVE).toBe("here");
-    delete process.env.VITEST_COMPAT_REMOVE;
+    try {
+      vi.stubEnv("VITEST_COMPAT_REMOVE", undefined);
+      expect(process.env.VITEST_COMPAT_REMOVE).toBeUndefined();
+      vi.unstubAllEnvs();
+      expect(process.env.VITEST_COMPAT_REMOVE).toBe("here");
+    } finally {
+      vi.unstubAllEnvs();
+      delete process.env.VITEST_COMPAT_REMOVE;
+    }
   });
 
   test("vi.stubGlobal and vi.unstubAllGlobals", () => {
-    vi.stubGlobal("__vitest_compat_new__", 42);
-    expect((globalThis as Record<string, unknown>).__vitest_compat_new__).toBe(42);
-
     const originalFetch = globalThis.fetch;
-    vi.stubGlobal("fetch", "not-a-function");
-    expect(globalThis.fetch as unknown).toBe("not-a-function");
+    try {
+      vi.stubGlobal("__vitest_compat_new__", 42);
+      expect((globalThis as Record<string, unknown>).__vitest_compat_new__).toBe(42);
 
-    vi.unstubAllGlobals();
-    expect("__vitest_compat_new__" in globalThis).toBe(false);
-    expect(globalThis.fetch).toBe(originalFetch);
+      vi.stubGlobal("fetch", "not-a-function");
+      expect(globalThis.fetch as unknown).toBe("not-a-function");
+
+      vi.unstubAllGlobals();
+      expect("__vitest_compat_new__" in globalThis).toBe(false);
+      expect(globalThis.fetch).toBe(originalFetch);
+    } finally {
+      vi.unstubAllGlobals();
+      globalThis.fetch = originalFetch;
+      delete (globalThis as Record<string, unknown>).__vitest_compat_new__;
+    }
+  });
+
+  test("stub calls chain like vitest's utils object", () => {
+    try {
+      expect(vi.stubEnv("VITEST_COMPAT_CHAIN", "1").stubGlobal("__vitest_compat_chain__", 2)).toBe(vi);
+      expect(vi.unstubAllGlobals().unstubAllEnvs()).toBe(vi);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+    }
   });
 
   test("vi.stubEnv rejects a non-string name", () => {
@@ -267,10 +289,46 @@ describe("onTestFailed", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toContain("FAILED_HOOK_SYNC");
     expect(stdout).toContain("FINISHED_HOOK");
     expect(stdout).toContain("FAILED_HOOK_ASYNC");
+    expect(stderr).toContain("2 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("runs for failure modes decided at sequence completion", async () => {
+    using dir = tempDir("vitest-compat-failhook-deferred", {
+      "deferred.test.ts": `
+        import { test, onTestFailed, expect } from "vitest";
+        test("assertion count mismatch", () => {
+          onTestFailed(() => console.log("FAILED_HOOK_ASSERTIONS"));
+          expect.assertions(2);
+          expect(1).toBe(1);
+        });
+        test.fails("test.fails whose body passes", () => {
+          onTestFailed(() => console.log("FAILED_HOOK_FAILS_PASSED"));
+          expect(1).toBe(1);
+        });
+        test.fails("test.fails whose body throws", () => {
+          onTestFailed(() => console.log("FAILED_HOOK_FAILS_THREW"));
+          throw new Error("expected");
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "deferred.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("FAILED_HOOK_ASSERTIONS");
+    expect(stdout).toContain("FAILED_HOOK_FAILS_PASSED");
+    // A test.fails test whose body throws ends up passing, so its hook must not run.
+    expect(stdout).not.toContain("FAILED_HOOK_FAILS_THREW");
+    expect(stderr).toContain("2 fail");
     expect(exitCode).toBe(1);
   });
 
@@ -289,8 +347,9 @@ describe("onTestFailed", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Cannot call onTestFailed() outside of a test");
+    expect(stdout).not.toContain("never runs");
     expect(exitCode).toBe(1);
   });
 });
@@ -328,7 +387,8 @@ test.concurrent("stub stores reset at the --isolate file boundary", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).not.toContain("ISO_LEAK");
   expect(stderr).toContain("2 pass");
   expect(exitCode).toBe(0);
 });
@@ -355,7 +415,33 @@ test.concurrent("a static import of a previously missing export no longer kills 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).not.toContain("SyntaxError");
+  expect(stdout).not.toContain("SyntaxError");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("vi.stubEnv outside bun test throws", async () => {
+  using dir = tempDir("vitest-compat-stub-outside", {
+    "stub-outside.ts": `
+      import { vi } from "bun:test";
+      try {
+        vi.stubEnv("X", "1");
+        console.log("NO_THROW");
+      } catch (e) {
+        console.log("THREW:", (e as Error).message);
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "stub-outside.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("THREW: vi.stubEnv() can only be used in bun test");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -397,6 +397,12 @@ describe("onTestFailed", () => {
           onTestFailed(() => console.log("FAILED_HOOK_FAILS_THREW"));
           throw new Error("expected");
         });
+        test("onTestFinished failure still triggers an earlier onTestFailed", () => {
+          onTestFailed(() => console.log("FAILED_AFTER_FINISHED"));
+          onTestFinished(() => {
+            throw new Error("finished boom");
+          });
+        });
       `,
     });
     await using proc = Bun.spawn({
@@ -411,7 +417,8 @@ describe("onTestFailed", () => {
     expect(stdout).toContain("FAILED_HOOK_FAILS_PASSED");
     // A test.fails test whose body throws ends up passing, so its hook must not run.
     expect(stdout).not.toContain("FAILED_HOOK_FAILS_THREW");
-    expect(stderr).toContain("2 fail");
+    expect(stdout).toContain("FAILED_AFTER_FINISHED");
+    expect(stderr).toContain("3 fail");
     expect(exitCode).toBe(1);
   });
 

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -193,6 +193,19 @@ describe("vi members", () => {
     }
   });
 
+  test("an integer-like name stubs and restores without crashing", () => {
+    const g = globalThis as Record<string, unknown>;
+    try {
+      vi.stubGlobal("0", "zero");
+      expect(g["0"]).toBe("zero");
+      vi.unstubAllGlobals();
+      expect("0" in g).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+      delete g["0"];
+    }
+  });
+
   test("restore keeps a global that was already undefined", () => {
     const g = globalThis as Record<string, unknown>;
     try {

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -396,7 +396,7 @@ describe("onTestFailed", () => {
   test.concurrent("runs for failure modes decided at sequence completion", async () => {
     using dir = tempDir("vitest-compat-failhook-deferred", {
       "deferred.test.ts": `
-        import { test, onTestFailed, expect } from "vitest";
+        import { test, onTestFailed, onTestFinished, expect } from "vitest";
         test("assertion count mismatch", () => {
           onTestFailed(() => console.log("FAILED_HOOK_ASSERTIONS"));
           expect.assertions(2);
@@ -452,7 +452,8 @@ describe("onTestFailed", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Cannot call onTestFailed() outside of a test");
-    expect(stdout).not.toContain("never runs");
+    // The file fails at load, so no test registers or passes.
+    expect(stderr).not.toContain("(pass)");
     expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -1,0 +1,301 @@
+// Tests for the vitest compatibility surface of bun:test (issue #40990).
+// `bun test` aliases the "vitest" specifier to "bun:test", so this file
+// imports through the alias on purpose.
+import { suite, vitest, vi, test, describe, expect, onTestFailed, onTestFinished, bench } from "vitest";
+import * as vitestModule from "vitest";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+suite("suite is describe", () => {
+  test("suite registers a describe block", () => {
+    expect(suite).toBe(describe as unknown as typeof suite);
+  });
+});
+
+suite.each([[1], [2]])("suite.each %i", n => {
+  test("runs", () => {
+    expect(n).toBeGreaterThan(0);
+  });
+});
+
+test("vitest is an alias of vi", () => {
+  expect(vitest).toBe(vi);
+});
+
+describe("unimplemented exports are throwing stubs, not missing", () => {
+  const stubNames = [
+    "assert",
+    "assertType",
+    "aroundAll",
+    "aroundEach",
+    "BenchmarkRunner",
+    "chai",
+    "createExpect",
+    "EvaluatedModules",
+    "inject",
+    "recordArtifact",
+    "should",
+    "Snapshots",
+    "TestRunner",
+  ] as const;
+
+  for (const name of stubNames) {
+    test(`${name} is exported and throws on call with its own name`, () => {
+      const member = (vitestModule as Record<string, unknown>)[name];
+      expect(typeof member).toBe("function");
+      expect(() => (member as () => void)()).toThrow(`${name}() is not yet implemented in bun:test`);
+    });
+  }
+});
+
+test("bench is a no-op that never runs its callback", () => {
+  expect(typeof bench).toBe("function");
+  expect(() => bench("name", () => {
+    throw new Error("bench callback must not run");
+  })).not.toThrow();
+});
+
+describe("vi members", () => {
+  test("vi.setSystemTime and vi.getMockedSystemTime", () => {
+    expect(vi.getMockedSystemTime()).toBeNull();
+    vi.setSystemTime(new Date("2020-01-01T00:00:00Z"));
+    try {
+      expect(Date.now()).toBe(1577836800000);
+      const mocked = vi.getMockedSystemTime();
+      expect(mocked).toBeInstanceOf(Date);
+      expect(mocked!.getTime()).toBe(1577836800000);
+    } finally {
+      vi.setSystemTime();
+    }
+    expect(vi.getMockedSystemTime()).toBeNull();
+  });
+
+  test("vi.getRealSystemTime ignores the mocked clock", () => {
+    vi.setSystemTime(new Date("2020-01-01T00:00:00Z"));
+    try {
+      const real = vi.getRealSystemTime();
+      expect(typeof real).toBe("number");
+      expect(real).toBeGreaterThan(1577836800000);
+    } finally {
+      vi.setSystemTime();
+    }
+  });
+
+  test("vi.isMockFunction", () => {
+    expect(vi.isMockFunction(vi.fn())).toBe(true);
+    expect(vi.isMockFunction(vi.spyOn({ a() {} }, "a"))).toBe(true);
+    expect(vi.isMockFunction(() => {})).toBe(false);
+    expect(vi.isMockFunction(undefined)).toBe(false);
+    expect(vi.isMockFunction(42)).toBe(false);
+  });
+
+  test("vi.mocked returns its argument", () => {
+    const fn = vi.fn();
+    expect(vi.mocked(fn)).toBe(fn);
+    const plain = {};
+    expect(vi.mocked(plain)).toBe(plain);
+  });
+
+  test("vi.stubEnv and vi.unstubAllEnvs", () => {
+    process.env.VITEST_COMPAT_EXISTING = "original";
+    delete process.env.VITEST_COMPAT_ADDED;
+
+    vi.stubEnv("VITEST_COMPAT_EXISTING", "stubbed");
+    vi.stubEnv("VITEST_COMPAT_EXISTING", "stubbed-twice");
+    vi.stubEnv("VITEST_COMPAT_ADDED", "added");
+    expect(process.env.VITEST_COMPAT_EXISTING).toBe("stubbed-twice");
+    expect(process.env.VITEST_COMPAT_ADDED).toBe("added");
+
+    vi.unstubAllEnvs();
+    expect(process.env.VITEST_COMPAT_EXISTING).toBe("original");
+    expect(process.env.VITEST_COMPAT_ADDED).toBeUndefined();
+    delete process.env.VITEST_COMPAT_EXISTING;
+  });
+
+  test("vi.stubEnv(name, undefined) removes the variable", () => {
+    process.env.VITEST_COMPAT_REMOVE = "here";
+    vi.stubEnv("VITEST_COMPAT_REMOVE", undefined);
+    expect(process.env.VITEST_COMPAT_REMOVE).toBeUndefined();
+    vi.unstubAllEnvs();
+    expect(process.env.VITEST_COMPAT_REMOVE).toBe("here");
+    delete process.env.VITEST_COMPAT_REMOVE;
+  });
+
+  test("vi.stubGlobal and vi.unstubAllGlobals", () => {
+    vi.stubGlobal("__vitest_compat_new__", 42);
+    expect((globalThis as Record<string, unknown>).__vitest_compat_new__).toBe(42);
+
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal("fetch", "not-a-function");
+    expect(globalThis.fetch as unknown).toBe("not-a-function");
+
+    vi.unstubAllGlobals();
+    expect("__vitest_compat_new__" in globalThis).toBe(false);
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+
+  test("vi.stubEnv rejects a non-string name", () => {
+    expect(() => (vi.stubEnv as (k: unknown, v: unknown) => void)(42, "x")).toThrow("vi.stubEnv() expects a string name");
+  });
+});
+
+describe("async fake timer variants", () => {
+  test("advanceTimersByTimeAsync flushes an awaiting callback", async () => {
+    vi.useFakeTimers();
+    try {
+      let done = false;
+      setTimeout(async () => {
+        await Promise.resolve();
+        done = true;
+      }, 100);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(done).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("runAllTimersAsync and friends resolve", async () => {
+    vi.useFakeTimers();
+    try {
+      let count = 0;
+      setTimeout(() => count++, 1);
+      setTimeout(() => count++, 2);
+      await vi.runAllTimersAsync();
+      expect(count).toBe(2);
+
+      setTimeout(() => count++, 1);
+      await vi.advanceTimersToNextTimerAsync();
+      expect(count).toBe(3);
+
+      setTimeout(() => count++, 1);
+      await vi.runOnlyPendingTimersAsync();
+      expect(count).toBe(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("jest object also has the async variants", () => {
+    const { jest } = vitestModule as unknown as { jest: Record<string, unknown> };
+    expect(typeof jest.advanceTimersByTimeAsync).toBe("function");
+    expect(typeof jest.runAllTimersAsync).toBe("function");
+    expect(typeof jest.runOnlyPendingTimersAsync).toBe("function");
+    expect(typeof jest.advanceTimersToNextTimerAsync).toBe("function");
+  });
+});
+
+describe("test and describe modifiers", () => {
+  test.fails("test.fails expects the test to fail", () => {
+    throw new Error("expected failure");
+  });
+
+  test.runIf(true)("test.runIf(true) runs", () => {
+    expect(true).toBe(true);
+  });
+
+  test.runIf(false)("test.runIf(false) skips", () => {
+    throw new Error("must not run");
+  });
+
+  describe.sequential("describe.sequential works", () => {
+    test("runs", () => {
+      expect(true).toBe(true);
+    });
+  });
+
+  test.sequential("test.sequential runs", () => {
+    expect(true).toBe(true);
+  });
+});
+
+describe("onTestFailed", () => {
+  let passHookRan = false;
+  test("does not run after a passing test", () => {
+    onTestFailed(() => {
+      passHookRan = true;
+    });
+    expect(true).toBe(true);
+  });
+  test("(checked in the next test)", () => {
+    expect(passHookRan).toBe(false);
+  });
+
+  test.concurrent("runs after a failing test, in registration context", async () => {
+    using dir = tempDir("vitest-compat-failhook", {
+      "failhook.test.ts": `
+        import { test, onTestFailed, onTestFinished, expect } from "vitest";
+        test("fails sync", () => {
+          onTestFailed(() => console.log("FAILED_HOOK_SYNC"));
+          onTestFinished(() => console.log("FINISHED_HOOK"));
+          expect(1).toBe(2);
+        });
+        test("fails async", async () => {
+          onTestFailed(async () => {
+            await Promise.resolve();
+            console.log("FAILED_HOOK_ASYNC");
+          });
+          throw new Error("boom");
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "failhook.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toContain("FAILED_HOOK_SYNC");
+    expect(stdout).toContain("FINISHED_HOOK");
+    expect(stdout).toContain("FAILED_HOOK_ASYNC");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("cannot be called outside of a test", async () => {
+    using dir = tempDir("vitest-compat-failhook-outside", {
+      "outside.test.ts": `
+        import { test, onTestFailed } from "vitest";
+        onTestFailed(() => {});
+        test("never runs", () => {});
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "outside.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Cannot call onTestFailed() outside of a test");
+    expect(exitCode).toBe(1);
+  });
+});
+
+test.concurrent("a static import of a previously missing export no longer kills the file", async () => {
+  using dir = tempDir("vitest-compat-static-import", {
+    "static-import.test.ts": `
+      import { test, suite, vitest, onTestFailed, assert, chai } from "vitest";
+      suite("loads", () => {
+        test("passes", () => {
+          vitest.fn();
+          // assert and chai are importable; only calling them throws.
+          void assert;
+          void chai;
+          void onTestFailed;
+        });
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "static-import.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("SyntaxError");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -162,6 +162,7 @@ describe("vi members", () => {
   });
 
   test("vi.stubEnv('TZ', ...) fires the timezone side effect", () => {
+    const originalTZ = process.env.TZ;
     process.env.TZ = "Etc/UTC";
     try {
       vi.stubEnv("TZ", "Etc/GMT-2");
@@ -170,7 +171,11 @@ describe("vi members", () => {
       expect(new Date(0).getTimezoneOffset()).toBe(0);
     } finally {
       vi.unstubAllEnvs();
-      process.env.TZ = "Etc/UTC";
+      if (originalTZ === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTZ;
+      }
     }
   });
 
@@ -185,6 +190,23 @@ describe("vi members", () => {
     } finally {
       vi.unstubAllGlobals();
       globalThis.structuredClone = original;
+    }
+  });
+
+  test("restore keeps a global that was already undefined", () => {
+    const g = globalThis as Record<string, unknown>;
+    try {
+      g.__vitest_compat_undef__ = undefined;
+      vi.stubGlobal("__vitest_compat_undef__", "stubbed");
+      expect(g.__vitest_compat_undef__).toBe("stubbed");
+      vi.unstubAllGlobals();
+      // The property existed with the value undefined, so restore keeps it
+      // instead of deleting it.
+      expect("__vitest_compat_undef__" in g).toBe(true);
+      expect(g.__vitest_compat_undef__).toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+      delete g.__vitest_compat_undef__;
     }
   });
 

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -154,6 +154,24 @@ describe("async fake timer variants", () => {
     }
   });
 
+  test("advanceTimersByTimeAsync flushes microtasks between timers", async () => {
+    // Pins vitest semantics: timer A's continuation (after an await) schedules
+    // timer B inside the advanced window, and B must fire in the same advance.
+    vi.useFakeTimers();
+    try {
+      const order: string[] = [];
+      setTimeout(async () => {
+        order.push("A");
+        await Promise.resolve();
+        setTimeout(() => order.push("B"), 50);
+      }, 100);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(order).toEqual(["A", "B"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("runAllTimersAsync and friends resolve", async () => {
     vi.useFakeTimers();
     try {
@@ -271,6 +289,44 @@ describe("onTestFailed", () => {
     expect(stderr).toContain("Cannot call onTestFailed() outside of a test");
     expect(exitCode).toBe(1);
   });
+});
+
+test.concurrent("stub stores reset at the --isolate file boundary", async () => {
+  using dir = tempDir("vitest-compat-isolate-stubs", {
+    "a.test.ts": `
+      import { test, vi, expect } from "vitest";
+      test("stub env and global, never unstub", () => {
+        process.env.ISO_LEAK = "original";
+        vi.stubEnv("ISO_LEAK", "stubbed");
+        vi.stubGlobal("structuredClone", "broken");
+        expect(process.env.ISO_LEAK).toBe("stubbed");
+      });
+    `,
+    "b.test.ts": `
+      import { test, vi, expect } from "vitest";
+      test("previous file's stub records are gone", () => {
+        // The realm swap rebuilt process.env, and the boundary cleared the
+        // stub stores: unstubAll* must be no-ops, not restore stale values
+        // recorded in the previous file's realm.
+        const cloneBefore = globalThis.structuredClone;
+        expect(typeof cloneBefore).toBe("function");
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+        expect(process.env.ISO_LEAK).toBeUndefined();
+        expect(globalThis.structuredClone).toBe(cloneBefore);
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--isolate", "a.test.ts", "b.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("2 pass");
+  expect(exitCode).toBe(0);
 });
 
 test.concurrent("a static import of a previously missing export no longer kills the file", async () => {

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -1,7 +1,7 @@
 // Tests for the vitest compatibility surface of bun:test (issue #40990).
 // `bun test` aliases the "vitest" specifier to "bun:test", so this file
 // imports through the alias on purpose.
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import * as vitestModule from "vitest";
 import { bench, describe, expect, onTestFailed, suite, test, vi, vitest } from "vitest";
 
@@ -144,6 +144,20 @@ describe("vi members", () => {
       vi.unstubAllGlobals();
       globalThis.fetch = originalFetch;
       delete (globalThis as Record<string, unknown>).__vitest_compat_new__;
+    }
+  });
+
+  test.skipIf(!isWindows)("vi.stubEnv dedups names case-insensitively on Windows", () => {
+    process.env.VITEST_COMPAT_CASE = "original";
+    try {
+      vi.stubEnv("VITEST_COMPAT_CASE", "one");
+      vi.stubEnv("vitest_compat_case", "two");
+      expect(process.env.VITEST_COMPAT_CASE).toBe("two");
+      vi.unstubAllEnvs();
+      expect(process.env.VITEST_COMPAT_CASE).toBe("original");
+    } finally {
+      vi.unstubAllEnvs();
+      delete process.env.VITEST_COMPAT_CASE;
     }
   });
 

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -206,6 +206,22 @@ describe("vi members", () => {
     }
   });
 
+  test("stubbing an inherited name restores by delete", () => {
+    const g = globalThis as Record<string, unknown>;
+    try {
+      vi.stubGlobal("hasOwnProperty", "stubbed");
+      expect(g.hasOwnProperty).toBe("stubbed");
+      vi.unstubAllGlobals();
+      // The name only existed on Object.prototype, so restore removes the
+      // own property instead of copying the inherited value onto globalThis.
+      expect(Object.getOwnPropertyDescriptor(globalThis, "hasOwnProperty")).toBeUndefined();
+      expect(typeof g.hasOwnProperty).toBe("function");
+    } finally {
+      vi.unstubAllGlobals();
+      delete g.hasOwnProperty;
+    }
+  });
+
   test("restore keeps a global that was already undefined", () => {
     const g = globalThis as Record<string, unknown>;
     try {

--- a/test/js/bun/test/vitest-compat.test.ts
+++ b/test/js/bun/test/vitest-compat.test.ts
@@ -1,9 +1,9 @@
 // Tests for the vitest compatibility surface of bun:test (issue #40990).
 // `bun test` aliases the "vitest" specifier to "bun:test", so this file
 // imports through the alias on purpose.
-import { suite, vitest, vi, test, describe, expect, onTestFailed, onTestFinished, bench } from "vitest";
-import * as vitestModule from "vitest";
 import { bunEnv, bunExe, tempDir } from "harness";
+import * as vitestModule from "vitest";
+import { bench, describe, expect, onTestFailed, suite, test, vi, vitest } from "vitest";
 
 suite("suite is describe", () => {
   test("suite registers a describe block", () => {
@@ -49,9 +49,11 @@ describe("unimplemented exports are throwing stubs, not missing", () => {
 
 test("bench is a no-op that never runs its callback", () => {
   expect(typeof bench).toBe("function");
-  expect(() => bench("name", () => {
-    throw new Error("bench callback must not run");
-  })).not.toThrow();
+  expect(() =>
+    bench("name", () => {
+      throw new Error("bench callback must not run");
+    }),
+  ).not.toThrow();
 });
 
 describe("vi members", () => {
@@ -134,7 +136,9 @@ describe("vi members", () => {
   });
 
   test("vi.stubEnv rejects a non-string name", () => {
-    expect(() => (vi.stubEnv as (k: unknown, v: unknown) => void)(42, "x")).toThrow("vi.stubEnv() expects a string name");
+    expect(() => (vi.stubEnv as (k: unknown, v: unknown) => void)(42, "x")).toThrow(
+      "vi.stubEnv() expects a string name",
+    );
   });
 });
 


### PR DESCRIPTION
### Problem

- `bun test` aliases the `vitest` specifier to `bun:test`, but many vitest members are missing (#40990). A missing named export is a load-time `SyntaxError: Export named 'onTestFailed' not found in module 'bun:test'`, so one unsupported import kills the whole file.
- The gaps span module exports (`suite`, `vitest`, `onTestFailed`), `vi` members, async fake-timer variants, and modifiers (`test.fails`, `test.runIf`, `describe.sequential`).

### Fix

- Implement the members bun already has machinery for: `suite` and `vitest` aliases, `onTestFailed` (an `only_on_failure` execution entry gated on the resolved final result, so assertion-count and `test.fails` outcomes count), `vi.setSystemTime`, `getMockedSystemTime`, `getRealSystemTime`, `isMockFunction`, `mocked`, `stubEnv`, `stubGlobal`, `unstubAllEnvs`, `unstubAllGlobals`, the four `*TimersAsync` variants, and the `fails`, `runIf`, `sequential` modifier aliases.
- Export the still unimplemented vitest names (`chai`, `assert`, `inject`, ...) as functions that throw with the member name on call. Only the tests that use them fail. `bench` is a no-op, which matches `vitest run`.
- The stub registries live on `TestRunner` (per-run state), reset at the `--isolate` file boundary. Originals record through a new own-property, encoding-aware, index-safe lookup, and writes go through a new method-table put, because a `putDirect` bypasses the env map custom setter and loses writes on Windows. Env names dedup case-insensitively on Windows.
- Verified: `test/js/bun/test/vitest-compat.test.ts` (44 tests, linux and Windows, stock bun fails the file at load). Also the fake-timers, mock-fn, bun-test, cli bun-test, isolation, and hooks suites. The issue's 53-test inventory goes from 0 to 17 passing. The rest (fixtures, module mocking, matchers) is out of scope here.

### Background

- The named ES exports of `bun:test` are derived from the module object's own properties (`BunTestModule.h`), so a new property becomes an importable named export for `vitest` and `@jest/globals` too.
- A microtask flush already happens between individual fired fake timers: each timer fires inside the event loop's enter and exit pair, and the exit drains microtasks. The async variants depend on that flush, and a chained-timer test pins it. #35496 plans to suppress that drain for the sync jest APIs. The comment in `FakeTimers.rs` states that such a guard belongs in the four sync host functions, not the shared execute paths.
- Self-reviewed, then reworked for bot review findings: per-runner stub storage, the `onTestFailed` final-result gate, the Windows env semantics, and `VitestUtils` typings with fluent returns. Declined: vitest's full conditional mock types for `vi.mocked` (the `Mock<T>` overload covers the common case).

<details><summary>Notes</summary>

- Issue inventory on this branch: 17 of 53 pass (0 before). The remaining failures are `test.extend` fixtures, `vi.hoisted` and the module-mocking cluster (#36297 covers hoisting), extra matchers (`toHaveResolved` family), and `expect` statics (`soft`, `poll`, `getState`).
- Overlapping open PRs checked: #35496 (fake timers sync microtask drain, same file, see Background), #33923 (`setSystemTime` typing), #36297 (mock hoisting), #32034 (`test.extend`), #36398 (fake timer reset between files). None implements the members added here.
- `vi.stubEnv` coerces the value to a string and treats `undefined` as delete. Both stub helpers record only the first original per key, like vitest, and return `this` for chaining. Outside `bun test` (no runner) they throw.
- `JSC__JSValue__putGeneric` is the new generic put. The existing `JSC__JSValue__put` is a `putDirect`: on Windows the env map's custom `getOwnPropertySlot` shadows a direct property, so stubbed values read back unchanged. The generic put runs `JSEnvironmentVariableMap::put` (value coercion, TZ side effects, case handling).
- Under `--isolate`, the realm swap rebuilds `process.env`, so an unstubbed env var does not leak on its own. The boundary reset exists so a later `vi.unstubAll*()` cannot restore values recorded in the previous file's realm, and so the stored `Strong` handles do not pin the discarded realm.
- The throwing stubs keep `typeof x === "function"`, which weakens feature detection for those names. For module exports this is the lesser evil: the alternative is a load-time `SyntaxError` that fails the whole file. Absent `vi` members stay absent, so `if (vi.hoisted)` style detection still works.
- `onTestFailed` callbacks run as ordinary sequence entries after `afterEach`. The gate calls `resolve_final_result`, the same pure function `on_sequence_completed` now uses, so deferred failure modes (assertion counts, `test.fails` inversion, todo-passed) are decided identically in both places. The callbacks do not yet receive vitest's task context argument.
- `onTestFinished` entries splice before the gated `onTestFailed` tail regardless of registration order, and a spliced hook that throws fails past only itself, so the remaining hooks still run and the gate sees the failure. A describe-level `afterEach` that throws still skips the spliced tail (a pre-existing `Order.rs` skip-layout gap shared with `onTestFinished`).
- Suites run locally: vitest-compat (linux + Windows), fake-timers (531), mock-fn (87), bun-test, bun_test, cli bun-test (104), isolation (32), test-on-test-finished, describe, concurrent, process.test.js (one pre-existing env-dependent failure, also fails on stock bun), bun-types integration (20).

</details>
