### PR TITLE
Remove dead code from bun_bundler, bun_install, bun_runtime, bun_parsers, and the JSC private host functions

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5068,14 +5068,6 @@ pub enum TimespecMockMode {
     ForceRealTime,
 }
 
-/// `bun_core::timespec_mode::Mode` namespace shim —
-/// Rust can't do inherent associated types stably, so expose a module
-/// instead. Callers write `bun_core::timespec_mode::AllowMockedTime` or use
-/// the `Timespec::now_allow_mocked_time()` helper.
-pub mod timespec_mode {
-    pub use super::TimespecMockMode::*;
-}
-
 /// Mocked-time storage. The data lives at T0 so `Timespec::now` reads it
 /// directly; the test-runner (`useFakeTimers`) writes via `set`/`clear`
 /// from `bun_runtime::test_runner::timers::FakeTimers::CurrentTime`.

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -494,7 +494,7 @@ fn alloc_buf(_arena: DynAlloc, n: usize) -> Result<Vec<u8>, AllocError> {
 fn additional_output_file_index(f: &AdditionalFile) -> usize {
     match *f {
         AdditionalFile::OutputFile(i) => i as usize,
-        AdditionalFile::SourceIndex(_) => {
+        AdditionalFile::SourceIndex => {
             unreachable!("asset additional_files entry must be .output_file")
         }
     }

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -157,7 +157,7 @@ pub enum OptionsData {
         // arena dropped — global mimalloc.
         data: Box<[u8]>,
     },
-    Saved(usize),
+    Saved,
 }
 
 pub struct Options {
@@ -185,7 +185,7 @@ impl OutputFile {
     pub(crate) fn init(options: Options) -> OutputFile {
         let size = options.size.unwrap_or(match &options.data {
             OptionsData::Buffer { data } => data.len(),
-            OptionsData::Saved(_) => 0,
+            OptionsData::Saved => 0,
         });
         let owned_src_path_text: Box<[u8]> = options.input_path;
         // SAFETY: `owned_src_path_text` is a sibling field that outlives `src_path`; the boxed buffer never moves.
@@ -208,7 +208,7 @@ impl OutputFile {
             is_executable: options.is_executable,
             value: match options.data {
                 OptionsData::Buffer { data } => Value::Buffer { bytes: data },
-                OptionsData::Saved(_) => Value::Saved(SavedFile::default()),
+                OptionsData::Saved => Value::Saved(SavedFile::default()),
             },
             side: options.side,
             entry_point_index: options.entry_point_index,

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -107,7 +107,7 @@ pub enum Value {
     Copy(FileOperation),
     Noop,
     Buffer { bytes: Box<[u8]> },
-    Saved(SavedFile),
+    Saved,
 }
 
 impl Value {
@@ -142,15 +142,12 @@ impl Value {
                     noop,
                 )
             }
-            Value::Copy(_) | Value::Saved(_) => {
+            Value::Copy(_) | Value::Saved => {
                 bun_core::todo_panic!("to_bun_string_ref: Copy/Saved")
             }
         }
     }
 }
-
-#[derive(Default, Clone, Copy)]
-pub struct SavedFile {}
 
 pub enum OptionsData {
     Buffer {
@@ -208,7 +205,7 @@ impl OutputFile {
             is_executable: options.is_executable,
             value: match options.data {
                 OptionsData::Buffer { data } => Value::Buffer { bytes: data },
-                OptionsData::Saved => Value::Saved(SavedFile::default()),
+                OptionsData::Saved => Value::Saved,
             },
             side: options.side,
             entry_point_index: options.entry_point_index,
@@ -223,7 +220,7 @@ impl OutputFile {
     pub fn write_to_disk(&self, root_dir: Fd) -> Result<(), Error> {
         match &self.value {
             Value::Noop => {}
-            Value::Saved(_) => {
+            Value::Saved => {
                 // already written to disk
             }
             Value::Buffer { bytes } => {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2772,8 +2772,7 @@ pub mod bv2_impl {
                     let additional_files: &mut bun_alloc::AstVec<crate::AdditionalFile> =
                         &mut self.graph.input_files.items_additional_files_mut()
                             [source_index.get() as usize];
-                    additional_files
-                        .push(crate::AdditionalFile::SourceIndex(task.source_index.get()));
+                    additional_files.push(crate::AdditionalFile::SourceIndex);
                     self.graph.input_files.items_side_effects_mut()[source_index.get() as usize] =
                         bun_ast::SideEffects::NoSideEffectsPureData;
                     self.graph.estimated_file_loader_count += 1;
@@ -2884,8 +2883,7 @@ pub mod bv2_impl {
                     let additional_files: &mut bun_alloc::AstVec<crate::AdditionalFile> =
                         &mut self.graph.input_files.items_additional_files_mut()
                             [source_index.get() as usize];
-                    additional_files
-                        .push(crate::AdditionalFile::SourceIndex(task.source_index.get()));
+                    additional_files.push(crate::AdditionalFile::SourceIndex);
                     self.graph.input_files.items_side_effects_mut()[source_index.get() as usize] =
                         bun_ast::SideEffects::NoSideEffectsPureData;
                     self.graph.estimated_file_loader_count += 1;
@@ -3751,8 +3749,7 @@ pub mod bv2_impl {
                     let additional_files: &mut bun_alloc::AstVec<crate::AdditionalFile> =
                         &mut self.graph.input_files.items_additional_files_mut()
                             [source_index.get() as usize];
-                    additional_files
-                        .push(crate::AdditionalFile::SourceIndex(task.source_index.get()));
+                    additional_files.push(crate::AdditionalFile::SourceIndex);
                     self.graph.input_files.items_side_effects_mut()[source_index.get() as usize] =
                         bun_ast::SideEffects::NoSideEffectsPureData;
                     self.graph.estimated_file_loader_count += 1;
@@ -3849,7 +3846,7 @@ pub mod bv2_impl {
                     let additional_files: &mut bun_alloc::AstVec<crate::AdditionalFile> =
                         &mut self.graph.input_files.items_additional_files_mut()
                             [source_index.get() as usize];
-                    additional_files.push(crate::AdditionalFile::SourceIndex(source_index.get()));
+                    additional_files.push(crate::AdditionalFile::SourceIndex);
                     self.graph.input_files.items_side_effects_mut()[source_index.get() as usize] =
                         bun_ast::SideEffects::NoSideEffectsPureData;
                     self.graph.estimated_file_loader_count += 1;
@@ -4622,8 +4619,7 @@ pub mod bv2_impl {
                         let additional_files: &mut bun_alloc::AstVec<crate::AdditionalFile> =
                             &mut this.graph.input_files.items_additional_files_mut()
                                 [source_index.get() as usize];
-                        let _ = additional_files
-                            .push(crate::AdditionalFile::SourceIndex(source_index.get()));
+                        let _ = additional_files.push(crate::AdditionalFile::SourceIndex);
                         this.graph.input_files.items_side_effects_mut()
                             [source_index.get() as usize] =
                             bun_ast::SideEffects::NoSideEffectsPureData;
@@ -5010,9 +5006,7 @@ pub mod bv2_impl {
                                         crate::AdditionalFile,
                                     > = &mut this.graph.input_files.items_additional_files_mut()
                                         [source_index.get() as usize];
-                                    additional_files.push(crate::AdditionalFile::SourceIndex(
-                                        task.source_index.get(),
-                                    ));
+                                    additional_files.push(crate::AdditionalFile::SourceIndex);
                                     this.graph.input_files.items_side_effects_mut()
                                         [source_index.get() as usize] =
                                         bun_ast::SideEffects::NoSideEffectsPureData;
@@ -5394,7 +5388,7 @@ pub mod bv2_impl {
                 b"metafile.md".as_slice()
             }),
             output_path: Box::<[u8]>::from(file_path),
-            data: crate::output_file::OptionsData::Saved(content.len()),
+            data: crate::output_file::OptionsData::Saved,
             output_kind,
             is_executable: false,
             side: None,
@@ -6920,9 +6914,7 @@ pub mod bv2_impl {
                         let additional_files: &mut bun_alloc::AstVec<crate::AdditionalFile> =
                             &mut self.graph.input_files.items_additional_files_mut()
                                 [importer_source_index as usize];
-                        additional_files.push(crate::AdditionalFile::SourceIndex(
-                            new_task.source_index.get(),
-                        ));
+                        additional_files.push(crate::AdditionalFile::SourceIndex);
                         self.graph.input_files.items_side_effects_mut()
                             [new_task.source_index.get() as usize] =
                             bun_ast::SideEffects::NoSideEffectsPureData;
@@ -6932,12 +6924,10 @@ pub mod bv2_impl {
                     self.graph.pool().schedule(new_task);
                 } else {
                     if loader.should_copy_for_bundling() {
-                        // SAFETY: value_ptr is valid (see above).
-                        let existing_idx = unsafe { *value_ptr };
                         let additional_files: &mut bun_alloc::AstVec<crate::AdditionalFile> =
                             &mut self.graph.input_files.items_additional_files_mut()
                                 [importer_source_index as usize];
-                        additional_files.push(crate::AdditionalFile::SourceIndex(existing_idx));
+                        additional_files.push(crate::AdditionalFile::SourceIndex);
                         self.graph.estimated_file_loader_count += 1;
                     }
 

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -228,7 +228,7 @@ pub use thread_pool::{ThreadPool, Worker};
 /// See `transpiler`.
 pub use transpiler::Transpiler;
 pub enum AdditionalFile {
-    SourceIndex(u32),
+    SourceIndex,
     OutputFile(u32),
 }
 

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -16,7 +16,7 @@ use crate::linker_context_mod::debug;
 use crate::options::{self, Loader, OutputFile, SourceMapOption};
 use crate::output_file::{
     BakeExtra, Index as OutputFileIndex, IndexOptional, Options as OutputFileInit,
-    OptionsData as OutputFileData, SavedFile, Value as OutputFileValue,
+    OptionsData as OutputFileData, Value as OutputFileValue,
 };
 use crate::{BundleV2, Chunk, cheap_prefix_normalizer};
 
@@ -673,7 +673,7 @@ pub(crate) fn write_output_files_to_disk(
             let bytes_len = bytes.len();
             drop(bytes);
             *dest = core::mem::replace(src, OutputFile::zero_value());
-            dest.value = OutputFileValue::Saved(SavedFile::default());
+            dest.value = OutputFileValue::Saved;
             dest.size = bytes_len;
         }
     }

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -152,7 +152,7 @@ pub(crate) fn write_output_files_to_disk(
                             input_loader: Loader::File,
                             output_kind: options::OutputKind::Sourcemap,
                             size: Some(output_source_map.len()),
-                            data: OutputFileData::Saved(0),
+                            data: OutputFileData::Saved,
                             side: Some(options::Side::Client),
                             entry_point_index: None,
                             is_executable: false,
@@ -172,7 +172,7 @@ pub(crate) fn write_output_files_to_disk(
             };
 
             let _ = output_files.insert_for_chunk(OutputFile::init(OutputFileInit {
-                data: OutputFileData::Saved(0),
+                data: OutputFileData::Saved,
                 hash: None,
                 loader: chunk.content.loader(),
                 input_path: Box::default(),
@@ -348,7 +348,7 @@ pub(crate) fn write_output_files_to_disk(
                     input_loader: Loader::File,
                     output_kind: options::OutputKind::Sourcemap,
                     size: Some(output_source_map.len()),
-                    data: OutputFileData::Saved(0),
+                    data: OutputFileData::Saved,
                     side: Some(options::Side::Client),
                     entry_point_index: None,
                     is_executable: false,
@@ -476,7 +476,7 @@ pub(crate) fn write_output_files_to_disk(
                             loader: Loader::File,
                             size: Some(bytecode.len()),
                             display_size: bytecode.len() as u32,
-                            data: OutputFileData::Saved(0),
+                            data: OutputFileData::Saved,
                             side: None,
                             entry_point_index: None,
                             is_executable: false,
@@ -558,7 +558,7 @@ pub(crate) fn write_output_files_to_disk(
             size: Some(code_result.buffer.len()),
             display_size: display_size as u32,
             is_executable: chunk.flags.contains(ChunkFlags::IS_EXECUTABLE),
-            data: OutputFileData::Saved(0),
+            data: OutputFileData::Saved,
             side: Some(if matches!(chunk.content, Content::Css(_)) {
                 options::Side::Client
             } else {

--- a/src/exe_format/macho_types.rs
+++ b/src/exe_format/macho_types.rs
@@ -14,9 +14,7 @@
 // Canonical `<mach-o/loader.h>` POD layouts live in `bun_sys::macho` (lower-tier
 // crate, also consumed by `crash_handler`). Re-export so `exe_format::macho`
 // keeps its existing `macho::segment_command_64` etc. paths.
-pub use bun_sys::macho::{
-    cpu_subtype_t, cpu_type_t, load_command, mach_header_64, segment_command_64, vm_prot_t,
-};
+pub use bun_sys::macho::{cpu_type_t, mach_header_64, segment_command_64, vm_prot_t};
 
 pub(crate) const CPU_TYPE_ARM64: cpu_type_t = 0x0100_000C;
 
@@ -193,7 +191,7 @@ unsafe impl bytemuck::NoUninit for SuperBlob {}
 // ── load-command iterator ─────────────────────────────────────────────────
 // Canonical impl lives in `bun_sys::macho` (raw-ptr storage; see module-level
 // SAFETY note above for why a borrowed `&[u8]` does not work for `macho.rs`).
-pub use bun_sys::macho::{LoadCommand, LoadCommandIterator, RawSlice};
+pub use bun_sys::macho::LoadCommandIterator;
 
 #[inline]
 fn parse_name(name: &[u8; 16]) -> &[u8] {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -512,7 +512,6 @@ pub fn enqueue_package_for_download(
 }
 
 pub enum DependencyToEnqueue {
-    Pending(DependencyID),
     Resolution {
         package_id: PackageID,
         resolution: Resolution,

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -388,7 +388,6 @@ impl hooks::AutoInstaller for PackageManager {
                 package_id,
                 resolution: resolution_to_hooks(&resolution),
             },
-            enqueue::DependencyToEnqueue::Pending(id) => hooks::EnqueueResult::Pending(id),
             enqueue::DependencyToEnqueue::NotFound => hooks::EnqueueResult::NotFound,
             enqueue::DependencyToEnqueue::Failure(e) => hooks::EnqueueResult::Failure(e.into()),
         }

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1406,7 +1406,6 @@ pub enum EnqueueResult {
         package_id: PackageID,
         resolution: Resolution,
     },
-    Pending(DependencyID),
     NotFound,
     Failure(bun_core::Error),
 }

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -63,7 +63,6 @@ using namespace JSC;
     macro(createCommonJSModule) \
     macro(createFIFO) \
     macro(createInternalModuleById) \
-    macro(createUninitializedArrayBuffer) \
     macro(ctimeMs) \
     macro(data) \
     macro(decode) \

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -44,7 +44,6 @@ using namespace JSC;
     macro(_owner) \
     macro(_store) \
     macro(abort) \
-    macro(addAbortAlgorithmToSignal) \
     macro(arrayBuffer) \
     macro(asUint8Array) \
     macro(atimeMs) \
@@ -104,7 +103,6 @@ using namespace JSC;
     macro(internalMessage) \
     macro(internalModuleRegistry) \
     macro(internalRequire) \
-    macro(isAbortSignal) \
     macro(isAbsolute) \
     macro(isUncloneable) \
     macro(isUntransferable) \
@@ -117,9 +115,7 @@ using namespace JSC;
     macro(loadEsmIntoCjs) \
     macro(main) \
     macro(makeAbortError) \
-    macro(makeDOMException) \
     macro(makeErrorWithCode) \
-    macro(makeGetterTypeError) \
     macro(maxAge) \
     macro(metafileJson) \
     macro(method) \
@@ -155,7 +151,6 @@ using namespace JSC;
     macro(readableType) \
     macro(redirect) \
     macro(relative) \
-    macro(removeAbortAlgorithmFromSignal) \
     macro(require) \
     macro(requireESM) \
     macro(requireMap) \

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -84,7 +84,6 @@
 #include "IDLTypes.h"
 #include "ImportMetaObject.h"
 #include "JS2Native.h"
-#include "JSAbortAlgorithm.h"
 #include "JSAbortController.h"
 #include "JSAbortSignal.h"
 #include "streams/JSCompressionStream.h"
@@ -1774,92 +1773,11 @@ JSC_DEFINE_HOST_FUNCTION(functionNavigatorGetHardwareConcurrency, (JSC::JSGlobal
     return JSValue::encode(JSC::jsNumber(WTF::numberOfProcessorCores()));
 }
 
-JSC_DECLARE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins);
-JSC_DECLARE_HOST_FUNCTION(makeDOMExceptionForBuiltins);
-JSC_DECLARE_HOST_FUNCTION(isAbortSignal);
 JSC_DECLARE_HOST_FUNCTION(jsBunPeekPromiseStatus);
 JSC_DECLARE_HOST_FUNCTION(jsBunPeekPromiseSettledValue);
 JSC_DECLARE_HOST_FUNCTION(jsBunPokePromiseAsHandled);
 JSC_DECLARE_HOST_FUNCTION(jsWebStreamClosedPromise);
 JSC_DECLARE_HOST_FUNCTION(jsWebStreamControllerError);
-
-JSC_DEFINE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    ASSERT(callFrame);
-    ASSERT(callFrame->argumentCount() == 2);
-    VM& vm = globalObject->vm();
-    DeferTermination deferScope(vm);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto interfaceName = callFrame->uncheckedArgument(0).getString(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto attributeName = callFrame->uncheckedArgument(1).getString(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    auto error = static_cast<ErrorInstance*>(createTypeError(globalObject, JSC::makeDOMAttributeGetterTypeErrorMessage(interfaceName.utf8().data(), attributeName)));
-    error->setNativeGetterTypeError();
-    return JSValue::encode(error);
-}
-
-JSC_DEFINE_HOST_FUNCTION(makeDOMExceptionForBuiltins, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    ASSERT(callFrame);
-    ASSERT(callFrame->argumentCount() == 2);
-
-    auto& vm = JSC::getVM(globalObject);
-    DeferTermination deferScope(vm);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto codeValue = callFrame->uncheckedArgument(0).getString(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    auto message = callFrame->uncheckedArgument(1).getString(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    ExceptionCode code { TypeError };
-    if (codeValue == "AbortError"_s)
-        code = AbortError;
-    auto value = createDOMException(globalObject, code, message);
-
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
-
-    return JSValue::encode(value);
-}
-
-JSC_DEFINE_HOST_FUNCTION(addAbortAlgorithmToSignal, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    ASSERT(callFrame);
-    ASSERT(callFrame->argumentCount() == 2);
-
-    auto& vm = JSC::getVM(globalObject);
-    auto* abortSignal = dynamicDowncast<JSAbortSignal>(callFrame->uncheckedArgument(0));
-    if (!abortSignal) [[unlikely]]
-        return JSValue::encode(JSValue(JSC::JSValue::JSFalse));
-
-    Ref<AbortAlgorithm> abortAlgorithm = JSAbortAlgorithm::create(vm, callFrame->uncheckedArgument(1).getObject());
-
-    auto algorithmIdentifier = AbortSignal::addAbortAlgorithmToSignal(abortSignal->wrapped(), WTF::move(abortAlgorithm));
-    return JSValue::encode(JSC::jsNumber(algorithmIdentifier));
-}
-
-JSC_DEFINE_HOST_FUNCTION(removeAbortAlgorithmFromSignal, (JSGlobalObject*, CallFrame* callFrame))
-{
-    ASSERT(callFrame);
-    ASSERT(callFrame->argumentCount() == 2);
-
-    auto* abortSignal = dynamicDowncast<JSAbortSignal>(callFrame->uncheckedArgument(0));
-    if (!abortSignal) [[unlikely]]
-        return JSValue::encode(JSValue(JSC::JSValue::JSFalse));
-
-    AbortSignal::removeAbortAlgorithmFromSignal(abortSignal->wrapped(), callFrame->uncheckedArgument(1).asUInt32());
-    return JSValue::encode(JSC::jsUndefined());
-}
-
-JSC_DEFINE_HOST_FUNCTION(isAbortSignal, (JSGlobalObject*, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argumentCount() == 1);
-    return JSValue::encode(jsBoolean(callFrame->uncheckedArgument(0).inherits<JSAbortSignal>()));
-}
 
 // JSPromise lost its JSInternalFieldObjectImpl<2> layout in WebKit, so the
 // @getPromiseInternalField/@putPromiseInternalField bytecode intrinsics that
@@ -2861,11 +2779,6 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         JSC::EncodedJSValue(JSC_HOST_CALL_ATTRIBUTES* function)(JSC::JSGlobalObject*, JSC::CallFrame*);
     };
     static constexpr PrivateFunction privateFunctions[] = {
-        { BuiltinName::k_makeGetterTypeError, 2, makeGetterTypeErrorForBuiltins },
-        { BuiltinName::k_makeDOMException, 2, makeDOMExceptionForBuiltins },
-        { BuiltinName::k_addAbortAlgorithmToSignal, 2, addAbortAlgorithmToSignal },
-        { BuiltinName::k_removeAbortAlgorithmFromSignal, 2, removeAbortAlgorithmFromSignal },
-        { BuiltinName::k_isAbortSignal, 1, isAbortSignal },
         { BuiltinName::k_peekPromiseStatus, 1, jsBunPeekPromiseStatus },
         { BuiltinName::k_peekPromiseSettledValue, 1, jsBunPeekPromiseSettledValue },
         { BuiltinName::k_pokePromiseAsHandled, 1, jsBunPokePromiseAsHandled },

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1620,22 +1620,6 @@ extern "C" JSC::EncodedJSValue Bun__createTypedArrayForCopy(JSC::JSGlobalObject*
     return {};
 }
 
-JSC_DECLARE_HOST_FUNCTION(functionCreateUninitializedArrayBuffer);
-JSC_DEFINE_HOST_FUNCTION(functionCreateUninitializedArrayBuffer,
-    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
-{
-    size_t len = static_cast<size_t>(JSC__JSValue__toInt64(JSC::JSValue::encode(callFrame->argument(0))));
-    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto arrayBuffer = JSC::ArrayBuffer::tryCreateUninitialized(len, 1);
-
-    if (!arrayBuffer) [[unlikely]] {
-        JSC::throwOutOfMemoryError(globalObject, scope);
-        return {};
-    }
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSArrayBuffer::create(globalObject->vm(), globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(arrayBuffer))));
-}
-
 static inline JSC::EncodedJSValue jsFunctionAddEventListenerBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, Zig::GlobalObject* castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -2818,7 +2802,6 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     putDirectBuiltinFunction(vm, this, builtinNames.overridableRequirePrivateName(), commonJSOverridableRequireCodeGenerator(vm), 0);
 
-    putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, functionImportMeta__resolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.createInternalModuleByIdPrivateName(), 1, InternalModuleRegistry::jsCreateInternalModuleById, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -818,8 +818,6 @@ pub mod resolved_source_tag {
 
     #[allow(non_upper_case_globals)]
     impl ResolvedSourceTag {
-        /// `InternalModuleRegistryFlag` in SyntheticModuleType.h: builtin-module tags are `(1 << 9) | InternalModuleRegistry id`.
-        pub const INTERNAL_MODULE_REGISTRY_FLAG: u32 = 1 << 9;
         // Structural variants — keep in lock-step with the generated
         // `build/*/codegen/SyntheticModuleType.h` and
         // `src/jsc/bindings/headers-handwritten.h` (`ResolvedSourceTagPackageJSONTypeModule = 1`).

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -1088,7 +1088,7 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
             NodeTag::Str => {
                 // always becomes string
             }
-            NodeTag::Verbatim(_) | NodeTag::Unknown(_) => {
+            NodeTag::Verbatim | NodeTag::Unknown => {
                 // also always becomes a string
             }
         }
@@ -1538,9 +1538,9 @@ pub enum NodeTag {
     /// '!!str'
     Str,
     /// '!<...>'
-    Verbatim(StringRange),
+    Verbatim,
     /// '!!unknown'
-    Unknown(StringRange),
+    Unknown,
 }
 
 impl NodeTag {
@@ -1551,8 +1551,8 @@ impl NodeTag {
             | NodeTag::Int
             | NodeTag::Float
             | NodeTag::Null
-            | NodeTag::Verbatim(_)
-            | NodeTag::Unknown(_) => Expr::init(E::Null {}, loc),
+            | NodeTag::Verbatim
+            | NodeTag::Unknown => Expr::init(E::Null {}, loc),
 
             // non-specific tags become seq, map, or str
             NodeTag::NonSpecific | NodeTag::Str => Expr::init(E::String::default(), loc),
@@ -5557,21 +5557,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 // c-verbatim-tag
                 self.inc(1);
 
-                let prefix = 'prefix: {
-                    if Enc::wide(self.next()) == 0x21 /* '!' */ {
-                        self.inc(1);
-                        let range = self.string_range();
-                        self.skip_ns_uri_chars();
-                        break 'prefix range.end(self.pos);
-                    }
-                    if let Some(len) = self.is_ns_tag_char() {
-                        let range = self.string_range();
-                        self.inc(len as usize);
-                        self.skip_ns_uri_chars();
-                        break 'prefix range.end(self.pos);
-                    }
+                if Enc::wide(self.next()) == 0x21 /* '!' */ {
+                    self.inc(1);
+                    self.skip_ns_uri_chars();
+                } else if let Some(len) = self.is_ns_tag_char() {
+                    self.inc(len as usize);
+                    self.skip_ns_uri_chars();
+                } else {
                     return Err(ParseError::UnexpectedCharacter);
-                };
+                }
 
                 self.try_skip_char(Enc::ch(b'>'))?;
 
@@ -5579,7 +5573,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     start,
                     indent: self.line_indent,
                     line: self.line,
-                    tag: NodeTag::Verbatim(prefix),
+                    tag: NodeTag::Verbatim,
                 }));
             }
             0x21 /* '!' */ => {
@@ -5612,7 +5606,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             }
             _ => {
                 // c-ns-shorthand-tag / named tag handle
-                let mut range = self.string_range();
+                let range = self.string_range();
                 let off = range.off;
                 self.try_skip_ns_word_chars()?;
                 let mut handle_or_shorthand = range.end(self.pos);
@@ -5627,15 +5621,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         return Err(ParseError::UnresolvedTagHandle);
                     }
 
-                    range = self.string_range();
                     self.try_skip_ns_tag_chars()?;
-                    let shorthand = range.end(self.pos);
 
                     return Ok(Token::tag(TagInit {
                         start,
                         indent: self.line_indent,
                         line: self.line,
-                        tag: NodeTag::Unknown(shorthand),
+                        tag: NodeTag::Unknown,
                     }));
                 }
 
@@ -5672,7 +5664,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         if eq_ascii::<Enc>(s, b"str") {
             return NodeTag::Str;
         }
-        NodeTag::Unknown(shorthand)
+        NodeTag::Unknown
     }
 
     // ── scan ────────────────────────────────────────────────────────────────

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3002,16 +3002,10 @@ impl<'a> Resolver<'a> {
                         &esm,
                         dependency_behavior,
                         &mut resolved_package_id,
-                        dependency_version.clone(),
+                        &dependency_version,
                         string_buf,
                     ) {
                         DependencyToResolve::Resolution(res) => break 'brk res,
-                        DependencyToResolve::Pending(pending) => {
-                            if let Some(d) = self.debug_logs.as_mut() {
-                                d.decrease_indent();
-                            }
-                            return MatchStatus::Pending(pending);
-                        }
                         DependencyToResolve::Failure(err) => {
                             if let Some(d) = self.debug_logs.as_mut() {
                                 d.decrease_indent();
@@ -3479,7 +3473,7 @@ impl<'a> Resolver<'a> {
         esm: &crate::package_json::Package<'_>,
         behavior: Dependency::Behavior,
         input_package_id_: &mut Install::PackageID,
-        version: Dependency::Version,
+        version: &Dependency::Version,
         version_buf: &[u8],
     ) -> DependencyToResolve {
         if let Some(debug) = self.debug_logs.as_mut() {
@@ -3507,7 +3501,7 @@ impl<'a> Resolver<'a> {
             };
         }
         // we should never be trying to resolve a dependency that is already resolved
-        debug_assert!(pm!().lockfile_resolve(esm.name, &version).is_none());
+        debug_assert!(pm!().lockfile_resolve(esm.name, version).is_none());
 
         // Add the containing package to the lockfile
 
@@ -3547,7 +3541,7 @@ impl<'a> Resolver<'a> {
         }
 
         if self.opts.install_preference == bun_options_types::offline_mode::OfflineMode::Offline {
-            if let Some(package_id) = pm!().resolve_from_disk_cache(esm.name, &version) {
+            if let Some(package_id) = pm!().resolve_from_disk_cache(esm.name, version) {
                 *input_package_id_ = package_id;
                 return DependencyToResolve::Resolution(
                     pm!().lockfile_package_resolution(package_id),
@@ -3558,25 +3552,13 @@ impl<'a> Resolver<'a> {
         if input_package_id == Install::INVALID_PACKAGE_ID || input_package_id == 0 {
             // All packages are enqueued to the root
             // because we download all the npm package dependencies
-            match pm!().enqueue_dependency_to_root(esm.name, &version, version_buf, behavior) {
+            match pm!().enqueue_dependency_to_root(esm.name, version, version_buf, behavior) {
                 Install::EnqueueResult::Resolution {
                     package_id,
                     resolution,
                 } => {
                     *input_package_id_ = package_id;
                     return DependencyToResolve::Resolution(resolution);
-                }
-                Install::EnqueueResult::Pending(id) => {
-                    let (cloned, string_buf) = esm.copy().expect("unreachable");
-
-                    return DependencyToResolve::Pending(Box::new(PendingResolution {
-                        esm: cloned,
-                        dependency: version,
-                        root_dependency_id: id,
-                        string_buf,
-                        tag: PendingResolutionTag::Resolve,
-                        ..Default::default()
-                    }));
                 }
                 Install::EnqueueResult::NotFound => {
                     return DependencyToResolve::NotFound;
@@ -6600,7 +6582,6 @@ impl<'a> Resolver<'a> {
 
 enum DependencyToResolve {
     NotFound,
-    Pending(Box<PendingResolution>),
     Failure(crate::Error),
     Resolution(Resolution),
 }

--- a/src/runtime/api/output_file_jsc.rs
+++ b/src/runtime/api/output_file_jsc.rs
@@ -82,7 +82,7 @@ impl OutputFileJsc for OutputFile {
                 // the leak/from_raw pair lives once in the `#[js_class]` shim.
                 BuildArtifact::to_js_boxed(build_output, global_object)
             }
-            OutputFileValue::Saved(_) => {
+            OutputFileValue::Saved => {
                 let path_to_use: &[u8] = owned_pathname.unwrap_or(self.src_path.text);
 
                 let file_blob = match BlobStore::init_file(
@@ -160,7 +160,7 @@ impl OutputFileJsc for OutputFile {
                 )?;
                 Ok(Blob::init_with_store(file_blob, global_this))
             }
-            OutputFileValue::Saved(_) => {
+            OutputFileValue::Saved => {
                 let file_blob = BlobStore::init_file(
                     PathOrFileDescriptor::Path(PathLike::owned(self.src_path.text.to_vec())),
                     Some(mime),

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2426,7 +2426,6 @@ pub mod internal {
 
     pub enum DNSRequestOwner {
         Socket(*mut ConnectingSocket),           // FFI
-        Prefetch(*mut Loop),                     // FFI
         Quic(*mut bun_http::H3::PendingConnect), // BORROW_PARAM
     }
 
@@ -2443,7 +2442,6 @@ pub mod internal {
                 DNSRequestOwner::Socket(socket) => unsafe {
                     us_internal_dns_callback_threadsafe(*socket, req)
                 },
-                DNSRequestOwner::Prefetch(_) => freeaddrinfo(req, 0),
                 // SAFETY: `pc` is the live PendingConnect borrowed for the lifetime of the request.
                 DNSRequestOwner::Quic(pc) => unsafe {
                     bun_http::H3::PendingConnect::on_dns_resolved_threadsafe(*pc)
@@ -2459,7 +2457,6 @@ pub mod internal {
         #[allow(clippy::not_unsafe_ptr_arg_deref)]
         pub(crate) fn notify(&self, req: *mut Request) {
             match self {
-                DNSRequestOwner::Prefetch(_) => freeaddrinfo(req, 0),
                 // SAFETY: `socket` is the live usockets handle stored when the request was registered.
                 DNSRequestOwner::Socket(socket) => unsafe {
                     us_internal_dns_callback(*socket, req)

--- a/src/runtime/ffi/mod.rs
+++ b/src/runtime/ffi/mod.rs
@@ -23,11 +23,6 @@ pub mod ffi {
 #[path = "FFIObject.rs"]
 pub mod ffi_object_draft;
 
-// Canonical name (re-exported by `runtime::api`
-// as `FFIObject`); the module itself still lives under the draft name because
-// `api/BunObject.rs` references `crate::ffi::ffi_object_draft::getter`.
-pub use ffi_object_draft as ffi_object;
-
 // ─── DOMCall slowpath C-ABI exports ──────────────────────────────────────────
 // The C++ DOMJIT side expects a `<class>__<fn>__slowpath` export with
 // signature `slowpath(global, this, args_ptr, args_len)`. The bodies live in

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -172,7 +172,7 @@ pub enum AnyRoute {
     /// Bundle an HTML import — `import html from "./index.html"; "/": html`
     Html(bun_ptr::RefPtr<html_bundle::Route>),
     /// Use file-system routing — `"/*": { dir: …, style: "nextjs-pages" }`
-    FrameworkRouter(crate::bake::framework_router::TypeIndex),
+    FrameworkRouter,
 }
 
 impl AnyRoute {
@@ -182,9 +182,7 @@ impl AnyRoute {
             AnyRoute::File(r) => r.memory_cost(),
             AnyRoute::Directory(r) => r.memory_cost(),
             AnyRoute::Html(r) => r.memory_cost(),
-            AnyRoute::FrameworkRouter(_) => {
-                core::mem::size_of::<crate::bake::FileSystemRouterType>()
-            }
+            AnyRoute::FrameworkRouter => core::mem::size_of::<crate::bake::FileSystemRouterType>(),
         }
     }
 
@@ -2553,7 +2551,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     }
                     needs_plugins = true;
                 }
-                AnyRoute::FrameworkRouter(_) => {}
+                AnyRoute::FrameworkRouter => {}
             }
         }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -877,11 +877,7 @@ impl AnyRoute {
                         limit
                     )));
                 }
-                return Ok(Some(AnyRoute::FrameworkRouter(
-                    FrameworkRouter::TypeIndex::init(
-                        u8::try_from(init_ctx.framework_router_list.len() - 1).expect("int cast"),
-                    ),
-                )));
+                return Ok(Some(AnyRoute::FrameworkRouter));
             }
         }
 

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -257,7 +257,7 @@ pub enum BuiltinIO {
 /// Input stream of a builtin.
 pub enum BuiltinInput {
     Fd(Arc<IOReader>),
-    ArrayBuf { buf: PinnedArrayBuffer, i: u32 },
+    ArrayBuf { buf: PinnedArrayBuffer },
     Blob(Arc<BuiltinBlob>),
     Ignore,
 }
@@ -431,7 +431,7 @@ impl Builtin {
     /// only.
     #[cfg(not(windows))]
     pub(crate) fn defuse_array_buf_pins(&mut self) {
-        if let BuiltinInput::ArrayBuf { buf, .. } = &mut self.stdin {
+        if let BuiltinInput::ArrayBuf { buf } = &mut self.stdin {
             buf.defuse();
         }
         if let BuiltinIO::ArrayBuf { buf, .. } = &mut self.stdout {
@@ -707,7 +707,7 @@ impl Builtin {
                         let Some(buf) = root() else {
                             return Some(Yield::failed());
                         };
-                        me.stdin = BuiltinInput::ArrayBuf { buf, i: 0 };
+                        me.stdin = BuiltinInput::ArrayBuf { buf };
                     }
                     if redirect.stdout() {
                         let Some(buf) = root() else {
@@ -873,7 +873,7 @@ impl Builtin {
     /// (arraybuf / piped buf / blob).
     pub(crate) fn read_stdin_no_io<'a>(interp: &'a Interpreter, cmd: NodeId) -> &'a [u8] {
         match &Self::of(interp, cmd).stdin {
-            BuiltinInput::ArrayBuf { buf, .. } => buf.slice(),
+            BuiltinInput::ArrayBuf { buf } => buf.slice(),
             BuiltinInput::Blob(b) => b.blob.shared_view(),
             BuiltinInput::Fd(_) | BuiltinInput::Ignore => b"",
         }

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -84,7 +84,7 @@ pub enum PromptBehaviour {
     #[default]
     Never,
     /// `-I`, `--interactive=once`
-    Once { removed_count: u32 },
+    Once,
     /// `-i`, `--interactive=always`
     Always,
 }
@@ -527,7 +527,7 @@ impl Rm {
                     RmParseFlag::ContinueParsing
                 }
                 b"--interactive=once" => {
-                    opts.prompt_behaviour = PromptBehaviour::Once { removed_count: 0 };
+                    opts.prompt_behaviour = PromptBehaviour::Once;
                     RmParseFlag::ContinueParsing
                 }
                 b"--interactive=always" => {
@@ -546,7 +546,7 @@ impl Rm {
                 b'r' | b'R' => opts.recursive = true,
                 b'v' => opts.verbose = true,
                 b'd' => opts.remove_empty_dirs = true,
-                b'i' => opts.prompt_behaviour = PromptBehaviour::Once { removed_count: 0 },
+                b'i' => opts.prompt_behaviour = PromptBehaviour::Once,
                 b'I' => opts.prompt_behaviour = PromptBehaviour::Always,
                 _ => return RmParseFlag::IllegalOptionWithFlag,
             }

--- a/src/runtime/shell/states/Async.rs
+++ b/src/runtime/shell/states/Async.rs
@@ -29,7 +29,7 @@ pub enum AsyncState {
     Exec {
         child: Option<NodeId>,
     },
-    Done(ExitCode),
+    Done,
 }
 
 impl Async {
@@ -90,7 +90,7 @@ impl Async {
                         NextAction::SpawnChild
                     }
                 }
-                AsyncState::Done(_) => NextAction::Finish,
+                AsyncState::Done => NextAction::Finish,
             }
         };
         match action {
@@ -137,11 +137,11 @@ impl Async {
         interp: &Interpreter,
         this: NodeId,
         child: NodeId,
-        exit_code: ExitCode,
+        _exit_code: ExitCode,
     ) -> Yield {
         log!("Async {} childDone", this);
         interp.deinit_node(child);
-        interp.as_async_mut(this).state = AsyncState::Done(exit_code);
+        interp.as_async_mut(this).state = AsyncState::Done;
         Self::enqueue_self(interp, this);
         Yield::suspended()
     }

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -131,16 +131,10 @@ impl ByteBlobLoader {
         debug_assert!(buffer.as_ptr() != temporary.as_ptr());
         buffer[..temporary.len()].copy_from_slice(temporary);
         if self.remain == 0 {
-            return streams::Result::IntoArrayAndDone(streams::IntoArray {
-                value: array,
-                len: copied,
-            });
+            return streams::Result::IntoArrayAndDone(streams::IntoArray { len: copied });
         }
 
-        streams::Result::IntoArray(streams::IntoArray {
-            value: array,
-            len: copied,
-        })
+        streams::Result::IntoArray(streams::IntoArray { len: copied })
     }
 
     pub(crate) fn to_any_blob(&mut self, global: &JSGlobalObject) -> Option<blob::Any> {

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -607,19 +607,17 @@ impl ByteStream {
                         self.pending.with_mut(|p| p.result = streams::Result::Done);
                     }
                 } else {
-                    let v = self.value();
+                    self.value();
                     self.pending.with_mut(|p| {
                         p.result = streams::Result::IntoArrayAndDone(IntoArray {
-                            value: v,
                             len: to_copy_len as blob::SizeType, // @truncate
                         });
                     });
                 }
             } else {
-                let v = self.value();
+                self.value();
                 self.pending.with_mut(|p| {
                     p.result = streams::Result::IntoArray(IntoArray {
-                        value: v,
                         len: to_copy_len as blob::SizeType, // @truncate
                     });
                 });
@@ -752,13 +750,11 @@ impl ByteStream {
                 self.done.set(true);
 
                 return streams::Result::IntoArrayAndDone(IntoArray {
-                    value: view,
                     len: to_write as blob::SizeType, // @truncate
                 });
             }
 
             return streams::Result::IntoArray(IntoArray {
-                value: view,
                 len: to_write as blob::SizeType, // @truncate
             });
         }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -709,7 +709,6 @@ impl FileReader {
             } else if pending_buf.len() >= buffered.len() {
                 pending_buf[..buffered.len()].copy_from_slice(&buffered);
                 streams::Result::IntoArrayAndDone(streams::IntoArray {
-                    value: self.pending_value.get().get().unwrap_or_default(),
                     len: buffered.len() as u64,
                 })
             } else {
@@ -721,7 +720,6 @@ impl FileReader {
             let result = if pending_buf.len() >= chunk.len() {
                 pending_buf[..chunk.len()].copy_from_slice(&chunk);
                 let into = streams::IntoArray {
-                    value: self.pending_value.get().get().unwrap_or_default(),
                     len: chunk.len() as u64,
                 };
                 if was_done {
@@ -781,12 +779,10 @@ impl FileReader {
 
                 if self.reader().is_done() {
                     return streams::Result::IntoArrayAndDone(streams::IntoArray {
-                        value: array,
                         len: drained_len as u64,
                     });
                 } else {
                     return streams::Result::IntoArray(streams::IntoArray {
-                        value: array,
                         len: drained_len as u64,
                     });
                 }
@@ -810,7 +806,6 @@ impl FileReader {
             let done = state == ReadState::Eof || self.reader().is_done();
             if amount_read > 0 {
                 let into = streams::IntoArray {
-                    value: array,
                     len: amount_read as u64,
                 };
                 return if done {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -486,7 +486,6 @@ impl Writable {
 
 #[derive(Copy, Clone)]
 pub struct IntoArray {
-    pub value: JSValue,
     pub(crate) len: BlobSizeType,
 }
 

--- a/src/sql_jsc/mysql/protocol/ResultSet.rs
+++ b/src/sql_jsc/mysql/protocol/ResultSet.rs
@@ -15,8 +15,6 @@ use crate::shared::sql_data_cell::{Flags as SQLDataCellFlags, SQLDataCell};
 
 use super::decode_binary_value::{self, decode_binary_value};
 
-pub use bun_sql::mysql::protocol::ResultSetHeader as Header;
-
 bun_core::declare_scope!(MySQLResultSet, visible);
 
 pub(crate) struct Row<'a> {

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -11,7 +11,7 @@ use bun_sql::shared::data::Data;
 use bun_sql::shared::sql_query_result_mode::SQLQueryResultMode as PostgresSQLQueryResultMode;
 
 pub(crate) use crate::shared::sql_data_cell::SQLDataCell;
-pub use crate::shared::sql_data_cell::{Array, Flags, Raw, Tag, TypedArray, Value};
+pub use crate::shared::sql_data_cell::{Array, Flags, Tag, TypedArray, Value};
 
 type Result<T, E = AnyPostgresError> = core::result::Result<T, E>;
 


### PR DESCRIPTION
### Problem
- These items have no caller, no reader, or no constructor anywhere in the tree. The workspace denies `dead_code`, so what remains is cross-crate `pub` items and private host functions that the lints cannot see. A relink of the debug binary with `--gc-sections --print-gc-sections` and a rebuild of the C++ with `-Wunused-function -Wunused-template` confirm the same set.
- Each deletion was checked with a repo-wide search (`src/`, `packages/`, `scripts/`, `build/debug/codegen/`, `.classes.ts`, string literals) and against the deletions in every open dead-code PR.

### Fix
- Rust: drop never-constructed enum variants and never-read payloads. `DependencyToEnqueue::Pending` (and the `EnqueueResult::Pending` / `DependencyToResolve::Pending` arms that only it fed), `DNSRequestOwner::Prefetch`, `OptionsData::Saved(usize)`, `Value::Saved(SavedFile)` with the empty `SavedFile` struct, `AdditionalFile::SourceIndex(u32)`, `AnyRoute::FrameworkRouter(TypeIndex)`, `AsyncState::Done(ExitCode)`, `PromptBehaviour::Once { removed_count }`, `BuiltinInput::ArrayBuf.i`, `IntoArray.value`, yaml `NodeTag::{Verbatim, Unknown}(StringRange)`.
- Rust: drop unused re-exports and consts. `bun_core::timespec_mode`, `ResolvedSourceTag::INTERNAL_MODULE_REGISTRY_FLAG`, `ffi::ffi_object`, `macho_types::{cpu_subtype_t, load_command, LoadCommand, RawSlice}`, `ResultSet::Header`, `DataCell::Raw`.
- C++: drop six private host functions that no builtin calls any more: `$makeGetterTypeError`, `$makeDOMException`, `$addAbortAlgorithmToSignal`, `$removeAbortAlgorithmFromSignal`, `$isAbortSignal`, `$createUninitializedArrayBuffer` in `ZigGlobalObject.cpp`, with their `BunBuiltinNames.h` entries. The stream builtins that used the abort helpers moved to C++ and call `AbortSignal::addAbortAlgorithmToSignal` directly.
- Verified: `bun bd` builds, `cargo check --workspace`, `cargo clippy --workspace --no-deps`, `bun run rust:check-all` (12 targets), and `bun bd test` on the shell, streams, yaml, bundler, `Bun.build`, bunx, and auto-install suites. Self-reviewed: 8 concerns raised, 2 folded in (`$createUninitializedArrayBuffer`, `SavedFile`), the rest are series-level follow-ups listed in the notes.
- No test is added on purpose. Every line this PR removes is unreferenced, so there is no behavior a test can observe before and after the change. The code that stays is covered by the suites above.

### Background
- `dead_code = "deny"` covers private items only. A `pub` item reachable from the crate root is an "external API root" and exempt. To find cross-crate dead code, the sweep rewrote every `pub` item whose name appears nowhere outside its crate to `pub(crate)` and ran `cargo check` with `--cap-lints warn`. rustc then reported what nothing in the crate uses either. The rewrite is not part of this PR.
- Most "never read" fields that rustc reported are false positives: `multi_array_columns!` reads them through `items_<field>()` accessors by name, RAII fields own memory a sibling borrows, and some structs are layout-punned. Those stay.
- `enqueue_dependency_to_root` resolves synchronously (it sleeps until the task queue drains), so it never returned `Pending`. The Zig original had the same shape. The `Pending` arms downstream were unreachable since before the port.

<details><summary>Notes</summary>

Overlap with open PRs:

- #39939 (`Bun.YAML.parse` tags option) edits the same `scan_tag_property` lines in `src/parsers/yaml.rs`. On that branch the `Verbatim` / `Unknown` payload is still only matched as `_` and the new `custom_tag()` reads the local range, so whichever PR lands second takes the other side in five hunks. No payload is consumed there.
- #40690 removes the six `src/js/builtins.d.ts` declarations that match the removed host functions. They are left in place here to avoid duplicate deletions. Until one of the two lands, the declarations describe functions that no longer exist, which only affects type checking of `src/js`.

Related:

- #39993 (closed) deleted the whole pending-module queue in `src/jsc/AsyncModule.rs`, including the remainder this PR leaves: `PendingResolutionTag::Resolve` and `Queue::on_package_manifest_error`. With `DependencyToEnqueue::Pending` gone that callback body is a no-op. Removing the callback would switch the auto-install manifest-error path to the `else` branches in `runTasks.rs`, which log, so it is a behaviour change and stays out of this sweep.
- #38121 reworks what auto-install reports when a resolution fails and touches the same callback.

Scanned and found clean: `src/js/**` (module exports, `$builtin` functions, whole files), unused extern declarations in the `*_sys` crates, orphan `.rs` files outside any `mod` tree, unused Cargo dependencies, `#if ENABLE(...)` branches in the bindings, and commented-out code blocks older than six months.

Flagged by the tools but kept on purpose:

- `EmptyCopyFileState`, `WriteKind`, `Handle::init_close_on_complete`, `WIN_SOCKET_INFO_KEY`, `ListenerType::NamedPipe`, `TaskXmlError::*`, `CalendarError::InvalidCron`, the `kernel32` re-export module: live under `#[cfg(windows)]` or `#[cfg(target_os = "macos")]`.
- `inflate_embedded`, `inflate_embedded_nul`: live under `cfg(bun_codegen_embed)` through the `embed_compressed!` macro.
- `SSRKind::Regular`, `ErrorKind::Js*` (bake `serialized_failure.rs`): part of a tag space shared with C++ or TypeScript.
- `PerformanceResourceTiming`, `PerformanceServerTiming` and their `ResourceTiming` / `NetworkLoadMetrics` helpers: never instantiated, but the JS wrapper classes are exposed as globals and their prototype getters reference the implementation. Removing the implementation changes the prototype shape, so it needs a design decision.
- `CowSliceZ::init_dupe`: only its own unit test uses it, and that test is the only in-tree `Z = true` instantiation.

Open dead-code PRs already hold the rest of what the tools flagged (`ExportRenamer`, `BindgenTrivial`, `has_termination_request`, `rsplit_once`, `Pink`, `AllStmts`, `FontFeatureValues`, the `compile_result.rs` types, and the `formatStackTraceToJSValueWithoutPrepareStackTrace` helper among others). Those were left out of this PR to avoid duplicate deletions.

Series-level follow-ups the self-review suggested, not done here: a source lint that fails when a `BunBuiltinNames.h` entry has no `$name` caller, a `pub` to `pub(crate)` narrowing pass over `src/runtime`, and the hawk gate in #37328.
</details>
