### PR TITLE
Store array-index property names as indexed properties in native object builders

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1421,19 +1421,16 @@ impl JSValue {
         const I52_MAX: i64 = (1i64 << 51) - 1;
         Ok(len.clamp(0.0, I52_MAX as f64) as u64)
     }
-    /// Set a property. Key dispatch goes through the [`PutKey`] trait so
-    /// callers may pass `&[u8]`, `EncodedSlice`, `String`, or `&String`.
+    /// Set a property whose name is known at compile time. Key dispatch goes
+    /// through the [`PutKey`] trait, which only `'static` byte and string
+    /// slices implement. A name that comes from data (a column, a header, a
+    /// symbol, a file name) goes through [`put_may_be_index`](Self::put_may_be_index).
     pub fn put<K: PutKey>(self, global: &JSGlobalObject, key: K, value: JSValue) {
         key.put(self, global, value)
     }
     /// [`put`] with `PropertyAttribute::DontEnum`.
-    pub fn put_non_enumerable(
-        self,
-        global: &JSGlobalObject,
-        key: impl AsRef<[u8]>,
-        value: JSValue,
-    ) {
-        let key = bun_core::EncodedSlice::latin1(key.as_ref());
+    pub fn put_non_enumerable(self, global: &JSGlobalObject, key: &'static [u8], value: JSValue) {
+        let key = bun_core::EncodedSlice::latin1(key);
         JSC__JSValue__putNonEnumerable(self, global, &key, value)
     }
     /// [`put`] only when `val` is `Some`; the property is *omitted* (not set to
@@ -1479,9 +1476,9 @@ impl JSValue {
         let key = bun_core::EncodedSlice::latin1(key.as_ref());
         crate::call_check_slow(global, || JSC__JSValue__deleteProperty(self, global, &key))
     }
-    /// `JSValue.putMayBeIndex` — same as [`put`] but accepts
-    /// both non-numeric and numeric keys. Prefer [`put`] when the key is
-    /// guaranteed non-numeric.
+    /// `JSValue.putMayBeIndex` — same as [`put`](Self::put) but for a key that
+    /// comes from data. An array-index name such as `"0"` is stored as an
+    /// indexed property, which plain `putDirect` cannot do.
     pub fn put_may_be_index(
         self,
         global: &JSGlobalObject,
@@ -1842,42 +1839,26 @@ impl<T: FromAny> FromAny for Option<T> {
     }
 }
 
-/// Dispatch trait for [`JSValue::put`]'s key parameter: routes
-/// `EncodedSlice`/`String`/byte-slice keys to the matching FFI.
+/// Dispatch trait for [`JSValue::put`]'s key parameter. Only a key that is
+/// known at compile time implements it: the C++ side is a plain `putDirect`,
+/// which asserts on an array-index name such as `"0"`. A key that comes from
+/// data goes through [`JSValue::put_may_be_index`].
 pub trait PutKey {
     fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue);
 }
-impl PutKey for bun_core::EncodedSlice<'_> {
+impl PutKey for &'static [u8] {
     #[inline]
     fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue) {
-        JSC__JSValue__put(target, global, &self, value)
+        JSC__JSValue__put(target, global, &bun_core::EncodedSlice::latin1(self), value)
     }
 }
-impl PutKey for &bun_core::String {
-    #[inline]
-    fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue) {
-        JSC__JSValue__putBunString(target, global, self, value)
-    }
-}
-impl PutKey for bun_core::String {
-    #[inline]
-    fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue) {
-        (&self).put(target, global, value)
-    }
-}
-impl PutKey for &[u8] {
-    #[inline]
-    fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue) {
-        bun_core::EncodedSlice::latin1(self).put(target, global, value)
-    }
-}
-impl<const N: usize> PutKey for &[u8; N] {
+impl<const N: usize> PutKey for &'static [u8; N] {
     #[inline]
     fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue) {
         self.as_slice().put(target, global, value)
     }
 }
-impl PutKey for &str {
+impl PutKey for &'static str {
     #[inline]
     fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue) {
         self.as_bytes().put(target, global, value)
@@ -2065,12 +2046,6 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         key: &bun_core::EncodedSlice,
     ) -> bool;
-    safe fn JSC__JSValue__putBunString(
-        this: JSValue,
-        global: &JSGlobalObject,
-        key: &bun_core::String,
-        value: JSValue,
-    );
     safe fn JSC__JSValue__putMayBeIndex(
         this: JSValue,
         global: &JSGlobalObject,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1421,8 +1421,7 @@ impl JSValue {
         const I52_MAX: i64 = (1i64 << 51) - 1;
         Ok(len.clamp(0.0, I52_MAX as f64) as u64)
     }
-    /// Set a property whose name is known at compile time. A name that comes
-    /// from data goes through [`put_may_be_index`](Self::put_may_be_index).
+    /// Set a property with a compile-time name. A data-derived name uses [`put_may_be_index`](Self::put_may_be_index).
     pub fn put<K: PutKey>(self, global: &JSGlobalObject, key: K, value: JSValue) {
         key.put(self, global, value)
     }
@@ -1474,8 +1473,7 @@ impl JSValue {
         let key = bun_core::EncodedSlice::latin1(key.as_ref());
         crate::call_check_slow(global, || JSC__JSValue__deleteProperty(self, global, &key))
     }
-    /// `JSValue.putMayBeIndex` — [`put`](Self::put) for a name that comes from
-    /// data: an array-index name such as `"0"` becomes an indexed property.
+    /// `JSValue.putMayBeIndex` — [`put`](Self::put) for a data-derived name, which can be an array index like `"0"`.
     pub fn put_may_be_index(
         self,
         global: &JSGlobalObject,
@@ -1836,8 +1834,7 @@ impl<T: FromAny> FromAny for Option<T> {
     }
 }
 
-/// Dispatch trait for [`JSValue::put`]'s key parameter. Only `'static` keys
-/// implement it: the C++ side is plain `putDirect`, which asserts on an index name.
+/// Key dispatch for [`JSValue::put`]: only `'static` keys, because the C++ side is plain `putDirect`.
 pub trait PutKey {
     fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue);
 }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1421,10 +1421,8 @@ impl JSValue {
         const I52_MAX: i64 = (1i64 << 51) - 1;
         Ok(len.clamp(0.0, I52_MAX as f64) as u64)
     }
