### PR TITLE
bump mordant and turn on the generic body lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "7c5f269b1fde5877937632f3349abc1379881fee" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "8f0803f66dee128cca7cc0e950d8ec051cdd537a" },
 ]
 
 [workspace.package]

--- a/dylint.toml
+++ b/dylint.toml
@@ -3,6 +3,7 @@
 # fails only when it adds one. Regenerate after fixing some or bumping mordant:
 #   bun run rust:mordant:baseline
 baseline = "mordant-baseline.toml"
+generic-body-not-generic-enabled = true
 validator-resource-errors = ["bun_alloc::AllocError", "bun_sys::Error", "bun_errno::SystemErrno"]
 # Lints this repo has decided not to act on. Everything else in the pack is
 # on; add a lint here only with a reason.

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -2,8 +2,6 @@
 "defaulted_failure:src/bundler/bundle_v2.rs" = 1
 "generic_body_not_generic:src/bundler/Chunk.rs" = 3
 "generic_body_not_generic:src/bundler/ParseTask.rs" = 1
-"generic_body_not_generic:src/bundler/bundle_v2.rs" = 1
-"generic_body_not_generic:src/bundler/linker_context/findAllImportedPartsInJSOrder.rs" = 1
 "generic_body_not_generic:src/bundler/linker_context/generateChunksInParallel.rs" = 1
 "narrowed_two_ways:src/bundler/bundle_v2.rs" = 1
 
@@ -14,7 +12,6 @@
 
 [bun_css]
 "derived_field:src/css/properties/margin_padding.rs" = 105
-"generic_body_not_generic:src/css/css_parser.rs" = 2
 "generic_body_not_generic:src/css/media_query.rs" = 2
 "generic_body_not_generic:src/css/values/color.rs" = 3
 
@@ -23,21 +20,19 @@
 
 [bun_http]
 "generic_body_not_generic:src/http/HTTPContext.rs" = 1
-"generic_body_not_generic:src/http/lib.rs" = 3
+"generic_body_not_generic:src/http/lib.rs" = 2
 
 [bun_http_jsc]
 "generic_body_not_generic:src/http_jsc/websocket_client.rs" = 2
-"generic_body_not_generic:src/http_jsc/websocket_client/WebSocketUpgradeClient.rs" = 2
+"generic_body_not_generic:src/http_jsc/websocket_client/WebSocketUpgradeClient.rs" = 1
 
 [bun_install]
 "defaulted_failure:src/install/npm.rs" = 1
-"generic_body_not_generic:src/install/PackageManager/install_with_manager.rs" = 1
 "generic_body_not_generic:src/install/bin.rs" = 1
 "generic_body_not_generic:src/install/extract_tarball.rs" = 1
 "generic_body_not_generic:src/install/isolated_install/Installer.rs" = 2
 "generic_body_not_generic:src/install/lockfile.rs" = 2
-"generic_body_not_generic:src/install/lockfile/Tree.rs" = 2
-"generic_body_not_generic:src/install/lockfile/bun.lock.rs" = 1
+"generic_body_not_generic:src/install/lockfile/Tree.rs" = 1
 "generic_body_not_generic:src/install/lockfile/printer/Yarn.rs" = 1
 "generic_body_not_generic:src/install/lockfile/printer/tree_printer.rs" = 4
 "interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
@@ -46,19 +41,16 @@
 "generic_body_not_generic:src/io/pipes.rs" = 1
 
 [bun_js_parser]
-"generic_body_not_generic:src/js_parser/fold.rs" = 2
+"generic_body_not_generic:src/js_parser/fold.rs" = 1
 "generic_body_not_generic:src/js_parser/lower/lower_decorators.rs" = 1
-"generic_body_not_generic:src/js_parser/lower/lower_esm_exports_hmr.rs" = 3
-"generic_body_not_generic:src/js_parser/p.rs" = 15
-"generic_body_not_generic:src/js_parser/parse/mod.rs" = 1
+"generic_body_not_generic:src/js_parser/lower/lower_esm_exports_hmr.rs" = 2
+"generic_body_not_generic:src/js_parser/p.rs" = 12
 "generic_body_not_generic:src/js_parser/parse/parse_entry.rs" = 1
-"generic_body_not_generic:src/js_parser/parse/parse_prefix.rs" = 1
-"generic_body_not_generic:src/js_parser/parse/parse_typescript.rs" = 2
-"generic_body_not_generic:src/js_parser/parser.rs" = 1
+"generic_body_not_generic:src/js_parser/parse/parse_typescript.rs" = 1
 "generic_body_not_generic:src/js_parser/repl_transforms.rs" = 2
 "generic_body_not_generic:src/js_parser/scan/scan_side_effects.rs" = 1
