### PR TITLE
compile: report an error instead of panicking when a Mach-O offset passes 4 GiB

### DIFF
--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -29,9 +29,7 @@ pub enum MachoError {
     MissingRequiredSegment,
     #[error("OutOfMemory")]
     OutOfMemory,
-    /// Embedding the bundle moved a `__LINKEDIT` load command offset past
-    /// `u32::MAX`. Mach-O stores those offsets as 32-bit, so the output cannot
-    /// be written whatever the segment layout.
+    /// A shifted `__LINKEDIT` load command offset no longer fits the u32 Mach-O stores.
     #[error("executable would exceed 4 GiB (Mach-O load commands store 32-bit file offsets)")]
     ExecutableTooLarge,
 }

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -29,6 +29,11 @@ pub enum MachoError {
     MissingRequiredSegment,
     #[error("OutOfMemory")]
     OutOfMemory,
+    /// Embedding the bundle moved a `__LINKEDIT` load command offset past
+    /// `u32::MAX`. Mach-O stores those offsets as 32-bit, so the output cannot
+    /// be written whatever the segment layout.
+    #[error("executable would exceed 4 GiB (Mach-O load commands store 32-bit file offsets)")]
+    ExecutableTooLarge,
 }
 bun_core::oom_from_alloc!(MachoError);
 
@@ -535,7 +540,7 @@ struct Shifter {
 }
 
 impl Shifter {
-    fn do_(value: u64, amount: u64, range_min: u64, range_max: u64) -> Result<u64, MachoError> {
+    fn do_(value: u64, amount: u64, range_min: u64, range_max: u64) -> Result<u32, MachoError> {
         if value == 0 {
             return Ok(0);
         }
@@ -546,23 +551,21 @@ impl Shifter {
             return Err(MachoError::OffsetOutOfRange);
         }
 
-        // Check for overflow
-        if value > u64::MAX - amount {
-            return Err(MachoError::OffsetOverflow);
-        }
-
-        Ok(value + amount)
+        // The shifted offset goes back into a u32 load command field.
+        value
+            .checked_add(amount)
+            .and_then(|shifted| u32::try_from(shifted).ok())
+            .ok_or(MachoError::ExecutableTooLarge)
     }
 
     #[inline]
     fn shift_one(&self, field: &mut u32) -> Result<(), MachoError> {
-        *field = u32::try_from(Self::do_(
+        *field = Self::do_(
             *field as u64,
             self.amount,
             self.start,
-            self.linkedit_fileoff + self.linkedit_filesize,
-        )?)
-        .unwrap();
+            self.linkedit_fileoff.saturating_add(self.linkedit_filesize),
+        )?;
         Ok(())
     }
 }

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1545,71 +1545,98 @@ const server = serve({
   }, 30_000);
 });
 
