### PR TITLE
css: recognize ::details-content, ::picker(), ::checkmark and ::picker-icon

### DIFF
--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1222,7 +1222,7 @@ impl<'a> SelectorParser<'a> {
         // `::View-Transition-Group(..)` fall through to `CustomFunction`,
         // so look up `name` verbatim with no case folding.
         //
-        // PERF: 6 entries with near-unique lengths (3/10/19/19/21/26) —
+        // PERF: 7 entries with near-unique lengths (3/6/10/19/19/21/26) —
         // a length-gated `match` rejects the overwhelmingly-common miss path
         // (unknown `::-webkit-foo(...)` etc.) on a single `usize` compare,
         // versus a hash lookup's hash + table load + slice compare. Only
@@ -1234,6 +1234,11 @@ impl<'a> SelectorParser<'a> {
             3 if name == b"cue" => {
                 return Ok(PseudoElement::CueFunction {
                     selector: Box::new(Selector::parse(self, input)?),
+                });
+            }
+            6 if name == b"picker" => {
+                return Ok(PseudoElement::PickerFunction {
+                    identifier: Ident::parse(input)?,
                 });
             }
             10 if name == b"cue-region" => {
@@ -1552,6 +1557,9 @@ fn lookup_pseudo_element(name: &[u8]) -> Option<PseudoElement> {
         b"-webkit-scrollbar-corner" => PE::WebkitScrollbar(WS::Corner),
         b"-webkit-resizer" => PE::WebkitScrollbar(WS::Resizer),
         b"view-transition" => PE::ViewTransition,
+        b"details-content" => PE::DetailsContent,
+        b"picker-icon" => PE::PickerIcon,
+        b"checkmark" => PE::Checkmark,
         _ => return None,
     } })
 }
@@ -2959,6 +2967,17 @@ pub enum PseudoElement {
         /// A part name selector.
         part_name: ViewTransitionPartName,
     },
+    /// The [::details-content](https://drafts.csswg.org/css-pseudo-4/#details-content-pseudo) pseudo element.
+    DetailsContent,
+    /// The [::picker-icon](https://drafts.csswg.org/css-forms-1/#picker-icon-pseudo) pseudo element.
+    PickerIcon,
+    /// The [::checkmark](https://drafts.csswg.org/css-forms-1/#checkmark-pseudo) pseudo element.
+    Checkmark,
+    /// The [::picker()](https://drafts.csswg.org/css-forms-1/#picker-pseudo) functional pseudo element.
+    PickerFunction {
+        /// The identifier argument, e.g. `select` in `::picker(select)`.
+        identifier: Ident,
+    },
     /// An unknown pseudo element.
     Custom {
         /// The name of the pseudo element.
@@ -3088,6 +3107,10 @@ impl fmt::Display for PseudoElement {
             Self::ViewTransitionImagePair { .. } => "view_transition_image_pair",
             Self::ViewTransitionOld { .. } => "view_transition_old",
             Self::ViewTransitionNew { .. } => "view_transition_new",
+            Self::DetailsContent => "details_content",
+            Self::PickerIcon => "picker_icon",
+            Self::Checkmark => "checkmark",
+            Self::PickerFunction { .. } => "picker_function",
             Self::Custom { .. } => "custom",
             Self::CustomFunction { .. } => "custom_function",
         })

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1255,6 +1255,14 @@ pub(crate) mod serialize {
                 part_name.to_css(dest)?;
                 dest.write_char(b')')?;
             }
