### PR TITLE
hot: keep the entry-point promise alive while the reload loop polls it

### DIFF
--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -251,14 +251,15 @@ impl JSPromise {
     }
 
     /// Safe `status()` for the common `*mut JSPromise`-stored case
-    /// (`vm.pending_internal_promise` etc.). `JSPromise` is a GC-managed JSC
-    /// heap cell; pointers to it are kept alive by the VM's strong-ref slots,
-    /// not by Rust ownership. Centralizes the per-call-site
-    /// `unsafe { (*p).status() }` deref so callers don't open-code it.
+    /// (`vm.pending_internal_promise()` etc.). `JSPromise` is a GC-managed JSC
+    /// heap cell; pointers to it are kept alive by a GC slot that marking
+    /// visits (the global's `WriteBarrier`, a `Strong`), not by Rust
+    /// ownership. Centralizes the per-call-site `unsafe { (*p).status() }`
+    /// deref so callers don't open-code it.
     #[inline]
     pub(crate) fn status_ptr(p: *mut JSPromise) -> Status {
         // `p` is a non-null GC-managed cell tracked by the VM (caller obtained
-        // it from a strong-ref VM field or a fresh
+        // it from a rooted VM slot or a fresh
         // `JSInternalPromise__resolvedPromise` return value).
         JSPromise::opaque_ref(p).status()
     }

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -250,17 +250,10 @@ impl JSPromise {
         }
     }
 
-    /// Safe `status()` for the common `*mut JSPromise`-stored case
-    /// (`vm.pending_internal_promise()` etc.). `JSPromise` is a GC-managed JSC
-    /// heap cell; pointers to it are kept alive by a GC slot that marking
-    /// visits (the global's `WriteBarrier`, a `Strong`), not by Rust
-    /// ownership. Centralizes the per-call-site `unsafe { (*p).status() }`
-    /// deref so callers don't open-code it.
+    /// `status()` for a non-null `*mut JSPromise` that a GC slot keeps alive
+    /// (`vm.pending_internal_promise()` etc.).
     #[inline]
     pub(crate) fn status_ptr(p: *mut JSPromise) -> Status {
-        // `p` is a non-null GC-managed cell tracked by the VM (caller obtained
-        // it from a rooted VM slot or a fresh
-        // `JSInternalPromise__resolvedPromise` return value).
         JSPromise::opaque_ref(p).status()
     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -297,8 +297,9 @@ pub struct VirtualMachine {
     pub rare_data: Option<Box<RareData>>,
     pub proxy_env_storage: crate::rare_data::ProxyEnvStorage,
     pub(crate) resolved_path_dups: Vec<Box<[u8]>>,
-    pub pending_internal_promise: Option<*mut JSInternalPromise>,
-    pub pending_internal_promise_is_protected: bool,
+    /// The entry-point promise the watcher loops poll. Always GC-protected
+    /// while stored: write it through `set_pending_internal_promise`.
+    pending_internal_promise: Option<*mut JSInternalPromise>,
     pub pending_internal_promise_reported_at: u32,
     pub(crate) hot_reload_deferred: bool,
     pub entry_point_result: EntryPointResult,
@@ -2905,10 +2906,7 @@ impl VirtualMachine {
                     // SAFETY: hook contract.
                     let p = unsafe { (hooks.load_preloads)(self) }?;
                     if !p.is_null() {
-                        JSValue::from_cell(p).ensure_still_alive();
-                        JSValue::from_cell(p).protect();
-                        self.pending_internal_promise = Some(p);
-                        self.pending_internal_promise_is_protected = true;
+                        self.set_pending_internal_promise(Some(p));
                         return Ok(p);
                     }
                 }
@@ -2916,8 +2914,7 @@ impl VirtualMachine {
                 // Check if Module.runMain was patched.
                 if self.has_patched_run_main {
                     bun_core::hint::cold();
-                    self.pending_internal_promise = None;
-                    self.pending_internal_promise_is_protected = false;
+                    self.set_pending_internal_promise(None);
                     let global_ref = self.global();
                     let argv1 = bun_string_jsc::create_utf8_for_js(global_ref, MAIN_FILE_NAME)
                         .map_err(|_| crate::CrateError::JSError)?;
@@ -2936,8 +2933,7 @@ impl VirtualMachine {
                         JSC__JSInternalPromise__resolvedPromise(global_ref, ret)
                     })
                     .map_err(|_| crate::CrateError::JSError)?;
-                    self.pending_internal_promise = Some(resolved);
-                    self.pending_internal_promise_is_protected = false;
+                    self.set_pending_internal_promise(Some(resolved));
                     return Ok(resolved);
                 }
             }
@@ -2964,9 +2960,7 @@ impl VirtualMachine {
                 p
             };
 
-            self.pending_internal_promise = Some(promise);
-            self.pending_internal_promise_is_protected = false;
-            JSValue::from_cell(promise).ensure_still_alive();
+            self.set_pending_internal_promise(Some(promise));
             Ok(promise)
         } else {
             self.entry_evaluation_started = false;
@@ -2976,10 +2970,27 @@ impl VirtualMachine {
                 jsc::JSModuleLoader::load_and_evaluate_module_ptr(global, Some(&main_str))
                     .map(NonNull::as_ptr)
                     .ok_or(crate::CrateError::JSError)?;
-            self.pending_internal_promise = Some(promise);
-            self.pending_internal_promise_is_protected = false;
-            JSValue::from_cell(promise).ensure_still_alive();
+            self.set_pending_internal_promise(Some(promise));
             Ok(promise)
+        }
+    }
+
+    /// The entry-point promise that the watcher loops poll, if one is stored.
+    #[inline]
+    pub fn pending_internal_promise(&self) -> Option<*mut JSInternalPromise> {
+        self.pending_internal_promise
+    }
+
+    /// Stores the entry-point promise and keeps it alive for as long as it is
+    /// stored. The module loader returns a plain GC cell that nothing refers to
+    /// once its reaction chain has settled, and the hot-reload loop reads the
+    /// slot on every tick.
+    pub fn set_pending_internal_promise(&mut self, promise: Option<*mut JSInternalPromise>) {
+        if let Some(p) = promise {
+            JSValue::from_cell(p).protect();
+        }
+        if let Some(old) = core::mem::replace(&mut self.pending_internal_promise, promise) {
+            JSValue::from_cell(old).unprotect();
         }
     }
 
