### PR TITLE
docs: correct Bun.semver.satisfies invalid range text and the escapeHTML hardware name

### DIFF
--- a/docs/runtime/semver.mdx
+++ b/docs/runtime/semver.mdx
@@ -34,7 +34,7 @@ semver.satisfies("1.0.0", "1.0.0 - 2.0.0"); // true
 semver.satisfies("1.0.0", "1.0.0 - 1.0.1"); // true
 ```
 
-If `range` or `version` is invalid, it returns `false`.
+If `version` is invalid, `satisfies` returns `false`. Bun ignores the parts of `range` that it cannot parse. A `range` with no parseable part behaves like `*`.
 
 ## `Bun.semver.order(versionA: string, versionB: string): 0 | 1 | -1`
 

--- a/docs/runtime/semver.mdx
+++ b/docs/runtime/semver.mdx
@@ -34,7 +34,7 @@ semver.satisfies("1.0.0", "1.0.0 - 2.0.0"); // true
 semver.satisfies("1.0.0", "1.0.0 - 1.0.1"); // true
 ```
 
-If `version` is invalid, `satisfies` returns `false`. Bun ignores the parts of `range` that it cannot parse. A `range` with no parseable part behaves like `*`.
+`satisfies` returns `false` if `version` is invalid, or if either argument contains a non-ASCII character. Bun ignores the parts of `range` that it cannot parse. A `range` with no parseable part behaves like `*`.
 
 ## `Bun.semver.order(versionA: string, versionB: string): 0 | 1 | -1`
 

--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -305,7 +305,7 @@ Escapes the following characters from an input string:
 - `<` becomes `&lt;`
 - `>` becomes `&gt;`
 
-This function is optimized for large input. On an M1X, it processes 480 MB/s -
+This function is optimized for large input. On an M1 Max, it processes 480 MB/s -
 20 GB/s, depending on how much data is being escaped and whether there is non-ASCII
 text. Bun converts non-string types to a string before escaping.
 


### PR DESCRIPTION
### Problem
- `docs/runtime/semver.mdx` says `Bun.semver.satisfies` returns `false` when `range` is invalid. It does not. `Bun.semver.satisfies("1.0.0", "!!not-a-range!!")` returns `true` on bun 1.4.1. Only an invalid `version` returns `false`.
- `docs/runtime/utils.mdx` names an "M1X" processor in the `Bun.escapeHTML` benchmark text. That chip does not exist. The benchmark ran on an M1 Max (#13342).

### Fix
- Rewrite the `satisfies` sentence. Bun skips the parts of `range` it cannot parse. A `range` with no parseable part behaves like `*`. An invalid `version`, or a non-ASCII character in either argument, returns `false`.
- Replace "M1X" with "M1 Max" on the docs page.
- Verified: every claim in the new sentence by execution on bun 1.4.1 (see Notes). Prettier is clean.

Fixes #13342

### Background
- `Bun.semver.satisfies` is `src/semver_jsc/SemverObject.rs`. It parses `range` with `bun_semver::query::parse`. That parser drops tokens it does not recognize and never fails on bad input. `Group::is_empty` documents this: "the input was only unrecognised words".
- An empty comparator group matches every non-prerelease version. That is the same behavior as the `*` range in node-semver.
- This PR carries the two items from #33709 that are still valid on main. The rest of that PR landed in #38899, #38441, and #38333, or is no longer correct after #34422.
- The `Bun.escapeHTML` JSDoc in `packages/bun-types/bun.d.ts` (line 2397) has the same "M1X" text. This PR is scoped to `docs/`. That copy is for a types change.

<details><summary>Notes</summary>

Probe on bun 1.4.1:

```
satisfies("1.0.0", "^1.0.0")             true
satisfies("1.0.0", "!!not-a-range!!")    true   (docs said false)
satisfies("1.0.0", "")                   true
satisfies("1.0.0-alpha", "garbage")      false  (same as "*": prereleases excluded)
satisfies("1.0.0-alpha", "*")            false
satisfies("2.0.0", "garbage || ^2.0.0")  true   (unparseable part dropped)
satisfies("2.0.0", "garbage ^1.0.0")     false
satisfies("!!not-a-version!!", "^1.0.0") false
satisfies("!!not-a-version!!", "*")      false
satisfies("1.x", "^1.0.0")               false  (wildcard in version)
satisfies("1.0.0", "^1.0.0 café")        false  (non-ASCII short-circuits to false)
satisfies("café", "*")                   false
```

The `version` half of the sentence is unchanged from main. It is not exact for every input: `satisfies("", "*")` and `satisfies("1.0.0.0", "^1.0.0")` return `true` because `satisfies` does not check the parser's `valid` flag, while `order` does. Those are degenerate inputs and the sentence describes the common case, as before.

Not included: #33709 also removed the "Export condition macro" section from `docs/bundler/macros.mdx`. On bun 1.4.1, `import { macro } from "my-package" with { type: "macro" }` resolves through the normal conditions, not the `"macro"` condition, so that section documents a behavior the bundler does not have. Whether the docs or the resolver changes is a maintainer decision. See the closing comment on #33709.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->