### PR TITLE
build: drop the dead rustSysroot/rustHostTriple fields from findRustLld()

### DIFF
--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -656,12 +656,8 @@ export interface CargoToolchain {
 export function findRustLld(os: OS): {
   rustLld: string | undefined;
   rustLlvmVersion: string | undefined;
-  /** `rustc --print sysroot`. */
-  rustSysroot: string | undefined;
-  /** `host:` line from `rustc -vV` — the rustlib subdirectory name. */
-  rustHostTriple: string | undefined;
 } {
-  const none = { rustLld: undefined, rustLlvmVersion: undefined, rustSysroot: undefined, rustHostTriple: undefined };
+  const none = { rustLld: undefined, rustLlvmVersion: undefined };
   // Look up rustc the same way findCargo does cargo: $CARGO_HOME/bin first.
   const cargoHome = process.env.CARGO_HOME ?? join(homedir(), ".cargo");
   const rustc =
@@ -735,7 +731,7 @@ export function findRustLld(os: OS): {
 
   const rustHostTriple = vv.match(/^host:\s*(\S+)/m)?.[1];
   const rustLlvmVersion = vv.match(/^LLVM version:\s*(\d+\.\d+\.\d+)/m)?.[1];
-  if (rustHostTriple === undefined) return { ...none, rustSysroot: sysroot, rustLlvmVersion };
+  if (rustHostTriple === undefined) return { ...none, rustLlvmVersion };
 
   const bin = join(sysroot, "lib", "rustlib", rustHostTriple, "bin");
   const candidate =
@@ -745,7 +741,7 @@ export function findRustLld(os: OS): {
         ? join(bin, "gcc-ld", "ld64.lld")
         : join(bin, "gcc-ld", "ld.lld");
   const rustLld = isExecutable(candidate) ? candidate : undefined;
-  return { rustLld, rustLlvmVersion, rustSysroot: sysroot, rustHostTriple };
+  return { rustLld, rustLlvmVersion };
 }
 
 /**

--- a/test/internal/build-rust-toolchain-probe.test.ts
+++ b/test/internal/build-rust-toolchain-probe.test.ts
@@ -6,9 +6,12 @@
  * measured 36s per CI job, silently, because the proxy's output is piped).
  * The probe must therefore pin the proxy to the channel with RUSTUP_TOOLCHAIN.
  *
- * The rustc here is a shell script that reports the RUSTUP_TOOLCHAIN it was
- * given as its sysroot and as its host triple, so both probes are covered;
- * PATH is emptied so no real rustup runs a pre-flight.
+ * The rustc here is a shell script that folds the RUSTUP_TOOLCHAIN it was
+ * given into its sysroot path and into its host triple, so both probes are
+ * covered. The fake sysroot has a `gcc-ld/ld.lld` only under the pinned
+ * names: an unpinned probe resolves to a path that does not exist and
+ * `rustLld` comes back undefined. PATH is emptied so no real rustup runs a
+ * pre-flight.
  */
 import { afterEach, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
@@ -29,26 +32,25 @@ afterEach(() => {
 });
 
 test.skipIf(isWindows)("the configure-time rustc probe pins the rustup proxy to the pinned channel", () => {
+  const ldLld = join(`sysroot-for-${channel}`, "lib", "rustlib", `host-for-${channel}`, "bin", "gcc-ld", "ld.lld");
   using dir = tempDir("build-rustc-probe", {
-    "bin/rustc": [
-      "#!/bin/sh",
-      'case "$1" in',
-      '  --print) printf "%s\\n" "sysroot-for:${RUSTUP_TOOLCHAIN:-unset}" ;;',
-      '  -vV) printf "host: host-for:%s\\nLLVM version: 22.1.4\\n" "${RUSTUP_TOOLCHAIN:-unset}" ;;',
-      "esac",
-      "",
-    ].join("\n"),
+    "bin/rustc": ({ root }) =>
+      [
+        "#!/bin/sh",
+        'case "$1" in',
+        `  --print) printf "%s\\n" "${root}/sysroot-for-\${RUSTUP_TOOLCHAIN:-unset}" ;;`,
+        '  -vV) printf "host: host-for-%s\\nLLVM version: 22.1.4\\n" "${RUSTUP_TOOLCHAIN:-unset}" ;;',
+        "esac",
+        "",
+      ].join("\n"),
+    [ldLld]: "",
   });
-  chmodSync(join(String(dir), "bin", "rustc"), 0o755);
+  for (const executable of ["bin/rustc", ldLld]) chmodSync(join(String(dir), executable), 0o755);
   process.env.CARGO_HOME = String(dir);
   process.env.PATH = join(String(dir), "bin");
 
   expect(findRustLld("linux")).toEqual({
-    rustSysroot: `sysroot-for:${channel}`,
-    // Both probes (sysroot and -vV) must carry the pin.
-    rustHostTriple: `host-for:${channel}`,
+    rustLld: join(String(dir), ldLld),
     rustLlvmVersion: "22.1.4",
-    // The fake sysroot has no lib/rustlib/<host>/bin/gcc-ld/ld.lld.
-    rustLld: undefined,
   });
 });

--- a/test/internal/build-rust-toolchain-probe.test.ts
+++ b/test/internal/build-rust-toolchain-probe.test.ts
@@ -10,8 +10,8 @@
  * given into its sysroot path and into its host triple, so both probes are
  * covered. The fake sysroot has a `gcc-ld/ld.lld` only under the pinned
  * names: an unpinned probe resolves to a path that does not exist and
- * `rustLld` comes back undefined. PATH is emptied so no real rustup runs a
- * pre-flight.
+ * `rustLld` comes back undefined. PATH holds only the fixture's `bin`
+ * directory, so no real rustup runs a pre-flight.
  */
 import { afterEach, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";


### PR DESCRIPTION
Follow-up to #41020. It finishes the last open review nit from that PR.

### Problem
- `findRustLld()` in `scripts/build/tools.ts:656` still declares and returns `rustSysroot` and `rustHostTriple`. Its only caller, `resolveLlvmToolchain()` (`tools.ts:575`), reads `rustLld` and `rustLlvmVersion` only since #41020 dropped the two fields from `Toolchain`.
- The two return fields have no reader. `test/internal/build-rust-toolchain-probe.test.ts` was the last one, and it only used them as a window into the probe.

### Fix
- Drop `rustSysroot` and `rustHostTriple` from the return type, from `none`, and from the two return sites. The local `sysroot` and `rustHostTriple` values stay. They build the `lib/rustlib/<host>/bin` path that locates rust-lld.
- The probe test now observes the pin through the real output. The fake sysroot has a `gcc-ld/ld.lld` only under `sysroot-for-<channel>/lib/rustlib/host-for-<channel>/`. With the pin, `findRustLld("linux")` returns that path. Without it, the fake rustc answers `…-for-unset`, the path does not exist, and `rustLld` is `undefined`.
- Verified: `test/internal/build-rust-toolchain-probe.test.ts` passes. With `RUSTUP_TOOLCHAIN` removed from the probe env in `tools.ts`, it fails with `rustLld: undefined`. The eight `test/internal` build-script tests pass (55 tests). `tsc -p scripts/build` reports the same six pre-existing errors as main.

### Background
- `findRustLld()` runs at configure time. It asks `rustc --print sysroot` and `rustc -vV` for the sysroot and the host triple, then looks for `<sysroot>/lib/rustlib/<host>/bin/gcc-ld/ld.lld`. The build links with that lld when rustc's LLVM is newer than clang's.
- `RUSTUP_TOOLCHAIN` pins the rustup proxy to the channel from `rust-toolchain.toml`. Without the pin, a proxy run in the repo root installs every component and target the file lists (about 2.4 GB). The probe test exists to keep that pin in place.

<details><summary>Notes</summary>

- The other two nits from the #41020 review are already in main: `scripts/build/rust.ts` no longer imports `join`, and the three `test/internal/source-lints/` mock `Toolchain` literals no longer set `rustSysroot`/`rustHostTriple`.
- The `tempDir` file map accepts a function value that receives `{ root }`. The fake rustc uses it to print an absolute sysroot path, so `rustLld` matches `join(String(dir), ldLld)` exactly.
- Commands run: `USE_SYSTEM_BUN=1 bun test` on the eight `test/internal` build-script files, `bun bd test test/internal/build-rust-toolchain-probe.test.ts`, `bunx tsc --noEmit -p scripts/build/tsconfig.json` on this branch and on main, `bunx prettier --check` on both files.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/internal/build-rust-toolchain-probe.test.ts

<!-- robobun:evidence:end -->