### PR TITLE
bun-types: type `with { type }` imports on TypeScript 7.1

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,6 +20,10 @@ scripts/build/xmac.mjs
 # the output codeblocks need to stay minified
 docs/bundler/minifier.mdx
 
+# `declare module "*" with { type: "text" }` is TypeScript 7.1 syntax that
+# prettier's parser does not accept yet
+packages/bun-types/ts7.1
+
 # generated working notes for the Rust port — dense markdown with inline code
 # refs that prettier doesn't reformat to a fixed point (it keeps re-escaping
 # `_`/`*` differently every pass), so autofix.ci ping-pongs commits forever.

--- a/docs/bundler/loaders.mdx
+++ b/docs/bundler/loaders.mdx
@@ -19,6 +19,12 @@ import my_toml from "./my_file" with { type: "toml" };
 const { default: my_toml } = await import("./my_file", { with: { type: "toml" } });
 ```
 
+<Note>
+  With TypeScript 7.1 or newer, `@types/bun` types these imports from the `type` attribute: a `type: "text"` import is a
+  `string`, a `type: "sqlite"` import is a `Database`. Older TypeScript versions type the import from the file extension
+  alone.
+</Note>
+
 ## Built-in loaders
 
 ### `js`

--- a/docs/runtime/file-types.mdx
+++ b/docs/runtime/file-types.mdx
@@ -17,6 +17,12 @@ import my_toml from "./my_file" with { type: "toml" };
 const { default: my_toml } = await import("./my_file", { with: { type: "toml" } });
 ```
 
+<Note>
+  With TypeScript 7.1 or newer, `@types/bun` types these imports from the `type` attribute: a `type: "text"` import is a
+  `string`, a `type: "sqlite"` import is a `Database`. Older TypeScript versions type the import from the file extension
+  alone.
+</Note>
+
 ---
 
 ## Built-in loaders

--- a/packages/bun-types/authoring.md
+++ b/packages/bun-types/authoring.md
@@ -58,6 +58,7 @@ Types are organized across multiple `.d.ts` files in the `packages/bun-types` di
 - `globals.d.ts` - Global type declarations
 - `test.d.ts` - Testing-related types
 - `sqlite.d.ts` - SQLite-related types
+- `ts7.1/` - Declarations that need TypeScript 7.1 syntax, such as `declare module "*" with { type: "text" }`. Older compilers reject that syntax even with `skipLibCheck`, so `typesVersions` in `package.json` sends TypeScript 7.1 and newer to `ts7.1/index.d.ts`, which references `../index.d.ts` plus the extra files. Every other version keeps loading `index.d.ts`. Prettier and the repository's own `tsconfig.json` skip this folder for the same reason.
 - ...etc. You can make more files
 
 Note: The order of references in `index.d.ts` is important - `bun.ns.d.ts` must be referenced last to ensure the `Bun` global gets defined properly.

--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -2,6 +2,13 @@
   "name": "bun-types",
   "license": "MIT",
   "types": "./index.d.ts",
