### PR TITLE
docs: remove trailing whitespace in upstash guide

### DIFF
--- a/docs/guides/ecosystem/upstash.mdx
+++ b/docs/guides/ecosystem/upstash.mdx
@@ -13,7 +13,7 @@ mode: center
 <Steps>
   <Step title="Create a new project">
     Create a new project with `bun init`:
-    
+
     ```sh terminal icon="terminal"
     bun init bun-upstash-redis
     cd bun-upstash-redis


### PR DESCRIPTION
Remove trailing whitespace in docs/guides/ecosystem/upstash.mdx