@@ -4013,12 +4024,6 @@ impl VirtualMachine {
         // the JSC module loader registry.
         self.global().reload().expect("Failed to reload");
         self.hot_reload_counter += 1;
-        if self.pending_internal_promise_is_protected {
-            if let Some(p) = self.pending_internal_promise {
-                JSValue::from_cell(p).unprotect();
-            }
-            self.pending_internal_promise_is_protected = false;
-        }
         // reload_entry_point() stores into pending_internal_promise on every return path.
         let main = self.main;
         // Note: reshaped for borrowck — copy the `RawSlice` first to avoid
@@ -4962,10 +4967,7 @@ impl VirtualMachine {
                 // SAFETY: hook contract.
                 let p = unsafe { (hooks.load_preloads)(self) }?;
                 if !p.is_null() {
-                    JSValue::from_cell(p).ensure_still_alive();
-                    self.pending_internal_promise = Some(p);
-                    JSValue::from_cell(p).protect();
-                    self.pending_internal_promise_is_protected = true;
+                    self.set_pending_internal_promise(Some(p));
                     return Ok(p);
                 }
             }
@@ -4977,9 +4979,7 @@ impl VirtualMachine {
         let promise = jsc::JSModuleLoader::load_and_evaluate_module_ptr(global, Some(&main_str))
             .map(NonNull::as_ptr)
             .ok_or(crate::CrateError::JSError)?;
-        self.pending_internal_promise = Some(promise);
-        self.pending_internal_promise_is_protected = false;
-        JSValue::from_cell(promise).ensure_still_alive();
+        self.set_pending_internal_promise(Some(promise));
         Ok(promise)
     }
 
@@ -5198,13 +5198,7 @@ impl VirtualMachine {
         self.entry_point_result.value.deinit();
         self.entry_point_result.cjs_set_value = false;
         self.entry_point_result.evaluated_as_cjs = false;
-        if let Some(promise) = self.pending_internal_promise {
-            if self.pending_internal_promise_is_protected {
-                JSValue::from_cell(promise).unprotect();
-                self.pending_internal_promise_is_protected = false;
-            }
-            self.pending_internal_promise = None;
-        }
+        self.set_pending_internal_promise(None);
         self.has_patched_run_main = false;
         self.set_main(b"");
         self.main_hash = 0;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -297,9 +297,6 @@ pub struct VirtualMachine {
     pub rare_data: Option<Box<RareData>>,
     pub proxy_env_storage: crate::rare_data::ProxyEnvStorage,
     pub(crate) resolved_path_dups: Vec<Box<[u8]>>,
-    /// The entry-point promise the watcher loops poll. Always GC-protected
-    /// while stored: write it through `set_pending_internal_promise`.
-    pending_internal_promise: Option<*mut JSInternalPromise>,
     pub pending_internal_promise_reported_at: u32,
     pub(crate) hot_reload_deferred: bool,
     pub entry_point_result: EntryPointResult,
@@ -410,6 +407,16 @@ unsafe extern "C" {
     safe fn Bun__closeAllNodeSqliteDatabasesForTermination(global: &JSGlobalObject);
     safe fn Bun__WebView__closeAllForTermination();
     safe fn Zig__GlobalObject__prepareForDestruction(global: &JSGlobalObject);
+    // safe: the global stores `promise` in a `WriteBarrier` slot that its
+    // `visitChildren` marks; null clears the slot. The returned cell is alive
+    // for as long as the slot holds it.
+    safe fn Bun__GlobalObject__pendingInternalPromise(
+        global: &JSGlobalObject,
+    ) -> *mut JSInternalPromise;
+    safe fn Bun__GlobalObject__setPendingInternalPromise(
+        global: &JSGlobalObject,
+        promise: *mut JSInternalPromise,
+    );
     safe fn Zig__GlobalObject__forbidExecution(global: &JSGlobalObject);
     safe fn Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(global: &JSGlobalObject);
     safe fn Zig__GlobalObject__destructOnExit(global: &JSGlobalObject);
@@ -2924,7 +2931,7 @@ impl VirtualMachine {
                     .map_err(|_| crate::CrateError::JSError)?;
                     // If the override stored a promise itself, use that; otherwise
                     // wrap its return value.
-                    if let Some(stored) = self.pending_internal_promise {
+                    if let Some(stored) = self.pending_internal_promise() {
                         return Ok(stored);
                     }
                     // `Promise.resolve(ret)` reads `ret.constructor` / `ret.then`,
@@ -2975,23 +2982,22 @@ impl VirtualMachine {
         }
     }
 
-    /// The entry-point promise that the watcher loops poll, if one is stored.
+    /// The promise for the current entry-point load, if one is stored. The
+    /// watcher loops poll it.
     #[inline]
     pub fn pending_internal_promise(&self) -> Option<*mut JSInternalPromise> {
-        self.pending_internal_promise
+        NonNull::new(Bun__GlobalObject__pendingInternalPromise(self.global())).map(NonNull::as_ptr)
     }
 
-    /// Stores the entry-point promise and keeps it alive for as long as it is
-    /// stored. The module loader returns a plain GC cell that nothing refers to
-    /// once its reaction chain has settled, and the hot-reload loop reads the
-    /// slot on every tick.
+    /// Stores the entry-point promise in a GC slot on the global object, so it
+    /// lives as long as the global that is loading it. The module loader
+    /// returns a plain cell that nothing refers to once its reaction chain has
+    /// settled, and the hot-reload loop reads the slot on every tick.
     pub fn set_pending_internal_promise(&mut self, promise: Option<*mut JSInternalPromise>) {
-        if let Some(p) = promise {
-            JSValue::from_cell(p).protect();
-        }
-        if let Some(old) = core::mem::replace(&mut self.pending_internal_promise, promise) {
-            JSValue::from_cell(old).unprotect();
-        }
+        Bun__GlobalObject__setPendingInternalPromise(
+            self.global(),
+            promise.unwrap_or(core::ptr::null_mut()),
+        );
     }
 
     /// `loadEntryPoint(entry_path)` — `reload_entry_point` + spin until the
@@ -3005,7 +3011,7 @@ impl VirtualMachine {
         // pending_internal_promise can change if hot module reloading is enabled
         if self.is_watcher_enabled() {
             loop {
-                let Some(p) = self.pending_internal_promise else {
+                let Some(p) = self.pending_internal_promise() else {
                     break;
                 };
                 // SAFETY: `p` is a live JSC heap cell tracked by the VM.
@@ -3013,7 +3019,7 @@ impl VirtualMachine {
                     break;
                 }
                 self.event_loop_mut().tick();
-                let Some(p) = self.pending_internal_promise else {
+                let Some(p) = self.pending_internal_promise() else {
                     break;
                 };
                 // SAFETY: see above.
@@ -3029,7 +3035,7 @@ impl VirtualMachine {
             let _ = self.wait_for_promise(jsc::AnyPromise::Internal(promise));
         }
 
-        Ok(self.pending_internal_promise.unwrap_or(promise))
+        Ok(self.pending_internal_promise().unwrap_or(promise))
     }
 }
 
@@ -3875,7 +3881,7 @@ impl VirtualMachine {
 
     /// After a hot reload, surfaces the entry-point promise's rejection (if any) and re-arms the watcher.
     pub fn report_exception_in_hot_reloaded_module_if_needed(&mut self) {
-        let promise = match self.pending_internal_promise {
+        let promise = match self.pending_internal_promise() {
             Some(p) => p,
             None => {
                 self.add_main_to_watcher_if_needed();
@@ -3986,7 +3992,7 @@ impl VirtualMachine {
             bun_core::reload_process(should_clear_terminal, false);
         }
 
-        if let Some(p) = self.pending_internal_promise {
+        if let Some(p) = self.pending_internal_promise() {
             // SAFETY: `p` is a live JSC heap cell tracked by the VM.
             match crate::JSPromise::status_ptr(p) {
                 crate::js_promise::Status::Pending => {
@@ -5012,7 +5018,7 @@ impl VirtualMachine {
         // pending_internal_promise can change if hot module reloading is enabled
         if self.is_watcher_enabled() {
             loop {
-                let Some(p) = self.pending_internal_promise else {
+                let Some(p) = self.pending_internal_promise() else {
                     break;
                 };
                 // SAFETY: `p` is a live JSC heap cell tracked by the VM.
@@ -5020,7 +5026,7 @@ impl VirtualMachine {
                     break;
                 }
                 self.event_loop_mut().tick();
-                let Some(p) = self.pending_internal_promise else {
+                let Some(p) = self.pending_internal_promise() else {
                     break;
                 };
                 // SAFETY: see above.
@@ -5039,7 +5045,7 @@ impl VirtualMachine {
         // Pre-arm the waker so this settled-promise tick cannot park (#36450).
         self.wakeup();
         self.auto_tick();
-        Ok(self.pending_internal_promise.unwrap())
+        Ok(self.pending_internal_promise().unwrap())
     }
 
     /// Tracks a listening socket so watch-mode reloads can close it.
@@ -5198,7 +5204,8 @@ impl VirtualMachine {
         self.entry_point_result.value.deinit();
         self.entry_point_result.cjs_set_value = false;
         self.entry_point_result.evaluated_as_cjs = false;
-        self.set_pending_internal_promise(None);
+        // The entry-point promise slot lives on the global, so the swap below
+        // leaves it behind with the old global.
         self.has_patched_run_main = false;
         self.set_main(b"");
         self.main_hash = 0;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -407,9 +407,7 @@ unsafe extern "C" {
     safe fn Bun__closeAllNodeSqliteDatabasesForTermination(global: &JSGlobalObject);
     safe fn Bun__WebView__closeAllForTermination();
     safe fn Zig__GlobalObject__prepareForDestruction(global: &JSGlobalObject);
-    // safe: the global stores `promise` in a `WriteBarrier` slot that its
-    // `visitChildren` marks; null clears the slot. The returned cell is alive
-    // for as long as the slot holds it.
+    // safe: a `WriteBarrier` slot on the global; null clears it.
     safe fn Bun__GlobalObject__pendingInternalPromise(
         global: &JSGlobalObject,
     ) -> *mut JSInternalPromise;
@@ -2982,17 +2980,14 @@ impl VirtualMachine {
         }
     }
 
-    /// The promise for the current entry-point load, if one is stored. The
-    /// watcher loops poll it.
+    /// The promise for the current entry-point load. The watcher loops poll it.
     #[inline]
     pub fn pending_internal_promise(&self) -> Option<*mut JSInternalPromise> {
         NonNull::new(Bun__GlobalObject__pendingInternalPromise(self.global())).map(NonNull::as_ptr)
     }
 
-    /// Stores the entry-point promise in a GC slot on the global object, so it
-    /// lives as long as the global that is loading it. The module loader
-    /// returns a plain cell that nothing refers to once its reaction chain has
-    /// settled, and the hot-reload loop reads the slot on every tick.
+    /// Stores the entry-point promise in a GC slot on the global, which keeps
+    /// it alive: once it settles nothing else refers to it.
     pub fn set_pending_internal_promise(&mut self, promise: Option<*mut JSInternalPromise>) {
         Bun__GlobalObject__setPendingInternalPromise(
             self.global(),
@@ -5204,8 +5199,7 @@ impl VirtualMachine {
         self.entry_point_result.value.deinit();
         self.entry_point_result.cjs_set_value = false;
         self.entry_point_result.evaluated_as_cjs = false;
-        // The entry-point promise slot lives on the global, so the swap below
-        // leaves it behind with the old global.
+        // The entry-point promise slot is on the global and goes with it.
         self.has_patched_run_main = false;
         self.set_main(b"");
         self.main_hash = 0;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4270,6 +4270,24 @@ void GlobalObject::setNodeWorkerEntryEvaluatedHook(JSObject* hook)
         m_nodeWorkerEntryEvaluatedHook.clear();
 }
 
+void GlobalObject::setPendingInternalPromise(JSC::JSPromise* promise)
+{
+    if (promise)
+        m_pendingInternalPromise.set(vm(), this, promise);
+    else
+        m_pendingInternalPromise.clear();
+}
+
+extern "C" JSC::JSPromise* Bun__GlobalObject__pendingInternalPromise(Zig::GlobalObject* globalObject)
+{
+    return globalObject->pendingInternalPromise();
+}
+
+extern "C" void Bun__GlobalObject__setPendingInternalPromise(Zig::GlobalObject* globalObject, JSC::JSPromise* promise)
+{
+    globalObject->setPendingInternalPromise(promise);
+}
+
 extern "C" void Bun__InspectorConnection__disconnectAllOnExit(Zig::GlobalObject*);
 
 void GlobalObject::setNodeParentPort(WebCore::MessagePort* port)

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -524,6 +524,9 @@ public:
     /* node:worker_threads worker: { stdin?, stdout, stderr } MessagePorts from the parent Worker; */        \
     /* process.stdin/stdout/stderr are built over these lazily (BunProcess.cpp constructStd*). */            \
     V(private, WriteBarrier<JSObject>, m_nodeWorkerStdioPorts)                                               \
+    /* The module loader's promise for the current entry-point load. The --hot loop polls it on every */     \
+    /* tick, and once it settles nothing else refers to it (VirtualMachine::pending_internal_promise). */    \
+    V(private, WriteBarrier<JSC::JSPromise>, m_pendingInternalPromise)                                       \
                                                                                                              \
     /* The original, unmodified Error.prepareStackTrace. */                                                  \
     /* */                                                                                                    \
@@ -764,6 +767,8 @@ public:
     void nodeWorkerEntryDidSettle();
     JSObject* nodeWorkerEntryEvaluatedHook() { return m_nodeWorkerEntryEvaluatedHook.get(); }
     void setNodeWorkerEntryEvaluatedHook(JSObject* hook);
+    JSC::JSPromise* pendingInternalPromise() { return m_pendingInternalPromise.get(); }
+    void setPendingInternalPromise(JSC::JSPromise* promise);
 
     Bun::MarkdownTagStrings& markdownTagStrings() { return m_markdownTagStrings; }
 #include "ZigGeneratedClasses+lazyStructureHeader.h"

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -524,8 +524,7 @@ public:
     /* node:worker_threads worker: { stdin?, stdout, stderr } MessagePorts from the parent Worker; */        \
     /* process.stdin/stdout/stderr are built over these lazily (BunProcess.cpp constructStd*). */            \
     V(private, WriteBarrier<JSObject>, m_nodeWorkerStdioPorts)                                               \
-    /* The module loader's promise for the current entry-point load. The --hot loop polls it on every */     \
-    /* tick, and once it settles nothing else refers to it (VirtualMachine::pending_internal_promise). */    \
+    /* The current entry-point load's promise (VirtualMachine::pending_internal_promise). */                 \
     V(private, WriteBarrier<JSC::JSPromise>, m_pendingInternalPromise)                                       \
                                                                                                              \
     /* The original, unmodified Error.prepareStackTrace. */                                                  \

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -103,9 +103,8 @@ pub fn set_override_module_run_main_promise(
     vm: &mut VirtualMachine,
     promise: *mut JSInternalPromise,
 ) {
-    if vm.pending_internal_promise.is_none() {
-        vm.pending_internal_promise = Some(promise);
-        vm.pending_internal_promise_is_protected = false;
+    if vm.pending_internal_promise().is_none() {
+        vm.set_pending_internal_promise(Some(promise));
     }
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -740,7 +740,7 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
     // SAFETY: per fn contract — `vm` is the live per-thread VM.
     unsafe { (*vm).is_in_preload = true };
     // Note: copy the raw ptr into a guard-owned local so the defer body
-    // doesn't borrow the fn param — later `(*vm).pending_internal_promise = …`
+    // doesn't borrow the fn param — later `(*vm).set_pending_internal_promise(…)`
     // would otherwise alias the guard's capture.
     let vm_for_guard = vm;
     scopeguard::defer! {
@@ -852,7 +852,7 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
         };
 
         // SAFETY: per fn contract.
-        unsafe { (*vm).pending_internal_promise = Some(promise) };
+        unsafe { (*vm).set_pending_internal_promise(Some(promise)) };
         let _protected = JSValue::from_cell(promise).protected();
 
         // ── wait ────────────────────────────────────────────────────────
@@ -869,7 +869,9 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
                     // SAFETY: `pending_internal_promise` was set just above (or
                     // swapped by HMR to another live cell); `status()` is a
                     // read-only FFI call on a live JSC heap cell.
-                    let pip = unsafe { &*vm }.pending_internal_promise.unwrap_or(promise);
+                    let pip = unsafe { &*vm }
+                        .pending_internal_promise()
+                        .unwrap_or(promise);
                     // SAFETY: `pip` is a live JSC heap cell (set just above or
                     // the protected `promise` fallback).
                     if unsafe { &*pip }.status() != PromiseStatus::Pending {
@@ -878,7 +880,9 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
                     // SAFETY: `el` is the live per-thread event loop.
                     unsafe { (*el).tick() };
                     // SAFETY: per fn contract — `vm` is the live per-thread VM.
-                    let pip = unsafe { &*vm }.pending_internal_promise.unwrap_or(promise);
+                    let pip = unsafe { &*vm }
+                        .pending_internal_promise()
+                        .unwrap_or(promise);
                     // SAFETY: `pip` is a live JSC heap cell (see above).
                     if unsafe { &*pip }.status() == PromiseStatus::Pending {
                         // SAFETY: per fn contract — short-lived `&mut *vm` for the

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -241,6 +241,10 @@ it(
     async function waitForOutput(what: string, done: () => boolean) {
       const deadline = Date.now() + stepTimeout;
       while (!done()) {
+        const exit = runner.exitCode ?? runner.signalCode;
+        if (exit !== null) {
+          throw new Error(`child exited (${exit}) while waiting for ${what}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+        }
         if (Date.now() > deadline) {
           throw new Error(`timed out waiting for ${what}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
         }

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -192,6 +192,77 @@ it(
   timeout,
 );
 
+it(
+  "should keep reloading after a GC runs between reloads",
+  async () => {
+    // Once the entry point's load promise settles, the only reference left to
+    // it is the VM slot the --hot loop polls on every tick. After a reload,
+    // collect that promise from an fs callback and fill the heap with pending
+    // promises so its cell is reused. If the slot does not root the promise,
+    // it now reads "pending" and every later reload is deferred forever.
+    const root = join(cwd, "hot-entry-promise-gc.js");
+    const source = `
+      import { readFile } from "fs";
+      globalThis.counter ??= 0;
+      const n = ++globalThis.counter;
+      console.write(\`[#!root] Reloaded: \${n}\\n\`);
+      if (n > 1) {
+        readFile(import.meta.path, () => {
+          Bun.gc(true);
+          globalThis.pending = Array.from({ length: 20_000 }, () => new Promise(() => {}));
+          console.write(\`[#!root] gc done: \${n}\\n\`);
+        });
+      }
+      setTimeout(() => {}, 9_999_999);
+    `;
+    writeFileSync(root, source);
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const drained = Promise.all([
+      (async () => {
+        for await (const chunk of runner.stdout) stdout += new TextDecoder().decode(chunk);
+      })(),
+      (async () => {
+        for await (const chunk of runner.stderr) stderr += new TextDecoder().decode(chunk);
+      })(),
+    ]);
+    const reloads = () => [...stdout.matchAll(/\[#!root\] Reloaded: (\d+)\n/g)].map(m => Number(m[1]));
+    const stepTimeout = isDebug ? 120_000 : 20_000;
+    async function waitForOutput(what: string, done: () => boolean) {
+      const deadline = Date.now() + stepTimeout;
+      while (!done()) {
+        if (Date.now() > deadline) {
+          throw new Error(`timed out waiting for ${what}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+        }
+        await Bun.sleep(20);
+      }
+    }
+
+    await waitForOutput("the first load", () => reloads().length > 0);
+    writeFileSync(root, source);
+    // A save can fire more than one watcher event, so count reloads instead of
+    // expecting exactly one.
+    await waitForOutput("the GC after a reload", () => stdout.includes("[#!root] gc done: "));
+    const before = Math.max(...reloads());
+    writeFileSync(root, source);
+    await waitForOutput(`a reload after reload ${before}`, () => Math.max(...reloads()) > before);
+
+    runner.kill();
+    await drained;
+  },
+  longTimeout,
+);
+
 it.each(["hot-file-loader.file", "hot-file-loader.css"])(
   "should hot reload when `%s` is overwritten",
   async (targetFilename: string) => {


### PR DESCRIPTION
### Problem
- `bun --hot` panics with `internal error: entered unreachable code: invalid JSPromise status 255` in `report_exception_in_hot_reloaded_module_if_needed` (Sentry BUN-4SK5), or segfaults in `JSC__JSPromise__status` (#41012). `bun test` has the same read: release ASAN reports `heap-use-after-free` in `print_error_from_maybe_private_data`.
- `VirtualMachine::pending_internal_promise` was a raw pointer to the entry point's load promise. Nothing roots that promise once it settles, but `--hot` polls it on every tick. A reused cell reads as `Pending`, so `reload()` defers every later reload forever.

### Fix
- The promise now lives in a `WriteBarrier<JSPromise>` on `Zig::GlobalObject`, which `visitChildren` marks. Rust reaches it through `pending_internal_promise()` and `set_pending_internal_promise()`. The raw field and its `is_protected` flag are gone.
- Correct because the global that loads the entry owns the slot: one global per `--hot` process, one per file under `bun test --isolate`.
- Verified: the new `test/cli/hot/hot.test.ts` test fails on a debug build of main and passes here. The new `test/cli/test/bun-test.test.ts` test fails only on a release ASAN build. Notes lists the runs and other suites.

### Background
- `--hot` keeps one process and one global. On a file change, `reload()` stores the new load promise in the slot.
- `JSC::loadAndEvaluateModule` returns a fresh `JSPromise`. Its only inbound GC edge is a reaction on the previous promise, and settlement clears it.
- A `WriteBarrier<T>` is a GC-aware pointer field on a cell. The owner's `visitChildren` marks it on every collection.
- `JSPromise::Status` uses two bits. A live promise never has status 3, so the binding returns 255 for it.

Fixes #41012.

<details><summary>Notes</summary>

**Tests.** `hot.test.ts`: "should keep reloading after a GC runs between reloads". `bun-test.test.ts`: "prints a test file's build error when a GC runs before it is reported".

**Evidence that nothing roots the promise** (debug build, `bun --hot`, after one reload):

- `generateHeapSnapshotForDebugging()` after `Bun.gc(true)` lists the cell at `vm->pending_internal_promise` with zero incoming edges and no entry in `roots`. The snapshot reports `StrongHandles`, `StrongReferences`, `DOMGCOutput` and `ProtectedValues` roots. Conservative roots are not reported.
- lldb at that point finds the cell's address only in stale stack slots of `jsc_hooks::auto_tick_active` and `timer::All::drain_timers`, left behind by the previous tick's `report_exception_in_hot_reloaded_module_if_needed` call at the same depth. The promise from the initial load sits in `Run::start`'s own locals.
- A GC run from an `fs.readFile` callback goes through `tick()` instead, and those frames overwrite the stale slots. The promise is then collected. That is how the hot test triggers the bug deterministically: reload once, collect from an `fs` callback, allocate 20k pending promises so the dead cell is reused (or scribbled under debug), then save the file again. Without the fix no reload follows.
- Release builds have neither debug locals nor scribbling, so the dead cell reads stale bits until the block is reused or unmapped: the 255 panic and the #41012 segfault.

Why the hot test needs two reloads: in a debug build the first load's promise is pinned by `Run::start`'s locals (`match vm.load_entry_point(entry) { Ok(promise) => ... }`) for the life of the process.

**The `bun test` route.** A test file that does not transpile rejects its load promise with a `BuildMessage`. `load_entry_point_for_test_runner` runs one more `auto_tick()` after the promise settles. In an optimized build only the raw slot holds the promise during that tick, so a GC there sweeps the promise and the `BuildMessage`. `TestCommand::run` then reads `promise.result()` and prints it. [This comment](https://github.com/oven-sh/bun/pull/41146#issuecomment-5720645731) has the ASAN report, the repro, and the run counts: on a release ASAN build the new test fails 3 of 3 runs without the `src/` change and passes with it. A debug build keeps the promise in a stack slot (opt-level 0), so it passes that test both ways.

**Suites run on a debug build of this branch (merged with main at 0d3492e353):** `hot.test.ts`, `watch.test.ts` (both), `watch-many-dirs.test.ts`, `bun-test.test.ts`, `isolation.test.ts`, `preload-test.test.js`, `node-module-module.test.js`. The hot test was checked again against `src/` from that main: it fails there (reload deferred forever) and passes with this branch.

**Design notes.**

- The first revision used `gcProtect`/`gcUnprotect` from a setter on the VM (the same shape as #32572, 2026-06, which conflicted with main and had no failing test). Review asked for a root tied to an object with the right lifetime instead of a manual protect count. The global object is that object.
- A stack slot the conservative scanner always sees was considered and rejected. `Run::start` is the only frame that lives for the whole process, and the reload creates the promise deep inside `tick()`. Between that store and any copy into `Run::start`'s frame, the promise can settle and a collection can run. The test-runner loops and worker loads would each need their own copy, and a slot that is never read again is not guaranteed to stay in the frame.
- Teardown needs no clear: the slot dies with the global.

Probably also #30436 (hot reload stops after `await Bun.build()` in the entry), which matches the "reads as Pending" shape. The repro there no longer reproduces on main, so it is not linked.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts, test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->