### PR TITLE
test(websocket): stream 32 MiB instead of 256 MiB in websocket-pause.test.ts

### DIFF
--- a/test/js/web/websocket/websocket-pause.test.ts
+++ b/test/js/web/websocket/websocket-pause.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, it } from "bun:test";
 import { tls } from "harness";
 import net from "node:net";
 import nodeTls from "node:tls";
+import { WebSocket as WS } from "ws";
 
 const CHUNK = new Uint8Array(64 * 1024);
-const TOTAL = 4096; // 256 MiB, far past any socket/TLS buffer
+// The origin's send() has to return -1 (TCP backpressure) before the stream
+// ends, so TOTAL_BYTES must exceed what the kernel buffers of one loopback
+// connection hold while the client does not read. Measured: 2.5 MiB on Linux
+// (sndbuf autotunes to 2.5 MiB, rcvbuf stays at its 128 KiB default), 192 KiB
+// on Windows. macOS caps a socket buffer at kern.ipc.maxsockbuf (8 MiB), so
+// 32 MiB keeps a 2x margin even over two such buffers. sendAll() fails the
+// test instead of hanging if the stream ever ends without backpressure.
+const TOTAL = 512; // 32 MiB
 const TOTAL_BYTES = TOTAL * CHUNK.byteLength;
 
 type Signals = {
@@ -16,16 +24,23 @@ type Signals = {
 // Streams TOTAL chunks. send() returning -1 means the chunk was enqueued
 // under backpressure; wait for the drain callback instead of re-sending.
 // The waiter is armed before send() because drain can fire synchronously
-// inside it on a plain TCP socket.
+// inside it on a plain TCP socket. Resolves to the number of sends that
+// backpressured.
 async function sendAll(ws: Bun.ServerWebSocket<Signals>): Promise<number> {
   let backpressured = 0;
   for (let i = 0; i < TOTAL; i++) {
     ws.data.drained = Promise.withResolvers();
-    if (ws.send(CHUNK) === -1) {
+    const status = ws.send(CHUNK);
+    if (status === -1) {
       backpressured++;
       ws.data.backpressured.resolve();
       await ws.data.drained.promise;
+    } else if (status !== CHUNK.byteLength) {
+      throw new Error(`send() returned ${status} for chunk ${i}`);
     }
+  }
+  if (backpressured === 0) {
+    ws.data.backpressured.reject(new Error(`sent ${TOTAL_BYTES} bytes to a paused peer without backpressure`));
   }
   return backpressured;
 }
@@ -58,7 +73,7 @@ function streamServer(signals: Signals, secure: boolean) {
 // end to end: with the client paused, the origin server's send() must back
 // up through the proxy. (proxy-test-utils copies with on("data") → write(),
 // which would absorb the whole stream in memory instead.)
-async function pipingConnectProxy(secure: boolean): Promise<{ port: number; close(): void }> {
+async function pipingConnectProxy(secure: boolean): Promise<{ port: number; [Symbol.dispose](): void }> {
   function onConnection(client: net.Socket) {
     client.once("data", head => {
       const match = /^CONNECT ([^:]+):(\d+) /.exec(head.toString("latin1"));
@@ -81,7 +96,7 @@ async function pipingConnectProxy(secure: boolean): Promise<{ port: number; clos
   const port = await new Promise<number>(resolve =>
     server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
   );
-  return { port, close: () => server.close() };
+  return { port, [Symbol.dispose]: () => server.close() };
 }
 
 // Forces the event loop through `n` I/O roundtrips without a timer. A
@@ -108,8 +123,9 @@ type Pausable = {
 };
 
 // The scenario every variant runs: the peer streams TOTAL_BYTES at us while
-// paused; we must see the peer block on TCP (its send() backpressures) with
-// our received count frozen far below the total, then drain it all on resume.
+// we are paused. pause() preceded its first send(), so we must see the peer
+// block on TCP (its send() backpressures) with our received count still at
+// zero, then drain it all on resume. Resolves to what resume() returned.
 async function expectPauseHolds({
   ws,
   signals,
@@ -122,26 +138,35 @@ async function expectPauseHolds({
   clock: WebSocket;
   getReceived: () => number;
   done: Promise<void>;
-}) {
+}): Promise<unknown> {
   const stream = await signals.stream.promise;
   const serverDone = sendAll(stream);
 
-  expect(ws.isPaused).toBe(true);
   // The peer's send() went to -1: our kernel receive buffer is full and the
-  // TCP window is closed. Frames decoded before the pause may already have
-  // dispatched; nothing more may arrive from here on.
+  // TCP window is closed. Nothing may arrive from here on.
   await signals.backpressured.promise;
-  const baseline = getReceived();
+  const receivedAtBackpressure = getReceived();
   await ioRoundtrips(clock, 20);
-  expect(getReceived()).toBe(baseline);
-  // Far below the total: the peer is blocked on TCP, not buffering in us.
-  expect(baseline).toBeLessThan(TOTAL_BYTES / 8);
+  expect({
+    isPaused: ws.isPaused,
+    receivedAtBackpressure,
+    receivedAfterRoundtrips: getReceived(),
+  }).toEqual({
+    isPaused: true,
+    receivedAtBackpressure: 0,
+    receivedAfterRoundtrips: 0,
+  });
 
-  ws.resume();
-  expect(ws.isPaused).toBe(false);
+  const resumed = ws.resume();
+  const isPausedAfterResume = ws.isPaused;
+  const backpressured = await serverDone;
   await done;
-  expect(getReceived()).toBe(TOTAL_BYTES);
-  expect(await serverDone).toBeGreaterThan(0);
+  expect({ isPausedAfterResume, received: getReceived() }).toEqual({
+    isPausedAfterResume: false,
+    received: TOTAL_BYTES,
+  });
+  expect(backpressured).toBeGreaterThan(0);
+  return resumed;
 }
 
 function newSignals(): Signals {
@@ -166,78 +191,83 @@ const MODES = [
   { name: "ws via https:// proxy", secure: false, proxy: "https" },
 ] as const;
 
+// The tests stay sequential on purpose: all of the work (framing, TLS, the
+// proxy copies) runs on this one thread, so concurrent tests only interleave
+// and each one's own duration grows toward the timeout.
 for (const mode of MODES) {
   const { secure } = mode;
   describe(`WebSocket.pause() / resume() (${mode.name})`, () => {
     it("stops reads while paused and drains after resume", async () => {
-      const proxy = mode.proxy ? await pipingConnectProxy(mode.proxy === "https") : undefined;
-      try {
-        const signals = newSignals();
-        using server = streamServer(signals, secure);
-        const url = `${secure ? "wss" : "ws"}://localhost:${server.port}`;
-        const options = {
-          tls: { rejectUnauthorized: false },
-          ...(proxy ? { proxy: `${mode.proxy}://127.0.0.1:${proxy.port}` } : {}),
-        };
+      using proxy = mode.proxy ? await pipingConnectProxy(mode.proxy === "https") : undefined;
+      const signals = newSignals();
+      using server = streamServer(signals, secure);
+      const url = `${secure ? "wss" : "ws"}://localhost:${server.port}`;
+      const options = {
+        tls: { rejectUnauthorized: false },
+        ...(proxy ? { proxy: `${mode.proxy}://127.0.0.1:${proxy.port}` } : {}),
+      };
 
-        const ws = new WebSocket(url, options);
-        ws.binaryType = "arraybuffer";
-        let received = 0;
-        const { promise: done, resolve: resolveDone } = Promise.withResolvers<void>();
-        ws.onmessage = ({ data }) => {
-          received += (data as ArrayBuffer).byteLength;
-          if (received >= TOTAL_BYTES) resolveDone();
-        };
-        await open(ws);
-        const clock = new WebSocket(url, options);
-        await open(clock);
+      const ws = new WebSocket(url, options);
+      ws.binaryType = "arraybuffer";
+      let received = 0;
+      const { promise: done, resolve: resolveDone } = Promise.withResolvers<void>();
+      ws.onmessage = ({ data }) => {
+        received += (data as ArrayBuffer).byteLength;
+        if (received >= TOTAL_BYTES) resolveDone();
+      };
+      await open(ws);
+      const clock = new WebSocket(url, options);
+      await open(clock);
 
-        expect(ws.isPaused).toBe(false);
-        expect(ws.pause()).toBe(true);
-        await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done });
+      expect({ isPausedBefore: ws.isPaused, paused: ws.pause(), isPausedAfterPause: ws.isPaused }).toEqual({
+        isPausedBefore: false,
+        paused: true,
+        isPausedAfterPause: true,
+      });
+      expect(await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done })).toBe(true);
 
-        ws.close();
-        clock.close();
-      } finally {
-        proxy?.close();
-      }
-    }, 60_000);
+      ws.close();
+      clock.close();
+    });
 
     it("pause() and resume() are idempotent", async () => {
-      const proxy = mode.proxy ? await pipingConnectProxy(mode.proxy === "https") : undefined;
-      try {
-        const signals = newSignals();
-        using server = streamServer(signals, secure);
-        const url = `${secure ? "wss" : "ws"}://localhost:${server.port}`;
-        const options = {
-          tls: { rejectUnauthorized: false },
-          ...(proxy ? { proxy: `${mode.proxy}://127.0.0.1:${proxy.port}` } : {}),
-        };
-        const ws = new WebSocket(url, options);
-        await open(ws);
-        expect(ws.resume()).toBe(true);
-        expect(ws.isPaused).toBe(false);
-        expect(ws.pause()).toBe(true);
-        expect(ws.pause()).toBe(true);
-        expect(ws.isPaused).toBe(true);
-        expect(ws.resume()).toBe(true);
-        expect(ws.resume()).toBe(true);
-        expect(ws.isPaused).toBe(false);
+      using proxy = mode.proxy ? await pipingConnectProxy(mode.proxy === "https") : undefined;
+      const signals = newSignals();
+      using server = streamServer(signals, secure);
+      const url = `${secure ? "wss" : "ws"}://localhost:${server.port}`;
+      const options = {
+        tls: { rejectUnauthorized: false },
+        ...(proxy ? { proxy: `${mode.proxy}://127.0.0.1:${proxy.port}` } : {}),
+      };
+      const ws = new WebSocket(url, options);
+      await open(ws);
 
-        // Still a working connection after the churn.
-        const { promise: echoed, resolve } = Promise.withResolvers<string>();
-        ws.onmessage = ({ data }) => resolve(data);
-        ws.send("still alive");
-        expect(await echoed).toBe("still alive");
+      // Each entry records the return value and the state right after the call.
+      const transitions = [
+        { call: "resume", returned: ws.resume(), isPaused: ws.isPaused },
+        { call: "pause", returned: ws.pause(), isPaused: ws.isPaused },
+        { call: "pause", returned: ws.pause(), isPaused: ws.isPaused },
+        { call: "resume", returned: ws.resume(), isPaused: ws.isPaused },
+        { call: "resume", returned: ws.resume(), isPaused: ws.isPaused },
+      ];
+      expect(transitions).toEqual([
+        { call: "resume", returned: true, isPaused: false },
+        { call: "pause", returned: true, isPaused: true },
+        { call: "pause", returned: true, isPaused: true },
+        { call: "resume", returned: true, isPaused: false },
+        { call: "resume", returned: true, isPaused: false },
+      ]);
 
-        const closed = new Promise(resolve => (ws.onclose = resolve));
-        ws.close();
-        await closed;
-        expect(ws.pause()).toBe(false);
-        expect(ws.resume()).toBe(false);
-      } finally {
-        proxy?.close();
-      }
+      // Still a working connection after the churn.
+      const { promise: echoed, resolve } = Promise.withResolvers<string>();
+      ws.onmessage = ({ data }) => resolve(data);
+      ws.send("still alive");
+      expect(await echoed).toBe("still alive");
+
+      const closed = new Promise(resolve => (ws.onclose = resolve));
+      ws.close();
+      await closed;
+      expect({ pause: ws.pause(), resume: ws.resume() }).toEqual({ pause: false, resume: false });
     });
   });
 }
@@ -250,8 +280,8 @@ describe("WebSocket.pause() before open", () => {
 
     const ws = new WebSocket(url);
     ws.binaryType = "arraybuffer";
-    expect(ws.pause()).toBe(true);
-    expect(ws.isPaused).toBe(true);
+    const paused = ws.pause();
+    const isPausedWhileConnecting = ws.isPaused;
     let received = 0;
     const { promise: done, resolve: resolveDone } = Promise.withResolvers<void>();
     ws.onmessage = ({ data }) => {
@@ -259,14 +289,18 @@ describe("WebSocket.pause() before open", () => {
       if (received >= TOTAL_BYTES) resolveDone();
     };
     await open(ws);
-    expect(ws.isPaused).toBe(true);
+    expect({ paused, isPausedWhileConnecting, isPausedAfterOpen: ws.isPaused }).toEqual({
+      paused: true,
+      isPausedWhileConnecting: true,
+      isPausedAfterOpen: true,
+    });
     const clock = new WebSocket(url);
     await open(clock);
 
-    await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done });
+    expect(await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done })).toBe(true);
     ws.close();
     clock.close();
-  }, 60_000);
+  });
 
   it("resume() before open clears the latch", async () => {
     using server = Bun.serve({
@@ -283,12 +317,25 @@ describe("WebSocket.pause() before open", () => {
       },
     });
     const ws = new WebSocket(`ws://localhost:${server.port}`);
-    expect(ws.pause()).toBe(true);
-    expect(ws.resume()).toBe(true);
-    expect(ws.isPaused).toBe(false);
+    const paused = ws.pause();
+    const resumed = ws.resume();
+    const isPausedWhileConnecting = ws.isPaused;
     const { promise: got, resolve } = Promise.withResolvers<string>();
     ws.onmessage = ({ data }) => resolve(data);
-    expect(await got).toBe("a");
+    await open(ws);
+    expect({
+      paused,
+      resumed,
+      isPausedWhileConnecting,
+      isPausedAfterOpen: ws.isPaused,
+      firstMessage: await got,
+    }).toEqual({
+      paused: true,
+      resumed: true,
+      isPausedWhileConnecting: false,
+      isPausedAfterOpen: false,
+      firstMessage: "a",
+    });
     ws.close();
   });
 
@@ -301,19 +348,26 @@ describe("WebSocket.pause() before open", () => {
       websocket: { message() {} },
     });
     const ws = new WebSocket(`ws://localhost:${server.port}`);
-    expect(ws.pause()).toBe(true);
+    const pausedWhileConnecting = ws.pause();
     const closed = new Promise(resolve => (ws.onclose = resolve));
     ws.onerror = () => {};
     await closed;
-    expect(ws.readyState).toBe(WebSocket.CLOSED);
-    expect(ws.pause()).toBe(false);
-    expect(ws.resume()).toBe(false);
+    expect({
+      pausedWhileConnecting,
+      readyState: ws.readyState,
+      pause: ws.pause(),
+      resume: ws.resume(),
+    }).toEqual({
+      pausedWhileConnecting: true,
+      readyState: WebSocket.CLOSED,
+      pause: false,
+      resume: false,
+    });
   });
 });
 
 describe("ws package", () => {
   it("pause()/resume()/isPaused reach the socket", async () => {
-    const { WebSocket: WS } = await import("ws");
     const signals = newSignals();
     using server = streamServer(signals, false);
     const url = `ws://localhost:${server.port}`;
@@ -329,10 +383,14 @@ describe("ws package", () => {
     const clock = new WebSocket(url);
     await open(clock);
 
-    expect(ws.isPaused).toBe(false);
-    ws.pause();
-    await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done });
+    // npm ws returns undefined from pause() and resume().
+    expect({ isPausedBefore: ws.isPaused, paused: ws.pause(), isPausedAfterPause: ws.isPaused }).toEqual({
+      isPausedBefore: false,
+      paused: undefined,
+      isPausedAfterPause: true,
+    });
+    expect(await expectPauseHolds({ ws, signals, clock, getReceived: () => received, done })).toBeUndefined();
     ws.close();
     clock.close();
-  }, 60_000);
+  });
 });

