### PR TITLE
node:http, node:fs, node:worker_threads: detect URLs structurally, and Uint8Array by cell type

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -34,6 +34,7 @@ type FSStream = import("node:fs").ReadStream &
 type FD = number;
 
 const { validateInteger, validateInt32, validateFunction } = require("internal/validators");
+const { isURL } = require("internal/url");
 
 const kIsPerformingIO = Symbol("kIsPerformingIO");
 const kIoDone = Symbol("kIoDone");
@@ -88,7 +89,7 @@ function streamFileHandleClose(this: FileHandle, fd: FD, cb: (err?: any) => void
 }
 
 function getValidatedPath(p: any) {
-  if (p instanceof URL) return Bun.fileURLToPath(p as URL);
+  if (isURL(p)) return Bun.fileURLToPath(p);
   if (typeof p !== "string") throw $ERR_INVALID_ARG_TYPE("path", "string or URL", p);
   return require("node:path").resolve(p);
 }

--- a/src/js/internal/fs/watch.ts
+++ b/src/js/internal/fs/watch.ts
@@ -1,6 +1,7 @@
 // fs.watch is lazily loaded so the FSWatcher class is only set up when it is used.
 const EventEmitter = require("node:events");
 const { basename } = require("node:path");
+const { isURL } = require("internal/url");
 
 // The native `node:fs` binding, shared via `internal/fs/binding`.
 const fs = require("internal/fs/binding");
