### PR TITLE
docs: add Oxford comma in run CLI docs

### DIFF
--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -220,7 +220,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--no-macros" type="boolean">
-  Disable macro execution in the bundler, transpiler and runtime
+  Disable macro execution in the bundler, transpiler, and runtime
 </ParamField>
 
 <ParamField path="--jsx-factory" type="string">


### PR DESCRIPTION
Add Oxford comma before and runtime in docs/snippets/cli/run.mdx:223 for consistency.