### PR TITLE
Write the sampling profiler report at exit from Bun, not JSC's atexit hook

### DIFF
--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -757,7 +757,8 @@ declare module "bun:jsc" {
    * value, use {@link profile} instead.
    *
    * @param optionalDirectory A directory to write a text report of the hottest
-   * functions and bytecodes into when the process exits. Created if it does not exist.
+   * functions and bytecodes into when the process (or the worker that called
+   * this) exits. Created if it does not exist.
    * @param sampleInterval How often to sample the stack, in microseconds. Defaults to 1000 (once a millisecond).
    */
   function startSamplingProfiler(optionalDirectory?: string, sampleInterval?: number): void;

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -41,6 +41,9 @@ unsafe extern "C" {
     );
     /// Plain by-value `c_int`; sets a global sampler interval, no pointer invariants.
     safe fn Bun__setSamplingInterval(interval_microseconds: c_int);
+    /// The C++ side writes a +1 ref into `out` (the text report of `vm`'s
+    /// sampling profiler) and leaves it empty when the VM has no profiler.
+    safe fn Bun__SamplingProfiler__report(vm: &mut VM, out: &mut BunString);
 }
 
 pub fn set_sampling_interval(interval: u32) {
@@ -52,6 +55,39 @@ pub fn set_sampling_interval(interval: u32) {
 
 pub fn start_cpu_profiler(vm: &mut VM) {
     Bun__startCPUProfiler(vm);
+}
+
+/// Writes the JSC sampling profiler report for `vm` into `directory` (the
+/// absolute UTF-8 path from `BUN_JSC_samplingProfilerPath` or `bun:jsc`'s
+/// `startSamplingProfiler()`), creating the directory if it is missing. Called
+/// once per VM from `VirtualMachine::on_exit`. A VM without a sampling
+/// profiler writes nothing.
+pub(crate) fn write_sampling_profiler_report(
+    vm: &mut VM,
+    directory: &[u8],
+) -> Result<(), ProfilerError> {
+    let mut report = BunString::EMPTY;
+    Bun__SamplingProfiler__report(vm, &mut report);
+    if report.is_empty() {
+        return Ok(());
+    }
+    let report = report.to_utf8();
+
+    let mut filename_buf = PathBuffer::uninit();
+    let filename = {
+        let mut cursor = std::io::Cursor::new(&mut filename_buf[..]);
+        write_diagnostic_filename(&mut cursor, "SamplingProfile", ".txt")
+            .map_err(|_| ProfilerError::FilenameTooLong)?;
+        let len = usize::try_from(cursor.position()).expect("int cast");
+        &filename_buf[..len]
+    };
+
+    let mut path_buf = AutoAbsPathChecked::init_top_level_dir();
+    path_buf
+        .join(&[directory, filename])
+        .map_err(|_| ProfilerError::FilenameTooLong)?;
+
+    write_file_creating_dir(&mut path_buf, directory, report.slice())
 }
 
 pub(crate) fn stop_and_write_profile(
@@ -93,30 +129,36 @@ fn write_profile_to_file(
 
     build_output_path(&mut path_buf, config, is_md_format)?;
 
+    write_file_creating_dir(&mut path_buf, config.dir, profile_slice.slice())
+}
+
+/// Writes `contents` to `path`. When the write fails because `dir` (the
+/// directory `path` is in) is missing, creates `dir` and retries once.
+fn write_file_creating_dir(
+    path: &mut AutoAbsPathChecked,
+    dir: &[u8],
+    contents: &[u8],
+) -> Result<(), ProfilerError> {
     // Convert to OS-specific path (UTF-16 on Windows, UTF-8 elsewhere)
     #[cfg(windows)]
     let mut path_buf_os = OSPathBuffer::uninit();
     #[cfg(windows)]
     let output_path_os =
-        bun_core::strings::convert_utf8_to_utf16_in_buffer_z(&mut path_buf_os, path_buf.slice_z());
+        bun_core::strings::convert_utf8_to_utf16_in_buffer_z(&mut path_buf_os, path.slice_z());
     #[cfg(not(windows))]
-    let output_path_os = path_buf.slice_z();
+    let output_path_os = path.slice_z();
 
     // Write the profile to disk using bun.sys.File.writeFile
-    let result =
-        bun_sys::File::write_file_os_path(Fd::cwd(), output_path_os, profile_slice.slice());
+    let result = bun_sys::File::write_file_os_path(Fd::cwd(), output_path_os, contents);
     if let Err(err) = result {
         // If we got ENOENT, PERM, or ACCES, try creating the directory and retry
         let errno = err.get_errno();
         if errno == Errno::ENOENT || errno == Errno::EPERM || errno == Errno::EACCES {
-            if !config.dir.is_empty() {
-                let _ = Fd::cwd().make_path(config.dir);
+            if !dir.is_empty() {
+                let _ = Fd::cwd().make_path(dir);
                 // Retry write
-                let retry_result = bun_sys::File::write_file_os_path(
-                    Fd::cwd(),
-                    output_path_os,
-                    profile_slice.slice(),
-                );
+                let retry_result =
+                    bun_sys::File::write_file_os_path(Fd::cwd(), output_path_os, contents);
                 if retry_result.is_err() {
                     return Err(ProfilerError::WriteFailed);
                 }

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -41,8 +41,7 @@ unsafe extern "C" {
     );
     /// Plain by-value `c_int`; sets a global sampler interval, no pointer invariants.
     safe fn Bun__setSamplingInterval(interval_microseconds: c_int);
-    /// The C++ side writes a +1 ref into `out` (the text report of `vm`'s
-    /// sampling profiler) and leaves it empty when the VM has no profiler.
+    /// Writes a +1 ref into `out`; leaves it empty when the VM has no sampling profiler.
     safe fn Bun__SamplingProfiler__report(vm: &mut VM, out: &mut BunString);
 }
 
@@ -57,11 +56,7 @@ pub fn start_cpu_profiler(vm: &mut VM) {
     Bun__startCPUProfiler(vm);
 }
 
-/// Writes the JSC sampling profiler report for `vm` into `directory` (the
-/// absolute UTF-8 path from `BUN_JSC_samplingProfilerPath` or `bun:jsc`'s
-/// `startSamplingProfiler()`), creating the directory if it is missing. Called
-/// once per VM from `VirtualMachine::on_exit`. A VM without a sampling
-/// profiler writes nothing.
+/// Writes `vm`'s sampling profiler report into `directory` (absolute UTF-8), creating it if missing.
 pub(crate) fn write_sampling_profiler_report(
     vm: &mut VM,
     directory: &[u8],
@@ -132,8 +127,7 @@ fn write_profile_to_file(
     write_file_creating_dir(&mut path_buf, config.dir, profile_slice.slice())
 }
 
-/// Writes `contents` to `path`. When the write fails because `dir` (the
-/// directory `path` is in) is missing, creates `dir` and retries once.
+/// Writes `contents` to `path`; on ENOENT/EPERM/EACCES creates `dir` and retries once.
 fn write_file_creating_dir(
     path: &mut AutoAbsPathChecked,
     dir: &[u8],

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -207,6 +207,12 @@ pub struct VirtualMachine {
     pub dns_result_order: u8,
     pub cpu_profiler_config: Option<crate::bun_cpu_profiler::CPUProfilerConfig>,
     pub heap_profiler_config: Option<crate::bun_heap_profiler::HeapProfilerConfig>,
+    /// Absolute UTF-8 directory for the sampling profiler report, from
+    /// `BUN_JSC_samplingProfilerPath` or `bun:jsc`'s `startSamplingProfiler()`.
+    /// Replaces JSC's own report-at-exit, which crashes when it cannot open the
+    /// output file and never runs under `quick_exit`. [`Self::on_exit`] writes
+    /// the report.
+    pub sampling_profiler_directory: Option<Box<[u8]>>,
     pub counters: Counters,
 
     /// `--hot` / `--watch` mode this VM runs under.
@@ -597,6 +603,19 @@ impl VMHolder {
         let Some(vm_ptr) = VM.get() else { return };
         // SAFETY: called on the JS thread that owns this VM (process._kill).
         let vm = unsafe { &mut *vm_ptr };
+        // Sampling report before the CPU profile: they share the per-VM
+        // SamplingProfiler and stopCPUProfiler clears its traces.
+        if let Some(directory) = vm.sampling_profiler_directory.take() {
+            if let Err(e) =
+                crate::bun_cpu_profiler::write_sampling_profiler_report(vm.jsc_vm_mut(), &directory)
+            {
+                bun_core::Output::err(
+                    <&'static str>::from(e),
+                    "Failed to write sampling profiler report",
+                    (),
+                );
+            }
+        }
         if let Some(config) = vm.cpu_profiler_config.take() {
             if let Err(e) =
                 crate::bun_cpu_profiler::stop_and_write_profile(vm.jsc_vm_mut(), &config)
@@ -1795,6 +1814,23 @@ impl VirtualMachine {
             }
         }
 
+        // Write the JSC sampling profiler report if a directory was set
+        // (BUN_JSC_samplingProfilerPath or bun:jsc's startSamplingProfiler()).
+        // Runs before the CPU profile flush: both share the per-VM
+        // SamplingProfiler and stopCPUProfiler clears its traces, while the
+        // report only reads them.
+        if let Some(directory) = self.sampling_profiler_directory.take() {
+            if let Err(e) = crate::bun_cpu_profiler::write_sampling_profiler_report(
+                self.jsc_vm_mut(),
+                &directory,
+            ) {
+                bun_core::Output::err(
+                    <&'static str>::from(e),
+                    "Failed to write sampling profiler report",
+                    (),
+                );
+            }
+        }
         // Write CPU profile if profiling was enabled - do this FIRST before any
         // shutdown begins. Grab the config and null it out to make this
         // idempotent.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -207,11 +207,7 @@ pub struct VirtualMachine {
     pub dns_result_order: u8,
     pub cpu_profiler_config: Option<crate::bun_cpu_profiler::CPUProfilerConfig>,
     pub heap_profiler_config: Option<crate::bun_heap_profiler::HeapProfilerConfig>,
-    /// Absolute UTF-8 directory for the sampling profiler report, from
-    /// `BUN_JSC_samplingProfilerPath` or `bun:jsc`'s `startSamplingProfiler()`.
-    /// Replaces JSC's own report-at-exit, which crashes when it cannot open the
-    /// output file and never runs under `quick_exit`. [`Self::on_exit`] writes
-    /// the report.
+    /// From `BUN_JSC_samplingProfilerPath` or `bun:jsc` `startSamplingProfiler()`; [`Self::write_profiles`] reads it.
     pub sampling_profiler_directory: Option<Box<[u8]>>,
     pub counters: Counters,
 
@@ -608,41 +604,6 @@ impl VMHolder {
         // the signal may prove non-fatal, and latching here would no-op the real exit's persist.
         // https://github.com/nodejs/node/blob/main/src/env.cc (AtExit(FlushCompileCache))
         crate::node_compile_cache::persist_now();
-    }
-}
-
-impl VirtualMachine {
-    /// Writes each configured profile at most once (each config is `take`n).
-    /// Call on the JS thread under the API lock. The sampling profiler report
-    /// goes first: it shares the per-VM `SamplingProfiler` with the CPU
-    /// profile, and `stopCPUProfiler` clears the traces the report reads.
-    pub fn write_profiles(&mut self) {
-        if let Some(directory) = self.sampling_profiler_directory.take() {
-            if let Err(e) = crate::bun_cpu_profiler::write_sampling_profiler_report(
-                self.jsc_vm_mut(),
-                &directory,
-            ) {
-                bun_core::Output::err(
-                    <&'static str>::from(e),
-                    "Failed to write sampling profiler report",
-                    (),
-                );
-            }
-        }
-        if let Some(config) = self.cpu_profiler_config.take() {
-            if let Err(e) =
-                crate::bun_cpu_profiler::stop_and_write_profile(self.jsc_vm_mut(), &config)
-            {
-                bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
-            }
-        }
-        if let Some(config) = self.heap_profiler_config.take() {
-            if let Err(e) =
-                crate::bun_heap_profiler::generate_and_write_profile(self.jsc_vm_mut(), &config)
-            {
-                bun_core::Output::err(e, "Failed to write heap profile", ());
-            }
-        }
     }
 }
 
@@ -1798,6 +1759,36 @@ impl VirtualMachine {
             }
 
             break;
+        }
+    }
+
+    /// Writes each configured profile once, the sampling report first: `stopCPUProfiler` clears the traces it reads.
+    pub fn write_profiles(&mut self) {
+        if let Some(directory) = self.sampling_profiler_directory.take() {
+            if let Err(e) = crate::bun_cpu_profiler::write_sampling_profiler_report(
+                self.jsc_vm_mut(),
+                &directory,
+            ) {
+                bun_core::Output::err(
+                    <&'static str>::from(e),
+                    "Failed to write sampling profiler report",
+                    (),
+                );
+            }
+        }
+        if let Some(config) = self.cpu_profiler_config.take() {
+            if let Err(e) =
+                crate::bun_cpu_profiler::stop_and_write_profile(self.jsc_vm_mut(), &config)
+            {
+                bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
+            }
+        }
+        if let Some(config) = self.heap_profiler_config.take() {
+            if let Err(e) =
+                crate::bun_heap_profiler::generate_and_write_profile(self.jsc_vm_mut(), &config)
+            {
+                bun_core::Output::err(e, "Failed to write heap profile", ());
+            }
         }
     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -596,19 +596,32 @@ impl VMHolder {
     }
 
     /// Node parity: `process.kill(self, sig)` with no JS handler for `sig`
-    /// flushes the CPU and heap profiles before sending the (likely fatal)
-    /// signal, mirroring node's `Kill` binding. Idempotent via `Option::take`.
+    /// flushes the profiles before sending the (likely fatal) signal,
+    /// mirroring node's `Kill` binding.
     #[unsafe(no_mangle)]
     pub(crate) extern "C" fn Bun__writeProfilesBeforeSelfKill() {
         let Some(vm_ptr) = VM.get() else { return };
         // SAFETY: called on the JS thread that owns this VM (process._kill).
         let vm = unsafe { &mut *vm_ptr };
-        // Sampling report before the CPU profile: they share the per-VM
-        // SamplingProfiler and stopCPUProfiler clears its traces.
-        if let Some(directory) = vm.sampling_profiler_directory.take() {
-            if let Err(e) =
-                crate::bun_cpu_profiler::write_sampling_profiler_report(vm.jsc_vm_mut(), &directory)
-            {
+        vm.write_profiles();
+        // Node runs RunAtExit (incl. compile cache) on self-directed fatal signals. Non-latching:
+        // the signal may prove non-fatal, and latching here would no-op the real exit's persist.
+        // https://github.com/nodejs/node/blob/main/src/env.cc (AtExit(FlushCompileCache))
+        crate::node_compile_cache::persist_now();
+    }
+}
+
+impl VirtualMachine {
+    /// Writes each configured profile at most once (each config is `take`n).
+    /// Call on the JS thread under the API lock. The sampling profiler report
+    /// goes first: it shares the per-VM `SamplingProfiler` with the CPU
+    /// profile, and `stopCPUProfiler` clears the traces the report reads.
+    pub fn write_profiles(&mut self) {
+        if let Some(directory) = self.sampling_profiler_directory.take() {
+            if let Err(e) = crate::bun_cpu_profiler::write_sampling_profiler_report(
+                self.jsc_vm_mut(),
+                &directory,
+            ) {
                 bun_core::Output::err(
                     <&'static str>::from(e),
                     "Failed to write sampling profiler report",
@@ -616,24 +629,20 @@ impl VMHolder {
                 );
             }
         }
-        if let Some(config) = vm.cpu_profiler_config.take() {
+        if let Some(config) = self.cpu_profiler_config.take() {
             if let Err(e) =
-                crate::bun_cpu_profiler::stop_and_write_profile(vm.jsc_vm_mut(), &config)
+                crate::bun_cpu_profiler::stop_and_write_profile(self.jsc_vm_mut(), &config)
             {
                 bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
             }
         }
-        if let Some(config) = vm.heap_profiler_config.take() {
+        if let Some(config) = self.heap_profiler_config.take() {
             if let Err(e) =
-                crate::bun_heap_profiler::generate_and_write_profile(vm.jsc_vm_mut(), &config)
+                crate::bun_heap_profiler::generate_and_write_profile(self.jsc_vm_mut(), &config)
             {
                 bun_core::Output::err(e, "Failed to write heap profile", ());
             }
         }
-        // Node runs RunAtExit (incl. compile cache) on self-directed fatal signals. Non-latching:
-        // the signal may prove non-fatal, and latching here would no-op the real exit's persist.
-        // https://github.com/nodejs/node/blob/main/src/env.cc (AtExit(FlushCompileCache))
-        crate::node_compile_cache::persist_now();
     }
 }
 
@@ -1814,42 +1823,8 @@ impl VirtualMachine {
             }
         }
 
-        // Write the JSC sampling profiler report if a directory was set
-        // (BUN_JSC_samplingProfilerPath or bun:jsc's startSamplingProfiler()).
-        // Runs before the CPU profile flush: both share the per-VM
-        // SamplingProfiler and stopCPUProfiler clears its traces, while the
-        // report only reads them.
-        if let Some(directory) = self.sampling_profiler_directory.take() {
-            if let Err(e) = crate::bun_cpu_profiler::write_sampling_profiler_report(
-                self.jsc_vm_mut(),
-                &directory,
-            ) {
-                bun_core::Output::err(
-                    <&'static str>::from(e),
-                    "Failed to write sampling profiler report",
-                    (),
-                );
-            }
-        }
-        // Write CPU profile if profiling was enabled - do this FIRST before any
-        // shutdown begins. Grab the config and null it out to make this
-        // idempotent.
-        if let Some(config) = self.cpu_profiler_config.take() {
-            if let Err(e) =
-                crate::bun_cpu_profiler::stop_and_write_profile(self.jsc_vm_mut(), &config)
-            {
-                bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
-            }
-        }
-        // Write heap profile if profiling was enabled - do this after CPU
-        // profile but before shutdown.
-        if let Some(config) = self.heap_profiler_config.take() {
-            if let Err(e) =
-                crate::bun_heap_profiler::generate_and_write_profile(self.jsc_vm_mut(), &config)
-            {
-                bun_core::Output::err(e, "Failed to write heap profile", ());
-            }
-        }
+        // Profiles go out first, before any shutdown begins.
+        self.write_profiles();
 
         ExitHandler::dispatch_on_exit(self);
 
@@ -4923,6 +4898,7 @@ impl VirtualMachine {
 
         drop(core::mem::take(&mut self.resolved_path_dups));
         drop(core::mem::take(&mut self.main_resolved_path));
+        drop(self.sampling_profiler_directory.take());
 
         self.overridden_main.deinit();
 

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -948,11 +948,7 @@ extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString*
         *outText = Bun::toStringRef(textResult);
 }
 
-// The text report JSC's own report-at-exit would write (top functions, then
-// top bytecodes) for `vm`'s sampling profiler. Leaves `out` empty when the VM
-// has no sampling profiler. Called once per VM from VirtualMachine::on_exit,
-// which writes it into the directory from BUN_JSC_samplingProfilerPath or
-// bun:jsc's startSamplingProfiler().
+// The text report (top functions, then top bytecodes) of vm's sampling profiler; empty when the VM has none.
 extern "C" void Bun__SamplingProfiler__report(JSC::VM* vm, BunString* out)
 {
     JSC::SamplingProfiler* profiler = vm->samplingProfiler();
@@ -962,9 +958,7 @@ extern "C" void Bun__SamplingProfiler__report(JSC::VM* vm, BunString* out)
     WTF::StringPrintStream report;
     {
         JSC::JSLockHolder locker(*vm);
-        // A terminated Worker reaches on_exit with its JSC termination exception
-        // still pending but the termination request already cleared; the report's
-        // DeferTermination asserts on that mix, so park the exception while reporting.
+        // A terminated Worker's still-pending termination exception trips the report's DeferTermination assert.
         JSC::SuspendExceptionScope suspendExceptions(*vm);
         profiler->reportTopFunctions(report);
         profiler->reportTopBytecodes(report);

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -3,6 +3,7 @@
 #include "ZigGlobalObject.h"
 #include "helpers.h"
 #include "BunString.h"
+#include <JavaScriptCore/FrameTracers.h>
 #include <JavaScriptCore/SamplingProfiler.h>
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/JSGlobalObject.h>
@@ -10,6 +11,7 @@
 #include <JavaScriptCore/FunctionExecutable.h>
 #include <JavaScriptCore/SourceProvider.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/StringPrintStream.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/JSONValues.h>
 #include <wtf/HashMap.h>
@@ -944,4 +946,28 @@ extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString*
         *outJSON = Bun::toStringRef(jsonResult);
     if (outText)
         *outText = Bun::toStringRef(textResult);
+}
+
+// The text report JSC's own report-at-exit would write (top functions, then
+// top bytecodes) for `vm`'s sampling profiler. Leaves `out` empty when the VM
+// has no sampling profiler. Called once per VM from VirtualMachine::on_exit,
+// which writes it into the directory from BUN_JSC_samplingProfilerPath or
+// bun:jsc's startSamplingProfiler().
+extern "C" void Bun__SamplingProfiler__report(JSC::VM* vm, BunString* out)
+{
+    JSC::SamplingProfiler* profiler = vm->samplingProfiler();
+    if (!profiler)
+        return;
+
+    WTF::StringPrintStream report;
+    {
+        JSC::JSLockHolder locker(*vm);
+        // A terminated Worker reaches on_exit with its JSC termination exception
+        // still pending but the termination request already cleared; the report's
+        // DeferTermination asserts on that mix, so park the exception while reporting.
+        JSC::SuspendExceptionScope suspendExceptions(*vm);
+        profiler->reportTopFunctions(report);
+        profiler->reportTopBytecodes(report);
+    }
+    *out = Bun::toStringRef(report.toString());
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -283,11 +283,7 @@ extern "C" void Bun__ensureICUDefaultLocale();
 // virtual_machine_exports.rs
 extern "C" void Bun__VirtualMachine__setSamplingProfilerDirectory(void* bunVM, const BunString* directory);
 
-// BUN_JSC_samplingProfilerPath, taken out of JSC::Options in JSCInitialize so
-// VM::VM does not register JSC's report-at-exit: that libc atexit handler
-// dereferences a null stream when it cannot open its output file, and
-// quick_exit skips it. VirtualMachine::on_exit writes the report instead.
-// Points at the fastStrDup'd copy Options::setOption made, never freed.
+// BUN_JSC_samplingProfilerPath, kept out of JSC::Options so VM::VM never registers JSC's atexit reporter (it crashes when fopen fails, and quick_exit skips it); VirtualMachine::write_profiles writes the report.
 static const char* s_samplingProfilerDirectory = nullptr;
 
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode, bool oneShotStartup, bool shortLivedGlobals)
@@ -574,8 +570,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
 
-    // Every VM samples under BUN_JSC_useSamplingProfiler, so every VM (workers
-    // included) gets the report directory; on_exit writes one report per VM.
+    // Every VM samples under BUN_JSC_useSamplingProfiler, so every VM gets the report directory.
     if (s_samplingProfilerDirectory) {
         auto directory = WTF::String::fromUTF8(s_samplingProfilerDirectory);
         if (!directory.isEmpty()) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -280,6 +280,16 @@ extern "C" long Bun__crashHandlerFromJSCFrame(void*, void*, void*, void*);
 // bun_icu_default_locale.cpp
 extern "C" void Bun__ensureICUDefaultLocale();
 
+// virtual_machine_exports.rs
+extern "C" void Bun__VirtualMachine__setSamplingProfilerDirectory(void* bunVM, const BunString* directory);
+
+// BUN_JSC_samplingProfilerPath, taken out of JSC::Options in JSCInitialize so
+// VM::VM does not register JSC's report-at-exit: that libc atexit handler
+// dereferences a null stream when it cannot open its output file, and
+// quick_exit skips it. VirtualMachine::on_exit writes the report instead.
+// Points at the fastStrDup'd copy Options::setOption made, never freed.
+static const char* s_samplingProfilerDirectory = nullptr;
+
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode, bool oneShotStartup, bool shortLivedGlobals)
 {
     static std::once_flag jsc_init_flag;
@@ -367,6 +377,10 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
                         onCrash(env, strlen(env));
                     }
                 }
+            }
+            if (const char* directory = JSC::Options::samplingProfilerPath()) {
+                s_samplingProfilerDirectory = directory;
+                JSC::Options::samplingProfilerPath() = nullptr;
             }
             JSC::Options::assertOptionsAreCoherent();
         }); // end JSC::initialize lambda
@@ -559,6 +573,16 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     globalObject->isThreadLocalDefaultGlobalObject = true;
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
+
+    // Every VM samples under BUN_JSC_useSamplingProfiler, so every VM (workers
+    // included) gets the report directory; on_exit writes one report per VM.
+    if (s_samplingProfilerDirectory) {
+        auto directory = WTF::String::fromUTF8(s_samplingProfilerDirectory);
+        if (!directory.isEmpty()) {
+            auto directoryString = Bun::toString(directory);
+            Bun__VirtualMachine__setSamplingProfilerDirectory(Bun__getVM(), &directoryString);
+        }
+    }
 
 #ifdef FUZZILLI_ENABLED
     Bun__REPRL__registerFuzzilliFunctions(static_cast<Zig::GlobalObject*>(globalObject));

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -455,6 +455,7 @@ JSC_DEFINE_HOST_FUNCTION(functionNeverInlineFunction,
 }
 
 extern "C" bool Bun__mkdirp(JSC::JSGlobalObject*, const char*);
+extern "C" void Bun__VirtualMachine__setSamplingProfilerDirectory(void* bunVM, const BunString* directory);
 
 JSC_DECLARE_HOST_FUNCTION(functionStartSamplingProfiler);
 JSC_DEFINE_HOST_FUNCTION(functionStartSamplingProfiler,
@@ -472,7 +473,12 @@ JSC_DEFINE_HOST_FUNCTION(functionStartSamplingProfiler,
         auto path = directoryValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         if (!path.isEmpty()) {
-            StringPrintStream pathOut;
+            if (path.contains(static_cast<UChar>(0))) {
+                throwVMError(
+                    globalObject, scope,
+                    createTypeError(globalObject, "directory must not contain null bytes"_s));
+                return {};
+            }
             auto pathCString = toCString(String(path));
             if (!Bun__mkdirp(globalObject, pathCString.span().data())) {
                 throwVMError(
@@ -481,8 +487,11 @@ JSC_DEFINE_HOST_FUNCTION(functionStartSamplingProfiler,
                 return {};
             }
 
-            Options::samplingProfilerPath() = pathCString.span().data();
-            samplingProfiler.registerForReportAtExit();
+            // Options::samplingProfilerPath() is frozen read-only since the VM
+            // was constructed (Config::finalize), so assigning it here segfaults.
+            // The directory lives on Bun's per-VM state; on_exit writes the report.
+            auto directory = Bun::toString(path);
+            Bun__VirtualMachine__setSamplingProfilerDirectory(bunVM(globalObject), &directory);
         }
     }
     if (sampleValue.isNumber()) {

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -487,9 +487,7 @@ JSC_DEFINE_HOST_FUNCTION(functionStartSamplingProfiler,
                 return {};
             }
 
-            // Options::samplingProfilerPath() is frozen read-only since the VM
-            // was constructed (Config::finalize), so assigning it here segfaults.
-            // The directory lives on Bun's per-VM state; on_exit writes the report.
+            // Options::samplingProfilerPath() has been read-only since Config::finalize; the VM holds the directory instead.
             auto directory = Bun::toString(path);
             Bun__VirtualMachine__setSamplingProfilerDirectory(bunVM(globalObject), &directory);
         }

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -66,6 +66,31 @@ pub fn exit_during_uncaught_exception(this: &mut VirtualMachine) {
     this.exit_on_uncaught_exception = true;
 }
 
+/// Directory for the sampling profiler report `on_exit` writes: from
+/// `BUN_JSC_samplingProfilerPath` at global object creation, or from
+/// `bun:jsc`'s `startSamplingProfiler(directory)` (see
+/// [`crate::VirtualMachine::sampling_profiler_directory`]). Resolved to an
+/// absolute path now: the report is written at exit, when the working
+/// directory may differ.
+// HOST_EXPORT(Bun__VirtualMachine__setSamplingProfilerDirectory, c)
+pub fn set_sampling_profiler_directory(this: &mut VirtualMachine, directory: &BunString) {
+    let directory = directory.to_owned_slice();
+    let directory = if bun_paths::is_absolute(&directory) {
+        directory
+    } else {
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
+        match bun_sys::getcwd_z(&mut cwd_buf) {
+            Ok(cwd) => bun_paths::resolve_path::join::<bun_paths::resolve_path::platform::Auto>(&[
+                cwd.as_bytes(),
+                &directory,
+            ])
+            .to_vec(),
+            Err(_) => directory,
+        }
+    };
+    this.sampling_profiler_directory = Some(directory.into_boxed_slice());
+}
+
 // `Bun__Process__send` lives in `bun_runtime::ipc_host` (its body — via
 // `do_send` — names the `bun_runtime::Listener` type; LAYERING).
 

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -66,12 +66,7 @@ pub fn exit_during_uncaught_exception(this: &mut VirtualMachine) {
     this.exit_on_uncaught_exception = true;
 }
 
-/// Directory for the sampling profiler report `on_exit` writes: from
-/// `BUN_JSC_samplingProfilerPath` at global object creation, or from
-/// `bun:jsc`'s `startSamplingProfiler(directory)` (see
-/// [`crate::VirtualMachine::sampling_profiler_directory`]). Resolved to an
-/// absolute path now: the report is written at exit, when the working
-/// directory may differ.
+/// Made absolute now: the report is written at exit, when the working directory may differ.
 // HOST_EXPORT(Bun__VirtualMachine__setSamplingProfilerDirectory, c)
 pub fn set_sampling_profiler_directory(this: &mut VirtualMachine, directory: &BunString) {
     let directory = directory.to_owned_slice();

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -625,18 +625,20 @@ describe.concurrent("sampling profiler report at exit", () => {
 
   it("startSamplingProfiler with a directory writes a report at exit", async () => {
     // https://github.com/oven-sh/bun/issues/32212
-    using dir = tempDir("sampling-profiler", {
-      "entry.mjs": `
+    using dir = tempDir("sampling-profiler", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         import { startSamplingProfiler } from "bun:jsc";
         import { join } from "node:path";
-        startSamplingProfiler(join(import.meta.dir, "profiles"));
+        startSamplingProfiler(join(process.cwd(), "profiles"));
         let x = 0;
         for (let i = 0; i < 2e6; i++) x += Math.sqrt(i);
         console.log("done", x > 0);
-      `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "entry.mjs"],
+        `,
+      ],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -698,8 +700,12 @@ describe.concurrent("sampling profiler report at exit", () => {
   });
 
   it("startSamplingProfiler resolves a relative directory against the working directory at call time", async () => {
-    using dir = tempDir("sampling-profiler-relative", {
-      "entry.mjs": `
+    using dir = tempDir("sampling-profiler-relative", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         import { startSamplingProfiler } from "bun:jsc";
         import { mkdirSync } from "node:fs";
         let nulThrew = false;
@@ -715,10 +721,8 @@ describe.concurrent("sampling profiler report at exit", () => {
         let x = 0;
         for (let i = 0; i < 2e6; i++) x += Math.sqrt(i);
         console.log("done", x > 0);
-      `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "entry.mjs"],
+        `,
+      ],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -768,8 +772,12 @@ describe.concurrent("sampling profiler report at exit", () => {
   });
 
   it("BUN_JSC_samplingProfilerPath resolves a relative directory against the startup working directory", async () => {
-    using dir = tempDir("sampling-profiler-env-relative", {
-      "entry.mjs": `
+    using dir = tempDir("sampling-profiler-env-relative", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         import { mkdirSync } from "node:fs";
         mkdirSync("elsewhere");
         process.chdir("elsewhere");
@@ -777,10 +785,8 @@ describe.concurrent("sampling profiler report at exit", () => {
         for (let i = 0; i < 2e6; i++) x += Math.sqrt(i);
         console.log("done", x > 0);
         process.exit(0);
-      `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "entry.mjs"],
+        `,
+      ],
       env: { ...bunEnv, BUN_JSC_useSamplingProfiler: "1", BUN_JSC_samplingProfilerPath: "profiles" },
       cwd: String(dir),
       stdout: "pipe",

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,9 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isWindows, tempDir } from "harness";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 describe("bun:jsc", () => {
   function count() {
@@ -614,5 +616,184 @@ describe("JsRef::Weak liveness", () => {
     expect(stillLive).toBeLessThan(dropped.length / 2);
     expect(jscInternals.isLiveCellAtRawAddress(keptAddr)).toBe(true);
     expect(kept.keep).toBe(true);
+  });
+});
+
+describe.concurrent("sampling profiler report at exit", () => {
+  const reportsIn = (profileDir: string) =>
+    readdirSync(profileDir).filter(name => name.startsWith("SamplingProfile.") && name.endsWith(".txt"));
+
+  it("startSamplingProfiler with a directory writes a report at exit", async () => {
+    // https://github.com/oven-sh/bun/issues/32212
+    using dir = tempDir("sampling-profiler", {
+      "entry.mjs": `
+        import { startSamplingProfiler } from "bun:jsc";
+        import { join } from "node:path";
+        startSamplingProfiler(join(import.meta.dir, "profiles"));
+        let x = 0;
+        for (let i = 0; i < 2e6; i++) x += Math.sqrt(i);
+        console.log("done", x > 0);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done true\n");
+    expect(exitCode).toBe(0);
+
+    const profileDir = join(String(dir), "profiles");
+    const reports = reportsIn(profileDir);
+    expect(reports).toHaveLength(1);
+    expect(statSync(join(profileDir, reports[0])).size).toBeGreaterThan(0);
+  });
+
+  it("startSamplingProfiler with a directory in a worker writes a report at worker teardown", async () => {
+    // https://github.com/oven-sh/bun/issues/32212
+    using dir = tempDir("sampling-profiler-worker", {
+      "main.mjs": `
+        import { readdirSync, statSync } from "node:fs";
+        import { join } from "node:path";
+        const worker = new Worker(new URL("./worker.mjs", import.meta.url));
+        const message = await new Promise((resolve, reject) => {
+          worker.onmessage = e => resolve(e.data);
+          worker.onerror = e => reject(new Error(e.message));
+          worker.addEventListener("close", () => reject(new Error("worker closed before posting a message")));
+        });
+        console.log(message);
+        // The report is written during worker VM teardown, which completes
+        // before the close event is dispatched to the parent.
+        const closed = new Promise(resolve => worker.addEventListener("close", resolve));
+        await worker.terminate();
+        await closed;
+        const profileDir = join(import.meta.dir, "profiles");
+        const reports = readdirSync(profileDir).filter(name => name.startsWith("SamplingProfile."));
+        console.log("reports", reports.length, reports.every(name => statSync(join(profileDir, name)).size > 0));
+      `,
+      "worker.mjs": `
+        import { startSamplingProfiler } from "bun:jsc";
+        import { join } from "node:path";
+        startSamplingProfiler(join(import.meta.dir, "profiles"));
+        let x = 0;
+        for (let i = 0; i < 2e6; i++) x += Math.sqrt(i);
+        postMessage("done " + (x > 0));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done true\nreports 1 true\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("startSamplingProfiler resolves a relative directory against the working directory at call time", async () => {
+    using dir = tempDir("sampling-profiler-relative", {
+      "entry.mjs": `
+        import { startSamplingProfiler } from "bun:jsc";
+        import { mkdirSync } from "node:fs";
+        let nulThrew = false;
+        try {
+          startSamplingProfiler("bad\\0dir");
+        } catch (e) {
+          nulThrew = e instanceof TypeError;
+        }
+        console.log("nul-throws", nulThrew);
+        startSamplingProfiler("profiles");
+        mkdirSync("elsewhere");
+        process.chdir("elsewhere");
+        let x = 0;
+        for (let i = 0; i < 2e6; i++) x += Math.sqrt(i);
+        console.log("done", x > 0);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("nul-throws true\ndone true\n");
+    expect(exitCode).toBe(0);
+
+    // The report lands in the directory as resolved when the profiler started,
+    // not relative to the working directory at exit.
+    const profileDir = join(String(dir), "profiles");
+    const reports = reportsIn(profileDir);
+    expect(reports).toHaveLength(1);
+    expect(statSync(join(profileDir, reports[0])).size).toBeGreaterThan(0);
+  });
+
+  // BUN_JSC_samplingProfilerPath used to make VM::VM register JSC's own
+  // report-at-exit, a libc atexit handler that dereferences a null stream when
+  // it cannot open the output file (Sentry BUN-4TKX: process.exit() with a
+  // missing directory segfaults on macOS). Bun writes the report itself now.
+  it("BUN_JSC_samplingProfilerPath writes a report on process.exit() into a directory that does not exist yet", async () => {
+    using dir = tempDir("sampling-profiler-env", {});
+    const profileDir = join(String(dir), "missing", "profiles");
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `let x = 0; for (let i = 0; i < 2e6; i++) x += Math.sqrt(i); console.log("done", x > 0); process.exit(0);`,
+      ],
+      env: { ...bunEnv, BUN_JSC_useSamplingProfiler: "1", BUN_JSC_samplingProfilerPath: profileDir },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done true\n");
+    expect(exitCode).toBe(0);
+
+    const reports = reportsIn(profileDir);
+    expect(reports).toHaveLength(1);
+    const report = readFileSync(join(profileDir, reports[0]), "utf8");
+    expect(report).toContain("Sampling rate:");
+    expect(report).toContain("Top functions as");
+  });
+
+  it("BUN_JSC_samplingProfilerPath resolves a relative directory against the startup working directory", async () => {
+    using dir = tempDir("sampling-profiler-env-relative", {
+      "entry.mjs": `
+        import { mkdirSync } from "node:fs";
+        mkdirSync("elsewhere");
+        process.chdir("elsewhere");
+        let x = 0;
+        for (let i = 0; i < 2e6; i++) x += Math.sqrt(i);
+        console.log("done", x > 0);
+        process.exit(0);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: { ...bunEnv, BUN_JSC_useSamplingProfiler: "1", BUN_JSC_samplingProfilerPath: "profiles" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done true\n");
+    expect(exitCode).toBe(0);
+
+    const profileDir = join(String(dir), "profiles");
+    const reports = reportsIn(profileDir);
+    expect(reports).toHaveLength(1);
+    expect(statSync(join(profileDir, reports[0])).size).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Fixes #32212. Fixes Sentry BUN-4TKX (`process.exit()` segfaults on macOS with `BUN_JSC_samplingProfilerPath` set).

### Problem
- `BUN_JSC_samplingProfilerPath=<dir>` makes `VM::VM` register JSC's report-at-exit, a libc `atexit` handler. When it cannot open its output file (missing directory, relative path after `process.chdir`), it passes a null `FilePrintStream` to `reportTopFunctions` (`SamplingProfiler.cpp:1225`, `:1284`): `Segmentation fault at address 0x0` in `WTF::Seconds::microseconds`. macOS only: Linux exits through `quick_exit`, which skips `atexit`.
- `jsc.startSamplingProfiler(directory)` wrote `Options::samplingProfilerPath()` at runtime (`BunJSCModule.h:484`). That page is read-only once the first VM exists (`Config::finalize`), so every call segfaulted.

### Fix
- `JSCInitialize` moves the path out of `JSC::Options` before the freeze and nulls the option, so JSC never registers its handler. Each VM (workers too) gets the directory at global object creation. `startSamplingProfiler` stores its directory on the VM.
- `VirtualMachine::write_profiles()` writes the sampling report, then the CPU profile, then the heap profile, from `on_exit` and the self-kill path. C++ renders the text. Rust writes `<dir>/SamplingProfile.<date>.<time>.<pid>.0.<seq>.txt`, creates a missing directory, and prints an error on failure.
- Correct because `on_exit` runs once per VM, on its thread, with the VM alive and the API lock held, on every exit path.
- Verified: `test/js/bun/jsc/bun-jsc.test.ts` (5 tests under `sampling profiler report at exit`, all fail on released bun). Also `cpu-prof.test.ts`, `29240.test.ts`, `bun-types.test.ts`.

### Background
- The JSC sampling profiler is a timer thread that records JS stack traces. `--cpu-prof` already reads it through `vm.samplingProfiler()`.
- JSC options live in a config page that `Config::finalize` makes read-only when the first VM is constructed. Bun applies `BUN_JSC_*` env vars before that, in the `JSC::initialize` callback.
- The per-VM directory and the `bun:jsc` fix are from #32217. This PR supersedes it.

<details><summary>Notes</summary>

- Sentry BUN-4TKX: 4 events on 1.4.0, macOS arm64, `AutoCommand` and `StandaloneExecutable`, all `exited=True`. Stack: `Bun__Process__exit` -> `Global::exit` -> libc -> `registerForReportAtExit` lambda -> `reportDataToOptionFile` -> `reportTopFunctions` -> `Seconds::microseconds` at fault address 0. `FilePrintStream::open` returns null when `fopen` fails and `reportDataToOptionFile` does not check it.
- Repro on the Linux ASAN debug build (libc `exit` path): `BUN_JSC_useSamplingProfiler=1 BUN_JSC_samplingProfilerPath=/tmp/does-not-exist bun-debug -e 'process.exit(0)'` aborts with `unique_ptr.h:453: Assertion 'get() != pointer()' failed`. Same with a relative path plus `process.chdir("/")`. An existing directory writes `JSCSampilingProfile-<ptr>.txt` and exits 0.
- `bun -e 'require("bun:jsc").startSamplingProfiler("/tmp/prof")'` on the debug build: ASAN SEGV on a WRITE at `BunJSCModule.h:484` (the frozen options page). The stored pointer was also a dangling local `CString`.
- A relative directory resolves against the working directory at the time it is set (startup for the env var, the call for `bun:jsc`).
- The file name follows Node's diagnostic naming (`write_diagnostic_filename`, shared with `--cpu-prof`), so the main thread and workers get distinct files. The old JSC name was `JSCSampilingProfile-<ptr>.txt`.
- `JSC::Options::samplingProfilerPath()` is read only by `VM::VM` (to register the handler) and `reportDataToOptionFile`. Nulling it has no other effect.
- `Global::exit` calls libc `exit()` on macOS and `quick_exit()` on Linux. `atexit` handlers run only for the former, which is why the crash is macOS only.
- Edge cases checked on the debug build: `BUN_JSC_samplingProfilerPath` without `useSamplingProfiler` writes nothing. `useSamplingProfiler` without a path writes nothing. A nested `process.exit()` inside an `exit` listener writes one report. An unwritable path (`/etc/passwd/x`) prints the error and exits with the requested code. `process.kill(process.pid, "SIGTERM")` writes the report before the signal.
- Pre-existing, not fixed here: `Fd::make_path` loops forever when `mkdir` returns `ENOENT` under an existing parent (procfs). `bun --cpu-prof --cpu-prof-dir=/proc/nope -e 1` hangs on released bun for the same reason. This PR reuses that helper, so the report writer inherits it. Handed off separately.
- #40191 (open) also introduces `VirtualMachine::write_profiles()` with the same shape (CPU, then heap) and adds call sites in the test runner. The helper here has the same name and order with the sampling report in front, so that rebase is a one-line merge.
- Self-reviewed: 3 concerns raised, 2 addressed (one `write_profiles()` helper for both exit sites instead of two copies of the flush block; `destroy()` releases the directory because the VM is deallocated raw and field drops never run). Rejected: drop the `startSamplingProfiler(directory)` argument instead of making it work. `jsc.d.ts` has documented it since 2022, and neither `profile()` nor `--cpu-prof-md` produces JSC's top-functions and top-bytecodes report at exit.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->