### PR TITLE
Bun.serve: cancel the body stream of a Response the server will never transmit

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -686,13 +686,14 @@ where
         ));
     }
 
-    pub(crate) fn on_resolve(_global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+    pub(crate) fn on_resolve(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         ctx_log!("onResolve");
 
         let arguments = callframe.arguments_as_array::<2>();
         let Some(ctx) = NativePromiseContext::take::<Self>(arguments[1]) else {
             // A termination path (abort, end, upgrade) reclaimed the cell's
             // claim; the context may already be gone.
+            Self::discard_response_body(global, arguments[0]);
             return Ok(JSValue::UNDEFINED);
         };
         let ctx = RequestContextRef::adopt(ctx.as_ptr());
@@ -701,8 +702,55 @@ where
         let result = arguments[0];
         result.ensure_still_alive();
 
-        ctx.ctx().handle_resolve(result);
+        ctx.ctx().handle_resolve(global, result);
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// Cancel the body stream of a Response the server will not transmit.
+    fn cancel_unread_body(response: &Response, global_this: &JSGlobalObject) {
+        if let Some(stream) = response.get_body_readable_stream() {
+            let _keep = jsc::EnsureStillAlive(stream.value);
+            response.detach_readable_stream(global_this);
+            // Not `cancel()`: it skips a stream with no reader, which an unattached body is.
+            crate::dispatch::fold(stream.cancel_with_reason(global_this, JSValue::UNDEFINED));
+        }
+        *response.get_body_value() = Body::Value::Used;
+    }
+
+    /// [`Self::cancel_unread_body`] for a rooted handler result: a `Response` or a settled promise of one.
+    fn discard_response_body(global_this: &JSGlobalObject, value: JSValue) {
+        let value = match value.as_any_promise() {
+            Some(promise) => {
+                match promise.unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
+                    jsc::PromiseResult::Fulfilled(fulfilled) => fulfilled,
+                    jsc::PromiseResult::Pending | jsc::PromiseResult::Rejected(_) => return,
+                }
+            }
+            None => value,
+        };
+        if let Some(response) = response::from_js_ref(value) {
+            Self::cancel_unread_body(response.get(), global_this);
+        }
+        value.ensure_still_alive();
+    }
+
+    /// [`Self::discard_response_body`] for a request this context can no longer respond to.
+    fn discard_handler_result(&self, global_this: &JSGlobalObject, result: JSValue) {
+        let Some(promise) = result.as_any_promise() else {
+            Self::discard_response_body(global_this, result);
+            return;
+        };
+        match promise.unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
+            // Only while `resp` is held: the `on_abort` that follows then reclaims the cell.
+            jsc::PromiseResult::Pending if self.resp.get().is_some() => {
+                let cell = self.create_promise_cell(global_this);
+                result.then_with_value(global_this, cell, Self::ON_RESOLVE, Self::ON_REJECT);
+            }
+            jsc::PromiseResult::Pending | jsc::PromiseResult::Rejected(_) => {}
+            jsc::PromiseResult::Fulfilled(fulfilled) => {
+                Self::discard_response_body(global_this, fulfilled);
+            }
+        }
     }
 
     fn render_missing_invalid_response(&self, value: JSValue) {
@@ -749,8 +797,9 @@ where
         self.render_missing();
     }
 
