### PR TITLE
worker_threads: read options.argv and options.execArgv by index, like Node

### DIFF
--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -58,7 +58,6 @@
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/HeapAnalyzer.h>
-#include <JavaScriptCore/IteratorOperations.h>
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
@@ -307,34 +306,41 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
             return original.isolatedCopy();
         };
 
+        // Node reads both options by index, not through Symbol.iterator: argv with
+        // Array.prototype.map, execArgv with a Get(i) loop in node_worker.cc.
+        auto appendStrings = [&](JSObject* arrayLike, Vector<String>& out) {
+            forEachInArrayLike(lexicalGlobalObject, arrayLike, [&](JSValue item) -> bool {
+                auto scope = DECLARE_THROW_SCOPE(vm);
+                String str = coerceToIsolatedString(item);
+                RETURN_IF_EXCEPTION(scope, false);
+                out.append(str);
+                return true;
+            });
+        };
+
         JSValue argvValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "argv"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (argvValue && argvValue.pureToBoolean() != TriState::False) {
             Bun::V::validateArray(throwScope, globalObject, argvValue, "options.argv"_s, jsNumber(0));
             RETURN_IF_EXCEPTION(throwScope, {});
-            forEachInIterable(lexicalGlobalObject, argvValue, [&options, &coerceToIsolatedString](JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue nextValue) {
-                auto scope = DECLARE_THROW_SCOPE(vm);
-                String str = coerceToIsolatedString(nextValue);
-                RETURN_IF_EXCEPTION(scope, );
-                options.argv.append(str);
-            });
+            appendStrings(asObject(argvValue), options.argv);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
 
         JSValue execArgvValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "execArgv"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (execArgvValue && execArgvValue.pureToBoolean() != TriState::False) {
-            Vector<String> execArgv;
             Bun::V::validateArray(throwScope, globalObject, execArgvValue, "options.execArgv"_s, jsNumber(0));
             RETURN_IF_EXCEPTION(throwScope, {});
-            forEachInIterable(lexicalGlobalObject, execArgvValue, [&execArgv, &coerceToIsolatedString](JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue nextValue) {
-                auto scope = DECLARE_THROW_SCOPE(vm);
-                String str = coerceToIsolatedString(nextValue);
-                RETURN_IF_EXCEPTION(scope, );
-                execArgv.append(str);
-            });
-            RETURN_IF_EXCEPTION(throwScope, {});
-            options.execArgv.emplace(WTF::move(execArgv));
+            // validateArray uses JSC::isArray(), which accepts a Proxy of an Array. Node's native check
+            // (`args[2]->IsArray()` in node_worker.cc) does not, so a Proxy is skipped and the worker
+            // inherits the parent's execArgv.
+            if (auto* execArgvArray = dynamicDowncast<JSC::JSArray>(execArgvValue)) {
+                Vector<String> execArgv;
+                appendStrings(execArgvArray, execArgv);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                options.execArgv.emplace(WTF::move(execArgv));
+            }
         }
     }
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -298,25 +298,21 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
             }
         }
 
