### PR TITLE
Fix commented code markers from HTML examples

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -422,8 +422,7 @@ You can now use TailwindCSS utility classes in your HTML and CSS files. Import `
 <!doctype html>
 <html>
   <head>
-    <!-- [!code ++] -->
-    <link rel="stylesheet" href="tailwindcss" />
+    <link rel="stylesheet" href="tailwindcss" /> <!-- [!code ++] -->
   </head>
   <!-- the rest of your HTML... -->
 </html>
@@ -443,8 +442,7 @@ Alternatively, you can import TailwindCSS in your CSS file:
 <!doctype html>
 <html>
   <head>
-    <!-- [!code ++] -->
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="./style.css" /> <!-- [!code ++] -->
   </head>
   <!-- the rest of your HTML... -->
 </html>


### PR DESCRIPTION
### What does this PR do?

The syntax highlighter at https://bun.sh/docs/bundler/fullstack#tailwindcss-plugin were highlighting the wrong line:  
<img width="820" height="730" alt="vvv" src="https://github.com/user-attachments/assets/445084ea-23f0-4196-8cd3-78c07be92af8" />
