### PR TITLE
fs(macOS): retry EINTR in the Darwin syscall wrappers instead of surfacing it

### DIFF
--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -1433,10 +1433,6 @@ impl<'a> SecurityScanSubprocess<'a> {
                                 spins = 0;
                             }
                             Err(e) => match e.get_errno() {
-                                // macOS `bun_sys::read` is single-shot
-                                // (`read$NOCANCEL`); WaiterThread
-                                // + PTY matrix arms can land signals mid-drain.
-                                bun_sys::E::EINTR => continue,
                                 bun_sys::E::EAGAIN => {
                                     // Bounded spin only — if we don't converge
                                     // to EOF here, fall through to the poll

--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -155,10 +155,11 @@ mod platform {
                             self.received_eof = true;
                             return Ok(None);
                         }
-                        return Err(sys::Error::from_code_int(
-                            sys::last_errno(),
-                            Tag::getdirentries64,
-                        ));
+                        let e = sys::last_errno();
+                        if e == libc::EINTR {
+                            continue 'start_over;
+                        }
+                        return Err(sys::Error::from_code_int(e, Tag::getdirentries64));
                     }
 
                     self.index = 0;

--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -9,7 +9,9 @@
 use core::mem::offset_of;
 
 use bun_core::RawSlice;
-use bun_sys::{self as sys, Fd, Tag};
+#[cfg(not(target_os = "macos"))]
+use bun_sys::Tag;
+use bun_sys::{self as sys, Fd};
 
 // `Entry.Kind` is `bun_core::FileKind`, re-exported here as
 // `bun_sys::EntryKind` (and as `crate::node::types::DirentKind`).
@@ -109,18 +111,6 @@ mod platform {
         }
 
         fn next_darwin(&mut self) -> Result {
-            unsafe extern "C" {
-                // Private libsystem symbol (`__getdirentries64`).
-                // SAFETY precondition: `buf` must be writable for `nbytes` and
-                // `basep` must point to a valid i64 — raw-pointer contract,
-                // cannot be `safe fn`.
-                fn __getdirentries64(
-                    fd: libc::c_int,
-                    buf: *mut u8,
-                    nbytes: usize,
-                    basep: *mut i64,
-                ) -> isize;
-            }
             'start_over: loop {
                 if self.index >= self.end_index {
                     if self.received_eof {
@@ -130,40 +120,31 @@ mod platform {
                     // getdirentries64() writes to the last 4 bytes of the
                     // buffer to indicate EOF. If that value is not zero, we
                     // have reached the end of the directory and we can skip
-                    // the extra syscall.
+                    // the extra syscall. The wrapper zeroes those bytes
+                    // before each attempt.
                     // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/vfs/vfs_syscalls.c#L10444-L10470
                     const GETDIRENTRIES64_EXTENDED_BUFSIZE: usize = 1024;
                     const _: () = assert!(8192 >= GETDIRENTRIES64_EXTENDED_BUFSIZE);
                     self.received_eof = false;
-                    // Always zero the bytes where the flag will be written
-                    // so we don't confuse garbage with EOF.
                     let len = self.buf.0.len();
-                    self.buf.0[len - 4..len].copy_from_slice(&[0, 0, 0, 0]);
 
-                    // SAFETY: FFI call into libc __getdirentries64; buf is 8192 bytes
-                    let rc = unsafe {
-                        __getdirentries64(
-                            self.dir.native(),
+                    // SAFETY: buf is 8192 writable bytes; seek is a valid *mut i64.
+                    let n = unsafe {
+                        sys::getdirentries64(
+                            self.dir,
                             self.buf.0.as_mut_ptr(),
-                            self.buf.0.len(),
+                            len,
                             &raw mut self.seek,
                         )
-                    };
+                    }?;
 
-                    if rc < 1 {
-                        if rc == 0 {
-                            self.received_eof = true;
-                            return Ok(None);
-                        }
-                        let e = sys::last_errno();
-                        if e == libc::EINTR {
-                            continue 'start_over;
-                        }
-                        return Err(sys::Error::from_code_int(e, Tag::getdirentries64));
+                    if n == 0 {
+                        self.received_eof = true;
+                        return Ok(None);
                     }
 
                     self.index = 0;
-                    self.end_index = usize::try_from(rc).expect("int cast");
+                    self.end_index = n;
                     let eof_flag = u32::from_ne_bytes(
                         self.buf.0[len - 4..len]
                             .try_into()

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -412,10 +412,11 @@ pub mod dir_iterator {
                             self.received_eof = true;
                             return Ok(None);
                         }
-                        return Err(Error::from_code_int(
-                            super::last_errno(),
-                            Tag::getdirentries64,
-                        ));
+                        let e = super::last_errno();
+                        if e == libc::EINTR {
+                            continue;
+                        }
+                        return Err(Error::from_code_int(e, Tag::getdirentries64));
                     }
                     self.index = 0;
                     self.end_index = rc as usize;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1819,11 +1819,11 @@ mod posix_impl {
             unsafe { libc::send(fd, buf, n, flags) }
         }
     }
-    // EINTR-retry: most wrappers loop on EINTR. NOT all — the macOS
-    // `$NOCANCEL` arms for open/openat/read/write/recv/send issue exactly one
-    // call and surface EINTR to the caller without looping. `check!` keeps the
-    // retry for the common path; `check_once!` is the single-shot variant for
-    // the Darwin arms.
+    // EINTR-retry: every wrapper loops on EINTR, matching libuv, so callers
+    // never see a raw EINTR (#41085). The macOS `$NOCANCEL` arms retry too:
+    // `$NOCANCEL` only opts out of pthread cancellation points, which is
+    // orthogonal to EINTR. The one exception is `close`, which must never be
+    // retried (see `close`).
     macro_rules! check {
         ($rc:expr, $tag:expr) => {{
             loop {
@@ -1872,27 +1872,6 @@ mod posix_impl {
             }
         }};
     }
-    // Single-shot: no EINTR retry (Darwin `$NOCANCEL` arms).
-    #[cfg(target_os = "macos")]
-    macro_rules! check_once {
-        ($rc:expr, $tag:expr) => {{
-            let rc = $rc;
-            if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), $tag));
-            }
-            rc
-        }};
-    }
-    #[cfg(target_os = "macos")]
-    macro_rules! check_once_p {
-        ($rc:expr, $tag:expr, $path:expr) => {{
-            let rc = $rc;
-            if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), $tag).with_path($path.as_bytes()));
-            }
-            rc
-        }};
-    }
 
     #[inline]
     pub fn open(path: &ZStr, flags: i32, mode: Mode) -> Maybe<Fd> {
@@ -1903,10 +1882,10 @@ mod posix_impl {
     }
     pub fn openat(dir: impl AsFd, path: &ZStr, flags: i32, mode: Mode) -> Maybe<Fd> {
         let dir = dir.as_fd();
-        // macOS: single `openat$NOCANCEL`, no EINTR retry.
+        // macOS: `openat$NOCANCEL`, retried on EINTR.
         #[cfg(target_os = "macos")]
         {
-            let rc = check_once_p!(
+            let rc = check_p!(
                 // SAFETY: `dir` is a live fd (or AT_FDCWD); `ZStr::as_ptr()` is
                 // a valid NUL-terminated C string.
                 unsafe { sys_openat(dir.native(), path.as_ptr(), flags, mode as libc::c_uint) },
@@ -2003,10 +1982,10 @@ mod posix_impl {
     }
     pub fn read(fd: Fd, buf: &mut [u8]) -> Maybe<usize> {
         let len = buf.len().min(MAX_COUNT);
-        // macOS: single `read$NOCANCEL`, no EINTR retry.
+        // macOS: `read$NOCANCEL`, retried on EINTR.
         #[cfg(target_os = "macos")]
         {
-            let n = check_once!(
+            let n = check!(
                 // SAFETY: `fd` is a live descriptor; `buf` is valid for `len` writes.
                 unsafe { sys_read(fd.native(), buf.as_mut_ptr().cast(), len) },
                 Tag::read
@@ -2029,10 +2008,10 @@ mod posix_impl {
     }
     pub fn write(fd: Fd, buf: &[u8]) -> Maybe<usize> {
         let len = buf.len().min(MAX_COUNT);
-        // macOS: single `write$NOCANCEL`, no EINTR retry.
+        // macOS: `write$NOCANCEL`, retried on EINTR.
         #[cfg(target_os = "macos")]
         {
-            let n = check_once!(
+            let n = check!(
                 // SAFETY: `fd` is a live descriptor; `buf` is valid for `len` reads.
                 unsafe { sys_write(fd.native(), buf.as_ptr().cast(), len) },
                 Tag::write
@@ -3038,9 +3017,9 @@ mod posix_impl {
     // exposed for shell/pipe IPC.
     pub(crate) fn recv(fd: Fd, buf: &mut [u8], flags: i32) -> Maybe<usize> {
         let len = buf.len().min(MAX_COUNT);
-        // macOS: single `recvfrom$NOCANCEL`, no EINTR retry.
+        // macOS: `recvfrom$NOCANCEL`, retried on EINTR.
         #[cfg(target_os = "macos")]
-        let n = check_once!(
+        let n = check!(
             // SAFETY: `fd` is a live socket; `buf` is valid for `len` writes.
             unsafe { sys_recv(fd.native(), buf.as_mut_ptr().cast(), len, flags) },
             Tag::recv
@@ -3057,9 +3036,9 @@ mod posix_impl {
     pub(crate) fn send(fd: Fd, buf: &[u8], flags: i32) -> Maybe<usize> {
         // `buf.len` is passed un-clamped (only `recv` clamps);
         // forward the full length and let the kernel decide.
-        // macOS: single `sendto$NOCANCEL`, no EINTR retry.
+        // macOS: `sendto$NOCANCEL`, retried on EINTR.
         #[cfg(target_os = "macos")]
-        let n = check_once!(
+        let n = check!(
             // SAFETY: `fd` is a live socket; `buf` is valid for `buf.len()` reads.
             unsafe { sys_send(fd.native(), buf.as_ptr().cast(), buf.len(), flags) },
             Tag::send
@@ -4461,9 +4440,8 @@ pub fn pwritev(fd: Fd, vecs: &[PlatformIoVecConst], offset: i64) -> Maybe<usize>
         // (asserted above); `pwritev(2)` only reads through `iov_base`.
         // Darwin uses `pwritev$NOCANCEL` (avoid cancellation point).
         #[cfg(target_os = "macos")]
-        {
-            // macOS: single `pwritev$NOCANCEL`, no
-            // EINTR retry (surfaces EINTR to caller).
+        loop {
+            // macOS: `pwritev$NOCANCEL`, retried on EINTR.
             // SAFETY: `fd` is a live descriptor; `vecs` gives an exact
             // (ptr, len) pair of layout-compatible iovecs (asserted above).
             let rc = unsafe {
@@ -4475,7 +4453,11 @@ pub fn pwritev(fd: Fd, vecs: &[PlatformIoVecConst], offset: i64) -> Maybe<usize>
                 )
             };
             if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), Tag::pwritev));
+                let e = last_errno();
+                if e == libc::EINTR {
+                    continue;
+                }
+                return Err(Error::from_code_int(e, Tag::pwritev));
             }
             return Ok(rc as usize);
         }
@@ -4589,20 +4571,24 @@ pub fn platform_iovec_const_create(buf: &[u8]) -> PlatformIoVecConst {
     }
 }
 
-/// `bun.sys.writev` — gather-write. macOS uses `writev$NOCANCEL` with no
-/// EINTR retry; other POSIX retries on EINTR.
+/// `bun.sys.writev` — gather-write. Retries on EINTR
+/// (macOS uses `writev$NOCANCEL`).
 pub fn writev(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
     #[cfg(unix)]
     {
         #[cfg(target_os = "macos")]
-        {
+        loop {
             // SAFETY: `PlatformIoVec` is `libc::iovec`; writev(2) only reads
-            // the descriptor table. Single shot, surfaces EINTR.
+            // the descriptor table. `writev$NOCANCEL`, retried on EINTR.
             let rc = unsafe {
                 nocancel::writev(fd.native(), vecs.as_ptr(), vecs.len() as core::ffi::c_int)
             };
             if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), Tag::writev).with_fd(fd));
+                let e = last_errno();
+                if e == libc::EINTR {
+                    continue;
+                }
+                return Err(Error::from_code_int(e, Tag::writev).with_fd(fd));
             }
             return Ok(rc as usize);
         }
@@ -4635,8 +4621,8 @@ pub fn writev(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
     }
 }
 
-/// `bun.sys.readv` — scatter-read. macOS uses `readv$NOCANCEL` with no
-/// EINTR retry; other POSIX retries on EINTR.
+/// `bun.sys.readv` — scatter-read. Retries on EINTR
+/// (macOS uses `readv$NOCANCEL`).
 pub fn readv(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
     #[cfg(debug_assertions)]
     if vecs.is_empty() {
@@ -4645,14 +4631,19 @@ pub fn readv(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
     #[cfg(unix)]
     {
         #[cfg(target_os = "macos")]
-        {
+        loop {
             // SAFETY: vecs.ptr is `*const iovec`; the kernel writes through
-            // each `iov_base`, never the array itself. Single shot.
+            // each `iov_base`, never the array itself. `readv$NOCANCEL`,
+            // retried on EINTR.
             let rc = unsafe {
                 nocancel::readv(fd.native(), vecs.as_ptr(), vecs.len() as core::ffi::c_int)
             };
             if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), Tag::readv).with_fd(fd));
+                let e = last_errno();
+                if e == libc::EINTR {
+                    continue;
+                }
+                return Err(Error::from_code_int(e, Tag::readv).with_fd(fd));
             }
             return Ok(rc as usize);
         }
@@ -4684,8 +4675,8 @@ pub fn readv(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
     }
 }
 
-/// `bun.sys.preadv` — scatter-read at `position`. macOS uses
-/// `preadv$NOCANCEL` with no EINTR retry.
+/// `bun.sys.preadv` — scatter-read at `position`. Retries on EINTR
+/// (macOS uses `preadv$NOCANCEL`).
 pub fn preadv(fd: Fd, vecs: &[PlatformIoVec], position: i64) -> Maybe<usize> {
     #[cfg(debug_assertions)]
     if vecs.is_empty() {
@@ -4694,8 +4685,8 @@ pub fn preadv(fd: Fd, vecs: &[PlatformIoVec], position: i64) -> Maybe<usize> {
     #[cfg(unix)]
     {
         #[cfg(target_os = "macos")]
-        {
-            // SAFETY: see `readv`. Single shot.
+        loop {
+            // SAFETY: see `readv`. `preadv$NOCANCEL`, retried on EINTR.
             let rc = unsafe {
                 nocancel::preadv(
                     fd.native(),
@@ -4705,7 +4696,11 @@ pub fn preadv(fd: Fd, vecs: &[PlatformIoVec], position: i64) -> Maybe<usize> {
                 )
             };
             if rc < 0 {
-                return Err(Error::from_code_int(last_errno(), Tag::preadv).with_fd(fd));
+                let e = last_errno();
+                if e == libc::EINTR {
+                    continue;
+                }
+                return Err(Error::from_code_int(e, Tag::preadv).with_fd(fd));
             }
             return Ok(rc as usize);
         }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -104,8 +104,51 @@ pub use bun_core::FileKind as EntryKind;
 // The high-tier `bun_runtime::node::dir_iterator` shares this surface; the
 // readdir loop lives here so `walker_skippable` / `bun_glob` / resolver can
 // iterate without pulling `bun_runtime` up-tier.
+
+/// `__getdirentries64` (private libsystem symbol): fills `buf` with
+/// variable-length dirent records and advances `*basep`. Returns the byte
+/// count written (0 means EOF). Retries EINTR (#41085). There is no
+/// `$NOCANCEL` variant to call: getdirentries64 is not a pthread
+/// cancellation point (xnu syscalls.master has no `_nocancel` entry for it).
+///
+/// On a buffer of at least 1024 bytes the kernel reports EOF in the last 4
+/// bytes; this wrapper zeroes them before each attempt so the caller can
+/// trust the flag even after a retry.
+///
+/// SAFETY precondition: `buf` must be writable for `len` bytes and `basep`
+/// must point to a valid `i64`.
+#[cfg(target_os = "macos")]
+pub unsafe fn getdirentries64(fd: Fd, buf: *mut u8, len: usize, basep: *mut i64) -> Maybe<usize> {
+    unsafe extern "C" {
+        fn __getdirentries64(
+            fd: libc::c_int,
+            buf: *mut u8,
+            nbytes: usize,
+            basep: *mut i64,
+        ) -> isize;
+    }
+    loop {
+        if len >= 4 {
+            // SAFETY: caller contract — `buf` is writable for `len` bytes.
+            unsafe { buf.add(len - 4).cast::<[u8; 4]>().write([0, 0, 0, 0]) };
+        }
+        // SAFETY: caller contract.
+        let rc = unsafe { __getdirentries64(fd.native(), buf, len, basep) };
+        if rc < 0 {
+            let e = last_errno();
+            if e == libc::EINTR {
+                continue;
+            }
+            return Err(Error::from_code_int(e, Tag::getdirentries64));
+        }
+        return Ok(rc as usize);
+    }
+}
+
 pub mod dir_iterator {
-    use super::{EntryKind, Error, Fd, Result, Tag};
+    #[cfg(not(target_os = "macos"))]
+    use super::{Error, Tag};
+    use super::{EntryKind, Fd, Result};
     use bun_paths::OSPathChar;
 
     const BUF_SIZE: usize = 8192;
@@ -364,15 +407,6 @@ pub mod dir_iterator {
             }
         }
         fn next(&mut self, dir: Fd) -> Result<Option<IteratorResult>> {
-            unsafe extern "C" {
-                // Private libsystem symbol.
-                fn __getdirentries64(
-                    fd: libc::c_int,
-                    buf: *mut u8,
-                    nbytes: usize,
-                    basep: *mut i64,
-                ) -> isize;
-            }
             loop {
                 if self.index >= self.end_index {
                     if self.received_eof {
@@ -382,44 +416,28 @@ pub mod dir_iterator {
                     // getdirentries64() writes to the last 4 bytes of the
                     // buffer to indicate EOF. If that value is not zero, we
                     // have reached the end of the directory and can skip the
-                    // extra syscall.
+                    // extra syscall. The wrapper zeroes those bytes before
+                    // each attempt.
                     // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/vfs/vfs_syscalls.c#L10444-L10470
                     const GETDIRENTRIES64_EXTENDED_BUFSIZE: usize = 1024;
                     const _: () = assert!(BUF_SIZE >= GETDIRENTRIES64_EXTENDED_BUFSIZE);
                     self.received_eof = false;
-                    // Always zero the bytes where the flag will be written so
-                    // we don't confuse garbage with EOF.
-                    // SAFETY: writing into our own MaybeUninit buffer.
-                    unsafe {
-                        self.buf
-                            .as_mut_ptr()
-                            .add(BUF_SIZE - 4)
-                            .cast::<[u8; 4]>()
-                            .write([0, 0, 0, 0]);
-                    }
 
                     // SAFETY: buf is valid for BUF_SIZE bytes; seek is a valid *mut i64.
-                    let rc = unsafe {
-                        __getdirentries64(
-                            dir.native(),
+                    let n = unsafe {
+                        super::getdirentries64(
+                            dir,
                             self.buf.as_mut_ptr(),
                             BUF_SIZE,
                             &raw mut self.seek,
                         )
-                    };
-                    if rc < 1 {
-                        if rc == 0 {
-                            self.received_eof = true;
-                            return Ok(None);
-                        }
-                        let e = super::last_errno();
-                        if e == libc::EINTR {
-                            continue;
-                        }
-                        return Err(Error::from_code_int(e, Tag::getdirentries64));
+                    }?;
+                    if n == 0 {
+                        self.received_eof = true;
+                        return Ok(None);
                     }
                     self.index = 0;
-                    self.end_index = rc as usize;
+                    self.end_index = n;
                     // SAFETY: we explicitly zeroed `[BUF_SIZE-4..BUF_SIZE)` above
                     // and the kernel may have overwritten it with the EOF flag —
                     // either way the 4 bytes are initialized.
@@ -1820,11 +1838,9 @@ mod posix_impl {
             unsafe { libc::send(fd, buf, n, flags) }
         }
     }
-    // EINTR-retry: every wrapper loops on EINTR, matching libuv, so callers
-    // never see a raw EINTR (#41085). The macOS `$NOCANCEL` arms retry too:
-    // `$NOCANCEL` only opts out of pthread cancellation points, which is
-    // orthogonal to EINTR. The one exception is `close`, which must never be
-    // retried (see `close`).
+    // EINTR-retry: every wrapper loops on EINTR (matching libuv) except
+    // `close` (see `close`). `$NOCANCEL` only opts out of pthread
+    // cancellation points; it does not affect EINTR.
     macro_rules! check {
         ($rc:expr, $tag:expr) => {{
             loop {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -146,9 +146,9 @@ pub unsafe fn getdirentries64(fd: Fd, buf: *mut u8, len: usize, basep: *mut i64)
 }
 
 pub mod dir_iterator {
+    use super::{EntryKind, Fd, Result};
     #[cfg(not(target_os = "macos"))]
     use super::{Error, Tag};
-    use super::{EntryKind, Fd, Result};
     use bun_paths::OSPathChar;
 
     const BUF_SIZE: usize = 8192;

--- a/test/js/node/fs/fs-eintr-darwin.test.ts
+++ b/test/js/node/fs/fs-eintr-darwin.test.ts
@@ -1,0 +1,31 @@
+// Issue #41085: on macOS, the syscall wrappers behind node:fs issued a single
+// $NOCANCEL call and surfaced raw EINTR to JS instead of retrying. Node
+// (libuv) and Bun's Linux wrappers retry EINTR, so application code never
+// expects it. This test only runs on macOS: the single-shot arms were gated
+// #[cfg(target_os = "macos")], and other platforms already retried.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
+import { mkfifo } from "mkfifo";
+import { join } from "node:path";
+
+test.skipIf(!isMacOS)("fs.openSync retries EINTR instead of surfacing it", async () => {
+  using dir = tempDir("fs-eintr", {});
+  const fifo = join(String(dir), "fs-eintr.fifo");
+  mkfifo(fifo);
+
+  // The fixture blocks its main thread in open(2) on the fifo while a worker
+  // thread pelts that thread with SIGUSR1 (handler installed without
+  // SA_RESTART, so every delivery interrupts the syscall with EINTR). The
+  // worker then opens the write end to let the open complete.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fs-eintr-open-fixture.ts"), fifo],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("EINTR");
+  expect(stdout).toBe("unblocked\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/fs/fs-eintr-darwin.test.ts
+++ b/test/js/node/fs/fs-eintr-darwin.test.ts
@@ -25,7 +25,10 @@ test.skipIf(!isMacOS)("fs.openSync retries EINTR instead of surfacing it", async
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).not.toContain("EINTR");
+  if (exitCode !== 0) {
+    // Surface the fixture's stderr (the EINTR error) in the failure message.
+    expect(stderr).toBe("");
+  }
   expect(stdout).toBe("unblocked\n");
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/fs/fs-eintr-open-fixture.ts
+++ b/test/js/node/fs/fs-eintr-open-fixture.ts
@@ -1,0 +1,55 @@
+// Fixture for fs-eintr-darwin.test.ts (macOS only).
+//
+// Installs a SIGUSR1 handler WITHOUT SA_RESTART, then blocks the main thread
+// in open(2) on a fifo that has no writer. A worker thread directs SIGUSR1 at
+// this thread with pthread_kill, so the blocked openat returns EINTR on every
+// delivery. Bun must retry internally; surfacing EINTR to JS is the bug
+// (issue #41085).
+import { dlopen, ptr } from "bun:ffi";
+import { closeSync, openSync, readSync } from "node:fs";
+
+const fifo = process.argv[2];
+const SIGUSR1 = 30; // macOS
+const RTLD_DEFAULT = -2; // macOS
+
+const libc = dlopen("libc.dylib", {
+  sigaction: { args: ["i32", "ptr", "ptr"], returns: "i32" },
+  pthread_self: { args: [], returns: "u64" },
+  dlsym: { args: ["i64", "ptr"], returns: "u64" },
+});
+
+// The handler is getpid: async-signal-safe, ignores its argument.
+const name = Buffer.from("getpid\0");
+const handler = libc.symbols.dlsym(RTLD_DEFAULT, ptr(name));
+if (handler === 0n) {
+  console.error("dlsym(getpid) failed");
+  process.exit(1);
+}
+
+// struct sigaction on macOS: { void* sa_handler; sigset_t sa_mask (u32); int sa_flags; }
+const act = new Uint8Array(16);
+const view = new DataView(act.buffer);
+view.setBigUint64(0, BigInt(handler), true); // sa_handler
+view.setUint32(8, 0, true); // sa_mask: empty
+view.setInt32(12, 0, true); // sa_flags: no SA_RESTART
+if (libc.symbols.sigaction(SIGUSR1, ptr(act), null) !== 0) {
+  console.error("sigaction failed");
+  process.exit(1);
+}
+
+const worker = new Worker(new URL("./fs-eintr-signal-worker.ts", import.meta.url).href);
+worker.postMessage({ tid: libc.symbols.pthread_self(), fifo });
+
+try {
+  // Blocks until the worker opens the fifo for writing. The worker keeps
+  // interrupting this thread with SIGUSR1 the whole time.
+  const fd = openSync(fifo, "r");
+  const buf = Buffer.alloc(16);
+  const n = readSync(fd, buf, 0, 16, null);
+  closeSync(fd);
+  console.log(buf.toString("utf8", 0, n));
+  process.exit(0);
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/test/js/node/fs/fs-eintr-signal-worker.ts
+++ b/test/js/node/fs/fs-eintr-signal-worker.ts
@@ -1,0 +1,25 @@
+// Worker side of fs-eintr-open-fixture.ts (macOS only): directs SIGUSR1 at
+// the main thread while it blocks in open(2), then opens the fifo for writing
+// to unblock it.
+import { dlopen } from "bun:ffi";
+import { closeSync, openSync, writeSync } from "node:fs";
+
+declare var self: Worker;
+
+const SIGUSR1 = 30; // macOS
+
+const libc = dlopen("libc.dylib", {
+  pthread_kill: { args: ["u64", "i32"], returns: "i32" },
+});
+
+self.onmessage = ({ data: { tid, fifo } }) => {
+  // Each delivery interrupts the main thread's blocked openat with EINTR.
+  for (let i = 0; i < 30; i++) {
+    libc.symbols.pthread_kill(tid, SIGUSR1);
+    Bun.sleepSync(8);
+  }
+  // Unblock the reader.
+  const fd = openSync(fifo, "w");
+  writeSync(fd, "unblocked");
+  closeSync(fd);
+};


### PR DESCRIPTION
### Problem

- On macOS, `node:fs` APIs surface raw `EINTR` to JS under load: `EINTR: interrupted system call, open ...` and `EINTR: interrupted system call, scandir ...` (#41085). Node and libuv retry EINTR, so application code never expects it.
- The Darwin `$NOCANCEL` arms in `src/sys/lib.rs` issued exactly one syscall and returned any errno: `openat`, `read`, `write`, `recv`, `send`, and the `readv`/`writev`/`preadv`/`pwritev` family. Both `__getdirentries64` call sites behind `readdir` had the same gap. The Linux wrappers (`src/sys/linux_syscall.rs`) retry EINTR, so only macOS was exposed.

### Fix

- Route the Darwin arms through the same EINTR retry the other platforms use: the `check!`/`check_p!` macros for `openat`/`read`/`write`/`recv`/`send`, and a retry loop for the iovec family. The unused single-shot macros are removed.
- Both dir iterators now call one `bun_sys::getdirentries64` wrapper. It owns the extern declaration, the EINTR retry, and the EOF-flag zeroing. There is no `$NOCANCEL` variant of getdirentries64: it is not a pthread cancellation point.
- `close` stays single-shot on purpose: after EINTR the fd may already be released, and a retry could close an unrelated fd. `$NOCANCEL` stays everywhere: it only opts out of pthread cancellation points, which is orthogonal to EINTR.
- Self-reviewed: the surviving concerns were the duplicated getdirentries64 site (fixed), stale caller-side EINTR handling (removed), and macOS runtime validation, which only CI can provide (see Notes).
- Verified: `test/js/node/fs/fs-eintr-darwin.test.ts` (macOS only), plus `cargo check` for the changed crates on `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, `x86_64-unknown-freebsd`, and the host.

### Background

- `EINTR` means the kernel aborted a blocked syscall to run a signal handler installed without `SA_RESTART`. POSIX expects the caller to retry. libuv wraps every fs op in such a loop, so the npm ecosystem never handles EINTR.
- The single-shot behavior was ported verbatim from the pre-rewrite Zig `sys.zig`, where only the Darwin arms did not loop. No rationale exists for it, and no test depended on it.
- The test cannot run on Linux CI: the bug is inside `#[cfg(target_os = "macos")]` code, and Linux already retries. The test installs a no-`SA_RESTART` `SIGUSR1` handler through `bun:ffi`, blocks the main thread in `open(2)` on a fifo, and has a worker thread `pthread_kill` that exact thread 30 times before opening the write end. Every delivery forces EINTR on the blocked `openat`.

<details><summary>Notes</summary>

- Test sensitivity probe: I cannot run macOS locally, so I validated the fixture's mechanics on Linux with adapted constants (SIGUSR2, glibc sigaction layout). Against the normal build it completes (`delivered: 30`, reads `unblocked`, exit 0). With the Linux `openat` retry temporarily removed, to simulate the single-shot behavior the macOS arms had, it fails with exactly the reported error: `EINTR: interrupted system call, open '/tmp/eintr.fifo'`. The probe change was reverted; only the macOS arms changed in this PR.
- `pthread_kill` targets the blocked thread directly, so the test does not depend on which thread process-directed signals land on. That is why the reporter's own repro attempts (SIGCHLD storms, handler floods) were flaky: `kill(2)` picks an arbitrary thread.
- Sites audited and already correct: `pread`/`pwrite` (use `check!` on macOS), `poll` (retry loop around `poll$NOCANCEL`), `stat`/`fstat` family, and the copyfile EINTR loops in `node_fs.rs`. The `sendfile` caller-side retry in `FileResponseStream.rs` stays: sendfile is not one of the wrappers this PR changes.
- Follow-up candidate, not in this PR: a few in-tree signal handlers install without `SA_RESTART` (`c-bindings.cpp` signal forwarding, `SigintWatcher.cpp:51`, test Coordinator, repl). Adding `SA_RESTART` there would reduce how often these retries trigger at all. The retry in the wrappers is still required for user-installed handlers.
- Related report of the same escape class (tty read): https://github.com/can1357/oh-my-pi/issues/5328.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs-eintr-darwin.test.ts

<!-- robobun:evidence:end -->