### PR TITLE
js_parser: keep the scan-only bodies out of the hot parse functions

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -804,24 +804,48 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // The import-record side-effect is order-independent of `Expr.init`'s
         // Store allocation.
         let expr = Expr::init(t, loc);
-        if self.scan_only {
-            if let js_ast::ExprData::ECall(call) = expr.data {
-                if let js_ast::ExprData::EIdentifier(ident) = call.target.data {
-                    // is this a require("something")
-                    if self.load_name_from_ref(ident.ref_) == b"require" && call.args.len_u32() == 1
-                    {
-                        if let js_ast::ExprData::EString(s) = call.args.at(0).data {
-                            let _ = self.add_import_record(
-                                ImportKind::Require,
-                                loc,
-                                s.string(self.arena).expect("unreachable"),
-                            );
-                        }
-                    }
-                }
+        if let js_ast::ExprData::ECall(call) = expr.data {
+            if self.scan_only {
+                self.scan_only_record_require_call(call, loc);
             }
         }
         expr
+    }
+
+    /// Scan-only pass: a name that is looked up by the parse pass marks the
+    /// matching `parse_pass_symbol_uses` entry as used. Kept out of line so
+    /// `store_name_in_ref` stays small.
+    #[cold]
+    #[inline(never)]
+    fn scan_only_mark_symbol_used(&mut self, name: &[u8]) {
+        if let Some(uses) = &mut self.parse_pass_symbol_uses {
+            if let Some(res) = uses.get_mut(name) {
+                res.used = true;
+            }
+        }
+    }
+
+    /// Scan-only pass: record `require("x")` as an import record. Kept out of
+    /// line so `new_expr::<E::Call>` stays small enough to inline.
+    #[cold]
+    #[inline(never)]
+    fn scan_only_record_require_call(
+        &mut self,
+        call: js_ast::StoreRef<E::Call>,
+        loc: bun_ast::Loc,
+    ) {
+        if let js_ast::ExprData::EIdentifier(ident) = call.target.data {
+            // is this a require("something")
+            if self.load_name_from_ref(ident.ref_) == b"require" && call.args.len_u32() == 1 {
+                if let js_ast::ExprData::EString(s) = call.args.at(0).data {
+                    let _ = self.add_import_record(
+                        ImportKind::Require,
+                        loc,
+                        s.string(self.arena).expect("unreachable"),
+                    );
+                }
+            }
+        }
     }
 
     #[inline]
@@ -4980,11 +5004,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
     pub(crate) fn store_name_in_ref(&mut self, name: &'a [u8]) -> Ref {
         if self.track_symbol_usage_during_parse_pass() {
-            if let Some(uses) = &mut self.parse_pass_symbol_uses {
-                if let Some(res) = uses.get_mut(name) {
-                    res.used = true;
-                }
-            }
+            self.scan_only_mark_symbol_used(name);
         }
 
         let contents_ptr = self.source.contents.as_ptr() as usize;


### PR DESCRIPTION
Stacked on #41081 (base branch is `ali/parser-scan-only-field`). Opened as a draft so CI builds the binary for an A/B measurement. The commit carries `[only builds]`.

### Problem
- In #41081, `new_expr::<E::Call>` carries the scan-only `require()` detection in its body. It grows from 156 to 409 bytes and LLVM stops inlining it into `parse_suffix` (base: 0 calls, PR: 2 calls per instantiation). Measured with exact instruction counts on the CI release builds: +0.13% to +0.16% instructions on a 13 MB parse and print workload, almost all from this one function.
- `store_name_in_ref` in the TypeScript instantiation carries the `parse_pass_symbol_uses` lookup the same way, behind a taken branch.

### Fix
- Both scan-only bodies move into `#[cold] #[inline(never)]` helpers. The hot path is one byte compare and a fall-through branch.
- Verified on the parser crate at -O3: `new_expr::<E::Call>` has no out-of-line symbol any more (inlined at every site), `P<true>::store_name_in_ref` shrinks from 803 to 280 bytes in that build, `parse_suffix` shrinks too.
- End-to-end numbers against the base and #41081 binaries follow once CI has built this.