### PR TITLE
node:zlib: accept ArrayBuffer and SharedArrayBuffer from another realm

### DIFF
--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -17,8 +17,7 @@ const ArrayPrototypeForEach = Array.prototype.forEach;
 const NumberIsNaN = Number.isNaN;
 const MathMax = Math.max;
 
-const isArrayBufferView = ArrayBuffer.isView;
-const isAnyArrayBuffer = b => b instanceof ArrayBuffer || b instanceof SharedArrayBuffer;
+const { isArrayBufferView, isAnyArrayBuffer } = require("node:util/types");
 const kMaxLength = $requireMap.$get("buffer")?.exports.kMaxLength ?? BufferModule.kMaxLength;
 
 const { Transform, finished } = require("node:stream");

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -7,6 +7,7 @@ import * as fs from "node:fs";
 import { resolve } from "node:path";
 import * as stream from "node:stream";
 import * as util from "node:util";
+import * as vm from "node:vm";
 import * as zlib from "node:zlib";
 
 describe("prototype and name and constructor", () => {
@@ -798,6 +799,71 @@ describe("dictionary buffer lifetime", () => {
     await promise;
 
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
+  });
+});
+
+describe("ArrayBuffer from another realm", () => {
+  // `instanceof ArrayBuffer` is false for a buffer created in a vm context.
+  // node accepts these because its check (util.types.isAnyArrayBuffer) is realm-independent.
+  const context = vm.createContext({});
+  const bytes = [104, 101, 108, 108, 111];
+  function realmBuffer(ctor) {
+    const ab = vm.runInContext(`new ${ctor}(${bytes.length})`, context);
+    new Uint8Array(ab).set(bytes);
+    return ab;
+  }
+
+  it("is not an instance of this realm's ArrayBuffer", () => {
+    expect(realmBuffer("ArrayBuffer") instanceof ArrayBuffer).toBe(false);
+    expect(realmBuffer("SharedArrayBuffer") instanceof SharedArrayBuffer).toBe(false);
+  });
+
+  const syncPairs = [
+    ["gzipSync", zlib.gzipSync, zlib.gunzipSync],
+    ["deflateSync", zlib.deflateSync, zlib.inflateSync],
+    ["deflateRawSync", zlib.deflateRawSync, zlib.inflateRawSync],
+    ["brotliCompressSync", zlib.brotliCompressSync, zlib.brotliDecompressSync],
+    ["zstdCompressSync", zlib.zstdCompressSync, zlib.zstdDecompressSync],
+  ];
+  for (const [name, compress, decompress] of syncPairs) {
+    for (const ctor of ["ArrayBuffer", "SharedArrayBuffer"]) {
+      it(`${name} accepts a ${ctor} from another realm`, () => {
+        const out = decompress(compress(realmBuffer(ctor)));
+        expect(Array.from(out)).toEqual(bytes);
+      });
+    }
+  }
+
+  const asyncPairs = [
+    ["gzip", zlib.gzip, zlib.gunzip],
+    ["deflate", zlib.deflate, zlib.inflate],
+    ["brotliCompress", zlib.brotliCompress, zlib.brotliDecompress],
+    ["zstdCompress", zlib.zstdCompress, zlib.zstdDecompress],
+  ];
+  for (const [name, compress, decompress] of asyncPairs) {
+    it(`${name} accepts an ArrayBuffer from another realm`, async () => {
+      const compressed = await util.promisify(compress)(realmBuffer("ArrayBuffer"));
+      const out = await util.promisify(decompress)(compressed);
+      expect(Array.from(out)).toEqual(bytes);
+    });
+  }
+
+  it("options.dictionary accepts an ArrayBuffer from another realm", () => {
+    const dictionary = realmBuffer("ArrayBuffer");
+    const input = "hello hello hello";
+    const compressed = zlib.deflateSync(input, { dictionary });
+    expect(zlib.inflateSync(compressed, { dictionary }).toString()).toBe(input);
+    const brotli = zlib.brotliCompressSync(input, { dictionary });
+    expect(zlib.brotliDecompressSync(brotli, { dictionary }).toString()).toBe(input);
+  });
+
+  it("still rejects a value that is not a buffer", () => {
+    expect(() => zlib.gzipSync(vm.runInContext("({})", context))).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => zlib.deflateSync("x", { dictionary: vm.runInContext("({})", context) })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
   });
 });
 