+const MH_MAGIC_64 = 0xfeedfacf;
+const CPU_TYPE_X86_64 = 0x01000007;
+const MH_EXECUTE = 2;
+const LC_SEGMENT_64 = 0x19;
+const LC_SYMTAB = 0x2;
+
+// Minimal Mach-O "base executable" for --compile-executable-path: a __BUN segment with one
+// __bun section followed by a 0x100-byte __LINKEDIT segment, plus an optional LC_SYMTAB whose
+// symbol table starts at __LINKEDIT and whose string table sits 0x80 bytes in.
+// `bunFileOff`/`bunFileSize` are where the load commands claim the __BUN data lives;
+// `fileSize` is how many bytes the template actually contains.
+function machoTemplate({
+  bunFileOff = 0x4000,
+  bunFileSize = 0x4000,
+  fileSize = 0x8100,
+  linkeditFileOff = bunFileOff + bunFileSize,
+  symtab = false,
+}: {
+  bunFileOff?: number;
+  bunFileSize?: number;
+  fileSize?: number;
+  linkeditFileOff?: number;
+  symtab?: boolean;
+} = {}): Buffer {
+  const segCmdSize = 72; // sizeof(segment_command_64)
+  const sectSize = 80; // sizeof(section_64)
+  const symtabCmdSize = 24; // sizeof(symtab_command)
+  const sizeofcmds = segCmdSize + sectSize + segCmdSize + (symtab ? symtabCmdSize : 0);
+  const buf = Buffer.alloc(fileSize);
+  const writeName = (off: number, name: string) => buf.write(name, off, 16, "latin1");
+
+  // mach_header_64
+  buf.writeUInt32LE(MH_MAGIC_64, 0);
+  buf.writeInt32LE(CPU_TYPE_X86_64, 4);
+  buf.writeInt32LE(3, 8); // cpusubtype
+  buf.writeUInt32LE(MH_EXECUTE, 12);
+  buf.writeUInt32LE(symtab ? 3 : 2, 16); // ncmds
+  buf.writeUInt32LE(sizeofcmds, 20);
+
+  // LC_SEGMENT_64 __BUN with one section
+  let o = 32;
+  buf.writeUInt32LE(LC_SEGMENT_64, o);
+  buf.writeUInt32LE(segCmdSize + sectSize, o + 4); // cmdsize
+  writeName(o + 8, "__BUN");
+  buf.writeBigUInt64LE(0x1_0000_4000n, o + 24); // vmaddr
+  buf.writeBigUInt64LE(BigInt(bunFileSize), o + 32); // vmsize
+  buf.writeBigUInt64LE(BigInt(bunFileOff), o + 40); // fileoff
+  buf.writeBigUInt64LE(BigInt(bunFileSize), o + 48); // filesize
+  buf.writeInt32LE(7, o + 56); // maxprot
+  buf.writeInt32LE(3, o + 60); // initprot
+  buf.writeUInt32LE(1, o + 64); // nsects
+
+  // section_64 __bun
+  o += segCmdSize;
+  writeName(o, "__bun");
+  writeName(o + 16, "__BUN");
+  buf.writeBigUInt64LE(0x1_0000_4000n, o + 32); // addr
+  buf.writeBigUInt64LE(BigInt(bunFileSize), o + 40); // size
+  buf.writeUInt32LE(bunFileOff, o + 48); // offset
+  buf.writeUInt32LE(14, o + 52); // align = 2^14
+
+  // LC_SEGMENT_64 __LINKEDIT
+  o += sectSize;
+  buf.writeUInt32LE(LC_SEGMENT_64, o);
+  buf.writeUInt32LE(segCmdSize, o + 4);
+  writeName(o + 8, "__LINKEDIT");
+  buf.writeBigUInt64LE(0x1_0001_0000n, o + 24); // vmaddr
+  buf.writeBigUInt64LE(0x1000n, o + 32); // vmsize
+  buf.writeBigUInt64LE(BigInt(linkeditFileOff), o + 40); // fileoff
+  buf.writeBigUInt64LE(0x100n, o + 48); // filesize
+  buf.writeInt32LE(1, o + 56); // maxprot
+  buf.writeInt32LE(1, o + 60); // initprot
+
+  if (symtab) {
+    // LC_SYMTAB
+    o += segCmdSize;
+    buf.writeUInt32LE(LC_SYMTAB, o);
+    buf.writeUInt32LE(symtabCmdSize, o + 4);
+    buf.writeUInt32LE(linkeditFileOff, o + 8); // symoff
+    buf.writeUInt32LE(0, o + 12); // nsyms
+    buf.writeUInt32LE(linkeditFileOff + 0x80, o + 16); // stroff
+    buf.writeUInt32LE(0x80, o + 20); // strsize
+  }
+
+  return buf;
+}
+
 test("compile --compile-executable-path rejects a Mach-O template whose __BUN segment offsets exceed the file bounds", async () => {
   // `bun build --compile --target=bun-darwin-*` patches the application bundle into the
   // __BUN,__bun section of the base executable named by --compile-executable-path. The
   // segment/section offsets in that file's load commands must be validated against the
   // actual file size before they are used as memmove destinations.
-  const MH_MAGIC_64 = 0xfeedfacf;
-  const CPU_TYPE_X86_64 = 0x01000007;
-  const MH_EXECUTE = 2;
-  const LC_SEGMENT_64 = 0x19;
-
-  // Minimal Mach-O "base executable": a __BUN segment with one __bun section followed by a
-  // __LINKEDIT segment. `bunFileOff`/`bunFileSize` are where the load commands claim the
-  // __BUN data lives; `fileSize` is how many bytes the template actually contains.
-  function machoTemplate(bunFileOff: number, bunFileSize = 0x4000, fileSize = 0x8100): Buffer {
-    const segCmdSize = 72; // sizeof(segment_command_64)
-    const sectSize = 80; // sizeof(section_64)
-    const sizeofcmds = segCmdSize + sectSize + segCmdSize;
-    const buf = Buffer.alloc(fileSize);
-    const writeName = (off: number, name: string) => buf.write(name, off, 16, "latin1");
-
-    // mach_header_64
-    buf.writeUInt32LE(MH_MAGIC_64, 0);
-    buf.writeInt32LE(CPU_TYPE_X86_64, 4);
-    buf.writeInt32LE(3, 8); // cpusubtype
-    buf.writeUInt32LE(MH_EXECUTE, 12);
-    buf.writeUInt32LE(2, 16); // ncmds
-    buf.writeUInt32LE(sizeofcmds, 20);
-
-    // LC_SEGMENT_64 __BUN with one section
-    let o = 32;
-    buf.writeUInt32LE(LC_SEGMENT_64, o);
-    buf.writeUInt32LE(segCmdSize + sectSize, o + 4); // cmdsize
-    writeName(o + 8, "__BUN");
-    buf.writeBigUInt64LE(0x1_0000_4000n, o + 24); // vmaddr
-    buf.writeBigUInt64LE(BigInt(bunFileSize), o + 32); // vmsize
-    buf.writeBigUInt64LE(BigInt(bunFileOff), o + 40); // fileoff
-    buf.writeBigUInt64LE(BigInt(bunFileSize), o + 48); // filesize
-    buf.writeInt32LE(7, o + 56); // maxprot
-    buf.writeInt32LE(3, o + 60); // initprot
-    buf.writeUInt32LE(1, o + 64); // nsects
-
-    // section_64 __bun
-    o += segCmdSize;
-    writeName(o, "__bun");
-    writeName(o + 16, "__BUN");
-    buf.writeBigUInt64LE(0x1_0000_4000n, o + 32); // addr
-    buf.writeBigUInt64LE(BigInt(bunFileSize), o + 40); // size
-    buf.writeUInt32LE(bunFileOff, o + 48); // offset
-    buf.writeUInt32LE(14, o + 52); // align = 2^14
-
-    // LC_SEGMENT_64 __LINKEDIT
-    o += sectSize;
-    buf.writeUInt32LE(LC_SEGMENT_64, o);
-    buf.writeUInt32LE(segCmdSize, o + 4);
-    writeName(o + 8, "__LINKEDIT");
-    buf.writeBigUInt64LE(0x1_0001_0000n, o + 24); // vmaddr
-    buf.writeBigUInt64LE(0x1000n, o + 32); // vmsize
-    buf.writeBigUInt64LE(BigInt(bunFileOff + bunFileSize), o + 40); // fileoff (right after __BUN)
-    buf.writeBigUInt64LE(0x100n, o + 48); // filesize
-    buf.writeInt32LE(1, o + 56); // maxprot
-    buf.writeInt32LE(1, o + 60); // initprot
-
-    return buf;
-  }
-
   using dir = tempDir("compile-macho-template-bounds", {
     "entry.js": `console.log("compiled-from-template");`,
   });
@@ -1617,13 +1644,13 @@ test("compile --compile-executable-path rejects a Mach-O template whose __BUN se
 
   for (const [name, bytes, wantErr] of [
     // __BUN fileoff points 1 GiB past the end of the 33 KB file.
-    ["fileoff-past-eof", machoTemplate(0x40000000), "OffsetOutOfRange"],
+    ["fileoff-past-eof", machoTemplate({ bunFileOff: 0x40000000 }), "OffsetOutOfRange"],
     // __BUN filesize (32 KB) exceeds the 256-byte file: the bounds check must reject this
     // before the growth `reserve()` (which would otherwise see a negative size_diff).
-    ["filesize-past-eof", machoTemplate(0, 0x8000, 256), "OffsetOutOfRange"],
+    ["filesize-past-eof", machoTemplate({ bunFileOff: 0, bunFileSize: 0x8000, fileSize: 256 }), "OffsetOutOfRange"],
     // __BUN filesize (32 KB) is in-bounds but larger than the 16 KB aligned bundle slot;
     // write_section only grows, so a template that would require shrinking is rejected.
-    ["filesize-needs-shrink", machoTemplate(0x4000, 0x8000, 0xc100), "InvalidObject"],
+    ["filesize-needs-shrink", machoTemplate({ bunFileSize: 0x8000, fileSize: 0xc100 }), "InvalidObject"],
   ] as const) {
     const badTemplate = join(cwd, `template-${name}`);
     await Bun.write(badTemplate, bytes);
@@ -1656,7 +1683,7 @@ test("compile --compile-executable-path rejects a Mach-O template whose __BUN se
 
   // The same template with in-bounds offsets is still accepted.
   const goodTemplate = join(cwd, "template-good");
-  await Bun.write(goodTemplate, machoTemplate(0x4000));
+  await Bun.write(goodTemplate, machoTemplate());
   const outGood = join(cwd, "out-good");
   {
     await using proc = Bun.spawn({
@@ -1691,75 +1718,6 @@ test("compile --compile-executable-path rejects a Mach-O template whose __LINKED
   // amount, so a bundle of about 4 GiB pushes them past u32::MAX. Building such a bundle
   // is too slow for a test, so this template places __LINKEDIT and the LC_SYMTAB offsets
   // just below 4 GiB: a 32 KB bundle is then enough to move them over the edge.
-  const MH_MAGIC_64 = 0xfeedfacf;
-  const CPU_TYPE_X86_64 = 0x01000007;
-  const MH_EXECUTE = 2;
-  const LC_SEGMENT_64 = 0x19;
-  const LC_SYMTAB = 0x2;
-  const segCmdSize = 72; // sizeof(segment_command_64)
-  const sectSize = 80; // sizeof(section_64)
-  const symtabCmdSize = 24; // sizeof(symtab_command)
-
-  // __BUN [0x4000, 0x8000) with one __bun section, then a 0x1000-byte __LINKEDIT at
-  // `linkeditFileOff` holding a symbol table at its start and a string table 0x800 bytes in.
-  function machoTemplate(linkeditFileOff: number): Buffer {
-    const sizeofcmds = segCmdSize + sectSize + segCmdSize + symtabCmdSize;
-    const buf = Buffer.alloc(0x9000);
-    const writeName = (off: number, name: string) => buf.write(name, off, 16, "latin1");
-
-    // mach_header_64
-    buf.writeUInt32LE(MH_MAGIC_64, 0);
-    buf.writeInt32LE(CPU_TYPE_X86_64, 4);
-    buf.writeInt32LE(3, 8); // cpusubtype
-    buf.writeUInt32LE(MH_EXECUTE, 12);
-    buf.writeUInt32LE(3, 16); // ncmds
-    buf.writeUInt32LE(sizeofcmds, 20);
-
-    // LC_SEGMENT_64 __BUN with one section
-    let o = 32;
-    buf.writeUInt32LE(LC_SEGMENT_64, o);
-    buf.writeUInt32LE(segCmdSize + sectSize, o + 4); // cmdsize
-    writeName(o + 8, "__BUN");
-    buf.writeBigUInt64LE(0x1_0000_4000n, o + 24); // vmaddr
-    buf.writeBigUInt64LE(0x4000n, o + 32); // vmsize
-    buf.writeBigUInt64LE(0x4000n, o + 40); // fileoff
-    buf.writeBigUInt64LE(0x4000n, o + 48); // filesize
-    buf.writeInt32LE(7, o + 56); // maxprot
-    buf.writeInt32LE(3, o + 60); // initprot
-    buf.writeUInt32LE(1, o + 64); // nsects
-
-    // section_64 __bun
-    o += segCmdSize;
-    writeName(o, "__bun");
-    writeName(o + 16, "__BUN");
-    buf.writeBigUInt64LE(0x1_0000_4000n, o + 32); // addr
-    buf.writeBigUInt64LE(0x4000n, o + 40); // size
-    buf.writeUInt32LE(0x4000, o + 48); // offset
-    buf.writeUInt32LE(14, o + 52); // align = 2^14
-
-    // LC_SEGMENT_64 __LINKEDIT
-    o += sectSize;
-    buf.writeUInt32LE(LC_SEGMENT_64, o);
-    buf.writeUInt32LE(segCmdSize, o + 4);
-    writeName(o + 8, "__LINKEDIT");
-    buf.writeBigUInt64LE(0x1_0001_0000n, o + 24); // vmaddr
-    buf.writeBigUInt64LE(0x1000n, o + 32); // vmsize
-    buf.writeBigUInt64LE(BigInt(linkeditFileOff), o + 40); // fileoff
-    buf.writeBigUInt64LE(0x1000n, o + 48); // filesize
-    buf.writeInt32LE(1, o + 56); // maxprot
-    buf.writeInt32LE(1, o + 60); // initprot
-
-    // LC_SYMTAB
-    o += segCmdSize;
-    buf.writeUInt32LE(LC_SYMTAB, o);
-    buf.writeUInt32LE(symtabCmdSize, o + 4);
-    buf.writeUInt32LE(linkeditFileOff, o + 8); // symoff
-    buf.writeUInt32LE(0, o + 12); // nsyms
-    buf.writeUInt32LE(linkeditFileOff + 0x800, o + 16); // stroff
-    buf.writeUInt32LE(0x800, o + 20); // strsize
-
-    return buf;
-  }
 
   // Returns the __LINKEDIT fileoff and the LC_SYMTAB offsets of a Mach-O file.
   function readLinkeditOffsets(buf: Buffer) {
@@ -1813,9 +1771,12 @@ test("compile --compile-executable-path rejects a Mach-O template whose __LINKED
     return { stderr, exitCode, outfile };
   };
 
-  // __LINKEDIT claims to end exactly at 4 GiB, so any growth of __BUN overflows its offsets.
+  // __LINKEDIT starts 4 KiB below 4 GiB, so any growth of __BUN (16 KiB steps) overflows its offsets.
   {
-    const { stderr, exitCode, outfile } = await build("too-large", machoTemplate(0xffff_f000));
+    const { stderr, exitCode, outfile } = await build(
+      "too-large",
+      machoTemplate({ linkeditFileOff: 0xffff_f000, symtab: true }),
+    );
     expect(stderr).toContain("executable would exceed 4 GiB");
     expect(stderr).toContain("failed to write compiled executable");
     expect(await Bun.file(outfile).exists()).toBe(false);
@@ -1824,16 +1785,16 @@ test("compile --compile-executable-path rejects a Mach-O template whose __LINKED
 
   // The same template with __LINKEDIT right after __BUN builds, and its offsets move together.
   {
-    const { stderr, exitCode, outfile } = await build("in-range", machoTemplate(0x8000));
+    const { stderr, exitCode, outfile } = await build("in-range", machoTemplate({ symtab: true }));
     expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 
     const out = Buffer.from(await Bun.file(outfile).arrayBuffer());
     const { linkeditFileOff, symoff, stroff } = readLinkeditOffsets(out);
     expect(linkeditFileOff).toBeGreaterThan(0x8000);
-    expect({ symoff, stroff }).toEqual({ symoff: linkeditFileOff, stroff: linkeditFileOff + 0x800 });
+    expect({ symoff, stroff }).toEqual({ symoff: linkeditFileOff, stroff: linkeditFileOff + 0x80 });
   }
-}, 60_000);
+});
 
 test("compile --compile-executable-path rejects a template shorter than the executable-format header", async () => {
   // `--compile-executable-path` accepts an arbitrary file. A file shorter than the target

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1685,6 +1685,156 @@ test("compile --compile-executable-path rejects a Mach-O template whose __BUN se
   }
 }, 60_000);
 
+test("compile --compile-executable-path rejects a Mach-O template whose __LINKEDIT offsets would pass 4 GiB once the bundle is embedded", async () => {
+  // Mach-O load commands (LC_SYMTAB, LC_CODE_SIGNATURE, ...) store file offsets as u32.
+  // Embedding the bundle grows __BUN and moves every __LINKEDIT offset forward by the same
+  // amount, so a bundle of about 4 GiB pushes them past u32::MAX. Building such a bundle
+  // is too slow for a test, so this template places __LINKEDIT and the LC_SYMTAB offsets
+  // just below 4 GiB: a 32 KB bundle is then enough to move them over the edge.
+  const MH_MAGIC_64 = 0xfeedfacf;
+  const CPU_TYPE_X86_64 = 0x01000007;
+  const MH_EXECUTE = 2;
+  const LC_SEGMENT_64 = 0x19;
+  const LC_SYMTAB = 0x2;
+  const segCmdSize = 72; // sizeof(segment_command_64)
+  const sectSize = 80; // sizeof(section_64)
+  const symtabCmdSize = 24; // sizeof(symtab_command)
+
+  // __BUN [0x4000, 0x8000) with one __bun section, then a 0x1000-byte __LINKEDIT at
+  // `linkeditFileOff` holding a symbol table at its start and a string table 0x800 bytes in.
+  function machoTemplate(linkeditFileOff: number): Buffer {
+    const sizeofcmds = segCmdSize + sectSize + segCmdSize + symtabCmdSize;
+    const buf = Buffer.alloc(0x9000);
+    const writeName = (off: number, name: string) => buf.write(name, off, 16, "latin1");
+
+    // mach_header_64
+    buf.writeUInt32LE(MH_MAGIC_64, 0);
+    buf.writeInt32LE(CPU_TYPE_X86_64, 4);
+    buf.writeInt32LE(3, 8); // cpusubtype
+    buf.writeUInt32LE(MH_EXECUTE, 12);
+    buf.writeUInt32LE(3, 16); // ncmds
+    buf.writeUInt32LE(sizeofcmds, 20);
+
+    // LC_SEGMENT_64 __BUN with one section
+    let o = 32;
+    buf.writeUInt32LE(LC_SEGMENT_64, o);
+    buf.writeUInt32LE(segCmdSize + sectSize, o + 4); // cmdsize
+    writeName(o + 8, "__BUN");
+    buf.writeBigUInt64LE(0x1_0000_4000n, o + 24); // vmaddr
+    buf.writeBigUInt64LE(0x4000n, o + 32); // vmsize
+    buf.writeBigUInt64LE(0x4000n, o + 40); // fileoff
+    buf.writeBigUInt64LE(0x4000n, o + 48); // filesize
+    buf.writeInt32LE(7, o + 56); // maxprot
+    buf.writeInt32LE(3, o + 60); // initprot
+    buf.writeUInt32LE(1, o + 64); // nsects
+
+    // section_64 __bun
+    o += segCmdSize;
+    writeName(o, "__bun");
+    writeName(o + 16, "__BUN");
+    buf.writeBigUInt64LE(0x1_0000_4000n, o + 32); // addr
+    buf.writeBigUInt64LE(0x4000n, o + 40); // size
+    buf.writeUInt32LE(0x4000, o + 48); // offset
+    buf.writeUInt32LE(14, o + 52); // align = 2^14
+
+    // LC_SEGMENT_64 __LINKEDIT
+    o += sectSize;
+    buf.writeUInt32LE(LC_SEGMENT_64, o);
+    buf.writeUInt32LE(segCmdSize, o + 4);
+    writeName(o + 8, "__LINKEDIT");
+    buf.writeBigUInt64LE(0x1_0001_0000n, o + 24); // vmaddr
+    buf.writeBigUInt64LE(0x1000n, o + 32); // vmsize
+    buf.writeBigUInt64LE(BigInt(linkeditFileOff), o + 40); // fileoff
+    buf.writeBigUInt64LE(0x1000n, o + 48); // filesize
+    buf.writeInt32LE(1, o + 56); // maxprot
+    buf.writeInt32LE(1, o + 60); // initprot
+
+    // LC_SYMTAB
+    o += segCmdSize;
+    buf.writeUInt32LE(LC_SYMTAB, o);
+    buf.writeUInt32LE(symtabCmdSize, o + 4);
+    buf.writeUInt32LE(linkeditFileOff, o + 8); // symoff
+    buf.writeUInt32LE(0, o + 12); // nsyms
+    buf.writeUInt32LE(linkeditFileOff + 0x800, o + 16); // stroff
+    buf.writeUInt32LE(0x800, o + 20); // strsize
+
+    return buf;
+  }
+
+  // Returns the __LINKEDIT fileoff and the LC_SYMTAB offsets of a Mach-O file.
+  function readLinkeditOffsets(buf: Buffer) {
+    const ncmds = buf.readUInt32LE(16);
+    let linkeditFileOff = -1;
+    let symoff = -1;
+    let stroff = -1;
+    let o = 32;
+    for (let i = 0; i < ncmds; i++) {
+      const cmd = buf.readUInt32LE(o);
+      const cmdsize = buf.readUInt32LE(o + 4);
+      if (cmd === LC_SEGMENT_64 && buf.toString("latin1", o + 8, o + 18) === "__LINKEDIT") {
+        linkeditFileOff = Number(buf.readBigUInt64LE(o + 40));
+      } else if (cmd === LC_SYMTAB) {
+        symoff = buf.readUInt32LE(o + 8);
+        stroff = buf.readUInt32LE(o + 16);
+      }
+      o += cmdsize;
+    }
+    return { linkeditFileOff, symoff, stroff };
+  }
+
+  // 32 KB of source does not fit the template's 16 KB __BUN slot, so __LINKEDIT has to move.
+  using dir = tempDir("compile-macho-template-4gib", {
+    "entry.js": `console.log("${Buffer.alloc(32 * 1024, "a").toString()}");`,
+  });
+  const cwd = String(dir);
+
+  const build = async (name: string, template: Buffer) => {
+    const templatePath = join(cwd, `template-${name}`);
+    await Bun.write(templatePath, template);
+    const outfile = join(cwd, `out-${name}`);
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        "--target=bun-darwin-x64",
+        "--compile-executable-path",
+        templatePath,
+        join(cwd, "entry.js"),
+        "--outfile",
+        outfile,
+      ],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stderr, exitCode, outfile };
+  };
+
+  // __LINKEDIT claims to end exactly at 4 GiB, so any growth of __BUN overflows its offsets.
+  {
+    const { stderr, exitCode, outfile } = await build("too-large", machoTemplate(0xffff_f000));
+    expect(stderr).toContain("executable would exceed 4 GiB");
+    expect(stderr).toContain("failed to write compiled executable");
+    expect(await Bun.file(outfile).exists()).toBe(false);
+    expect(exitCode).toBe(1);
+  }
+
+  // The same template with __LINKEDIT right after __BUN builds, and its offsets move together.
+  {
+    const { stderr, exitCode, outfile } = await build("in-range", machoTemplate(0x8000));
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const out = Buffer.from(await Bun.file(outfile).arrayBuffer());
+    const { linkeditFileOff, symoff, stroff } = readLinkeditOffsets(out);
+    expect(linkeditFileOff).toBeGreaterThan(0x8000);
+    expect({ symoff, stroff }).toEqual({ symoff: linkeditFileOff, stroff: linkeditFileOff + 0x800 });
+  }
+}, 60_000);
+
 test("compile --compile-executable-path rejects a template shorter than the executable-format header", async () => {
   // `--compile-executable-path` accepts an arbitrary file. A file shorter than the target
   // format's fixed header (or one whose header advertises more load-command bytes than the


### PR DESCRIPTION
### Problem
- `bun build --compile` (and `Bun.build({ compile })`) for a darwin target crashes with `panic: called Result::unwrap() on an Err value: TryFromIntError(PosOverflow)` in `macho::shift_one` when the embedded bundle is about 4 GiB. Reported through crash telemetry (BUN-4VCR, Bun 1.4.0, macOS arm64).
- The cause is `Shifter::shift_one` (`src/exe_format/macho.rs:558`). It adds the bundle growth to every `__LINKEDIT` load command offset and stores the result with `u32::try_from(..).unwrap()`. Mach-O stores these offsets as 32-bit, so an offset at or past 4 GiB cannot be stored and the unwrap panics.

### Fix
- `Shifter::do_` now returns the shifted offset as a `u32`. If the shifted value does not fit, it returns the new `MachoError::ExecutableTooLarge`. Its message reads: `executable would exceed 4 GiB (Mach-O load commands store 32-bit file offsets)`.
- The error flows through the existing `inject` path. The compile fails with that message plus `failed to write compiled executable <outfile>`, exit code 1, and no output file. The PE writer already rejects a payload over 4 GiB this way (`pe.rs`, `Error::Overflow`).
- The `range_max` bound in `shift_one` uses `saturating_add`, so a template with absurd `__LINKEDIT` sizes cannot trip a debug overflow check in the same function.
- Verified: `test/bundler/bundler_compile.test.ts` (new test, stock bun 1.4.1 hits the exact panic). Also the other `--compile-executable-path` tests in that file and `test/bundler/compile-macho-codesign.test.ts`.

### Background
- `bun build --compile` for a Mach-O target copies the bun binary, grows its `__BUN` segment to hold the bundle, and moves everything after it (`__LINKEDIT`) forward by the growth.
- `__LINKEDIT` holds the symbol table, string table, chained fixups, and code signature. The load commands `LC_SYMTAB`, `LC_DYSYMTAB`, `LC_DYLD_INFO`, and the `linkedit_data_command` family point at them with `u32` file offsets. Segment offsets (`fileoff`) are `u64`, but these table offsets are not.
- `--compile-executable-path` lets a test supply its own template binary. The new test uses a small synthetic Mach-O whose `__LINKEDIT` and `LC_SYMTAB` offsets sit just below 4 GiB, so a 32 KB bundle reproduces the same arithmetic as a 4 GiB bundle against a real template.

<details><summary>Notes</summary>

- Sentry event: `bun@1.4.0+34cbb9a40`, macOS aarch64, `AutoCommand`, tags `define`, `jsc`. Stack: `shift_one` <- `update_load_command_offsets` <- `MachoFile::write_section` <- `StandaloneModuleGraph::inject` <- `to_executable` <- `do_compilation` <- `JSBundleCompletionTask::on_complete`.
- The old overflow check in `do_` compared against `u64::MAX`. `value` comes from a `u32` field and `amount` is the bundle growth, so that check could never fire. The `u32` check replaces it.
- The Zig original had the same `@intCast` at this spot, so the panic predates the Rust port.
- Before the fix, the new test fails with the exact panic text from the report. After the fix it passes. The second half of the test builds the same template with `__LINKEDIT` at a normal offset and checks that `__LINKEDIT.fileoff`, `symoff`, and `stroff` all moved by the same amount, so the shifter still works.
- `bundler_compile.test.ts` has one unrelated failure on a local debug build: `compile/HelloWorldWithProcessVersionsBun` compares against `Bun.version` with `-debug` stripped, while the compiled debug executable reports `1.4.1-debug`. It fails the same way without this change and compiles for the host (ELF path).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->