### PR TITLE
Move the common string table from the global object to the VM client data

### DIFF
--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -69,6 +69,7 @@ class DOMWrapperWorld;
 #include <wtf/WeakHashSet.h>
 #include "JSCTaskScheduler.h"
 #include "HTTPHeaderIdentifiers.h"
+#include "BunCommonStrings.h"
 #include "DOMURLBaseCache.h"
 #include <JavaScriptCore/HeapObserver.h>
 namespace Zig {
@@ -234,6 +235,8 @@ public:
     // LazyProperty::initLater ~90 times (stores a tagged function pointer),
     // so there is no startup cost worth deferring.
     WebCore::HTTPHeaderIdentifiers& httpHeaderIdentifiers() { return m_httpHeaderIdentifiers; }
+    // Same shape and rooting as httpHeaderIdentifiers().
+    Bun::CommonStrings& commonStrings() { return m_commonStrings; }
 
     WebCore::DOMURLBaseCache& urlBaseCache() { return m_urlBaseCache; }
 
@@ -312,6 +315,7 @@ private:
     std::unique_ptr<ExtendedDOMClientIsoSubspaces> m_clientSubspaces;
 
     WebCore::HTTPHeaderIdentifiers m_httpHeaderIdentifiers;
+    Bun::CommonStrings m_commonStrings;
 
     WebCore::DOMURLBaseCache m_urlBaseCache;
 

--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -47,11 +47,11 @@ static const JSC::Identifier* identifierAt(VM& vm, CommonStrings::Index index)
     }
 }
 
