### PR TITLE
test(bundler): run esbuild/default.test.ts on the cli backend and pin more outputs

### DIFF
--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -3,7 +3,6 @@ import { describe, expect } from "bun:test";
 import { osSlashes } from "harness";
 import path from "path";
 import {
-  BundlerTestBundleAPI,
   BundlerTestInput,
   BundlerTestWrappedAPI,
   dedent,
@@ -1303,10 +1302,12 @@ describe.concurrent("bundler", () => {
       `,
     },
     banner: "#! from banner",
+    // esm output drops the directive. iife keeps it, so all three lines are observable.
+    format: "iife",
     // The cli backend passes --banner="..." with the quotes in the value.
     backend: "api",
     onAfterBundle(api) {
-      api.expectFile("/out.js").toStartWith("#! in file\n#! from banner\n");
+      api.expectFile("/out.js").toStartWith('#! in file\n#! from banner\n"use strict";\n');
     },
   });
   itBundled("default/RequireFSBrowser", {
@@ -2119,16 +2120,19 @@ describe.concurrent("bundler", () => {
       `,
     },
     format: "iife",
-    outfile: "/out.js",
+    // `var arguments` is only legal in sloppy mode, so the output runs as CommonJS.
+    outfile: "/out.cjs",
     minifyIdentifiers: true,
+    bundling: false,
     onAfterBundle(api) {
       // `arguments` inside a regular function is the implicit object and is
       // never renamed: the 8 functions keep their `(x = arguments)` default
       // and the 3 `var arguments` redeclarations survive.
-      const code = api.readFile("/out.js");
+      const code = api.readFile("/out.cjs");
       expect(code.match(/\(\w+ = arguments\)/g)).toHaveLength(8);
       expect(code.match(/var arguments;/g)).toHaveLength(3);
     },
+    run: { stdout: "marker" },
   });
   itBundled("default/WithStatementTaintingNoBundle", {
     files: {
@@ -2643,6 +2647,7 @@ describe.concurrent("bundler", () => {
       `,
     },
     minifyIdentifiers: true,
+    bundling: false,
     onAfterBundle(api) {
       const text = api.readFile("/out.js");
       assert(text.includes("doNotRenameMe"), "bundler should not have renamed `doNotRenameMe`");
@@ -2675,6 +2680,7 @@ describe.concurrent("bundler", () => {
       `,
     },
     minifyIdentifiers: true,
+    bundling: false,
     onAfterBundle(api) {
       const text = api.readFile("/out.js");
       const labels = [...text.matchAll(/([a-z0-9]+):/gi)].map(x => x[1]);
@@ -5404,34 +5410,34 @@ describe.concurrent("bundler", () => {
     `,
   };
   const relocateEntries = ["/top-level.js", "/nested.js", "/let.js", "/function.js", "/function-nested.js"];
-  const relocateChecks = (api: BundlerTestBundleAPI) => {
-    // The legacy `for (var i = 1 in {})` initializer becomes a statement
-    // before the loop in every file that has it.
-    for (const entry of relocateEntries) {
-      const code = api.readFile("/out" + entry);
-      expect(code).not.toContain("= 1 in");
-      if (entry !== "/let.js") expect(code).toContain("i = 1;");
-    }
-    // A function declaration in a nested block is hoisted as a `var`.
-    for (const entry of ["/nested.js", "/function-nested.js"]) {
-      const code = api.readFile("/out" + entry);
-      expect(code).not.toContain("function l()");
-      expect(code).toContain("var l");
-    }
-    expect(api.readFile("/out/function.js")).toContain("function l() {}");
-  };
 
   itBundled("default/VarRelocatingBundle", {
     files: relocateFiles,
     entryPoints: relocateEntries,
     format: "esm",
-    onAfterBundle: relocateChecks,
+    onAfterBundle(api) {
+      // The legacy `for (var i = 1 in {})` initializer becomes a statement
+      // before the loop in every file that has it.
+      for (const entry of relocateEntries) {
+        const code = api.readFile("/out" + entry);
+        expect(code).not.toContain("= 1 in");
+        if (entry !== "/let.js") expect(code).toContain("i = 1;");
+      }
+      // A function declaration in a nested block is hoisted as a `var`.
+      for (const entry of ["/nested.js", "/function-nested.js"]) {
+        const code = api.readFile("/out" + entry);
+        expect(code).not.toContain("function l()");
+        expect(code).toContain("var l");
+      }
+      expect(api.readFile("/out/function.js")).toContain("function l() {}");
+    },
   });
+  // Registered as todo: the harness has no --no-bundle for more than one entry point.
   itBundled("default/VarRelocatingNoBundle", {
     files: relocateFiles,
     entryPoints: relocateEntries,
     format: "esm",
-    onAfterBundle: relocateChecks,
+    bundling: false,
   });
   itBundled("default/ImportNamespaceThisValue", {
     // GENERATED

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2,12 +2,32 @@ import assert from "assert";
 import { describe, expect } from "bun:test";
 import { osSlashes } from "harness";
 import path from "path";
-import { dedent, ESBUILD_PATH, itBundled } from "../expectBundled";
+import {
+  BundlerTestBundleAPI,
+  BundlerTestInput,
+  BundlerTestWrappedAPI,
+  dedent,
+  ESBUILD_PATH,
+  itBundled as itBundledBase,
+} from "../expectBundled";
 
 // Tests ported from:
 // https://github.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_default_test.go
 
 // For debug, all files are written to $TEMP/bun-bundle-tests/default
+
+// Default to the CLI backend. The API backend calls process.chdir, so
+// expectBundled registers its cases with it.serial, and each one is a barrier
+// for the concurrent cases around it. A case that needs Bun.build sets
+// backend: "api" itself.
+const itBundled = Object.assign(
+  (id: string, opts: BundlerTestInput | ((metadata: BundlerTestWrappedAPI) => BundlerTestInput)) =>
+    itBundledBase(
+      id,
+      typeof opts === "function" ? metadata => ({ backend: "cli", ...opts(metadata) }) : { backend: "cli", ...opts },
+    ),
+  { skip: itBundledBase.skip },
+);
 
 describe.concurrent("bundler", () => {
   itBundled("default/SimpleES6", {
@@ -74,7 +94,11 @@ describe.concurrent("bundler", () => {
         module.exports = {Foo};
       `,
     },
-    run: true,
+    onAfterBundle(api) {
+      // The call must stay the target of `new`, not become `new require_foo().Foo`.
+      api.expectFile("/out.js").toContain("new (require_foo()).Foo");
+    },
+    run: { stdout: "" },
   });
   itBundled("default/CommonJSFromES6", {
     files: {
@@ -173,6 +197,7 @@ describe.concurrent("bundler", () => {
     format: "esm",
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ExportFormsIIFE", {
@@ -255,6 +280,7 @@ describe.concurrent("bundler", () => {
     },
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   // this two were edited heavily. They used to be all importing from `foo`, but here i have it
@@ -312,6 +338,7 @@ describe.concurrent("bundler", () => {
     },
     run: {
       file: "/test.js",
+      stdout: "",
     },
     bundling: false,
   } as const;
@@ -385,6 +412,7 @@ describe.concurrent("bundler", () => {
     },
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ExportChain", {
@@ -399,8 +427,14 @@ describe.concurrent("bundler", () => {
         strictEqual(module.a, 123);
       `,
     },
+    onAfterBundle(api) {
+      // The chain collapses to one binding exported under the final alias.
+      api.expectFile("/out.js").toContain("c as a");
+      api.expectFile("/out.js").not.toMatch(/\bb\b/);
+    },
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ExportInfiniteCycle1", {
@@ -1102,7 +1136,11 @@ describe.concurrent("bundler", () => {
         main('fs')
       `,
     },
-    run: true,
+    onAfterBundle(api) {
+      // A dynamic import of a non-literal stays a dynamic import.
+      api.expectFile("/out.js").toContain("return await import(name);");
+    },
+    run: { stdout: "" },
   });
   itBundled("default/ImportInsideTry", {
     files: {
@@ -1233,7 +1271,12 @@ describe.concurrent("bundler", () => {
         })()
       `,
     },
-    run: true,
+    onAfterBundle(api) {
+      // The call and the hoisted `var` must keep the same name.
+      api.expectFile("/out.js").toContain("b();");
+      api.expectFile("/out.js").toContain("var b = () => {};");
+    },
+    run: { stdout: "" },
   });
   itBundled("default/HashbangBundle", {
     files: {
@@ -1260,8 +1303,10 @@ describe.concurrent("bundler", () => {
       `,
     },
     banner: "#! from banner",
+    // The cli backend passes --banner="..." with the quotes in the value.
+    backend: "api",
     onAfterBundle(api) {
-      assert(api.readFile("/out.js").startsWith("#! in file"), "hashbang from banner does not override file hashbang");
+      api.expectFile("/out.js").toStartWith("#! in file\n#! from banner\n");
     },
   });
   itBundled("default/RequireFSBrowser", {
@@ -1350,6 +1395,7 @@ describe.concurrent("bundler", () => {
     target: "browser",
     run: {
       file: "out.js",
+      stdout: "",
     },
   });
   itBundled("default/ExportFSNode", {
@@ -1370,6 +1416,7 @@ describe.concurrent("bundler", () => {
     target: "node",
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ReExportFSNode", {
@@ -1394,6 +1441,7 @@ describe.concurrent("bundler", () => {
     target: "node",
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ExportFSNodeInCommonJSModule", {
@@ -1418,6 +1466,7 @@ describe.concurrent("bundler", () => {
     target: "node",
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ExportWildcardFSNodeES6", {
@@ -1427,13 +1476,18 @@ describe.concurrent("bundler", () => {
         import assert from 'assert';
         import * as fs from 'fs';
         import * as fs2 from './out.js';
-        assert(fs, fs2);
+        assert.strictEqual(fs2.readFileSync, fs.readFileSync);
+        assert.deepStrictEqual(Object.keys(fs2).sort(), Object.keys(fs).filter(k => k !== 'default').sort());
       `,
     },
     format: "esm",
     target: "node",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('export * from "fs";');
+    },
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ExportWildcardFSNodeCommonJS", {
@@ -1443,13 +1497,20 @@ describe.concurrent("bundler", () => {
         import assert from 'assert';
         import * as fs from 'fs';
         import * as fs2 from './out.js';
-        assert(fs, fs2);
+        assert.strictEqual(fs2.readFileSync, fs.readFileSync);
+        assert.strictEqual(fs2.default.readFileSync, fs.readFileSync);
+        const named = o => Object.keys(o).filter(k => k !== 'default').sort();
+        assert.deepStrictEqual(named(fs2), named(fs));
       `,
     },
     format: "cjs",
     target: "node",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('require("fs")');
+    },
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/MinifiedBundleES6", {
@@ -1698,6 +1759,7 @@ describe.concurrent("bundler", () => {
     },
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ThisInsideFunction", {
@@ -1764,6 +1826,7 @@ describe.concurrent("bundler", () => {
     },
     run: {
       file: "/test.js",
+      stdout: "",
     },
   });
   itBundled("default/ThisWithES6Syntax", {
@@ -1878,7 +1941,6 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/ArrowFnScope", {
-    // TODO: MANUAL CHECK: make sure the snapshot we use works.
     files: {
       "/entry.js": /* js */ `
         tests = {
@@ -1894,6 +1956,32 @@ describe.concurrent("bundler", () => {
       `,
     },
     minifyIdentifiers: true,
+    onAfterBundle(api) {
+      // Only the parameters are renamed. The globals the comma expressions
+      // assign and read keep their names.
+      const code = api.readFile("/out.js");
+      expect(code).toContain("4: (x = (");
+      expect(code).toContain("7: (y, z, x = (");
+      expect(code.match(/x \+ y \+ z\)/g)).toHaveLength(2);
+      expect(code).not.toMatch(/\((x|y|z)\) =>/);
+    },
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        import assert from 'assert';
+        globalThis.tests = undefined;
+        globalThis.x = globalThis.y = globalThis.z = 0;
+        await import('./out.js');
+        assert.strictEqual(tests[0](1, 2), 3);
+        assert.strictEqual(tests[1](1, 2), 3);
+        assert.strictEqual(tests[2](1, 2, 3), 6);
+        assert.strictEqual(tests[3](1, 2, 3), 6);
+        assert.strictEqual(typeof x, 'function');
+      `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: "",
+    },
   });
   itBundled("default/SwitchScopeNoBundle", {
     files: {
@@ -2033,6 +2121,14 @@ describe.concurrent("bundler", () => {
     format: "iife",
     outfile: "/out.js",
     minifyIdentifiers: true,
+    onAfterBundle(api) {
+      // `arguments` inside a regular function is the implicit object and is
+      // never renamed: the 8 functions keep their `(x = arguments)` default
+      // and the 3 `var arguments` redeclarations survive.
+      const code = api.readFile("/out.js");
+      expect(code.match(/\(\w+ = arguments\)/g)).toHaveLength(8);
+      expect(code.match(/var arguments;/g)).toHaveLength(3);
+    },
   });
   itBundled("default/WithStatementTaintingNoBundle", {
     files: {
@@ -2199,6 +2295,13 @@ describe.concurrent("bundler", () => {
       `,
     },
     external: ["aws-sdk"],
+    onAfterBundle(api) {
+      // An external package name also covers its subpaths.
+      expect(new Bun.Transpiler().scanImports(api.readFile("/out.js"))).toStrictEqual([
+        { kind: "import-statement", path: "aws-sdk" },
+        { kind: "import-statement", path: "aws-sdk/clients/dynamodb" },
+      ]);
+    },
   });
   itBundled("default/ExternalModuleExclusionScopedPackage", {
     files: {
@@ -2241,6 +2344,12 @@ describe.concurrent("bundler", () => {
       `,
     },
     external: ["@scope/foo"],
+    onAfterBundle(api) {
+      expect(new Bun.Transpiler().scanImports(api.readFile("/out.js"))).toStrictEqual([
+        { kind: "import-statement", path: "@scope/foo" },
+        { kind: "import-statement", path: "@scope/foo/bar" },
+      ]);
+    },
   });
   itBundled("default/ExternalModuleExclusionRelativePath", {
     todo: true,
@@ -2478,6 +2587,11 @@ describe.concurrent("bundler", () => {
       "/entry.js": `import "foo"`,
     },
     bundling: false,
+    onAfterBundle(api) {
+      expect(new Bun.Transpiler().scanImports(api.readFile("/out.js"))).toStrictEqual([
+        { kind: "import-statement", path: "foo" },
+      ]);
+    },
   });
   itBundled("default/ManyEntryPoints", {
     files: Object.fromEntries([
@@ -2488,6 +2602,15 @@ describe.concurrent("bundler", () => {
       ]),
     ]),
     entryPoints: Array.from({ length: 40 }, (_, i) => `/e${String(i).padStart(2, "0")}.js`),
+    onAfterBundle(api) {
+      // Without splitting every entry gets its own copy of shared.js.
+      for (let i = 0; i < 40; i++) {
+        const code = api.readFile(`/out/e${String(i).padStart(2, "0")}.js`);
+        expect(code).toContain("var shared_default = 123;");
+        expect(code).toContain("console.log(shared_default);");
+        expect(code).not.toContain("import");
+      }
+    },
   });
   itBundled("default/MinifyPrivateIdentifiersNoBundle", {
     files: {
@@ -3579,6 +3702,10 @@ describe.concurrent("bundler", () => {
       `,
     },
     bundling: false,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("await foo;");
+      api.expectFile("/out.js").toContain("for await (foo of bar)");
+    },
   });
   itBundled("default/TopLevelAwaitForbiddenRequire", {
     files: {
@@ -4859,6 +4986,14 @@ describe.concurrent("bundler", () => {
     },
     format: "cjs",
     target: "node",
+    onAfterBundle(api) {
+      // The entry keeps the real `require` for node, so `require.main` and
+      // `require.cache` survive instead of becoming `__require` members.
+      const code = api.readFile("/out.js");
+      expect(code).toContain("require.main");
+      expect(code).toContain("require.cache");
+      expect(code).not.toContain("__require.");
+    },
   });
   itBundled("default/ExternalES6ConvertedToCommonJS", {
     todo: true,
@@ -5269,16 +5404,34 @@ describe.concurrent("bundler", () => {
     `,
   };
   const relocateEntries = ["/top-level.js", "/nested.js", "/let.js", "/function.js", "/function-nested.js"];
+  const relocateChecks = (api: BundlerTestBundleAPI) => {
+    // The legacy `for (var i = 1 in {})` initializer becomes a statement
+    // before the loop in every file that has it.
+    for (const entry of relocateEntries) {
+      const code = api.readFile("/out" + entry);
+      expect(code).not.toContain("= 1 in");
+      if (entry !== "/let.js") expect(code).toContain("i = 1;");
+    }
+    // A function declaration in a nested block is hoisted as a `var`.
+    for (const entry of ["/nested.js", "/function-nested.js"]) {
+      const code = api.readFile("/out" + entry);
+      expect(code).not.toContain("function l()");
+      expect(code).toContain("var l");
+    }
+    expect(api.readFile("/out/function.js")).toContain("function l() {}");
+  };
 
   itBundled("default/VarRelocatingBundle", {
     files: relocateFiles,
     entryPoints: relocateEntries,
     format: "esm",
+    onAfterBundle: relocateChecks,
   });
   itBundled("default/VarRelocatingNoBundle", {
     files: relocateFiles,
     entryPoints: relocateEntries,
     format: "esm",
+    onAfterBundle: relocateChecks,
   });
   itBundled("default/ImportNamespaceThisValue", {
     // GENERATED
@@ -5521,6 +5674,11 @@ describe.concurrent("bundler", () => {
     entryPoints: ["/src/app1/main.ts", "/src/app2/main.ts", "/src/app3/main.ts"],
     outputPaths: ["/out/app1-main.js", "/out/app2-main.js", "/out/app3-main.js"],
     entryNaming: "[dir]-[name].[ext]",
+    onAfterBundle(api) {
+      for (const n of [1, 2, 3]) {
+        api.expectFile(`/out/app${n}-main.js`).toContain(`console.log(${n});`);
+      }
+    },
   });
   // itBundled("default/EntryNamesNonPortableCharacter", {
   //   // GENERATED
@@ -5634,6 +5792,7 @@ describe.concurrent("bundler", () => {
       `,
     },
     minifySyntax: true,
+    run: { stdout: "123" },
   });
   itBundled("default/WarnCommonJSExportsInESMBundle", {
     // GENERATED
@@ -6241,6 +6400,21 @@ describe.concurrent("bundler", () => {
       `,
     },
     minifyIdentifiers: true,
+    onAfterBundle(api) {
+      // The export keeps its public name while the local is minified.
+      const code = api.readFile("/out.js");
+      expect(code).toContain(" as aap");
+      expect(code).not.toContain("function aap(");
+    },
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        import assert from 'assert';
+        import { aap } from './out.js';
+        assert.strictEqual(aap(false, 4), 'teun');
+        assert.strictEqual(aap(true, 4), 10);
+      `,
+    },
+    run: { file: "/test.js", stdout: "" },
   });
   // itBundled("default/MinifiedJSXPreserveWithObjectSpread", {
   //   // GENERATED

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -212,7 +212,6 @@ test/bundler/bundler_jsx.test.ts
 test/bundler/bundler_loader.test.ts
 test/bundler/bundler_minify.test.ts
 test/bundler/esbuild/dce.test.ts
-test/bundler/esbuild/default.test.ts
 test/bundler/esbuild/extra.test.ts
 test/bundler/esbuild/importstar.test.ts
 test/bundler/esbuild/loader.test.ts


### PR DESCRIPTION
### Problem
- `test/bundler/esbuild/default.test.ts` takes 13s to 14s on the debian 13 x64-asan lane (build 108747), as a serial step: `test/no-validate-leaksan.txt` lists it. Inside the file, 128 of 152 live cases build through `Bun.build()` in-process, which `expectBundled` registers with `it.serial`, and every serial case is a barrier for the 24 concurrent ones.
- 17 run steps had no expected output, two fixtures asserted nothing, 12 cases only checked that the build succeeds, and three `*NoBundle` cases bundled.

### Fix
- The file defaults `itBundled` to the cli backend, as `bundler_compile.test.ts` does. 127 cases move with their options and assertions unchanged. `HashbangBannerUseStrictOrder` stays on the api backend (the cli harness quotes `--banner` values) and uses `iife`, so the hashbang, banner and `"use strict"` order is observable.
- The leaksan entry goes: the file is clean under the runner's `detect_leaks=1` env. The three `*NoBundle` cases and `VarRelocatingNoBundle` get `bundling: false` like upstream. The last one becomes todo: the harness has no multi-entry `--no-bundle`, and it was a copy of the bundle case.
- Assertions, 210 to 392 expect() calls (list in Notes): exact stdout on the 17 run steps, real `ExportWildcardFSNode` comparisons, four new runs, `onAfterBundle` checks on 18 cases.
- Verified: `bun bd test test/bundler/esbuild/default.test.ts` (debug, ASAN) 53.9s to 54.9s before, 20.4s to 21.0s after, 151 pass. Released bun 1.25s to 0.31s, Windows canary 2.32s to 0.73s. Self-reviewed: 8 concerns, 3 addressed, the harness-level alternative is in Notes.

### Background
- `itBundled` picks the backend from the options. Without `dotenv`, `production`, `bundling: false`, `define`, `env`, `bundleWarnings`, `emitDCEAnnotations` or `run.validate` it calls `Bun.build()` in the test process, else it spawns `bun build`. Only the in-process backend is serial: it wraps the build in `process.chdir`.
- bun test groups consecutive concurrent tests. A serial test ends the group. Under ASAN a group runs 5 tests at a time, else 20.
- The cli backend fails a case on a warning it does not declare. No case here emits one.

<details><summary>Notes</summary>

Timings on one 16-core container. Debug is `bun bd test` (debug build with ASAN). Released is `USE_SYSTEM_BUN=1 bun test` with bun 1.4.1. Windows is the canary bun 1.4.1 on a Windows Server 2019 machine, `USE_SYSTEM_BUN=1`, first revision of this branch.

| version | live cases | debug ASAN | released | windows |
| --- | --- | --- | --- | --- |
| main (2a0fda9) | 152: 128 api, 24 cli | 54.5s, 53.9s, 54.9s | 1.24s, 1.26s | 2.32s |
| this PR | 151: 1 api, 150 cli | 20.6s, 20.4s, 20.7s, 20.5s, 20.6s, 21.0s | 0.32s, 0.30s | 0.71s, 0.73s, 0.76s |

The per-test durations on main add up to 54.2s for a 54.5s run. After the change they add up to 77.8s for a 20.6s run: each cli case spawns `bun build` as well as the run child, and 5 cases overlap. The remaining cases above 1s have four run steps each (`ConditionalImport`, `ConditionalRequire`) or import `fs` in node mode.

Leaksan: the entry dates from #21142 (September 2025, group `Zig::SourceProvider::~SourceProvider()`). With `BUN_DESTRUCT_VM_ON_EXIT=1`, `ASAN_OPTIONS=...detect_leaks=1:abort_on_error=1` and the `test/leaksan.supp` suppressions, the debug ASAN build runs the whole file (children included, `bunEnv` spreads `process.env`) with exit 0 and no report, twice. `scripts/runner.node.mjs` (`isBucketCandidate`) requires `shouldValidateLeakSan` on the asan lane, so the file now joins the parallel bucket there. The other 14 files of that group are untouched. If the asan lane reports a leak this revision did not see locally, the line comes back.

Self-review: eight concerns. Addressed: `HashbangBannerUseStrictOrder` never reached the directive branch under `esm` (bun drops `"use strict"` there; upstream uses `FormatIIFE`), the three `*NoBundle` cases that bundled, the `VarRelocatingNoBundle` copy, the leaksan entry. Not done here, on scope: the serial barrier lives in `expectBundled.ts` (`process.chdir` and the module-global `configRef` around `await Bun.build`, then `it.serial`). A promise-chain mutex around that window plus plain `it` would let every api case of every `describe.concurrent` bundler file overlap while it keeps `Bun.build()` coverage, and a prototype of it ran the unmodified file in 17.0s against 20.2s for this flip. The handoff for this task keeps `expectBundled.ts` out of this PR (#38454, #40497 and #38471 edit it), so that is a follow-up. With it, the wrapper here and the one in `bundler_compile.test.ts` become unnecessary. Also a follow-up: `run: true` could default to `stdout: ""` in the harness.

Backend counts: the brief counted the 44 option-forced cases as the serial api ones. `resolveBackend` returns `"cli"` for those options, so they were the concurrent ones. 24 of them are live, the other 20 are `todo` or use an option the harness does not implement.

Assertion changes:
- `stdout: ""` on the 17 run steps that had no expectation. Their fixtures assert with `node:assert` and print nothing: `NewExpressionCommonJS`, `ExportFormsES6`, `ExportFormsWithMinifyIdentifiersAndNoBundle` (todo: multi-entry `--no-bundle`), `ImportFormsWithNoBundle`, `ImportFormsWithMinifyIdentifiersAndNoBundle`, `ExportFormsCommonJS`, `ExportChain`, `AwaitImportInsideTry`, `NestedScopeBug`, `ExportFSBrowser`, `ExportFSNode`, `ReExportFSNode`, `ExportFSNodeInCommonJSModule`, `ExportWildcardFSNodeES6`, `ExportWildcardFSNodeCommonJS`, `ThisOutsideFunctionNotRenamed`, `ThisInsideFunction`.
- `ExportWildcardFSNodeES6` and `CommonJS`: `assert(fs, fs2)` becomes `readFileSync` identity plus equal key sets (minus `default`). The es6 output must hold `export * from "fs"`, the cjs output `require("fs")`.
- New runs: `ArgumentsSpecialCaseNoBundle` prints `marker` and executes its 50 `assert.deepEqual` calls (as `out.cjs`: `var arguments` needs sloppy mode). `NamedFunctionExpressionArgumentCollision` prints `123`. `ArrowFnScope` runs a `test.js` that calls the four arrows without defaults (`tests[0](1, 2) === 3`, ...) and checks that the comma expressions assigned the global `x`. `NonDeterminismESBuildIssue2537` imports `aap` and checks `aap(false, 4) === "teun"` and `aap(true, 4) === 10`.
- `onAfterBundle` checks: `NewExpressionCommonJS` keeps `new (require_foo()).Foo`. `ExportChain` exports `c as a` and has no `b` binding. `AwaitImportInsideTry` keeps `await import(name)`. `NestedScopeBug` keeps `b()` and `var b` under one name. `HashbangBannerUseStrictOrder` starts with `#! in file`, `#! from banner`, `"use strict";` (before: only the file hashbang). `ArrowFnScope`: the globals `x`, `y`, `z` keep their names and no arrow has a parameter named like them. `ArgumentsSpecialCaseNoBundle`: 8 `(x = arguments)` defaults and 3 `var arguments` survive minification. `ExternalModuleExclusionPackage`, `ScopedExternalModuleExclusion`, `ExternalWildcardDoesNotMatchEntryPoint`: exact import list via `Bun.Transpiler.scanImports`. `ManyEntryPoints`: all 40 outputs hold their own `shared_default = 123` and no `import`. `TopLevelAwaitNoBundle` keeps `await foo` and `for await`. `RequireMainCacheCommonJS` keeps `require.main` and `require.cache` and has no `__require.` member. `VarRelocatingBundle`: `for (var i = 1 in {})` becomes `i = 1;` plus the loop, a block-level `function l` is lowered to `var l`, the one in a function body stays. `EntryNamesNoSlashAfterDir`: each output holds its `console.log(n)`. `NonDeterminismESBuildIssue2537`: the export keeps the name `aap`, the local is minified.

Found on the way, not asserted here because the case would fail:
- In bundle mode, the iife output of a CommonJS entry defines `require_entry` and never calls it (#37843), and `__require` is not defined in iife output (#38077). This is why `ArgumentsSpecialCaseNoBundle` runs as `--no-bundle` only.
- `ImportNamespaceThisValue`: in cjs output the call of a named import from an external is printed as `import_external.foo()`, so `foo` runs with `this === import_external`. esbuild prints `(0, import_external.foo)()`. A probe with a runtime `external` package confirms the leak, also under node.
- `ToESMWrapperOmission`: `bun build --no-bundle --format=cjs` leaves the ESM syntax in place, so the case cannot check the wrappers it is named for.
- `WarnCommonJSExportsInESMBundle`: the `cjs-in-esm.js` output references an undeclared `module_cjs_in_esm`. #40840 works in that area.
- `StrictModeNestedFnDeclKeepNamesVariableInliningESBuildIssue1552`: its output changes with #40503 (`--keep-names`), so nothing is pinned.
- `MetafileNoBundle`, `MetafileVariousCases`, `MetafileVeryLongExternalPaths` are `todo` through harness limits (multi-entry `--no-bundle`, `copy` and `dataurl` loaders).
- The 43 `todo: true` cases are #39058's job. No case was removed or skipped. `timeoutScale` is not used in this file. No case spawns a child of its own, except two todo cases that run esbuild on their output.

`BUN_BUNDLER_TEST_USE_ESBUILD=1` (first revision): 79 failures on main, 19 here. The esbuild api backend of the harness forwards almost no options, the cli backend does. Seven cases pass on main and fail here with esbuild: five pin bun's printer output or run through the api backend (`NestedScopeBug`, `VarRelocatingBundle`, `VarRelocatingNoBundle`, `RequireMainCacheCommonJS`, `HashbangBannerUseStrictOrder`), and `InjectDuplicate` and `RequireResolve` now reach esbuild with their real options.

The same four `tsc` errors exist on main and here (`automaticRuntime`, `copy` and `dataurl` loaders). prettier reports the file clean.

Related open PRs that edit this file (#40840, #40857, #40804, #39058, #38471 and others) add or flip cases in other hunks. `expectBundled.ts` is not touched (#38454, #40497). #38385 edits `test/no-validate-leaksan.txt` in other lines.

First revision (ed744b6): the banner case pinned only the first two lines under `esm`, the three `*NoBundle` cases bundled, `VarRelocatingNoBundle` ran the bundle checks, and the leaksan entry stayed. 152 pass, 405 expect() calls.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/esbuild/default.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/esbuild/default.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/esbuild/default.test.ts:
(pass) bundler > default/SimpleES6 [928.00ms]
(pass) bundler > default/SimpleCommonJS [586.69ms]
(pass) bundler > default/NewExpressionCommonJS [630.91ms]
(pass) bundler > default/CommonJSFromES6 [661.58ms]
(todo) bundler > default/ExportFormsIIFE
(todo) bundler > default/ExportFormsWithMinifyIdentifiersAndNoBundle
(pass) bundler > default/NestedCommonJS [731.75ms]
(pass) bundler > default/ES6FromCommonJS [573.57ms]
(pass) bundler > default/NestedES6FromCommonJS [636.18ms]
(pass) bundler > default/ImportFormsWithNoBundle [662.80ms]
(pass) bundler > default/ExportFormsES6 [730.16ms]
(todo) bundler > default/ExportInfiniteCycle2
(pass) bundler > default/ImportFormsWithMinifyIdentifiersAndNoBundle [664.67ms]
(pass) bundler > default/ExportInfiniteCycle1 [236.03ms]
(pass) bundler > default/JSXSyntaxInJS [232.42ms]
(pass) bundler > default/ExportChain [623.85ms]
(pass) bundler > default/ExportFormsCommonJS [849.50ms]
(pass) bundler > default/NodeModules [627.06ms]
(pass) bundler > default/RequireChildDirES6 [613.33ms]
(pass) bundler > default/RequireChildDirCommonJS [649.86ms]
(pass) bundler > default/ImportMissingES6 [285.32ms]
(todo) bundler > default/ImportMissingNeitherES6NorCommonJS
(pass) bundler > default/RequireParentDirCommonJS [627.74ms]
(pass) bundler > default/ImportMissingUnusedES6 [298.07ms]
(pass) bundler > default/ExportMissingES6 [302.13ms]
(pass) bundler > default/RequireParentDirES6 [699.05ms]
(pass) bundler > default/ImportMissingCommonJS [550.16ms]
(pass) bundler > default/DynamicImportWithExpressionCJS [221.17ms]
(pass) bundler > default/DotImport [680.44ms]
(pass) bundler > default/RequireWithTemplate [631.14ms]
(pass) bundler > default/DynamicImportWithTemplateIIFE [572.50ms]
(pass) bundler > default/MinifiedDynamicImportWithExpressionCJS [183.91ms]
(pass)
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/esbuild/default.test.ts | 198 +++++++++++++++++++++++++++++++++--
 test/no-validate-leaksan.txt         |   1 -
 2 files changed, 189 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
test/bundler/esbuild/default.test.ts     26     40      0
test/no-validate-leaksan.txt              1      1      0
```

</details>

<!-- robobun:evidence:end -->