### PR TITLE
test: lower the stall mark in fetch-backpressure.test.ts to the client's high-water mark

### DIFF
--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -20,6 +20,10 @@ const COUNT = 256; // 16 MiB
 const TOTAL = CHUNK * COUNT;
 const PAYLOAD = Buffer.alloc(CHUNK, 65);
 
+// What the client takes off the socket before it pauses it: `BODY_HIGH_WATER_MARK` in
+// src/http/Signals.rs. Past this mark, only the kernel's buffers take bytes.
+const HIGH_WATER_MARK = 256 * 1024;
+
 function md5(data: Uint8Array | string): string {
   return Bun.CryptoHasher.hash("md5", data, "hex");
 }
@@ -54,8 +58,9 @@ type Server = AsyncDisposable & {
   // What `sent()` reaches once a whole body is out.
   wire: number;
   // Resolves with `sent()` once the body has stopped moving: the socket stopped taking writes past
-  // its first packets (or the whole body is out), and `sent()` then held still for three samples
-  // 10 ms apart. No event reports "nothing more is coming", so the second half has to sample.
+  // the client's high-water mark (or the whole body is out), and `sent()` then held still for
+  // three samples 10 ms apart. No event reports "nothing more is coming", so the second half has
+  // to sample.
   settled: () => Promise<number>;
   // `sent()` reached `n`.
   wrote: (n: number) => Promise<void>;
@@ -76,10 +81,13 @@ function progress(wire: number) {
       for (let i = waiters.length; i--; ) if (sent >= waiters[i][0]) waiters.splice(i, 1)[0][1]();
       if (sent >= wire) finished.resolve();
     },
-    // A write that did not go through once the socket has taken more than 8 chunks: the kernel is
-    // full, not merely slow to take the first packets.
+    // A write that did not go through once the socket has taken more than the client holds before
+    // it pauses. Past that mark only the kernel takes bytes, and `sent()` holding still means it is
+    // full. The mark has to be this low: Windows loopback buffers can stay at about 256 KiB while
+    // the peer is paused, so with chunked framing the socket takes a few bytes short of 8 chunks,
+    // and a mark of 8 chunks was never reached.
     block() {
-      if (sent > 8 * CHUNK) blocked.resolve();
+      if (sent > HIGH_WATER_MARK) blocked.resolve();
     },
     close: () => closed.resolve(),
     api: {
@@ -600,7 +608,7 @@ describe.concurrent("fetch() receive backpressure — streaming consumer shapes"
         while (sent < declared) {
           const n = s.write(PAYLOAD);
           sent += Math.max(n, 0);
-          if (n < PAYLOAD.length) return void (sent > 4 * CHUNK && blocked.resolve(s));
+          if (n < PAYLOAD.length) return void (sent > HIGH_WATER_MARK && blocked.resolve(s));
         }
       };
       using listener = Bun.listen({


### PR DESCRIPTION
### Problem
- `fetch() h1-chunked receive backpressure > stalled no consumer drains the full body` times out after 90 s on Windows 11 aarch64. It failed in 33 of the last 38 builds on that lane, since #40965 landed. It reproduces 3 of 3 on a Windows 11 aarch64 VM when the test runs alone.
- `settled()` in `test/js/web/fetch/fetch-backpressure.test.ts` waits for a `res.write()` that returned false once `sent > 8 * CHUNK` (512 KiB). The client pauses the socket at 256 KiB (`BODY_HIGH_WATER_MARK`). The Windows 11 loopback buffers take about 256 KiB more and do not grow while the peer is paused. With chunked framing the socket takes a few bytes short of 8 chunks, so `sent` stops at exactly 8 chunks and the gate never opens. Nothing sends "go" to the client, and the test hangs.

### Fix
- The gate is now the client's high-water mark: `sent > HIGH_WATER_MARK` (256 KiB). Past that mark only the kernel takes bytes, so `sent()` holding still means the socket is full. The stability sampler that follows the gate does not change.
- Correct because the client always takes at least the high-water mark before it pauses. The gate cannot be missed on any platform, and the sampler still needs `sent()` to hold still for 30 ms before it reports a stall.
- The raw-socket gate in `peer terminate/end while receive is paused` already used this value (`4 * CHUNK`). It now uses the same named constant.
- Verified: `test/js/web/fetch/fetch-backpressure.test.ts` on Windows 11 aarch64 (65 pass, 3 runs), Windows Server 2019 x64 (65 pass, 3 runs), Linux release (70 pass, 2 runs) and Linux debug (67 pass, the 2 h3 timeouts are the known slow debug container case that #37445 covers).

### Background
- Receive backpressure: when nothing reads a fetch body, the HTTP thread stops reading the socket once 256 KiB is staged. The kernel buffers on both sides then fill, and the server's writes stop going through.
- In Bun, `res.write()` with a 64 KiB chunk returns false on every call, because writes are accounted per turn against the 16 KiB high-water mark and `drain` fires on the next tick. So `blocked` resolves on the first write past the gate, and the sampler does the real detection.
- `settled()` has to sample because no event reports "nothing more is coming".

<details><summary>Notes</summary>

- Kernel absorption measured with a raw TCP server and a client that never reads (`net.connect` then `pause()`), 64 KiB writes:
  - Windows 11 aarch64 (build 26100): about 320 KiB at once, grows to about 896 KiB within 2 ms, then no growth for 5 s. With the client reading 320 KiB first: about 1.4 MiB. Under the test's timing the socket took a few bytes short of 8 chunks and never more.
  - Windows Server 2019 x64: about 256 KiB at once, then a jump to about 2.9 MiB after 1.3 s, then 64 KiB every 1.3 to 2.4 s. That jump is why the "no consumer" tests took 1.8 s each on Windows x64: the gate opened only after the kernel grew. They take about 150 ms now.
- Why only h1-chunked: with content-length framing the same socket took 10 to 12 chunks on the same VM, so the 8 chunk gate opened. The chunked framing bytes (8 per chunk) push the 8th write to partial.
- "Passed alone" in CI: on the VM the original test hangs 3 of 3 alone and passes when the 4 "no consumer" siblings run together. The edge is at exactly 8 chunks, so small timing changes flip it.
- Linux release runs need the proxy env unset in this container (the fake S3 bucket's virtual-host URL is routed to the egress proxy otherwise). CI has no such proxy.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch-backpressure.test.ts

<!-- robobun:evidence:end -->