### PR TITLE
Add Bun.CookieMap.getAll() for cookie names that repeat in a header

### DIFF
--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -77,6 +77,17 @@ if (cookie != null) {
 }
 ```
 
+#### `getAll(name: string): string[]`
+
+Retrieves every value for a cookie name. A `Cookie` header can repeat a name, and `get()` returns only the first value.
+
+```ts title="get-all-cookies.ts" icon="/icons/typescript.svg"
+const cookies = new Bun.CookieMap("session=first; session=second");
+
+cookies.get("session"); // "first"
+cookies.getAll("session"); // ["first", "second"]
+```
+
 #### `has(name: string): boolean`
 
 Checks if a cookie with the given name exists.
@@ -438,6 +449,7 @@ class CookieMap implements Iterable<[string, string]> {
   constructor(init?: string[][] | Record<string, string> | string);
 
   get(name: string): string | null;
+  getAll(name: string): string[];
 
   toSetCookieHeaders(): string[];
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -10405,6 +10405,14 @@ declare module "bun" {
     get(name: string): string | null;
 
     /**
+     * Gets every value of the cookies with the specified name.
+     *
+     * @param name - The name of the cookies to retrieve
+     * @returns The cookie values in order, or an empty array if none match
+     */
+    getAll(name: string): string[];
+
+    /**
      * Returns the `Set-Cookie` header values that apply the changes made to this map.
      *
      * @returns An array of `Set-Cookie` header values

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -147,6 +147,18 @@ std::optional<String> CookieMap::get(const String& name) const
     return std::nullopt;
 }
 
+Vector<String> CookieMap::getAll(const String& name)
+{
+    Vector<String> values;
+    auto iterator = createIterator();
+    while (auto entry = iterator.next()) {
+        if (entry->key == name) {
+            values.append(entry->value);
+        }
+    }
+    return values;
+}
+
 bool CookieMap::has(const String& name) const
 {
     return get(name).has_value();

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -26,6 +26,7 @@ public:
     static ExceptionOr<Ref<CookieMap>> create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& init, bool throwOnInvalidCookieString = true);
 
     std::optional<String> get(const String& name) const;
+    Vector<String> getAll(const String& name);
     Vector<Ref<Cookie>> getAllChanges() const { return m_modifiedCookies; }
 
     bool has(const String& name) const;

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -47,6 +47,7 @@ CookieMap* toWrapped(JSGlobalObject& lexicalGlobalObject, ExceptionThrower&& exc
 }
 
 static JSC_DECLARE_HOST_FUNCTION(jsCookieMapPrototypeFunction_get);
+static JSC_DECLARE_HOST_FUNCTION(jsCookieMapPrototypeFunction_getAll);
 static JSC_DECLARE_HOST_FUNCTION(jsCookieMapPrototypeFunction_toSetCookieHeaders);
 static JSC_DECLARE_HOST_FUNCTION(jsCookieMapPrototypeFunction_has);
 static JSC_DECLARE_HOST_FUNCTION(jsCookieMapPrototypeFunction_set);
@@ -218,6 +219,7 @@ template<> void JSCookieMapDOMConstructor::initializeProperties(VM& vm, JSDOMGlo
 static const HashTableValue JSCookieMapPrototypeTableValues[] = {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsCookieMapConstructor, 0 } },
     { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsCookieMapPrototypeFunction_get, 1 } },
+    { "getAll"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsCookieMapPrototypeFunction_getAll, 1 } },
     { "toSetCookieHeaders"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsCookieMapPrototypeFunction_toSetCookieHeaders, 0 } },
     { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsCookieMapPrototypeFunction_has, 1 } },
     { "set"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsCookieMapPrototypeFunction_set, 2 } },
@@ -323,6 +325,37 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_getBody(JSC::JSGl
 JSC_DEFINE_HOST_FUNCTION(jsCookieMapPrototypeFunction_get, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     return IDLOperation<JSCookieMap>::call<jsCookieMapPrototypeFunction_getBody>(*lexicalGlobalObject, *callFrame, "get");
+}
+
+// Implementation of the getAll method
+static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_getAllBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSCookieMap>::ClassParameter castedThis)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto& impl = castedThis->wrapped();
+
+    Vector<WTF::String> values;
+    if (callFrame->argumentCount() >= 1) {
+        auto name = convert<IDLUSVString>(*lexicalGlobalObject, callFrame->uncheckedArgument(0));
+        RETURN_IF_EXCEPTION(throwScope, {});
+        values = impl.getAll(name);
+    }
+
+    JSC::JSArray* resultArray = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, values.size());
+    RETURN_IF_EXCEPTION(throwScope, {});
+    size_t i = 0;
+    for (auto& value : values) {
+        resultArray->putDirectIndex(lexicalGlobalObject, i, jsString(vm, value));
+        RETURN_IF_EXCEPTION(throwScope, {});
+        i += 1;
+    }
+
+    return JSValue::encode(resultArray);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsCookieMapPrototypeFunction_getAll, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSCookieMap>::call<jsCookieMapPrototypeFunction_getAllBody>(*lexicalGlobalObject, *callFrame, "getAll");
 }
 
 static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_toSetCookieHeadersBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSCookieMap>::ClassParameter castedThis)

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -455,6 +455,86 @@ describe("delete with prefixed cookie names", () => {
   });
 });
 
+describe("duplicate cookie names", () => {
+  test("a repeated name in a Cookie header keeps every value", () => {
+    const map = new Bun.CookieMap("session=first; other=x; session=second");
+    expect(map.size).toBe(3);
+    expect(map.get("session")).toBe("first");
+    expect(map.getAll("session")).toEqual(["first", "second"]);
+    expect(map.getAll("other")).toEqual(["x"]);
+    expect(map.getAll("missing")).toEqual([]);
+    expect([...map]).toEqual([
+      ["session", "first"],
+      ["other", "x"],
+      ["session", "second"],
+    ]);
+    expect(map.toJSON()).toEqual({ session: "first", other: "x" });
+  });
+
+  test("a repeated name in array pairs keeps every value", () => {
+    const map = new Bun.CookieMap([
+      ["session", "first"],
+      ["session", "second"],
+    ]);
+    expect(map.size).toBe(2);
+    expect(map.get("session")).toBe("first");
+    expect(map.getAll("session")).toEqual(["first", "second"]);
+  });
+
+  test("getAll matches the entries the iterator yields for that name", () => {
+    const map = new Bun.CookieMap("a=1; b=2; a=3; a=4");
+    const fromIterator = [...map].filter(([name]) => name === "a").map(([, value]) => value);
+    expect(map.getAll("a")).toEqual(fromIterator);
+    expect(map.getAll("a")).toEqual(["1", "3", "4"]);
+    expect(map.get("a")).toBe(fromIterator[0]);
+  });
+
+  test("getAll keeps identical repeated values", () => {
+    const map = new Bun.CookieMap("a=1; a=1");
+    expect(map.size).toBe(2);
+    expect(map.getAll("a")).toEqual(["1", "1"]);
+  });
+
+  test("getAll without a name returns an empty array", () => {
+    const map = new Bun.CookieMap("a=1");
+    // @ts-expect-error name is required
+    expect(map.getAll()).toEqual([]);
+  });
+
+  test("set replaces every value of that name", () => {
+    const map = new Bun.CookieMap("session=first; session=second");
+    map.set("session", "third");
+    expect(map.size).toBe(1);
+    expect(map.get("session")).toBe("third");
+    expect(map.getAll("session")).toEqual(["third"]);
+    expect(map.toSetCookieHeaders()).toEqual(["session=third; Path=/; SameSite=Lax"]);
+  });
+
+  test("delete removes every value of that name", () => {
+    const map = new Bun.CookieMap("session=first; session=second; other=x");
+    map.delete("session");
+    expect(map.size).toBe(1);
+    expect(map.get("session")).toBe(null);
+    expect(map.getAll("session")).toEqual([]);
+    expect(map.getAll("other")).toEqual(["x"]);
+  });
+
+  test("getAll sees values added with set", () => {
+    const map = new Bun.CookieMap();
+    expect(map.getAll("a")).toEqual([]);
+    map.set("a", "1");
+    expect(map.getAll("a")).toEqual(["1"]);
+    map.set("a", "2");
+    expect(map.getAll("a")).toEqual(["2"]);
+  });
+
+  test("getAll decodes percent-encoded values like get", () => {
+    const map = new Bun.CookieMap("a=hello%20world; a=caf%C3%A9");
+    expect(map.get("a")).toBe("hello world");
+    expect(map.getAll("a")).toEqual(["hello world", "café"]);
+  });
+});
+
 describe("invalid delete usage", () => {
   test("invalid usage does not crash", () => {
     expect(() => {

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -203,10 +203,7 @@ describe("Bun.CookieMap", () => {
     // Since we're overwriting cookies with the same name,
     // the size should still be 1
     expect(cookieMap.size).toBe(1);
-
-    // But this would work if we didn't overwrite
-    // const cookies = cookieMap.getAll("name");
-    // expect(cookies.length).toBe(2);
+    expect(cookieMap.getAll("name")).toEqual(["value2"]);
   });
 
   test("supports iteration", () => {


### PR DESCRIPTION
### Problem
- `new Bun.CookieMap("session=first; session=second")` has `size === 2` and iterates both entries, but `get("session")` only returns `"first"`. Nothing exposes the other value by name. Fixes #41037.

### Fix
- Add `CookieMap.getAll(name): string[]`. It collects the matching values from the same iterator that `entries()` uses. `get()` is unchanged.
- Verified: `test/js/bun/cookie/cookie-map.test.ts` (new `duplicate cookie names` block, fails on stock bun with `getAll is not a function`).

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/util/cookie.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [17.43ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [6.05ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [4.81ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [158.02ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.28ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.51ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [4.56ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [4.67ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [3.26ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [10.52ms]
(pass) Bun.Cookie an
... (truncated)

release without fix: 18 skipped
bun test v1.4.1-canary.1 (bd292f775)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.05ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.09ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [5.32ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.08ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [0.05ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [0.02ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.serialize creates cookie string [0.03ms]
(pass) Bun.Cookie and Bun.CookieMap > can create an empty CookieMap [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > can create Cooki
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/util/cookie.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [18.08ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [5.54ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [4.71ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [157.43ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.26ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.78ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [4.71ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [4.89ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.26ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [10.01ms]
(pass) Bun.Cookie an
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 587ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/30] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/30] gen cpp.rs (cppbind)
[3/30] gen JS modules (bundle-modules)
Preprocess modules (7325ms)
Bundle modules (33ms)
Postprocesss modules (265ms)
Bundle Functions (471ms)
Generate Code (25ms)

[8.13s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/23] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/cookies.mdx                 | 12 +++++
 packages/bun-types/bun.d.ts              |  8 ++++
 src/jsc/bindings/CookieMap.cpp           | 12 +++++
 src/jsc/bindings/CookieMap.h             |  1 +
 src/jsc/bindings/webcore/JSCookieMap.cpp | 33 +++++++++++++
 test/js/bun/cookie/cookie-map.test.ts    | 80 ++++++++++++++++++++++++++++++++
 test/js/bun/util/cookie.test.js          |  5 +-
 7 files changed, 147 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
docs/runtime/cookies.mdx                      2      6     12
packages/bun-types/bun.d.ts                   2      4     12
src/jsc/bindings/CookieMap.cpp                4      6     12
src/jsc/bindings/CookieMap.h                  1      2     12
src/jsc/bindings/webcore/JSCookieMap.cpp      1      3     13
test/js/bun/cookie/cookie-map.test.ts         2      2      9
test/js/bun/util/cookie.test.js               4      2      7
```

</details>

<!-- robobun:evidence:end -->