-        // needed to match the coercion behavior of `String(value)`, which returns a descriptive
-        // string for Symbols instead of throwing like JSValue::toString does.
-        // may throw an exception!
-        auto coerceToIsolatedString = [lexicalGlobalObject](JSValue v) -> String {
-            String original = v.isSymbol() ? asSymbol(v)->tryGetDescriptiveString().value_or(String()) : v.toWTFString(lexicalGlobalObject);
-            return original.isolatedCopy();
-        };
-
-        // Node reads argv and execArgv by index, not through Symbol.iterator.
-        auto appendStrings = [&](JSObject* arrayLike, Vector<String>& out) {
+        // Node reads argv and execArgv by index, not through Symbol.iterator. argv goes through
+        // `String(value)`, which describes a Symbol. execArgv goes through ToString, which throws on one.
+        enum class SymbolToString { Describe, Throw };
+        auto appendStrings = [&](JSObject* arrayLike, Vector<String>& out, SymbolToString symbolToString) {
             auto scope = DECLARE_THROW_SCOPE(vm);
             uint64_t length = toLength(lexicalGlobalObject, arrayLike);
             RETURN_IF_EXCEPTION(scope, );
             for (uint64_t i = 0; i < length; i++) {
                 JSValue item = arrayLike->getIndex(lexicalGlobalObject, i);
                 RETURN_IF_EXCEPTION(scope, );
-                String str = coerceToIsolatedString(item);
+                String str = item.isSymbol() && symbolToString == SymbolToString::Describe
+                    ? asSymbol(item)->tryGetDescriptiveString().value_or(String())
+                    : item.toWTFString(lexicalGlobalObject);
                 RETURN_IF_EXCEPTION(scope, );
-                out.append(str);
+                out.append(str.isolatedCopy());
             }
         };
 
@@ -325,7 +321,7 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
         if (argvValue && argvValue.pureToBoolean() != TriState::False) {
             Bun::V::validateArray(throwScope, globalObject, argvValue, "options.argv"_s, jsNumber(0));
             RETURN_IF_EXCEPTION(throwScope, {});
-            appendStrings(asObject(argvValue), options.argv);
+            appendStrings(asObject(argvValue), options.argv, SymbolToString::Describe);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
 
@@ -337,7 +333,7 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
             // validateArray accepts a Proxy of an Array (JSC::isArray). Node's native IsArray() does not: the worker inherits the parent's execArgv.
             if (auto* execArgvArray = dynamicDowncast<JSC::JSArray>(execArgvValue)) {
                 Vector<String> execArgv;
-                appendStrings(execArgvArray, execArgv);
+                appendStrings(execArgvArray, execArgv, SymbolToString::Throw);
                 RETURN_IF_EXCEPTION(throwScope, {});
                 options.execArgv.emplace(WTF::move(execArgv));
             }

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -308,13 +308,16 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
 
         // Node reads argv and execArgv by index, not through Symbol.iterator.
         auto appendStrings = [&](JSObject* arrayLike, Vector<String>& out) {
-            forEachInArrayLike(lexicalGlobalObject, arrayLike, [&](JSValue item) -> bool {
-                auto scope = DECLARE_THROW_SCOPE(vm);
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            uint64_t length = toLength(lexicalGlobalObject, arrayLike);
+            RETURN_IF_EXCEPTION(scope, );
+            for (uint64_t i = 0; i < length; i++) {
+                JSValue item = arrayLike->getIndex(lexicalGlobalObject, i);
+                RETURN_IF_EXCEPTION(scope, );
                 String str = coerceToIsolatedString(item);
-                RETURN_IF_EXCEPTION(scope, false);
+                RETURN_IF_EXCEPTION(scope, );
                 out.append(str);
-                return true;
-            });
+            }
         };
 
         JSValue argvValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "argv"_s));

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -299,7 +299,8 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
         }
 
         // Node reads both options by index. argv uses String(value), which describes a Symbol. execArgv uses ToString, which throws on one.
-        enum class SymbolToString { Describe, Throw };
+        enum class SymbolToString { Describe,
+            Throw };
         auto appendStrings = [&](JSObject* arrayLike, Vector<String>& out, SymbolToString symbolToString) {
             auto scope = DECLARE_THROW_SCOPE(vm);
             uint64_t length = toLength(lexicalGlobalObject, arrayLike);

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -306,8 +306,7 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
             return original.isolatedCopy();
         };
 
