### PR TITLE
Full collections + payload page-out while idle

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -87,6 +87,7 @@ new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 new!(pub BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS: unsigned, "BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS", {});
 new!(pub BUN_GC_TIMER_DISABLE: boolean, "BUN_GC_TIMER_DISABLE", {});
 new!(pub BUN_GC_TIMER_INTERVAL: unsigned, "BUN_GC_TIMER_INTERVAL", {});
+new!(pub BUN_IDLE_RELEASE_SECONDS: unsigned, "BUN_IDLE_RELEASE_SECONDS", { default: 30 });
 // TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior
 // so we'll keep it for now.
 new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 100_000 });

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -1,4 +1,4 @@
-//! Idle GC timer: JSC's own `GCActivityCallback` (via `WTFTimer`) paces eden/full against allocation rate; this only adds a 1 s / 30 s idle `collect_async()` so a process that stops allocating still releases memory. Knobs: `BUN_GC_TIMER_INTERVAL` (ms), `BUN_GC_TIMER_DISABLE`. One per JS thread, not thread-safe.
+//! Idle GC timer: JSC's own `GCActivityCallback` (via `WTFTimer`) paces eden/full against allocation rate; this only adds a 1 s / 30 s idle `collect_async()` so a process that stops allocating still releases memory, and — once per idle period, after `BUN_IDLE_RELEASE_SECONDS` (default 30, 0 = off) of the process using under 2% CPU — drops JIT code and pages out a standalone executable's embedded module graph (main thread only). Knobs: `BUN_GC_TIMER_INTERVAL` (ms), `BUN_GC_TIMER_DISABLE`. One per JS thread, not thread-safe.
 
 use core::cell::Cell;
 use core::ffi::c_int;
@@ -20,6 +20,12 @@ pub struct GarbageCollectionController {
     pub(crate) gc_timer_interval: Cell<i32>,
     pub(crate) gc_repeating_timer_fast: Cell<bool>,
     pub(crate) disabled: Cell<bool>,
+    /// Idle release: process CPU time (µs) at the last fire, how long the process has stayed under the idle CPU
+    /// threshold, CPU time at the last release (`u64::MAX` = armed), and the configured delay (0 = off).
+    idle_last_cpu_us: Cell<u64>,
+    idle_quiet_ms: Cell<u32>,
+    idle_released_at_cpu_us: Cell<u64>,
+    idle_release_after_ms: Cell<u32>,
 }
 
 bun_event_loop::impl_timer_owner!(
@@ -36,6 +42,10 @@ impl Default for GarbageCollectionController {
             gc_timer_interval: Cell::new(0),
             gc_repeating_timer_fast: Cell::new(true),
             disabled: Cell::new(false),
+            idle_last_cpu_us: Cell::new(0),
+            idle_quiet_ms: Cell::new(0),
+            idle_released_at_cpu_us: Cell::new(u64::MAX),
+            idle_release_after_ms: Cell::new(0),
         }
     }
 }
