### PR TITLE
bun-types test: check the fixture with the current stable TypeScript

### DIFF
--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -333,26 +333,21 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // TypeScript 7's native (Go-based) compiler does not expose a JS compiler API yet,
-  // so unlike the tests above we have to write a real tsconfig and spawn the CLI.
+  // The fixture depends on typescript@latest, so this is the current stable release:
+  // since 7.0 that is the native (Go-based) compiler, which does not expose a JS
+  // compiler API, so unlike the tests above we write a real tsconfig and spawn the CLI.
   // https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/
-  describe("tsgo (TypeScript 7 native preview)", () => {
+  describe("TypeScript latest", () => {
     test.skipIf(isDebug)("checks without lib.dom.d.ts", async () => {
-      const fixtureDir = await createIsolatedFixture(["@typescript/native-preview"]);
+      const fixtureDir = await createIsolatedFixture();
 
       const tsconfig = structuredClone(sourceTsconfig);
       tsconfig.compilerOptions.skipLibCheck = false;
       tsconfig.include = ["*.ts", "*.tsx"];
       await Bun.write(join(fixtureDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
 
-      // Resolve the entrypoint from the package's own bin field; the nightly
-      // has renamed it before (bin/tsgo.js -> bin/tsgo).
-      const tsgoPkgDir = join(fixtureDir, "node_modules", "@typescript", "native-preview");
-      const tsgoPkg = await Bun.file(join(tsgoPkgDir, "package.json")).json();
-      const tsgo = join(tsgoPkgDir, typeof tsgoPkg.bin === "string" ? tsgoPkg.bin : tsgoPkg.bin.tsgo);
-
       await using proc = Bun.spawn({
-        cmd: [bunExe(), tsgo, "-p", "."],
+        cmd: [bunExe(), join(fixtureDir, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
         env: bunEnv,
         cwd: fixtureDir,
         stdout: "pipe",


### PR DESCRIPTION
### Problem
- The bun-types integration test never type-checks the whole fixture with the current stable TypeScript. The in-process cases use the repository's pinned 6.0.2. The "tsgo" case installs `@typescript/native-preview`, whose last publish is `7.0.0-dev.20260707.2`. Stable 7.0.2 only sees the single-file spawns (`Bun.mmap`, `TextDecoder`) with `skipLibCheck: true`.
- Since 7.0 the `typescript` package is the native compiler, and the fixture already depends on `typescript@latest`. The preview package has no role left.

### Fix
- The "tsgo" case becomes "TypeScript latest": it spawns the fixture's own `node_modules/typescript/bin/tsc` over the whole fixture with `skipLibCheck: false`, instead of installing the frozen preview.
- Correct because `typescript@latest` is what users install, so a regression in bun-types against the current release now fails this case on every run. The 6.0.2 and 7.1 cases are unchanged.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts` with the system bun, 21 pass (the new case runs 7.0.2 today).

### Background
- `test/integration/bun-types/fixture` is a project that imports and exercises the public types. The test packs `packages/bun-types`, installs it into a copy of the fixture, and type-checks it under several configurations.
- `skipLibCheck: false` makes tsc check the `.d.ts` files of bun-types themselves, not only the fixture's own code.
- Follow-up to #41076, which added a 7.1-only entry point and made the question "does the test cover stable?" worth answering with a test.
