### PR TITLE
prune: detect the layout of node_modules instead of refusing to run

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -1903,7 +1903,7 @@
         },
         {
           "name": "linker",
-          "description": "Prune a node_modules installed with the given linker (one of \"isolated\" or \"hoisted\")",
+          "description": "Linker to assume when node_modules mixes isolated and hoisted installs (one of \"isolated\" or \"hoisted\")",
           "hasValue": true,
           "valueType": "val",
           "required": false,

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -225,7 +225,7 @@ complete -c bun -n "__fish_seen_subcommand_from prune" -s "p" -l "production" -d
 complete -c bun -n "__fish_seen_subcommand_from prune" -s "P" -l "prod" -d "Also remove packages that are only needed by devDependencies" -f
 complete -c bun -n "__fish_seen_subcommand_from prune" -l "os" -r -d "Prune for a different operating system than the current one" -f
 complete -c bun -n "__fish_seen_subcommand_from prune" -l "cpu" -r -d "Prune for a different CPU architecture than the current one" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -l "linker" -r -a "isolated hoisted" -d "Prune a node_modules installed with the given linker" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -l "linker" -r -a "isolated hoisted" -d "Linker to assume when node_modules mixes isolated and hoisted installs" -f
 complete -c bun -n "__fish_seen_subcommand_from prune" -s "F" -l "filter" -r -d "Prune only the matching workspaces" -f
 complete -c bun -n "__fish_seen_subcommand_from prune" -l "silent" -d "Don't log anything" -f
 complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "cwd" -r -d "Set a specific cwd"

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -739,7 +739,7 @@ _bun_prune_completion() {
         '--dry-run[Print what would be removed without deleting anything]' \
         '*--os[Prune for a different operating system than the current one]:os' \
         '*--cpu[Prune for a different CPU architecture than the current one]:cpu' \
-        '--linker[Prune a node_modules installed with the given linker]:linker:(isolated hoisted)' \
+        '--linker[Linker to assume when node_modules mixes isolated and hoisted installs]:linker:(isolated hoisted)' \
         '*--filter[Only prune the node_modules folders of the matching workspaces]:workspace pattern' \
         '*-F[Only prune the node_modules folders of the matching workspaces]:workspace pattern' \
         '--silent[Don'"'"'t log anything]' \

--- a/docs/pm/cli/prune.mdx
+++ b/docs/pm/cli/prune.mdx
@@ -63,7 +63,7 @@ bun prune --production --filter app
 
 - Always runs from the workspace root and covers every workspace's `node_modules`, even when invoked inside a workspace package.
 - Requires `bun.lock` to match `package.json`. If you edited dependencies since the last install, run `bun install` first.
-- Uses the same linker as `bun install` would. If `node_modules` was created with the other linker, `bun prune` refuses to run. Pass the matching `--linker`, or run `bun install`.
+- Detects whether `node_modules` was laid out by the hoisted or the isolated linker and prunes it as it is. If the folders hold both layouts (for example after a switch of linkers without a clean install), Bun uses the linker `bun install` would use. Pass `--linker` to choose.
 - Matches packages by name. If a package is at the wrong version, Bun leaves it for `bun install` to replace. Bun only removes a nested copy (`node_modules/a/node_modules/b`) once the correct version is installed above it; otherwise Bun keeps it and prints a warning.
 - Never removes workspace folders, `.bin` entries still in use, dot-directories like `.cache`, plain files, or anything outside `node_modules`.
 - Removes packages disabled for the current `os`/`cpu`. Pass `--os`/`--cpu` to prune for another platform.

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -483,7 +483,7 @@ const PRUNE_HELP_PARAMS: &[ParamType] = &[
         "--cpu <STR>...                         Prune for a different CPU architecture than the current one"
     ),
     clap::param!(
-        "--linker <STR>                         Prune a node_modules installed with the given linker (one of \"isolated\" or \"hoisted\")"
+        "--linker <STR>                         Linker to assume when node_modules mixes isolated and hoisted installs (one of \"isolated\" or \"hoisted\")"
     ),
     clap::param!(
         "-F, --filter <STR>...                  Only prune the node_modules folders of the matching workspaces"

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -14,7 +14,7 @@ use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _, entry 
 use crate::isolated_install::{Store, Timings, build_store};
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::tree::is_filtered_dependency_or_workspace;
-use crate::lockfile::{LoadResult, Lockfile, PackageIndexEntry, reachable, tree};
+use crate::lockfile::{LoadResult, Lockfile, reachable, tree};
 use crate::lockfile_real::package::{Diff, DiffSummary, Package};
 use crate::package_manager::Options::{Enable, LogLevel};
 use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
@@ -389,12 +389,8 @@ fn lockfile_extracts(lockfile: &Lockfile, name: &[u8]) -> bool {
     let Some(entry) = lockfile.package_index.get(&name_hash) else {
         return false;
     };
-    let ids: &[PackageID] = match entry {
-        PackageIndexEntry::Id(id) => core::slice::from_ref(id),
-        PackageIndexEntry::Ids(ids) => ids,
-    };
     let pkg_res = lockfile.packages.items_resolution();
-    ids.iter().any(|&id| {
+    entry.as_slice().iter().any(|&id| {
         pkg_res
             .get(id as usize)
             .is_some_and(|res| extracted(res.tag))
@@ -998,12 +994,8 @@ impl<'a> HoistedTree<'a> {
         let Some(entry) = lockfile.package_index.get(&name_hash) else {
             return false;
         };
-        let ids: &[PackageID] = match entry {
-            PackageIndexEntry::Id(id) => core::slice::from_ref(id),
-            PackageIndexEntry::Ids(ids) => ids,
-        };
         let pkg_res = lockfile.packages.items_resolution();
-        ids.iter().any(|&id| {
+        entry.as_slice().iter().any(|&id| {
             pkg_res.get(id as usize).is_some_and(|res| {
                 res.tag == ResolutionTag::Npm
                     && without_build(version)

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -363,7 +363,6 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
     Ok(())
 }
 
-// Store entries are symlinks into the global store when `globalStore` is on.
 fn store_has_entries() -> bool {
     let Ok(store) = Dir::open(STORE_DIR) else {
         return false;
@@ -397,9 +396,7 @@ fn lockfile_extracts(lockfile: &Lockfile, name: &[u8]) -> bool {
     })
 }
 
-/// What the importer folders (the root and workspace `node_modules`) say about how they were
-/// installed: the hoisted linker extracts packages into real directories there, the isolated
-/// linker links them into `node_modules/.bun`.
+/// Which linkers the entries of the importer folders (root and workspace `node_modules`) come from.
 #[derive(Default)]
 struct LayoutEvidence {
     hoisted: bool,
@@ -434,7 +431,7 @@ impl LayoutEvidence {
         }
     }
 
-    // A link into a store that is gone is junk either linker's prune removes, not evidence.
+    // A dangling store link is junk, not evidence.
     fn vote(&mut self, lockfile: &Lockfile, dir: &Dir, alias: &[u8], name: &[u8], kind: EntryKind) {
         match kind {
             EntryKind::Directory if lockfile_extracts(lockfile, alias) => self.hoisted = true,
@@ -448,8 +445,7 @@ impl LayoutEvidence {
     }
 }
 
-/// Picks the planner from the layout on disk. `configured` (the linker `bun install` would use,
-/// or `--linker`) only decides when the folders hold both layouts.
+/// `configured` only decides when the folders hold both layouts.
 fn detect_layout(manager: &PackageManager, node_modules: &Dir, configured: Layout) -> Layout {
     let lockfile: &Lockfile = &manager.lockfile;
     let mut evidence = LayoutEvidence::default();
@@ -941,8 +937,7 @@ impl<'a> HoistedTree<'a> {
             ResolutionTag::Folder if kind == EntryKind::SymLink => return Installed::Matches,
             _ => {}
         }
-        // A link (an isolated install's, or the user's) counts as whatever it points at, as it does
-        // for the installer's own check.
+        // A link counts as what it points at, as in `PackageInstall::verify`.
         let package = match kind {
             EntryKind::SymLink if is_dangling(&folder, alias) => return Installed::Missing,
             EntryKind::SymLink => folder.open_at(alias).ok(),

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -385,8 +385,7 @@ fn extracted(tag: ResolutionTag) -> bool {
 
 /// Which linkers the entries of the importer folders (root and workspace `node_modules`) come from.
 struct LayoutEvidence<'a> {
-    /// Every dependency name (alias) that resolves to an extracted package: the names the hoisted
-    /// linker installs real directories under.
+    /// Sorted dependency names that resolve to an extracted package.
     extracted_aliases: Vec<&'a [u8]>,
     hoisted: bool,
     isolated: bool,

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -259,8 +259,8 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
     manager.options.enable.set(Enable::FROZEN_LOCKFILE, true);
     manager.summary = exit_unless_lockfile_matches_package_json(manager, "prune")?;
 
-    let store_present = match Dir::open(ROOT_DIR) {
-        Ok(node_modules) => lstat_kind(&node_modules, b".bun") == EntryKind::Directory,
+    let node_modules = match Dir::open(ROOT_DIR) {
+        Ok(node_modules) => node_modules,
         Err(err) if err.get_errno() == E::ENOENT => {
             if !quiet {
                 Output::flush();
@@ -279,13 +279,12 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
         }
     };
 
-    let layout = match linker {
+    let configured = match linker {
         NodeLinker::Isolated => Layout::Isolated,
         _ => Layout::Hoisted,
     };
-    if layout == Layout::Hoisted && store_present && store_has_entries() {
-        refuse_layout_mismatch(layout, quiet);
-    }
+    let layout = detect_layout(manager, &node_modules, configured);
+    drop(node_modules);
 
     let workspace_names = collect_workspace_names(manager);
     let selection = select_importers(manager, original_cwd);
@@ -296,10 +295,6 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
         Layout::Isolated => plan_isolated(manager, &workspace_names, selection.as_ref(), &mut plan),
     }
     Output::flush();
-
-    if layout_mismatch(&plan, layout, store_present) {
-        refuse_layout_mismatch(layout, quiet);
-    }
 
     let n = plan.removals.len();
     let checked = plan.checked;
@@ -368,32 +363,122 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
     Ok(())
 }
 
+// Store entries are symlinks into the global store when `globalStore` is on.
 fn store_has_entries() -> bool {
     let Ok(store) = Dir::open(STORE_DIR) else {
         return false;
     };
     read_entries(&store)
         .iter()
-        .any(|(name, kind)| *kind == EntryKind::Directory && split_store_key(name).1.is_some())
+        .any(|(name, _)| split_store_key(name).1.is_some())
 }
 
-fn refuse_layout_mismatch(layout: Layout, quiet: bool) -> ! {
-    if !quiet {
-        let (configured, actual) = match layout {
-            Layout::Hoisted => ("hoisted", "isolated"),
-            Layout::Isolated => ("isolated", "hoisted"),
-        };
-        Output::err_generic(
-            "node_modules was installed with the {s} linker, but bun prune would use the {s} linker",
-            (actual, configured),
-        );
-        bun_core::note!(
-            "run 'bun prune --linker {}' to prune it as-is, or 'bun install' to reinstall with the {} linker",
-            actual,
-            configured
-        );
+fn extracted(tag: ResolutionTag) -> bool {
+    matches!(
+        tag,
+        ResolutionTag::Npm
+            | ResolutionTag::LocalTarball
+            | ResolutionTag::RemoteTarball
+            | ResolutionTag::Git
+            | ResolutionTag::Github
+    )
+}
+
+fn lockfile_extracts(lockfile: &Lockfile, name: &[u8]) -> bool {
+    let name_hash = bun_semver::string::Builder::string_hash(name);
+    let Some(entry) = lockfile.package_index.get(&name_hash) else {
+        return false;
+    };
+    let ids: &[PackageID] = match entry {
+        PackageIndexEntry::Id(id) => core::slice::from_ref(id),
+        PackageIndexEntry::Ids(ids) => ids,
+    };
+    let pkg_res = lockfile.packages.items_resolution();
+    ids.iter().any(|&id| {
+        pkg_res
+            .get(id as usize)
+            .is_some_and(|res| extracted(res.tag))
+    })
+}
+
+/// What the importer folders (the root and workspace `node_modules`) say about how they were
+/// installed: the hoisted linker extracts packages into real directories there, the isolated
+/// linker links them into `node_modules/.bun`.
+#[derive(Default)]
+struct LayoutEvidence {
+    hoisted: bool,
+    isolated: bool,
+}
+
+impl LayoutEvidence {
+    fn mixed(&self) -> bool {
+        self.hoisted && self.isolated
     }
-    Global::exit(1);
+
+    fn scan(&mut self, lockfile: &Lockfile, dir: &Dir) {
+        let mut alias = Vec::new();
+        for (name, kind) in read_entries(dir) {
+            if self.mixed() {
+                return;
+            }
+            if name.first() == Some(&b'@') && kind == EntryKind::Directory {
+                let Ok(scope_dir) = dir.open_at(&name) else {
+                    continue;
+                };
+                for (inner, inner_kind) in read_entries(&scope_dir) {
+                    alias.clear();
+                    alias.extend_from_slice(&name);
+                    alias.push(b'/');
+                    alias.extend_from_slice(&inner);
+                    self.vote(lockfile, &scope_dir, &alias, &inner, inner_kind);
+                }
+                continue;
+            }
+            self.vote(lockfile, dir, &name, &name, kind);
+        }
+    }
+
+    // A link into a store that is gone is junk either linker's prune removes, not evidence.
+    fn vote(&mut self, lockfile: &Lockfile, dir: &Dir, alias: &[u8], name: &[u8], kind: EntryKind) {
+        match kind {
+            EntryKind::Directory if lockfile_extracts(lockfile, alias) => self.hoisted = true,
+            EntryKind::SymLink
+                if store_link_target(dir, name).is_some() && !is_dangling(dir, name) =>
+            {
+                self.isolated = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Picks the planner from the layout on disk. `configured` (the linker `bun install` would use,
+/// or `--linker`) only decides when the folders hold both layouts.
+fn detect_layout(manager: &PackageManager, node_modules: &Dir, configured: Layout) -> Layout {
+    let lockfile: &Lockfile = &manager.lockfile;
+    let mut evidence = LayoutEvidence::default();
+    evidence.scan(lockfile, node_modules);
+    for pkg_id in 0..lockfile.packages.len() {
+        if evidence.mixed() {
+            break;
+        }
+        if is_pruned_workspace(manager, pkg_id) {
+            continue;
+        }
+        let Some(folder) = workspace_node_modules(lockfile, pkg_id as PackageID) else {
+            continue;
+        };
+        if let Ok(dir) = Dir::open(&folder) {
+            evidence.scan(lockfile, &dir);
+        }
+    }
+    match (evidence.isolated, evidence.hoisted) {
+        (true, false) => Layout::Isolated,
+        (false, true) => Layout::Hoisted,
+        (true, true) => configured,
+        (false, false) if store_has_entries() => Layout::Isolated,
+        (false, false) => Layout::Hoisted,
+    }
 }
 
 fn print_apply_hint() {
@@ -860,7 +945,14 @@ impl<'a> HoistedTree<'a> {
             ResolutionTag::Folder if kind == EntryKind::SymLink => return Installed::Matches,
             _ => {}
         }
-        let Some(package) = descend(&folder, alias) else {
+        // A link (an isolated install's, or the user's) counts as whatever it points at, as it does
+        // for the installer's own check.
+        let package = match kind {
+            EntryKind::SymLink if is_dangling(&folder, alias) => return Installed::Missing,
+            EntryKind::SymLink => folder.open_at(alias).ok(),
+            _ => descend(&folder, alias),
+        };
+        let Some(package) = package else {
             return Installed::Mismatch;
         };
         let expected_name = self.lockfile.packages.items_name()[pkg_id as usize].slice(buf);
@@ -1023,15 +1115,7 @@ fn plan_hoisted(
             {
                 continue;
             }
-            let extracted = matches!(
-                pkg_res[pkg_id as usize].tag,
-                ResolutionTag::Npm
-                    | ResolutionTag::LocalTarball
-                    | ResolutionTag::RemoteTarball
-                    | ResolutionTag::Git
-                    | ResolutionTag::Github
-            );
-            if !extracted || has_bundled_deps(lockfile, pkg_id) {
+            if !extracted(pkg_res[pkg_id as usize].tag) || has_bundled_deps(lockfile, pkg_id) {
                 continue;
             }
             let Some(nested) = descend(&dir, alias)
@@ -1723,17 +1807,6 @@ fn plan_isolated(
             plan,
         );
         plan.folders[folder_idx].direct = Some(direct);
-    }
-}
-
-fn layout_mismatch(plan: &Plan, layout: Layout, store_present: bool) -> bool {
-    match layout {
-        Layout::Isolated => {
-            !store_present && plan.removals.iter().any(|r| r.kind == EntryKind::Directory)
-        }
-        Layout::Hoisted => plan.removals.iter().any(|r| {
-            r.kind == EntryKind::SymLink && store_link_target(plan.dir(r.folder), &r.name).is_some()
-        }),
     }
 }
 

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -383,32 +383,45 @@ fn extracted(tag: ResolutionTag) -> bool {
     )
 }
 
-fn lockfile_extracts(lockfile: &Lockfile, name: &[u8]) -> bool {
-    let name_hash = bun_semver::string::Builder::string_hash(name);
-    let Some(entry) = lockfile.package_index.get(&name_hash) else {
-        return false;
-    };
-    let pkg_res = lockfile.packages.items_resolution();
-    entry.as_slice().iter().any(|&id| {
-        pkg_res
-            .get(id as usize)
-            .is_some_and(|res| extracted(res.tag))
-    })
-}
-
 /// Which linkers the entries of the importer folders (root and workspace `node_modules`) come from.
-#[derive(Default)]
-struct LayoutEvidence {
+struct LayoutEvidence<'a> {
+    /// Every dependency name (alias) that resolves to an extracted package: the names the hoisted
+    /// linker installs real directories under.
+    extracted_aliases: Vec<&'a [u8]>,
     hoisted: bool,
     isolated: bool,
 }
 
-impl LayoutEvidence {
+impl<'a> LayoutEvidence<'a> {
+    fn init(lockfile: &'a Lockfile) -> LayoutEvidence<'a> {
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let deps = lockfile.buffers.dependencies.as_slice();
+        let resolutions = lockfile.buffers.resolutions.as_slice();
+        let pkg_res = lockfile.packages.items_resolution();
+        let mut extracted_aliases: Vec<&[u8]> = deps
+            .iter()
+            .zip(resolutions)
+            .filter(|(_, pkg_id)| {
+                pkg_res
+                    .get(**pkg_id as usize)
+                    .is_some_and(|res| extracted(res.tag))
+            })
+            .map(|(dep, _)| dep.name.slice(buf))
+            .collect();
+        index_sort::sort_vec_unstable_by(&mut extracted_aliases, |a, b| a.cmp(b));
+        extracted_aliases.dedup();
+        LayoutEvidence {
+            extracted_aliases,
+            hoisted: false,
+            isolated: false,
+        }
+    }
+
     fn mixed(&self) -> bool {
         self.hoisted && self.isolated
     }
 
-    fn scan(&mut self, lockfile: &Lockfile, dir: &Dir) {
+    fn scan(&mut self, dir: &Dir) {
         let mut alias = Vec::new();
         for (name, kind) in read_entries(dir) {
             if self.mixed() {
@@ -423,18 +436,20 @@ impl LayoutEvidence {
                     alias.extend_from_slice(&name);
                     alias.push(b'/');
                     alias.extend_from_slice(&inner);
-                    self.vote(lockfile, &scope_dir, &alias, &inner, inner_kind);
+                    self.vote(&scope_dir, &alias, &inner, inner_kind);
                 }
                 continue;
             }
-            self.vote(lockfile, dir, &name, &name, kind);
+            self.vote(dir, &name, &name, kind);
         }
     }
 
     // A dangling store link is junk, not evidence.
-    fn vote(&mut self, lockfile: &Lockfile, dir: &Dir, alias: &[u8], name: &[u8], kind: EntryKind) {
+    fn vote(&mut self, dir: &Dir, alias: &[u8], name: &[u8], kind: EntryKind) {
         match kind {
-            EntryKind::Directory if lockfile_extracts(lockfile, alias) => self.hoisted = true,
+            EntryKind::Directory if self.extracted_aliases.binary_search(&alias).is_ok() => {
+                self.hoisted = true;
+            }
             EntryKind::SymLink
                 if store_link_target(dir, name).is_some() && !is_dangling(dir, name) =>
             {
@@ -448,8 +463,8 @@ impl LayoutEvidence {
 /// `configured` only decides when the folders hold both layouts.
 fn detect_layout(manager: &PackageManager, node_modules: &Dir, configured: Layout) -> Layout {
     let lockfile: &Lockfile = &manager.lockfile;
-    let mut evidence = LayoutEvidence::default();
-    evidence.scan(lockfile, node_modules);
+    let mut evidence = LayoutEvidence::init(lockfile);
+    evidence.scan(node_modules);
     for pkg_id in 0..lockfile.packages.len() {
         if evidence.mixed() {
             break;
@@ -461,7 +476,7 @@ fn detect_layout(manager: &PackageManager, node_modules: &Dir, configured: Layou
             continue;
         };
         if let Ok(dir) = Dir::open(&folder) {
-            evidence.scan(lockfile, &dir);
+            evidence.scan(&dir);
         }
     }
     match (evidence.isolated, evidence.hoisted) {

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -2683,6 +2683,29 @@ test.concurrent("mixed: a stale store under a hoisted install does not make the 
   expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "one-dep@1.0.0"]);
 });
 
+// The hoisted linker installs an `npm:` alias under the alias, a name only the dependency rows know.
+test.concurrent("mixed: real directories of npm: aliases are hoisted evidence", async () => {
+  const dir = await setupWithLinker("isolated", {
+    name: "foo",
+    dependencies: { x: "npm:no-deps@1.0.0", y: "npm:no-deps@2.0.0" },
+  });
+  const nm = join(dir, "node_modules");
+  for (const name of readdirSync(nm)) {
+    if (!name.startsWith(".")) rmSync(join(nm, name), { recursive: true });
+  }
+  await install(dir, "--linker", "hoisted");
+  expect(isSymlink(join(nm, "x"))).toBeFalse();
+  expect(existsSync(join(nm, "x", "package.json"))).toBeTrue();
+  expect(existsSync(join(nm, "y", "package.json"))).toBeTrue();
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0", "no-deps@2.0.0"]);
+
+  // The hoisted planner checks the two directories; the isolated planner would check the store too.
+  const { stdout, stderr, exitCode } = await prune(dir, "--linker", "isolated");
+  expect(stderr).toBe("");
+  expect(lines(stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
+  expect(exitCode).toBe(0);
+});
+
 // pnpm#5960
 test.concurrent.each(["hoisted", "isolated"] as Linker[])(
   "%s: --production keeps an npm: alias whose real name is also a dev-only dependency",

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -784,39 +784,30 @@ test.concurrent("hoisted: dot entries and files are never touched even when the 
   expect(existsSync(integrity)).toBeTrue();
 });
 
-// A hoisted prune over a tree whose store still holds entries would report the store as checked without looking at it.
-test.concurrent(
-  "hoisted: refuses up front when node_modules/.bun holds store entries, even with nothing to remove",
-  async () => {
-    const dir = await setupWithLinker("isolated", { name: "foo", dependencies: { "no-deps": "1.0.0" } });
-    const nm = join(dir, "node_modules");
-    expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0"]);
+// The links into node_modules/.bun say how the tree was installed; a contradicting --linker does not make
+// the hoisted planner report the store as checked without looking at it.
+test.concurrent("--linker hoisted on an isolated install prunes it as isolated", async () => {
+  const dir = await setupWithLinker("isolated", { name: "foo", dependencies: { "no-deps": "1.0.0" } });
+  const nm = join(dir, "node_modules");
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0"]);
 
-    for (const flags of [
-      ["--linker", "hoisted"],
-      ["--linker", "hoisted", "--dry-run"],
-      ["--linker", "hoisted", "--production"],
-    ]) {
-      const { stdout, stderr, exitCode } = await prune(dir, ...flags);
-      expect(out(stdout)).toBe(BANNER);
-      expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
-      "error: node_modules was installed with the isolated linker, but bun prune would use the hoisted linker
-      note: run 'bun prune --linker isolated' to prune it as-is, or 'bun install' to reinstall with the hoisted linker"
-    `);
-      expect(exitCode).toBe(1);
-    }
-    const silent = await prune(dir, "--linker", "hoisted", "--silent");
-    expect(silent.stdout).toBe("");
-    expect(silent.stderr).toBe("");
-    expect(silent.exitCode).toBe(1);
-    expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0"]);
-    expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
-
-    const same = await prune(dir, "--linker", "isolated");
-    expect(lines(same.stdout)).toStrictEqual([BANNER, "", NOTHING(2, 2)]);
-    expect(same.exitCode).toBe(0);
-  },
-);
+  for (const flags of [
+    ["--linker", "hoisted"],
+    ["--linker", "hoisted", "--dry-run"],
+    ["--linker", "hoisted", "--production"],
+  ]) {
+    const { stdout, stderr, exitCode } = await prune(dir, ...flags);
+    expect(stderr).toBe("");
+    expect(lines(stdout)).toStrictEqual([BANNER, "", NOTHING(2, 2)]);
+    expect(exitCode).toBe(0);
+  }
+  const silent = await prune(dir, "--linker", "hoisted", "--silent");
+  expect(silent.stdout).toBe("");
+  expect(silent.stderr).toBe("");
+  expect(silent.exitCode).toBe(0);
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0"]);
+  expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
+});
 
 test.concurrent(
   "hoisted: a nested tree owned by a package that was replaced with a symlink is not walked",
@@ -2503,8 +2494,8 @@ test.concurrent("hoisted: nested node_modules of packages without a tree node ar
   expect(existsSync(join(nm, "@scoped", "has-bin-entry", "package.json"))).toBeTrue();
 });
 
-// pnpm#8307
-test.concurrent("refuses to prune a hoisted install with the isolated linker", async () => {
+// pnpm#8307: the isolated planner keeps only direct dependencies in node_modules, which would wipe a hoisted tree.
+test.concurrent("--linker isolated on a hoisted install prunes it as hoisted", async () => {
   const dir = await setupWithLinker("hoisted", { name: "foo", dependencies: { "one-dep": "1.0.0" } });
   const nm = join(dir, "node_modules");
   const hoisted = join(nm, "no-deps", "package.json");
@@ -2516,42 +2507,180 @@ test.concurrent("refuses to prune a hoisted install with the isolated linker", a
     ["--linker", "isolated", "--dry-run"],
   ]) {
     const { stdout, stderr, exitCode } = await prune(dir, ...flags);
-    expect(out(stdout)).toMatchInlineSnapshot(`"bun prune <version> (<revision>)"`);
-    expect(stderr).toContain("node_modules was installed with the hoisted linker");
-    expect(stderr).toContain("bun prune --linker hoisted");
-    expect(exitCode).toBe(1);
+    expect(stderr).toBe("");
+    expect(lines(stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
+    expect(exitCode).toBe(0);
     expect(existsSync(hoisted)).toBeTrue();
   }
-
-  const same = await prune(dir, "--linker", "hoisted");
-  expect(out(same.stdout)).toEndWith(NOTHING(2, 1));
-  expect(same.exitCode).toBe(0);
 });
 
 // pnpm#8307
-test.concurrent("refuses to prune an isolated install with the hoisted linker", async () => {
+test.concurrent("--production --linker hoisted on an isolated install prunes the store too", async () => {
   const dir = await setupWithLinker("isolated", { name: "foo", devDependencies: { "one-dep": "1.0.0" } });
   const nm = join(dir, "node_modules");
   expect(isSymlink(join(nm, "one-dep"))).toBeTrue();
 
-  const mismatch = await prune(dir, "--production", "--linker", "hoisted");
-  expect(out(mismatch.stdout)).toMatchInlineSnapshot(`"bun prune <version> (<revision>)"`);
-  expect(mismatch.stderr).toContain("node_modules was installed with the isolated linker");
-  expect(mismatch.stderr).toContain("bun prune --linker isolated");
-  expect(mismatch.exitCode).toBe(1);
+  const dryRun = await prune(dir, "--production", "--linker", "hoisted", "--dry-run");
+  expect(dryRun.stderr).toBe("");
+  expect(out(dryRun.stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - no-deps@1.0.1
+    - one-dep@1.0.0
+    2 packages can be removed (checked 3 installed packages)
+      bun prune --production --linker hoisted"
+  `);
+  expect(dryRun.exitCode).toBe(0);
   expect(isSymlink(join(nm, "one-dep"))).toBeTrue();
   expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
 
-  const same = await prune(dir, "--production", "--linker", "isolated");
-  expect(out(same.stdout)).toMatchInlineSnapshot(`
+  const { stdout, exitCode } = await prune(dir, "--production", "--linker", "hoisted");
+  expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - no-deps@1.0.1
     - one-dep@1.0.0
     2 packages removed (checked 3 installed packages)"
   `);
-  expect(same.exitCode).toBe(0);
+  expect(exitCode).toBe(0);
   expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
+  expect(storeEntries(dir)).toStrictEqual([]);
+});
+
+// A hoisted install after an isolated one reuses the links into the store that still match bun.lock.
+// The hoisted planner trusts them the way the installer does; --linker isolated prunes the same
+// mixed tree as an isolated install.
+test.concurrent("mixed: a hoisted install over an isolated one is pruned as the configured linker", async () => {
+  const dir = await setupWorkspaces("isolated", {
+    root: { dependencies: { "no-deps": "2.0.0" } },
+    packages: { a: { dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } } },
+  });
+  const nm = join(dir, "node_modules");
+  const aNm = join(dir, "packages", "a", "node_modules");
+  await install(dir, "--linker", "hoisted");
+  expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
+  expect(isSymlink(join(nm, "one-dep"))).toBeFalse();
+  expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
+  expect(isSymlink(join(aNm, "no-deps"))).toBeTrue();
+  expect(isSymlink(join(aNm, "one-dep"))).toBeTrue();
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0", "one-dep@1.0.0"]);
+
+  // bunfig.toml says isolated, so that is the tiebreak without --linker.
+  const dryRun = await prune(dir, "--dry-run");
+  expect(dryRun.stderr).toBe("");
+  expect(out(dryRun.stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - one-dep@1.0.0
+    1 package can be removed (checked 8 installed packages)
+      bun prune"
+  `);
+  expect(dryRun.exitCode).toBe(0);
+
+  const hoisted = await prune(dir, "--linker", "hoisted");
+  expect(hoisted.stderr).toBe("");
+  expect(out(hoisted.stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - no-deps@2.0.0 (packages/a/node_modules)
+    - one-dep@1.0.0 (packages/a/node_modules)
+    2 packages removed (checked 6 installed packages)"
+  `);
+  expect(hoisted.exitCode).toBe(0);
+  expect(() => lstatSync(join(aNm, "no-deps"))).toThrow();
+  expect(() => lstatSync(join(aNm, "one-dep"))).toThrow();
+  expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
+  expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0", "one-dep@1.0.0"]);
+
+  const isolated = await prune(dir, "--linker", "isolated");
+  expect(isolated.stderr).toBe("");
+  expect(out(isolated.stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - one-dep@1.0.0
+    1 package removed (checked 6 installed packages)"
+  `);
+  expect(isolated.exitCode).toBe(0);
+  expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
+  expect(isSymlink(join(nm, "no-deps"))).toBeTrue();
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0", "one-dep@1.0.0"]);
+});
+
+// `rm -rf node_modules` leaves the workspace folders' links into the store behind. After a hoisted
+// install, neither linker may refuse the tree: the root is hoisted and the links are junk.
+test.concurrent("mixed: dangling links into a deleted store do not make the tree isolated", async () => {
+  const dir = await setupWorkspaces("isolated", {
+    root: { dependencies: { "no-deps": "2.0.0" } },
+    packages: { a: { dependencies: { "one-dep": "1.0.0", "no-deps": "2.0.0" } } },
+  });
+  const nm = join(dir, "node_modules");
+  const aNm = join(dir, "packages", "a", "node_modules");
+  rmSync(nm, { recursive: true });
+  await install(dir, "--linker", "hoisted");
+  expect(existsSync(join(nm, ".bun"))).toBeFalse();
+  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
+  expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
+  expect(isSymlink(join(aNm, "no-deps"))).toBeTrue();
+  expect(existsSync(join(aNm, "no-deps"))).toBeFalse();
+
+  const dryRun = await prune(dir, "--linker", "isolated", "--dry-run");
+  expect(dryRun.stderr).toBe("");
+  expect(out(dryRun.stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - no-deps (packages/a/node_modules)
+    - one-dep (packages/a/node_modules)
+    2 packages can be removed (checked 6 installed packages)
+      bun prune --linker isolated"
+  `);
+  expect(dryRun.exitCode).toBe(0);
+
+  const { stdout, stderr, exitCode } = await prune(dir);
+  expect(stderr).toBe("");
+  expect(out(stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - no-deps (packages/a/node_modules)
+    - one-dep (packages/a/node_modules)
+    2 packages removed (checked 6 installed packages)"
+  `);
+  expect(exitCode).toBe(0);
+  expect(() => lstatSync(join(aNm, "no-deps"))).toThrow();
+  expect(() => lstatSync(join(aNm, "one-dep"))).toThrow();
+  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
+  expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
+
+  for (const flags of [[], ["--linker", "isolated"], ["--linker", "hoisted"]]) {
+    const again = await prune(dir, ...flags);
+    expect(again.stderr).toBe("");
+    expect(lines(again.stdout)).toStrictEqual([BANNER, "", NOTHING(4, 3)]);
+    expect(again.exitCode).toBe(0);
+  }
+});
+
+// `rm -rf node_modules/*` keeps the hidden store. The hoisted packages above it decide the layout, so
+// the isolated planner never removes what they depend on.
+test.concurrent("mixed: a stale store under a hoisted install does not make the tree isolated", async () => {
+  const dir = await setupWithLinker("isolated", { name: "foo", dependencies: { "one-dep": "1.0.0" } });
+  const nm = join(dir, "node_modules");
+  for (const name of readdirSync(nm)) {
+    if (!name.startsWith(".")) rmSync(join(nm, name), { recursive: true });
+  }
+  await install(dir, "--linker", "hoisted");
+  expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
+  expect(isSymlink(join(nm, "one-dep"))).toBeFalse();
+  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "one-dep@1.0.0"]);
+
+  for (const flags of [[], ["--linker", "isolated"], ["--linker", "hoisted"]]) {
+    const { stdout, stderr, exitCode } = await prune(dir, ...flags);
+    expect(stderr).toBe("");
+    expect(lines(stdout)).toStrictEqual([BANNER, "", NOTHING(2, 1)]);
+    expect(exitCode).toBe(0);
+  }
+  expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
+  expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "one-dep@1.0.0"]);
 });
 
 // pnpm#5960
@@ -2729,14 +2858,8 @@ test.concurrent(
     expect(existsSync(join(nm, ".bun"))).toBeFalse();
     expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
     const junk = plant(dir, "node_modules/junk");
-    plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
-
-    // The refusal names the linker that was picked.
-    const withStore = await prune(dir, "--production");
-    expect(withStore.stderr).toContain("but bun prune would use the hoisted linker");
-    expect(withStore.exitCode).toBe(1);
-    expect(existsSync(junk)).toBeTrue();
-    rmSync(join(nm, ".bun"), { recursive: true });
+    // A stale store does not turn the hoisted packages above it into an isolated install.
+    const storeJunk = plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
 
     const { stdout, stderr, exitCode } = await prune(dir, "--production");
     expect(stderr).toBe("");
@@ -2749,6 +2872,7 @@ test.concurrent(
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(junk)).toBeFalse();
+    expect(existsSync(storeJunk)).toBeTrue();
     expect(existsSync(join(nm, "a-dep"))).toBeFalse();
     expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
     expect(existsSync(join(nm, "one-dep", "package.json"))).toBeTrue();
@@ -2762,13 +2886,7 @@ test.concurrent("without --linker, a project without workspaces is pruned with t
   expect(existsSync(join(nm, ".bun"))).toBeFalse();
   expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
   const junk = plant(dir, "node_modules/junk");
-  plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
-
-  const withStore = await prune(dir, "--production");
-  expect(withStore.stderr).toContain("but bun prune would use the hoisted linker");
-  expect(withStore.exitCode).toBe(1);
-  expect(existsSync(junk)).toBeTrue();
-  rmSync(join(nm, ".bun"), { recursive: true });
+  const storeJunk = plant(dir, "node_modules/.bun/junk@1.0.0/node_modules/junk");
 
   const { stdout, stderr, exitCode } = await prune(dir, "--production");
   expect(stderr).toBe("");
@@ -2781,6 +2899,7 @@ test.concurrent("without --linker, a project without workspaces is pruned with t
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
+  expect(existsSync(storeJunk)).toBeTrue();
   expect(existsSync(join(nm, "a-dep"))).toBeFalse();
   expect(existsSync(join(nm, "no-deps", "package.json"))).toBeTrue();
 });
@@ -3357,7 +3476,7 @@ test.concurrent("--help lists every flag; -F is --filter, -p is --production", a
           --dry-run         Print what would be removed without deleting anything
           --os=<val>        Prune for a different operating system than the current one
           --cpu=<val>       Prune for a different CPU architecture than the current one
-          --linker=<val>    Prune a node_modules installed with the given linker (one of "isolated" or "hoisted")
+          --linker=<val>    Linker to assume when node_modules mixes isolated and hoisted installs (one of "isolated" or "hoisted")
       -F, --filter=<val>    Only prune the node_modules folders of the matching workspaces
           --silent          Don't log anything
           --cwd=<val>       Set a specific cwd


### PR DESCRIPTION
### Problem
- `bun prune` picked its planner from the configured linker and refused when `node_modules` looked like the other layout. On some trees both `--linker` values refuse, and each error points at the other: `error: node_modules was installed with the isolated linker, but bun prune would use the hoisted linker`, then `error: node_modules was installed with the hoisted linker, but bun prune would use the isolated linker`. Reported in Slack by @Jarred-Sumner.
- The tree: a workspace repo installed with the isolated linker, then `rm -rf node_modules` and a hoisted install. The workspace folders keep dangling links into the deleted `node_modules/.bun`. The hoisted check (`src/install/prune.rs`, `layout_mismatch`) took any link into `.bun/<name@version>` as proof of an isolated install. The isolated check saw no store and real directories to remove.
- The note also gave harmful advice. On a hoisted tree with a stale `.bun` left behind (`rm -rf node_modules/*` keeps hidden folders), `bun prune` refused and suggested `--linker isolated`, which then removed the hoisted transitive packages.

### Fix
- `detect_layout` reads the importer folders (the root and each workspace `node_modules`). A real directory under a dependency name that resolves to an extracted package (so an `npm:` alias counts) means hoisted. A link into `node_modules/.bun` that resolves means isolated. A dangling store link is junk either planner removes, not evidence. A store with entries only decides when the folders say nothing.
- Only a tree that holds both layouts (a hoisted install over an isolated one) falls back to the configured linker (`--linker`, bunfig, or the lockfile default). Both refusals are gone.
- The hoisted planner now verifies a link at an expected position by what it points at, the same way `PackageInstall::verify` does. Without this, a hoisted prune of a mixed tree warned that a correct store link is "not the version bun.lock expects".
- Verified: `test/cli/install/bun-prune.test.ts` (three rewritten refusal tests, four new `mixed:` tests, all fail on the released `bun`). Also `bun-dedupe`, `bun-update`, `bun-update-transitive`, `bun-audit`.

### Background
- The isolated linker puts every package in `node_modules/.bun/<name@version>/node_modules/<name>` and links the direct dependencies of each importer into it. The hoisted linker extracts packages as real directories in the importer folders and nests only version conflicts.
- `bun prune` has one planner per layout. The isolated planner keeps only direct dependencies in an importer folder, so it would wipe a hoisted tree (pnpm#8307). The hoisted planner never touches `.bun`.
- The hoisted installer reuses a store link when the linked version matches, so a hoisted install over an isolated tree leaves a mixed tree. #38779 makes `bun install` reset the tree in that case. This PR makes `bun prune` work on the trees that exist today.

<details><summary>Notes</summary>

Repro of the loop with a released bun (1.4.1), local registry:

```
bun install --linker isolated      # workspaces, configVersion 1
rm -rf node_modules
bun install --linker hoisted
bun prune                          # refuses: installed with isolated
bun prune --linker isolated        # refuses: installed with hoisted
bun prune --linker hoisted         # refuses: installed with isolated
```

With this PR the first command removes the two dangling links in `packages/a/node_modules` and the other two report nothing to prune.

Other trees checked:

- isolated install, then hoisted install, store kept (mixed): `bun prune` with bunfig `linker = "hoisted"` removes the workspace links whose package is hoisted at the root; with `--linker isolated` it removes the hoisted real directory that is not a direct dependency. Both leave a tree that resolves.
- isolated install, `rm -rf node_modules/*`, hoisted install (stale store): all three commands report nothing to prune. The released bun removed `node_modules/no-deps`, which `one-dep` needs.
- `store_has_entries` now counts symlink entries too, since `globalStore` installs link each store entry into the cache.

Help text, completions (`bun.zsh`, `bun.fish`, `bun-cli.json`) and `docs/pm/cli/prune.mdx` describe `--linker` as the tiebreak for a mixed tree.
</details>

