### PR TITLE
util.parseEnv: store array-index keys as indexed properties

### DIFF
--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -1,5 +1,5 @@
 use bun_core::strings::EncodingNonAscii;
-use bun_core::{self as bstr, EncodedSlice, String as BunString, strings};
+use bun_core::{self as bstr, String as BunString, strings};
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, bun_string_jsc};
 use bun_sys::UV_E;
 
@@ -235,11 +235,12 @@ pub(crate) fn parse_env(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
 
     let obj = JSValue::create_empty_object(global, p.map.map.count());
     for (k, v) in p.map.map.iter() {
-        obj.put(
+        // A key like `0=` or `2023=` is an array index. `put` asserts on those.
+        obj.put_may_be_index(
             global,
-            EncodedSlice::from_bytes(k),
+            &BunString::from_bytes(k),
             bun_string_jsc::create_utf8_for_js(global, &v.value)?,
-        );
+        )?;
     }
     Ok(obj)
 }

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -636,4 +636,31 @@ describe("util.parseEnv", () => {
   it("accepts a String object without crashing", () => {
     expect(util.parseEnv(new String("FOO=bar"))).toEqual({ FOO: "bar" });
   });
+
+  it("stores array-index keys as indexed properties", () => {
+    // 4294967295 is 2^32 - 1, the first integer that is not an array index.
+    const parsed = util.parseEnv("A=1\n0=zero\n2023=y\n4294967295=notidx\n");
+    expect(parsed[0]).toBe("zero");
+    expect(parsed["0"]).toBe("zero");
+    expect(0 in parsed).toBe(true);
+    expect(parsed[2023]).toBe("y");
+    expect(parsed[4294967295]).toBe("notidx");
+    expect(Object.getOwnPropertyDescriptor(parsed, "0")).toEqual({
+      value: "zero",
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    // Index keys come first, in ascending order. The rest keep file order.
+    expect(Object.entries(parsed)).toEqual([
+      ["0", "zero"],
+      ["2023", "y"],
+      ["A", "1"],
+      ["4294967295", "notidx"],
+    ]);
+
+    parsed[0] = "set";
+    expect(parsed[0]).toBe("set");
+    expect(JSON.parse(JSON.stringify(parsed))).toEqual({ 0: "set", 2023: "y", A: "1", 4294967295: "notidx" });
+  });
 });


### PR DESCRIPTION
### Problem
- `util.parseEnv("0=zero")` returns an object that lists `"0"` in `Object.keys` and `JSON.stringify`, but `r[0]`, `r["0"]` and `0 in r` say the property does not exist. Debug builds abort instead: `ASSERTION FAILED: !parseIndex(propertyName)` in `JSObject::putDirectInternal`, reached from `JSC__JSValue__put`.
- `parse_env` (`src/runtime/node/node_util_binding.rs:238`) wrote each key with `JSValue::put`, which is `putDirect`. `putDirect` requires a non-index key. For a key that parses as an array index (`0` to `4294967294`) it stores the value in the structure's property table, and every index lookup goes to indexed storage instead. `process.loadEnvFile` reaches the same code.

### Fix
- Write each key with `put_may_be_index` (`putDirectMayBeIndex`). It sends an index key to indexed storage and any other key to `putDirect`. The call is fallible, so the loop now propagates its `JsResult`.
- This is the existing idiom for keys that come from data: `parse_args.rs`, `cares_jsc.rs` and `YAMLObject.rs` already use it.
- Verified: `test/js/node/util/util.test.js` (new test, fails on stock bun at `parsed[0]`). Also `test/js/node/test/parallel/test-util-parse-env.js`, `test-process-load-env-file.js`, the `parseEnv` tests in `test/cli/run/env.test.ts`, and the `loadEnvFile` test in `test/js/node/process/process.test.js`.

### Background
- JSC stores an object's named properties in a `Structure` plus a butterfly, and its integer-index properties (`0` to `2^32 - 2`) in separate indexed storage. A property read with an index-like name always looks in indexed storage.
- `putDirect` is the fast path that writes straight into the named-property table. It asserts that the name is not an index, because a name that is an index would be unreachable from there. Release builds compile the assert out, so the write succeeds and the object ends up self-contradictory.
- `putDirectMayBeIndex` checks `parseIndex` first and picks the right storage. It can throw (for example out of memory on a huge sparse index), so the binding is exception-checked.

<details><summary>Notes</summary>

Repro on stock bun 1.4.1:

```js
import { parseEnv } from "node:util";
const r = parseEnv("A=1\n0=zero\n2023=y\n4294967295=notidx\n");
console.log(JSON.stringify(r));             // {"A":"1","0":"zero","2023":"y","4294967295":"notidx"}
console.log(Object.hasOwn(r, "0"));         // true
console.log(r[0], r["0"], 0 in r, r[2023]); // undefined undefined false undefined
console.log(r[4294967295]);                 // "notidx" (2^32 - 1 is not an array index)
r[0] = "set"; console.log(JSON.stringify(r)); // "0":"zero" still printed: two "0" properties
```

With the fix the same script prints `{"0":"zero","2023":"y","A":"1","4294967295":"notidx"}`, then `zero zero true y`, `notidx`, and after the assignment `"0":"set"`. Node prints the same values. Node orders the non-index keys differently because its parser collects into a sorted `std::map`.

`Object.entries` and `JSON.stringify` on the broken object showed `"zero"` because JSC's fast paths for those read the structure's property table directly. Only ordinary `Get` and `HasProperty` miss it.

Automatic `.env` loading, `--env-file`, `Bun.TOML.parse` and TOML imports are not affected. They go through other code (`ZigGlobalObject.cpp` already uses `putDirectMayBeIndex` for `process.env`).

Other `put` callers whose key comes from data and that are not changed here: `node_os.rs` (`networkInterfaces`, key is an interface name) and `ffi_body.rs` (`dlopen`, key is a symbol name from the user's map). Both need a key that is an integer string to hit the same assert.

</details>
