### PR TITLE
ci: filter stale robobun PRs on the server so --limit cannot hide them

### DIFF
--- a/.github/workflows/close-stale-robobun-prs.yml
+++ b/.github/workflows/close-stale-robobun-prs.yml
@@ -20,10 +20,16 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           ninety_days_ago=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          ninety_days_ago_day=$(date -u -d '90 days ago' +%Y-%m-%d)
 
+          # gh pr list sorts by creation date, so a client-side filter over
+          # --limit N never sees the oldest PRs once more than N are open.
+          # Filter and sort on the server. The jq select re-checks the live
+          # updatedAt in case the search index lags.
           gh pr list \
             --author robobun \
             --state open \
+            --search "updated:<$ninety_days_ago_day sort:updated-asc" \
             --json number,updatedAt \
             --limit 1000 \
             --jq ".[] | select(.updatedAt < \"$ninety_days_ago\") | .number" |

--- a/.github/workflows/close-stale-robobun-prs.yml
+++ b/.github/workflows/close-stale-robobun-prs.yml
@@ -20,7 +20,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           ninety_days_ago=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
-          ninety_days_ago_day=$(date -u -d '90 days ago' +%Y-%m-%d)
 
           # gh pr list sorts by creation date, so a client-side filter over
           # --limit N never sees the oldest PRs once more than N are open.
@@ -29,7 +28,7 @@ jobs:
           gh pr list \
             --author robobun \
             --state open \
-            --search "updated:<$ninety_days_ago_day sort:updated-asc" \
+            --search "updated:<$ninety_days_ago sort:updated-asc" \
             --json number,updatedAt \
             --limit 1000 \
             --jq ".[] | select(.updatedAt < \"$ninety_days_ago\") | .number" |


### PR DESCRIPTION
### Problem
- `.github/workflows/close-stale-robobun-prs.yml` runs every night and closes nothing. 29 open robobun PRs have had no update for more than 90 days (oldest: #29114, 2026-04-10). The latest run (id 33457964828) is green with zero closes.
- Cause (`.github/workflows/close-stale-robobun-prs.yml:24`): `gh pr list` sorts by creation date, so `--limit 1000` returns the 1000 newest PRs. robobun has 4361 open PRs. The oldest `updatedAt` in that page is 2026-08-14, so the `--jq select(.updatedAt < cutoff)` filter never matches.

### Fix
- Pass the cutoff to the server: `--search "updated:<$ninety_days_ago sort:updated-asc"`. GitHub filters and sorts before the limit applies, so the oldest PRs come first and the limit cannot hide them.
- The qualifier takes the same full timestamp as the `--jq select`, so the server and the client use one instant. The `--jq select` stays as a guard against a lagging search index.
- Verified read-only, with `gh pr close` stubbed: the `run:` block on `main` selects 0 PRs, this branch selects the same 29 PRs that `search/issues` counts for the same cutoff, oldest first. I did not run the workflow against the repo.

### Background
- `gh pr list` without `--search` calls the GraphQL `pullRequests` connection, ordered by `CREATED_AT DESC`. `--limit` caps that page. A `--jq` filter runs on the client after the cap.
- With `--search`, gh calls the GraphQL search API. Qualifiers such as `updated:<...` and `sort:updated-asc` run on the server. Search results cap at 1000, which is fine here because the filter runs before the cap.
- `updated:` accepts an ISO 8601 date with an optional time. `updated:<2026-05-04T10:40:00Z` and `updated:<2026-05-04T10:39:00Z` return 5 and 4 PRs (#29662 was updated at 10:39:57Z), so the time part is honored.

<details><summary>Notes</summary>

Read-only checks from a dev container on 2026-09-01:

```
gh api -X GET search/issues -f q='repo:oven-sh/bun is:pr is:open author:robobun' -f per_page=1 --jq .total_count
# 4361
gh api -X GET search/issues -f q='repo:oven-sh/bun is:pr is:open author:robobun updated:<2026-06-03T03:06:14Z' -f per_page=1 --jq .total_count
# 29
gh pr list --author robobun --state open --json number,updatedAt --limit 1000 --jq 'min_by(.updatedAt) | "\(.number) \(.updatedAt)"'
# 38669 2026-08-14T20:14:45Z   (the oldest PR the current query can see)
gh pr list --author robobun --state open --limit 1000 --search "updated:<2026-06-03T03:06:14Z sort:updated-asc" --json number,updatedAt
# 29 rows, from #29114 (2026-04-10) to #31718 (2026-06-02)
```

Dry run: I extracted the `run:` block from the YAML and executed it with a `gh` wrapper on `PATH` that prints and skips `gh pr close` and passes every other subcommand to the real `gh`. The block from `main` printed 0 closes. The block from this branch printed 29, in ascending `updatedAt` order. #29114 and #31718 are still open afterwards.

Review follow-up: the first revision used a date-only cutoff (`updated:<2026-06-03`). That excludes PRs updated between midnight and the run time on the cutoff day until the next night. The full timestamp removes the gap. Both `Z` and `+00:00` work as the UTC suffix in REST and GraphQL search.

History: #27125 added the workflow with `--limit 200`. #27126 raised it to 1000 for the same reason. The limit cannot fix this because the filter runs after it.

`prettier --check` passes on the file.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->