### PR TITLE
bun:test: call a function passed to .resolves/.rejects and wait on its result

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -920,18 +920,22 @@ declare module "bun:test" {
     not: Matchers<unknown>;
 
     /**
-     * Expects the value to be a promise that resolves.
+     * Expects the value to be a promise (or any thenable) that resolves.
+     * A function is called first, and the matcher waits on what it returns.
      *
      * @example
      * expect(Promise.resolve(1)).resolves.toBe(1);
+     * expect(async () => 1).resolves.toBe(1);
      */
-    resolves: Matchers<Awaited<T>>;
+    resolves: Matchers<Awaited<T extends (...args: any[]) => infer R ? R : T>>;
 
     /**
-     * Expects the value to be a promise that rejects.
+     * Expects the value to be a promise (or any thenable) that rejects.
+     * A function is called first, and the matcher waits on what it returns.
      *
      * @example
      * expect(Promise.reject("error")).rejects.toBe("error");
+     * expect(async () => { throw new Error("error"); }).rejects.toThrow("error");
      */
     rejects: Matchers<unknown>;
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -507,7 +507,13 @@ impl Expect {
     ) -> JsResult<JSValue> {
         match flags.promise() {
             resolution @ (Promise::Resolves | Promise::Rejects) => {
-                if let Some(promise) = Self::thenable_to_wait_for(global_this, value)? {
+                // Jest calls a function receiver and waits on what it returns.
+                let received = if value.is_callable() {
+                    value.call(global_this, JSValue::UNDEFINED, &[])?
+                } else {
+                    value
+                };
+                if let Some(promise) = Self::thenable_to_wait_for(global_this, received)? {
                     let vm = global_this.vm();
 
                     // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
@@ -528,7 +534,7 @@ impl Expect {
                                         global_this, custom_label, matcher_name, matcher_params, flags,
                                         "Expected promise that rejects",
                                         "Received promise that resolved: ",
-                                        value.to_fmt(&mut formatter),
+                                        new_value.to_fmt(&mut formatter),
                                     ));
                                 }
                                 return Err(JsError::Thrown);
@@ -544,7 +550,7 @@ impl Expect {
                                         global_this, custom_label, matcher_name, matcher_params, flags,
                                         "Expected promise that resolves",
                                         "Received promise that rejected: ",
-                                        value.to_fmt(&mut formatter),
+                                        new_value.to_fmt(&mut formatter),
                                     ));
                                 }
                                 return Err(JsError::Thrown);
@@ -561,7 +567,7 @@ impl Expect {
                         let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
                         return Err(Self::throw_promise_matcher_error(
                             global_this, custom_label, matcher_name, matcher_params, flags,
-                            "Expected promise",
+                            "Expected a promise or a function returning a promise",
                             "Received: ",
                             value.to_fmt(&mut formatter),
                         ));

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -78,6 +78,25 @@ describe("bun:test", () => {
     expect(undefined).toBeUndefined();
     expect(undefined).not.toBeDefined();
   });
+
+  test("resolves / rejects", async () => {
+    await expect(Promise.resolve(1)).resolves.toBe(1);
+    await expect({
+      then(resolve: (value: number) => void) {
+        resolve(1);
+      },
+    }).resolves.toBe(1);
+    await expect(() => Promise.resolve(1)).resolves.toBe(1);
+    await expect(async () => "a").resolves.toBe("a");
+    expectType(expect(Promise.resolve(1)).resolves).is<Matchers<number>>();
+    expectType(expect(() => Promise.resolve(1)).resolves).is<Matchers<number>>();
+    expectType(expect(async () => "a").resolves).is<Matchers<string>>();
+
+    await expect(Promise.reject(new Error("Bad"))).rejects.toThrow("Bad");
+    await expect(async () => {
+      throw new Error("Bad");
+    }).rejects.toThrow("Bad");
+  });
 });
 
 test.each([1, 2, 3])("test.each", a => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -201,15 +201,16 @@ describe("expect()", () => {
     }
 
     if (isBun) {
-      // The mismatch message names the settled value, not the function.
+      // The mismatch message names the settled value, not the function. A color
+      // code may sit between the label and the value.
       await expectFailure(() => expect(() => Promise.resolve("settled to this")).rejects.toBe(1)).toThrow(
-        /Received promise that resolved: "settled to this"/,
+        /Received promise that resolved: .*"settled to this"/,
       );
       await expectFailure(() => expect(async () => "settled to this").rejects.toBe(1)).toThrow(
-        /Received promise that resolved: "settled to this"/,
+        /Received promise that resolved: .*"settled to this"/,
       );
       await expectFailure(() => expect(() => Promise.reject("settled to this")).resolves.toBe(1)).toThrow(
-        /Received promise that rejected: "settled to this"/,
+        /Received promise that rejected: .*"settled to this"/,
       );
       // A function that returns a non-thenable is a usage error.
       await expectFailure(() => expect(ANY(() => 4)).resolves.toBe(4)).toThrow(

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -169,7 +169,61 @@ describe("expect()", () => {
         /Received promise that rejected/,
       );
       // A non-callable `then` does not make a thenable.
-      await expectFailure(() => expect({ then: 4 }).resolves.toBe(4)).toThrow(/Expected promise/);
+      await expectFailure(() => expect({ then: 4 }).resolves.toBe(4)).toThrow(
+        /Expected a promise or a function returning a promise/,
+      );
+    }
+  });
+
+  // Jest calls a function receiver and waits on what it returns. Vitest does
+  // this for `.rejects` only.
+  test("resolves/rejects on a function returning a promise", async () => {
+    await expect(() => Promise.reject(new Error("fn boom"))).rejects.toThrow("fn boom");
+    await expect(async () => {
+      throw new Error("async fn boom");
+    }).rejects.toThrow("async fn boom");
+    await expect(() => ({
+      /** @param {(reason: unknown) => void} reject */
+      then(_, reject) {
+        reject(4);
+      },
+    })).rejects.toBe(4);
+
+    if (!isVitest) {
+      await expect(() => Promise.resolve(4)).resolves.toBe(4);
+      await expect(async () => 4).resolves.not.toBe(5);
+      await expect(() => ({
+        /** @param {(value: unknown) => void} resolve */
+        then(resolve) {
+          resolve(4);
+        },
+      })).resolves.toBe(4);
+    }
+
+    if (isBun) {
+      // The mismatch message names the settled value, not the function.
+      await expectFailure(() => expect(() => Promise.resolve("settled to this")).rejects.toBe(1)).toThrow(
+        /Received promise that resolved: "settled to this"/,
+      );
+      await expectFailure(() => expect(async () => "settled to this").rejects.toBe(1)).toThrow(
+        /Received promise that resolved: "settled to this"/,
+      );
+      await expectFailure(() => expect(() => Promise.reject("settled to this")).resolves.toBe(1)).toThrow(
+        /Received promise that rejected: "settled to this"/,
+      );
+      // A function that returns a non-thenable is a usage error.
+      await expectFailure(() => expect(ANY(() => 4)).resolves.toBe(4)).toThrow(
+        /Expected a promise or a function returning a promise/,
+      );
+      await expectFailure(() => expect(ANY(() => 4)).rejects.toBe(4)).toThrow(
+        /Expected a promise or a function returning a promise/,
+      );
+      // A function that throws synchronously propagates its own error.
+      const boom = () => {
+        throw new Error("sync boom");
+      };
+      await expectFailure(() => expect(ANY(boom)).rejects.toThrow("anything")).toThrow("sync boom");
+      await expectFailure(() => expect(ANY(boom)).resolves.toBe(1)).toThrow("sync boom");
     }
   });
 
@@ -4695,6 +4749,12 @@ describe("expect()", () => {
         await expect({ a: Promise.reject("1") }).toEqual({ a: expect.not.rejectsTo.stringContaining("2") });
         await expect(Promise.reject(new Error("rejectMessage"))).rejects.toMatchObject({ message: "rejectMessage" });
 
+        // a thenable and a function returning a promise match like a promise does
+        await expect({ then: (/** @type {any} */ _, /** @type {any} */ reject) => reject("1") }).toEqual(
+          expect.rejectsTo.stringContaining("1"),
+        );
+        await expect({ a: () => Promise.reject("1") }).toEqual({ a: expect.rejectsTo.stringContaining("1") });
+
         // a resolved promise should not match
         await expect(Promise.resolve("a")).not.toEqual(expect.rejectsTo.stringContaining("a"));
 
@@ -4720,6 +4780,12 @@ describe("expect()", () => {
           }),
         ).resolves.toThrow();
 
+        // a thenable and a function returning a promise match like a promise does
+        await expect({ then: (/** @type {any} */ resolve) => resolve("1") }).toEqual(
+          expect.resolvesTo.stringContaining("1"),
+        );
+        await expect({ a: () => Promise.resolve("1") }).toEqual({ a: expect.resolvesTo.stringContaining("1") });
+
         // a rejected promise should not match
         await expect(Promise.reject("a")).not.toEqual(expect.resolvesTo.stringContaining("a"));
 
@@ -4732,6 +4798,20 @@ describe("expect()", () => {
             setTimeout(() => resolve("a"), 0);
           }),
         ).toEqual(expect.resolvesTo.stringContaining("a"));
+      });
+
+      // A function receiver that throws synchronously fails the test with its own
+      // error. `.not` must not turn the pending exception into a pass.
+      test("expect.rejectsTo / resolvesTo propagate a sync throw from a received function", () => {
+        const boom = () => {
+          throw new Error("asymmetric sync boom");
+        };
+        expect(() => expect(boom).toEqual(expect.rejectsTo.anything())).toThrow("asymmetric sync boom");
+        expect(() => expect(boom).toEqual(expect.not.rejectsTo.anything())).toThrow("asymmetric sync boom");
+        expect(() => expect({ a: boom }).toEqual({ a: expect.resolvesTo.anything() })).toThrow("asymmetric sync boom");
+        expect(() => expect({ a: boom }).toEqual({ a: expect.not.resolvesTo.anything() })).toThrow(
+          "asymmetric sync boom",
+        );
       });
     }
   });


