### PR TITLE
bun test --todo: report a todo body that times out as todo, not as a …

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -768,7 +768,14 @@ impl Execution {
         let Some((sequence_ptr, _group_ptr)) =
             self.get_current_and_valid_execution_sequence(user_data)
         else {
-            return HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests;
+            // The entry this error belongs to already finished, typically a test body settling
+            // after it timed out. The result is final either way; for a todo body (--todo) the
+            // late failure is the failure the todo mark already accounts for.
+            return if self.is_todo_test_body(user_data) {
+                HandleUncaughtExceptionResult::HideError
+            } else {
+                HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests
+            };
         };
         // SAFETY: sequence_ptr points into self.sequences; `self` is not accessed for the
         // remainder of this function, so this is the unique live `&mut` to that element.
@@ -803,6 +810,29 @@ impl Execution {
                 HandleUncaughtExceptionResult::ShowHandledError
             }
         }
+    }
+
+    /// Whether `data` was issued for the test callback (not a hook) of a `test.todo`, regardless
+    /// of whether that sequence is still running it. Unlike
+    /// [`Self::get_current_and_valid_execution_sequence`] this also answers for entries that
+    /// already completed; the group/sequence tables never shrink, so the indices stay valid.
+    fn is_todo_test_body(&self, data: &RefDataValue) -> bool {
+        let RefDataValue::Execution { group_index, entry_data: Some(entry_data) } = data else {
+            return false;
+        };
+        let Some(group) = self.groups.get(*group_index) else {
+            return false;
+        };
+        let seq_abs = group.sequence_start + entry_data.sequence_index;
+        if seq_abs >= group.sequence_end {
+            return false;
+        }
+        let sequence = &self.sequences[seq_abs];
+        let Some(test_entry) = sequence.test_entry else {
+            return false;
+        };
+        core::ptr::eq(test_entry.as_ptr().cast_const().cast::<()>(), entry_data.entry)
+            && sequence.entry_mode() == ScopeMode::Todo
     }
 }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1299,8 +1299,9 @@ impl BunTest {
 
         let handle_status: HandleUncaughtExceptionResult = match self.phase {
             Phase::Collection => self.collection.handle_uncaught_exception(user_data),
-            Phase::Done => HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests,
-            Phase::Execution => self.execution.handle_uncaught_exception(user_data),
+            // Once done, every entry is stale; Execution still knows which test body (if any)
+            // the error came from, e.g. a todo that settles while the loop drains after the file.
+            Phase::Execution | Phase::Done => self.execution.handle_uncaught_exception(user_data),
         };
 
         bun_core::scoped_log!(bun_test_group, "onUncaughtException -> {}", <&'static str>::from(handle_status));
@@ -1959,10 +1960,14 @@ impl ExecutionEntry {
                 .test_entry
                 .is_some_and(|p| core::ptr::eq(p.as_ptr().cast_const(), self));
             sequence.result = if is_test_entry {
-                if self.has_done_parameter {
-                    Execution::Result::FailBecauseTimeoutWithDoneCallback
-                } else {
-                    Execution::Result::FailBecauseTimeout
+                match self.base.mode {
+                    // Mirrors the todo arm of Execution::handle_uncaught_exception: a todo body
+                    // (only run under --todo) that never finishes is still a failing todo; only a
+                    // passing one fails the run. `.failing` is intentionally not mapped: a timeout
+                    // still fails a failing test.
+                    ScopeMode::Todo => Execution::Result::Todo,
+                    _ if self.has_done_parameter => Execution::Result::FailBecauseTimeoutWithDoneCallback,
+                    _ => Execution::Result::FailBecauseTimeout,
                 }
             } else if self.has_done_parameter {
                 Execution::Result::FailBecauseHookTimeoutWithDoneCallback

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -223,6 +223,105 @@ describe("bun test", () => {
         `,
       });
       expect(stderr).toContain("should run");
+    });
+
+    async function runTodo(fixture: string, env: Record<string, string> = {}) {
+      using dir = tempDir("bun-test-todo", { "todo.test.ts": fixture });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--todo", "todo.test.ts"],
+        cwd: String(dir),
+        env: { ...bunEnv, ...env },
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      return { stderr: normalizeBunSnapshot(stderr, String(dir)), exitCode };
+    }
+
+    test.concurrent("a todo whose body times out is still a todo", async () => {
+      const { stderr, exitCode } = await runTodo(`
+        import { describe, test } from "bun:test";
+        const late = Promise.withResolvers<void>();
+        test.todo("never settles", () => new Promise(() => {}), 1);
+        test.todo("never calls done", done => {}, 1);
+        describe.todo("describe.todo", () => {
+          test("never settles", () => new Promise(() => {}), 1);
+        });
+        test.todo("fails after it timed out", async () => {
+          await late.promise;
+          throw new Error("still a todo");
+        }, 1);
+        test("the next test is not blamed for the late failure", async () => {
+          late.resolve();
+          await Bun.sleep(0);
+        });
+      `);
+      expect(stderr).toMatchInlineSnapshot(`
+        "todo.test.ts:
+        (todo) never settles
+        (todo) never calls done
+        (todo) describe.todo > never settles
+        (todo) fails after it timed out
+        (pass) the next test is not blamed for the late failure
+
+         1 pass
+         4 todo
+         0 fail
+        Ran 5 tests across 1 file."
+      `);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("timeouts outside a todo body still fail under --todo", async () => {
+      const { stderr, exitCode } = await runTodo(`
+        import { beforeEach, describe, test } from "bun:test";
+        const late = Promise.withResolvers<void>();
+        test("fails after it timed out", async () => {
+          await late.promise;
+          throw new Error("late failure");
+        }, 1);
+        describe("hanging beforeEach", () => {
+          beforeEach(() => new Promise(() => {}), 1);
+          test.todo("todo", () => {});
+        });
+        test("releases the late failure", async () => {
+          late.resolve();
+          await Bun.sleep(0);
+        });
+      `);
+      expect(stderr).toContain("(fail) fails after it timed out\n  ^ this test timed out after 1ms.");
+      expect(stderr).toContain(
+        "(fail) hanging beforeEach > todo\n  ^ a beforeEach/afterEach hook timed out for this test.",
+      );
+      expect(stderr).toContain("# Unhandled error between tests");
+      expect(stderr).toContain("error: late failure");
+      expect(stderr).toContain(" 2 fail\n 1 error\n");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("a timed out todo that fails after the file finished is not an unhandled error", async () => {
+      // BUN_TEST_DRAIN_EVENT_LOOP keeps the file alive after its last test, so
+      // the body settles once the runner is already done with the file.
+      const { stderr, exitCode } = await runTodo(
+        `
+          import { test } from "bun:test";
+          test.todo("fails after the file is done", async () => {
+            await Bun.sleep(50);
+            throw new Error("still a todo");
+          }, 1);
+        `,
+        { BUN_TEST_DRAIN_EVENT_LOOP: "1" },
+      );
+      expect(stderr).toMatchInlineSnapshot(`
+        "todo.test.ts:
+        (todo) fails after the file is done
+
+         0 pass
+         1 todo
+         0 fail
+        Ran 1 test across 1 file."
+      `);
+      expect(exitCode).toBe(0);
     });
   });
   describe("only", () => {


### PR DESCRIPTION
…failure

evaluate_timeout set FailBecauseTimeout (or the done-callback variant) for every test entry regardless of its mode, so under --todo a todo whose body never finished was counted as a failure and made the run exit 1, while a todo body that threw was already reported as todo. Map a Todo test entry to Result::Todo on timeout, the same as the exception path.

A timed out todo body can still settle later (the test runner kills its dangling processes, an awaited promise then rejects). That rejection reached handle_uncaught_exception with data for an entry that already finished and was reported as an unhandled error between tests. When the stale data names the test callback of a todo, hide the error instead; the todo result already accounts for it. Phase::Done goes through the same classification so a body settling while the event loop drains after the file is handled the same way.

Hooks and .failing tests are unchanged: a hook timing out for a todo test is still a failure, and a timeout still fails a failing test.

### What does this PR do?

### How did you verify your code works?