-    fn handle_resolve(&self, value: JSValue) {
+    fn handle_resolve(&self, global_this: &JSGlobalObject, value: JSValue) {
         if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
+            Self::discard_response_body(global_this, value);
             return;
         }
 
@@ -2035,7 +2084,8 @@ where
         // Armed here, not in `to_async()`: `stop(true)` inside `pull()` must reach `on_abort`; see `end_already_responded_stream`.
         this.set_abort_handler();
         if this.is_aborted_or_ended() {
-            crate::dispatch::fold(stream.cancel(global_this));
+            // No reader yet: `cancel()` would skip the stream.
+            crate::dispatch::fold(stream.cancel_with_reason(global_this, JSValue::UNDEFINED));
             this.response_body_readable_stream_ref
                 .with_mut(|s| s.deinit());
             return;
@@ -2602,19 +2652,10 @@ where
                     // SAFETY: FFI handle
                     resp.write_header(b"transfer-encoding", b"chunked");
                 }
-                // HEAD never transmits the body: cancel the stream so the
-                // source's cancel() runs and its resources are released.
-                // SAFETY: sole `&mut Response`; render_metadata's reborrow ended.
-                let response = unsafe { &mut *response_ptr };
-                if let Some(stream) = response.get_body_readable_stream() {
-                    let _keep = jsc::EnsureStillAlive(stream.value);
-                    response.detach_readable_stream(global_this);
-                    // Unread stream has no reader; `cancel()` would no-op.
-                    crate::dispatch::fold(
-                        stream.cancel_with_reason(global_this, JSValue::UNDEFINED),
-                    );
+                // HEAD never transmits the body.
+                if let Some(response) = this.response_mut() {
+                    Self::cancel_unread_body(response, global_this);
                 }
-                *response.get_body_value() = Body::Value::Used;
                 this.end_without_body(this.should_close_connection());
             }
             Body::Value::Used | Body::Value::Null | Body::Value::Empty | Body::Value::Error(_) => {
@@ -2630,10 +2671,7 @@ where
     #[cold]
     fn on_connection_closed_during_dispatch(&self, this: &ThisServer, result: JSValue) {
         ctx_log!("connection closed during dispatch");
-        if let Some(promise) = result.as_any_promise() {
-            // Subscribing to it would have made a later rejection handled.
-            promise.set_handled(this.global_this().vm());
-        }
+        self.discard_handler_result(this.global_this(), result);
         self.set_abort_handler();
     }
 
@@ -2662,7 +2700,11 @@ where
         let ctx = self;
         request_value.ensure_still_alive();
         response_value.ensure_still_alive();
-        if ctx.drain_microtasks().is_err() || ctx.is_aborted_or_ended() {
+        if ctx.drain_microtasks().is_err() {
+            return;
+        }
+        if ctx.is_aborted_or_ended() {
+            ctx.discard_handler_result(this.global_this(), response_value);
             return;
         }
         if ctx.resp.get().is_some_and(|resp| resp.is_closed()) {
@@ -2674,6 +2716,7 @@ where
         // just ignore the Response object. It doesn't do anything.
         // it's better to do that than to throw an error
         if ctx.did_upgrade_web_socket() {
+            ctx.discard_handler_result(this.global_this(), response_value);
             return;
         }
 
@@ -3429,6 +3472,14 @@ where
 
         this.render_metadata();
 
+        // A null-body status never transmits the body.
+        if let Some(server) = this.server.get()
+            && let Some(response) = this.response_mut()
+            && matches!(response.get_body_value(), Body::Value::Locked(_))
+        {
+            Self::cancel_unread_body(response, server.global_this());
+        }
+
         if status == 304 {
             if let Some(resp) = this.resp.get() {
                 if let Some(len) = app_content_length {
@@ -3591,6 +3642,7 @@ where
                 // error() may have ended the request or called server.upgrade(req),
                 // either of which already released this context's ref.
                 if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
+                    self.discard_handler_result(server.global_this(), result);
                     return;
                 }
                 if self.resp.get().is_some_and(|resp| resp.is_closed()) {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -179,6 +179,14 @@ pub fn from_js(value: JSValue) -> Option<*mut Response> {
     js::from_js(value).map(<*mut ()>::cast::<Response>)
 }
 
+/// [`from_js`] as a shared borrow; `value` must stay rooted while it is used.
+#[inline]
+pub fn from_js_ref(value: JSValue) -> Option<bun_ptr::ParentRef<Response>> {
+    from_js(value)
+        .and_then(core::ptr::NonNull::new)
+        .map(bun_ptr::ParentRef::from)
+}
+
 // `JsClass` impl delegates to `bun_jsc::generated::JSResponse` — the
 // `js_class_module!` expansion already declares the
 // `Response__{fromJS,fromJSDirect,create,getConstructor}` externs with the

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -669,3 +669,231 @@ test.each(stoppedRequests)("server.stop(true) inside the handler of %s aborts it
   expect(server.pendingRequests).toBe(0);
   await stopped!;
 });
+
+// A Response the server will never render still owns a body stream that
+// somebody produces into. The server has to cancel it, like a client abort
+// after the stream was attached does, or the producer waits for a pull that
+// never comes: a `pull()` source is never told, and a writer feeding a
+// TransformStream (hono's streamSSE) blocks forever with everything it
+// closes over.
+test("a Promise<Response> that settles after the client aborted has its body stream cancelled", async () => {
+  const { promise: handlerEntered, resolve: signalHandler } = Promise.withResolvers<void>();
+  const { promise: abortObserved, resolve: signalAbort } = Promise.withResolvers<void>();
+  const { promise: gate, resolve: openGate } = Promise.withResolvers<void>();
+  let handlerResult: Promise<Response> | undefined;
+  const cancelReasons: unknown[] = [];
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      req.signal.addEventListener("abort", () => signalAbort(), { once: true });
+      signalHandler();
+      handlerResult = (async () => {
+        await gate;
+        return new Response(
+          new ReadableStream({
+            cancel(reason) {
+              cancelReasons.push(reason);
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      })();
+      return handlerResult;
+    },
+  });
+
+  const ac = new AbortController();
+  const p = fetch(server.url, { signal: ac.signal }).catch(() => {});
+  await handlerEntered;
+  ac.abort();
+  await p;
+  await abortObserved;
+
+  // The abort tore the context down. Only now does the handler produce its Response.
+  openGate();
+  // The native reaction was attached when the handler returned, so it runs
+  // before this continuation: the cancel is already done here.
+  await handlerResult!;
+  // The same `undefined` reason a client abort after attachment delivers.
+  expect(cancelReasons).toStrictEqual([undefined]);
+  await stopAndAssertDrained(server);
+});
+
+test("a TransformStream writer behind a Response that settles after the client aborted is released", async () => {
+  // hono's streamSSE shape: the handler writes into a TransformStream whose
+  // readable side is the Response body. Nothing reads the body, so the first
+  // write parks on backpressure. Cancelling the body errors the writable side
+  // and settles that write.
+  const { promise: handlerEntered, resolve: signalHandler } = Promise.withResolvers<void>();
+  const { promise: abortObserved, resolve: signalAbort } = Promise.withResolvers<void>();
+  const { promise: gate, resolve: openGate } = Promise.withResolvers<void>();
+  let handlerResult: Promise<Response> | undefined;
+  let writeOutcome: Promise<string> | undefined;
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      req.signal.addEventListener("abort", () => signalAbort(), { once: true });
+      signalHandler();
+      handlerResult = (async () => {
+        await gate;
+        const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+        const writer = writable.getWriter();
+        writeOutcome = writer.write(new TextEncoder().encode("data: hello\n\n")).then(
+          () => "written",
+          () => "rejected",
+        );
+        return new Response(readable, { headers: { "Content-Type": "text/event-stream" } });
+      })();
+      return handlerResult;
+    },
+  });
+
+  const ac = new AbortController();
+  const p = fetch(server.url, { signal: ac.signal }).catch(() => {});
+  await handlerEntered;
+  ac.abort();
+  await p;
+  await abortObserved;
+
+  openGate();
+  await handlerResult!;
+  expect(await writeOutcome!).toBe("rejected");
+  await stopAndAssertDrained(server);
+});
+
+// server.stop(true) inside the handler closes the connection under the
+// request. The handler's result is then a Response the server drops: a plain
+// one, an already-settled promise (an async handler with no await), or a
+// promise that settles after the dispatch is over. The request's signal
+// aborts through the regular teardown either way; the body cancel is the
+// part that was missing.
+type StoppingHandler = (req: Request, srv: ReturnType<typeof Bun.serve>) => Response | Promise<Response>;
+const stoppedServers: Promise<void>[] = [];
+const stoppedHandlers: Array<[string, (body: () => ReadableStream, gate: Promise<void>) => StoppingHandler]> = [
+  [
+    "a Response",
+    body => (_req, srv) => {
+      stoppedServers.push(srv.stop(true));
+      return new Response(body());
+    },
+  ],
+  [
+    "a settled Promise<Response>",
+    body => async (_req, srv) => {
+      stoppedServers.push(srv.stop(true));
+      return new Response(body());
+    },
+  ],
+  [
+    "a pending Promise<Response>",
+    (body, gate) => async (_req, srv) => {
+      stoppedServers.push(srv.stop(true));
+      await gate;
+      return new Response(body());
+    },
+  ],
+];
+
+test.each(stoppedHandlers)(
+  "%s returned after server.stop(true) in the handler has its body stream cancelled",
+  async (_what, makeFetch) => {
+    const { promise: gate, resolve: openGate } = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const body = () =>
+      new ReadableStream({
+        cancel(reason) {
+          events.push(`cancel ${reason}`);
+        },
+      });
+    const handler = makeFetch(body, gate);
+
+    using server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch(req, srv) {
+        req.signal.addEventListener("abort", () => events.push("abort"), { once: true });
+        return handler(req, srv);
+      },
+    });
+
+    await fetch(server.url).then(
+      () => {
+        throw new Error("the request should not get a response");
+      },
+      () => {},
+    );
+    // The stopped server tears the request down as the dispatch ends. A
+    // pending handler result settles only now, into a context that is gone.
+    await stoppedServers.pop()!;
+    expect(server.pendingRequests).toBe(0);
+    openGate();
+    // The cancel runs inside the promise reaction the server attached, which
+    // was registered before anything this test awaits.
+    await gate;
+    await new Promise(resolve => setImmediate(resolve));
+    expect(events.sort()).toEqual(["abort", "cancel undefined"]);
+  },
+);
+
+test("error() returning a streaming Response after server.stop(true) has its body stream cancelled", async () => {
+  let stopped: Promise<void> | undefined;
+  const cancelReasons: unknown[] = [];
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      throw new Error("boom");
+    },
+    error() {
+      stopped = server.stop(true);
+      return new Response(
+        new ReadableStream({
+          cancel(reason) {
+            cancelReasons.push(reason);
+          },
+        }),
+      );
+    },
+  });
+
+  await fetch(server.url).then(
+    () => {
+      throw new Error("the request should not get a response");
+    },
+    () => {},
+  );
+  await stopped!;
+  expect(cancelReasons).toStrictEqual([undefined]);
+  expect(server.pendingRequests).toBe(0);
+});
+
+// A null-body status is sent without its body, as HEAD is: the stream behind
+// it has to be cancelled the same way.
+test.each([204, 304])("a %d Response with a ReadableStream body cancels the stream", async status => {
+  const cancelReasons: unknown[] = [];
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          cancel(reason) {
+            cancelReasons.push(reason);
+          },
+        }),
+        { status },
+      );
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(res.status).toBe(status);
+  expect(await res.text()).toBe("");
+  expect(cancelReasons).toStrictEqual([undefined]);
+  await stopAndAssertDrained(server);
+});


