### PR TITLE
build: version-check clang++ the same way as clang

### DIFF
--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -397,11 +397,15 @@ function findLlvmTool(
  *
  * zig/bun/esbuild are resolved separately (they come from cache/, not PATH)
  * so pass them in as placeholders for now; they'll be filled by downloaders.
+ *
+ * `searchPaths` replaces the default LLVM search directories (plus $PATH,
+ * which findTool always appends). Tests use it to point at a fake toolchain.
  */
 export function resolveLlvmToolchain(
   os: OS,
   arch: Arch,
   targetOs: OS = os,
+  searchPaths?: string[],
 ): Pick<
   Toolchain,
   | "cc"
@@ -431,22 +435,24 @@ export function resolveLlvmToolchain(
   // so calling it per-tool would burn ~600ms. Every tool below gets
   // the same paths; first-match-wins in findTool means whichever LLVM
   // install is highest-priority wins consistently.
-  const paths = llvmSearchPaths(os, arch);
+  const paths = searchPaths ?? llvmSearchPaths(os, arch);
 
   // The MSVC-style tool family is selected by the TARGET: building for
   // windows needs clang-cl/llvm-lib/lld-link/llvm-rc regardless of host.
   const msvcTarget = targetOs === "windows";
 
-  // clang — version-checked. clang++ is the same binary (hardlink or
-  // symlink) from the same install; a second version-check spawn would
-  // just return the same answer. We still locate it separately so the
-  // "not found" error names the right tool.
+  // clang and clang++ — both version-checked. They are the same binary
+  // within one install, but with several LLVM installs on the machine the
+  // two lookups can diverge: `clang` falls through to a version-suffixed
+  // name (clang-21) while a bare `clang++` from a newer default install
+  // matches first. Mixing majors breaks the C++ compile (#41000), so the
+  // clang++ lookup must reject out-of-range versions the same way.
   const ccResult = findLlvmTool(msvcTarget ? "clang-cl" : "clang", paths, os, {
     checkVersion: true,
     required: true,
   });
   const cxx = findLlvmTool(msvcTarget ? "clang-cl" : "clang++", paths, os, {
-    checkVersion: false,
+    checkVersion: true,
     required: true,
   })?.path;
 
@@ -477,8 +483,10 @@ export function resolveLlvmToolchain(
   let hostCc: string | undefined;
   let hostCxx: string | undefined;
   if (msvcTarget && os !== "windows") {
-    hostCc = findLlvmTool("clang", paths, os, { checkVersion: false, required: true })?.path;
-    hostCxx = findLlvmTool("clang++", paths, os, { checkVersion: false, required: true })?.path;
+    // Version-checked for the same reason as cc/cxx above: a bare `clang`
+    // from a different install than the pinned one must not win.
+    hostCc = findLlvmTool("clang", paths, os, { checkVersion: true, required: true })?.path;
+    hostCxx = findLlvmTool("clang++", paths, os, { checkVersion: true, required: true })?.path;
   }
 
   // ar: llvm-ar (or llvm-lib for windows targets)

--- a/test/internal/build-llvm-toolchain-version.test.ts
+++ b/test/internal/build-llvm-toolchain-version.test.ts
@@ -32,30 +32,57 @@ function fakeTool(version: string): string {
   return `#!/bin/sh\nprintf 'version %s\\n' '${version}'\n`;
 }
 
-test.skipIf(isWindows)("clang++ is version-checked so cc and cxx come from the same LLVM major", () => {
-  // Two installs visible through one bin dir, as on gentoo in #41000: the
-  // bare names are a newer default install, the suffixed names the pinned one.
+/**
+ * A bin dir with two installs visible through it, as on gentoo in #41000:
+ * the bare clang/clang++ are a newer default install, the suffixed names
+ * the pinned one. `extra` adds the tools a given target also requires.
+ */
+function fakeToolchain(extra: string[]): Record<string, string> {
   const tools: Record<string, string> = {
     "bin/clang": fakeTool("99.0.0"),
     [`bin/clang-${llvmMajor}`]: fakeTool(LLVM_VERSION),
     "bin/clang++": fakeTool("99.0.0"),
     [`bin/clang++-${llvmMajor}`]: fakeTool(LLVM_VERSION),
-    "bin/ld.lld": fakeTool(LLVM_VERSION),
     "bin/llvm-ar": fakeTool(LLVM_VERSION),
     "bin/llvm-ranlib": fakeTool(LLVM_VERSION),
     "bin/strip": fakeTool(LLVM_VERSION),
   };
-  using dir = tempDir("build-llvm-version", tools);
-  const bin = join(String(dir), "bin");
-  for (const name of Object.keys(tools)) chmodSync(join(String(dir), name), 0o755);
+  for (const name of extra) tools[`bin/${name}`] = fakeTool(LLVM_VERSION);
+  return tools;
+}
+
+function useFakeToolchain(dir: string, tools: Record<string, string>): string {
+  const bin = join(dir, "bin");
+  for (const name of Object.keys(tools)) chmodSync(join(dir, name), 0o755);
   process.env.PATH = bin;
   // Keep findRustLld() away from the machine's real rustc.
-  process.env.CARGO_HOME = String(dir);
+  process.env.CARGO_HOME = dir;
+  return bin;
+}
+
+test.skipIf(isWindows)("clang++ is version-checked so cc and cxx come from the same LLVM major", () => {
+  const tools = fakeToolchain(["ld.lld"]);
+  using dir = tempDir("build-llvm-version", tools);
+  const bin = useFakeToolchain(String(dir), tools);
 
   const llvm = resolveLlvmToolchain("linux", "x64", "linux", [bin]);
   expect({ cc: llvm.cc, cxx: llvm.cxx, clangVersion: llvm.clangVersion }).toEqual({
     cc: join(bin, `clang-${llvmMajor}`),
     cxx: join(bin, `clang++-${llvmMajor}`),
     clangVersion: LLVM_VERSION,
+  });
+});
+
+test.skipIf(isWindows)("hostCc and hostCxx are version-checked for unix-to-windows cross builds", () => {
+  const tools = fakeToolchain(["clang-cl", "lld-link", "llvm-lib", "llvm-rc"]);
+  using dir = tempDir("build-llvm-cross", tools);
+  const bin = useFakeToolchain(String(dir), tools);
+
+  const llvm = resolveLlvmToolchain("linux", "x64", "windows", [bin]);
+  expect({ cc: llvm.cc, cxx: llvm.cxx, hostCc: llvm.hostCc, hostCxx: llvm.hostCxx }).toEqual({
+    cc: join(bin, "clang-cl"),
+    cxx: join(bin, "clang-cl"),
+    hostCc: join(bin, `clang-${llvmMajor}`),
+    hostCxx: join(bin, `clang++-${llvmMajor}`),
   });
 });

--- a/test/internal/build-llvm-toolchain-version.test.ts
+++ b/test/internal/build-llvm-toolchain-version.test.ts
@@ -1,0 +1,61 @@
+/**
+ * resolveLlvmToolchain() (scripts/build/tools.ts) must version-check clang
+ * and clang++ the same way. With several LLVM installs on one machine (a
+ * newer default under the bare names, the pinned major under suffixed
+ * names), the clang lookup rejects the default and falls through to
+ * clang-<major>, but an unchecked clang++ lookup takes the bare name from
+ * the newer install. That mixes two compiler majors in one build
+ * (oven-sh/bun#41000).
+ *
+ * The fake tools are shell scripts that print a version string; PATH and
+ * the toolchain's search paths point only at them, so no real LLVM
+ * install on the test machine can win.
+ */
+import { afterEach, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+
+import { LLVM_VERSION, resolveLlvmToolchain } from "../../scripts/build/tools.ts";
+
+const llvmMajor = LLVM_VERSION.split(".")[0];
+
+const savedEnv = { PATH: process.env.PATH, CARGO_HOME: process.env.CARGO_HOME };
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function fakeTool(version: string): string {
+  return `#!/bin/sh\nprintf 'version %s\\n' '${version}'\n`;
+}
+
+test.skipIf(isWindows)("clang++ is version-checked so cc and cxx come from the same LLVM major", () => {
+  // Two installs visible through one bin dir, as on gentoo in #41000: the
+  // bare names are a newer default install, the suffixed names the pinned one.
+  const tools: Record<string, string> = {
+    "bin/clang": fakeTool("99.0.0"),
+    [`bin/clang-${llvmMajor}`]: fakeTool(LLVM_VERSION),
+    "bin/clang++": fakeTool("99.0.0"),
+    [`bin/clang++-${llvmMajor}`]: fakeTool(LLVM_VERSION),
+    "bin/ld.lld": fakeTool(LLVM_VERSION),
+    "bin/llvm-ar": fakeTool(LLVM_VERSION),
+    "bin/llvm-ranlib": fakeTool(LLVM_VERSION),
+    "bin/strip": fakeTool(LLVM_VERSION),
+  };
+  using dir = tempDir("build-llvm-version", tools);
+  const bin = join(String(dir), "bin");
+  for (const name of Object.keys(tools)) chmodSync(join(String(dir), name), 0o755);
+  process.env.PATH = bin;
+  // Keep findRustLld() away from the machine's real rustc.
+  process.env.CARGO_HOME = String(dir);
+
+  const llvm = resolveLlvmToolchain("linux", "x64", "linux", [bin]);
+  expect({ cc: llvm.cc, cxx: llvm.cxx, clangVersion: llvm.clangVersion }).toEqual({
+    cc: join(bin, `clang-${llvmMajor}`),
+    cxx: join(bin, `clang++-${llvmMajor}`),
+    clangVersion: LLVM_VERSION,
+  });
+});


### PR DESCRIPTION
### Problem

- `bun run build:release` fails on a machine with more than one LLVM install. Example from #41000 (Gentoo, clang-21 and clang-22, 22 default): `error: no member named 'BitsFromMask' in namespace 'hwy::N_SVE'` while `/usr/lib/llvm/22/bin/clang++` compiles code configured for clang 21.
- The cause is in `resolveLlvmToolchain` (`scripts/build/tools.ts:444`). The `clang` lookup is version-checked, so it rejects the newer default and falls through to `clang-21`. The `clang++` lookup is not version-checked, so the bare `clang++` from the newer install matches first. One build then mixes two compiler majors.

### Fix

- Version-check the `clang++` lookup with the same pinned range as `clang`, as the reporter suggested. Also version-check the host `clang`/`clang++` pair used for unix-to-windows cross builds, which had the same unchecked lookup.
- Correct because the range (`>=21.1.0 <21.1.99`) is the contract the rest of the build pins. `ld.lld` already uses the same checked lookup. The cost is one extra `--version` spawn at configure time.
- Add an optional `searchPaths` parameter to `resolveLlvmToolchain` so a test can point discovery at a fake toolchain. The default call path is unchanged.
- Verified: `test/internal/build-llvm-toolchain-version.test.ts`. With the check reverted, the test fails with `cxx` resolved to the fake newer `clang++`. Also ran the other `test/internal/build-*` tests and a full `--configure-only` pass.

### Background

- Toolchain discovery runs at configure time. `findTool` walks the known LLVM directories plus `$PATH`, and for each base name it also tries version-suffixed variants (`clang`, `clang-21.1`, `clang-21`), first match wins.
- A version check spawns `<tool> --version`, parses `X.Y.Z`, and skips candidates outside the pinned range. Unchecked lookups take the first executable match.
- The `BUN_TOOLCHAIN_LLVM` override is not affected. It searches a single directory, so both compilers come from the same install by construction.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/internal/build-llvm-toolchain-version.test.ts

<!-- robobun:evidence:end -->