### PR TITLE
server: run the error handler when a locked response body cannot become a stream

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -27,7 +27,6 @@
 "reimplemented_helper:src/react_compiler/reactive_scopes/propagate_early_returns.rs" = 1
 
 [bun_runtime]
-"defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
 "error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1
 "error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3277,9 +3277,13 @@ where
 
                 if lock.on_receive_value.is_some() || lock.task.is_some() {
                     // someone else is waiting for the stream or waiting for `onStartStreaming`
-                    let Ok(readable) = value.to_readable_stream(global_this) else {
-                        return;
-                    }; // TODO: properly propagate exception upwards
+                    let readable = match value.to_readable_stream(global_this) {
+                        Ok(readable) => readable,
+                        Err(err) => {
+                            this.run_error_handler(global_this.take_exception(err));
+                            return;
+                        }
+                    };
                     readable.ensure_still_alive();
                     this.do_render_with_body(std::ptr::from_mut(value), None);
                     return;


### PR DESCRIPTION
### Problem
- `do_render_with_body` (`src/runtime/server/RequestContext.rs:3280`) renders a `Response` whose body is still `Locked` and owned by a producer, the `return fetch(url)` proxy case. It calls `Body::Value::to_readable_stream` to materialize the stream. When that call fails, the code is `let Ok(readable) = ... else { return; }` with a `TODO: properly propagate exception upwards`.
- The failure is a `JsError`: the exception stays pending on the VM, no error handler runs, no status is written, and the request is never answered. The client waits until the idle timeout. The mordant lint `defaulted_failure` reports this site as the one entry for `defaulted_failure:src/runtime/server/RequestContext.rs`.

### Fix
- Match on the result. On `Err`, take the exception with `global_this.take_exception(err)` and hand it to `this.run_error_handler(..)`, the same path the `Body::Value::Error` arm of this function uses. The request then gets the `error()` handler result or the default 500.
- `run_error_handler_with_status_code` already returns early when the response has been written or when the VM has stopped, so a termination "exception" still ends quietly.
- Removes the `"defaulted_failure:src/runtime/server/RequestContext.rs" = 1` line from `mordant-baseline.toml`. Verified with the pinned mordant locally: `bun_runtime` reports no finding over the baseline.
- Verified: `test/js/bun/http/serve.test.ts`, `proxy-stress-errors.test.ts`, `serve-direct-readable-stream.test.ts` with the debug build. No new test: `to_readable_stream` fails here only when JSC cannot allocate the stream wrapper or the VM is terminating, which a test cannot trigger without fault injection.

### Background
- `Body::Value::Locked` is a body whose bytes are still arriving from a producer (the HTTP client, the server request body, HTMLRewriter). `to_readable_stream` wraps it in a native `ByteStream` backed `ReadableStream` so the server can pipe it.
- `JsError` is the marker that a JS exception is pending on the VM. `take_exception` clears it and returns the value. A pending exception that nobody takes surfaces at the next unrelated JS entry.
- `mordant-baseline.toml` is a ratchet of lint findings accepted as pre-existing. CI fails only when a (lint, file) pair grows past its count. Fixing a site lets its line be removed.
