### PR TITLE
dev server: name an anonymous export default class that stays a statement

### DIFF
--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -229,20 +229,20 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                         );
                     }
                     js_ast::StmtOrExpr::Stmt(s) => {
+                        let ref_ = match s.data {
+                            js_ast::StmtData::SClass(mut class) => {
+                                // The visit pass names an anonymous default function
+                                // but leaves an anonymous default class unnamed. A
+                                // class statement needs a binding, so use the
+                                // statement's default name like convertStmtsForChunk.
+                                class.class.class_name.get_or_insert(st.default_name).ref_
+                            }
+                            js_ast::StmtData::SFunction(func) => func.func.name.unwrap().ref_,
+                            _ => unreachable!(),
+                        };
                         self.export_props.push(G::Property {
                             key: Some(Expr::init(E::EString::init(b"default"), stmt.loc)),
-                            value: Some(Expr::init_identifier(
-                                match s.data {
-                                    js_ast::StmtData::SClass(class) => {
-                                        class.class.class_name.unwrap().ref_
-                                    }
-                                    js_ast::StmtData::SFunction(func) => {
-                                        func.func.name.unwrap().ref_
-                                    }
-                                    _ => unreachable!(),
-                                },
-                                stmt.loc,
-                            )),
+                            value: Some(Expr::init_identifier(ref_, stmt.loc)),
                             ..Default::default()
                         });
                         break 'stmt *s;

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -201,6 +201,60 @@ devTest("default export same-scope handling", {
     c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
   },
 });
+// An anonymous `export default class` that cannot be moved into the exports
+// object (it has an `extends` clause, a static block, or a computed key) has to
+// stay a class statement, which needs a name. It used to crash the dev server
+// with `called Option::unwrap() on a None value` while visiting the file.
+devTest("anonymous export default class that must stay a statement", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import.meta.hot.accept();
+      import { Base } from "./base";
+      import Derived from "./derived";
+      import StaticBlock from "./static-block";
+      import ComputedKey from "./computed-key";
+      console.log("extends: " + (new Derived() instanceof Base) + " " + new Derived().tag);
+      console.log("static block: " + StaticBlock.initialized);
+      console.log("computed key: " + new ComputedKey().computed);
+    `,
+    "base.ts": `
+      export class Base {
+        tag = "base";
+      }
+    `,
+    "derived.ts": `
+      import { Base } from "./base";
+      export default class extends Base {
+        tag = "derived";
+      }
+    `,
+    "static-block.ts": `
+      export default class {
+        static initialized = false;
+        static {
+          this.initialized = true;
+        }
+      }
+    `,
+    "computed-key.ts": `
+      const key = "computed";
+      export default class {
+        [key] = "value";
+      }
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("extends: true derived", "static block: true", "computed key: value");
+
+    await dev.patch("derived.ts", { find: '"derived"', replace: '"updated"' });
+    await c.expectMessage("extends: true updated", "static block: true", "computed key: value");
+  },
+});
 devTest("directory cache bust case #17576", {
   files: {
     "web/index.html": emptyHtmlFile({


### PR DESCRIPTION
### Problem
- `bun index.html` crashes with `panic: called Option::unwrap() on a None value` / `Crashed while visiting .../app.js` when a module contains an anonymous `export default class extends X {}`. The same happens for an anonymous default class with a static block, a computed key, or a static initializer with side effects. This is the usual React class component shape, `export default class extends React.Component {}`.
- The cause is `src/js_parser/lower/lower_esm_exports_hmr.rs:237`. When the class cannot move into the exports object, the HMR lowering keeps it as a class statement and exports `class.class.class_name.unwrap().ref_`. The visit pass (`visit_stmt.rs:587`) gives an anonymous default function its default name, but it names an anonymous default class only when decorator lowering needs a binding (`visit_stmt.rs:818`). So `class_name` is `None` here.

### Fix
- In that arm, give the class the statement's `default_name` with `get_or_insert` and export that ref. The module becomes `class app_default extends Base {}` followed by `hmr.exports = { default: app_default }`.
- This is what the bundler already does for the same input. `convertStmtsForChunk.rs:549` sets `class_name = Some(s.default_name)` when it strips exports, and `bun build` prints `class app_default extends Base {}`. The dev server output now matches it.
- A movable anonymous class is not affected. It still goes into `hmr.exports = { default: class {} }`, so its `.name` stays `"default"`.
- Verified: `test/bake/dev/bundle.test.ts` (new test, the released bun crashes on it). Also the rest of that file, `test/bake/dev/esm.test.ts` and `test/bake/dev/react-spa.test.ts`.

### Background
- The dev server wraps each module in a function and replaces ESM `export` syntax with an `hmr.exports = {...}` object. `ConvertESMExportsForHmr::convert_stmt` does that rewrite after the visit pass.
- `Class::can_be_moved()` (`src/ast/g.rs:85`) says whether a class expression can be evaluated later, at the end of the module, without a change in behavior. An `extends` clause, a static block, a computed key, or a static initializer with side effects must run in place, so such a class stays a statement.
- `S::ExportDefault::default_name` is a generated symbol (`<file>_default`, from `create_default_name`) that every default export carries. The bundler uses it as the binding name when it strips `export default` from a function or class statement.

<details><summary>Notes</summary>

Repro against the released bun 1.4.1:

```
printf '<!doctype html><script type="module" src="./app.js"></script>' > index.html
echo 'export class Base {}' > base.js
printf 'import { Base } from "./base.js";\nexport default class extends Base {}\n' > app.js
bun index.html   # then request the page
# panic: called `Option::unwrap()` on a `None` value
# Crashed while visiting .../app.js
```

Dev server output for `app.js` with this change:

```js
var [import_base] = hmr.imports;
hmr.updateImport = [(module) => import_base = module];
class app_default extends import_base.Base {
}
hmr.exports = {
  default: app_default
};
```

Also checked by hand with the debug build: `export default abstract class extends Base {}` (TypeScript), a decorated anonymous default class (already named by the visit pass, unchanged), a class with a static initializer that calls a function, and `export default class extends React.Component {}` in a `.tsx` file with React Fast Refresh enabled. All load, and a hot update to the class file re-evaluates the importer with the new class.

The anonymous default function arm next to this one is safe as it is. An anonymous function is always movable (`can_be_moved_to_inner_scope` is true when `func.name` is `None`), so its `unwrap()` only runs for a named function.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-SbtuYk
[0;30mdev|[0m Started development server: http://localhost:42219
[0;30mdev|[0m [32mBundled page in 154ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 84ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 70ms[0
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-CJCJk0
[0;30mdev|[0m Started development server: http://localhost:36551
[0;30mdev|[0m [32mBundled page in 5ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 2ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 2ms[0m[2m:[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [211.64ms]
[0;30mdev|[0m Started development server: http://localhos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-xKf5d2
[0;30mdev|[0m Started development server: http://localhost:45705
[0;30mdev|[0m [32mBundled page in 200ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 56ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 38ms[0
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b5916c9d8b
  features     baseline

23 deps, 131 codegen, 1172 objects in 835ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] fetch zlib
[zlib] up to date
[7/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lower/lower_esm_exports_hmr.rs | 24 ++++++-------
 test/bake/dev/bundle.test.ts                 | 54 ++++++++++++++++++++++++++++
 2 files changed, 66 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/js_parser/lower/lower_esm_exports_hmr.rs      2      2      9
test/bake/dev/bundle.test.ts                      2      2      9
```

</details>

<!-- robobun:evidence:end -->