-"generic_body_not_generic:src/js_parser/visit/mod.rs" = 2
-"generic_body_not_generic:src/js_parser/visit/visit_expr.rs" = 2
+"generic_body_not_generic:src/js_parser/visit/mod.rs" = 1
+"generic_body_not_generic:src/js_parser/visit/visit_expr.rs" = 1
 "generic_body_not_generic:src/js_parser/visit/visit_stmt.rs" = 2
 
 [bun_js_printer]
@@ -78,7 +70,6 @@
 
 [bun_react_compiler]
 "generic_body_not_generic:src/react_compiler/inference/analyse_functions.rs" = 2
-"generic_body_not_generic:src/react_compiler/lowering/hir_builder.rs" = 1
 
 [bun_resolver]
 "generic_body_not_generic:src/resolver/data_url.rs" = 1
@@ -94,19 +85,19 @@
 "error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 31
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
-"generic_body_not_generic:src/runtime/api/bun/h2_frame_parser.rs" = 1
+"generic_body_not_generic:src/runtime/api/bun/h2_frame_parser.rs" = 2
 "generic_body_not_generic:src/runtime/api/cron.rs" = 1
-"generic_body_not_generic:src/runtime/api/html_rewriter.rs" = 1
 "generic_body_not_generic:src/runtime/bake/dev_server/incremental_graph.rs" = 2
+"generic_body_not_generic:src/runtime/cli/create_command.rs" = 1
 "generic_body_not_generic:src/runtime/cli/multi_run.rs" = 1
 "generic_body_not_generic:src/runtime/cli/outdated_command.rs" = 1
 "generic_body_not_generic:src/runtime/cli/pack_command.rs" = 1
-"generic_body_not_generic:src/runtime/cli/pm_diff_normalize.rs" = 2
+"generic_body_not_generic:src/runtime/cli/pm_diff_normalize.rs" = 1
 "generic_body_not_generic:src/runtime/cli/publish_command.rs" = 2
 "generic_body_not_generic:src/runtime/cli/test_command.rs" = 3
 "generic_body_not_generic:src/runtime/jsc_hooks.rs" = 1
-"generic_body_not_generic:src/runtime/node/assert/myers_diff.rs" = 2
-"generic_body_not_generic:src/runtime/node/node_fs.rs" = 4
+"generic_body_not_generic:src/runtime/node/assert/myers_diff.rs" = 1
+"generic_body_not_generic:src/runtime/node/node_fs.rs" = 3
 "generic_body_not_generic:src/runtime/node/node_net_binding.rs" = 1
 "generic_body_not_generic:src/runtime/server/NodeHTTPResponse.rs" = 1
 "generic_body_not_generic:src/runtime/server/RequestContext.rs" = 8
@@ -116,9 +107,11 @@
 "generic_body_not_generic:src/runtime/socket/Listener.rs" = 1
 "generic_body_not_generic:src/runtime/socket/socket_body.rs" = 6
 "generic_body_not_generic:src/runtime/test_runner/diff/text_diff.rs" = 3
-"generic_body_not_generic:src/runtime/test_runner/expect.rs" = 2
-"generic_body_not_generic:src/runtime/test_runner/pretty_format.rs" = 2
+"generic_body_not_generic:src/runtime/test_runner/expect.rs" = 1
+"generic_body_not_generic:src/runtime/test_runner/pretty_format.rs" = 1
+"generic_body_not_generic:src/runtime/webcore/Blob.rs" = 2
 "generic_body_not_generic:src/runtime/webcore/ReadableStream.rs" = 2
+"generic_body_not_generic:src/runtime/webcore/Sink.rs" = 1
 "generic_body_not_generic:src/runtime/webcore/TextDecoder.rs" = 1
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1
@@ -129,17 +122,11 @@
 "unchecked_construction:src/runtime/server/HTMLBundle.rs" = 2
 "unchecked_construction:src/runtime/server/server_body.rs" = 5
 
-[bun_shell_parser]
-"generic_body_not_generic:src/shell_parser/parse.rs" = 1
-
 [bun_sql_jsc]
 "generic_body_not_generic:src/sql_jsc/mysql/JSMySQLConnection.rs" = 1
-"generic_body_not_generic:src/sql_jsc/mysql/MySQLConnection.rs" = 6
+"generic_body_not_generic:src/sql_jsc/mysql/MySQLConnection.rs" = 4
 "generic_body_not_generic:src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs" = 1
-"generic_body_not_generic:src/sql_jsc/mysql/protocol/ResultSet.rs" = 1
 "generic_body_not_generic:src/sql_jsc/postgres/PostgresSQLConnection.rs" = 1
-"generic_body_not_generic:src/sql_jsc/shared/CachedStructure.rs" = 1
-"generic_body_not_generic:src/sql_jsc/shared/SQLDataCell.rs" = 1
 
 [bun_sys]
 "error_collapsed_to_bool:src/sys/lib.rs" = 4


### PR DESCRIPTION
Updates the mordant pin to the version where generic_body_not_generic is opt-in, enables it in dylint.toml, and regenerates the baseline (134 findings).