### PR TITLE
install: treat an unset $VAR credential reference in bunfig as no credential

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -566,9 +566,7 @@ impl Loader {
         self.map.get(_key)
     }
 
-    /// Resolves a `$VAR` reference; a non-reference passes through. An unset
-    /// variable resolves to "", never the literal `$VAR` text: callers send
-    /// the result as a registry credential.
+    /// Resolves a leading `$VAR` reference; an unset variable resolves to "", never the literal text.
     pub fn get_auto<'b>(&'b self, key: &'b [u8]) -> &'b [u8] {
         // If it's "" or "$", it's not a variable
         if key.len() < 2 || key[0] != b'$' {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -566,13 +566,17 @@ impl Loader {
         self.map.get(_key)
     }
 
+    /// Resolves a `$VAR` reference to the variable's value. A non-reference
+    /// (no leading `$`) is returned as-is. An unset variable resolves to ""
+    /// rather than the literal `$VAR` text: callers feed the result to
+    /// registries as a credential, and the literal must never reach the wire.
     pub fn get_auto<'b>(&'b self, key: &'b [u8]) -> &'b [u8] {
         // If it's "" or "$", it's not a variable
         if key.len() < 2 || key[0] != b'$' {
             return key;
         }
 
-        self.get(&key[1..]).unwrap_or(key)
+        self.get(&key[1..]).unwrap_or(b"")
     }
 
     // `copyForDefine` moved up into `bun_bundler::defines::copy_env_for_define`

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -566,14 +566,14 @@ impl Loader {
         self.map.get(_key)
     }
 
-    /// Resolves a leading `$VAR` reference; an unset variable resolves to "", never the literal text.
+    /// Substitutes a leading `$VAR` reference when the variable is set; otherwise returns the input unchanged.
     pub fn get_auto<'b>(&'b self, key: &'b [u8]) -> &'b [u8] {
         // If it's "" or "$", it's not a variable
         if key.len() < 2 || key[0] != b'$' {
             return key;
         }
 
-        self.get(&key[1..]).unwrap_or(b"")
+        self.get(&key[1..]).unwrap_or(key)
     }
 
     // `copyForDefine` moved up into `bun_bundler::defines::copy_env_for_define`

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -566,10 +566,9 @@ impl Loader {
         self.map.get(_key)
     }
 
-    /// Resolves a `$VAR` reference to the variable's value. A non-reference
-    /// (no leading `$`) is returned as-is. An unset variable resolves to ""
-    /// rather than the literal `$VAR` text: callers feed the result to
-    /// registries as a credential, and the literal must never reach the wire.
+    /// Resolves a `$VAR` reference; a non-reference passes through. An unset
+    /// variable resolves to "", never the literal `$VAR` text: callers send
+    /// the result as a registry credential.
     pub fn get_auto<'b>(&'b self, key: &'b [u8]) -> &'b [u8] {
         // If it's "" or "$", it's not a variable
         if key.len() < 2 || key[0] != b'$' {

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1300,6 +1300,7 @@ mod draft {
         }
         if let Some(registry) = install.default_registry.as_mut() {
             if !registry.has_resolved_credentials(env) {
+                registry.clear_unresolved_credentials(env);
                 for item in auth {
                     let matched = item.matches(if registry.url.is_empty() {
                         bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL.as_bytes()
@@ -1317,6 +1318,7 @@ mod draft {
                 if registry.has_resolved_credentials(env) {
                     continue;
                 }
+                registry.clear_unresolved_credentials(env);
                 for item in auth {
                     let matched = item.matches(&registry.url);
                     if matched {

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1300,7 +1300,6 @@ mod draft {
         }
         if let Some(registry) = install.default_registry.as_mut() {
             if !registry.has_resolved_credentials(env) {
-                registry.clear_unresolved_credentials(env);
                 for item in auth {
                     let matched = item.matches(if registry.url.is_empty() {
                         bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL.as_bytes()
@@ -1318,7 +1317,6 @@ mod draft {
                 if registry.has_resolved_credentials(env) {
                     continue;
                 }
-                registry.clear_unresolved_credentials(env);
                 for item in auth {
                     let matched = item.matches(&registry.url);
                     if matched {

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1290,16 +1290,12 @@ mod draft {
         configs
     }
 
-    pub fn apply_registry_auth(
-        install: &mut BunInstall,
-        env: &DotEnvLoader,
-        auth: &[RegistryAuth],
-    ) {
+    pub fn apply_registry_auth(install: &mut BunInstall, auth: &[RegistryAuth]) {
         if auth.is_empty() {
             return;
         }
         if let Some(registry) = install.default_registry.as_mut() {
-            if !registry.has_resolved_credentials(env) {
+            if !registry.has_usable_credentials() {
                 for item in auth {
                     let matched = item.matches(if registry.url.is_empty() {
                         bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL.as_bytes()
@@ -1314,7 +1310,7 @@ mod draft {
         }
         if let Some(scoped) = install.scoped.as_mut() {
             for registry in scoped.scopes.values_mut() {
-                if registry.has_resolved_credentials(env) {
+                if registry.has_usable_credentials() {
                     continue;
                 }
                 for item in auth {

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1290,12 +1290,16 @@ mod draft {
         configs
     }
 
-    pub fn apply_registry_auth(install: &mut BunInstall, auth: &[RegistryAuth]) {
+    pub fn apply_registry_auth(
+        install: &mut BunInstall,
+        env: &DotEnvLoader,
+        auth: &[RegistryAuth],
+    ) {
         if auth.is_empty() {
             return;
         }
         if let Some(registry) = install.default_registry.as_mut() {
-            if !registry.has_credentials() {
+            if !registry.has_resolved_credentials(env) {
                 for item in auth {
                     let matched = item.matches(if registry.url.is_empty() {
                         bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL.as_bytes()
@@ -1310,7 +1314,7 @@ mod draft {
         }
         if let Some(scoped) = install.scoped.as_mut() {
             for registry in scoped.scopes.values_mut() {
-                if registry.has_credentials() {
+                if registry.has_resolved_credentials(env) {
                     continue;
                 }
                 for item in auth {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1962,7 +1962,18 @@ pub fn init(
             ini::load_npmrc_config(&mut install, env, true, &[&*npmrc_local])
         };
 
-        ini::apply_registry_auth(&mut bunfig_install, env, &registry_auth);
+        // bunfig credentials document `$VAR` references. Resolve them here,
+        // after .env loading, so every later consumer sees literal values.
+        if let Some(registry) = bunfig_install.default_registry.as_mut() {
+            registry.resolve_credential_refs(env);
+        }
+        if let Some(scoped) = bunfig_install.scoped.as_mut() {
+            for registry in scoped.scopes.values_mut() {
+                registry.resolve_credential_refs(env);
+            }
+        }
+
+        ini::apply_registry_auth(&mut bunfig_install, &registry_auth);
         overlay_bunfig_install(&mut install, bunfig_install);
         ctx.install = Some(Box::new(install));
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2258,6 +2258,7 @@ pub fn init(
             env,
             Some(cli),
             ctx.install.as_deref(),
+            false,
             subcommand,
         )?;
 
@@ -2668,7 +2669,7 @@ fn init_with_runtime_once(
 
     match manager
         .options
-        .load(log, env, Some(cli), bun_install, Subcommand::Install)
+        .load(log, env, Some(cli), bun_install, true, Subcommand::Install)
     {
         Ok(()) => {}
         Err(e) => {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1962,7 +1962,7 @@ pub fn init(
             ini::load_npmrc_config(&mut install, env, true, &[&*npmrc_local])
         };
 
-        ini::apply_registry_auth(&mut bunfig_install, &registry_auth);
+        ini::apply_registry_auth(&mut bunfig_install, env, &registry_auth);
         overlay_bunfig_install(&mut install, bunfig_install);
         ctx.install = Some(Box::new(install));
     }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -647,10 +647,8 @@ impl Options {
                             }
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
-                        // The carried credentials went through `$VAR`
-                        // resolution when the previous scope was built. Assign
-                        // them after `from_api` so they are not resolved a
-                        // second time.
+                        // Assigned after `from_api` so the already-resolved
+                        // credentials do not go through `$VAR` resolution twice.
                         if !carried_token.is_empty() {
                             self.scope.token = carried_token;
                         }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -629,12 +629,13 @@ impl Options {
                     if !registry_.is_empty()
                         && (registry_.starts_with(b"https://") || registry_.starts_with(b"http://"))
                     {
-                        let api_registry = Api::NpmRegistry::from_url(registry_);
+                        let mut api_registry = Api::NpmRegistry::from_url(registry_);
+                        api_registry.resolve_credential_refs(env);
                         // Credentials in the URL win, as they do for `registry=` in .npmrc.
                         let mut carried_token: Box<[u8]> = Box::default();
                         let mut carried_auth: Box<[u8]> = Box::default();
                         let mut carried_user: Box<[u8]> = Box::default();
-                        if !api_registry.has_resolved_credentials(env) {
+                        if !api_registry.has_usable_credentials() {
                             let prev_url = self.scope.url.url();
                             let new_url = bun_url::URL::parse(&api_registry.url);
                             if bun_core::without_trailing_slash(new_url.host)
@@ -647,9 +648,9 @@ impl Options {
                             }
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
-                        // A credential `from_api` parsed out of the URL's pathname wins over the
-                        // carry. Assigned after `from_api` so already-resolved credentials are
-                        // not resolved twice.
+                        // A credential `from_api` parsed out of the URL's pathname wins over
+                        // the carry. Assigned after `from_api` so the carried values skip
+                        // `$VAR` substitution.
                         if self.scope.token.is_empty() && self.scope.auth.is_empty() {
                             if !carried_token.is_empty() {
                                 self.scope.token = carried_token;
@@ -667,8 +668,9 @@ impl Options {
 
         if let Some(cli) = &maybe_cli {
             if !cli.registry.is_empty() {
-                let api_registry = Api::NpmRegistry::from_url(cli.registry);
-                if api_registry.has_resolved_credentials(env) {
+                let mut api_registry = Api::NpmRegistry::from_url(cli.registry);
+                api_registry.resolve_credential_refs(env);
+                if api_registry.has_usable_credentials() {
                     self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
                 } else {
                     let new_url = bun_url::URL::parse(&api_registry.url);

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -648,9 +648,7 @@ impl Options {
                             }
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
-                        // A credential `from_api` parsed out of the URL's pathname wins over
-                        // the carry. Assigned after `from_api` so the carried values skip
-                        // `$VAR` substitution.
+                        // A credential parsed out of the URL's pathname wins over the carry.
                         if self.scope.token.is_empty() && self.scope.auth.is_empty() {
                             if !carried_token.is_empty() {
                                 self.scope.token = carried_token;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -647,13 +647,17 @@ impl Options {
                             }
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
-                        // Assigned after `from_api` so already-resolved credentials are not resolved twice.
-                        if !carried_token.is_empty() {
-                            self.scope.token = carried_token;
-                        }
-                        if !carried_auth.is_empty() {
-                            self.scope.auth = carried_auth;
-                            self.scope.user = carried_user;
+                        // A credential `from_api` parsed out of the URL's pathname wins over the
+                        // carry. Assigned after `from_api` so already-resolved credentials are
+                        // not resolved twice.
+                        if self.scope.token.is_empty() && self.scope.auth.is_empty() {
+                            if !carried_token.is_empty() {
+                                self.scope.token = carried_token;
+                            }
+                            if !carried_auth.is_empty() {
+                                self.scope.auth = carried_auth;
+                                self.scope.user = carried_user;
+                            }
                         }
                         break;
                     }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -632,6 +632,8 @@ impl Options {
                         let api_registry = Api::NpmRegistry::from_url(registry_);
                         // Credentials in the URL win, as they do for `registry=` in .npmrc.
                         let mut carried_token: Box<[u8]> = Box::default();
+                        let mut carried_auth: Box<[u8]> = Box::default();
+                        let mut carried_user: Box<[u8]> = Box::default();
                         if !api_registry.has_resolved_credentials(env) {
                             let prev_url = self.scope.url.url();
                             let new_url = bun_url::URL::parse(&api_registry.url);
@@ -640,14 +642,21 @@ impl Options {
                                 && (new_url.is_https() || !prev_url.is_https())
                             {
                                 carried_token = core::mem::take(&mut self.scope.token);
+                                carried_auth = core::mem::take(&mut self.scope.auth);
+                                carried_user = core::mem::take(&mut self.scope.user);
                             }
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
-                        // The carried token went through `$VAR` resolution
-                        // when the previous scope was built. Assign it after
-                        // `from_api` so it is not resolved a second time.
+                        // The carried credentials went through `$VAR`
+                        // resolution when the previous scope was built. Assign
+                        // them after `from_api` so they are not resolved a
+                        // second time.
                         if !carried_token.is_empty() {
                             self.scope.token = carried_token;
+                        }
+                        if !carried_auth.is_empty() {
+                            self.scope.auth = carried_auth;
+                            self.scope.user = carried_user;
                         }
                         break;
                     }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -629,19 +629,26 @@ impl Options {
                     if !registry_.is_empty()
                         && (registry_.starts_with(b"https://") || registry_.starts_with(b"http://"))
                     {
-                        let mut api_registry = Api::NpmRegistry::from_url(registry_);
+                        let api_registry = Api::NpmRegistry::from_url(registry_);
                         // Credentials in the URL win, as they do for `registry=` in .npmrc.
-                        if !api_registry.has_credentials() {
+                        let mut carried_token: Box<[u8]> = Box::default();
+                        if !api_registry.has_resolved_credentials(env) {
                             let prev_url = self.scope.url.url();
                             let new_url = bun_url::URL::parse(&api_registry.url);
                             if bun_core::without_trailing_slash(new_url.host)
                                 == bun_core::without_trailing_slash(prev_url.host)
                                 && (new_url.is_https() || !prev_url.is_https())
                             {
-                                api_registry.token = core::mem::take(&mut self.scope.token);
+                                carried_token = core::mem::take(&mut self.scope.token);
                             }
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
+                        // The carried token went through `$VAR` resolution
+                        // when the previous scope was built. Assign it after
+                        // `from_api` so it is not resolved a second time.
+                        if !carried_token.is_empty() {
+                            self.scope.token = carried_token;
+                        }
                         break;
                     }
                 }
@@ -651,7 +658,7 @@ impl Options {
         if let Some(cli) = &maybe_cli {
             if !cli.registry.is_empty() {
                 let api_registry = Api::NpmRegistry::from_url(cli.registry);
-                if api_registry.has_credentials() {
+                if api_registry.has_resolved_credentials(env) {
                     self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
                 } else {
                     let new_url = bun_url::URL::parse(&api_registry.url);

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -647,8 +647,7 @@ impl Options {
                             }
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
-                        // Assigned after `from_api` so the already-resolved
-                        // credentials do not go through `$VAR` resolution twice.
+                        // Assigned after `from_api` so already-resolved credentials are not resolved twice.
                         if !carried_token.is_empty() {
                             self.scope.token = carried_token;
                         }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -427,6 +427,10 @@ impl Options {
         // Taking `&` (not `&mut`) keeps provenance coherent with the bundler/
         // resolver storage (`Option<NonNull<api::BunInstall>>`).
         bun_install_: Option<&Api::BunInstall>,
+        // True when `bun_install_` is the raw bunfig config (the runtime
+        // auto-install path). The CLI install path resolves `$VAR` credential
+        // references before the .npmrc merge and passes false.
+        resolve_bunfig_credential_refs: bool,
         subcommand: Subcommand,
     ) -> Result<(), bun_alloc::AllocError> {
         let mut base = Api::NpmRegistry::default();
@@ -434,6 +438,9 @@ impl Options {
         if let Some(config) = bun_install_ref {
             if let Some(registry) = &config.default_registry {
                 base = registry.clone();
+                if resolve_bunfig_credential_refs {
+                    base.resolve_credential_refs(env);
+                }
             }
             if let Some(link_workspace_packages) = config.link_workspace_packages {
                 self.link_workspace_packages = link_workspace_packages;
@@ -458,6 +465,9 @@ impl Options {
                 for (name, registry_) in scoped.scopes.keys().iter().zip(scoped.scopes.values()) {
                     debug_assert_eq!(scoped.scopes.keys().len(), scoped.scopes.values().len());
                     let mut registry = registry_.clone();
+                    if resolve_bunfig_credential_refs {
+                        registry.resolve_credential_refs(env);
+                    }
                     if registry.url.is_empty() {
                         registry.url.clone_from(&base.url);
                     }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1760,6 +1760,7 @@ impl<'a> Printer<'a> {
             &mut env_loader,
             None,
             None,
+            false,
             crate::Subcommand::Install,
         )?;
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -371,11 +371,9 @@ pub mod registry {
             // username:password.
             let mut output_buf_owned: Box<[u8]> = Box::default();
 
-            // Gate on resolved values: an unresolvable `$VAR` reference must
-            // not shadow the username/password pair or the URL's credentials.
-            if env.get_auto(&registry.token).is_empty() {
+            if registry.token.is_empty() {
                 'outer: {
-                    if env.get_auto(&registry.password).is_empty() {
+                    if registry.password.is_empty() {
                         let mut pathname: &[u8] = url.pathname;
                         let mut needs_to_check_slash = true;
                         while let Some(colon) = strings::last_index_of_char(pathname, b':') {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -371,9 +371,11 @@ pub mod registry {
             // username:password.
             let mut output_buf_owned: Box<[u8]> = Box::default();
 
-            if registry.token.is_empty() {
+            // Gate on resolved values: an unresolvable `$VAR` reference must
+            // not shadow the username/password pair or the URL's credentials.
+            if env.get_auto(&registry.token).is_empty() {
                 'outer: {
-                    if registry.password.is_empty() {
+                    if env.get_auto(&registry.password).is_empty() {
                         let mut pathname: &[u8] = url.pathname;
                         let mut needs_to_check_slash = true;
                         while let Some(colon) = strings::last_index_of_char(pathname, b':') {

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -174,14 +174,24 @@ pub mod api {
             registry
         }
 
-        /// True after `$VAR` resolution for a credential that can produce an
-        /// Authorization header: a token, or a username+password pair.
-        pub fn has_resolved_credentials(&self, env: &bun_dotenv::Loader) -> bool {
-            !env.get_auto(&self.token).is_empty()
-                || (!env.get_auto(&self.username).is_empty()
-                    && !env.get_auto(&self.password).is_empty())
+        /// True for a credential that can produce an Authorization header:
+        /// a token, or a username+password pair.
+        pub fn has_usable_credentials(&self) -> bool {
+            !self.token.is_empty() || (!self.username.is_empty() && !self.password.is_empty())
         }
 
+        /// Resolves `$VAR` credential references in place. A reference to an
+        /// unset variable resolves to no credential, never the literal text.
+        /// Call this once, at the entry points that document `$VAR` support
+        /// (bunfig fields, registry URLs from the env or the CLI). Values from
+        /// other sources (.npmrc) stay literal.
+        pub fn resolve_credential_refs(&mut self, env: &bun_dotenv::Loader) {
+            for field in [&mut self.token, &mut self.username, &mut self.password] {
+                if field.len() >= 2 && field[0] == b'$' {
+                    *field = env.get(field).map_or_else(Box::default, Box::from);
+                }
+            }
+        }
     }
 
     /// Per-scope npm registry overrides, keyed by scope name.

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -178,11 +178,9 @@ pub mod api {
             !self.token.is_empty() || !self.username.is_empty() || !self.password.is_empty()
         }
 
-        /// Like `has_credentials`, but resolves `$VAR` references first and
-        /// only counts a credential that can produce an Authorization header:
-        /// a token, or a username and password pair. A reference to an unset
-        /// variable resolves to no credential, so other credential sources
-        /// (such as .npmrc) still apply.
+        /// `has_credentials` with `$VAR` references resolved, counting only a
+        /// credential that can produce an Authorization header: a token, or a
+        /// username and password pair.
         pub fn has_resolved_credentials(&self, env: &bun_dotenv::Loader) -> bool {
             !env.get_auto(&self.token).is_empty()
                 || (!env.get_auto(&self.username).is_empty()

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -180,11 +180,9 @@ pub mod api {
             !self.token.is_empty() || (!self.username.is_empty() && !self.password.is_empty())
         }
 
-        /// Resolves `$VAR` credential references in place. A reference to an
-        /// unset variable resolves to no credential, never the literal text.
-        /// Call this once, at the entry points that document `$VAR` support
-        /// (bunfig fields, registry URLs from the env or the CLI). Values from
-        /// other sources (.npmrc) stay literal.
+        /// Resolves `$VAR` credential references in place; a reference to an
+        /// unset variable becomes no credential. Called only at entry points
+        /// that document `$VAR` support; .npmrc values stay literal.
         pub fn resolve_credential_refs(&mut self, env: &bun_dotenv::Loader) {
             for field in [&mut self.token, &mut self.username, &mut self.password] {
                 if field.len() >= 2 && field[0] == b'$' {

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -181,12 +181,26 @@ pub mod api {
         }
 
         /// Resolves `$VAR` credential references in place; a reference to an
-        /// unset variable becomes no credential. Called only at entry points
-        /// that document `$VAR` support; .npmrc values stay literal.
+        /// unset variable warns and becomes no credential. Called only at entry
+        /// points that document `$VAR` support; .npmrc values stay literal.
         pub fn resolve_credential_refs(&mut self, env: &bun_dotenv::Loader) {
-            for field in [&mut self.token, &mut self.username, &mut self.password] {
+            for (name, field) in [
+                ("token", &mut self.token),
+                ("username", &mut self.username),
+                ("password", &mut self.password),
+            ] {
                 if field.len() >= 2 && field[0] == b'$' {
-                    *field = env.get(field).map_or_else(Box::default, Box::from);
+                    match env.get(field) {
+                        Some(value) => *field = Box::from(value),
+                        None => {
+                            bun_core::warn!(
+                                "registry {} references <b>${}<r>, but that environment variable is not set; treating it as no credential",
+                                name,
+                                bstr::BStr::new(&field[1..]),
+                            );
+                            *field = Box::default();
+                        }
+                    }
                 }
             }
         }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -174,15 +174,22 @@ pub mod api {
             registry
         }
 
-        pub fn has_credentials(&self) -> bool {
-            !self.token.is_empty() || !self.username.is_empty() || !self.password.is_empty()
-        }
-
-        /// `has_credentials` with `$VAR` resolved; counts only a token or a username+password pair.
+        /// True after `$VAR` resolution for a credential that can produce an
+        /// Authorization header: a token, or a username+password pair.
         pub fn has_resolved_credentials(&self, env: &bun_dotenv::Loader) -> bool {
             !env.get_auto(&self.token).is_empty()
                 || (!env.get_auto(&self.username).is_empty()
                     && !env.get_auto(&self.password).is_empty())
+        }
+
+        /// Clears credential fields whose `$VAR` reference resolves to nothing,
+        /// so a stale literal cannot shadow another credential source.
+        pub fn clear_unresolved_credentials(&mut self, env: &bun_dotenv::Loader) {
+            for field in [&mut self.token, &mut self.username, &mut self.password] {
+                if !field.is_empty() && env.get_auto(field).is_empty() {
+                    *field = Box::default();
+                }
+            }
         }
     }
 

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -182,15 +182,6 @@ pub mod api {
                     && !env.get_auto(&self.password).is_empty())
         }
 
-        /// Clears credential fields whose `$VAR` reference resolves to nothing,
-        /// so a stale literal cannot shadow another credential source.
-        pub fn clear_unresolved_credentials(&mut self, env: &bun_dotenv::Loader) {
-            for field in [&mut self.token, &mut self.username, &mut self.password] {
-                if !field.is_empty() && env.get_auto(field).is_empty() {
-                    *field = Box::default();
-                }
-            }
-        }
     }
 
     /// Per-scope npm registry overrides, keyed by scope name.

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -178,9 +178,7 @@ pub mod api {
             !self.token.is_empty() || !self.username.is_empty() || !self.password.is_empty()
         }
 
-        /// `has_credentials` with `$VAR` references resolved, counting only a
-        /// credential that can produce an Authorization header: a token, or a
-        /// username and password pair.
+        /// `has_credentials` with `$VAR` resolved; counts only a token or a username+password pair.
         pub fn has_resolved_credentials(&self, env: &bun_dotenv::Loader) -> bool {
             !env.get_auto(&self.token).is_empty()
                 || (!env.get_auto(&self.username).is_empty()

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -177,6 +177,17 @@ pub mod api {
         pub fn has_credentials(&self) -> bool {
             !self.token.is_empty() || !self.username.is_empty() || !self.password.is_empty()
         }
+
+        /// Like `has_credentials`, but resolves `$VAR` references first and
+        /// only counts a credential that can produce an Authorization header:
+        /// a token, or a username and password pair. A reference to an unset
+        /// variable resolves to no credential, so other credential sources
+        /// (such as .npmrc) still apply.
+        pub fn has_resolved_credentials(&self, env: &bun_dotenv::Loader) -> bool {
+            !env.get_auto(&self.token).is_empty()
+                || (!env.get_auto(&self.username).is_empty()
+                    && !env.get_auto(&self.password).is_empty())
+        }
     }
 
     /// Per-scope npm registry overrides, keyed by scope name.

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -916,6 +916,19 @@ describe("registry credentials from $VAR env references", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  // An unresolvable token must not shadow the scope's own username/password pair.
+  test.concurrent("an unset $VAR token next to a resolved username/password pair sends Basic auth", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir(
+      "bunfig-unset-token-own-pair",
+      scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044", username = "alice", password = "s3cret"`, false),
+    );
+    const exitCode = await install(String(dir), {});
+    expect(auths).toEqual([`Basic ${btoa("alice:s3cret")}`]);
+    expect(exitCode).not.toBe(0);
+  });
+
   // The stale "$UNSET" token must not block from_api's username/password
   // branch once .npmrc supplies the pair.
   test.concurrent("an unset $VAR token falls back to a .npmrc username/_password pair", async () => {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -814,3 +814,143 @@ describe.skipIf(!isIPv6())("registry on a bracketed IPv6 host", () => {
     expect(exitCode).not.toBe(0);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/41044
+describe("registry credentials from $VAR env references", () => {
+  function authLoggingRegistry(auths: (string | null)[]) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        auths.push(req.headers.get("authorization"));
+        return new Response("unauthorized", { status: 401 });
+      },
+    });
+  }
+
+  function scopeFiles(port: number, creds: string, withNpmrc: boolean) {
+    return {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "@myscope/no-deps": "1.0.0" },
+      }),
+      "bunfig.toml": `[install.scopes]\nmyscope = { url = "http://127.0.0.1:${port}/", ${creds} }\n`,
+      ...(withNpmrc ? { ".npmrc": `//127.0.0.1:${port}/:_authToken=npmrc-token\n` } : {}),
+    };
+  }
+
+  function defaultRegistryFiles(port: number, token: string) {
+    return {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = { url = "http://127.0.0.1:${port}/", token = "${token}" }\n`,
+    };
+  }
+
+  async function install(dir: string, extraEnv: Record<string, string>, cliArgs: string[] = []) {
+    const testEnv: Record<string, string | undefined> = {
+      ...env,
+      // An ambient proxy would intercept the requests to the local registry.
+      http_proxy: "",
+      https_proxy: "",
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+    };
+    delete testEnv.UNSET_TOKEN_41044;
+    Object.assign(testEnv, extraEnv);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-cache", "--ignore-scripts", ...cliArgs],
+      cwd: dir,
+      env: testEnv as Record<string, string>,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The registry answers 401, so the install itself fails.
+    expect(exitCode).not.toBe(0);
+  }
+
+  test.concurrent("an unset $VAR token sends no Authorization header", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-unset-token", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, false));
+    await install(String(dir), {});
+    expect(auths).toEqual([null]);
+  });
+
+  test.concurrent("an unset $VAR token falls back to the .npmrc credential", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-unset-token-npmrc", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, true));
+    await install(String(dir), {});
+    expect(auths).toEqual(["Bearer npmrc-token"]);
+  });
+
+  test.concurrent("a set $VAR token wins over the .npmrc credential", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-set-token-npmrc", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, true));
+    await install(String(dir), { UNSET_TOKEN_41044: "bunfig-token" });
+    expect(auths).toEqual(["Bearer bunfig-token"]);
+  });
+
+  // A lone password can never produce an Authorization header, so it must
+  // not block the .npmrc fallback either.
+  test.concurrent("an unset $VAR username with a literal password falls back to the .npmrc credential", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir(
+      "bunfig-half-pair-npmrc",
+      scopeFiles(server.port!, `username = "$UNSET_TOKEN_41044", password = "literalpass"`, true),
+    );
+    await install(String(dir), {});
+    expect(auths).toEqual(["Bearer npmrc-token"]);
+  });
+
+  test.concurrent("a resolved $VAR username and password pair wins over the .npmrc credential", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir(
+      "bunfig-pair-npmrc",
+      scopeFiles(server.port!, `username = "$USER_41044", password = "$PASS_41044"`, true),
+    );
+    await install(String(dir), { USER_41044: "alice", PASS_41044: "s3cret" });
+    expect(auths).toEqual([`Basic ${btoa("alice:s3cret")}`]);
+  });
+
+  test.concurrent("BUN_CONFIG_REGISTRY with an unset $VAR credential keeps the same-host bunfig token", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-env-registry-unset", defaultRegistryFiles(server.port!, "realtoken"));
+    await install(String(dir), {
+      BUN_CONFIG_REGISTRY: `http://:$UNSET_TOKEN_41044@127.0.0.1:${server.port}/`,
+    });
+    expect(auths).toEqual(["Bearer realtoken"]);
+  });
+
+  test.concurrent("--registry with an unset $VAR credential keeps the same-origin bunfig token", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-cli-registry-unset", defaultRegistryFiles(server.port!, "realtoken"));
+    await install(String(dir), {}, [`--registry=http://:$UNSET_TOKEN_41044@127.0.0.1:${server.port}/`]);
+    expect(auths).toEqual(["Bearer realtoken"]);
+  });
+
+  // The BUN_CONFIG_REGISTRY same-host path carries the already-resolved
+  // token into the new scope. A token value that itself starts with "$"
+  // must not go through $VAR resolution a second time.
+  test.concurrent("a token value that starts with $ survives the BUN_CONFIG_REGISTRY same-host carry", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-env-registry-dollar", defaultRegistryFiles(server.port!, "$TOK_41044"));
+    await install(String(dir), {
+      TOK_41044: "$ecret123",
+      BUN_CONFIG_REGISTRY: `http://127.0.0.1:${server.port}/`,
+    });
+    expect(auths).toEqual(["Bearer $ecret123"]);
+  });
+});

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -916,6 +916,22 @@ describe("registry credentials from $VAR env references", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  // The stale "$UNSET" token must not block from_api's username/password
+  // branch once .npmrc supplies the pair.
+  test.concurrent("an unset $VAR token falls back to a .npmrc username/_password pair", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-unset-token-npmrc-pair", {
+      ...scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, false),
+      ".npmrc":
+        `//127.0.0.1:${server.port}/:username=bob\n` +
+        `//127.0.0.1:${server.port}/:_password=${btoa("s3cret")}\n`,
+    });
+    const exitCode = await install(String(dir), {});
+    expect(auths).toEqual([`Basic ${btoa("bob:s3cret")}`]);
+    expect(exitCode).not.toBe(0);
+  });
+
   test.concurrent("a resolved $VAR username and password pair wins over the .npmrc credential", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -995,4 +995,18 @@ describe("registry credentials from $VAR env references", () => {
     expect(auths).toEqual([`Basic ${btoa("alice:s3cret")}`]);
     expect(exitCode).not.toBe(0);
   });
+
+  test.concurrent("a credential in the BUN_CONFIG_REGISTRY URL wins over the bunfig credential", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir(
+      "bunfig-env-registry-url-auth",
+      defaultRegistryFiles(server.port!, `username = "alice", password = "s3cret"`),
+    );
+    const exitCode = await install(String(dir), {
+      BUN_CONFIG_REGISTRY: `http://127.0.0.1:${server.port}/:_auth=${btoa("urluser:urlpass")}`,
+    });
+    expect(auths).toEqual([`Basic ${btoa("urluser:urlpass")}`]);
+    expect(exitCode).not.toBe(0);
+  });
 });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -916,6 +916,27 @@ describe("registry credentials from $VAR env references", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  // .npmrc values never go through $VAR substitution: a decoded _password
+  // that happens to start with "$" is a literal.
+  test.concurrent("a .npmrc _password that decodes to a $-prefixed value is sent verbatim", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("npmrc-dollar-password", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "@myscope/no-deps": "1.0.0" },
+      }),
+      "bunfig.toml": `[install.scopes]\nmyscope = { url = "http://127.0.0.1:${server.port}/" }\n`,
+      ".npmrc":
+        `//127.0.0.1:${server.port}/:username=alice\n` +
+        `//127.0.0.1:${server.port}/:_password=${btoa("$uperSecret")}\n`,
+    });
+    const exitCode = await install(String(dir), {});
+    expect(auths).toEqual([`Basic ${btoa("alice:$uperSecret")}`]);
+    expect(exitCode).not.toBe(0);
+  });
+
   // An unresolvable token must not shadow the scope's own username/password pair.
   test.concurrent("an unset $VAR token next to a resolved username/password pair sends Basic auth", async () => {
     const auths: (string | null)[] = [];

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -924,8 +924,7 @@ describe("registry credentials from $VAR env references", () => {
     using dir = tempDir("bunfig-unset-token-npmrc-pair", {
       ...scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, false),
       ".npmrc":
-        `//127.0.0.1:${server.port}/:username=bob\n` +
-        `//127.0.0.1:${server.port}/:_password=${btoa("s3cret")}\n`,
+        `//127.0.0.1:${server.port}/:username=bob\n` + `//127.0.0.1:${server.port}/:_password=${btoa("s3cret")}\n`,
     });
     const exitCode = await install(String(dir), {});
     expect(auths).toEqual([`Basic ${btoa("bob:s3cret")}`]);

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -916,6 +916,37 @@ describe("registry credentials from $VAR env references", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  // The runtime auto-install path feeds the raw bunfig config to the
+  // package manager and must resolve $VAR references too.
+  test.concurrent("runtime auto-install does not send an unset $VAR token", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir("bunfig-auto-install-unset", {
+      "index.ts": `import "@myscope/no-deps";`,
+      "bunfig.toml": `[install.scopes]\nmyscope = { url = "http://127.0.0.1:${server.port}/", token = "$UNSET_TOKEN_41044" }\n`,
+    });
+    const testEnv: Record<string, string | undefined> = {
+      ...env,
+      http_proxy: "",
+      https_proxy: "",
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+    };
+    delete testEnv.UNSET_TOKEN_41044;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "index.ts"],
+      cwd: String(dir),
+      env: testEnv as Record<string, string>,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(auths).toEqual([null]);
+    // The registry answers 401, so the run fails to resolve the import.
+    expect(exitCode).not.toBe(0);
+  });
+
   // .npmrc values never go through $VAR substitution: a decoded _password
   // that happens to start with "$" is a literal.
   test.concurrent("a .npmrc _password that decodes to a $-prefixed value is sent verbatim", async () => {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -853,7 +853,7 @@ describe("registry credentials from $VAR env references", () => {
 
   // The registry answers 401, so the install itself always fails. Assert the
   // returned exit code last, after the Authorization assertions.
-  async function install(dir: string, extraEnv: Record<string, string>, cliArgs: string[] = []): Promise<number> {
+  async function install(dir: string, extraEnv: Record<string, string>, cliArgs: string[] = []) {
     const testEnv: Record<string, string | undefined> = {
       ...env,
       // An ambient proxy would intercept the requests to the local registry.
@@ -871,16 +871,18 @@ describe("registry credentials from $VAR env references", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return exitCode;
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stderr, exitCode };
   }
 
-  test.concurrent("an unset $VAR token sends no Authorization header", async () => {
+  test.concurrent("an unset $VAR token sends no Authorization header and warns", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-unset-token", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, false));
-    const exitCode = await install(String(dir), {});
+    const { stderr, exitCode } = await install(String(dir), {});
     expect(auths).toEqual([null]);
+    expect(stderr).toContain("$UNSET_TOKEN_41044");
+    expect(stderr).toContain("is not set");
     expect(exitCode).not.toBe(0);
   });
 
@@ -888,7 +890,7 @@ describe("registry credentials from $VAR env references", () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-unset-token-npmrc", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, true));
-    const exitCode = await install(String(dir), {});
+    const { exitCode } = await install(String(dir), {});
     expect(auths).toEqual(["Bearer npmrc-token"]);
     expect(exitCode).not.toBe(0);
   });
@@ -897,7 +899,7 @@ describe("registry credentials from $VAR env references", () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-set-token-npmrc", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, true));
-    const exitCode = await install(String(dir), { UNSET_TOKEN_41044: "bunfig-token" });
+    const { exitCode } = await install(String(dir), { UNSET_TOKEN_41044: "bunfig-token" });
     expect(auths).toEqual(["Bearer bunfig-token"]);
     expect(exitCode).not.toBe(0);
   });
@@ -911,7 +913,7 @@ describe("registry credentials from $VAR env references", () => {
       "bunfig-half-pair-npmrc",
       scopeFiles(server.port!, `username = "$UNSET_TOKEN_41044", password = "literalpass"`, true),
     );
-    const exitCode = await install(String(dir), {});
+    const { exitCode } = await install(String(dir), {});
     expect(auths).toEqual(["Bearer npmrc-token"]);
     expect(exitCode).not.toBe(0);
   });
@@ -963,7 +965,7 @@ describe("registry credentials from $VAR env references", () => {
         `//127.0.0.1:${server.port}/:username=alice\n` +
         `//127.0.0.1:${server.port}/:_password=${btoa("$uperSecret")}\n`,
     });
-    const exitCode = await install(String(dir), {});
+    const { exitCode } = await install(String(dir), {});
     expect(auths).toEqual([`Basic ${btoa("alice:$uperSecret")}`]);
     expect(exitCode).not.toBe(0);
   });
@@ -976,7 +978,7 @@ describe("registry credentials from $VAR env references", () => {
       "bunfig-unset-token-own-pair",
       scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044", username = "alice", password = "s3cret"`, false),
     );
-    const exitCode = await install(String(dir), {});
+    const { exitCode } = await install(String(dir), {});
     expect(auths).toEqual([`Basic ${btoa("alice:s3cret")}`]);
     expect(exitCode).not.toBe(0);
   });
@@ -991,7 +993,7 @@ describe("registry credentials from $VAR env references", () => {
       ".npmrc":
         `//127.0.0.1:${server.port}/:username=bob\n` + `//127.0.0.1:${server.port}/:_password=${btoa("s3cret")}\n`,
     });
-    const exitCode = await install(String(dir), {});
+    const { exitCode } = await install(String(dir), {});
     expect(auths).toEqual([`Basic ${btoa("bob:s3cret")}`]);
     expect(exitCode).not.toBe(0);
   });
@@ -1003,7 +1005,7 @@ describe("registry credentials from $VAR env references", () => {
       "bunfig-pair-npmrc",
       scopeFiles(server.port!, `username = "$USER_41044", password = "$PASS_41044"`, true),
     );
-    const exitCode = await install(String(dir), { USER_41044: "alice", PASS_41044: "s3cret" });
+    const { exitCode } = await install(String(dir), { USER_41044: "alice", PASS_41044: "s3cret" });
     expect(auths).toEqual([`Basic ${btoa("alice:s3cret")}`]);
     expect(exitCode).not.toBe(0);
   });
@@ -1012,7 +1014,7 @@ describe("registry credentials from $VAR env references", () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-env-registry-unset", defaultRegistryFiles(server.port!, `token = "realtoken"`));
-    const exitCode = await install(String(dir), {
+    const { exitCode } = await install(String(dir), {
       BUN_CONFIG_REGISTRY: `http://:$UNSET_TOKEN_41044@127.0.0.1:${server.port}/`,
     });
     expect(auths).toEqual(["Bearer realtoken"]);
@@ -1023,7 +1025,7 @@ describe("registry credentials from $VAR env references", () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-cli-registry-unset", defaultRegistryFiles(server.port!, `token = "realtoken"`));
-    const exitCode = await install(String(dir), {}, [
+    const { exitCode } = await install(String(dir), {}, [
       `--registry=http://:$UNSET_TOKEN_41044@127.0.0.1:${server.port}/`,
     ]);
     expect(auths).toEqual(["Bearer realtoken"]);
@@ -1037,7 +1039,7 @@ describe("registry credentials from $VAR env references", () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-env-registry-dollar", defaultRegistryFiles(server.port!, `token = "$TOK_41044"`));
-    const exitCode = await install(String(dir), {
+    const { exitCode } = await install(String(dir), {
       TOK_41044: "$ecret123",
       BUN_CONFIG_REGISTRY: `http://127.0.0.1:${server.port}/`,
     });
@@ -1052,7 +1054,7 @@ describe("registry credentials from $VAR env references", () => {
       "bunfig-env-registry-basic",
       defaultRegistryFiles(server.port!, `username = "$USER_41044", password = "$PASS_41044"`),
     );
-    const exitCode = await install(String(dir), {
+    const { exitCode } = await install(String(dir), {
       USER_41044: "alice",
       PASS_41044: "s3cret",
       BUN_CONFIG_REGISTRY: `http://127.0.0.1:${server.port}/`,
@@ -1068,7 +1070,7 @@ describe("registry credentials from $VAR env references", () => {
       "bunfig-env-registry-url-auth",
       defaultRegistryFiles(server.port!, `username = "alice", password = "s3cret"`),
     );
-    const exitCode = await install(String(dir), {
+    const { exitCode } = await install(String(dir), {
       BUN_CONFIG_REGISTRY: `http://127.0.0.1:${server.port}/:_auth=${btoa("urluser:urlpass")}`,
     });
     expect(auths).toEqual([`Basic ${btoa("urluser:urlpass")}`]);

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -840,18 +840,20 @@ describe("registry credentials from $VAR env references", () => {
     };
   }
 
-  function defaultRegistryFiles(port: number, token: string) {
+  function defaultRegistryFiles(port: number, creds: string) {
     return {
       "package.json": JSON.stringify({
         name: "app",
         version: "1.0.0",
         dependencies: { "no-deps": "1.0.0" },
       }),
-      "bunfig.toml": `[install]\nregistry = { url = "http://127.0.0.1:${port}/", token = "${token}" }\n`,
+      "bunfig.toml": `[install]\nregistry = { url = "http://127.0.0.1:${port}/", ${creds} }\n`,
     };
   }
 
-  async function install(dir: string, extraEnv: Record<string, string>, cliArgs: string[] = []) {
+  // The registry answers 401, so the install itself always fails. Assert the
+  // returned exit code last, after the Authorization assertions.
+  async function install(dir: string, extraEnv: Record<string, string>, cliArgs: string[] = []): Promise<number> {
     const testEnv: Record<string, string | undefined> = {
       ...env,
       // An ambient proxy would intercept the requests to the local registry.
@@ -870,32 +872,34 @@ describe("registry credentials from $VAR env references", () => {
       stderr: "pipe",
     });
     const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // The registry answers 401, so the install itself fails.
-    expect(exitCode).not.toBe(0);
+    return exitCode;
   }
 
   test.concurrent("an unset $VAR token sends no Authorization header", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-unset-token", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, false));
-    await install(String(dir), {});
+    const exitCode = await install(String(dir), {});
     expect(auths).toEqual([null]);
+    expect(exitCode).not.toBe(0);
   });
 
   test.concurrent("an unset $VAR token falls back to the .npmrc credential", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-unset-token-npmrc", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, true));
-    await install(String(dir), {});
+    const exitCode = await install(String(dir), {});
     expect(auths).toEqual(["Bearer npmrc-token"]);
+    expect(exitCode).not.toBe(0);
   });
 
   test.concurrent("a set $VAR token wins over the .npmrc credential", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
     using dir = tempDir("bunfig-set-token-npmrc", scopeFiles(server.port!, `token = "$UNSET_TOKEN_41044"`, true));
-    await install(String(dir), { UNSET_TOKEN_41044: "bunfig-token" });
+    const exitCode = await install(String(dir), { UNSET_TOKEN_41044: "bunfig-token" });
     expect(auths).toEqual(["Bearer bunfig-token"]);
+    expect(exitCode).not.toBe(0);
   });
 
   // A lone password can never produce an Authorization header, so it must
@@ -907,8 +911,9 @@ describe("registry credentials from $VAR env references", () => {
       "bunfig-half-pair-npmrc",
       scopeFiles(server.port!, `username = "$UNSET_TOKEN_41044", password = "literalpass"`, true),
     );
-    await install(String(dir), {});
+    const exitCode = await install(String(dir), {});
     expect(auths).toEqual(["Bearer npmrc-token"]);
+    expect(exitCode).not.toBe(0);
   });
 
   test.concurrent("a resolved $VAR username and password pair wins over the .npmrc credential", async () => {
@@ -918,39 +923,61 @@ describe("registry credentials from $VAR env references", () => {
       "bunfig-pair-npmrc",
       scopeFiles(server.port!, `username = "$USER_41044", password = "$PASS_41044"`, true),
     );
-    await install(String(dir), { USER_41044: "alice", PASS_41044: "s3cret" });
+    const exitCode = await install(String(dir), { USER_41044: "alice", PASS_41044: "s3cret" });
     expect(auths).toEqual([`Basic ${btoa("alice:s3cret")}`]);
+    expect(exitCode).not.toBe(0);
   });
 
   test.concurrent("BUN_CONFIG_REGISTRY with an unset $VAR credential keeps the same-host bunfig token", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
-    using dir = tempDir("bunfig-env-registry-unset", defaultRegistryFiles(server.port!, "realtoken"));
-    await install(String(dir), {
+    using dir = tempDir("bunfig-env-registry-unset", defaultRegistryFiles(server.port!, `token = "realtoken"`));
+    const exitCode = await install(String(dir), {
       BUN_CONFIG_REGISTRY: `http://:$UNSET_TOKEN_41044@127.0.0.1:${server.port}/`,
     });
     expect(auths).toEqual(["Bearer realtoken"]);
+    expect(exitCode).not.toBe(0);
   });
 
   test.concurrent("--registry with an unset $VAR credential keeps the same-origin bunfig token", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
-    using dir = tempDir("bunfig-cli-registry-unset", defaultRegistryFiles(server.port!, "realtoken"));
-    await install(String(dir), {}, [`--registry=http://:$UNSET_TOKEN_41044@127.0.0.1:${server.port}/`]);
+    using dir = tempDir("bunfig-cli-registry-unset", defaultRegistryFiles(server.port!, `token = "realtoken"`));
+    const exitCode = await install(String(dir), {}, [
+      `--registry=http://:$UNSET_TOKEN_41044@127.0.0.1:${server.port}/`,
+    ]);
     expect(auths).toEqual(["Bearer realtoken"]);
+    expect(exitCode).not.toBe(0);
   });
 
   // The BUN_CONFIG_REGISTRY same-host path carries the already-resolved
-  // token into the new scope. A token value that itself starts with "$"
-  // must not go through $VAR resolution a second time.
+  // credentials into the new scope. A token value that itself starts with
+  // "$" must not go through $VAR resolution a second time.
   test.concurrent("a token value that starts with $ survives the BUN_CONFIG_REGISTRY same-host carry", async () => {
     const auths: (string | null)[] = [];
     await using server = authLoggingRegistry(auths);
-    using dir = tempDir("bunfig-env-registry-dollar", defaultRegistryFiles(server.port!, "$TOK_41044"));
-    await install(String(dir), {
+    using dir = tempDir("bunfig-env-registry-dollar", defaultRegistryFiles(server.port!, `token = "$TOK_41044"`));
+    const exitCode = await install(String(dir), {
       TOK_41044: "$ecret123",
       BUN_CONFIG_REGISTRY: `http://127.0.0.1:${server.port}/`,
     });
     expect(auths).toEqual(["Bearer $ecret123"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test.concurrent("BUN_CONFIG_REGISTRY with no credentials keeps the same-host bunfig Basic credentials", async () => {
+    const auths: (string | null)[] = [];
+    await using server = authLoggingRegistry(auths);
+    using dir = tempDir(
+      "bunfig-env-registry-basic",
+      defaultRegistryFiles(server.port!, `username = "$USER_41044", password = "$PASS_41044"`),
+    );
+    const exitCode = await install(String(dir), {
+      USER_41044: "alice",
+      PASS_41044: "s3cret",
+      BUN_CONFIG_REGISTRY: `http://127.0.0.1:${server.port}/`,
+    });
+    expect(auths).toEqual([`Basic ${btoa("alice:s3cret")}`]);
+    expect(exitCode).not.toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- An `[install.scopes]` entry with `token = "$VAR"` sends the literal text when the variable is unset: `Authorization: Bearer $UNSET_TOKEN` goes to the registry. The variable name leaks to the remote log and the request 401s.
- The cause is `Loader::get_auto` (src/dotenv/env_loader.rs:569). It substitutes a set variable but falls back to the literal `$VAR` bytes when it is unset. The non-empty literal then blocks the `.npmrc` credential for the same host in `apply_registry_auth` (src/ini/lib.rs), shadows the scope's own username and password pair in `Scope::from_api`, and makes the `BUN_CONFIG_REGISTRY` and `--registry` gates drop a valid same-origin token.

### Fix
- `$VAR` references now resolve once, at the entry points that document them: bunfig registry and scope credentials (after .env loading, before the `.npmrc` merge), registry URLs from `BUN_CONFIG_REGISTRY` or `--registry`, and the raw bunfig config on the runtime auto-install path. A reference to an unset variable warns (naming the variable) and resolves to no credential. `NpmRegistry::resolve_credential_refs` does the substitution.
- Every later check runs on literal values. `has_usable_credentials` replaces `has_credentials` and counts only a token or a username and password pair, so a lone field cannot block the `.npmrc` fallback. `.npmrc` values never go through `$VAR` substitution, so a decoded `_password` that starts with `$` is sent verbatim, as before.
- The `BUN_CONFIG_REGISTRY` same-host path carries the full resolved credential set (token and Basic auth), and a credential embedded in the override URL still wins.
- Verified: 14 new tests in test/cli/install/npmrc.test.ts (9 fail on bun 1.4.0, 5 guard existing behavior). Also config-precedence.test.ts and the auth and registry subsets of bun-install.test.ts.
- Self-reviewed, 3 concerns addressed. Later review-bot findings (Basic-auth carry, `.npmrc` pair fallback, URL pathname precedence, `$`-prefixed `.npmrc` literals) are fixed with tests.

### Background
- The bunfig fields `token`, `username`, and `password` support `$VAR` env references. `.npmrc` has its own `${VAR}` expansion in the ini parser and its plain values are literal.
- `.npmrc` credentials merge into bunfig registries only when the bunfig entry has no usable credential of its own. Since 1.4, a set bunfig credential wins over `.npmrc`. This PR keeps that precedence, as the issue requests.
- Tradeoff: a bunfig credential whose literal value starts with `$` and names an unset variable now resolves to no credential instead of being sent verbatim. The docs advertise `$variable` notation for these fields, and npm tokens do not start with `$`.

<details><summary>Notes</summary>

Reproduction (issue #41044): a registry that logs the `Authorization` header, `bunfig.toml` with `test = { url = "...", token = "$UNSET_TOKEN" }`, and the variable unset. Observed `Bearer $UNSET_TOKEN` on both bare install and with a valid `.npmrc` `_authToken` for the same host. After the fix: no header in the first case, `Bearer REALTOKEN` in the second.

Design history: the first draft resolved unset references inside `get_auto` (empty instead of literal). Review found that `Scope::from_api` runs `get_auto` on every credential, including `.npmrc`-sourced values, so a literal `.npmrc` password that starts with `$` would have been erased. The final shape restores `get_auto` and moves resolution to the entry points, which also fixes an unresolvable token shadowing the scope's own username/password pair.

Fail-before matrix on bun 1.4.0+34cbb9a40 (all 13 pass with this PR):

- unset `$VAR` token sends no header and warns: fail (sends the literal)
- unset `$VAR` token falls back to `.npmrc` `_authToken`: fail
- unset `$VAR` token falls back to a `.npmrc` username/_password pair: fail
- unset `$VAR` token next to a resolved username/password pair sends Basic: fail
- unset `$VAR` username with literal password falls back to `.npmrc`: fail
- `BUN_CONFIG_REGISTRY` with unset `$VAR` userinfo keeps the same-host bunfig token: fail
- `--registry` with unset `$VAR` userinfo keeps the same-origin bunfig token: fail
- `BUN_CONFIG_REGISTRY` with no credentials keeps the same-host bunfig Basic credentials: fail (only the token was carried)
- runtime auto-install does not send an unset `$VAR` token: fail (`bun run` auto-install sent the literal)
- set `$VAR` token wins over `.npmrc`: pass (precedence guard)
- resolved username/password pair wins over `.npmrc`: pass (guard)
- `.npmrc` `_password` that decodes to a `$`-prefixed value is sent verbatim: pass (guard for the literal-passthrough contract)
- token value `$ecret123` survives the `BUN_CONFIG_REGISTRY` same-host carry: pass (guard against double resolution)
- credential in the `BUN_CONFIG_REGISTRY` URL wins over the bunfig credential: pass (guard for URL-wins precedence)

`NpmRegistry::has_credentials` lost its last caller and is deleted. The registry URL `$VAR` expansion in `from_api` uses `env.get` directly and is unchanged.

Suites run locally on the debug build: test/cli/install/npmrc.test.ts (54 pass), test/cli/install/config-precedence.test.ts (51 pass), bun-install.test.ts `-t auth` and `-t registry` (all pass).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/npmrc.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_5se14T/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [245.40ms]
package dir /tmp/verdaccio-test-_OvbnG6
bun install v1.4.1 (a6c4cc276)
No packages! Deleted empty lockfile

[89.00ms] done
(pass) npmrc > works with empty file [182.25ms]
package dir /tmp/verdaccio-test-_E8YIQx
bun install v1.4.1 (a6c4cc276)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [140.00ms]
(pass) npmrc > sets default registry [203.43ms]
bun install v1.4.1 (a6c4cc276)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [127.00ms]
(pass) npmrc > sets scoped registry [194.15ms]
package dir /tmp/verdaccio-test-_zbJ8Wz
home dir /tmp/verdaccio-test-_zbJ8Wz/home_dir
bun install v1.4.1 (a6c4cc276)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package in
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (f2f6af22e)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_cM3yyf/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [3.96ms]
package dir /tmp/verdaccio-test-_CqEBEn
bun install v1.4.1-canary.1 (f2f6af22e)
No packages! Deleted empty lockfile

[0.00ms] done
(pass) npmrc > works with empty file [3.81ms]
package dir /tmp/verdaccio-test-_ihI737
bun install v1.4.1-canary.1 (f2f6af22e)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [19.00ms]
(pass) npmrc > sets default registry [22.69ms]
bun install v1.4.1-canary.1 (f2f6af22e)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [4.00ms]
(pass) npmrc > sets scoped registry [6.71ms]
package dir /tmp/verdaccio-test-_9jnIC9
home dir /tmp/verdaccio-test-_9jnIC9/home_dir
bun install v1.4.1-canary.1 (f2f6af22e)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [1.00ms]
(pass) npmrc > works with home config [3.37ms]
package dir /tmp/verdaccio-test-_wu4HLN
home dir /tmp/verdaccio-te
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/npmrc.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_UWgfSl/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [234.29ms]
package dir /tmp/verdaccio-test-_SQzB5L
bun install v1.4.1 (a6c4cc276)
No packages! Deleted empty lockfile

[92.00ms] done
(pass) npmrc > works with empty file [179.80ms]
package dir /tmp/verdaccio-test-_DQQbkW
bun install v1.4.1 (a6c4cc276)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [212.00ms]
(pass) npmrc > sets default registry [274.54ms]
bun install v1.4.1 (a6c4cc276)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [129.00ms]
(pass) npmrc > sets scoped registry [197.50ms]
package dir /tmp/verdaccio-test-_xmdJuK
home dir /tmp/verdaccio-test-_xmdJuK/home_dir
bun install v1.4.1 (a6c4cc276)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package in
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 580ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/124] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[3/124] gen cpp.rs (cppbind)
[3/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/dotenv/env_loader.rs                           |   1 +
 src/ini/lib.rs                                     |   4 +-
 src/install/PackageManager.rs                      |  14 +-
 .../PackageManager/PackageManagerOptions.rs        |  35 ++-
 src/install/lockfile.rs                            |   1 +
 src/options_types/schema.rs                        |  31 ++-
 test/cli/install/npmrc.test.ts                     | 263 +++++++++++++++++++++
 7 files changed, 340 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 3 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/dotenv/env_loader.rs                                 3      6      0
src/ini/lib.rs                                           5      7      0
src/install/PackageManager.rs                            3      5      0
src/install/PackageManager/PackageManagerOptions.rs      6      8      0
src/install/lockfile.rs                                  1      2      0
src/options_types/schema.rs                              7     11      0
test/cli/install/npmrc.test.ts                           4     13      0
```

</details>

**root cause** · written by the author bot

The install scopes credential expansion treated a `$VAR` reference to an unset environment variable as a literal string, so Bun sent the raw variable name as the bearer token instead of recognizing that no credential was configured. The fix resolves credential references after dotenv loading and converts references to unset variables into empty credentials, emitting a warning that names the missing variable. Authentication checks now use a stricter usability test requiring a token or a complete username and password pair, so the scope correctly falls through to other credential sources such…

<!-- robobun:evidence:end -->