### PR TITLE
test(install): run public-hoist-pattern.test.ts concurrently from a warm cache and pin its outputs

### DIFF
--- a/test/cli/install/public-hoist-pattern.test.ts
+++ b/test/cli/install/public-hoist-pattern.test.ts
@@ -1,423 +1,349 @@
-import { spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { readlinkSync } from "fs";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall } from "harness";
-import { join } from "path";
+import { realpath } from "fs/promises";
+import {
+  type DirectoryTree,
+  VerdaccioRegistry,
+  bunEnv,
+  bunExe,
+  normalizeBunSnapshot,
+  readdirSorted,
+  tempDir,
+} from "harness";
+import { join, relative } from "path";
 
 const registry = new VerdaccioRegistry();
 
+// Every case installs from this one cache. `beforeAll` fills it with every version the cases resolve, so a case
+// downloads and extracts nothing and its stderr is exactly "Saved lockfile". The env var is needed because CI exports
+// BUN_INSTALL_CACHE_DIR (one per test file), which overrides the bunfig `cache` that createTestDir writes.
+const cacheDir = tempDir("public-hoist-pattern-cache-", {});
+const installEnv = { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) };
+
 beforeAll(async () => {
   await registry.start();
+
+  // `two-range-deps@1.0.0` depends on `no-deps@^1.0.0` and `@types/is-number@>=1.0.0`. A case that pins
+  // no-deps@1.0.0 or @types/is-number@1.0.0 dedupes the range onto the pin, every other case resolves 1.1.0 and
+  // 2.0.0. The aliases put both versions in the cache.
+  const { packageDir } = await registry.createTestDir({
+    files: {
+      "package.json": JSON.stringify({
+        name: "warm-cache",
+        dependencies: {
+          "two-range-deps": "1.0.0",
+          "a-dep": "1.0.1",
+          "basic-1": "1.0.0",
+          "no-deps": "1.0.0",
+          "no-deps-1.1.0": "npm:no-deps@1.1.0",
+          "@types/is-number": "1.0.0",
+          "types-is-number-2.0.0": "npm:@types/is-number@2.0.0",
+        },
+      }),
+    },
+  });
+  const { stdout, stderr, exitCode } = await install(packageDir);
+  expect(stderr).toMatch(/^Resolving dependencies\nResolved, downloaded and extracted \[\d+\]\nSaved lockfile$/);
+  expect(stdout).toEndWith("7 packages installed");
+  expect(exitCode).toBe(0);
 });
 
 afterAll(() => {
   registry.stop();
+  cacheDir[Symbol.dispose]();
 });
 
