### PR TITLE
Move the common string table to a struct on the VM client data

### DIFF
--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -53,7 +53,8 @@ JSHeapData::~JSHeapData() = default;
 #define CLIENT_ISO_SUBSPACE_INIT(subspace) subspace(m_heapData->subspace)
 
 JSVMClientData::JSVMClientData(VM& vm, RefPtr<JSC::SourceProvider> sourceProvider)
-    : m_builtinNames(vm)
+    : commonStrings(vm)
+    , m_builtinNames(vm)
     , m_builtinFunctions(makeUnique<JSBuiltinFunctions>(vm, sourceProvider, m_builtinNames))
     , m_heapData(JSHeapData::ensureHeapData(vm.heap))
     , CLIENT_ISO_SUBSPACE_INIT(m_domConstructorSpace)
@@ -170,6 +171,15 @@ void JSVMClientData::create(VM* vm, void* bunVM, WorkerMessagingProxy* worker)
             visitor.appendUnbarriered(clientData->m_strongRootBlockHead);
             visitor.appendUnbarriered(clientData->m_strongRootBlockFree);
             visitor.appendUnbarriered(clientData->m_strongRootBlockStructure);
+        })),
+        JSC::ConstraintVolatility::GreyedByExecution));
+
+    // The common string cache: slots filled by the JS thread, read here with the world stopped (as above).
+    vm->heap.addMarkingConstraint(makeUnique<JSC::SimpleMarkingConstraint>(
+        "Bcs", "Bun CommonStrings",
+        MAKE_MARKING_CONSTRAINT_EXECUTOR_PAIR(([clientData](auto& visitor) {
+            JSC::SetRootMarkReasonScope rootScope(visitor, JSC::RootMarkReason::StrongHandles);
+            clientData->commonStrings.visit(visitor);
         })),
         JSC::ConstraintVolatility::GreyedByExecution));
 

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -69,6 +69,7 @@ class DOMWrapperWorld;
 #include <wtf/WeakHashSet.h>
 #include "JSCTaskScheduler.h"
 #include "HTTPHeaderIdentifiers.h"
+#include "BunCommonStrings.h"
 #include "DOMURLBaseCache.h"
 #include <JavaScriptCore/HeapObserver.h>
 namespace Zig {
@@ -234,6 +235,8 @@ public:
     // LazyProperty::initLater ~90 times (stores a tagged function pointer),
     // so there is no startup cost worth deferring.
     WebCore::HTTPHeaderIdentifiers& httpHeaderIdentifiers() { return m_httpHeaderIdentifiers; }
+    // Same shape and rooting as httpHeaderIdentifiers().
+    Bun::CommonStrings& commonStrings() { return m_commonStrings; }
 
     WebCore::DOMURLBaseCache& urlBaseCache() { return m_urlBaseCache; }
 
@@ -312,6 +315,7 @@ private:
     std::unique_ptr<ExtendedDOMClientIsoSubspaces> m_clientSubspaces;
 
     WebCore::HTTPHeaderIdentifiers m_httpHeaderIdentifiers;
+    Bun::CommonStrings m_commonStrings;
 
     WebCore::DOMURLBaseCache m_urlBaseCache;
 

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -235,8 +235,9 @@ public:
     // LazyProperty::initLater ~90 times (stores a tagged function pointer),
     // so there is no startup cost worth deferring.
     WebCore::HTTPHeaderIdentifiers& httpHeaderIdentifiers() { return m_httpHeaderIdentifiers; }
-    // Same shape and rooting as httpHeaderIdentifiers().
-    Bun::CommonStrings& commonStrings() { return m_commonStrings; }
+
+    // Public so Bun::commonStrings(vm) below is a static_cast and a member load.
+    Bun::CommonStrings commonStrings;
 
     WebCore::DOMURLBaseCache& urlBaseCache() { return m_urlBaseCache; }
 
@@ -315,7 +316,6 @@ private:
     std::unique_ptr<ExtendedDOMClientIsoSubspaces> m_clientSubspaces;
 
     WebCore::HTTPHeaderIdentifiers m_httpHeaderIdentifiers;
-    Bun::CommonStrings m_commonStrings;
 
     WebCore::DOMURLBaseCache m_urlBaseCache;
 
@@ -402,6 +402,15 @@ static inline BunBuiltinNames& builtinNames(JSC::VM& vm)
 }
 
 } // namespace WebCore
+
+namespace Bun {
+
+ALWAYS_INLINE CommonStrings& commonStrings(JSC::VM& vm)
+{
+    return static_cast<WebCore::JSVMClientData*>(vm.clientData)->commonStrings;
+}
+
+} // namespace Bun
 
 inline void* bunVM(JSC::VM& vm)
 {

--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -3,8 +3,6 @@
 #include "BunCommonStrings.h"
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/JSGlobalObject.h>
-#include <JavaScriptCore/LazyProperty.h>
-#include <JavaScriptCore/LazyPropertyInlines.h>
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/SlotVisitorInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
@@ -47,29 +45,28 @@ static const JSC::Identifier* identifierAt(VM& vm, CommonStrings::Index index)
     }
 }
 
