### PR TITLE
test(sql): prestart postgres for sql-reserve-abort, run its tests concurrently, assert results

### DIFF
--- a/test/docker/prestart-map.mjs
+++ b/test/docker/prestart-map.mjs
@@ -21,6 +21,7 @@ export const prestartMap = {
   "js/sql/postgres-simple-query-pipeline": ["postgres_plain"],
   "js/sql/sql-onconnect-onclose-throw": ["postgres_plain", "mysql_plain"],
   "js/sql/sql-prepare-false": ["postgres_plain"],
+  "js/sql/sql-reserve-abort": ["postgres_plain"],
   "js/valkey/": ["redis_unified"],
   "js/bun/s3/": ["minio"],
   "js/web/websocket/autobahn": ["autobahn"],

--- a/test/js/sql/sql-reserve-abort.test.ts
+++ b/test/js/sql/sql-reserve-abort.test.ts
@@ -3,15 +3,19 @@
 // the loser of a Promise.race timeout) still receives a connection once one
 // frees up; nobody releases it, so the pool permanently shrinks and
 // sql.end() never resolves (issue #39451).
+//
+// Every test owns its pool, so the tests run concurrently. Most pools have
+// max: 1, which is what makes "the connection is busy" observable.
 import { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
 
-describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+describeWithContainer("postgres", { image: "postgres_plain", concurrent: true }, container => {
   const connect = (max = 1) =>
     new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max });
   // pg_advisory_lock key; no other test takes it
   const LOCK_KEY = 39454;
+  const closed = { name: "PostgresError", code: "ERR_POSTGRES_CONNECTION_CLOSED", message: "Connection closed" };
 
   test("aborting a queued reserve() keeps the pool intact and lets end() resolve", async () => {
     await container.ready;
@@ -30,8 +34,9 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
 
     // the aborted reservation must not have consumed the pool's only
     // connection: a query and a fresh reserve both succeed
-    expect((await sql`select 1 as x`)[0].x).toBe(1);
+    expect(await sql`select 1 as x`).toEqual([{ x: 1 }]);
     const again = await sql.reserve();
+    expect(await again`select 2 as x`).toEqual([{ x: 2 }]);
     again.release();
 
     // hangs forever if the aborted reserve still holds a connection
@@ -45,8 +50,12 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
 
     const controller = new AbortController();
     const reason = new Error("gave up waiting");
+    const events: string[] = [];
     // registered before reserve(), so it runs first on dispatch
-    controller.signal.addEventListener("abort", e => e.stopImmediatePropagation());
+    controller.signal.addEventListener("abort", e => {
+      events.push("user listener");
+      e.stopImmediatePropagation();
+    });
     const pending = sql.reserve({ signal: controller.signal });
     controller.abort(reason);
     try {
@@ -54,6 +63,9 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     } finally {
       reserved.release();
     }
+    expect(events).toEqual(["user listener"]);
+
+    expect(await sql`select 1 as x`).toEqual([{ x: 1 }]);
     await sql.end();
   });
 
@@ -69,6 +81,8 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     controller.abort(reason);
     await expect(pending).rejects.toBe(reason);
     await ended;
+
+    await expect(sql.reserve()).rejects.toMatchObject(closed);
   });
 
   test("abort while the pool is still establishing its first connection", async () => {
@@ -81,7 +95,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     controller.abort(reason);
     await expect(pending).rejects.toBe(reason);
 
-    expect((await sql`select 2 as x`)[0].x).toBe(2);
+    expect(await sql`select 2 as x`).toEqual([{ x: 2 }]);
     await sql.end();
   });
 
@@ -92,7 +106,9 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     const reason = new Error("already aborted");
     await expect(sql.reserve({ signal: AbortSignal.abort(reason) })).rejects.toBe(reason);
 
+    // max is 1: this reserve() hangs if the rejected one took the connection
     const reserved = await sql.reserve();
+    expect(await reserved`select 1 as x`).toEqual([{ x: 1 }]);
     reserved.release();
     await sql.end();
   });
@@ -106,10 +122,12 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     controller.abort();
 
     try {
-      expect((await reserved`select 3 as x`)[0].x).toBe(3);
+      expect(await reserved`select 3 as x`).toEqual([{ x: 3 }]);
     } finally {
       reserved.release();
     }
+    // release() put the connection back, so a pool query gets it
+    expect(await sql`select 4 as x`).toEqual([{ x: 4 }]);
     await sql.end();
   });
 
@@ -118,8 +136,13 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     await using sql = connect();
 
     await expect(sql.reserve({ signal: 123 as unknown as AbortSignal })).rejects.toMatchObject({
+      name: "TypeError",
       code: "ERR_INVALID_ARG_TYPE",
+      message: 'The "options.signal" property must be of type AbortSignal. Received type number (123)',
     });
