### PR TITLE
bun:ffi: store array-index symbol names as indexed properties

### DIFF
--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1221,7 +1221,11 @@ impl FFI {
                         function.symbol_from_dynamic_library,
                     );
                     // `cb` is rooted by the `symbolsValue` cached own-property set below.
-                    obj.put(global_this, symbol_name, cb);
+                    obj.put_may_be_index(
+                        global_this,
+                        &bun_core::String::borrow_utf8(function_name.as_bytes()),
+                        cb,
+                    )?;
                 }
             }
         }
@@ -1560,7 +1564,16 @@ impl FFI {
                         return ret;
                     }
                 };
-            obj.put(global, symbol_name, cb);
+            if let Err(err) = obj.put_may_be_index(
+                global,
+                &bun_core::String::borrow_utf8(function_name.as_bytes()),
+                cb,
+            ) {
+                dylib.close();
+                // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
+                unsafe { &*lib_ptr }.do_close();
+                return Err(err);
+            }
         }
 
         // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
@@ -1645,7 +1658,15 @@ impl FFI {
                         return err;
                     }
                 };
-            obj.put(global, symbol_name, cb);
+            if let Err(err) = obj.put_may_be_index(
+                global,
+                &bun_core::String::borrow_utf8(function_name.as_bytes()),
+                cb,
+            ) {
+                // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
+                unsafe { &*lib_ptr }.do_close();
+                return Err(err);
+            }
         }
 
         // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -914,16 +914,17 @@ describe("symbol names that are array indexes", () => {
           : "libc.musl-x86_64.so.1"
         : "libc.so.6";
 