-    /// Set a property whose name is known at compile time. Key dispatch goes
-    /// through the [`PutKey`] trait, which only `'static` byte and string
-    /// slices implement. A name that comes from data (a column, a header, a
-    /// symbol, a file name) goes through [`put_may_be_index`](Self::put_may_be_index).
+    /// Set a property whose name is known at compile time. A name that comes
+    /// from data goes through [`put_may_be_index`](Self::put_may_be_index).
     pub fn put<K: PutKey>(self, global: &JSGlobalObject, key: K, value: JSValue) {
         key.put(self, global, value)
     }
@@ -1476,9 +1474,8 @@ impl JSValue {
         let key = bun_core::EncodedSlice::latin1(key.as_ref());
         crate::call_check_slow(global, || JSC__JSValue__deleteProperty(self, global, &key))
     }
-    /// `JSValue.putMayBeIndex` — same as [`put`](Self::put) but for a key that
-    /// comes from data. An array-index name such as `"0"` is stored as an
-    /// indexed property, which plain `putDirect` cannot do.
+    /// `JSValue.putMayBeIndex` — [`put`](Self::put) for a name that comes from
+    /// data: an array-index name such as `"0"` becomes an indexed property.
     pub fn put_may_be_index(
         self,
         global: &JSGlobalObject,
@@ -1839,10 +1836,8 @@ impl<T: FromAny> FromAny for Option<T> {
     }
 }
 