+            PseudoElement::DetailsContent => dest.write_str(b"::details-content")?,
+            PseudoElement::PickerIcon => dest.write_str(b"::picker-icon")?,
+            PseudoElement::Checkmark => dest.write_str(b"::checkmark")?,
+            PseudoElement::PickerFunction { identifier } => {
+                dest.write_str(b"::picker(")?;
+                identifier.to_css(dest)?;
+                dest.write_char(b')')?;
+            }
             PseudoElement::Custom { name } => {
                 dest.write_str(b"::")?;
                 return dest.serialize_identifier(name);

--- a/test/bundler/css/forms-pseudo-elements-41120.test.ts
+++ b/test/bundler/css/forms-pseudo-elements-41120.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import path from "node:path";
+
+// https://github.com/oven-sh/bun/issues/41120
+// ::details-content, ::picker(), ::checkmark and ::picker-icon are known
+// pseudo-elements (css-pseudo-4 and css-forms-1, also in lightningcss's
+// tables). Bundling them must not emit an "Unsupported pseudo-class or
+// pseudo-element" warning.
+describe("css", () => {
+  test("known form pseudo-elements do not warn (#41120)", async () => {
+    using dir = tempDir("css-41120", {
+      "in.css": `
+        .a::details-content { height: auto }
+        .b::picker(select) { border: none }
+        .c::checkmark { color: teal }
+        .d::picker-icon { rotate: 90deg }
+      `,
+    });
+    const result = await Bun.build({
+      entrypoints: [path.join(String(dir), "in.css")],
+      minify: true,
+      throw: true,
+    });
+    expect(result.logs.map(String)).toEqual([]);
+    const out = await result.outputs[0].text();
+    expect(out.trim()).toBe(
+      ".a::details-content{height:auto}.b::picker(select){border:none}.c::checkmark{color:teal}.d::picker-icon{rotate:90deg}",
+    );
+  });
+
+  test("the pseudo-element lookup is case-insensitive (#41120)", async () => {
+    using dir = tempDir("css-41120-case", {
+      "in.css": `
+        .a::DETAILS-CONTENT { height: auto }
+        .b::Checkmark { color: teal }
+      `,
+    });
+    const result = await Bun.build({
+      entrypoints: [path.join(String(dir), "in.css")],
+      minify: true,
+      throw: true,
+    });
+    expect(result.logs.map(String)).toEqual([]);
+    const out = await result.outputs[0].text();
+    expect(out.trim()).toBe(".a::details-content{height:auto}.b::checkmark{color:teal}");
+  });
+});


### PR DESCRIPTION
### Problem
- `bun build` warns `Invalid selector. Unsupported pseudo-class or pseudo-element 'details-content'` (and the same for `picker`, `checkmark`, `picker-icon`) on valid CSS. The emitted CSS is correct, only the diagnostic is wrong.
- The cause: the pseudo-element lookup tables in `src/css/selectors/parser.rs` trail lightningcss 1.33.0, the source this parser is ported from. `lookup_pseudo_element` (line 1528) misses `details-content`, `picker-icon`, `checkmark`. The functional table in `parse_functional_pseudo_element` (line 1238) misses `picker()`.

### Fix
- Add the four entries. Each is a real `PseudoElement` variant with its own serialization (`DetailsContent`, `PickerIcon`, `Checkmark`, `PickerFunction { identifier: Ident }`), the same shape lightningcss uses, not a mapping to `Custom`.
- `::picker()` parses one `<ident>` argument, as upstream does. The simple entries go through the existing case-insensitive table, so `::DETAILS-CONTENT` now serializes as `::details-content`.
- The scroll-marker family (`::scroll-marker`, `::scroll-marker-group`, `::scroll-button()`) from the issue still warns. lightningcss warns on those too, including current master, so this PR stays at upstream parity.
- Verified: `test/bundler/css/forms-pseudo-elements-41120.test.ts` (both tests fail on 1.4.1). Also ran `test/bundler/css/` (174 pass) and `test/js/bun/css/` (failures there are pre-existing fuzz-test timeouts, identical on an unpatched build).

### Background
- Bun's CSS selector parser is a port of lightningcss. An unknown pseudo-element parses as `PseudoElement::Custom`, passes through unchanged, and warns unless it is vendor-prefixed. The warning path is intentional and is not touched here.
- `::details-content` is css-pseudo-4. `::picker()`, `::picker-icon`, `::checkmark` are css-forms-1 (the customizable `<select>` styling). All four ship in Chromium stable.
- The functional table is a length-gated case-sensitive match (see the PERF comment at the parse site). The `picker` entry follows that shape, with the comment updated for the new length set.

<details><summary>Notes</summary>

- Upstream reference: parcel-bundler/lightningcss v1.33.0 `src/selector.rs`: `details-content` (line 284), `picker-icon` (line 310), `checkmark` (line 311) in the simple table, `picker` in the functional table (line 339). No scroll-marker family entries there, on the tag or on master.
- `:target-current` from the issue is quiet in Bun today because bare pseudo-class warnings gate on a `_` prefix instead of `-`. #38572 fixes that gate separately. Upstream gates `:target-current` behind a non-default `scroll_navigation_controls` option, so no entry is added here.
- Behavior edge: `::picker(not an ident)` now fails selector parsing instead of parsing as a custom function. lightningcss behaves the same way.
- Only `src/css/selectors/parser.rs` and `src/css/selectors/selector.rs` match on these variants. `CssEql`/`CssHash` come from derives. The targets-compat check in `selector.rs` treats the new variants like other post-selectors-4 pseudo-elements (not downlevelable), unchanged from upstream.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/css/forms-pseudo-elements-41120.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/css/forms-pseudo-elements-41120.test.ts:
20 |     const result = await Bun.build({
21 |       entrypoints: [path.join(String(dir), "in.css")],
22 |       minify: true,
23 |       throw: true,
24 |     });
25 |     expect(result.logs.map(String)).toEqual([]);
                                         ^
error: expect(received).toEqual(expected)

- []
+ [
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'details-content'",
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'picker'",
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'checkmark'",
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'picker-icon'",
+ ]

- Expected  - 1
+ Received  + 6

      at <anonymous> (/workspace/bun/test/bundler/css/forms-pseudo-elements-41120.test.ts:25:37)
(fail) css > known form pseudo-elements do not warn (#41120) [167.32ms]
39 |     cons
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bundler/css/forms-pseudo-elements-41120.test.ts:
20 |     const result = await Bun.build({
21 |       entrypoints: [path.join(String(dir), "in.css")],
22 |       minify: true,
23 |       throw: true,
24 |     });
25 |     expect(result.logs.map(String)).toEqual([]);
                                         ^
error: expect(received).toEqual(expected)

- []
+ [
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'details-content'",
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'picker'",
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'checkmark'",
+   "BuildMessage: Invalid selector. Unsupported pseudo-class or pseudo-element 'picker-icon'",
+ ]

- Expected  - 1
+ Received  + 6

      at <anonymous> (/workspace/bun/test/bundler/css/forms-pseudo-elements-41120.test.ts:25:37)
(fail) css > known form pseudo-elements do not warn (#41120) [3.86ms]
39 |     const result = await Bun.build({
40 |       entrypoints: [path.join(String(dir), "in.css")],
41 |       minify: true,
42 |       throw: true,
43 |     });
44 |     expect(result.logs.m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/css/forms-pseudo-elements-41120.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/css/forms-pseudo-elements-41120.test.ts:
(pass) css > known form pseudo-elements do not warn (#41120) [146.12ms]
(pass) css > the pseudo-element lookup is case-insensitive (#41120) [86.75ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [2.40s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4a4430180f
  features     baseline

23 deps, 131 codegen, 1172 objects in 736ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [14.00ms]
[2/1244] gen bindgenv2
[3/1244] fetch zlib
[zlib] up to date
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1216] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[7/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1216] gen ErrorCode+*.h
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[11
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/selectors/parser.rs                        | 25 ++++++++++-
 src/css/selectors/selector.rs                      |  8 ++++
 .../css/forms-pseudo-elements-41120.test.ts        | 48 ++++++++++++++++++++++
 3 files changed, 80 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/css/selectors/parser.rs                               2      2      4
src/css/selectors/selector.rs                             2      1      4
test/bundler/css/forms-pseudo-elements-41120.test.ts      0      2      4
```

</details>

**root cause** · written by the author bot

The pseudo-element lookup tables in the CSS selector parser were ported from an older snapshot of lightningcss and lacked entries that upstream later added, so `::details-content`, `::picker()`, `::checkmark` and `::picker-icon` fell through to the fallback path that emits an "unsupported pseudo-element" warning while still passing the selector through as a custom pseudo-element. The fix adds these four names as proper pseudo-element variants with upstream-matching serialization, including registering `picker()` in the functional pseudo-element table, so they parse cleanly without warnings.…

<!-- robobun:evidence:end -->