@@ -86,6 +96,53 @@ impl GarbageCollectionController {
 
         self.disabled
             .set(env_var::BUN_GC_TIMER_DISABLE::get().unwrap_or(false));
+
+        if vm.is_main_thread() {
+            self.idle_release_after_ms.set(
+                (env_var::BUN_IDLE_RELEASE_SECONDS::get()
+                    .unwrap_or(30)
+                    .min(3600)
+                    * 1000) as u32,
+            );
+        }
+    }
+
+    /// Called on every repeating-timer fire with the interval that just elapsed. "Idle" is judged by process CPU
+    /// time rather than by whether any JS ran: an interactive app sitting at a prompt still fires the odd timer.
+    fn note_tick_for_idle_release(&self, vm: &VirtualMachine, elapsed_ms: i32) {
+        const IDLE_CPU_PERCENT: u64 = 2;
+        const REARM_AFTER_CPU_US: u64 = 250_000;
+        let after = self.idle_release_after_ms.get();
+        if after == 0 {
+            return;
+        }
+        let Some(cpu_us) = process_cpu_time_us() else {
+            return;
+        };
+        let elapsed_ms = elapsed_ms.max(1) as u64;
+        let busy = cpu_us.saturating_sub(self.idle_last_cpu_us.get()) * 100
+            > elapsed_ms * 1000 * IDLE_CPU_PERCENT;
+        self.idle_last_cpu_us.set(cpu_us);
+        if busy {
+            self.idle_quiet_ms.set(0);
+            return;
+        }
+        let quiet = self.idle_quiet_ms.get().saturating_add(elapsed_ms as u32);
+        self.idle_quiet_ms.set(quiet);
+        let released_at = self.idle_released_at_cpu_us.get();
+        let armed =
+            released_at == u64::MAX || cpu_us.saturating_sub(released_at) >= REARM_AFTER_CPU_US;
+        if quiet >= after && armed && !vm.is_inspector_enabled() {
+            vm.jsc_vm().release_memory_for_idle();
+            if let Some(graph) = vm.standalone_module_graph {
+                let _ = std::thread::Builder::new()
+                    .name("idle page-out".into())
+                    .spawn(move || graph.page_out());
+            }
+            // Read again so the release's own work does not count towards re-arming.
+            self.idle_released_at_cpu_us
+                .set(process_cpu_time_us().unwrap_or(cpu_us));
+        }
     }
 
     /// Idempotent. Must run before JSC teardown: `~RunLoop::Timer` frees the
@@ -143,6 +200,8 @@ impl GarbageCollectionController {
         if this.disabled.get() {
             return;
         }
+        // SAFETY: per fn contract.
+        this.note_tick_for_idle_release(unsafe { &*vm }, this.repeat_interval());
         let prev_heap_size = this.gc_last_heap_size.get();
         this.perform_gc();
         if prev_heap_size == this.gc_last_heap_size.get() {
@@ -169,6 +228,26 @@ impl GarbageCollectionController {
                 .cast_mut(),
             interval,
         );
+    }
+}
+
+/// User + system CPU time of the whole process (all threads), in microseconds.
+fn process_cpu_time_us() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        let mut ru = core::mem::MaybeUninit::<libc::rusage>::zeroed();
+        // SAFETY: getrusage writes a complete rusage into `ru`.
+        if unsafe { libc::getrusage(libc::RUSAGE_SELF, ru.as_mut_ptr()) } != 0 {
+            return None;
+        }
+        // SAFETY: initialised by the successful call above.
+        let ru = unsafe { ru.assume_init() };
+        let us = |t: libc::timeval| t.tv_sec as u64 * 1_000_000 + t.tv_usec as u64;
+        Some(us(ru.ru_utime) + us(ru.ru_stime))
+    }
+    #[cfg(not(unix))]
+    {
+        None
     }
 }
 

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -121,7 +121,7 @@ impl GarbageCollectionController {
         };
         let elapsed_ms = elapsed_ms.max(1) as u64;
         let busy = cpu_us.saturating_sub(self.idle_last_cpu_us.get()) * 100
