### PR TITLE
Test the dynamic import TLA cycle through a helper module

### DIFF
--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -480,14 +480,19 @@ describe("dynamic import through a helper whose target imports the TLA awaiter b
 
   // The entry does not await the helper's import(): nothing is deadlocked, so
   // the chunk must wait for the entry (12.b.v) and see its post-await exports.
-  // The timer only keeps the entry suspended while the chunk is being loaded.
+  // The timer keeps the entry suspended while the chunk loads. A fixed delay
+  // is the only option: in the correct outcome the chunk's body does not run
+  // until the entry finishes, so nothing on the chunk side can signal the
+  // entry, and any promise from the import() back to the entry's await would
+  // make the entry wait on the chunk for real. A slow machine can only make
+  // this check pass vacuously, never fail.
   test.concurrent("a helper's import() that the awaiter does not wait for still waits for the awaiter", async () => {
     const result = await run({
       "entry.ts": `
         export const early = "early";
         import { preload } from "./loader.ts";
         preload();
-        await new Promise(resolve => setTimeout(resolve, 200));
+        await new Promise(resolve => setTimeout(resolve, 500));
         export const late = "late";
         console.log("entry done");
       `,

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // A top-level-awaited dynamic import whose target statically imports the
@@ -239,4 +239,268 @@ test("sibling dynamic imports sharing a TLA wrapper wait for its post-await expo
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("foo bar");
   expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/41029
+//
+// The import() that closes the cycle is not written in the awaiting module. A
+// helper module issues it, and the entry awaits the helper. The deadlock is the
+// same: the chunk waits for the entry (12.b.v), the entry waits for the helper,
+// the helper waits for the chunk. The skip has to follow the await chain hanging
+// off the import() promise back to the suspended entry, whatever code issued
+// the import() and however many promises sit in between.
+describe("dynamic import through a helper whose target imports the TLA awaiter back", () => {
+  async function run(files: Record<string, string>, entry = "entry.ts") {
+    using dir = tempDir("dyn-tla-helper-cycle", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  const child = `
+    import { helper } from "./entry.ts";
+    export function start() { return helper(); }
+  `;
+
+  // The issue's repro: two levels of import(), the helper calls import()
+  // synchronously and awaits it.
+  test.concurrent("helper reached by import(), import() before the helper's first await", async () => {
+    const result = await run({
+      "entry.ts": `
+        export function helper() { return "helper from entry"; }
+        const { load } = await import("./loader.ts");
+        await load();
+        console.log("BOOT OK");
+      `,
+      "loader.ts": `
+        export async function load() {
+          const m = await import("./child.ts");
+          console.log("child:", m.start());
+        }
+      `,
+      "child.ts": child,
+    });
+    expect(result).toEqual({ stdout: "child: helper from entry\nBOOT OK", stderr: "", exitCode: 0 });
+  });
+
+  // A plugin loader: statically imported, scans a directory, then imports what
+  // it found. The entry's body is long gone from the stack when import() runs.
+  test.concurrent("statically imported async helper that awaits I/O before import()", async () => {
+    const result = await run({
+      "entry.ts": `
+        export function helper() { return "helper from entry"; }
+        import { load } from "./loader.ts";
+        await load();
+        console.log("BOOT OK");
+      `,
+      "loader.ts": `
+        import { readdir } from "node:fs/promises";
+        export async function load() {
+          const files = (await readdir(new URL("./plugins/", import.meta.url))).sort();
+          for (const file of files) {
+            const m = await import("./plugins/" + file);
+            console.log("plugin:", file, m.start());
+          }
+        }
+      `,
+      "plugins/a.ts": `
+        import { helper } from "../entry.ts";
+        export function start() { return "a:" + helper(); }
+      `,
+      "plugins/b.ts": `
+        import { helper } from "../entry.ts";
+        export function start() { return "b:" + helper(); }
+      `,
+    });
+    expect(result).toEqual({
+      stdout: "plugin: a.ts a:helper from entry\nplugin: b.ts b:helper from entry\nBOOT OK",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("three levels of import()", async () => {
+    const result = await run({
+      "entry.ts": `
+        export function helper() { return "helper from entry"; }
+        const { load } = await import("./loader.ts");
+        await load();
+        console.log("BOOT OK");
+      `,
+      "loader.ts": `
+        export async function load() {
+          await 0;
+          const { loadMore } = await import("./loader2.ts");
+          await loadMore();
+        }
+      `,
+      "loader2.ts": `
+        export async function loadMore() {
+          await 0;
+          const m = await import("./child.ts");
+          console.log("child:", m.start());
+        }
+      `,
+      "child.ts": child,
+    });
+    expect(result).toEqual({ stdout: "child: helper from entry\nBOOT OK", stderr: "", exitCode: 0 });
+  });
+
+  // No await in the helper: its promise is resolved with the import() promise.
+  test.concurrent("helper returns the import() promise", async () => {
+    const result = await run({
+      "entry.ts": `
+        export function helper() { return "helper from entry"; }
+        import { load } from "./loader.ts";
+        const m = await load();
+        console.log("child:", m.start());
+      `,
+      "loader.ts": `
+        export function load() {
+          return import("./child.ts");
+        }
+      `,
+      "child.ts": child,
+    });
+    expect(result).toEqual({ stdout: "child: helper from entry", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("helper chains .then() on the import() promise", async () => {
+    const result = await run({
+      "entry.ts": `
+        export function helper() { return "helper from entry"; }
+        import { load } from "./loader.ts";
+        console.log("child:", await load());
+      `,
+      "loader.ts": `
+        export function load() {
+          return import("./child.ts").then(m => m.start()).finally(() => {});
+        }
+      `,
+      "child.ts": child,
+    });
+    expect(result).toEqual({ stdout: "child: helper from entry", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("helper awaits Promise.all of several import()s", async () => {
+    const result = await run({
+      "entry.ts": `
+        export function helper() { return "helper from entry"; }
+        import { load } from "./loader.ts";
+        await load();
+        console.log("BOOT OK");
+      `,
+      "loader.ts": `
+        export async function load() {
+          await 0;
+          const [a, b] = await Promise.all([import("./a.ts"), import("./b.ts")]);
+          console.log(a.start(), b.start());
+        }
+      `,
+      "a.ts": `
+        import { helper } from "./entry.ts";
+        export function start() { return "a:" + helper(); }
+      `,
+      "b.ts": `
+        import { helper } from "./entry.ts";
+        export function start() { return "b:" + helper(); }
+      `,
+    });
+    expect(result).toEqual({ stdout: "a:helper from entry b:helper from entry\nBOOT OK", stderr: "", exitCode: 0 });
+  });
+
+  // Each import() is created when the loop asks for it, so its await is in place
+  // before the module graph evaluates. Creating them all up front is a race: a
+  // later import() can evaluate before the loop has reached and awaited it, and
+  // then nothing shows that the entry waits for it.
+  test.concurrent("helper iterates import() promises with for await", async () => {
+    const result = await run({
+      "entry.ts": `
+        export function helper() { return "helper from entry"; }
+        import { load } from "./loader.ts";
+        await load();
+        console.log("BOOT OK");
+      `,
+      "loader.ts": `
+        function* plugins() {
+          yield import("./a.ts");
+          yield import("./b.ts");
+        }
+        export async function load() {
+          await 0;
+          for await (const m of plugins()) {
+            console.log(m.start());
+          }
+        }
+      `,
+      "a.ts": `
+        import { helper } from "./entry.ts";
+        export function start() { return "a:" + helper(); }
+      `,
+      "b.ts": `
+        import { helper } from "./entry.ts";
+        export function start() { return "b:" + helper(); }
+      `,
+    });
+    expect(result).toEqual({ stdout: "a:helper from entry\nb:helper from entry\nBOOT OK", stderr: "", exitCode: 0 });
+  });
+
+  // The awaiting module is a static dependency of the entry, not the entry.
+  test.concurrent("awaiter is a non-entry module", async () => {
+    const result = await run({
+      "entry.ts": `
+        import { result } from "./mid.ts";
+        console.log("result:", result);
+      `,
+      "mid.ts": `
+        export function helper() { return "helper from mid"; }
+        import { load } from "./loader.ts";
+        export const result = await load();
+      `,
+      "loader.ts": `
+        export async function load() {
+          await 0;
+          const m = await import("./chunk.ts");
+          return m.start();
+        }
+      `,
+      "chunk.ts": `
+        import { helper } from "./mid.ts";
+        export function start() { return helper(); }
+      `,
+    });
+    expect(result).toEqual({ stdout: "result: helper from mid", stderr: "", exitCode: 0 });
+  });
+
+  // The entry does not await the helper's import(): nothing is deadlocked, so
+  // the chunk must wait for the entry (12.b.v) and see its post-await exports.
+  // The timer only keeps the entry suspended while the chunk is being loaded.
+  test.concurrent("a helper's import() that the awaiter does not wait for still waits for the awaiter", async () => {
+    const result = await run({
+      "entry.ts": `
+        export const early = "early";
+        import { preload } from "./loader.ts";
+        preload();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        export const late = "late";
+        console.log("entry done");
+      `,
+      "loader.ts": `
+        export function preload() {
+          import("./chunk.ts").then(m => console.log("chunk loaded:", m.report));
+        }
+      `,
+      "chunk.ts": `
+        import { early, late } from "./entry.ts";
+        export const report = early + " " + late;
+      `,
+    });
+    expect(result).toEqual({ stdout: "entry done\nchunk loaded: early late", stderr: "", exitCode: 0 });
+  });
 });


### PR DESCRIPTION
### Problem
- A top-level `await` that reaches a dynamic `import()` through a helper module hung forever at 100% CPU with no output when the imported module statically imported the awaiting module back (#41029). Bun 1.3.14 ran it. The reported shape is a plugin framework boot: the entry awaits a loader, the loader imports each plugin, a plugin imports a helper from the entry.
- The cause is `innerModuleEvaluation` step 12.b.v in JavaScriptCore: the plugin waits for the entry, which is `EvaluatingAsync`. The entry waits for the loader, and the loader waits for the plugin's `import()`. Bun's escape hatch from #32437 compares the dependency's async order with the order of the module that lexically contains the `import()` call (`ZigGlobalObject.cpp:3573`). With a loader module in between, that module has no order and the skip never fires.

### Fix
- oven-sh/WebKit#543 (fork `main` 742c886cdc) passes the dynamic import's promise into `Evaluate()`. At 12.b.v, before waiting on an `EvaluatingAsync` dependency, the loader follows the pending reactions hanging off that promise: `await` in an async function (the function's own promise), `await` in a module body (the module), `.then()`/`.finally()` and resolve-with-promise plumbing (the derived promise), `Promise.all`/`allSettled` (the combined promise), and the loader's own steps. When a chain ends in the dependency's body, or in a module the dependency waits on, the wait is a guaranteed deadlock and is skipped. Fork `main` 2718370ec0 keeps the lexical referrer skip next to the walk for chains that leave JS (a request to the module's own server, a captured resolver). oven-sh/WebKit#548 adds the `for await` step.
- The fix reached Bun with the WebKit pin move to fork `main` 491b5cc236 in #41083. This PR adds the regression tests. No source changes.
- Verified: `test/js/bun/resolve/dynamic-import-tla-cycle.test.ts` gains nine tests. Eight hang on Bun 1.4.1 (two and three `import()` levels, an async helper that awaits `readdir()` before `import()`, `return import()`, a `.then().finally()` chain, `Promise.all`, `for await` over lazily created imports, a non-entry awaiter). The ninth is a fire-and-forget guard: a helper's `import()` the entry does not wait for still waits for the entry and sees its post-await exports. All 15 pass on a debug build against 491b5cc236, as do the six tests that were already in the file.

### Background
- A module with top-level `await` gets an `asyncEvaluationOrder` when its evaluation starts and stays `EvaluatingAsync` until its body finishes. Per spec, a module that imports it must wait for it (12.b.v). When the suspended module is itself waiting on the `import()` result, that wait is a deadlock. Node accepts the deadlock and exits 13. Bun 1.3.14 and Safari evaluated the new module against the awaiter's already-initialized bindings, and #32437 restored that for an `import()` written directly in the awaiting module.
- A dynamic `import()` evaluates its graph in a microtask. By then the caller has attached what it does with the promise (`await`, `.then`, `Promise.all`), and those reactions are plain heap cells (`JSPromiseReaction`, async function generators, module records). The walk reads them and does not allocate on the JS heap.
- #39835 attacks the same bug by walking the machine stack for a module body frame. That covers a helper that calls `import()` before its first `await`, but not a loader that awaits I/O first, which is the realistic shape and also hangs on 1.4.1.

<details><summary>Notes</summary>

Repro numbers, Linux x64: stock 1.4.1 hangs on the issue's three files and on the async-loader variant (`await readdir()` then `import()`), killed by timeout. Node 26.3.0 exits 13 on both (the issue's claim that Node prints the output does not hold on Node 26). A debug build against the patched JavaScriptCore prints `child: function` / `BOOT OK` and `plugin: a.ts function` / `BOOT OK`, exit 0.

Limit of the walk: it is a snapshot of the reaction graph at `Evaluate()` time. An `import()` created before anything awaits it (`const p = import(x); await other; await p`, or `for await` over an array of already created imports) can evaluate before the await exists, and then only the lexical referrer skip can catch it. The `for await` test therefore yields its imports from a sync generator, one per loop step.

Why not the stack walk of #39835: after `await readdir()` the helper resumes from a microtask and no module body frame is on the machine stack, so `JSC::StackVisitor` finds nothing. The promise reaction graph still has the full chain (`entry` awaits `load()`'s promise, `load()`'s generator awaits the import promise).

Suites run on the debug build against the fixed JavaScriptCore: `dynamic-import-tla-cycle.test.ts` (15 pass), `concurrent-dynamic-import`, `import-defer`, `import-query`, `require-esm-evaluating-cycle`, `require-esm-gc-roots`, `require-esm-microtask-order`, `require-esm-transitive-tla`, `esModule`, `import-meta`, `require`, `builtin-esm-lazy-exports`, `test/js/node/vm/vm.test.ts`, `sourcetextmodule-link-gc.test.ts`, `test/js/bun/http/bun-server.test.ts` (including the `js-sink-sourmap-fixture` self-fetch, which needs the lexical referrer skip), `test/js/node/module/`. Buildkite build 108989 (182 jobs) passed on the stacked version of this PR with the same pin.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/resolve/dynamic-import-tla-cycle.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/resolve/dynamic-import-tla-cycle.test.ts:
(pass) dynamic import inside TLA whose target imports the awaiter back does not deadlock [463.44ms]
(pass) dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock [278.63ms]
(pass) static sibling import waits for an async-pending SCC from the same Evaluate() [298.90ms]
(pass) static sibling import waits for a TLA dep that suspended earlier in the same Evaluate() [284.59ms]
(pass) static sibling import waits for an indirectly-shared TLA dep in the same Evaluate() [289.23ms]
(pass) sibling dynamic imports sharing a TLA wrapper wait for its post-await exports [300.03ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > helper reached by import(), import() before the helper's first await [308.81ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > helper returns the import() promise [280.46ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > three levels of import() [304.77ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > helper chains .then() on the import() promise [294.16ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > statically imported async helper that awaits I/O before import() [537.09ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > awaiter is a non-entry module [276.89ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > helper awaits Promise.all of several import()s [361.84ms]
(pass) dynamic import through a helper whose target imports the TLA awaiter back > helper iterates import() promises with for await [365.48ms]
(pass) dynamic import through a helper wh
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../bun/resolve/dynamic-import-tla-cycle.test.ts   | 271 ++++++++++++++++++++-
 1 file changed, 270 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
test/js/bun/resolve/dynamic-import-tla-cycle.test.ts      7     10     21
```

</details>

<!-- robobun:evidence:end -->