### PR TITLE
test(inspector): park the inspectee at a second debugger statement before it exits

### DIFF
--- a/test/cli/inspect/bun-inspector-protocol.test.ts
+++ b/test/cli/inspect/bun-inspector-protocol.test.ts
@@ -98,13 +98,19 @@ function checkObject(
 const fixtureFiles = ["entry.mjs", "dep.cjs"];
 
 test("the protocol snapshot in packages/bun-inspector-protocol matches what bun sends", async () => {
+  // reportError() counts as an unhandled error, so bun exits with code 1 as soon as the module
+  // body finishes, whatever else is scheduled. The inspector writes its messages from the
+  // debugger thread, and an inspectee that exits right after Debugger.resume can be gone before
+  // the resume response and the Debugger.resumed event reach the socket. The second debugger
+  // statement parks the inspectee after the first resume until the test has those messages and
+  // closes the connection, which resumes it for good.
   using dir = tempDir("bun-inspector-protocol", {
     "entry.mjs": `
       import "./dep.cjs";
       console.log("hello");
       reportError(new Error("reported"));
       debugger;
-      setInterval(() => {}, 60_000);
+      debugger;
     `,
     "dep.cjs": `module.exports = 1;`,
   });
@@ -230,9 +236,12 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
     await send("LifecycleReporter.getModuleGraph");
 
     const resumed = waitForEvent("Debugger.resumed");
+    const pausedAgain = waitForEvent("Debugger.paused");
     await send("Debugger.resume");
     await resumed;
+    await pausedAgain;
   } finally {
+    // Closing the last connection resumes the parked inspectee, which then exits.
     ws.close();
   }
 
@@ -261,4 +270,6 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
       "LifecycleReporter.error",
     ]),
   );
+  // The disconnect resumed the inspectee, and reportError() made its exit fatal.
+  expect(await proc.exited).toBe(1);
 });


### PR DESCRIPTION
### Problem
- `test/cli/inspect/bun-inspector-protocol.test.ts` is red on main (build 108947, about ten builds since 108873, every Linux lane): `WebSocket closed (1006) (inspectee exit: 1)` from `failWith` at line 146.
- The fixture calls `reportError()`. Bun counts that as an unhandled error, so `is_event_loop_alive_excluding_immediates` (`src/jsc/VirtualMachine.rs:1336`) is false from then on. The `setInterval` never kept the inspectee alive: it exits with code 1 when the module body finishes.
- The inspector writes its messages from the debugger thread (`src/jsc/bindings/BunDebugger.cpp:455`). Under load the process is gone before the `Debugger.resume` response and the `Debugger.resumed` event reach the socket. The race exists since #39110 added the test.

### Fix
- A second `debugger` statement in the fixture. After the first resume the inspectee pauses again at once, so it is alive while the debugger thread writes the resume messages. The test waits for that second `Debugger.paused` event, then closes the socket.
- Closing the last connection resumes a paused inspectee (`runWhilePaused`, `src/jsc/bindings/BunDebugger.cpp:279`). The test asserts the exit code 1 that `reportError()` produces.
- Verified: `bun bd test test/cli/inspect/bun-inspector-protocol.test.ts`. Released bun, 12 copies in a loop: 10 failures in 96 runs before, 0 in 240 after. Debug build: 48 of 48 loaded runs pass.

### Background
- `--inspect-wait` starts the script only after a client sends `Inspector.initialized`. The test enables every domain first, so `debugger` statements pause the script.
- A pause runs `runWhilePaused` on the JS thread until a client resumes the script or every connection is closed.
- Bun does not flush queued inspector messages when the process exits on a fatal error. That gap is tracked separately.

Supersedes #39698.

<details><summary>Notes</summary>

An instrumented copy of the old test recorded the step in progress when the socket dropped. In 144 runs at 12x parallel with the released bun 1.4.1: 15 failures, 8 waiting on the `Debugger.resume` response, 7 waiting on the `Debugger.resumed` event. None elsewhere.

`reportError()` marks the error unhandled in `VirtualMachine::uncaught_exception` (`src/jsc/VirtualMachine.rs:1709`) and exits the process with code 1 even with a pending timer:

```
$ bun -e 'reportError(new Error("x")); setInterval(() => {}, 1000)'; echo $?
error: x
1
```

The second `Debugger.paused` event is ordered after the resume response and `Debugger.resumed` on the same connection, so once the test has it, it has the messages it validates.

The failure rate rose on 08-31. The candidates are load changes in CI (#40993 changed the batch packing), not a change in the inspector or the exit paths: nothing in `src/jsc/bindings/BunDebugger.cpp`, `src/jsc/Debugger.rs` or `src/js/internal/debugger.ts` changed since 08-29. The test file is in `test/parallel-denylist.txt`, so it runs in the serial part of a shard.

#39698 proposed the same shape on 08-19 and went stale. This PR adds the exit code assertion and is rebased on main.

`LifecycleReporter.preventExit` (`src/jsc/bindings/InspectorLifecycleAgent.cpp:115`) sets `m_preventingExit`, which nothing reads.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/inspect/bun-inspector-protocol.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/inspect/bun-inspector-protocol.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/inspect/bun-inspector-protocol.test.ts:
(pass) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends [906.03ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [2.89s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/inspect/bun-inspector-protocol.test.ts | 13 ++++++++++++-
 1 file changed, 12 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/cli/inspect/bun-inspector-protocol.test.ts      3      3      7
```

</details>

<!-- robobun:evidence:end -->