### PR TITLE
mimalloc: collect the page when heap meta data is freed into it

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "942b8342575bdece649438ca76f32276a019c51e";
+const MIMALLOC_COMMIT = "04ced98dece1ec70ce794e781c4d6adff0072a49";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -64,6 +64,58 @@ describe("heapStats() mimalloc integration", () => {
     void before;
   });
 
+  // Every `new Bun.Transpiler(opts)` owns a mimalloc heap (a bun_alloc::Arena). A `define` value that
+  // goes through the JSON parser allocates into that heap, so the heap also gets its per-arena page
+  // bitmaps (`mi_arena_pages_t`, about 150 KiB). The GC finalizes the instances in one batch, so
+  // hundreds of heaps are destroyed while their meta data fills whole pages of the main heap.
+  // mimalloc abandons a page once it is full. A free into an abandoned page has to collect the page
+  // (free it, reclaim it, or re-map it), or the block is stranded: the page stays abandoned and
+  // resident forever. `mi_heap_destroy` used to free the meta data without collecting, so every
+  // destroyed heap leaked about 150 KiB of RSS and left one more abandoned page behind.
+  test("destroying many heaps at once does not strand their meta data", async () => {
+    const heapsPerRound = 200;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { heapStats } from "bun:jsc";
+         const opts = { loader: "ts", define: { A: '"x"' } };
+         const rounds = [];
+         for (let round = 0; round < 4; round++) {
+           for (let i = 0; i < ${heapsPerRound}; i++) new Bun.Transpiler(opts);
+           Bun.gc(true);
+           Bun.gc(true);
+           rounds.push({ abandoned: heapStats().mimalloc.pages_abandoned.current, rss: process.memoryUsage.rss() });
+         }
+         console.log(JSON.stringify(rounds));`,
+      ],
+      env: {
+        ...bunEnv,
+        // ASAN's quarantine pins freed blocks and keeps RSS at peak.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+          .filter(Boolean)
+          .join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const rounds: { abandoned: number; rss: number }[] = JSON.parse(stdout.trim());
+    expect(rounds).toHaveLength(4);
+    expect(exitCode).toBe(0);
+
+    const abandoned = rounds.map(r => r.abandoned);
+    const rssMiB = rounds.map(r => r.rss / 1024 / 1024);
+    // A stranded page stays abandoned, so the count used to grow by about 29 per round: one 4 MiB
+    // page per 28 `mi_arena_pages_t` and one 64 KiB page per 9 `mi_heap_t`. A collected page is
+    // freed, or taken over by the next round's heaps, so the count stays where the first round left it.
+    expect(abandoned[3] - abandoned[0]).toBeLessThan(heapsPerRound / 10);
+    // The stranded pages were resident: about 150 KiB per heap, so a round cost about 30 MiB in a
+    // release build and more in a debug build. A round now reuses the memory the rounds before it freed.
+    expect(rssMiB[3] - rssMiB[2]).toBeLessThan(20);
+  });
+
   // mimalloc tags its arena mmaps with an app-reserved VM tag (240-255). The old default,
   // 100, is VM_MEMORY_IOACCELERATOR, so profilers reported Bun's heap as GPU memory.
   // The tags are read back from the kernel (mach_vm_region's user_tag), not from vmmap's


### PR DESCRIPTION
Draft until oven-sh/mimalloc#31 merges. The pin points at the head of that PR so CI builds with the fix. Once it merges into `bun-dev3-v2`, the pin moves to the merge commit and this PR leaves draft. Only the pin and the test change.

### Problem
- `new Bun.Transpiler({ define })` leaks about 150 KiB of RSS per instance when 100 or more instances die in one GC. There is no bound: 10,000 instances leave 1.45 GB, and an idle event loop does not give it back.
- Each instance owns a mimalloc heap (`bun_alloc::Arena`, `JSTranspiler.rs:952`). `mi_heap_destroy` frees the heap's meta data (about 150 KiB) with `_mi_free_subproc_safe` (`heap.c:232`), which never collects the page it frees into (`free.c:280`). In a full, abandoned page the block is stranded for good.

### Fix
- oven-sh/mimalloc#31: `_mi_free_subproc_safe` collects when the page belongs to the current sub-process. A free across sub-processes keeps the old behavior. The fork PR carries a C test for it.
- Correct because a plain `mi_free` takes this path for a block of another thread: claim the page, fold its thread-free list into `used`, then free, reclaim, or re-map it.
- Verified: `test/js/bun/jsc/heapStats-mimalloc.test.ts` (84 stranded pages on main, 0 with the fix, debug and release). Also the transpiler and bundler suites, `test/js/bun/util/`, `process.test.js`, and the fork's `ctest` suite. Self-reviewed: 7 concerns raised, 7 addressed (see Notes).

### Background
- A mimalloc heap is a set of pages. `bun_alloc::Arena` is one heap: `mi_heap_new` on creation, `mi_heap_destroy` on drop. The heap's own meta data lives in pages of the main heap.
- mimalloc v3 abandons a page once it is full. Only a free into it brings it back. A page abandoned while full is not in the arena's abandoned bitmap, so no allocation or idle sweep reaches it.
- `heapStats().mimalloc.pages_abandoned.current` counts abandoned pages. A stranded page stays abandoned, so the test pins the leak with an exact count.

<details><summary>Notes</summary>

Repro on the released binary (`bun 1.4.1`), `define: { A: '"x"' }`, RSS per instance after `Bun.gc(true)` and 1.5 s idle:

| GC every | unfixed | with the fix |
| --- | --- | --- |
| 1 | 0.7 KiB | |
| 10 | 0.2 KiB | |
| 100 | 141 KiB | 0.8 KiB |
| 1000 | 145 KiB | 2.5 KiB |
| never (3000 at once) | 152 KiB | 8.9 KiB |

28 live heaps fill one 4 MiB page with `mi_arena_pages_t` blocks, so a batch of 100 or more finalizers strands almost every heap. The residual with 3000 instances alive at once (about 9 KiB per instance, 25 MB) is proportional to the peak live count, not to the total, and is the same with and without the fix. It is not part of this change.

Stats from `heapStats().mimalloc` over 4 rounds of 200 instances (the test's fixture), release build:

```
unfixed:  abandoned 30 -> 58 -> 86 -> 114   rss 53 -> 86 -> 118 -> 141 MB
fixed:    abandoned  3 ->  3 ->  3 ->   3   rss 70 -> 91 ->  96 -> 101 MB
```

Over 10 rounds the fixed build plateaus at 102 MB; the unfixed one reaches 315 MB (+29 MB per round).

A C harness against Bun's release `static.c.o` shows the mimalloc side alone: 100 live heaps with one 200-byte block each, created and destroyed in rounds, grow RSS by 150 KiB per destroyed heap without the fix (10 rounds: +146 MB) and plateau at +21 MB with it. 20 live heaps never fill a page and do not leak either way.

Upstream used a plain `mi_free` for the heap meta data until the sub-process work (microsoft/mimalloc 360d7967b8). Sub-processes (`mi_subproc_new`) own separate arenas and heaps. `_mi_free_subproc_safe` exists so that a sub-process teardown can free a block in the pages of another sub-process without collecting a page there. Bun has one sub-process, so every heap teardown now collects. Upstream `dev3` still has the same code.

The self-review raised: the `.patch` carrier that maintainers turned down before (#38168, #38199), so this is a pin bump like #40409 and #40138; an `export const MIMALLOC_COMMIT` that broke the `process.versions` test; a hash-keyed `workarounds.ts` entry that would fail every future pin bump; a read of `page->heap` on an unowned page against the rule at `mi_page_heap` (the fork PR now derives the sub-process from the page's arena); and the overlap with #40130, which is closed as superseded. All addressed in this shape.

Related PRs: #40130 was an earlier draft of the same mimalloc change, as a `.patch`. It concluded that the patch has no effect in Bun because its RSS probe (64 instances alive in a ring) did not show the growth, and it had no test. The repro here shows the growth on every run. #32384 removes the per-instance heap from `Bun.Transpiler`; that would hide this one trigger but leave the allocator bug for every other `bun_alloc::Arena` that dies in a batch.

Nothing in this PR is under `src/`, so the automated fail-before check has nothing to revert. The fail-before run is the released binary (`USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/heapStats-mimalloc.test.ts`).

Pre-existing failures seen while running the suites, unrelated to this change: `test/js/bun/util/fuzzy-wuzzy.test.ts` aborts the debug build in `js_valkey.rs:1289` (`on_valkey_unsubscribe`), and four 5 s timeouts in `test/js/bun/util/` under debug+ASAN.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/jsc/heapStats-mimalloc.test.ts

<!-- robobun:evidence:end -->