### PR TITLE
bun:test: await a thenable or lazy Promise subclass returned from a test callback

### DIFF
--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -271,14 +271,6 @@ impl JSPromise {
         JSC__JSPromise__setHandled(self)
     }
 
-    /// True when `then()` on this promise is the built-in one: a plain `Promise` whose
-    /// realm has not patched `Promise.prototype.then`. Attaching a reaction to its
-    /// internal state is then not observable. A `Promise` subclass, an own `then`, or a
-    /// patched prototype returns false, and `await`-like code has to call `then()`.
-    pub fn is_then_fast_and_non_observable(&self) -> bool {
-        crate::cpp::JSC__JSPromise__isThenFastAndNonObservable(self)
-    }
-
     /// Returns the promise whose settlement is `value`'s outcome, or `None` when `value`
     /// is not a thenable. Use it on a value that user code returned and native code
     /// wants to await: a test callback, a hook, a handler.
@@ -287,31 +279,18 @@ impl JSPromise {
     /// `wait_for_promise`) never calls the value's own `then()`. A `Promise` subclass
     /// that starts its work inside an overridden `then()` (Bun.SQL's `Query`, `Bun.$`'s
     /// `ShellPromise`) never settles that way, and a plain thenable has no internal
-    /// state at all. Such a value is adopted by a fresh native promise through the spec
-    /// resolve steps, which read `then` once and call it, the same as `await` does. The
-    /// adopter is marked handled: the caller observes its outcome, and a `then` getter
-    /// that throws rejects it before the caller can attach a reaction.
+    /// state at all. This is the coercion `await` applies (spec `PromiseResolve`): a
+    /// promise whose constructor is `Promise` is returned as is, and anything else is
+    /// adopted by a fresh native promise whose resolve steps read `then` once and call
+    /// it. The adopter is marked handled: the caller observes its outcome, and a `then`
+    /// getter that throws rejects it before the caller can attach a reaction.
     ///
-    /// A promise that already settled, or a pending promise with the built-in `then`,
-    /// is returned as is. A pending promise whose `then` is not callable counts as a
-    /// plain object, as `typeof value.then !== "function"` does in Jest.
+    /// An object whose `then` is not callable is not a thenable, as in
+    /// `typeof value.then !== "function"` in Jest.
     pub fn awaitable(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<&mut JSPromise>> {
-        if let Some(promise) = value.as_promise() {
-            // `JSPromise` is an `opaque_ffi!` ZST: safe `*mut` to `&mut` deref.
-            let promise = JSPromise::opaque_mut(promise);
-            if promise.status() != Status::Pending || promise.is_then_fast_and_non_observable() {
-                return Ok(Some(promise));
-            }
-        } else if !value.is_object() {
-            return Ok(None);
-        }
-        let adopter = JSPromise::create(global);
-        adopter.set_handled();
-        adopter.resolve(global, value)?;
-        Ok(match adopter.status() {
-            Status::Fulfilled => None,
-            Status::Pending | Status::Rejected => Some(adopter),
-        })
+        let promise = crate::cpp::JSC__JSPromise__awaitable(global, value)?;
+        // A non-null return is a GC-managed cell tied to `global`'s VM.
+        Ok((!promise.is_null()).then(|| JSPromise::opaque_mut(promise)))
     }
 
     /// Create a new resolved promise resolving to a given value.

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -271,25 +271,13 @@ impl JSPromise {
         JSC__JSPromise__setHandled(self)
     }
 
-    /// Returns the promise whose settlement is `value`'s outcome, or `None` when `value`
-    /// is not a thenable. Use it on a value that user code returned and native code
-    /// wants to await: a test callback, a hook, a handler.
-    ///
-    /// A reaction attached to a promise's internal state (`JSValue::then`,
-    /// `wait_for_promise`) never calls the value's own `then()`. A `Promise` subclass
-    /// that starts its work inside an overridden `then()` (Bun.SQL's `Query`, `Bun.$`'s
-    /// `ShellPromise`) never settles that way, and a plain thenable has no internal
-    /// state at all. This is the coercion `await` applies (spec `PromiseResolve`): a
-    /// promise whose constructor is `Promise` is returned as is, and anything else is
-    /// adopted by a fresh native promise whose resolve steps read `then` once and call
-    /// it. The adopter is marked handled: the caller observes its outcome, and a `then`
-    /// getter that throws rejects it before the caller can attach a reaction.
-    ///
-    /// An object whose `then` is not callable is not a thenable, as in
-    /// `typeof value.then !== "function"` in Jest.
+    /// The promise `await value` would wait on, or `None` when `value` is not a thenable.
+    /// Spec `PromiseResolve`: a promise whose constructor is `Promise` is returned as is.
+    /// Anything else (a subclass with its own `then()`, a plain thenable) is adopted by a
+    /// fresh promise that calls `value.then()`. `JSValue::then` never does, so a lazy
+    /// subclass such as Bun.SQL's `Query` would never start. The adopter is marked handled.
     pub fn awaitable(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<&mut JSPromise>> {
         let promise = crate::cpp::JSC__JSPromise__awaitable(global, value)?;
-        // A non-null return is a GC-managed cell tied to `global`'s VM.
         Ok((!promise.is_null()).then(|| JSPromise::opaque_mut(promise)))
     }
 

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -271,8 +271,7 @@ impl JSPromise {
         JSC__JSPromise__setHandled(self)
     }
 
-    /// Spec `PromiseResolve(%Promise%, value)`: the promise `await value` waits on, with the
-    /// value's own `then()` called for a subclass or a thenable. `None`: not a thenable.
+    /// Spec `PromiseResolve(%Promise%, value)`, what `await value` waits on. `None`: not a thenable.
     pub fn awaitable(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<&mut JSPromise>> {
         let promise = crate::cpp::JSC__JSPromise__awaitable(global, value)?;
         Ok((!promise.is_null()).then(|| JSPromise::opaque_mut(promise)))

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -271,11 +271,8 @@ impl JSPromise {
         JSC__JSPromise__setHandled(self)
     }
 
-    /// The promise `await value` would wait on, or `None` when `value` is not a thenable.
-    /// Spec `PromiseResolve`: a promise whose constructor is `Promise` is returned as is.
-    /// Anything else (a subclass with its own `then()`, a plain thenable) is adopted by a
-    /// fresh promise that calls `value.then()`. `JSValue::then` never does, so a lazy
-    /// subclass such as Bun.SQL's `Query` would never start. The adopter is marked handled.
+    /// Spec `PromiseResolve(%Promise%, value)`: the promise `await value` waits on, with the
+    /// value's own `then()` called for a subclass or a thenable. `None`: not a thenable.
     pub fn awaitable(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<&mut JSPromise>> {
         let promise = crate::cpp::JSC__JSPromise__awaitable(global, value)?;
         Ok((!promise.is_null()).then(|| JSPromise::opaque_mut(promise)))

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -271,6 +271,49 @@ impl JSPromise {
         JSC__JSPromise__setHandled(self)
     }
 
+    /// True when `then()` on this promise is the built-in one: a plain `Promise` whose
+    /// realm has not patched `Promise.prototype.then`. Attaching a reaction to its
+    /// internal state is then not observable. A `Promise` subclass, an own `then`, or a
+    /// patched prototype returns false, and `await`-like code has to call `then()`.
+    pub fn is_then_fast_and_non_observable(&self) -> bool {
+        crate::cpp::JSC__JSPromise__isThenFastAndNonObservable(self)
+    }
+
+    /// Returns the promise whose settlement is `value`'s outcome, or `None` when `value`
+    /// is not a thenable. Use it on a value that user code returned and native code
+    /// wants to await: a test callback, a hook, a handler.
+    ///
+    /// A reaction attached to a promise's internal state (`JSValue::then`,
+    /// `wait_for_promise`) never calls the value's own `then()`. A `Promise` subclass
+    /// that starts its work inside an overridden `then()` (Bun.SQL's `Query`, `Bun.$`'s
+    /// `ShellPromise`) never settles that way, and a plain thenable has no internal
+    /// state at all. Such a value is adopted by a fresh native promise through the spec
+    /// resolve steps, which read `then` once and call it, the same as `await` does. The
+    /// adopter is marked handled: the caller observes its outcome, and a `then` getter
+    /// that throws rejects it before the caller can attach a reaction.
+    ///
+    /// A promise that already settled, or a pending promise with the built-in `then`,
+    /// is returned as is. A pending promise whose `then` is not callable counts as a
+    /// plain object, as `typeof value.then !== "function"` does in Jest.
+    pub fn awaitable(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<&mut JSPromise>> {
+        if let Some(promise) = value.as_promise() {
+            // `JSPromise` is an `opaque_ffi!` ZST: safe `*mut` to `&mut` deref.
+            let promise = JSPromise::opaque_mut(promise);
+            if promise.status() != Status::Pending || promise.is_then_fast_and_non_observable() {
+                return Ok(Some(promise));
+            }
+        } else if !value.is_object() {
+            return Ok(None);
+        }
+        let adopter = JSPromise::create(global);
+        adopter.set_handled();
+        adopter.resolve(global, value)?;
+        Ok(match adopter.status() {
+            Status::Fulfilled => None,
+            Status::Pending | Status::Rejected => Some(adopter),
+        })
+    }
+
     /// Create a new resolved promise resolving to a given value.
     ///
     /// Note: If you want the result as a `JSValue`, use `resolved_promise_value` instead.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4014,9 +4014,28 @@ JSC::JSPromise* JSC__JSPromise__resolvedPromise(JSC::JSGlobalObject* globalObjec
     promise->markAsHandled();
 }
 
-[[ZIG_EXPORT(nothrow)]] bool JSC__JSPromise__isThenFastAndNonObservable(JSC::JSPromise* promise)
+// The coercion `await` applies to a value, spec PromiseResolve(%Promise%, value): a promise
+// whose constructor is %Promise% is returned as is, so no then() call is observable on it
+// even when Promise.prototype.then is patched. Anything else is adopted by a fresh promise
+// whose resolve steps read the value's `then` once and call it. Returns nullptr when the
+// value is not a thenable (`then` is not callable): the caller already holds the outcome.
+[[ZIG_EXPORT(check_slow)]] JSC::JSPromise* JSC__JSPromise__awaitable(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
 {
-    return promise->isThenFastAndNonObservable();
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
+    if (!value.isObject())
+        return nullptr;
+    JSC::JSPromise* promise = JSC::JSPromise::resolvedPromise(globalObject, value);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (JSC::JSValue(promise) == value)
+        return promise;
+    // The adopter's outcome is the caller's to observe. A `then` getter that threw has
+    // already rejected it, so the unhandled rejection tracker must not report it.
+    promise->markAsHandled();
+    if (promise->status() == JSC::JSPromise::Status::Fulfilled)
+        return nullptr;
+    return promise;
 }
 
 #pragma mark - JSC::JSInternalPromise (now aliased to JSPromise)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4014,11 +4014,7 @@ JSC::JSPromise* JSC__JSPromise__resolvedPromise(JSC::JSGlobalObject* globalObjec
     promise->markAsHandled();
 }
 
-// The coercion `await` applies to a value, spec PromiseResolve(%Promise%, value): a promise
-// whose constructor is %Promise% is returned as is, so no then() call is observable on it
-// even when Promise.prototype.then is patched. Anything else is adopted by a fresh promise
-// whose resolve steps read the value's `then` once and call it. Returns nullptr when the
-// value is not a thenable (`then` is not callable): the caller already holds the outcome.
+// Spec PromiseResolve(%Promise%, value), the coercion `await` applies. nullptr: not a thenable.
 [[ZIG_EXPORT(check_slow)]] JSC::JSPromise* JSC__JSPromise__awaitable(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -4030,9 +4026,9 @@ JSC::JSPromise* JSC__JSPromise__resolvedPromise(JSC::JSGlobalObject* globalObjec
     RETURN_IF_EXCEPTION(scope, nullptr);
     if (JSC::JSValue(promise) == value)
         return promise;
-    // The adopter's outcome is the caller's to observe. A `then` getter that threw has
-    // already rejected it, so the unhandled rejection tracker must not report it.
+    // The caller observes the adopter; a `then` getter that threw already rejected it.
     promise->markAsHandled();
+    // `then` is not callable: the value itself is the outcome.
     if (promise->status() == JSC::JSPromise::Status::Fulfilled)
         return nullptr;
     return promise;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4024,6 +4024,7 @@ JSC::JSPromise* JSC__JSPromise__resolvedPromise(JSC::JSGlobalObject* globalObjec
         return nullptr;
     JSC::JSPromise* promise = JSC::JSPromise::resolvedPromise(globalObject, value);
     RETURN_IF_EXCEPTION(scope, nullptr);
+    ASSERT(promise);
     if (JSC::JSValue(promise) == value)
         return promise;
     // The caller observes the adopter; a `then` getter that threw already rejected it.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4014,6 +4014,11 @@ JSC::JSPromise* JSC__JSPromise__resolvedPromise(JSC::JSGlobalObject* globalObjec
     promise->markAsHandled();
 }
 
+[[ZIG_EXPORT(nothrow)]] bool JSC__JSPromise__isThenFastAndNonObservable(JSC::JSPromise* promise)
+{
+    return promise->isThenFastAndNonObservable();
+}
+
 #pragma mark - JSC::JSInternalPromise (now aliased to JSPromise)
 
 JSC::JSPromise* JSC__JSInternalPromise__create(JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -120,8 +120,8 @@ CPP_DECL void WebCore__AbortSignal__unref(WebCore::AbortSignal* arg0);
 #pragma mark - JSC::JSPromise
 
 CPP_DECL JSC::EncodedJSValue JSC__JSPromise__asValue(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1);
+CPP_DECL JSC::JSPromise* JSC__JSPromise__awaitable(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);
 CPP_DECL JSC::JSPromise* JSC__JSPromise__create(JSC::JSGlobalObject* arg0);
-CPP_DECL bool JSC__JSPromise__isThenFastAndNonObservable(JSC::JSPromise* arg0);
 CPP_DECL void JSC__JSPromise__reject(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__JSPromise__rejectAsHandled(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL JSC::JSPromise* JSC__JSPromise__rejectedPromise(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -121,6 +121,7 @@ CPP_DECL void WebCore__AbortSignal__unref(WebCore::AbortSignal* arg0);
 
 CPP_DECL JSC::EncodedJSValue JSC__JSPromise__asValue(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::JSPromise* JSC__JSPromise__create(JSC::JSGlobalObject* arg0);
+CPP_DECL bool JSC__JSPromise__isThenFastAndNonObservable(JSC::JSPromise* arg0);
 CPP_DECL void JSC__JSPromise__reject(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__JSPromise__rejectAsHandled(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL JSC::JSPromise* JSC__JSPromise__rejectedPromise(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1137,7 +1137,7 @@ impl BunTest {
         // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point (before JS re-entry).
         unsafe { (*this).update_min_timeout(global_this, timeout) };
         let args_slice: &[JSValue] = if !done_arg.is_empty() { core::slice::from_ref(&done_arg) } else { &[] };
-        let result: JSValue = match vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
+        let mut result: JSValue = match vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
             cfg_callback,
             global_this,
             JSValue::UNDEFINED,
@@ -1155,17 +1155,28 @@ impl BunTest {
 
         done_callback.ensure_still_alive();
 
+        // A lazy `Promise` subclass (Bun.SQL's `Query`) or a plain thenable is awaited
+        // through its own `then()`; `JSValue::then` alone would never start its work.
+        let mut awaited: Option<&mut bun_jsc::JSPromise> = None;
+        if !result.is_empty() {
+            match bun_jsc::JSPromise::awaitable(global_this, result) {
+                Ok(promise) => awaited = promise,
+                Err(_) => {
+                    global_this.clear_termination_exception();
+                    // SAFETY: re-derive after the `then` getter ran JS; no outer `&mut` was held across it.
+                    unsafe { (*this).on_uncaught_exception(global_this, global_this.try_take_exception(), false, &cfg_data) };
+                    bun_core::scoped_log!(bun_test_group, "callTestCallback -> thenable adoption threw");
+                    result = JSValue::ZERO;
+                }
+            }
+        }
+
         // Drain unhandled promise rejections.
         loop {
             // Prevent the user's Promise rejection from going into the uncaught promise rejection queue.
-            if !result.is_empty() {
-                if let Some(promise) = result.as_promise() {
-                    // SAFETY: `as_promise` returned a non-null GC-managed JSPromise.
-                    unsafe {
-                        if (*promise).status() == PromiseStatus::Rejected {
-                            (*promise).set_handled();
-                        }
-                    }
+            if let Some(promise) = awaited.as_deref_mut() {
+                if promise.status() == PromiseStatus::Rejected {
+                    promise.set_handled();
                 }
             }
 
@@ -1203,56 +1214,52 @@ impl BunTest {
             }
         }
 
-        if !result.is_empty() {
-            if let Some(promise) = result.as_promise() {
-                let _keep = bun_jsc::EnsureStillAlive(result); // because sometimes we use promise without result
+        if let Some(promise) = awaited {
+            let _keep = bun_jsc::EnsureStillAlive(result); // because sometimes we use promise without result
 
-                bun_core::scoped_log!(bun_test_group, "callTestCallback -> promise: data {}", cfg_data);
+            bun_core::scoped_log!(bun_test_group, "callTestCallback -> promise: data {}", cfg_data);
 
-                // S012: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
-                match bun_jsc::JSPromise::opaque_mut(promise).status() {
-                    PromiseStatus::Pending => {
-                        // not immediately resolved; register 'then' to handle the result when it becomes available
-                        let this_ref: RefPtr<RefData> = if let Some(dcb_ref_value) = dcb_ref {
-                            // SAFETY: `dcb_ref_value` aliases the live RefData
-                            // owned by `dcb_data.r#ref` (set just above; GC
-                            // roots `done_callback` for this frame). Bump the
-                            // refcount 1→2.
-                            unsafe { RefPtr::init_ref(dcb_ref_value.as_ptr()) }
-                        } else {
-                            Self::ref_(this_strong, cfg_data)
-                        };
-                        // Track the `+1` handed to `Promise.then()` in case the promise never settles.
-                        let raw_ref: *mut RefData = RefPtr::into_raw(this_ref);
-                        this_strong
-                            .bun_test_root
-                            .get()
-                            .pending_then_refs
-                            .borrow_mut()
-                            .push(raw_ref.cast_const());
-                        let _ = result.then(
-                            global_this,
-                            raw_ref,
-                            Bun__TestScope__Describe2__bunTestThen,
-                            Bun__TestScope__Describe2__bunTestCatch,
-                        );
-                        // TODO: properly propagate exception upwards
-                        return None;
-                    }
-                    PromiseStatus::Fulfilled => {
-                        // Do not register a then callback when it's already fulfilled.
-                        return Some(cfg_data);
-                    }
-                    PromiseStatus::Rejected => {
-                        let value = bun_jsc::JSPromise::opaque_mut(promise).result(global_this.vm());
-                        // SAFETY: re-derive via `UnsafeCell` after the JS/microtask
-                        // drain above; sole `&mut` at this point.
-                        unsafe { (*this).on_uncaught_exception(global_this, Some(value), true, &cfg_data) };
+            match promise.status() {
+                PromiseStatus::Pending => {
+                    // not immediately resolved; register 'then' to handle the result when it becomes available
+                    let this_ref: RefPtr<RefData> = if let Some(dcb_ref_value) = dcb_ref {
+                        // SAFETY: `dcb_ref_value` aliases the live RefData
+                        // owned by `dcb_data.r#ref` (set just above; GC
+                        // roots `done_callback` for this frame). Bump the
+                        // refcount 1→2.
+                        unsafe { RefPtr::init_ref(dcb_ref_value.as_ptr()) }
+                    } else {
+                        Self::ref_(this_strong, cfg_data)
+                    };
+                    // Track the `+1` handed to `Promise.then()` in case the promise never settles.
+                    let raw_ref: *mut RefData = RefPtr::into_raw(this_ref);
+                    this_strong
+                        .bun_test_root
+                        .get()
+                        .pending_then_refs
+                        .borrow_mut()
+                        .push(raw_ref.cast_const());
+                    promise.to_js().then(
+                        global_this,
+                        raw_ref,
+                        Bun__TestScope__Describe2__bunTestThen,
+                        Bun__TestScope__Describe2__bunTestCatch,
+                    );
+                    return None;
+                }
+                PromiseStatus::Fulfilled => {
+                    // Do not register a then callback when it's already fulfilled.
+                    return Some(cfg_data);
+                }
+                PromiseStatus::Rejected => {
+                    let value = promise.result(global_this.vm());
+                    // SAFETY: re-derive via `UnsafeCell` after the JS/microtask
+                    // drain above; sole `&mut` at this point.
+                    unsafe { (*this).on_uncaught_exception(global_this, Some(value), true, &cfg_data) };
 
-                        // We previously marked it as handled above.
+                    // We previously marked it as handled above.
 
-                        return Some(cfg_data);
-                    }
+                    return Some(cfg_data);
                 }
             }
         }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1176,8 +1176,7 @@ impl BunTest {
             }
         }
 
-        // A lazy `Promise` subclass (Bun.SQL's `Query`) or a plain thenable is awaited
-        // through its own `then()`; `JSValue::then` alone would never start its work.
+        // Await a lazy `Promise` subclass (Bun.SQL's `Query`) or a thenable through its own `then()`.
         let mut awaited: Option<&mut bun_jsc::JSPromise> = None;
         if !result.is_empty() {
             match bun_jsc::JSPromise::awaitable(global_this, result) {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1155,6 +1155,27 @@ impl BunTest {
 
         done_callback.ensure_still_alive();
 
+        // Drain unhandled promise rejections.
+        loop {
+            // Prevent the user's Promise rejection from going into the uncaught promise rejection queue.
+            if !result.is_empty() {
+                if let Some(promise) = result.as_promise() {
+                    // SAFETY: `as_promise` returned a non-null GC-managed JSPromise.
+                    unsafe {
+                        if (*promise).status() == PromiseStatus::Rejected {
+                            (*promise).set_handled();
+                        }
+                    }
+                }
+            }
+
+            let prev_unhandled_count = vm.unhandled_error_counter;
+            let _ = global_this.handle_rejected_promises();
+            if vm.unhandled_error_counter == prev_unhandled_count {
+                break;
+            }
+        }
+
         // A lazy `Promise` subclass (Bun.SQL's `Query`) or a plain thenable is awaited
         // through its own `then()`; `JSValue::then` alone would never start its work.
         let mut awaited: Option<&mut bun_jsc::JSPromise> = None;
@@ -1163,27 +1184,11 @@ impl BunTest {
                 Ok(promise) => awaited = promise,
                 Err(_) => {
                     global_this.clear_termination_exception();
-                    // SAFETY: re-derive after the `then` getter ran JS; no outer `&mut` was held across it.
+                    // SAFETY: re-derive after the `constructor`/`then` getter ran JS; no outer `&mut` was held across it.
                     unsafe { (*this).on_uncaught_exception(global_this, global_this.try_take_exception(), false, &cfg_data) };
                     bun_core::scoped_log!(bun_test_group, "callTestCallback -> thenable adoption threw");
                     result = JSValue::ZERO;
                 }
-            }
-        }
-
-        // Drain unhandled promise rejections.
-        loop {
-            // Prevent the user's Promise rejection from going into the uncaught promise rejection queue.
-            if let Some(promise) = awaited.as_deref_mut() {
-                if promise.status() == PromiseStatus::Rejected {
-                    promise.set_handled();
-                }
-            }
-
-            let prev_unhandled_count = vm.unhandled_error_counter;
-            let _ = global_this.handle_rejected_promises();
-            if vm.unhandled_error_counter == prev_unhandled_count {
-                break;
             }
         }
 

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -839,6 +839,22 @@ describe.concurrent("thenable test callbacks", () => {
           return { then: null };
         });
 
+        // A native promise is awaited the way \`await\` awaits it: without a then()
+        // call, even while Promise.prototype.then is replaced (the WPT streams
+        // suite does this inside a test body).
+        test("a plain promise is awaited without calling a patched then()", async () => {
+          const then = Promise.prototype.then;
+          Promise.prototype.then = () => {
+            throw new Error("patched then() called");
+          };
+          try {
+            await new Promise(resolve => setImmediate(resolve));
+            order.push("patched");
+          } finally {
+            Promise.prototype.then = then;
+          }
+        });
+
         test("every value settled before the next test started", () => {
           expect(order).toEqual([
             "beforeEach", "subclass",
@@ -847,6 +863,7 @@ describe.concurrent("thenable test callbacks", () => {
             "beforeEach",
             "beforeEach", "then read", "thenable",
             "beforeEach", "done",
+            "beforeEach", "patched",
             "beforeEach",
           ]);
         });
@@ -877,12 +894,13 @@ describe.concurrent("thenable test callbacks", () => {
       (pass) a Bun.$ shell promise returned directly is run and awaited
       (pass) a plain thenable is awaited
       (pass) a non-thenable object does not complete the test
+      (pass) a plain promise is awaited without calling a patched then()
       (pass) every value settled before the next test started
 
-       7 pass
+       8 pass
        0 fail
        2 expect() calls
-      Ran 7 tests across 1 file."
+      Ran 8 tests across 1 file."
       ,
         "stdout": "bun test <version> (<revision>)",
       }

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -748,4 +748,207 @@ test("my-test", () => {
       expect(output).toContain("Ran 1 test across 1 file");
     });
   }
+});
+
+// A test or hook callback that returns a thenable is awaited the way `await`
+// awaits it: through the value's own `then()`. A `Promise` subclass that starts
+// its work inside `then()` (Bun.$'s ShellPromise, Bun.SQL's Query) never settles
+// if only its internal state is watched, and the test times out. A plain thenable
+// is not a promise at all and used to be treated as a synchronous return.
+describe.concurrent("thenable test callbacks", () => {
+  // The shape of Bun.SQL's Query: a Promise subclass that does nothing until then() is called.
+  const lazyPromiseClass = /* ts */ `
+    class LazyPromise<T> extends Promise<T> {
+      #start: () => void;
+      #started = false;
+      constructor(start: (resolve: (value: T) => void, reject: (error: unknown) => void) => void) {
+        let resolve!: (value: T) => void;
+        let reject!: (error: unknown) => void;
+        super((res, rej) => {
+          resolve = res;
+          reject = rej;
+        });
+        this.#start = () => start(resolve, reject);
+      }
+      then(onfulfilled?: any, onrejected?: any): any {
+        if (!this.#started) {
+          this.#started = true;
+          this.#start();
+        }
+        return super.then(onfulfilled, onrejected);
+      }
+      static get [Symbol.species]() {
+        return Promise;
+      }
+    }
+  `;
+
+  test("a lazy promise subclass or a thenable is awaited", async () => {
+    using dir = tempDir("thenable-await", {
+      "thenable.test.ts": `
+        import { SQL } from "bun";
+        import { beforeEach, expect, test } from "bun:test";
+        ${lazyPromiseClass}
+
+        const order: string[] = [];
+        const sql = new SQL("sqlite://:memory:");
+
+        beforeEach(() => new LazyPromise<void>(resolve => {
+          setImmediate(() => {
+            order.push("beforeEach");
+            resolve();
+          });
+        }));
+
+        test("a lazy promise subclass is started and awaited", () => new LazyPromise<void>(resolve => {
+          setImmediate(() => {
+            order.push("subclass");
+            resolve();
+          });
+        }));
+
+        test("a Bun.SQL query is run and awaited", () => sql\`select 1 as x\`.then(rows => {
+          order.push("sql");
+          expect(rows).toEqual([{ x: 1 }]);
+        }));
+
+        test("a Bun.SQL query returned directly is run and awaited", () => sql\`select 1 as x\`);
+
+        test("a Bun.$ shell promise returned directly is run and awaited", () => Bun.$\`echo shell\`.quiet());
+
+        test("a plain thenable is awaited", () => ({
+          // Reading \`then\` is observable: the runner reads it exactly once, as Promise.resolve() does.
+          get then() {
+            order.push("then read");
+            return (resolve: () => void) => {
+              setImmediate(() => {
+                order.push("thenable");
+                resolve();
+              });
+            };
+          },
+        }));
+
+        // setImmediate does not run between two synchronous tests, so "done" is
+        // only in the order if the runner waited for the done callback.
+        test("a non-thenable object does not complete the test", done => {
+          setImmediate(() => {
+            order.push("done");
+            done();
+          });
+          return { then: null };
+        });
+
+        test("every value settled before the next test started", () => {
+          expect(order).toEqual([
+            "beforeEach", "subclass",
+            "beforeEach", "sql",
+            "beforeEach",
+            "beforeEach",
+            "beforeEach", "then read", "thenable",
+            "beforeEach", "done",
+            "beforeEach",
+          ]);
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "thenable.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      stdout: normalizeBunSnapshot(stdout, String(dir)),
+      stderr: normalizeBunSnapshot(stderr, String(dir)),
+      exitCode,
+    }).toMatchInlineSnapshot(`
+      {
+        "exitCode": 0,
+        "stderr": 
+      "thenable.test.ts:
+      (pass) a lazy promise subclass is started and awaited
+      (pass) a Bun.SQL query is run and awaited
+      (pass) a Bun.SQL query returned directly is run and awaited
+      (pass) a Bun.$ shell promise returned directly is run and awaited
+      (pass) a plain thenable is awaited
+      (pass) a non-thenable object does not complete the test
+      (pass) every value settled before the next test started
+
+       7 pass
+       0 fail
+       2 expect() calls
+      Ran 7 tests across 1 file."
+      ,
+        "stdout": "bun test <version> (<revision>)",
+      }
+    `);
+  });
+
+  test("a rejected lazy promise subclass or thenable fails the test", async () => {
+    using dir = tempDir("thenable-reject", {
+      "thenable.test.ts": `
+        import { beforeEach, describe, test } from "bun:test";
+        ${lazyPromiseClass}
+
+        test("a rejected lazy promise subclass fails", () => new LazyPromise<void>((_resolve, reject) => {
+          setImmediate(() => reject(new Error("rejected subclass")));
+        }));
+
+        test("a rejected thenable fails", () => ({
+          then(_resolve: () => void, reject: (error: unknown) => void) {
+            reject(new Error("rejected thenable"));
+          },
+        }));
+
+        test("a throwing then fails", () => ({
+          then(): void {
+            throw new Error("throwing then");
+          },
+        }));
+
+        test("a throwing then getter fails", () => ({
+          get then(): never {
+            throw new Error("throwing then getter");
+          },
+        }));
+
+        describe("rejected hook", () => {
+          beforeEach(() => ({
+            then(_resolve: () => void, reject: (error: unknown) => void) {
+              reject(new Error("rejected hook"));
+            },
+          }));
+
+          test("never runs", () => {
+            console.log("THIS TEST SHOULD NOT RUN");
+          });
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "thenable.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("error: rejected subclass");
+    expect(stderr).toContain("error: rejected thenable");
+    expect(stderr).toContain("error: throwing then\n");
+    expect(stderr).toContain("error: throwing then getter");
+    expect(stderr).toContain("error: rejected hook");
+    expect(stderr).toContain(" 0 pass");
+    expect(stderr).toContain(" 5 fail");
+    expect(stderr).not.toContain("Unhandled error between tests");
+    expect(stdout).not.toContain("THIS TEST SHOULD NOT RUN");
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### Problem
- `test("q", () => sql\`select 1\`)` times out: a returned `Promise` subclass whose overridden `then()` starts the work (Bun.SQL's `Query`, `Bun.$`'s `ShellPromise`) never settles. A plain thenable (supertest's request) passes at once and its rejection is lost. Fixes #27945.
- Cause: `run_test_callback` (`src/runtime/test_runner/bun_test.rs:1207`) calls `JSValue::then`, which is `performPromiseThen` on the internal promise state (`bindings.cpp:3146`). It never calls the value's own `then()`, and a thenable is not a `JSPromise` at all.

### Fix
- New `JSPromise::awaitable(global, value)` in `bun_jsc`, over a new `JSC__JSPromise__awaitable` binding. It applies the coercion `await` applies, spec `PromiseResolve(%Promise%, value)` through JSC's `JSPromise::resolvedPromise`: a promise whose constructor is `Promise` is returned as is, anything else is adopted by a fresh promise whose resolve steps read `then` once and call it. `None` means the value is not a thenable.
- `run_test_callback` attaches its reactions to that promise instead of the raw value. A plain promise takes the exact path it took before, so no `then()` call is observable on it, even while a test has `Promise.prototype.then` replaced (the WPT streams suite does this).
- Jest awaits any returned value with a callable `then` by calling it. A `then` or `constructor` getter that throws fails the test with that error.
- Verified: `test/js/bun/test/test-test.test.ts`, two new child-process tests that time out on bun 1.4.1. Also all of `test/js/bun/test/` and `wpt-streams.test.ts` on the debug build.

### Background
- A thenable is any object with a callable `then`. `await` handles one through the spec's Promise Resolve Functions: read `then`, then queue a job that calls `then(resolveFn, rejectFn)` (`JSPromise::resolvePromise` in JSC).
- `PromiseResolve(C, x)` returns `x` itself when `x` is a promise and `x.constructor === C`. JSC's `await` (`resolveWithInternalMicrotaskForAsyncAwait`) and `JSPromise::resolvedPromise` both implement it. A subclass has its own constructor, so it is adopted and its `then()` runs.

<details><summary>Notes</summary>

- `Query` (`src/js/internal/sql/query.ts`) and `ShellPromise` (`src/js/builtins/shell.ts`) are lazy: the constructor queues nothing, and the first `then()` call dispatches the work. `.then(cb)` on them returns a plain promise through `Symbol.species`, which is why `test(() => sql\`...\`.then(cb))` always worked and `test(() => sql\`...\`)` did not.
- Supersedes #33372, which coerces only non-`JSPromise` thenables and leaves the subclass case broken. #40996 (open) is the same fix for `.resolves` / `.rejects` in `expect.rs` and can call `JSPromise::awaitable` once this lands. The same `as_any_promise` + internal-state wait exists for other user-returned values (`cron.rs`, `html_rewriter.rs`, `RequestContext.rs`, `JSBundler.rs`, `Macro.rs`) and has the same gap for a lazy subclass. Those are separate changes that can reuse the helper.
- Predicate: the first push gated the fast path on JSC's `isThenFastAndNonObservable`, which reads the realm's `Promise.prototype.then` watchpoint. Any patch of `then()` fires that watchpoint for good, so after a WPT subtest patched `then()` to throw, every later test's pending promise was adopted through the patched `then()` and 458 WPT subtests failed. The `constructor` check of `PromiseResolve` does not depend on `then`, and it is what `await` does.
- An object whose `then` is not callable fulfils the adopter at once with the object itself. The runner then treats the callback as synchronous, as Jest does (`typeof returnValue.then !== "function"`), and a `done` callback is still awaited.
- A thenable whose `then` throws when called rejects the adopter inside the resolve job, so the test fails with that error. Jest fails the test with the same error.
- The adopter is marked handled right after it is created because a `then` getter that throws rejects it synchronously, before the runner's reactions exist. The rejection would otherwise be reported as an unhandled error between tests. An already rejected subclass promise is marked handled by the existing drain loop, so it is reported once, through the adopter.
- Other cases probed on the debug build: `done` callback plus a thenable (waits for both), `done` plus a rejecting thenable (fails), a never-settling thenable (per-test timeout, the next test runs), settlement after the timeout (no-op), a `constructor` getter that throws (fails with that error), a body that patches `Promise.prototype.then` (no call, later plain promises still awaited directly). `BUN_JSC_validateExceptionChecks=1` reports nothing for the new paths.
- Fail before: on bun 1.4.1 both new tests time out. The first fixture's lazy `beforeEach` and lazy tests never start, and the second fixture's rejected thenables pass instead of failing.
- Suites run on the debug build: all of `test/js/bun/test/` (1189 pass), `test/js/third_party/wpt-streams/wpt-streams.test.ts` (1175 pass), `test/js/node/test_runner/node-test.test.ts`, `readablestreamtoarraybuffer.test.ts`, `plugin-sync-exception-fallback.test.ts`. Two failures in `test/js/bun/test/` are unrelated and reproduce with main's `src/`: `pretty-format-overflow.test.ts` segfaults on this machine's 8 MB stack under the debug ASAN build (it passes with 16 MB), and `snapshot.test.ts` "error snapshots" expects TTY colors.
- Self-reviewed: 8 concerns raised, 8 addressed. The helper moved from a private `BunTest` function into `bun_jsc::JSPromise::awaitable` so #40996 and the other sites can share it, the predicate is the spec's `PromiseResolve` rather than a new one, and the commit records the superseded PR and the fixed issue.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts

<!-- robobun:evidence:end -->