### PR TITLE
test: run the stream.finished AsyncLocalStorage regression test in-process

### DIFF
--- a/test/regression/issue/27428.test.ts
+++ b/test/regression/issue/27428.test.ts
@@ -6,9 +6,7 @@ import type { AddressInfo } from "node:net";
 import { finished } from "node:stream";
 
 // https://github.com/oven-sh/bun/issues/27428
-// The callback of stream.finished() must run in the AsyncLocalStorage context
-// that was active when finished() was called, not in the one active when the
-// stream emits 'finish' or 'close'.
+// The stream.finished() callback must run in the AsyncLocalStorage context that was active when finished() was called.
 test("stream.finished callback preserves AsyncLocalStorage context", async () => {
   const asyncLocalStorage = new AsyncLocalStorage<{ foo: string }>();
   const store = { foo: "bar" };

--- a/test/regression/issue/27428.test.ts
+++ b/test/regression/issue/27428.test.ts
@@ -1,47 +1,41 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { finished } from "node:stream";
 
+// https://github.com/oven-sh/bun/issues/27428
+// The callback of stream.finished() must run in the AsyncLocalStorage context
+// that was active when finished() was called, not in the one active when the
+// stream emits 'finish' or 'close'.
 test("stream.finished callback preserves AsyncLocalStorage context", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-const asyncHooks = require('async_hooks');
-const http = require('http');
-const finished = require('stream').finished;
+  const asyncLocalStorage = new AsyncLocalStorage<{ foo: string }>();
+  const store = { foo: "bar" };
+  const calls: { err: unknown; store: unknown }[] = [];
+  const { promise: responseClosed, resolve: onResponseClosed } = Promise.withResolvers<void>();
 
-const asyncLocalStorage = new asyncHooks.AsyncLocalStorage();
-const store = { foo: 'bar' };
-
-const server = http.createServer(function (req, res) {
-  asyncLocalStorage.run(store, function () {
-    finished(res, function () {
-      const value = asyncLocalStorage.getStore()?.foo;
-      if (value !== 'bar') {
-        console.log('FAIL: expected "bar" but got ' + value);
-        process.exitCode = 1;
-      } else {
-        console.log('PASS');
-      }
+  await using server = http.createServer((req, res) => {
+    asyncLocalStorage.run(store, () => {
+      finished(res, err => {
+        calls.push({ err, store: asyncLocalStorage.getStore() });
+      });
     });
+    res.on("close", onResponseClosed);
+    // Like the issue, end the response on a later tick, outside run(): the
+    // stream events then fire with no store active, so only the context that
+    // finished() captured can reach the callback.
+    setImmediate(() => res.end());
   });
-  setTimeout(res.end.bind(res), 0);
-}).listen(0, function () {
-  const port = this.address().port;
-  http.get('http://127.0.0.1:' + port, function onResponse(res) {
-    res.resume();
-    res.on('end', server.close.bind(server));
-  });
-});
-`,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
-  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const response = await fetch(`http://127.0.0.1:${port}/`);
+  expect(await response.text()).toBe("");
+  // 'close' is the last event finished() listens for, so after it the callback
+  // count is final.
+  await responseClosed;
 
-  expect(stdout).toContain("PASS");
-  expect(exitCode).toBe(0);
+  expect(calls).toEqual([{ err: undefined, store: { foo: "bar" } }]);
+  expect(calls[0].store).toBe(store);
 });


### PR DESCRIPTION
### Problem
- `test/regression/issue/27428.test.ts` took 6.5 s on the debian 13 x64-asan lane (build #108977). The test spawned a child `bun -e` that created an http server, called `stream.finished()` inside `AsyncLocalStorage.run()`, and printed `PASS` or `FAIL`. Almost all of the time was child start-up under ASAN.
- The assertions were weak. The test checked that stdout contains `PASS` and that the exit code is 0. It never looked at the store object, the callback error argument, or the call count.

### Fix
- Run the scenario in the test process. The server listens on port 0, `fetch()` makes the request, and the request handler ends the response from `setImmediate()` outside `run()`, as the issue did. The `finished()` callback records `err` and `asyncLocalStorage.getStore()`.
- Assert the exact store object (`toBe(store)`), that `err` is `undefined`, and that the callback ran once (the test waits for the response `'close'` event, the last event `finished()` listens for). `await using` closes the server on every path.
- Sensitivity checks. With `finished()` called outside `run()`, the test fails with `store: undefined`. With the `hasAsyncContext()` binding in `src/js/internal/streams/end-of-stream.ts` removed (the fix from #27429) and a rebuild, the test fails the same way. Restored, it passes.
- Verified: `bun bd test test/regression/issue/27428.test.ts`, 3 timed runs before and after, then 15 more runs (all pass), and `USE_SYSTEM_BUN=1` (passes, 11 ms).

### Background
- `stream.finished(stream, cb)` calls `cb` once the stream has finished or closed. Node runs `cb` in the async context that was active when `finished()` was called. Bun does this in `end-of-stream.ts` through `bindAsyncResource()` when a context is active.
- `AsyncLocalStorage.run(store, fn)` makes `store` the active context for `fn` and for the async work `fn` starts. A callback that fires from another context (here: a timer that ends the response) sees a different store unless something bound it.
- A `node:http` `ServerResponse` emits `'finish'` and then `'close'` after `res.end()`. Both fire from the context that called `res.end()`.

<details><summary>Notes</summary>

Timing, local debug build (`bun bd`), wall time reported by the test runner.

Before (3 runs):
- test body: 2660 ms, 2712 ms, 2658 ms
- file total: 4.65 s, 4.68 s, 4.71 s

After (3 runs):
- test body: 693 ms, 700 ms, 695 ms
- file total: 3.09 s, 3.01 s, 3.08 s

The file total includes about 2.3 s of test runner start-up for the debug build, which the test does not control. 15 more runs of the new test: 15 pass, test body 687 ms to 700 ms. Under the release build (`USE_SYSTEM_BUN=1`) the test body is 11 ms.

Where the remaining 0.7 s goes under the debug build: the first `fetch()` plus the first request through the `node:http` server (about 300 ms), the first `AsyncLocalStorage.run()` and `finished()` call (about 250 ms), and `res.end()` through `'close'` (about 90 ms). These are first-use costs of the debug build, not waits in the test.

The callback fires on the response `'close'` event, not on `'finish'`. This matches Node for a `ServerResponse`: `finished()` treats the legacy `Stream` as readable, so `'finish'` alone does not settle it. The test waits for `'close'` before it asserts the call count.

Other checks: `prettier --check` passes. `tsc -p test/tsconfig.json --noEmit` reports no error for this file.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/27428.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/27428.test.ts"
bun test v1.4.1 (a6c4cc276)

test/regression/issue/27428.test.ts:
(pass) stream.finished callback preserves AsyncLocalStorage context [707.06ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.05s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/27428.test.ts | 68 ++++++++++++++++---------------------
 1 file changed, 30 insertions(+), 38 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/regression/issue/27428.test.ts      2      3     14
```

</details>

<!-- robobun:evidence:end -->