### PR TITLE
bun test --isolate: put the synthetic allocation limit back after every file

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -378,6 +378,11 @@ pub struct TestIsolationState {
     /// The proxy env keys as the env map held them at startup, restored after
     /// every file. See [`crate::rare_data::ProxyEnvSnapshot`].
     pub proxy_env: Option<crate::rare_data::ProxyEnvSnapshot>,
+    /// The synthetic allocation limit at startup (the default, or
+    /// `BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT`). The limit is process-wide
+    /// and `setSyntheticAllocationLimitForTesting` lowers it, so it is put back
+    /// after every file.
+    pub synthetic_allocation_limit: Option<usize>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -5232,6 +5237,19 @@ impl VirtualMachine {
         }
 
         self.undo_process_env_side_effects();
+        self.undo_synthetic_allocation_limit();
+    }
+
+    /// `setSyntheticAllocationLimitForTesting` (bun:internal-for-testing)
+    /// lowers the process-wide string/allocation limit. A file that does not
+    /// raise it again (or dies before its restore runs) would otherwise fail
+    /// every later file in this process with ERR_STRING_TOO_LONG. Put the
+    /// startup value back.
+    fn undo_synthetic_allocation_limit(&mut self) {
+        if let Some(limit) = self.test_isolation_state.synthetic_allocation_limit {
+            SYNTHETIC_ALLOCATION_LIMIT.store(limit, core::sync::atomic::Ordering::Relaxed);
+            STRING_ALLOCATION_LIMIT.store(limit, core::sync::atomic::Ordering::Relaxed);
+        }
     }
 
     /// The `process.env` keys with a custom setter (`applySharedEnvSideEffects`

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -378,10 +378,8 @@ pub struct TestIsolationState {
     /// The proxy env keys as the env map held them at startup, restored after
     /// every file. See [`crate::rare_data::ProxyEnvSnapshot`].
     pub proxy_env: Option<crate::rare_data::ProxyEnvSnapshot>,
-    /// The synthetic allocation limit at startup (the default, or
-    /// `BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT`). The limit is process-wide
-    /// and `setSyntheticAllocationLimitForTesting` lowers it, so it is put back
-    /// after every file.
+    /// The synthetic allocation limit at startup, restored after every file.
+    /// `setSyntheticAllocationLimitForTesting` lowers it process-wide.
     pub synthetic_allocation_limit: Option<usize>,
 }
 
@@ -5240,11 +5238,8 @@ impl VirtualMachine {
         self.undo_synthetic_allocation_limit();
     }
 