+
+    // the rejected call did not take the pool's only connection
+    expect(await sql`select 1 as x`).toEqual([{ x: 1 }]);
     await sql.end();
   });
 
@@ -142,7 +165,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       // execute() binds a query to the pool's only connection synchronously.
       // Nothing yields before the `await` below, so the connection is busy
       // during the whole reserve / abort / query / reserve sequence.
-      const inflight = sql`select 1`.execute();
+      const inflight = sql`select 1 as x`.execute();
 
       const controller = new AbortController();
       const reason = new Error("gave up waiting");
@@ -150,8 +173,9 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       controller.abort(reason);
 
       const order: string[] = [];
-      const queryDone = sql`select 2 as x`.execute().then(() => {
+      const queryDone = sql`select 2 as x`.execute().then(rows => {
         order.push("query");
+        return rows;
       });
       const secondReserve = sql.reserve();
       await expect(aborted).rejects.toBe(reason);
@@ -160,8 +184,8 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       order.push("reserve");
       reserved.release();
 
-      await queryDone;
-      await inflight;
+      expect(await queryDone).toEqual([{ x: 2 }]);
+      expect(await inflight).toEqual([{ x: 1 }]);
       expect(order).toEqual(["query", "reserve"]);
       await sql.end();
     });
@@ -185,22 +209,24 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       // Each connection gets one query. reserve() holds the first busy
       // connection it sees, which is the one the blocked query went to.
       const blocked = sql`select pg_advisory_lock(${LOCK_KEY}::bigint)`.execute();
-      const quick = sql`select 1`.execute();
+      const quick = sql`select 1 as x`.execute();
       const firstReserve = sql.reserve();
 
       // only the quick connection can go idle, so it serves the reservation
       const reserved = await firstReserve;
-      await quick;
+      expect(await quick).toEqual([{ x: 1 }]);
 
       // No reservation is pending, so this query belongs on the blocked
       // connection at once, ahead of the reserve() issued right after it.
       const order: string[] = [];