### PR DESCRIPTION
### Problem
- `node:zlib` rejects an `ArrayBuffer` or `SharedArrayBuffer` that was created in another realm (`vm.runInContext`). Every convenience method (`gzipSync`, `gzip`, `deflateSync`, `brotliCompressSync`, `zstdCompressSync`, ...) and the `dictionary` option throw `ERR_INVALID_ARG_TYPE`. The message contradicts itself: `The "buffer" argument must be of type string, Buffer, TypedArray, DataView, or ArrayBuffer. Received an instance of ArrayBuffer`. Node 26.3.0 accepts the same input.
- The cause is the local check in `src/js/node/zlib.ts:21`: `b instanceof ArrayBuffer || b instanceof SharedArrayBuffer`. `instanceof` walks the prototype chain, and a buffer from another realm has that realm's `ArrayBuffer.prototype`. TypedArray and DataView inputs were not affected because `ArrayBuffer.isView` reads the internal type.

### Fix
- Take `isArrayBufferView` and `isAnyArrayBuffer` from `node:util/types`. Both are native and check the cell type (`JSArrayBuffer`, typed array or DataView), so the realm does not matter. This is what node's `lib/zlib.js` does, and what `node:crypto` and the internal stream modules in bun already do.
- Verified: `test/js/node/zlib/zlib.test.js` (new `ArrayBuffer from another realm` block, 15 of 17 cases fail on bun 1.4.1). Also the rest of `test/js/node/zlib/` and the vendored `test-zlib-convenience-methods.js`, `test-zlib-dictionary.js`, `test-zlib-brotli-dictionary.js`, `test-zlib-zstd-dictionary.js`, `test-zlib-not-string-or-buffer.js`, `test-zlib-invalid-input.js`.

### Background
- A realm is one set of JavaScript globals. `vm.createContext()` creates a new realm with its own `ArrayBuffer`, `Object` and so on. A value created there and passed to the main realm has a different `[[Prototype]]`, so `instanceof` against a main-realm constructor is false.
- `util.types.isAnyArrayBuffer(value)` is realm-independent. Bun implements it in `src/jsc/modules/NodeUtilTypesModule.cpp` as `dynamicDowncast<JSArrayBuffer>`.

<details><summary>Notes</summary>

Repro on bun 1.4.1 (node 26.3.0 prints the decompressed bytes for every line):

```js
const vm = require("node:vm");
const zlib = require("node:zlib");
const ab = vm.runInContext("new ArrayBuffer(4)", vm.createContext({}));
new Uint8Array(ab).set([1, 2, 3, 4]);
zlib.gunzipSync(zlib.gzipSync(ab));            // ERR_INVALID_ARG_TYPE
zlib.deflateSync("x", { dictionary: ab });     // ERR_INVALID_ARG_TYPE (options.dictionary)
zlib.gzip(ab, cb);                             // writable rejects the raw ArrayBuffer as a chunk
```

`test/js/node/zlib/leak.test.ts` times out in its `beforeAll` on this debug ASAN build with and without this change (10,000 `deflateSync` calls in one hook). It is not related to this diff.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.1 (a6c4cc276)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [3.40ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [2.32ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.58ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [2.84ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.65ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.41ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.41ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.44ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release without fix: 15 failed, 2 skipped
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [0.03ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [0.01ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate
(pass) pr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.1 (a6c4cc276)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.10ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.46ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.05ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.69ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.41ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.25ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.24ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.32ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 714ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/28] gen cpp.rs (cppbind)
[3/28] gen JS modules (bundle-modules)
Preprocess modules (12161ms)
Bundle modules (61ms)
Postprocesss modules (26ms)
Bundle Functions (569ms)
Generate Code (33ms)

[12.86s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/23] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/zlib.ts            |  3 +-
 test/js/node/zlib/zlib.test.js | 66 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 67 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/js/node/zlib.ts                 2      1      6
test/js/node/zlib/zlib.test.js      2      2      5
```

</details>

<!-- robobun:evidence:end -->