-CommonStrings::CommonStrings()
+void CommonStrings::initialize(JSString*& slot, Index index)
 {
-    for (auto& string : m_strings) {
-        string.initLater([](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {
-            auto& self = WebCore::clientData(init.vm)->commonStrings();
-            size_t i = &init.property - self.m_strings;
-            ASSERT(i < std::size(self.m_strings));
-            auto literal = commonStringLiterals[i];
-            if (const auto* identifier = identifierAt(init.vm, static_cast<Index>(i))) {
-                ASSERT(identifier->string() == literal);
-                init.set(jsOwnedString(init.vm, identifier->string()));
-                return;
-            }
-            init.set(jsString(init.vm, AtomString(literal)));
-        });
+    ASSERT(m_vm.currentThreadIsHoldingAPILock());
+    auto literal = commonStringLiterals[static_cast<size_t>(index)];
+    if (const auto* identifier = identifierAt(m_vm, index)) {
+        ASSERT(identifier->string() == literal);
+        slot = jsOwnedString(m_vm, identifier->string());
+        return;
     }
+    slot = jsString(m_vm, AtomString(literal));
 }
 
 template<typename Visitor>
 void CommonStrings::visit(Visitor& visitor)
 {
-    for (auto& string : m_strings)
-        string.visit(visitor);
+#define BUN_COMMON_STRINGS_VISIT(name, ...) \
+    if (m_##name)                           \
+        visitor.appendUnbarriered(m_##name);
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_VISIT)
+    BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_VISIT)
+    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_VISIT)
+#undef BUN_COMMON_STRINGS_VISIT
 }
 
 template void CommonStrings::visit(JSC::AbstractSlotVisitor&);
@@ -129,9 +126,10 @@ enum class HTTPMethod : uint8_t {
 
 static JSC::JSValue toJS(Zig::GlobalObject* globalObject, HTTPMethod method)
 {
+    auto& commonStrings = Bun::commonStrings(globalObject->vm());
 #define FOR_EACH_METHOD(method)    \
     case HTTPMethod::http##method: \
-        return WebCore::clientData(globalObject->vm())->commonStrings().http##method##String(globalObject);
+        return commonStrings.http##method##String();
 
     switch (method) {
         FOR_EACH_METHOD(ACL)
@@ -214,56 +212,56 @@ enum class CommonStringsForRust : uint8_t {
 
 static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForRust commonString)
 {
-    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(globalObject->vm());
     switch (commonString) {
     case CommonStringsForRust::IPv4:
-        return commonStrings.IPv4String(globalObject);
+        return commonStrings.IPv4String();
     case CommonStringsForRust::IPv6:
-        return commonStrings.IPv6String(globalObject);
+        return commonStrings.IPv6String();
     case CommonStringsForRust::IN4Loopback:
-        return commonStrings.IN4LoopbackString(globalObject);
+        return commonStrings.IN4LoopbackString();
     case CommonStringsForRust::IN6Any:
-        return commonStrings.IN6AnyString(globalObject);
+        return commonStrings.IN6AnyString();
     case CommonStringsForRust::ipv4Lower:
-        return commonStrings.ipv4LowerString(globalObject);
+        return commonStrings.ipv4LowerString();
     case CommonStringsForRust::ipv6Lower:
-        return commonStrings.ipv6LowerString(globalObject);
+        return commonStrings.ipv6LowerString();
     case CommonStringsForRust::fetchDefault:
         return globalObject->vm().smallStrings.defaultString();
     case CommonStringsForRust::fetchError:
-        return commonStrings.fetchErrorString(globalObject);
+        return commonStrings.fetchErrorString();
     case CommonStringsForRust::fetchInclude:
-        return commonStrings.fetchIncludeString(globalObject);
+        return commonStrings.fetchIncludeString();
     case CommonStringsForRust::buffer:
-        return commonStrings.bufferString(globalObject);
+        return commonStrings.bufferString();
     case CommonStringsForRust::binaryTypeArrayBuffer:
-        return commonStrings.binaryTypeArrayBufferString(globalObject);
+        return commonStrings.binaryTypeArrayBufferString();
     case CommonStringsForRust::binaryTypeNodeBuffer:
-        return commonStrings.binaryTypeNodeBufferString(globalObject);
+        return commonStrings.binaryTypeNodeBufferString();
     case CommonStringsForRust::binaryTypeUint8Array:
-        return commonStrings.binaryTypeUint8ArrayString(globalObject);
+        return commonStrings.binaryTypeUint8ArrayString();
     case CommonStringsForRust::binaryTypeBlob:
-        return commonStrings.binaryTypeBlobString(globalObject);
+        return commonStrings.binaryTypeBlobString();
     case CommonStringsForRust::unknown:
-        return commonStrings.unknownString(globalObject);
+        return commonStrings.unknownString();
     case CommonStringsForRust::protocolHttp:
-        return commonStrings.protocolHttpString(globalObject);
+        return commonStrings.protocolHttpString();
     case CommonStringsForRust::protocolHttps:
-        return commonStrings.protocolHttpsString(globalObject);
+        return commonStrings.protocolHttpsString();
     case CommonStringsForRust::alpnH2:
-        return commonStrings.alpnH2String(globalObject);
+        return commonStrings.alpnH2String();
     case CommonStringsForRust::alpnHttp11:
-        return commonStrings.alpnHttp11String(globalObject);
+        return commonStrings.alpnHttp11String();
     case CommonStringsForRust::utf8WithDash:
-        return commonStrings.utf8WithDashString(globalObject);
+        return commonStrings.utf8WithDashString();
     case CommonStringsForRust::quicDatagramAbandoned:
-        return commonStrings.quicDatagramAbandonedString(globalObject);
+        return commonStrings.quicDatagramAbandonedString();
     case CommonStringsForRust::quicDatagramAcknowledged:
-        return commonStrings.quicDatagramAcknowledgedString(globalObject);
+        return commonStrings.quicDatagramAcknowledgedString();
     case CommonStringsForRust::quicDatagramLost:
-        return commonStrings.quicDatagramLostString(globalObject);
+        return commonStrings.quicDatagramLostString();
     case CommonStringsForRust::base64:
-        return commonStrings.base64String(globalObject);
+        return commonStrings.base64String();
     default: {
         ASSERT_NOT_REACHED();
         return jsUndefined();
@@ -288,20 +286,20 @@ enum class FetchCacheMode : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchCacheMode__toJS(FetchCacheMode mode, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(globalObject->vm());
     switch (mode) {
     case FetchCacheMode::Default:
         return JSValue::encode(globalObject->vm().smallStrings.defaultString());
     case FetchCacheMode::NoStore:
-        return JSValue::encode(commonStrings.fetchNoStoreString(globalObject));
+        return JSValue::encode(commonStrings.fetchNoStoreString());
     case FetchCacheMode::Reload:
-        return JSValue::encode(commonStrings.fetchReloadString(globalObject));
+        return JSValue::encode(commonStrings.fetchReloadString());
     case FetchCacheMode::NoCache:
-        return JSValue::encode(commonStrings.fetchNoCacheString(globalObject));
+        return JSValue::encode(commonStrings.fetchNoCacheString());
     case FetchCacheMode::ForceCache:
-        return JSValue::encode(commonStrings.fetchForceCacheString(globalObject));
+        return JSValue::encode(commonStrings.fetchForceCacheString());
     case FetchCacheMode::OnlyIfCached:
-        return JSValue::encode(commonStrings.fetchOnlyIfCachedString(globalObject));
+        return JSValue::encode(commonStrings.fetchOnlyIfCachedString());
     default: {
         ASSERT_NOT_REACHED();
         return JSValue::encode(jsUndefined());
@@ -318,14 +316,14 @@ enum class FetchRedirect : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchRedirect__toJS(FetchRedirect redirect, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(globalObject->vm());
     switch (redirect) {
     case FetchRedirect::Follow:
-        return JSValue::encode(commonStrings.fetchFollowString(globalObject));
+        return JSValue::encode(commonStrings.fetchFollowString());
     case FetchRedirect::Manual:
-        return JSValue::encode(commonStrings.fetchManualString(globalObject));
+        return JSValue::encode(commonStrings.fetchManualString());
     case FetchRedirect::Error:
-        return JSValue::encode(commonStrings.fetchErrorString(globalObject));
+        return JSValue::encode(commonStrings.fetchErrorString());
     default: {
         ASSERT_NOT_REACHED();
         return JSValue::encode(jsUndefined());
@@ -343,16 +341,16 @@ enum class FetchRequestMode : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchRequestMode__toJS(FetchRequestMode mode, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(globalObject->vm());
     switch (mode) {
     case FetchRequestMode::SameOrigin:
-        return JSValue::encode(commonStrings.fetchSameOriginString(globalObject));
+        return JSValue::encode(commonStrings.fetchSameOriginString());
     case FetchRequestMode::NoCors:
-        return JSValue::encode(commonStrings.fetchNoCorsString(globalObject));
+        return JSValue::encode(commonStrings.fetchNoCorsString());
     case FetchRequestMode::Cors:
-        return JSValue::encode(commonStrings.fetchCorsString(globalObject));
+        return JSValue::encode(commonStrings.fetchCorsString());
     case FetchRequestMode::Navigate:
-        return JSValue::encode(commonStrings.fetchNavigateString(globalObject));
+        return JSValue::encode(commonStrings.fetchNavigateString());
     default: {
         ASSERT_NOT_REACHED();
         return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -12,29 +12,38 @@
 namespace Bun {
 using namespace JSC;
 
-#define BUN_COMMON_STRINGS_LITERAL_ENTRY(name) ASCIILiteral(),
+// Every entry's text, by Index. Identifier-backed entries share the identifier's atom (see identifierAt).
+#define BUN_COMMON_STRINGS_LITERAL_ENTRY(name, builtinName) #builtinName##_s,
+#define BUN_COMMON_STRINGS_LITERAL_ENTRY_VM_PROPERTY_NAME(name, propertyName, literal) literal##_s,
 #define BUN_COMMON_STRINGS_LITERAL_ENTRY_NOT_BUILTIN_NAMES(name, literal) literal##_s,
 // clang-format off
 static constexpr ASCIILiteral commonStringLiterals[] = {
     BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LITERAL_ENTRY)
+    BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_LITERAL_ENTRY_VM_PROPERTY_NAME)
     BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_LITERAL_ENTRY_NOT_BUILTIN_NAMES)
 };
 // clang-format on
 #undef BUN_COMMON_STRINGS_LITERAL_ENTRY
+#undef BUN_COMMON_STRINGS_LITERAL_ENTRY_VM_PROPERTY_NAME
 #undef BUN_COMMON_STRINGS_LITERAL_ENTRY_NOT_BUILTIN_NAMES
 static_assert(std::size(commonStringLiterals) == static_cast<size_t>(CommonStrings::Index::Count));
 
-static const JSC::Identifier& builtinNameAt(VM& vm, CommonStrings::Index index)
+// The identifier an entry shares its atom with, or null for a literal-only entry.
+static const JSC::Identifier* identifierAt(VM& vm, CommonStrings::Index index)
 {
-    auto& names = WebCore::builtinNames(vm);
     switch (index) {
-#define BUN_COMMON_STRINGS_BUILTIN_NAME_CASE(name) \
-    case CommonStrings::Index::name:               \
-        return names.name##PublicName();
+#define BUN_COMMON_STRINGS_BUILTIN_NAME_CASE(name, builtinName) \
+    case CommonStrings::Index::name:                            \
+        return &WebCore::builtinNames(vm).builtinName##PublicName();
         BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_BUILTIN_NAME_CASE)
 #undef BUN_COMMON_STRINGS_BUILTIN_NAME_CASE
+#define BUN_COMMON_STRINGS_VM_PROPERTY_NAME_CASE(name, propertyName, literal) \
+    case CommonStrings::Index::name:                                          \
+        return &vm.propertyNames->propertyName;
+        BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_VM_PROPERTY_NAME_CASE)
+#undef BUN_COMMON_STRINGS_VM_PROPERTY_NAME_CASE
     default:
-        RELEASE_ASSERT_NOT_REACHED();
+        return nullptr;
     }
 }
 
@@ -46,8 +55,9 @@ void CommonStrings::initialize()
             size_t i = &init.property - self.m_strings;
             ASSERT(i < std::size(self.m_strings));
             auto literal = commonStringLiterals[i];
-            if (literal.isNull()) {
-                init.set(jsOwnedString(init.vm, builtinNameAt(init.vm, static_cast<Index>(i)).string()));
+            if (const auto* identifier = identifierAt(init.vm, static_cast<Index>(i))) {
+                ASSERT(identifier->string() == literal);
+                init.set(jsOwnedString(init.vm, identifier->string()));
                 return;
             }
             init.set(jsString(init.vm, AtomString(literal)));
@@ -68,18 +78,7 @@ template void CommonStrings::visit(JSC::SlotVisitor&);
 #if ASSERT_ENABLED
 bool CommonStrings::isCommonStringLiteral(std::span<const Latin1Character> literal)
 {
-    // The builtin-name entries have a null literal above; their text is the name itself.
-#define BUN_COMMON_STRINGS_BUILTIN_NAME_LITERAL(name) #name##_s,
-    static constexpr ASCIILiteral builtinNameLiterals[] = {
-        BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_BUILTIN_NAME_LITERAL)
-    };
-#undef BUN_COMMON_STRINGS_BUILTIN_NAME_LITERAL
-
     for (const auto& entry : commonStringLiterals) {
-        if (!entry.isNull() && equalSpans(entry.span8(), literal))
-            return true;
-    }
-    for (const auto& entry : builtinNameLiterals) {
         if (equalSpans(entry.span8(), literal))
             return true;
     }

--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -47,11 +47,11 @@ static const JSC::Identifier* identifierAt(VM& vm, CommonStrings::Index index)
     }
 }
 
-void CommonStrings::initialize()
+CommonStrings::CommonStrings()
 {
     for (auto& string : m_strings) {
         string.initLater([](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {
-            auto& self = defaultGlobalObject(init.owner)->commonStrings();
+            auto& self = WebCore::clientData(init.vm)->commonStrings();
             size_t i = &init.property - self.m_strings;
             ASSERT(i < std::size(self.m_strings));
             auto literal = commonStringLiterals[i];
@@ -131,7 +131,7 @@ static JSC::JSValue toJS(Zig::GlobalObject* globalObject, HTTPMethod method)
 {
 #define FOR_EACH_METHOD(method)    \
     case HTTPMethod::http##method: \
-        return globalObject->commonStrings().http##method##String(globalObject);
+        return WebCore::clientData(globalObject->vm())->commonStrings().http##method##String(globalObject);
 
     switch (method) {
         FOR_EACH_METHOD(ACL)
@@ -214,7 +214,7 @@ enum class CommonStringsForRust : uint8_t {
 
 static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForRust commonString)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (commonString) {
     case CommonStringsForRust::IPv4:
         return commonStrings.IPv4String(globalObject);
@@ -288,7 +288,7 @@ enum class FetchCacheMode : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchCacheMode__toJS(FetchCacheMode mode, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (mode) {
     case FetchCacheMode::Default:
         return JSValue::encode(globalObject->vm().smallStrings.defaultString());
@@ -318,7 +318,7 @@ enum class FetchRedirect : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchRedirect__toJS(FetchRedirect redirect, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (redirect) {
     case FetchRedirect::Follow:
         return JSValue::encode(commonStrings.fetchFollowString(globalObject));
@@ -343,7 +343,7 @@ enum class FetchRequestMode : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchRequestMode__toJS(FetchRequestMode mode, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (mode) {
     case FetchRequestMode::SameOrigin:
         return JSValue::encode(commonStrings.fetchSameOriginString(globalObject));

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -133,12 +133,12 @@ class SlotVisitor;
 
 #define BUN_COMMON_STRINGS_INDEX_ENTRY(name, ...) name,
 #define BUN_COMMON_STRINGS_SLOT(name, ...) JSC::JSString* m_##name { nullptr };
-#define BUN_COMMON_STRINGS_ACCESSOR(name, ...)  \
-    JSC::JSString* name##String()               \
-    {                                           \
-        if (!m_##name) [[unlikely]]             \
-            initialize(m_##name, Index::name);  \
-        return m_##name;                        \
+#define BUN_COMMON_STRINGS_ACCESSOR(name, ...) \
+    JSC::JSString* name##String()              \
+    {                                          \
+        if (!m_##name) [[unlikely]]            \
+            initialize(m_##name, Index::name); \
+        return m_##name;                       \
     }
 
 namespace Bun {

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -143,8 +143,7 @@ class SlotVisitor;
 
 namespace Bun {
 
-// One JSString per entry above, created on first use. A member of JSVMClientData
-// (reach it with Bun::commonStrings(vm)), rooted by the "Bcs" marking constraint.
+// One JSString per entry above, created on first use; see Bun::commonStrings(vm) in BunClientData.h.
 struct CommonStrings {
     // clang-format off
     enum class Index : uint8_t {

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -3,10 +3,21 @@
 // clang-format off
 // The items in this list must also be present in BunBuiltinNames.h
 // If we use it as an identifier name in hot code, we should put it in this list.
+// macro(name, builtinName): the cached JSString shares the atom behind `builtinNames(vm).<builtinName>PublicName()`.
 #define BUN_COMMON_STRINGS_EACH_NAME(macro) \
-    macro(require)                          \
-    macro(resolve) \
-    macro(mockedFunction)
+    macro(require, require) \
+    macro(resolve, resolve) \
+    macro(mockedFunction, mockedFunction) \
+    macro(binaryTypeBlob, blob)
+
+// These are JSC common identifiers: the cached JSString shares the atom behind `vm.propertyNames->propertyName`.
+// macro(name, propertyName, literal)
+#define BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(macro) \
+    macro(fetchError, error, "error") \
+    macro(keyTypePrivate, privateKeyword, "private") \
+    macro(keyTypePublic, publicKeyword, "public") \
+    macro(mockResultReturn, returnKeyword, "return") \
+    macro(mockResultThrow, throwKeyword, "throw")
 
 // These ones don't need to be in BunBuiltinNames.h
 // If we don't use it as an identifier name, but we want to avoid allocating the string frequently, put it in this list.
@@ -61,12 +72,10 @@
     macro(base64, "base64") \
     macro(base64url, "base64url") \
     macro(binaryTypeArrayBuffer, "arraybuffer") \
-    macro(binaryTypeBlob, "blob") \
     macro(binaryTypeNodeBuffer, "nodebuffer") \
     macro(binaryTypeUint8Array, "uint8array") \
     macro(buffer, "buffer") \
     macro(fetchCors, "cors") \
-    macro(fetchError, "error") \
     macro(fetchFollow, "follow") \
     macro(fetchForceCache, "force-cache") \
     macro(fetchInclude, "include") \
@@ -81,14 +90,10 @@
     macro(hex, "hex") \
     macro(ipv4Lower, "ipv4") \
     macro(ipv6Lower, "ipv6") \
-    macro(keyTypePrivate, "private") \
-    macro(keyTypePublic, "public") \
     macro(keyTypeSecret, "secret") \
     macro(latin1, "latin1") \
     macro(lax, "lax") \
     macro(mockResultIncomplete, "incomplete") \
-    macro(mockResultReturn, "return") \
-    macro(mockResultThrow, "throw") \
     macro(none, "none") \
     macro(protocolHttp, "http") \
     macro(protocolHttps, "https") \
@@ -122,7 +127,8 @@
 
 // clang-format on
 
-#define BUN_COMMON_STRINGS_INDEX_ENTRY(name) name,
+#define BUN_COMMON_STRINGS_INDEX_ENTRY(name, builtinName) name,
+#define BUN_COMMON_STRINGS_INDEX_ENTRY_VM_PROPERTY_NAME(name, propertyName, literal) name,
 #define BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES(name, literal) name,
 
 #define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)                                                 \
@@ -130,6 +136,12 @@
     {                                                                                                \
         return m_strings[static_cast<size_t>(Index::name)].getInitializedOnMainThread(globalObject); \
     }
+
+#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME(name, builtinName) \
+    BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)
+
+#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME(name, propertyName, literal) \
+    BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)
 
 #define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES(name, literal) \
     BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)
@@ -141,12 +153,14 @@ public:
     // clang-format off
     enum class Index : uint8_t {
         BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_INDEX_ENTRY)
+        BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_INDEX_ENTRY_VM_PROPERTY_NAME)
         BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES)
         Count
     };
     // clang-format on
 
-    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION)
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME)
+    BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME)
     BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES)
     void initialize();
 
@@ -165,6 +179,9 @@ private:
 } // namespace Bun
 
 #undef BUN_COMMON_STRINGS_INDEX_ENTRY
+#undef BUN_COMMON_STRINGS_INDEX_ENTRY_VM_PROPERTY_NAME
 #undef BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES
 #undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION
+#undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME
+#undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME
 #undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -1,17 +1,14 @@
 #pragma once
 
 // clang-format off
-// The items in this list must also be present in BunBuiltinNames.h
-// If we use it as an identifier name in hot code, we should put it in this list.
-// macro(name, builtinName): the cached JSString shares the atom behind `builtinNames(vm).<builtinName>PublicName()`.
+// macro(name, builtinName): strings that are also Bun builtin names (BunBuiltinNames.h).
 #define BUN_COMMON_STRINGS_EACH_NAME(macro) \
     macro(require, require) \
     macro(resolve, resolve) \
     macro(mockedFunction, mockedFunction) \
     macro(binaryTypeBlob, blob)
 
-// These are JSC common identifiers: the cached JSString shares the atom behind `vm.propertyNames->propertyName`.
-// macro(name, propertyName, literal)
+// macro(name, propertyName, literal): strings that are also JSC common identifiers (vm.propertyNames).
 #define BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(macro) \
     macro(fetchError, error, "error") \
     macro(keyTypePrivate, privateKeyword, "private") \
@@ -127,45 +124,49 @@
 
 // clang-format on
 
-#define BUN_COMMON_STRINGS_INDEX_ENTRY(name, builtinName) name,
-#define BUN_COMMON_STRINGS_INDEX_ENTRY_VM_PROPERTY_NAME(name, propertyName, literal) name,
-#define BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES(name, literal) name,
+namespace JSC {
+class VM;
+class JSString;
+class AbstractSlotVisitor;
+class SlotVisitor;
+}
 
-#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)                                                 \
-    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject)                                   \
-    {                                                                                                \
-        return m_strings[static_cast<size_t>(Index::name)].getInitializedOnMainThread(globalObject); \
+#define BUN_COMMON_STRINGS_INDEX_ENTRY(name, ...) name,
+#define BUN_COMMON_STRINGS_SLOT(name, ...) JSC::JSString* m_##name { nullptr };
+#define BUN_COMMON_STRINGS_ACCESSOR(name, ...)  \
+    JSC::JSString* name##String()               \
+    {                                           \
+        if (!m_##name) [[unlikely]]             \
+            initialize(m_##name, Index::name);  \
+        return m_##name;                        \
     }
-
-#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME(name, builtinName) \
-    BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)
-
-#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME(name, propertyName, literal) \
-    BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)
-
-#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES(name, literal) \
-    BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)
 
 namespace Bun {
 
-// Per-VM cache of the strings above (one JSString each, created on first use).
-// Lives in JSVMClientData; every Zig::GlobalObject visits it.
-class CommonStrings {
-public:
+// One JSString per entry above, created on first use. A member of JSVMClientData
+// (reach it with Bun::commonStrings(vm)), rooted by the "Bcs" marking constraint.
+struct CommonStrings {
     // clang-format off
     enum class Index : uint8_t {
         BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_INDEX_ENTRY)
-        BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_INDEX_ENTRY_VM_PROPERTY_NAME)
-        BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES)
+        BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_INDEX_ENTRY)
+        BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_INDEX_ENTRY)
         Count
     };
+
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_SLOT)
+    BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_SLOT)
+    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_SLOT)
+
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR)
+    BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_ACCESSOR)
+    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_ACCESSOR)
     // clang-format on
 
-    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME)
-    BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME)
-    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES)
-
-    CommonStrings();
+    explicit CommonStrings(JSC::VM& vm)
+        : m_vm(vm)
+    {
+    }
 
     template<typename Visitor>
     void visit(Visitor& visitor);
@@ -176,15 +177,13 @@ public:
 #endif
 
 private:
-    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_strings[static_cast<size_t>(Index::Count)];
+    void initialize(JSC::JSString*& slot, Index);
+
+    JSC::VM& m_vm;
 };
 
 } // namespace Bun
 
 #undef BUN_COMMON_STRINGS_INDEX_ENTRY
-#undef BUN_COMMON_STRINGS_INDEX_ENTRY_VM_PROPERTY_NAME
-#undef BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES
-#undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION
-#undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME
-#undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME
-#undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES
+#undef BUN_COMMON_STRINGS_SLOT
+#undef BUN_COMMON_STRINGS_ACCESSOR

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -148,6 +148,8 @@
 
 namespace Bun {
 
+// Per-VM cache of the strings above (one JSString each, created on first use).
+// Lives in JSVMClientData; every Zig::GlobalObject visits it.
 class CommonStrings {
 public:
     // clang-format off
@@ -162,7 +164,8 @@ public:
     BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME)
     BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME)
     BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES)
-    void initialize();
+
+    CommonStrings();
 
     template<typename Visitor>
     void visit(Visitor& visitor);

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -145,6 +145,10 @@ namespace Bun {
 
 // One JSString per entry above, created on first use; see Bun::commonStrings(vm) in BunClientData.h.
 struct CommonStrings {
+    // Only the instance in JSVMClientData is rooted: a copy would hand out unrooted cells.
+    WTF_MAKE_NONCOPYABLE(CommonStrings);
+    WTF_MAKE_NONMOVABLE(CommonStrings);
+
     // clang-format off
     enum class Index : uint8_t {
         BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_INDEX_ENTRY)

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1729,10 +1729,10 @@ extern "C" JSC::EncodedJSValue Bun__wrapAbortError(JSC::JSGlobalObject* lexicalG
     auto cause = JSC::JSValue::decode(causeParam);
 
     if (cause.isUndefined()) {
-        return JSC::JSValue::encode(Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, globalObject->commonStrings().OperationWasAbortedString(globalObject)));
+        return JSC::JSValue::encode(Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject)));
     }
 
-    auto message = globalObject->commonStrings().OperationWasAbortedString(globalObject);
+    auto message = WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject);
     JSC::JSObject* options = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 24);
     Bun::putDirectNamed(vm, options, "cause"_s, cause);
 
@@ -1750,10 +1750,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionMakeAbortError, (JSC::JSGlobalObject * lexica
     if (!options.isUndefined() && options.isCell() && !options.asCell()->isObject()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
 
     if (message.isUndefined() && options.isUndefined()) {
-        return JSValue::encode(Bun::createError(vm, lexicalGlobalObject, Bun::ErrorCode::ABORT_ERR, JSValue(globalObject->commonStrings().OperationWasAbortedString(globalObject))));
+        return JSValue::encode(Bun::createError(vm, lexicalGlobalObject, Bun::ErrorCode::ABORT_ERR, JSValue(WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject))));
     }
 
-    if (message.isUndefined()) message = globalObject->commonStrings().OperationWasAbortedString(globalObject);
+    if (message.isUndefined()) message = WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject);
     auto error = Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, message, options);
     return JSC::JSValue::encode(error);
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1729,10 +1729,10 @@ extern "C" JSC::EncodedJSValue Bun__wrapAbortError(JSC::JSGlobalObject* lexicalG
     auto cause = JSC::JSValue::decode(causeParam);
 
     if (cause.isUndefined()) {
-        return JSC::JSValue::encode(Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject)));
+        return JSC::JSValue::encode(Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, Bun::commonStrings(vm).OperationWasAbortedString()));
     }
 
-    auto message = WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject);
+    auto message = Bun::commonStrings(vm).OperationWasAbortedString();
     JSC::JSObject* options = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 24);
     Bun::putDirectNamed(vm, options, "cause"_s, cause);
 
@@ -1750,10 +1750,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionMakeAbortError, (JSC::JSGlobalObject * lexica
     if (!options.isUndefined() && options.isCell() && !options.asCell()->isObject()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
 
     if (message.isUndefined() && options.isUndefined()) {
-        return JSValue::encode(Bun::createError(vm, lexicalGlobalObject, Bun::ErrorCode::ABORT_ERR, JSValue(WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject))));
+        return JSValue::encode(Bun::createError(vm, lexicalGlobalObject, Bun::ErrorCode::ABORT_ERR, JSValue(Bun::commonStrings(vm).OperationWasAbortedString())));
     }
 
-    if (message.isUndefined()) message = WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject);
+    if (message.isUndefined()) message = Bun::commonStrings(vm).OperationWasAbortedString();
     auto error = Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, message, options);
     return JSC::JSValue::encode(error);
 }

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -131,13 +131,13 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void Bun__REPL__setupGlobalRequire(
 
     auto* resolveFunction = JSBoundFunction::create(vm, globalObject,
         globalObject->requireResolveFunctionUnbound(), moduleObject,
-        ArgList(), 1, globalObject->commonStrings().resolveString(globalObject),
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject),
         makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
     RETURN_IF_EXCEPTION(scope, );
 
     auto* requireFunction = JSBoundFunction::create(vm, globalObject,
         globalObject->requireFunctionUnbound(), moduleObject,
-        ArgList(), 1, globalObject->commonStrings().requireString(globalObject),
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject),
         makeSource("require"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
     RETURN_IF_EXCEPTION(scope, );
 

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -131,13 +131,13 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void Bun__REPL__setupGlobalRequire(
 
     auto* resolveFunction = JSBoundFunction::create(vm, globalObject,
         globalObject->requireResolveFunctionUnbound(), moduleObject,
-        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject),
+        ArgList(), 1, Bun::commonStrings(vm).resolveString(),
         makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
     RETURN_IF_EXCEPTION(scope, );
 
     auto* requireFunction = JSBoundFunction::create(vm, globalObject,
         globalObject->requireFunctionUnbound(), moduleObject,
-        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject),
+        ArgList(), 1, Bun::commonStrings(vm).requireString(),
         makeSource("require"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
     RETURN_IF_EXCEPTION(scope, );
 

--- a/src/jsc/bindings/JSBufferEncodingType.cpp
+++ b/src/jsc/bindings/JSBufferEncodingType.cpp
@@ -30,19 +30,18 @@ using namespace JSC;
 
 template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, BufferEncodingType enumerationValue)
 {
-    auto* globalObject = &lexicalGlobalObject;
-    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(lexicalGlobalObject.vm());
     // clang-format off
     switch (enumerationValue) {
-    case BufferEncodingType::utf8:      return commonStrings.utf8String(globalObject);
-    case BufferEncodingType::ucs2:      return commonStrings.ucs2String(globalObject);
-    case BufferEncodingType::utf16le:   return commonStrings.utf16leString(globalObject);
-    case BufferEncodingType::latin1:    return commonStrings.latin1String(globalObject);
-    case BufferEncodingType::ascii:     return commonStrings.asciiString(globalObject);
-    case BufferEncodingType::base64:    return commonStrings.base64String(globalObject);
-    case BufferEncodingType::base64url: return commonStrings.base64urlString(globalObject);
-    case BufferEncodingType::hex:       return commonStrings.hexString(globalObject);
-    case BufferEncodingType::buffer:    return commonStrings.bufferString(globalObject);
+    case BufferEncodingType::utf8:      return commonStrings.utf8String();
+    case BufferEncodingType::ucs2:      return commonStrings.ucs2String();
+    case BufferEncodingType::utf16le:   return commonStrings.utf16leString();
+    case BufferEncodingType::latin1:    return commonStrings.latin1String();
+    case BufferEncodingType::ascii:     return commonStrings.asciiString();
+    case BufferEncodingType::base64:    return commonStrings.base64String();
+    case BufferEncodingType::base64url: return commonStrings.base64urlString();
+    case BufferEncodingType::hex:       return commonStrings.hexString();
+    case BufferEncodingType::buffer:    return commonStrings.bufferString();
     }
     // clang-format on
     ASSERT_NOT_REACHED();

--- a/src/jsc/bindings/JSBufferEncodingType.cpp
+++ b/src/jsc/bindings/JSBufferEncodingType.cpp
@@ -20,7 +20,7 @@
 
 #include "config.h"
 #include "JSBufferEncodingType.h"
-#include "ZigGlobalObject.h"
+#include "BunClientData.h"
 #include "wtf/Forward.h"
 
 #include <JavaScriptCore/JSCInlines.h>
@@ -30,8 +30,8 @@ using namespace JSC;
 
 template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, BufferEncodingType enumerationValue)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto* globalObject = &lexicalGlobalObject;
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     // clang-format off
     switch (enumerationValue) {
     case BufferEncodingType::utf8:      return commonStrings.utf8String(globalObject);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -139,7 +139,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
             globalObject,
             globalObject->requireResolveFunctionUnbound(),
             moduleObject,
-            ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject), resolveSourceCode);
+            ArgList(), 1, Bun::commonStrings(vm).resolveString(), resolveSourceCode);
         RETURN_IF_EXCEPTION(scope, );
 
         SourceCode requireSourceCode = makeSource("require"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
@@ -147,7 +147,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
             globalObject,
             globalObject->requireFunctionUnbound(),
             moduleObject,
-            ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject), requireSourceCode);
+            ArgList(), 1, Bun::commonStrings(vm).requireString(), requireSourceCode);
         RETURN_IF_EXCEPTION(scope, );
         requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
         RETURN_IF_EXCEPTION(scope, );
