### PR TITLE
console.table: walk an array by its own properties instead of trusting length

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -572,6 +572,10 @@ pub struct TablePrinter<'a> {
     tabular_data: JSValue,
     properties: JSValue,
 
+    /// Rows come from the iterator protocol (Map, Set, generators and other
+    /// iterables). Otherwise they are the own enumerable properties, like
+    /// Node's `Object.keys`: that includes arrays, so a hole or a `length`
+    /// an object merely reports never becomes a row.
     is_iterable: bool,
     jstype: jsc::JSType,
 
@@ -658,7 +662,7 @@ impl<'a> TablePrinter<'a> {
             global_object,
             tabular_data,
             properties,
-            is_iterable: tabular_data.is_iterable(global_object)?,
+            is_iterable: tabular_data.is_non_array_iterable(global_object)?,
             jstype: tabular_data.js_type(),
             value_formatter: {
                 // `Formatter` has a `Drop` impl, so struct-update

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2426,6 +2426,12 @@ impl JSValue {
     pub fn is_iterable(self, global: &JSGlobalObject) -> JsResult<bool> {
         host_fn::from_js_host_call_generic(global, || JSC__JSValue__isIterable(self, global))
     }
+    /// [`is_iterable`](Self::is_iterable), but false for an array (through a
+    /// Proxy too) and for anything that iterates with the intrinsic Array
+    /// iterator, such as an `arguments` object.
+    pub fn is_non_array_iterable(self, global: &JSGlobalObject) -> JsResult<bool> {
+        crate::cpp::Bun__JSValue__isNonArrayIterable(self, global)
+    }
     /// `JSValue.forEach` — invoke `callback` for each iterable element.
     pub fn for_each(
         self,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4251,6 +4251,38 @@ bool JSC__JSValue__isIterable(JSC::EncodedJSValue JSValue, JSC::JSGlobalObject* 
     return JSC::hasIteratorMethod(global, JSC::JSValue::decode(JSValue));
 }
 
+// Like hasIteratorMethod, but false for an array (IsArray, so a Proxy around
+// an array too) and for anything that iterates with the intrinsic Array
+// iterator (Array.prototype.values): an `arguments` object, a plain
+// array-like. That iterator trusts the `length` the object reports and never
+// checks that an element exists, so a caller that wants one step per existing
+// element walks the object's own properties instead.
+extern "C" [[ZIG_EXPORT(check_slow)]] bool Bun__JSValue__isNonArrayIterable(JSC::EncodedJSValue encodedValue, JSC::JSGlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
+    if (!value.isObject())
+        return false;
+    bool isArray = JSC::isArray(globalObject, value);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (isArray)
+        return false;
+
+    JSC::CallData callData;
+    JSC::JSValue method = asObject(value)->getMethod(globalObject, callData, vm.propertyNames->iteratorSymbol, "Symbol.iterator property should be callable"_s);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (method.isUndefined())
+        return false;
+
+    auto* function = dynamicDowncast<JSC::JSFunction>(method);
+    if (function && function == function->globalObject()->arrayProtoValuesFunctionConcurrently())
+        return false;
+
+    return true;
+}
+
 void JSC__JSValue__forEach(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, void* ctx, void (*ArgFn3)(JSC::VM* arg0, JSC::JSGlobalObject* arg1, void* arg2, JSC::EncodedJSValue JSValue3))
 {
     JSC::forEachInIterable(

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -363,3 +363,86 @@ console.log("calls=" + calls);`,
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: box("1") + "calls=1\n", stderr: "", exitCode: 0 });
   });
 });
+
+// The rows of an array or array-like are the elements that exist, like Node's
+// console.table (Object.keys). The Array iterator instead trusts whatever
+// `length` the object reports and yields `undefined` for every missing index,
+// so a Proxy that lies about `length`, or a sparse array, would produce one
+// row per reported index (up to 2^32 - 1 of them).
+describe("console.table rows come from the elements that exist, not from length", () => {
+  const table = (...lines: string[]) =>
+    `┌───┬───┐\n│   │ a │\n├───┼───┤\n${lines.map(l => l + "\n").join("")}└───┴───┘\n`;
+
+  test("a Proxy that reports a length far beyond its elements", () => {
+    const proxy = new Proxy([{ a: 1 }, { a: 2 }], {
+      get(t, p, r) {
+        return p === "length" ? 1_000 : Reflect.get(t, p, r);
+      },
+    });
+    expect(Bun.inspect.table(proxy)).toBe(table("│ 0 │ 1 │", "│ 1 │ 2 │"));
+  });
+
+  test("a Proxy around an array still reads its cells through the get trap", () => {
+    const proxy = new Proxy([{ a: 1 }], {
+      get(t, p, r) {
+        return p === "0" ? { a: 2 } : Reflect.get(t, p, r);
+      },
+    });
+    expect(Bun.inspect.table(proxy)).toBe(table("│ 0 │ 2 │"));
+  });
+
+  test("a sparse array shows only the indices that hold an element", () => {
+    const sparse = [{ a: 1 }, , { a: 2 }];
+    sparse.length = 1_000;
+    expect(Bun.inspect.table(sparse)).toBe(table("│ 0 │ 1 │", "│ 2 │ 2 │"));
+  });
+
+  test("an array with only holes is an empty table", () => {
+    expect(Bun.inspect.table(new Array(1_000))).toBe(Bun.inspect.table([]));
+  });
+
+  test("a properties filter applies to the elements that exist", () => {
+    const sparse = [{ a: 1, b: 2 }, , { a: 3, b: 4 }];
+    expect(Bun.inspect.table(sparse, ["a"])).toBe(table("│ 0 │ 1 │", "│ 2 │ 3 │"));
+  });
+
+  // Object.freeze moves every element of an array into its sparse map.
+  test("a frozen array with a hole", () => {
+    const frozen = Object.freeze([{ a: 1 }, , { a: 2 }]);
+    expect(Bun.inspect.table(frozen)).toBe(table("│ 0 │ 1 │", "│ 2 │ 2 │"));
+  });
+
+  test("an array is walked like an object: its named properties are rows too", () => {
+    const arr = Object.assign([{ a: 1 }], { foo: { a: 2 } });
+    expect(Bun.inspect.table(arr)).toBe(Bun.inspect.table({ 0: { a: 1 }, foo: { a: 2 } }));
+    expect(Bun.inspect.table(new Proxy(arr, {}))).toBe(Bun.inspect.table(arr));
+  });
+
+  test("an Array subclass with its own iterator is still walked by its elements", () => {
+    class Rows extends Array {
+      *[Symbol.iterator]() {
+        yield { a: "from the iterator" };
+      }
+    }
+    expect(Bun.inspect.table(Rows.from([{ a: 1 }]))).toBe(table("│ 0 │ 1 │"));
+  });
+
+  test("console.table", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const proxy = new Proxy([{ a: 1 }, { a: 2 }], {
+  get(t, p, r) {
+    return p === "length" ? 1_000 : Reflect.get(t, p, r);
+  },
+});
+console.table(proxy);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: table("│ 0 │ 1 │", "│ 1 │ 2 │"), stderr: "", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
### Problem
- `console.table(px)` and `Bun.inspect.table(px)` never return when `px` is a Proxy whose `get` trap reports `length` 4294967295 for a 2 element array. With `length` 16M, `Bun.inspect.table` returns a 486,539,380 char string. `Bun.inspect.table(new Array(50_000_000))` returns 1.25 GB in 16 s, and `a = []; a[1e9] = 1; console.table(a)` hangs. Node prints the real rows, or an empty table, at once.
- `TablePrinter::print_table` (`src/jsc/ConsoleObject.rs:904`) reads every object that has `Symbol.iterator` through `JSC::forEachInIterable`. The Array iterator re-reads `length` on each step and yields `undefined` for every index that has no element. Nothing bounds the row count by the elements that exist.

### Fix
- An array (through a Proxy too, per `IsArray`) and any object whose `Symbol.iterator` is the intrinsic `Array.prototype.values` (`arguments`, a plain array-like) now take the own-property walk that plain objects already use. That is Node's model: `console.table` uses `Object.keys` for anything that is not a Map or a Set. The new `Bun__JSValue__isNonArrayIterable` binding makes the decision. Sets, Maps, generators, typed arrays and other iterables keep the iterator path.
- Correct because the row set is now bounded by what exists: the array's storage, or the own keys an object (or its Proxy handler) reports. A reported `length` is never read. Cell values still go through `[[Get]]`, so a Proxy `get` trap is honored, as in Node.
- Holes are skipped and an array's named enumerable properties become rows (`arr.foo`), both as in Node. Dense arrays, the existing snapshots and the generator test render unchanged.
- Verified: `test/js/bun/console/console-table.test.ts` (9 new tests, 8 fail on stock bun 1.4.1). Also `bun-inspect-table.test.ts` and `test/js/bun/util/inspect.test.js`.

### Background
- `TablePrinter` collects all rows in one width pass, then renders them. Rows come from one of two walks: the iterator protocol, or own enumerable properties through `JSPropertyIterator` (`getOwnPropertyNames` with `DontEnum` excluded, the same key set as `Object.keys`). This PR only changes which objects take which walk.
- The intrinsic Array iterator is the realm's `arrayProtoValuesFunction`. Its `next` does `ToLength(Get(O, "length"))` on every step. For a non-array `O` that value is whatever the object says. The check compares the method against its own realm's intrinsic, so cross-realm objects (`node:vm`) are covered.
- `JSC::isArray` is the spec `IsArray`: true for `Array`, an `Array` subclass, and a Proxy whose target is one.

<details><summary>Notes</summary>

Behavior changes, all match Node:
- A hole is no longer rendered as an `undefined` row. `console.table([1, , 3])` prints rows 0 and 2.
- An array's named enumerable properties are rows: `Object.assign([1, 2], { foo: 3 })` prints rows 0, 1, foo.
- An array with a custom `Symbol.iterator` is walked by its elements, not by that iterator.

Unchanged: Set, Map, Map/Set iterators, generators, typed arrays, `String` objects, `Headers`, `arguments` (same rows, now through the property walk), a Proxy around a Set (TypeError, as before), a non-callable `Symbol.iterator` (TypeError, as before). A revoked Proxy still throws a TypeError, now from `IsArray`.

Alternatives considered:
- A row cap. Arbitrary, and it still prints thousands of wrong `undefined` rows for the Proxy case.
- Unwrapping the Proxy to its target, as the formatter does for `console.log`. That bypasses `get` traps, which Node honors, and does nothing for sparse arrays.
- A dedicated present-index walk for arrays with `Bun__JSArray__nextPresentIndex` (the formatter's sparse array helper). Its output is identical to the property walk, but it rescans the whole sparse map per call, so a frozen array (`Object.freeze` moves every element into the sparse map) of 10k rows took 17 s in a debug build against 0.8 s for the property walk.

Cost of the property walk for real arrays: one atomized index string per row. In a debug build a dense and a frozen 10k row table both take about 0.8 s. The 50M hole case spends its time allocating the array, not in the table.

Measurements on stock bun 1.4.1 (release, linux x64): the 2^32-1 Proxy was killed at 10 s; `new Array(50_000_000)` took 16.4 s and returned 1,250,000,100 chars. With the fix both return in under 5 ms of table work.

Self-reviewed: 8 concerns raised. Addressed: the first version kept a separate present-index walk for arrays (quadratic on sparse maps, and a bare array hid `arr.foo` while a Proxy around it did not) and used `isJSArray` (misses `Array` subclasses and Proxies). Both are gone.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/console/console-table.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [7.91ms]
(pass) console.table > expected output for: not object (number) [8.89ms]
(pass) console.table > expected output for: not object (string) [1.70ms]
(pass) console.table > expected output for: object - empty [1.40ms]
(pass) console.table > expected output for: object [2.15ms]
(pass) console.table > expected output for: array - empty [1.16ms]
(pass) console.table > expected output for: array - plain [1.64ms]
(pass) console.table > expected output for: array - object [1.55ms]
(pass) console.table > expected output for: array - objects with diff props [2.00ms]
(pass) console.table > expected output for: array - mixed [2.17ms]
(pass) console.table > expected output for: set [1.61ms]
(pass) console.table > expected output for: map [2.44ms]
(pass) console
... (truncated)

release without fix: 8 failed, 1 skipped
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [0.10ms]
(pass) console.table > expected output for: not object (number) [0.39ms]
(pass) console.table > expected output for: not object (string) [0.02ms]
(pass) console.table > expected output for: object - empty [0.02ms]
(pass) console.table > expected output for: object [0.03ms]
(pass) console.table > expected output for: array - empty [0.01ms]
(pass) console.table > expected output for: array - plain [0.02ms]
(pass) console.table > expected output for: array - object [0.01ms]
(pass) console.table > expected output for: array - objects with diff props [0.01ms]
(pass) console.table > expected output for: array - mixed [0.02ms]
(pass) console.table > expected output for: set [0.02ms]
(pass) console.table > expected output for: map [0.02ms]
(pass) console.table > expected output for: properties [0.02ms]
(pass) console.table > expected output for: properties - empty [0.01ms]
(pass) console.table > expected output for:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/console/console-table.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [7.10ms]
(pass) console.table > expected output for: not object (number) [8.84ms]
(pass) console.table > expected output for: not object (string) [1.58ms]
(pass) console.table > expected output for: object - empty [1.38ms]
(pass) console.table > expected output for: object [2.11ms]
(pass) console.table > expected output for: array - empty [1.14ms]
(pass) console.table > expected output for: array - plain [1.74ms]
(pass) console.table > expected output for: array - object [1.58ms]
(pass) console.table > expected output for: array - objects with diff props [2.19ms]
(pass) console.table > expected output for: array - mixed [2.18ms]
(pass) console.table > expected output for: set [1.56ms]
(pass) console.table > expected output for: map [2.52ms]
(pass) console
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     27135adc86
  features     baseline

23 deps, 131 codegen, 1172 objects in 611ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [3.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 K
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                  |  6 ++-
 src/jsc/JSValue.rs                        |  6 +++
 src/jsc/bindings/bindings.cpp             | 32 ++++++++++++
 test/js/bun/console/console-table.test.ts | 83 +++++++++++++++++++++++++++++++
 4 files changed, 126 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/ConsoleObject.rs                       4      6     15
src/jsc/JSValue.rs                             1      3     16
src/jsc/bindings/bindings.cpp                  1      4     15
test/js/bun/console/console-table.test.ts      3      3     15
```

</details>

<!-- robobun:evidence:end -->