### PR TITLE
test: speed up and strengthen the cc() C_INCLUDE_PATH regression test

### DIFF
--- a/test/regression/issue/26249.test.ts
+++ b/test/regression/issue/26249.test.ts
@@ -1,122 +1,108 @@
 // https://github.com/oven-sh/bun/issues/26249
-// Test that bun:ffi's cc() respects C_INCLUDE_PATH and LIBRARY_PATH environment variables.
-// This is important for systems like NixOS where standard FHS paths don't exist.
+// bun:ffi's cc() adds the directories in C_INCLUDE_PATH and LIBRARY_PATH, the
+// standard C compiler search path variables, to TinyCC's search paths. Systems
+// without FHS paths (NixOS) rely on them.
+//
+// Each test spawns a child bun. cc() reads both variables through a
+// process-wide cache (bun_core::env_var) that fills on the first cc() call, so
+// setting process.env in the test runner would not reach it.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir, type DirectoryTree } from "harness";
 import path from "path";
 
-test.skipIf(isWindows)("cc() respects C_INCLUDE_PATH environment variable", async () => {
-  // Create a temp directory with a custom include dir and header file
-  using dir = tempDir("ffi-include-path-test", {
-    "custom_include": {
-      "myheader.h": `
-#define MY_MAGIC_NUMBER 42
-`,
-    },
-    "test.c": `
-#include <myheader.h>
-int get_magic() {
-    return MY_MAGIC_NUMBER;
-}
-`,
-    "test.js": `
+const systemCC = Bun.which("cc") || Bun.which("clang") || Bun.which("gcc");
+
+// Compiles the test.c next to it, prints get_value(), and closes the library.
+function fixtureJs(library: string[] = []) {
+  return `
 import { cc } from "bun:ffi";
 import path from "path";
 
-const {
-  symbols: { get_magic },
-} = cc({
+const lib = cc({
   source: path.join(import.meta.dir, "test.c"),
-  symbols: {
-    get_magic: {
-      returns: "int",
-    },
-  },
+  library: ${JSON.stringify(library)},
+  symbols: { get_value: { returns: "int" } },
 });
+console.log(lib.symbols.get_value());
+lib.close();
+`;
+}
 
-console.log(get_magic());
-`,
-  });
-
-  // Run with C_INCLUDE_PATH set to our custom include directory
+async function runFixture(cwd: string, env: Record<string, string>) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test.js"],
-    cwd: String(dir),
-    env: {
-      ...bunEnv,
-      C_INCLUDE_PATH: path.join(String(dir), "custom_include"),
-    },
+    cwd,
+    env: { ...bunEnv, ...env },
     stdout: "pipe",
     stderr: "pipe",
   });
-
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
 
-  // Check that the header was found and the code compiled successfully
-  expect(stderr).not.toContain("myheader.h");
-  expect(stdout.trim()).toBe("42");
-  expect(exitCode).toBe(0);
-});
-
-test.skipIf(isWindows)("cc() respects multiple paths in C_INCLUDE_PATH", async () => {
-  // Create a temp directory with multiple custom include dirs
-  using dir = tempDir("ffi-multi-include-path-test", {
-    "include1": {
-      "header1.h": `
-#define VALUE_A 10
+// `headers` maps each include directory to its header files.
+const includeCases: { label: string; headers: DirectoryTree; source: string; stdout: string }[] = [
+  {
+    label: "one directory",
+    headers: { custom_include: { "myheader.h": "#define MY_MAGIC_NUMBER 42\n" } },
+    source: `
+#include <myheader.h>
+int get_value(void) { return MY_MAGIC_NUMBER; }
 `,
+    stdout: "42\n",
+  },
+  {
+    label: "two directories",
+    headers: {
+      include1: { "header1.h": "#define VALUE_A 10\n" },
+      include2: { "header2.h": "#define VALUE_B 20\n" },
     },
-    "include2": {
-      "header2.h": `
-#define VALUE_B 20
-`,
-    },
-    "test.c": `
+    source: `
 #include <header1.h>
 #include <header2.h>
-int get_sum() {
-    return VALUE_A + VALUE_B;
-}
+int get_value(void) { return VALUE_A + VALUE_B; }
 `,
-    "test.js": `
-import { cc } from "bun:ffi";
-import path from "path";
-
-const {
-  symbols: { get_sum },
-} = cc({
-  source: path.join(import.meta.dir, "test.c"),
-  symbols: {
-    get_sum: {
-      returns: "int",
-    },
+    stdout: "30\n",
   },
-});
+];
 
-console.log(get_sum());
+test.concurrent.skipIf(isWindows).each(includeCases)(
+  "cc() finds headers through C_INCLUDE_PATH ($label)",
+  async ({ headers, source, stdout }) => {
+    using dir = tempDir("ffi-include-path", { ...headers, "test.c": source, "test.js": fixtureJs() });
+    const includeDirs = Object.keys(headers).map(name => path.join(String(dir), name));
+
+    const result = await runFixture(String(dir), { C_INCLUDE_PATH: includeDirs.join(":") });
+    expect(result).toEqual({ stdout, stderr: "", exitCode: 0 });
+  },
+);
+
+test.concurrent.skipIf(isWindows || !systemCC)("cc() finds libraries through LIBRARY_PATH", async () => {
+  using dir = tempDir("ffi-library-path", {
+    lib: { "libbunffitest.c": "int value_from_library(void) { return 7; }\n" },
+    "test.c": `
+int value_from_library(void);
+int get_value(void) { return value_from_library(); }
 `,
+    "test.js": fixtureJs(["bunffitest"]),
   });
+  const libDir = path.join(String(dir), "lib");
 
-  // Run with C_INCLUDE_PATH set to multiple directories (colon-separated)
-  const include1 = path.join(String(dir), "include1");
-  const include2 = path.join(String(dir), "include2");
+  // TinyCC looks for lib<name>.so on Linux and lib<name>.dylib on macOS.
+  const libFile = `libbunffitest.${isMacOS ? "dylib" : "so"}`;
+  {
+    await using proc = Bun.spawn({
+      cmd: [systemCC!, "-shared", "-fPIC", "-o", libFile, "libbunffitest.c"],
+      cwd: libDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(`${systemCC} -shared failed (exit ${exitCode}):\n${stderr}`);
+  }
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test.js"],
-    cwd: String(dir),
-    env: {
-      ...bunEnv,
-      C_INCLUDE_PATH: `${include1}:${include2}`,
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).not.toContain("header1.h");
-  expect(stderr).not.toContain("header2.h");
-  expect(stdout.trim()).toBe("30");
-  expect(exitCode).toBe(0);
+  const result = await runFixture(String(dir), { LIBRARY_PATH: libDir });
+  expect(result).toEqual({ stdout: "7\n", stderr: "", exitCode: 0 });
 });


### PR DESCRIPTION
### Problem
- `test/regression/issue/26249.test.ts` took 10 s on the debian 13 x64-asan lane (build #108977). Its two tests ran in sequence, each with a child bun start-up and a TinyCC compile under ASAN.
- The assertions were loose: `stderr` only had to not contain the header name. Nothing covered `LIBRARY_PATH`.

### Fix
- The two `C_INCLUDE_PATH` cases are one `test.concurrent.each` table with a shared fixture, so the children overlap.
- The child spawn stays. `cc()` reads both variables through the `bun_core::env_var` cache (`src/runtime/ffi/ffi_body.rs:752`). It fills on the first `cc()` call and lives for the process, out of reach of `process.env` in the test runner.
- Each test compares the whole spawn result with `toEqual`: exact stdout, `stderr: ""`, `exitCode: 0`. A new case links a shared library that TinyCC finds only through `LIBRARY_PATH`. The system C compiler builds it, and the case skips when none is installed.
- Verified: `bun bd test`, 3 runs, local debug+ASAN: 2.80 to 2.99 s before (2 tests, 490 + 370 ms in sequence), 2.40 to 2.47 s after (3 tests, slowest 480 ms). A no-op file that imports `harness` takes 1.90 s. All three tests fail with the variables unset (Notes).

### Background
- `cc()` in `bun:ffi` compiles a C file in memory with TinyCC. `library: ["name"]` is `-lname`: TinyCC searches its library paths for `libname.so` (`.dylib` on macOS) and `dlopen`s it.
- `C_INCLUDE_PATH` and `LIBRARY_PATH` are the standard C compiler search path variables. #26250 made `cc()` honor them (NixOS has no FHS paths).

<details><summary>Notes</summary>

Negative probe: a copy of the file with the variables renamed (`C_INCLUDE_PATH_DISABLED`, `LIBRARY_PATH_DISABLED`) fails all three tests under `bun bd test`:

```
/tmp/ffi-include-path_IwaWkj/test.c:2: error: include file 'myheader.h' not found
(fail) cc() finds headers through C_INCLUDE_PATH (one directory)
/tmp/ffi-include-path_4Rw6V6/test.c:2: error: include file 'header1.h' not found
(fail) cc() finds headers through C_INCLUDE_PATH (two directories)
tcc: error: library 'bunffitest' not found
(fail) cc() finds libraries through LIBRARY_PATH
 0 pass
 3 fail
```

Wall time of `bun bd test` including the build check: 3.58 s, 3.59 s, 3.82 s before. 3.14 s, 3.16 s, 3.21 s after.

The file also passes with the release binary (`USE_SYSTEM_BUN=1 bun test`, 100 ms).

The compiler gate follows `test/regression/issue/29585.test.ts`: `Bun.which("cc") || Bun.which("clang") || Bun.which("gcc")`, and `skipIf` when none is found.

The fixture closes the library with `lib.close()`. This frees the TinyCC state and the `dlopen` handle before exit, which keeps the leak check quiet without suppressions (see #38385).

The library is named `libbunffitest` on purpose. A real library name such as `libmagic` exists in the system library directory, which TinyCC searches before `LIBRARY_PATH`.

`process.env` assignments in bun do not call `setenv`, and the env_var cache would hold the first value anyway. So an in-process test cannot exercise these variables.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/regression/issue/26249.test.ts

<!-- robobun:evidence:end -->