-  // Subprocess: a debug build of the unfixed code aborts on a JSC assertion.
-  it.concurrent.each([
+  describe.each([
     ["linkSymbols", "linkSymbols(map)"],
     ["dlopen", `dlopen(${JSON.stringify(systemLib)}, map)`],
-  ])("%s stores them as indexed properties", async (_, open) => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `import { dlopen, linkSymbols, JSCallback } from "bun:ffi";
+  ])("%s", (_, open) => {
+    // Subprocess: a debug build of the unfixed code aborts on a JSC assertion.
+    it.concurrent("stores them as indexed properties", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { dlopen, linkSymbols, JSCallback } from "bun:ffi";
         const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
         const fn = { ptr: cb.ptr, returns: "int32_t", args: [] };
         // 4294967295 is 2^32 - 1, the first integer that is not an array index.
@@ -941,23 +942,24 @@ describe("symbol names that are array indexes", () => {
         );
         lib.close();
         cb.close();`,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ result: JSON.parse(stdout.trim() || "null"), stderr, exitCode }).toEqual({
-      result: {
-        // Index keys come first, in ascending order. The rest keep insertion order.
-        keys: ["0", "2023", "named", "4294967295"],
-        types: ["function", "function", "function", "function"],
-        has: [true, true, true, true],
-        sameFunction: true,
-        results: [42, 42, 42, 42],
-      },
-      stderr: "",
-      exitCode: 0,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ result: JSON.parse(stdout.trim() || "null"), stderr, exitCode }).toEqual({
+        result: {
+          // Index keys come first, in ascending order. The rest keep insertion order.
+          keys: ["0", "2023", "named", "4294967295"],
+          types: ["function", "function", "function", "function"],
+          has: [true, true, true, true],
+          sameFunction: true,
+          results: [42, 42, 42, 42],
+        },
+        stderr: "",
+        exitCode: 0,
+      });
     });
   });
 });

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,6 +1,16 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, compileFixture, isDebug, isGlibcVersionAtLeast, isWindows, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  compileFixture,
+  isDebug,
+  isGlibcVersionAtLeast,
+  isMacOS,
+  isMusl,
+  isWindows,
+  tempDir,
+} from "harness";
 import { platform } from "os";
 
 import {
@@ -889,6 +899,66 @@ describe("CFunction", () => {
 
   it("reports a missing ptr the same way linkSymbols() does", () => {
     expect(() => new CFunction({ returns: "int32_t", args: [] })).toThrow(/CFunction.*ptr.*(linkSymbols|CFunction)/);
+  });
+});
+
+describe("symbol names that are array indexes", () => {
+  // A `ptr` field skips the dlsym lookup, so any loadable library works for dlopen.
+  const systemLib = isWindows
+    ? "kernel32.dll"
+    : isMacOS
+      ? "libSystem.B.dylib"
+      : isMusl
+        ? process.arch === "arm64"
+          ? "libc.musl-aarch64.so.1"
+          : "libc.musl-x86_64.so.1"
+        : "libc.so.6";
+
+  // Subprocess: a debug build of the unfixed code aborts on a JSC assertion.
+  it.concurrent.each([
+    ["linkSymbols", "linkSymbols(map)"],
+    ["dlopen", `dlopen(${JSON.stringify(systemLib)}, map)`],
+  ])("%s stores them as indexed properties", async (_, open) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { dlopen, linkSymbols, JSCallback } from "bun:ffi";
+        const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
+        const fn = { ptr: cb.ptr, returns: "int32_t", args: [] };
+        // 4294967295 is 2^32 - 1, the first integer that is not an array index.
+        const map = { "0": fn, named: fn, "2023": fn, "4294967295": fn };
+        const lib = ${open};
+        const { symbols } = lib;
+        console.log(
+          JSON.stringify({
+            keys: Object.keys(symbols),
+            types: [typeof symbols[0], typeof symbols["0"], typeof symbols[2023], typeof symbols[4294967295]],
+            has: [0 in symbols, "0" in symbols, 2023 in symbols, Object.hasOwn(symbols, "0")],
+            sameFunction: symbols[0] === symbols["0"],
+            results: [symbols[0](), symbols[2023](), symbols.named(), symbols[4294967295]()],
+          }),
+        );
+        lib.close();
+        cb.close();`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ result: JSON.parse(stdout.trim() || "null"), stderr, exitCode }).toEqual({
+      result: {
+        // Index keys come first, in ascending order. The rest keep insertion order.
+        keys: ["0", "2023", "named", "4294967295"],
+        types: ["function", "function", "function", "function"],
+        has: [true, true, true, true],
+        sameFunction: true,
+        results: [42, 42, 42, 42],
+      },
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `linkSymbols` with a symbol named `"0"` returns a `symbols` object where `Object.keys` lists `"0"`, but `symbols[0]` is `undefined` and `0 in symbols` is `false`. `dlopen` does the same. Debug builds abort: `ASSERTION FAILED: !parseIndex(propertyName)` in `JSC::JSObject::putDirectInternal`.
- `linkSymbols`, `dlopen` and `cc` (`src/runtime/ffi/ffi_body.rs:1648`, `:1563`, `:1224`) store each symbol with `JSValue::put`, which is `putDirect`. `putDirect` requires a non-index key. An index key (`0` to `4294967294`) lands in the named-property table, where an index lookup never looks.

### Fix
- Store each symbol with `put_may_be_index` (`putDirectMayBeIndex`). `parse_args.rs`, `cares_jsc.rs` and `util.parseEnv` (#41063) already use it for keys from data.
- `put_may_be_index` is fallible. `dlopen` and `linkSymbols` clean up on failure like their neighboring exits. `cc` uses `?`. `cc` cannot reach its site with an index key (it throws `"0" is missing` first), so it changes only to match.
- Verified: two new tests in `test/js/bun/ffi/ffi.test.js` (`linkSymbols`, and `dlopen` with a `ptr` field). Both fail on stock bun. Also all of `test/js/bun/ffi/`.
- Self-reviewed: 2 concerns raised, 1 addressed (the `dlopen` test), 1 deferred (a `'static` bound on `PutKey`, a `bun_jsc`-wide change, see notes).

### Background
- JSC keeps named properties in a `Structure` plus a butterfly, and integer-index properties in separate indexed storage. A read with an index-like name always goes to indexed storage.
- `putDirect` writes straight into the named-property table and asserts that the name is not an index. Release builds compile the assert out, so the write succeeds and the object contradicts itself.
- `putDirectMayBeIndex` checks `parseIndex` first and picks the right storage. It can throw (out of memory on a huge sparse index), so the Rust binding returns `JsResult<()>`.

<details><summary>Notes</summary>

Found while reviewing the `put` callers that #41063 listed as unchanged. No user report.

Repro on stock bun 1.4.1:

```js
import { linkSymbols, JSCallback } from "bun:ffi";
const cb = new JSCallback(() => {}, { args: [], returns: "void" });
const { symbols } = linkSymbols({ "0": { ptr: cb.ptr, args: [], returns: "void" } });
console.log(Object.keys(symbols), typeof symbols[0], typeof symbols["0"], 0 in symbols);
// [ "0" ] undefined undefined false
```

A debug build prints `ASSERTION FAILED: !parseIndex(propertyName)` from `JSObjectInlines.h(501)` and aborts. The assertion is reached from `JSC__JSValue__put`.

`dlopen` reaches the same store in two ways. A `ptr` field skips the `dlsym` lookup, so `dlopen("libc.so.6", { "0": { ptr, ... } })` works with any loadable library. That is what the test uses. A library can also export a symbol named `0`: GNU as accepts quoted symbol names (`.globl "0"`), and `dlopen(lib, { "0": { args: [], returns: "int32_t" } }).symbols[0]` was `undefined` on stock bun and returns the function's value with this change.

`cc` cannot reach its store with an index key. `Function::compile` looks the name up in the TinyCC state first and throws `"0" is missing from <file>`. `CFunction` is not affected. It returns the function itself and does not build a keyed object.

Remaining `put` callers with a key that comes from data, not changed here:

- `src/runtime/node/node_os.rs:1136` and `:1316` (`networkInterfaces`, interface name). Linux accepts a numeric interface name, but creating one needs `CAP_NET_ADMIN`, and the `ret.get()` before the store (`getIfPropertyExistsImpl`) has the same index limitation.
- `src/runtime/bake/FrameworkRouter.rs:1886` (route param names) and `:1237` (`put_bun_string_one_or_array`, `putDirect` in `BunString.cpp`).

The review suggested closing the class in the types: make the `PutKey` impls in `src/jsc/JSValue.rs` accept only `'static` keys, so a data key no longer compiles with `put`. That touches `bun_jsc` and every caller, so it belongs in its own change.

Suites run: `test/js/bun/ffi/` (6 files, 233 pass). `ptr argument: ArrayBuffer cells through an FTL-compiled call site` times out at 5 s in this debug environment with and without the change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/ffi/ffi.test.js

<!-- robobun:evidence:end -->