@@ -1685,7 +1685,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
         globalObject,
         globalObject->requireFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject), requireSourceCode);
+        ArgList(), 1, Bun::commonStrings(vm).requireString(), requireSourceCode);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     SourceCode resolveSourceCode = makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
@@ -1694,7 +1694,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
         globalObject,
         globalObject->requireResolveFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject), resolveSourceCode);
+        ArgList(), 1, Bun::commonStrings(vm).resolveString(), resolveSourceCode);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -139,7 +139,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
             globalObject,
             globalObject->requireResolveFunctionUnbound(),
             moduleObject,
-            ArgList(), 1, globalObject->commonStrings().resolveString(globalObject), resolveSourceCode);
+            ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject), resolveSourceCode);
         RETURN_IF_EXCEPTION(scope, );
 
         SourceCode requireSourceCode = makeSource("require"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
@@ -147,7 +147,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
             globalObject,
             globalObject->requireFunctionUnbound(),
             moduleObject,
-            ArgList(), 1, globalObject->commonStrings().requireString(globalObject), requireSourceCode);
+            ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject), requireSourceCode);
         RETURN_IF_EXCEPTION(scope, );
         requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
         RETURN_IF_EXCEPTION(scope, );
@@ -1685,7 +1685,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
         globalObject,
         globalObject->requireFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, globalObject->commonStrings().requireString(globalObject), requireSourceCode);
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject), requireSourceCode);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     SourceCode resolveSourceCode = makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
@@ -1694,7 +1694,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
         globalObject,
         globalObject->requireResolveFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, globalObject->commonStrings().resolveString(globalObject), resolveSourceCode);
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject), resolveSourceCode);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -235,7 +235,7 @@ public:
         function->finishCreation(vm);
 
         // Do not forget to set the original name: https://github.com/oven-sh/bun/issues/8794
