### PR TITLE
docs: fix typo ambiugous -> ambiguous and grammar in utils

### DIFF
--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -435,7 +435,7 @@ namespace Bun {
        */
       countAnsiEscapeCodes?: boolean;
       /**
-       * When it's ambiugous and `true`, count emoji as 1 characters wide. If `false`, emoji are counted as 2 character wide.
+       * When it's ambiguous and `true`, count emoji as 1 character wide. If `false`, emoji are counted as 2 characters wide.
        *
        * @default true
        */


### PR DESCRIPTION
Fix typo mbiugous -> mbiguous and grammar 1 characters -> 1 character, 2 character -> 2 characters in docs/runtime/utils.mdx:438.