### PR TITLE
docs: fix TypeScript casing in sveltekit guide

### DIFF
--- a/docs/guides/ecosystem/sveltekit.mdx
+++ b/docs/guides/ecosystem/sveltekit.mdx
@@ -16,8 +16,8 @@ bunx sv create my-app
 ◇  Which template would you like?
 │  SvelteKit demo
 │
-◇  Add type checking with Typescript?
-│  Yes, using Typescript syntax
+◇  Add type checking with TypeScript?
+│  Yes, using TypeScript syntax
 │
 ◆  Project created
 │


### PR DESCRIPTION
Fix Typescript -> TypeScript in docs/guides/ecosystem/sveltekit.mdx (2 occurrences).