-        function->m_originalName.set(vm, function, WebCore::clientData(vm)->commonStrings().mockedFunctionString(globalObject));
+        function->m_originalName.set(vm, function, Bun::commonStrings(vm).mockedFunctionString());
 
         return function;
     }
@@ -805,17 +805,17 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, Mo
 {
     JSC::Structure* structure = globalObject->mockModule.mockResultStructure.getInitializedOnMainThread(globalObject);
 
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto& commonStrings = Bun::commonStrings(vm);
     JSC::JSString* typeString = nullptr;
     switch (type) {
     case MockResultType::Return:
-        typeString = commonStrings.mockResultReturnString(globalObject);
+        typeString = commonStrings.mockResultReturnString();
         break;
     case MockResultType::Throw:
-        typeString = commonStrings.mockResultThrowString(globalObject);
+        typeString = commonStrings.mockResultThrowString();
         break;
     case MockResultType::Incomplete:
-        typeString = commonStrings.mockResultIncompleteString(globalObject);
+        typeString = commonStrings.mockResultIncompleteString();
         break;
     }
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -235,7 +235,7 @@ public:
         function->finishCreation(vm);
 
         // Do not forget to set the original name: https://github.com/oven-sh/bun/issues/8794
-        function->m_originalName.set(vm, function, globalObject->commonStrings().mockedFunctionString(globalObject));
+        function->m_originalName.set(vm, function, WebCore::clientData(vm)->commonStrings().mockedFunctionString(globalObject));
 
         return function;
     }
