### PR TITLE
make the parser scan_only flag a runtime field

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -48,7 +48,7 @@ fn e_string_eql_bytes(s: &E::EString, other: &[u8]) -> bool {
 
 // File-split mixin pattern: a direct `impl P` block.
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) fn maybe_relocate_vars_to_top_level(
         &mut self,
         decls: &[G::Decl],

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -240,9 +240,7 @@ pub enum AlreadyBundled {
 }
 
 /// `impl EqlParser for P` — moved out of `bun_ast::expr` (next to `P`).
-impl<'a, const IS_TS: bool> bun_ast::expr::EqlParser
-    for crate::p::P<'a, IS_TS>
-{
+impl<'a, const IS_TS: bool> bun_ast::expr::EqlParser for crate::p::P<'a, IS_TS> {
     #[inline]
     fn arena(&self) -> &bun_alloc::Arena {
         self.arena

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -240,8 +240,8 @@ pub enum AlreadyBundled {
 }
 
 /// `impl EqlParser for P` — moved out of `bun_ast::expr` (next to `P`).
-impl<'a, const IS_TS: bool, const SCAN: bool> bun_ast::expr::EqlParser
-    for crate::p::P<'a, IS_TS, SCAN>
+impl<'a, const IS_TS: bool> bun_ast::expr::EqlParser
+    for crate::p::P<'a, IS_TS>
 {
     #[inline]
     fn arena(&self) -> &bun_alloc::Arena {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -141,7 +141,7 @@ fn can_be_class_binding_name(name: &[u8]) -> bool {
 
 // ── impl P ───────────────────────────────────────────────────────────────────
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     // ── Expression builder helpers ───────────────────────
 
     /// recordUsage + E.Identifier in one call.

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -35,11 +35,11 @@ struct DeduplicatedImportResult {
 }
 
 impl<'a> ConvertESMExportsForHmr<'a> {
-    // Note: takes the concrete `P<'p, TS, SCAN>`; `AstBuilder` instead
+    // Note: takes the concrete `P<'p, TS>`; `AstBuilder` instead
     // open-codes the equivalent transform (see bundler/AstBuilder.rs).
-    pub(crate) fn convert_stmt<'p, const TS: bool, const SCAN: bool>(
+    pub(crate) fn convert_stmt<'p, const TS: bool>(
         &mut self,
-        p: &mut P<'p, TS, SCAN>,
+        p: &mut P<'p, TS>,
         stmt: Stmt,
     ) -> Result<(), AllocError> {
         let new_stmt: Stmt = match stmt.data {
@@ -393,9 +393,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
     /// Deduplicates imports, returning a previously used Ref and import record
     /// index if present.
-    fn deduplicated_import<'p, const TS: bool, const SCAN: bool>(
+    fn deduplicated_import<'p, const TS: bool>(
         &mut self,
-        p: &mut P<'p, TS, SCAN>,
+        p: &mut P<'p, TS>,
         import_record_index: u32,
         namespace_ref: Ref,
         items: js_ast::StoreSlice<js_ast::ClauseItem>,
@@ -512,9 +512,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         })
     }
 
-    fn visit_binding_to_export<'p, const TS: bool, const SCAN: bool>(
+    fn visit_binding_to_export<'p, const TS: bool>(
         &mut self,
-        p: &mut P<'p, TS, SCAN>,
+        p: &mut P<'p, TS>,
         binding: Binding,
     ) -> Result<(), AllocError> {
         match binding.data {
@@ -536,9 +536,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         Ok(())
     }
 
-    fn visit_ref_to_export<'p, const TS: bool, const SCAN: bool>(
+    fn visit_ref_to_export<'p, const TS: bool>(
         &mut self,
-        p: &mut P<'p, TS, SCAN>,
+        p: &mut P<'p, TS>,
         ref_: Ref,
         export_symbol_name: Option<js_ast::StoreStr>,
         loc: bun_ast::Loc,
@@ -633,9 +633,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         Ok(())
     }
 
-    pub(crate) fn finalize<'p, const TS: bool, const SCAN: bool>(
+    pub(crate) fn finalize<'p, const TS: bool>(
         &mut self,
-        p: &mut P<'p, TS, SCAN>,
+        p: &mut P<'p, TS>,
         // Note: `self.last_part` must not alias into this slice
         // (Stacked Borrows: `&mut [Part]` asserts
         // exclusive access to every element). Caller passes the `[0..len-1]`

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -42,7 +42,7 @@ type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
 type List<'a, T> = BumpVec<'a, T>;
 type ListManaged<'a, T> = BumpVec<'a, T>;
 
-/// Erases `P<'a, TS, SCAN>`'s const-generics so helpers like `JSXTag::parse`
+/// Erases `P<'a, TS>`'s const-generic so helpers like `JSXTag::parse`
 /// can take any instantiation. Only the surface those helpers actually
 /// touch is exposed.
 pub(crate) trait ParserLike<'a> {
@@ -55,7 +55,7 @@ pub(crate) trait ParserLike<'a> {
 }
 // Trait + impl defined so Expr methods can bound on it. Method bodies
 // forward to the inherent impls.
-impl<'a, const TS: bool, const SCAN: bool> ParserLike<'a> for P<'a, TS, SCAN> {
+impl<'a, const TS: bool> ParserLike<'a> for P<'a, TS> {
     #[inline]
     fn lexer(&mut self) -> &mut js_lexer::Lexer<'a> {
         &mut self.lexer
@@ -230,13 +230,15 @@ pub enum ReactRefreshExportKind {
 // P — the parser struct.
 // `'a` covers borrowed init() params (log/define/source) AND the arena (`bump`).
 // ─────────────────────────────────────────────────────────────────────────────
-pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
+pub struct P<'a, const TYPESCRIPT: bool> {
     /// Runtime JSX transform mode. Was the `<J: JsxT>` const-generic type
     /// parameter; demoted to a field because JSX only affects a handful of
     /// expression arms (see the `bun .` startup note in `parser.rs`) and the
     /// 4× monomorphization (TYPESCRIPT × JSX) faulted in four copies of every
     /// parser / visitor / lowerer body at startup.
     pub(crate) jsx_transform: JSXTransformType,
+    /// Runtime replacement for the former `SCAN_ONLY` const-generic parameter.
+    pub(crate) scan_only: bool,
     pub(crate) macro_: MacroState<'a>,
     pub(crate) arena: &'a Bump,
     pub(crate) options: ParserOptions<'a>,
@@ -670,12 +672,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 }
 
 // `binding::ToExprWrapper` type-erases `*P` (which is generic over
-// `<'a, TYPESCRIPT, J, SCAN_ONLY>`). Wired in `prepare_for_visit_pass`.
+// `<'a, TYPESCRIPT>`). Wired in `prepare_for_visit_pass`.
 pub(crate) type Binding2ExprWrapperNamespace = bun_ast::binding::ToExprWrapper;
 pub(crate) type Binding2ExprWrapperHoisted = bun_ast::binding::ToExprWrapper;
 
 // ═══════════════════════════════════════════════════════════════════════════
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> Drop for P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> Drop for P<'a, TYPESCRIPT> {
     fn drop(&mut self) {
         // Arena-allocated structs never run Drop; free their global-heap maps here.
         for mut scope in self.ts_namespace_scopes.drain(..) {
@@ -687,9 +689,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> Drop for P<'a, TYPESCRIP
     }
 }
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) const IS_TYPESCRIPT_ENABLED: bool = TYPESCRIPT;
-    pub(crate) const TRACK_SYMBOL_USAGE_DURING_PARSE_PASS: bool = SCAN_ONLY && TYPESCRIPT;
+
+    #[inline]
+    pub(crate) fn track_symbol_usage_during_parse_pass(&self) -> bool {
+        self.scan_only && TYPESCRIPT
+    }
 
     /// Runtime replacement for the former `IS_JSX_ENABLED` associated const
     /// (JSX is no longer a const-generic type parameter — see `jsx_transform`).
@@ -798,7 +804,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // The import-record side-effect is order-independent of `Expr.init`'s
         // Store allocation.
         let expr = Expr::init(t, loc);
-        if SCAN_ONLY {
+        if self.scan_only {
             if let js_ast::ExprData::ECall(call) = expr.data {
                 if let js_ast::ExprData::EIdentifier(ident) = call.target.data {
                     // is this a require("something")
@@ -845,7 +851,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 }
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) const ALLOW_MACROS: bool = !cfg!(target_family = "wasm");
 
     /// use this instead of checking p.source.index
@@ -3010,13 +3016,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // SAFETY: `ctx` was derived from the caller's live `&mut P`
                     // immediately before `Binding::to_expr`; no other `&mut P`
                     // borrow is active for the duration of this call.
-                    let p = unsafe { &mut *ctx.cast::<P<'a, TYPESCRIPT, SCAN_ONLY>>() };
+                    let p = unsafe { &mut *ctx.cast::<P<'a, TYPESCRIPT>>() };
                     p.wrap_identifier_namespace(loc, ref_)
                 });
             self.to_expr_wrapper_hoisted =
                 bun_ast::binding::ToExprWrapper::new(self.arena, |ctx, loc, ref_| {
                     // SAFETY: same as above.
-                    let p = unsafe { &mut *ctx.cast::<P<'a, TYPESCRIPT, SCAN_ONLY>>() };
+                    let p = unsafe { &mut *ctx.cast::<P<'a, TYPESCRIPT>>() };
                     p.wrap_identifier_hoisting(loc, ref_)
                 });
         }
@@ -4038,7 +4044,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let name = self.load_name_from_ref(stmt.namespace_ref);
             stmt.namespace_ref = self.declare_symbol(js_ast::symbol::Kind::Import, star, name)?;
 
-            if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
+            if self.track_symbol_usage_during_parse_pass() {
                 if let Some(uses) = &mut self.parse_pass_symbol_uses {
                     uses.put(
                         name,
@@ -4117,7 +4123,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         self.import_records.items_mut()[new_import_id as usize]
                             .flags
                             .insert(bun_ast::ImportRecordFlags::IS_UNUSED);
-                        if SCAN_ONLY {
+                        if self.scan_only {
                             self.import_records.items_mut()[new_import_id as usize]
                                 .flags
                                 .insert(bun_ast::ImportRecordFlags::IS_INTERNAL);
@@ -4131,7 +4137,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
 
-                if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
+                if self.track_symbol_usage_during_parse_pass() {
                     if let Some(uses) = &mut self.parse_pass_symbol_uses {
                         uses.put(
                             name,
@@ -4198,7 +4204,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.import_records.items_mut()[new_import_id as usize]
                         .flags
                         .insert(bun_ast::ImportRecordFlags::IS_UNUSED);
-                    if SCAN_ONLY {
+                    if self.scan_only {
                         self.import_records.items_mut()[new_import_id as usize]
                             .flags
                             .insert(bun_ast::ImportRecordFlags::IS_INTERNAL);
@@ -4211,7 +4217,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
-            if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
+            if self.track_symbol_usage_during_parse_pass() {
                 if let Some(uses) = &mut self.parse_pass_symbol_uses {
                     uses.put(
                         name,
@@ -4242,7 +4248,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .flags
                 .insert(bun_ast::ImportRecordFlags::IS_UNUSED);
 
-            if SCAN_ONLY {
+            if self.scan_only {
                 self.import_records.items_mut()[stmt.import_record_index as usize]
                     .path
                     .is_disabled = true;
@@ -4973,7 +4979,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub(crate) fn store_name_in_ref(&mut self, name: &'a [u8]) -> Ref {
-        if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
+        if self.track_symbol_usage_during_parse_pass() {
             if let Some(uses) = &mut self.parse_pass_symbol_uses {
                 if let Some(res) = uses.get_mut(name) {
                     res.used = true;
@@ -6787,7 +6793,7 @@ fn path_package_name<'a>(path: &fs::Path<'a>) -> Option<&'a [u8]> {
     Some(pkgname)
 }
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) fn lower_class(&mut self, stmtorexpr: js_ast::StmtOrExpr) -> &'a mut [Stmt] {
         use js_ast::g::PropertyKind;
         match stmtorexpr {
@@ -8330,7 +8336,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 // ═══════════════════════════════════════════════════════════════════════════
 // P::to_ast — final assembly P→Ast.
 // ═══════════════════════════════════════════════════════════════════════════
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) fn to_ast(
         &mut self,
         parts: &mut ListManaged<'a, js_ast::Part>,
@@ -8385,7 +8391,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             for part in head_parts.iter() {
                 // Bake does not care about 'import =', as it handles it on it's own
-                let _ = ImportScanner::scan::<TYPESCRIPT, SCAN_ONLY, true>(
+                let _ = ImportScanner::scan::<TYPESCRIPT, true>(
                     self,
                     part.stmts.slice_mut(),
                     wrap_mode != WrapMode::None,
@@ -8395,7 +8401,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Re-run for the last part.
             {
                 let last_stmts = hmr_transform_ctx.last_part.stmts;
-                let _ = ImportScanner::scan::<TYPESCRIPT, SCAN_ONLY, true>(
+                let _ = ImportScanner::scan::<TYPESCRIPT, true>(
                     self,
                     last_stmts.slice_mut(),
                     wrap_mode != WrapMode::None,
@@ -8431,7 +8437,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.import_records_for_current_part.clear();
                     self.declared_symbols.clear_retaining_capacity();
 
-                    let result = match ImportScanner::scan::<TYPESCRIPT, SCAN_ONLY, false>(
+                    let result = match ImportScanner::scan::<TYPESCRIPT, false>(
                         self,
                         part.stmts.slice_mut(),
                         wrap_mode != WrapMode::None,
@@ -9046,7 +9052,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 // The Binding2ExprWrapper self-referential helpers are
 // seeded with arena-unit placeholders inside the struct literal; the real `*P`
 // back-pointer is wired lazily by the call sites.
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     /// Construct a `P` in place at `out`.
     ///
     /// PERF: an earlier shape returned `Result<Self, _>` by value. `P`
@@ -9070,6 +9076,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         define: &'a Define,
         mut lexer: js_lexer::Lexer<'a>,
         mut opts: ParserOptions<'a>,
+        scan_only: bool,
     ) -> Result<(), crate::Error> {
         // Pre-size the parser's per-file name/ref-keyed symbol maps so the
         // common case never re-hashes while it grows. Profiling the runtime
@@ -9149,7 +9156,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         };
 
         let mut fn_or_arrow_data_parse = FnOrArrowDataParse::default();
-        if opts.features.top_level_await || SCAN_ONLY {
+        if opts.features.top_level_await || scan_only {
             fn_or_arrow_data_parse.allow_await = crate::AwaitOrYield::AllowExpr;
             fn_or_arrow_data_parse.is_top_level = true;
         }
@@ -9303,6 +9310,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             decorator_class_name: None,
 
             jsx_transform,
+            scan_only,
 
             // Moved-in last so the field expressions above can still read `opts.*`.
             options: opts,
@@ -9331,8 +9339,8 @@ pub(crate) struct LowerUsingDeclarationsContext {
 }
 
 impl LowerUsingDeclarationsContext {
-    pub(crate) fn init<'a, const T: bool, const S_: bool>(
-        p: &mut P<'a, T, S_>,
+    pub(crate) fn init<'a, const T: bool>(
+        p: &mut P<'a, T>,
     ) -> Result<Self, crate::Error> {
         Ok(Self {
             first_using_loc: bun_ast::Loc::EMPTY,
@@ -9341,9 +9349,9 @@ impl LowerUsingDeclarationsContext {
         })
     }
 
-    pub(crate) fn scan_stmts<'a, const T: bool, const S_: bool>(
+    pub(crate) fn scan_stmts<'a, const T: bool>(
         &mut self,
-        p: &mut P<'a, T, S_>,
+        p: &mut P<'a, T>,
         stmts: &mut [Stmt],
     ) {
         for stmt in stmts.iter_mut() {
@@ -9406,9 +9414,9 @@ impl LowerUsingDeclarationsContext {
         }
     }
 
-    pub(crate) fn finalize<'a, const T: bool, const S_: bool>(
+    pub(crate) fn finalize<'a, const T: bool>(
         &mut self,
-        p: &mut P<'a, T, S_>,
+        p: &mut P<'a, T>,
         stmts: &'a mut [Stmt],
         should_hoist_fns: bool,
     ) -> ListManaged<'a, Stmt> {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9339,9 +9339,7 @@ pub(crate) struct LowerUsingDeclarationsContext {
 }
 
 impl LowerUsingDeclarationsContext {
-    pub(crate) fn init<'a, const T: bool>(
-        p: &mut P<'a, T>,
-    ) -> Result<Self, crate::Error> {
+    pub(crate) fn init<'a, const T: bool>(p: &mut P<'a, T>) -> Result<Self, crate::Error> {
         Ok(Self {
             first_using_loc: bun_ast::Loc::EMPTY,
             stack_ref: p.generate_temp_ref(Some(b"__stack")),
@@ -9349,11 +9347,7 @@ impl LowerUsingDeclarationsContext {
         })
     }
 
-    pub(crate) fn scan_stmts<'a, const T: bool>(
-        &mut self,
-        p: &mut P<'a, T>,
-        stmts: &mut [Stmt],
-    ) {
+    pub(crate) fn scan_stmts<'a, const T: bool>(&mut self, p: &mut P<'a, T>, stmts: &mut [Stmt]) {
         for stmt in stmts.iter_mut() {
             // Match the `StoreRef` by value (Copy ptr)
             // so DerefMut writes through to the arena slot.

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -36,7 +36,7 @@ use bun_ast::{B, Binding, E, Expr, ExprNodeIndex, ExprNodeList, Flags, G, LocRef
 // File-split mixin: Round-C lowered `const JSX: JSXTransformType` → `J: JsxT`,
 // so this is a direct `impl P` block.
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     #[inline]
     pub(crate) fn parse_expr_or_bindings(
         &mut self,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -22,9 +22,9 @@ use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
 use bun_ast::{B, E, Expr, G, S, Stmt};
 
-// Named instantiations of `P<'_, TS, SCAN>`.
-pub type JavaScriptParser<'a> = P<'a, false, false>;
-pub type TSXParser<'a> = P<'a, true, false>;
+// Named instantiations of `P<'_, TS>`.
+pub type JavaScriptParser<'a> = P<'a, false>;
+pub type TSXParser<'a> = P<'a, true>;
 
 // In AST crates, ListManaged(T) backed by the arena → bumpalo Vec.
 type BumpVec<'bump, T> = bun_alloc::ArenaVec<'bump, T>;
@@ -393,7 +393,7 @@ impl<'a> Parser<'a> {
         &mut self,
         scan_pass: &'a mut ScanPassResult,
     ) -> Result<(), Error> {
-        type Pi<'a, const TS: bool> = P<'a, TS, true>;
+        type Pi<'a, const TS: bool> = P<'a, TS>;
         // `Lexer` owns `Vec`s and `Options` owns
         // `jsx: Pragma` boxes, so a bitwise `ptr::read` would double-free
         // when `self` later drops. Move them out, leaving inert placeholders.
@@ -416,7 +416,7 @@ impl<'a> Parser<'a> {
         // field docs), so handing the same raw pointer to both is defined —
         // no `&mut` is materialized.
         let mut __p = init_p!(Pi<'_, TS>;
-            self.bump, self.log, self.source, self.define, lexer, options);
+            self.bump, self.log, self.source, self.define, lexer, options, true);
         // SAFETY: `init_p!` only yields after `init` succeeded.
         let p: &mut Pi<'_, TS> = unsafe { __p.assume_init_mut() };
         p.import_records = crate::p::ImportRecordList::Borrowed(&mut scan_pass.import_records);
@@ -558,7 +558,7 @@ impl<'a> Parser<'a> {
         // field docs), so handing the same raw pointer to both is defined —
         // no `&mut` is materialized.
         let mut __p = init_p!(JavaScriptParser<'_>;
-            self.bump, self.log, self.source, self.define, lexer, options);
+            self.bump, self.log, self.source, self.define, lexer, options, false);
         // SAFETY: `init_p!` only yields after `init` succeeded.
         let p: &mut JavaScriptParser<'_> = unsafe { __p.assume_init_mut() };
 
@@ -759,10 +759,10 @@ impl<'a> Parser<'a> {
         // `P.log` and `Lexer.log` are both `NonNull<Log>` (see P.rs / lexer.rs
         // field docs), so handing the same raw pointer to both is defined —
         // no `&mut` is materialized.
-        let mut __p = init_p!(P<'_, TS, false>;
-            bump, log, source, define, lexer, options);
+        let mut __p = init_p!(P<'_, TS>;
+            bump, log, source, define, lexer, options, false);
         // SAFETY: `init_p!` only yields after `init` succeeded.
-        let p: &mut P<'_, TS, false> = unsafe { __p.assume_init_mut() };
+        let p: &mut P<'_, TS> = unsafe { __p.assume_init_mut() };
 
         if p.options.features.hot_module_reloading {
             debug_assert!(!p.options.tree_shaking);

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -14,7 +14,7 @@ use bun_ast::{E, Expr, Flags, G, S, Stmt};
 
 type Error = crate::Error;
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     /// This assumes the "function" token has already been parsed
     pub(crate) fn parse_fn_stmt(
         &mut self,

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -8,7 +8,7 @@ use bun_ast::expr::Data as ExprData;
 use bun_ast::op::Level;
 use bun_ast::{ClauseItem, E, Expr, LocRef, Ref};
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     /// Note: The caller has already parsed the "import" keyword
     pub(crate) fn parse_import_expr(
         &mut self,
@@ -72,7 +72,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         p.allow_in = old_allow_in;
 
-        if SCAN_ONLY {
+        if p.scan_only {
             // Reshaped for borrowck — EString::slice takes &mut self (rope flatten),
             // so capture the slice (arena-lifetime) before re-using `value` by-value below.
             let slice_opt: Option<&'a [u8]> = if let ExprData::EString(e_string) = &mut value.data {

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -8,7 +8,7 @@ use bun_ast::op::Level;
 use bun_ast::{E, Expr, ExprNodeIndex, ExprNodeList, G};
 use bun_collections::VecExt;
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) fn parse_jsx_element(&mut self, loc: bun_ast::Loc) -> crate::CrateResult<Expr> {
         let p = self;
         // Nested child elements (`<a><b><c>...`) recurse back into this function,
@@ -16,7 +16,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !p.stack_check.is_safe_to_recurse() {
             return Err(crate::Error::StackOverflow);
         }
-        if SCAN_ONLY {
+        if p.scan_only {
             p.needs_jsx_import = true;
         }
 

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -19,7 +19,7 @@ type PResult<T> = crate::CrateResult<T>;
 // The 30+ per-token `t_*` helpers are private; only `parse_prefix` is surfaced. Helper
 // names pfx_-prefixed to avoid colliding with parseStmt.rs / parseSuffix.rs mixins on the same `P`.
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     fn pfx_t_super(p: &mut Self, level: Level) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let super_range = p.lexer.range();

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -22,7 +22,7 @@ use js_ast::{
 };
 use js_lexer::T;
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     fn parse_method_expression(
         &mut self,
         kind: PropertyKind,

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -15,7 +15,7 @@ use bun_ast::ts::Metadata;
 // canonical definition in `TypeScript.rs`.
 pub(crate) type SkipTypeOptionsBitset = typescript::SkipTypeOptionsBitset;
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     #[inline]
     pub(crate) fn skip_typescript_return_type(&mut self) -> Result<(), Error> {
         self.skip_type_script_type_with_opts::<false>(

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -24,7 +24,7 @@ type Result<T> = crate::CrateResult<T>;
 
 // The 25+ per-token `t_*` helpers are private; only `parse_stmt` is surfaced.
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     // Note on `#[inline]` / `#[inline(never)]` / `#[cold]` annotations across the `t_*` arms:
     // `parse_stmt` is invoked once per leading statement token; profiling showed its
     // stack-adjust prologue/epilogue dominating because LLVM was hoisting the larger
@@ -33,8 +33,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // trivial forwarders in so the `parse_stmts_up_to → parse_stmt → t_* → parse_*` chain
     // loses a hop on the hot statements (`;`, `function`, `var`, `const`, `return`, …).
     //
-    // `P` is monomorphized over `(TYPESCRIPT, SCAN_ONLY)` (JSX is a runtime field, not a
-    // type parameter — see `parser.rs`), so every `#[inline(never)]`
+    // `P` is monomorphized over `TYPESCRIPT` (JSX/scan_only are runtime fields, not
+    // type parameters — see `parser.rs`), so every `#[inline(never)]`
     // `t_*` becomes 2-3 sibling symbols that the linker would otherwise interleave with the
     // hot ones. Anything that can't fire on a plain `bun run` of a `.js`/`.ts` script — the
     // TS-only keyword forms (`enum`, `@decorator`, `type`/`namespace`/`module`/`declare`),
@@ -1258,7 +1258,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     );
                 }
 
-                if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
+                if p.track_symbol_usage_during_parse_pass() {
                     // In the scan pass, we need _some_ way of knowing *not* to mark as unused
                     p.import_records.items_mut()[import_record_index as usize]
                         .flags
@@ -1328,7 +1328,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.store_name_in_ref(p.arena.alloc_slice_copy(&buf))
                     };
 
-                    if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
+                    if p.track_symbol_usage_during_parse_pass() {
                         // In the scan pass, we need _some_ way of knowing *not* to mark as unused
                         p.import_records.items_mut()[import_record_index as usize]
                             .flags

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -20,7 +20,7 @@ enum Continuation {
 
 type CResult = core::result::Result<Continuation, Error>;
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     fn sfx_handle_typescript_as(p: &mut Self, level: Level) -> CResult {
         if Self::IS_TYPESCRIPT_ENABLED
             && level.lt(Level::Compare)

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -31,7 +31,7 @@ fn clone_ts_member_data(d: &TSNamespaceMemberData) -> TSNamespaceMemberData {
     }
 }
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) fn parse_type_script_decorators(&mut self) -> Result<ExprNodeList, Error> {
         let p = self;
         if !Self::IS_TYPESCRIPT_ENABLED && !p.options.features.standard_decorators {

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -10,19 +10,19 @@ use bun_collections::VecExt;
 use crate::JSXImport;
 use crate::p::P;
 
-pub struct ReactCompilerHost<'p, 'a, const TS: bool, const SCAN_ONLY: bool> {
-    p: &'p mut P<'a, TS, SCAN_ONLY>,
+pub struct ReactCompilerHost<'p, 'a, const TS: bool> {
+    p: &'p mut P<'a, TS>,
 }
 
-impl<'p, 'a, const TS: bool, const SCAN_ONLY: bool> ReactCompilerHost<'p, 'a, TS, SCAN_ONLY> {
+impl<'p, 'a, const TS: bool> ReactCompilerHost<'p, 'a, TS> {
     #[inline]
-    pub(crate) fn new(p: &'p mut P<'a, TS, SCAN_ONLY>) -> Self {
+    pub(crate) fn new(p: &'p mut P<'a, TS>) -> Self {
         Self { p }
     }
 }
 
-impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
-    for ReactCompilerHost<'_, 'a, TS, SCAN_ONLY>
+impl<'a, const TS: bool> bun_react_compiler::Host
+    for ReactCompilerHost<'_, 'a, TS>
 {
     fn symbols(&self) -> &[js_ast::Symbol] {
         self.p.symbols.as_slice()
@@ -129,7 +129,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
     }
 }
 
-impl<'a, const TS: bool, const SCAN_ONLY: bool> P<'a, TS, SCAN_ONLY> {
+impl<'a, const TS: bool> P<'a, TS> {
     /// Port of upstream `findFunctionDeclarationOrExpression` for the
     /// expression positions (decl init / `export default` / expression
     /// statement). Returns `Some(in_react_hoc)` only for the shapes the

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -21,9 +21,7 @@ impl<'p, 'a, const TS: bool> ReactCompilerHost<'p, 'a, TS> {
     }
 }
 
-impl<'a, const TS: bool> bun_react_compiler::Host
-    for ReactCompilerHost<'_, 'a, TS>
-{
+impl<'a, const TS: bool> bun_react_compiler::Host for ReactCompilerHost<'_, 'a, TS> {
     fn symbols(&self) -> &[js_ast::Symbol] {
         self.p.symbols.as_slice()
     }

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -16,7 +16,7 @@ use bun_ast::{B, Binding, E, Expr, ExprNodeList, G, S, Stmt};
 
 use crate::p::P;
 
-impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
+impl<'a, const TS: bool> P<'a, TS> {
     /// Apply REPL-mode transforms to the AST.
     /// This transforms code for interactive evaluation:
     /// - Wraps the last expression in { value: expr } for result capture

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -31,10 +31,9 @@ impl<'a> ImportScanner<'a> {
     pub(crate) fn scan<
         'p,
         const TYPESCRIPT: bool,
-        const SCAN_ONLY: bool,
         const HOT_MODULE_RELOADING_TRANSFORMATIONS: bool,
     >(
-        p: &mut P<'p, TYPESCRIPT, SCAN_ONLY>,
+        p: &mut P<'p, TYPESCRIPT>,
         stmts: &'a mut [Stmt],
         will_transform_to_common_js: bool,
         // Const generics can't gate a param type on a const, so use Option and

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -35,8 +35,8 @@ impl SideEffects {
             && left != bun_ast::expr::PrimitiveType::Mixed
     }
 
-    pub(crate) fn simplify_boolean<'a, const TS: bool, const SCAN: bool>(
-        p: &P<'a, TS, SCAN>,
+    pub(crate) fn simplify_boolean<'a, const TS: bool>(
+        p: &P<'a, TS>,
         expr: Expr,
     ) -> Expr {
         if !p.options.features.dead_code_elimination {
@@ -47,8 +47,8 @@ impl SideEffects {
         result
     }
 
-    fn _simplify_boolean<'a, const TS: bool, const SCAN: bool>(
-        p: &P<'a, TS, SCAN>,
+    fn _simplify_boolean<'a, const TS: bool>(
+        p: &P<'a, TS>,
         expr: &mut Expr,
     ) {
         loop {
@@ -118,8 +118,8 @@ impl SideEffects {
         )
     }
 
-    pub(crate) fn simplify_unused_expr<'a, const TS: bool, const SCAN: bool>(
-        p: &mut P<'a, TS, SCAN>,
+    pub(crate) fn simplify_unused_expr<'a, const TS: bool>(
+        p: &mut P<'a, TS>,
         expr: Expr,
     ) -> Option<Expr> {
         if !p.options.features.dead_code_elimination {
@@ -465,8 +465,8 @@ impl SideEffects {
     /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.
     /// Hand-rolled because that helper takes `fn(&C, _)` and we need `&mut P` for the
     /// recursive `simplify_unused_expr` call.
-    fn join_all_simplified<'a, const TS: bool, const SCAN: bool>(
-        p: &mut P<'a, TS, SCAN>,
+    fn join_all_simplified<'a, const TS: bool>(
+        p: &mut P<'a, TS>,
         items: &[Expr],
     ) -> Option<Expr> {
         let len = items.len();
@@ -495,8 +495,8 @@ impl SideEffects {
     }
 
     ///
-    fn simplify_unused_binary_comma_expr<'a, const TS: bool, const SCAN: bool>(
-        p: &mut P<'a, TS, SCAN>,
+    fn simplify_unused_binary_comma_expr<'a, const TS: bool>(
+        p: &mut P<'a, TS>,
         expr: Expr,
     ) -> Option<Expr> {
         let ExprData::EBinary(root_bin) = expr.data else {
@@ -710,8 +710,8 @@ impl SideEffects {
         }
     }
 
-    pub(crate) fn is_primitive_with_side_effects<'a, const TS: bool, const SCAN: bool>(
-        p: &P<'a, TS, SCAN>,
+    pub(crate) fn is_primitive_with_side_effects<'a, const TS: bool>(
+        p: &P<'a, TS>,
         loc: bun_ast::Loc,
         data: &ExprData,
     ) -> bool {
@@ -779,8 +779,8 @@ impl SideEffects {
         }
     }
 
-    pub(crate) fn to_null_or_undefined<'a, const TS: bool, const SCAN: bool>(
-        p: &P<'a, TS, SCAN>,
+    pub(crate) fn to_null_or_undefined<'a, const TS: bool>(
+        p: &P<'a, TS>,
         exp: &ExprData,
     ) -> Option<Known> {
         if !p.options.features.dead_code_elimination {
@@ -856,8 +856,8 @@ impl SideEffects {
         }
     }
 
-    pub(crate) fn to_boolean<'a, const TS: bool, const SCAN: bool>(
-        p: &P<'a, TS, SCAN>,
+    pub(crate) fn to_boolean<'a, const TS: bool>(
+        p: &P<'a, TS>,
         exp: &ExprData,
     ) -> Option<Known> {
         if !p.options.features.dead_code_elimination {

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -35,10 +35,7 @@ impl SideEffects {
             && left != bun_ast::expr::PrimitiveType::Mixed
     }
 
-    pub(crate) fn simplify_boolean<'a, const TS: bool>(
-        p: &P<'a, TS>,
-        expr: Expr,
-    ) -> Expr {
+    pub(crate) fn simplify_boolean<'a, const TS: bool>(p: &P<'a, TS>, expr: Expr) -> Expr {
         if !p.options.features.dead_code_elimination {
             return expr;
         }
@@ -47,10 +44,7 @@ impl SideEffects {
         result
     }
 
-    fn _simplify_boolean<'a, const TS: bool>(
-        p: &P<'a, TS>,
-        expr: &mut Expr,
-    ) {
+    fn _simplify_boolean<'a, const TS: bool>(p: &P<'a, TS>, expr: &mut Expr) {
         loop {
             match &mut expr.data {
                 ExprData::EUnary(e) => {
@@ -465,10 +459,7 @@ impl SideEffects {
     /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.
     /// Hand-rolled because that helper takes `fn(&C, _)` and we need `&mut P` for the
     /// recursive `simplify_unused_expr` call.
-    fn join_all_simplified<'a, const TS: bool>(
-        p: &mut P<'a, TS>,
-        items: &[Expr],
-    ) -> Option<Expr> {
+    fn join_all_simplified<'a, const TS: bool>(p: &mut P<'a, TS>, items: &[Expr]) -> Option<Expr> {
         let len = items.len();
         if len == 0 {
             return None;
@@ -856,10 +847,7 @@ impl SideEffects {
         }
     }
 
-    pub(crate) fn to_boolean<'a, const TS: bool>(
-        p: &P<'a, TS>,
-        exp: &ExprData,
-    ) -> Option<Known> {
+    pub(crate) fn to_boolean<'a, const TS: bool>(p: &P<'a, TS>, exp: &ExprData) -> Option<Known> {
         if !p.options.features.dead_code_elimination {
             return None;
         }

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -4,7 +4,7 @@ use crate::parser::FindSymbolResult;
 use bun_ast as js_ast;
 use bun_ast::{Ref, Scope};
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) fn find_symbol(
         &mut self,
         loc: bun_ast::Loc,

--- a/src/js_parser/typescript.rs
+++ b/src/js_parser/typescript.rs
@@ -6,7 +6,7 @@ use crate::p::P;
 
 // This function is taken from the official TypeScript compiler source code:
 // https://github.com/microsoft/TypeScript/blob/master/src/compiler/parser.ts
-impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
+impl<'a, const TS: bool> P<'a, TS> {
     pub(crate) fn can_follow_type_arguments_in_expression(&mut self) -> bool {
         let p = self;
         match p.lexer.token {
@@ -40,7 +40,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     }
 } // end impl P (can_follow_type_arguments_in_expression)
 
-impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
+impl<'a, const TS: bool> P<'a, TS> {
     pub(crate) fn is_ts_arrow_fn_jsx(&mut self) -> crate::CrateResult<bool> {
         let p = self;
         // Lexer holds `&mut Log` so it cannot Clone; use the LexerSnapshot POD

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -37,7 +37,7 @@ use core::ptr::NonNull;
 // In the AST crate, ListManaged is arena-backed.
 type ListManaged<'bump, T> = BumpVec<'bump, T>;
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     // Thin alias of `current_scope_mut()` kept for local readability.
     #[inline(always)]
     fn vis_scope(&mut self) -> &mut js_ast::Scope {
@@ -50,7 +50,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         opts: &mut PrependTempRefsOpts,
     ) -> Result<(), crate::Error> {
         debug_assert!(
-            !SCAN_ONLY,
+            !self.scan_only,
             "only_scan_imports_and_do_not_visit must not run this."
         );
 
@@ -73,7 +73,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub(crate) fn visit_func(&mut self, mut func: G::Fn, open_parens_loc: bun_ast::Loc) -> G::Fn {
         debug_assert!(
-            !SCAN_ONLY,
+            !self.scan_only,
             "only_scan_imports_and_do_not_visit must not run this."
         );
 
@@ -311,7 +311,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 debug_assert!(
-                    !SCAN_ONLY,
+                    !self.scan_only,
                     "only_scan_imports_and_do_not_visit must not run this."
                 );
                 // Propagate name from binding to anonymous decorated class expressions
@@ -954,7 +954,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         default_name_ref: Ref,
     ) -> Ref {
         debug_assert!(
-            !SCAN_ONLY,
+            !self.scan_only,
             "only_scan_imports_and_do_not_visit must not run this."
         );
 
@@ -1436,7 +1436,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         kind: StmtsKind,
     ) -> Result<(), crate::Error> {
         debug_assert!(
-            !SCAN_ONLY,
+            !self.scan_only,
             "only_scan_imports_and_do_not_visit must not run this."
         );
 

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -13,9 +13,9 @@ use bun_ast::{
 
 /// Try to optimize "typeof x === 'undefined'" to "typeof x > 'u'" or similar
 /// Returns the optimized expression if successful, None otherwise
-fn try_optimize_typeof_undefined<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+fn try_optimize_typeof_undefined<'a, const TYPESCRIPT: bool>(
     e_: &mut E::Binary,
-    p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
+    p: &mut P<'a, TYPESCRIPT>,
     replacement_op: js_ast::op::Code,
 ) -> Option<Expr> {
     // Check if this is a typeof comparison with "undefined"
@@ -77,10 +77,10 @@ fn try_optimize_typeof_undefined<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bo
 // canonical `ExprData::eql<P, K: EqlKindT>` (Expr.rs). Kept as a free fn so
 // the call sites don't each repeat the `LooseEql`/`StrictEql` type-select.
 #[inline]
-fn data_eql<'a, const STRICT: bool, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+fn data_eql<'a, const STRICT: bool, const TYPESCRIPT: bool>(
     left: &ExprData,
     right: &ExprData,
-    p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
+    p: &mut P<'a, TYPESCRIPT>,
 ) -> Equality {
     if STRICT {
         ExprData::eql::<_, StrictEql>(left, right, p)
@@ -102,9 +102,9 @@ pub struct BinaryExpressionVisitor {
 }
 
 impl BinaryExpressionVisitor {
-    pub(crate) fn visit_right_and_finish<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+    pub(crate) fn visit_right_and_finish<'a, const TYPESCRIPT: bool>(
         v: &mut Self,
-        p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
+        p: &mut P<'a, TYPESCRIPT>,
     ) -> Expr {
         // `v.e: StoreRef<E::Binary>` is the safe arena back-reference (Copy).
         // Snapshot the handle for the identity check / tail re-wrap, then take
@@ -252,7 +252,7 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinLooseEq => {
-                match data_eql::<false, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<false, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage_of_runtime_require();
                         p.ignore_usage(p.module_ref);
@@ -282,7 +282,7 @@ impl BinaryExpressionVisitor {
                 // TODO: warn about typeof string
             }
             Op::Code::BinStrictEq => {
-                match data_eql::<true, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<true, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage(p.module_ref);
                         p.ignore_usage_of_runtime_require();
@@ -305,7 +305,7 @@ impl BinaryExpressionVisitor {
                 // TODO: warn about typeof string
             }
             Op::Code::BinLooseNe => {
-                match data_eql::<false, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<false, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage(p.module_ref);
                         p.ignore_usage_of_runtime_require();
@@ -332,7 +332,7 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinStrictNe => {
-                match data_eql::<true, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<true, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage(p.module_ref);
                         p.ignore_usage_of_runtime_require();
@@ -716,9 +716,9 @@ impl BinaryExpressionVisitor {
         }
     }
 
-    pub(crate) fn check_and_prepare<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+    pub(crate) fn check_and_prepare<'a, const TYPESCRIPT: bool>(
         v: &mut Self,
-        p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
+        p: &mut P<'a, TYPESCRIPT>,
     ) -> Option<Expr> {
         // Snapshot the `Copy` arena handle before taking the working `&mut`
         // via `StoreRef::DerefMut`, so the early-return re-wrap below does not

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -25,16 +25,16 @@ use js_ast::OpCode as Op;
 // The 25+ per-variant `e_*` helpers are private; only `visit_expr` /
 // `visit_expr_in_out` are surfaced.
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     // PERF(port:noalias): `e: &mut Expr` is lowered to a `noalias` LLVM param, so reads
     // through `e` can be cached in registers across child recursion. The by-value
     // `Expr -> Expr` shape moved 24B in + 24B out per frame; the in-place form moves 8B
     // and only writes back when the visitor produces a *different* node.
     #[inline]
     pub(crate) fn visit_expr(&mut self, e: &mut Expr) {
-        // SCAN_ONLY monomorphizations must never reach the visit pass.
+        // Scan-only parsers must never reach the visit pass.
         debug_assert!(
-            !SCAN_ONLY,
+            !self.scan_only,
             "only_scan_imports_and_do_not_visit must not run visit_expr",
         );
         self.visit_expr_in_out(e, ExprIn::default())

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -37,7 +37,7 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
 // a direct `impl P` block. The 30+ per-variant `s_*` helpers are private; only
 // `visit_and_append_stmt` is surfaced. Full draft body preserved under  mod _draft below.
 
-impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     // Thin alias of `current_scope_mut()` kept for local readability.
     #[inline(always)]
     fn cur_scope(&mut self) -> &mut js_ast::Scope {

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -578,6 +578,7 @@ impl Snapshots {
                         &vm.transpiler.options.define,
                         lexer,
                         opts,
+                        false,
                     )?;
                     // SAFETY: `init` returned `Ok`, so `*__parser_slot` is initialized;
                     // the guard's drop closure is the sole owner of the slot from here.


### PR DESCRIPTION
The JS parser was compiled four times, once per (TYPESCRIPT, SCAN_ONLY) pair; SCAN_ONLY is now a field, so it is compiled twice. macOS arm64 release binary: 59,217,568 -> 58,969,632 bytes.