### PR TITLE
Honor Bun.file().slice() bounds for unread file streams and in file routes

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -325,8 +325,6 @@ impl FileRoute {
         resp: AnyResponse,
         method: Method,
     ) -> Serve {
-        // The blob's window clamped to the file as it is now (a slice past EOF
-        // is cut short or empty), as `RequestContext::do_sendfile` does.
         let (can_serve_file, offset, size, file_type, pollable) = 'brk: {
             let stat = match bun_sys::fstat(fd) {
                 Ok(s) => s,
@@ -415,9 +413,7 @@ impl FileRoute {
             return Serve::Done;
         }
 
-        // A regular file always gets a length (even 0), so the body sent is
-        // exactly the Content-Length written below; pipes and sockets are
-        // read to EOF.
+        // `None` (read to EOF) is only for pipes and sockets; a file's body is its Content-Length.
         let (body_offset, body_len): (u64, Option<u64>) = match range {
             RangeRequest::Result::Satisfiable { .. } => {
                 let (start, len) = write_content_range(resp, range, size).unwrap();

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -325,19 +325,22 @@ impl FileRoute {
         resp: AnyResponse,
         method: Method,
     ) -> Serve {
-        let (can_serve_file, size, file_type, pollable): (bool, u64, FileType, bool) = 'brk: {
+        // The blob's window clamped to the file as it is now (a slice past EOF
+        // is cut short or empty), as `RequestContext::do_sendfile` does.
+        let (can_serve_file, offset, size, file_type, pollable) = 'brk: {
             let stat = match bun_sys::fstat(fd) {
                 Ok(s) => s,
                 // file_type is never read because can_serve_file == false
-                Err(_) => break 'brk (false, 0, FileType::File, false),
+                Err(_) => break 'brk (false, 0, 0, FileType::File, false),
             };
 
             let stat_size: u64 = u64::try_from(stat.st_size.max(0)).expect("int cast");
-            let _size: u64 = stat_size.min(self.blob.size.get());
+            let offset: u64 = self.blob.offset.get().min(stat_size);
+            let size: u64 = self.blob.size.get().min(stat_size - offset);
 
             let mode = stat.st_mode as bun_sys::Mode;
             if bun_sys::S::ISDIR(mode) {
-                break 'brk (false, 0, FileType::File, false);
+                break 'brk (false, 0, 0, FileType::File, false);
             }
 
             // `Cell::take` → mutate → `set`: single-threaded event loop, no
@@ -347,14 +350,14 @@ impl FileRoute {
             self.stat_hash.set(sh);
 
             if bun_sys::S::ISFIFO(mode) || bun_sys::S::ISCHR(mode) {
-                break 'brk (true, _size, FileType::Pipe, true);
+                break 'brk (true, offset, size, FileType::Pipe, true);
             }
 
             if bun_sys::S::ISSOCK(mode) {
-                break 'brk (true, _size, FileType::Socket, true);
+                break 'brk (true, offset, size, FileType::Socket, true);
             }
 
-            break 'brk (true, _size, FileType::File, false);
+            break 'brk (true, offset, size, FileType::File, false);
         };
 
         if !can_serve_file {
@@ -412,37 +415,42 @@ impl FileRoute {
             return Serve::Done;
         }
 
+        // A regular file always gets a length (even 0), so the body sent is
+        // exactly the Content-Length written below; pipes and sockets are
+        // read to EOF.
         let (body_offset, body_len): (u64, Option<u64>) = match range {
             RangeRequest::Result::Satisfiable { .. } => {
                 let (start, len) = write_content_range(resp, range, size).unwrap();
-                (self.blob.offset.get() + start, Some(len))
+                (offset + start, Some(len))
             }
             RangeRequest::Result::Unsatisfiable => {
                 write_content_range(resp, range, size);
                 resp.end(b"", resp.should_close_connection());
                 return Serve::Done;
             }
-            RangeRequest::Result::None => (
+            RangeRequest::Result::None => {
                 if file_type == FileType::File {
-                    self.blob.offset.get()
+                    (offset, Some(size))
                 } else {
-                    0
-                },
-                if file_type == FileType::File && self.blob.size.get() > 0 {
-                    Some(size)
-                } else {
-                    None
-                },
-            ),
+                    (0, None)
+                }
+            }
         };
 
-        if file_type == FileType::File && !resp.state().has_written_content_length_header() {
-            resp.write_header_int(b"content-length", body_len.unwrap_or(size));
-            resp.mark_wrote_content_length_header();
+        if let Some(len) = body_len {
+            if !resp.state().has_written_content_length_header() {
+                resp.write_header_int(b"content-length", len);
+                resp.mark_wrote_content_length_header();
+            }
         }
 
         if method == Method::HEAD {
             resp.end_without_body(resp.should_close_connection());
+            return Serve::Done;
+        }
+
+        if body_len == Some(0) {
+            resp.end(b"", resp.should_close_connection());
             return Serve::Done;
         }
 

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -210,6 +210,15 @@ impl ReadableStream {
                 let blobby = self.ptr.file().expect("matched File");
                 if let webcore::file_reader::Lazy::Blob(store) = blobby.lazy.get() {
                     let blob = Blob::init_with_store(store.clone(), global_this);
+                    // `init_with_store` spans the whole store; the window of the
+                    // Blob this stream was made from lives on the reader
+                    // (see `from_blob_copy_ref`).
+                    if let Some(offset) = blobby.start_offset {
+                        blob.offset.set(offset as webcore::blob::SizeType);
+                    }
+                    if let Some(size) = blobby.max_size {
+                        blob.size.set(size as webcore::blob::SizeType);
+                    }
                     // it should be lazy, file shouldn't have opened yet.
                     debug_assert!(!blobby.started.get());
                     self.done();

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -210,9 +210,7 @@ impl ReadableStream {
                 let blobby = self.ptr.file().expect("matched File");
                 if let webcore::file_reader::Lazy::Blob(store) = blobby.lazy.get() {
                     let blob = Blob::init_with_store(store.clone(), global_this);
-                    // `init_with_store` spans the whole store; the window of the
-                    // Blob this stream was made from lives on the reader
-                    // (see `from_blob_copy_ref`).
+                    // The window `from_blob_copy_ref` moved onto the reader.
                     if let Some(offset) = blobby.start_offset {
                         blob.offset.set(offset as webcore::blob::SizeType);
                     }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -72,9 +72,8 @@ describe("Bun.file in serve routes", () => {
       }),
       "/partial.txt": new Response(Bun.file(join(tempDir, "partial.txt"))),
       "/partial-slice.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10)),
-      // An unread Bun.file() stream is turned back into the file Blob when a
-      // route or handler response is built from it; the slice must survive.
-      "/partial-slice-stream.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
+      // Rendering a handler response built from an unread Bun.file() stream
+      // turns the stream back into the file Blob; the slice must survive that.
       "/partial-slice-stream-handler": () => new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
       "/partial-open-slice-stream-handler": () =>
         new Response(Bun.file(join(tempDir, "partial.txt")).slice(10).stream()),
@@ -722,13 +721,6 @@ describe("Bun.file in serve routes", () => {
       expect(res.headers.get("Content-Length")).toBe("5");
     });
 
-    it("serves the slice behind a sliced file's stream as a route", async () => {
-      const res = await fetch(new URL(`/partial-slice-stream.txt`, server.url));
-      expect(res.status).toBe(200);
-      expect(await res.text()).toBe("56789");
-      expect(res.headers.get("Content-Length")).toBe("5");
-    });
-
     it("serves the slice behind a sliced file's stream from a handler", async () => {
       const serve = async (pathname: string) => {
         const get = await fetch(new URL(pathname, server.url));
@@ -1219,6 +1211,85 @@ test.skipIf(isWindows)("Response(Bun.file(FIFO)) frames the body as chunked, not
   } finally {
     closeSync(writerFd);
   }
+});
+
+// A file route serves the window of the Bun.file() slice it was built from,
+// given either the slice or its unread stream (which is turned back into the
+// slice). FileRoute used to clamp the window to the file size without taking
+// the offset off, and to send an empty window to EOF: on this 16-byte file
+// slice(10) declared Content-Length: 16 and sent 6 bytes, slice(5, 5) declared
+// 0 and sent 11. Only the wire shows that (RFC 9112 6.3); fetch() drops bytes
+// past the declared length and turns a short body into a connection error.
+test("file routes frame a slice that reaches or starts past EOF by the bytes they serve", async () => {
+  using dir = tempDir("serve-file-route-slice-framing", { "partial.txt": "0123456789ABCDEF" });
+  const file = () => Bun.file(join(String(dir), "partial.txt"));
+  const windows = {
+    "slice(5, 10)": () => file().slice(5, 10),
+    "slice(10)": () => file().slice(10),
+    "slice(10, 100)": () => file().slice(10, 100),
+    "slice(5, 5)": () => file().slice(5, 5),
+    "slice(100)": () => file().slice(100),
+    "whole file": () => file(),
+  };
+  const names = Object.keys(windows) as (keyof typeof windows)[];
+  await using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    routes: Object.fromEntries(
+      names.flatMap((name, i) => [
+        [`/blob/${i}`, new Response(windows[name]())],
+        [`/stream/${i}`, new Response(windows[name]().stream())],
+      ]),
+    ),
+    fetch: () => new Response("fallback", { status: 404 }),
+  });
+
+  // One GET on its own connection; `Connection: close` makes the server hang
+  // up once it considers the response finished, so `body` is every byte that
+  // followed the head, however many the head declared.
+  async function wire(path: string) {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    let captured = "";
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        open(socket) {
+          socket.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+        },
+        data(_socket, chunk) {
+          captured += Buffer.from(chunk).toString("latin1");
+        },
+        close() {
+          resolve(captured);
+        },
+        error() {
+          resolve(captured);
+        },
+      },
+    });
+    const raw = await promise;
+    const headEnd = raw.indexOf("\r\n\r\n");
+    return {
+      contentLength: /^content-length:\s*(\d+)/im.exec(raw.slice(0, headEnd))?.[1] ?? null,
+      body: raw.slice(headEnd + 4),
+    };
+  }
+
+  const results: Record<string, unknown> = {};
+  for (const [i, name] of names.entries()) {
+    results[name] = { blob: await wire(`/blob/${i}`), stream: await wire(`/stream/${i}`) };
+  }
+
+  const exactly = (body: string) => ({ contentLength: String(body.length), body });
+  expect(results).toEqual({
+    "slice(5, 10)": { blob: exactly("56789"), stream: exactly("56789") },
+    "slice(10)": { blob: exactly("ABCDEF"), stream: exactly("ABCDEF") },
+    "slice(10, 100)": { blob: exactly("ABCDEF"), stream: exactly("ABCDEF") },
+    "slice(5, 5)": { blob: exactly(""), stream: exactly("") },
+    "slice(100)": { blob: exactly(""), stream: exactly("") },
+    "whole file": { blob: exactly("0123456789ABCDEF"), stream: exactly("0123456789ABCDEF") },
+  });
 });
 
 // A request that declares a body arms the request-body (onData) callback on

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -72,6 +72,15 @@ describe("Bun.file in serve routes", () => {
       }),
       "/partial.txt": new Response(Bun.file(join(tempDir, "partial.txt"))),
       "/partial-slice.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10)),
+      // An unread Bun.file() stream is turned back into the file Blob when a
+      // route or handler response is built from it; the slice must survive.
+      "/partial-slice-stream.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
+      "/partial-slice-stream-handler": () => new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
+      "/partial-open-slice-stream-handler": () =>
+        new Response(Bun.file(join(tempDir, "partial.txt")).slice(10).stream()),
+      "/partial-empty-slice-stream-handler": () =>
+        new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 5).stream()),
+      "/partial-stream-handler": () => new Response(Bun.file(join(tempDir, "partial.txt")).stream()),
       "/fd-not-supported.txt": (() => {
         // This would test file descriptors, but they're not supported yet
         return new Response(Bun.file(join(tempDir, "hello.txt")));
@@ -711,6 +720,36 @@ describe("Bun.file in serve routes", () => {
       expect(res.status).toBe(200);
       expect(await res.text()).toBe("56789");
       expect(res.headers.get("Content-Length")).toBe("5");
+    });
+
+    it("serves the slice behind a sliced file's stream as a route", async () => {
+      const res = await fetch(new URL(`/partial-slice-stream.txt`, server.url));
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("56789");
+      expect(res.headers.get("Content-Length")).toBe("5");
+    });
+
+    it("serves the slice behind a sliced file's stream from a handler", async () => {
+      const serve = async (pathname: string) => {
+        const get = await fetch(new URL(pathname, server.url));
+        const head = await fetch(new URL(pathname, server.url), { method: "HEAD" });
+        return {
+          body: await get.text(),
+          contentLength: get.headers.get("Content-Length"),
+          headContentLength: head.headers.get("Content-Length"),
+        };
+      };
+      expect({
+        "slice(5, 10)": await serve("/partial-slice-stream-handler"),
+        "slice(10)": await serve("/partial-open-slice-stream-handler"),
+        "slice(5, 5)": await serve("/partial-empty-slice-stream-handler"),
+        "whole file": await serve("/partial-stream-handler"),
+      }).toEqual({
+        "slice(5, 10)": { body: "56789", contentLength: "5", headContentLength: "5" },
+        "slice(10)": { body: "ABCDEF", contentLength: "6", headContentLength: "6" },
+        "slice(5, 5)": { body: "", contentLength: "0", headContentLength: "0" },
+        "whole file": { body: "0123456789ABCDEF", contentLength: "16", headContentLength: "16" },
+      });
     });
 
     // The slice is shorter than the file, so the byte budget runs out before

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, exampleSite } from "harness";
+import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
 import net from "net";
 
 const exampleServer = exampleSite("http");
@@ -286,6 +286,59 @@ for (const { body, fn } of bodyTypes) {
         expect(subject.body).toBeInstanceOf(ReadableStream);
         expect(await subject.text()).toBe("bye");
         expect(subject.bodyUsed).toBe(true);
+      });
+
+      // The readers move an unread Bun.file() stream back into a Blob the same
+      // way. That Blob has to cover the slice the stream was made from, not
+      // the whole file. (text() is not in here: it pumps the stream instead.)
+      describe("made from a sliced Bun.file()", () => {
+        const alphabet = "abcdefghijklmnopqrstuvwxyz";
+
+        test("bytes() returns the window of the slice the stream was made from", async () => {
+          using dir = tempDir("body-file-slice-stream", { "data.txt": alphabet });
+          const file = () => Bun.file(`${dir}/data.txt`);
+          const bytesOf = async (blob: Blob) => Buffer.from(await fn(blob.stream()).bytes()).toString();
+          expect({
+            "slice(3, 8)": await bytesOf(file().slice(3, 8)),
+            "slice(21)": await bytesOf(file().slice(21)),
+            "slice(3, 1000)": await bytesOf(file().slice(3, 1000)),
+            "slice(4, 4)": await bytesOf(file().slice(4, 4)),
+            "slice(3, 20).slice(2, 6)": await bytesOf(file().slice(3, 20).slice(2, 6)),
+            "whole file": await bytesOf(file()),
+          }).toEqual({
+            "slice(3, 8)": "defgh",
+            "slice(21)": "vwxyz",
+            "slice(3, 1000)": "defghijklmnopqrstuvwxyz",
+            "slice(4, 4)": "",
+            "slice(3, 20).slice(2, 6)": "fghi",
+            "whole file": alphabet,
+          });
+        });
+
+        test("arrayBuffer() and blob() return the slice too", async () => {
+          using dir = tempDir("body-file-slice-stream-readers", { "data.txt": alphabet });
+          const slice = () => Bun.file(`${dir}/data.txt`).slice(3, 8);
+          const blob = await fn(slice().stream()).blob();
+          expect({
+            arrayBuffer: Buffer.from(await fn(slice().stream()).arrayBuffer()).toString(),
+            blob: [blob.size, await blob.text()],
+          }).toEqual({
+            arrayBuffer: "defgh",
+            blob: [5, "defgh"],
+          });
+        });
+
+        test("json() parses only the slice", async () => {
+          using dir = tempDir("body-file-slice-stream-json", { "data.json": `--{"ok":true}--` });
+          expect(await fn(Bun.file(`${dir}/data.json`).slice(2, 13).stream()).json()).toEqual({ ok: true });
+        });
+
+        test("bytes() after the body getter turned a sliced Bun.file() body into a stream", async () => {
+          using dir = tempDir("body-file-slice-body-getter", { "data.txt": alphabet });
+          const subject = fn(Bun.file(`${dir}/data.txt`).slice(3, 8));
+          expect(subject.body).toBeInstanceOf(ReadableStream);
+          expect([Buffer.from(await subject.bytes()).toString(), subject.bodyUsed]).toEqual(["defgh", true]);
+        });
       });
     });
     for (const { string, buffer } of utf8) {


### PR DESCRIPTION
Fixes #40096

Replaces #39241, rebased on main with the `FileRoute.rs` conflicts resolved. Same code change.

### Problem
- `Bun.file(p).slice(3, 8).stream()` delivers the whole file wherever the unread stream is turned back into a Blob: `Bun.serve` responses, `new Response(inner.body, inner)` (#40096), `bytes()` / `blob()` / `json()`. Reproduces on 1.4.1.
- Cause 1: the `Source::File` arm of `to_any_blob` (src/runtime/webcore/ReadableStream.rs:212) rebuilds the Blob from the store alone: offset 0, whole file. The slice window sits on the `FileReader` and the arm never read it.
- Cause 2: `FileRoute::serve` (src/runtime/server/FileRoute.rs:328) clamps the size to the file size without the offset, and sends an empty window to EOF. On a 16-byte file a `slice(10)` route declares `Content-Length: 16` and sends 6 bytes. `slice(5, 5)` declares 0 and sends 11.

### Fix
- `to_any_blob`: copy the reader's `start_offset` / `max_size` onto the rebuilt Blob, the inverse of `from_blob_copy_ref`. The `Source::Blob` arm already does this.
- `FileRoute::serve`: clamp the offset to the file size and the length to what is left, as `RequestContext::do_sendfile` does. Every regular file gets a length, so `Content-Length` and the bytes sent agree. A zero-length body ends without a file stream.
- Verified: 8 new tests in `test/js/web/fetch/body.test.ts` and 2 in `test/js/bun/http/bun-serve-file.test.ts` fail on 1.4.1 and on a debug build of main, pass with this change. Neighbouring suites stay green (Notes).

### Background
- A `Blob` is a view (`offset`, `size`) onto a refcounted `Blob.Store`. `slice()` changes only the view. `blob.stream()` on a file Blob makes a `FileReader` that keeps the store and the view as `start_offset` / `max_size`.
- `to_any_blob` is a shortcut: if a native stream is unread, a consumer takes the Blob it was made from instead of pumping it.
- A `FileRoute` serves `routes: { "/x": new Response(Bun.file(p)) }`. Per request it writes `Content-Length` and hands the fd to `FileResponseStream` with an offset and a byte count, or read-to-EOF for pipes and sockets.

<details><summary>Notes</summary>

Also run on the patched build, all green: the rest of both test files, bun-serve-static, bun-serve-routes, serve-directory-routes, serve-file-slice-read-error, blob.test.ts, streams.test.js, body-clone.

Probe on a 26-byte file `abcdefghijklmnopqrstuvwxyz`, every line uses `Bun.file(p).slice(3, 8).stream()`:

```
                                        1.4.x                   this build
Bun.serve handler, GET body / CL        whole file / 26         "defgh" / 5
Bun.serve handler, HEAD CL              26                      5
new Response(stream).arrayBuffer()      whole file              "defgh"
new Response(stream).bytes()            whole file              "defgh"
new Response(stream).blob()             size 26                 size 5, "defgh"
new Request(url, {body: stream}).bytes  whole file              "defgh"
new Response(slice); .body; .bytes()    whole file              "defgh"
Bun.spawn({ stdin: stream })            whole file              whole file (#31931)
```

16-byte file `0123456789ABCDEF` served as routes, `GET` with `Connection: close`, `cl` is the declared Content-Length:

```
route body                  1.4.x                                   this build
slice(5, 10)                cl=5  "56789"                           cl=5 "56789"
slice(5, 10).stream()       cl=16 whole file                        cl=5 "56789"
slice(10)                   cl=16, 6 bytes, connection closed       cl=6 "ABCDEF"
slice(10).stream()          cl=16 whole file                        cl=6 "ABCDEF"
slice(10, 100)              cl=16, 6 bytes, connection closed       cl=6 "ABCDEF"
slice(5, 5)                 cl=0 followed by "56789ABCDEF"          cl=0, nothing
slice(5, 5).stream()        cl=16 whole file                        cl=0, nothing
whole file (both forms)     cl=16 whole file                        cl=16 whole file
```

An unsliced `Bun.file(p).stream()` has `start_offset == Some(0)` and `max_size == None`, so the rebuilt Blob is unchanged for it. A file store reports its size as `MAX_SIZE` (unknown), which is why a Blob built from the store alone means the whole file.

Not fixed here: `Bun.spawn({ stdin: sliceStream })` still sends the whole file. Spawn's `extract_blob` redirects any file-backed Blob by path or fd, for a directly passed `Bun.file().slice()` too. That is #31931.

The same `to_any_blob` arm also drops a user-set `type` on the rebuilt Blob. Pre-existing, unrelated to slicing, left alone.

`text()`, `for await` and `Bun.readableStreamTo*()` pump the stream and do not take this path.

#31674 carries the same nine-line `to_any_blob` change inside a larger rework of the Response and file-stream paths. Whichever lands first, the other loses this hunk as a trivial conflict.

Rebase: main split `FileRoute::on` into `on` and `serve` (which returns a `Serve` enum) in #40136. The `FileRoute` commit was re-applied onto `serve`. The zero-length early return now returns `Serve::Done`, so `on` closes the fd and completes the response on the same path as HEAD and 412.

The earlier PR's review threads (two bot reviews, both LGTM) and its status comment are on #39241.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts, test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->