### PR TITLE
test(install): serve the fixture registry in-process in isolated-relink.test.ts and assert the exact output and layout

### DIFF
--- a/test/cli/install/isolated-relink.test.ts
+++ b/test/cli/install/isolated-relink.test.ts
@@ -1,215 +1,326 @@
-import { file, write } from "bun";
+import { file, type Server, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "fs";
-import { lstat, mkdir, realpath, unlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
-import { dirname, join } from "path";
+import { lstat, mkdir, readdir, readFile, realpath, unlink } from "fs/promises";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+import { join, relative } from "path";
 
-const registry = new VerdaccioRegistry();
+const packagesPath = join(import.meta.dir, "registry", "packages");
+let registry: Server;
 
-beforeAll(async () => {
-  await registry.start();
+type Packument = {
+  versions: Record<string, { dist: { tarball: string }; scripts?: Record<string, string>; hasInstallScript?: boolean }>;
+};
+
+// The verdaccio fixture store served in-process: the same packuments and tarballs as `VerdaccioRegistry`, without the
+// seconds verdaccio takes to start under the binary under test.
+beforeAll(() => {
+  registry = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const { origin, pathname } = new URL(request.url);
+      const path = decodeURIComponent(pathname.slice(1));
+      const separator = path.indexOf("/-/");
+      if (separator !== -1) {
+        const tarball = file(join(packagesPath, path.slice(0, separator), path.slice(path.lastIndexOf("/") + 1)));
+        return (await tarball.exists()) ? new Response(tarball) : new Response("not found", { status: 404 });
+      }
+      const stored = file(join(packagesPath, path, "package.json"));
+      if (!(await stored.exists())) return new Response("not found", { status: 404 });
+      const packument: Packument = await stored.json();
+      for (const version of Object.values(packument.versions)) {
+        // verdaccio serves each stored tarball from its own host, and the abbreviated manifest bun asks for carries
+        // `hasInstallScript`, which bun reads from the manifest (src/install/npm.rs).
+        const tarball = version.dist.tarball;
+        version.dist.tarball = `${origin}/${path}/-/${tarball.slice(tarball.lastIndexOf("/") + 1)}`;
+        version.hasInstallScript = ["preinstall", "install", "postinstall"].some(
+          name => name in (version.scripts ?? {}),
+        );
+      }
+      return Response.json(packument);
+    },
+  });
 });
 
 afterAll(() => {
-  registry.stop();
+  registry.stop(true);
 });
 
-type Output = [stdout: string, stderr: string, exitCode: number];
+function project(packageJson: object) {
+  return tempDir("isolated-relink-", {
+    "package.json": JSON.stringify(packageJson),
+    "bunfig.toml": Bun.TOML.stringify({ install: { registry: registry.url.href, linker: "isolated" } }),
+  });
+}
 
+function oneRangeDep(overrides?: Record<string, string>) {
+  return { name: "foo", dependencies: { "one-range-dep": "1.0.0" }, ...(overrides && { overrides }) };
+}
+
+function usesWhatBin(extra: Record<string, unknown> = {}) {
+  return { name: "foo", dependencies: { "uses-what-bin": "1.0.0" }, ...extra };
+}
+
+type Output = { out: string; err: string; exitCode: number };
+
+// Runs `bun <cmd> --linker isolated` in `dir`. The task count of the resolve summary depends on the state of the cache
+// and is masked.
 async function run(cmd: string, dir: string, env: Record<string, string> = {}): Promise<Output> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), cmd, "--linker", "isolated"],
+    // CI exports BUN_INSTALL_CACHE_DIR for the whole file. Concurrent installs into one cache race on Windows.
     env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache"), ...env },
     cwd: dir,
     stdout: "pipe",
     stderr: "pipe",
   });