--- a/test/js/web/websocket/websocket-pause.test.ts
+++ b/test/js/web/websocket/websocket-pause.test.ts
@@ -25,7 +25,7 @@ type Signals = {
 // under backpressure; wait for the drain callback instead of re-sending.
 // The waiter is armed before send() because drain can fire synchronously
 // inside it on a plain TCP socket. Resolves to the number of sends that
-// backpressured.
+// backpressured; rejects if a send is dropped or the stream never backs up.
 async function sendAll(ws: Bun.ServerWebSocket<Signals>): Promise<number> {
   let backpressured = 0;
   for (let i = 0; i < TOTAL; i++) {
@@ -40,7 +40,7 @@ async function sendAll(ws: Bun.ServerWebSocket<Signals>): Promise<number> {
     }
   }
   if (backpressured === 0) {
-    ws.data.backpressured.reject(new Error(`sent ${TOTAL_BYTES} bytes to a paused peer without backpressure`));
+    throw new Error(`sent ${TOTAL_BYTES} bytes to a paused peer without backpressure`);
   }
   return backpressured;
 }
@@ -143,8 +143,9 @@ async function expectPauseHolds({
   const serverDone = sendAll(stream);
 
   // The peer's send() went to -1: our kernel receive buffer is full and the
-  // TCP window is closed. Nothing may arrive from here on.
-  await signals.backpressured.promise;
+  // TCP window is closed. Nothing may arrive from here on. The race fails
+  // the test at once if sendAll() rejects before that first -1.
+  await Promise.race([signals.backpressured.promise, serverDone]);
   const receivedAtBackpressure = getReceived();
   await ioRoundtrips(clock, 20);
   expect({


### PR DESCRIPTION
### Problem
- `test/js/web/websocket/websocket-pause.test.ts` takes 11 s on alpine x64 and 7 to 10 s on the other Linux lanes (CI build #108977).
- Its 7 streaming tests each push 256 MiB through a paused client. The assertion only needs one `send()` to return -1, which happens once the kernel buffers of one loopback connection are full.

### Fix
- `TOTAL_BYTES` is 32 MiB. The first -1 comes after 2.5 MiB on Linux and 192 KiB on Windows: a 12x margin on Linux, and 2x over two macOS buffers at `kern.ipc.maxsockbuf` (8 MiB).
- `sendAll()` fails the test with a message if the stream ends without backpressure or a `send()` is dropped, instead of hanging to the timeout. The 60 s per-test timeouts are gone.
- Stricter assertions: received bytes are exactly 0 at backpressure and after the 20 I/O roundtrips (was `< TOTAL_BYTES / 8`). `isPaused` transitions and `pause()`/`resume()` return values are checked as structured objects, including the `ws` shim.
- Verified: `bun bd test test/js/web/websocket/websocket-pause.test.ts`, 3 runs before 16.4 s, 18.6 s, 18.0 s, after 5.0 s, 5.1 s, 5.2 s. Release build 1.2 s to 0.27 s. Also 30 repeat runs, 5 runs on Windows x64, and the sibling websocket suites.

### Background
- `pause()` drops READABLE from the socket's poll (`us_socket_pause`). Bytes stay in the kernel receive buffer, the TCP window closes, and the origin's `send()` returns -1 once its own send buffer is full.
- Concurrency was measured and not used: the work is CPU-bound on one thread. `--concurrent` gave the same wall time, and each test's own duration grew 3 to 4x toward the 5 s default timeout.

<details><summary>Notes</summary>

**Backpressure threshold per mode.** A probe streamed 64 KiB chunks to a paused client and recorded the bytes sent before the first `send() === -1`, 5 rounds per mode, under `bun bd` on Linux and under the canary build on Windows x64. The client had received 0 bytes at that point and after 20 I/O roundtrips in every round.

| mode | Linux | Windows |
| --- | --- | --- |
| ws | 2.44 MiB | 0.13 MiB |
| wss | 2.50 to 2.56 MiB | 0.19 MiB |
| wss via http:// proxy | 2.50 MiB | 0.19 MiB |
| wss via https:// proxy | 2.50 MiB | 0.19 MiB |
| ws via https:// proxy | 2.44 to 2.50 MiB | 0.13 MiB |

The first -1 is the same in the proxy modes because `sendAll()` runs synchronously until then, so the in-process proxy cannot drain in between. `ss -tmi` during a paused stream on Linux shows the sender at `tb2626560` (sndbuf 2.5 MiB, `cwnd:10`, `rwnd_limited 100%`) and the paused receiver at `rb131072`. Linux default `tcp_wmem[2]` is 4 MiB and `tcp_rmem[1]` is 128 KiB, so the default-kernel ceiling is about 4.1 MiB. macOS: `kern.ipc.maxsockbuf` is 8 MiB per socket buffer, so two buffers cannot hold more than 16 MiB. 32 MiB keeps the margin the cross-platform guidance asks for (exceed the largest platform limit).

**Where the time goes** (debug build, one streaming test, 32 MiB): `Bun.serve` 30 ms, two connections 20 to 35 ms, until backpressure 10 ms, 20 roundtrips 15 ms, drain after resume 200 ms (ws) to 300 ms (wss). The drain is per-byte bound: 256 KiB chunks only cut it by 25%, so `CHUNK` stays at 64 KiB. Process startup of the debug build is 2.1 s of the 5 s total (an empty test file takes 2.1 s).

**Concurrency.** At 32 MiB, sequential: 4.97 s, 4.95 s. `--concurrent`: 5.07 s, 4.93 s, with the streaming tests at 1.2 to 2.2 s each instead of 0.3 to 0.6 s.

**Hoisting servers into `beforeAll`** was not done: it saves about 40 ms per mode in the debug build and would need a per-connection signal registry, since both tests in a mode would share one server.

**Fail-fast check.** `expectPauseHolds()` races the backpressure signal against the `sendAll()` promise (review finding, 5c1397f). With `TOTAL = 16` (1 MiB) the streaming tests fail in 60 to 140 ms with `sent 1048576 bytes to a paused peer without backpressure`. With the status check forced to fail on the first chunk, they fail in 60 to 100 ms with `send() returned 65536 for chunk 0`.

**Stability.** 10 debug runs and 20 release runs on Linux, 5 runs on Windows x64 (about 0.6 s each): no failure. Also ran `websocket-buffered-amount.test.ts` and `websocket-server-send-from-drain.test.ts` (22 pass across the 3 files).

The `ws` import moved from a dynamic `import("ws")` inside the test to a module-scope import, per test/CLAUDE.md.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/websocket/websocket-pause.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/websocket/websocket-pause.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/web/websocket/websocket-pause.test.ts:
(pass) WebSocket.pause() / resume() (ws) > stops reads while paused and drains after resume [331.99ms]
(pass) WebSocket.pause() / resume() (ws) > pause() and resume() are idempotent [33.06ms]
(pass) WebSocket.pause() / resume() (wss) > stops reads while paused and drains after resume [408.53ms]
(pass) WebSocket.pause() / resume() (wss) > pause() and resume() are idempotent [25.42ms]
(pass) WebSocket.pause() / resume() (wss via http:// proxy) > stops reads while paused and drains after resume [497.22ms]
(pass) WebSocket.pause() / resume() (wss via http:// proxy) > pause() and resume() are idempotent [46.03ms]
(pass) WebSocket.pause() / resume() (wss via https:// proxy) > stops reads while paused and drains after resume [493.31ms]
(pass) WebSocket.pause() / resume() (wss via https:// proxy) > pause() and resume() are idempotent [36.28ms]
(pass) WebSocket.pause() / resume() (ws via https:// proxy) > stops reads while paused and drains after resume [312.34ms]
(pass) WebSocket.pause() / resume() (ws via https:// proxy) > pause() and resume() are idempotent [26.69ms]
(pass) WebSocket.pause() before open > latches and applies once connected [267.22ms]
(pass) WebSocket.pause() before open > resume() before open clears the latch [24.27ms]
(pass) WebSocket.pause() before open > a latched pause is dropped when the connection fails [36.43ms]
(pass) ws package > pause()/resume()/isPaused reach the socket [245.40ms]

 14 pass
 0 fail
 52 expect() calls
Ran 14 tests across 1 file. [5.08s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/websocket/websocket-pause.test.ts | 257 ++++++++++++++++----------
 1 file changed, 158 insertions(+), 99 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/web/websocket/websocket-pause.test.ts      7      7     21
```

</details>

<!-- robobun:evidence:end -->