### PR TITLE
docs: fix TypeScript casing in expandable code titles

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -228,7 +228,7 @@ sink.start({
 
 ## Reference
 
-```ts See Typescript Definitions expandable
+```ts See TypeScript Definitions expandable
 /**
  * Fast incremental writer that becomes an `ArrayBuffer` on end().
  */

--- a/docs/runtime/transpiler.mdx
+++ b/docs/runtime/transpiler.mdx
@@ -182,7 +182,7 @@ const result = transpiler.scanImports(code);
 
 ## Reference
 
-```ts See Typescript Definitions expandable
+```ts See TypeScript Definitions expandable
 type Loader = "jsx" | "js" | "ts" | "tsx";
 
 interface TranspilerOptions {


### PR DESCRIPTION
Fix Typescript -> TypeScript in 3 expandable code block titles (bundler/index.mdx, runtime/streams.mdx, runtime/transpiler.mdx).