-        // Node reads both options by index, not through Symbol.iterator: argv with
-        // Array.prototype.map, execArgv with a Get(i) loop in node_worker.cc.
+        // Node reads argv and execArgv by index, not through Symbol.iterator.
         auto appendStrings = [&](JSObject* arrayLike, Vector<String>& out) {
             forEachInArrayLike(lexicalGlobalObject, arrayLike, [&](JSValue item) -> bool {
                 auto scope = DECLARE_THROW_SCOPE(vm);
@@ -332,9 +331,7 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
         if (execArgvValue && execArgvValue.pureToBoolean() != TriState::False) {
             Bun::V::validateArray(throwScope, globalObject, execArgvValue, "options.execArgv"_s, jsNumber(0));
             RETURN_IF_EXCEPTION(throwScope, {});
-            // validateArray uses JSC::isArray(), which accepts a Proxy of an Array. Node's native check
-            // (`args[2]->IsArray()` in node_worker.cc) does not, so a Proxy is skipped and the worker
-            // inherits the parent's execArgv.
+            // validateArray accepts a Proxy of an Array (JSC::isArray). Node's native IsArray() does not: the worker inherits the parent's execArgv.
             if (auto* execArgvArray = dynamicDowncast<JSC::JSArray>(execArgvValue)) {
                 Vector<String> execArgv;
                 appendStrings(execArgvArray, execArgv);

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -298,8 +298,7 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
             }
         }
 
-        // Node reads argv and execArgv by index, not through Symbol.iterator. argv goes through
-        // `String(value)`, which describes a Symbol. execArgv goes through ToString, which throws on one.
+        // Node reads both options by index. argv uses String(value), which describes a Symbol. execArgv uses ToString, which throws on one.
         enum class SymbolToString { Describe, Throw };
         auto appendStrings = [&](JSObject* arrayLike, Vector<String>& out, SymbolToString symbolToString) {
             auto scope = DECLARE_THROW_SCOPE(vm);

--- a/test/js/node/worker_threads/fixture-execargv.js
+++ b/test/js/node/worker_threads/fixture-execargv.js
@@ -4,7 +4,9 @@ import { Worker } from "node:worker_threads";
 // parent thread needs to have nonempty execArgv, otherwise the test is faulty
 assert(process.execArgv.length > 0);
 
-const execArgvToPass = JSON.parse(process.argv[2]);
+// The argument is a JS expression, so a test can pass values JSON cannot
+// express: a Proxy, an Array subclass, an array with a custom iterator.
+const execArgvToPass = new Function(`return (${process.argv[2]});`)();
 new Worker("console.log(JSON.stringify(process.execArgv));", { eval: true, execArgv: execArgvToPass }).on(
   "error",
   e => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -348,42 +348,43 @@ describe("execArgv option", async () => {
     // so Node never reads the Proxy and the worker inherits the parent's flags.
     await run('new Proxy(["--no-warnings"], {})', '["--smol"]\n');
   });
-  it("reads an Array by index, like Node", async () => {
-    await Promise.all([
-      // a custom Symbol.iterator is not consulted
-      run(
-        'Object.assign(["--no-warnings"], { [Symbol.iterator]: function* () { yield "--from-iterator"; } })',
-        '["--no-warnings"]\n',
-      ),
-      run('Object.setPrototypeOf(["--no-warnings"], null)', '["--no-warnings"]\n'),
-      run('new (class extends Array {})("--no-warnings")', '["--no-warnings"]\n'),
-    ]);
+  // Node reads the array by index, so Symbol.iterator and the prototype do not matter.
+  it.concurrent.each([
+    [
+      "an array with a custom Symbol.iterator",
+      'Object.assign(["--no-warnings"], { [Symbol.iterator]: function* () { yield "--from-iterator"; } })',
+    ],
+    ["an array with a null prototype", 'Object.setPrototypeOf(["--no-warnings"], null)'],
+    ["an Array subclass", 'new (class extends Array {})("--no-warnings")'],
+  ])("reads %s by index, like Node", async (_, execArgv) => {
+    await run(execArgv, '["--no-warnings"]\n');
   });
-  // TODO(@190n) get our handling of non-string array elements in line with Node's
+  it("throws for a Symbol element, like Node", () => {
+    // Node converts each execArgv element with ToString, which throws on a Symbol.
+    expect(() => new Worker("", { eval: true, execArgv: [Symbol("flag")] })).toThrow(TypeError);
+  });
 });
 
 // Node maps options.argv with Array.prototype.map: an index walk over `length`
 // that follows a Proxy and does not consult Symbol.iterator or the prototype.
-test("argv option is read by index, like Node", async () => {
-  const src = `require("node:worker_threads").parentPort.postMessage(process.argv.slice(2))`;
-  const argvs = [
-    new Proxy(["a", "b"], {}),
+test.concurrent.each([
+  ["a Proxy", new Proxy(["a", "b"], {})],
+  [
+    "an array with a custom Symbol.iterator",
     Object.assign(["a", "b"], {
       [Symbol.iterator]: function* () {
         yield "from-iterator";
       },
     }),
-    Object.setPrototypeOf(["a", "b"], null),
-  ];
-  const workers = argvs.map(argv => new Worker(src, { eval: true, argv }));
+  ],
+  ["an array with a null prototype", Object.setPrototypeOf(["a", "b"], null)],
+])("argv option reads %s by index, like Node", async (_, argv) => {
+  const src = `require("node:worker_threads").parentPort.postMessage(process.argv.slice(2))`;
+  const worker = new Worker(src, { eval: true, argv });
   // events.once rejects when the worker emits "error" instead
-  const got = await Promise.all(workers.map(w => once(w, "message").then(([data]) => data)));
-  expect(got).toEqual([
-    ["a", "b"],
-    ["a", "b"],
-    ["a", "b"],
-  ]);
-  await Promise.all(workers.map(w => w.terminate()));
+  const [got] = await once(worker, "message");
+  expect(got).toEqual(["a", "b"]);
+  await worker.terminate();
 });
 
 test("eval does not leak source code", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -376,7 +376,8 @@ test("argv option is read by index, like Node", async () => {
     Object.setPrototypeOf(["a", "b"], null),
   ];
   const workers = argvs.map(argv => new Worker(src, { eval: true, argv }));
-  const got = await Promise.all(workers.map(w => new Promise(res => w.once("message", res))));
+  // events.once rejects when the worker emits "error" instead
+  const got = await Promise.all(workers.map(w => once(w, "message").then(([data]) => data)));
   expect(got).toEqual([
     ["a", "b"],
     ["a", "b"],

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -319,6 +319,7 @@ describe("execArgv option", async () => {
   // this needs to be a subprocess to ensure that the parent's execArgv is not empty
   // otherwise we could not distinguish between the worker inheriting the parent's execArgv
   // vs. the worker getting a fresh empty execArgv
+  // `execArgv` is a JS expression the fixture evaluates for the option.
   async function run(execArgv: string, expected: string) {
     const proc = Bun.spawn({
       // pass --smol so that the parent thread has some known, non-empty execArgv
@@ -342,7 +343,42 @@ describe("execArgv option", async () => {
   it("can specify an array of strings", async () => {
     await run('["--no-warnings"]', '["--no-warnings"]\n');
   });
+  it("inherits the parent's execArgv when passed a Proxy, like Node", async () => {
+    // Array.isArray() accepts a Proxy of an array. Node's native check does not,
+    // so Node never reads the Proxy and the worker inherits the parent's flags.
+    await run('new Proxy(["--no-warnings"], {})', '["--smol"]\n');
+  });
+  it("reads an Array by index, like Node", async () => {
+    await Promise.all([
+      // a custom Symbol.iterator is not consulted
+      run(
+        'Object.assign(["--no-warnings"], { [Symbol.iterator]: function* () { yield "--from-iterator"; } })',
+        '["--no-warnings"]\n',
+      ),
+      run('Object.setPrototypeOf(["--no-warnings"], null)', '["--no-warnings"]\n'),
+      run('new (class extends Array {})("--no-warnings")', '["--no-warnings"]\n'),
+    ]);
+  });
   // TODO(@190n) get our handling of non-string array elements in line with Node's
+});
+
+// Node maps options.argv with Array.prototype.map: an index walk over `length`
+// that follows a Proxy and does not consult Symbol.iterator or the prototype.
+test("argv option is read by index, like Node", async () => {
+  const src = `require("node:worker_threads").parentPort.postMessage(process.argv.slice(2))`;
+  const argvs = [
+    new Proxy(["a", "b"], {}),
+    Object.assign(["a", "b"], { [Symbol.iterator]: function* () { yield "from-iterator"; } }),
+    Object.setPrototypeOf(["a", "b"], null),
+  ];
+  const workers = argvs.map(argv => new Worker(src, { eval: true, argv }));
+  const got = await Promise.all(workers.map(w => new Promise(res => w.once("message", res))));
+  expect(got).toEqual([
+    ["a", "b"],
+    ["a", "b"],
+    ["a", "b"],
+  ]);
+  await Promise.all(workers.map(w => w.terminate()));
 });
 
 test("eval does not leak source code", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -368,7 +368,11 @@ test("argv option is read by index, like Node", async () => {
   const src = `require("node:worker_threads").parentPort.postMessage(process.argv.slice(2))`;
   const argvs = [
     new Proxy(["a", "b"], {}),
-    Object.assign(["a", "b"], { [Symbol.iterator]: function* () { yield "from-iterator"; } }),
+    Object.assign(["a", "b"], {
+      [Symbol.iterator]: function* () {
+        yield "from-iterator";
+      },
+    }),
     Object.setPrototypeOf(["a", "b"], null),
   ];
   const workers = argvs.map(argv => new Worker(src, { eval: true, argv }));


### PR DESCRIPTION
### Problem
- `new Worker(url, { argv, execArgv })` reads both options through the iterator protocol (`src/jsc/bindings/webcore/JSWorker.cpp:315`, `:330`). Node reads them by index: `argv` with `Array.prototype.map`, `execArgv` with a `Get(i)` loop in `node_worker.cc`. So in Bun a custom `Symbol.iterator` replaces the elements, and a null-prototype array throws a bare `TypeError`.
- For `execArgv`, Bun walks a Proxy. `Bun::V::validateArray` uses `JSC::isArray()`, which accepts a Proxy of an Array. Node's native `v8::Value::IsArray()` rejects it, so Node skips the option and the worker inherits the parent's `execArgv`.
- Found with a Proxy whose `length` trap lies: the constructor runs for as long as the reported length says (16e6 takes 6.6s, `2**32 - 1` never returns). Every element coerces to a string, so nothing stops the walk.

### Fix
- Read both options by index: `toLength`, then `getIndex(i)` and the string coercion, with an exception check after each step, as `process.execve` does in `BunProcess.cpp`. `argv` still follows a Proxy, as Node's `map` does.
- For `execArgv`, downcast to a `JSC::JSArray` after `validateArray`. A Proxy fails the downcast, `options.execArgv` stays unset, and the worker inherits the parent's `execArgv`, as in Node. #7962 had this gate, #18758 dropped it.
- A Symbol in `execArgv` throws a `TypeError` (Node uses `ToString`). `argv` keeps `String(value)`, which describes a Symbol (Node uses `map(String)`). This closes the TODO in the test file.
- A real array with a huge sparse `length` is still walked, as in Node.
- Verified: `test/js/node/worker_threads/worker_threads.test.ts` (eight new cases, stock bun fails six). Also the whole file and `test/js/node/test/parallel/test-worker-process-argv.js`.

### Background
- Spec `IsArray` looks through a Proxy to its target. `dynamicDowncast<JSC::JSArray>` checks the cell type: `Array` and its subclasses match, a `ProxyObject` does not. `process.setgroups` in `BunProcess.cpp` uses the same two-step check.
- `toLength` plus `getIndex(i)` is the spec `CreateListFromArrayLike` walk. It does not consult `Symbol.iterator`. JSC's `forEachInArrayLike` is not used: it does not check for an exception after its functor returns, and the coercion can throw.
- `WorkerOptions::execArgv` is a `std::optional`. Unset means "inherit the parent's execArgv".

<details><summary>Notes</summary>

History: #7962 added both options behind an `ArrayType` cell check, which excluded a Proxy. #18758 replaced the check with `validateArray` to get Node's `ERR_INVALID_ARG_TYPE` for a non-array, and the iterator walk after it accepted a Proxy from then on.

Node v26.3.0 vs Bun, parent started with a known flag (`--smol` for Bun, `--stack-size=2000` for Node). Rows marked `*` differ between stock Bun 1.4.1 and this branch.

```
execArgv                                   node                 bun 1.4.1            this branch
new Proxy(["--no-warnings"], {})           inherits parent *    ["--no-warnings"]    inherits parent
custom Symbol.iterator yielding "--x"      ["--no-warnings"] *  ["--x"]              ["--no-warnings"]
Object.setPrototypeOf([...], null)         ["--no-warnings"] *  TypeError            ["--no-warnings"]
new (class extends Array {})("--no-w..")   ["--no-warnings"]    ["--no-warnings"]    ["--no-warnings"]
[Symbol("flag")]                           TypeError *          ["Symbol(flag)"]     TypeError
"nope"                                     ERR_INVALID_ARG_TYPE ERR_INVALID_ARG_TYPE ERR_INVALID_ARG_TYPE

argv                                       node                 bun 1.4.1            this branch
new Proxy(["a", "b"], {})                  ["a","b"]            ["a","b"]            ["a","b"]
custom Symbol.iterator yielding "x"        ["a","b"] *          ["x"]                ["a","b"]
Object.setPrototypeOf(["a","b"], null)     ["a","b"] *          TypeError            ["a","b"]
[Symbol("s"), null, 1]                     ["Symbol(s)","null","1"]  same             same
```

The lying-length repro (`length` trap returns `2**32 - 1`) constructs the worker in 71 ms with the debug build.

Still different from Node, unchanged here: a hole in `argv` becomes `"undefined"` in Bun and `undefined` in Node.

`preload` keeps the WebIDL `convert<IDLSequence<IDLDOMString>>` path. It is a Bun-only option with sequence semantics.

The test fixture `fixture-execargv.js` now evaluates its argument as a JS expression instead of JSON, so a row can pass a Proxy, a subclass, or a custom iterator. The four existing rows are valid expressions and are unchanged.

Two open PRs add a `Bun__Worker__validateExecArgv` call after the `execArgv` walk (#33363, #34654). On a rebase over this change, that call belongs inside the new `if (auto* execArgvArray = ...)` block, after `appendStrings`, so a Proxy is not walked and an unset option is not validated.

Also ran `test/js/web/workers/worker.test.ts`. Its argv/execArgv tests pass. Two tests in its "terminate() races" block fail in this container under the debug ASAN build with or without this change (checked with main's `JSWorker.cpp`). They are tracked separately.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1037.16ms]
(pass) all worker_threads module properties are present [22.10ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.26ms]
(pass) all worker_threads worker instance properties are present [144.82ms]
(pass) threadId module and worker property is consistent [195.66ms]
(pass) receiveMessageOnPort works across threads [968.65ms]
(pass) receiveMessageOnPort works as FIFO [11.43ms]
(pass) you can override globalThis.postMessage [974.74ms]
(pass) support require in eval [955.20ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [970.44ms]
(pass) support require in eval for a file that doesnt exist [949.17ms]
(pass) support worker eval that throws [940.96ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [4089.61ms]
(pass) e
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (34506baef)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [18.47ms]
(pass) all worker_threads module properties are present [0.32ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.35ms]
(pass) all worker_threads worker instance properties are present [2.20ms]
(pass) threadId module and worker property is consistent [3.12ms]
(pass) receiveMessageOnPort works across threads [17.46ms]
(pass) receiveMessageOnPort works as FIFO [0.19ms]
(pass) you can override globalThis.postMessage [16.65ms]
(pass) support require in eval [15.68ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [15.44ms]
(pass) support require in eval for a file that doesnt exist [13.67ms]
(pass) support worker eval that throws [13.11ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [64.56ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [32.24ms]
(pass) execArgv option > can specify an array of strings [33.41ms]
(pass) execArgv option > inherits the parent's
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1027.39ms]
(pass) all worker_threads module properties are present [22.22ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.39ms]
(pass) all worker_threads worker instance properties are present [144.32ms]
(pass) threadId module and worker property is consistent [194.34ms]
(pass) receiveMessageOnPort works across threads [984.01ms]
(pass) receiveMessageOnPort works as FIFO [11.57ms]
(pass) you can override globalThis.postMessage [969.68ms]
(pass) support require in eval [970.57ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [979.11ms]
(pass) support require in eval for a file that doesnt exist [958.38ms]
(pass) support worker eval that throws [937.07ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [4048.55ms]
(pass) e
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 601ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSWorker.cpp              | 46 +++++++++++-----------
 test/js/node/worker_threads/fixture-execargv.js    |  4 +-
 test/js/node/worker_threads/worker_threads.test.ts | 44 ++++++++++++++++++++-
 3 files changed, 70 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/JSWorker.cpp                   6     12     32
test/js/node/worker_threads/fixture-execargv.js         2      3     31
test/js/node/worker_threads/worker_threads.test.ts      3      5     31
```

</details>

<!-- robobun:evidence:end -->
