### PR TITLE
test: stall the CompressionStream HTTP sink test with a paused raw socket, not fetch

### DIFF
--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -563,19 +563,29 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
   // 32 MiB is beyond any of that, so a source that gets this far was never paused.
   const RUNAWAY = 512;
 
-  /** A pull source of copies of `chunk` that keeps producing until `endAfter()` or RUNAWAY. */
-  function countingSource(chunk: Uint8Array) {
+  /**
+   * A pull source of copies of `chunk` that keeps producing until `endAfter()` or RUNAWAY.
+   * With `numbered`, each copy carries its 1-based pull number in its first 4 bytes, so a
+   * consumer can check that it received every block in order.
+   */
+  function countingSource(chunk: Uint8Array, numbered = false) {
     let pulls = 0;
     let closeAt = RUNAWAY;
+    const block = (n: number) => {
+      const copy = Buffer.from(chunk);
+      if (numbered) copy.writeUInt32BE(n, 0);
+      return copy;
+    };
     const stream = new ReadableStream({
       pull(c) {
         pulls++;
-        c.enqueue(chunk.slice());
+        c.enqueue(block(pulls));
         if (pulls >= closeAt) c.close();
       },
     });
     return {
       stream,
+      block,
       get pulls() {
         return pulls;
       },
@@ -624,7 +634,7 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
     await using server = Bun.serve({
       port: 0,
       fetch() {
-        source = countingSource(chunk);
+        source = countingSource(chunk, true);
         onRequest();
         return new Response(source.stream.pipeThrough(new CompressionStream("gzip")));
       },
@@ -658,7 +668,7 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
     expect(source.pulls).toBe(closeAt);
 
     // The stall and the resume must not lose or reorder output: de-chunk the
-    // response and compare the gunzipped body with the source.
+    // response and compare the gunzipped body with the numbered source blocks.
     const raw = Buffer.concat(received);
     const headEnd = raw.indexOf("\r\n\r\n");
     const head = raw.subarray(0, headEnd).toString();
@@ -675,9 +685,10 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
     }
     const out = zlib.gunzipSync(Buffer.concat(body));
     expect(out.byteLength).toBe(closeAt * chunk.byteLength);
-    for (let i = 0; i < closeAt; i++) {
-      if (!out.subarray(i * chunk.byteLength, (i + 1) * chunk.byteLength).equals(chunk)) {
-        throw new Error(`chunk ${i} of ${closeAt} does not match the source`);
+    for (let n = 1; n <= closeAt; n++) {
+      const got = out.subarray((n - 1) * chunk.byteLength, n * chunk.byteLength);
+      if (!got.equals(source.block(n))) {
+        throw new Error(`block ${n} of ${closeAt} is block ${got.readUInt32BE(0)} of the source, or corrupt`);
       }
     }
   });

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -609,28 +609,77 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
   // (slow client), the transform arm's writeBytes returns a pending promise and
   // the writable side parks on m_nativeSinkReadyPromise. Without that, a fast
   // source with a stalled client fills the sink buffer unboundedly.
+  //
+  // The stalled client is a raw socket paused before it sends the request, so
+  // nothing reads until the stall is observed. The kernel then absorbs only the
+  // server's send buffer plus the client's untouched receive buffer. A fetch()
+  // client would not do: it reads ahead in bursts, and every read lets TCP
+  // receive autotuning grow the window, up to tcp_rmem[2] (32 MiB since Linux
+  // 6.16), which holds RUNAWAY chunks on its own.
   test("CompressionStream -> native HTTP sink applies backpressure to a stalled client", async () => {
     // Incompressible data so the gzipped output is ~as large as the input.
     const chunk = crypto.getRandomValues(new Uint8Array(64 * 1024));
     let source!: ReturnType<typeof countingSource>;
+    const { promise: requested, resolve: onRequest } = Promise.withResolvers<void>();
     await using server = Bun.serve({
       port: 0,
       fetch() {
         source = countingSource(chunk);
+        onRequest();
         return new Response(source.stream.pipeThrough(new CompressionStream("gzip")));
       },
     });
-    const res = await fetch(server.url);
-    const reader = res.body!.getReader();
-    await reader.read();
+    const received: Buffer[] = [];
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    using socket = await Bun.connect({
+      hostname: server.url.hostname,
+      port: server.port,
+      socket: {
+        open(s) {
+          s.pause();
+          s.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+        },
+        data(_s, data) {
+          received.push(data);
+        },
+        close() {
+          onClose();
+        },
+      },
+    });
+    await requested;
     const pullsWhileStalled = await waitUntilParked(source);
-    if (pullsWhileStalled >= RUNAWAY) await reader.cancel();
     expect(pullsWhileStalled).toBeGreaterThan(0);
     expect(pullsWhileStalled).toBeLessThan(RUNAWAY);
     // Reading again must resume the parked pull loop and run it to the end.
     const closeAt = source.endAfter(8);
-    while (!(await reader.read()).done) {}
+    socket.resume();
+    await closed;
     expect(source.pulls).toBe(closeAt);
+
+    // The stall and the resume must not lose or reorder output: de-chunk the
+    // response and compare the gunzipped body with the source.
+    const raw = Buffer.concat(received);
+    const headEnd = raw.indexOf("\r\n\r\n");
+    const head = raw.subarray(0, headEnd).toString();
+    expect(head).toStartWith("HTTP/1.1 200");
+    expect(head.toLowerCase()).toContain("transfer-encoding: chunked");
+    const body: Buffer[] = [];
+    for (let i = headEnd + 4; ; ) {
+      const sizeEnd = raw.indexOf("\r\n", i);
+      const size = parseInt(raw.subarray(i, sizeEnd).toString(), 16);
+      if (sizeEnd < 0 || Number.isNaN(size)) throw new Error(`malformed chunk framing at offset ${i}`);
+      if (size === 0) break;
+      body.push(raw.subarray(sizeEnd + 2, sizeEnd + 2 + size));
+      i = sizeEnd + 2 + size + 2;
+    }
+    const out = zlib.gunzipSync(Buffer.concat(body));
+    expect(out.byteLength).toBe(closeAt * chunk.byteLength);
+    for (let i = 0; i < closeAt; i++) {
+      if (!out.subarray(i * chunk.byteLength, (i + 1) * chunk.byteLength).equals(chunk)) {
+        throw new Error(`chunk ${i} of ${closeAt} does not match the source`);
+      }
+    }
   });
 
   test("request body -> DecompressionStream propagates backpressure to the client", async () => {


### PR DESCRIPTION
### Problem
- `compression.test.ts > CompressionStream -> native HTTP sink applies backpressure to a stalled client` fails on the alpine 3.23 lanes (x64 and aarch64): `expect(pullsWhileStalled).toBeLessThan(RUNAWAY)`, `Expected: < 512`, `Received: 512`. In the last 400 Buildkite builds it was the flaky test in 96 of them, every hit on alpine, and 36 of those hits were after #40966 raised the bound to 512.
- The stalled client is a `fetch()` whose reader holds one chunk. Fetch reads ahead in bursts, and each read lets TCP receive autotuning grow the window up to `tcp_rmem[2]`. That is 32 MiB on Linux 6.16 and later, which the alpine lanes run. With the server's 4 MiB send buffer the kernel alone holds about 580 chunks, so the source reaches 512 without the sink ever pushing back.

### Fix
- The client is a `Bun.connect` socket, paused in `open()` before it sends the request. Nothing reads until the stall is observed, so the receive window stays at its initial size and only the two socket buffers absorb data. Here it parks at 43 pulls on every run, release and debug, on a 6.17 kernel with the same 32 MiB cap. The old client parked anywhere from 93 to 105.
- Correct because the test is about the server: `HTTPServerWritable` returns a pending promise when uWS did not take all the bytes, and the native `CompressionStream` parks on it. Fetch's read-ahead and the kernel's autotuning cap were hidden inputs to the assertion.
- Each source block carries its pull number in its first 4 bytes. The test de-chunks the response and compares the gunzipped body with the numbered blocks in order, so a lost, duplicated or reordered block across the stall and the resume fails it.
- Verified: `bun bd test test/js/web/streams/compression.test.ts` (65 pass). The new case passes 6 of 6 with the released bun and 4 of 4 with the debug build.

### Background
- `Bun.serve` writes a streaming response through `HTTPServerWritable` (`src/runtime/webcore/streams.rs`). When the socket buffer is full its `write()` returns a pending promise, and a native `CompressionStream` piped into it waits on `m_nativeSinkReadyPromise`.
- TCP receive autotuning sizes a socket's receive buffer from the application's read rate. A socket that never reads keeps its initial buffer (128 KiB on Linux).
- `socket.pause()` on a `Bun.connect` socket stops reading from the fd. A pause in `open()` applies before the server's first byte arrives.

<details><summary>Notes</summary>

- #40487 proposed this client before #40966 merged and was closed in favor of it. The comment on #40966 (https://github.com/oven-sh/bun/pull/40966#issuecomment-5470725579) noted that the 512 bound is below what the kernel can hold on the alpine lanes. The failures since confirm it.
- Parked pull counts measured here with the released bun 1.4.1, 6 runs each: new client 43, 43, 43, 43, 43, 43. Old client 99, 105, 104, 105, 93, 99.
- `Connection: close` makes the server close the socket after the response, which is how the client learns the body is complete.
- The request-body case (`DecompressionStream propagates backpressure to the client`) is unchanged. It stalls the server, not the client, and has not appeared in the Buildkite annotations.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/streams/compression.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/streams/compression.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [9.56ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.81ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [2.10ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.34ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [15.07ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [20.70ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [48.48ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [9.32ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [19.09ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [47.25ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [15.50ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = zstd frame) [18.47ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = skippable frame) [7.70ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses many concatenated zstd frames larger than one output chunk [13.80ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a zstd stream with a leading skippable frame [9.25ms]
(pass) CompressionStream and DecompressionStream > zstd > rejects trailing garbage after a zstd frame [9.77ms]
(pass) CompressionStream and DecompressionStream > all formats > works with all
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/streams/compression.test.ts | 78 +++++++++++++++++++++++++++++----
 1 file changed, 69 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
test/js/web/streams/compression.test.ts      2      6     19
```

</details>

<!-- robobun:evidence:end -->