-/// Dispatch trait for [`JSValue::put`]'s key parameter. Only a key that is
-/// known at compile time implements it: the C++ side is a plain `putDirect`,
-/// which asserts on an array-index name such as `"0"`. A key that comes from
-/// data goes through [`JSValue::put_may_be_index`].
+/// Dispatch trait for [`JSValue::put`]'s key parameter. Only `'static` keys
+/// implement it: the C++ side is plain `putDirect`, which asserts on an index name.
 pub trait PutKey {
     fn put(self, target: JSValue, global: &JSGlobalObject, value: JSValue);
 }

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -889,6 +889,7 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__upsertBunStringArray(
     auto existingValue = target->getIfPropertyExists(global, id);
     RETURN_IF_EXCEPTION(scope, {});
 
+    // The key is a route parameter name, so it can be an array index.
     if (!existingValue.isEmpty()) {
         // If existing value is already an array, push to it
         if (existingValue.isObject() && existingValue.getObject()->inherits<JSC::JSArray>()) {
@@ -901,29 +902,16 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__upsertBunStringArray(
             array->putDirectIndex(global, 0, existingValue);
             RETURN_IF_EXCEPTION(scope, {});
             array->putDirectIndex(global, 1, newValue);
-            target->putDirect(vm, id, array, 0);
+            RETURN_IF_EXCEPTION(scope, {});
+            target->putDirectMayBeIndex(global, id, array);
         }
     } else {
         // No existing value, just put the new value directly
-        target->putDirect(vm, id, newValue, 0);
+        target->putDirectMayBeIndex(global, id, newValue);
     }
 
     RETURN_IF_EXCEPTION(scope, {});
     return JSC::JSValue::encode(JSC::jsUndefined());
-}
-
-extern "C" void JSC__JSValue__putBunString(
-    JSC::EncodedJSValue encodedTarget,
-    JSC::JSGlobalObject* global,
-    const BunString* key,
-    JSC::EncodedJSValue encodedValue)
-{
-    JSC::JSObject* target = JSC::JSValue::decode(encodedTarget).getObject();
-    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
-    auto& vm = global->vm();
-    WTF::String str = key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString();
-    Identifier id = Identifier::fromString(vm, str);
-    target->putDirect(vm, id, value, 0);
 }
 
 bool BunString::isEmpty() const

--- a/src/jsc/bindings/JSBunRequest.cpp
+++ b/src/jsc/bindings/JSBunRequest.cpp
@@ -119,7 +119,9 @@ JSBunRequest* JSBunRequest::clone(JSC::VM& vm, JSGlobalObject* globalObject)
         for (auto& property : propertyNames) {
             auto value = params->get(globalObject, property);
             RETURN_IF_EXCEPTION(throwScope, nullptr);
-            paramsClone->putDirect(vm, property, value);
+            // User code can add an own property with an array-index name to `params` before `clone()`.
+            paramsClone->putDirectMayBeIndex(globalObject, property, value);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
         }
 
         clone->setParams(paramsClone);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -848,7 +848,9 @@ bool JSSharedEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* globalO
                 if (!existing.isNull()) {
                     syncWindowsEnv(store, String(uid), nullptr);
                     store->remove(String(uid));
-                    object->putDirect(vm, propertyName, jsString(vm, existing), 0);
+                    // An env var name can be an array index (`process.env[0] = "x"` or `env 0=x`).
+                    object->putDirectMayBeIndex(globalObject, propertyName, jsString(vm, existing));
+                    RETURN_IF_EXCEPTION(scope, false);
                 }
             }
         }

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -77,12 +77,16 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
 static JSValue scriptFetchParametersToImportAttributes(JSGlobalObject* globalObject, JSC::ScriptFetchParameters* params)
 {
     auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* obj = constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
     if (!params)
         return obj;
     if (!params->attributes().isEmpty()) {
-        for (auto& [key, value] : params->attributes())
-            obj->putDirect(vm, JSC::Identifier::fromUid(vm, key.get()), jsString(vm, value));
+        // `import(x, { with: { "0": "a" } })` gives an attribute key that is an array index.
+        for (auto& [key, value] : params->attributes()) {
+            obj->putDirectMayBeIndex(globalObject, JSC::Identifier::fromUid(vm, key.get()), jsString(vm, value));
+            RETURN_IF_EXCEPTION(scope, {});
+        }
         return obj;
     }
     switch (params->type()) {
@@ -320,6 +324,7 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue importAttributes = scriptFetchParametersToImportAttributes(globalObject, parameters.get());
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     MarkedArgumentBuffer args;
     args.append(moduleName);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -35,8 +35,16 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
     RETURN_IF_EXCEPTION(scope, {});
 
     for (const auto& [key, value] : m_importAttributes) {
-        attributes->putDirect(globalObject->vm(), JSC::Identifier::fromString(globalObject->vm(), key), JSC::jsString(globalObject->vm(), value),
-            PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
+        constexpr unsigned propertyAttributes = PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete;
+        JSC::Identifier identifier = JSC::Identifier::fromString(vm, key);
+        JSValue attributeValue = JSC::jsString(vm, value);
+        // An attribute key can be any string literal, including an array index.
+        if (auto index = parseIndex(identifier)) {
+            attributes->putDirectIndex(globalObject, *index, attributeValue, propertyAttributes, PutDirectIndexLikePutDirect);
+            RETURN_IF_EXCEPTION(scope, {});
+        } else {
+            attributes->putDirect(vm, identifier, attributeValue, propertyAttributes);
+        }
     }
     array->putDirectIndex(globalObject, 1, attributes);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -286,7 +286,9 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
         if (ImportAttributesListNode* attributesNode = attributesNodes.at(i)) {
             for (auto [key, value] : attributesNode->attributes()) {
                 attributeMap.set(key->string(), value->string());
-                attributesObject->putDirect(vm, *key, JSC::jsString(vm, value->string()));
+                // An attribute key can be any string literal, including an array index.
+                attributesObject->putDirectMayBeIndex(globalObject, *key, JSC::jsString(vm, value->string()));
+                RETURN_IF_EXCEPTION(scope, {});
             }
         }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3031,8 +3031,13 @@ void JSC__JSObject__putRecord(JSC::JSObject* object, JSC::JSGlobalObject* global
         // Pre-convert all strings to JSValues before entering ObjectInitializationScope,
         // since jsString() allocates GC cells which is not allowed inside the scope.
         MarkedArgumentBuffer strings;
+        strings.ensureCapacity(valuesLen);
         for (size_t i = 0; i < valuesLen; ++i) {
             strings.append(JSC::jsString(vm, Zig::toStringCopy(values[i])));
+        }
+        if (strings.hasOverflowed()) [[unlikely]] {
+            JSC::throwOutOfMemoryError(global, scope);
+            return;
         }
 
         JSC::JSArray* array = nullptr;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3019,28 +3019,25 @@ double JSC__JSValue__getLengthIfPropertyExistsInternal(JSC::EncodedJSValue value
 [[ZIG_EXPORT(check_slow)]]
 void JSC__JSObject__putRecord(JSC::JSObject* object, JSC::JSGlobalObject* global, EncodedSlice* key, EncodedSlice* values, size_t valuesLen)
 {
-    auto scope = DECLARE_THROW_SCOPE(global->vm());
-    auto ident = Identifier::fromString(global->vm(), Zig::toStringCopy(*key));
-    JSC::PropertyDescriptor descriptor;
-
-    descriptor.setEnumerable(1);
-    descriptor.setConfigurable(1);
-    descriptor.setWritable(1);
+    auto& vm = global->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto ident = Identifier::fromString(vm, Zig::toStringCopy(*key));
+    JSC::JSValue value;
 
     if (valuesLen == 1) {
-        descriptor.setValue(JSC::jsString(global->vm(), Zig::toStringCopy(values[0])));
+        value = JSC::jsString(vm, Zig::toStringCopy(values[0]));
     } else {
 
         // Pre-convert all strings to JSValues before entering ObjectInitializationScope,
         // since jsString() allocates GC cells which is not allowed inside the scope.
         MarkedArgumentBuffer strings;
         for (size_t i = 0; i < valuesLen; ++i) {
-            strings.append(JSC::jsString(global->vm(), Zig::toStringCopy(values[i])));
+            strings.append(JSC::jsString(vm, Zig::toStringCopy(values[i])));
         }
 
         JSC::JSArray* array = nullptr;
         {
-            JSC::ObjectInitializationScope initializationScope(global->vm());
+            JSC::ObjectInitializationScope initializationScope(vm);
             if ((array = JSC::JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, global->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous), valuesLen))) {
 
                 for (size_t i = 0; i < valuesLen; ++i) {
@@ -3054,12 +3051,12 @@ void JSC__JSObject__putRecord(JSC::JSObject* object, JSC::JSGlobalObject* global
             return;
         }
 
-        descriptor.setValue(array);
+        value = array;
     }
 
-    object->methodTable()->defineOwnProperty(object, global, ident, descriptor, true);
-    object->putDirect(global->vm(), ident, descriptor.value());
-    scope.release();
+    // The key is a query-string name or a route parameter, so it can be an array index.
+    object->putDirectMayBeIndex(global, ident, value);
+    RETURN_IF_EXCEPTION(scope, );
 }
 
 JSC::JSPromise* JSC__JSValue__asInternalPromise(JSC::EncodedJSValue JSValue0)
@@ -3444,17 +3441,12 @@ JSC::EncodedJSValue JSC__JSValue__fromEntries(JSC::JSGlobalObject* globalObject,
     JSC::JSObject* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), std::min(static_cast<unsigned int>(initialCapacity), JSFinalObject::maxInlineCapacity));
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (!clone) {
-        for (size_t i = 0; i < initialCapacity; ++i) {
-            object->putDirect(
-                vm, JSC::PropertyName(JSC::Identifier::fromString(vm, Zig::toString(keys[i]))),
-                Zig::toJSStringGC(values[i], globalObject), 0);
-        }
-    } else {
-        for (size_t i = 0; i < initialCapacity; ++i) {
-            object->putDirect(vm, JSC::PropertyName(Zig::toIdentifier(keys[i], globalObject)),
-                Zig::toJSStringGC(values[i], globalObject), 0);
-        }
+    for (size_t i = 0; i < initialCapacity; ++i) {
+        JSC::Identifier key = clone
+            ? Zig::toIdentifier(keys[i], globalObject)
+            : JSC::Identifier::fromString(vm, Zig::toString(keys[i]));
+        object->putDirectMayBeIndex(globalObject, key, Zig::toJSStringGC(values[i], globalObject));
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return JSC::JSValue::encode(object);

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1883,11 +1883,12 @@ impl JSFrameworkRouter {
                         JSValue::create_empty_object(global, params_out.params.len() as usize);
                     for param in params_out.params.slice() {
                         // key/value borrow from `path`/pattern, both live here (RawSlice invariant)
-                        params_obj.put(
+                        // A file named `[0].tsx` gives a param name that is an array index.
+                        params_obj.put_may_be_index(
                             global,
-                            param.key.slice(),
+                            &bun_core::String::borrow_utf8(param.key.slice()),
                             bun_string_jsc::create_utf8_for_js(global, param.value.slice())?,
-                        );
+                        )?;
                     }
                     params_obj
                 } else {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1221,7 +1221,11 @@ impl FFI {
                         function.symbol_from_dynamic_library,
                     );
                     // `cb` is rooted by the `symbolsValue` cached own-property set below.
-                    obj.put(global_this, symbol_name, cb);
+                    obj.put_may_be_index(
+                        global_this,
+                        &bun_core::String::borrow_utf8(function_name.as_bytes()),
+                        cb,
+                    )?;
                 }
             }
         }
@@ -1560,7 +1564,14 @@ impl FFI {
                         return ret;
                     }
                 };
-            obj.put(global, symbol_name, cb);
+            // The user picks the symbol names, so one can be an array index like "0".
+            let key = bun_core::String::borrow_utf8(function_name.as_bytes());
+            if let Err(err) = obj.put_may_be_index(global, &key, cb) {
+                dylib.close();
+                // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
+                unsafe { &*lib_ptr }.do_close();
+                return Err(err);
+            }
         }
 
         // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
@@ -1645,7 +1656,13 @@ impl FFI {
                         return err;
                     }
                 };
-            obj.put(global, symbol_name, cb);
+            // The user picks the symbol names, so one can be an array index like "0".
+            let key = bun_core::String::borrow_utf8(function_name.as_bytes());
+            if let Err(err) = obj.put_may_be_index(global, &key, cb) {
+                // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
+                unsafe { &*lib_ptr }.do_close();
+                return Err(err);
+            }
         }
 
         // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).

--- a/src/runtime/node/node_assert.rs
+++ b/src/runtime/node/node_assert.rs
@@ -239,16 +239,8 @@ where
         Output::Lines { colors, .. } => {
             let (out, skipped) = render_lines::<C, T>(diff_list, colors);
             let result = JSValue::create_empty_object(global, 2);
-            result.put(
-                global,
-                BunString::static_("message"),
-                C::to_bun_string(&out).into_js(global)?,
-            );
-            result.put(
-                global,
-                BunString::static_("skipped"),
-                JSValue::from(skipped),
-            );
+            result.put(global, b"message", C::to_bun_string(&out).into_js(global)?);
+            result.put(global, b"skipped", JSValue::from(skipped));
             Ok(result)
         }
     }