@@ -138,7 +139,7 @@ class FSWatcher extends EventEmitter {
   constructor(path, options, listener) {
     super();
 
-    if (path instanceof URL) {
+    if (isURL(path)) {
       path = Bun.fileURLToPath(path);
     } else if (typeof path === "string" && path.startsWith("file:")) {
       path = Bun.fileURLToPath(path);

--- a/src/js/internal/url.ts
+++ b/src/js/internal/url.ts
@@ -1,3 +1,12 @@
+// Node's isURL (lib/internal/url.js): a duck-type check rather than
+// `instanceof`, so a URL instance still counts after globalThis.URL was
+// replaced (happy-dom's global registrator does that), and so do compatible
+// foreign implementations; `auth`/`path` must be absent to exclude legacy
+// `url.parse` objects, which carry both.
+function isURL(self) {
+  return Boolean(self?.href && self.protocol && self.auth === undefined && self.path === undefined);
+}
+
 function urlToHttpOptions(url) {
   const options = {
     ...url,
@@ -23,5 +32,6 @@ function urlToHttpOptions(url) {
 }
 
 export default {
+  isURL,
   urlToHttpOptions,
 };

--- a/src/js/internal/url.ts
+++ b/src/js/internal/url.ts
@@ -1,5 +1,4 @@
-// Node's isURL (lib/internal/url.js). Legacy url.parse() objects carry `auth`
-// and `path`, which is what rules them out.
+// Node's isURL (lib/internal/url.js). Legacy url.parse() objects have auth and path.
 function isURL(self) {
   return Boolean(self?.href && self.protocol && self.auth === undefined && self.path === undefined);
 }

--- a/src/js/internal/url.ts
+++ b/src/js/internal/url.ts
@@ -1,8 +1,5 @@
-// Node's isURL (lib/internal/url.js): a duck-type check rather than
-// `instanceof`, so a URL instance still counts after globalThis.URL was
-// replaced (happy-dom's global registrator does that), and so do compatible
-// foreign implementations; `auth`/`path` must be absent to exclude legacy
-// `url.parse` objects, which carry both.
+// Node's isURL (lib/internal/url.js). Legacy url.parse() objects carry `auth`
+// and `path`, which is what rules them out.
 function isURL(self) {
   return Boolean(self?.href && self.protocol && self.auth === undefined && self.path === undefined);
 }

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -4,6 +4,7 @@ const { isUint8Array } = require("node:util/types");
 
 const RegExpPrototypeExec = RegExp.prototype.exec;
 const ArrayIsArray = Array.isArray;
+const Uint8ArrayPrototypeIncludes = Uint8Array.prototype.includes;
 
 const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
 /**
@@ -111,7 +112,7 @@ function getValidatedFsPath(p: any, propName: string = "path") {
     return p;
   }
   if (isUint8Array(p)) {
-    if (p.indexOf(0) !== -1) {
+    if (Uint8ArrayPrototypeIncludes.$call(p, 0)) {
       throw $ERR_INVALID_ARG_VALUE(propName, p, "must be a string, Uint8Array, or URL without null bytes");
     }
     return p;

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -101,11 +101,7 @@ function throwIfNullBytesInFileName(filename: string) {
   }
 }
 
-/**
- * node's fs getValidatedPath (lib/internal/fs/utils.js): converts URLs via
- * fileURLToPath, accepts strings and Buffers as-is (no path.resolve, no
- * "file:"-prefix string sniffing), and rejects null bytes.
- */
+/** node's fs getValidatedPath (lib/internal/fs/utils.js): a URL becomes a path, strings and Buffers pass as-is. */
 function getValidatedFsPath(p: any, propName: string = "path") {
   if (isURL(p)) p = Bun.fileURLToPath(p);
   if (typeof p === "string") {

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -1,7 +1,5 @@
 const { hideFromStack } = require("internal/shared");
 const { isURL } = require("internal/url");
-// Native and keyed on the cell type, so a Uint8Array from another realm (a
-// node:vm context) passes. `instanceof Uint8Array` would not.
 const { isUint8Array } = require("node:util/types");
 
 const RegExpPrototypeExec = RegExp.prototype.exec;
@@ -89,15 +87,7 @@ function validateBoolean(value, name) {
   if (typeof value !== "boolean") throw $ERR_INVALID_ARG_TYPE(name, "boolean", value);
 }
 
-/**
- * Validate a string-or-URL path and return it resolved to an absolute path string.
- *
- * URLs are detected with node's structural isURL, but converted by the native
- * Bun.fileURLToPath, which takes URL instances only (by class, whatever
- * globalThis.URL is). The native fs path parser has the same rule, so a
- * URL-like object that is not a URL instance is rejected the same way as in
- * fs.readFileSync.
- */
+/** Validate a string-or-URL path and return it resolved to an absolute path string. */
 function getValidatedPath(p: any) {
   if (isURL(p)) return Bun.fileURLToPath(p);
   if (typeof p !== "string") throw $ERR_INVALID_ARG_TYPE("path", "string or URL", p);
@@ -113,9 +103,8 @@ function throwIfNullBytesInFileName(filename: string) {
 
 /**
  * node's fs getValidatedPath (lib/internal/fs/utils.js): converts URLs via
- * fileURLToPath (see getValidatedPath above for which objects that takes),
- * accepts strings and Buffers as-is (no path.resolve, no "file:"-prefix
- * string sniffing), and rejects null bytes.
+ * fileURLToPath, accepts strings and Buffers as-is (no path.resolve, no
+ * "file:"-prefix string sniffing), and rejects null bytes.
  */
 function getValidatedFsPath(p: any, propName: string = "path") {
   if (isURL(p)) p = Bun.fileURLToPath(p);

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -1,4 +1,5 @@
 const { hideFromStack } = require("internal/shared");
+const { isURL } = require("internal/url");
 
 const RegExpPrototypeExec = RegExp.prototype.exec;
 const ArrayIsArray = Array.isArray;
@@ -85,9 +86,17 @@ function validateBoolean(value, name) {
   if (typeof value !== "boolean") throw $ERR_INVALID_ARG_TYPE(name, "boolean", value);
 }
 
-/** Validate a string-or-URL path and return it resolved to an absolute path string. */
+/**
+ * Validate a string-or-URL path and return it resolved to an absolute path string.
+ *
+ * URLs are detected with node's structural isURL, but converted by the native
+ * Bun.fileURLToPath, which takes URL instances only (by class, whatever
+ * globalThis.URL is). The native fs path parser has the same rule, so a
+ * URL-like object that is not a URL instance is rejected the same way as in
+ * fs.readFileSync.
+ */
 function getValidatedPath(p: any) {
-  if (p instanceof URL) return Bun.fileURLToPath(p as URL);
+  if (isURL(p)) return Bun.fileURLToPath(p);
   if (typeof p !== "string") throw $ERR_INVALID_ARG_TYPE("path", "string or URL", p);
   if (p.startsWith("file:")) return Bun.fileURLToPath(p);
   return require("node:path").resolve(p);
@@ -100,12 +109,13 @@ function throwIfNullBytesInFileName(filename: string) {
 }
 
 /**
- * node's fs getValidatedPath (lib/internal/fs/utils.js): converts URL
- * *instances* via fileURLToPath, accepts strings and Buffers as-is (no
- * path.resolve, no "file:"-prefix string sniffing), and rejects null bytes.
+ * node's fs getValidatedPath (lib/internal/fs/utils.js): converts URLs via
+ * fileURLToPath (see getValidatedPath above for which objects that takes),
+ * accepts strings and Buffers as-is (no path.resolve, no "file:"-prefix
+ * string sniffing), and rejects null bytes.
  */
 function getValidatedFsPath(p: any, propName: string = "path") {
-  if (p instanceof URL) p = Bun.fileURLToPath(p);
+  if (isURL(p)) p = Bun.fileURLToPath(p);
   if (typeof p === "string") {
     if (p.indexOf("\u0000") !== -1) {
       throw $ERR_INVALID_ARG_VALUE(propName, p, "must be a string, Uint8Array, or URL without null bytes");

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -1,5 +1,8 @@
 const { hideFromStack } = require("internal/shared");
 const { isURL } = require("internal/url");
+// Native and keyed on the cell type, so a Uint8Array from another realm (a
+// node:vm context) passes. `instanceof Uint8Array` would not.
+const { isUint8Array } = require("node:util/types");
 
 const RegExpPrototypeExec = RegExp.prototype.exec;
 const ArrayIsArray = Array.isArray;
@@ -122,7 +125,7 @@ function getValidatedFsPath(p: any, propName: string = "path") {
     }
     return p;
   }
-  if (p instanceof Uint8Array) {
+  if (isUint8Array(p)) {
     if (p.indexOf(0) !== -1) {
       throw $ERR_INVALID_ARG_VALUE(propName, p, "must be a string, Uint8Array, or URL without null bytes");
     }
@@ -181,7 +184,7 @@ export default {
   validateBuffer: $newCppFunction("NodeValidator.cpp", "jsFunction_validateBuffer", 0),
   /** `(value, name, oneOf)` */
   validateOneOf: $newCppFunction("NodeValidator.cpp", "jsFunction_validateOneOf", 0),
-  isUint8Array: value => value instanceof Uint8Array,
+  isUint8Array,
   /** `(path)` — accepts a string or file URL, returns it resolved to an absolute path string */
   getValidatedPath,
   getValidatedFsPath,

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -16,7 +16,7 @@ const {
 } = require("node:_http_common");
 const { kUniqueHeaders, parseUniqueHeadersOption, OutgoingMessage } = require("node:_http_outgoing");
 const Agent = require("node:_http_agent");
-const { urlToHttpOptions } = require("internal/url");
+const { isURL, urlToHttpOptions } = require("internal/url");
 const { kOutHeaders, kNeedDrain, kProxyConfig, checkShouldUseProxy } = require("internal/http");
 const { validateInteger, validateBoolean, validateString, validateOneOf } = require("internal/validators");
 const { getTimerDuration } = require("internal/timers");
@@ -95,10 +95,6 @@ function closeRequest(req) {
   req.emit("close");
 }
 
-function isURLInstance(input) {
-  return input != null && typeof input === "object" && input instanceof URL;
-}
-
 // When proxying a HTTP request, the following needs to be done:
 // https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.2
 // 1. Rewrite the request path to absolute-form.
@@ -169,7 +165,7 @@ function ClientRequest(input, options, cb) {
   if (typeof input === "string") {
     const urlStr = input;
     input = urlToHttpOptions(new URL(urlStr));
-  } else if (isURLInstance(input)) {
+  } else if (isURL(input)) {
     // url.URL instance
     input = urlToHttpOptions(input);
   } else {

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -9,6 +9,7 @@ const {
   validateArray,
   validateObject,
   validateOneOf,
+  isUint8Array,
 } = require("internal/validators");
 
 var NetModule;
@@ -1923,10 +1924,6 @@ function getValidatedPath(fileURLOrPath, propName = "path") {
   const path = toPathIfFileURL(fileURLOrPath);
   validatePath(path, propName);
   return path;
-}
-
-function isUint8Array(value) {
-  return typeof value === "object" && value !== null && value instanceof Uint8Array;
 }
 
 //------------------------------------------------------------------------------

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -3,7 +3,7 @@
 // https://github.com/nodejs/node/blob/v26.3.0/lib/https.js
 const http = require("node:http");
 const { isIP } = require("internal/net/isIP");
-const { urlToHttpOptions } = require("internal/url");
+const { isURL, urlToHttpOptions } = require("internal/url");
 const { kEmptyObject, once } = require("internal/shared");
 const { validateObject } = require("internal/validators");
 const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel } = require("internal/http");
@@ -20,7 +20,7 @@ function request(...args) {
   if (typeof args[0] === "string") {
     const urlStr = ArrayPrototypeShift.$call(args);
     options = urlToHttpOptions(new URL(urlStr));
-  } else if (args[0] instanceof URL) {
+  } else if (isURL(args[0])) {
     options = urlToHttpOptions(ArrayPrototypeShift.$call(args));
   }
 

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -27,7 +27,7 @@
 
 const { URL, URLSearchParams, URLPattern } = globalThis;
 const [domainToASCII, domainToUnicode, idnaToASCII] = $cpp("NodeURL.cpp", "Bun::createNodeURLBinding");
-const { urlToHttpOptions } = require("internal/url");
+const { isURL, urlToHttpOptions } = require("internal/url");
 const { validateString, validateObject } = require("internal/validators");
 const ObjectSetPrototypeOf = Object.setPrototypeOf;
 
@@ -1328,14 +1328,6 @@ function hexByteToNumber(byte: number): number {
   if (byte >= 0x41 && byte <= 0x46) return byte - 0x41 + 10; // A-F
   if (byte >= 0x61 && byte <= 0x66) return byte - 0x61 + 10; // a-f
   return -1;
-}
-
-// Node's isURL (lib/internal/url.js): a duck-type check rather than
-// `instanceof`, so cross-realm URLs and compatible foreign implementations
-// are accepted; `auth`/`path` must be absent to exclude legacy `url.parse`
-// objects, which carry both.
-function isURL(self: any): boolean {
-  return Boolean(self?.href && self.protocol && self.auth === undefined && self.path === undefined);
 }
 
 function fileURLToPathBuffer(path: unknown, options?: { windows?: boolean }): Buffer {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -29,9 +29,8 @@ const { isURL } = require("internal/url");
 // paths and file: URL objects; bare specifiers and string URLs are rejected.
 function validateWorkerFilename(filename) {
   if (isURL(filename)) {
-    // The href, so a URL-like object that is not a URL instance works like in
-    // node. Bun.fileURLToPath throws ERR_INVALID_URL_SCHEME for non-file: URLs.
     if (filename.protocol === "data:") return filename.href;
+    // throws ERR_INVALID_URL_SCHEME (TypeError) for non-file: URLs
     return Bun.fileURLToPath(filename.href);
   }
   if (typeof filename !== "string") {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -23,14 +23,16 @@ function normalizeWorkerName(rawName) {
 }
 
 const { isAbsolute: pathIsAbsolute } = require("node:path");
+const { isURL } = require("internal/url");
 
 // node's filename validation for non-eval workers: absolute or "./"/"../"-relative
 // paths and file: URL objects; bare specifiers and string URLs are rejected.
 function validateWorkerFilename(filename) {
-  if (filename instanceof URL) {
+  if (isURL(filename)) {
     if (filename.protocol === "data:") return `${filename}`;
-    // throws ERR_INVALID_URL_SCHEME (TypeError) for non-file: URLs
-    return Bun.fileURLToPath(filename);
+    // throws ERR_INVALID_URL_SCHEME (TypeError) for non-file: URLs. The href,
+    // so a URL-like object that is not a URL instance works like in node.
+    return Bun.fileURLToPath(filename.href);
   }
   if (typeof filename !== "string") {
     // Not a string or URL: defer to the native Worker constructor, which

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -29,9 +29,9 @@ const { isURL } = require("internal/url");
 // paths and file: URL objects; bare specifiers and string URLs are rejected.
 function validateWorkerFilename(filename) {
   if (isURL(filename)) {
-    if (filename.protocol === "data:") return `${filename}`;
-    // throws ERR_INVALID_URL_SCHEME (TypeError) for non-file: URLs. The href,
-    // so a URL-like object that is not a URL instance works like in node.
+    // The href, so a URL-like object that is not a URL instance works like in
+    // node. Bun.fileURLToPath throws ERR_INVALID_URL_SCHEME for non-file: URLs.
+    if (filename.protocol === "data:") return filename.href;
     return Bun.fileURLToPath(filename.href);
   }
   if (typeof filename !== "string") {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -17,6 +17,7 @@ import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spaw
 import { getEventListeners, once, setMaxListeners } from "node:events";
 import os from "node:os";
 import { promisify } from "node:util";
+import vm from "node:vm";
 import path from "path";
 const debug = process.env.DEBUG ? console.log : () => {};
 
@@ -743,6 +744,25 @@ describe("spawnSync()", () => {
       status: 0,
       signal: null,
     });
+  });
+
+  it("validates a cwd Uint8Array from another realm like a same-realm one", () => {
+    // A typed array from a node:vm context has that realm's prototype, so
+    // `instanceof Uint8Array` is false for it. node checks the cell type
+    // (util.types.isUint8Array), so both inputs take the same route. A bare
+    // Uint8Array cwd does not spawn in either runtime (only a Buffer
+    // stringifies to a path), so compare the outcomes instead of asserting one.
+    const bytes = [...Buffer.from(tmpdirSync())];
+    const sameRealm = new Uint8Array(bytes);
+    const otherRealm = vm.runInNewContext(`new Uint8Array(${JSON.stringify(bytes)})`);
+    expect(otherRealm instanceof Uint8Array).toBe(false);
+
+    const run = (cwd: Uint8Array) => {
+      const { status, error } = spawnSync(bunExe(), ["-e", ""], { cwd: cwd as any, env: bunEnv });
+      return { status, code: (error as any)?.code };
+    };
+    // Before: ERR_INVALID_ARG_TYPE for options.cwd "Received an instance of Uint8Array".
+    expect(run(otherRealm)).toEqual(run(sameRealm));
   });
 });
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -29,6 +29,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { Duplex, duplexPair, PassThrough, Writable } from "node:stream";
 import { connect as tlsConnect } from "node:tls";
+import vm from "node:vm";
 import tunnel from "tunnel";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);
@@ -1190,6 +1191,40 @@ describe("node:http", () => {
         });
       } finally {
         req.destroy();
+      }
+    });
+
+    it("req.write() and req.end() accept a Uint8Array from another realm", async () => {
+      // A typed array created in a node:vm context has that realm's
+      // Uint8Array.prototype, so `instanceof Uint8Array` is false for it. The
+      // chunk check has to look at the cell type, like util.types.isUint8Array.
+      const chunk = vm.runInNewContext("new Uint8Array([104, 105])");
+      expect(chunk instanceof Uint8Array).toBe(false);
+
+      const server = createServer((req, res) => {
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", part => (body += part));
+        req.on("end", () => res.end(body));
+      });
+      server.listen(0);
+      await once(server, "listening");
+      try {
+        const { port } = server.address() as AddressInfo;
+        const echoed = await new Promise<string>((resolve, reject) => {
+          const req = request({ port, method: "POST" }, res => {
+            let body = "";
+            res.setEncoding("utf8");
+            res.on("data", part => (body += part));
+            res.on("end", () => resolve(body));
+          });
+          req.on("error", reject);
+          req.write(chunk);
+          req.end(chunk);
+        });
+        expect(echoed).toBe("hihi");
+      } finally {
+        server.close();
       }
     });
   });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1079,6 +1079,119 @@ describe("node:http", () => {
         req.end();
       });
     });
+
+    // node decides "is this a URL?" structurally (lib/internal/url.js isURL:
+    // truthy href and protocol, no legacy url.parse() `auth`/`path`), so a
+    // WHATWG URL from another implementation (jsdom, whatwg-url) counts. A
+    // plain object holding a URL's fields stands in for one here.
+    function urlLikeOf(href: string) {
+      const url = new URL(href);
+      const urlLike = Object.create({
+        toString() {
+          return this.href;
+        },
+      });
+      for (const key of [
+        "href",
+        "origin",
+        "protocol",
+        "username",
+        "password",
+        "host",
+        "hostname",
+        "port",
+        "pathname",
+        "search",
+        "hash",
+      ]) {
+        urlLike[key] = url[key];
+      }
+      return urlLike;
+    }
+
+    function requestJSON(...args: any[]) {
+      return new Promise<any>((resolve, reject) => {
+        const req = request(...(args as [any]), (res: IncomingMessage) => {
+          let body = "";
+          res.setEncoding("utf8");
+          res.on("data", chunk => (body += chunk));
+          res.on("end", () => resolve(JSON.parse(body)));
+        });
+        req.on("error", reject);
+        req.end();
+      });
+    }
+
+    it("request() and get() read a URL-like object that is not a URL instance as a URL", async () => {
+      const server = createServer((req, res) => {
+        res.end(JSON.stringify({ method: req.method, url: req.url, host: req.headers.host }));
+      });
+      server.listen(0);
+      await once(server, "listening");
+      try {
+        const { port } = server.address() as AddressInfo;
+        const urlLike = urlLikeOf(`http://localhost:${port}/some/path?q=1#frag`);
+        expect(urlLike instanceof URL).toBe(false);
+        const expected = { method: "GET", url: "/some/path?q=1", host: `localhost:${port}` };
+
+        // An `instanceof URL` check took this object for an options bag. It has
+        // no `path` key, so the request silently went to "/".
+        expect(await requestJSON(urlLike)).toEqual(expected);
+        expect(await requestJSON(urlLike, { method: "POST" })).toEqual({ ...expected, method: "POST" });
+        expect(await requestJSON(urlLike, { headers: { "x-extra": "1" } })).toEqual(expected);
+
+        const viaGet = await new Promise<any>((resolve, reject) => {
+          get(urlLike, res => {
+            let body = "";
+            res.setEncoding("utf8");
+            res.on("data", chunk => (body += chunk));
+            res.on("end", () => resolve(JSON.parse(body)));
+          }).on("error", reject);
+        });
+        expect(viaGet).toEqual(expected);
+      } finally {
+        server.close();
+      }
+    });
+
+    it("request() accepts a URL instance after globalThis.URL was replaced", async () => {
+      // @happy-dom/global-registrator installs its own URL class on globalThis.
+      // A URL made before that, or by node:url, is then not `instanceof URL`.
+      // Before the fix it was taken for an options bag, and a URL instance has
+      // no own properties to copy, so the request went to localhost:80.
+      const NativeURL = URL;
+      const server = createServer((req, res) => {
+        res.end(JSON.stringify({ method: req.method, url: req.url, host: req.headers.host }));
+      });
+      server.listen(0);
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      const url = new NativeURL(`http://localhost:${port}/some/path?q=1`);
+      globalThis.URL = class URL extends NativeURL {};
+      try {
+        expect(url instanceof URL).toBe(false);
+        expect(await requestJSON(url)).toEqual({ method: "GET", url: "/some/path?q=1", host: `localhost:${port}` });
+      } finally {
+        globalThis.URL = NativeURL;
+        server.close();
+      }
+    });
+
+    it("https.request() reads a URL-like object that is not a URL instance as a URL", () => {
+      const urlLike = urlLikeOf("https://localhost:1/some/path?q=1");
+      const req = https.request(urlLike);
+      // Nothing listens on port 1; the connect error is expected and ignored.
+      req.on("error", () => {});
+      try {
+        expect({ protocol: req.protocol, host: req.host, path: req.path }).toEqual({
+          protocol: "https:",
+          host: "localhost",
+          path: "/some/path?q=1",
+        });
+      } finally {
+        req.destroy();
+      }
+    });
   });
 
   describe("https.request with custom tls options", () => {

--- a/test/js/node/url/url-is-url.test.js
+++ b/test/js/node/url/url-is-url.test.js
@@ -1,5 +1,6 @@
 // Flags: --expose-internals
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import assert from "node:assert";
 import { URL, parse } from "node:url";
 
@@ -18,5 +19,108 @@ describe("internal/url", () => {
       }),
       false,
     );
+  });
+
+  // The consumers of isURL, driven with URL instances after globalThis.URL was
+  // replaced. @happy-dom/global-registrator (the DOM testing setup in
+  // docs/test/dom.mdx) installs its own URL class there, so a URL made by
+  // node:url or Bun.pathToFileURL, or before the registration, is no longer
+  // `instanceof URL`. Node detects URLs structurally and is not affected.
+  test("URL instances are still URLs after globalThis.URL is replaced", async () => {
+    using dir = tempDir("is-url-consumers", {
+      "a.txt": "hello",
+      "worker.js": `require("node:worker_threads").parentPort.postMessage("from worker");`,
+      "main.js": `
+        const NativeURL = URL;
+        globalThis.URL = class URL extends NativeURL {};
+        const fs = require("node:fs");
+        const http = require("node:http");
+        const { once } = require("node:events");
+        const { Worker } = require("node:worker_threads");
+        const { pathToFileURL } = require("node:url");
+        const fileURL = name => new NativeURL(pathToFileURL(name).href);
+
+        const out = {};
+        const probe = async (name, fn) => {
+          try {
+            out[name] = await fn();
+          } catch (e) {
+            out[name] = e.code ?? e.message;
+          }
+        };
+        out.instanceOfURL = fileURL("a.txt") instanceof URL;
+
+        await probe("createReadStream", async () => {
+          let body = "";
+          for await (const chunk of fs.createReadStream(fileURL("a.txt"), "utf8")) body += chunk;
+          return body;
+        });
+        await probe("createWriteStream", async () => {
+          const stream = fs.createWriteStream(fileURL("w.txt"));
+          stream.end("written");
+          await once(stream, "finish");
+          return fs.readFileSync("w.txt", "utf8");
+        });
+        await probe("watch", () => {
+          fs.watch(fileURL("a.txt")).close();
+          return "ok";
+        });
+        await probe("watchFile", () => {
+          fs.watchFile(fileURL("a.txt"), () => {});
+          fs.unwatchFile(fileURL("a.txt"));
+          return "ok";
+        });
+        await probe("cpSync", () => {
+          fs.cpSync(fileURL("a.txt"), "b.txt");
+          return fs.readFileSync("b.txt", "utf8");
+        });
+        await probe("cp", async () => {
+          await fs.promises.cp(fileURL("a.txt"), "c.txt");
+          return fs.readFileSync("c.txt", "utf8");
+        });
+        await probe("Worker", async () => {
+          const worker = new Worker(fileURL("worker.js"));
+          const [message] = await once(worker, "message");
+          await worker.terminate();
+          return message;
+        });
+        await probe("http.get", async () => {
+          const server = http.createServer((req, res) => res.end(req.url));
+          server.listen(0);
+          await once(server, "listening");
+          try {
+            const url = new NativeURL("http://127.0.0.1:" + server.address().port + "/some/path?q=1");
+            const [res] = await once(http.get(url), "response");
+            let body = "";
+            for await (const chunk of res.setEncoding("utf8")) body += chunk;
+            return body;
+          } finally {
+            server.close();
+          }
+        });
+        console.log(JSON.stringify(out));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      instanceOfURL: false,
+      createReadStream: "hello",
+      createWriteStream: "written",
+      watch: "ok",
+      watchFile: "ok",
+      cpSync: "hello",
+      cp: "hello",
+      Worker: "from worker",
+      "http.get": "/some/path?q=1",
+    });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -330,6 +330,13 @@ test("filename accepts a URL-like object that is not a URL instance", async () =
   expect(message).toBe("from url-like");
   await worker.terminate();
 
+  // A data: URL-like object runs its href, not its string form.
+  const dataHref = `data:text/javascript,postMessage("from data url")`;
+  const dataWorker = new Worker({ href: dataHref, protocol: "data:", pathname: dataHref.slice(5) } as any);
+  const [dataMessage] = await once(dataWorker, "message");
+  expect(dataMessage).toBe("from data url");
+  await dataWorker.terminate();
+
   // Like node, a URL-like object goes through fileURLToPath, so a non-file
   // scheme fails on the scheme and not on the argument type.
   expect(() => new Worker({ ...urlLike, href: "http://example.com/worker.js", protocol: "http:" } as any)).toThrow(

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -4,6 +4,7 @@ import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { Readable } from "node:stream";
+import { pathToFileURL } from "node:url";
 import wt, {
   BroadcastChannel,
   getEnvironmentData,
@@ -313,6 +314,32 @@ test("support worker eval that throws", async () => {
   expect(result.toString()).toInclude("Unexpected throw");
   expect(result.name).toBe("SyntaxError");
   await worker.terminate();
+});
+
+test("filename accepts a URL-like object that is not a URL instance", async () => {
+  using dir = tempDir("worker-url-like", {
+    "worker.js": `require("node:worker_threads").parentPort.postMessage("from url-like");`,
+  });
+  const url = pathToFileURL(join(String(dir), "worker.js"));
+  // node decides "is this a URL?" structurally (lib/internal/url.js isURL), so
+  // a WHATWG URL from another implementation (jsdom, whatwg-url) counts. A
+  // plain object with a URL's fields stands in for one here.
+  const urlLike = { href: url.href, protocol: url.protocol, hostname: url.hostname, pathname: url.pathname };
+  const worker = new Worker(urlLike as any);
+  const [message] = await once(worker, "message");
+  expect(message).toBe("from url-like");
+  await worker.terminate();
+
+  // Like node, a URL-like object goes through fileURLToPath, so a non-file
+  // scheme fails on the scheme and not on the argument type.
+  expect(() => new Worker({ ...urlLike, href: "http://example.com/worker.js", protocol: "http:" } as any)).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_URL_SCHEME" }),
+  );
+  // A legacy url.parse() object has `auth` and `path` (null, not undefined),
+  // so it is not a URL.
+  expect(() => new Worker({ ...urlLike, auth: null, path: url.pathname } as any)).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+  );
 });
 
 describe("execArgv option", async () => {


### PR DESCRIPTION
### Problem
- The JS side of `node:http`, `node:https`, `node:fs` and `node:worker_threads` decides "is this a URL?" with `instanceof URL`. That is false for a URL instance once `globalThis.URL` is replaced, which `@happy-dom/global-registrator` (the setup in `docs/test/dom.mdx`) does, and for a URL from another implementation (jsdom, whatwg-url).
- `http.request(url)` then takes the object for an options bag. A URL instance has no own properties, so the request goes to `localhost:80`. A URL-like object has no `path`, so it goes to `/`. `fs.createReadStream`, `fs.watchFile`, `fs.cpSync` and `new Worker` throw `ERR_INVALID_ARG_TYPE`.
- `ClientRequest.write(chunk)` with a `Uint8Array` from a `node:vm` context throws `The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Uint8Array`. `validators.isUint8Array` and its copy in `child_process.ts` are `instanceof Uint8Array`.

### Fix
- Move node's structural `isURL` from `node/url.ts` (`fileURLToPathBuffer` had its own copy) into `internal/url` and use it at every JS-side URL check: `_http_client`, `https`, `worker_threads`, `internal/validators`, `internal/fs/streams`, `internal/fs/watch`. Node uses it at the same sites.
- The fs helpers still convert with the native `Bun.fileURLToPath`, which takes URL instances by class. A URL-like object that is not a URL instance fails there like in `fs.readFileSync`. #34202 is the place to widen that. The Worker passes the href, so such an object works like in node.
- `validators.isUint8Array` is the native `util.types.isUint8Array` (cell type), as in node. `child_process` takes that export.
- Self-reviewed: 6 concerns raised, 5 addressed. Rejected one: a shared `fileURLToPath(urlLike)` helper in `internal/url` for the Worker, because #34202 owns that helper. The Worker passes `href` until it lands.
- Verified: `test/js/node/url/url-is-url.test.js` (one subprocess run over all the sites with `globalThis.URL` replaced), plus 6 tests in the http, worker_threads and child_process files. All fail on bun 1.4.1.

### Background
- A realm is one set of JavaScript globals. `vm.createContext()` makes a new one with its own `Uint8Array.prototype`, so `instanceof` against the main realm's constructor is false for a typed array made there. `util.types.isUint8Array` checks the JSC cell type instead.
- Node's `isURL` (`lib/internal/url.js`) accepts an object with `href` and `protocol` that is not a legacy `url.parse()` result (those have `auth` and `path` set to `null`).

<details><summary>Notes</summary>

Census of the `instanceof <builtin>` sites in `src/js/**`, checked against node v26.3.0. Sites left alone, with the reason:

- `node:zlib` `isAnyArrayBuffer`: #41101 is open for it.
- `url.fileURLToPath` with URL-like objects (`node/url.ts`, the `windows` option branch): #34202 is open for it.
- `fs.promises.watch` rejects every URL with its own `TypeError`, so its `instanceof URL` only picks the error message.
- `util.aborted`: node v26 validates with a WebIDL converter (`ObjectPrototypeIsPrototypeOf(AbortSignal.prototype, signal)`), not `validateAbortSignal`, so it rejects duck signals too. Bun matches, except that bun throws where node rejects the returned promise.
- `url.format(urlObject)`: node also uses `instanceof URL` there.
- `Readable.from`, `Readable.push`, `Writable.write`, `net` `bytesWritten`, `assert`, the `events` async iterator `throw`, `process.emitWarning`, `util.inspect`: node uses the same `instanceof` checks.
- `diagnostics_channel.tracePromise`: a promise from another realm takes the `PromiseResolve` branch, which wraps it. Same result.
- `child_process` `toPathIfFileURL` and `internal/fs/glob` already duck-type (`href` and `origin` / `href` and `protocol`).
- Bun APIs (`Bun.dlopen`, `Bun.SQL`) and the `undici` and `@vercel/fetch` shims have their own `instanceof URL` / `instanceof Date` checks. Out of this node-compat pass.

Found on the way, handed off: `fs.cpSync`, `fs.cp` and `fs.promises.cp` reject a `Buffer` path from any realm (`The "path" property must be of type string, got object`). That is #41112. The `isUint8Array` change in `getValidatedFsPath` and `child_process` is therefore error-path consistency: a cross-realm `Uint8Array` now takes the same route as a same-realm one. For `spawnSync` with a bare `Uint8Array` `cwd` that route ends in `ENOENT` in node too (only a `Buffer` stringifies to a path), so the `child_process` test compares the two outcomes.

`fs.watch(url)` and `new Worker(url)` with a URL instance already worked with `globalThis.URL` replaced: the unconverted object reached native code that checks the class. The Worker change matters for URL-like objects only.

Repro on bun 1.4.1 (node prints `/some/path?q=1`, bun fails with `ECONNREFUSED 127.0.0.1:80`):

```js
const http = require("node:http");
const NativeURL = URL;
globalThis.URL = class URL extends NativeURL {}; // what @happy-dom/global-registrator does
const server = http.createServer((req, res) => res.end(req.url)).listen(0, () => {
  const url = new NativeURL(`http://127.0.0.1:${server.address().port}/some/path?q=1`);
  http.get(url, res => { res.setEncoding("utf8"); res.on("data", d => { console.log(d); server.close(); }); });
});
```

Other suites run on the debug build: `test/js/node/fs/fs.test.ts`, `test/js/node/fs/cp.test.ts`, `test/js/node/fs/glob.test.ts`, `test/js/node/watch/fs.watch.test.ts`, `test/js/node/watch/fs.watchFile.test.ts`, `test/js/node/url/` (one pre-existing 1e5-iteration `URL.canParse` loop times out under ASAN), the node `test-http-url.parse-*`, `test-https-request-arguments`, `test-http-client-request-options`, `test-worker-type-check`, `test-worker-unsupported-*`, `test-child-process-*cwd*`, `test-child-process-fork-*`, `test-child-process-spawn*`, `test-fs-read-stream*`, `test-fs-write-stream*`, `test-fs-watch*`, `test-url-fileurltopath` parallel tests. `test/js/node/child_process/child_process.test.ts` has two failures on this debug build with and without this change (`should allow us to spawn in the default shell`: `$SHELL` is empty in the container, and `extra stdio pipes are not double-closed on GC` times out).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->