### PR TITLE
test(bundler): run bundler_dynamic_import_dce.test.ts concurrently and pin output shapes

### DIFF
--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -1,21 +1,43 @@
 import { describe, expect } from "bun:test";
 import { readdirSync, readFileSync } from "fs";
 import path from "path";
-import { itBundled } from "./expectBundled";
+import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
-function readAllOutputs(outdir: string) {
+function jsOutputs(outdir: string) {
   return readdirSync(outdir)
     .filter(f => f.endsWith(".js"))
-    .map(f => readFileSync(path.join(outdir, f), "utf8"))
-    .join("\n");
+    .sort()
+    .map(f => readFileSync(path.join(outdir, f), "utf8").replaceAll("\r\n", "\n"));
 }
+
+function readAllOutputs(outdir: string) {
+  return jsOutputs(outdir).join("\n");
+}
+
+// The part of a bundle these cases are about: the runtime helpers (`__export`,
+// `__esm`, ... before the first `// file` comment) are dropped and the
+// `[name]-[hash].js` chunk hash is replaced, so an inline snapshot pins the
+// narrowed export object or chunk and nothing else.
+function bundleBody(code: string) {
+  const start = code.search(/^\/\/ [\w./-]+$/m);
+  return (start === -1 ? code : code.slice(start)).replace(/-[a-z0-9]{8}\.js/g, "-[hash].js");
+}
+
+function outputBodies(outdir: string) {
+  return jsOutputs(outdir).map(bundleBody).join("\n");
+}
+
+// Default to the CLI backend: itBundled registers API-backend cases with
+// it.serial (the harness chdirs into the case root around Bun.build), so only
+// CLI-backend cases overlap under describe.concurrent.
+const itBundled = (id: string, opts: BundlerTestInput) => itBundledBase(id, { backend: "cli", ...opts });
 
 // Tree-shaking of `import()` results. esbuild does not implement this
 // (evanw/esbuild#3987, #4255); coverage here is ported from rolldown's
 // `tree_shaking/dynamic_import_*` and rspack's `statical-dynamic-import*`
 // fixtures plus Bun-specific cases.
 
-describe("bundler", () => {
+describe.concurrent("bundler", () => {
   // ──────────────────────────────────────────────────────────────────────
   // No code-splitting: the `import()` stays a lazy `init_x()` of the
   // ESM-wrapped importee, but its `exports_x` object is narrowed to the
@@ -41,8 +63,22 @@ describe("bundler", () => {
     run: { stdout: "43" },
     onAfterBundle(api) {
       // Still lazy (namespace served from `exports_b`), `d` tree-shaken.
-      api.expectFile("/out.js").toContain("exports_b");
-      api.expectFile("/out.js").not.toContain("99");
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.js
+        var exports_b = {};
+        __export(exports_b, {
+          c: () => c
+        });
+        var c = (x) => x + 1;
+
+        // entry.js
+        async function foo() {
+          const { c: c2 } = await Promise.resolve().then(() => exports_b);
+          return c2(42);
+        }
+        console.log(await foo());
+        "
+      `);
     },
   });
 
@@ -136,7 +172,22 @@ describe("bundler", () => {
     dce: true,
     run: { stdout: "1 2" },
     onAfterBundle(api) {
-      api.expectFile("/out.js").not.toContain("DROPPED");
+      // The export object is the union of both sites.
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.js
+        var exports_b = {};
+        __export(exports_b, {
+          c: () => c,
+          d: () => d
+        });
+        var c = 1, d = 2;
+
+        // entry.js
+        var { c: c2 } = await Promise.resolve().then(() => exports_b);
+        var { d: d2 } = await Promise.resolve().then(() => exports_b);
+        console.log(c2, d2);
+        "
+      `);
     },
   });
 
@@ -155,7 +206,21 @@ describe("bundler", () => {
     },
     run: { stdout: "1 99" },
     onAfterBundle(api) {
-      api.expectFile("/out.js").toContain("99");
+      // `...rest` observes the whole namespace: every export stays.
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.js
+        var exports_b = {};
+        __export(exports_b, {
+          c: () => c,
+          d: () => d
+        });
+        var c = 1, d = 99;
+
+        // entry.js
+        var { c: c2, ...rest } = await Promise.resolve().then(() => exports_b);
+        console.log(c2, rest.d);
+        "
+      `);
     },
   });
 
@@ -218,9 +283,21 @@ describe("bundler", () => {
     onAfterBundle(api) {
       // The entry chunk must keep the lazy `import()`; the `b` chunk must
       // not export (or even contain) `d`.
-      const entry = api.readFile("/out/entry.js");
-      expect(entry).toContain("import(");
-      expect(readAllOutputs(api.outdir)).not.toContain("DROPPED");
+      expect(outputBodies(api.outdir)).toMatchInlineSnapshot(`
+        "// b.js
+        var c = (x) => x + 1;
+        export {
+          c
+        };
+
+        // entry.js
+        async function foo() {
+          const { c } = await import("./b-[hash].js");
+          return c(42);
+        }
+        console.log(await foo());
+        "
+      `);
     },
   });
 
@@ -249,7 +326,25 @@ describe("bundler", () => {
       { file: "/out/b.js", stdout: "b 2" },
     ],
     onAfterBundle(api) {
-      expect(readAllOutputs(api.outdir)).not.toContain("DROPPED");
+      // The shared chunk exports the union of what each importer reads.
+      expect(outputBodies(api.outdir)).toMatchInlineSnapshot(`
+        "// a.js
+        var { c } = await import("./lib-[hash].js");
+        console.log("a", c);
+
+        // b.js
+        var { d } = await import("./lib-[hash].js");
+        console.log("b", d);
+
+        // lib.js
+        var c = 1;
+        var d = 2;
+        export {
+          c,
+          d
+        };
+        "
+      `);
     },
   });
 
@@ -568,7 +663,7 @@ describe("bundler", () => {
       target: "bun",
       format: "esm",
       outdir: "/out",
-      run: { file: "/out/entry.js", stdout: '["a","b"] ["a","b"]' },
+      run: { file: "/out/entry.js", stdout: '["a","b"] ["a","b"]', stderr: "" },
     });
   }
 
@@ -826,9 +921,30 @@ describe("bundler", () => {
     outdir: "/out",
     run: { file: "/out/entry.js", stdout: "1\n2" },
     onAfterBundle(api) {
-      const all = readAllOutputs(api.outdir);
-      expect(all).not.toContain("DROP_A");
-      expect(all).toContain("KEEP_B");
+      // `a` is dropped whole, `b` is kept whole (`keep_b` is never read).
+      expect(outputBodies(api.outdir)).toMatchInlineSnapshot(`
+        "// entry.js
+        console.log((await import("./lib-[hash].js")).b.f());
+        var { b: { bbb } } = await import("./lib-[hash].js");
+        console.log(bbb);
+
+        // b.js
+        var exports_b = {};
+        __export(exports_b, {
+          bbb: () => bbb,
+          f: () => f,
+          keep_b: () => keep_b
+        });
+        function f() {
+          return 1;
+        }
+        var bbb = 2;
+        var keep_b = "KEEP_B";
+        export {
+          exports_b as b
+        };
+        "
+      `);
     },
   });
 
@@ -971,7 +1087,7 @@ describe("bundler", () => {
     target: "bun",
     format: "esm",
     outdir: "/out",
-    run: { file: "/out/entry.js", stdout: 'threw ["x","y"] ["x","y"]' },
+    run: { file: "/out/entry.js", stdout: 'threw ["x","y"] ["x","y"]', stderr: "" },
   });
 
   // webpack JavascriptParser._preWalkObjectPattern: string-literal keys narrow;
@@ -1352,8 +1468,25 @@ describe("bundler", () => {
     outdir: "/out",
     run: { file: "/out/entry.js", stdout: "43" },
     onAfterBundle(api) {
-      expect(api.readFile("/out/entry.js")).toContain("import.meta.require(");
-      expect(readAllOutputs(api.outdir)).not.toContain("DROPPED");
+      // The importee is its own chunk behind `import.meta.require()`, narrowed to `c`.
+      expect(outputBodies(api.outdir)).toMatchInlineSnapshot(`
+        "// b.ts
+        var c = (x) => x + 1;
+        export {
+          c
+        };
+
+        // entry.ts
+        function tool() {
+          const { c } = import.meta.require("./b-[hash].js");
+          return c(42);
+        }
+        console.log(tool());
+        export {
+          tool
+        };
+        "
+      `);
     },
   });
 
@@ -1516,7 +1649,27 @@ describe("bundler", () => {
     target: "bun",
     run: { stdout: "3" },
     onAfterBundle(api) {
-      api.expectFile("/out.js").not.toContain("DROPPED");
+      // `__toCommonJS(exports_b)` sees only the two exports the importer reads.
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.ts
+        var exports_b = {};
+        __export(exports_b, {
+          c: () => c,
+          e: () => e
+        });
+        var c = 1, e = 2;
+
+        // entry.ts
+        function tool() {
+          const { c: c2 } = __toCommonJS(exports_b);
+          return c2 + __toCommonJS(exports_b).e;
+        }
+        console.log(tool());
+        export {
+          tool
+        };
+        "
+      `);
     },
   });
 
@@ -1541,13 +1694,21 @@ describe("bundler", () => {
     outdir: "/out",
     run: { file: "/out/entry.js", stdout: "foo" },
     onAfterBundle(api) {
-      const all = readAllOutputs(api.outdir);
-      expect(all).not.toContain("DROPPED1");
-      expect(all).not.toContain("DROPPED2");
       // `thing` is destructured but `a` is never read; per-reference
       // filtering drops it from the chunk (the property name still appears
-      // in the entry's destructure pattern, so check for the value form).
-      expect(all).not.toContain('"thing"');
+      // in the entry's destructure pattern).
+      expect(outputBodies(api.outdir)).toMatchInlineSnapshot(`
+        "// entry.js
+        var { foo: x, thing: a } = await import("./lib-[hash].js");
+        console.log(x);
+
+        // lib.js
+        var foo = "foo";
+        export {
+          foo
+        };
+        "
+      `);
     },
   });
 
@@ -1900,8 +2061,15 @@ describe("bundler", () => {
     },
     run: { stdout: "dep\nentry" },
     onAfterBundle(api) {
-      api.expectFile("/out.js").not.toContain("DROPPED");
-      api.expectFile("/out.js").not.toContain("loadTS");
+      // `loadTS` is unused, so it and the `import()` it holds are dropped.
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// dep.js
+        console.log("dep");
+
+        // entry.js
+        console.log("entry");
+        "
+      `);
     },
   });
 
@@ -1970,8 +2138,24 @@ describe("bundler", () => {
     onAfterBundle(api) {
       // .then((res) => res.a) tracks `res.a` as the only used export and
       // hoists it; the unused re-export `b` is tree-shaken.
-      api.expectFile("/out.js").toContain("KEPT_A");
-      api.expectFile("/out.js").not.toContain("DROPPED_B");
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// module.js
+        var a = "KEPT_A";
+
+        // lib.js
+        var exports_lib = {};
+        __export(exports_lib, {
+          a: () => a
+        });
+        var init_lib = () => {};
+
+        // entry.js
+        Promise.resolve().then(() => (init_lib(), exports_lib)).then((res) => {
+          console.log(res.a);
+          return res.a;
+        });
+        "
+      `);
     },
   });
 
