### PR TITLE
install: tie the borrow store_header_buf returns to self

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -712,13 +712,11 @@ impl NetworkTask {
         Ok(())
     }
 
-    /// Moves the fully written header block into `self.header_buf` and returns the
-    /// view of it that the HTTP thread reads.
-    fn store_header_buf(&mut self, header_builder: &mut HeaderBuilder) -> &'static [u8] {
+    /// Moves the fully written header block into `self.header_buf` and returns a view of it.
+    fn store_header_buf<'a>(&'a mut self, header_builder: &mut HeaderBuilder) -> &'a [u8] {
         debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
         self.header_buf = header_builder.content.move_to_slice();
-        // SAFETY: `self.header_buf` outlives the request; it is freed when the slot returns to the pool.
-        unsafe { bun_ptr::detach_lifetime(&*self.header_buf) }
+        &self.header_buf
     }
 
     pub(crate) fn get_completion_callback(&mut self) -> HTTPClientResultCallback {
@@ -850,7 +848,7 @@ impl NetworkTask {
         let mut header_builder = HeaderBuilder::default();
 
         // Configured credentials win over the URL's userinfo, as in npm.
-        let header_buf: &'static [u8] = match (credentials, url_authorization) {
+        let header_buf: &[u8] = match (credentials, url_authorization) {
             (Some(credentials), _) => {
                 count_auth(&mut header_builder, credentials);
                 header_builder.allocate()?;
@@ -868,6 +866,12 @@ impl NetworkTask {
                 b""
             }
         };
+        // SAFETY: lifetime extension. `header_buf` is `b""` or a view of the heap
+        // allocation `self.header_buf` owns, which is freed only when the slot returns
+        // to the pool, after the request completes. `AsyncHTTP::init` demands a
+        // `'static` borrow because the HTTP thread reads it concurrently, as for
+        // `url_buf` below.
+        let header_buf: &'static [u8] = unsafe { bun_ptr::detach_lifetime(header_buf) };
 
         // SAFETY: lifetime extension — `url_buf` is a heap allocation owned by
         // `*self`, which outlives the HTTP request. `AsyncHTTP::init` demands a


### PR DESCRIPTION
Requested by @dylan-conway on #40423 ([thread](https://github.com/oven-sh/bun/pull/40423#discussion_r3907861217)). Targets the PR branch.

### Problem
- `NetworkTask::store_header_buf` returned `&'static [u8]`. It got there with `bun_ptr::detach_lifetime` inside the helper, so the signature hid where the borrow really ends, and the helper carried its own `unsafe` block.

### Fix
- The helper is now `fn store_header_buf<'a>(&'a mut self, ..) -> &'a [u8]` and returns `&self.header_buf`. It is safe code.
- `for_tarball` extends the borrow to `'static` once, right after the `match`, with the SAFETY comment. That is the one place that needs it: `self.unsafe_http_client` is `MaybeUninit<AsyncHTTP<'static>>`, and `AsyncHTTP::init` takes `headers_buf: &'a [u8]` for that same `'a`. `url_buf` is extended at the same place already.
- Zero behavior or perf change. `detach_lifetime` is `#[inline(always)]` and is `&*ptr::from_ref(s)`, a no-op. The same pointer and length reach `AsyncHTTP::init`, and the `b""` arm is unchanged.
- Verified: `cargo check -p bun_install` and `cargo clippy -p bun_install` are clean. With the debug build, `bun bd test test/cli/install/npmrc.test.ts` passes (141 tests) and `bun bd test test/cli/install/bun-install.test.ts -t "auth|token|credential|userinfo|tarball"` passes 140 of 141. The one failure, `should treat non-GitHub http(s) URLs as tarballs`, fetches `gitpkg-fork.vercel.sh` over the public internet and gets a 403 in this container.

### Background
- `NetworkTask` is a pool slot. It owns `url_buf` and `header_buf`, and it owns the `AsyncHTTP` that borrows both. A self-referential struct cannot carry a lifetime, so the `AsyncHTTP` is stored as `AsyncHTTP<'static>` and each borrow is detached where the `AsyncHTTP` is built.
- The `header_buf` allocation is freed when the slot returns to the pool, after the response is processed. A retry re-enqueues the same slot and does not touch `header_buf`. That is why the `'static` extension is sound.

<details><summary>Notes</summary>

No `test/` change. The diff moves a no-op lifetime cast from inside a helper to its one call site and changes no statement, so no test can fail before it and pass after it. The header path it touches is pinned by the tarball credential tests in `test/cli/install/npmrc.test.ts` (141 pass with the debug build).

Why `'static` stays at all: `NetworkTask` is a pool slot that owns both `header_buf` and the `AsyncHTTP` that borrows it, and a self-referential struct cannot carry a lifetime. So `unsafe_http_client` is `MaybeUninit<AsyncHTTP<'static>>`, and the borrow is detached once where the `AsyncHTTP` is built, as `for_manifest` and `s3/simple_request.rs` already do for their buffers.
</details>
