### PR TITLE
[measurement] js_parser: make the TYPESCRIPT flag a runtime field

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -48,7 +48,7 @@ fn e_string_eql_bytes(s: &E::EString, other: &[u8]) -> bool {
 
 // File-split mixin pattern: a direct `impl P` block.
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     pub(crate) fn maybe_relocate_vars_to_top_level(
         &mut self,
         decls: &[G::Decl],

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -240,7 +240,7 @@ pub enum AlreadyBundled {
 }
 
 /// `impl EqlParser for P` — moved out of `bun_ast::expr` (next to `P`).
-impl<'a, const IS_TS: bool> bun_ast::expr::EqlParser for crate::p::P<'a, IS_TS> {
+impl<'a> bun_ast::expr::EqlParser for crate::p::P<'a> {
     #[inline]
     fn arena(&self) -> &bun_alloc::Arena {
         self.arena

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -141,7 +141,7 @@ fn can_be_class_binding_name(name: &[u8]) -> bool {
 
 // ── impl P ───────────────────────────────────────────────────────────────────
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     // ── Expression builder helpers ───────────────────────
 
     /// recordUsage + E.Identifier in one call.

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -35,13 +35,9 @@ struct DeduplicatedImportResult {
 }
 
 impl<'a> ConvertESMExportsForHmr<'a> {
-    // Note: takes the concrete `P<'p, TS>`; `AstBuilder` instead
+    // Note: takes the concrete `P<'p>`; `AstBuilder` instead
     // open-codes the equivalent transform (see bundler/AstBuilder.rs).
-    pub(crate) fn convert_stmt<'p, const TS: bool>(
-        &mut self,
-        p: &mut P<'p, TS>,
-        stmt: Stmt,
-    ) -> Result<(), AllocError> {
+    pub(crate) fn convert_stmt<'p>(&mut self, p: &mut P<'p>, stmt: Stmt) -> Result<(), AllocError> {
         let new_stmt: Stmt = match stmt.data {
             js_ast::StmtData::SLocal(mut st) => 'stmt: {
                 if !st.is_export {
@@ -393,9 +389,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
     /// Deduplicates imports, returning a previously used Ref and import record
     /// index if present.
-    fn deduplicated_import<'p, const TS: bool>(
+    fn deduplicated_import<'p>(
         &mut self,
-        p: &mut P<'p, TS>,
+        p: &mut P<'p>,
         import_record_index: u32,
         namespace_ref: Ref,
         items: js_ast::StoreSlice<js_ast::ClauseItem>,
@@ -512,9 +508,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         })
     }
 
-    fn visit_binding_to_export<'p, const TS: bool>(
+    fn visit_binding_to_export<'p>(
         &mut self,
-        p: &mut P<'p, TS>,
+        p: &mut P<'p>,
         binding: Binding,
     ) -> Result<(), AllocError> {
         match binding.data {
@@ -536,9 +532,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         Ok(())
     }
 
-    fn visit_ref_to_export<'p, const TS: bool>(
+    fn visit_ref_to_export<'p>(
         &mut self,
-        p: &mut P<'p, TS>,
+        p: &mut P<'p>,
         ref_: Ref,
         export_symbol_name: Option<js_ast::StoreStr>,
         loc: bun_ast::Loc,
@@ -633,9 +629,9 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         Ok(())
     }
 
-    pub(crate) fn finalize<'p, const TS: bool>(
+    pub(crate) fn finalize<'p>(
         &mut self,
-        p: &mut P<'p, TS>,
+        p: &mut P<'p>,
         // Note: `self.last_part` must not alias into this slice
         // (Stacked Borrows: `&mut [Part]` asserts
         // exclusive access to every element). Caller passes the `[0..len-1]`

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -42,7 +42,7 @@ type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
 type List<'a, T> = BumpVec<'a, T>;
 type ListManaged<'a, T> = BumpVec<'a, T>;
 
-/// Erases `P<'a, TS>`'s const-generic so helpers like `JSXTag::parse`
+/// Erases `P<'a>`'s const-generic so helpers like `JSXTag::parse`
 /// can take any instantiation. Only the surface those helpers actually
 /// touch is exposed.
 pub(crate) trait ParserLike<'a> {
@@ -55,7 +55,7 @@ pub(crate) trait ParserLike<'a> {
 }
 // Trait + impl defined so Expr methods can bound on it. Method bodies
 // forward to the inherent impls.
-impl<'a, const TS: bool> ParserLike<'a> for P<'a, TS> {
+impl<'a> ParserLike<'a> for P<'a> {
     #[inline]
     fn lexer(&mut self) -> &mut js_lexer::Lexer<'a> {
         &mut self.lexer
@@ -230,7 +230,7 @@ pub enum ReactRefreshExportKind {
 // P — the parser struct.
 // `'a` covers borrowed init() params (log/define/source) AND the arena (`bump`).
 // ─────────────────────────────────────────────────────────────────────────────
-pub struct P<'a, const TYPESCRIPT: bool> {
+pub struct P<'a> {
     /// Runtime JSX transform mode. Was the `<J: JsxT>` const-generic type
     /// parameter; demoted to a field because JSX only affects a handful of
     /// expression arms (see the `bun .` startup note in `parser.rs`) and the
@@ -239,6 +239,9 @@ pub struct P<'a, const TYPESCRIPT: bool> {
     pub(crate) jsx_transform: JSXTransformType,
     /// Runtime replacement for the former `SCAN_ONLY` const-generic parameter.
     pub(crate) scan_only: bool,
+    /// Runtime replacement for the former `TYPESCRIPT` const-generic parameter.
+    /// Set from `options.ts` in `init` and never changed after that.
+    pub(crate) ts: bool,
     pub(crate) macro_: MacroState<'a>,
     pub(crate) arena: &'a Bump,
     pub(crate) options: ParserOptions<'a>,
@@ -677,7 +680,7 @@ pub(crate) type Binding2ExprWrapperNamespace = bun_ast::binding::ToExprWrapper;
 pub(crate) type Binding2ExprWrapperHoisted = bun_ast::binding::ToExprWrapper;
 
 // ═══════════════════════════════════════════════════════════════════════════
-impl<'a, const TYPESCRIPT: bool> Drop for P<'a, TYPESCRIPT> {
+impl<'a> Drop for P<'a> {
     fn drop(&mut self) {
         // Arena-allocated structs never run Drop; free their global-heap maps here.
         for mut scope in self.ts_namespace_scopes.drain(..) {
@@ -689,12 +692,10 @@ impl<'a, const TYPESCRIPT: bool> Drop for P<'a, TYPESCRIPT> {
     }
 }
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
-    pub(crate) const IS_TYPESCRIPT_ENABLED: bool = TYPESCRIPT;
-
+impl<'a> P<'a> {
     #[inline]
     pub(crate) fn track_symbol_usage_during_parse_pass(&self) -> bool {
-        self.scan_only && TYPESCRIPT
+        self.scan_only && self.ts
     }
 
     /// Runtime replacement for the former `IS_JSX_ENABLED` associated const
@@ -875,7 +876,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     }
 }
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     pub(crate) const ALLOW_MACROS: bool = !cfg!(target_family = "wasm");
 
     /// use this instead of checking p.source.index
@@ -1866,7 +1867,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // The correctness of TypeScript-to-JavaScript conversion relies on accurate
         // symbol use counts for the whole file, including dead code regions. This is
         // tracked separately in a parser-only data structure.
-        if TYPESCRIPT {
+        if self.ts {
             self.ts_use_counts[ref_.inner_index() as usize] += 1;
         }
     }
@@ -2023,7 +2024,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             );
         }
 
-        if TYPESCRIPT {
+        if self.ts {
             if let Some(member_data) = self.ref_to_ts_namespace_member.get(&ref_) {
                 match member_data {
                     js_ast::ts::Data::EnumNumber(num) => {
@@ -3040,13 +3041,13 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     // SAFETY: `ctx` was derived from the caller's live `&mut P`
                     // immediately before `Binding::to_expr`; no other `&mut P`
                     // borrow is active for the duration of this call.
-                    let p = unsafe { &mut *ctx.cast::<P<'a, TYPESCRIPT>>() };
+                    let p = unsafe { &mut *ctx.cast::<P<'a>>() };
                     p.wrap_identifier_namespace(loc, ref_)
                 });
             self.to_expr_wrapper_hoisted =
                 bun_ast::binding::ToExprWrapper::new(self.arena, |ctx, loc, ref_| {
                     // SAFETY: same as above.
-                    let p = unsafe { &mut *ctx.cast::<P<'a, TYPESCRIPT>>() };
+                    let p = unsafe { &mut *ctx.cast::<P<'a>>() };
                     p.wrap_identifier_hoisting(loc, ref_)
                 });
         }
@@ -3878,7 +3879,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     pub(crate) fn mark_type_script_only(&self) {
         // Const-generic specialization can't express a compile error in stable
         // Rust, so this is a runtime assertion instead.
-        if !TYPESCRIPT {
+        if !self.ts {
             unreachable!();
         }
     }
@@ -4366,7 +4367,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             ..Default::default()
         });
 
-        if TYPESCRIPT {
+        if self.ts {
             self.ts_use_counts.push(0);
         }
 
@@ -4901,11 +4902,19 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             let symbol_idx = existing.ref_.inner_index() as usize;
 
             use js_ast::scope::SymbolMergeResult as MR;
-            let merge = js_ast::Scope::can_merge_symbol_kinds::<TYPESCRIPT>(
-                scope_kind,
-                self.symbols[symbol_idx].kind,
-                kind,
-            );
+            let merge = if self.ts {
+                js_ast::Scope::can_merge_symbol_kinds::<true>(
+                    scope_kind,
+                    self.symbols[symbol_idx].kind,
+                    kind,
+                )
+            } else {
+                js_ast::Scope::can_merge_symbol_kinds::<false>(
+                    scope_kind,
+                    self.symbols[symbol_idx].kind,
+                    kind,
+                )
+            };
             match merge {
                 MR::Forbidden => {
                     // Entry already holds `existing`; leave it untouched.
@@ -6813,7 +6822,7 @@ fn path_package_name<'a>(path: &fs::Path<'a>) -> Option<&'a [u8]> {
     Some(pkgname)
 }
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     pub(crate) fn lower_class(&mut self, stmtorexpr: js_ast::StmtOrExpr) -> &'a mut [Stmt] {
         use js_ast::g::PropertyKind;
         match stmtorexpr {
@@ -6833,7 +6842,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     return out.into_bump_slice_mut();
                 }
 
-                if !TYPESCRIPT {
+                if !self.ts {
                     if !s_class.class.has_decorators {
                         return self.arena.alloc_slice_copy(&[stmt]);
                     }
@@ -7857,7 +7866,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // that later reuses the index must not inherit their namespace data.
         if self.symbols.len() > snapshot.symbols_len {
             self.symbols.truncate(snapshot.symbols_len);
-            if TYPESCRIPT {
+            if self.ts {
                 self.ts_use_counts.truncate(snapshot.symbols_len);
             }
             let stale: Vec<Ref> = self
@@ -8356,7 +8365,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 // ═══════════════════════════════════════════════════════════════════════════
 // P::to_ast — final assembly P→Ast.
 // ═══════════════════════════════════════════════════════════════════════════
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     pub(crate) fn to_ast(
         &mut self,
         parts: &mut ListManaged<'a, js_ast::Part>,
@@ -8411,7 +8420,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
             for part in head_parts.iter() {
                 // Bake does not care about 'import =', as it handles it on it's own
-                let _ = ImportScanner::scan::<TYPESCRIPT, true>(
+                let _ = ImportScanner::scan::<true>(
                     self,
                     part.stmts.slice_mut(),
                     wrap_mode != WrapMode::None,
@@ -8421,7 +8430,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             // Re-run for the last part.
             {
                 let last_stmts = hmr_transform_ctx.last_part.stmts;
-                let _ = ImportScanner::scan::<TYPESCRIPT, true>(
+                let _ = ImportScanner::scan::<true>(
                     self,
                     last_stmts.slice_mut(),
                     wrap_mode != WrapMode::None,
@@ -8457,7 +8466,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     self.import_records_for_current_part.clear();
                     self.declared_symbols.clear_retaining_capacity();
 
-                    let result = match ImportScanner::scan::<TYPESCRIPT, false>(
+                    let result = match ImportScanner::scan::<false>(
                         self,
                         part.stmts.slice_mut(),
                         wrap_mode != WrapMode::None,
@@ -9072,7 +9081,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 // The Binding2ExprWrapper self-referential helpers are
 // seeded with arena-unit placeholders inside the struct literal; the real `*P`
 // back-pointer is wired lazily by the call sites.
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     /// Construct a `P` in place at `out`.
     ///
     /// PERF: an earlier shape returned `Result<Self, _>` by value. `P`
@@ -9138,7 +9147,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         lexer.track_comments = opts.features.minify_identifiers;
         lexer.track_react_suppressions = opts.features.react_compiler.is_enabled();
 
-        if !TYPESCRIPT {
+        if !opts.ts {
             // This is so it doesn't impact runtime transpiler caching when not in use
             opts.features.emit_decorator_metadata = false;
         }
@@ -9331,6 +9340,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
             jsx_transform,
             scan_only,
+            ts: opts.ts,
 
             // Moved-in last so the field expressions above can still read `opts.*`.
             options: opts,
@@ -9359,7 +9369,7 @@ pub(crate) struct LowerUsingDeclarationsContext {
 }
 
 impl LowerUsingDeclarationsContext {
-    pub(crate) fn init<'a, const T: bool>(p: &mut P<'a, T>) -> Result<Self, crate::Error> {
+    pub(crate) fn init<'a>(p: &mut P<'a>) -> Result<Self, crate::Error> {
         Ok(Self {
             first_using_loc: bun_ast::Loc::EMPTY,
             stack_ref: p.generate_temp_ref(Some(b"__stack")),
@@ -9367,7 +9377,7 @@ impl LowerUsingDeclarationsContext {
         })
     }
 
-    pub(crate) fn scan_stmts<'a, const T: bool>(&mut self, p: &mut P<'a, T>, stmts: &mut [Stmt]) {
+    pub(crate) fn scan_stmts<'a>(&mut self, p: &mut P<'a>, stmts: &mut [Stmt]) {
         for stmt in stmts.iter_mut() {
             // Match the `StoreRef` by value (Copy ptr)
             // so DerefMut writes through to the arena slot.
@@ -9428,9 +9438,9 @@ impl LowerUsingDeclarationsContext {
         }
     }
 
-    pub(crate) fn finalize<'a, const T: bool>(
+    pub(crate) fn finalize<'a>(
         &mut self,
-        p: &mut P<'a, T>,
+        p: &mut P<'a>,
         stmts: &'a mut [Stmt],
         should_hoist_fns: bool,
     ) -> ListManaged<'a, Stmt> {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -36,7 +36,7 @@ use bun_ast::{B, Binding, E, Expr, ExprNodeIndex, ExprNodeList, Flags, G, LocRef
 // File-split mixin: Round-C lowered `const JSX: JSXTransformType` → `J: JsxT`,
 // so this is a direct `impl P` block.
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     #[inline]
     pub(crate) fn parse_expr_or_bindings(
         &mut self,
@@ -154,12 +154,12 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             // This seems kind of wasteful to me but it's what the official compiler
             // does and it probably doesn't have that high of a performance overhead
             // because "extends" clauses aren't that frequent, so it should be ok.
-            if Self::IS_TYPESCRIPT_ENABLED {
+            if p.ts {
                 let _ = p.skip_type_script_type_arguments::<false, false>()?; // isInsideJSXElement
             }
         }
 
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             if p.lexer.is_contextual_keyword(b"implements") {
                 p.lexer.next()?;
 
@@ -456,14 +456,14 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             }
 
             // Skip over types
-            if Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TColon {
+            if p.ts && p.lexer.token == T::TColon {
                 type_colon_range = p.lexer.range();
                 p.lexer.next()?;
                 p.skip_type_script_type(Level::Lowest)?;
             }
 
             // There may be a "=" after the type (but not after an "as" cast)
-            if Self::IS_TYPESCRIPT_ENABLED
+            if p.ts
                 && p.lexer.token == T::TEquals
                 && !p.forbid_suffix_after_as_loc.eql(p.lexer.loc())
             {
@@ -499,10 +499,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
         // Are these arguments to an arrow function?
         let mut is_arrow_fn = p.lexer.token == T::TEqualsGreaterThan;
-        if is_arrow_fn
-            || opts.force_arrow_fn
-            || (Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TColon)
-        {
+        if is_arrow_fn || opts.force_arrow_fn || (p.ts && p.lexer.token == T::TColon) {
             // Arrow functions are not allowed inside certain expressions
             if level.gt(Level::Assign) {
                 p.lexer.unexpected()?;
@@ -556,7 +553,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             // attempt to convert the expressions to bindings first before deciding
             // whether this is an arrow function, and only pick an arrow function if
             // there were no conversion errors.
-            if Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TColon && invalid_log.is_empty() {
+            if p.ts && p.lexer.token == T::TColon && invalid_log.is_empty() {
                 if opts.is_after_question_and_before_colon {
                     // Only do this very expensive check if we must
                     is_arrow_fn = p
@@ -678,8 +675,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         let is_identifier = p.lexer.token == T::TIdentifier;
 
         if !opts.is_name_optional
-            || (is_identifier
-                && (!Self::IS_TYPESCRIPT_ENABLED || p.lexer.identifier != b"implements"))
+            || (is_identifier && (!p.ts || p.lexer.identifier != b"implements"))
         {
             let name_loc = p.lexer.loc();
             let name_text = p.lexer.identifier;
@@ -715,7 +711,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         }
 
         // Even anonymous classes can have TypeScript type parameters
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             let _ = p.skip_type_script_type_parameters(
                 TypeParameterFlag::ALLOW_IN_OUT_VARIANCE_ANNOTATIONS
                     | TypeParameterFlag::ALLOW_CONST_MODIFIER,
@@ -735,7 +731,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             .expect("unreachable");
         let class = p.parse_class(class_keyword, name, &class_opts)?;
 
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             if opts.is_typescript_declare {
                 p.pop_and_discard_scope(scope_index);
                 if opts.scope.is_namespace() && opts.is_export {
@@ -1290,7 +1286,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 .expect("unreachable");
 
             // Skip over types
-            if Self::IS_TYPESCRIPT_ENABLED {
+            if p.ts {
                 // "let foo!"
                 let is_definite_assignment_assertion =
                     p.lexer.token == T::TExclamation && !p.lexer.has_newline_before;
@@ -1480,7 +1476,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             let mut stmt = p.parse_stmt(&mut current_opts)?;
 
             // Skip TypeScript types entirely
-            if Self::IS_TYPESCRIPT_ENABLED {
+            if p.ts {
                 if let js_ast::stmt::Data::STypeScript(_) = stmt.data {
                     continue;
                 }
@@ -1622,8 +1618,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                         // In TypeScript, "async <ident>" not followed by "=>" treats "async" as
                         // a plain identifier (e.g. "async as T"), matching tsc's two-token
                         // lookahead in isUnParenthesizedAsyncArrowFunctionWorker (TypeScript#8444).
-                        let is_arrow_fn = !Self::IS_TYPESCRIPT_ENABLED
-                            || p.check_for_arrow_after_the_current_token();
+                        let is_arrow_fn = !p.ts || p.check_for_arrow_after_the_current_token();
 
                         if is_arrow_fn {
                             let ref_ = p.store_name_in_ref(p.lexer.identifier);
@@ -1680,9 +1675,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 // "async<T>()"
                 // "async <T>() => {}"
                 T::TLessThan => {
-                    if Self::IS_TYPESCRIPT_ENABLED
-                        && (!p.is_jsx_enabled() || p.is_ts_arrow_fn_jsx()?)
-                    {
+                    if p.ts && (!p.is_jsx_enabled() || p.is_ts_arrow_fn_jsx()?) {
                         match p
                             .try_skip_type_script_type_parameters_then_open_paren_with_backtracking(
                             ) {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -22,9 +22,9 @@ use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
 use bun_ast::{B, E, Expr, G, S, Stmt};
 
-// Named instantiations of `P<'_, TS>`.
-pub type JavaScriptParser<'a> = P<'a, false>;
-pub type TSXParser<'a> = P<'a, true>;
+// Named instantiations of `P<'_>`.
+pub type JavaScriptParser<'a> = P<'a>;
+pub type TSXParser<'a> = P<'a>;
 
 // In AST crates, ListManaged(T) backed by the arena → bumpalo Vec.
 type BumpVec<'bump, T> = bun_alloc::ArenaVec<'bump, T>;
@@ -359,7 +359,7 @@ impl<'a> Parser<'a> {
         {
             self.options.ts = true;
             self.options.jsx.parse = true;
-            return self._parse::<true>();
+            return self._parse();
         }
 
         // JSX is no longer part of the parser's monomorphization (it only
@@ -369,9 +369,9 @@ impl<'a> Parser<'a> {
         #[cfg(not(target_arch = "wasm32"))]
         {
             if self.options.ts {
-                self._parse::<true>()
+                self._parse()
             } else {
-                self._parse::<false>()
+                self._parse()
             }
         }
     }
@@ -382,18 +382,15 @@ impl<'a> Parser<'a> {
     #[cold]
     pub fn scan_imports(&mut self, scan_pass: &'a mut ScanPassResult) -> Result<(), Error> {
         if self.options.ts {
-            self._scan_imports::<true>(scan_pass)
+            self._scan_imports(scan_pass)
         } else {
-            self._scan_imports::<false>(scan_pass)
+            self._scan_imports(scan_pass)
         }
     }
 
     #[cold]
-    fn _scan_imports<const TS: bool>(
-        &mut self,
-        scan_pass: &'a mut ScanPassResult,
-    ) -> Result<(), Error> {
-        type Pi<'a, const TS: bool> = P<'a, TS>;
+    fn _scan_imports(&mut self, scan_pass: &'a mut ScanPassResult) -> Result<(), Error> {
+        type Pi<'a> = P<'a>;
         // `Lexer` owns `Vec`s and `Options` owns
         // `jsx: Pragma` boxes, so a bitwise `ptr::read` would double-free
         // when `self` later drops. Move them out, leaving inert placeholders.
@@ -415,17 +412,17 @@ impl<'a> Parser<'a> {
         // `P.log` and `Lexer.log` are both `NonNull<Log>` (see P.rs / lexer.rs
         // field docs), so handing the same raw pointer to both is defined —
         // no `&mut` is materialized.
-        let mut __p = init_p!(Pi<'_, TS>;
+        let mut __p = init_p!(Pi<'_>;
             self.bump, self.log, self.source, self.define, lexer, options, true);
         // SAFETY: `init_p!` only yields after `init` succeeded.
-        let p: &mut Pi<'_, TS> = unsafe { __p.assume_init_mut() };
+        let p: &mut Pi<'_> = unsafe { __p.assume_init_mut() };
         p.import_records = crate::p::ImportRecordList::Borrowed(&mut scan_pass.import_records);
         p.named_imports = crate::p::NamedImportsType::Borrowed(&mut scan_pass.named_imports);
 
         // The problem with our scan pass approach is type-only imports.
         // We don't have accurate symbol counts.
         // So we don't have a good way to distinguish between a type-only import and not.
-        if TS {
+        if p.ts {
             // Pre-size the name-keyed usage map so the scan pass doesn't
             // re-hash it one identifier reference at a time (≈ one tracked
             // symbol per 16 source bytes). `ensure_total_capacity` is a no-op
@@ -463,7 +460,7 @@ impl<'a> Parser<'a> {
         }
 
         //
-        if TS {
+        if p.ts {
             for import_record in p.import_records.items_mut() {
                 // Mark everything as unused
                 // Except:
@@ -735,7 +732,7 @@ fn lower_one_date_time_literal<'a>(
 }
 
 impl<'a> Parser<'a> {
-    fn _parse<const TS: bool>(self) -> Result<crate::Result<'a>, Error> {
+    fn _parse(self) -> Result<crate::Result<'a>, Error> {
         // `Source.path` is `Path<'static>`, so
         // `path.text` satisfies `Action::Parse(&'static [u8])` directly.
         let _action_guard = bun_crash_handler::scoped_action(bun_crash_handler::Action::Parse(
@@ -759,10 +756,10 @@ impl<'a> Parser<'a> {
         // `P.log` and `Lexer.log` are both `NonNull<Log>` (see P.rs / lexer.rs
         // field docs), so handing the same raw pointer to both is defined —
         // no `&mut` is materialized.
-        let mut __p = init_p!(P<'_, TS>;
+        let mut __p = init_p!(P<'_>;
             bump, log, source, define, lexer, options, false);
         // SAFETY: `init_p!` only yields after `init` succeeded.
-        let p: &mut P<'_, TS> = unsafe { __p.assume_init_mut() };
+        let p: &mut P<'_> = unsafe { __p.assume_init_mut() };
 
         if p.options.features.hot_module_reloading {
             debug_assert!(!p.options.tree_shaking);

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -14,7 +14,7 @@ use bun_ast::{E, Expr, Flags, G, S, Stmt};
 
 type Error = crate::Error;
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     /// This assumes the "function" token has already been parsed
     pub(crate) fn parse_fn_stmt(
         &mut self,
@@ -64,7 +64,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         }
 
         // Even anonymous functions can have TypeScript type parameters
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             let _ = p.skip_type_script_type_parameters(TypeParameterFlag::ALLOW_CONST_MODIFIER)?;
         }
 
@@ -95,13 +95,13 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 is_typescript_declare: opts.is_typescript_declare,
 
                 // Only allow omitting the body if we're parsing TypeScript
-                allow_missing_body_for_type_script: Self::IS_TYPESCRIPT_ENABLED,
+                allow_missing_body_for_type_script: p.ts,
                 ..Default::default()
             },
         )?;
         p.fn_or_arrow_data_parse.has_argument_decorators = false;
 
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             // Don't output anything if it's just a forward declaration of a function
             if opts.is_typescript_declare
                 || func.flags.contains(Flags::Function::IsForwardDeclaration)
@@ -212,7 +212,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         let mut args = bun_alloc::ArenaVec::<G::Arg>::new_in(p.arena);
         while p.lexer.token != T::TCloseParen {
             // Skip over "this" type annotations
-            if Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TThis {
+            if p.ts && p.lexer.token == T::TThis {
                 p.lexer.next()?;
                 if p.lexer.token == T::TColon {
                     p.lexer.next()?;
@@ -247,7 +247,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             let mut arg = p.parse_binding(Default::default())?;
             let mut ts_metadata = bun_ast::ts::Metadata::default();
 
-            if Self::IS_TYPESCRIPT_ENABLED {
+            if p.ts {
                 if is_identifier && opts.is_constructor {
                     // Skip over TypeScript accessibility modifiers, which turn this argument
                     // into a class field when used inside a class constructor. This is known
@@ -368,7 +368,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         p.fn_or_arrow_data_parse.has_argument_decorators = arg_has_decorators;
 
         // "function foo(): any {}"
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             if p.lexer.token == T::TColon {
                 p.lexer.next()?;
 
@@ -453,7 +453,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         }
 
         // Even anonymous functions can have TypeScript type parameters
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             let _ = p.skip_type_script_type_parameters(TypeParameterFlag::ALLOW_CONST_MODIFIER)?;
         }
 

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -8,7 +8,7 @@ use bun_ast::expr::Data as ExprData;
 use bun_ast::op::Level;
 use bun_ast::{ClauseItem, E, Expr, LocRef, Ref};
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     /// Note: The caller has already parsed the "import" keyword
     pub(crate) fn parse_import_expr(
         &mut self,
@@ -134,7 +134,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             let mut original_name = alias;
             p.lexer.next()?;
 
-            let probably_type_only_import = if TYPESCRIPT {
+            let probably_type_only_import = if p.ts {
                 alias == b"type" && p.lexer.token != T::TComma && p.lexer.token != T::TCloseBrace
             } else {
                 false
@@ -280,11 +280,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         Ok(ImportClause {
             items: items.into_bump_slice_mut(),
             is_single_line,
-            had_type_only_imports: if TYPESCRIPT {
-                had_type_only_imports
-            } else {
-                false
-            },
+            had_type_only_imports: if p.ts { had_type_only_imports } else { false },
         })
     }
 
@@ -321,7 +317,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             }
             p.lexer.next()?;
 
-            if TYPESCRIPT {
+            if p.ts {
                 if alias == b"type" && p.lexer.token != T::TComma && p.lexer.token != T::TCloseBrace
                 {
                     if p.lexer.is_contextual_keyword(b"as") {

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -8,7 +8,7 @@ use bun_ast::op::Level;
 use bun_ast::{E, Expr, ExprNodeIndex, ExprNodeList, G};
 use bun_collections::VecExt;
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     pub(crate) fn parse_jsx_element(&mut self, loc: bun_ast::Loc) -> crate::CrateResult<Expr> {
         let p = self;
         // Nested child elements (`<a><b><c>...`) recurse back into this function,
@@ -23,7 +23,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         let tag = JSXTag::parse(p)?;
 
         // The tag may have TypeScript type arguments: "<Foo<T>/>"
-        if TYPESCRIPT {
+        if p.ts {
             // Pass a flag to the type argument skipper because we need to call
             let _ = p.skip_type_script_type_arguments::<true, false>()?;
         }

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -19,7 +19,7 @@ type PResult<T> = crate::CrateResult<T>;
 // The 30+ per-token `t_*` helpers are private; only `parse_prefix` is surfaced. Helper
 // names pfx_-prefixed to avoid colliding with parseStmt.rs / parseSuffix.rs mixins on the same `P`.
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     fn pfx_t_super(p: &mut Self, level: Level) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let super_range = p.lexer.range();
@@ -553,7 +553,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // Parse an optional class name
         if p.lexer.token == T::TIdentifier {
             let name_text = p.lexer.identifier;
-            if !Self::IS_TYPESCRIPT_ENABLED || name_text != b"implements" {
+            if !p.ts || name_text != b"implements" {
                 if p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
                     && name_text == b"await"
                 {
@@ -573,7 +573,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         }
 
         // Even anonymous classes can have TypeScript type parameters
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             let _ = p.skip_type_script_type_parameters(
                 TypeParameterFlag::ALLOW_IN_OUT_VARIANCE_ANNOTATIONS
                     | TypeParameterFlag::ALLOW_CONST_MODIFIER,
@@ -584,8 +584,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             class_keyword,
             name,
             &ParseClassOptions {
-                allow_ts_decorators: Self::IS_TYPESCRIPT_ENABLED
-                    || p.options.features.standard_decorators,
+                allow_ts_decorators: p.ts || p.options.features.standard_decorators,
                 ..Default::default()
             },
         )?;
@@ -616,7 +615,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // Parse an optional class name
         if p.lexer.token == T::TIdentifier {
             let name_text = p.lexer.identifier;
-            if !Self::IS_TYPESCRIPT_ENABLED || name_text != b"implements" {
+            if !p.ts || name_text != b"implements" {
                 if p.fn_or_arrow_data_parse.allow_await != AwaitOrYield::AllowIdent
                     && name_text == b"await"
                 {
@@ -636,7 +635,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         }
 
         // Even anonymous classes can have TypeScript type parameters
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             let _ = p.skip_type_script_type_parameters(
                 TypeParameterFlag::ALLOW_IN_OUT_VARIANCE_ANNOTATIONS
                     | TypeParameterFlag::ALLOW_CONST_MODIFIER,
@@ -691,7 +690,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         let mut target = Expr::EMPTY;
         p.parse_expr_with_flags(Level::Member, flags, &mut target)?;
 
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             // Skip over TypeScript type arguments here if there are any
             if p.lexer.token == T::TLessThan {
                 let _ = p.try_skip_type_script_type_arguments_with_backtracking();
@@ -929,7 +928,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         //     <A[]>(x)
         //     <A>(x) => {}
         //     <A = B>(x) => {}
-        if Self::IS_TYPESCRIPT_ENABLED && p.is_jsx_enabled() {
+        if p.ts && p.is_jsx_enabled() {
             if p.is_ts_arrow_fn_jsx()? {
                 let _ =
                     p.skip_type_script_type_parameters(TypeParameterFlag::ALLOW_CONST_MODIFIER)?;
@@ -958,7 +957,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             return Ok(element);
         }
 
-        if Self::IS_TYPESCRIPT_ENABLED {
+        if p.ts {
             // This is either an old-style type cast or a generic lambda function
 
             // "<T>(x)"

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -22,7 +22,7 @@ use js_ast::{
 };
 use js_lexer::T;
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     fn parse_method_expression(
         &mut self,
         kind: PropertyKind,
@@ -109,7 +109,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     || (opts.has_class_decorators && is_constructor),
 
                 // Only allow omitting the body if we're parsing TypeScript class
-                allow_missing_body_for_type_script: Self::IS_TYPESCRIPT_ENABLED && opts.is_class,
+                allow_missing_body_for_type_script: p.ts && opts.is_class,
                 ..Default::default()
             },
         )?;
@@ -296,7 +296,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     let was_identifier = p.lexer.token == T::TIdentifier;
                     let expr = p.parse_expr(Level::Comma)?;
 
-                    if Self::IS_TYPESCRIPT_ENABLED {
+                    if p.ts {
                         // Handle index signatures
                         if p.lexer.token == T::TColon && was_identifier && opts.is_class {
                             match expr.data {
@@ -415,7 +415,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                                         // skip declare keyword entirely
                                         // https://github.com/oven-sh/bun/issues/1907
                                         if opts.is_class
-                                            && Self::IS_TYPESCRIPT_ENABLED
+                                            && p.ts
                                             && !p.lexer.has_newline_before
                                             && raw == b"declare"
                                         {
@@ -439,7 +439,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                                     }
                                     PropertyModifierKeyword::PAbstract => {
                                         if opts.is_class
-                                            && Self::IS_TYPESCRIPT_ENABLED
+                                            && p.ts
                                             && !p.lexer.has_newline_before
                                             && !opts.is_ts_abstract
                                             && raw == b"abstract"
@@ -482,7 +482,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                                     | PropertyModifierKeyword::POverride => {
                                         // Skip over TypeScript keywords
                                         if opts.is_class
-                                            && Self::IS_TYPESCRIPT_ENABLED
+                                            && p.ts
                                             && PropertyModifierKeyword::find(raw) == Some(keyword)
                                         {
                                             errors = None;
@@ -603,7 +603,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             let mut has_type_parameters = false;
             let mut has_definite_assignment_assertion_operator = false;
 
-            if Self::IS_TYPESCRIPT_ENABLED {
+            if p.ts {
                 if opts.is_class {
                     if p.lexer.token == T::TQuestion {
                         // "class X { foo?: number }"
@@ -661,7 +661,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     }
                 }
 
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     // Skip over types
                     if p.lexer.token == T::TColon {
                         p.lexer.next()?;
@@ -677,7 +677,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 }
 
                 if p.lexer.token == T::TEquals {
-                    if Self::IS_TYPESCRIPT_ENABLED {
+                    if p.ts {
                         if !opts.declare_range.is_empty() {
                             p.log().add_range_error(
                                 Some(p.source),

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -15,7 +15,7 @@ use bun_ast::ts::Metadata;
 // canonical definition in `TypeScript.rs`.
 pub(crate) type SkipTypeOptionsBitset = typescript::SkipTypeOptionsBitset;
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     #[inline]
     pub(crate) fn skip_typescript_return_type(&mut self) -> Result<(), Error> {
         self.skip_type_script_type_with_opts::<false>(

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -24,7 +24,7 @@ type Result<T> = crate::CrateResult<T>;
 
 // The 25+ per-token `t_*` helpers are private; only `parse_stmt` is surfaced.
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     // Note on `#[inline]` / `#[inline(never)]` / `#[cold]` annotations across the `t_*` arms:
     // `parse_stmt` is invoked once per leading statement token; profiling showed its
     // stack-adjust prologue/epilogue dominating because LLVM was hoisting the larger
@@ -66,7 +66,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
     ) -> Result<Stmt> {
-        if !Self::IS_TYPESCRIPT_ENABLED {
+        if !p.ts {
             p.lexer.unexpected()?;
             return Err(crate::Error::SyntaxError);
         }
@@ -77,7 +77,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
     #[inline(never)]
     fn t_at(p: &mut Self, opts: &mut ParseStatementOptions<'a>) -> Result<Stmt> {
         // Parse decorators before class statements, which are potentially exported
-        if Self::IS_TYPESCRIPT_ENABLED || p.options.features.standard_decorators {
+        if p.ts || p.options.features.standard_decorators {
             let scope_index = p.scopes_in_order.len();
             let ts_decorators = p.parse_type_script_decorators()?;
 
@@ -114,8 +114,8 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             // (but reject "export @decorator export class Foo {}")
             if p.lexer.token != T::TClass
                 && !(p.lexer.token == T::TExport && !opts.is_export)
-                && !(Self::IS_TYPESCRIPT_ENABLED && p.lexer.is_contextual_keyword(b"abstract"))
-                && !(Self::IS_TYPESCRIPT_ENABLED && p.lexer.is_contextual_keyword(b"declare"))
+                && !(p.ts && p.lexer.is_contextual_keyword(b"abstract"))
+                && !(p.ts && p.lexer.is_contextual_keyword(b"declare"))
             {
                 p.lexer.expected(T::TClass)?;
             }
@@ -174,7 +174,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
         p.lexer.next()?;
 
-        if Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TEnum {
+        if p.ts && p.lexer.token == T::TEnum {
             return p.parse_typescript_enum_stmt(loc, opts);
         }
 
@@ -429,7 +429,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 let mut value = p.parse_binding(Default::default())?;
 
                 // Skip over types
-                if Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TColon {
+                if p.ts && p.lexer.token == T::TColon {
                     p.lexer.expect(T::TColon)?;
                     p.skip_type_script_type(Level::Lowest)?;
                 }
@@ -862,7 +862,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
             T::TImport => {
                 // "export import foo = bar"
-                if Self::IS_TYPESCRIPT_ENABLED && opts.scope != StatementScope::Nested {
+                if p.ts && opts.scope != StatementScope::Nested {
                     opts.is_export = true;
                     return p.parse_stmt(opts);
                 }
@@ -872,7 +872,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             }
 
             T::TEnum => {
-                if !Self::IS_TYPESCRIPT_ENABLED {
+                if !p.ts {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -887,7 +887,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     return p.parse_stmt(opts);
                 }
 
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     if p.lexer.is_contextual_keyword(b"as") {
                         // "export as namespace ns;"
                         p.lexer.next()?;
@@ -915,7 +915,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     return p.parse_fn_stmt(loc, opts, Some(async_range));
                 }
 
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     use typescript::identifier::StmtIdentifier;
                     if let Some(ident) = typescript::identifier::for_str(p.lexer.identifier) {
                         match ident {
@@ -1116,7 +1116,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 let expr = p.parse_expr(Level::Comma)?;
 
                 // Handle the default export of an abstract class in TypeScript
-                if Self::IS_TYPESCRIPT_ENABLED
+                if p.ts
                     && is_identifier
                     && (p.lexer.token == T::TClass || opts.ts_decorators.is_some())
                     && name == b"abstract"
@@ -1289,7 +1289,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
                     p.lexer.expect_or_insert_semicolon()?;
 
-                    if Self::IS_TYPESCRIPT_ENABLED {
+                    if p.ts {
                         // export {type Foo} from 'bar';
                         // ->
                         // nothing
@@ -1350,7 +1350,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 }
                 p.lexer.expect_or_insert_semicolon()?;
 
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     // export {type Foo};
                     // ->
                     // nothing
@@ -1374,7 +1374,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 // "export = value;"
 
                 p.esm_export_keyword = previous_export_keyword; // This wasn't an ESM export statement after all
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     p.lexer.next()?;
                     let value = p.parse_expr(Level::Lowest)?;
                     p.lexer.expect_or_insert_semicolon()?;
@@ -1462,7 +1462,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     return Err(crate::Error::SyntaxError);
                 }
                 let import_clause = p.parse_import_clause()?;
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     if import_clause.had_type_only_imports && import_clause.items.is_empty() {
                         p.lexer.expect_contextual_keyword(b"from")?;
                         let _ = p.parse_path()?;
@@ -1543,7 +1543,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     return p.process_import_statement(stmt, path, loc, false);
                 }
 
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     // Skip over type-only imports
                     if default_name == b"type" {
                         match p.lexer.token {
@@ -1742,7 +1742,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     return Self::parse_labeled_stmt(p, opts, loc, expr.loc, ident.ref_);
                 }
 
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if p.ts {
                     if let Some(ts_stmt) = js_lexer::TypescriptStmtKeyword::from_bytes(name) {
                         // Hand the cold TS-keyword statement forms (`type`/`interface`/`namespace`/
                         // `module`/`abstract`/`global`/`declare`) to an out-of-line helper so the

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -20,9 +20,9 @@ enum Continuation {
 
 type CResult = core::result::Result<Continuation, Error>;
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     fn sfx_handle_typescript_as(p: &mut Self, level: Level) -> CResult {
-        if Self::IS_TYPESCRIPT_ENABLED
+        if p.ts
             && level.lt(Level::Compare)
             && !p.lexer.has_newline_before
             && (p.lexer.is_contextual_keyword(b"as") || p.lexer.is_contextual_keyword(b"satisfies"))
@@ -187,7 +187,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             }
             T::TLessThan | T::TLessThanLessThan => {
                 // "a?.<T>()"
-                if !Self::IS_TYPESCRIPT_ENABLED {
+                if !p.ts {
                     p.lexer.expected(T::TIdentifier)?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -418,7 +418,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // "(a?) => {}"
         // "(a?: b) => {}"
         // "(a?, b?) => {}"
-        if Self::IS_TYPESCRIPT_ENABLED
+        if p.ts
             && left.loc.start == p.latest_arrow_arg_loc.start
             && (p.lexer.token == T::TColon
                 || p.lexer.token == T::TCloseParen
@@ -493,7 +493,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
             return Ok(Continuation::Done);
         }
 
-        if !Self::IS_TYPESCRIPT_ENABLED {
+        if !p.ts {
             p.lexer.unexpected()?;
             return Err(crate::Error::SyntaxError);
         }
@@ -879,8 +879,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // TypeScript allows type arguments to be specified with angle brackets
         // inside an expression. Unlike in other languages, this unfortunately
         // appears to require backtracking to parse.
-        if Self::IS_TYPESCRIPT_ENABLED && p.try_skip_type_script_type_arguments_with_backtracking()
-        {
+        if p.ts && p.try_skip_type_script_type_arguments_with_backtracking() {
             *optional_chain = old_optional_chain;
             return Ok(Continuation::Next);
         }
@@ -970,8 +969,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
         // TypeScript allows type arguments to be specified with angle brackets
         // inside an expression. Unlike in other languages, this unfortunately
         // appears to require backtracking to parse.
-        if Self::IS_TYPESCRIPT_ENABLED && p.try_skip_type_script_type_arguments_with_backtracking()
-        {
+        if p.ts && p.try_skip_type_script_type_arguments_with_backtracking() {
             *optional_chain = old_optional_chain;
             return Ok(Continuation::Next);
         }
@@ -1486,7 +1484,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 }
             }
 
-            if Self::IS_TYPESCRIPT_ENABLED {
+            if p.ts {
                 // Stop now if this token is forbidden to follow a TypeScript "as" cast
                 if p.forbid_suffix_after_as_loc.start > -1
                     && p.lexer.loc().start == p.forbid_suffix_after_as_loc.start

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -31,10 +31,10 @@ fn clone_ts_member_data(d: &TSNamespaceMemberData) -> TSNamespaceMemberData {
     }
 }
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     pub(crate) fn parse_type_script_decorators(&mut self) -> Result<ExprNodeList, Error> {
         let p = self;
-        if !Self::IS_TYPESCRIPT_ENABLED && !p.options.features.standard_decorators {
+        if !p.ts && !p.options.features.standard_decorators {
             return Ok(bun_alloc::AstAlloc::vec());
         }
 
@@ -110,7 +110,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     if p.lexer.has_newline_before {
                         break;
                     }
-                    if !Self::IS_TYPESCRIPT_ENABLED {
+                    if !p.ts {
                         p.lexer.unexpected()?;
                         return Err(crate::Error::SyntaxError);
                     }
@@ -189,9 +189,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
 
                 _ => {
                     // "@x<y>" / "@x.y<z>"
-                    if Self::IS_TYPESCRIPT_ENABLED
-                        && p.skip_type_script_type_arguments::<false, false>()?
-                    {
+                    if p.ts && p.skip_type_script_type_arguments::<false, false>()? {
                         continue;
                     }
                     break;

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -10,18 +10,18 @@ use bun_collections::VecExt;
 use crate::JSXImport;
 use crate::p::P;
 
-pub struct ReactCompilerHost<'p, 'a, const TS: bool> {
-    p: &'p mut P<'a, TS>,
+pub struct ReactCompilerHost<'p, 'a> {
+    p: &'p mut P<'a>,
 }
 
-impl<'p, 'a, const TS: bool> ReactCompilerHost<'p, 'a, TS> {
+impl<'p, 'a> ReactCompilerHost<'p, 'a> {
     #[inline]
-    pub(crate) fn new(p: &'p mut P<'a, TS>) -> Self {
+    pub(crate) fn new(p: &'p mut P<'a>) -> Self {
         Self { p }
     }
 }
 
-impl<'a, const TS: bool> bun_react_compiler::Host for ReactCompilerHost<'_, 'a, TS> {
+impl<'a> bun_react_compiler::Host for ReactCompilerHost<'_, 'a> {
     fn symbols(&self) -> &[js_ast::Symbol] {
         self.p.symbols.as_slice()
     }
@@ -127,7 +127,7 @@ impl<'a, const TS: bool> bun_react_compiler::Host for ReactCompilerHost<'_, 'a, 
     }
 }
 
-impl<'a, const TS: bool> P<'a, TS> {
+impl<'a> P<'a> {
     /// Port of upstream `findFunctionDeclarationOrExpression` for the
     /// expression positions (decl init / `export default` / expression
     /// statement). Returns `Some(in_react_hoc)` only for the shapes the

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -16,7 +16,7 @@ use bun_ast::{B, Binding, E, Expr, ExprNodeList, G, S, Stmt};
 
 use crate::p::P;
 
-impl<'a, const TS: bool> P<'a, TS> {
+impl<'a> P<'a> {
     /// Apply REPL-mode transforms to the AST.
     /// This transforms code for interactive evaluation:
     /// - Wraps the last expression in { value: expr } for result capture

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -28,12 +28,8 @@ fn raw_str(s: &'static [u8]) -> js_ast::StoreStr {
 impl<'a> ImportScanner<'a> {
     // Only the parser P is handled here — the bundler scans imports via its own
     // path and does not go through this function.
-    pub(crate) fn scan<
-        'p,
-        const TYPESCRIPT: bool,
-        const HOT_MODULE_RELOADING_TRANSFORMATIONS: bool,
-    >(
-        p: &mut P<'p, TYPESCRIPT>,
+    pub(crate) fn scan<'p, const HOT_MODULE_RELOADING_TRANSFORMATIONS: bool>(
+        p: &mut P<'p>,
         stmts: &'a mut [Stmt],
         will_transform_to_common_js: bool,
         // Const generics can't gate a param type on a const, so use Option and
@@ -49,7 +45,7 @@ impl<'a> ImportScanner<'a> {
         let mut stmts_end: usize = 0;
         // `arena` (p.arena) dropped — see §Allocators (AST crate).
         // Arena allocs below go through `p.arena` (a &Bump) where they persist.
-        let is_typescript_enabled: bool = TYPESCRIPT;
+        let is_typescript_enabled: bool = p.ts;
 
         for i in 0..stmts.len() {
             // Index directly to allow in-place mutation + reassignment.

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -35,7 +35,7 @@ impl SideEffects {
             && left != bun_ast::expr::PrimitiveType::Mixed
     }
 
-    pub(crate) fn simplify_boolean<'a, const TS: bool>(p: &P<'a, TS>, expr: Expr) -> Expr {
+    pub(crate) fn simplify_boolean<'a>(p: &P<'a>, expr: Expr) -> Expr {
         if !p.options.features.dead_code_elimination {
             return expr;
         }
@@ -44,7 +44,7 @@ impl SideEffects {
         result
     }
 
-    fn _simplify_boolean<'a, const TS: bool>(p: &P<'a, TS>, expr: &mut Expr) {
+    fn _simplify_boolean<'a>(p: &P<'a>, expr: &mut Expr) {
         loop {
             match &mut expr.data {
                 ExprData::EUnary(e) => {
@@ -112,10 +112,7 @@ impl SideEffects {
         )
     }
 
-    pub(crate) fn simplify_unused_expr<'a, const TS: bool>(
-        p: &mut P<'a, TS>,
-        expr: Expr,
-    ) -> Option<Expr> {
+    pub(crate) fn simplify_unused_expr<'a>(p: &mut P<'a>, expr: Expr) -> Option<Expr> {
         if !p.options.features.dead_code_elimination {
             return Some(expr);
         }
@@ -459,7 +456,7 @@ impl SideEffects {
     /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.
     /// Hand-rolled because that helper takes `fn(&C, _)` and we need `&mut P` for the
     /// recursive `simplify_unused_expr` call.
-    fn join_all_simplified<'a, const TS: bool>(p: &mut P<'a, TS>, items: &[Expr]) -> Option<Expr> {
+    fn join_all_simplified<'a>(p: &mut P<'a>, items: &[Expr]) -> Option<Expr> {
         let len = items.len();
         if len == 0 {
             return None;
@@ -486,10 +483,7 @@ impl SideEffects {
     }
 
     ///
-    fn simplify_unused_binary_comma_expr<'a, const TS: bool>(
-        p: &mut P<'a, TS>,
-        expr: Expr,
-    ) -> Option<Expr> {
+    fn simplify_unused_binary_comma_expr<'a>(p: &mut P<'a>, expr: Expr) -> Option<Expr> {
         let ExprData::EBinary(root_bin) = expr.data else {
             if cfg!(debug_assertions) {
                 unreachable!("simplify_unused_binary_comma_expr: not e_binary");
@@ -701,8 +695,8 @@ impl SideEffects {
         }
     }
 
-    pub(crate) fn is_primitive_with_side_effects<'a, const TS: bool>(
-        p: &P<'a, TS>,
+    pub(crate) fn is_primitive_with_side_effects<'a>(
+        p: &P<'a>,
         loc: bun_ast::Loc,
         data: &ExprData,
     ) -> bool {
@@ -770,10 +764,7 @@ impl SideEffects {
         }
     }
 
-    pub(crate) fn to_null_or_undefined<'a, const TS: bool>(
-        p: &P<'a, TS>,
-        exp: &ExprData,
-    ) -> Option<Known> {
+    pub(crate) fn to_null_or_undefined<'a>(p: &P<'a>, exp: &ExprData) -> Option<Known> {
         if !p.options.features.dead_code_elimination {
             return None;
         }
@@ -847,7 +838,7 @@ impl SideEffects {
         }
     }
 
-    pub(crate) fn to_boolean<'a, const TS: bool>(p: &P<'a, TS>, exp: &ExprData) -> Option<Known> {
+    pub(crate) fn to_boolean<'a>(p: &P<'a>, exp: &ExprData) -> Option<Known> {
         if !p.options.features.dead_code_elimination {
             return None;
         }

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -4,7 +4,7 @@ use crate::parser::FindSymbolResult;
 use bun_ast as js_ast;
 use bun_ast::{Ref, Scope};
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     pub(crate) fn find_symbol(
         &mut self,
         loc: bun_ast::Loc,
@@ -61,7 +61,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 // `scope.ts_namespace` is only assigned behind `IS_TYPESCRIPT_ENABLED`
                 // guards, so the probe is dead for JS inputs — gate it so the
                 // load+branch fold away in the `TYPESCRIPT == false` monomorphization.
-                if Self::IS_TYPESCRIPT_ENABLED {
+                if self.ts {
                     if let Some(mut ts_namespace) = scope.ts_namespace {
                         let ts = &*ts_namespace;
                         let exported: &js_ast::TSNamespaceMemberMap = &ts.exported_members;

--- a/src/js_parser/typescript.rs
+++ b/src/js_parser/typescript.rs
@@ -6,7 +6,7 @@ use crate::p::P;
 
 // This function is taken from the official TypeScript compiler source code:
 // https://github.com/microsoft/TypeScript/blob/master/src/compiler/parser.ts
-impl<'a, const TS: bool> P<'a, TS> {
+impl<'a> P<'a> {
     pub(crate) fn can_follow_type_arguments_in_expression(&mut self) -> bool {
         let p = self;
         match p.lexer.token {
@@ -40,7 +40,7 @@ impl<'a, const TS: bool> P<'a, TS> {
     }
 } // end impl P (can_follow_type_arguments_in_expression)
 
-impl<'a, const TS: bool> P<'a, TS> {
+impl<'a> P<'a> {
     pub(crate) fn is_ts_arrow_fn_jsx(&mut self) -> crate::CrateResult<bool> {
         let p = self;
         // Lexer holds `&mut Log` so it cannot Clone; use the LexerSnapshot POD

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -37,7 +37,7 @@ use core::ptr::NonNull;
 // In the AST crate, ListManaged is arena-backed.
 type ListManaged<'bump, T> = BumpVec<'bump, T>;
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     // Thin alias of `current_scope_mut()` kept for local readability.
     #[inline(always)]
     fn vis_scope(&mut self) -> &mut js_ast::Scope {
@@ -1089,7 +1089,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                         }
                     }
                 } else if property.flags.contains(flags::Property::IsMethod) {
-                    if Self::IS_TYPESCRIPT_ENABLED
+                    if self.ts
                         && !property.flags.contains(flags::Property::IsStatic)
                         && !property.flags.contains(flags::Property::IsComputed)
                     {
@@ -1129,7 +1129,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                         self.visit_expr(property.value.as_mut().unwrap());
                     }
 
-                    if Self::IS_TYPESCRIPT_ENABLED {
+                    if self.ts {
                         if constructor_function_.is_some() {
                             if let Some(value) = property.value {
                                 if let ExprData::EFunction(e_func) = value.data {
@@ -1167,7 +1167,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 self.fn_only_data_visit.is_this_nested = old_is_this_captured;
             }
 
-            if Self::IS_TYPESCRIPT_ENABLED {
+            if self.ts {
                 // `lower_standard_decorators_stmt` owns field placement for such classes.
                 let use_define = self.options.use_define_for_class_fields
                     || class.should_lower_standard_decorators;

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -13,9 +13,9 @@ use bun_ast::{
 
 /// Try to optimize "typeof x === 'undefined'" to "typeof x > 'u'" or similar
 /// Returns the optimized expression if successful, None otherwise
-fn try_optimize_typeof_undefined<'a, const TYPESCRIPT: bool>(
+fn try_optimize_typeof_undefined<'a>(
     e_: &mut E::Binary,
-    p: &mut P<'a, TYPESCRIPT>,
+    p: &mut P<'a>,
     replacement_op: js_ast::op::Code,
 ) -> Option<Expr> {
     // Check if this is a typeof comparison with "undefined"
@@ -77,11 +77,7 @@ fn try_optimize_typeof_undefined<'a, const TYPESCRIPT: bool>(
 // canonical `ExprData::eql<P, K: EqlKindT>` (Expr.rs). Kept as a free fn so
 // the call sites don't each repeat the `LooseEql`/`StrictEql` type-select.
 #[inline]
-fn data_eql<'a, const STRICT: bool, const TYPESCRIPT: bool>(
-    left: &ExprData,
-    right: &ExprData,
-    p: &mut P<'a, TYPESCRIPT>,
-) -> Equality {
+fn data_eql<'a, const STRICT: bool>(left: &ExprData, right: &ExprData, p: &mut P<'a>) -> Equality {
     if STRICT {
         ExprData::eql::<_, StrictEql>(left, right, p)
     } else {
@@ -102,10 +98,7 @@ pub struct BinaryExpressionVisitor {
 }
 
 impl BinaryExpressionVisitor {
-    pub(crate) fn visit_right_and_finish<'a, const TYPESCRIPT: bool>(
-        v: &mut Self,
-        p: &mut P<'a, TYPESCRIPT>,
-    ) -> Expr {
+    pub(crate) fn visit_right_and_finish<'a>(v: &mut Self, p: &mut P<'a>) -> Expr {
         // `v.e: StoreRef<E::Binary>` is the safe arena back-reference (Copy).
         // Snapshot the handle for the identity check / tail re-wrap, then take
         // the working `&mut` via `StoreRef::DerefMut` — the arena-backref
@@ -252,7 +245,7 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinLooseEq => {
-                match data_eql::<false, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<false>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage_of_runtime_require();
                         p.ignore_usage(p.module_ref);
@@ -282,7 +275,7 @@ impl BinaryExpressionVisitor {
                 // TODO: warn about typeof string
             }
             Op::Code::BinStrictEq => {
-                match data_eql::<true, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<true>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage(p.module_ref);
                         p.ignore_usage_of_runtime_require();
@@ -305,7 +298,7 @@ impl BinaryExpressionVisitor {
                 // TODO: warn about typeof string
             }
             Op::Code::BinLooseNe => {
-                match data_eql::<false, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<false>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage(p.module_ref);
                         p.ignore_usage_of_runtime_require();
@@ -332,7 +325,7 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinStrictNe => {
-                match data_eql::<true, TYPESCRIPT>(&e_.left.data, &e_.right.data, p) {
+                match data_eql::<true>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
                         p.ignore_usage(p.module_ref);
                         p.ignore_usage_of_runtime_require();
@@ -716,10 +709,7 @@ impl BinaryExpressionVisitor {
         }
     }
 
-    pub(crate) fn check_and_prepare<'a, const TYPESCRIPT: bool>(
-        v: &mut Self,
-        p: &mut P<'a, TYPESCRIPT>,
-    ) -> Option<Expr> {
+    pub(crate) fn check_and_prepare<'a>(v: &mut Self, p: &mut P<'a>) -> Option<Expr> {
         // Snapshot the `Copy` arena handle before taking the working `&mut`
         // via `StoreRef::DerefMut`, so the early-return re-wrap below does not
         // overlap `e_`'s borrow of `v.e`.

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -25,7 +25,7 @@ use js_ast::OpCode as Op;
 // The 25+ per-variant `e_*` helpers are private; only `visit_expr` /
 // `visit_expr_in_out` are surfaced.
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     // PERF(port:noalias): `e: &mut Expr` is lowered to a `noalias` LLVM param, so reads
     // through `e` can be cached in registers across child recursion. The by-value
     // `Expr -> Expr` shape moved 24B in + 24B out per frame; the in-place form moves 8B

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -37,7 +37,7 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
 // a direct `impl P` block. The 30+ per-variant `s_*` helpers are private; only
 // `visit_and_append_stmt` is surfaced. Full draft body preserved under  mod _draft below.
 
-impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
+impl<'a> P<'a> {
     // Thin alias of `current_scope_mut()` kept for local readability.
     #[inline(always)]
     fn cur_scope(&mut self) -> &mut js_ast::Scope {
@@ -198,7 +198,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     // Silently strip exports of non-local symbols in TypeScript, since
                     // those likely correspond to type-only exports. But report exports of
                     // non-local symbols as errors in JavaScript.
-                    if !TYPESCRIPT {
+                    if !p.ts {
                         let r = js_lexer::range_of_identifier(p.source, items[i].name.loc);
                         p.log().add_range_error_fmt(
                             Some(p.source),
@@ -228,7 +228,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                     // Silently strip exports of non-local symbols in TypeScript, since
                     // those likely correspond to type-only exports. But report exports of
                     // non-local symbols as errors in JavaScript.
-                    if !TYPESCRIPT {
+                    if !p.ts {
                         let r = js_lexer::range_of_identifier(p.source, items[i].name.loc);
                         p.log().add_range_error_fmt(
                             Some(p.source),
@@ -438,7 +438,7 @@ impl<'a, const TYPESCRIPT: bool> P<'a, TYPESCRIPT> {
                 );
 
                 // Discard type-only export default statements
-                if TYPESCRIPT {
+                if p.ts {
                     if let js_ast::ExprData::EIdentifier(ident) = expr.data {
                         if !ident.ref_.is_source_contents_slice() {
                             let symbol = &p.symbols[ident.ref_.inner_index() as usize];

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -556,10 +556,13 @@ impl Snapshots {
                     }
                     lexer.next()?;
                     // `ParserOptions` isn't `Clone`; rebuild per-iteration.
-                    let opts = js_parser::ParserOptions::init(
+                    let mut opts = js_parser::ParserOptions::init(
                         vm.transpiler.options.jsx.clone(),
                         bun_ast::Loader::Js,
                     );
+                    // `TSXParser` used to be the `P<true>` instantiation. TypeScript
+                    // is a runtime flag now, so turn it on explicitly.
+                    opts.ts = true;
                     // `P::init` takes an out-param
                     // since 9a98701c980c — `P` is ~5 KiB and the previous
                     // `let p = P::init(..)?` shape forced 2-3 by-value moves.


### PR DESCRIPTION
Measurement branch, not a proposal yet. Stacked on #41128 and #41081. Opened as a draft so CI builds the binary for an A/B against the base, #41081 and #41128 binaries. The commit carries `[only builds]`.

### What it does
- Removes the last const-generic parameter of `P`. TypeScript mode is read from `options.ts` at `init` and checked at runtime at the 69 sites that used the const.
- `can_merge_symbol_kinds::<TYPESCRIPT>` dispatches on the runtime flag to the two existing instantiations.
- The snapshot updater sets `opts.ts = true` explicitly, because `TSXParser` used to be the `P<true>` instantiation.

### What to measure
- Binary size: the symbol table of the #41081 build has 313 JS/TS twin functions. 153 pairs are already folded by the linker. The 160 unfolded pairs total 391 KB in their smaller copies, so that is the ceiling.
- Instruction count and wall clock on `.js` input: the TypeScript gates sit on the per-token path (`parse_stmt` 17 sites, `parse_prefix` 8, `parse_property` 8, `parse_suffix` 7, `parse_fn` 7).