### PR TITLE
test(bake): speed up dev/html.test.ts and tighten its assertions

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6691,9 +6691,11 @@ pub mod bv2_impl {
                                     interned_slice(
                                         self.arena()
                                             .alloc_str(&format!(
-                                                "{}/{:016x}{}",
+                                                "{}/{}{}",
                                                 bake_types::ASSET_PREFIX,
-                                                hash,
+                                                bun_core::fmt::bytes_to_hex_lower_string(
+                                                    &hash.to_ne_bytes()
+                                                ),
                                                 bstr::BStr::new(bun_paths::extension(path.text)),
                                             ))
                                             .as_bytes(),

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -77,6 +77,9 @@ devTest("image tag", {
       });
       await dev.fetch("/").expect.toInclude('alt="modified image"');
     });
+    // The image did not change, so the reloaded page keeps its URL and the asset is still served.
+    expect(await c.js`document.querySelector("img").src`).toBe(url);
+    await dev.fetch(url).expect.toBe("FIRST");
 
     // Editing image content causes a hard reload because the html must reflect the new image content
     await c.expectReload(async () => {

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -1,5 +1,122 @@
 // HTML tests are tests relating to HTML files themselves.
-import { devTest, emptyHtmlFile } from "../bake-harness";
+//
+// Every devTest boots a dev server, usually a happy-dom client too, and waits
+// for the server to exit. That is most of a case's time, so cases that start
+// from the same project are one sequence of steps on one server.
+import { expect } from "bun:test";
+import { isWindows } from "harness";
+import { Dev, devTest, emptyHtmlFile } from "../bake-harness";
+
+/** The one module script the dev server injects into every page. */
+const BUNDLE_URL = /^\/_bun\/client\/index-[0-9a-f]{16}\.js$/;
+/** A hashed asset URL. The hash changes with the content. */
+function assetUrl(extension: string) {
+  return new RegExp(`^/_bun/asset/[0-9a-f]{16}\\.${extension}$`);
+}
+
+/**
+ * Fetches a page. The bundler drops the page's own `<script>` and
+ * `<link rel="stylesheet">` tags, and the dev server injects, right before
+ * `</head>`: one `<link>` per stylesheet the page imports, the page's bundle as
+ * one module script, and an inline snippet. Returns the injected URLs and the
+ * rest of the document, with the whitespace between tags collapsed so the
+ * expected document fits on one line.
+ */
+async function fetchPage(dev: Dev, url = "/") {
+  const res = await dev.fetch(url);
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toBe("text/html;charset=utf-8");
+  const html = await res.text();
+  const injected = html.match(
+    /((?:<link rel="stylesheet" href="[^"]+">)*)<script type="module" crossorigin src="([^"]+)" data-bun-dev-server-script><\/script><script>[^<]*<\/script>(?=<\/head>)/,
+  );
+  if (!injected) throw new Error("The dev server did not inject its script tag before </head>:\n" + html);
+  return {
+    html: html.replace(injected[0], "").replace(/\s+/g, " ").replaceAll("> <", "><").trim(),
+    styles: Array.from(injected[1].matchAll(/href="([^"]+)"/g), m => m[1]),
+    script: injected[2],
+  };
+}
+
+/** Fetches an asset and asserts its status and content type. Returns the body as text. */
+async function fetchAsset(dev: Dev, url: string, contentType: string) {
+  const res = await dev.fetch(url);
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toBe(contentType);
+  return res.text();
+}
+
+// Wire format of POST /_bun/report_error (little-endian, length-prefixed):
+//   string32 error name, string32 message, string32 browser url,
+//   u32 frame count, then per frame: i32 line, i32 column,
+//   string32 function name, string32 file name.
+function u32(n: number) {
+  const b = Buffer.alloc(4);
+  b.writeUInt32LE(n >>> 0, 0);
+  return b;
+}
+function i32(n: number) {
+  const b = Buffer.alloc(4);
+  b.writeInt32LE(n, 0);
+  return b;
+}
+function bytes32(bytes: Buffer) {
+  return Buffer.concat([u32(bytes.length), bytes]);
+}
+function str32(s: string) {
+  return bytes32(Buffer.from(s, "utf8"));
+}
+function frame(line: number, column: number, functionName: string | Buffer, fileName: string) {
+  return Buffer.concat([
+    i32(line),
+    i32(column),
+    typeof functionName === "string" ? str32(functionName) : bytes32(functionName),
+    str32(fileName),
+  ]);
+}
+
+async function postErrorReport(dev: Dev, message: string, frames: Buffer[], headers?: Record<string, string>) {
+  const body = Buffer.concat([str32("Error"), str32(message), str32(dev.baseUrl + "/"), u32(frames.length), ...frames]);
+  const res = await dev.fetch("/_bun/report_error", { method: "POST", headers, body });
+  return {
+    status: res.status,
+    contentType: res.headers.get("content-type"),
+    reply: Buffer.from(await res.arrayBuffer()),
+  };
+}
+
+/**
+ * Decodes the reply: u32 frame count, then per frame i32 line, i32 column,
+ * string32 function name, string32 file name (relative to the project root when
+ * it is inside it), then a u8 count of source context lines, which is 0 unless
+ * a frame was remapped through a source map.
+ */
+function decodeReport(reply: Buffer) {
+  let pos = 0;
+  const readU32 = () => {
+    const n = reply.readUInt32LE(pos);
+    pos += 4;
+    return n;
+  };
+  const readI32 = () => {
+    const n = reply.readInt32LE(pos);
+    pos += 4;
+    return n;
+  };
+  const readStr32 = () => {
+    const len = readU32();
+    const s = reply.toString("utf8", pos, pos + len);
+    pos += len;
+    return s;
+  };
+  const frames: { line: number; column: number; functionName: string; fileName: string }[] = [];
+  for (let n = readU32(); n > 0; n--) {
+    frames.push({ line: readI32(), column: readI32(), functionName: readStr32(), fileName: readStr32() });
+  }
+  const contextLines = reply.readUInt8(pos++);
+  expect(pos).toBe(reply.length);
+  return { frames, contextLines };
+}
 
 devTest("html file is watched", {
   files: {
@@ -12,122 +129,117 @@ devTest("html file is watched", {
     `,
   },
   async test(dev) {
-    await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
-    await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
-    await dev.patch("index.html", {
-      find: "Hello",
-      replace: "World",
+    const page = (body: string) => ({
+      html: `<!DOCTYPE html><html><head></head><body>${body}</body></html>`,
+      styles: [],
+      script: expect.stringMatching(BUNDLE_URL),
     });
-    await dev.fetch("/").expect.toInclude("<h1>World</h1>");
+    const first = await fetchPage(dev);
+    expect(first).toEqual(page("<h1>Hello</h1>"));
+    // The second request is served from the cached response.
+    expect(await fetchPage(dev)).toEqual(first);
 
-    // Works
+    await dev.patch("index.html", { find: "Hello", replace: "World" });
+    expect(await fetchPage(dev)).toEqual(page("<h1>World</h1>"));
+
     await using c = await dev.client("/");
     await c.expectMessage("hello");
+    expect(await c.elemText("h1")).toBe("World");
 
-    // Editing HTML reloads
+    // Editing HTML reloads the page.
     await c.expectReload(async () => {
-      await dev.patch("index.html", {
-        find: "World",
-        replace: "Hello",
-      });
-      await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
+      await dev.patch("index.html", { find: "World", replace: "Hello" });
+      expect(await fetchPage(dev)).toEqual(page("<h1>Hello</h1>"));
     });
     await c.expectMessage("hello");
+    expect(await c.elemText("h1")).toBe("Hello");
 
     await c.expectReload(async () => {
-      await dev.patch("index.html", {
-        find: "Hello",
-        replace: "Bar",
-      });
-      await dev.fetch("/").expect.toInclude("<h1>Bar</h1>");
+      await dev.patch("index.html", { find: "Hello", replace: "Bar" });
+      expect(await fetchPage(dev)).toEqual(page("<h1>Bar</h1>"));
     });
     await c.expectMessage("hello");
+    expect(await c.elemText("h1")).toBe("Bar");
 
+    // Editing the script reloads the page too, because the module does not
+    // accept updates. The HTML does not change.
     await c.expectReload(async () => {
-      await dev.patch("script.ts", {
-        find: "hello",
-        replace: "world",
-      });
+      await dev.patch("script.ts", { find: "hello", replace: "world" });
     });
     await c.expectMessage("world");
+    expect(await fetchPage(dev)).toEqual(page("<h1>Bar</h1>"));
   },
 });
 
-devTest("image tag", {
+devTest("image tag and image import", {
   files: {
     "index.html": `
       <!DOCTYPE html><html><head></head><body>
       <img src="image.png" alt="test image">
-      </body></html>
-    `,
-    "image.png": "FIRST",
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-
-    const url: string = await c.js`document.querySelector("img").src`;
-    expect(url).toBeString(); // image tag exists
-    await dev.fetch(url).expect.toBe("FIRST");
-
-    // Editing HTML causes reload but image still works
-    await c.expectReload(async () => {
-      await dev.patch("index.html", {
-        find: 'alt="test image"',
-        replace: 'alt="modified image"',
-      });
-      await dev.fetch("/").expect.toInclude('alt="modified image"');
-    });
-    // The image did not change, so the reloaded page keeps its URL and the asset is still served.
-    expect(await c.js`document.querySelector("img").src`).toBe(url);
-    await dev.fetch(url).expect.toBe("FIRST");
-
-    // Editing image content causes a hard reload because the html must reflect the new image content
-    await c.expectReload(async () => {
-      await dev.patch("image.png", {
-        find: "FIRST",
-        replace: "SECOND",
-      });
-    });
-
-    const url2 = await c.js`document.querySelector("img").src`;
-    expect(url).not.toBe(url2);
-    await dev.fetch(url2).expect.toBe("SECOND");
-
-    await dev.fetch(url).expect404(); // TODO
-  },
-});
-devTest("image import in JS", {
-  files: {
-    "index.html": `
-      <!DOCTYPE html><html><head></head><body>
       <script type="module" src="script.ts"></script>
       </body></html>
     `,
     "script.ts": `
-      import img from "./image.png";
-      console.log(img);
+      import icon from "./icon.png";
+      console.log(icon);
     `,
     "image.png": "FIRST",
+    "icon.png": "ICON 1",
   },
   async test(dev) {
+    const page = (img: string) => ({
+      html: `<!DOCTYPE html><html><head></head><body>${img}</body></html>`,
+      styles: [],
+      script: expect.stringMatching(BUNDLE_URL),
+    });
     await using c = await dev.client("/");
 
-    const img1 = await c.getStringMessage();
-    await dev.fetch(img1).expect.toBe("FIRST");
+    // Both the tag's src and the import resolve to hashed asset URLs. The page
+    // resolves the src against its origin.
+    const icon = await c.getStringMessage();
+    expect(icon).toMatch(assetUrl("png"));
+    const img = new URL(await c.js`document.querySelector("img").src`);
+    expect(img.origin).toBe(dev.baseUrl);
+    expect(img.pathname).toMatch(assetUrl("png"));
+    expect(img.pathname).not.toBe(icon);
+    expect(await fetchPage(dev)).toEqual(page(`<img src="${img.pathname}" alt="test image">`));
+    expect(await fetchAsset(dev, img.pathname, "image/png")).toBe("FIRST");
+    expect(await fetchAsset(dev, icon, "image/png")).toBe("ICON 1");
 
-    // Editing image content updates the image URL
+    // Editing HTML reloads the page. Neither image changed, so neither did its URL.
     await c.expectReload(async () => {
-      await dev.patch("image.png", {
-        find: "FIRST",
-        replace: "SECOND",
-      });
+      await dev.patch("index.html", { find: 'alt="test image"', replace: 'alt="modified image"' });
     });
+    await c.expectMessage(icon);
+    expect(await c.js`document.querySelector("img").src`).toBe(img.href);
+    expect(await fetchPage(dev)).toEqual(page(`<img src="${img.pathname}" alt="modified image">`));
 
-    const img2 = await c.getStringMessage();
-    await dev.fetch(img2).expect.toBe("SECOND");
-    // await dev.fetch(img1).expect404();
+    // Editing the image in the tag reloads the page, because the HTML must
+    // point at the new content. The old URL is gone.
+    await c.expectReload(async () => {
+      await dev.patch("image.png", { find: "FIRST", replace: "SECOND" });
+    });
+    await c.expectMessage(icon);
+    const img2 = new URL(await c.js`document.querySelector("img").src`);
+    expect(img2.pathname).toMatch(assetUrl("png"));
+    expect(img2.pathname).not.toBe(img.pathname);
+    expect(await fetchPage(dev)).toEqual(page(`<img src="${img2.pathname}" alt="modified image">`));
+    expect(await fetchAsset(dev, img2.pathname, "image/png")).toBe("SECOND");
+    await dev.fetch(img.pathname).expect404();
+
+    // Editing the imported image reloads the page, and the import sees the new URL.
+    await c.expectReload(async () => {
+      await dev.patch("icon.png", { find: "ICON 1", replace: "ICON 2" });
+    });
+    const icon2 = await c.getStringMessage();
+    expect(icon2).toMatch(assetUrl("png"));
+    expect(icon2).not.toBe(icon);
+    expect(await fetchAsset(dev, icon2, "image/png")).toBe("ICON 2");
+    await dev.fetch(icon).expect404();
+    expect(await c.js`document.querySelector("img").src`).toBe(img2.href);
   },
 });
+
 devTest("import then create", {
   files: {
     "index.html": `
@@ -145,15 +257,30 @@ devTest("import then create", {
     `,
   },
   async test(dev) {
-    const c = await dev.client("/", {
+    // The unresolved import fails the build, so the route serves the error page.
+    // Serving it once leaked the route's source map in memory (#17738), which
+    // the dev server's allocation checks at exit catch.
+    const failed = await dev.fetch("/");
+    expect(failed.status).toBe(500);
+    expect(failed.headers.get("content-type")).toBe("text/html;charset=utf-8");
+    expect(await failed.text()).toContain("<title>Bun - Build Failed</title>");
+
+    await using c = await dev.client("/", {
       errors: ['script.ts:1:18: error: Could not resolve: "./data"'],
     });
+    // Creating the missing file fixes the build and reloads the page.
     await c.expectReload(async () => {
       await dev.write("data.ts", "export default 'data';");
     });
     await c.expectMessage("data");
+    expect(await fetchPage(dev)).toEqual({
+      html: "<!DOCTYPE html><html><head></head><body></body></html>",
+      styles: [],
+      script: expect.stringMatching(BUNDLE_URL),
+    });
   },
 });
+
 devTest("external links", {
   files: {
     "index.html": `
@@ -182,197 +309,106 @@ devTest("external links", {
     `,
   },
   async test(dev) {
+    // The relative stylesheet and script are bundled and move into the injected
+    // tags. The external icon link stays as it is.
+    const page = await fetchPage(dev);
+    expect(page).toEqual({
+      html: '<!doctype html><html><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>index | Powered by Bun</title><link rel="icon" type="image/x-icon" href="https://bun.sh/favicon.ico" /></head><body><div id="root"></div></body></html>',
+      styles: [expect.stringMatching(assetUrl("css"))],
+      script: expect.stringMatching(BUNDLE_URL),
+    });
+    expect(await fetchAsset(dev, page.styles[0], "text/css;charset=utf-8")).toBe(
+      "/* index.css */\nbody {\n  background-color: red;\n}\n",
+    );
+    expect(await fetchAsset(dev, page.script, "text/javascript;charset=utf-8")).toContain('console.log("hello")');
+
     await using c = await dev.client("/");
     await c.expectMessage("hello");
-
+    await c.style("body").backgroundColor.expect.toBe("red");
     const ico: string = await c.js`document.querySelector("link[rel='icon']").href`;
     expect(ico).toBe("https://bun.sh/favicon.ico");
   },
 });
-devTest("memory leak case 1", {
-  files: {
-    "index.html": `
-      <script type="module" src="/script.ts"></script>
-    `,
-    "script.ts": `
-      import data from "./data";
-    `,
-  },
-  async test(dev) {
-    await dev.fetch("/"); // previously leaked source map
-  },
-});
 
-devTest("chrome devtools automatic workspace folders", {
+devTest("chrome devtools json and error report endpoints", {
   files: {
-    "index.html": `
-      <script type="module" src="/script.ts"></script>
-    `,
+    "index.html": emptyHtmlFile({
+      scripts: ["/script.ts"],
+      body: "<h1>Endpoints</h1>",
+    }),
     "script.ts": `
       console.log("hello");
     `,
   },
   async test(dev) {
-    const response = await dev.fetch("/.well-known/appspecific/com.chrome.devtools.json");
-    expect(response.status).toBe(200);
-    const json = await response.json();
-    const root = dev.join(".");
-    expect(json).toMatchObject({
+    // Chrome DevTools automatic workspace folders. The uuid is a hash of the
+    // entry point and the project root, so every request gets the same one.
+    const devtoolsUrl = "/.well-known/appspecific/com.chrome.devtools.json";
+    const devtools = await dev.fetch(devtoolsUrl);
+    expect(devtools.status).toBe(200);
+    expect(devtools.headers.get("content-type")).toBe("application/json");
+    const workspace = await devtools.json();
+    expect(workspace).toEqual({
       workspace: {
-        root,
-        uuid: expect.any(String),
+        root: dev.rootDir,
+        uuid: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/),
       },
     });
-  },
-});
+    expect(await dev.fetch(devtoolsUrl).json()).toEqual(workspace);
 
-devTest("error report endpoint handles stack frames with very long absolute paths", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["/script.ts"],
-      body: "<h1>Error Report</h1>",
-    }),
-    "script.ts": `
-      console.log("hello");
-    `,
-  },
-  async test(dev) {
-    // Wire format of POST /_bun/report_error (length-prefixed binary):
-    //   string32 error name, string32 message, string32 browser url,
-    //   u32 frame count, then per frame: i32 line, i32 column,
-    //   string32 function name, string32 file name.
-    function u32(n: number) {
-      const b = Buffer.alloc(4);
-      b.writeUInt32LE(n >>> 0, 0);
-      return b;
-    }
-    function i32(n: number) {
-      const b = Buffer.alloc(4);
-      b.writeInt32LE(n, 0);
-      return b;
-    }
-    function str32(s: string) {
-      const bytes = Buffer.from(s, "utf8");
-      return Buffer.concat([u32(bytes.length), bytes]);
-    }
-    function frame(line: number, column: number, functionName: string, fileName: string) {
-      return Buffer.concat([i32(line), i32(column), str32(functionName), str32(fileName)]);
-    }
-
-    // One ordinary frame pointing at a real project file, plus one frame whose
-    // absolute path is far larger than any platform path buffer (16 KiB).
-    const normalPath = dev.join("script.ts");
-    const oversizedPath = "/" + "A/".repeat(8192);
-    const body = Buffer.concat([
-      str32("Error"), // error name
-      str32("test message"), // error message
-      str32(dev.baseUrl + "/"), // browser url
-      u32(2), // stack frame count
-      frame(1, 1, "first", normalPath),
+    // One frame in a project file and one whose absolute path is far larger
+    // than any platform path buffer (16 KiB). Neither is in a bundle, so
+    // neither is remapped. The reply makes a path relative to the root only
+    // when it starts with "/": the project file on posix, never on Windows.
+    // The oversized path is longer than the posix path buffers, so it stays
+    // as is there. Windows (98K buffer) can make it relative, which drops its
+    // trailing slash. The run of segments before that is stable.
+    const projectFile = dev.join("script.ts");
+    const segments = Buffer.alloc(2 * 8192, "A/").toString();
+    const oversizedPath = "/" + segments;
+    const longPath = await postErrorReport(dev, "test message", [
+      frame(1, 1, "first", projectFile),
       frame(1, 1, "second", oversizedPath),
     ]);
-
-    const res = await dev.fetch("/_bun/report_error", { method: "POST", body });
-    expect(res.status).toBe(200);
-    // The reply still references the legitimate frame's file.
-    const text = await res.text();
-    expect(text).toContain("script.ts");
-
-    // The dev server must still be serving requests afterwards.
-    await dev.fetch("/").expect.toInclude("<h1>Error Report</h1>");
-  },
-});
-
-devTest("error report endpoint rejects requests whose origin header does not match the dev server", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["/script.ts"],
-      body: "<h1>Origin Check</h1>",
-    }),
-    "script.ts": `
-      console.log("hello");
-    `,
-  },
-  async test(dev) {
-    function u32(n: number) {
-      const b = Buffer.alloc(4);
-      b.writeUInt32LE(n >>> 0, 0);
-      return b;
-    }
-    function str32(s: string) {
-      const bytes = Buffer.from(s, "utf8");
-      return Buffer.concat([u32(bytes.length), bytes]);
-    }
-    const body = Buffer.concat([str32("Error"), str32("origin-check-message"), str32(dev.baseUrl + "/"), u32(0)]);
-
-    const crossOrigin = await dev.fetch("/_bun/report_error", {
-      method: "POST",
-      headers: { Origin: "http://other-page.example" },
-      body,
+    expect(longPath.status).toBe(200);
+    expect(longPath.contentType).toBe("application/octet-stream");
+    expect(decodeReport(longPath.reply)).toEqual({
+      frames: [
+        { line: 1, column: 1, functionName: "first", fileName: isWindows ? projectFile : "script.ts" },
+        { line: 1, column: 1, functionName: "second", fileName: expect.stringContaining(segments.slice(0, -1)) },
+      ],
+      contextLines: 0,
     });
-    expect(await crossOrigin.text()).toBe("Blocked: Origin header does not match the dev server");
+    // The report is printed to the dev server's terminal.
+    await dev.output.waitForLine(/error.*test message/);
+
+    // The Origin header has to be the dev server's own when it is present.
+    const crossOrigin = await postErrorReport(dev, "origin-check-message", [], { Origin: "http://other-page.example" });
+    expect(crossOrigin.reply.toString()).toBe("Blocked: Origin header does not match the dev server");
     expect(crossOrigin.status).toBe(403);
-
-    const sameOrigin = await dev.fetch("/_bun/report_error", {
-      method: "POST",
-      headers: { Origin: dev.baseUrl },
-      body,
-    });
+    const sameOrigin = await postErrorReport(dev, "origin-check-message", [], { Origin: dev.baseUrl });
     expect(sameOrigin.status).toBe(200);
+    expect(decodeReport(sameOrigin.reply)).toEqual({ frames: [], contextLines: 0 });
 
-    await dev.fetch("/").expect.toInclude("<h1>Origin Check</h1>");
-  },
-});
-
-devTest("error report endpoint blanks stray non-text bytes in reported frames", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["/script.ts"],
-      body: "<h1>Frame Bytes</h1>",
-    }),
-    "script.ts": `
-      console.log("hello");
-    `,
-  },
-  async test(dev) {
-    function u32(n: number) {
-      const b = Buffer.alloc(4);
-      b.writeUInt32LE(n >>> 0, 0);
-      return b;
-    }
-    function i32(n: number) {
-      const b = Buffer.alloc(4);
-      b.writeInt32LE(n, 0);
-      return b;
-    }
-    function bytes32(bytes: Buffer) {
-      return Buffer.concat([u32(bytes.length), bytes]);
-    }
-    function str32(s: string) {
-      return bytes32(Buffer.from(s, "utf8"));
-    }
-
+    // A stray C1 control byte in a frame is blanked, in the terminal and in the reply.
     const functionName = Buffer.concat([Buffer.from("fnstart"), Buffer.from([0x9b]), Buffer.from("fnend")]);
-    const body = Buffer.concat([
-      str32("Error"),
-      str32("frame-bytes-message"),
-      str32(dev.baseUrl + "/"),
-      u32(1),
-      i32(1),
-      i32(1),
-      bytes32(functionName),
-      str32("foo.ts"),
-    ]);
+    const strayByte = await postErrorReport(dev, "frame-bytes-message", [frame(1, 1, functionName, "foo.ts")]);
+    expect(strayByte.status).toBe(200);
+    expect(decodeReport(strayByte.reply)).toEqual({
+      frames: [{ line: 1, column: 1, functionName: "fnstart fnend", fileName: "foo.ts" }],
+      contextLines: 0,
+    });
+    await dev.output.waitForLine(/at .*fnstart fnend.*foo\.ts/);
 
-    const res = await dev.fetch("/_bun/report_error", { method: "POST", body });
-    const reply = Buffer.from(await res.arrayBuffer());
-    expect(reply.includes(Buffer.from("fnstart fnend", "latin1"))).toBe(true);
-    expect(reply.includes(0x9b)).toBe(false);
-    expect(res.status).toBe(200);
-
-    await dev.fetch("/").expect.toInclude("<h1>Frame Bytes</h1>");
+    // The dev server still serves the page afterwards.
+    expect(await fetchPage(dev)).toEqual({
+      html: "<!DOCTYPE html><html><head></head><body><h1>Endpoints</h1></body></html>",
+      styles: [],
+      script: expect.stringMatching(BUNDLE_URL),
+    });
   },
 });
+
 devTest("editing a file imported from outside the project root hot-reloads", {
   // The Windows watcher does not watch files outside the project directory.
   skip: ["win32"],


### PR DESCRIPTION
### Problem
- `test/bake/dev/html.test.ts` takes 10s on the debian 13 x64-asan lane (build 108747), 24.7s locally on debug+ASAN. Its 11 cases boot one dev server each, and each exit costs about 1.2s on a debug build. Some assertions are substring checks or cannot fail.
- The first commit is #41059, a one-line fix for a regression these assertions found (a cached asset's URL comes out byte-reversed after an HTML edit). It is here so CI runs green. This PR is the second commit only.

### Fix
- Cases from the same project share one server: 11 cases become 6. Debug+ASAN: 24.7s before, 16.0s to 16.3s after (4 runs). Release: 3s.
- The devtools and the three error report cases are one case, the memory leak case is the first step of "import then create", the two image cases share one page with two assets. The watch case and "external links" keep their server, the out-of-root case its `cwd`.
- Assertions: the whole served document, status and content type of each page and asset, the decoded `/_bun/report_error` reply, the devtools JSON, the client's DOM after reloads. 40 `expect()` calls become 105. The client in "import then create" is disposed.
- Verified: `bun bd test test/bake/dev/html.test.ts`, 4 runs of this shape. Without #41059 the image case fails at the URL comparison. Also `dev/css.test.ts` and `dev-and-prod.test.ts`.

### Background
- `devTest` (`test/bake/bake-harness.ts`) boots a dev server per case. `dev.client()` is a happy-dom page that reports its `console.log` output and reloads. No harness change here: it has no concurrent or shared-server mode.
- The dev server replaces a page's `<script>` and stylesheet `<link>` tags with tags injected before `</head>`: a `<link>` per stylesheet, one module script, an inline snippet. The test splits them off and pins their URLs by shape.
- The `/_bun/report_error` reply is length-prefixed binary: the frames, then source context lines. The test decodes it and compares frame by frame.

<details><summary>Notes</summary>

**Timing.** Per case under debug+ASAN, from the log: about 0.3s to the port line, 0.5s for the first `dev.client()`, 0.8s to 1.2s for `gracefulExit`. That last cost is `require("bun:internal-for-testing")` in the harness's graceful-exit handler (`bake-harness.ts:2055`), 1.2s on the debug build and 15ms on release. #37494 makes that module lazy, which would remove it for every bake case. Before: html-1 2.9s, html-2 2.3s, html-3 2.3s, html-4 2.1s, html-5 2.0s, html-6 1.6s, html-7 1.4s, html-8 1.6s, html-9 1.5s, html-10 1.6s, html-11 2.2s. After: 2.8s, 2.4s, 2.1s, 1.9s, 1.6s, 2.2s. Whole file: 24.66s and 24.80s before, 16.08s, 16.33s, 16.09s and 15.98s after.

**The harness.** #40541 adds a `concurrent` option to `devTest`. This PR does not depend on it and does not copy it. If #40541 lands, every case here can opt in as is, because each still owns its directory, server and clients. The two changes stack: with 5 concurrent cases on an ASAN lane, the file's time becomes its longest case.

**The merges and what each keeps.**
- The chrome devtools case and the three error report cases are one case. None of them edited files. Their old "still serving" checks are one fetch of the whole document at the end.
- "memory leak case 1" is the first step of "import then create": a fetch of a route whose script has an unresolved import, the same starting state, which that case's client loads anyway. The leak it guards (#17738) is caught by the dev server's allocation scope at exit, which runs at the end of every case.
- "image tag" and "image import in JS" share one page with two assets (`image.png` in the tag, `icon.png` in the script), so each edit reloads the page for one reason and the other asset's URL can be asserted unchanged. With one asset in both places the debug HMR runtime hits `DEBUG.ASSERT(!boundary.endsWith(".html"))` in `replaceModules` (`src/runtime/bake/hmr-module.ts:694`): the server sends the asset's update as a JS hot update and the client finds the HTML route as the non-accepting root. That is a separate bug, not changed here.
- #40733, #40326 and #36013 each add cases next to the old endpoint cases. Whichever lands first, the other side moves its new cases once.

**Assertion changes, case by case.**
- html watch: full document equality after each fetch (the second must equal the first), the `<h1>` in the client's DOM after each reload, the document after the script edit.
- images: both URLs pinned by shape and distinct, `image/png` content type and body for each, the `<img>` in the served document, the URL unchanged after the HTML edit (fails without #41059), the old URL 404 after each content edit, the other asset unchanged on each edit.
- import then create: the failing route's 500 status, content type and `<title>Bun - Build Failed</title>`, the served document after the fix, `await using` on the client.
- external links: full document, the stylesheet's `text/css` body, the bundle's `text/javascript` content type and that it holds the module, the computed `background-color` in the client.
- devtools: content type, exact JSON with the uuid's shape, a second request returns the same JSON (the uuid is a hash of the entry point and the root).
- error reports: content type, the reply decoded frame by frame (2 frames, 0 frames, 1 frame: function names, file names, line and column, no source context), the 403 body, the dev server's terminal lines for the report and for the blanked frame name. The reply relativizes only paths that start with `/`, so on Windows the project file frame keeps its absolute path. The oversized path stays as is on posix (longer than the path buffers) and can be made relative on Windows, which drops its trailing slash, so the assertion is on the segments before it.

**Not changed.** `test/expected-durations.json` is regenerated from CI by its own pipeline.

**Runs.** `bun bd test test/bake/dev/html.test.ts` 4 times in this shape (16.08s, 16.33s, 16.09s, 15.98s), `bun bd test test/bake/dev/css.test.ts test/bake/dev-and-prod.test.ts` (27 pass), prettier.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/html.test.ts

<!-- robobun:evidence:end -->