-  return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const normalize = (text: string) =>
+    normalizeBunSnapshot(text, dir).replace(/(Resolved, downloaded and extracted) \[\d+\]/, "$1 [<n>]");
+  return { out: normalize(out), err: normalize(err), exitCode };
 }
 
 const install = (dir: string, env?: Record<string, string>) => run("install", dir, env);
 const prune = (dir: string) => run("prune", dir);
 
-async function installOk(dir: string, env?: Record<string, string>) {
-  const [out, err, exitCode] = await install(dir, env);
-  expect(err).not.toContain("error:");
-  expect(exitCode).toBe(0);
-  return out;
+// The output of a `bun install` that linked packages. A `resolved` install fetched manifests and saved bun.lock.
+function installed(summary: string, resolved = true): Output {
+  return {
+    out: `bun install <version> (<revision>)\n\n${summary}`,
+    err: resolved ? "Resolving dependencies\nResolved, downloaded and extracted [<n>]\nSaved lockfile" : "",
+    exitCode: 0,
+  };
 }
 
-// Store entry names may carry peer-hash suffixes, so reach an entry's node_modules through its top-level link.
-async function storeNodeModules(packageDir: string, name: string) {
-  return dirname(await realpath(join(packageDir, "node_modules", name)));
+const noChanges = installed("Done! Checked 3 packages (no changes)", false);
+
+/**
+ * Every link and package below `node_modules`, keyed by path relative to it with `/` separators. A link (a symlink,
+ * or a junction or a `.bunx` bin shim on Windows) maps to `-> ` and the path it resolves to, also relative to
+ * `node_modules`. A real directory with a package.json maps to its `name@version` and is not entered.
+ */
+async function layout(packageDir: string): Promise<Record<string, string>> {
+  const nm = join(packageDir, "node_modules");
+  const entries: Record<string, string> = {};
+  const rel = (path: string) => relative(nm, path).replaceAll("\\", "/");
+  async function walk(dir: string) {
+    for (const name of await readdir(dir)) {
+      const path = join(dir, name);
+      const stats = await lstat(path);
+      if (stats.isSymbolicLink()) {
+        entries[rel(path)] = `-> ${rel(await realpath(path))}`;
+      } else if (stats.isDirectory()) {
+        const packageJson = file(join(path, "package.json"));
+        if (await packageJson.exists()) {
+          const { name, version } = await packageJson.json();
+          entries[rel(path)] = `${name}@${version}`;
+        } else {
+          await walk(path);
+        }
+      } else if (isWindows && name.endsWith(".bunx")) {
+        // A Windows bin is a `<name>.exe` + `<name>.bunx` pair. The first UTF-16LE field of the shim is the bin
+        // target, relative to the parent of `.bin`.
+        const shim = (await readFile(path)).toString("utf16le");
+        const target = join(dir, "..", shim.slice(0, shim.indexOf('"')));
+        entries[rel(path).slice(0, -".bunx".length)] = `-> ${rel(await realpath(target))}`;
+      }
+    }
+  }
+  await walk(nm);
+  return entries;
 }
 
-async function nestedNoDeps(packageDir: string) {
-  return join(await storeNodeModules(packageDir, "one-range-dep"), "no-deps");
+function without(entries: Record<string, string>, key: string) {
+  const { [key]: _, ...rest } = entries;
+  return rest;
 }
 
-function nestedNoDepsPackageJson(link: string) {
-  return file(join(link, "package.json")).json();
+// The `node_modules` of a store entry. The fixtures have no peers, so the entry names carry no peer hash.
+function storeNodeModules(packageDir: string, name: string, version: string) {
+  return join(packageDir, "node_modules", ".bun", `${name}@${version}`, "node_modules");
 }
 
-function oneRangeDep(overrides?: Record<string, string>) {
-  return JSON.stringify({ name: "foo", dependencies: { "one-range-dep": "1.0.0" }, ...(overrides && { overrides }) });
-}
-
-function usesWhatBin(extra: Record<string, unknown> = {}) {
-  return JSON.stringify({ name: "foo", dependencies: { "uses-what-bin": "1.0.0" }, ...extra });
-}
-
-// POSIX bins are symlinks; Windows writes `<name>.exe` + `<name>.bunx` whose first UTF-16LE field is the target relative to node_modules.
+// On Windows a bin is a `<name>.exe` + `<name>.bunx` shim pair instead of a symlink.
 function binFiles(nm: string, name: string) {
   const bin = join(nm, ".bin", name);
   return isWindows ? [`${bin}.exe`, `${bin}.bunx`] : [bin];
 }
 
-async function binTargetContents(nm: string, name: string) {
-  if (isWindows) {
-    const raw = readFileSync(join(nm, ".bin", `${name}.bunx`)).toString("utf16le");
-    return await file(join(nm, raw.slice(0, raw.indexOf('"')))).text();
-  }
-  return await file(await realpath(join(nm, ".bin", name))).text();
+const noDepsStore = (version: string) => `.bun/no-deps@${version}/node_modules/no-deps`;
+const noDepsPackage = (version: string) => ({ [noDepsStore(version)]: `no-deps@${version}` });
+
+// `oneRangeDep()` installed, with `no-deps@<version>` linked under one-range-dep.
+function oneRangeDepLayout(noDeps: string) {
+  const oneRangeDep = ".bun/one-range-dep@1.0.0/node_modules/one-range-dep";
+  return {
+    "one-range-dep": `-> ${oneRangeDep}`,
+    ".bun/node_modules/one-range-dep": `-> ${oneRangeDep}`,
+    ".bun/node_modules/no-deps": `-> ${noDepsStore(noDeps)}`,
+    [oneRangeDep]: "one-range-dep@1.0.0",
+    ".bun/one-range-dep@1.0.0/node_modules/no-deps": `-> ${noDepsStore(noDeps)}`,
+    ...noDepsPackage(noDeps),
+  };
+}
+
+const whatBinStore = (version: string) => `.bun/what-bin@${version}/node_modules/what-bin`;
+
+// The store entry of `what-bin@<version>`. A package's own bins are linked in its store entry too.
+function whatBinPackage(version: string) {
+  return {
+    [whatBinStore(version)]: `what-bin@${version}`,
+    [`.bun/what-bin@${version}/node_modules/.bin/what-bin`]: `-> ${whatBinStore(version)}/what-bin.js`,
+  };
+}
+
+// `usesWhatBin()` installed, with `what-bin@<version>` linked under uses-what-bin.
+function usesWhatBinLayout(whatBin: string) {
+  const usesWhatBin = ".bun/uses-what-bin@1.0.0/node_modules/uses-what-bin";
+  return {
+    "uses-what-bin": `-> ${usesWhatBin}`,
+    ".bun/node_modules/uses-what-bin": `-> ${usesWhatBin}`,
+    ".bun/node_modules/what-bin": `-> ${whatBinStore(whatBin)}`,
+    [usesWhatBin]: "uses-what-bin@1.0.0",
+    ".bun/uses-what-bin@1.0.0/node_modules/what-bin": `-> ${whatBinStore(whatBin)}`,
+    ".bun/uses-what-bin@1.0.0/node_modules/.bin/what-bin": `-> ${whatBinStore(whatBin)}/what-bin.js`,
+    ...whatBinPackage(whatBin),
+  };
 }
 
 test.concurrent("an existing store entry is re-linked when an override re-resolves its dependency", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  using packageDir = project(oneRangeDep());
+  const link = join(storeNodeModules(packageDir, "one-range-dep", "1.0.0"), "no-deps");
 
-  await write(packageJson, oneRangeDep());
-  await installOk(packageDir);
-  const link = await nestedNoDeps(packageDir);
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.1.0" });
+  expect(await install(packageDir)).toEqual(installed("+ one-range-dep@1.0.0\n\n2 packages installed"));
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 
-  await write(packageJson, oneRangeDep({ "no-deps": "1.0.0" }));
-  const out = await installOk(packageDir);
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.0.0" });
-  expect(out).toMatch(/\d+ packages? installed/);
-  expect(out).not.toContain("(no changes)");
+  await write(join(packageDir, "package.json"), JSON.stringify(oneRangeDep({ "no-deps": "1.0.0" })));
+  expect(await install(packageDir)).toEqual(installed("+ one-range-dep@1.0.0\n\n2 packages installed"));
+  // no-deps@1.1.0 is orphaned, not removed
+  const relinked = { ...oneRangeDepLayout("1.0.0"), ...noDepsPackage("1.1.0") };
+  expect(await layout(packageDir)).toEqual(relinked);
 
   const linkMtime = (await lstat(link)).mtimeMs;
-  const again = await installOk(packageDir);
-  expect(again).toContain("(no changes)");
+  expect(await install(packageDir)).toEqual(noChanges);
   expect((await lstat(link)).mtimeMs).toBe(linkMtime);
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.0.0" });
+  expect(await layout(packageDir)).toEqual(relinked);
 });
 
 test.concurrent("a dependency link deleted from an existing store entry is recreated", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  using packageDir = project(oneRangeDep());
+  const link = ".bun/one-range-dep@1.0.0/node_modules/no-deps";
 
-  await write(packageJson, oneRangeDep());
-  await installOk(packageDir);
-  const link = await nestedNoDeps(packageDir);
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.1.0" });
+  expect(await install(packageDir)).toEqual(installed("+ one-range-dep@1.0.0\n\n2 packages installed"));
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 
-  await unlink(link);
-  expect((await lstat(link).catch(e => e.code)) as string).toBe("ENOENT");
+  await unlink(join(packageDir, "node_modules", link));
+  expect(await layout(packageDir)).toEqual(without(oneRangeDepLayout("1.1.0"), link));
 
-  const out = await installOk(packageDir);
-  expect(out).toMatch(/\d+ packages? installed/);
-  expect(out).not.toContain("(no changes)");
-  expect((await lstat(link)).isSymbolicLink()).toBeTrue();
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.1.0" });
+  expect(await install(packageDir)).toEqual(installed("+ one-range-dep@1.0.0\n\n1 package installed", false));
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 
-  expect(await installOk(packageDir)).toContain("(no changes)");
+  expect(await install(packageDir)).toEqual(noChanges);
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 });
 
 test.concurrent("dependency bins are re-linked when a store entry is re-linked", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  using packageDir = project(usesWhatBin());
+  const nm = storeNodeModules(packageDir, "uses-what-bin", "1.0.0");
 
-  await write(packageJson, usesWhatBin());
-  await installOk(packageDir);
-  const nm = await storeNodeModules(packageDir, "uses-what-bin");
-  expect(await file(join(nm, "what-bin", "package.json")).json()).toMatchObject({ name: "what-bin", version: "1.0.0" });
-  expect(await binTargetContents(nm, "what-bin")).toContain("what-bin@1.0.0");
+  expect(await install(packageDir)).toEqual(
+    installed("+ uses-what-bin@1.0.0 (v1.5.0 available)\n\n2 packages installed"),
+  );
+  expect(await layout(packageDir)).toEqual(usesWhatBinLayout("1.0.0"));
 
   for (const bin of binFiles(nm, "what-bin")) await unlink(bin);
+  expect(await layout(packageDir)).toEqual(
+    without(usesWhatBinLayout("1.0.0"), ".bun/uses-what-bin@1.0.0/node_modules/.bin/what-bin"),
+  );
 
-  await write(packageJson, usesWhatBin({ overrides: { "what-bin": "1.5.0" } }));
-  const out = await installOk(packageDir);
-  expect(out).not.toContain("(no changes)");
-  expect(await file(join(nm, "what-bin", "package.json")).json()).toMatchObject({ name: "what-bin", version: "1.5.0" });
-  expect(binFiles(nm, "what-bin").map(bin => existsSync(bin))).toStrictEqual(binFiles(nm, "what-bin").map(() => true));
-  expect(await binTargetContents(nm, "what-bin")).toContain("what-bin@1.5.0");
+  await write(join(packageDir, "package.json"), JSON.stringify(usesWhatBin({ overrides: { "what-bin": "1.5.0" } })));
+  expect(await install(packageDir)).toEqual(installed("+ uses-what-bin@1.0.0\n\n2 packages installed"));
+  // what-bin@1.0.0 is orphaned, not removed
+  expect(await layout(packageDir)).toEqual({ ...usesWhatBinLayout("1.5.0"), ...whatBinPackage("1.0.0") });
 });
 
 test.concurrent("re-linking a store entry does not re-run its lifecycle scripts", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  using packageDir = project(usesWhatBin({ trustedDependencies: ["uses-what-bin"] }));
+  // The `install` script of uses-what-bin runs `what-bin`, which writes its own version to this file.
+  const marker = join(storeNodeModules(packageDir, "uses-what-bin", "1.0.0"), "uses-what-bin", "what-bin.txt");
 
-  await write(packageJson, usesWhatBin({ trustedDependencies: ["uses-what-bin"] }));
-  await installOk(packageDir);
-  const nm = await storeNodeModules(packageDir, "uses-what-bin");
-  const marker = join(nm, "uses-what-bin", "what-bin.txt");
+  expect(await install(packageDir)).toEqual(
+    installed("+ uses-what-bin@1.0.0 (v1.5.0 available)\n\n2 packages installed"),
+  );
+  expect(await layout(packageDir)).toEqual(usesWhatBinLayout("1.0.0"));
   expect(await file(marker).text()).toBe("what-bin@1.0.0");
+  const markerMtime = (await lstat(marker)).mtimeMs;
 
-  await unlink(marker);
-  await write(packageJson, usesWhatBin({ trustedDependencies: ["uses-what-bin"], overrides: { "what-bin": "1.5.0" } }));
-  const out = await installOk(packageDir);
-  expect(out).not.toContain("(no changes)");
-  expect(await file(join(nm, "what-bin", "package.json")).json()).toMatchObject({ name: "what-bin", version: "1.5.0" });
-  expect(existsSync(marker)).toBeFalse();
+  await write(
+    join(packageDir, "package.json"),
+    JSON.stringify(usesWhatBin({ trustedDependencies: ["uses-what-bin"], overrides: { "what-bin": "1.5.0" } })),
+  );
+  expect(await install(packageDir)).toEqual(installed("+ uses-what-bin@1.0.0\n\n2 packages installed"));
+  expect(await layout(packageDir)).toEqual({ ...usesWhatBinLayout("1.5.0"), ...whatBinPackage("1.0.0") });
+  // The bin now resolves to what-bin@1.5.0. A re-run of the script would have written that version.
+  expect(await file(marker).text()).toBe("what-bin@1.0.0");
+  expect((await lstat(marker)).mtimeMs).toBe(markerMtime);
 });
 
 test.concurrent(
   "a real directory in a store entry's dependency slot is left alone and not counted as a change",
   async () => {
-    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    using packageDir = project(oneRangeDep());
+    const link = join(storeNodeModules(packageDir, "one-range-dep", "1.0.0"), "no-deps");
 
-    await write(packageJson, oneRangeDep());
-    await installOk(packageDir);
-    const link = await nestedNoDeps(packageDir);
+    expect(await install(packageDir)).toEqual(installed("+ one-range-dep@1.0.0\n\n2 packages installed"));
+    expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 
     await unlink(link);
     await mkdir(link);
     await write(join(link, "package.json"), JSON.stringify({ name: "no-deps", version: "0.0.0-local-edit" }));
+    const withLocalEdit = {
+      ...oneRangeDepLayout("1.1.0"),
+      ".bun/one-range-dep@1.0.0/node_modules/no-deps": "no-deps@0.0.0-local-edit",
+    };
 
-    const out = await installOk(packageDir);
-    expect(out).toContain("(no changes)");
-    expect((await lstat(link)).isDirectory()).toBeTrue();
-    expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "0.0.0-local-edit" });
+    expect(await install(packageDir)).toEqual(noChanges);
+    expect(await layout(packageDir)).toEqual(withLocalEdit);
   },
 );
 
 test.concurrent.skipIf(!isWindows)("junction-mode warm install reports no changes", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  using packageDir = project(oneRangeDep());
+  const link = join(storeNodeModules(packageDir, "one-range-dep", "1.0.0"), "no-deps");
   const env = { BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS: "1" };
 
-  await write(packageJson, oneRangeDep());
-  const first = await installOk(packageDir, env);
-  expect(first).toMatch(/\d+ packages? installed/);
-  const link = await nestedNoDeps(packageDir);
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.1.0" });
+  expect(await install(packageDir, env)).toEqual(installed("+ one-range-dep@1.0.0\n\n2 packages installed"));
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 
   const linkMtime = (await lstat(link)).mtimeMs;
-  expect(await installOk(packageDir, env)).toContain("(no changes)");
+  expect(await install(packageDir, env)).toEqual(noChanges);
   expect((await lstat(link)).mtimeMs).toBe(linkMtime);
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 });
 
 test.concurrent("the orphaned store entry survives the re-link until bun prune", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
-  const orphan = join(packageDir, "node_modules", ".bun", "no-deps@1.1.0");
+  using packageDir = project(oneRangeDep());
 
-  await write(packageJson, oneRangeDep());
-  await installOk(packageDir);
-  expect(existsSync(join(orphan, "node_modules", "no-deps", "package.json"))).toBeTrue();
+  expect(await install(packageDir)).toEqual(installed("+ one-range-dep@1.0.0\n\n2 packages installed"));
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.1.0"));
 
-  await write(packageJson, oneRangeDep({ "no-deps": "1.0.0" }));
-  await installOk(packageDir);
-  const link = await nestedNoDeps(packageDir);
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.0.0" });
-  expect(existsSync(join(orphan, "node_modules", "no-deps", "package.json"))).toBeTrue();
+  await write(join(packageDir, "package.json"), JSON.stringify(oneRangeDep({ "no-deps": "1.0.0" })));
+  expect(await install(packageDir)).toEqual(installed("+ one-range-dep@1.0.0\n\n2 packages installed"));
+  expect(await layout(packageDir)).toEqual({ ...oneRangeDepLayout("1.0.0"), ...noDepsPackage("1.1.0") });
 
-  const [out, err, exitCode] = await prune(packageDir);
-  expect(normalizeBunSnapshot(out).replaceAll("\\", "/")).toMatchInlineSnapshot(`
+  const { out, err, exitCode } = await prune(packageDir);
+  expect(out).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
     - no-deps@1.1.0
     1 package removed (checked 4 installed packages)"
   `);
-  expect(err).not.toContain("error:");
+  expect(err).toBe("");
   expect(exitCode).toBe(0);
-  expect(existsSync(orphan)).toBeFalse();
-  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.0.0" });
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.0.0"));
 
-  expect(await installOk(packageDir)).toContain("(no changes)");
+  expect(await install(packageDir)).toEqual(noChanges);
+  expect(await layout(packageDir)).toEqual(oneRangeDepLayout("1.0.0"));
 });