+async function install(cwd: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: installEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout, cwd), stderr: normalizeBunSnapshot(stderr, cwd), exitCode };
+}
+
+/**
+ * The isolated linker's layout: `store` lists `node_modules/.bun` (one `<name>@<version>` folder per installed
+ * package, plus `node_modules`, the linker's fallback directory that links every package). `links` maps every entry
+ * of the given node_modules directories (scoped names flattened) to the store folder it resolves into. Real paths are
+ * compared, not link text: on Windows the linker falls back to a junction, whose target is absolute.
+ */
+async function layout(packageDir: string, nodeModulesDirs = ["node_modules"]) {
+  const store = join(await realpath(packageDir), "node_modules", ".bun");
+  const links: Record<string, string> = {};
+  for (const dir of nodeModulesDirs) {
+    for (const entry of await readdirSorted(join(packageDir, dir))) {
+      if (entry === ".bun") continue;
+      const names = entry.startsWith("@")
+        ? (await readdirSorted(join(packageDir, dir, entry))).map(name => `${entry}/${name}`)
+        : [entry];
+      for (const name of names) {
+        const real = relative(store, await realpath(join(packageDir, dir, name))).replaceAll("\\", "/");
+        const suffix = `/node_modules/${name}`;
+        links[`${dir}/${name}`] = real.endsWith(suffix) ? real.slice(0, -suffix.length) : real;
+      }
+    }
+  }
+  return { store: await readdirSorted(store), links };
+}
+
+type Case = {
+  name: string;
+  /** `install.publicHoistPattern` in bunfig.toml */
+  bunfig?: string | string[];
+  /** `public-hoist-pattern` lines in .npmrc */
+  npmrc?: string;
+  packageJson: Record<string, unknown>;
+  /** workspace members */
+  files?: DirectoryTree;
+  /** the node_modules directories `links` covers, the root one when absent */
+  nodeModulesDirs?: string[];
+  /** stdout after the `bun install <version>` header */
+  stdout: string[];
+  store: string[];
+  links: Record<string, string>;
+};
+
+const cases: Case[] = [
+  {
+    name: "bunfig string",
+    bunfig: "*typ*",
+    packageJson: { name: "include-patterns", dependencies: { "two-range-deps": "1.0.0" } },
+    stdout: ["+ two-range-deps@1.0.0", "", "3 packages installed"],
+    store: ["@types+is-number@2.0.0", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@2.0.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "bunfig array",
+    bunfig: ["*types*", "no-deps"],
+    packageJson: { name: "array-patterns", dependencies: { "two-range-deps": "1.0.0", "a-dep": "1.0.1" } },
+    stdout: ["+ a-dep@1.0.1 (v1.0.10 available)", "+ two-range-deps@1.0.0", "", "4 packages installed"],
+    store: ["@types+is-number@2.0.0", "a-dep@1.0.1", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@2.0.0",
+      "node_modules/a-dep": "a-dep@1.0.1",
+      "node_modules/no-deps": "no-deps@1.1.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    // direct dependencies are always linked, the transitive @types/is-number is installed but not hoisted
+    name: "all exclude pattern",
+    bunfig: "!*",
+    packageJson: { name: "exclude-all", dependencies: { "two-range-deps": "1.0.0", "no-deps": "1.0.0" } },
+    stdout: ["+ no-deps@1.0.0 (v2.0.0 available)", "+ two-range-deps@1.0.0", "", "3 packages installed"],
+    store: ["@types+is-number@2.0.0", "no-deps@1.0.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/no-deps": "no-deps@1.0.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "all include pattern",
+    bunfig: "*",
+    packageJson: { name: "include-all", dependencies: { "two-range-deps": "1.0.0" } },
+    stdout: ["+ two-range-deps@1.0.0", "", "3 packages installed"],
+    store: ["@types+is-number@2.0.0", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@2.0.0",
+      "node_modules/no-deps": "no-deps@1.1.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "mixed include and exclude patterns",
+    bunfig: ["*", "!@types*", "!no-deps"],
+    packageJson: { name: "mixed-patterns", dependencies: { "two-range-deps": "1.0.0", "a-dep": "1.0.1" } },
+    stdout: ["+ a-dep@1.0.1 (v1.0.10 available)", "+ two-range-deps@1.0.0", "", "4 packages installed"],
+    store: ["@types+is-number@2.0.0", "a-dep@1.0.1", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/a-dep": "a-dep@1.0.1",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "npmrc string configuration",
+    npmrc: "public-hoist-pattern=*types*",
+    packageJson: { name: "npmrc-string", dependencies: { "two-range-deps": "1.0.0" } },
+    stdout: ["+ two-range-deps@1.0.0", "", "3 packages installed"],
+    store: ["@types+is-number@2.0.0", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@2.0.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "npmrc array configuration",
+    npmrc: "public-hoist-pattern[]=*types*\npublic-hoist-pattern[]=no-deps",
+    packageJson: { name: "npmrc-array", dependencies: { "two-range-deps": "1.0.0", "a-dep": "1.0.1" } },
+    stdout: ["+ a-dep@1.0.1 (v1.0.10 available)", "+ two-range-deps@1.0.0", "", "4 packages installed"],
+    store: ["@types+is-number@2.0.0", "a-dep@1.0.1", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@2.0.0",
+      "node_modules/a-dep": "a-dep@1.0.1",
+      "node_modules/no-deps": "no-deps@1.1.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "npmrc mixed patterns",
+    npmrc: "public-hoist-pattern[]=*\npublic-hoist-pattern[]=!@types*\npublic-hoist-pattern[]=!no-deps",
+    packageJson: { name: "npmrc-mixed", dependencies: { "two-range-deps": "1.0.0", "a-dep": "1.0.1" } },
+    stdout: ["+ a-dep@1.0.1 (v1.0.10 available)", "+ two-range-deps@1.0.0", "", "4 packages installed"],
+    store: ["@types+is-number@2.0.0", "a-dep@1.0.1", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/a-dep": "a-dep@1.0.1",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    // two-range-deps is excluded from hoisting but stays linked because it is a direct dependency
+    name: "exclude specific packages",
+    bunfig: ["*", "!two-range-deps"],
+    packageJson: { name: "exclude-specific", dependencies: { "two-range-deps": "1.0.0", "no-deps": "1.0.0" } },
+    stdout: ["+ no-deps@1.0.0 (v2.0.0 available)", "+ two-range-deps@1.0.0", "", "3 packages installed"],
+    store: ["@types+is-number@2.0.0", "no-deps@1.0.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@2.0.0",
+      "node_modules/no-deps": "no-deps@1.0.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "scoped package patterns",
+    bunfig: "@types/*",
+    packageJson: { name: "scoped-patterns", dependencies: { "two-range-deps": "1.0.0", "@types/is-number": "1.0.0" } },
+    stdout: ["+ @types/is-number@1.0.0 (v2.0.0 available)", "+ two-range-deps@1.0.0", "", "3 packages installed"],
+    store: ["@types+is-number@1.0.0", "no-deps@1.1.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@1.0.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    // no-deps matches `no-*` but `!no-deps` wins
+    name: "complex pattern combinations",
+    bunfig: ["@types/*", "no-*", "!no-deps", "a-*"],
+    packageJson: {
+      name: "complex-patterns",
+      dependencies: { "two-range-deps": "1.0.0", "a-dep": "1.0.1", "basic-1": "1.0.0" },
+    },
+    stdout: [
+      "+ a-dep@1.0.1 (v1.0.10 available)",
+      "+ basic-1@1.0.0",
+      "+ two-range-deps@1.0.0",
+      "",
+      "5 packages installed",
+    ],
+    store: [
+      "@types+is-number@2.0.0",
+      "a-dep@1.0.1",
+      "basic-1@1.0.0",
+      "no-deps@1.1.0",
+      "node_modules",
+      "two-range-deps@1.0.0",
+    ],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@2.0.0",
+      "node_modules/a-dep": "a-dep@1.0.1",
+      "node_modules/basic-1": "basic-1@1.0.0",
+      "node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+  {
+    name: "workspaces with publicHoistPattern",
+    bunfig: ["*types*", "no-deps"],
+    packageJson: { name: "workspace-root", workspaces: ["packages/*"], dependencies: { "no-deps": "1.0.0" } },
+    files: {
+      "packages/pkg1/package.json": JSON.stringify({
+        name: "pkg1",
+        dependencies: { "@types/is-number": "1.0.0", "a-dep": "1.0.1" },
+      }),
+      "packages/pkg2/package.json": JSON.stringify({ name: "pkg2", dependencies: { "two-range-deps": "1.0.0" } }),
+    },
+    nodeModulesDirs: ["node_modules", "packages/pkg1/node_modules", "packages/pkg2/node_modules"],
+    stdout: ["+ no-deps@1.0.0 (v2.0.0 available)", "", "4 packages installed"],
+    store: ["@types+is-number@1.0.0", "a-dep@1.0.1", "no-deps@1.0.0", "node_modules", "two-range-deps@1.0.0"],
+    links: {
+      "node_modules/@types/is-number": "@types+is-number@1.0.0",
+      "node_modules/no-deps": "no-deps@1.0.0",
+      "packages/pkg1/node_modules/@types/is-number": "@types+is-number@1.0.0",
+      "packages/pkg1/node_modules/a-dep": "a-dep@1.0.1",
+      "packages/pkg2/node_modules/two-range-deps": "two-range-deps@1.0.0",
+    },
+  },
+];
+
 describe("publicHoistPattern", () => {
-  test("bunfig string", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: "*typ*" },
-      files: {
-        "package.json": JSON.stringify({
-          name: "include-patterns",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-          },
-        }),
-      },
-    });
+  test.concurrent.each(cases)(
+    "$name",
+    async ({ bunfig, npmrc, packageJson, files, nodeModulesDirs, stdout, store, links }) => {
+      const { packageDir } = await registry.createTestDir({
+        bunfigOpts: { linker: "isolated", publicHoistPattern: bunfig },
+        files: {
+          "package.json": JSON.stringify(packageJson),
+          ...(npmrc === undefined ? {} : { ".npmrc": npmrc }),
+          ...files,
+        },
+      });
 
-    await runBunInstall(bunEnv, packageDir);
-
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "@types", "two-range-deps"]);
-  });
-
-  test("bunfig array", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: ["*types*", "no-deps"] },
-      files: {
-        "package.json": JSON.stringify({
-          name: "array-patterns",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "a-dep": "1.0.1",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should hoist @types and no-deps
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
-      ".bun",
-      "@types",
-      "a-dep",
-      "no-deps",
-      "two-range-deps",
-    ]);
-  });
-
-  test("all exclude pattern", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: "!*" },
-      files: {
-        "package.json": JSON.stringify({
-          name: "exclude-all",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "no-deps": "1.0.0",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should not hoist any dependencies
-    const [nodeModules, hasTypes] = await Promise.all([
-      readdirSorted(join(packageDir, "node_modules")),
-      Bun.file(join(packageDir, "node_modules", "@types")).exists(),
-    ]);
-
-    expect(nodeModules).toEqual([".bun", "no-deps", "two-range-deps"]);
-    // Verify transitive deps are not hoisted
-    expect(hasTypes).toBeFalse();
-  });
-
-  test("all include pattern", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: "*" },
-      files: {
-        "package.json": JSON.stringify({
-          name: "include-all",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should hoist all dependencies including transitive
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
-      ".bun",
-      "@types",
-      "no-deps",
-      "two-range-deps",
-    ]);
-  });
-
-  test("mixed include and exclude patterns", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: ["*", "!@types*", "!no-deps"] },
-      files: {
-        "package.json": JSON.stringify({
-          name: "mixed-patterns",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "a-dep": "1.0.1",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should hoist everything except @types and no-deps
-    const [nodeModules, hasTypes, hasNoDeps] = await Promise.all([
-      readdirSorted(join(packageDir, "node_modules")),
-      Bun.file(join(packageDir, "node_modules", "@types")).exists(),
-      Bun.file(join(packageDir, "node_modules", "no-deps")).exists(),
-    ]);
-
-    expect(nodeModules).toEqual([".bun", "a-dep", "two-range-deps"]);
-    expect(hasTypes).toBeFalse();
-    expect(hasNoDeps).toBeFalse();
-  });
-
-  test("npmrc string configuration", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated" },
-      files: {
-        "package.json": JSON.stringify({
-          name: "npmrc-string",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-          },
-        }),
-        ".npmrc": `public-hoist-pattern=*types*`,
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "@types", "two-range-deps"]);
-  });
-
-  test("npmrc array configuration", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated" },
-      files: {
-        "package.json": JSON.stringify({
-          name: "npmrc-array",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "a-dep": "1.0.1",
-          },
-        }),
-        ".npmrc": `public-hoist-pattern[]=*types*
-public-hoist-pattern[]=no-deps`,
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should hoist @types and no-deps
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
-      ".bun",
-      "@types",
-      "a-dep",
-      "no-deps",
-      "two-range-deps",
-    ]);
-  });
-
-  test("npmrc mixed patterns", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated" },
-      files: {
-        "package.json": JSON.stringify({
-          name: "npmrc-mixed",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "a-dep": "1.0.1",
-          },
-        }),
-        ".npmrc": `public-hoist-pattern[]=*
-public-hoist-pattern[]=!@types*
-public-hoist-pattern[]=!no-deps`,
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should hoist everything except @types and no-deps
-    const [nodeModules, hasTypes, hasNoDeps] = await Promise.all([
-      readdirSorted(join(packageDir, "node_modules")),
-      Bun.file(join(packageDir, "node_modules", "@types")).exists(),
-      Bun.file(join(packageDir, "node_modules", "no-deps")).exists(),
-    ]);
-
-    expect(nodeModules).toEqual([".bun", "a-dep", "two-range-deps"]);
-    expect(hasTypes).toBeFalse();
-    expect(hasNoDeps).toBeFalse();
-  });
-
-  test("exclude specific packages", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: ["*", "!two-range-deps"] },
-      files: {
-        "package.json": JSON.stringify({
-          name: "exclude-specific",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "no-deps": "1.0.0",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should hoist everything, two-range-deps included because it's a direct dependency
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
-      ".bun",
-      "@types",
-      "no-deps",
-      "two-range-deps",
-    ]);
-    // two-range-deps should still be linked
-    expect(readlinkSync(join(packageDir, "node_modules", "two-range-deps"))).toBe(
-      join(".bun", "two-range-deps@1.0.0", "node_modules", "two-range-deps"),
-    );
-  });
-
-  test("scoped package patterns", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: "@types/*" },
-      files: {
-        "package.json": JSON.stringify({
-          name: "scoped-patterns",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "@types/is-number": "1.0.0",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should only hoist @types packages
-    const [nodeModules, nodeModulesTypes, hasNoDeps] = await Promise.all([
-      readdirSorted(join(packageDir, "node_modules")),
-      readdirSorted(join(packageDir, "node_modules", "@types")),
-      Bun.file(join(packageDir, "node_modules", "no-deps")).exists(),
-    ]);
-
-    expect(nodeModules).toEqual([".bun", "@types", "two-range-deps"]);
-    expect(nodeModulesTypes).toEqual(["is-number"]);
-    expect(hasNoDeps).toBeFalse();
-  });
-
-  test("complex pattern combinations", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: {
-        linker: "isolated",
-        publicHoistPattern: ["@types/*", "no-*", "!no-deps", "a-*"],
-      },
-      files: {
-        "package.json": JSON.stringify({
-          name: "complex-patterns",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-            "a-dep": "1.0.1",
-            "basic-1": "1.0.0",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Should hoist: @types/*, a-* packages
-    // Should not hoist: no-deps (excluded by !no-deps, but matches no-*)
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
-      ".bun",
-      "@types",
-      "a-dep",
-      "basic-1",
-      "two-range-deps",
-    ]);
-  });
-
-  test("workspaces with publicHoistPattern", async () => {
-    const { packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", publicHoistPattern: ["*types*", "no-deps"] },
-      files: {
-        "package.json": JSON.stringify({
-          name: "workspace-root",
-          workspaces: ["packages/*"],
-          dependencies: {
-            "no-deps": "1.0.0",
-          },
-        }),
-        "packages/pkg1/package.json": JSON.stringify({
-          name: "pkg1",
-          dependencies: {
-            "@types/is-number": "1.0.0",
-            "a-dep": "1.0.1",
-          },
-        }),
-        "packages/pkg2/package.json": JSON.stringify({
-          name: "pkg2",
-          dependencies: {
-            "two-range-deps": "1.0.0",
-          },
-        }),
-      },
-    });
-
-    await runBunInstall(bunEnv, packageDir);
-
-    // Root should have hoisted packages
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "@types", "no-deps"]);
-
-    // Workspace packages should have their dependencies
-    expect(await readdirSorted(join(packageDir, "packages", "pkg1", "node_modules"))).toEqual(["@types", "a-dep"]);
-    expect(await readdirSorted(join(packageDir, "packages", "pkg2", "node_modules"))).toEqual(["two-range-deps"]);
-  });
+      const result = await install(packageDir);
+      expect({ ...result, stdout: result.stdout.split("\n") }).toEqual({
+        stdout: ["bun install <version> (<revision>)", "", ...stdout],
+        stderr: "Saved lockfile",
+        exitCode: 0,
+      });
+      expect(await layout(packageDir, nodeModulesDirs)).toEqual({ store, links });
+    },
+  );
 
   describe("error cases", () => {
-    test("invalid publicHoistPattern type in bunfig", async () => {
-      const { packageDir } = await registry.createTestDir({
-        bunfigOpts: { linker: "isolated" },
-        files: {
-          "package.json": JSON.stringify({
-            name: "invalid-pattern-type",
-            dependencies: {
-              "no-deps": "1.0.0",
-            },
-          }),
-        },
-      });
+    const invalid: { name: string; publicHoistPattern: unknown; stderr: string[] }[] = [
+      {
+        name: "a number",
+        publicHoistPattern: 123,
+        stderr: [
+          "4 | publicHoistPattern = 123",
+          "                         ^",
+          "error: Expected a string or an array of strings",
+          "    at <dir>/bunfig.toml:4:22",
+          "",
+          "Invalid Bunfig: failed to load bunfig",
+        ],
+      },
+      {
+        name: "an array with a boolean",
+        publicHoistPattern: ["*types*", true],
+        stderr: [
+          '4 | publicHoistPattern = ["*types*", true]',
+          "                                     ^",
+          "error: Expected a string",
+          "    at <dir>/bunfig.toml:4:34",
+          "",
+          "Invalid Bunfig: failed to load bunfig",
+        ],
+      },
+    ];
 
-      // Manually write invalid bunfig
-      await write(
-        join(packageDir, "bunfig.toml"),
-        Bun.TOML.stringify({
-          install: {
-            cache: join(packageDir, ".bun-cache"),
-            registry: registry.registryUrl(),
-            linker: "isolated",
-            publicHoistPattern: 123,
-          },
-        }),
-      );
+    test.concurrent.each(invalid)(
+      "$name in bunfig fails the install before anything is written",
+      async ({ publicHoistPattern, stderr }) => {
+        using dir = tempDir("public-hoist-pattern-", {
+          "package.json": JSON.stringify({ name: "invalid-pattern", dependencies: { "no-deps": "1.0.0" } }),
+          "bunfig.toml": Bun.TOML.stringify({
+            install: { registry: registry.registryUrl(), linker: "isolated", publicHoistPattern },
+          })!,
+        });
 
-      const { stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      expect(await exited).not.toBe(0);
-      const err = await stderr.text();
-      expect(err).toContain("error: Expected a string or an array of strings");
-    });
-
-    test("malformed bunfig with array syntax", async () => {
-      const { packageDir } = await registry.createTestDir({
-        bunfigOpts: { linker: "isolated" },
-        files: {
-          "package.json": JSON.stringify({
-            name: "malformed-array",
-            dependencies: {
-              "no-deps": "1.0.0",
-            },
-          }),
-        },
-      });
-
-      // Should error from boolean in the array
-      await write(
-        join(packageDir, "bunfig.toml"),
-        Bun.TOML.stringify({
-          install: {
-            cache: join(packageDir, ".bun-cache"),
-            registry: registry.registryUrl(),
-            linker: "isolated",
-            publicHoistPattern: ["*types*", true],
-          },
-        }),
-      );
-
-      const { stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const err = await stderr.text();
-      expect(await exited).toBe(1);
-      expect(err).toContain("error: Expected a string");
-    });
+        const result = await install(String(dir));
+        expect({ ...result, stderr: result.stderr.split("\n") }).toEqual({ stdout: "", stderr, exitCode: 1 });
+        expect(await readdirSorted(String(dir))).toEqual(["bunfig.toml", "package.json"]);
+      },
+    );
   });
 });


### PR DESCRIPTION
### Problem
- `test/cli/install/public-hoist-pattern.test.ts` took 5.5s on the debian 13 x64 lane (build 108977). Its 14 cases ran one at a time, each with a cold cache, so every install downloaded again.
- The cases checked the `node_modules` listing only. The error cases used `toContain` on stderr and disagreed on the exit code.

### Fix
- `beforeAll` installs every version the cases resolve into one cache, and every case installs from it through `BUN_INSTALL_CACHE_DIR`. Nothing is downloaded, so stderr is exactly `Saved lockfile`. CI exports that variable per file and it overrides the bunfig cache.
- The 12 positive cases are one `test.concurrent.each` table. A row holds the config, the package.json, the exact stdout, the store listing, and a map from every link to the store folder it resolves into (through `realpath`).
- The 2 error cases pin the exact stderr and exit code 1, and check that nothing was written next to `bunfig.toml` and `package.json`.
- Verified: `bun bd test test/cli/install/public-hoist-pattern.test.ts`, 3 runs: 5.81s, 6.28s, 6.19s before, 3.72s, 3.69s, 3.65s after. `--rerun-each 5` passes 70 of 70, on Linux and Windows x64.

### Background
- The isolated linker installs each package into `node_modules/.bun/<name>@<version>/node_modules/<name>` (the store) and links direct dependencies from the project's `node_modules`. `publicHoistPattern` selects which transitive packages get a root link too.
- A warm install only reads the cache: manifests stay fresh for 300s and index links are written during extraction only. So concurrent cases do not race on it, unlike the cold installs of other files.

<details><summary>Notes</summary>

Timing breakdown (local debug + ASAN build, 16 cores). Before: the 14 sequential cases summed to about 3.0s, a cold install took about 310ms, a warm one about 140ms. After: the warm-up install takes about 250ms and the 12 positive cases run in about 360ms together. About 2.6s of the remaining 3.7s is outside this file: about 1.85s for bun's startup plus the harness import and about 0.75s for the verdaccio start. The release binary (`USE_SYSTEM_BUN=1`) runs the file in 0.77s.

Why the cache must hold two versions of two packages: `two-range-deps@1.0.0` depends on `no-deps@^1.0.0` and `@types/is-number@>=1.0.0`. A case that pins `no-deps@1.0.0` or `@types/is-number@1.0.0` dedupes the range onto the pin; every other case resolves `no-deps@1.1.0` and `@types/is-number@2.0.0`. The warm-up uses two `npm:` aliases to install both versions of each. If the warm-up ever misses a version, the case that needs it fails deterministically on its stderr (`Resolving dependencies` and `Resolved, downloaded and extracted [N]` appear), so a gap cannot turn into a silent race.

Cold installs print `Resolved, downloaded and extracted [N]` where N is the manager's task count (network plus extraction tasks). It depends on the cache state, so the warm-up matches it with a regex and the cases pin `Saved lockfile` exactly.

Links are compared through `realpath` rather than `readlink`: on Windows the isolated linker falls back to a junction when it cannot create a symlink, and a junction's target is absolute. The map covers the root `node_modules` and, in the workspace case, each member's `node_modules`.

The store listing includes `node_modules`: `node_modules/.bun/node_modules` is the isolated linker's fallback directory that links every package (see #36972). It is listed as is rather than filtered out.

Assertion changes: each positive case now checks exit code, exact stdout (header, `+ name@version` lines with the `(vX available)` hints, `N packages installed`), exact stderr, the full store listing, and every link in every `node_modules` the case creates. Before, one case read one link and four cases checked `exists()` on a path that the listing already covered. The error cases used `not.toBe(0)` in one case and `toBe(1)` in the other; both are exit code 1. `expect()` calls drop from 110 to 28 because one `toEqual` on a structured object replaces several `toBe` and `toContain` calls.

Windows x64 (canary release build, `USE_SYSTEM_BUN=1 bun test ... --timeout=90000`): new file 0.93s, 0.97s, 1.01s, original 1.01s, 1.08s, 1.15s. The release build is fast enough that the fixed cost dominates there.

A local run with `CI=1` and no `--timeout` fails in `beforeAll` with both the old and the new file: `CI=1` makes the harness start verdaccio under the binary under test, which takes longer than the default 5s hook timeout with a debug build. The CI runner passes `--timeout=90000`, and with that flag the new file passes under `CI=1` with `BUN_INSTALL_CACHE_DIR` exported (the exported directory stays empty, which confirms every install used the warm cache).

`cd test && bun run typecheck` reports no error in this file.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/public-hoist-pattern.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/public-hoist-pattern.test.ts
bun test v1.4.1 (a6c4cc276)

test/cli/install/public-hoist-pattern.test.ts:
(pass) publicHoistPattern > all exclude pattern [197.02ms]
(pass) publicHoistPattern > mixed include and exclude patterns [196.12ms]
(pass) publicHoistPattern > bunfig string [211.31ms]
(pass) publicHoistPattern > bunfig array [239.30ms]
(pass) publicHoistPattern > all include pattern [257.28ms]
(pass) publicHoistPattern > npmrc mixed patterns [162.42ms]
(pass) publicHoistPattern > exclude specific packages [147.16ms]
(pass) publicHoistPattern > scoped package patterns [168.82ms]
(pass) publicHoistPattern > npmrc string configuration [254.74ms]
(pass) publicHoistPattern > npmrc array configuration [266.69ms]
(pass) publicHoistPattern > complex pattern combinations [156.90ms]
(pass) publicHoistPattern > error cases > a number in bunfig fails the install before anything is written [126.91ms]
(pass) publicHoistPattern > workspaces with publicHoistPattern [170.56ms]
(pass) publicHoistPattern > error cases > an array with a boolean in bunfig fails the install before anything is written [200.56ms]

 14 pass
 0 fail
 28 expect() calls
Ran 14 tests across 1 file. [3.65s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/install/public-hoist-pattern.test.ts | 726 ++++++++++++--------------
 1 file changed, 326 insertions(+), 400 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/cli/install/public-hoist-pattern.test.ts      5      5     18
```

</details>

<!-- robobun:evidence:end -->