### PR TITLE
docs: remove trailing whitespace in esbuild guide

### DIFF
--- a/docs/bundler/esbuild.mdx
+++ b/docs/bundler/esbuild.mdx
@@ -277,7 +277,7 @@ const myPlugin: BunPlugin = {
 
   </Tab>
   <Tab title="arguments">
-  
+
     - 🟢 `path`
     - 🟢 `namespace`
     - 🔴 `suffix`


### PR DESCRIPTION
Remove trailing whitespace in docs/bundler/esbuild.mdx