### PR TITLE
docs: remove trailing whitespace in minifier guide

### DIFF
--- a/docs/bundler/minifier.mdx
+++ b/docs/bundler/minifier.mdx
@@ -1055,7 +1055,7 @@ throw(console.log(x),new Error());
 
 Inlines enum values across module boundaries.
 
-```ts Input 
+```ts Input
 // lib.ts
 export enum Color { Red, Green, Blue }
 


### PR DESCRIPTION
Remove trailing whitespace in docs/bundler/minifier.mdx