### PR TITLE
test(net): run socket.test.ts concurrently, wait for events instead of sleeping, pin exact outputs

### DIFF
--- a/test/js/bun/net/keep-event-loop-alive.js
+++ b/test/js/bun/net/keep-event-loop-alive.js
@@ -1,28 +1,34 @@
 (async () => {
   const port = process.argv[2] ? parseInt(process.argv[2]) : null;
   const hostname = process.argv[3] ? process.argv[3] : "localhost";
+  // A port nothing listens on. The test passes one it keeps bound for the run.
+  const refusedPort = process.argv[4] ? parseInt(process.argv[4]) : 9999;
   await Bun.sleep(10);
   // failed connection
-  console.log("test 1: failed connection");
   try {
     const socket = await Bun.connect({
       hostname: hostname,
-      port: 9999,
+      port: refusedPort,
       socket: { data() {} },
     });
     socket.end();
-  } catch (error) {}
+    console.log("test 1: failed connection did not fail");
+  } catch (error) {
+    console.log("test 1: failed connection", error.code);
+  }
   // failed connection tls
-  console.log("test 2: failed connection [tls]");
   try {
     const socket = await Bun.connect({
       hostname: hostname,
-      port: 9999,
+      port: refusedPort,
       socket: { data() {} },
       tls: true,
     });
     socket.end();
-  } catch (error) {}
+    console.log("test 2: failed connection [tls] did not fail");
+  } catch (error) {
+    console.log("test 2: failed connection [tls]", error.code);
+  }
   if (port) {
     // successful connection
     console.log("test 3: successful connection");

--- a/test/js/bun/net/socket-huge-fixture.js
+++ b/test/js/bun/net/socket-huge-fixture.js
@@ -1,7 +1,9 @@
 import { connect, listen } from "bun";
 import { fillRepeating } from "harness";
 
-const huge = Buffer.alloc(1024 * 1024 * 1024);
+// The test passes the transfer size; it is smaller on debug and ASAN builds.
+const size = process.argv[2] ? parseInt(process.argv[2]) : 1024 * 1024 * 1024;
+const huge = Buffer.alloc(size);
 for (let i = 0; i < 1024; i++) {
   huge[i] = (Math.random() * 255) | 0;
 }
@@ -17,22 +19,18 @@ var server = listen({
   data: { sent: 0 },
   socket: {
     open(socket) {
-      console.time("send 1 GB (server)");
       socket.data.sent = socket.write(huge);
       if (socket.data.sent === huge.length) {
-        console.timeEnd("send 1 GB (server)");
         socket.shutdown();
-        serverResolve();
+        serverResolve(socket.data.sent);
       }
     },
     async drain(socket) {
       socket.data.sent += socket.write(huge.subarray(socket.data.sent));
-      // console.error("Sent", socket.data.sent, "bytes");
 
       if (socket.data.sent === huge.length) {
-        console.timeEnd("send 1 GB (server)");
         socket.shutdown();
-        serverResolve();
+        serverResolve(socket.data.sent);
       }
     },
   },
@@ -44,25 +42,22 @@ const socket = await connect({
   data: { received: 0 },
   socket: {
     open(socket) {
-      console.time("recv 1 GB (client)");
       socket.data.received = 0;
     },
 
     data(socket, data) {
       socket.data.received += data.length;
-      // console.error("Received", data.length, "bytes");
       received.update(data);
 
       if (socket.data.received === huge.length) {
-        console.timeEnd("recv 1 GB (client)");
         socket.end();
-        clientResolve();
+        clientResolve(socket.data.received);
       }
     },
   },
 });
 
-await Promise.all([clientPromise, serverPromise]);
+const [receivedBytes, sentBytes] = await Promise.all([clientPromise, serverPromise]);
 server.stop(true);
 socket.end();
 
@@ -70,4 +65,5 @@ if (received.digest("hex") !== Bun.SHA256.hash(huge, "hex")) {
   throw new Error("Received data doesn't match sent data");
 }
 
+console.log(`sent ${sentBytes} bytes, received ${receivedBytes} bytes, digest matches`);
 process.exit(0);

--- a/test/js/bun/net/socket-huge-fixture.js
+++ b/test/js/bun/net/socket-huge-fixture.js
@@ -2,7 +2,10 @@ import { connect, listen } from "bun";
 import { fillRepeating } from "harness";
 
 // The test passes the transfer size; it is smaller on debug and ASAN builds.
-const size = process.argv[2] ? parseInt(process.argv[2]) : 1024 * 1024 * 1024;
+const size = process.argv[2] ? Number.parseInt(process.argv[2], 10) : 1024 * 1024 * 1024;
+if (!Number.isInteger(size) || size <= 0) {
+  throw new Error(`transfer size must be a positive integer, got ${process.argv[2]}`);
+}
 const huge = Buffer.alloc(size);
 for (let i = 0; i < 1024; i++) {
   huge[i] = (Math.random() * 255) | 0;

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -9,6 +9,8 @@ import {
   bunRun,
   expectMaxObjectTypeCount,
   getMaxFD,
+  isASAN,
+  isDebug,
   isLinux,
   isWindows,
   libcPathForDlopen,
@@ -18,51 +20,73 @@ import {
 import net from "node:net";
 import { join } from "node:path";
 import { createSecureContext, connect as tlsConnect } from "node:tls";
+
+type ErrorShape = { name: string; code: string | undefined; message: string };
+const errorShape = (error: unknown): ErrorShape => {
+  const e = error as Error & { code?: string };
+  return { name: e.name, code: e.code, message: e.message };
+};
+const refusedShape: ErrorShape = { name: "Error", code: "ECONNREFUSED", message: "Failed to connect" };
+
+// A port nothing listens on. The established connection keeps its local port bound, so no
+// `port: 0` listener can take it while the holder is alive, and a connect to it is refused.
+async function refusedPort() {
+  const sink = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+  const holder = await Bun.connect({ hostname: "127.0.0.1", port: sink.port, socket: { data() {} } });
+  return {
+    port: holder.localPort,
+    [Symbol.dispose]() {
+      holder.terminate();
+      sink.stop(true);
+    },
+  };
+}
+
 describe.concurrent("socket", () => {
   it("should throw when a socket from a file descriptor has a bad file descriptor", async () => {
     const open = jest.fn();
     const close = jest.fn();
     const data = jest.fn();
-    const connectError = jest.fn(() => {});
-    {
-      expect(
-        async () =>
-          await Bun.connect({
-            fd: getMaxFD() + 1024,
-            socket: {
-              open,
-              close,
-              data,
-              connectError,
-            },
-          }),
-      ).toThrow();
-      Bun.gc(true);
-      await Bun.sleep(10);
-      Bun.gc(true);
-    }
-
-    await Bun.sleep(10);
+    const connectErrorCalled = Promise.withResolvers<ErrorShape>();
+    const connectError = jest.fn((_socket: Socket, error: Error) => connectErrorCalled.resolve(errorShape(error)));
+    const rejection = await Bun.connect({
+      fd: getMaxFD() + 1024,
+      socket: {
+        open,
+        close,
+        data,
+        connectError,
+      },
+    }).then(
+      () => null,
+      error => errorShape(error),
+    );
+    // The connect failed synchronously, so the callback has already run and no
+    // socket exists that could still call open, data or close. The code is not
+    // pinned: the platforms map a bad descriptor to different errnos.
+    const failedToConnect = { name: "Error", message: "Failed to connect" };
+    expect({ rejection, connectError: await connectErrorCalled.promise }).toMatchObject({
+      rejection: failedToConnect,
+      connectError: failedToConnect,
+    });
+    Bun.gc(true);
     expect(open).toHaveBeenCalledTimes(0);
     expect(close).toHaveBeenCalledTimes(0);
     expect(data).toHaveBeenCalledTimes(0);
     expect(connectError).toHaveBeenCalledTimes(1);
-    connectError.mockClear();
-    open.mockClear();
-    close.mockClear();
-    data.mockClear();
   });
 
   it.skipIf(isWindows)(
     "should not crash when a socket from a file descriptor is already closed after opening",
     async () => {
       const [server, client] = createSocketPair();
+      const closed = Promise.withResolvers<void>();
       const open = jest.fn();
-      const close = jest.fn();
+      const close = jest.fn(() => closed.resolve());
       const data = jest.fn();
       closeSync(client);
       {
-        const socket = await Bun.connect({
+        await Bun.connect({
           fd: server,
           socket: {
             open,
@@ -71,17 +95,14 @@ describe.concurrent("socket", () => {
           },
         });
         Bun.gc(true);
-        await Bun.sleep(10);
+        // The peer end is already closed, so the adopted fd reads EOF and closes.
+        await closed.promise;
         Bun.gc(true);
       }
-      await Bun.sleep(10);
 
       expect(open).toHaveBeenCalledTimes(1);
       expect(close).toHaveBeenCalledTimes(1);
       expect(data).toHaveBeenCalledTimes(0);
-      open.mockClear();
-      close.mockClear();
-      data.mockClear();
     },
   );
 
@@ -115,7 +136,7 @@ describe.concurrent("socket", () => {
   });
 
   it("should keep process alive only when active", async () => {
-    const { exited, stdout, stderr } = spawn({
+    await using proc = spawn({
       cmd: [bunExe(), "echo.js"],
       cwd: import.meta.dir,
       stdout: "pipe",
@@ -124,23 +145,25 @@ describe.concurrent("socket", () => {
       env: bunEnv,
     });
 
-    expect(await exited).toBe(0);
-    expect(await stderr.text()).toBe("");
-    var lines = (await stdout.text()).split(/\r?\n/);
-    expect(
-      lines.filter(function (line) {
-        return line.startsWith("[Server]");
-      }),
-    ).toEqual(["[Server] OPENED", "[Server] GOT request", "[Server] CLOSED"]);
-    expect(
-      lines.filter(function (line) {
-        return line.startsWith("[Client]");
-      }),
-    ).toEqual(["[Client] OPENED", "[Client] GOT response", "[Client] CLOSED"]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The server and client lines interleave, but each side's own order is fixed.
+    const lines = stdout.split(/\r?\n/).filter(Boolean);
+    expect({
+      stderr,
+      server: lines.filter(line => line.startsWith("[Server]")),
+      client: lines.filter(line => line.startsWith("[Client]")),
+      other: lines.filter(line => !line.startsWith("[Server]") && !line.startsWith("[Client]")),
+    }).toEqual({
+      stderr: "",
+      server: ["[Server] OPENED", "[Server] GOT request", "[Server] CLOSED"],
+      client: ["[Client] OPENED", "[Client] GOT response", "[Client] CLOSED"],
+      other: [],
+    });
+    expect(exitCode).toBe(0);
   });
 
   it("connect without top level await should keep process alive", async () => {
-    const server = Bun.listen({
+    using server = Bun.listen({
       socket: {
         open(socket) {},
         data(socket, data) {},
@@ -148,22 +171,29 @@ describe.concurrent("socket", () => {
       hostname: "localhost",
       port: 0,
     });
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "keep-event-loop-alive.js", String(server.port), server.hostname],
+    using refused = await refusedPort();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "keep-event-loop-alive.js", String(server.port), server.hostname, String(refused.port)],
       cwd: import.meta.dir,
       env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-    await proc.exited;
-    try {
-      expect(proc.exitCode).toBe(0);
-      expect(await proc.stdout.text()).toContain("event loop was not killed");
-    } finally {
-      server.stop();
-    }
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({
+      stdout:
+        "test 1: failed connection ECONNREFUSED\n" +
+        "test 2: failed connection [tls] ECONNREFUSED\n" +
+        "test 3: successful connection\n" +
+        "test 4: successful connection [tls]\n" +
+        "success: event loop was not killed\n",
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
   });
 
   it("connect() should return the socket object", async () => {
-    const { exited, stdout, stderr } = spawn({
+    await using proc = spawn({
       cmd: [bunExe(), "connect-returns-socket.js"],
       cwd: import.meta.dir,
       stdout: "pipe",
@@ -172,10 +202,24 @@ describe.concurrent("socket", () => {
       env: bunEnv,
     });
 
-    const [stderrText, stdoutText, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
-    // stderr first so an ASAN/LSAN report isn't swallowed behind a bare "exit 134".
-    expect(stderrText).toBe("");
-    expect(stdoutText).toContain("CLIENT RECEIVED");
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The two echoed writes can arrive in one or two data events, so compare their concatenation.
+    const lines = stdout.split(/\r?\n/).filter(Boolean);
+    const RECEIVED = "CLIENT RECEIVED ";
+    expect({
+      stderr,
+      opened: lines.filter(line => line.endsWith(" OPENED")).toSorted(),
+      localPort: lines.filter(line => /^\d+$/.test(line)).length,
+      received: lines
+        .filter(line => line.startsWith(RECEIVED))
+        .map(line => line.slice(RECEIVED.length))
+        .join(""),
+    }).toEqual({
+      stderr: "",
+      opened: ["CLIENT OPENED", "SERVER OPENED"],
+      localPort: 1,
+      received: "Hello, world!From returned socket",
+    });
     expect(exitCode).toBe(0);
   });
 
@@ -197,54 +241,41 @@ describe.concurrent("socket", () => {
     }).toThrow();
   });
 
-  it("should reject on connection error, calling both connectError() and rejecting the promise", done => {
-    var data = {};
-    connect({
+  it("should reject on connection error, calling both connectError() and rejecting the promise", async () => {
+    using refused = await refusedPort();
+    const data = {};
+    const events: string[] = [];
+    const unexpected = (name: string) => () => void events.push(name);
+    let connectErrorArgs: { sameData: boolean; error: ErrorShape } | undefined;
+    const rejection = await connect({
       data,
       hostname: "localhost",
-      port: 55555,
+      port: refused.port,
       socket: {
         connectError(socket, error) {
-          expect(socket).toBeDefined();
-          expect(socket.data).toBe(data);
-          expect(error).toBeDefined();
-          expect(error.name).toBe("Error");
-          expect(error.code).toBe("ECONNREFUSED");
-          expect(error.message).toBe("Failed to connect");
+          events.push("connectError");
+          connectErrorArgs = { sameData: socket.data === data, error: errorShape(error) };
         },
-        data() {
-          done(new Error("Unexpected data()"));
-        },
-        drain() {
-          done(new Error("Unexpected drain()"));
-        },
-        close() {
-          done(new Error("Unexpected close()"));
-        },
-        end() {
-          done(new Error("Unexpected end()"));
-        },
-        error() {
-          done(new Error("Unexpected error()"));
-        },
-        open() {
-          done(new Error("Unexpected open()"));
-        },
+        data: unexpected("data"),
+        drain: unexpected("drain"),
+        close: unexpected("close"),
+        end: unexpected("end"),
+        error: unexpected("error"),
+        open: unexpected("open"),
       },
     }).then(
-      () => done(new Error("Promise should reject instead")),
-      err => {
-        expect(err).toBeDefined();
-        expect(err.name).toBe("Error");
-        expect(err.code).toBe("ECONNREFUSED");
-        expect(err.message).toBe("Failed to connect");
-
-        done();
-      },
+      () => null,
+      error => errorShape(error),
     );
+    expect({ events, connectErrorArgs, rejection }).toEqual({
+      events: ["connectError"],
+      connectErrorArgs: { sameData: true, error: refusedShape },
+      rejection: refusedShape,
+    });
   });
 
   it("should not leak memory when connect() fails", async () => {
+    using refused = await refusedPort();
     await (async () => {
       // windows can take more than a second per connection
       const quantity = isWindows ? 10 : 50;
@@ -252,7 +283,7 @@ describe.concurrent("socket", () => {
       for (let i = 0; i < quantity; i++) {
         promises[i] = connect({
           hostname: "localhost",
-          port: 55555,
+          port: refused.port,
           socket: {
             connectError(socket, error) {},
             data() {},
@@ -264,7 +295,8 @@ describe.concurrent("socket", () => {
           },
         });
       }
-      await Promise.allSettled(promises);
+      const settled = await Promise.allSettled(promises);
+      expect(settled.map(result => result.status)).toEqual(new Array(quantity).fill("rejected"));
       promises.length = 0;
     })();
 
@@ -272,90 +304,82 @@ describe.concurrent("socket", () => {
   }, 60_000);
 
   // this also tests we mark the promise as handled if connectError() is called
-  it("should handle connection error", done => {
-    var data = {};
+  it("should handle connection error", async () => {
+    using refused = await refusedPort();
+    const data = {};
+    const events: string[] = [];
+    const unexpected = (name: string) => () => void events.push(name);
+    const connectErrorCalled = Promise.withResolvers<{ sameData: boolean; error: ErrorShape }>();
     connect({
       data,
       hostname: "localhost",
-      port: 55555,
+      port: refused.port,
       socket: {
         connectError(socket, error) {
-          expect(socket).toBeDefined();
-          expect(socket.data).toBe(data);
-          expect(error).toBeDefined();
-          expect(error.name).toBe("Error");
-          expect(error.message).toBe("Failed to connect");
-          expect((error as any).code).toBe("ECONNREFUSED");
-          done();
+          events.push("connectError");
+          connectErrorCalled.resolve({ sameData: socket.data === data, error: errorShape(error) });
         },
-        data() {
-          done(new Error("Unexpected data()"));
-        },
-        drain() {
-          done(new Error("Unexpected drain()"));
-        },
-        close() {
-          done(new Error("Unexpected close()"));
-        },
-        end() {
-          done(new Error("Unexpected end()"));
-        },
-        error() {
-          done(new Error("Unexpected error()"));
-        },
-        open() {
-          done(new Error("Unexpected open()"));
-        },
+        data: unexpected("data"),
+        drain: unexpected("drain"),
+        close: unexpected("close"),
+        end: unexpected("end"),
+        error: unexpected("error"),
+        open: unexpected("open"),
       },
     });
+    expect(await connectErrorCalled.promise).toEqual({ sameData: true, error: refusedShape });
+    expect(events).toEqual(["connectError"]);
   });
 
   it("socket.timeout works", async () => {
-    try {
-      const { promise, resolve } = Promise.withResolvers<any>();
-
-      var server = Bun.listen({
-        socket: {
-          binaryType: "buffer",
-          open(socket) {
-            socket.write("hello");
-          },
-          data(socket, data) {
-            if (data.toString("utf-8") === "I have timed out!") {
-              client.end();
-              resolve(undefined);
-            }
-          },
+    const { promise, resolve } = Promise.withResolvers<string>();
+    let timeouts = 0;
+    let received = "";
+    using server = Bun.listen({
+      socket: {
+        binaryType: "buffer",
+        open(socket) {
+          socket.write("hello");
         },
-        hostname: "localhost",
-        port: 0,
-      });
-      var client = await connect({
-        hostname: server.hostname,
-        port: server.port,
-        socket: {
-          timeout(socket) {
-            socket.write("I have timed out!");
-          },
-          data() {},
-          drain() {},
-          close() {},
-          end() {},
-          error() {},
-          open() {},
+        data(socket, data) {
+          received += data.toString("utf-8");
+          if (received === "I have timed out!") {
+            client.end();
+            resolve(received);
+          }
         },
-      });
-      client.timeout(1);
-      await promise;
-    } finally {
-      server!.stop(true);
-    }
+      },
+      hostname: "localhost",
+      port: 0,
+    });
+    const client = await connect({
+      hostname: server.hostname,
+      port: server.port,
+      socket: {
+        timeout(socket) {
+          timeouts++;
+          socket.write("I have timed out!");
+        },
+        data() {},
+        drain() {},
+        close() {},
+        end() {},
+        error() {},
+        open() {},
+      },
+    });
+    client.timeout(1);
+    // The timeout sweep runs every few seconds, so this waits for the next sweep.
+    expect(await promise).toBe("I have timed out!");
+    expect(timeouts).toBe(1);
   }, 60_000);
 
   it("should allow large amounts of data to be sent and received", async () => {
-    const { stderr, exitCode } = await bunRun(fileURLToPath(new URL("./socket-huge-fixture.js", import.meta.url)));
-    if (exitCode !== 0) console.error(stderr);
-    expect(exitCode).toBe(0);
+    // A stress test: the transfer is 4x smaller on debug and ASAN builds, where the
+    // per-byte cost of the hashing and copying makes 1 GiB take several seconds.
+    const size = isDebug || isASAN ? 256 * 1024 * 1024 : 1024 * 1024 * 1024;
+    const fixture = fileURLToPath(new URL("./socket-huge-fixture.js", import.meta.url));
+    expect(await bunRun([fixture, String(size)])).toSpawn(`sent ${size} bytes, received ${size} bytes, digest matches`);
   }, 60_000);
 
   it.skipIf(isWindows)("kqueue should not dispatch spurious drain events on readable", async () => {
@@ -377,8 +401,8 @@ describe.concurrent("socket", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({ stdout: "OK\n", exitCode: 0 });
-    void stderr;
+    expect({ stdout, stderr }).toEqual({ stdout: "OK\n", stderr: "" });
+    expect(exitCode).toBe(0);
   }, 30_000);
 
   it("it should not crash when getting a ReferenceError on client socket open", async () => {
@@ -390,13 +414,8 @@ describe.concurrent("socket", () => {
       },
     });
     {
-      const { resolve, reject, promise } = Promise.withResolvers();
-      let client: Socket<undefined> | null = null;
-      const timeout = setTimeout(() => {
-        client?.end();
-        reject(new Error("Timeout"));
-      }, 1000);
-      client = await Bun.connect({
+      const { resolve, promise } = Promise.withResolvers<{ handler: string; name?: string; message?: string }>();
+      const client = await Bun.connect({
         port: server.port,
         hostname: server.hostname,
         socket: {
@@ -406,19 +425,18 @@ describe.concurrent("socket", () => {
             socket.write(bytes);
           },
           error(socket, error) {
-            clearTimeout(timeout);
-            resolve(error);
+            resolve({ handler: "error", name: error.name, message: error.message });
           },
           close(socket) {
             // we need the close handler
-            resolve({ message: "Closed" });
+            resolve({ handler: "close" });
           },
           data(socket, data) {},
         },
       });
 
-      const result: any = await promise;
-      expect(result?.message).toBe("bytes is not defined");
+      expect(await promise).toEqual({ handler: "error", name: "ReferenceError", message: "bytes is not defined" });
+      client.end();
     }
   });
 
@@ -431,13 +449,8 @@ describe.concurrent("socket", () => {
       },
     });
     {
-      const { resolve, reject, promise } = Promise.withResolvers();
-      let client: Socket<undefined> | null = null;
-      const timeout = setTimeout(() => {
-        client?.end();
-        reject(new Error("Timeout"));
-      }, 1000);
-      client = await Bun.connect({
+      const { resolve, promise } = Promise.withResolvers<{ handler: string; name?: string; message?: string }>();
+      const client = await Bun.connect({
         port: server.port,
         hostname: server.hostname,
         socket: {
@@ -446,19 +459,18 @@ describe.concurrent("socket", () => {
             return new Error("CustomError");
           },
           error(socket, error) {
-            clearTimeout(timeout);
-            resolve(error);
+            resolve({ handler: "error", name: error.name, message: error.message });
           },
           close(socket) {
             // we need the close handler
-            resolve({ message: "Closed" });
+            resolve({ handler: "close" });
           },
           data(socket, data) {},
         },
       });
 
-      const result: any = await promise;
-      expect(result?.message).toBe("CustomError");
+      expect(await promise).toEqual({ handler: "error", name: "Error", message: "CustomError" });
+      client.end();
     }
   });
 
@@ -474,30 +486,32 @@ describe.concurrent("socket", () => {
       },
     });
 
-    const { resolve, reject, promise } = Promise.withResolvers();
+    const { resolve, promise } = Promise.withResolvers<void>();
 
-    let client: Socket<undefined> | null = null;
-    let opened = false;
-    client = await Bun.connect({
+    let opens = 0;
+    let connectErrors = 0;
+    let received = "";
+    await Bun.connect({
       port: server.port,
       hostname: "localhost",
       socket: {
         open(socket) {
-          expect(opened).toBe(false);
-          opened = true;
+          opens++;
         },
         connectError(socket, error) {
-          expect().fail("connectError should not be called");
+          connectErrors++;
         },
         close(socket) {
           resolve();
         },
-        data(socket, data) {},
+        data(socket, data) {
+          received += data.toString();
+        },
       },
     });
 
     await promise;
-    expect(opened).toBe(true);
+    expect({ opens, connectErrors, received }).toEqual({ opens: 1, connectErrors: 0, received: "Hello" });
   });
 
   it.skipIf(isWindows)("should not leak file descriptors when connecting", async () => {
@@ -516,34 +530,34 @@ describe.concurrent("socket", () => {
       },
     });
 
-    const { resolve, reject, promise } = Promise.withResolvers();
-
-    let client: Socket<undefined> | null = null;
-    let hadError = false;
-    try {
-      client = await Bun.connect({
-        port: server.port,
-        hostname: "::1",
-        socket: {
-          open(socket) {
-            expect().fail("open should not be called, the connection should fail");
-          },
-          connectError(socket, error) {
-            expect(hadError).toBe(false);
-            hadError = true;
-            resolve();
-          },
-          close(socket) {
-            expect().fail("close should not be called, the connection should fail");
-          },
-          data(socket, data) {},
+    const events: string[] = [];
+    const rejection = await Bun.connect({
+      port: server.port,
+      hostname: "::1",
+      socket: {
+        open(socket) {
+          events.push("open");
         },
-      });
-    } catch (e) {}
+        connectError(socket, error) {
+          events.push("connectError");
+        },
+        close(socket) {
+          events.push("close");
+        },
+        data(socket, data) {},
+      },
+    }).then(
+      () => null,
+      error => errorShape(error),
+    );
 
-    await Bun.sleep(50);
-    await promise;
-    expect(hadError).toBe(true);
+    // The attempt is over once the promise has settled: connectError is the only
+    // callback of a failed connect, and no socket exists to call open or close.
+    // The code is not pinned: a host without IPv6 fails this connect with another errno.
+    expect({ events, rejection }).toMatchObject({
+      events: ["connectError"],
+      rejection: { name: "Error", message: "Failed to connect" },
+    });
   });
 
   it("should connect directly when using an ip address", async () => {
@@ -558,50 +572,64 @@ describe.concurrent("socket", () => {
       },
     });
 
-    const { resolve, reject, promise } = Promise.withResolvers();
+    const { resolve, promise } = Promise.withResolvers<void>();
 
-    let client: Socket<undefined> | null = null;
-    let opened = false;
-    client = await Bun.connect({
+    let opens = 0;
+    let connectErrors = 0;
+    let received = "";
+    await Bun.connect({
       port: server.port,
       hostname: "127.0.0.1",
       socket: {
         open(socket) {
-          expect(opened).toBe(false);
-          opened = true;
+          opens++;
         },
         connectError(socket, error) {
-          expect().fail("connectError should not be called");
+          connectErrors++;
         },
         close(socket) {
           resolve();
         },
-        data(socket, data) {},
+        data(socket, data) {
+          received += data.toString();
+        },
       },
     });
 
     await promise;
-    expect(opened).toBe(true);
+    expect({ opens, connectErrors, received }).toEqual({ opens: 1, connectErrors: 0, received: "Hello" });
   });
 
   it("should not call drain before handshake", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    using socket = await Bun.connect({
-      hostname: "www.example.com",
-      tls: true,
-      port: 443,
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls,
       socket: {
-        drain() {
-          if (!socket.authorized) {
-            reject(new Error("Socket not authorized"));
-          }
-        },
-        handshake() {
-          resolve();
-        },
+        data() {},
+        error() {},
       },
     });
-    await promise;
+    const { promise, resolve } = Promise.withResolvers<{ success: boolean; authorized: boolean }>();
+    let handshook = false;
+    let drainsBeforeHandshake = 0;
+    using socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      tls: { ca: tls.cert },
+      port: server.port,
+      socket: {
+        drain() {
+          if (!handshook) drainsBeforeHandshake++;
+        },
+        handshake(socket, success) {
+          handshook = true;
+          resolve({ success, authorized: socket.authorized });
+        },
+        data() {},
+      },
+    });
+    expect(await promise).toEqual({ success: true, authorized: true });
+    expect(drainsBeforeHandshake).toBe(0);
     expect(socket.authorized).toBe(true);
   });
   // A server-side upgradeTLS handed only a SecureContext has no parsed tls
@@ -616,7 +644,7 @@ describe.concurrent("socket", () => {
       requestCert: true,
       rejectUnauthorized: true,
     });
-    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    const { promise, resolve, reject } = Promise.withResolvers<string | null>();
     const server = Bun.listen({
       hostname: "127.0.0.1",
       port: 0,
@@ -629,8 +657,8 @@ describe.concurrent("socket", () => {
             data: {},
             socket: {
               handshake(tlsSocket) {
-                const peer = tlsSocket.getPeerCertificate();
-                resolve(!!peer && Object.keys(peer).length > 0);
+                // An empty object means the client sent no certificate.
+                resolve(tlsSocket.getPeerCertificate()?.subject?.CN ?? null);
               },
               data() {},
               close() {},
@@ -655,7 +683,7 @@ describe.concurrent("socket", () => {
         key: tls.key,
       });
       client.on("error", () => {});
-      expect(await promise).toBe(true);
+      expect(await promise).toBe("server-bun");
       client.destroy();
     } finally {
       server.stop(true);
@@ -830,10 +858,21 @@ describe.concurrent("socket", () => {
         expect(tls_socket).toBeDefined();
       }
       const [tlsData, rawData] = await Promise.all([tlsSocketPromise, rawSocketPromise]);
-      expect(tlsData).toContain("HTTP/1.1 200 OK");
-      expect(tlsData).toContain("Content-Length: 11");
-      expect(tlsData).toContain("\r\nHello World");
-      expect(rawData.byteLength).toBeGreaterThanOrEqual(1980);
+      const [head, responseBody] = (tlsData as string).split("\r\n\r\n");
+      const [statusLine, ...headerLines] = head.split("\r\n");
+      const headers = Object.fromEntries(
+        headerLines.map(line => {
+          const colon = line.indexOf(":");
+          return [line.slice(0, colon).toLowerCase(), line.slice(colon + 1).trim()];
+        }),
+      );
+      expect({ statusLine, contentLength: headers["content-length"], responseBody }).toEqual({
+        statusLine: "HTTP/1.1 200 OK",
+        contentLength: "11",
+        responseBody: "Hello World",
+      });
+      // The raw twin sees only ciphertext: the handshake records plus the sealed response.
+      expect((rawData as Buffer).byteLength).toBeGreaterThanOrEqual(1980);
     }
   });
   it("upgradeTLS feeds the initialData bytes captured at call time", async () => {
@@ -976,40 +1015,45 @@ console.log("completed", done, "cycles without crashing");
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout.trim()).toBe("completed 64 cycles without crashing");
+    expect({ stdout, stderr }).toEqual({ stdout: "completed 64 cycles without crashing\n", stderr: "" });
     expect(exitCode).toBe(0);
   }, 30_000); // subprocess + debug/ASAN startup is slow
 });
 
-it.skipIf(isWindows)("should not crash when a socket from a file descriptor is closed after opening", async () => {
-  const [server, client] = createSocketPair();
-  const open = jest.fn();
-  const close = jest.fn();
-  const data = jest.fn();
-  {
-    const socket = await Bun.connect({
-      fd: server,
-      socket: {
-        open,
-        close,
-        data,
-      },
-    });
-    Bun.gc(true);
-    await Bun.sleep(10);
-    closeSync(client);
-    Bun.gc(true);
-  }
+it.concurrent.skipIf(isWindows)(
+  "should not crash when a socket from a file descriptor is closed after opening",
+  async () => {
+    const [server, client] = createSocketPair();
+    const opened = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
+    const open = jest.fn(() => opened.resolve());
+    const close = jest.fn(() => closed.resolve());
+    const data = jest.fn();
+    {
+      await Bun.connect({
+        fd: server,
+        socket: {
+          open,
+          close,
+          data,
+        },
+      });
+      Bun.gc(true);
+      await opened.promise;
+      closeSync(client);
+      Bun.gc(true);
+    }
 
-  await Bun.sleep(10);
-  expect(open).toHaveBeenCalledTimes(1);
-  expect(close).toHaveBeenCalledTimes(1);
-  expect(data).toHaveBeenCalledTimes(0);
-  open.mockClear();
-  close.mockClear();
-  data.mockClear();
-});
+    // Closing the peer end makes the adopted fd read EOF and close.
+    await closed.promise;
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(data).toHaveBeenCalledTimes(0);
+  },
+);
 
+// The two object-count checks below stay serial: they run once every socket the
+// tests above created is closed, and nothing else may be live while they count.
 it("should not leak memory", async () => {
   // assert we don't leak the sockets
   // we expect 1 or 2 because that's the prototype / structure.
@@ -1026,7 +1070,9 @@ it("should not leak memory when connect() fails again", async () => {
   await expectMaxObjectTypeCount(expect, "TCPSocket", 5, 50);
 });
 
-it("should throw on empty hostname from truthy non-string value", () => {
+// Every test from here on creates its own listener on port 0 or runs in its own child process,
+// so they share one concurrent group.
+it.concurrent("should throw on empty hostname from truthy non-string value", () => {
   const socket = { data() {}, open() {}, close() {} };
   // A truthy value whose toString() returns "" should throw, not crash
   for (const hostname of [[], new String("")]) {
@@ -1037,7 +1083,7 @@ it("should throw on empty hostname from truthy non-string value", () => {
   }
 });
 
-it("should throw on empty unix path from truthy non-string value", () => {
+it.concurrent("should throw on empty unix path from truthy non-string value", () => {
   const socket = { data() {}, open() {}, close() {} };
   // unix uses a strict string type in bindgen, so non-string values are rejected before
   // reaching the empty-string check — the error message differs from hostname
@@ -1045,7 +1091,7 @@ it("should throw on empty unix path from truthy non-string value", () => {
   expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });
 
-it("reading .listener on a closed client socket does not use-after-free handlers", async () => {
+it.concurrent("reading .listener on a closed client socket does not use-after-free handlers", async () => {
   // Client-mode Handlers is heap-allocated per-connect and freed in
   // markInactive once the socket closes. `socket.listener` read
   // `handlers.mode` through the dangling pointer before the isDetached()
@@ -1098,7 +1144,7 @@ it("reading .listener on a closed client socket does not use-after-free handlers
   expect(exitCode).toBe(0);
 });
 
-it("reading fd of a TLS listener should not crash", () => {
+it.concurrent("reading fd of a TLS listener should not crash", () => {
   using listener = Bun.listen({
     hostname: "localhost",
     port: 0,
@@ -1109,7 +1155,7 @@ it("reading fd of a TLS listener should not crash", () => {
   expect(listener.fd).toBeGreaterThanOrEqual(0);
 });
 
-it("getServername on a closed TLS socket should not crash", async () => {
+it.concurrent("getServername on a closed TLS socket should not crash", async () => {
   using listener = Bun.listen({
     hostname: "127.0.0.1",
     port: 0,
@@ -1150,12 +1196,14 @@ it("getServername on a closed TLS socket should not crash", async () => {
   expect(await promise).toBeUndefined();
   expect(client.getServername()).toBeUndefined();
 });
-it("exportKeyingMaterial with a context whose toPrimitive terminates the socket does not use-after-free", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+it.concurrent(
+  "exportKeyingMaterial with a context whose toPrimitive terminates the socket does not use-after-free",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
       const tls = ${JSON.stringify(tls)};
       const listener = Bun.listen({
         hostname: "127.0.0.1",
@@ -1190,26 +1238,28 @@ it("exportKeyingMaterial with a context whose toPrimitive terminates the socket 
       console.log(await promise);
       listener.stop(true);
       `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("undefined\n");
-  if (exitCode !== 0) expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-});
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "undefined\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  },
+);
 
-it("TLS client: flush() after end() does not double-teardown before deferred onClose", async () => {
-  // `end()` on a TLS client sends close_notify and defers the raw close until the
-  // peer replies, leaving `is_active` set so the eventual onClose can release the
-  // Handlers. A `flush()` in that window must not re-enter markInactive and free
-  // the Handlers early — when the peer's close_notify then arrives, onClose would
-  // deref freed memory (ASAN heap-use-after-free). Run in a subprocess so an ASAN
-  // abort surfaces as a clean test failure rather than taking down the runner.
-  using dir = tempDir("tls-flush-after-end", {
-    "run.ts": `
+it.concurrent(
+  "TLS client: flush() after end() does not double-teardown before deferred onClose",
+  async () => {
+    // `end()` on a TLS client sends close_notify and defers the raw close until the
+    // peer replies, leaving `is_active` set so the eventual onClose can release the
+    // Handlers. A `flush()` in that window must not re-enter markInactive and free
+    // the Handlers early — when the peer's close_notify then arrives, onClose would
+    // deref freed memory (ASAN heap-use-after-free). Run in a subprocess so an ASAN
+    // abort surfaces as a clean test failure rather than taking down the runner.
+    using dir = tempDir("tls-flush-after-end", {
+      "run.ts": `
       const tls = JSON.parse(process.env.TLS_JSON!);
 
       using server = Bun.listen({
@@ -1250,205 +1300,48 @@ it("TLS client: flush() after end() does not double-teardown before deferred onC
       await closed;
       console.log("OK");
     `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "run.ts"],
-    env: { ...bunEnv, TLS_JSON: JSON.stringify(tls) },
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("OK");
-  expect(exitCode).toBe(0);
-}, 30_000); // debug subprocess startup + ASAN symbolication on failure is slow
-
-it("writing to an established TLS socket from another TLS client's open() does not divert either connection", async () => {
-  // Proxy-style flow: an inbound TLS connection is already established, then an
-  // outbound TLS client is opened and its open() callback synchronously writes a
-  // status frame back to the inbound socket. The outbound socket's handshake must
-  // still be sent to *its own* upstream server (so it completes and the proxy can
-  // report "upstream-ready"), and the inbound client's TLS stream must only ever
-  // carry the proxy's application data — never bytes belonging to the outbound
-  // connection. Previously the per-loop SSL output target was not re-pointed after
-  // the open() dispatch, so the outbound handshake bytes landed in the inbound
-  // client's stream, corrupting its session and stalling the outbound connection.
-  const { promise: clientResult, resolve: resolveClientResult } = Promise.withResolvers<{
-    outcome: string;
-    received: string;
-  }>();
-
-  let clientReceived = "";
-
-  // Upstream TLS server the proxy connects out to.
-  const upstream = Bun.listen({
-    hostname: "127.0.0.1",
-    port: 0,
-    tls,
-    socket: {
-      open() {},
-      data() {},
-      close() {},
-      error() {},
-    },
-  });
-
-  let outbound: Socket | undefined;
-  let inboundRequest = "";
-
-  // Proxy: TLS server that, when the inbound client asks, opens an outbound TLS
-  // connection and writes to the inbound socket from the outbound open() callback.
-  const proxy = Bun.listen({
-    hostname: "127.0.0.1",
-    port: 0,
-    tls,
-    socket: {
-      open() {},
-      async data(inbound, chunk) {
-        inboundRequest += chunk.toString();
-        if (!inboundRequest.includes("CONNECT\n") || outbound) return;
-        outbound = await Bun.connect({
-          hostname: "127.0.0.1",
-          port: upstream.port,
-          tls: { ...tls, rejectUnauthorized: false },
-          socket: {
-            open() {
-              // Writes to the already-established inbound TLS socket while the
-              // outbound socket's own handshake has not been flushed to the wire yet.
-              inbound.write("hello-from-proxy\n");
-            },
-            handshake(_socket, success) {
-              inbound.write(success ? "upstream-ready\n" : "upstream-handshake-failed\n");
-            },
-            data() {},
-            close() {},
-            error() {},
-          },
-        });
-      },
-      close() {},
-      error() {},
-    },
-  });
-
-  let client: Socket | undefined;
-  try {
-    // Inbound client talking TLS to the proxy.
-    client = await Bun.connect({
-      hostname: "127.0.0.1",
-      port: proxy.port,
-      tls: { ...tls, rejectUnauthorized: false },
-      socket: {
-        open() {},
-        handshake(socket) {
-          socket.write("CONNECT\n");
-        },
-        data(_socket, chunk) {
-          clientReceived += chunk.toString();
-          if (clientReceived.includes("upstream-ready\n") || clientReceived.includes("upstream-handshake-failed\n")) {
-            resolveClientResult({ outcome: "ok", received: clientReceived });
-          }
-        },
-        close() {
-          resolveClientResult({ outcome: "closed", received: clientReceived });
-        },
-        error(_socket, err) {
-          resolveClientResult({ outcome: `error: ${err}`, received: clientReceived });
-        },
-      },
     });
 
-    // The inbound client's TLS session stays intact (no error/close) and sees
-    // exactly the proxy's two status frames, and the outbound handshake reached
-    // its own upstream server — otherwise "upstream-ready" is never produced.
-    expect(await clientResult).toEqual({
-      outcome: "ok",
-      received: "hello-from-proxy\nupstream-ready\n",
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.ts"],
+      env: { ...bunEnv, TLS_JSON: JSON.stringify(tls) },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
     });
-  } finally {
-    client?.end();
-    outbound?.end();
-    proxy.stop(true);
-    upstream.stop(true);
-  }
-}, 30_000);
 
-it("TLS mid-read boundary dispatch: writing to another TLS socket from data() does not corrupt the rest of the stream", async () => {
-  // When SSL_read fills the per-loop 512KiB output buffer exactly, uSockets
-  // dispatches that chunk to the data() callback mid-read and then continues
-  // decrypting the rest of the same TCP read. If the callback does TLS work on
-  // another socket on the same loop (here: write() to a second TLS client),
-  // the per-loop ssl_read_input/offset/length and ssl_socket must be restored
-  // afterwards — otherwise the remaining ciphertext is dropped and the stream
-  // desyncs (bad record MAC / truncated payload).
-  const BOUNDARY_CHUNK = 512 * 1024;
-  const PAYLOAD_SIZE = 12 * 1024 * 1024;
-  const block = Buffer.alloc(64 * 1024);
-  for (let i = 0; i < block.length; i++) block[i] = i & 0xff;
-  const payload = Buffer.concat(Array(PAYLOAD_SIZE / block.length).fill(block));
-  const expectedHash = new Bun.CryptoHasher("sha256").update(payload).digest("hex");
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+); // debug subprocess startup + ASAN symbolication on failure is slow
 
-  const downloadDone = Promise.withResolvers<string>();
-  const sideReceived = Promise.withResolvers<void>();
+it.concurrent(
+  "writing to an established TLS socket from another TLS client's open() does not divert either connection",
+  async () => {
+    // Proxy-style flow: an inbound TLS connection is already established, then an
+    // outbound TLS client is opened and its open() callback synchronously writes a
+    // status frame back to the inbound socket. The outbound socket's handshake must
+    // still be sent to *its own* upstream server (so it completes and the proxy can
+    // report "upstream-ready"), and the inbound client's TLS stream must only ever
+    // carry the proxy's application data — never bytes belonging to the outbound
+    // connection. Previously the per-loop SSL output target was not re-pointed after
+    // the open() dispatch, so the outbound handshake bytes landed in the inbound
+    // client's stream, corrupting its session and stalling the outbound connection.
+    const { promise: clientResult, resolve: resolveClientResult } = Promise.withResolvers<{
+      outcome: string;
+      received: string;
+    }>();
 
-  // Server that streams the 12MiB payload once the client asks for it.
-  let sent = 0;
-  const pump = (socket: Socket) => {
-    while (sent < payload.length) {
-      const written = socket.write(payload.subarray(sent, Math.min(sent + 1024 * 1024, payload.length)));
-      if (written <= 0) break;
-      sent += written;
-    }
-    socket.flush();
-  };
-  const payloadServer = Bun.listen({
-    hostname: "127.0.0.1",
-    port: 0,
-    tls,
-    socket: {
-      open() {},
-      data(socket) {
-        pump(socket);
-      },
-      drain(socket) {
-        pump(socket);
-      },
-      close() {},
-      error() {},
-    },
-  });
+    let clientReceived = "";
 
-  // Second TLS server + client on the same loop; the download's data() handler
-  // writes to this client from inside the boundary dispatch.
-  const sideServer = Bun.listen({
-    hostname: "127.0.0.1",
-    port: 0,
-    tls,
-    socket: {
-      open() {},
-      data() {
-        sideReceived.resolve();
-      },
-      close() {},
-      error() {},
-    },
-  });
-
-  let sideSocket: Socket | undefined;
-  let downloadSocket: Socket | undefined;
-  const hasher = new Bun.CryptoHasher("sha256");
-  let receivedBytes = 0;
-  let boundaryChunks = 0;
-  let sideWrites = 0;
-
-  try {
-    sideSocket = await Bun.connect({
+    // Upstream TLS server the proxy connects out to.
+    const upstream = Bun.listen({
       hostname: "127.0.0.1",
-      port: sideServer.port,
-      tls: { ...tls, rejectUnauthorized: false },
+      port: 0,
+      tls,
       socket: {
         open() {},
         data() {},
@@ -1457,54 +1350,232 @@ it("TLS mid-read boundary dispatch: writing to another TLS socket from data() do
       },
     });
 
-    downloadSocket = await Bun.connect({
+    let outbound: Socket | undefined;
+    let inboundRequest = "";
+
+    // Proxy: TLS server that, when the inbound client asks, opens an outbound TLS
+    // connection and writes to the inbound socket from the outbound open() callback.
+    const proxy = Bun.listen({
       hostname: "127.0.0.1",
-      port: payloadServer.port,
-      tls: { ...tls, rejectUnauthorized: false },
+      port: 0,
+      tls,
       socket: {
         open() {},
-        handshake(socket) {
-          socket.write("GO\n");
+        async data(inbound, chunk) {
+          inboundRequest += chunk.toString();
+          if (!inboundRequest.includes("CONNECT\n") || outbound) return;
+          outbound = await Bun.connect({
+            hostname: "127.0.0.1",
+            port: upstream.port,
+            tls: { ...tls, rejectUnauthorized: false },
+            socket: {
+              open() {
+                // Writes to the already-established inbound TLS socket while the
+                // outbound socket's own handshake has not been flushed to the wire yet.
+                inbound.write("hello-from-proxy\n");
+              },
+              handshake(_socket, success) {
+                inbound.write(success ? "upstream-ready\n" : "upstream-handshake-failed\n");
+              },
+              data() {},
+              close() {},
+              error() {},
+            },
+          });
         },
-        data(_socket, chunk) {
-          hasher.update(chunk);
-          receivedBytes += chunk.byteLength;
-
-          const isBoundary = chunk.byteLength === BOUNDARY_CHUNK;
-          if (isBoundary) boundaryChunks += 1;
-          // Write to the second TLS socket from the boundary dispatch; if this
-          // run never produces an exact 512KiB chunk, fall back to writing on
-          // every data event so the re-entrancy is still exercised.
-          if (isBoundary || boundaryChunks === 0) {
-            sideWrites += 1;
-            sideSocket!.write("ping\n");
-          }
-
-          if (receivedBytes >= PAYLOAD_SIZE) {
-            downloadDone.resolve("done");
-          }
-        },
-        close() {
-          downloadDone.resolve(`closed after ${receivedBytes} bytes`);
-        },
-        error(_socket, err) {
-          downloadDone.resolve(`error: ${err} after ${receivedBytes} bytes`);
-        },
+        close() {},
+        error() {},
       },
     });
 
-    expect(await downloadDone.promise).toBe("done");
-    expect(receivedBytes).toBe(PAYLOAD_SIZE);
-    expect(hasher.digest("hex")).toBe(expectedHash);
-    expect(sideWrites).toBeGreaterThan(0);
-    await sideReceived.promise;
-  } finally {
-    downloadSocket?.end();
-    sideSocket?.end();
-    payloadServer.stop(true);
-    sideServer.stop(true);
-  }
-}, 60_000);
+    let client: Socket | undefined;
+    try {
+      // Inbound client talking TLS to the proxy.
+      client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: proxy.port,
+        tls: { ...tls, rejectUnauthorized: false },
+        socket: {
+          open() {},
+          handshake(socket) {
+            socket.write("CONNECT\n");
+          },
+          data(_socket, chunk) {
+            clientReceived += chunk.toString();
+            if (clientReceived.includes("upstream-ready\n") || clientReceived.includes("upstream-handshake-failed\n")) {
+              resolveClientResult({ outcome: "ok", received: clientReceived });
+            }
+          },
+          close() {
+            resolveClientResult({ outcome: "closed", received: clientReceived });
+          },
+          error(_socket, err) {
+            resolveClientResult({ outcome: `error: ${err}`, received: clientReceived });
+          },
+        },
+      });
+
+      // The inbound client's TLS session stays intact (no error/close) and sees
+      // exactly the proxy's two status frames, and the outbound handshake reached
+      // its own upstream server — otherwise "upstream-ready" is never produced.
+      expect(await clientResult).toEqual({
+        outcome: "ok",
+        received: "hello-from-proxy\nupstream-ready\n",
+      });
+    } finally {
+      client?.end();
+      outbound?.end();
+      proxy.stop(true);
+      upstream.stop(true);
+    }
+  },
+  30_000,
+);
+
+it.concurrent(
+  "TLS mid-read boundary dispatch: writing to another TLS socket from data() does not corrupt the rest of the stream",
+  async () => {
+    // When SSL_read fills the per-loop 512KiB output buffer exactly, uSockets
+    // dispatches that chunk to the data() callback mid-read and then continues
+    // decrypting the rest of the same TCP read. If the callback does TLS work on
+    // another socket on the same loop (here: write() to a second TLS client),
+    // the per-loop ssl_read_input/offset/length and ssl_socket must be restored
+    // afterwards — otherwise the remaining ciphertext is dropped and the stream
+    // desyncs (bad record MAC / truncated payload).
+    const BOUNDARY_CHUNK = 512 * 1024;
+    const PAYLOAD_SIZE = 12 * 1024 * 1024;
+    const block = Buffer.alloc(64 * 1024);
+    for (let i = 0; i < block.length; i++) block[i] = i & 0xff;
+    const payload = Buffer.concat(Array(PAYLOAD_SIZE / block.length).fill(block));
+    const expectedHash = new Bun.CryptoHasher("sha256").update(payload).digest("hex");
+
+    const downloadDone = Promise.withResolvers<string>();
+    const sideReceived = Promise.withResolvers<void>();
+
+    // Server that streams the 12MiB payload once the client asks for it.
+    let sent = 0;
+    const pump = (socket: Socket) => {
+      while (sent < payload.length) {
+        const written = socket.write(payload.subarray(sent, Math.min(sent + 1024 * 1024, payload.length)));
+        if (written <= 0) break;
+        sent += written;
+      }
+      socket.flush();
+    };
+    const payloadServer = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls,
+      socket: {
+        open() {},
+        data(socket) {
+          pump(socket);
+        },
+        drain(socket) {
+          pump(socket);
+        },
+        close() {},
+        error() {},
+      },
+    });
+
+    // Second TLS server + client on the same loop; the download's data() handler
+    // writes to this client from inside the boundary dispatch.
+    const sideServer = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls,
+      socket: {
+        open() {},
+        data() {
+          sideReceived.resolve();
+        },
+        close() {},
+        error() {},
+      },
+    });
+
+    let sideSocket: Socket | undefined;
+    let downloadSocket: Socket | undefined;
+    const hasher = new Bun.CryptoHasher("sha256");
+    let receivedBytes = 0;
+    let boundaryChunks = 0;
+    const sideWrites: number[] = [];
+    const sideHandshake = Promise.withResolvers<void>();
+
+    try {
+      sideSocket = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: sideServer.port,
+        tls: { ...tls, rejectUnauthorized: false },
+        socket: {
+          open() {},
+          handshake(_socket, success, authorizationError) {
+            if (success) sideHandshake.resolve();
+            else sideHandshake.reject(authorizationError ?? new Error("side handshake failed"));
+          },
+          data() {},
+          close() {},
+          error(_socket, err) {
+            sideHandshake.reject(err);
+          },
+        },
+      });
+      // connect() resolves when the TCP connection opens. A write issued before the
+      // handshake completes is parked (write() returns 0), not sent.
+      await sideHandshake.promise;
+
+      downloadSocket = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: payloadServer.port,
+        tls: { ...tls, rejectUnauthorized: false },
+        socket: {
+          open() {},
+          handshake(socket) {
+            socket.write("GO\n");
+          },
+          data(_socket, chunk) {
+            hasher.update(chunk);
+            receivedBytes += chunk.byteLength;
+
+            const isBoundary = chunk.byteLength === BOUNDARY_CHUNK;
+            if (isBoundary) boundaryChunks += 1;
+            // Write to the second TLS socket from the boundary dispatch; if this
+            // run never produces an exact 512KiB chunk, fall back to writing on
+            // every data event so the re-entrancy is still exercised.
+            if (isBoundary || boundaryChunks === 0) {
+              sideWrites.push(sideSocket!.write("ping\n"));
+            }
+
+            if (receivedBytes >= PAYLOAD_SIZE) {
+              downloadDone.resolve("done");
+            }
+          },
+          close() {
+            downloadDone.resolve(`closed after ${receivedBytes} bytes`);
+          },
+          error(_socket, err) {
+            downloadDone.resolve(`error: ${err} after ${receivedBytes} bytes`);
+          },
+        },
+      });
+
+      expect(await downloadDone.promise).toBe("done");
+      expect(receivedBytes).toBe(PAYLOAD_SIZE);
+      expect(hasher.digest("hex")).toBe(expectedHash);
+      // Every side write was accepted on the spot: a 0 would mean it was parked and never sent.
+      expect(sideWrites.length).toBeGreaterThan(0);
+      expect(sideWrites.filter(written => written !== "ping\n".length)).toEqual([]);
+      await sideReceived.promise;
+    } finally {
+      downloadSocket?.end();
+      sideSocket?.end();
+      payloadServer.stop(true);
+      sideServer.stop(true);
+    }
+  },
+  60_000,
+);
 
 describe.concurrent("TLS server: write() to the accepted socket from inside its own selection callback", () => {
   // alpnCallback / serverName are the listener hooks node:tls's ALPNCallback /
@@ -1598,13 +1669,15 @@ describe.concurrent("TLS server: write() to the accepted socket from inside its 
   }
 });
 
-it("alpnCallback: a selection whose ToString throws surfaces the thrown Error, not an engine-internal cell", async () => {
-  // The thrown value must reach the `error` handler as a plain Error, not the
-  // JSC::Exception wrapper cell: `Object.prototype.toString.call` on the cell
-  // aborts the process and `instanceof Error` on it is false. The crash fires
-  // on the first property load of the value, so probe it in a subprocess.
-  using dir = tempDir("alpn-tostring-throw", {
-    "fixture.cjs": `
+it.concurrent(
+  "alpnCallback: a selection whose ToString throws surfaces the thrown Error, not an engine-internal cell",
+  async () => {
+    // The thrown value must reach the `error` handler as a plain Error, not the
+    // JSC::Exception wrapper cell: `Object.prototype.toString.call` on the cell
+    // aborts the process and `instanceof Error` on it is false. The crash fires
+    // on the first property load of the value, so probe it in a subprocess.
+    using dir = tempDir("alpn-tostring-throw", {
+      "fixture.cjs": `
       const tlsMod = require("node:tls");
       const server = Bun.listen({
         hostname: "127.0.0.1",
@@ -1638,23 +1711,24 @@ it("alpnCallback: a selection whose ToString throws surfaces the thrown Error, n
         server.stop(true);
       });
     `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "fixture.cjs"],
-    env: { ...bunEnv, ASAN_OPTIONS: "symbolize=0:abort_on_error=1:allow_user_segv_handler=1" },
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.cjs"],
+      env: { ...bunEnv, ASAN_OPTIONS: "symbolize=0:abort_on_error=1:allow_user_segv_handler=1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ lines: stdout.trim().split(/\r?\n/), stderr, exitCode }).toEqual({
-    lines: ["error:true:[object Error]:TypeError"],
-    stderr: "",
-    exitCode: 0,
-  });
-});
+    expect({ lines: stdout.trim().split(/\r?\n/), stderr, exitCode }).toEqual({
+      lines: ["error:true:[object Error]:TypeError"],
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);
 
 // Bun.connect() on a Windows named pipe takes a dedicated early branch in
 // Listener.connectInner that heap-allocates a standalone Handlers block. That
@@ -1662,7 +1736,7 @@ it("alpnCallback: a selection whose ToString throws surfaces the thrown Error, n
 // close; the `.server` path does `@fieldParentPtr("handlers", ...)` expecting
 // a surrounding Listener struct and would read past the standalone
 // allocation (heap-buffer-overflow under ASAN) and leak the block.
-describe.skipIf(!isWindows)("Bun.connect named-pipe client Handlers lifecycle", () => {
+describe.concurrent.skipIf(!isWindows)("Bun.connect named-pipe client Handlers lifecycle", () => {
   it("open → close cleans up without reading past the Handlers allocation", async () => {
     const src = /* js */ `
       const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-connect-" + Math.random().toString(36).slice(2);
@@ -1941,7 +2015,7 @@ describe.concurrent.skipIf(!isWindows)("named-pipe socket closed and event loop 
   });
 });
 
-it("reload() backs out cleanly when a handler getter closes the socket mid-reload", async () => {
+it.concurrent("reload() backs out cleanly when a handler getter closes the socket mid-reload", async () => {
   // socket.reload() reads the new callbacks off the user object property by
   // property, so a getter can run arbitrary JS — including terminating the
   // very socket being reloaded, which releases its current handlers. The
@@ -2031,12 +2105,11 @@ it("reload() backs out cleanly when a handler getter closes the socket mid-reloa
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("reload-with-terminate-ok\nsecond-reload:polo\nDONE\n");
+  expect({ stdout, stderr }).toEqual({ stdout: "reload-with-terminate-ok\nsecond-reload:polo\nDONE\n", stderr: "" });
   expect(exitCode).toBe(0);
-  void stderr;
 });
 
-it("node:net connect() reusing a server-accepted handle keeps the listener's handlers working", async () => {
+it.concurrent("node:net connect() reusing a server-accepted handle keeps the listener's handlers working", async () => {
   // A Bun.listen()-accepted socket wrapper does not own its handlers — they
   // live inside the listener. Reusing such a wrapper as the handle for an
   // outbound node:net connect must not release the listener's handlers: the
@@ -2151,9 +2224,11 @@ it("node:net connect() reusing a server-accepted handle keeps the listener's han
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("STEP1\nSTEP2:connected+data\nSTEP3:second-accept\nDONE\n");
+  expect({ stdout, stderr }).toEqual({
+    stdout: "STEP1\nSTEP2:connected+data\nSTEP3:second-accept\nDONE\n",
+    stderr: "",
+  });
   expect(exitCode).toBe(0);
-  void stderr;
 });
 
 it.concurrent("setTypeOfService validates its argument instead of asserting", async () => {
@@ -2215,7 +2290,7 @@ it.concurrent("setTypeOfService validates its argument instead of asserting", as
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+  expect({ stdout: stdout.trim().split("\n"), stderr }).toEqual({
     stdout: [
       "object=ERR_INVALID_ARG_TYPE",
       "string=ERR_INVALID_ARG_TYPE",
@@ -2226,9 +2301,9 @@ it.concurrent("setTypeOfService validates its argument instead of asserting", as
       "ok=no-throw",
       "get=no-throw",
     ],
-    exitCode: 0,
+    stderr: "",
   });
-  void stderr;
+  expect(exitCode).toBe(0);
 });
 
 // initialDelay is ms; TCP_KEEPIDLE is seconds. 0 = enable SO_KEEPALIVE and
@@ -2316,7 +2391,7 @@ it.concurrent.skipIf(isWindows)("setKeepAlive converts ms to seconds and treats 
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ out: JSON.parse(stdout.trim() || "null"), exitCode }).toEqual({
+  expect({ out: JSON.parse(stdout.trim() || "null"), stderr }).toEqual({
     out: {
       a_ret: true,
       a_keepalive: 1,
@@ -2328,12 +2403,12 @@ it.concurrent.skipIf(isWindows)("setKeepAlive converts ms to seconds and treats 
       b_keepidle: 4,
       net_keepidle: 4,
     },
-    exitCode: 0,
+    stderr: "",
   });
-  void stderr;
+  expect(exitCode).toBe(0);
 });
 
-it("socket handler validation errors throw instead of crashing", async () => {
+it.concurrent("socket handler validation errors throw instead of crashing", async () => {
   // Handlers protects its callbacks only after validation succeeds, so the
   // validation error paths must throw without tearing down a never-protected
   // Handlers (debug builds assert on the protect/unprotect balance). Run in
@@ -2362,29 +2437,32 @@ it("socket handler validation errors throw instead of crashing", async () => {
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe(
-    'connect:Expected at least "data" or "drain" callback\n' +
+  expect({ stdout, stderr }).toEqual({
+    stdout:
+      'connect:Expected at least "data" or "drain" callback\n' +
       'listen:Expected at least "data" or "drain" callback\n' +
       'connect:Expected "onEnd" callback to be a function\n' +
       'listen:Expected "onEnd" callback to be a function\n',
-  );
+    stderr: "",
+  });
   expect(exitCode).toBe(0);
-  void stderr;
 });
 
 // https://bun-p9.sentry.io/issues/7573683042/ (BUN-3PK7)
-it("socket handler validation errors don't steal GC protection from live sockets sharing the same callbacks", async () => {
-  // node:net passes one module-level handler table to every connection, so
-  // every live socket protects the same JSFunction identities. A Handlers
-  // dropped on a validation error before protect() ran must not gcUnprotect
-  // those shared functions, or GC collects them while a live socket's
-  // Handlers still points at the freed cells and the socket's finalizer
-  // later dereferences cell->vm() inside Bun__JSValue__unprotect.
-  await using proc = spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+it.concurrent(
+  "socket handler validation errors don't steal GC protection from live sockets sharing the same callbacks",
+  async () => {
+    // node:net passes one module-level handler table to every connection, so
+    // every live socket protects the same JSFunction identities. A Handlers
+    // dropped on a validation error before protect() ran must not gcUnprotect
+    // those shared functions, or GC collects them while a live socket's
+    // Handlers still points at the freed cells and the socket's finalizer
+    // later dereferences cell->vm() inside Bun__JSValue__unprotect.
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         let listener;
         let errors = 0;
         (function setup() {
@@ -2449,19 +2527,19 @@ it("socket handler validation errors don't steal GC protection from live sockets
         for (let i = 0; i < 20; i++) Bun.gc(true);
         console.log("done");
       `,
-    ],
-    env: { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }) },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+      ],
+      env: { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("errors=8\nreceived=hello\ndone\n");
-  expect(exitCode).toBe(0);
-  void stderr;
-});
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "errors=8\nreceived=hello\ndone\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  },
+);
 
-describe("TLS rejectUnauthorized", () => {
+describe.concurrent("TLS rejectUnauthorized", () => {
   // Regenerate with: openssl req -x509 -newkey rsa:2048 -nodes -days 3650 for
   // each CA, then sign two "localhost" leaves (SAN localhost,127.0.0.1,::1):
   // one by CA_CRT (SERVER_*) and one by a second, untrusted CA (ROGUE_*).
@@ -2670,10 +2748,13 @@ Reo=
       };
     }
 
-    it("closes a connection whose server certificate is not trusted", async () => {
-      using t = await connectTo({ key: ROGUE_KEY, cert: ROGUE_CRT }, { ca: CA_CRT });
-      // A rejecting client reports the failed verdict at the callback, like
-      // node v26.3.0 (secureConnect never fires; socket.authorized is false).
+    // A rejecting client reports the failed verdict at the callback, like
+    // node v26.3.0 (secureConnect never fires; socket.authorized is false).
+    it.each([
+      ["closes a connection whose server certificate is not trusted", { ca: CA_CRT }],
+      ["closes an untrusted connection with tls: true", true],
+    ] as const)("%s", async (_name, clientTls) => {
+      using t = await connectTo({ key: ROGUE_KEY, cert: ROGUE_CRT }, clientTls);
       expect(await t.handshake.promise).toEqual({
         authorizedArg: false,
         authorizedGetter: false,
@@ -2684,20 +2765,6 @@ Reo=
       expect(t.received).toEqual([]);
       // The verdict must stay readable after the forced close.
       expect(t.client.getAuthorizationError()?.message).toBe(UNTRUSTED_MESSAGE);
-    });
-
-    it("closes an untrusted connection with tls: true", async () => {
-      using t = await connectTo({ key: ROGUE_KEY, cert: ROGUE_CRT }, true);
-      // Same node v26.3.0 contract as above: the rejected handshake reports
-      // authorized=false at the callback.
-      expect(await t.handshake.promise).toEqual({
-        authorizedArg: false,
-        authorizedGetter: false,
-        callbackError: UNTRUSTED_MESSAGE,
-        getterError: UNTRUSTED_MESSAGE,
-      });
-      await t.closed.promise;
-      expect(t.received).toEqual([]);
     });
 
     it("reports authorized=false but keeps the connection with rejectUnauthorized: false", async () => {
@@ -2713,61 +2780,13 @@ Reo=
       expect(t.received.join("")).toBe("hello-from-server\nping");
     });
 
-    it("closes an untrusted connection upgraded with only a secureContext", async () => {
-      using server = Bun.listen({
-        hostname: "127.0.0.1",
-        port: 0,
-        tls: { key: ROGUE_KEY, cert: ROGUE_CRT },
-        socket: {
-          open() {},
-          handshake(socket) {
-            socket.write("hello-from-server\n");
-          },
-          data(socket, data) {
-            socket.write(data);
-          },
-          close() {},
-          error() {},
-        },
-      });
-
-      const received: string[] = [];
-      const handshake = Promise.withResolvers<{ authorized: boolean; error: string | null }>();
-      const closed = Promise.withResolvers<void>();
-
-      using tcp = await Bun.connect({
-        hostname: "127.0.0.1",
-        port: server.port,
-        socket: { data() {}, close() {}, error() {} },
-      });
-      const { context } = createSecureContext({ ca: CA_CRT }) as any;
-      const [raw, secure] = tcp.upgradeTLS({
-        secureContext: context,
-        socket: {
-          handshake(socket: Socket, _success: boolean, authorizationError: Error | null) {
-            handshake.resolve({
-              authorized: socket.authorized,
-              error: authorizationError?.message ?? null,
-            });
-          },
-          data(_socket: Socket, data: Buffer) {
-            received.push(data.toString());
-          },
-          close() {
-            closed.resolve();
-          },
-          error() {},
-        },
-      } as any);
-      using _raw = raw;
-      using _secure = secure;
-
-      expect(await handshake.promise).toEqual({ authorized: false, error: UNTRUSTED_MESSAGE });
-      await closed.promise;
-      expect(received).toEqual([]);
-    });
-
-    it("closes an untrusted connection upgraded with tls: true", async () => {
+    it.each([
+      [
+        "closes an untrusted connection upgraded with only a secureContext",
+        () => ({ secureContext: (createSecureContext({ ca: CA_CRT }) as any).context }),
+      ],
+      ["closes an untrusted connection upgraded with tls: true", () => ({ tls: true })],
+    ] as const)("%s", async (_name, upgradeOptions) => {
       using server = Bun.listen({
         hostname: "127.0.0.1",
         port: 0,
@@ -2795,7 +2814,7 @@ Reo=
         socket: { data() {}, close() {}, error() {} },
       });
       const [raw, secure] = tcp.upgradeTLS({
-        tls: true,
+        ...upgradeOptions(),
         socket: {
           handshake(socket: Socket, _success: boolean, authorizationError: Error | null) {
             handshake.resolve({
@@ -3479,18 +3498,30 @@ Reo=
 
     // A bare `secureContext` carries no parsed config; the policy comes from
     // the context's own verify mode.
-    it("closes an untrusted client certificate on an isServer upgrade with only a secureContext", async () => {
+    it.each([
+      [
+        "closes an untrusted client certificate on an isServer upgrade with only a secureContext",
+        () => ({
+          secureContext: (
+            createSecureContext({
+              key: SERVER_KEY,
+              cert: SERVER_CRT,
+              ca: CA_CRT,
+              requestCert: true,
+              rejectUnauthorized: true,
+            } as any) as any
+          ).context,
+        }),
+      ],
+      [
+        "closes an untrusted client certificate on a socket upgraded with isServer: true",
+        () => ({ tls: { key: SERVER_KEY, cert: SERVER_CRT, ca: CA_CRT, requestCert: true } }),
+      ],
+    ] as const)("%s", async (_name, upgradeOptions) => {
       const serverReceived: string[] = [];
       const handshake = Promise.withResolvers<{ authorized: boolean; error: string | null; writeResult: number }>();
       const serverClosed = Promise.withResolvers<void>();
       const clientClosed = Promise.withResolvers<void>();
-      const { context } = createSecureContext({
-        key: SERVER_KEY,
-        cert: SERVER_CRT,
-        ca: CA_CRT,
-        requestCert: true,
-        rejectUnauthorized: true,
-      } as any) as any;
       using listener = Bun.listen({
         hostname: "127.0.0.1",
         port: 0,
@@ -3500,76 +3531,7 @@ Reo=
             raw.upgradeTLS({
               isServer: true,
               initialData: chunk,
-              secureContext: context,
-              socket: {
-                handshake(secure: Socket, _success: boolean, authorizationError: Error | null) {
-                  handshake.resolve({
-                    authorized: secure.authorized,
-                    error: authorizationError?.message ?? null,
-                    writeResult: secure.write("hello-from-server\n"),
-                  });
-                },
-                data(_secure: Socket, payload: Buffer) {
-                  serverReceived.push(payload.toString());
-                },
-                close() {
-                  serverClosed.resolve();
-                },
-                error() {},
-              },
-            } as any);
-          },
-          error(_raw, err) {
-            handshake.reject(err);
-            serverClosed.reject(err);
-          },
-          close() {},
-        },
-      });
-      using client = await Bun.connect({
-        hostname: "127.0.0.1",
-        port: listener.port,
-        tls: { ca: CA_CRT, serverName: "localhost", key: ROGUE_KEY, cert: ROGUE_CRT },
-        socket: {
-          open() {},
-          handshake(socket) {
-            socket.write("client-app-data\n");
-          },
-          data() {},
-          close() {
-            clientClosed.resolve();
-          },
-          error() {},
-          connectError(_socket, err) {
-            handshake.reject(err);
-            clientClosed.reject(err);
-            serverClosed.reject(err);
-          },
-        },
-      });
-      void client;
-      expect(await handshake.promise).toEqual({ authorized: false, error: UNTRUSTED_MESSAGE, writeResult: -1 });
-      await serverClosed.promise;
-      expect(serverReceived).toEqual([]);
-      await clientClosed.promise;
-    });
-
-    it("closes an untrusted client certificate on a socket upgraded with isServer: true", async () => {
-      const serverReceived: string[] = [];
-      const handshake = Promise.withResolvers<{ authorized: boolean; error: string | null; writeResult: number }>();
-      const serverClosed = Promise.withResolvers<void>();
-      const clientClosed = Promise.withResolvers<void>();
-      const serverTls = { key: SERVER_KEY, cert: SERVER_CRT, ca: CA_CRT, requestCert: true };
-      using listener = Bun.listen({
-        hostname: "127.0.0.1",
-        port: 0,
-        socket: {
-          open() {},
-          data(raw, chunk) {
-            raw.upgradeTLS({
-              isServer: true,
-              initialData: chunk,
-              tls: serverTls,
+              ...upgradeOptions(),
               socket: {
                 open() {},
                 handshake(secure: Socket, _success: boolean, authorizationError: Error | null) {
@@ -3617,6 +3579,7 @@ Reo=
           },
         },
       });
+      void client;
       expect(await handshake.promise).toEqual({ authorized: false, error: UNTRUSTED_MESSAGE, writeResult: -1 });
       await serverClosed.promise;
       expect(serverReceived).toEqual([]);
@@ -3752,7 +3715,7 @@ Reo=
 
 // Linux-only: uses /proc/self/fd to find and close the connected socket's fd
 // so getsockname()/getpeername() fail with EBADF.
-it.skipIf(!isLinux)(
+it.concurrent.skipIf(!isLinux)(
   "socket.localPort / socket.remotePort return undefined when the underlying fd is gone",
   async () => {
     const script = /* js */ `
@@ -3807,16 +3770,15 @@ it.skipIf(!isLinux)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
+    // If the child died before reporting, the diff shows its raw output.
+    const out = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    if (out?.skipped) return;
+    expect({ out, stderr }).toEqual({ out: { localPort: null, remotePort: null }, stderr: "" });
     expect(exitCode).toBe(0);
-
-    const out = JSON.parse(stdout.trim());
-    if (out.skipped) return;
-    expect(out).toEqual({ localPort: null, remotePort: null });
   },
 );
 
-describe("TLS handshake callback throw", () => {
+describe.concurrent("TLS handshake callback throw", () => {
   // A throw from a Bun-native handshake callback must reach the socket's own
   // error handler (the documented contract), not crash the process — node:tls
   // gets its uncaughtException semantics in net.ts, not in the shared native
@@ -3858,16 +3820,18 @@ describe("TLS handshake callback throw", () => {
   });
 });
 
-it("an unref'd Bun.listen() with no other references keeps accepting across GC", async () => {
-  // Listener.unref() used to downgrade the wrapper's GC ref to weak while the
-  // socket was still listening. GC then collected the wrapper (and the
-  // handlers cell it roots), so the next accepted connection either dispatched
-  // on_open into a swept cell (SIGABRT / type confusion) or, once the
-  // finalizer had closed the socket, got ECONNREFUSED. unref() must only
-  // release the event-loop hold; the wrapper stays reachable until stop().
-  // Raw TCP instead of fetch: the server replies and ends without reading the
-  // request, and on Windows closing with the request unread RSTs the exchange.
-  const src = `
+it.concurrent(
+  "an unref'd Bun.listen() with no other references keeps accepting across GC",
+  async () => {
+    // Listener.unref() used to downgrade the wrapper's GC ref to weak while the
+    // socket was still listening. GC then collected the wrapper (and the
+    // handlers cell it roots), so the next accepted connection either dispatched
+    // on_open into a swept cell (SIGABRT / type confusion) or, once the
+    // finalizer had closed the socket, got ECONNREFUSED. unref() must only
+    // release the event-loop hold; the wrapper stays reachable until stop().
+    // Raw TCP instead of fetch: the server replies and ends without reading the
+    // request, and on Windows closing with the request unread RSTs the exchange.
+    const src = `
     const churnSink = [];
     function churn() {
       let a = [];
@@ -3904,7 +3868,8 @@ it("an unref'd Bun.listen() with no other references keeps accepting across GC",
       churn();
       Bun.gc(true);
       churn();
-      await Bun.sleep(1);
+      // One event-loop turn, so work the collection deferred to the loop runs before the next GC.
+      await new Promise(resolve => setImmediate(resolve));
       Bun.gc(true);
       for (const port of ports) {
         const got = await roundTrip(port);
@@ -3913,21 +3878,23 @@ it("an unref'd Bun.listen() with no other references keeps accepting across GC",
     }
     console.log("served " + ports.length + " listeners");
   `;
-  // The subprocess must also exit on its own: unref() still has to release
-  // the listeners' event-loop refs even though their wrappers stay reachable.
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout: "served 4 listeners",
-    stderr: "",
-    exitCode: 0,
-  });
-});
+    // The subprocess must also exit on its own: unref() still has to release
+    // the listeners' event-loop refs even though their wrappers stay reachable.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "served 4 listeners",
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+  30_000,
+); // eight full GCs over 60k live objects take several seconds on a debug build
 
 describe.concurrent("TLS session/keylog handlers", () => {
   // `session`/`keylog` dispatch from the event loop after the SSL stack
@@ -3976,10 +3943,16 @@ describe.concurrent("TLS session/keylog handlers", () => {
       const session = await promise;
       expect(session).toBeInstanceOf(Buffer);
       expect(session.length).toBeGreaterThan(0);
-      // The handshake's key material was logged before the session ticket.
-      expect(keylogLines.length).toBeGreaterThan(0);
-      expect(keylogLines[0]).toBeInstanceOf(Buffer);
-      expect(keylogLines[0].toString()).toContain("_TRAFFIC_SECRET");
+      // The handshake's key material was logged before the session ticket: one
+      // NSS key log line per TLS 1.3 secret, in the order the handshake derives them.
+      expect(keylogLines.every(line => line instanceof Buffer)).toBe(true);
+      expect(keylogLines.map(line => line.toString().replace(/^(\S+) [0-9a-f]{64} [0-9a-f]{64}\n$/, "$1"))).toEqual([
+        "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
+        "SERVER_HANDSHAKE_TRAFFIC_SECRET",
+        "CLIENT_TRAFFIC_SECRET_0",
+        "SERVER_TRAFFIC_SECRET_0",
+        "EXPORTER_SECRET",
+      ]);
       socket.end();
     } finally {
       server.stop(true);
@@ -4191,7 +4164,7 @@ describe.concurrent("connect() failure promise settlement", () => {
   });
 });
 
-describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
+describe.concurrent("allowHalfOpen socket whose peer resets behind pending writes", () => {
   // The full victim matrix (Bun.listen/Bun.serve/node:http(s)/fetch, plain and
   // TLS) runs as test/js/bun/test/parallel/test-net-half-open-peer-reset-*.mjs;
   // this covers the shared usockets core in bun:test form. Unfixed, epoll
@@ -4203,6 +4176,7 @@ describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
     const ended = Promise.withResolvers<void>();
     const closed = Promise.withResolvers<void>();
     let endCount = 0;
+    let closeCount = 0;
     const big = Buffer.alloc(4 * 1024 * 1024, 0x78);
 
     using server = Bun.listen({
@@ -4227,6 +4201,7 @@ describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
         },
         error() {},
         close() {
+          closeCount++;
           closed.resolve();
         },
       },
@@ -4250,12 +4225,13 @@ describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
     await issued.promise; // victim has queued more than the kernel will buffer
     peer.shutdown(); // FIN
     await ended.promise; // victim saw it
-    // The FIN-to-RST gap is where the bug lived; an immediate RST can overtake
-    // the FIN and just read as ECONNRESET on the readable side.
-    await Bun.sleep(50);
+    // The FIN-to-RST gap is where the bug lived: a re-delivered end fires on the
+    // victim's next poll, so a few event-loop turns with the socket half-open expose
+    // it. An immediate RST could instead just read as ECONNRESET on the readable side.
+    for (let turn = 0; turn < 10; turn++) await new Promise(resolve => setImmediate(resolve));
     peer.terminate(); // RST
     await closed.promise; // victim must tear down, not spin or strand
-    expect(endCount).toBe(1);
+    expect({ endCount, closeCount }).toEqual({ endCount: 1, closeCount: 1 });
   });
 });
 
@@ -4266,7 +4242,7 @@ describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
 // samples the usockets loop iteration counter, we send SEGMENTS one-byte writes from here,
 // then it samples again. A loop that wakes per segment reports ~SEGMENTS iterations; one that
 // does not reports the handful caused by our two control lines.
-it("a paused socket does not wake the event loop for every segment its peer sends", async () => {
+it.concurrent("a paused socket does not wake the event loop for every segment its peer sends", async () => {
   const SEGMENTS = 200;
   await using child = spawn({
     cmd: [
@@ -4422,7 +4398,7 @@ describe.concurrent.each(["tcp", "tls"] as const)("%s socket paused when its pee
 
 // A paused socket with a backpressured write of its own must also close on the reset: an owner
 // that resumes only after 'drain' (node:http's flood guard) would otherwise wait forever.
-it("a paused socket with a backpressured write still closes when its peer resets", async () => {
+it.concurrent("a paused socket with a backpressured write still closes when its peer resets", async () => {
   const closedWith = Promise.withResolvers<Error | undefined>();
   let backpressured!: () => void;
   const isBackpressured = new Promise<void>(resolve => (backpressured = resolve));
@@ -4460,7 +4436,7 @@ it("a paused socket with a backpressured write still closes when its peer resets
   await isBackpressured;
   peer.terminate();
   const error = (await closedWith.promise) as NodeJS.ErrnoException | undefined;
-  expect(error?.code).toBe("ECONNRESET");
+  expect({ reported: error instanceof Error, code: error?.code }).toEqual({ reported: true, code: "ECONNRESET" });
 });
 
 // A close that the event loop initiated passes the read error to close(). usockets
@@ -4663,7 +4639,7 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
   });
 });
 
-it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async () => {
+it.concurrent("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async () => {
   // Each end() sends close_notify and defers its fd close for the peer's
   // reply. The reply arrives without a FIN, so the ZERO_RETURN path has to
   // complete the deferred close instead of keeping the socket half-open.
@@ -4672,6 +4648,7 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
   const clientClosed = Promise.withResolvers<void>();
   const serverShake = Promise.withResolvers<void>();
   const clientShake = Promise.withResolvers<void>();
+  const closes = { server: 0, client: 0 };
 
   using server = Bun.listen({
     hostname: "127.0.0.1",
@@ -4682,7 +4659,10 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
       open: s => serverOpen.resolve(s),
       handshake: () => serverShake.resolve(),
       data() {},
-      close: () => serverClosed.resolve(),
+      close: () => {
+        closes.server++;
+        serverClosed.resolve();
+      },
     },
   });
   const client = await Bun.connect({
@@ -4693,7 +4673,10 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
     socket: {
       handshake: () => clientShake.resolve(),
       data() {},
-      close: () => clientClosed.resolve(),
+      close: () => {
+        closes.client++;
+        clientClosed.resolve();
+      },
     },
   });
 
@@ -4705,4 +4688,5 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
   serverSock.end();
 
   await Promise.all([serverClosed.promise, clientClosed.promise]);
+  expect(closes).toEqual({ server: 1, client: 1 });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4143,16 +4143,13 @@ describe.concurrent("connect() failure promise settlement", () => {
   });
 
   it("an error thrown by connectError() becomes the connect() rejection", async () => {
-    // Grab a port nothing is listening on anymore.
-    const probe = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
-    const port = probe.port;
-    probe.stop(true);
+    using refused = await refusedPort();
 
     const boom = new Error("boom-connect-error");
     await expect(
       Bun.connect({
         hostname: "127.0.0.1",
-        port,
+        port: refused.port,
         socket: {
           connectError() {
             throw boom;


### PR DESCRIPTION
### Problem
- `test/js/bun/net/socket.test.ts` takes 15 s on the debian 13 x64-asan lane (build 108747): 40 of 96 tests ran serially, 11 of them child processes, with 12 fixed sleeps.
- One test dialed `www.example.com:443`. Three used port 55555, which a `port: 0` listener can get.

### Fix
- Every test that owns its listener or child is now concurrent. The two object-count tests stay serial as the barrier between the groups.
- Each sleep is replaced by the event it stood in for: a `connectError`, `open`, `close` or `handshake` callback, or a bounded number of loop turns.
- Assertions pin exact child output before the exit code, connect failure `{ name, code, message }`, received bytes and handler call counts. Three pairs of TLS variants share one `it.each` each, names unchanged.
- Verified: `bun bd test test/js/bun/net/socket.test.ts` 28.4 s before, 14.3 to 16.0 s after (5 runs, same machine). 11 debug runs and 12 release runs pass.

### Background
- The runner groups consecutive concurrent tests, 5 at a time on ASAN builds. A serial test is a barrier: nothing overlaps with it.
- `Bun.connect()` resolves at TCP open, before the TLS handshake. A `write()` before the handshake returns 0 and is parked. The mid-read boundary test wrote to its side socket without that wait and hung on release builds 4 times out of 7 once concurrent. It now waits.
- `socket.timeout(1)` fires on the next usockets sweep, every 4 s. That bounds the file on release builds (4.85 s before, 4.5 s after).

<details><summary>Notes</summary>

Timings are the `Ran 101 tests` total that `bun test` prints.

Debug (ASAN) build, this container, low load: before 28.41 s. After, 5 runs: 14.78, 16.01, 14.29, 14.80, 14.67 s. Interleaved A/B later under heavy host load (load average about 40): before 31.1, 32.7, 30.6 s; after 18.0, 19.1, 14.5 s. Release build (`USE_SYSTEM_BUN=1`, 1.4.1-canary a6c4cc276): before 4.85 s, after 4.5 s, 12 of 12 runs pass.

What is still the long pole after the change, and why it stays: "socket.timeout works" (4 s sweep), the `tls-handshake-pause-spin` fixture (a 2 s CPU measurement window), and the unref'd listener GC test (eight full GCs over 60k live objects in a debug child, 3.5 s alone). That last test now has a 30 s budget like its child-process siblings: under 5-way contention it took 5.0 s and timed out at the local 5 s default (CI passes `--timeout 90000`).

Scaled stress loop: the 1 GiB socket-huge-fixture transfer is 256 MiB on debug and ASAN builds (`isDebug || isASAN`, passed as argv). It still exceeds every kernel buffer and still goes through hundreds of partial writes and drains. The fixture prints `sent N bytes, received N bytes, digest matches`, which the test pins with `toSpawn(...)`, instead of `console.time` output on stderr.

Child processes: none removed. Each remaining child exists to observe an ASAN abort, a process exit, fd numbering, or a loop with nothing else on it. #40108 (open) converts the one child that only existed to reset a peer; this diff does not touch that block (lines 4479 to 4548 of the base file) so both apply.

Hardcoded ports: `refusedPort()` listens on port 0, connects to itself, and hands out the connection's local port. The established connection keeps the port bound so no concurrent `port: 0` listener can take it, and a connect to it is refused. `keep-event-loop-alive.js` takes that port as argv[4] (default 9999 as before) and now prints each failure's code.

Assertion changes, by test:
- bad fd connect: `{ name, message }` of both the callback error and the rejection, exactly one `connectError`, no other callback.
- fd already closed / closed after open: `open` and `close` awaited as events, called once each.
- echo.js: server lines, client lines, no other lines, empty stderr, then exit code.
- keep-event-loop-alive.js: full stdout with the failure codes, empty stderr, then exit code.
- connect-returns-socket.js: both OPENED lines, one localPort line, echoed bytes `"Hello, world!From returned socket"` (the two writes can arrive as one or two data events), empty stderr.
- refused connect (2 tests): events `["connectError"]`, `socket.data` identity, `{ name: "Error", code: "ECONNREFUSED", message: "Failed to connect" }` for callback and rejection. The leak variant asserts all 50 promises rejected.
- socket.timeout: the server received exactly `"I have timed out!"`, timeout fired once.
- open() ReferenceError / returned Error: `{ handler: "error", name, message }` (a `close` first would fail). The 1 s `setTimeout` watchdogs are gone.
- open once (2 tests): `{ opens: 1, connectErrors: 0, received: "Hello" }`.
- ::1 connect to an IPv4 listener: events `["connectError"]` and the rejection's name and message (the code is not pinned: a host without IPv6 fails with another errno).
- drain before handshake: local TLS server, `{ success: true, authorized: true }`, zero drains before the handshake.
- upgradeTLS with a secureContext: peer certificate CN `"server-bun"`.
- upgrade to TLS loop: status line `HTTP/1.1 200 OK`, `Content-Length: 11`, body `"Hello World"`.
- mid-read boundary: every side `write()` returned 5.
- session/keylog: the five TLS 1.3 labels in derivation order, each line `LABEL <64 hex> <64 hex>\n`.
- allowHalfOpen reset, concurrent end(): close counts.
- backpressured reset: `{ reported: true, code: "ECONNRESET" }`.
- 9 child tests: `stderr: ""` added, `void stderr` removed, exit code last.

The `it.concurrent(` form with a timeout argument is not a prettier "test call", so prettier puts the name, function and timeout on separate lines and re-indents the body. Seven tests are affected; `git diff -w` shows the 440 changed lines.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->