### PR TITLE
test(bundler): run esbuild/dce.test.ts concurrently and tighten its assertions

### DIFF
--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1472,7 +1472,8 @@ describe.concurrent("bundler", () => {
       "/b.js": `export class Base { x() { console.log(1); return this; } }`,
     },
     dce: true,
-    dceKeepMarkerCount: false,
+    // `class Keep` and `new Keep()`
+    dceKeepMarkerCount: 2,
     run: {
       stdout: "1\n2",
     },
@@ -1631,7 +1632,6 @@ describe.concurrent("bundler", () => {
       `,
     },
     dce: true,
-    dceKeepMarkerCount: false,
     run: {
       stdout: `{"0":"FOO","1":"BAR","FOO":0,"BAR":1}`,
     },
@@ -1811,7 +1811,8 @@ describe.concurrent("bundler", () => {
     },
     format: "esm",
     dce: true,
-    dceKeepMarkerCount: false,
+    // keep1 and keep2: the two declarations, the two string literals, and the two calls
+    dceKeepMarkerCount: 6,
     run: {
       stdout: '["keep1",{"default":"keep2"}]',
     },
@@ -2070,6 +2071,10 @@ describe.concurrent("bundler", () => {
     dce: true,
     minifySyntax: true,
     bundling: false,
+    onAfterBundle(api) {
+      // the unused imports could be types, so TS drops them despite the eval and keeps no bare import
+      api.expectFile("/out.js").toBe('eval("foo(a, b, c)");\n');
+    },
   });
   itBundled("dce/DCEClassStaticBlocks", {
     files: {
@@ -2126,6 +2131,18 @@ describe.concurrent("bundler", () => {
     },
     dce: true,
     entryPoints: ["/a.js", "/b.js", "/c.js"],
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        import a from './out/a.js'
+        import b from './out/b.js'
+        import * as c from './out/c.js'
+        console.log(JSON.stringify([a, b, c.foo]))
+      `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: '[{"keep":123},{"keep":123},{"keep":123}]',
+    },
   });
   itBundled("dce/DCETemplateLiteral", {
     files: {
@@ -3042,6 +3059,23 @@ describe.concurrent("bundler", () => {
     },
     entryPoints: ["/enum-entry.ts", "/const-entry.js", "/nested-entry.ts"],
     dce: true,
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        const log = console.log
+        console.log = (...args) => log(args.map(x => JSON.stringify(x)).join(' '))
+        await import('./out/enum-entry.js')
+        await import('./out/const-entry.js')
+        await import('./out/nested-entry.js')
+      `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: [
+        '[6,-6,-7,false,"number"] [9,-3,18,0.5,3,729] [true,false,true,false,false,true,false,true] [12,3,3] [2,7,5] [6,3,3]',
+        '[6,-6,-7,false,"number"] [9,-3,18,0.5,3,729] [true,false,true,false,false,true,false,true] [12,3,3] [2,7,5] [6,3,3]',
+        '{"should be 4":4,"should be 32":32}',
+      ].join("\n"),
+    },
   });
   itBundled("dce/MultipleDeclarationTreeShaking", {
     files: {
@@ -3264,6 +3298,40 @@ describe.concurrent("bundler", () => {
       `,
     },
     entryPoints: ["/entry.js", "/entry-outer.js"],
+    minifySyntax: true,
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        globalThis.args = {
+          tag: 'args',
+          [Symbol.iterator]() {
+            console.log('spread')
+            return {
+              next() {
+                return { done: true, value: undefined }
+              }
+            }
+          }
+        };
+        globalThis.check = (...values) => console.log(JSON.stringify(values));
+
+        await import('./out/entry.js');
+        console.log('---')
+        await import('./out/entry-outer.js');
+      `,
+    },
+    run: {
+      file: "/test.js",
+      // each spread iterates `args` exactly once, and only identity2 returns its argument
+      stdout: [
+        "spread",
+        "spread",
+        '[null,null,null,null,{"tag":"args"},null]',
+        "---",
+        "spread",
+        "spread",
+        '[null,null,null,null,{"tag":"args"},null]',
+      ].join("\n"),
+    },
   });
   // im confused what this is testing. cross platform slash? there is none?? not even in the go source
   itBundled("dce/PackageJsonSideEffectsFalseCrossPlatformSlash", {
@@ -3293,6 +3361,9 @@ describe.concurrent("bundler", () => {
         /* @__PURE__ */ noSideEffects();
       `,
     },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toBe("");
+    },
     run: {
       stdout: "",
     },
@@ -3302,6 +3373,9 @@ describe.concurrent("bundler", () => {
       "/entry.js": /* js */ `
         /* @__PURE__ */ new NoSideEffects();
       `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toBe("");
     },
     run: {
       stdout: "",

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test";
-import { dedent, itBundled } from "../expectBundled";
+import { BundlerTestInput, dedent, itBundled as itBundledBase } from "../expectBundled";
 
 // Tests ported from:
 // https://github.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_dce_test.go
@@ -8,7 +8,12 @@ import { dedent, itBundled } from "../expectBundled";
 
 // To understand what `dce: true` is doing, see ../expectBundled.md's "dce: true" section
 
-describe("bundler", () => {
+// Default to the CLI backend: itBundled registers API-backend cases with
+// it.serial (Bun.build needs process.chdir), so only CLI-backend cases overlap
+// under describe.concurrent.
+const itBundled = (id: string, opts: BundlerTestInput) => itBundledBase(id, { backend: "cli", ...opts });
+
+describe.concurrent("bundler", () => {
   itBundled("dce/PackageJsonSideEffectsFalseKeepNamedImportES6", {
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
@@ -1236,7 +1241,6 @@ describe("bundler", () => {
       },
       minifyWhitespace: minify,
       emitDCEAnnotations: emitDCEAnnotations,
-      backend: "cli",
       onAfterBundle(api) {
         const code = api.readFile("/out.js");
         expect(code).not.toContain("_yes"); // should not contain any *_yes variables
@@ -1300,6 +1304,10 @@ describe("bundler", () => {
     },
     target: "bun",
     dce: true,
+    // The harness passes jsx.runtime as --jsx-runtime, and any --jsx-* flag makes
+    // `bun build` use the production JSX runtime (Arguments.rs sets development: false).
+    // This fixture only ships jsx-dev-runtime, so build with the API.
+    backend: "api",
     run: {
       stdout: `["F",{"children":[null,{"children":["div",{}]}]}]`,
     },


### PR DESCRIPTION
### Problem
- `dce.test.ts` takes 10s on the debian 13 x64-asan lane (build 108747): 102 `itBundled` cases in sequence, 54 with a bun subprocess (about 350ms each under ASAN).
- `describe.concurrent` alone changes nothing: `itBundled` registers its default API backend as `it.serial` (`Bun.build` needs `process.chdir`). Only CLI-backend cases overlap.
- Weak checks: one case only built, two only scanned markers, three disabled the keep count.

### Fix
- Commit 1: `describe.concurrent`, and the file defaults to the CLI backend with the one-line wrapper from `bundler_compile.test.ts` (as #41028). `TreeShakingReactElements` pins `backend: "api"`: any `--jsx-*` flag makes `bun build` set `development: false` (`src/runtime/cli/Arguments.rs:1602`), the harness passes `--jsx-runtime`, and the fixture only ships `jsx-dev-runtime`.
- The CLI backend also fails a case on an unexpected warning, which the API backend ignored. `...NoWarningInNodeModulesESBuildIssue999` now checks its name.
- Commit 2: exact keep counts in `TreeShakingImportIdentifier` (2) and `TreeShakingInESMWrapper` (6). `DCEVarExports`, `CrossModuleConstantFolding` and `NestedFunctionInliningWithSpread` (now `minifySyntax: true`, as upstream) run their outputs and assert the exact stdout. `RemoveUnusedImportsEvalTS`, `CallWithNoArg` and `ConstructWithNoArg` pin the exact bundle.
- Verified: `bun bd test test/bundler/esbuild/dce.test.ts` (debug, ASAN): 31.0s to 41.3s before, 12.8s to 12.9s after. Released bun: 0.67s before, 0.25s after. Always 79 pass, 25 todo. Each new expected value was mutation-checked.

### Background
- `itBundled` (`test/bundler/expectBundled.ts`) builds a case with `Bun.build()` in-process by default, or with a `bun build` subprocess under `backend: "cli"`. Only the CLI path parses warnings from stderr.
- `dce: true` fails a case whose output contains FAIL, DROP or REMOVE, and compares the count of `keep` in the output with the first input file. `dceKeepMarkerCount` overrides it, `false` disables it.
- Under ASAN `bun test` caps concurrent tests at 5 (`src/options_types/context.rs:512`), release builds at 20.

<details><summary>Notes</summary>

Timings in this container (16 vCPUs), same machine for before and after, all green.

| build | before | after |
| --- | --- | --- |
| debug ASAN, `bun bd test` | 38.0s, 41.3s, 32.4s, 31.0s | 12.9s, 12.8s, 12.9s (commit 1 alone: 12.9s) |
| released bun 1.4.1, `USE_SYSTEM_BUN=1 bun test` | 0.66s, 0.68s, 0.68s | 0.25s, 0.25s, 0.26s |

Per case, debug ASAN, before: a case with a run took 350ms to 1100ms (the run subprocess is most of it), a case without one 90ms to 250ms. A `bun-debug` start costs about 350ms wall here. With the CLI backend a case has a build subprocess too, so the file uses more CPU in total but much less wall time.

Shape: a first revision put `backend: "cli"` on the 53 cases with a `run` and left the other cases on the API backend. The self-review pointed at the file-level wrapper in `test/bundler/bundler_compile.test.ts:13`, which #41028 (esbuild/importstar.test.ts) also uses. With the wrapper the cases without a run overlap too instead of acting as `it.serial` barriers: 16s to 19s for the per-case shape, 12.8s to 12.9s for the wrapper. The one explicit `backend: "cli"` the file already had (the `RemoveUnusedPureCommentCalls` loop) is removed as redundant.

Every case now goes through `bun build`. Options this file uses that the CLI branch handles differently: `treeShaking: true` is not forwarded (it is the default when bundling), `mainFields` and `unsupportedJSFeatures` throw `UnsupportedOptionError` on both backends (those cases are todo), `bundleErrors` is parsed from stderr (`ConstValueInliningAssign` passes). The todo set is identical to main (25 cases, compared by name).

`TreeShakingReactElements`: `jsx: { runtime: "automatic" }` is bun's default runtime, so the option could be dropped to let the case run on the CLI. It is kept as in the upstream port, with the `backend: "api"` pin and a comment that names the real cause.

Assertion changes in detail:
- `TreeShakingImportIdentifier`: the output holds `class Keep` and `new Keep()`, so 2. The automatic count (1, from `a.Keep` in the entry) did not match, which is why it was `false`.
- `TreeShakingInESMWrapper`: `keep1`/`keep2` appear as two declarations, two string literals and two calls, so 6.
- `TreeShakingClassEnumKey`: no keep markers anywhere, `false` is removed and the automatic count (0) applies.
- `DCEVarExports`: `out/a.js` and `out/b.js` are CommonJS entries wrapped as `export default require_x()`, `out/c.js` (local `var module`, `exports.foo = module`) is converted to an ESM named export. The runner imports all three and prints `[{"keep":123},{"keep":123},{"keep":123}]`.
- `CrossModuleConstantFolding`: bun inlines the enum members (`3 /* a */ + 6 /* b */`) but does not fold them, and does not inline the cross-module `const`s. The run pins the computed values. The runner wraps `console.log` in `JSON.stringify` so the 8-element array stays on one line instead of depending on the inspect line wrapping.
- `NestedFunctionInliningWithSpread`: upstream runs this with `MinifySyntax: true`. Bun does not inline the empty and identity calls yet (the `Inline*` cases are todo), so the output keeps the calls. The run pins that each `...args` spread iterates once and that only `identity2(args)` returns its argument (`{"tag":"args"}`), so it also holds once inlining lands.
- `RemoveUnusedImportsEvalTS`: the bundle is exactly `eval("foo(a, b, c)");`, the same as esbuild's snapshot.
- `CallWithNoArg`, `ConstructWithNoArg`: the bundle is empty.
- Every case: an unexpected bundler warning now fails it (`expectBundled.ts`, "Warnings were thrown while bundling"). #35308 adds `bundleWarnings` to the four cases that will warn once it lands, so the two PRs agree.

`bun bd test --todo`: same result as main (79 pass, 24 todo, 1 fail: `PackageJsonSideEffectsArrayKeepModuleImplicitMain`, a todo case that passes on main too; #39058 covers stale todos and is not duplicated here). With every case on the CLI backend, the todo cases no longer share `process.chdir`, so a `--todo` run cannot race on it.

Out of scope: a CLI default in `resolveBackend()` itself (`expectBundled.ts`) would give every `itBundled` file this behavior at once, but the CLI branch would first need `UnsupportedOptionError` guards for the API-only options (`treeShaking: false`, `jsx.development`, `throw`, `onAfterApiBundle`). Several open PRs edit that file, so this PR stays in `dce.test.ts`.

Also ran prettier on the file. No test was deleted, skipped or flipped from todo.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/esbuild/dce.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/esbuild/dce.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/esbuild/dce.test.ts:
(pass) bundler > dce/PackageJsonSideEffectsFalseKeepNamedImportES6 [923.47ms]
(pass) bundler > dce/UnreferencedObjectLiteral [569.05ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseKeepNamedImportCommonJS [571.28ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseKeepStarImportES6 [642.35ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseKeepStarImportCommonJS [650.79ms]
(pass) bundler > dce/PackageJsonSideEffectsTrueKeepES6 [606.85ms]
(pass) bundler > dce/PackageJsonSideEffectsTrueKeepCommonJS [605.14ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseRemoveBareImportES6 [535.62ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseKeepBareImportAndRequireCommonJS [586.48ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseKeepBareImportAndRequireES6 [705.28ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseRemoveBareImportCommonJS [549.32ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseRemoveNamedImportES6 [554.98ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseRemoveNamedImportCommonJS [548.70ms]
(todo) bundler > dce/PackageJsonSideEffectsArrayKeepMainUseModule
(todo) bundler > dce/PackageJsonSideEffectsArrayKeepMainUseMain
(pass) bundler > dce/PackageJsonSideEffectsFalseRemoveStarImportES6 [556.24ms]
(pass) bundler > dce/PackageJsonSideEffectsFalseRemoveStarImportCommonJS [628.06ms]
(pass) bundler > dce/PackageJsonSideEffectsArrayRemove [545.61ms]
(pass) bundler > dce/PackageJsonSideEffectsArrayKeep [636.33ms]
(pass) bundler > dce/PackageJsonSideEffectsArrayKeepMainImplicitModule [637.70ms]
(todo) bundler > dce/PackageJsonSideEffectsArrayKeepModuleImplicitMain
(pass) bundler > dce/PackageJsonSideEffectsArrayKeepMainImplicitMain [634.94ms]
(pass) bundler > dce/PackageJsonSideEffectsArrayKeepModuleUseModule [639.82ms]
(pass) bundler > dce/PackageJsonSideEffectsArrayKeepModu
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/esbuild/dce.test.ts | 94 +++++++++++++++++++++++++++++++++++++---
 1 file changed, 88 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
test/bundler/esbuild/dce.test.ts     15     13      0
```

</details>

<!-- robobun:evidence:end -->