-            > elapsed_ms * 1000 * IDLE_CPU_PERCENT;
+            >= elapsed_ms * 1000 * IDLE_CPU_PERCENT;
         self.idle_last_cpu_us.set(cpu_us);
         if busy {
             self.idle_quiet_ms.set(0);
@@ -133,6 +133,8 @@ impl GarbageCollectionController {
         let armed =
             released_at == u64::MAX || cpu_us.saturating_sub(released_at) >= REARM_AFTER_CPU_US;
         if quiet >= after && armed && !vm.is_inspector_enabled() {
+            // A fresh BUN_IDLE_RELEASE_SECONDS of quiet is needed before the next release, not just re-arming.
+            self.idle_quiet_ms.set(0);
             vm.jsc_vm().release_memory_for_idle();
             if let Some(graph) = vm.standalone_module_graph {
                 let _ = std::thread::Builder::new()

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -26,6 +26,7 @@ unsafe extern "C" {
     safe fn JSC__VM__releaseAPILock(vm: &VM);
     safe fn JSC__VM__reportExtraMemory(vm: &VM, size: usize);
     safe fn JSC__VM__shrinkFootprint(vm: &VM);
+    safe fn JSC__VM__releaseMemoryForIdle(vm: &VM);
     safe fn JSC__VM__runGC(vm: &VM, sync: bool) -> usize;
     safe fn JSC__VM__heapSize(vm: &VM) -> usize;
     safe fn JSC__VM__collectAsync(vm: &VM);
@@ -84,6 +85,11 @@ impl VM {
 
     pub fn shrink_footprint(&self) {
         JSC__VM__shrinkFootprint(self)
+    }
+
+    /// Drop JIT code + CodeBlocks and start a concurrent full GC. For a process that has gone idle.
+    pub fn release_memory_for_idle(&self) {
+        JSC__VM__releaseMemoryForIdle(self)
     }
 
     pub fn run_gc(&self, sync: bool) -> usize {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5003,7 +5003,15 @@ bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0)
 void JSC__VM__shrinkFootprint(JSC::VM* arg0)
 {
     arg0->shrinkFootprintWhenIdle();
-};
+}
+
+void JSC__VM__releaseMemoryForIdle(JSC::VM* vm)
+{
+    JSC::JSLockHolder lock(*vm);
+    JSC::sanitizeStackForVM(*vm);
+    vm->deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
+    vm->heap.collectAsync(JSC::CollectionScope::Full);
+}
 
 void JSC__VM__holdAPILock(JSC::VM* arg0, void* ctx, void (*callback)(void* arg0))
 {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -279,6 +279,7 @@ CPP_DECL void JSC__VM__releaseWeakRefs(JSC::VM* arg0);
 CPP_DECL size_t JSC__VM__runGC(JSC::VM* arg0, bool arg1);
 CPP_DECL void JSC__VM__enableControlFlowProfiler(JSC::VM* arg0);
 CPP_DECL void JSC__VM__shrinkFootprint(JSC::VM* arg0);
+CPP_DECL void JSC__VM__releaseMemoryForIdle(JSC::VM* arg0);
 CPP_DECL void JSC__VM__throwError(JSC::VM* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__VM__throwError(JSC::VM* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 

--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -100,4 +100,7 @@ pub trait StandaloneModuleGraph: Send + Sync {
     fn module_graph_load_bytes(&self) -> usize {
         0
     }
+    /// Ask the kernel to drop the (clean, file-backed) pages of the embedded graph from memory. They fault back in
+    /// from the executable when touched. May block on the syscall; call off the JS thread.
+    fn page_out(&self) {}
 }

--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -100,7 +100,7 @@ pub trait StandaloneModuleGraph: Send + Sync {
     fn module_graph_load_bytes(&self) -> usize {
         0
     }
-    /// Ask the kernel to drop the (clean, file-backed) pages of the embedded graph from memory. They fault back in
-    /// from the executable when touched. May block on the syscall; call off the JS thread.
+    /// Ask the kernel to reclaim the resident pages of the embedded graph (clean file-backed pages are dropped and
+    /// re-read from the executable when touched). May block on the syscall; call off the JS thread.
     fn page_out(&self) {}
 }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -362,13 +362,19 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
     fn page_out(&self) {
         #[cfg(target_os = "linux")]
         {
+            if bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE::get()
+                .unwrap_or(false)
+            {
+                return;
+            }
             let bytes = self.bytes;
             let page = bun_alloc::page_size();
             let lo = (bytes.cast::<u8>() as usize + page - 1) & !(page - 1);
             let hi = (bytes.cast::<u8>() as usize + bytes.len()) & !(page - 1);
             if hi > lo {
-                // SAFETY: `[lo, hi)` is inside the mapped executable image; MADV_PAGEOUT only drops clean pages,
-                // which the kernel refills from the file on the next access.
+                // SAFETY: `[lo, hi)` is inside the mapped executable image. MADV_PAGEOUT reclaims the pages without
+                // losing data: clean file-backed pages are dropped and re-read from the file on the next access, the
+                // few dirtied (COW) ones go to swap if there is any and otherwise stay.
                 unsafe { libc::madvise(lo as *mut core::ffi::c_void, hi - lo, libc::MADV_PAGEOUT) };
             }
         }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -359,6 +359,20 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
             .sum();
         modules + builtins + self.bytecode_string_table.len()
     }
+    fn page_out(&self) {
+        #[cfg(target_os = "linux")]
+        {
+            let bytes = self.bytes;
+            let page = bun_alloc::page_size();
+            let lo = (bytes.cast::<u8>() as usize + page - 1) & !(page - 1);
+            let hi = (bytes.cast::<u8>() as usize + bytes.len()) & !(page - 1);
+            if hi > lo {
+                // SAFETY: `[lo, hi)` is inside the mapped executable image; MADV_PAGEOUT only drops clean pages,
+                // which the kernel refills from the file on the next access.
+                unsafe { libc::madvise(lo as *mut core::ffi::c_void, hi - lo, libc::MADV_PAGEOUT) };
+            }
+        }
+    }
 }
 
 #[repr(C)]

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
 
 // Bun's GarbageCollectionController used to sample `blockBytesAllocated +
 // extraMemorySize` on every event-loop tick and arm a 16 ms one-shot whenever
@@ -157,7 +157,9 @@ describe.skipIf(isDebug)("GarbageCollectionController eden cadence", () => {
 // ran: an app parked at a prompt still fires the odd timer and should count as
 // idle; one that keeps a core busy should not.
 describe("idle release", () => {
-  const script = (mode: "idle" | "busy") => `
+  // `idle`: warm some functions, then do nothing but poll once a second (well under the idle CPU threshold) until the
+  // CodeBlock count drops or `waitMs` passes. `busy`: same, while keeping a core ~75% busy.
+  const script = (mode: "idle" | "busy", waitMs: number) => `
     const { heapStats } = require("bun:jsc");
     const fns = [];
     for (let i = 0; i < 200; i++) fns.push(new Function("a", "let s = 0; for (let j = 0; j < 100; j++) s += a * " + i + " + j; return s"));
@@ -165,37 +167,50 @@ describe("idle release", () => {
     const codeBlocks = () => { const c = heapStats().objectTypeCounts; return (c.FunctionCodeBlock || 0) + (c.CodeBlock || 0); };
     const before = codeBlocks();
     ${mode === "busy" ? `const iv = setInterval(() => { const end = performance.now() + 150; while (performance.now() < end) fns[0](1); }, 200);` : ``}
-    setTimeout(() => {
-      ${mode === "busy" ? `clearInterval(iv);` : ``}
-      console.log(JSON.stringify({ before, after: codeBlocks() }));
-    }, 3500);
+    const deadline = Date.now() + ${waitMs};
+    const poll = setInterval(() => {
+      const after = codeBlocks();
+      if (${mode === "idle" ? `after < before / 4 || ` : ``}Date.now() >= deadline) {
+        clearInterval(poll);
+        ${mode === "busy" ? `clearInterval(iv);` : ``}
+        console.log(JSON.stringify({ before, after }));
+      }
+    }, 1000);
   `;
 
-  async function run(mode: "idle" | "busy", seconds: string) {
+  async function run(mode: "idle" | "busy", seconds: string, waitMs = 3_500) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script(mode)],
-      env: { ...bunEnv, BUN_IDLE_RELEASE_SECONDS: seconds },
+      cmd: [bunExe(), "-e", script(mode, waitMs)],
+      env: {
+        ...bunEnv,
+        BUN_IDLE_RELEASE_SECONDS: seconds,
+        BUN_GC_TIMER_DISABLE: undefined,
+        BUN_GC_TIMER_INTERVAL: undefined,
+      },
       stdout: "pipe",
       stderr: "inherit",
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    return JSON.parse(stdout.trim()) as { before: number; after: number };
+    return { ...(JSON.parse(stdout.trim()) as { before: number; after: number }), exitCode };
   }
 
-  test.concurrent("fires once the process has been idle long enough", async () => {
-    const { before, after } = await run("idle", "1");
+  // The idle signal is process CPU time via getrusage; not implemented on Windows yet.
+  test.skipIf(isWindows).concurrent("fires once the process has been idle long enough", async () => {
+    const { before, after, exitCode } = await run("idle", "1", 30_000);
     expect(before).toBeGreaterThan(150);
     expect(after).toBeLessThan(before / 4);
-  });
+    expect(exitCode).toBe(0);
+  }, 40_000);
 
   test.concurrent("does not fire while the process is busy", async () => {
-    const { before, after } = await run("busy", "1");
+    const { before, after, exitCode } = await run("busy", "1");
     expect(after).toBeGreaterThanOrEqual(before - 20);
+    expect(exitCode).toBe(0);
   });
 
   test.concurrent("BUN_IDLE_RELEASE_SECONDS=0 disables it", async () => {
-    const { before, after } = await run("idle", "0");
+    const { before, after, exitCode } = await run("idle", "0");
     expect(after).toBeGreaterThanOrEqual(before - 20);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -164,6 +164,7 @@ describe("idle release", () => {
     const fns = [];
     for (let i = 0; i < 200; i++) fns.push(new Function("a", "let s = 0; for (let j = 0; j < 100; j++) s += a * " + i + " + j; return s"));
     for (let r = 0; r < 30; r++) for (const f of fns) f(r);
+    globalThis.fns = fns; // keep the functions (and so their CodeBlocks) reachable; only the idle release should drop them
     const codeBlocks = () => { const c = heapStats().objectTypeCounts; return (c.FunctionCodeBlock || 0) + (c.CodeBlock || 0); };
     const before = codeBlocks();
     ${mode === "busy" ? `const iv = setInterval(() => { const end = performance.now() + 150; while (performance.now() < end) fns[0](1); }, 200);` : ``}

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -150,3 +150,52 @@ describe.skipIf(isDebug)("GarbageCollectionController eden cadence", () => {
     expect(eden).toBeLessThan(5);
   });
 });
+
+// After BUN_IDLE_RELEASE_SECONDS during which the process used (almost) no CPU,
+// the controller drops JIT code and CodeBlocks once (they re-tier if the code
+// gets hot again). Idle is judged by process CPU time, not by whether any JS
+// ran: an app parked at a prompt still fires the odd timer and should count as
+// idle; one that keeps a core busy should not.
+describe("idle release", () => {
+  const script = (mode: "idle" | "busy") => `
+    const { heapStats } = require("bun:jsc");
+    const fns = [];
+    for (let i = 0; i < 200; i++) fns.push(new Function("a", "let s = 0; for (let j = 0; j < 100; j++) s += a * " + i + " + j; return s"));
+    for (let r = 0; r < 30; r++) for (const f of fns) f(r);
+    const codeBlocks = () => { const c = heapStats().objectTypeCounts; return (c.FunctionCodeBlock || 0) + (c.CodeBlock || 0); };
+    const before = codeBlocks();
+    ${mode === "busy" ? `const iv = setInterval(() => { const end = performance.now() + 150; while (performance.now() < end) fns[0](1); }, 200);` : ``}
+    setTimeout(() => {
+      ${mode === "busy" ? `clearInterval(iv);` : ``}
+      console.log(JSON.stringify({ before, after: codeBlocks() }));
+    }, 3500);
+  `;
+
+  async function run(mode: "idle" | "busy", seconds: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script(mode)],
+      env: { ...bunEnv, BUN_IDLE_RELEASE_SECONDS: seconds },
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout.trim()) as { before: number; after: number };
+  }
+
+  test.concurrent("fires once the process has been idle long enough", async () => {
+    const { before, after } = await run("idle", "1");
+    expect(before).toBeGreaterThan(150);
+    expect(after).toBeLessThan(before / 4);
+  });
+
+  test.concurrent("does not fire while the process is busy", async () => {
+    const { before, after } = await run("busy", "1");
+    expect(after).toBeGreaterThanOrEqual(before - 20);
+  });
+
+  test.concurrent("BUN_IDLE_RELEASE_SECONDS=0 disables it", async () => {
+    const { before, after } = await run("idle", "0");
+    expect(after).toBeGreaterThanOrEqual(before - 20);
+  });
+});

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -160,7 +160,7 @@ describe("idle release", () => {
   // `idle`: warm some functions, then do nothing but poll once a second (well under the idle CPU threshold) until the
   // CodeBlock count drops or `waitMs` passes. `busy`: same, while keeping a core ~75% busy.
   const script = (mode: "idle" | "busy", waitMs: number) => `
-    const { heapStats } = require("bun:jsc");
+    import { heapStats } from "bun:jsc";
     const fns = [];
     for (let i = 0; i < 200; i++) fns.push(new Function("a", "let s = 0; for (let j = 0; j < 100; j++) s += a * " + i + " + j; return s"));
     for (let r = 0; r < 30; r++) for (const f of fns) f(r);

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -195,12 +195,16 @@ describe("idle release", () => {
   }
 
   // The idle signal is process CPU time via getrusage; not implemented on Windows yet.
-  test.skipIf(isWindows).concurrent("fires once the process has been idle long enough", async () => {
-    const { before, after, exitCode } = await run("idle", "1", 30_000);
-    expect(before).toBeGreaterThan(150);
-    expect(after).toBeLessThan(before / 4);
-    expect(exitCode).toBe(0);
-  }, 40_000);
+  test.skipIf(isWindows).concurrent(
+    "fires once the process has been idle long enough",
+    async () => {
+      const { before, after, exitCode } = await run("idle", "1", 30_000);
+      expect(before).toBeGreaterThan(150);
+      expect(after).toBeLessThan(before / 4);
+      expect(exitCode).toBe(0);
+    },
+    40_000,
+  );
 
   test.concurrent("does not fire while the process is busy", async () => {
     const { before, after, exitCode } = await run("busy", "1");


### PR DESCRIPTION
### What

`GarbageCollectionController` already runs an idle `collectAsync` (JSC picks the scope, usually eden). This adds two **full** concurrent collections per idle period: one once the process has used almost no CPU for `BUN_IDLE_RELEASE_SECONDS` (default 30; `0` disables; main thread only; skipped while a debugger is attached), and one 65 s later. The first also `MADV_PAGEOUT`s a standalone executable's embedded module graph (Linux; clean file-backed pages that fault back on demand; honours `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE`).

Idleness is judged by process CPU time (< 2 % of the interval and < 100 ms per tick) rather than "no JS ran": an interactive app parked at a prompt still fires timers and does keep-alive I/O — measured ~0.3–1.1 % CPU — while real work is whole cores. The collections we request ourselves don't count as activity.

### Why

Full collections are where JSC ages out CodeBlocks that no longer run, sweeps, returns dead pages inside MarkedBlocks and releases idle JIT code (oven-sh/WebKit#542, #546). JSC's own `FullGCActivityCallback` is allocation-paced — it fires at most once after the last allocation burst and never again without new allocation — so an idle process otherwise never gets there. Two collections are the minimum with sampled execution counters: the first records which code is still running, the second (a lease later) frees what hasn't run since.

### Numbers

Large `--compile --bytecode` TUI app, 100 scripted turns then hands-off (with WebKit#542 + #546):

| | RSS | JIT memory |
|---|---|---|
| main, 2.5 min idle | ~470 MB | 45–48 MB |
| this PR, after 1st idle GC (~50 s) | ~430 MB | |
| this PR, after 2nd idle GC (~115 s) | **~358 MB** | 16 MB |

Cost while busy: none (nothing fires). Cost while idle: two concurrent full GCs per idle period.

### Tests

`test/js/bun/gc/gc-controller-cadence.test.ts`: a `FullCollection` is logged while idle, none while a core is busy, none with `BUN_IDLE_RELEASE_SECONDS=0`.