### PR TITLE
build: local WebKit builds use mimalloc like the prebuilt does

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -331,6 +331,8 @@ export const webkit: Dependency = {
       CMAKE_EXPORT_COMPILE_COMMANDS: "ON",
       USE_BUN_JSC_ADDITIONS: "ON",
       USE_BUN_EVENT_LOOP: "ON",
+      // Match the prebuilt: JSC allocates through Bun's mimalloc, not libpas.
+      ...(cfg.asan ? {} : { USE_MIMALLOC: "ON", USE_EXTERNAL_MIMALLOC: "ON" }),
       ENABLE_BUN_SKIP_FAILING_ASSERTIONS: "ON",
       ALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS: "ON",
       ENABLE_REMOTE_INSPECTOR: "ON",


### PR DESCRIPTION
The prebuilt WebKit tarballs are configured with `USE_MIMALLOC=ON USE_EXTERNAL_MIMALLOC=ON` (JSC allocates through Bun's mimalloc). Local mode (`BUN_WEBKIT_PATH` / `vendor/WebKit`, i.e. `build:local` / `release-local`) never passed those, so it silently linked libpas and had different allocator/RSS behaviour from what ships — noticed while A/B-ing a JSC heap change where the local build's RSS didn't match release at all. ASAN builds are left as they are.