### PR DESCRIPTION
### Problem
- `test/cli/install/isolated-relink.test.ts` takes 13 s on alpine 3.23 x64 (build #108977). Its 7 concurrent tests finish in 1.2 s. The rest is `beforeAll`: it starts verdaccio under the binary under test, which takes more than 5 s with the debug binary.
- Installs were checked with `not.toContain("error:")`, an exit code and a regex, the disk with single `existsSync` calls.

### Fix
- The verdaccio fixture store is served in-process by `Bun.serve` on port 0: the same packuments and tarballs. Like verdaccio, it points each tarball URL at its own host and sets `hasInstallScript`, which bun reads from the manifest. Same shape as `serveFixtures()` in isolated-install.test.ts.
- Each install and prune is checked as one `{ out, err, exitCode }` value. `layout()` lists the whole `node_modules` after each step: every link with the path it resolves to, every package as `name@version`. The lifecycle test checks the marker's content and mtime after the re-link.
- Verified: `bun bd test test/cli/install/isolated-relink.test.ts`, 3 runs each. Old file 5.4 s to 6.8 s, and 44.6 s to 49.6 s with `CI=1` (verdaccio under the debug binary, like CI). New file 3.6 s to 5.4 s, 3.4 s of it the harness import. CI build #109070: 0.66 s on alpine 3.23 x64 (13 s in #108977), 0.55 s on alpine aarch64 (11 s), 0.88 s on debian x64-asan, 0.38 s on Windows 2019 x64, 7 pass.
- Self-reviewed: 4 concerns raised, 2 addressed (`hasInstallScript`, per-version tarball URLs). Rejected: drop the server and wait for #40766, which fixes the verdaccio host for all files (Notes).

### Background
- The isolated linker installs each package once under `node_modules/.bun/<name>@<version>/node_modules/<name>` (a store entry) and symlinks it into the `node_modules` of each dependent. A re-link rewrites those symlinks when the dependencies of an existing entry resolve to other versions.
- A verdaccio fixture is one directory per package: the packument and the published tarballs.

<details><summary>Notes</summary>

Timings, all on one machine. All runs passed unless noted.

- Linux x64 debug ASAN (`bun bd test`), old file: 6.31 s, 6.78 s, 5.40 s. Locally `VerdaccioRegistry` starts verdaccio under `Bun.which("bun")`, the release build, because `isCI` is false. With `CI=1` it forks verdaccio under the debug binary: the `beforeAll` hook times out after 5 s with the default hook timeout, and with `--timeout 120000` the file takes 44.61 s, 49.64 s, 45.69 s.
- Linux x64 debug ASAN, new file: 4.46 s, 5.28 s, 5.39 s, and 4.71 s, 5.48 s, 5.46 s with `CI=1`, on the first revision. The final revision (manifest rewrite): 3.83 s, 3.88 s, 3.55 s. Per test 0.7 s to 1.3 s, all concurrent. A test file with one trivial test that imports `harness` takes 3.42 s on this build.
- Windows x64, `USE_SYSTEM_BUN=1` with the canary release build: new file 0.20 s to 0.22 s in 7 runs, 7 pass (junction test included). Old file: one run failed in `beforeAll` (verdaccio did not start within the 5 s hook timeout), the next took 3.22 s.
- CI, build #109070 (this PR) against #108977 (the sweep): alpine 3.23 x64 663 ms (was 13 s), alpine 3.23 aarch64 553 ms (was 11 s), debian 13 x64-asan 877 ms, Windows 2019 x64 378 ms with 7 pass (the junction test ran).

Self-review.

- Addressed: the served manifests now carry `hasInstallScript`, derived the way verdaccio's abbreviated manifest derives it (`storage-utils.js`), because bun reads that flag (`src/install/npm.rs:2424`). Each version's `dist.tarball` is rebuilt from the stored file name instead of a text replace of the stored host, so the server also serves the fixtures stored with another host.
- Rejected: drop the in-process server and land only the assertions, with the speed to come from #40766 (fork verdaccio under node in CI). #40766 is open and fixes the host for all 31 verdaccio files. It measured that within one CI shard the first verdaccio start is the slow one (4 s to 9 s under node, 6 s to 14 s under the ASAN binary) and that an in-process server in one file moves that cold start to the next verdaccio file of the shard. This PR still takes this file off verdaccio: its own time no longer depends on its position in the shard, and under the ASAN binary each verdaccio request costs about 1.3 s (#40766's measurement) against a file read here. Both changes can land. The same file-local shape exists on main in isolated-install.test.ts (`serveFixtures()`) and migration/migrate.test.ts (`localRegistry()`). A harness-level `FixtureRegistry` that replaces all of them is a separate change.
- Rejected: give the bins test `trustedDependencies`. It covers the untrusted case: bins are re-linked, no script runs. With `hasInstallScript` served, it reports whatever bun prints for a blocked script, like verdaccio.

A shared warm cache (one `BUN_INSTALL_CACHE_DIR` warmed in `beforeAll`) was measured too: the tests take 0.24 s to 0.68 s instead of 0.7 s to 1.3 s, and the file 4.0 s to 4.2 s (first revision). It is not in this PR. The install tests of this directory keep one cache per concurrent case because concurrent installs into one cache race on Windows (see the `installEnv` comments in bun-dedupe.test.ts, bun-add-filter.test.ts and bun-prune.test.ts), and with a warm cache the first install prints no resolve summary, so the test could no longer check that the install fetched from the registry. With the in-process registry a cold cache costs two loopback requests per package.

The task count of the resolve summary (`Resolved, downloaded and extracted [N]`) is masked as `[<n>]`, as in #40635. It counts the network and extract tasks of the run.

Assertions, per test.

- Override re-resolves a dependency: exact output of the cold install, the re-link (`2 packages installed`, lockfile saved) and the warm install (`(no changes)`, empty stderr). Layout after each: `no-deps@1.1.0` linked, then `no-deps@1.0.0` linked with `no-deps@1.1.0` orphaned in the store, unchanged after the warm install. The link mtime check is kept. Before: `not.toContain("error:")`, a regex, the package.json of one link.
- Deleted dependency link: the layout without the link, the install that recreates it (`1 package installed`, nothing resolved, empty stderr), the full layout again, then `(no changes)`. Before: `lstat` `ENOENT`, `isSymbolicLink()`, one package.json.
- Bins: the layout includes the `.bin/what-bin` link of the dependent and of the store entry of what-bin itself, with the file each resolves to. After the bins are deleted the layout lacks the dependent's bin. After the override it resolves into `what-bin@1.5.0`, and `what-bin@1.0.0` is orphaned. Before: `existsSync` of the bin files and `toContain("what-bin@1.5.0")` on the target's contents.
- Lifecycle scripts: the marker is `what-bin@1.0.0` after the first install. After the re-link the marker has the same content and the same mtime, and the layout shows that the bin now resolves to `what-bin@1.5.0`, so a re-run would have written that version. Before: the marker was deleted and checked with `existsSync` only.
- Real directory in a dependency slot: `(no changes)` with an empty stderr, and the layout shows `no-deps@0.0.0-local-edit` in the slot with everything else unchanged. Before: `isDirectory()` and one package.json.
- Junction mode (Windows): exact outputs and the full layout, junctions resolved with `realpath`, plus the mtime check.
- Orphan and prune: the orphan is in the layout after the re-link, the prune output is an inline snapshot with an empty stderr, the orphan is gone from the layout after prune, `(no changes)` after.

`expect()` calls went from 66 to 40 (45 on Windows). Each `toEqual` on a layout replaces several single-path checks and covers 6 to 10 entries. No test was removed, skipped or merged.

The in-process server handles `/<name>` (packument) and `/<name>/-/<file>` (tarball). The temp directory of each test is removed when the test ends (`using`). The old file left them behind.

`test/expected-durations.json` is not touched. CI regenerates it.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-relink.test.ts

<!-- robobun:evidence:end -->
