### PR TITLE
Buffer.concat, Bun.concatArrayBuffers, fs.writev/readv: reject the first invalid element before reading the rest of the list

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -131,11 +131,6 @@ JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Array(JSGlobalObj
         RELEASE_AND_RETURN(throwScope, JSValue::encode(JSC::JSArrayBuffer::create(vm, lexicalGlobalObject->arrayBufferStructure(), JSC::ArrayBuffer::create(static_cast<size_t>(0), 1))));
     };
 
-    // Resolve every element of the input array into a MarkedArgumentBuffer
-    // first so that all user-observable side effects (index getters) run to
-    // completion before we read any byte lengths or allocate the output
-    // buffer. Reject the first element that is neither an ArrayBuffer nor an
-    // ArrayBufferView as soon as it is read.
     MarkedArgumentBuffer args;
     bool any_buffer = false;
     bool any_typed = false;
@@ -157,10 +152,8 @@ JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Array(JSGlobalObj
         return {};
     }
 
-    // All user code is done running. Check that no element was detached by
-    // a later getter and sum their byte lengths. Nothing between here and
-    // the final memcpy loop can call back into JavaScript, so the lengths we
-    // measure now are the lengths we copy below.
+    // Nothing between here and the memcpy loop calls back into JavaScript, so
+    // the lengths read now are the lengths copied below.
     size_t byteLength = 0;
     for (size_t i = 0; i < args.size(); i++) {
         JSValue element = args.at(i);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -4,6 +4,7 @@
 #include <JavaScriptCore/HeapSnapshotBuilder.h>
 #include "ZigGlobalObject.h"
 #include "JavaScriptCore/ArgList.h"
+#include "CollectArrayLike.h"
 #include "JSDOMURL.h"
 #include "helpers.h"
 #include "IDLTypes.h"
@@ -133,19 +134,22 @@ JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Array(JSGlobalObj
     // Resolve every element of the input array into a MarkedArgumentBuffer
     // first so that all user-observable side effects (index getters) run to
     // completion before we read any byte lengths or allocate the output
-    // buffer. This avoids a TOCTOU where a getter at index N detaches or
-    // resizes the buffer backing index M < N after M's length was measured,
-    // which previously left uninitialized bytes in the output.
+    // buffer. Reject the first element that is neither an ArrayBuffer nor an
+    // ArrayBufferView as soon as it is read.
     MarkedArgumentBuffer args;
-    args.ensureCapacity(array->length());
-    if (args.hasOverflowed()) [[unlikely]] {
-        throwOutOfMemoryError(lexicalGlobalObject, throwScope);
-        return {};
-    }
-
-    JSC::forEachInArrayLike(lexicalGlobalObject, array, [&](JSValue element) -> bool {
-        args.append(element);
-        return true;
+    bool any_buffer = false;
+    bool any_typed = false;
+    Bun::collectArrayLike(lexicalGlobalObject, array, args, [&](JSValue element) -> bool {
+        if (dynamicDowncast<JSC::JSArrayBufferView>(element)) {
+            any_typed = true;
+            return true;
+        }
+        if (dynamicDowncast<JSC::JSArrayBuffer>(element)) {
+            any_buffer = true;
+            return true;
+        }
+        throwTypeError(lexicalGlobalObject, throwScope, "Expected TypedArray"_s);
+        return false;
     });
     RETURN_IF_EXCEPTION(throwScope, {});
     if (args.hasOverflowed()) [[unlikely]] {
@@ -153,32 +157,24 @@ JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Array(JSGlobalObj
         return {};
     }
 
-    // All user code is done running. Validate each element and sum their
-    // byte lengths. Nothing between here and the final memcpy loop can call
-    // back into JavaScript, so the lengths we measure now are the lengths we
-    // copy below.
+    // All user code is done running. Check that no element was detached by
+    // a later getter and sum their byte lengths. Nothing between here and
+    // the final memcpy loop can call back into JavaScript, so the lengths we
+    // measure now are the lengths we copy below.
     size_t byteLength = 0;
-    bool any_buffer = false;
-    bool any_typed = false;
-
     for (size_t i = 0; i < args.size(); i++) {
         JSValue element = args.at(i);
         if (auto* typedArray = dynamicDowncast<JSC::JSArrayBufferView>(element)) {
             if (typedArray->isDetached()) [[unlikely]] {
                 return Bun::ERR::INVALID_STATE(throwScope, lexicalGlobalObject, "Cannot validate on a detached buffer"_s);
             }
-            any_typed = true;
             byteLength += typedArray->byteLength();
-        } else if (auto* arrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(element)) {
-            auto* impl = arrayBuffer->impl();
+        } else {
+            auto* impl = uncheckedDowncast<JSC::JSArrayBuffer>(element)->impl();
             if (!impl || impl->isDetached()) [[unlikely]] {
                 return Bun::ERR::INVALID_STATE(throwScope, lexicalGlobalObject, "Cannot validate on a detached buffer"_s);
             }
-            any_buffer = true;
             byteLength += impl->byteLength();
-        } else {
-            throwTypeError(lexicalGlobalObject, throwScope, "Expected TypedArray"_s);
-            return {};
         }
     }
     byteLength = std::min(byteLength, maxLength);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -152,8 +152,7 @@ JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Array(JSGlobalObj
         return {};
     }
 
-    // Nothing between here and the memcpy loop calls back into JavaScript, so
-    // the lengths read now are the lengths copied below.
+    // Nothing between here and the memcpy loop calls back into JavaScript, so the lengths read now are the lengths copied below.
     size_t byteLength = 0;
     for (size_t i = 0; i < args.size(); i++) {
         JSValue element = args.at(i);

--- a/src/jsc/bindings/CollectArrayLike.h
+++ b/src/jsc/bindings/CollectArrayLike.h
@@ -8,27 +8,20 @@
 
 namespace Bun {
 
-// Reads every element of an array-like object into `out`, in index order, so
-// that all user code an indexed read can run (getters, proxy traps) finishes
-// before the caller reads byte lengths or takes raw pointers. A getter at
-// index N can otherwise detach or resize the buffer at index M < N after
-// M's length was measured.
-//
-// `accept(element)` runs on each element before it is appended. It returns
-// false to stop the loop, which the caller uses to reject an element of the
-// wrong type right away: a later getter cannot change an element's type,
-// only detach or resize it. Without that early exit, a list whose reported
-// length is far larger than its contents (a Proxy with a lying `length` trap,
-// a sparse array) would cost O(length) [[Get]] calls before the caller could
-// reject it.
+// Reads every element of an array-like into `out` before the caller reads any
+// byte length or raw pointer, so a getter or proxy trap cannot detach or resize
+// an element after it was measured. `accept(element)` runs before each append
+// and returns false to stop. A type check belongs there, not after the loop: a
+// later getter cannot change an element's type, and a list that lies about its
+// length (a Proxy `length` trap, a sparse array) then fails at its first bad
+// element instead of after O(length) [[Get]] calls.
 //
 // The caller checks for an exception first, then for `out.hasOverflowed()`.
 template<typename Accept>
 void collectArrayLike(JSC::JSGlobalObject* globalObject, JSC::JSObject* arrayLike, JSC::MarkedArgumentBuffer& out, const Accept& accept)
 {
-    // Only a densely stored JSArray has a length that matches its element
-    // count. A sparse array can report a length of 2^32 - 1 with two elements
-    // in it, and pre-sizing to that fails before the loop can reject it.
+    // A sparse array's length says nothing about its element count, so only
+    // pre-size for dense storage.
     if (auto* array = dynamicDowncast<JSC::JSArray>(arrayLike); array && !JSC::hasAnyArrayStorage(array->indexingType())) [[likely]] {
         out.ensureCapacity(array->length());
         if (out.hasOverflowed()) [[unlikely]]

--- a/src/jsc/bindings/CollectArrayLike.h
+++ b/src/jsc/bindings/CollectArrayLike.h
@@ -8,20 +8,15 @@
 
 namespace Bun {
 
-// Reads every element of an array-like into `out` before the caller reads any
-// byte length or raw pointer, so a getter or proxy trap cannot detach or resize
-// an element after it was measured. `accept(element)` runs before each append
-// and returns false to stop. A type check belongs there, not after the loop: a
-// later getter cannot change an element's type, and a list that lies about its
-// length (a Proxy `length` trap, a sparse array) then fails at its first bad
-// element instead of after O(length) [[Get]] calls.
-//
-// The caller checks for an exception first, then for `out.hasOverflowed()`.
+// Reads every element of `arrayLike` into `out` before the caller reads any byte
+// length or raw pointer, so a getter or proxy trap cannot invalidate an element
+// that was already measured. `accept` rejects an element by returning false. A
+// type check belongs there, so a list that lies about its length (a Proxy `length`
+// trap, a sparse array) fails at its first bad element, not after O(length) reads.
 template<typename Accept>
 void collectArrayLike(JSC::JSGlobalObject* globalObject, JSC::JSObject* arrayLike, JSC::MarkedArgumentBuffer& out, const Accept& accept)
 {
-    // A sparse array's length says nothing about its element count, so only
-    // pre-size for dense storage.
+    // A sparse array's length says nothing about its element count, so only pre-size for dense storage.
     if (auto* array = dynamicDowncast<JSC::JSArray>(arrayLike); array && !JSC::hasAnyArrayStorage(array->indexingType())) [[likely]] {
         out.ensureCapacity(array->length());
         if (out.hasOverflowed()) [[unlikely]]

--- a/src/jsc/bindings/CollectArrayLike.h
+++ b/src/jsc/bindings/CollectArrayLike.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "root.h"
+
+#include <JavaScriptCore/ArgList.h>
+#include <JavaScriptCore/JSArray.h>
+#include <JavaScriptCore/JSObjectInlines.h>
+
+namespace Bun {
+
+// Reads every element of an array-like object into `out`, in index order, so
+// that all user code an indexed read can run (getters, proxy traps) finishes
+// before the caller reads byte lengths or takes raw pointers. A getter at
+// index N can otherwise detach or resize the buffer at index M < N after
+// M's length was measured.
+//
+// `accept(element)` runs on each element before it is appended. It returns
+// false to stop the loop, which the caller uses to reject an element of the
+// wrong type right away: a later getter cannot change an element's type,
+// only detach or resize it. Without that early exit, a list whose reported
+// length is far larger than its contents (a Proxy with a lying `length` trap,
+// a sparse array) would cost O(length) [[Get]] calls before the caller could
+// reject it.
+//
+// The caller checks for an exception first, then for `out.hasOverflowed()`.
+template<typename Accept>
+void collectArrayLike(JSC::JSGlobalObject* globalObject, JSC::JSObject* arrayLike, JSC::MarkedArgumentBuffer& out, const Accept& accept)
+{
+    // Only a densely stored JSArray has a length that matches its element
+    // count. A sparse array can report a length of 2^32 - 1 with two elements
+    // in it, and pre-sizing to that fails before the loop can reject it.
+    if (auto* array = dynamicDowncast<JSC::JSArray>(arrayLike); array && !JSC::hasAnyArrayStorage(array->indexingType())) [[likely]] {
+        out.ensureCapacity(array->length());
+        if (out.hasOverflowed()) [[unlikely]]
+            return;
+    }
+
+    JSC::forEachInArrayLike(globalObject, arrayLike, [&](JSC::JSValue element) -> bool {
+        if (!accept(element))
+            return false;
+        out.append(element);
+        return true;
+    });
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/CollectArrayLike.h
+++ b/src/jsc/bindings/CollectArrayLike.h
@@ -27,7 +27,7 @@ void collectArrayLike(JSC::JSGlobalObject* globalObject, JSC::JSObject* arrayLik
         if (!accept(element))
             return false;
         out.append(element);
-        return true;
+        return !out.hasOverflowed();
     });
 }
 

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -919,8 +919,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
 
     JSValue totalLengthValue = callFrame->argument(1);
 
-    // `JSC::isArray()` is true for Proxy->Array, so `length` and each index
-    // can come from traps.
+    // `JSC::isArray()` is true for Proxy->Array, so `length` and each index can come from traps.
     MarkedArgumentBuffer args;
     Bun::collectArrayLike(lexicalGlobalObject, asObject(listValue), args, [&](JSValue element) -> bool {
         if (dynamicDowncast<JSC::JSUint8Array>(element)) [[likely]]
@@ -939,8 +938,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
     }
 
-    // Nothing between here and the memcpy loop calls back into JavaScript, so
-    // the lengths read now are the lengths copied below.
+    // Nothing between here and the memcpy loop calls back into JavaScript, so the lengths read now are the lengths copied below.
     size_t availableLength = 0;
     for (unsigned i = 0; i < args.size(); i++) {
         auto* typedArray = uncheckedDowncast<JSC::JSUint8Array>(args.at(i));

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -81,6 +81,7 @@
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>
+#include "CollectArrayLike.h"
 
 extern "C" bool Bun__Node__ZeroFillBuffers;
 
@@ -921,26 +922,19 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
     // Resolve every element of `list` into a MarkedArgumentBuffer first so
     // that all user-observable side effects (index getters, proxy traps)
     // run to completion before we read any byte lengths or allocate the
-    // output buffer. This avoids a TOCTOU where a getter at index N detaches
-    // or resizes the buffer backing index M < N after M's length was
-    // measured, which previously left uninitialized bytes in the output.
+    // output buffer. Like Node, reject the first element that is not a
+    // Uint8Array as soon as it is read.
     //
     // Note: `validateArray` uses `JSC::isArray()` which returns true for
     // Proxy->Array. `forEachInArrayLike` reads `.length` and each index via
     // `JSObject::getIndex`, which fast-paths dense JSArrays and falls back
     // to [[Get]] for proxies and sparse arrays.
     MarkedArgumentBuffer args;
-    if (auto* array = dynamicDowncast<JSC::JSArray>(listValue)) [[likely]] {
-        args.ensureCapacity(array->length());
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(lexicalGlobalObject, throwScope);
-            return {};
-        }
-    }
-
-    JSC::forEachInArrayLike(lexicalGlobalObject, asObject(listValue), [&](JSValue element) -> bool {
-        args.append(element);
-        return true;
+    Bun::collectArrayLike(lexicalGlobalObject, asObject(listValue), args, [&](JSValue element) -> bool {
+        if (dynamicDowncast<JSC::JSUint8Array>(element)) [[likely]]
+            return true;
+        Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, makeString("list["_s, args.size(), "]"_s), "Buffer or Uint8Array"_s, element);
+        return false;
     });
     RETURN_IF_EXCEPTION(throwScope, {});
     if (args.hasOverflowed()) [[unlikely]] {
@@ -953,17 +947,13 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
     }
 
-    // All user code is done running. Validate each element and sum their
-    // byte lengths. Nothing between here and the final memcpy loop can call
-    // back into JavaScript, so the lengths we measure now are the lengths we
-    // copy below.
+    // All user code is done running. Check that no element was detached by
+    // a later getter and sum their byte lengths. Nothing between here and
+    // the final memcpy loop can call back into JavaScript, so the lengths we
+    // measure now are the lengths we copy below.
     size_t availableLength = 0;
     for (unsigned i = 0; i < args.size(); i++) {
-        JSValue element = args.at(i);
-        auto* typedArray = dynamicDowncast<JSC::JSUint8Array>(element);
-        if (!typedArray) [[unlikely]] {
-            return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, makeString("list["_s, i, "]"_s), "Buffer or Uint8Array"_s, element);
-        }
+        auto* typedArray = uncheckedDowncast<JSC::JSUint8Array>(args.at(i));
         if (typedArray->isDetached()) [[unlikely]] {
             return throwVMTypeError(lexicalGlobalObject, throwScope, "ArrayBufferView is detached"_s);
         }

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -919,16 +919,8 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
 
     JSValue totalLengthValue = callFrame->argument(1);
 
-    // Resolve every element of `list` into a MarkedArgumentBuffer first so
-    // that all user-observable side effects (index getters, proxy traps)
-    // run to completion before we read any byte lengths or allocate the
-    // output buffer. Like Node, reject the first element that is not a
-    // Uint8Array as soon as it is read.
-    //
-    // Note: `validateArray` uses `JSC::isArray()` which returns true for
-    // Proxy->Array. `forEachInArrayLike` reads `.length` and each index via
-    // `JSObject::getIndex`, which fast-paths dense JSArrays and falls back
-    // to [[Get]] for proxies and sparse arrays.
+    // `JSC::isArray()` is true for Proxy->Array, so `length` and each index
+    // can come from traps.
     MarkedArgumentBuffer args;
     Bun::collectArrayLike(lexicalGlobalObject, asObject(listValue), args, [&](JSValue element) -> bool {
         if (dynamicDowncast<JSC::JSUint8Array>(element)) [[likely]]
@@ -947,10 +939,8 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
     }
 
-    // All user code is done running. Check that no element was detached by
-    // a later getter and sum their byte lengths. Nothing between here and
-    // the final memcpy loop can call back into JavaScript, so the lengths we
-    // measure now are the lengths we copy below.
+    // Nothing between here and the memcpy loop calls back into JavaScript, so
+    // the lengths read now are the lengths copied below.
     size_t availableLength = 0;
     for (unsigned i = 0; i < args.size(); i++) {
         auto* typedArray = uncheckedDowncast<JSC::JSUint8Array>(args.at(i));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6978,10 +6978,11 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
 }
 
 // Collects every ArrayBufferView in a JSArray and the (data, byteLength) span
-// of each. Bun::collectArrayLike reads the elements first and stops at the
-// first one that is not an ArrayBufferView, so no getter runs after a raw
-// pointer is taken. A backing store detached during that pass reads back as a
-// zero-length span.
+// of each. Two passes, mirroring Buffer.concat: the first reads every element
+// into a MarkedArgumentBuffer, so any user code an indexed read can run
+// (getters, proxy traps) finishes before the second pass takes raw pointers.
+// A backing store detached during the first pass reads back as a zero-length
+// span.
 //
 // When `pinBuffers` is true, each view's backing ArrayBuffer is materialized
 // and pinned before its data pointer is read, so the span stays valid after

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6978,11 +6978,10 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
 }
 
 // Collects every ArrayBufferView in a JSArray and the (data, byteLength) span
-// of each. Two passes, mirroring Buffer.concat: the first reads every element
-// into a MarkedArgumentBuffer and stops at the first one that is not an
-// ArrayBufferView, so any user code an indexed read can run (getters, proxy
-// traps) finishes before the second pass takes raw pointers. A backing store
-// detached during the first pass reads back as a zero-length span.
+// of each. Bun::collectArrayLike reads the elements first and stops at the
+// first one that is not an ArrayBufferView, so no getter runs after a raw
+// pointer is taken. A backing store detached during that pass reads back as a
+// zero-length span.
 //
 // When `pinBuffers` is true, each view's backing ArrayBuffer is materialized
 // and pinned before its data pointer is read, so the span stays valid after

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -99,6 +99,7 @@
 #include "JavaScriptCore/WasmFaultSignalHandler.h"
 #include "ZigGlobalObject.h"
 #include "helpers.h"
+#include "CollectArrayLike.h"
 #include "JavaScriptCore/JSObjectInlines.h"
 
 #include "wtf/Assertions.h"
@@ -6978,10 +6979,10 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
 
 // Collects every ArrayBufferView in a JSArray and the (data, byteLength) span
 // of each. Two passes, mirroring Buffer.concat: the first reads every element
-// into a MarkedArgumentBuffer, so any user code an indexed read can run
-// (getters, proxy traps) finishes before the second pass takes raw pointers.
-// A backing store detached during the first pass reads back as a zero-length
-// span.
+// into a MarkedArgumentBuffer and stops at the first one that is not an
+// ArrayBufferView, so any user code an indexed read can run (getters, proxy
+// traps) finishes before the second pass takes raw pointers. A backing store
+// detached during the first pass reads back as a zero-length span.
 //
 // When `pinBuffers` is true, each view's backing ArrayBuffer is materialized
 // and pinned before its data pointer is read, so the span stays valid after
@@ -7007,22 +7008,19 @@ extern "C" int32_t Bun__JSArray__collectBufferSpans(
     JSC::JSArray* array = uncheckedDowncast<JSC::JSArray>(value.asCell());
 
     JSC::MarkedArgumentBuffer values;
-    values.ensureCapacity(array->length());
-    if (values.hasOverflowed()) [[unlikely]]
-        return 2;
-
-    JSC::forEachInArrayLike(globalObject, array, [&](JSC::JSValue element) -> bool {
-        values.append(element);
-        return true;
+    bool allViews = true;
+    Bun::collectArrayLike(globalObject, array, values, [&](JSC::JSValue element) -> bool {
+        allViews = !!dynamicDowncast<JSC::JSArrayBufferView>(element);
+        return allViews;
     });
     RETURN_IF_EXCEPTION(scope, -1);
+    if (!allViews)
+        return 1;
     if (values.hasOverflowed()) [[unlikely]]
         return 2;
 
     for (unsigned i = 0; i < unsigned(values.size()); i++) {
-        auto* view = dynamicDowncast<JSC::JSArrayBufferView>(values.at(i));
-        if (!view)
-            return 1;
+        auto* view = uncheckedDowncast<JSC::JSArrayBufferView>(values.at(i));
         if (pinBuffers) {
             // possiblySharedBuffer() converts a FastTypedArray (GC-movable
             // storage, no ArrayBuffer yet) into a malloc-backed one and can

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("Buffer.concat throws RangeError for too large buffers", () => {
   const bufferToUse = Buffer.allocUnsafe(1024 * 1024 * 64);
@@ -189,4 +190,84 @@ describe("does not leak uninitialized memory when a getter mutates input buffers
     expect(out.length).toBe(16);
     expect(out.every(b => b === 0xbb)).toBe(true);
   });
+});
+
+describe("rejects the first invalid element without reading the rest of the list", () => {
+  // A list can report a length far larger than its contents: a Proxy with a
+  // lying `length` trap, or a sparse array. Node validates each element as it
+  // reads it and throws at the first one that is not a Uint8Array. Reading
+  // all 2^32 - 1 indices first would take minutes, or never finish.
+
+  const listTwoError = {
+    code: "ERR_INVALID_ARG_TYPE",
+    message: 'The "list[2]" argument must be an instance of Buffer or Uint8Array. Received undefined',
+  };
+
+  test("Buffer.concat with a Proxy whose length trap lies", async () => {
+    // The child runs the concat. If it is still reading indices after the
+    // timeout, the kill makes the assertions below fail.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const real = [Buffer.from("aa"), Buffer.from("bb")];
+        const px = new Proxy(real, {
+          get(target, prop, receiver) {
+            return prop === "length" ? 4294967295 : Reflect.get(target, prop, receiver);
+          },
+        });
+        for (const args of [[px], [px, 4]]) {
+          try {
+            Buffer.concat(...args);
+            console.log("no throw");
+          } catch (e) {
+            console.log(e.code, e.message);
+          }
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const line = `${listTwoError.code} ${listTwoError.message}\n`;
+    expect(stdout).toBe(line + line);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Buffer.concat with a Proxy that does not lie still works", () => {
+    const real = [Buffer.from("aa"), Buffer.from("bb")];
+    const px = new Proxy(real, {});
+    expect(Buffer.concat(px).toString()).toBe("aabb");
+    expect(Buffer.concat(px, 3).toString()).toBe("aab");
+  });
+
+  test("Buffer.concat with a sparse array of length 2^32 - 1", () => {
+    const list = [Buffer.from("aa"), Buffer.from("bb")];
+    list.length = 4294967295;
+    for (const args of [[list], [list, 4]] as const) {
+      const { code, message } = catchError(() => Buffer.concat(...args));
+      expect({ code, message }).toEqual(listTwoError);
+    }
+  });
+
+  test("Bun.concatArrayBuffers with a sparse array of length 2^32 - 1", () => {
+    const list = [new Uint8Array(2), new ArrayBuffer(2)];
+    list.length = 4294967295;
+    expect(() => Bun.concatArrayBuffers(list)).toThrow("Expected TypedArray");
+  });
+
+  function catchError(fn: () => unknown): any {
+    try {
+      fn();
+    } catch (e) {
+      return e;
+    }
+    throw new Error("expected the call to throw");
+  }
 });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2085,6 +2085,54 @@ it("preadv", () => {
   expect(buffers[2]).toEqual(new Uint8Array([10, 11, 12]));
 });
 
+// Node throws ERR_INVALID_ARG_TYPE at the first element of `buffers` that is
+// not an ArrayBufferView and does not read the rest of the list.
+describe("writevSync and readvSync reject the first invalid element", () => {
+  function codeOf(fn: () => unknown): string | undefined {
+    try {
+      fn();
+    } catch (e: any) {
+      return e.code;
+    }
+    throw new Error("expected the call to throw");
+  }
+
+  it("sparse array of length 2^32 - 1", () => {
+    using dir = tempDir("fs-vectored-sparse", { "f.txt": "abc" });
+    const fd = openSync(join(String(dir), "f.txt"), "r+");
+    try {
+      const buffers = [Buffer.from("a"), Buffer.from("b")];
+      buffers.length = 4294967295;
+      expect(codeOf(() => writevSync(fd, buffers))).toBe("ERR_INVALID_ARG_TYPE");
+      expect(codeOf(() => readvSync(fd, buffers))).toBe("ERR_INVALID_ARG_TYPE");
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it("a getter after the invalid element does not run", () => {
+    using dir = tempDir("fs-vectored-getter", { "f.txt": "abc" });
+    const fd = openSync(join(String(dir), "f.txt"), "r+");
+    try {
+      let ran = false;
+      const buffers: unknown[] = [1];
+      Object.defineProperty(buffers, 1, {
+        enumerable: true,
+        get() {
+          ran = true;
+          return Buffer.from("x");
+        },
+      });
+      buffers.length = 2;
+      expect(codeOf(() => writevSync(fd, buffers as any))).toBe("ERR_INVALID_ARG_TYPE");
+      expect(codeOf(() => readvSync(fd, buffers as any))).toBe("ERR_INVALID_ARG_TYPE");
+      expect(ran).toBe(false);
+    } finally {
+      closeSync(fd);
+    }
+  });
+});
+
 // Node defaults an explicit `undefined` len to 0 on every truncate entry point
 // (`if (len === undefined) len = 0` in truncateSync, `len = 0` default params
 // elsewhere), while `null` still fails validateInteger.


### PR DESCRIPTION
### Problem
- `Buffer.concat(list)` reads every element of `list` before it checks any type. A Proxy whose `length` trap returns 4294967295 makes it do about 4.3e9 `[[Get]]` calls before it can throw, and never returns. Node throws `ERR_INVALID_ARG_TYPE` for `list[2]` in 3 ms.
- The cause is the order in `jsBufferConstructorFunction_concatBody` (`src/jsc/bindings/JSBuffer.cpp`). #30061 snapshots all elements into a `MarkedArgumentBuffer` to fix a TOCTOU and checks types afterwards.
- `Bun.concatArrayBuffers` and `fs.writev`/`fs.readv` share this code. A sparse array reaches all three: `list.length = 2**32 - 1` throws `RangeError: Out of memory`.

### Fix
- Add `Bun::collectArrayLike` (`src/jsc/bindings/CollectArrayLike.h`). It reads the elements in index order and runs an `accept` callback on each one first. All three sites reject the first element of the wrong type, like Node.
- The detached check and byte length reads stay after the loop, so the #30061 TOCTOU fix holds: a later getter cannot change an element's type.
- The helper pre-sizes the buffer only for an array with dense storage.
- Verified: `test/js/node/buffer-concat.test.ts` and `test/js/node/fs/fs.test.ts` (6 new tests, 5 fail on bun 1.4.1), plus Node's buffer, writev and readv tests.

### Background
- `JSC::isArray()` is true for a Proxy over an Array, so `forEachInArrayLike` reads `length` and each index through the Proxy's `get` trap.
- `MarkedArgumentBuffer` is a GC-visible vector of `JSValue`. The snapshot runs all user code before any raw pointer is taken.
- A JSArray with `ArrayStorage` indexing can report a `length` far larger than its element count. `ensureCapacity(2**32 - 1)` overflows, which read as out of memory.

<details><summary>Notes</summary>

Measurements on bun 1.4.1 (release) and node v26.3.0, both on linux x64:

| input | bun 1.4.1 | node 26.3.0 | this PR (debug build) |
| --- | --- | --- | --- |
| `Buffer.concat`, Proxy `length` trap = 4294967295 | no return, killed | `list[2]` error, 3 ms | `list[2]` error, 6 ms |
| `Buffer.concat`, Proxy `length` trap = 16777216 | `list[2]` error, 6349 ms | 3 ms | 6 ms |
| `Buffer.concat(px, 4)` (explicit totalLength) | same hang | `list[2]` error | `list[2]` error |
| `Buffer.concat`, sparse `length = 4294967295` | `RangeError: Out of memory` | `list[2]` error, 3 ms | `list[2]` error, 3 ms |
| `Buffer.concat`, sparse `length = 100000000` | `list[2]` error, 2247 ms | 3 ms | 3 ms |
| `Bun.concatArrayBuffers`, sparse `length = 4294967295` | `RangeError: Out of memory` | n/a | `Expected TypedArray` |
| `fs.writevSync`, sparse `length = 4294967295` | `RangeError: Out of memory` | `ERR_INVALID_ARG_TYPE` | `ERR_INVALID_ARG_TYPE` |
| `fs.writevSync`, sparse `length = 100000000` | 333 s (debug build of main) | 0 ms | 0 ms |

Behavior checked against node for: an invalid element at index 0 followed by a getter (the getter does not run in either runtime, for `Buffer.concat` and for `fs.writevSync`), a primitive element (`Received type number (1)`), `Buffer.concat([], -1)` (returns an empty buffer), a hole in a contiguous array (`list[1]` error), a dense array of 100000 buffers with and without `totalLength`, and a `Uint8Array` subclass mixed with `Buffer`.

`Bun.concatArrayBuffers` and `fs.writev`/`fs.readv` require a real `JSArray`, so only the sparse array reaches them, not a Proxy. The error messages and the status codes that `Bun__JSArray__collectBufferSpans` returns to Rust are unchanged. The pin loop for async `fs.writev`/`fs.readv` is unchanged.

The pre-size gate uses `hasAnyArrayStorage`, the same predicate `JSArray.h` uses to pick its dense fast path. For `ArrayWithInt32`, `ArrayWithDouble`, `ArrayWithContiguous` and `ArrayWithUndecided` the public length equals the butterfly's slot count, so the pre-size is exact. Arrays with `ArrayStorage` grow the vector by doubling instead.

The new Proxy test runs in a child process with a 20 s kill timeout. Without the fix the child never exits, the runner's per-test timeout or the kill fires, and the stdout assertion fails.

Self-reviewed. The review raised the third site (`Bun__JSArray__collectBufferSpans`) and the shared helper, both addressed here. It also corrected the history: only the Proxy hang dates to #30061, the sparse-array out-of-memory error is older.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->