### PR TITLE
test: run bun-options.test.ts concurrently and assert exact output

### DIFF
--- a/test/cli/env/bun-options.test.ts
+++ b/test/cli/env/bun-options.test.ts
@@ -1,131 +1,107 @@
-import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { readdirSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
-describe("BUN_OPTIONS environment variable", () => {
-  test("basic usage - passes options to bun command", () => {
-    const result = spawnSync({
-      cmd: [bunExe()],
-      env: {
-        ...bunEnv,
-        BUN_OPTIONS: "--print='BUN_OPTIONS WAS A SUCCESS'",
-      },
-    });
+async function run(cmd: string[], BUN_OPTIONS: string) {
+  await using proc = Bun.spawn({
+    cmd,
+    env: { ...bunEnv, BUN_OPTIONS },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout.toString()).toContain("BUN_OPTIONS WAS A SUCCESS");
+// CPU.<yyyymmdd>.<hhmmss>.<pid>.<tid>.<seq>.cpuprofile
+const cpuProfileFileName = /^CPU\.\d{8}\.\d{6}\.\d+\.\d+\.\d{3}\.cpuprofile$/;
+
+async function expectOneCpuProfile(dir: string) {
+  const files = readdirSync(dir);
+  expect(files).toEqual([expect.stringMatching(cpuProfileFileName)]);
+  expect(await Bun.file(join(dir, files[0])).json()).toEqual({
+    nodes: expect.any(Array),
+    startTime: expect.any(Number),
+    endTime: expect.any(Number),
+    samples: expect.any(Array),
+    timeDeltas: expect.any(Array),
+  });
+}
+
+describe.concurrent("BUN_OPTIONS environment variable", () => {
+  test.each([
+    {
+      name: "passes an option to the bun command",
+      BUN_OPTIONS: "--print='BUN_OPTIONS WAS A SUCCESS'",
+      argv: [],
+      stdout: "BUN_OPTIONS WAS A SUCCESS\n",
+    },
+    {
+      name: "passes every option when a bare flag follows a flag with a value",
+      BUN_OPTIONS: "--print=typeof(gc) --expose-gc",
+      argv: [],
+      stdout: "function\n",
+    },
+    {
+      name: "keeps a double quoted value as one option",
+      BUN_OPTIONS: '--print="QUOTED OPTIONS"',
+      argv: [],
+      stdout: "QUOTED OPTIONS\n",
+    },
+    {
+      name: "puts environment options before command line options, so the command line wins",
+      BUN_OPTIONS: "--title=from-env",
+      argv: ["--title=from-cli", "--print=process.title"],
+      stdout: "from-cli\n",
+    },
+    {
+      name: "an empty value changes nothing",
+      BUN_OPTIONS: "",
+      argv: ["--print='NORMAL'"],
+      stdout: "NORMAL\n",
+    },
+  ])("$name", async ({ BUN_OPTIONS, argv, stdout }) => {
+    expect(await run([bunExe(), ...argv], BUN_OPTIONS)).toEqual({ stdout, stderr: "", exitCode: 0 });
   });
 
-  test("multiple options - passes all options to bun command", () => {
-    const result = spawnSync({
-      cmd: [bunExe()],
-      env: {
-        ...bunEnv,
-        BUN_OPTIONS: "--print='MULTIPLE OPTIONS' --quiet",
-      },
+  test("a bare flag before a flag with a value keeps no trailing whitespace", async () => {
+    // Before #26464 the parser received "--expose-gc " and skipped it as an unknown flag.
+    const code = "console.log(JSON.stringify(process.execArgv), typeof gc, process.title)";
+    expect(await run([bunExe(), "-e", code], "--expose-gc --title=bun-options-test")).toEqual({
+      stdout: `${JSON.stringify(["--expose-gc", "--title=bun-options-test", "-e", code])} function bun-options-test\n`,
+      stderr: "",
+      exitCode: 0,
     });
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout.toString()).toContain("MULTIPLE OPTIONS");
   });
 
-  test("options with quotes - properly handles quoted options", () => {
-    const result = spawnSync({
-      cmd: [bunExe()],
-      env: {
-        ...bunEnv,
-        BUN_OPTIONS: '--print="QUOTED OPTIONS"',
-      },
-    });
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout.toString()).toContain("QUOTED OPTIONS");
-  });
-
-  test("priority - environment options go before command line options", () => {
-    // First BUN_OPTIONS arg should be inserted before command line args
-    const result = spawnSync({
-      cmd: [bunExe(), "--print='COMMAND LINE'"],
-      env: {
-        ...bunEnv,
-        BUN_OPTIONS: "--quiet",
-      },
-    });
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout.toString()).toContain("COMMAND LINE");
-  });
-
-  test("bare flag before flag with value is recognized", () => {
-    // Bare flags (no =) that aren't the last option must not get a
-    // trailing space appended. --cpu-prof is a bare flag; --cpu-prof-dir
-    // uses = syntax. If --cpu-prof isn't recognized, no profile is written.
+  test("--cpu-prof before --cpu-prof-dir writes one profile", async () => {
     using dir = tempDir("bun-options-cpu-prof", {});
 
-    const result = spawnSync({
-      cmd: [bunExe(), "-e", "1"],
-      env: {
-        ...bunEnv,
-        BUN_OPTIONS: `--cpu-prof --cpu-prof-dir=${dir}`,
-      },
+    expect(await run([bunExe(), "-e", "1"], `--cpu-prof --cpu-prof-dir=${dir}`)).toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
     });
-
-    expect(result.exitCode).toBe(0);
-
-    // --cpu-prof should have produced a .cpuprofile file in the dir
-    const files = readdirSync(String(dir));
-    const cpuProfiles = files.filter((f: string) => f.endsWith(".cpuprofile"));
-    expect(cpuProfiles.length).toBeGreaterThanOrEqual(1);
+    await expectOneCpuProfile(String(dir));
   });
 
-  // `bun build --compile` plus running the resulting standalone executable
-  // means two full Bun process lifecycles. Under sanitizer builds (ASAN/LSan)
-  // each exit pass + symbolization is slow enough that the pair blows past the
-  // default 5s test timeout, so give this test extra headroom.
-  test("bare flag before flag with value is recognized (standalone executable)", () => {
-    // Same test as above but with a compiled standalone executable.
+  test("--cpu-prof before --cpu-prof-dir writes one profile (standalone executable)", async () => {
     using dir = tempDir("bun-options-cpu-prof-compile", {
-      "entry.ts": "console.log('ok');",
+      "entry.ts": "console.log(JSON.stringify(process.execArgv));",
     });
+    const exePath = join(String(dir), "app");
+    const profDir = join(String(dir), "profiles");
 
-    const exePath = String(dir) + "/app";
-    const profDir = String(dir) + "/profiles";
-
-    // Compile
-    const build = spawnSync({
-      cmd: [bunExe(), "build", "--compile", String(dir) + "/entry.ts", "--outfile", exePath],
-      env: bunEnv,
-    });
+    const build = await run([bunExe(), "build", "--compile", join(String(dir), "entry.ts"), "--outfile", exePath], "");
+    expect(build.stderr).toBe("");
     expect(build.exitCode).toBe(0);
 
-    // Run with BUN_OPTIONS
-    const result = spawnSync({
-      cmd: [exePath],
-      env: {
-        ...bunEnv,
-        BUN_OPTIONS: `--cpu-prof --cpu-prof-dir=${profDir}`,
-      },
+    expect(await run([exePath], `--cpu-prof --cpu-prof-dir=${profDir}`)).toEqual({
+      stdout: `${JSON.stringify(["--cpu-prof", `--cpu-prof-dir=${profDir}`])}\n`,
+      stderr: "",
+      exitCode: 0,
     });
-
-    expect(result.stdout.toString()).toContain("ok");
-    expect(result.exitCode).toBe(0);
-
-    const files = readdirSync(profDir);
-    const cpuProfiles = files.filter((f: string) => f.endsWith(".cpuprofile"));
-    expect(cpuProfiles.length).toBeGreaterThanOrEqual(1);
-  }, 60_000);
-
-  test("empty BUN_OPTIONS - should work normally", () => {
-    const result = spawnSync({
-      cmd: [bunExe(), "--print='NORMAL'"],
-      env: {
-        ...bunEnv,
-        BUN_OPTIONS: "",
-      },
-    });
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout.toString()).toContain("NORMAL");
+    await expectOneCpuProfile(profDir);
   });
 });


### PR DESCRIPTION
### Problem
- `test/cli/env/bun-options.test.ts` takes 7.4 s on the debian 13 x64-asan lane (daily slow-test sweep, build #108977). Its seven tests run one after another, each blocked on a `spawnSync`. Nine child processes start in sequence, one of them a full `bun build --compile`.
- The assertions are loose. They check `exitCode === 0` and `stdout.toContain(...)`. Two cases pass `--quiet`, which the runtime does not know and skips, so they only test tokenization. The cpu-prof cases accept any number of `.cpuprofile` files and never read one.

### Fix
- Run every test in a `describe.concurrent` block with async `Bun.spawn` and `await using`. The five `--print` cases are one `test.each` table. The children now overlap, so the file takes about as long as its slowest test (the compile).
- Compare the whole child result with one `toEqual`: exact stdout, empty stderr, exit code. Replace `--quiet` with `--expose-gc` and `--title`, whose effect the child prints (`typeof gc`, `process.title`). The priority case now shows that a command line `--title` wins over the one from `BUN_OPTIONS`.
- Add a direct regression case for #26464: `BUN_OPTIONS="--expose-gc --title=..."` with `-e` prints the exact `process.execArgv`, `typeof gc` and `process.title`. With the old bug the token is `"--expose-gc "`, the flag is skipped, and `typeof gc` is `undefined` (confirmed by passing that token on the command line).
- The cpu-prof cases assert exactly one file that matches `CPU.<date>.<time>.<pid>.<tid>.<seq>.cpuprofile` and that it parses to an object with exactly `nodes`, `startTime`, `endTime`, `samples`, `timeDeltas`. The standalone executable prints its `process.execArgv`, which must be exactly the two `BUN_OPTIONS` tokens.
- Verified: `bun bd test test/cli/env/bun-options.test.ts`, 3 runs before: 7.53 s, 8.49 s, 8.45 s. 3 runs after: 5.81 s, 5.44 s, 5.95 s. Also passes with the release build (0.34 s).

### Background
- `BUN_OPTIONS` is split into tokens by `append_options_env` (`src/bun_core/util.rs:3949`) and spliced into argv after argv[0]. `process.execArgv` is built from that argv, so it shows the exact tokens the parser saw.
- Unknown `--flags` are skipped without an error in `bun <script>` mode (`src/clap/streaming.rs:830`). That is why `--quiet` proved nothing.
- The 60 s per-test timeout is gone. The standalone test takes 2.5 to 2.9 s under the ASAN debug build here. CI runs `bun test` with `--timeout=90000` (270000 on ASAN), so the default never applied there.

<details><summary>Notes</summary>

Timing detail, ASAN debug build, this container:

- An empty test file reports 2.28 s, so about 2.3 s of every number above is the runner's own start-up.
- The standalone test is the critical path: `bun build --compile` takes 2.1 s (it writes an 818 MB debug binary) and the compiled executable runs in 0.24 s.
- Before the change the test bodies summed to 4.8 to 5.9 s. After, the longest test is 2.5 to 2.9 s and the others overlap with it.

The `--quiet` flag only exists for `bun create` (`src/runtime/cli/create_command.rs`). `bun --quiet --print 1` and `bun --definitely-unknown-flag --print 1` both exit 0 and print `1`.

No test was removed or skipped. The original 7 cases map to the new 8 as follows: basic, quotes, empty (same inputs, exact output), multiple options (`--quiet` replaced by `--expose-gc`, prints `function`), priority (`--title` from env and command line), cpu-prof and cpu-prof standalone (same inputs, stronger checks), plus the new execArgv regression case.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/env/bun-options.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/env/bun-options.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/env/bun-options.test.ts:
(pass) BUN_OPTIONS environment variable > passes every option when a bare flag follows a flag with a value [345.70ms]
(pass) BUN_OPTIONS environment variable > puts environment options before command line options, so the command line wins [369.34ms]
(pass) BUN_OPTIONS environment variable > passes an option to the bun command [546.12ms]
(pass) BUN_OPTIONS environment variable > an empty value changes nothing [490.35ms]
(pass) BUN_OPTIONS environment variable > keeps a double quoted value as one option [500.77ms]
(pass) BUN_OPTIONS environment variable > --cpu-prof before --cpu-prof-dir writes one profile [348.94ms]
(pass) BUN_OPTIONS environment variable > a bare flag before a flag with a value keeps no trailing whitespace [393.76ms]
(pass) BUN_OPTIONS environment variable > --cpu-prof before --cpu-prof-dir writes one profile (standalone executable) [2867.94ms]

 8 pass
 0 fail
 14 expect() calls
Ran 8 tests across 1 file. [6.38s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/env/bun-options.test.ts | 192 +++++++++++++++++----------------------
 1 file changed, 84 insertions(+), 108 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
test/cli/env/bun-options.test.ts      1      1      7
```

</details>

<!-- robobun:evidence:end -->