-void CommonStrings::initialize()
+CommonStrings::CommonStrings()
 {
     for (auto& string : m_strings) {
         string.initLater([](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {
-            auto& self = defaultGlobalObject(init.owner)->commonStrings();
+            auto& self = WebCore::clientData(init.vm)->commonStrings();
             size_t i = &init.property - self.m_strings;
             ASSERT(i < std::size(self.m_strings));
             auto literal = commonStringLiterals[i];
@@ -131,7 +131,7 @@ static JSC::JSValue toJS(Zig::GlobalObject* globalObject, HTTPMethod method)
 {
 #define FOR_EACH_METHOD(method)    \
     case HTTPMethod::http##method: \
-        return globalObject->commonStrings().http##method##String(globalObject);
+        return WebCore::clientData(globalObject->vm())->commonStrings().http##method##String(globalObject);
 
     switch (method) {
         FOR_EACH_METHOD(ACL)
@@ -214,7 +214,7 @@ enum class CommonStringsForRust : uint8_t {
 
 static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForRust commonString)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (commonString) {
     case CommonStringsForRust::IPv4:
         return commonStrings.IPv4String(globalObject);
@@ -288,7 +288,7 @@ enum class FetchCacheMode : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchCacheMode__toJS(FetchCacheMode mode, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (mode) {
     case FetchCacheMode::Default:
         return JSValue::encode(globalObject->vm().smallStrings.defaultString());
@@ -318,7 +318,7 @@ enum class FetchRedirect : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchRedirect__toJS(FetchRedirect redirect, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (redirect) {
     case FetchRedirect::Follow:
         return JSValue::encode(commonStrings.fetchFollowString(globalObject));
@@ -343,7 +343,7 @@ enum class FetchRequestMode : uint8_t {
 
 extern "C" JSC::EncodedJSValue Bun__FetchRequestMode__toJS(FetchRequestMode mode, Zig::GlobalObject* globalObject)
 {
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (mode) {
     case FetchRequestMode::SameOrigin:
         return JSValue::encode(commonStrings.fetchSameOriginString(globalObject));

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -148,6 +148,8 @@
 
 namespace Bun {
 
+// Per-VM cache of the strings above (one JSString each, created on first use).
+// Lives in JSVMClientData; every Zig::GlobalObject visits it.
 class CommonStrings {
 public:
     // clang-format off
@@ -162,7 +164,8 @@ public:
     BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_BUILTIN_NAME)
     BUN_COMMON_STRINGS_EACH_VM_PROPERTY_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_VM_PROPERTY_NAME)
     BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES)
-    void initialize();
+
+    CommonStrings();
 
     template<typename Visitor>
     void visit(Visitor& visitor);

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1729,10 +1729,10 @@ extern "C" JSC::EncodedJSValue Bun__wrapAbortError(JSC::JSGlobalObject* lexicalG
     auto cause = JSC::JSValue::decode(causeParam);
 
     if (cause.isUndefined()) {
-        return JSC::JSValue::encode(Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, globalObject->commonStrings().OperationWasAbortedString(globalObject)));
+        return JSC::JSValue::encode(Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject)));
     }
 
-    auto message = globalObject->commonStrings().OperationWasAbortedString(globalObject);
+    auto message = WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject);
     JSC::JSObject* options = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 24);
     Bun::putDirectNamed(vm, options, "cause"_s, cause);
 
@@ -1750,10 +1750,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionMakeAbortError, (JSC::JSGlobalObject * lexica
     if (!options.isUndefined() && options.isCell() && !options.asCell()->isObject()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
 
     if (message.isUndefined() && options.isUndefined()) {
-        return JSValue::encode(Bun::createError(vm, lexicalGlobalObject, Bun::ErrorCode::ABORT_ERR, JSValue(globalObject->commonStrings().OperationWasAbortedString(globalObject))));
+        return JSValue::encode(Bun::createError(vm, lexicalGlobalObject, Bun::ErrorCode::ABORT_ERR, JSValue(WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject))));
     }
 
-    if (message.isUndefined()) message = globalObject->commonStrings().OperationWasAbortedString(globalObject);
+    if (message.isUndefined()) message = WebCore::clientData(vm)->commonStrings().OperationWasAbortedString(globalObject);
     auto error = Bun::createError(vm, globalObject, Bun::ErrorCode::ABORT_ERR, message, options);
     return JSC::JSValue::encode(error);
 }

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -131,13 +131,13 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void Bun__REPL__setupGlobalRequire(
 
     auto* resolveFunction = JSBoundFunction::create(vm, globalObject,
         globalObject->requireResolveFunctionUnbound(), moduleObject,
-        ArgList(), 1, globalObject->commonStrings().resolveString(globalObject),
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject),
         makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
     RETURN_IF_EXCEPTION(scope, );
 
     auto* requireFunction = JSBoundFunction::create(vm, globalObject,
         globalObject->requireFunctionUnbound(), moduleObject,
-        ArgList(), 1, globalObject->commonStrings().requireString(globalObject),
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject),
         makeSource("require"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
     RETURN_IF_EXCEPTION(scope, );
 

--- a/src/jsc/bindings/JSBufferEncodingType.cpp
+++ b/src/jsc/bindings/JSBufferEncodingType.cpp
@@ -20,7 +20,7 @@
 
 #include "config.h"
 #include "JSBufferEncodingType.h"
-#include "ZigGlobalObject.h"
+#include "BunClientData.h"
 #include "wtf/Forward.h"
 
 #include <JavaScriptCore/JSCInlines.h>
@@ -30,8 +30,8 @@ using namespace JSC;
 
 template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, BufferEncodingType enumerationValue)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto* globalObject = &lexicalGlobalObject;
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     // clang-format off
     switch (enumerationValue) {
     case BufferEncodingType::utf8:      return commonStrings.utf8String(globalObject);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -139,7 +139,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
             globalObject,
             globalObject->requireResolveFunctionUnbound(),
             moduleObject,
-            ArgList(), 1, globalObject->commonStrings().resolveString(globalObject), resolveSourceCode);
+            ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject), resolveSourceCode);
         RETURN_IF_EXCEPTION(scope, );
 
         SourceCode requireSourceCode = makeSource("require"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
@@ -147,7 +147,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
             globalObject,
             globalObject->requireFunctionUnbound(),
             moduleObject,
-            ArgList(), 1, globalObject->commonStrings().requireString(globalObject), requireSourceCode);
+            ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject), requireSourceCode);
         RETURN_IF_EXCEPTION(scope, );
         requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
         RETURN_IF_EXCEPTION(scope, );
@@ -1685,7 +1685,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
         globalObject,
         globalObject->requireFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, globalObject->commonStrings().requireString(globalObject), requireSourceCode);
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().requireString(globalObject), requireSourceCode);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     SourceCode resolveSourceCode = makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
@@ -1694,7 +1694,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
         globalObject,
         globalObject->requireResolveFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, globalObject->commonStrings().resolveString(globalObject), resolveSourceCode);
+        ArgList(), 1, WebCore::clientData(globalObject->vm())->commonStrings().resolveString(globalObject), resolveSourceCode);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -235,7 +235,7 @@ public:
         function->finishCreation(vm);
 
         // Do not forget to set the original name: https://github.com/oven-sh/bun/issues/8794
-        function->m_originalName.set(vm, function, globalObject->commonStrings().mockedFunctionString(globalObject));
+        function->m_originalName.set(vm, function, WebCore::clientData(vm)->commonStrings().mockedFunctionString(globalObject));
 
         return function;
     }
@@ -805,7 +805,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, Mo
 {
     JSC::Structure* structure = globalObject->mockModule.mockResultStructure.getInitializedOnMainThread(globalObject);
 
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
     JSC::JSString* typeString = nullptr;
     switch (type) {
     case MockResultType::Return:

--- a/src/jsc/bindings/JSSocketAddressDTO.cpp
+++ b/src/jsc/bindings/JSSocketAddressDTO.cpp
@@ -17,7 +17,8 @@ JSObject* create(Zig::GlobalObject* globalObject, JSString* value, int32_t port,
 {
     VM& vm = globalObject->vm();
 
-    auto* family = isIPv6 ? globalObject->commonStrings().IPv6String(globalObject) : globalObject->commonStrings().IPv4String(globalObject);
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto* family = isIPv6 ? commonStrings.IPv6String(globalObject) : commonStrings.IPv4String(globalObject);
 
     JSObject* thisObject = constructEmptyObject(vm, globalObject->JSSocketAddressDTOStructure());
     thisObject->putDirectOffset(vm, addressOffset, value);
@@ -71,7 +72,8 @@ extern "C" JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto* global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
 
-    auto* af = isIPv6 ? global->commonStrings().IPv6String(global) : global->commonStrings().IPv4String(global);
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
+    auto* af = isIPv6 ? commonStrings.IPv6String(global) : commonStrings.IPv4String(global);
 
     JSObject* thisObject = constructEmptyObject(vm, global->JSSocketAddressDTOStructure());
     thisObject->putDirectOffset(vm, Bun::JSSocketAddressDTO::addressOffset, JSValue::decode(address));

--- a/src/jsc/bindings/S3Error.cpp
+++ b/src/jsc/bindings/S3Error.cpp
@@ -38,7 +38,7 @@ SYSV_ABI JSC::EncodedJSValue S3Error__toErrorInstance(const S3Error* arg0,
 
     auto prototype = defaultGlobalObject(globalObject)->m_S3ErrorStructure.getInitializedOnMainThread(globalObject);
     JSC::JSObject* result = JSC::ErrorInstance::create(vm, prototype, message, {});
-    result->putDirect(vm, vm.propertyNames->name, defaultGlobalObject(globalObject)->commonStrings().s3ErrorString(globalObject), JSC::PropertyAttribute::DontEnum | 0);
+    result->putDirect(vm, vm.propertyNames->name, WebCore::clientData(vm)->commonStrings().s3ErrorString(globalObject), JSC::PropertyAttribute::DontEnum | 0);
     if (err.code.tag != BunStringTag::Empty) {
         JSC::JSValue code = Bun::toJS(globalObject, err.code);
         if (scope.exception()) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2042,7 +2042,6 @@ void GlobalObject::finishCreation(VM& vm)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
-    m_commonStrings.initialize();
     m_bakeAdditions.initialize();
     m_markdownTagStrings.initialize();
 
@@ -3200,6 +3199,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     // A stale m_vm surfaces as a SEGV in TypeCastTraits<JSVMClientData>::isType
     // when downcast<> calls the virtual isWebCoreJSClientData() on garbage.
     WebCore::clientData(visitor.vm())->httpHeaderIdentifiers().template visit<Visitor>(visitor);
+    WebCore::clientData(visitor.vm())->commonStrings().template visit<Visitor>(visitor);
 
     thisObject->visitGeneratedLazyClasses<Visitor>(thisObject, visitor);
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -63,7 +63,6 @@ struct node_module;
 #include "JSMockFunction.h"
 #include "InternalModuleRegistry.h"
 #include "headers-handwritten.h"
-#include "BunCommonStrings.h"
 #include "BunMarkdownTagStrings.h"
 #include "BunGlobalScope.h"
 #include <js_native_api.h>
@@ -554,7 +553,6 @@ public:
                                                                                                              \
     V(private, std::unique_ptr<WebCore::JSBuiltinInternalFunctions>, m_builtinInternalFunctions)             \
     V(private, std::unique_ptr<WebCore::DOMConstructors>, m_constructors)                                    \
-    V(private, Bun::CommonStrings, m_commonStrings)                                                          \
     V(private, Bun::MarkdownTagStrings, m_markdownTagStrings)                                                \
                                                                                                              \
     /* JSC's hashtable code-generator tries to access these properties, so we make them public. */           \
@@ -767,7 +765,6 @@ public:
     JSObject* nodeWorkerEntryEvaluatedHook() { return m_nodeWorkerEntryEvaluatedHook.get(); }
     void setNodeWorkerEntryEvaluatedHook(JSObject* hook);
 
-    Bun::CommonStrings& commonStrings() { return m_commonStrings; }
     Bun::MarkdownTagStrings& markdownTagStrings() { return m_markdownTagStrings; }
 #include "ZigGeneratedClasses+lazyStructureHeader.h"
 

--- a/src/jsc/bindings/node/crypto/JSKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSKeyObjectPrototype.cpp
@@ -70,14 +70,13 @@ JSC_DEFINE_CUSTOM_GETTER(jsKeyObjectPrototype_type, (JSGlobalObject * globalObje
 
     KeyObject& handle = keyObject->handle();
 
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    auto& commonStrings = zigGlobalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
     switch (handle.type()) {
     case CryptoKeyType::Secret:
-        return JSValue::encode(commonStrings.keyTypeSecretString(zigGlobalObject));
+        return JSValue::encode(commonStrings.keyTypeSecretString(globalObject));
     case CryptoKeyType::Public:
-        return JSValue::encode(commonStrings.keyTypePublicString(zigGlobalObject));
+        return JSValue::encode(commonStrings.keyTypePublicString(globalObject));
     case CryptoKeyType::Private:
-        return JSValue::encode(commonStrings.keyTypePrivateString(zigGlobalObject));
+        return JSValue::encode(commonStrings.keyTypePrivateString(globalObject));
     }
 }

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -154,8 +154,7 @@ JSC::JSValue KeyObject::exportJwkAkpKey(JSC::JSGlobalObject* lexicalGlobalObject
 JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     const auto& pkey = m_data->asymmetricKey;
 
@@ -217,8 +216,7 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
 JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     const auto& pkey = m_data->asymmetricKey;
     ASSERT(pkey.id() == EVP_PKEY_EC);
@@ -295,8 +293,7 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
 JSC::JSValue KeyObject::exportJwkRsaKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, CryptoKeyType exportType)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 
@@ -338,8 +335,7 @@ JSC::JSValue KeyObject::exportJwkSecretKey(JSC::JSGlobalObject* lexicalGlobalObj
 {
 
     VM& vm = lexicalGlobalObject->vm();
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(vm)->commonStrings();
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -931,7 +931,7 @@ size_t JSCookie::estimatedSize(JSC::JSCell* cell, JSC::VM& vm)
 
 JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, CookieSameSite sameSite)
 {
-    auto& commonStrings = defaultGlobalObject(globalObject)->commonStrings();
+    auto& commonStrings = WebCore::clientData(globalObject->vm())->commonStrings();
     switch (sameSite) {
     case CookieSameSite::Strict:
         return commonStrings.strictString(globalObject);

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -207,8 +207,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderConstructor, (JSGlobalObject * lexicalGlob
 
 static inline JSValue jsTextEncoder_encodingGetter(JSGlobalObject& lexicalGlobalObject, JSTextEncoder&)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    return globalObject->commonStrings().utf8WithDashString(globalObject);
+    return WebCore::clientData(lexicalGlobalObject.vm())->commonStrings().utf8WithDashString(&lexicalGlobalObject);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTextEncoder_encoding, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -665,15 +665,14 @@ JSC_DEFINE_CUSTOM_GETTER(jsWebSocket_extensions, (JSGlobalObject * lexicalGlobal
 
 static inline JSValue jsWebSocket_binaryTypeGetter(JSGlobalObject& lexicalGlobalObject, JSWebSocket& thisObject)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(lexicalGlobalObject.vm())->commonStrings();
     switch (thisObject.wrapped().binaryType()) {
     case WebSocket::BinaryType::Blob:
-        return commonStrings.binaryTypeBlobString(globalObject);
+        return commonStrings.binaryTypeBlobString(&lexicalGlobalObject);
     case WebSocket::BinaryType::ArrayBuffer:
-        return commonStrings.binaryTypeArrayBufferString(globalObject);
+        return commonStrings.binaryTypeArrayBufferString(&lexicalGlobalObject);
     case WebSocket::BinaryType::NodeBuffer:
-        return commonStrings.binaryTypeNodeBufferString(globalObject);
+        return commonStrings.binaryTypeNodeBufferString(&lexicalGlobalObject);
     }
     ASSERT_NOT_REACHED();
     return jsUndefined();

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -159,9 +159,8 @@ JSC_DEFINE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom, (JSGlobalOb
     // streams classes, whose inspect methods just fault on a bad `this`.
     if (!thisObject) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
-    Bun::putDirectNamed(vm, data, "encoding"_s, globalObject->commonStrings().utf8WithDashString(globalObject));
+    Bun::putDirectNamed(vm, data, "encoding"_s, WebCore::clientData(vm)->commonStrings().utf8WithDashString(lexicalGlobalObject));
     Bun::putDirectNamed(vm, data, "readable"_s, thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined());
     Bun::putDirectNamed(vm, data, "writable"_s, thisObject->m_writable.get() ? JSValue(thisObject->m_writable.get()) : jsUndefined());
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TextEncoderStream"_s, data));
@@ -237,8 +236,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_encoding, (JSGlobalO
     auto* stream = dynamicDowncast<JSTextEncoderStream>(JSValue::decode(thisValue));
     if (!stream) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    return JSValue::encode(globalObject->commonStrings().utf8WithDashString(globalObject));
+    return JSValue::encode(WebCore::clientData(vm)->commonStrings().utf8WithDashString(lexicalGlobalObject));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_readable, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -66,15 +66,14 @@ using namespace JSC;
 
 template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, CryptoKey::Type enumerationValue)
 {
-    auto* globalObject = defaultGlobalObject(&lexicalGlobalObject);
-    auto& commonStrings = globalObject->commonStrings();
+    auto& commonStrings = WebCore::clientData(lexicalGlobalObject.vm())->commonStrings();
     switch (enumerationValue) {
     case CryptoKey::Type::Public:
-        return commonStrings.keyTypePublicString(globalObject);
+        return commonStrings.keyTypePublicString(&lexicalGlobalObject);
     case CryptoKey::Type::Private:
-        return commonStrings.keyTypePrivateString(globalObject);
+        return commonStrings.keyTypePrivateString(&lexicalGlobalObject);
     case CryptoKey::Type::Secret:
-        return commonStrings.keyTypeSecretString(globalObject);
+        return commonStrings.keyTypeSecretString(&lexicalGlobalObject);
     }
     ASSERT_NOT_REACHED();
     return jsEmptyString(lexicalGlobalObject.vm());


### PR DESCRIPTION
### Problem
- `Bun::CommonStrings` (the table behind `commonStrings().xxxString()`) was a member of `Zig::GlobalObject`. Its entries are `JSString` cells, which belong to the VM, not to a global object. Every `Zig::GlobalObject` in a VM (workers aside, that is node:vm contexts, ShadowRealms, `bun test --isolate` globals) carried its own copy, and code that only had a `JSC::JSGlobalObject*` had to go through `defaultGlobalObject()` to reach it.

### Fix
- Move the table into `JSVMClientData`, next to `HTTPHeaderIdentifiers`, which already follows this shape: constructed eagerly with the client data, lazily filled, visited from `Zig::GlobalObject::visitChildrenImpl` through `WebCore::clientData(visitor.vm())`.
- `CommonStrings::initialize()` becomes the constructor. The init lambda finds the table through `WebCore::clientData(init.vm)` instead of the owner global.
- Call sites use `WebCore::clientData(vm)->commonStrings()`. The accessor keeps its `JSGlobalObject*` parameter: `LazyProperty` needs an owner for the write barrier, and any global of the VM works. Several `defaultGlobalObject(...)` detours that existed only to reach the table are gone.
- Verified: `bun bd test` on `mock-fn.test.js`, `crypto.key-objects.test.ts`, `web-crypto.test.ts`, `websocket-blob.test.ts`, `text-encoder.test.js`, `text-encoder-stream.test.ts`, `string-decoder.test.js`, `cookie.test.ts`, `vm.test.ts`, `worker.test.ts`, `abort.test.ts`, `node-module-module.test.js`. A GC stress script touching the strings from 50 `vm.createContext` globals and a Worker behaves.

### Background
- `JSVMClientData` (`BunClientData.h`) is Bun's per-VM data attached to `JSC::VM::clientData`: builtin names, heap data, and caches such as `HTTPHeaderIdentifiers`.
- `LazyProperty<JSGlobalObject, JSString>` stores one tagged pointer per entry. On first access it runs the init lambda, stores the cell and write-barriers the owner global so the concurrent marker revisits it. `visit()` marks the cell on later collections.

<details><summary>Notes</summary>

- Stacked on #40999. The base is that branch so the diff shows only the move.
- `worker.test.ts` has two tests that fail under the debug build in this container ("message flood ... does not starve", "preload with an un-awaited import()"). They pass with the release canary and are timing bound (30 ms and a 4000-function module transpiled three times). `s3.test.ts` failures here need S3 credentials.
</details>
