### PR TITLE
Bun.serve: release the body stream of a Response whose client aborted mid-stream

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1568,6 +1568,21 @@ where
             self.flags.set_has_finalized(true);
         }
 
+        // A stream pump that settles after this point finds no context
+        // (`reclaim_promise_cell`), so its `handle_*_stream` cleanup never
+        // runs: release the body's hold on the stream here.
+        if let Some(resp) = self.response_mut() {
+            if let Some(stream) = resp.get_body_readable_stream() {
+                stream.value.ensure_still_alive();
+                resp.detach_readable_stream(global_this);
+                stream.done();
+            }
+            let body_value = resp.get_body_value();
+            if matches!(body_value, Body::Value::Locked(_)) {
+                *body_value = Body::Value::Used;
+            }
+        }
+
         let response_jsvalue = self.response_jsvalue.get();
         if !response_jsvalue.is_empty() {
             ctx_log!("finalizeWithoutDeinit: response_jsvalue != .zero");

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -434,6 +434,71 @@ test("pendingRequests drops when the client aborts a parked direct-stream pull()
   expect(server.pendingRequests).toBe(0);
 });
 
+// The abort tears the context down before the stream pump settles, so the
+// pump's cleanup of the Response body never runs. The body kept a strong ref
+// on the stream. When the stream can reach the Response (hono's streamSSE
+// keeps a WeakMap from the body stream to its Context), that ref closed a
+// cycle through a GC root and every disconnect leaked the Response, the
+// stream, and everything the handler closed over.
+test.each(["sync", "async"])(
+  "client abort of a streaming Response releases the body stream it held (%s handler)",
+  async kind => {
+    const stash = new WeakMap<ReadableStream, Response>();
+    const streams: WeakRef<ReadableStream>[] = [];
+    const respond = () => {
+      const stream = new ReadableStream({
+        pull(controller) {
+          controller.enqueue("data: x\n\n");
+          return new Promise<void>(() => {});
+        },
+      });
+      streams.push(new WeakRef(stream));
+      const response = new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+      stash.set(stream, response);
+      return response;
+    };
+
+    using server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch:
+        kind === "async"
+          ? async () => {
+              await Promise.resolve();
+              return respond();
+            }
+          : () => respond(),
+    });
+
+    async function abortAfterFirstChunk() {
+      const ac = new AbortController();
+      const res = await fetch(server.url, { signal: ac.signal });
+      const reader = res.body!.getReader();
+      await reader.read();
+      ac.abort();
+      await reader.closed.catch(() => {});
+    }
+
+    const iterations = 8;
+    for (let i = 0; i < iterations; i++) {
+      await abortAfterFirstChunk();
+    }
+    expect(streams).toHaveLength(iterations);
+
+    // stop() resolves once every abort tore its context down, which is when
+    // the body's ref must be gone.
+    await stopAndAssertDrained(server);
+
+    let alive = iterations;
+    for (let i = 0; i < 20 && alive > 0; i++) {
+      Bun.gc(true);
+      await Bun.sleep(1);
+      alive = streams.filter(ref => ref.deref() !== undefined).length;
+    }
+    expect(alive).toBe(0);
+  },
+);
+
 // Between the abort and the late settle, the server itself goes away: stop()
 // (issued before or after the abort) plus pendingRequests reaching 0 lets the
 // server release its JS wrapper, and dropping the last reference lets GC free


### PR DESCRIPTION
### Problem
- A client disconnect from a streaming `Response` leaves its body holding a strong GC ref on the `ReadableStream`. hono's `streamSSE` maps that stream back to its `Context`, which holds the `Response`, so the ref closes a cycle through a GC root: every SSE disconnect leaks the `Response`, the `Request`, the stream, and the handler closure. bun 1.4.0 is clean; every canary since #39743 (2026-08-20) leaks.
- Cause: `on_abort` reclaims the stream pump's promise cell and frees the context (`RequestContext.rs:1516`). The pump's settle reaction then finds no context, so `handle_resolve_stream` / `handle_reject_stream` never detach the stream from the body. The `Strong` that `do_render_stream` stored there (`RequestContext.rs:2239`) is never released.

### Fix
- `finalize_without_deinit` detaches the body stream from the `Response` and marks the body used, as the settle handlers do. Every context teardown goes through it.
- Correct because the stream is done by then: the sink abort ran the source's `cancel()`, nothing reads it any more. Only the body's hold on it remained.
- Verified: `test/js/bun/http/serve-pending-promise-abort-leak.test.ts`, 2 new tests (sync and async handler); without the fix 8 of 8 streams stay alive. Also `serve.test.ts`, `bun-server.test.ts`, and the `serve-*` stream, abort, and leak files.

### Background
- A streaming `Response` is sent by a pump whose promise the context subscribes to through a `NativePromiseContext` cell. The settle handlers tear the sink down and clean the body.
- #39743 made `on_abort` reclaim that cell so an aborted request is freed at abort time instead of at GC. The settle still runs later, as a no-op.
- `Body::Value::Locked` holds a `readable_stream::Strong` on the stream, a GC root until the body is detached or the `Response` is collected.

<details><summary>Notes</summary>

Found while following up on #41011: with the SSE loops now ending promptly, the reporter's app churned reconnects faster and the growth became obvious. Measured with hono 4.12.28 and an async middleware: 600 disconnects add about 17,000 live objects (about 28 per disconnect) that survive `Bun.gc(true)`, on the canary before #41011 (a6c4cc276) and after it (2bf11c53f) alike; bun 1.4.0, 1.3.14 and 1.3.0 stay flat. A heap snapshot shows the retained `ReadableStream` under a `StrongRootBlock` and the `Context` under `(GC roots)` (the ephemeron value), with `#res` and `#rawRequest` hanging off it.

The minimal repro needs the stream to reach the `Response`; without that, the `Response` is collected and its body drops the `Strong`. So a plain `new Response(stream)` handler does not show it, and hono does.

With a sync handler hono returns the `Response` directly and the leak did not reproduce in the hono harness, but the minimal repro leaks for both sync and async handlers. Both shapes are in the test.

Known failures on this container that also fail on main: `serve.test.ts` root range port and `/bun:info` loopback, and `bun-server.test.ts` IPv6 listen.
</details>