### PR DESCRIPTION
### Problem
- An async `fetch` handler that returns a streaming `Response` after the client disconnected never tells the stream's source to stop. hono's `streamSSE` loop then never exits and holds its closure until its next write parks. Measured with hono 4.12.28 on bun 1.4.1: +11.7 MB heap per 100 disconnects.
- Cause: `on_abort` reclaims the promise cell and frees the `RequestContext`. When the `Promise<Response>` settles later, `on_resolve` (`src/runtime/server/RequestContext.rs:689`) finds no context and drops the `Response` with its body stream open.

### Fix
- `cancel_unread_body`, split out of the HEAD path (#33661), detaches and cancels a body stream the server will not transmit (ReadableStreamCancel with reason `undefined`; `ReadableStream::cancel` is not used because it skips a stream with no reader).
- `discard_response_body` applies it to a dropped handler result, a `Response` or a settled promise of one, through the new safe `response::from_js_ref`. `discard_handler_result` also subscribes a pending promise, while the context still holds its uWS response, so its value reaches `on_resolve` and is discarded there.
- Called from `on_resolve` (reclaimed cell), `handle_resolve`, `on_response` when the request is already aborted, stopped, upgraded, or closed during dispatch, the `error()` early return, `do_render_stream`, and the 204/304 path. No new `unsafe`; the HEAD block's inline deref is gone.
- Verified: `test/js/bun/http/serve-pending-promise-abort-leak.test.ts`, 8 new tests that fail on bun 1.4.1. Also `serve.test.ts`, `bun-server.test.ts`, `websocket-server.test.ts`, and the `serve-*` stream and abort files.

### Background
- A `RequestContext` is the server's per-request state. While the handler's promise is pending, a GC-managed `NativePromiseContext` cell owns a ref on it. `on_resolve` takes the ref back from the cell.
- `on_abort` runs when the connection closes. It reclaims the cell's claim itself and releases the context, so the later `take()` returns `None`. It also fires `request.signal`.
- The server reads a stream body by attaching a sink in `do_render_stream`. Until then the stream has no reader.

<details><summary>Notes</summary>

Reproduction (hono 4.12.28, `streamSSE`, handler awaits 300 ms before returning; client aborts 100 ms after connecting): on bun 1.4.0 and 1.4.1 every round of 100 disconnects leaves 100 `streamJsonChanges` loops alive. hono's `responseReadable` pulls once at start, so the first SSE write goes through and sits in its queue; the loop then polls every second until the next write (a data change, or the heartbeat after 15 s) parks on the `TransformStream`'s backpressure. Only then is the closure unreachable. `heapUsed` grows about 11.7 MB per round while the load runs. The plain connect, read, disconnect pattern (the abort arrives after the stream is attached) does not leak: RSS and object count are flat over 8000 connections. With this fix the loops exit at their next `sleep()` and the heap returns to the idle baseline.

`request.signal` is not touched here. Every path that drops a `Response` because the connection is gone already fires it through `on_abort`: the late-resolve case fired it at the abort, and the `server.stop(true)` and closed-during-dispatch cases reach `on_abort` through `set_abort_handler` in the same dispatch. The `stop(true)` tests assert both the abort event and the cancel. HEAD and 204/304 complete normally, so the signal must not fire there.

`undefined` is the reason an abort after attachment already delivers to the source's `cancel()`. A `Response` fresh from the handler always holds an unlocked, undisturbed stream (the constructor rejects a locked or disturbed one), so `cancel_with_reason` never reaches the native-locked case that `ReadableStream::cancel`'s reader check guards against.

The pending-promise subscription is gated on `resp` still being held. Then the socket under it is closed and `set_abort_handler` runs `on_abort`, which reclaims the claim at once (the "pending Promise<Response> after server.stop(true)" test sees `pendingRequests` at 0 before the promise settles). After an upgrade or a finished abort no teardown runs again, and a claim would pin the context until the promise settles, so those arms discard only a settled value.

The `do_render_stream` change replaces a `cancel()` that was a no-op there (no reader yet). That arm needs the socket to close during a nested event loop run and has no portable test (see #40034).

Known failures on this container that also fail on main: `serve.test.ts` root range port and `/bun:info` loopback, `bun-server.test.ts` IPv6 listen, and the four `websocket-server.test.ts` `send()` benchmark timeouts on the debug build (#39370).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-pending-promise-abort-leak.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/165] gen ErrorCode+*.h
[2/165] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/165] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[4/165] gen cpp.rs (cppbind)
[4/165] cargo bun_runtime → libbun_runtime.a
[162/165] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-13.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings_webcore-13.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections -fdata-sections -faddrsig -fno-semantic
... (truncated)

release without fix: 8 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/http/serve-pending-promise-abort-leak.test.ts:
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: false) [64.57ms]
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: true) [40.93ms]
(pass) Promise<Response> still works normally when not aborted [2.39ms]
(pass) resolve() inside abort handler is handled safely [0.98ms]
(pass) streaming 413 detaches the response so a late resolve/reject is a no-op [2325.31ms]
(pass) chunked request body consumed as a ReadableStream is capped at maxRequestBodySize [8.40ms]
(pass) client abort frees the context even while the resolve function stays reachable [1.29ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.text() read [1.30ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending for await (req.body) read [1.09ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.textStream() read [1.10ms]
(pass) pendingRequests drops when the client aborts a parked di
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-pending-promise-abort-leak.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/http/serve-pending-promise-abort-leak.test.ts:
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: false) [2636.36ms]
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: true) [2084.17ms]
(pass) Promise<Response> still works normally when not aborted [31.22ms]
(pass) resolve() inside abort handler is handled safely [29.85ms]
(pass) streaming 413 detaches the response so a late resolve/reject is a no-op [6837.80ms]
(pass) chunked request body consumed as a ReadableStream is capped at maxRequestBodySize [453.02ms]
(pass) client abort frees the context even while the resolve function stays reachable [34.19ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.text() read [47.07ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending for await (req.body) read [39.03ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 586ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen ErrorCode+*.h
[2/125] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[4/125] gen cpp.rs (cppbind)
[4/125] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs               |  94 +++++++--
 src/runtime/webcore/Response.rs                    |   8 +
 .../http/serve-pending-promise-abort-leak.test.ts  | 228 +++++++++++++++++++++
 3 files changed, 309 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/server/RequestContext.rs                         24     29      0
src/runtime/webcore/Response.rs                               2      3      0
…st/js/bun/http/serve-pending-promise-abort-leak.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->