@@ -805,7 +805,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, Mo
 {
     JSC::Structure* structure = globalObject->mockModule.mockResultStructure.getInitializedOnMainThread(globalObject);
 
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
     JSC::JSString* typeString = nullptr;
     switch (type) {
     case MockResultType::Return:

--- a/src/jsc/bindings/JSSocketAddressDTO.cpp
+++ b/src/jsc/bindings/JSSocketAddressDTO.cpp
@@ -17,8 +17,8 @@ JSObject* create(Zig::GlobalObject* globalObject, JSString* value, int32_t port,
 {
     VM& vm = globalObject->vm();
 
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
-    auto* family = isIPv6 ? commonStrings.IPv6String(globalObject) : commonStrings.IPv4String(globalObject);
+    auto& commonStrings = Bun::commonStrings(vm);
+    auto* family = isIPv6 ? commonStrings.IPv6String() : commonStrings.IPv4String();
 
     JSObject* thisObject = constructEmptyObject(vm, globalObject->JSSocketAddressDTOStructure());
     thisObject->putDirectOffset(vm, addressOffset, value);
@@ -72,8 +72,8 @@ extern "C" JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto* global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
 
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
-    auto* af = isIPv6 ? commonStrings.IPv6String(global) : commonStrings.IPv4String(global);
+    auto& commonStrings = Bun::commonStrings(vm);
+    auto* af = isIPv6 ? commonStrings.IPv6String() : commonStrings.IPv4String();
 
     JSObject* thisObject = constructEmptyObject(vm, global->JSSocketAddressDTOStructure());
     thisObject->putDirectOffset(vm, Bun::JSSocketAddressDTO::addressOffset, JSValue::decode(address));

--- a/src/jsc/bindings/JSSocketAddressDTO.cpp
+++ b/src/jsc/bindings/JSSocketAddressDTO.cpp
@@ -17,7 +17,8 @@ JSObject* create(Zig::GlobalObject* globalObject, JSString* value, int32_t port,
 {
     VM& vm = globalObject->vm();
 
-    auto* family = isIPv6 ? globalObject->commonStrings().IPv6String(globalObject) : globalObject->commonStrings().IPv4String(globalObject);
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto* family = isIPv6 ? commonStrings.IPv6String(globalObject) : commonStrings.IPv4String(globalObject);
 
     JSObject* thisObject = constructEmptyObject(vm, globalObject->JSSocketAddressDTOStructure());
     thisObject->putDirectOffset(vm, addressOffset, value);
@@ -71,7 +72,8 @@ extern "C" JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto* global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
 
-    auto* af = isIPv6 ? global->commonStrings().IPv6String(global) : global->commonStrings().IPv4String(global);
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto* af = isIPv6 ? commonStrings.IPv6String(global) : commonStrings.IPv4String(global);
 
     JSObject* thisObject = constructEmptyObject(vm, global->JSSocketAddressDTOStructure());
     thisObject->putDirectOffset(vm, Bun::JSSocketAddressDTO::addressOffset, JSValue::decode(address));

--- a/src/jsc/bindings/S3Error.cpp
+++ b/src/jsc/bindings/S3Error.cpp
@@ -38,7 +38,7 @@ SYSV_ABI JSC::EncodedJSValue S3Error__toErrorInstance(const S3Error* arg0,
 
     auto prototype = defaultGlobalObject(globalObject)->m_S3ErrorStructure.getInitializedOnMainThread(globalObject);
     JSC::JSObject* result = JSC::ErrorInstance::create(vm, prototype, message, {});
-    result->putDirect(vm, vm.propertyNames->name, defaultGlobalObject(globalObject)->commonStrings().s3ErrorString(globalObject), JSC::PropertyAttribute::DontEnum | 0);
+    result->putDirect(vm, vm.propertyNames->name, WebCore::clientData(vm)->commonStrings().s3ErrorString(globalObject), JSC::PropertyAttribute::DontEnum | 0);
     if (err.code.tag != BunStringTag::Empty) {
         JSC::JSValue code = Bun::toJS(globalObject, err.code);
         if (scope.exception()) {

--- a/src/jsc/bindings/S3Error.cpp
+++ b/src/jsc/bindings/S3Error.cpp
@@ -38,7 +38,7 @@ SYSV_ABI JSC::EncodedJSValue S3Error__toErrorInstance(const S3Error* arg0,
 
     auto prototype = defaultGlobalObject(globalObject)->m_S3ErrorStructure.getInitializedOnMainThread(globalObject);
     JSC::JSObject* result = JSC::ErrorInstance::create(vm, prototype, message, {});
-    result->putDirect(vm, vm.propertyNames->name, WebCore::clientData(vm)->commonStrings().s3ErrorString(globalObject), JSC::PropertyAttribute::DontEnum | 0);
+    result->putDirect(vm, vm.propertyNames->name, Bun::commonStrings(vm).s3ErrorString(), JSC::PropertyAttribute::DontEnum | 0);
     if (err.code.tag != BunStringTag::Empty) {
         JSC::JSValue code = Bun::toJS(globalObject, err.code);
         if (scope.exception()) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2042,7 +2042,6 @@ void GlobalObject::finishCreation(VM& vm)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
-    m_commonStrings.initialize();
     m_bakeAdditions.initialize();
     m_markdownTagStrings.initialize();
 
@@ -3200,6 +3199,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     // A stale m_vm surfaces as a SEGV in TypeCastTraits<JSVMClientData>::isType
     // when downcast<> calls the virtual isWebCoreJSClientData() on garbage.
     WebCore::clientData(visitor.vm())->httpHeaderIdentifiers().template visit<Visitor>(visitor);
+    WebCore::clientData(visitor.vm())->commonStrings().template visit<Visitor>(visitor);
 
     thisObject->visitGeneratedLazyClasses<Visitor>(thisObject, visitor);
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3199,7 +3199,6 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     // A stale m_vm surfaces as a SEGV in TypeCastTraits<JSVMClientData>::isType
     // when downcast<> calls the virtual isWebCoreJSClientData() on garbage.
     WebCore::clientData(visitor.vm())->httpHeaderIdentifiers().template visit<Visitor>(visitor);
-    WebCore::clientData(visitor.vm())->commonStrings().template visit<Visitor>(visitor);
 
     thisObject->visitGeneratedLazyClasses<Visitor>(thisObject, visitor);
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -63,7 +63,6 @@ struct node_module;
 #include "JSMockFunction.h"
 #include "InternalModuleRegistry.h"
 #include "headers-handwritten.h"
-#include "BunCommonStrings.h"
 #include "BunMarkdownTagStrings.h"
 #include "BunGlobalScope.h"
 #include <js_native_api.h>
@@ -554,7 +553,6 @@ public:
                                                                                                              \
     V(private, std::unique_ptr<WebCore::JSBuiltinInternalFunctions>, m_builtinInternalFunctions)             \
     V(private, std::unique_ptr<WebCore::DOMConstructors>, m_constructors)                                    \
-    V(private, Bun::CommonStrings, m_commonStrings)                                                          \
     V(private, Bun::MarkdownTagStrings, m_markdownTagStrings)                                                \
                                                                                                              \
     /* JSC's hashtable code-generator tries to access these properties, so we make them public. */           \
@@ -767,7 +765,6 @@ public:
     JSObject* nodeWorkerEntryEvaluatedHook() { return m_nodeWorkerEntryEvaluatedHook.get(); }
     void setNodeWorkerEntryEvaluatedHook(JSObject* hook);
 
-    Bun::CommonStrings& commonStrings() { return m_commonStrings; }
     Bun::MarkdownTagStrings& markdownTagStrings() { return m_markdownTagStrings; }
 #include "ZigGeneratedClasses+lazyStructureHeader.h"
 

--- a/src/jsc/bindings/node/crypto/JSKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSKeyObjectPrototype.cpp
@@ -70,14 +70,13 @@ JSC_DEFINE_CUSTOM_GETTER(jsKeyObjectPrototype_type, (JSGlobalObject * globalObje
 
     KeyObject& handle = keyObject->handle();
 
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    auto& commonStrings = zigGlobalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
     switch (handle.type()) {
     case CryptoKeyType::Secret:
-        return JSValue::encode(commonStrings.keyTypeSecretString(zigGlobalObject));
+        return JSValue::encode(commonStrings.keyTypeSecretString(globalObject));
     case CryptoKeyType::Public:
-        return JSValue::encode(commonStrings.keyTypePublicString(zigGlobalObject));
+        return JSValue::encode(commonStrings.keyTypePublicString(globalObject));
     case CryptoKeyType::Private:
-        return JSValue::encode(commonStrings.keyTypePrivateString(zigGlobalObject));
+        return JSValue::encode(commonStrings.keyTypePrivateString(globalObject));
     }
 }

--- a/src/jsc/bindings/node/crypto/JSKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSKeyObjectPrototype.cpp
@@ -70,13 +70,13 @@ JSC_DEFINE_CUSTOM_GETTER(jsKeyObjectPrototype_type, (JSGlobalObject * globalObje
 
     KeyObject& handle = keyObject->handle();
 
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto& commonStrings = Bun::commonStrings(vm);
     switch (handle.type()) {
     case CryptoKeyType::Secret:
-        return JSValue::encode(commonStrings.keyTypeSecretString(globalObject));
+        return JSValue::encode(commonStrings.keyTypeSecretString());
     case CryptoKeyType::Public:
-        return JSValue::encode(commonStrings.keyTypePublicString(globalObject));
+        return JSValue::encode(commonStrings.keyTypePublicString());
     case CryptoKeyType::Private:
-        return JSValue::encode(commonStrings.keyTypePrivateString(globalObject));
+        return JSValue::encode(commonStrings.keyTypePrivateString());
     }
 }

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -154,7 +154,7 @@ JSC::JSValue KeyObject::exportJwkAkpKey(JSC::JSGlobalObject* lexicalGlobalObject
 JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto& commonStrings = Bun::commonStrings(vm);
 
     const auto& pkey = m_data->asymmetricKey;
 
@@ -175,7 +175,7 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
         }
     })();
 
-    auto crvKey = commonStrings.jwkCrvString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    auto crvKey = commonStrings.jwkCrvString()->value(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
@@ -187,7 +187,7 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
 
         JSValue encoded = JSValue::decode(StringBytes::encode(lexicalGlobalObject, scope, privateData.span(), BufferEncodingType::base64url));
         RETURN_IF_EXCEPTION(scope, {});
-        auto dKey = commonStrings.jwkDString(lexicalGlobalObject)->value(lexicalGlobalObject);
+        auto dKey = commonStrings.jwkDString()->value(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(scope, {});
         jwk->putDirect(
             vm,
@@ -198,7 +198,7 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
     ncrypto::DataPointer publicData = pkey.rawPublicKey();
     JSValue encoded = JSValue::decode(StringBytes::encode(lexicalGlobalObject, scope, publicData.span(), BufferEncodingType::base64url));
     RETURN_IF_EXCEPTION(scope, {});
-    auto xKey = commonStrings.jwkXString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    auto xKey = commonStrings.jwkXString()->value(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
@@ -207,8 +207,8 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
 
     jwk->putDirect(
         vm,
-        Identifier::fromString(vm, commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject)),
-        commonStrings.jwkOkpString(lexicalGlobalObject));
+        Identifier::fromString(vm, commonStrings.jwkKtyString()->value(lexicalGlobalObject)),
+        commonStrings.jwkOkpString());
 
     return jwk;
 }
@@ -216,7 +216,7 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
 JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto& commonStrings = Bun::commonStrings(vm);
 
     const auto& pkey = m_data->asymmetricKey;
     ASSERT(pkey.id() == EVP_PKEY_EC);
@@ -241,16 +241,16 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 
-    auto ktyKey = commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    auto ktyKey = commonStrings.jwkKtyString()->value(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
         Identifier::fromString(vm, ktyKey),
-        commonStrings.jwkEcString(lexicalGlobalObject));
+        commonStrings.jwkEcString());
 
-    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkXString(lexicalGlobalObject), x.get(), degree_bytes);
+    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkXString(), x.get(), degree_bytes);
     RETURN_IF_EXCEPTION(scope, {});
-    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkYString(lexicalGlobalObject), y.get(), degree_bytes);
+    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkYString(), y.get(), degree_bytes);
     RETURN_IF_EXCEPTION(scope, {});
 
     WTF::ASCIILiteral crvName;
@@ -274,7 +274,7 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
     }
     }
 
-    auto crvKey = commonStrings.jwkCrvString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    auto crvKey = commonStrings.jwkCrvString()->value(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
@@ -283,7 +283,7 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
 
     if (exportType == CryptoKeyType::Private) {
         auto pvt = ncrypto::ECKeyPointer::GetPrivateKey(ec);
-        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDString(lexicalGlobalObject), pvt, degree_bytes);
+        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDString(), pvt, degree_bytes);
         RETURN_IF_EXCEPTION(scope, {});
     }
 
@@ -293,7 +293,7 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
 JSC::JSValue KeyObject::exportJwkRsaKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto& commonStrings = Bun::commonStrings(vm);
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 
@@ -302,30 +302,30 @@ JSC::JSValue KeyObject::exportJwkRsaKey(JSC::JSGlobalObject* lexicalGlobalObject
 
     auto publicKey = rsa.getPublicKey();
 
-    auto ktyKey = commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    auto ktyKey = commonStrings.jwkKtyString()->value(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(vm,
         Identifier::fromString(vm, ktyKey),
-        commonStrings.jwkRsaString(lexicalGlobalObject));
+        commonStrings.jwkRsaString());
 
-    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkNString(lexicalGlobalObject), publicKey.n);
+    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkNString(), publicKey.n);
     RETURN_IF_EXCEPTION(scope, {});
-    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkEString(lexicalGlobalObject), publicKey.e);
+    setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkEString(), publicKey.e);
     RETURN_IF_EXCEPTION(scope, {});
 
     if (exportType == CryptoKeyType::Private) {
         auto privateKey = rsa.getPrivateKey();
-        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDString(lexicalGlobalObject), publicKey.d);
+        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDString(), publicKey.d);
         RETURN_IF_EXCEPTION(scope, {});