+  "typesVersions": {
+    ">=7.1": {
+      "index.d.ts": [
+        "ts7.1/index.d.ts"
+      ]
+    }
+  },
   "description": "Type definitions and documentation for Bun, an incredibly fast JavaScript runtime",
   "repository": {
     "type": "git",
@@ -10,6 +17,7 @@
   },
   "files": [
     "./*.d.ts",
+    "./ts7.1/*.d.ts",
     "./CLAUDE.md",
     "./docs/*.md",
     "./docs/*.mdx",

--- a/packages/bun-types/ts7.1/import-attributes.d.ts
+++ b/packages/bun-types/ts7.1/import-attributes.d.ts
@@ -1,0 +1,87 @@
+// Bun picks the loader from the `type` import attribute, so a file with any
+// extension can be imported as text, TOML, a SQLite database, and so on:
+//
+//   import template from "./template.html" with { type: "text" };
+//
+// TypeScript 7.1 resolves an import that has attributes against the pattern
+// ambient modules below before it looks at the file extension. Older compilers
+// reject this syntax even with `skipLibCheck`, so this file lives under ts7.1/
+// and is only reachable through `typesVersions` in package.json.
+//
+// `type: "json"` and `type: "macro"` are absent on purpose. A matching
+// declaration here wins over the real file, so `import pkg from
+// "./package.json" with { type: "json" }` would become `any` instead of
+// keeping the precise type of the JSON file. The same goes for a macro's
+// exports.
+
+declare module "*" with { type: "text" } {
+  /**
+   * The contents of the file as a string.
+   */
+  var text: string;
+  export = text;
+}
+
+declare module "*" with { type: "file" } {
+  /**
+   * The path to the file. At runtime this is the absolute path on disk. In a
+   * bundle it is the path of the copied asset, prefixed with `publicPath`.
+   */
+  var path: string;
+  export = path;
+}
+
+declare module "*" with { type: "md" } {
+  /**
+   * The Markdown rendered to HTML.
+   */
+  var html: string;
+  export = html;
+}
+
+declare module "*" with { type: "markdown" } {
+  /**
+   * The Markdown rendered to HTML.
+   */
+  var html: string;
+  export = html;
+}
+
+declare module "*" with { type: "toml" } {
+  var contents: any;
+  export = contents;
+}
+
+declare module "*" with { type: "yaml" } {
+  var contents: any;
+  export = contents;
+}
+
+declare module "*" with { type: "jsonc" } {
+  var contents: any;
+  export = contents;
+}
+
+declare module "*" with { type: "json5" } {
+  var contents: any;
+  export = contents;
+}
+
+declare module "*" with { type: "xml" } {
+  var contents: import("bun").XML.Document;
+  export = contents;
+}
+
+declare module "*" with { type: "sqlite" } {
+  /**
+   * The database, opened with `bun:sqlite`. `embed: "true"` bundles the
+   * database file into the output and resolves here as well.
+   */
+  var db: import("bun:sqlite").Database;
+  export = db;
+}
+
+declare module "*" with { type: "html" } {
+  var contents: import("bun").HTMLBundle;
+  export = contents;
+}

--- a/packages/bun-types/ts7.1/index.d.ts
+++ b/packages/bun-types/ts7.1/index.d.ts
@@ -1,0 +1,6 @@
+// Entry point for TypeScript 7.1 and newer, selected by `typesVersions` in
+// package.json. It adds the declarations that use syntax older compilers
+// cannot parse. Everything else comes from ../index.d.ts.
+
+/// <reference path="../index.d.ts" />
+/// <reference path="./import-attributes.d.ts" />

--- a/packages/bun-types/tsconfig.json
+++ b/packages/bun-types/tsconfig.json
@@ -8,5 +8,6 @@
     "declarationDir": "out"
   },
   "include": ["**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  // ts7.1/ uses syntax that the repository's TypeScript cannot parse yet.
+  "exclude": ["dist", "node_modules", "ts7.1"]
 }

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -367,6 +367,36 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // TypeScript 7.1 resolves `import x from "./f" with { type: "text" }` against
+  // `declare module "*" with { type: "text" }` (microsoft/TypeScript#63931).
+  // bun-types ships those declarations in ts7.1/, reached through
+  // package.json#typesVersions, so they are invisible to the compilers above.
+  // `>=7.1.0-0` takes the nightly until a 7.1 release exists, then the release.
+  describe("TypeScript 7.1", () => {
+    test.skipIf(isDebug)("import attributes pick the loader's module type", async () => {
+      const fixtureDir = await createIsolatedFixture(["typescript@>=7.1.0-0"]);
+
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.compilerOptions.skipLibCheck = false;
+      tsconfig.include = ["ts7.1/*.ts"];
+      await Bun.write(join(fixtureDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(fixtureDir, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: fixtureDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   // Runs on debug builds too: spawning tsc over a single file is cheap,
   // unlike the in-process LanguageService runs above.
   describe("Bun.mmap", () => {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -371,14 +371,16 @@ describe("@types/bun integration test", () => {
   // `declare module "*" with { type: "text" }` (microsoft/TypeScript#63931).
   // bun-types ships those declarations in ts7.1/, reached through
   // package.json#typesVersions, so they are invisible to the compilers above.
+  // This run checks the whole fixture through that entry point, plus the
+  // fixture/ts7.1 files that only that compiler can type.
   // `>=7.1.0-0` takes the nightly until a 7.1 release exists, then the release.
   describe("TypeScript 7.1", () => {
-    test.skipIf(isDebug)("import attributes pick the loader's module type", async () => {
+    test.skipIf(isDebug)("checks the fixture and import attributes through ts7.1/index.d.ts", async () => {
       const fixtureDir = await createIsolatedFixture(["typescript@>=7.1.0-0"]);
 
       const tsconfig = structuredClone(sourceTsconfig);
       tsconfig.compilerOptions.skipLibCheck = false;
-      tsconfig.include = ["ts7.1/*.ts"];
+      tsconfig.include = ["*.ts", "*.tsx", "ts7.1/*.ts"];
       await Bun.write(join(fixtureDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
 
       await using proc = Bun.spawn({

--- a/test/integration/bun-types/fixture/ts7.1/import-attributes.ts
+++ b/test/integration/bun-types/fixture/ts7.1/import-attributes.ts
@@ -1,0 +1,61 @@
+// Checked by the "TypeScript 7.1" case in ../../bun-types.test.ts, with a compiler
+// that understands `declare module "*" with { type: "text" }`. It lives outside the
+// fixture root so the older compilers used by the other cases never see it.
+
+import type { HTMLBundle, XML } from "bun";
+import type { Database } from "bun:sqlite";
+import { expectType } from "../utilities";
+
+// The `type` attribute picks the loader, whatever the extension says.
+import text from "./template.html" with { type: "text" };
+expectType(text).is<string>();
+
+import path from "./logo.svg" with { type: "file" };
+expectType(path).is<string>();
+
+import md from "./notes.txt" with { type: "md" };
+expectType(md).is<string>();
+
+import markdown from "./notes.txt" with { type: "markdown" };
+expectType(markdown).is<string>();
+
+import toml from "./config" with { type: "toml" };
+expectType(toml).is<any>();
+
+import yaml from "./config.txt" with { type: "yaml" };
+expectType(yaml).is<any>();
+
+import jsonc from "./config.txt" with { type: "jsonc" };
+expectType(jsonc).is<any>();
+
+import json5 from "./config.txt" with { type: "json5" };
+expectType(json5).is<any>();
+
+import feed from "./feed.rss" with { type: "xml" };
+expectType(feed).is<XML.Document>();
+
+import db from "./app.db" with { type: "sqlite" };
+expectType(db).is<Database>();
+
+// `embed` narrows the attributes, so the `sqlite` declaration still matches.
+import embedded from "./app.db" with { type: "sqlite", embed: "true" };
+expectType(embedded).is<Database>();
+
+import bundle from "./page.txt" with { type: "html" };
+expectType(bundle).is<HTMLBundle>();
+
+// Dynamic imports carry their attributes too.
+const dynamic = await import("./template.html", { with: { type: "text" } });
+expectType(dynamic.default).is<string>();
+
+// Without an attribute the extension still decides.
+import html from "./page.html";
+expectType(html).is<HTMLBundle>();
+
+import txt from "./notes.txt";
+expectType(txt).is<string>();
+
+// `type: "json"` has no declaration on purpose: the import resolves to the real
+// file and keeps its precise type.
+import fact from "../file.json" with { type: "json" };
+expectType(fact).is<{ bun: string; fact: boolean }>();

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -41,6 +41,7 @@
     "./snapshots",
     "./js/deno",
     "./node.js", // entire node.js upstream repository
-    "regression/issue/14477/*-mismatch.tsx" // deliberately-mismatched JSX, the test asserts the parse error
+    "regression/issue/14477/*-mismatch.tsx", // deliberately-mismatched JSX, the test asserts the parse error
+    "integration/bun-types/fixture/ts7.1" // only types with TypeScript >= 7.1, see bun-types.test.ts
   ]
 }


### PR DESCRIPTION
### Problem
- `import html from "./index.html" with { type: "text" }` is a `string` at runtime, but bun-types types an import from its extension only (`*.html` gives `HTMLBundle`). Same for `type: "sqlite"`, `type: "toml"` and the other loaders. #25508 was closed for this reason.
- TypeScript 7.1 adds `declare module "*" with { type: "text" } { ... }` (microsoft/TypeScript#63931, merged 2026-09-01). An import with attributes resolves to the matching pattern module before the extension.
- Fixes #25508 and #13662 (`with { type: "text" }` on an `.html` file typed as `HTMLBundle`) and the `ts(2307)` half of #25328 (`./my.db with { type: "sqlite" }`).

### Fix
- `packages/bun-types/ts7.1/import-attributes.d.ts` declares `"*" with { type }` modules for text, file, md, markdown, toml, yaml, jsonc, json5, xml, sqlite (also with `embed: "true"`) and html, with the shapes `extensions.d.ts` gives the same loaders.
- TypeScript 6.0 and 7.0 report syntax errors on this syntax even with `skipLibCheck`. So `package.json#typesVersions` sends `>=7.1` to `ts7.1/index.d.ts`, which references `../index.d.ts` plus the new file. Every other version loads `index.d.ts` as before. Verified with 6.0.2, 7.0.2 and a `tsc` built from the TS merge commit.
- `type: "json"` and `type: "macro"` have no declaration on purpose. A matching declaration beats the real file, so `./package.json with { type: "json" }` would become `any`.
- Verified: the new "TypeScript 7.1" case in `test/integration/bun-types/bun-types.test.ts` type-checks the whole fixture plus `fixture/ts7.1/import-attributes.ts` through `ts7.1/index.d.ts` with `typescript@>=7.1.0-0`. The other cases pass unchanged.

### Background
- A pattern ambient module, `declare module "*.txt" { ... }`, types every import whose specifier matches. `extensions.d.ts` uses them for `.txt`, `.toml`, `.html` and so on.
- `typesVersions` picks a different entry file per TypeScript version. TypeScript compares the range with its major.minor, so `>=7.1` covers the 7.1 nightlies and the release.
- TypeScript 7.1 matches an import to a module when the import's attributes are assignable to the module's attribute type. The most specific match wins.

### Status
- `typescript@7.1.0-dev.20260901.1` (published 2026-09-01 08:38 UTC) is the first nightly with the feature. The "TypeScript 7.1" case passes with it; the earlier red runs used the 20260831 nightly.

<details><summary>Notes</summary>

Runtime shapes, probed with bun 1.4.1 (one file per attribute to avoid the module cache of #19834):

- `text`: `string` default export, no named exports.
- `file`, `base64`, `dataurl`: the absolute path as a `string` at runtime (the bundler turns `base64`/`dataurl` into strings too).
- `md`, `markdown`: rendered HTML `string`.
- `toml`, `yaml`, `json`, `jsonc`, `json5`: the parsed object, default plus named exports for the top-level keys.
- `xml`: the compact `Bun.XML.Document` shape.
- `sqlite`: a `bun:sqlite` `Database`.
- `html`: an `HTMLBundle`.
- `css`: an empty object. Not declared, browsers give `type: "css"` another meaning.
- `wasm`: depends on the module. Not declared.

Verification of the gate (fake package with the same layout): TS 6.0.2 and 7.0.2 load `index.d.ts` and report nothing. `typescript@7.1.0-dev.20260831.1` (the nightly from before the merge) loads `ts7.1/index.d.ts` and reports TS1005, which proves the redirect. A `tsc` built from microsoft/TypeScript@253c5e2 (Go 1.26 built from source, because the toolchain proxy is blocked here) type-checks the new fixture with `skipLibCheck: false` and exits 0. It also exits 0 with `module: esnext`, with `lib.dom`, and with `types: ["bun-types"]`. Without the new declarations the same fixture reports 11 errors. A probe with a `type: "json"` declaration added turned `../file.json with { type: "json" }` into `any`, which is why json is left out.

`{ type: "sqlite", embed: "true" }` is assignable to `{ type: "sqlite" }`, so the `embed` form resolves to the same `Database` declaration. The fixture covers it.

`export =` was kept over `export default` so the attribute module and the matching `extensions.d.ts` module give the same types, and so `any` keeps working for default imports of toml/yaml/jsonc/json5. Named imports from the `any` modules report TS2305 in TypeScript today, the same as `*.toml`.

Repository plumbing: prettier 3.6.2 cannot parse the new syntax, so `.prettierignore` skips `packages/bun-types/ts7.1`. `packages/bun-types/tsconfig.json` excludes the folder for the same reason (its `include` is `**/*.ts`, and the repository pins typescript 6.0.2), and `test/tsconfig.json` excludes `integration/bun-types/fixture/ts7.1`, which only types with the compiler the test installs. The bun.com API reference bakes `packages/bun-types`; if that build parses every `.d.ts` with a compiler older than 7.1, `ts7.1/` has to be skipped there too.

Follow-up: #40836 adds a `bytes` loader. Once it lands, `declare module "*" with { type: "bytes" }` returning `Uint8Array` belongs in the same file.

</details>
