### PR TITLE
test: run the 26360 regression tests concurrently and assert exact output

### DIFF
--- a/test/regression/issue/26360.test.ts
+++ b/test/regression/issue/26360.test.ts
@@ -39,6 +39,11 @@ function withoutMacroDebugLines(stdout: string) {
     .join("\n");
 }
 
+// Kill switch for the child processes: a deadlock hangs the child forever. Kill it so the
+// assertions fail with a clear message instead of the whole file hanging.
+const killSwitch = { timeout: 60_000, killSignal: "SIGKILL" } as const;
+const hungMessage = "the child hung and was killed after 60s";
+
 // The outer Bun.build runs in a child process: before the fix it deadlocked the bundler
 // thread, and an in-process deadlock would take the test runner down with it.
 test.concurrent("Bun.build from macro during bundling throws instead of hanging", async () => {
@@ -66,14 +71,11 @@ if (!result.success) {
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
-    // Kill switch: a regression hangs the child forever. Kill it so the assertions below
-    // fail instead of the whole file hanging.
-    timeout: 60_000,
-    killSignal: "SIGKILL",
+    ...killSwitch,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(proc.signalCode, "the child hung and was killed after 60s").toBeNull();
+  expect(proc.signalCode, hungMessage).toBeNull();
   expect(normalizeBunSnapshot(withoutMacroDebugLines(stdout), String(dir))).toMatchInlineSnapshot(`
     "BUILD_SUCCESS
     // index.ts
@@ -98,9 +100,11 @@ test.concurrent("CLI bun build with macro that calls Bun.build also throws", asy
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
+    ...killSwitch,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(proc.signalCode, hungMessage).toBeNull();
   // With no --outdir the CLI writes the bundle to stdout and prints no summary.
   expect(normalizeBunSnapshot(withoutMacroDebugLines(stdout), String(dir))).toMatchInlineSnapshot(`
     "// index.ts

--- a/test/regression/issue/26360.test.ts
+++ b/test/regression/issue/26360.test.ts
@@ -1,33 +1,23 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/26360
-// Bug: Bun.build API hangs indefinitely when called from within a macro that is
-// evaluated during another Bun.build call. The CLI `bun build` works correctly.
-//
-// Root cause: The bundler uses a singleton thread for processing Bun.build calls.
-// When a macro is evaluated during bundling and that macro calls Bun.build:
-// 1. The singleton bundler thread is processing the outer Bun.build
-// 2. The macro runs on the bundler thread and calls Bun.build
-// 3. The inner Bun.build tries to enqueue to the same singleton thread
-// 4. The singleton thread is blocked waiting for the macro to complete -> deadlock
-//
-// Fix: Detect when Bun.build is called from within macro mode and throw a clear error.
+// Bun.build called from a macro that runs during another Bun.build used to deadlock.
+// Every Bun.build call runs on one singleton bundler thread. The outer build blocks that
+// thread while it waits for the macro, and the macro's inner Bun.build waits for the same
+// thread. The fix makes Bun.build throw when it is called in macro mode.
 
-test("Bun.build from macro during bundling throws instead of hanging", async () => {
-  using dir = tempDir("issue-26360", {
-    // A simple file that will be bundled by the macro
-    "browser.ts": `console.log("browser code");
+// Shared by the two child-process tests. The macro catches the inner Bun.build error and
+// returns its message, so the bundled output shows exactly what the macro saw.
+const fixture = {
+  "browser.ts": `console.log("browser code");
 export default "";
 `,
-
-    // A macro that calls Bun.build and catches the error
-    // The error should indicate that Bun.build cannot be called from macro context
-    "macro.ts": `import browserCode from "./browser" with { type: "file" };
+  "macro.ts": `import browserCode from "./browser" with { type: "file" };
 
 let errorMessage = "no error";
 try {
-  const built = await Bun.build({
+  await Bun.build({
     entrypoints: [browserCode],
     format: "esm",
   });
@@ -36,13 +26,24 @@ try {
 }
 export const getErrorMessage = (): string => errorMessage;
 `,
-
-    // File that imports from the macro
-    "index.ts": `import { getErrorMessage } from "./macro" with { type: "macro" };
+  "index.ts": `import { getErrorMessage } from "./macro" with { type: "macro" };
 console.log("ERROR_MSG:", getErrorMessage());
 `,
+};
 
-    // Build script that uses Bun.build API (this would hang before the fix)
+// Debug builds print "[macro] call <name>" to stdout when a macro runs.
+function withoutMacroDebugLines(stdout: string) {
+  return stdout
+    .split("\n")
+    .filter(line => !line.startsWith("[macro]"))
+    .join("\n");
+}
+
+// The outer Bun.build runs in a child process: before the fix it deadlocked the bundler
+// thread, and an in-process deadlock would take the test runner down with it.
+test.concurrent("Bun.build from macro during bundling throws instead of hanging", async () => {
+  using dir = tempDir("issue-26360", {
+    ...fixture,
     "build_script.ts": `const result = await Bun.build({
   entrypoints: ["./index.ts"],
 });
@@ -54,57 +55,43 @@ if (!result.success) {
   }
 } else {
   console.log("BUILD_SUCCESS");
-  // Print the output to verify the macro caught the error
-  const text = await result.outputs[0].text();
-  console.log(text);
+  console.log(await result.outputs[0].text());
 }
 `,
   });
 
-  // Run the build script - should complete (not hang) and the macro should have caught the error
   await using proc = Bun.spawn({
     cmd: [bunExe(), "build_script.ts"],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
+    // Kill switch: a regression hangs the child forever. Kill it so the assertions below
+    // fail instead of the whole file hanging.
+    timeout: 60_000,
+    killSignal: "SIGKILL",
   });
-
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // The build should succeed (the macro catches the error)
-  expect(stdout).toContain("BUILD_SUCCESS");
-  // The macro should have received the error message about Bun.build not being allowed
-  expect(stdout).toContain("Bun.build cannot be called from within a macro");
+  expect(proc.signalCode, "the child hung and was killed after 60s").toBeNull();
+  expect(normalizeBunSnapshot(withoutMacroDebugLines(stdout), String(dir))).toMatchInlineSnapshot(`
+    "BUILD_SUCCESS
+    // index.ts
+    console.log("ERROR_MSG:", \`CAUGHT: Bun.build cannot be called from within a macro during bundling.
+
+    This would cause a deadlock because the bundler is waiting for the macro to complete,
+    but the macro's Bun.build call is waiting for the bundler.
+
+    To bundle code at compile time in a macro, use Bun.spawnSync to invoke the CLI:
+      const result = Bun.spawnSync(["bun", "build", entrypoint, "--format=esm"]);\`);"
+  `);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
-test("CLI bun build with macro that calls Bun.build also throws", async () => {
-  using dir = tempDir("issue-26360-cli", {
-    "browser.ts": `console.log("browser code");
-export default "";
-`,
+test.concurrent("CLI bun build with macro that calls Bun.build also throws", async () => {
+  using dir = tempDir("issue-26360-cli", fixture);
 
-    // A macro that calls Bun.build and catches the error
-    "macro.ts": `import browserCode from "./browser" with { type: "file" };
-
-let errorMessage = "";
-try {
-  const built = await Bun.build({
-    entrypoints: [browserCode],
-    format: "esm",
-  });
-} catch (e) {
-  errorMessage = e.message;
-}
-export const getErrorMessage = (): string => errorMessage;
-`,
-
-    "index.ts": `import { getErrorMessage } from "./macro" with { type: "macro" };
-console.log("ERROR_MSG:", getErrorMessage());
-`,
-  });
-
-  // Run via CLI
   await using proc = Bun.spawn({
     cmd: [bunExe(), "build", "index.ts", "--target=node"],
     cwd: String(dir),
@@ -112,19 +99,28 @@ console.log("ERROR_MSG:", getErrorMessage());
     stdout: "pipe",
     stderr: "pipe",
   });
-
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // The CLI build should also work and show the error message was caught
-  expect(stdout).toContain("Bun.build cannot be called from within a macro");
+  // With no --outdir the CLI writes the bundle to stdout and prints no summary.
+  expect(normalizeBunSnapshot(withoutMacroDebugLines(stdout), String(dir))).toMatchInlineSnapshot(`
+    "// index.ts
+    console.log("ERROR_MSG:", \`CAUGHT: Bun.build cannot be called from within a macro during bundling.
+
+    This would cause a deadlock because the bundler is waiting for the macro to complete,
+    but the macro's Bun.build call is waiting for the bundler.
+
+    To bundle code at compile time in a macro, use Bun.spawnSync to invoke the CLI:
+      const result = Bun.spawnSync(["bun", "build", entrypoint, "--format=esm"]);\`);"
+  `);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
-test("regular Bun.build (not in macro) still works", async () => {
+test.concurrent("regular Bun.build (not in macro) still works", async () => {
   using dir = tempDir("issue-26360-normal", {
-    "entry.ts": `
-      console.log("hello world");
-      export default "";
-    `,
+    "entry.ts": `console.log("hello world");
+export default "";
+`,
   });
 
   const result = await Bun.build({
@@ -132,8 +128,20 @@ test("regular Bun.build (not in macro) still works", async () => {
     format: "esm",
   });
 
-  expect(result.success).toBe(true);
-  expect(result.outputs.length).toBeGreaterThan(0);
-  const text = await result.outputs[0].text();
-  expect(text).toContain("hello world");
+  expect({ success: result.success, logs: result.logs, outputs: result.outputs.length }).toEqual({
+    success: true,
+    logs: [],
+    outputs: 1,
+  });
+  // The "// <path>" comment on the first line is relative to the test runner's cwd, so it
+  // changes from machine to machine. The rest of the bundle is exact.
+  const text = normalizeBunSnapshot(await result.outputs[0].text()).replace(/^\/\/ .*\/entry\.ts$/m, "// entry.ts");
+  expect(text).toMatchInlineSnapshot(`
+    "// entry.ts
+    console.log("hello world");
+    var entry_default = "";
+    export {
+      entry_default as default
+    };"
+  `);
 });


### PR DESCRIPTION
### Problem
- `test/regression/issue/26360.test.ts` took 10 s on the debian 13 x64-asan lane (CI build #108977). Its three tests ran in sequence. Two spawn a child process.
- Each test checked one substring of stdout. The spawn tests never asserted `stderr` or `exitCode`.

### Fix
- The three tests run with `test.concurrent`, so the two child processes overlap. They share one `fixture` object.
- The outer `Bun.build` stays in a child process: before the fix for #26360 it deadlocked, and an in-process deadlock would take the test runner down. A 60 s `timeout` with `killSignal: "SIGKILL"` turns a hang into a clear failure.
- The spawn tests assert stdout with an inline snapshot, then `stderr` is `""`, then `exitCode` is 0. The in-process test asserts `{ success, logs, outputs }` with one `toEqual` and the bundle text with an inline snapshot.
- Verified: `bun bd test test/regression/issue/26360.test.ts` passes (3 runs, `--rerun-each 15`: 45/45). `USE_SYSTEM_BUN=1 bun test` passes too, as expected for a test-only change.

### Background
- A macro is a function that runs at bundle time on the bundler's thread. The bundler inlines its return value.
- Every `Bun.build` call runs on one singleton bundler thread. The fix for #26360 makes `Bun.build` throw in macro mode. The fixture's macro catches that error, so the bundle shows its message.
- Debug builds print `[macro] call <name>` to stdout when a macro runs. The test drops those lines, as `macro-test.test.ts` does. #40658 moves that line to a scoped logger and makes the filter a no-op.

<details><summary>Notes</summary>

Local timing with the debug (ASAN) build, `bun bd test test/regression/issue/26360.test.ts`, 3 runs each. The first number is the runner's own total, the second is wall time.

Before:
- 3.04 s / 3.9 s (tests: 514 ms, 452 ms, 107 ms)
- 2.95 s / 3.75 s (tests: 523 ms, 355 ms, 96 ms)
- 3.30 s / 4.09 s (tests: 554 ms, 395 ms, 103 ms)

After:
- 2.57 s / 3.28 s (tests: 556 ms, 343 ms, 107 ms, overlapped)
- 2.55 s / 3.28 s (tests: 493 ms, 344 ms, 109 ms, overlapped)
- 2.62 s / 3.33 s (tests: 562 ms, 340 ms, 107 ms, overlapped)

The test bodies went from about 1.05 s sequential to about 0.55 s (the longest test). The remaining 2 s is the debug runner's startup: a one-line test file with no imports reports about 2.0 s on this machine. That part is not specific to this file.

The in-process test's bundle starts with a `// <path>` comment. The bundler writes that path relative to the process cwd, not to the build root, so it differs between machines. The test replaces that line with `// entry.ts` before the snapshot.

The kill switch path was checked by hand: with a fixture that never finishes and a 2 s timeout, the test fails with `error: the child hung and was killed after 60s` / `Received: "SIGKILL"`.

#33704 (open, conflicting) adds `test.concurrent` to this file as part of a 53-file sweep. It does not change the fixture or the assertions.

Other open PRs that run this file in their verification but do not change it: #40059, #40658, #39182.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/26360.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/26360.test.ts"
bun test v1.4.1 (a6c4cc276)

test/regression/issue/26360.test.ts:
(pass) regular Bun.build (not in macro) still works [107.84ms]
(pass) CLI bun build with macro that calls Bun.build also throws [343.66ms]
(pass) Bun.build from macro during bundling throws instead of hanging [557.84ms]

 3 pass
 0 fail
 3 snapshots, 10 expect() calls
Ran 3 tests across 1 file. [2.56s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/26360.test.ts | 156 +++++++++++++++++++-----------------
 1 file changed, 84 insertions(+), 72 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/regression/issue/26360.test.ts      4      7     17
```

</details>

<!-- robobun:evidence:end -->