-        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkPString(lexicalGlobalObject), privateKey.p);
+        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkPString(), privateKey.p);
         RETURN_IF_EXCEPTION(scope, {});
-        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkQString(lexicalGlobalObject), privateKey.q);
+        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkQString(), privateKey.q);
         RETURN_IF_EXCEPTION(scope, {});
-        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDpString(lexicalGlobalObject), privateKey.dp);
+        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDpString(), privateKey.dp);
         RETURN_IF_EXCEPTION(scope, {});
-        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDqString(lexicalGlobalObject), privateKey.dq);
+        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkDqString(), privateKey.dq);
         RETURN_IF_EXCEPTION(scope, {});
-        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkQiString(lexicalGlobalObject), privateKey.qi);
+        setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkQiString(), privateKey.qi);
     }
 
     return jwk;
@@ -335,21 +335,21 @@ JSC::JSValue KeyObject::exportJwkSecretKey(JSC::JSGlobalObject* lexicalGlobalObj
 {
 
     VM& vm = lexicalGlobalObject->vm();
-    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto& commonStrings = Bun::commonStrings(vm);
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 
     JSValue encoded = JSValue::decode(StringBytes::encode(lexicalGlobalObject, scope, m_data->symmetricKey, BufferEncodingType::base64url));
     RETURN_IF_EXCEPTION(scope, {});
 
-    auto ktyKey = commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    auto ktyKey = commonStrings.jwkKtyString()->value(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(vm,
         Identifier::fromString(vm, ktyKey),
-        commonStrings.jwkOctString(lexicalGlobalObject));
+        commonStrings.jwkOctString());
 
     jwk->putDirect(vm,
-        Identifier::fromString(vm, commonStrings.jwkKString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+        Identifier::fromString(vm, commonStrings.jwkKString()->value(lexicalGlobalObject)),
         encoded);
 
     return jwk;

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -154,8 +154,7 @@ JSC::JSValue KeyObject::exportJwkAkpKey(JSC::JSGlobalObject* lexicalGlobalObject
 JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     const auto& pkey = m_data->asymmetricKey;
 
@@ -217,8 +216,7 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
 JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     const auto& pkey = m_data->asymmetricKey;
     ASSERT(pkey.id() == EVP_PKEY_EC);
@@ -295,8 +293,7 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
 JSC::JSValue KeyObject::exportJwkRsaKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 
@@ -338,8 +335,7 @@ JSC::JSValue KeyObject::exportJwkSecretKey(JSC::JSGlobalObject* lexicalGlobalObj
 {
 
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -931,14 +931,14 @@ size_t JSCookie::estimatedSize(JSC::JSCell* cell, JSC::VM& vm)
 
 JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, CookieSameSite sameSite)
 {
-    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(globalObject->vm());
     switch (sameSite) {
     case CookieSameSite::Strict:
-        return commonStrings.strictString(globalObject);
+        return commonStrings.strictString();
     case CookieSameSite::Lax:
-        return commonStrings.laxString(globalObject);
+        return commonStrings.laxString();
     case CookieSameSite::None:
-        return commonStrings.noneString(globalObject);
+        return commonStrings.noneString();
     default: {
         break;
     }

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -931,7 +931,7 @@ size_t JSCookie::estimatedSize(JSC::JSCell* cell, JSC::VM& vm)
 
 JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, CookieSameSite sameSite)
 {
-    auto& commonStrings = defaultGlobalObject(globalObject)->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (sameSite) {
     case CookieSameSite::Strict:
         return commonStrings.strictString(globalObject);

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -207,8 +207,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderConstructor, (JSGlobalObject * lexicalGlob
 
 static inline JSValue jsTextEncoder_encodingGetter(JSGlobalObject& lexicalGlobalObject, JSTextEncoder&)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    return globalObject->commonStrings().utf8WithDashString(globalObject);
+    return WebCore::clientData(lexicalGlobalObject.vm())->commonStrings().utf8WithDashString(&lexicalGlobalObject);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTextEncoder_encoding, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -207,7 +207,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderConstructor, (JSGlobalObject * lexicalGlob
 
 static inline JSValue jsTextEncoder_encodingGetter(JSGlobalObject& lexicalGlobalObject, JSTextEncoder&)
 {
-    return WebCore::clientData(lexicalGlobalObject.vm())->commonStrings().utf8WithDashString(&lexicalGlobalObject);
+    return Bun::commonStrings(lexicalGlobalObject.vm()).utf8WithDashString();
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTextEncoder_encoding, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -665,14 +665,14 @@ JSC_DEFINE_CUSTOM_GETTER(jsWebSocket_extensions, (JSGlobalObject * lexicalGlobal
 
 static inline JSValue jsWebSocket_binaryTypeGetter(JSGlobalObject& lexicalGlobalObject, JSWebSocket& thisObject)
 {
-    auto& commonStrings = WebCore::clientData(lexicalGlobalObject.vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(lexicalGlobalObject.vm());
     switch (thisObject.wrapped().binaryType()) {
     case WebSocket::BinaryType::Blob:
-        return commonStrings.binaryTypeBlobString(&lexicalGlobalObject);
+        return commonStrings.binaryTypeBlobString();
     case WebSocket::BinaryType::ArrayBuffer:
-        return commonStrings.binaryTypeArrayBufferString(&lexicalGlobalObject);
+        return commonStrings.binaryTypeArrayBufferString();
     case WebSocket::BinaryType::NodeBuffer:
-        return commonStrings.binaryTypeNodeBufferString(&lexicalGlobalObject);
+        return commonStrings.binaryTypeNodeBufferString();
     }
     ASSERT_NOT_REACHED();
     return jsUndefined();

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -665,15 +665,14 @@ JSC_DEFINE_CUSTOM_GETTER(jsWebSocket_extensions, (JSGlobalObject * lexicalGlobal
 
 static inline JSValue jsWebSocket_binaryTypeGetter(JSGlobalObject& lexicalGlobalObject, JSWebSocket& thisObject)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(lexicalGlobalObject.vm())->commonStrings();
     switch (thisObject.wrapped().binaryType()) {
     case WebSocket::BinaryType::Blob:
-        return commonStrings.binaryTypeBlobString(globalObject);
+        return commonStrings.binaryTypeBlobString(&lexicalGlobalObject);
     case WebSocket::BinaryType::ArrayBuffer:
-        return commonStrings.binaryTypeArrayBufferString(globalObject);
+        return commonStrings.binaryTypeArrayBufferString(&lexicalGlobalObject);
     case WebSocket::BinaryType::NodeBuffer:
-        return commonStrings.binaryTypeNodeBufferString(globalObject);
+        return commonStrings.binaryTypeNodeBufferString(&lexicalGlobalObject);
     }
     ASSERT_NOT_REACHED();
     return jsUndefined();

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -160,7 +160,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom, (JSGlobalOb
     if (!thisObject) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
-    Bun::putDirectNamed(vm, data, "encoding"_s, WebCore::clientData(vm)->commonStrings().utf8WithDashString(lexicalGlobalObject));
+    Bun::putDirectNamed(vm, data, "encoding"_s, Bun::commonStrings(vm).utf8WithDashString());
     Bun::putDirectNamed(vm, data, "readable"_s, thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined());
     Bun::putDirectNamed(vm, data, "writable"_s, thisObject->m_writable.get() ? JSValue(thisObject->m_writable.get()) : jsUndefined());
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TextEncoderStream"_s, data));
@@ -236,7 +236,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_encoding, (JSGlobalO
     auto* stream = dynamicDowncast<JSTextEncoderStream>(JSValue::decode(thisValue));
     if (!stream) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
-    return JSValue::encode(WebCore::clientData(vm)->commonStrings().utf8WithDashString(lexicalGlobalObject));
+    return JSValue::encode(Bun::commonStrings(vm).utf8WithDashString());
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_readable, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -159,9 +159,8 @@ JSC_DEFINE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom, (JSGlobalOb
     // streams classes, whose inspect methods just fault on a bad `this`.
     if (!thisObject) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
-    Bun::putDirectNamed(vm, data, "encoding"_s, globalObject->commonStrings().utf8WithDashString(globalObject));
+    Bun::putDirectNamed(vm, data, "encoding"_s, WebCore::clientData(vm)->commonStrings().utf8WithDashString(lexicalGlobalObject));
     Bun::putDirectNamed(vm, data, "readable"_s, thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined());
     Bun::putDirectNamed(vm, data, "writable"_s, thisObject->m_writable.get() ? JSValue(thisObject->m_writable.get()) : jsUndefined());
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TextEncoderStream"_s, data));
@@ -237,8 +236,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_encoding, (JSGlobalO
     auto* stream = dynamicDowncast<JSTextEncoderStream>(JSValue::decode(thisValue));
     if (!stream) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    return JSValue::encode(globalObject->commonStrings().utf8WithDashString(globalObject));
+    return JSValue::encode(WebCore::clientData(vm)->commonStrings().utf8WithDashString(lexicalGlobalObject));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_readable, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -66,14 +66,14 @@ using namespace JSC;
 
 template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, CryptoKey::Type enumerationValue)
 {
-    auto& commonStrings = WebCore::clientData(lexicalGlobalObject.vm())->commonStrings();
+    auto& commonStrings = Bun::commonStrings(lexicalGlobalObject.vm());
     switch (enumerationValue) {
     case CryptoKey::Type::Public:
-        return commonStrings.keyTypePublicString(&lexicalGlobalObject);
+        return commonStrings.keyTypePublicString();
     case CryptoKey::Type::Private:
-        return commonStrings.keyTypePrivateString(&lexicalGlobalObject);
+        return commonStrings.keyTypePrivateString();
     case CryptoKey::Type::Secret:
-        return commonStrings.keyTypeSecretString(&lexicalGlobalObject);
+        return commonStrings.keyTypeSecretString();
     }
     ASSERT_NOT_REACHED();
     return jsEmptyString(lexicalGlobalObject.vm());

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -66,15 +66,14 @@ using namespace JSC;
 
 template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, CryptoKey::Type enumerationValue)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(lexicalGlobalObject.vm())->commonStrings();
     switch (enumerationValue) {
     case CryptoKey::Type::Public:
-        return commonStrings.keyTypePublicString(globalObject);
+        return commonStrings.keyTypePublicString(&lexicalGlobalObject);
     case CryptoKey::Type::Private:
-        return commonStrings.keyTypePrivateString(globalObject);
+        return commonStrings.keyTypePrivateString(&lexicalGlobalObject);
     case CryptoKey::Type::Secret:
-        return commonStrings.keyTypeSecretString(globalObject);
+        return commonStrings.keyTypeSecretString(&lexicalGlobalObject);
     }
     ASSERT_NOT_REACHED();
     return jsEmptyString(lexicalGlobalObject.vm());

--- a/test/js/bun/jsc/common-strings.test.ts
+++ b/test/js/bun/jsc/common-strings.test.ts
@@ -35,7 +35,11 @@ const script = /* js */ `
       binaryTypes: types,
       responseTypes: [Response.error().type, new Response("x").type],
       credentials: new Request("http://localhost/", { credentials: "include" }).credentials,
+      request: (({ method, mode, cache, redirect }) => [method, mode, cache, redirect])(
+        new Request("http://localhost/", { method: "POST", mode: "cors", cache: "no-store", redirect: "manual" }),
+      ),
       cookie: ["strict", "lax", "none"].map(s => new Bun.Cookie("a", "b", { sameSite: s }).sameSite),
+      requireNames: [require.name, require.resolve.name],
     };
   }
 
@@ -52,7 +56,9 @@ const script = /* js */ `
     binaryTypes: ["blob", "arraybuffer", "nodebuffer"],
     responseTypes: ["error", "default"],
     credentials: "include",
+    request: ["POST", "cors", "no-store", "manual"],
     cookie: ["strict", "lax", "none"],
+    requireNames: ["bound require", "bound resolve"],
   };
 
   function check(where) {

--- a/test/js/bun/jsc/common-strings.test.ts
+++ b/test/js/bun/jsc/common-strings.test.ts
@@ -1,0 +1,106 @@
+// The getters below return strings from the per-VM common string table
+// (src/jsc/bindings/BunCommonStrings.h). The table is filled lazily and kept
+// alive by a GC marking constraint, so every value is read before and after a
+// full GC, from the main global, from node:vm contexts, and from a Worker.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const script = /* js */ `
+  const { StringDecoder } = require("string_decoder");
+  const { createSecretKey, generateKeyPairSync } = require("crypto");
+  const { mock } = require("bun:test");
+  const vm = require("vm");
+
+  function read() {
+    const sk = createSecretKey(Buffer.alloc(16));
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const fn = mock(x => { if (x === 1) throw new Error("boom"); return x; });
+    fn(0);
+    try { fn(1); } catch {}
+    const ws = new WebSocket("ws://127.0.0.1:1/");
+    ws.onerror = () => {};
+    const types = [];
+    for (const t of ["blob", "arraybuffer", "nodebuffer"]) { ws.binaryType = t; types.push(ws.binaryType); }
+    ws.close();
+    return {
+      textEncoder: new TextEncoder().encoding,
+      textDecoder: new TextDecoder().encoding,
+      textDecoderLatin1: new TextDecoder("latin1").encoding,
+      textEncoderStream: new TextEncoderStream().encoding,
+      textDecoderStream: new TextDecoderStream().encoding,
+      stringDecoder: ["utf8", "hex", "base64", "base64url", "ascii", "latin1", "ucs2", "utf16le"].map(e => new StringDecoder(e).encoding),
+      keyTypes: [sk.type, publicKey.type, privateKey.type],
+      jwkKty: publicKey.export({ format: "jwk" }).kty,
+      mockResults: fn.mock.results.map(r => r.type),
+      binaryTypes: types,
+      responseTypes: [Response.error().type, new Response("x").type],
+      credentials: new Request("http://localhost/", { credentials: "include" }).credentials,
+      cookie: ["strict", "lax", "none"].map(s => new Bun.Cookie("a", "b", { sameSite: s }).sameSite),
+    };
+  }
+
+  const expected = {
+    textEncoder: "utf-8",
+    textDecoder: "utf-8",
+    textDecoderLatin1: "windows-1252",
+    textEncoderStream: "utf-8",
+    textDecoderStream: "utf-8",
+    stringDecoder: ["utf8", "hex", "base64", "base64url", "ascii", "latin1", "utf16le", "utf16le"],
+    keyTypes: ["secret", "public", "private"],
+    jwkKty: "OKP",
+    mockResults: ["return", "throw"],
+    binaryTypes: ["blob", "arraybuffer", "nodebuffer"],
+    responseTypes: ["error", "default"],
+    credentials: "include",
+    cookie: ["strict", "lax", "none"],
+  };
+
+  function check(where) {
+    const got = read();
+    if (JSON.stringify(got) !== JSON.stringify(expected)) {
+      console.error("mismatch in " + where, got);
+      process.exit(1);
+    }
+  }
+
+  check("main");
+  Bun.gc(true);
+  check("main after gc");
+
+  for (let i = 0; i < 8; i++) {
+    const context = vm.createContext({ TextEncoder, TextDecoder, Response, Bun, out: {} });
+    vm.runInContext("out.encoding = new TextEncoder().encoding; out.type = Response.error().type; Bun.gc(true);", context);
+    if (context.out.encoding !== "utf-8" || context.out.type !== "error") {
+      console.error("mismatch in vm context", context.out);
+      process.exit(1);
+    }
+  }
+  Bun.gc(true);
+  check("main after vm contexts");
+
+  const worker = new Worker(URL.createObjectURL(new Blob([
+    "const values = []; for (let i = 0; i < 4; i++) { values.push(new TextEncoder().encoding, Response.error().type); Bun.gc(true); } postMessage(values);",
+  ], { type: "application/javascript" })));
+  worker.onmessage = e => {
+    const ok = e.data.every((v, i) => v === (i % 2 === 0 ? "utf-8" : "error"));
+    if (!ok) {
+      console.error("mismatch in worker", e.data);
+      process.exit(1);
+    }
+    worker.terminate();
+    console.log("ok");
+  };
+`;
+
+test("common strings survive GC on every global of a VM and in a Worker", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/jsc/common-strings.test.ts
+++ b/test/js/bun/jsc/common-strings.test.ts
@@ -87,6 +87,10 @@ const script = /* js */ `
   const worker = new Worker(URL.createObjectURL(new Blob([
     "const values = []; for (let i = 0; i < 4; i++) { values.push(new TextEncoder().encoding, Response.error().type); Bun.gc(true); } postMessage(values);",
   ], { type: "application/javascript" })));
+  worker.onerror = e => {
+    console.error("worker error", e.message ?? e);
+    process.exit(1);
+  };
   worker.onmessage = e => {
     const ok = e.data.every((v, i) => v === (i % 2 === 0 ? "utf-8" : "error"));
     if (!ok) {


### PR DESCRIPTION
### Problem
- After #40995 the common string table lived on `Zig::GlobalObject`, so every global in a VM (node:vm contexts, ShadowRealms, `bun test --isolate`) carried its own copy, and each accessor took a `JSGlobalObject*` because `LazyProperty` needs an owner cell for its write barrier.
- Five of its literals (`"error"`, `"private"`, `"public"`, `"return"`, `"throw"`) are JSC `vm.propertyNames` identifiers and `"blob"` is a Bun builtin name. The table atomized a second literal for each instead of saying so.

### Fix
- `Bun::CommonStrings` is now a struct with one `JSString*` slot per entry, a public member of `JSVMClientData`. `Bun::commonStrings(vm)` is a `static_cast` of `vm.clientData` plus a member load. Accessors take no arguments: `Bun::commonStrings(vm).utf8WithDashString()`.
- Slots are filled on first use by the JS thread and rooted by a `SimpleMarkingConstraint` on the VM (`"Bcs"`), next to the StrongRootBlock one. No global object is involved: the `LazyProperty` owner and the visit from `Zig::GlobalObject::visitChildrenImpl` are gone, and so are the `defaultGlobalObject()` detours at call sites.
- Two identifier-backed lists in `BunCommonStrings.h`: `BUN_COMMON_STRINGS_EACH_NAME(name, builtinName)` and `BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(name, propertyName, literal)`. Their slot is `jsOwnedString` over the identifier's atom, and initialization asserts the literal matches. The literal table covers every entry, so the debug check in `Bun::toJS(BunString)` reads one array.
- Verified: new `test/js/bun/jsc/common-strings.test.ts` reads every cached getter before and after a full GC, from 8 node:vm contexts and a Worker. Also `bun bd test` on `mock-fn.test.js`, `crypto.key-objects.test.ts`, `web-crypto.test.ts`, `websocket-blob.test.ts`, `text-encoder.test.js`, `text-encoder-stream.test.ts`, `string-decoder.test.js`, `cookie.test.ts`, `vm.test.ts`, `abort.test.ts`, `node-module-module.test.js`, `fs.test.ts`, `rm.test.ts`, `fetch-redirect.test.ts`.

### Background
- `JSVMClientData` (`BunClientData.h`) is Bun's per-VM data hung off `JSC::VM::clientData`: builtin names, heap data, caches such as `HTTPHeaderIdentifiers`. A `JSString` is a cell of one VM's heap, so per-VM is the right scope for this cache.
- A `SimpleMarkingConstraint` with `GreyedByExecution` runs at every fixpoint of a collection with the mutator stopped, so it sees every slot the JS thread filled. The same mechanism roots the `StrongRootBlock` list.
- `vm.propertyNames` is JSC's `CommonIdentifiers`, the property names and keywords the engine pre-atomizes for every VM. `WebCore::builtinNames(vm)` is Bun's list of the same kind.

<details><summary>Notes</summary>

- #41002 (the first version of the move, `LazyProperty` slots visited from every `Zig::GlobalObject`) was merged into this branch and then replaced by the struct design above.
- The Rust bridge (`Bun__CommonStringsForRust__toJS`) still takes the global object and reads `globalObject->vm()`; the Rust API `global.common_strings()` is unchanged.
- `HTTPHeaderIdentifiers` keeps its `LazyProperty` shape and its visit from the global object; it is not touched here.
- This is a behavior-preserving refactor: every getter returns the same text before and after, and JS cannot observe which `JSString` cell it got. The new test therefore passes on main as well. It guards the part that can regress, the GC rooting of the per-VM slots, by reading the strings across full collections from several globals and a Worker.
- `CommonStrings` is non-copyable and non-movable: a copy would hand out slots that no constraint visits.
</details>