@@ -2549,9 +2733,24 @@ describe("bundler", () => {
       `,
       "/b.js": `throw new Error("boom"); export const c = 1;`,
     },
-    run: { stdout: "caught boom" },
+    run: { stdout: "caught boom", stderr: "" },
     onAfterBundle(api) {
-      api.expectFile("/out.js").toContain("__esm");
+      // The importee stays `__esm`-wrapped, so the throw rejects the promise.
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.js
+        var exports_b = {};
+        __export(exports_b, {
+          c: () => c
+        });
+        var c = 1;
+        var init_b = __esm(() => {
+          throw new Error("boom");
+        });
+
+        // entry.js
+        Promise.resolve().then(() => (init_b(), exports_b)).then(({ c: c2 }) => console.log(c2), (err) => console.log("caught", err.message));
+        "
+      `);
     },
   });
 
@@ -2673,8 +2872,18 @@ describe("bundler", () => {
     format: "esm",
     run: { stdout: "after" },
     onAfterBundle(api) {
-      api.expectFile("/out.js").toContain("exports_b");
-      api.expectFile("/out.js").not.toContain("DROPPED");
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.js
+        var exports_b = {};
+
+        // entry.js
+        async function main() {
+          let { c } = await Promise.resolve().then(() => exports_b);
+          console.log("after");
+        }
+        await main();
+        "
+      `);
     },
   });
 
@@ -3174,7 +3383,7 @@ describe("bundler", () => {
       "/b.js": `if (!globalThis.NO_BOOM) throw new Error("x"); export const c = 1;`,
     },
     format: "esm",
-    run: { stdout: "caught" },
+    run: { stdout: "caught", stderr: "" },
   });
 
   itBundled("dynamic_import_dce/NoSplitTryAwaitThenCatches", {
@@ -3189,7 +3398,7 @@ describe("bundler", () => {
       "/b.js": `throw new Error("boom"); export const c = 1;`,
     },
     format: "esm",
-    run: { stdout: "caught boom" },
+    run: { stdout: "caught boom", stderr: "" },
   });
 
   // The `await` checkpoint stays.
@@ -3239,31 +3448,21 @@ describe("bundler", () => {
   // Importee exports `then`: `await import()` resolves through it. `then` is
   // observed by the `await` itself, so it must be kept even though no
   // importer names it.
-  itBundled("dynamic_import_dce/NoSplitThenableImportee", {
-    files: {
-      "/entry.js": /* js */ `
-        const { v } = await import("./b.js");
-        console.log(v);
-      `,
-      "/b.js": `export const v = "direct"; export function then(r) { r({ v: "unwrapped" }); }`,
-    },
-    format: "esm",
-    run: { stdout: "unwrapped" },
-  });
-
-  itBundled("dynamic_import_dce/SplittingThenableImportee", {
-    files: {
-      "/entry.js": /* js */ `
-        const { v } = await import("./b.js");
-        console.log(v);
-      `,
-      "/b.js": `export const v = "direct"; export function then(r) { r({ v: "unwrapped" }); }`,
-    },
-    splitting: true,
-    format: "esm",
-    outdir: "/out",
-    run: { file: "/out/entry.js", stdout: "unwrapped" },
-  });
+  for (const splitting of [true, false]) {
+    itBundled(`dynamic_import_dce/${splitting ? "Splitting" : "NoSplit"}ThenableImportee`, {
+      files: {
+        "/entry.js": /* js */ `
+          const { v } = await import("./b.js");
+          console.log(v);
+        `,
+        "/b.js": `export const v = "direct"; export function then(r) { r({ v: "unwrapped" }); }`,
+      },
+      splitting,
+      format: "esm",
+      outdir: "/out",
+      run: { file: "/out/entry.js", stdout: "unwrapped" },
+    });
+  }
 
   // `const {x}` is a snapshot, not a live binding.
   itBundled("dynamic_import_dce/NoSplitDestructureIsSnapshot", {
@@ -3327,7 +3526,7 @@ describe("bundler", () => {
       `,
       "/b.js": `throw new Error("boom"); export const c = 1;`,
     },
-    run: { stdout: "caught boom" },
+    run: { stdout: "caught boom", stderr: "" },
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain("__esm");
     },
@@ -3448,7 +3647,19 @@ describe("bundler", () => {
     run: { stdout: "3 3" },
     onAfterBundle(api) {
       // The original destructure must survive so both bindings are declared.
-      api.expectFile("/out.js").toMatch(/\{\s*foo:\s*\w+,\s*foo:\s*bar\s*\}/);
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.js
+        var exports_b = {};
+        __export(exports_b, {
+          foo: () => foo
+        });
+        var foo = 3;
+
+        // entry.js
+        var { foo: foo2, foo: bar } = await Promise.resolve().then(() => exports_b);
+        console.log(foo2, bar);
+        "
+      `);
     },
   });
 
@@ -3488,6 +3699,25 @@ describe("bundler", () => {
     },
     format: "esm",
     run: { stdout: "1" },
+    onAfterBundle(api) {
+      expect(bundleBody(api.readFile("/out.js"))).toMatchInlineSnapshot(`
+        "// b.js
+        var exports_b = {};
+        __export(exports_b, {
+          x: () => x
+        });
+        var x = 1;
+
+        // a.js
+        var exports_a = {};
+        var init_a = () => {};
+
+        // entry.js
+        init_a();
+        await Promise.resolve().then(() => exports_b).then(({ x: x2 }) => console.log(x2));
+        "
+      `);
+    },
   });
 
   // `.then(...).finally(...).catch(err)` — `.finally` must propagate the
@@ -3502,7 +3732,7 @@ describe("bundler", () => {
       `,
       "/b.js": `throw new Error("boom"); export const c = 1;`,
     },
-    run: { stdout: "cleanup\ncaught boom" },
+    run: { stdout: "cleanup\ncaught boom", stderr: "" },
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain("__esm");
     },


### PR DESCRIPTION
### Problem
- `test/bundler/bundler_dynamic_import_dce.test.ts` takes 27s on the x64-asan lane (build 108977): 164 cases in sequence, 151 with a bun subprocess.
- `describe.concurrent` alone does nothing: API-backend cases register as `it.serial` because the harness chdirs around `Bun.build()`.
- Most cases only check that a `DROPPED` sentinel is absent, so a regression in the shape of the export object passes.

### Fix
- Every case builds with the CLI backend through a one-line wrapper (as #41028 and #41057) under `describe.concurrent`. ASAN `bun test` overlaps 5 cases.
- 15 cases whose comments describe an output shape pin it with an inline snapshot of the bundle body (runtime helpers and chunk hash stripped). Six caught-throw runs expect an empty stderr. Two `ThenableImportee` cases become one loop. Every `run` stays, nothing is deleted or skipped.
- Verified: `bun bd test test/bundler/bundler_dynamic_import_dce.test.ts` (debug ASAN): 79.2s, 75.7s, 76.3s before, 24.1s, 24.2s, 24.0s after. CI build 109038: 8.6s on x64-asan, every lane green. `expectBundled.ts` is untouched.
- Self-reviewed: 6 concerns raised, 0 addressed. Four prefer a harness fix (serialize the chdir window in `expectBundled.ts`) to per-file wrappers: a follow-up that deletes this wrapper. Also `itBundled.only`/`.skip` are unavailable (unused here) and `Bun.build()` no longer runs these cases (the linker is shared).

### Background
- `itBundled` (`test/bundler/expectBundled.ts`) builds in-process with `Bun.build()` by default, or with a `bun build` subprocess under `backend: "cli"`. Only CLI cases overlap.
- `run: { stdout }` spawns bun on the output and requires exit code 0 and an exact stdout. It checks stderr only when set.
- With `splitting`, the importee is a `[name]-[hash].js` chunk whose `export { }` list is the narrowed set. Without it, its `exports_x` object is narrowed.

<details><summary>Notes</summary>

Every `run` stays because it is the only positive check: the text checks prove a dropped export is absent, the run proves the kept exports still resolve. Removing a run would let over-shaking pass.

CI build 109038, this file per lane: x64-asan 8.59s (27.4s in build 108977, 19.8s in `test/expected-durations.json`), debian x64 1.62s, alpine x64 1.10s, Windows 2019 x64 2.11s, Windows 11 aarch64 3.46s, darwin aarch64 2.31s. 164 pass and 15 snapshots on each.

Timings in this container (16 vCPUs), same machine for before and after, all green. Per case, debug ASAN: 350ms to 1100ms serial before (the run subprocess is most of it). After, a case takes 500ms to 1000ms wall because a `bun build` subprocess is added and 5 cases share the CPU, but 5 run at once.

The released bun (1.4.1) does not have the `import()` tree-shaking these cases cover (93 of 164 fail on main with `USE_SYSTEM_BUN=1`), so there is no meaningful release-build timing.

The CLI path fails a case on an unexpected bundler warning. No case here warns. Options this file uses and how the CLI branch handles them: `splitting`, `format`, `target`, `outdir`, `minifySyntax`, `define` (already CLI on main because of `resolveBackend`), `entryPoints`, `runtimeFiles`, `bundleErrors` (parsed from stderr, `UnwrapCjsAssignStillErrors` passes). Every case already wrote to its own directory under the harness temp root, and every `node_modules` fixture is a file the case writes. Nothing contacts the network.

`bundleBody()`: the first line matching `^// [\w./-]+$` is the first module comment (`// b.js`, `// node_modules/lib/index.js`). `// @bun` (target bun) does not match, so it is dropped with the helpers. The chunk hash is 8 chars, the same pattern `bundler_splitting.test.ts` strips. `jsOutputs()` sorts the file names so a multi-file snapshot has a stable order. A snapshot holds only the narrowed `__export` object, the chunk's `export { }` list, and the import sites.

Snapshot cases: AwaitDestructure, TwoSitesUnion, BailoutRest, SplittingNarrowedExports, SplittingTwoImportersUnion, WebpackExportStarAsBehindImport, SplitRequireDestructureNarrows, NoSplitRequireNarrows, RolldownAwaitDestructPartial, RolldownUnusedDynamicImportedChunk, RolldownInlineDynamicImportsThenNarrow, InlineThenRejectHandlerBails, InlineLetDestructureUnused, InlineDuplicateDestructureKeyBails, InlineThenWrappedSiblingExportsRefLive (this one had a run only). Each snapshot replaces the substring checks it subsumes. The other substring checks stay: a full snapshot of every case would make any printer change touch 150 snapshots.

`stderr: ""` cases: MinifyInlinedNamespaceLocalEscapes (5 shapes), WebpackCallingNamespaceKeepsAll, InlineThenRejectHandlerBails, NoSplitTryCatchCatches, NoSplitTryAwaitThenCatches, InlineThenCatchChainBails, InlineThenFinallyCatchChainBails.

Other near-identical pairs (`Splitting`/`Inline` ExportedDestructureKept, ThenFunctionArgumentsBailout, ThenRejectHandler, ThenCatchChain) differ in their inputs or expectations, so they stay separate cases.

Also ran prettier on the file.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/bundler_dynamic_import_dce.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [579.26ms]
(pass) bundler > dynamic_import_dce/AwaitDestructure [978.15ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [625.45ms]
(pass) bundler > dynamic_import_dce/AwaitDot [660.99ms]
(pass) bundler > dynamic_import_dce/LetBinding [647.28ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [568.03ms]
(pass) bundler > dynamic_import_dce/BailoutRest [565.22ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [523.80ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [569.11ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [616.87ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [560.70ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [549.45ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [622.65ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllDestructure [569.65ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [964.49ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllThenDestructure [665.62ms]
(pass) bundler > dynamic_import_dce/BareStatementSideEffectsOnlySplitting [638.07ms]
(pass) bundler > dynamic_import_dce/BareStatementSideEffectsOnlyNoSplit [629.29ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllEscapeKeepsAll [769.81ms]
(pass) bundler > dynamic_import_dce/BareRequireStatementSideEffectsOnly [647.15ms]
(pass) bundler > dynamic_import_dce/AwaitedRequireStatementKeepsThen [613.39ms]
(pass) bundler > dynamic_import_dce/GatedRequireBuildTimeTrue [571.19ms]
(pass) bundler > dynamic_import_dce/GatedRequireRuntime [655.70ms]
(pass) bundler > dynamic_import_dce/GatedRequireBothBranchesNarrowAlike [656.19ms]
(pass) bundler > dynamic_import_dce/GatedRequireOrEscapes [641.49ms]
(pass) bundler 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/bundler_dynamic_import_dce.test.ts | 358 +++++++++++++++++++-----
 1 file changed, 294 insertions(+), 64 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/bundler/bundler_dynamic_import_dce.test.ts      9     23     25
```

</details>

**self-review** · 6 surviving concerns

- should-fix: Test-infra/perf change: the concurrency half of this PR is the Nth per-file workaround for one harness invariant (the `process.chdir`+`configRef` window around `await Bun.build()` at expectBundled.ts:1306-1338 that forces `it.serial` at :1972), and a ~15-line promise-chain mutex in expectBundled.…
- should-fix: Test-infra/perf change: the CLI-wrapper + describe.concurrent hunk is the 7th hand copy of a workaround for a 30-line harness limitation in expectBundled.ts that the same author has already prototyped fixing at the source (and measured as faster), so the backend flip should be replaced by that on…
- should-fix: Test-infra/perf change: the speed win is real (27s -> 8.6s on the asan lane), but the per-file `backend: "cli"` wrapper is a workaround for a 12-line harness gap (`it.serial` on API cases at expectBundled.ts:1972) that a measured harness-level lock beats by ~25% with one fewer ASAN child per case…
- should-fix: Test-infra/perf change: the per-file CLI-backend wrapper is a workaround for one `it.serial` line in expectBundled.ts; a 4-hunk promise-chain mutex in the harness is faster on this very file under the ASAN cap (20.5s vs 26.0s), keeps `Bun.build()` coverage, fixes every `describe.concurrent` bundl…
- consider: Kind: test-infra (speed + assertion tightening, justified by the measured 27s ASAN-lane time). One file, no open PR overlaps it, so nothing to fold or absorb - but this is the fifth hand-copied CLI-default wrapper and third hand-rolled chunk-hash normalizer across main plus three sibling sweep PR…
- consider: Test-infra change whose own cost is small (1 test file, no harness or src edits, no new public surface, measured 3x wall-clock win), but it is the third copy of a per-file `backend: "cli"` wrapper that reverses #22646's API-by-default decision file-by-file and adds 15 inline snapshots that will c…

31 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->