### PR TITLE
bake: fix the URL of a cached asset after its HTML file is rebundled

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6691,9 +6691,11 @@ pub mod bv2_impl {
                                     interned_slice(
                                         self.arena()
                                             .alloc_str(&format!(
-                                                "{}/{:016x}{}",
+                                                "{}/{}{}",
                                                 bake_types::ASSET_PREFIX,
-                                                hash,
+                                                bun_core::fmt::bytes_to_hex_lower_string(
+                                                    &hash.to_ne_bytes()
+                                                ),
                                                 bstr::BStr::new(bun_paths::extension(path.text)),
                                             ))
                                             .as_bytes(),

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -77,6 +77,9 @@ devTest("image tag", {
       });
       await dev.fetch("/").expect.toInclude('alt="modified image"');
     });
+    // The image did not change, so the reloaded page keeps its URL and the asset is still served.
+    expect(await c.js`document.querySelector("img").src`).toBe(url);
+    await dev.fetch(url).expect.toBe("FIRST");
 
     // Editing image content causes a hard reload because the html must reflect the new image content
     await c.expectReload(async () => {


### PR DESCRIPTION
### Problem
- In the dev server, after any edit to an HTML file, every `<img>` in it points at a URL that returns 404. With `image.png` = `FIRST` the first page serves `/_bun/asset/1d3d39e3e397ac0d.png` (200). After the edit it serves `/_bun/asset/0dac97e3e3393d1d.png` (404) while the asset still lives at the first URL.
- The cause is `src/bundler/bundle_v2.rs:6694`. When an HTML file is rebundled and one of its assets is already in the asset store, the bundler writes the asset URL into the import record with `{:016x}`, the numeric hex of the hash. The file loader (`ParseTask.rs:1337`), the store (`dev_server/assets.rs:61`) and the `/_bun/asset` route (`parse_hex_to_int`) all use the hex of the hash's native-endian bytes. On a little-endian host the two are the same 8 bytes in opposite order.
- The Zig code used `std.fmt.bytesToHex(std.mem.asBytes(&hash))`. #30412 ported it as `{:016x}`. The regression is in v1.4.0.

### Fix
- The `format!` now calls `bun_core::fmt::bytes_to_hex_lower_string(&hash.to_ne_bytes())`, the same call as `ParseTask.rs:1337`. It is the only site that encoded the hash numerically.
- The "image tag" case in `test/bake/dev/html.test.ts` reads the image URL again after the HTML edit, asserts it is unchanged, and fetches it. Before, the case never fetched the image after the edit.
- Verified: `bun bd test test/bake/dev/html.test.ts` (11 pass). `USE_SYSTEM_BUN=1 bun test test/bake/dev/html.test.ts -t "image tag"` fails at the new assertion with the two URLs above. Also `test/bake/dev/css.test.ts` and `test/bake/dev-and-prod.test.ts`.

### Background
- The dev server keeps assets (`Loader::File`) in a content-addressable store, served at `/_bun/asset/<16 hex>.<ext>`. The route handler decodes the hex back into the `u64` key with `parse_hex_to_int`, which reads the pairs as native-endian bytes.
- On a rebundle, the bundler does not parse an asset that the store already has. It asks the dev server for the asset's hash (`asset_hash`) and writes the URL straight into the import record. That path is the one this PR fixes.
- #41032 rewrites the same test file for speed and stricter assertions. It is stacked on this PR and its image case also fails without this fix.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/html.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-Iawkhb
[0;30mdev|[0m Started development server: http://localhost:39867
[0;30mdev|[0m [32mBundled page in 102ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 47ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 48ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 29ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 61ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-qXnmaE
[0;30mdev|[0m Started development server: http://localhost:36639
[0;30mdev|[0m [32mBundled page in 2ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 2ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 1ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 1ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 1ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:html-1: html file is watched [685.24ms]
[0;30mdev|[0m Started development server: http://localhost:33517
[0;30mdev|[0m [32mBundled page in 2ms[0m[2m:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/html.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-AjjU4Y
[0;30mdev|[0m Started development server: http://localhost:35677
[0;30mdev|[0m [32mBundled page in 105ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 52ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 46ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 34ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 27ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f3d52098d7
  features     baseline

23 deps, 131 codegen, 1172 objects in 666ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [6.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [7.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs   | 6 ++++--
 test/bake/dev/html.test.ts | 3 +++
 2 files changed, 7 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                        reads  edits  tests
src/bundler/bundle_v2.rs        3      1      0
test/bake/dev/html.test.ts     10      8      0
```

</details>

<!-- robobun:evidence:end -->