--- a/src/runtime/node/node_assert_binding.rs
+++ b/src/runtime/node/node_assert_binding.rs
@@ -111,7 +111,7 @@ pub(crate) fn generate(global: &JSGlobalObject) -> JSValue {
 
     exports.put(
         global,
-        bstring::String::static_("myersDiff"),
+        b"myersDiff",
         JSFunction::create(
             global,
             "myersDiff",
@@ -122,7 +122,7 @@ pub(crate) fn generate(global: &JSGlobalObject) -> JSValue {
     );
     exports.put(
         global,
-        bstring::String::static_("printSimpleMyersDiff"),
+        b"printSimpleMyersDiff",
         JSFunction::create(
             global,
             "printSimpleMyersDiff",
@@ -133,7 +133,7 @@ pub(crate) fn generate(global: &JSGlobalObject) -> JSValue {
     );
     exports.put(
         global,
-        bstring::String::static_("printMyersDiff"),
+        b"printMyersDiff",
         JSFunction::create(
             global,
             "printMyersDiff",

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -1124,7 +1124,9 @@ mod _impl {
             }
 
             // Does this entry already exist?
-            if let Some(array) = ret.get(global_this, interface_name)? {
+            // The OS picks the interface name, so it can be an array index like "0".
+            let key = bun_core::String::from_bytes(interface_name);
+            if let Some(array) = ret.get_own(global_this, &key)? {
                 // Add this interface entry to the existing array
                 let next_index: u32 =
                     u32::try_from(array.get_length(global_this)?).expect("int cast");
@@ -1133,7 +1135,7 @@ mod _impl {
                 // Add it as an array with this interface as an element
                 let array = JSValue::create_empty_array(global_this, 1)?;
                 array.put_index(global_this, 0, interface)?;
-                ret.put(global_this, interface_name, array);
+                ret.put_may_be_index(global_this, &key, array)?;
             }
 
             it = next;
@@ -1304,7 +1306,9 @@ mod _impl {
             // Does this entry already exist?
             // SAFETY: iface.name is a NUL-terminated C string from libuv
             let interface_name = unsafe { bun_core::ffi::cstr(iface.name) }.to_bytes();
-            if let Some(array) = ret.get(global_this, interface_name)? {
+            // The OS picks the interface name, so it can be an array index like "0".
+            let key = bun_core::String::from_bytes(interface_name);
+            if let Some(array) = ret.get_own(global_this, &key)? {
                 // Add this interface entry to the existing array
                 let next_index: u32 =
                     u32::try_from(array.get_length(global_this)?).expect("int cast");
@@ -1313,7 +1317,7 @@ mod _impl {
                 // Add it as an array with this interface as an element
                 let array = JSValue::create_empty_array(global_this, 1)?;
                 array.put_index(global_this, 0, interface)?;
-                ret.put(global_this, interface_name, array);
+                ret.put_may_be_index(global_this, &key, array)?;
             }
         }
 

--- a/src/runtime/node/node_quic_binding.rs
+++ b/src/runtime/node/node_quic_binding.rs
@@ -74,11 +74,25 @@ fn set_callbacks(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue
     Ok(JSValue::UNDEFINED)
 }
 
-fn put_num(obj: JSValue, global: &JSGlobalObject, key: &str, value: u64) {
+fn put_num(obj: JSValue, global: &JSGlobalObject, key: &'static str, value: u64) {
     obj.put(global, key.as_bytes(), JSValue::js_number(value as f64));
 }
 
-fn put_str(obj: JSValue, global: &JSGlobalObject, key: &str, value: &'static [u8]) -> JsResult<()> {
+/// [`put_num`] for a key built at runtime with `format!`.
+fn put_num_formatted(obj: JSValue, global: &JSGlobalObject, key: &str, value: u64) -> JsResult<()> {
+    obj.put_may_be_index(
+        global,
+        &bun_core::String::borrow_utf8(key.as_bytes()),
+        JSValue::js_number(value as f64),
+    )
+}
+
+fn put_str(
+    obj: JSValue,
+    global: &JSGlobalObject,
+    key: &'static str,
+    value: &'static [u8],
+) -> JsResult<()> {
     let value = bun_core::String::static_(value).to_js(global)?;
     obj.put(global, key.as_bytes(), value);
     Ok(())
@@ -123,7 +137,7 @@ pub(crate) fn create_node_quic_binding(global: &JSGlobalObject) -> JsResult<JSVa
 
     // Endpoint constants (node/src/quic/endpoint.cc Endpoint::InitPerContext)
     for (i, name) in endpoint::ENDPOINT_STATS_FIELDS.iter().enumerate() {
-        put_num(obj, global, &format!("IDX_STATS_ENDPOINT_{name}"), i as u64);
+        put_num_formatted(obj, global, &format!("IDX_STATS_ENDPOINT_{name}"), i as u64)?;
     }
     put_num(
         obj,
@@ -217,7 +231,7 @@ pub(crate) fn create_node_quic_binding(global: &JSGlobalObject) -> JsResult<JSVa
     )?;
     put_str(obj, global, "DEFAULT_GROUPS", b"X25519:P-256:P-384:P-521")?;
     for (i, name) in session::SESSION_STATS_FIELDS.iter().enumerate() {
-        put_num(obj, global, &format!("IDX_STATS_SESSION_{name}"), i as u64);
+        put_num_formatted(obj, global, &format!("IDX_STATS_SESSION_{name}"), i as u64)?;
     }
     put_num(
         obj,
@@ -247,7 +261,7 @@ pub(crate) fn create_node_quic_binding(global: &JSGlobalObject) -> JsResult<JSVa
 
     // Stream constants (node/src/quic/streams.cc Stream::InitPerContext)
     for (i, name) in stream::STREAM_STATS_FIELDS.iter().enumerate() {
-        put_num(obj, global, &format!("IDX_STATS_STREAM_{name}"), i as u64);
+        put_num_formatted(obj, global, &format!("IDX_STATS_STREAM_{name}"), i as u64)?;
     }
     put_num(
         obj,

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -1083,7 +1083,7 @@ fn apply_transport_params(
 pub(super) fn alloc_exposed_array_buffer(
     global: &JSGlobalObject,
     holder: JSValue,
-    name: &[u8],
+    name: &'static [u8],
     size: usize,
 ) -> JsResult<*mut u8> {
     let zeroes = vec![0u8; size];

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2226,7 +2226,7 @@ impl QuicSession {
         tp: &lsquic::NqTransportParams,
     ) -> JsResult<JSValue> {
         let obj = JSValue::create_empty_object_with_null_prototype(global);
-        let put = |name: &[u8], v: u64| -> JsResult<()> {
+        let put = |name: &'static [u8], v: u64| -> JsResult<()> {
             obj.put(global, name, JSValue::from_uint64_no_truncate(global, v)?);
             Ok(())
         };
@@ -2255,7 +2255,7 @@ impl QuicSession {
             b"disableActiveMigration",
             JSValue::js_boolean(tp.disable_active_migration != 0),
         );
-        let put_cid = |name: &[u8], s: &str| -> JsResult<()> {
+        let put_cid = |name: &'static [u8], s: &str| -> JsResult<()> {
             let v = if s.is_empty() {
                 JSValue::UNDEFINED
             } else {

--- a/test/bake/dev/route-params.test.ts
+++ b/test/bake/dev/route-params.test.ts
@@ -1,0 +1,34 @@
+// Route params tests cover the `params` object the dev server hands to a framework.
+import { devTest, minimalFramework } from "../bake-harness";
+
+// A file named `[0].ts` gives a route parameter whose name is a canonical array
+// index. The params object has to keep it in its indexed storage, or
+// Object.keys() lists a key that `params[0]` cannot read.
+devTest("a param named like an array index is stored under the index", {
+  framework: minimalFramework,
+  files: {
+    "routes/[0].ts": `
+      export default function (req, meta) {
+        const params = meta.params;
+        return Response.json({
+          keys: Object.keys(params),
+          byIndex: params[0],
+          byString: params["0"],
+        });
+      }
+    `,
+    "routes/posts/[...0].ts": `
+      export default function (req, meta) {
+        const params = meta.params;
+        return Response.json({
+          keys: Object.keys(params),
+          byIndex: params[0],
+        });
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/hello").equals({ keys: ["0"], byIndex: "hello", byString: "hello" });
+    await dev.fetch("/posts/a/b").equals({ keys: ["0"], byIndex: ["a", "b"] });
+  },
+});

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -133,3 +133,23 @@ test("discovers from filesystem paths", () => {
     ],
   });
 });
+
+// A file named `[0].tsx` gives a route parameter whose name is a canonical
+// array index. The params object has to keep it in its indexed storage, or
+// Object.keys() lists a key that `params[0]` cannot read.
+test("match() stores a param named like an array index under the index", () => {
+  using dir = tempDir("fsr-index-param", {
+    "index.tsx": "1",
+    "[0].tsx": "1",
+    "posts/[0]/[1].tsx": "1",
+  });
+  const router = new FrameworkRouter({ root: dir, style: "nextjs-pages" });
+
+  const single = router.match("/hello");
+  expect(single.params).toEqual({ 0: "hello" });
+  expect(single.params[0]).toBe("hello");
+
+  const nested = router.match("/posts/a/b");
+  expect(nested.params).toEqual({ 0: "a", 1: "b" });
+  expect([nested.params[0], nested.params[1]]).toEqual(["a", "b"]);
+});

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1403,13 +1403,16 @@ describe("symbols named like an array index", () => {
     const callback = new JSCallback(() => void calls++, { args: [], returns: "void" });
     try {
       const lib = linkSymbols({ "0": { ptr: callback.ptr, args: [], returns: "void" } });
-      expect(Object.keys(lib.symbols)).toEqual(["0"]);
-      expect(typeof lib.symbols[0]).toBe("function");
-      expect(lib.symbols["0"]).toBe(lib.symbols[0]);
-      expect(0 in lib.symbols).toBe(true);
-      lib.symbols[0]();
-      expect(calls).toBe(1);
-      lib.close();
+      try {
+        expect(Object.keys(lib.symbols)).toEqual(["0"]);
+        expect(typeof lib.symbols[0]).toBe("function");
+        expect(lib.symbols["0"]).toBe(lib.symbols[0]);
+        expect(0 in lib.symbols).toBe(true);
+        lib.symbols[0]();
+        expect(calls).toBe(1);
+      } finally {
+        lib.close();
+      }
     } finally {
       callback.close();
     }

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1416,18 +1416,26 @@ describe("symbols named like an array index", () => {
   });
 
   it.if(!!libPath)("dlopen() stores a ptr-backed symbol under the index", () => {
-    const { strlen } = dlopen(libPath, { strlen: libSymbols.strlen }).symbols;
-    const lib = dlopen(libPath, {
-      "0": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
-      "4294967294": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
-      strlen: libSymbols.strlen,
-    });
-    expect(Object.keys(lib.symbols).sort()).toEqual(["0", "4294967294", "strlen"]);
-    expect(typeof lib.symbols[0]).toBe("function");
-    expect(typeof lib.symbols[4294967294]).toBe("function");
-    expect(lib.symbols[0](Buffer.from("bunbun\0", "ascii"))).toBe(6n);
-    expect(lib.symbols["4294967294"](Buffer.from("bun\0", "ascii"))).toBe(3n);
-    lib.close();
+    const source = dlopen(libPath, { strlen: libSymbols.strlen });
+    try {
+      const { strlen } = source.symbols;
+      const lib = dlopen(libPath, {
+        "0": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
+        "4294967294": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
+        strlen: libSymbols.strlen,
+      });
+      try {
+        expect(Object.keys(lib.symbols).sort()).toEqual(["0", "4294967294", "strlen"]);
+        expect(typeof lib.symbols[0]).toBe("function");
+        expect(typeof lib.symbols[4294967294]).toBe("function");
+        expect(lib.symbols[0](Buffer.from("bunbun\0", "ascii"))).toBe(6n);
+        expect(lib.symbols["4294967294"](Buffer.from("bun\0", "ascii"))).toBe(3n);
+      } finally {
+        lib.close();
+      }
+    } finally {
+      source.close();
+    }
   });
 });
 

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1394,6 +1394,43 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
   }
 });
 
+// A symbol name that is a canonical array index ("0") has to land in the
+// indexed storage of `symbols`. A named property of the same spelling shows up
+// in Object.keys() but `symbols[0]` cannot find it.
+describe("symbols named like an array index", () => {
+  it("linkSymbols() stores the function under the index", () => {
+    let calls = 0;
+    const callback = new JSCallback(() => void calls++, { args: [], returns: "void" });
+    try {
+      const lib = linkSymbols({ "0": { ptr: callback.ptr, args: [], returns: "void" } });
+      expect(Object.keys(lib.symbols)).toEqual(["0"]);
+      expect(typeof lib.symbols[0]).toBe("function");
+      expect(lib.symbols["0"]).toBe(lib.symbols[0]);
+      expect(0 in lib.symbols).toBe(true);
+      lib.symbols[0]();
+      expect(calls).toBe(1);
+      lib.close();
+    } finally {
+      callback.close();
+    }
+  });
+
+  it.if(!!libPath)("dlopen() stores a ptr-backed symbol under the index", () => {
+    const { strlen } = dlopen(libPath, { strlen: libSymbols.strlen }).symbols;
+    const lib = dlopen(libPath, {
+      "0": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
+      "4294967294": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
+      strlen: libSymbols.strlen,
+    });
+    expect(Object.keys(lib.symbols).sort()).toEqual(["0", "4294967294", "strlen"]);
+    expect(typeof lib.symbols[0]).toBe("function");
+    expect(typeof lib.symbols[4294967294]).toBe("function");
+    expect(lib.symbols[0](Buffer.from("bunbun\0", "ascii"))).toBe(6n);
+    expect(lib.symbols["4294967294"](Buffer.from("bun\0", "ascii"))).toBe(3n);
+    lib.close();
+  });
+});
+
 // oven-sh/bun#35405: toBuffer without a finalizer used to mi_free caller-owned
 // memory on GC. Subprocess because unpatched builds crash.
 describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,6 +1,16 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, compileFixture, isDebug, isGlibcVersionAtLeast, isWindows, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  compileFixture,
+  isDebug,
+  isGlibcVersionAtLeast,
+  isMacOS,
+  isMusl,
+  isWindows,
+  tempDir,
+} from "harness";
 import { platform } from "os";
 
 import {
@@ -1398,46 +1408,44 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
 // indexed storage of `symbols`. A named property of the same spelling shows up
 // in Object.keys() but `symbols[0]` cannot find it.
 describe("symbols named like an array index", () => {
-  it("linkSymbols() stores the function under the index", () => {
+  // A `ptr` field skips the dlsym lookup, so any loadable library works for dlopen.
+  const systemLib = isWindows
+    ? "kernel32.dll"
+    : isMacOS
+      ? "libSystem.B.dylib"
+      : isMusl
+        ? process.arch === "arm64"
+          ? "libc.musl-aarch64.so.1"
+          : "libc.musl-x86_64.so.1"
+        : "libc.so.6";
+
+  it.each([
+    ["linkSymbols()", map => linkSymbols(map)],
+    ["dlopen()", map => dlopen(systemLib, map)],
+  ])("%s stores the function under the index", (_, open) => {
     let calls = 0;
-    const callback = new JSCallback(() => void calls++, { args: [], returns: "void" });
+    const callback = new JSCallback(() => ++calls, { args: [], returns: "int32_t" });
     try {
-      const lib = linkSymbols({ "0": { ptr: callback.ptr, args: [], returns: "void" } });
+      const fn = { ptr: callback.ptr, args: [], returns: "int32_t" };
+      // 4294967294 is the last array index. 4294967295 (2^32 - 1) is the first name that is not one.
+      const lib = open({ "0": fn, named: fn, "4294967294": fn, "4294967295": fn });
       try {
-        expect(Object.keys(lib.symbols)).toEqual(["0"]);
-        expect(typeof lib.symbols[0]).toBe("function");
-        expect(lib.symbols["0"]).toBe(lib.symbols[0]);
-        expect(0 in lib.symbols).toBe(true);
-        lib.symbols[0]();
-        expect(calls).toBe(1);
+        const { symbols } = lib;
+        // Index keys come first, in ascending order. The rest keep insertion order.
+        expect(Object.keys(symbols)).toEqual(["0", "4294967294", "named", "4294967295"]);
+        expect([typeof symbols[0], typeof symbols[4294967294], typeof symbols[4294967295]]).toEqual([
+          "function",
+          "function",
+          "function",
+        ]);
+        expect(symbols["0"]).toBe(symbols[0]);
+        expect([0 in symbols, 4294967294 in symbols, Object.hasOwn(symbols, "0")]).toEqual([true, true, true]);
+        expect([symbols[0](), symbols[4294967294](), symbols.named(), symbols[4294967295]()]).toEqual([1, 2, 3, 4]);
       } finally {
         lib.close();
       }
     } finally {
       callback.close();
-    }
-  });
-
-  it.if(!!libPath)("dlopen() stores a ptr-backed symbol under the index", () => {
-    const source = dlopen(libPath, { strlen: libSymbols.strlen });
-    try {
-      const { strlen } = source.symbols;
-      const lib = dlopen(libPath, {
-        "0": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
-        "4294967294": { ptr: strlen.ptr, args: ["ptr"], returns: "usize" },
-        strlen: libSymbols.strlen,
-      });
-      try {
-        expect(Object.keys(lib.symbols).sort()).toEqual(["0", "4294967294", "strlen"]);
-        expect(typeof lib.symbols[0]).toBe("function");
-        expect(typeof lib.symbols[4294967294]).toBe("function");
-        expect(lib.symbols[0](Buffer.from("bunbun\0", "ascii"))).toBe(6n);
-        expect(lib.symbols["4294967294"](Buffer.from("bun\0", "ascii"))).toBe(3n);
-      } finally {
-        lib.close();
-      }
-    } finally {
-      source.close();
     }
   });
 });

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1107,3 +1107,35 @@ describe.concurrent("false route with no fetch handler", () => {
     await proc.exited;
   });
 });
+
+describe("request.clone() params", () => {
+  // `params` is a plain extensible object, so user code can add a property whose
+  // name is a canonical array index ("0") before clone() copies it. The copy has
+  // to keep such a property in its indexed storage, or `params[0]` misses it.
+  it("copies an own property named like an array index", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/users/:id": req => {
+          (req.params as Record<string, string>)[0] = "zero";
+          (req.params as Record<string, string>)[4294967294] = "max";
+          const params = req.clone().params as Record<string, string>;
+          return Response.json({
+            keys: Object.keys(params).sort(),
+            byIndex: [params[0], params[4294967294]],
+            byString: [params["0"], params["4294967294"]],
+            id: params.id,
+          });
+        },
+      },
+    });
+
+    const res = await fetch(`${server.url}users/42`);
+    expect(await res.json()).toEqual({
+      keys: ["0", "4294967294", "id"],
+      byIndex: ["zero", "max"],
+      byString: ["zero", "max"],
+      id: "42",
+    });
+  });
+});

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -1068,3 +1068,27 @@ it.skipIf(isWindows || isMacOS)(
     expect(exitCode).toBe(0);
   },
 );
+
+// A query-string name or a route parameter that is a canonical array index
+// ("0") has to land in the indexed storage of the object. A named property of
+// the same spelling shows up in Object.keys() but `query[0]` cannot find it.
+it(".query and .params store an array-index name as an indexed property", () => {
+  const { dir } = make(["posts.tsx", "[0].tsx"]);
+  const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+  const query = router.match("/posts?0=a&0=b&1=c&x=y")!.query;
+  expect(query).toEqual({ 0: ["a", "b"], 1: "c", x: "y" });
+  expect(query[0]).toEqual(["a", "b"]);
+  expect(query["1"]).toBe("c");
+  expect(Object.getOwnPropertyDescriptor(query, "0")).toEqual({
+    value: ["a", "b"],
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  const params = router.match("/hello?0=ignored")!.params;
+  expect(params).toEqual({ 0: "hello" });
+  expect(params[0]).toBe("hello");
+  expect(Object.getOwnPropertyNames(params)).toEqual(["0"]);
+});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1985,6 +1985,7 @@ describe("import attributes with an array-index key", () => {
     expect(attributes).toEqual({ 0: "a", 4294967294: "b", type: "json" });
     expect(attributes[0]).toBe("a");
     expect(attributes["4294967294"]).toBe("b");
+    expect(attributes[4294967294]).toBe("b");
   });
 
   test("importModuleDynamically receives the attributes argument", async () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1974,3 +1974,30 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     expect(position).toBeLessThanOrEqual(INT32_MAX);
   });
 });
+
+// An import attribute key is any string literal, so it can be a canonical array
+// index ("0"). The attributes object has to keep it in its indexed storage, or
+// Object.keys() lists a key that `attributes[0]` cannot read.
+describe("import attributes with an array-index key", () => {
+  test("SourceTextModule.moduleRequests[].attributes", () => {
+    const mod = new SourceTextModule('import x from "./y" with { "0": "a", "4294967294": "b", type: "json" };');
+    const { attributes } = mod.moduleRequests[0];
+    expect(attributes).toEqual({ 0: "a", 4294967294: "b", type: "json" });
+    expect(attributes[0]).toBe("a");
+    expect(attributes["4294967294"]).toBe("b");
+  });
+
+  test("importModuleDynamically receives the attributes argument", async () => {
+    const { promise, resolve } = Promise.withResolvers<Record<string, string>>();
+    const script = new Script('import("x", { with: { "0": "a", custom: "b" } })', {
+      importModuleDynamically(_specifier, _referrer, attributes) {
+        resolve(attributes);
+        return new SourceTextModule("export default 1;");
+      },
+    });
+    await script.runInThisContext().catch(() => {});
+    const attributes = await promise;
+    expect(attributes).toEqual({ 0: "a", custom: "b" });
+    expect(attributes[0]).toBe("a");
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1694,6 +1694,42 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
     });
   });
 
+  // A partial descriptor moves the entry from the shared store onto the JS object.
+  // An env var name can be a canonical array index ("0"), and such a property has
+  // to land in the indexed storage, or `process.env[0]` misses it afterwards.
+  it("keeps an array-index env var readable after a partial defineProperty on the shared map", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker, SHARE_ENV } = require("worker_threads");
+         new Worker("1", { eval: true, env: SHARE_ENV }).on("exit", () => {
+           process.env[0] = "zero";
+           Object.defineProperty(process.env, "0", { enumerable: true });
+           console.log(JSON.stringify({
+             byIndex: process.env[0],
+             byString: process.env["0"],
+             listed: Object.keys(process.env).includes("0"),
+             descriptor: Object.getOwnPropertyDescriptor(process.env, "0"),
+           }));
+         });`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ parsed: stdout ? JSON.parse(stdout) : stdout, stderr, exitCode }).toEqual({
+      parsed: {
+        byIndex: "zero",
+        byString: "zero",
+        listed: true,
+        descriptor: { value: "zero", writable: true, enumerable: true, configurable: true },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   // node roots a main-founded SHARE_ENV tree at its RealEnvStore, so a worker writing
   // through it reaches the real environment a child process inherits; a snapshot
   // worker's store is private and never does. (child_process enumerates the JS


### PR DESCRIPTION
### Problem
- Seven native object builders store a data-derived property name with plain `putDirect`. For an array index such as `"0"`, a debug build aborts with `ASSERTION FAILED: !parseIndex(propertyName)` (`JSObjectInlines.h:501`, `putDirectInternal`). A release build stores a named "ghost" property: `Object.keys()` lists it, `obj[0]` misses it.
- Reachable from `bun:ffi` `dlopen()`/`linkSymbols()`, `Bun.FileSystemRouter` `.query`/`.params`, `node:vm` import attributes, `request.clone().params`, `process.env` under `SHARE_ENV`, bake `FrameworkRouter` params (a `[0].tsx` file), and `os.networkInterfaces()` (an interface named `0`). File:line per site in Notes.
- Every Rust member went through one door, `JSValue::put`, whose `PutKey` trait accepted any runtime key. This is the 16th per-site fix of the class.

### Fix
- `PutKey` accepts only `'static` byte and string slices, so a name from data has to use `put_may_be_index`. The compiler found the `cc()` site (`ffi_body.rs:1224`) and three `format!` keys in `node_quic_binding.rs`; the other breaks were constant keys. `JSC__JSValue__putBunString` is dead and removed.
- The C++ sites call `putDirectMayBeIndex`. `NodeVMModuleRequest::toJS` needs `ReadOnly | DontDelete`, so it splits on `parseIndex` like `JSMockFunction.cpp` does.
- The C++ helpers that take runtime keys from Rust (`putRecord`, `upsertBunStringArray`, `fromEntries`) are index-safe themselves.
- Verified: one new test per member in seven files (list in Notes). Each fails on stock bun 1.4.1 or aborts an unfixed debug build.

### Background
- JSC keeps a property whose name is a canonical array index (`"0"` to `"4294967294"`, no leading zero) in the indexed storage of the object, never in its Structure. `putDirect` writes the Structure only. `putDirectMayBeIndex` picks the storage with `parseIndex`.
- Self-reviewed: 5 concerns raised, 3 addressed. Rejected: absorbing the open sibling PR #32240 (listed in Notes), and `putDirectMayBeIndex` in `NodeVMModule.cpp` (no attributes parameter). #41071 (the `bun:ffi` sites alone) is closed and folded into this PR.

<details><summary>Notes</summary>

Tests: `test/js/bun/ffi/ffi.test.js`, `test/js/bun/util/filesystem_router.test.ts`, `test/js/node/vm/vm.test.ts`, `test/js/bun/http/bun-serve-routes.test.ts`, `test/js/node/worker_threads/worker_threads.test.ts`, `test/bake/framework-router.test.ts`, `test/bake/dev/route-params.test.ts` (new file: dev server tests have to live in `test/bake/dev`).

Helpers: `putRecord` builds `FileSystemRouter.query` and `.params`, `upsertBunStringArray` builds bake params (a repeated catch-all key becomes an array), `fromEntries` builds `FileSystemRouter.routes`.

Sites, before this change:

- `src/runtime/ffi/ffi_body.rs:1563` (`dlopen`), `:1648` (`linkSymbols`), `:1224` (`cc`, not reachable with an index name: TinyCC rejects a C identifier named `0` first).
- `src/jsc/bindings/bindings.cpp:3055` (`JSC__JSObject__putRecord`, the `FileSystemRouter` `.query` and `.params` builder, a redundant `putDirect` after `defineOwnProperty`) and `:3443` (`JSC__JSValue__fromEntries`, `.routes`, names always start with `/`).
- `src/jsc/bindings/NodeVMSourceTextModule.cpp:289` (`moduleRequests[].attributes`), `NodeVMModule.cpp:38` (`getModuleRequests()`), `NodeVM.cpp:85` (the `attributes` argument of `importModuleDynamically`).
- `src/jsc/bindings/JSBunRequest.cpp:122` (`clone()` copies `params`, which user code can extend with `req.params[0] = "x"`).
- `src/jsc/bindings/JSEnvironmentVariableMap.cpp:851` (`JSSharedEnvMap::defineOwnProperty`, the partial-descriptor path).
- `src/runtime/bake/FrameworkRouter.rs:1237` (`MatchedParams::to_js`, through `JSC__JSValue__upsertBunStringArray` in `BunString.cpp`) and `:1886` (`FrameworkRouter.match()`).
- `src/runtime/node/node_os.rs:1136` and `:1316` (`networkInterfaces`). The lookup before the store moved from `JSValue::get` to `get_own`: `getNonIndexPropertySlotPrototypePollutionMitigation` asserts on an index name as well.

Release symptom on bun 1.4.1: `linkSymbols({ "0": { ptr, args: [], returns: "void" } }).symbols[0]` is `undefined` while `Object.keys()` lists `"0"`. Same for `dlopen()` with a `ptr`-backed symbol, `new vm.SourceTextModule('import x from "./y" with { "0": "json" }').moduleRequests[0].attributes[0]`, the `attributes` argument of `importModuleDynamically` for `import("x", { with: { "0": "a" } })`, `req.clone().params[0]` after `req.params[0] = "x"`, and `new FrameworkRouter(...).match("/hello").params[0]` with a `[0].tsx` page. `FileSystemRouter` and the `SHARE_ENV` map show no release symptom (`defineOwnProperty` and the store answered reads). Their tests fail on a debug build only.

`os.networkInterfaces()` has no test. An interface named `0` needs `CAP_NET_ADMIN`, which the test environment does not have. The change has the same shape as the others and `cargo check --target x86_64-pc-windows-msvc` covers the Windows branch.

`PutKey` change, call sites the compiler named: `ffi_body.rs:1224` (`put_may_be_index`), `node_quic_binding.rs` (three `format!("IDX_STATS_..._{name}")` keys, now `put_num_formatted` over `put_may_be_index`; `put_num` and `put_str` take `&'static str`), `quic/endpoint.rs:1086` and `quic/session.rs:2229`, `:2258` (`&'static [u8]` parameters), `node_assert.rs:244`, `:249` and `node_assert_binding.rs:114`, `:125`, `:136` (`String::static_("x")` to `b"x"`). `put_non_enumerable` takes `&'static [u8]` for the same reason. `util.parseEnv` (`node_util_binding.rs:240`) was the same kind of site and #41063 fixed it first.

Same class, separate PRs: #41071 fixed the `bun:ffi` sites on their own with the same `ffi_body.rs` edits. It is closed in favor of this PR. Its test covered `dlopen()` on every platform through a `ptr`-backed symbol in a system library, and the `4294967295` boundary (the first name that is not an index). Both are now in the `ffi.test.js` test here. #37238 (`bun:sqlite` rows, `JSSQLStatement.cpp:858`, `:2066`), #32240 (`JSBroadcastChannel.cpp:200`) and #40008 (`URLSearchParams` and web streams inspect options) cover the remaining known C++ members and stay separate.

Suites run with the debug build: the seven test files above in full, plus `test/js/node/os/os.test.js`, `test/js/node/util/util.test.js`, `test/js/node/assert/assert.spec.ts`, `test/js/node/quic/quic-endpoint.test.ts`, `quic-stream.test.ts`, `test/js/bun/ffi/cc.test.ts`, `test/js/node/test/parallel/test-vm-module-{basic,dynamic-import,errors}.js`, and `worker_threads.test.ts` (138 pass). Pre-existing failures in this container: `ffi.test.js` "ptr argument: ArrayBuffer cells through an FTL-compiled call site" hits the 5 s timeout on debug+ASAN, and `os.test.js` "userInfo" expects `$USER`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts, test/js/bun/util/filesystem_router.test.ts, test/js/bun/ffi/ffi.test.js

<!-- robobun:evidence:end -->