-      const queryDone = sql`select 2 as x`.execute().then(() => {
+      const queryDone = sql`select 2 as x`.execute().then(rows => {
         order.push("query");
+        return rows;
       });
       const secondReserve = sql.reserve();
 
-      await locker`select pg_advisory_unlock(${LOCK_KEY}::bigint)`;
+      // true: the locker session held the lock until now
+      expect(await locker`select pg_advisory_unlock(${LOCK_KEY}::bigint) as unlocked`).toEqual([{ unlocked: true }]);
       await blocked;
 
       const reservedAgain = await secondReserve;
@@ -208,7 +234,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       reservedAgain.release();
       reserved.release();
 
-      await queryDone;
+      expect(await queryDone).toEqual([{ x: 2 }]);
       expect(order).toEqual(["query", "reserve"]);
       // closing the pool ends the session that now holds the lock
       await sql.end();


### PR DESCRIPTION
### Problem
- `test/js/sql/sql-reserve-abort.test.ts` reports 14 to 20 s per Linux CI lane. Its nine tests take 44 ms on the release build. The rest is the `postgres_plain` cold start, paid in `beforeAll` because the file is not in `test/docker/prestart-map.mjs`.
- Without a map entry the runner also puts the file in the parallel bucket. On alpine x64 (build 108977) it reported 19.87 s of a 73-file bucket that took 19.93 s.

### Fix
- Add `"js/sql/sql-reserve-abort": ["postgres_plain"]` to the prestart map. The coordinator starts the container at shard launch. The runner takes the file out of the bucket and runs it after the non-docker tests. Same pattern as #40193 and #40537.
- The describe block is concurrent (`concurrent: true`). Every test owns its pool, and one test alone uses the advisory lock key.
- Assertions check the rows of each follow-up query, the exact `ERR_INVALID_ARG_TYPE` name, code and message, that `reserve()` after `end()` rejects with `ERR_POSTGRES_CONNECTION_CLOSED`, that the `stopImmediatePropagation()` listener ran, and that `pg_advisory_unlock` returns `true`. `expect()` calls go from 12 to 24. No test was removed or skipped.
- Verified: `bun bd test test/js/sql/sql-reserve-abort.test.ts`, 9 pass, 10 debug runs and 20 release runs with 0 failures. Timings are in the Notes.

### Background
- `describeWithContainer` (`test/harness.ts`) is a describe block whose `beforeAll` asks the docker coordinator for a service. The first file to ask pays the container start.
- `test/docker/prestart-map.mjs` maps test-path prefixes (relative to `test/`) to services. `test/docker/coordinator.ts` prestarts them at launch. `scripts/runner.node.mjs` runs mapped files last, outside the parallel bucket.

<details><summary>Notes</summary>

CI attribution, build 108977, job `01a05b21-c374-49d9-a4cd-db2db22cf827` (`:alpine: 3.23 x64 - test-bun`): the file ran inside `bun test --parallel` with 72 other files. `coordinator: postgres_plain ready` is logged 41 ms before the file's first line, the nine dots and the bucket summary follow 44 ms later. The bucket summary is `Ran 5155 tests across 73 files. [19.93s]` and the file is reported as `test/js/sql/sql-reserve-abort.test.ts (19.87s)`. The prefix rule: `coordinator.ts` calls `testPath.startsWith(prefix)` on each argv path, `runner.node.mjs` uses the same check in `needsDockerService`, which excludes the file from `isBucketCandidate` and sorts it to the end of the serial list.

Local timings, debug ASAN build, 16 vCPU host with a load average near 30, postgres already running (`BUN_TEST_SERVICE_postgres_plain` set, so the container start is not measured). Test phase is the time from the root `beforeAll` to the root `afterAll`, measured with a `--preload` file, five interleaved runs each:

| | before | after |
|---|---|---|
| test phase, ms | 1132, 1144, 1281, 1293, 1129 | 1066, 1091, 1055, 1400, 941 |
| whole file (`Ran 9 tests`), 3 runs | 3.28 s, 3.88 s, 4.25 s | 3.31 s, 3.44 s, 3.93 s |
| release build (`USE_SYSTEM_BUN=1`, bun 1.4.1), 3 runs | 118, 120, 132 ms | 102, 103, 107 ms |

The whole-file number is dominated by module load: a file with the same imports and one no-op test takes 2.8 to 3.6 s on this build. The tests are CPU-bound on the JS thread under ASAN, so concurrency overlaps only the loopback round trips. The gain is small locally. The CI gain is the container start.

Assertion changes per test:
- `aborting a queued reserve()`: rows of `select 1 as x` and of a query through the fresh reservation, instead of `[0].x`.
- `stopImmediatePropagation()`: an event log proves the user listener ran before the cancellation, and a follow-up query proves the pool is intact.
- `end() resolves when an aborted reserve was the only pending work`: `reserve()` after `end()` rejects with `{ name: "PostgresError", code: "ERR_POSTGRES_CONNECTION_CLOSED", message: "Connection closed" }`.
- `an already aborted signal`: the follow-up reservation runs a query.
- `aborting after reserve() resolved`: a pool query after `release()` gets the connection back.
- `non-AbortSignal signal`: `name: "TypeError"` and the message `The "options.signal" property must be of type AbortSignal. Received type number (123)`.
- ordering tests: the in-flight and parked queries return their rows, `pg_advisory_unlock` returns `true` (the locker session held the lock).

Every rejection the tests await is already settled when `expect().rejects` runs (`sql.reserve` rejects with `Promise.$reject` or from the synchronous abort listener, `src/js/bun/sql.ts:923`), so the matcher does not re-enter the event loop (#33261).

Open PRs #36075 and #40537 add their own lines to `prestart-map.mjs`. No other open PR touches this test file.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/sql-reserve-abort.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/sql-reserve-abort.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/sql/sql-reserve-abort.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > end() resolves when an aborted reserve was the only pending work [124.80ms]
(pass) postgres > aborting a queued reserve() keeps the pool intact and lets end() resolve [600.20ms]
(pass) postgres > a user abort listener calling stopImmediatePropagation() cannot starve the cancellation [462.07ms]
(pass) postgres > abort while the pool is still establishing its first connection [343.36ms]
(pass) postgres > an already aborted signal rejects without taking a connection [281.38ms]
(pass) postgres > aborting after reserve() resolved does not revoke the connection [268.64ms]
(pass) postgres > a non-AbortSignal signal option rejects with ERR_INVALID_ARG_TYPE [166.18ms]
(pass) postgres > a connection held for a reservation that no longer exists > aborting the reservation gives the connection back to queries [148.12ms]
(pass) postgres > a connection held for a reservation that no longer exists > serving the reservation from another connection gives the held one back to queries [167.20ms]

 9 pass
 0 fail
 24 expect() calls
Ran 9 tests across 1 file. [3.91s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/docker/prestart-map.mjs          |  1 +
 test/js/sql/sql-reserve-abort.test.ts | 54 ++++++++++++++++++++++++++---------
 2 files changed, 41 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
test/docker/prestart-map.mjs               1      1     12
test/js/sql/sql-reserve-abort.test.ts      1      1     12
```

</details>

<!-- robobun:evidence:end -->