### PR TITLE
install: re-hoist a transitive dependency that moves with its dependent

### DIFF
--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -209,6 +209,7 @@ fn redirect(lockfile: &mut Lockfile, pairs: Vec<(PackageID, PackageID)>) {
     if pairs.is_empty() {
         return;
     }
+    let pairs = with_moved_subtrees(lockfile, pairs);
     let mut new_of: Vec<PackageID> = vec![invalid_package_id; lockfile.packages.len()];
     for (old, new) in pairs {
         let slot = &mut new_of[old as usize];
@@ -250,6 +251,97 @@ fn redirect(lockfile: &mut Lockfile, pairs: Vec<(PackageID, PackageID)>) {
     for (j, new) in moved {
         lockfile.buffers.resolutions[j] = new;
     }
+}
+
+/// A moved package's subtree moves with it: each row of the old package whose same-name row on
+/// the new package resolves to a different npm package of that name is a further `(old, new)`
+/// pair, transitively. Without this, an edge owned by an unchanged package (a loose peer range,
+/// say) keeps the old transitive target alive, and the hoister nests the new copy under the
+/// moved package instead of replacing the root one (#41048). A package the root's or a
+/// workspace's own rows still resolve to is pinned by the user, so it never counts as moved.
+fn with_moved_subtrees(
+    lockfile: &Lockfile,
+    pairs: Vec<(PackageID, PackageID)>,
+) -> Vec<(PackageID, PackageID)> {
+    let packages_len = lockfile.packages.len();
+    let pkg_res = lockfile.packages.items_resolution();
+    let name_hashes = lockfile.packages.items_name_hash();
+    let dep_slices = lockfile.packages.items_dependencies();
+    let res_slices = lockfile.packages.items_resolutions();
+    let deps = lockfile.buffers.dependencies.as_slice();
+    let resolutions = lockfile.buffers.resolutions.as_slice();
+
+    let mut direct_targets = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
+    for owner in 0..packages_len {
+        if !matches!(
+            pkg_res[owner].tag,
+            ResolutionTag::Root | ResolutionTag::Workspace
+        ) {
+            continue;
+        }
+        for &target in res_slices[owner].get(resolutions) {
+            if (target as usize) < packages_len {
+                direct_targets.set(target as usize);
+            }
+        }
+    }
+
+    let mut seen = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
+    for &(old, _) in &pairs {
+        if (old as usize) < packages_len {
+            seen.set(old as usize);
+        }
+    }
+    let mut out = pairs;
+    let mut i = 0usize;
+    while let Some(&(old, new)) = out.get(i) {
+        i += 1;
+        if (old as usize) >= packages_len || (new as usize) >= packages_len {
+            continue;
+        }
+        let new_rows: Vec<(PackageNameHash, Behavior, PackageID)> = dep_slices[new as usize]
+            .get(deps)
+            .iter()
+            .zip(res_slices[new as usize].get(resolutions))
+            .map(|(dep, &target)| (dep.name_hash, dep.behavior, target))
+            .collect();
+        let old_rows = dep_slices[old as usize]
+            .get(deps)
+            .iter()
+            .zip(res_slices[old as usize].get(resolutions));
+        for (dep, &old_target) in old_rows {
+            if dep.behavior.is_bundled() || (old_target as usize) >= packages_len {
+                continue;
+            }
+            // Same-behavior row first; a row whose dependency group changed between the two
+            // versions still matches by name alone.
+            let hit = new_rows
+                .iter()
+                .find(|&&(name_hash, behavior, _)| {
+                    name_hash == dep.name_hash && behavior == dep.behavior
+                })
+                .or_else(|| {
+                    new_rows
+                        .iter()
+                        .find(|&&(name_hash, _, _)| name_hash == dep.name_hash)
+                });
+            let Some(&(_, _, new_target)) = hit else {
+                continue;
+            };
+            if new_target == old_target
+                || (new_target as usize) >= packages_len
+                || pkg_res[new_target as usize].tag != ResolutionTag::Npm
+                || name_hashes[old_target as usize] != name_hashes[new_target as usize]
+                || direct_targets.is_set(old_target as usize)
+                || seen.is_set(old_target as usize)
+            {
+                continue;
+            }
+            seen.set(old_target as usize);
+            out.push((old_target, new_target));
+        }
+    }
+    out
 }
 
 struct Pin {

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -426,6 +426,58 @@ test.concurrent("a moved direct dependency is still followed after its row index
   expect(exitCode).toBe(0);
 });
 
+// one-fixed-dep pins no-deps exactly, so bumping it moves no-deps with it; forward-peer-deps' `*` edge follows the move, the stale root copy is dropped and the new one hoists to the root instead of nesting (#41048). The peer owner sorts ahead of one-fixed-dep, so without the redirect its stale edge wins the root slot.
+test.concurrent("`bun install` after a version bump re-points loose edges at a moved exact child", async () => {
+  const dir = await setup({ "package.json": pkgJson({ "forward-peer-deps": "1.0.0", "one-fixed-dep": "1.0.0" }) });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0"]);
+  await reinstall(dir, pkgJson({ "forward-peer-deps": "1.0.0", "one-fixed-dep": "2.0.0" }));
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
+  expect((await lock(dir)).packages["one-fixed-dep/no-deps"]).toBeUndefined();
+  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  expect(await exists(join(dir, "node_modules", "one-fixed-dep", "node_modules"))).toBe(false);
+  await frozen(dir);
+});
+
+// peer-deps-fixed's `^1.0.0` rejects 2.0.0, so the old copy stays for it, nested under its one dependent.
+test.concurrent("`bun install` after a version bump keeps the old copy for an edge out of range", async () => {
+  const dir = await setup({ "package.json": pkgJson({ "one-fixed-dep": "1.0.0", "peer-deps-fixed": "1.0.0" }) });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0"]);
+  await reinstall(dir, pkgJson({ "one-fixed-dep": "2.0.0", "peer-deps-fixed": "1.0.0" }));
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0", "2.0.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  expect(await installedVersion(dir, "peer-deps-fixed", "node_modules", "no-deps")).toBe("1.0.0");
+  await frozen(dir);
+});
+
+// The root's own `>=1.0.0` row is the user's pin: bumping the sibling must not drag it along, even though 2.0.0 is in range. The stale-for-the-root copy stays at the root and the bumped pin nests its own.
+test.concurrent("`bun install` after a version bump never moves the root's own locked dependency", async () => {
+  const dir = await setup({ "package.json": pkgJson({ "no-deps": "1.0.0", "one-fixed-dep": "1.0.0" }) });
+  await reinstall(dir, pkgJson({ "no-deps": ">=1.0.0", "one-fixed-dep": "1.0.0" }));
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0"]);
+  await reinstall(dir, pkgJson({ "no-deps": ">=1.0.0", "one-fixed-dep": "2.0.0" }));
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0", "2.0.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("1.0.0");
+  expect(await installedVersion(dir, "one-fixed-dep", "node_modules", "no-deps")).toBe("2.0.0");
+  await frozen(dir);
+});
+
+// Two exact-pinned levels move together: parent's bump moves mid, mid's move moves leaf, and holder's peer edge follows the leaf.
+test.concurrent("`bun install` after a version bump follows a moved chain two levels deep", async () => {
+  using server = await serveRegistry({
+    holder: { "1.0.0": { peerDependencies: { leaf: "*" } } },
+    parent: { "1.0.0": { dependencies: { mid: "1.0.0" } }, "2.0.0": { dependencies: { mid: "2.0.0" } } },
+    mid: { "1.0.0": { dependencies: { leaf: "1.0.0" } }, "2.0.0": { dependencies: { leaf: "2.0.0" } } },
+    leaf: { "1.0.0": {}, "2.0.0": {} },
+  });
+  const dir = await installServed(server, "install-moved-chain-", pkgJson({ holder: "1.0.0", parent: "1.0.0" }));
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  await reinstall(dir, pkgJson({ holder: "1.0.0", parent: "2.0.0" }));
+  expect(await lockedVersions(dir, "mid")).toStrictEqual(["2.0.0"]);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["2.0.0"]);
+  expect(await installedVersion(dir, "leaf")).toBe("2.0.0");
+  await frozen(dir);
+});
+
 // The plan is the same block a real run prints, with a "would be updated" count line in place of "installed"; nothing is installed and no lockfile dump follows.
 test.concurrent.each([
   ["bare", []],
@@ -1231,7 +1283,10 @@ test.concurrent("in a workspace, `bun update` from one member also re-points a s
   expect(exitCode).toBe(0);
 });
 
-type Manifests = Record<string, Record<string, { dependencies?: Record<string, string> }>>;
+type Manifests = Record<
+  string,
+  Record<string, { dependencies?: Record<string, string>; peerDependencies?: Record<string, string> }>
+>;
 type Tags = Record<string, Record<string, string>>;
 
 // Serves one manifest per name from memory; verdaccio has no parent whose newer version keeps a range on the same child, and its dist-tags cannot move mid-test. `tags` is read per request, so a test can move a tag after installing.


### PR DESCRIPTION
### Problem
- An incremental `bun install` after a version bump strands a stale transitive dependency. Bumping `@tanstack/react-query` from `5.101.4` to `^5.102.2` leaves `@tanstack/query-core@5.101.4` hoisted at the root with zero dependents, and nests the new `5.102.8` under `@tanstack/react-query`. A fresh install produces a single root copy (#41048).
- The cause is the redirect pass (`redirect` in `src/install/update_transitive.rs`). It re-points edges that still resolve to the old package of a moved direct dependency, but not edges on that package's transitive children that moved with it. A loose peer range (`>=5.80.2` on `@orpc/tanstack-query`) keeps the stale child reachable, the lockfile clean keeps it, and the hoister nests the new copy.

### Fix
- `with_moved_subtrees` expands the moved `(old, new)` pairs to a transitive closure: each same-name row of the old and the new package that resolves to a different npm package of that name is a further pair. `redirect` then moves each edge only when the edge's own range accepts the new version, as before.
- A package the root's or a workspace's own rows still resolve to is the user's pin. The closure never treats it as moved, so a sibling bump cannot drag a locked direct dependency along.
- Verified: four new tests in `test/cli/install/bun-update-transitive.test.ts`. Two fail on the released bun (stranded copy, depth-2 chain). Two pin the preserved behavior (out-of-range edge, locked root dependency). The real-package repro now yields one root `query-core@5.102.8` and `bun why` is consistent.
- Self-reviewed. The review caught that the closure could move a locked root dependency. The user-pin guard and its test fix that. It also asked for a depth-2 closure test and a name-only row-match fallback for rows whose dependency group changed. Both are in.

### Background
- bun.lock records one entry per hoisted `node_modules` path. After resolution, `Lockfile::clean_with_logger` garbage-collects packages no resolution edge reaches, and the tree builder assigns each package a path. A name slot taken at the root forces a same-name, different-version package into a nested path.
- The differ re-resolves only the rows whose range no longer accepts the locked version. Unchanged packages keep their recorded edges verbatim, which is what left the peer edge on the old copy.
- The redirect pass runs after resolution for all three move paths: a changed direct dependency, `bun update`'s transitive plan, and named updates. The closure sits inside `redirect`, so all three gain it.

<details><summary>Notes</summary>

- Reproduction (from the issue): install `@orpc/tanstack-query@^1.15.0` + `@orpc/client@^1.15.0` + `@tanstack/react-query@5.101.4`, then bump react-query to `^5.102.2` and reinstall. Before the fix, bun.lock has both `"@tanstack/query-core"` (5.101.4) and `"@tanstack/react-query/@tanstack/query-core"` (5.102.8), `bun why` reports the root copy with "No dependents found", and `bun dedupe --check` reports nothing (the orphan is unreachable from the root, so the dedupe reachability filter skips it).
- A frozen install from such a duplicated lockfile already materialises one copy: on load, the peer edge re-resolves away from the orphan. The bug is in the in-memory incremental path only, so lockfiles that already carry the orphan heal on the next install that rewrites the lockfile.
- The hoist order decides which copy shows the bug. The stale copy wins the root slot only when the peer owner sorts before the moved package (`@orpc/*` < `@tanstack/*`). The new test mirrors that with `forward-peer-deps` < `one-fixed-dep`.
- The user-pin guard scans the current resolutions of every Root- or Workspace-owned row at redirect time, not a pre-differ snapshot, so a direct edge that legitimately moved does not protect its old target, and the `bun update <name> --latest` path (which has no snapshot) is covered.
- Suites run with the debug build: bun-update-transitive (178), bun-install (only pre-existing network-blocked bitbucket/gitlab/tarball-URL tests fail, same on main), bun-update, bun-dedupe, bun-add, bun-audit, bun-pm-why, bun-lock, bun-update-lockfile-sync, lockfile-only, isolated-install.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update-transitive.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/install/bun-update-transitive.test.ts:
(pass) `bun update` moves a transitive dependency within its dependent's range (isolated linker) [875.80ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (binary lockfile) [926.54ms]
(pass) `bun update --latest` still moves transitive dependencies only within their ranges [926.31ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (text lockfile) [986.27ms]
(pass) `bun update no-deps` reaches a package that is only a transitive dependency [986.86ms]
(pass) `bun update` with a bare `*` reaches a package that is only a transitive dependency [726.92ms]
(pass) `bun update` with a negated name reaches a package that is only a transitive dependency [720.53ms]
(pass) `bun update` with a pattern reaches a package that is only a transitive dependency [792.67ms]
(pass) `bun update` with a pattern alongside a direct name reaches a package that is only a transitiv
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/cli/install/bun-update-transitive.test.ts:
(pass) without a lockfile, `bun update <undeclared>` is rejected and writes no lockfile [18.13ms]
(pass) without a lockfile, `bun update <declared>` resolves and saves [112.83ms]
429 | // one-fixed-dep pins no-deps exactly, so bumping it moves no-deps with it; forward-peer-deps' `*` edge follows the move, the stale root copy is dropped and the new one hoists to the root instead of nesting (#41048). The peer owner sorts ahead of one-fixed-dep, so without the redirect its stale edge wins the root slot.
430 | test.concurrent("`bun install` after a version bump re-points loose edges at a moved exact child", async () => {
431 |   const dir = await setup({ "package.json": pkgJson({ "forward-peer-deps": "1.0.0", "one-fixed-dep": "1.0.0" }) });
432 |   expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0"]);
433 |   await reinstall(dir, pkgJson({ "forward-peer-deps": "1.0.0", "one-fixed-dep": "2.0.0" }));
434 |   expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
                                                     ^
error: expect(received).toStrictEqual(e
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update-transitive.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/install/bun-update-transitive.test.ts:
(pass) `bun update` moves a transitive dependency within its dependent's range (isolated linker) [850.83ms]
(pass) `bun update --latest` still moves transitive dependencies only within their ranges [861.57ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (binary lockfile) [894.50ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (text lockfile) [997.92ms]
(pass) `bun update no-deps` reaches a package that is only a transitive dependency [1095.32ms]
(pass) `bun update` with a pattern reaches a package that is only a transitive dependency [785.47ms]
(pass) `bun update` with a negated name reaches a package that is only a transitive dependency [710.08ms]
(pass) `bun update` with a bare `*` reaches a package that is only a transitive dependency [801.20ms]
(pass) `bun update --latest no-deps` reaches a package that is only a transitive dependency [1033.19
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 616ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_install_jsc v0.0.0 (/workspace/bun/src/install_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/update_transitive.rs               | 92 ++++++++++++++++++++++++++
 test/cli/install/bun-update-transitive.test.ts | 57 +++++++++++++++-
 2 files changed, 148 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/install/update_transitive.rs                    3      7      0
test/cli/install/bun-update-transitive.test.ts      3      5      0
```

</details>

**root cause** · written by the author bot

The root cause was in the installer's redirect logic for moved packages: when a direct dependency moved to a new version, only edges on that package were re-pointed, so a transitive dependency pinned exactly by the moved package was left stranded at the root while a fresh copy was nested underneath. The fix expands the set of moved pairs by walking the old and new dependency rows of each moved package and discovering transitive targets that changed alongside it, then redirects compatible edges to the new versions so the tree converges on a single hoisted copy. A guard excludes targets that …

<!-- robobun:evidence:end -->