### PR TITLE
test(bundler): run esbuild/importstar.test.ts concurrently and tighten its assertions

### DIFF
--- a/test/bundler/esbuild/importstar.test.ts
+++ b/test/bundler/esbuild/importstar.test.ts
@@ -1,12 +1,17 @@
 import { describe } from "bun:test";
-import { itBundled } from "../expectBundled";
+import { BundlerTestInput, itBundled as itBundledBase } from "../expectBundled";
 
 // Tests ported from:
 // https://github.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_importstar_test.go
 
 // For debug, all files are written to $TEMP/bun-bundle-tests/importstar
 
-describe("bundler", () => {
+// Default to the CLI backend: itBundled registers API-backend cases with
+// it.serial (Bun.build needs process.chdir), so only CLI-backend cases overlap
+// under describe.concurrent.
+const itBundled = (id: string, opts: BundlerTestInput) => itBundledBase(id, { backend: "cli", ...opts });
+
+describe.concurrent("bundler", () => {
   itBundled("importstar/ImportStarUnused", {
     files: {
       "/entry.js": /* js */ `
@@ -46,6 +51,10 @@ describe("bundler", () => {
         console.log(ns.foo, ns.foo, foo)
       `,
       "/foo.js": `export const foo = 123`,
+    },
+    onAfterBundle(api) {
+      // ns.foo binds to foo directly, so no namespace object is created
+      api.expectFile("/out.js").not.toContain("__export");
     },
     run: {
       stdout: "123 123 234",
@@ -171,6 +180,9 @@ describe("bundler", () => {
       "/foo.js": `export const foo = 123`,
       "/bar.js": `export * from './foo'`,
     },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__export");
+    },
     run: {
       stdout: "123 123 234",
     },
@@ -236,6 +248,13 @@ describe("bundler", () => {
         console.log(ns.foo, ns2.foo)
       `,
       "/foo.js": `export const foo = 123`,
+    },
+    onAfterBundle(api) {
+      // foo.js stays an ES module; require() of it goes through __toCommonJS
+      api.expectFile("/out.js").not.toContain("__commonJS");
+    },
+    run: {
+      stdout: "123 123",
     },
   });
   itBundled("importstar/ImportStarNoBundleUnused", {
@@ -325,7 +344,7 @@ describe("bundler", () => {
       "/entry.js": /* js */ `
         import * as ns from './foo'
         let foo = 234
-        console.log(JSON.stringify(ns), ns.foo, foo)
+        console.log(ns.foo, ns.foo, foo)
       `,
     },
     minifySyntax: true,
@@ -334,7 +353,7 @@ describe("bundler", () => {
       "/foo.js": `export const foo = 123`,
     },
     run: {
-      stdout: '{"foo":123} 123 234',
+      stdout: "123 123 234",
     },
   });
   itBundled("importstar/ImportStarExportStarOmitAmbiguous", {
@@ -559,6 +578,13 @@ describe("bundler", () => {
       `,
     },
     format: "iife",
+    onAfterBundle(api) {
+      // the self re-export resolves statically: no runtime re-export helper
+      api.expectFile("/out.js").not.toContain("__reExport");
+    },
+    run: {
+      stdout: "",
+    },
   });
   itBundled("importstar/ExportSelfIIFEWithName", {
     todo: true,
@@ -846,6 +872,16 @@ describe("bundler", () => {
       "/foo.js": `exports.foo = 123`,
     },
     format: "cjs",
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        const foo = require('./out.js')
+        console.log(JSON.stringify(foo));
+      `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: '{"ns":{"default":{"foo":123},"foo":123}}',
+    },
   });
   itBundled("importstar/NamespaceImportMissingES6", {
     files: {


### PR DESCRIPTION
### Problem
- `test/bundler/esbuild/importstar.test.ts` takes 11s on the debian 13 x64-asan lane (build 108747). The default `itBundled` backend is `api`, which the harness registers with `it.serial` (`expectBundled.ts:1962`), so its 75 cases run one at a time. 64 of them spawn a subprocess for `run`.
- Three cases only check that the build succeeds. `ImportStarMangleNoBundleNoCapture` is a copy of the Capture case.

### Fix
- Default the file to the CLI backend (the wrapper from `bundler_compile.test.ts`) and use `describe.concurrent`. Error and warning cases pass on it unchanged.
- New checks: `ImportStarAndCommonJS` runs the bundle, no `__commonJS` wrapper. `ExportSelfIIFE` runs the bundle, no `__reExport` helper. `ImportExportOtherAsNamespaceCommonJS` requires the bundle and checks the JSON. `ImportStarNoCapture` and `ImportStarExportStarNoCapture`: no namespace object (`__export`). `ImportStarMangleNoBundleNoCapture` gets the upstream no-capture entry point.
- Verified: `bun bd test test/bundler/esbuild/importstar.test.ts` (debug, ASAN): 35.3s and 35.4s before, 12.4s to 14.5s after (six runs). Released bun: 0.7s before, 0.25s after. 75 pass, 4 todo, every run. expect() calls: 64 before, 71 after.

### Background
- The `api` backend calls `Bun.build()` in the test process with `process.chdir`, so the harness makes it serial. The `cli` backend spawns `bun build` in the case's own directory and can overlap.
- `bun test` runs consecutive concurrent cases as one group of up to 20. A serial case ends the group, so the no-`run` cases also use `cli` (on `api` they measured 15.4s).
- `__export` builds a namespace object. `__commonJS` wraps a CommonJS module. `__reExport` copies exports at runtime for `export *` of an external module.

<details><summary>Notes</summary>

What was not changed, and why:
- `ImportStarExportStarAsNoCapture` and `ImportStarExportImportStarNoCapture` get no `__export` check. Bun still materializes the namespace for `ns.foo` through a re-export (esbuild binds `foo` directly). #41009 changes that and adds cases at the end of this file. This branch does not touch those lines.
- `ImportDefaultNamespaceComboNoDefault1` to `4` stay separate builds. Bun reports only the first entry point's error, so one build with four entry points would check one error instead of four.
- No case in the file sets `timeoutScale`.
- No cases are grouped into shared builds. Each case has its own module graph with the same file names (`entry.js`, `foo.js`, `bar.js`).

Other checks:
- `bun bd test ... --todo`: the 4 todo cases still fail, as on main.
- `BUN_BUNDLER_TEST_USE_ESBUILD=1`: main fails 32 cases because the API backend passes neither `format` nor `external` to `esbuild.build()`. This branch fails 2: `ImportStarCommonJSCapture` (esbuild adds `default` to the CommonJS namespace, noted in the case) and `ReExportStarEntryPointAndInnerFileExternal` (#37829).
- Mutation check of the new output checks with the released bun: capturing `ns` in `ImportStarNoCapture` makes `__export` appear and the case fails. A CommonJS `foo.js` in `ImportStarAndCommonJS` makes `__commonJS` appear and the case fails.
- Line 2 (the `itBundled` import) also changes in #36714 and #36134 (they add `expect` to line 1). The merge conflict is those two lines.
- Debug ASAN runs after the change: 12.4s, 12.4s, 12.5s, 14.1s, 12.6s, 14.5s (runner's own `Ran 79 tests` line, host load average about 30). Released bun: 0.78s and 0.67s before, 0.25s and 0.24s after.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/esbuild/importstar.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/esbuild/importstar.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/esbuild/importstar.test.ts:
(pass) bundler > importstar/ImportStarExportImportStarUnused [860.67ms]
(pass) bundler > importstar/ImportStarCapture [933.82ms]
(pass) bundler > importstar/ImportStarUnused [1362.73ms]
(pass) bundler > importstar/ImportStarExportImportStarNoCapture [981.69ms]
(pass) bundler > importstar/ImportStarNoCapture [1252.30ms]
(pass) bundler > importstar/ImportStarExportImportStarCapture [737.57ms]
(pass) bundler > importstar/ImportStarExportStarAsUnused [729.34ms]
(pass) bundler > importstar/ImportStarExportStarAsNoCapture [754.71ms]
(pass) bundler > importstar/ImportStarExportStarAsCapture [944.90ms]
(pass) bundler > importstar/ImportStarExportStarUnused [767.40ms]
(pass) bundler > importstar/ImportStarExportStarCapture [680.23ms]
(pass) bundler > importstar/ImportStarCommonJSUnused [664.77ms]
(pass) bundler > importstar/ImportStarExportStarNoCapture [791.44ms]
(pass) bundler > importstar/ImportStarCommonJSNoCapture [701.31ms]
(pass) bundler > importstar/ImportStarCommonJSCapture [782.90ms]
(pass) bundler > importstar/ImportStarNoBundleUnused [414.74ms]
(pass) bundler > importstar/ImportStarAndCommonJS [682.71ms]
(pass) bundler > importstar/ImportStarNoBundleCapture [696.13ms]
(pass) bundler > importstar/ImportStarNoBundleNoCapture [689.50ms]
(pass) bundler > importstar/ImportStarMangleNoBundleUnused [726.10ms]
(pass) bundler > importstar/ImportStarMangleNoBundleCapture [718.23ms]
(pass) bundler > importstar/ImportStarMangleNoBundleNoCapture [640.67ms]
(pass) bundler > importstar/ImportExportStarAmbiguousError [366.27ms]
(pass) bundler > importstar/ImportStarExportStarOmitAmbiguous [723.51ms]
(pass) bundler > importstar/ImportExportStarAmbiguous [604.14ms]
(pass) bundler > importstar/ReExportStarNameCollisionNotAmbiguousImport [606.40ms]
(pass) bundler > importstar/ReExportS
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/esbuild/importstar.test.ts | 44 ++++++++++++++++++++++++++++++---
 1 file changed, 40 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
test/bundler/esbuild/importstar.test.ts      2      9      0
```

</details>

<!-- robobun:evidence:end -->