### PR TITLE
bundler: assign chunks from live parts, not from every import record

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2723,8 +2723,7 @@ impl<'a> LinkerContext<'a> {
 
             let records = &ctx.import_records[source_index as usize];
 
-            // CSS and HTML files have no parts of their own: follow every
-            // import record, as tree shaking does.
+            // CSS and HTML files have no parts: follow every import record.
             if ctx.css_reprs[source_index as usize].is_some()
                 || ctx.loaders[source_index as usize] == Loader::Html
             {
@@ -2739,9 +2738,7 @@ impl<'a> LinkerContext<'a> {
                 continue;
             }
 
-            // Every live part of this file prints wherever the file lands, so
-            // the entry point needs what each of them imports or depends on.
-            // A dead part prints nothing and needs nothing.
+            // A dead part prints nothing, so only live parts reach other files.
             let parts_live = &self.graph.parts_live[source_index as usize];
             for (part_index, part) in ctx.parts[source_index as usize]
                 .as_slice()
@@ -2761,13 +2758,8 @@ impl<'a> LinkerContext<'a> {
                     }
                     let other = record.source_index.get();
 
-                    // An `import` or `export ... from` of a file that declares no
-                    // side effects prints nothing: the bindings it brings in are
-                    // part dependencies, resolved below. Tree shaking keeps the
-                    // target only through those dependencies, so this entry
-                    // point reaches it only through them too. Without this, a
-                    // `"sideEffects": false` barrel would hand every module it
-                    // re-exports to each entry point that uses one of them.
+                    // An `import`/`export from` of a side-effect-free file prints
+                    // nothing; its bindings are the part dependencies below.
                     if record.kind == ImportKind::Stmt && self.file_has_no_side_effects(other) {
                         continue;
                     }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2758,8 +2758,7 @@ impl<'a> LinkerContext<'a> {
                     }
                     let other = record.source_index.get();
 
-                    // An `import`/`export from` of a side-effect-free file prints
-                    // nothing; its bindings are the part dependencies below.
+                    // Prints nothing; its bindings are the part dependencies below.
                     if record.kind == ImportKind::Stmt && self.file_has_no_side_effects(other) {
                         continue;
                     }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -877,6 +877,7 @@ impl<'a> LinkerContext<'a> {
         let entry_points: *const [crate::IndexInt] = self.graph.entry_points.items_source_index();
         let distances: *mut [u32] = self.graph.files.items_distance_from_entry_point_mut();
         let file_entry_bits: *mut [AutoBitSet] = self.graph.files.items_entry_bits_mut();
+        let loaders: *const [Loader] = self.parse_graph().input_files.items_loader();
 
         // SAFETY: see block comment above — disjoint SoA columns, stable slabs
         // (no reallocation during tree-shaking). All column derefs share that
@@ -892,6 +893,7 @@ impl<'a> LinkerContext<'a> {
             parts_live,
             distances,
             file_entry_bits,
+            loaders,
         ) = unsafe {
             (
                 &*entry_points,
@@ -902,6 +904,7 @@ impl<'a> LinkerContext<'a> {
                 &mut *parts_live,
                 &mut *distances,
                 &mut *file_entry_bits,
+                &*loaders,
             )
         };
         let entry_points_len = entry_points.len();
@@ -952,6 +955,7 @@ impl<'a> LinkerContext<'a> {
                 import_records,
                 file_entry_bits,
                 css_reprs,
+                loaders,
                 queue: std::collections::VecDeque::new(),
             };
 
@@ -2674,6 +2678,7 @@ pub(crate) struct CodeSplitCtx<'a, 'r> {
     pub(crate) import_records: &'r [bun_ast::import_record::List<'a>],
     pub(crate) file_entry_bits: &'r mut [AutoBitSet],
     pub(crate) css_reprs: &'r [crate::bundled_ast::CssCol],
+    pub(crate) loaders: &'r [Loader],
     pub(crate) queue: std::collections::VecDeque<(crate::IndexInt, u32)>,
 }
 
@@ -2716,22 +2721,62 @@ impl<'a> LinkerContext<'a> {
             }
             let out_dist = distance + 1;
 
-            for record in ctx.import_records[source_index as usize].iter() {
-                if record.source_index.is_valid()
-                    && !self.is_external_dynamic_import(record, source_index)
-                    && !ctx.file_entry_bits[record.source_index.get() as usize]
-                        .is_set(entry_points_count)
-                {
-                    ctx.queue.push_back((record.source_index.get(), out_dist));
-                }
-            }
+            let records = &ctx.import_records[source_index as usize];
 
-            // CSS files only follow their import records.
-            if ctx.css_reprs[source_index as usize].is_some() {
+            // CSS and HTML files have no parts of their own: follow every
+            // import record, as tree shaking does.
+            if ctx.css_reprs[source_index as usize].is_some()
+                || ctx.loaders[source_index as usize] == Loader::Html
+            {
+                for record in records.iter() {
+                    if record.source_index.is_valid()
+                        && !ctx.file_entry_bits[record.source_index.get() as usize]
+                            .is_set(entry_points_count)
+                    {
+                        ctx.queue.push_back((record.source_index.get(), out_dist));
+                    }
+                }
                 continue;
             }
 
-            for part in ctx.parts[source_index as usize].as_slice() {
+            // Every live part of this file prints wherever the file lands, so
+            // the entry point needs what each of them imports or depends on.
+            // A dead part prints nothing and needs nothing.
+            let parts_live = &self.graph.parts_live[source_index as usize];
+            for (part_index, part) in ctx.parts[source_index as usize]
+                .as_slice()
+                .iter()
+                .enumerate()
+            {
+                if !parts_live.is_set(part_index) {
+                    continue;
+                }
+
+                for &import_index in part.import_record_indices.iter() {
+                    let record = &records[import_index as usize];
+                    if !record.source_index.is_valid()
+                        || self.is_external_dynamic_import(record, source_index)
+                    {
+                        continue;
+                    }
+                    let other = record.source_index.get();
+
+                    // An `import` or `export ... from` of a file that declares no
+                    // side effects prints nothing: the bindings it brings in are
+                    // part dependencies, resolved below. Tree shaking keeps the
+                    // target only through those dependencies, so this entry
+                    // point reaches it only through them too. Without this, a
+                    // `"sideEffects": false` barrel would hand every module it
+                    // re-exports to each entry point that uses one of them.
+                    if record.kind == ImportKind::Stmt && self.file_has_no_side_effects(other) {
+                        continue;
+                    }
+
+                    if !ctx.file_entry_bits[other as usize].is_set(entry_points_count) {
+                        ctx.queue.push_back((other, out_dist));
+                    }
+                }
+
                 for dependency in part.dependencies.iter() {
                     let dep = dependency.source_index.get();
                     if dep != source_index

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1094,6 +1094,353 @@ describe("bundler", () => {
     run: { file: "/out/entry.js", stdout: "b runs\nAAAA\nBBBB_MARK" },
   });
 
+  // Ported from Rollup's chunking-form/samples/chunk-assigment-in-dynamic.
+  itBundled("splitting/SideEffectFreeCommonJSSharedByTwoLazyChunks", {
+    files: {
+      "/node_modules/icons/package.json": JSON.stringify({ name: "icons", main: "c.js", sideEffects: false }),
+      "/node_modules/icons/c.js": /* js */ `
+        exports.preFaPrint = { foo: 1 };
+        exports.faPrint = exports.preFaPrint;
+      `,
+      "/entry.js": /* js */ `
+        const a = await import('./a.js')
+        const b = await import('./b.js')
+        console.log(a.A().icon.foo, b.B().icon.foo)
+      `,
+      "/a.js": /* js */ `
+        import { faPrint } from 'icons'
+        export function A() { return { icon: faPrint } }
+      `,
+      "/b.js": /* js */ `
+        import { faPrint } from 'icons'
+        export function B() { return { icon: faPrint } }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: { file: "/out/entry.js", stdout: "1 1" },
+  });
+
+  // Ported from Rollup's chunking-form/samples/deoptimized-module-with-dynamic-import.
+  itBundled("splitting/SideEffectFreeModuleWithTopLevelDynamicImport", {
+    files: {
+      "/node_modules/loader/package.json": JSON.stringify({ name: "loader", main: "index.js", sideEffects: false }),
+      "/node_modules/loader/index.js": /* js */ `
+        export function fn() { return 'fn' }
+        import('./cjs.js')
+      `,
+      "/node_modules/loader/cjs.js": /* js */ `
+        export const cjs = 'cjs-value'
+      `,
+      "/entry.js": /* js */ `
+        import { value, loadCjs } from './a.js'
+        console.log(value)
+        loadCjs().then(m => console.log(m.cjs))
+      `,
+      "/a.js": /* js */ `
+        import { fn } from 'loader'
+        export const value = fn()
+        export function loadCjs() { return import('loader/cjs.js') }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: { file: "/out/entry.js", stdout: "fn\ncjs-value" },
+  });
+
+  // Ported from Rollup's chunking-form/samples/namespace-reexport-side-effect-cache.
+  itBundled("splitting/SideEffectFreeStarBarrelKeepsEffectForEveryEntry", {
+    files: {
+      "/node_modules/lib/package.json": JSON.stringify({
+        name: "lib",
+        main: "index.js",
+        sideEffects: ["./foo.js", "./effect.js"],
+      }),
+      "/node_modules/lib/index.js": `export * from './foo.js'`,
+      "/node_modules/lib/foo.js": /* js */ `
+        export { foo } from './fooImpl.js'
+        import './effect.js'
+      `,
+      "/node_modules/lib/effect.js": `console.log('side effect')`,
+      "/node_modules/lib/fooImpl.js": `export const foo = 'foo'`,
+      "/entry1.js": /* js */ `
+        import { foo } from 'lib'
+        console.log('entry1', foo)
+      `,
+      "/entry2.js": /* js */ `
+        import { foo } from 'lib'
+        console.log('entry2', foo)
+      `,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: [
+      { file: "/out/entry1.js", stdout: "side effect\nentry1 foo" },
+      { file: "/out/entry2.js", stdout: "side effect\nentry2 foo" },
+    ],
+  });
+
+  // Ported from Rollup's chunking-form/samples/side-effect-free-dependencies/module-side-effects-reexports-{1,2,3}.
+  for (const [name, main] of [
+    ["ExportFrom", `export { value } from 'dep1'`],
+    ["ImportThenExport", `import { value } from 'dep1'\nexport { value }`],
+    ["ExportStar", `export * from 'dep1'`],
+  ]) {
+    itBundled(`splitting/EntryReExportsThroughSideEffectFreeStarChain${name}`, {
+      files: {
+        "/node_modules/dep1/package.json": JSON.stringify({ name: "dep1", main: "index.js", sideEffects: false }),
+        "/node_modules/dep1/index.js": `export * from './dep2.js'`,
+        "/node_modules/dep1/dep2.js": `export const value = 42`,
+        "/main.js": main,
+        "/use.js": /* js */ `
+          import { value } from './main.js'
+          console.log(value)
+        `,
+      },
+      entryPoints: ["/main.js", "/use.js"],
+      splitting: true,
+      outdir: "/out",
+      format: "esm",
+      run: { file: "/out/use.js", stdout: "42" },
+    });
+  }
+
+  // Ported from Rollup's chunking-form/samples/side-effect-free-dependencies/module-side-effects-empty-imports.
+  itBundled("splitting/SideEffectFreeImportUnusedByOneEntry", {
+    files: {
+      "/node_modules/dep/package.json": JSON.stringify({ name: "dep", main: "index.js", sideEffects: false }),
+      "/node_modules/dep/index.js": /* js */ `
+        export default 'DEP_VALUE'
+        console.log('dep body')
+      `,
+      "/main1.js": /* js */ `
+        import value from 'dep'
+        console.log('main1', value)
+      `,
+      "/main2.js": /* js */ `
+        import value from 'dep'
+        console.log('main2')
+      `,
+    },
+    entryPoints: ["/main1.js", "/main2.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(jsOutputs(api)).toEqual(["main1.js", "main2.js"]);
+      api.expectFile("/out/main2.js").not.toContain("DEP_VALUE");
+      api.expectFile("/out/main2.js").not.toContain("import ");
+    },
+    run: [
+      { file: "/out/main1.js", stdout: "dep body\nmain1 DEP_VALUE" },
+      { file: "/out/main2.js", stdout: "main2" },
+    ],
+  });
+
+  // Ported from Rollup's function/samples/module-side-effects/reexports; lib.js still runs, as in esbuild.
+  for (const splitting of [false, true]) {
+    itBundled(`splitting/SideEffectFreeReExportRunsOnlyUsedModule${splitting ? "" : "NoSplitting"}`, {
+      files: {
+        "/node_modules/lib/package.json": JSON.stringify({ name: "lib", main: "lib.js", sideEffects: false }),
+        "/node_modules/lib/lib.js": /* js */ `
+          globalThis.effects.push('lib')
+          export { value as value1 } from './dep1.js'
+          export { value as value2 } from './dep2.js'
+        `,
+        "/node_modules/lib/dep1.js": /* js */ `
+          globalThis.effects.push('dep1')
+          export const value = 'dep1'
+        `,
+        "/node_modules/lib/dep2.js": /* js */ `
+          globalThis.effects.push('dep2')
+          export const value = 'dep2'
+        `,
+        "/setup.js": `globalThis.effects = []`,
+        "/entry.js": /* js */ `
+          import './setup.js'
+          import { value1 } from 'lib'
+          console.log(value1, JSON.stringify(globalThis.effects))
+        `,
+      },
+      entryPoints: ["/entry.js"],
+      splitting,
+      outdir: "/out",
+      format: "esm",
+      run: { file: "/out/entry.js", stdout: `dep1 ["dep1","lib"]` },
+    });
+  }
+
+  // Ported from Rollup's function/samples/tree-shake-module-side-effects-dependencies.
+  itBundled("splitting/SideEffectFreeModuleKeepsImpureDependencyInLazyChunk", {
+    files: {
+      "/node_modules/lib/package.json": JSON.stringify({ name: "lib", main: "dep.js", sideEffects: ["./effect.js"] }),
+      "/node_modules/lib/dep.js": /* js */ `
+        import './effect.js'
+        export const value = true
+      `,
+      "/node_modules/lib/effect.js": /* js */ `
+        import { updateSharedValue } from './shared.js'
+        updateSharedValue()
+      `,
+      "/node_modules/lib/shared.js": /* js */ `
+        export let sharedValue = 'original'
+        export function updateSharedValue() { sharedValue = 'updated' }
+      `,
+      "/entry.js": /* js */ `
+        import('./lazy.js').then(m => m.run())
+      `,
+      "/lazy.js": /* js */ `
+        import { value } from 'lib'
+        import { sharedValue } from 'lib/shared.js'
+        export function run() { console.log(value, sharedValue) }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: { file: "/out/entry.js", stdout: "true updated" },
+  });
+
+  // Ported from Rolldown's tree_shaking/advanced_barrel_exports_bailout_dynamic_key.
+  itBundled("splitting/SideEffectFreeBarrelNamespaceComputedKey", {
+    files: {
+      ...sideEffectFreeBarrel,
+      "/entry.js": /* js */ `
+        import * as pkg from 'pkg'
+        console.log(pkg.A)
+        import('./lazy.js').then(m => m.run('B'))
+      `,
+      "/lazy.js": /* js */ `
+        import * as pkg from 'pkg'
+        export function run(key) { console.log(pkg[key]) }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: { file: "/out/entry.js", stdout: "AAAA\nBBBB_MARK" },
+  });
+
+  // Ported from Rolldown's tree_shaking/advanced_barrel_exports2.
+  itBundled("splitting/SideEffectFreeRenamedNamespaceReExport", {
+    files: {
+      "/node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "shared.js", sideEffects: false }),
+      "/node_modules/pkg/a.js": /* js */ `
+        export const c = 1000
+        export const b = 500
+        export const a = 100
+      `,
+      "/node_modules/pkg/c.js": `export * as c from './a.js'`,
+      "/node_modules/pkg/shared.js": /* js */ `
+        import { c } from './c.js'
+        export { c as a }
+      `,
+      "/entry.js": /* js */ `
+        import * as ns from 'pkg'
+        console.log(ns.a.b)
+        import('./lazy.js').then(m => m.run())
+      `,
+      "/lazy.js": /* js */ `
+        import * as ns from 'pkg'
+        export function run() { console.log(ns.a['a'], Object.keys(ns.a).sort().join()) }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: { file: "/out/entry.js", stdout: "500\n100 a,b,c" },
+  });
+
+  // Ported from Rolldown's code_splitting/issue_8184.
+  itBundled("splitting/StaticAndDynamicCycleAcrossTwoEntries", {
+    files: {
+      "/dbp-1.js": `import './a.js'`,
+      "/dbp-activity-showcase.js": `import('./dbp-2.js').then(() => console.log('done'))`,
+      "/dbp-2.js": `import './b.js'`,
+      "/a.js": /* js */ `
+        import './c.js'
+        console.log('a')
+      `,
+      "/b.js": /* js */ `
+        import './a.js'
+        import './x.js'
+        console.log('b')
+      `,
+      "/c.js": /* js */ `
+        import('./a.js')
+        console.log('c')
+      `,
+      "/x.js": /* js */ `
+        console.log('x')
+        module.exports = 42
+      `,
+    },
+    entryPoints: ["/dbp-1.js", "/dbp-activity-showcase.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: [
+      { file: "/out/dbp-1.js", stdout: "c\na" },
+      { file: "/out/dbp-activity-showcase.js", stdout: "c\na\nx\nb\ndone" },
+    ],
+  });
+
+  // Ported from Rolldown's code_splitting/issue_5276_2.
+  itBundled("splitting/NamespaceImportAndDynamicImportOfSameModule", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from './imp.js'
+        console.log(ns.imp2, ns.imp22)
+        import('./imp.js').then(m => console.log(m.imp22))
+      `,
+      "/imp.js": /* js */ `
+        export const imp2 = 2
+        export const imp22 = 22
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: { file: "/out/entry.js", stdout: "2 22\n22" },
+  });
+
+  // Ported from Rolldown's tree_shaking/unused_dynamic_imported_chunk.
+  itBundled("splitting/SideEffectFreeModuleDynamicImportInLiveFunction", {
+    files: {
+      "/node_modules/dep/package.json": JSON.stringify({ name: "dep", main: "index.js", sideEffects: false }),
+      "/node_modules/dep/index.js": /* js */ `
+        export async function loadTS() { return import('./dynamic.js') }
+      `,
+      "/node_modules/dep/dynamic.js": /* js */ `
+        console.log('dynamic')
+        export const ok = 'OK'
+      `,
+      "/entry.js": /* js */ `
+        import { loadTS } from 'dep'
+        console.log('entry')
+        loadTS().then(m => console.log(m.ok))
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").not.toContain('"OK"');
+    },
+    run: { file: "/out/entry.js", stdout: "entry\ndynamic\nOK" },
+  });
+
   // The chunks an output file imports, in statement order.
   const chunkImportsIn = (api: BundlerTestBundleAPI, name: string) =>
     [...api.readFile("/out/" + name).matchAll(/^import\b[^;]*?"\.\/([^"]+)";$/gms)].map(m => m[1]);

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1234,6 +1234,7 @@ describe("bundler", () => {
     format: "esm",
     onAfterBundle(api) {
       expect(jsOutputs(api)).toEqual(["main1.js", "main2.js"]);
+      api.expectFile("/out/main1.js").toContain("DEP_VALUE");
       api.expectFile("/out/main2.js").not.toContain("DEP_VALUE");
       api.expectFile("/out/main2.js").not.toContain("import ");
     },
@@ -1436,7 +1437,9 @@ describe("bundler", () => {
     outdir: "/out",
     format: "esm",
     onAfterBundle(api) {
+      expect(jsOutputs(api)).toEqual(["dynamic.js", "entry.js"]);
       api.expectFile("/out/entry.js").not.toContain('"OK"');
+      expect(jsOutput(api, "dynamic")).toContain('"OK"');
     },
     run: { file: "/out/entry.js", stdout: "entry\ndynamic\nOK" },
   });

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -957,6 +957,143 @@ describe("bundler", () => {
     ],
   });
 
+  // A re-export from a `"sideEffects": false` barrel prints nothing: the
+  // importer binds straight to the module that declares the name. So an entry
+  // point reaches, through the barrel, only the modules it uses, and a module
+  // only an import() uses lives in that import()'s chunk.
+  const sideEffectFreeBarrel = {
+    "/node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js", sideEffects: false }),
+    "/node_modules/pkg/index.js": /* js */ `
+      export { A } from './a.js'
+      export { B } from './b.js'
+    `,
+    "/node_modules/pkg/a.js": /* js */ `
+      export const A = 'AAAA'
+    `,
+    "/node_modules/pkg/b.js": /* js */ `
+      export const B = 'BBBB_MARK'
+    `,
+  };
+
+  itBundled("splitting/SideEffectFreeBarrelLeavesLazyModulesToTheirChunk", {
+    files: {
+      ...sideEffectFreeBarrel,
+      "/entry.js": /* js */ `
+        import { A } from 'pkg'
+        console.log(A)
+        import('./lazy.js').then(m => m.run())
+      `,
+      "/lazy.js": /* js */ `
+        import { B } from 'pkg'
+        export function run() { console.log(B) }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(jsOutputs(api)).toEqual(["entry.js", "lazy.js"]);
+      api.expectFile("/out/entry.js").toContain("AAAA");
+      api.expectFile("/out/entry.js").not.toContain("BBBB_MARK");
+      expect(jsOutput(api, "lazy")).toContain("BBBB_MARK");
+      expect(jsOutput(api, "lazy")).not.toContain("import ");
+    },
+    run: { file: "/out/entry.js", stdout: "AAAA\nBBBB_MARK" },
+  });
+
+  // The same through a namespace whose properties bind directly.
+  itBundled("splitting/SideEffectFreeBarrelNamespacePropertyAccess", {
+    files: {
+      ...sideEffectFreeBarrel,
+      "/entry.js": /* js */ `
+        import * as pkg from 'pkg'
+        console.log(pkg.A)
+        import('./lazy.js').then(m => m.run())
+      `,
+      "/lazy.js": /* js */ `
+        import * as pkg from 'pkg'
+        export function run() { console.log(pkg.B) }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(jsOutputs(api)).toEqual(["entry.js", "lazy.js"]);
+      api.expectFile("/out/entry.js").not.toContain("BBBB_MARK");
+      expect(jsOutput(api, "lazy")).toContain("BBBB_MARK");
+    },
+    run: { file: "/out/entry.js", stdout: "AAAA\nBBBB_MARK" },
+  });
+
+  // Without splitting, each entry point's bundle holds only what that entry
+  // uses from the barrel.
+  itBundled("splitting/SideEffectFreeBarrelPerEntryWithoutSplitting", {
+    files: {
+      ...sideEffectFreeBarrel,
+      "/e1.js": /* js */ `
+        import { A } from 'pkg'
+        console.log(A)
+      `,
+      "/e2.js": /* js */ `
+        import { B } from 'pkg'
+        console.log(B)
+      `,
+    },
+    entryPoints: ["/e1.js", "/e2.js"],
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      api.expectFile("/out/e1.js").toContain("AAAA");
+      api.expectFile("/out/e1.js").not.toContain("BBBB_MARK");
+      api.expectFile("/out/e2.js").toContain("BBBB_MARK");
+      api.expectFile("/out/e2.js").not.toContain("AAAA");
+    },
+    run: [
+      { file: "/out/e1.js", stdout: "AAAA" },
+      { file: "/out/e2.js", stdout: "BBBB_MARK" },
+    ],
+  });
+
+  // A barrel that does not declare itself side-effect free still loads every
+  // module it re-exports wherever it is imported: b.js may have side effects,
+  // and they run before the entry's own code.
+  itBundled("splitting/BarrelWithSideEffectsLoadsEveryReExport", {
+    files: {
+      "/entry.js": /* js */ `
+        import { A } from './lib/index.js'
+        console.log(A)
+        import('./lazy.js').then(m => m.run())
+      `,
+      "/lazy.js": /* js */ `
+        import { B } from './lib/index.js'
+        export function run() { console.log(B) }
+      `,
+      "/lib/index.js": /* js */ `
+        export { A } from './a.js'
+        export { B } from './b.js'
+      `,
+      "/lib/a.js": /* js */ `
+        export const A = 'AAAA'
+      `,
+      "/lib/b.js": /* js */ `
+        console.log('b runs')
+        export const B = 'BBBB_MARK'
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(jsOutputs(api)).toEqual(["entry.js", "lazy.js"]);
+      api.expectFile("/out/entry.js").toContain("BBBB_MARK");
+    },
+    run: { file: "/out/entry.js", stdout: "b runs\nAAAA\nBBBB_MARK" },
+  });
+
   // The chunks an output file imports, in statement order.
   const chunkImportsIn = (api: BundlerTestBundleAPI, name: string) =>
     [...api.readFile("/out/" + name).matchAll(/^import\b[^;]*?"\.\/([^"]+)";$/gms)].map(m => m[1]);

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -107,11 +107,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-2gf83hha.js",
+                "path": "./client-qjznw47b.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "whAPiONREUo",
+                  "etag": "l5IfNVyE54s",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -121,7 +121,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "0QzlnAGasio",
+                  "etag": "xh1kdn7wbmI",
                   "content-type": "text/html;charset=utf-8"
                 }
               },


### PR DESCRIPTION
### Problem
- With `--splitting`, a module that only a lazy `import()` uses lands in the entry chunk when both reach it through a `"sideEffects": false` barrel. `entry.js` imports `A` from `pkg`, `lazy.js` imports `B` from `pkg`, and `pkg/b.js` prints into `out/entry.js` with `export { B }` for the lazy chunk. On the Medusa admin dashboard (185 lazy routes behind the `@medusajs/ui`, `@medusajs/icons` and radix barrels) this puts about 500 KB of route-only code into the startup closure.
- The cause is `mark_file_reachable_for_code_splitting` (`src/bundler/LinkerContext.rs:2686`). It gives an entry point's bit to the target of every import record of a live file, and to the dependencies of dead parts. The barrel is live once one entry uses `A`, so its record for `./b.js` hands that entry's bit to `b.js`, although tree shaking drops that `export { B } from "./b.js"` statement and binds `B` straight to `b.js`.

### Fix
- The walk now visits only live parts. It follows their part dependencies and their import records, and skips an `import` or `export ... from` record whose target declares no side effects (`file_has_no_side_effects`, the predicate tree shaking uses for the same record). Such a statement prints nothing, and the bindings it brings in are part dependencies, which the walk follows.
- A barrel that does not declare itself side-effect free is unchanged: tree shaking keeps its targets for their side effects, and so does the walk. CSS and HTML files keep following every record, as tree shaking does.
- Without splitting, each entry point's bundle now holds only what that entry uses through such a barrel. Runtime helpers no longer print into a bundle whose only tie to the runtime was a dead namespace-export part (one chunk hash moves in `html-import-manifest.test.ts`).
- Verified: `test/bundler/bundler_splitting.test.ts` (four new tests and fifteen splitting and `sideEffects` cases ported from Rollup and Rolldown, stock bun fails four of them). Also `test/bundler/esbuild/*` and the other `test/bundler/*` suites, `test/bake/dev-and-prod.test.ts`, and the regression tests that build.

### Background
- Code splitting assigns each file a set of entry bits: the entry points whose chunk must load the file. Files with equal bits form one chunk. `merge_small_chunks` then folds a chunk keyed `{entry, lazy}` into the entry chunk when the lazy entry is only reachable from that entry, which is why `b.js` printed into `out/entry.js`.
- A part is one top-level statement plus the parts it depends on, across files. Tree shaking marks parts live. An import binding is a dependency on the part that declares the export, so a re-export chain adds no code of its own.
- An ESM `import` or `export ... from` statement prints nothing when bundling unless its target is wrapped (CommonJS, or ESM that is also required). A wrapped target is a dependency on the wrapper part, so the walk still reaches it through dependencies.
- esbuild shares the old behaviour. Rolldown assigns chunks from the post-tree-shaking graph and places `b.js` in the lazy chunk.

<details><summary>Notes</summary>

Repro (1.4.1):

```sh
mkdir -p node_modules/pkg
echo '{"name":"pkg","main":"index.js","sideEffects":false}' > node_modules/pkg/package.json
echo 'export { A } from "./a.js"; export { B } from "./b.js";' > node_modules/pkg/index.js
echo 'export const A = "AAAA";' > node_modules/pkg/a.js
echo 'export const B = "BBBB_MARK";' > node_modules/pkg/b.js
echo 'import { A } from "pkg"; console.log(A); import("./lazy.js").then(m => m.run());' > entry.js
echo 'import { B } from "pkg"; export function run() { console.log(B); }' > lazy.js
bun build ./entry.js --splitting --outdir=out && grep -l BBBB_MARK out/*.js
# before: out/entry.js    after: out/lazy-*.js
```

Why the barrel is live at all: `match_import_with_export` records the re-exporting parts between the importer and the declaring file as `re_exports` dependencies, so `lazy.js`'s part depends on the barrel's `export { B } from "./b.js"` part. That part is live but prints nothing. An `export * from` barrel already behaved well because star re-exports add no such dependency, so the barrel file stayed dead and the walk never entered it.

What else the old walk reached: the dependencies of dead parts. In `html-import-manifest.test.ts` the client HTML file's dead namespace-export part depends on the runtime's `__export`, which gave the runtime the client entry's bit. Without splitting, a file prints its live parts into every entry bundle whose bits it intersects, so the server's live `__jsonParse` helper printed into the client chunk. It no longer does, and the chunk hash and etag in the inline snapshot move.

Edges the walk still follows from a live part: `require()` and non-split `import()` records (their targets are also wrapper dependencies), `import`/`export ... from` records whose target has side effects, and every part dependency.

Suites run with the debug build: `test/bundler/esbuild/` (850 pass), `bundler_splitting`, `bundler_barrel`, `bundler_edgecase`, `bundler_regressions`, `bundler_html`, `bundler_html_server`, `html-import-manifest`, `bundler_dynamic_import_dce`, `bundler_promiseall_deadcode`, `bundler_cjs2esm`, `bundler_cjs`, `bundler_npm`, `bundler_jsx`, `bundler_loader`, `bundler_files`, `bundler_defer`, `bundler_browser`, `bundler_bun`, `metafile`, `bun-build-api`, `bundler_compile_splitting`, `bundler_minify`, `bundler_compile`, `bun-build-compile`, `test/bake/dev-and-prod.test.ts`, `test/bake/framework-router.test.ts`, and the `test/regression/issue` files that call the bundler. The only failures were 5 s timeouts of bytecode and compile tests under the debug build (they pass with a longer timeout) and `compile/HelloWorldWithProcessVersionsBun`, which compares `process.versions.bun` against a version string with `-debug` stripped and fails on any debug build.
</details>