-    /// `setSyntheticAllocationLimitForTesting` (bun:internal-for-testing)
-    /// lowers the process-wide string/allocation limit. A file that does not
-    /// raise it again (or dies before its restore runs) would otherwise fail
-    /// every later file in this process with ERR_STRING_TOO_LONG. Put the
-    /// startup value back.
+    /// `setSyntheticAllocationLimitForTesting` lowers a process-wide limit.
+    /// Put the startup value back so a file's limit stays with that file.
     fn undo_synthetic_allocation_limit(&mut self) {
         if let Some(limit) = self.test_isolation_state.synthetic_allocation_limit {
             SYNTHETIC_ALLOCATION_LIMIT.store(limit, core::sync::atomic::Ordering::Relaxed);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1995,6 +1995,8 @@ impl TestCommand {
             vm.test_isolation_state.proxy_env = Some(
                 bun_jsc::rare_data::ProxyEnvSnapshot::capture(&vm.env_loader().map),
             );
+            vm.test_isolation_state.synthetic_allocation_limit =
+                Some(bun_jsc::virtual_machine::synthetic_allocation_limit());
         }
 
         if ctx.test_options.test_worker {

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -213,16 +213,19 @@ describe.concurrent("bun test --isolate", () => {
       `,
     };
     const files = ["./a-limit.test.ts", "./b-limit.test.ts"];
+    // The second file builds 8 MiB strings, so the runner must start at the
+    // default limit even on a machine that lowers it through the environment.
+    const env = { ...bunEnv, BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: undefined };
 
     using isolated = tempDir("isolate-alloc-limit", limitFixtures);
-    const serial = await runTests(String(isolated), ["--isolate"], files);
+    const serial = await runTests(String(isolated), ["--isolate"], files, env);
     expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("2 pass");
     expect(serial.exitCode).toBe(0);
 
     using parallel = tempDir("isolate-alloc-limit-parallel", limitFixtures);
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--parallel=2", ...files],
-      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "60000" },
+      env: { ...env, BUN_TEST_PARALLEL_SCALE_MS: "60000" },
       cwd: String(parallel),
       stderr: "pipe",
       stdout: "pipe",

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -187,6 +187,51 @@ describe.concurrent("bun test --isolate", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The synthetic allocation limit is process-wide. A file that lowers it and
+  // does not put it back (or dies before its restore runs) must not make every
+  // later file in the same process fail to build strings.
+  test("with --isolate, a file's lowered synthetic allocation limit is undone before the next file", async () => {
+    const MiB = 1024 * 1024;
+    const limitFixtures = {
+      "a-limit.test.ts": `
+        import { test, expect } from "bun:test";
+        import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
+        test("lower the limit and leave it lowered", async () => {
+          setSyntheticAllocationLimitForTesting(${MiB});
+          await expect(new Response(Buffer.alloc(${2 * MiB}, 97)).text()).rejects.toMatchObject({
+            code: "ERR_STRING_TOO_LONG",
+          });
+        });
+      `,
+      "b-limit.test.ts": `
+        import { test, expect } from "bun:test";
+        test("strings over the previous file's limit can be built again", async () => {
+          const text = await new Response(Buffer.alloc(${8 * MiB}, 97)).text();
+          expect(text.length).toBe(${8 * MiB});
+          expect(Buffer.alloc(${8 * MiB}, 97).toString().length).toBe(${8 * MiB});
+        });
+      `,
+    };
+    const files = ["./a-limit.test.ts", "./b-limit.test.ts"];
+
+    using isolated = tempDir("isolate-alloc-limit", limitFixtures);
+    const serial = await runTests(String(isolated), ["--isolate"], files);
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("2 pass");
+    expect(serial.exitCode).toBe(0);
+
+    using parallel = tempDir("isolate-alloc-limit-parallel", limitFixtures);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", ...files],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "60000" },
+      cwd: String(parallel),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("2 pass");
+    expect(exitCode).toBe(0);
+  });
+
   test("with --isolate, --preload re-runs in each file's fresh global", async () => {
     using dir = tempDir("isolate-preload", {
       "preload.ts": `


### PR DESCRIPTION
### Problem
- `test/js/bun/http/bun-serve-file.test.ts` fails in the CI parallel batch with `Cannot create a string longer than 2147483647 characters` (`ERR_STRING_TOO_LONG`) on an 8 MiB `res.text()`. It passes when it runs alone. 191 of the last 400 builds hit it, on the Linux lanes only.
- The cause is process-wide test state. `setSyntheticAllocationLimitForTesting` writes `SYNTHETIC_ALLOCATION_LIMIT` and `STRING_ALLOCATION_LIMIT` (`src/jsc/virtual_machine_exports.rs:321`), and a `--parallel` worker runs many files in one process. Every failing bucket also contains `fs-oom.test.ts`, which lowers the limit to 2 MiB in its Linux-only cases. Once a file leaves the limit lowered, every later file in that worker fails to build a string over it.

### Fix
- Capture the limit at startup in `TestIsolationState` (`src/runtime/cli/test_command.rs`), next to the TZ and proxy env snapshots.
- Restore it in `swap_global_for_test_isolation` (`src/jsc/VirtualMachine.rs`), after `undo_process_env_side_effects`. This is the same contract the other per-file resets follow: a file's write does not reach the files after it.
- The startup value is the default or `BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT`, so an env-configured limit still applies to every file.
- Verified: `test/cli/test/isolation.test.ts` (new case, fails on stock bun with the CI error, passes with the fix). Also the full `isolation.test.ts`, and `fs-oom.test.ts`, `blob-oom.test.ts`, `bun-serve-file.test.ts` under `--isolate`.

### Background
- `bun test --parallel=N` spawns N `bun test --test-worker --isolate` processes. Each worker walks a contiguous range of the sorted file list and steals from other ranges when it runs out, so which files share a process depends on timing.
- `--isolate` gives each file a fresh global object. `swap_global_for_test_isolation` runs between files and also undoes process-wide side effects (TZ, proxy env, TLS verification).
- The synthetic allocation limit is a test-only knob from `bun:internal-for-testing`. String constructors and `Response.text()` compare lengths against it so tests can reach the 2 GiB limit paths without 2 GiB of input.

<details><summary>Notes</summary>

- Scan: 400 Buildkite builds (108490 to 108889). The per-build `flaky` annotation lists every file that failed in the parallel batch and passed alone. `bun-serve-file.test.ts` appears in 191 builds with this error, all on ubuntu and debian lanes (x64 and aarch64). The alpine and ASAN hits for the same file are a different failure (the pollable file response timeout).
- For 8 of those builds I pulled the shard log. The bucket held `fs-oom.test.ts` every time. `fs-oom.test.ts` restores the limit in `afterAll`, and I could not reproduce the leak locally, including a run of the exact 298-file CI bucket with the CI env. The restore in the isolation swap does not depend on why a file's own restore did not take effect.
- The repro for the new test: file A lowers the limit to 1 MiB and does not raise it. File B builds an 8 MiB string. On stock bun, B fails with the CI error under both `--isolate` and `--parallel=2`.
- While writing the test I hit a separate bug: a matcher failure whose message exceeds the limit is dropped without an exception (debug builds assert in `JSGlobalObject::throw`). It is already tracked by another PR.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [346.15ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [335.43ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [328.96ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [295.63ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [383.59ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1181.18ms]
217 |     // default limit even on a machine that lowers it through the environment.
218 |     const env = { ...bunEnv, BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: undefined };
219 | 
220 |     using isolated = tempDir("isolate-alloc-limit", limitFixtures);
221 |     const serial = await runTests(String(isolated), ["--isolate"], files, env);
222 |     expect(normalizeBun
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/cli/test/isolation.test.ts:
217 |     // default limit even on a machine that lowers it through the environment.
218 |     const env = { ...bunEnv, BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: undefined };
219 | 
220 |     using isolated = tempDir("isolate-alloc-limit", limitFixtures);
221 |     const serial = await runTests(String(isolated), ["--isolate"], files, env);
222 |     expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("2 pass");
                                                                ^
error: expect(received).toContain(expected)

Expected to contain: "2 pass"
Received: "a-limit.test.ts:\n(pass) lower the limit and leave it lowered\n\nb-limit.test.ts:\n1 | \n2 |         import { test, expect } from \"bun:test\";\n3 |         test(\"strings over the previous file's limit can be built again\", async () => {\n4 |           const text = await new Response(Buffer.alloc(8388608, 97)).text();\n                                                                         ^\nerror: Cannot create a string longer than 2147483647 characters\n code: \"ERR_STRING_TOO_LONG\"\n    at <anonymous> (file:NN:NN)\n(fail) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [357.51ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [349.89ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [338.85ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [301.42ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [392.98ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1205.88ms]
(pass) bun test --isolate > with --isolate, a file's process.env writes with native side effects are undone before the next file [1534.53ms]
(pass) bun test --isolate > with --isolate, cached module records keep short, Latin-1 and UTF-16 names [1262.31ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [1202.73ms]
(pass) bun test
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 627ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/128] gen ErrorCode+*.h
[2/128] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/128] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[4/128] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/128] gen cpp.rs (cppbind)
[6/128] gen JS modules (bundle-modules)
Preprocess modules (7523ms)
Bundle modules (48ms)
Postprocesss modules (25ms)
Bundle Functions (470ms)
Generate Code (22ms)

[8.10s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[6/127] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs       | 13 +++++++++++
 src/runtime/cli/test_command.rs |  2 ++
 test/cli/test/isolation.test.ts | 48 +++++++++++++++++++++++++++++++++++++++++
 3 files changed, 63 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/jsc/VirtualMachine.rs            3      6      0
src/runtime/cli/test_command.rs      1      1      0
test/cli/test/isolation.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->