### PR DESCRIPTION
### Problem
- `expect(fn).rejects` and `expect(fn).resolves` fail with `Expected promise` when `fn` is a function. Jest calls the function and waits on what it returns: `.rejects` since jest 26 (jestjs/jest#9817), `.resolves` since jest 30.0.4 (jestjs/jest#15714). Fixes #16144.
- Cause: `process_promise` (`src/runtime/test_runner/expect.rs:510`) hands the receiver straight to the thenable check. A function has no `then`, so it fails as a non-promise.

### Fix
- `process_promise` calls a callable receiver, then waits on the return value through `thenable_to_wait_for` (#40996). A synchronous throw propagates as the test error, as in Jest. The usage error takes Jest's wording: `Expected a promise or a function returning a promise`.
- The mismatch messages print the settled value (`Received promise that resolved: "x"`), not the receiver, which printed as `Promise { <resolved> }`.
- `resolves` in `bun-types` unwraps a function receiver's return type, so `expect(async () => 1).resolves.toBe(1)` type-checks.
- Verified: `test/js/bun/test/expect.test.js` (new test `resolves/rejects on a function returning a promise`, function cases for `expect.rejectsTo` / `expect.resolvesTo`), `test/integration/bun-types/fixture/test.ts`. Also the other expect suites in `test/js/bun/test`.

### Background
- Stacked on #40996, which adds `thenable_to_wait_for`, an adopter promise that calls a value's own `then()`. Merge #40996 first. This PR is the function receiver half of #32944.
- `expect.resolvesTo` / `expect.rejectsTo` are Bun-only asymmetric matchers. They reach `process_promise` through `Expect_readFlagsAndProcessPromise`, so inside `toEqual` a function-valued property that faces one of them is now called.
- `.resolves` follows Jest 30.0.4. Vitest 4.1.9 calls a function receiver for `.rejects` only, so the `.resolves` cases in `expect.test.js` are gated on `!isVitest`.

<details><summary>Notes</summary>

- Jest semantics (`packages/expect/src/index.ts`, `makeResolveMatcher` / `makeRejectMatcher`): `typeof actual === 'function' ? actual() : actual`, then `isPromise(actualWrapper)` (any object or function with a callable `then`). The usage error prints the original receiver, not its return value. This PR keeps both.
- A function receiver that returns a non-thenable (`() => 4`) is the usage error, with `Received: [Function]`, as in Jest.
- In the asymmetric matcher path `process_promise` runs with `silent = true`. A thrown error from the received function stays pending on the VM, `Expect_readFlagsAndProcessPromise` returns false, and the `RETURN_IF_EXCEPTION` that #40996 adds in `matchAsymmetricMatcher` propagates it instead of letting `.not` flip the FAIL to PASS. The new `expect.rejectsTo / resolvesTo propagate a sync throw from a received function` test covers all four combinations.
- The settled value is printed with the same console formatter the other matchers use for `Received:`, so an `Error` prints with its stack, as `expect(new Error("x")).toBe(1)` does today.
- `rejects` stays `Matchers<unknown>`. The `resolves` type is `Matchers<Awaited<T extends (...args: any[]) => infer R ? R : T>>`. Without it, `expect(() => Promise.resolve(1)).resolves.toBe(1)` is `TS2769: No overload matches this call`. The fixture checks `Matchers<number>` for a promise and for a function receiver.
- Fail before: on the #40996 branch the new `expect.test.js` test fails with `Expected promise` on its first assertion, and the fixture reports four type errors without the `.d.ts` change.
- Suites run on the debug build: `expect.test.js` 417 pass, `bun-test.test.ts` 5 pass, `expect-extend.test.js`, `jest-extended.test.js`, `spyMatchers.test.ts`, `expect-assertions.test.ts`, `mock-fn.test.js`, `bun-types.test.ts` 20 pass. `BUN_JSC_validateExceptionChecks=1` on the new tests reports nothing.
- Self-reviewed: 2 concerns raised. Addressed: the change was first folded into #40996, which had excluded this feature from its scope. It is now this stacked PR, so the hang fix and the Jest parity feature are reviewed on their own. Not addressed here: the settled-promise direct read in `thenable_to_wait_for` skips an overridden `then()` on an already settled subclass. That helper belongs to #40996, which documents the choice, and #41008 adds a shared `JSPromise::awaitable` that #40996 plans to adopt.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/expect.test.js:
(pass) expect() > () [300.70ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.20ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.46ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.24ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.25ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.25ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.23ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.23ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.25ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.44ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.34ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.29ms]
(pass) e
... (truncated)

release without fix: 2 skipped
bun test v1.4.1-canary.1 (6f9e95b81)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.64ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.02ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.02ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/expect.test.js:
(pass) expect() > () [303.08ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [1.85ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.43ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.27ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.26ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.23ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.26ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.24ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.22ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.48ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.31ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) e
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 597ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/test.d.ts               | 10 ++--
 src/runtime/test_runner/expect.rs          | 14 +++--
 test/integration/bun-types/fixture/test.ts | 19 +++++++
 test/js/bun/test/expect.test.js            | 83 +++++++++++++++++++++++++++++-
 4 files changed, 118 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-types/test.d.ts                    1      1      0
src/runtime/test_runner/expect.rs               2      4      0
test/integration/bun-types/fixture/test.ts      1      3      0
test/js/bun/test/expect.test.js                 4      5      0
```

</details>

<!-- robobun:evidence:end -->