### PR TITLE
bundler: abort on allocation failure when enqueuing a plugin-resolved entry point

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,7 +1,6 @@
 [bun_ast]
 
 [bun_bundler]
-"defaulted_failure:src/bundler/bundle_v2.rs" = 2
 "narrowed_two_ways:src/bundler/bundle_v2.rs" = 1
 
 [bun_core]

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4815,14 +4815,17 @@ pub mod bv2_impl {
                                 return;
                             };
                             let mut resolved = resolved;
-                            let Ok(source_index) = this.enqueue_entry_item(
-                                &mut resolved,
-                                true,
-                                target,
-                                resolve.import_record.loader,
-                            ) else {
-                                return;
-                            };
+                            // `enqueue_entry_item` fails only on allocation, after it has
+                            // already counted the pending parse task: a silent return here
+                            // would leave the build waiting for a task that never runs.
+                            let source_index = this
+                                .enqueue_entry_item(
+                                    &mut resolved,
+                                    true,
+                                    target,
+                                    resolve.import_record.loader,
+                                )
+                                .expect("oom");
 
                             // Store the original entry point name for virtual entries that fall back to file resolution
                             if let Some(idx) = source_index {


### PR DESCRIPTION
### Problem
- `BundleV2::on_resolve` (`src/bundler/bundle_v2.rs:4818`) handles a plugin `onResolve` that returned no match for an entry point by resolving it from disk and calling `enqueue_entry_item`. The call was `let Ok(source_index) = this.enqueue_entry_item(..) else { return; }`.
- `enqueue_entry_item` calls `increment_scan_counter()` (line 2819) before its two fallible steps, `path_with_pretty_initialized(..)?` (line 2828) and `input_files.append(..)?` (line 2867). Both fail only on allocation. When one fails, `pending_items` stays one too high with no parse task to pay it back, `is_done()` never fires, and the build waits forever instead of failing. The mordant lint `defaulted_failure` reports this site for `defaulted_failure:src/bundler/bundle_v2.rs`.

### Fix
- Replace the silent return with `.expect("oom")`. This is what the `Success` arm of the same function does for the same `path_with_pretty_initialized` failure (line 4934), and what the workspace does for allocation failure in general (`bun_core::handle_oom`): a controlled abort, not a hang.
- Removes the `"defaulted_failure:src/bundler/bundle_v2.rs" = 2` line from `mordant-baseline.toml`. The count was stale: the pinned mordant reports one site on main, this one. Verified locally: `bun_bundler` reports no finding over the baseline. #40309 lowers the same line to 1 for the stale half, so one of the two PRs will need a trivial rebase on this file.
- Verified: `test/bundler/bundler_plugin.test.ts`, `bundler_plugin_chain.test.ts`, `bundler_edgecase.test.ts` with the debug build. No new test: the changed path runs only when the arena or the filename store cannot allocate.

### Background
- `pending_items` is the bundler's count of work still in flight. Every enqueued parse task adds one, every completed task subtracts one, and the bundle finishes when it reaches zero.
- `on_resolve` runs when a JS plugin's `onResolve` callback settles. `EntryPointBuild` records are the entry points themselves. A plugin that does not claim one lets the file resolver handle it.
- `mordant-baseline.toml` is a ratchet of lint findings accepted as pre-existing. CI fails only when a (lint, file) pair grows past its count. Fixing a site lets its line be removed.

<details><summary>Notes</summary>

- CI on this PR: 180 of 181 jobs pass. The one red job is `test/cli/run/require-cache.test.ts` on debian 13 x64-asan, a require.cache leak test that times out. It is marked pre-existing (also red on main) and is with main-break triage. The other failures in that build passed on retry.

- #38600 (open, 2026-08-14) reshapes the same `on_resolve` block for a different reason (in-memory entry points that an `onResolve` plugin declines) and is behind main on this function's signature. Whichever lands second needs a small rebase here.
- Findings on main at the pinned mordant (`12d2797`), with an empty baseline: `defaulted_failure` reports one site in `bundle_v2.rs`, line 4818. The baseline's count of 2 was recorded at an older mordant revision. Other stale entries found the same way, left alone because open PRs already touch those lines: `[bun_ast]` and `[bun_sql_jsc]` empty sections, `h2_frame_parser.rs` 32 (31 real), `reimplemented_helper:Terminal.rs` (gone).
- `resolve_entry_point` on the line above keeps its `let Ok(..) else { return }`: it logs the resolution error into the build log before returning `Err`, so the build fails with a message.
</details>
