### PR TITLE
Pass feature flags from Bun.build config to macro modules

### DIFF
--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -906,8 +906,6 @@ impl CompletionStruct for JSBundleCompletionTask {
 
         transpiler.options.env.behavior = config.env_behavior;
         transpiler.options.env.prefix = Box::from(config.env_prefix.list.as_slice());
-        // `bundler_feature_flags` is set by `BundleOptions::from_api` from
-        // `TransformOptions.feature_flags` (see `create_and_configure_transpiler`).
         if config.force_node_env != options::ForceNodeEnv::Unspecified {
             transpiler.options.force_node_env = config.force_node_env;
         }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -906,9 +906,8 @@ impl CompletionStruct for JSBundleCompletionTask {
 
         transpiler.options.env.behavior = config.env_behavior;
         transpiler.options.env.prefix = Box::from(config.env_prefix.list.as_slice());
-        // `BundleOptions.bundler_feature_flags: Option<Box<StringSet>>` owns
-        // its set, so clone rather than alias `config.features`.
-        transpiler.options.bundler_feature_flags = Some(Box::new(config.features.clone()?));
+        // `bundler_feature_flags` is set by `BundleOptions::from_api` from
+        // `TransformOptions.feature_flags` (see `create_and_configure_transpiler`).
         if config.force_node_env != options::ForceNodeEnv::Unspecified {
             transpiler.options.force_node_env = config.force_node_env;
         }
@@ -1192,6 +1191,9 @@ impl CompletionStruct for JSBundleCompletionTask {
             conditions: config.conditions.keys().to_vec(),
             // Use the config value, which `configure_bundler` reapplies anyway.
             ignore_dce_annotations: config.ignore_dce_annotations,
+            // Flows into `BundleOptions.bundler_feature_flags` via `from_api`,
+            // and into the macro VM's transpiler through `Macro::init`.
+            feature_flags: config.features.keys().to_vec(),
             drop: config.drop.keys().to_vec(),
             bunfig_path: Box::default(),
             jsx: Some(config.jsx.clone()),

--- a/test/bundler/bundler_feature_flag.test.ts
+++ b/test/bundler/bundler_feature_flag.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
 import { itBundled } from "./expectBundled";
 
 describe("bundler feature flags", () => {
@@ -425,6 +426,56 @@ console.log(x);
       },
     });
   }
+
+  // Macros run in their own VM whose transpiler options come from the build's
+  // TransformOptions, not from the bundle's parse tasks. Spawn a subprocess so
+  // the macro VM is created fresh with this build's feature flags.
+  test("feature() works inside a macro with the Bun.build API", async () => {
+    using dir = tempDir("bundler-feature-flag-macro", {
+      "index.ts": `
+import { a } from "./macro.ts" with { type: "macro" };
+console.log(a());
+`,
+      "macro.ts": `
+import { feature } from "bun:bundle";
+console.log("module-level:", feature("MACRO_FLAG") ? "on" : "off");
+export function a() {
+  return feature("MACRO_FLAG") ? "feat-on" : "feat-off";
+}
+`,
+      "build.ts": `
+const result = await Bun.build({
+  entrypoints: ["./index.ts"],
+  features: ["MACRO_FLAG"],
+  outdir: "./out",
+});
+if (!result.success) {
+  console.error(...result.logs);
+  process.exit(1);
+}
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "build.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    // The macro module's top-level code sees the flag.
+    expect(stdout).toContain("module-level: on");
+    expect(exitCode).toBe(0);
+
+    // The macro's return value was folded with the flag enabled.
+    const bundled = await Bun.file(path.join(String(dir), "out", "index.js")).text();
+    expect(bundled).toContain("feat-on");
+    expect(bundled).not.toContain("feat-off");
+  });
 
   // Runtime tests - these must remain as manual tests since they test bun run and bun test
   test("works correctly at runtime with bun run", async () => {


### PR DESCRIPTION
### Problem
- `feature("X")` from `bun:bundle` always folds to false inside a module imported with `{ type: "macro" }` when the build runs through the `Bun.build` API with `features: ["X"]`. The CLI path (`bun build --feature=X`) works. Fixes #41098.
- The cause: `configure_bundler` set `bundler_feature_flags` only on the bundle's own transpiler (src/runtime/api/js_bundle_completion_task.rs:911). The macro VM is created from the build's `TransformOptions` (`Macro::init`, src/js_parser_jsc/Macro.rs:435), and `create_and_configure_transpiler` left `feature_flags` empty there.

### Fix
- Put `config.features` into the `api::TransformOptions` that `create_and_configure_transpiler` builds. `BundleOptions::from_api` then sets `bundler_feature_flags` for the bundle transpiler, and `Macro::init` passes the same `TransformOptions` to the macro VM.
- Remove the now redundant direct assignment in `configure_bundler`. `from_api` also sorts the flags, which keeps the set consistent with the CLI path.
- Verified: new test in `test/bundler/bundler_feature_flag.test.ts` (fails on current bun, passes with this change). Also ran the full `bundler_feature_flag.test.ts` (42 pass) and `test/bundler/transpiler/macro-test.test.ts` (26 pass).

### Background
- A macro import is not bundled. The parser calls into a VM that loads and runs the macro module as JS, then splices the returned value into the AST.
- That VM transpiles the macro module with its own transpiler options, built from the build's `TransformOptions`. Options set only on the bundle's transpiler never reach it.
- The CLI path works because `Arguments.rs` puts `--feature` into the `TransformOptions` it builds, so the macro VM already sees the flags there.

<details><summary>Notes</summary>

- Repro: `index.ts` imports `a` from `./macro.ts` with `{ type: "macro" }`, `macro.ts` branches on `feature("FEAT")`, `build.ts` calls `Bun.build({ entrypoints: ["./index.ts"], features: ["FEAT"] })`. Before the fix the macro's module-level `feature("FEAT")` and its return value both fold to false while a regular (non-macro) module in the same build folds to true.
- `bun bd test test/bundler/bun-build-api.test.ts` has two pre-existing bytecode test timeouts (5s limit) that also fail on clean main with the same debug build, unrelated to this change.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_feature_flag.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_feature_flag.test.ts:
(pass) bundler feature flags > backend: cli > feature_flag/cli/FeatureReturnsTrue [633.84ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/FeatureReturnsFalse [273.98ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/MultipleFlags [335.00ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/DeadCodeElimination [339.54ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/ImportRemoved [272.60ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/IfBlockRemoved [342.79ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/KeepsElseBranch [278.69ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/RemovesElseBranch [268.76ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/AliasedImport [260.34ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/TernaryDisabled [271.77ms]
(pass) bundler feature flags > b
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (ea8a94a48)

test/bundler/bundler_feature_flag.test.ts:
(pass) bundler feature flags > backend: cli > feature_flag/cli/FeatureReturnsTrue [13.65ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/FeatureReturnsFalse [4.94ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/MultipleFlags [4.57ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/DeadCodeElimination [4.36ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/ImportRemoved [4.42ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/IfBlockRemoved [4.45ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/KeepsElseBranch [4.59ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/RemovesElseBranch [4.68ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/AliasedImport [5.10ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/TernaryDisabled [5.03ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/TernaryEnabled [4.27ms]
(pass) bundler feature flags > backend: api > feature_flag/api/FeatureReturnsTrue [4.19ms]
(pass) bundler feature flags > backend
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_feature_flag.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_feature_flag.test.ts:
(pass) bundler feature flags > backend: cli > feature_flag/cli/FeatureReturnsTrue [629.28ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/FeatureReturnsFalse [272.87ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/MultipleFlags [274.04ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/DeadCodeElimination [341.85ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/ImportRemoved [343.23ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/IfBlockRemoved [349.78ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/KeepsElseBranch [269.76ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/RemovesElseBranch [273.46ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/AliasedImport [268.18ms]
(pass) bundler feature flags > backend: cli > feature_flag/cli/TernaryDisabled [336.22ms]
(pass) bundler feature flags > b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 607ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/js_bundle_completion_task.rs |  6 ++--
 test/bundler/bundler_feature_flag.test.ts    | 51 ++++++++++++++++++++++++++++
 2 files changed, 54 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/runtime/api/js_bundle_completion_task.rs      3      3      7
test/bundler/bundler_feature_flag.test.ts         2      2      7
```

</details>

**root cause** · written by the author bot

When building through the Bun.build JS API, feature flags were assigned directly to the bundle transpiler after initialization rather than being included in the shared api::TransformOptions, so the macro VM, which constructs its own transpiler from those options, never saw them and feature() always folded to false inside macro modules. The fix populates feature_flags on TransformOptions from config.features during transpiler creation, matching the pattern used for conditions and drop, so both the bundle transpiler (via BundleOptions::from_api) and the macro VM receive the flags. The now red…

<!-- robobun:evidence:end -->