### PR TITLE
server: release a response body's stream from one non-generic helper

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -100,7 +100,7 @@
 "generic_body_not_generic:src/runtime/node/node_fs.rs" = 3
 "generic_body_not_generic:src/runtime/node/node_net_binding.rs" = 1
 "generic_body_not_generic:src/runtime/server/NodeHTTPResponse.rs" = 1
-"generic_body_not_generic:src/runtime/server/RequestContext.rs" = 8
+"generic_body_not_generic:src/runtime/server/RequestContext.rs" = 7
 "generic_body_not_generic:src/runtime/server/mod.rs" = 2
 "generic_body_not_generic:src/runtime/server/server_body.rs" = 2
 "generic_body_not_generic:src/runtime/shell/Builtin.rs" = 1

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -354,6 +354,23 @@ fn as_response(value: JSValue) -> Option<*mut Response> {
     response::from_js(value).map(|p| p.cast::<Response>())
 }
 
+/// Release the body's hold on a stream the sink is done with, and mark a
+/// `Locked` body used. Non-generic and out of line: the eight `RequestContext`
+/// monomorphizations share one copy.
+#[inline(never)]
+fn release_body_stream(response: &mut Response, global_this: &JSGlobalObject) {
+    if let Some(stream) = response.get_body_readable_stream() {
+        stream.value.ensure_still_alive();
+        response.detach_readable_stream(global_this);
+        stream.done();
+    }
+    // Read after the stream calls: the check observes the post-detach state.
+    let body_value = response.get_body_value();
+    if matches!(body_value, Body::Value::Locked(_)) {
+        *body_value = Body::Value::Used;
+    }
+}
+
 // ─── sibling-subtree shims ───────────────────────────────────────────────────
 // These forward to methods that exist in webcore/ but are currently inside
 // impl blocks that fail to compile (codegen gc-slot stubs, opaque AbortSignal).
@@ -1572,15 +1589,7 @@ where
         // (`reclaim_promise_cell`), so its `handle_*_stream` cleanup never
         // runs: release the body's hold on the stream here.
         if let Some(resp) = self.response_mut() {
-            if let Some(stream) = resp.get_body_readable_stream() {
-                stream.value.ensure_still_alive();
-                resp.detach_readable_stream(global_this);
-                stream.done();
-            }
-            let body_value = resp.get_body_value();
-            if matches!(body_value, Body::Value::Locked(_)) {
-                *body_value = Body::Value::Used;
-            }
+            release_body_stream(resp, global_this);
         }
 
         let response_jsvalue = self.response_jsvalue.get();
@@ -3014,18 +3023,7 @@ where
         }
 
         if let Some(resp) = self.response_mut() {
-            // NOTE: the body value is read after the stream calls (the check
-            // observes the post-detach state).
-            if let Some(stream) = resp.get_body_readable_stream() {
-                stream.value.ensure_still_alive();
-                resp.detach_readable_stream(global_this);
-                stream.done();
-            }
-
-            let body_value = resp.get_body_value();
-            if matches!(body_value, Body::Value::Locked(_)) {
-                *body_value = Body::Value::Used;
-            }
+            release_body_stream(resp, global_this);
         }
 
         // aborted so call finalizeForAbort


### PR DESCRIPTION
### Problem
- The `mordant` job fails on every PR since 2026-09-01: one `generic_body_not_generic` finding over the baseline, named as `src/runtime/server/RequestContext.rs:4439` (`get_remote_socket_info`). The baseline holds 8, the file has 9. Mordant names the last finding in the file.
- The new one is the block #41080 added to `finalize_without_deinit`, a copy of the block in `handle_reject_stream`. It uses no type parameter and is compiled eight times. #41082 wrote the baseline ten minutes before #41080 merged.

### Fix
- Move the block into `release_body_stream`, a free `#[inline(never)]` function called from both places. One copy instead of sixteen.
- No behavior change: the statements and their order are the same.
- The file drops from nine findings to seven, so `mordant-baseline.toml` goes from 8 to 7. Checked with the pinned mordant: 7 reports nothing over, 6 reports one over.
- Verified: seven stream, abort and leak serve tests (85 pass, listed in Notes), `serve.test.ts`, and the `mordant` job on this PR.

### Background
- `RequestContext<ThisServer, SSL, DEBUG, MUX>` is the per-request state of `Bun.serve`. It has eight monomorphizations. Every method body is compiled once per instantiation.
- `generic_body_not_generic` is a mordant lint. It flags a region of a generic function that uses no type parameter (30 MIR statements here) and asks for a non-generic function that takes what the region reads.
- `mordant-baseline.toml` is a ratchet: per lint and file, the number of findings that predate the job. A file over its count fails the job. A fixed finding lowers the entry.
- #40423 carries f0b5a3b, which hoists `get_remote_socket_info` itself. It touches other lines, so both can land.

<details><summary>Notes</summary>

No `test/` change. The diff moves two identical blocks into one function and changes no statement, so no test can fail before it and pass after it. The regression check for this PR is the `mordant` job itself: red on main and on every open PR, green here. The behavior of the moved block is pinned by the existing tests listed below, in particular `serve-pending-promise-abort-leak.test.ts` (#41080, the `finalize_without_deinit` caller) and `serve-stream-reject-flush-leak.test.ts` (the `handle_reject_stream` caller).

Tests run with the debug build: `test/js/bun/http/serve-pending-promise-abort-leak.test.ts`, `serve-stream-reject-flush-leak.test.ts`, `serve-async-stream-client-abort.test.ts`, `serve-response-stream-sink-leak.test.ts`, `serve-stream-body-error.test.ts`, `serve-error-handler-stream.test.ts`, `serve-body-leak.test.ts`: 85 pass. `serve.test.ts` on this container: 295 pass, 2 fail (`root range port` and `/bun:info to loopback clients`). Both fail on main here too; #41080 noted the same two.

How the cause was found: with the pinned mordant (`cargo dylint --all -p bun_runtime`), reverting only the `RequestContext.rs` hunk of e5a18d5225 leaves nothing over the baseline. With the baseline line commented out and `--cap-lints warn`, the nine findings in the file are `cancel_unread_body`, `render_missing_invalid_response`, `finalize_without_deinit` (30 of 373 statements, the #41080 block), `do_sendfile`, `handle_reject_stream` (30 of 246 statements, the same block), `render_metadata`, `do_write_status`, `on_buffered_body_chunk` and `get_remote_socket_info`. Mordant reports the findings past the baseline count in file order, which is why the job names the last one.

With this PR and f0b5a3b both on main, the file has six findings under a baseline of seven.
</details>
