### PR TITLE
node:module: default runMain() argument to process.argv[1]

### DIFF
--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -790,8 +790,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
         if (auto* process = zigGlobalObject->processObject()) {
             JSValue argv = process->getArgv(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
-            // A plain property get like Node's `process.argv[1]`: a replaced
-            // string indexes, null and undefined throw a TypeError.
             arg1 = argv.get(globalObject, 1u);
             RETURN_IF_EXCEPTION(scope, {});
         }

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -795,10 +795,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
                 RETURN_IF_EXCEPTION(scope, {});
             }
         }
-        if (arg1.isUndefined()) {
-            // Node: resolveMainPath() calls path.resolve(process.argv[1]) and throws this
-            return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "paths[0]"_s, "string"_s, arg1);
-        }
+    }
+    if (!arg1.isString()) {
+        // Node: resolveMainPath() calls path.resolve(main) and throws this
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "paths[0]"_s, "string"_s, arg1);
     }
 
     auto name = arg1.toWTFString(globalObject);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -790,10 +790,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
         if (auto* process = zigGlobalObject->processObject()) {
             JSValue argv = process->getArgv(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
-            if (argv.isObject()) {
-                arg1 = argv.getObject()->get(globalObject, 1u);
-                RETURN_IF_EXCEPTION(scope, {});
-            }
+            // A plain property get like Node's `process.argv[1]`: a replaced
+            // string indexes, null and undefined throw a TypeError.
+            arg1 = argv.get(globalObject, 1u);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
     if (!arg1.isString()) {

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -784,10 +784,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto arg1 = callFrame->argument(0);
 
-    // Node defaults the argument to process.argv[1] (the main entry point):
-    // `function executeUserEntryPoint(main = process.argv[1])`. Without this,
-    // `runMain()` with no argument would coerce `undefined` to the literal
-    // string "undefined" and fail to resolve it as a module.
+    // Node: `function executeUserEntryPoint(main = process.argv[1])`
     if (arg1.isUndefined()) {
         auto* zigGlobalObject = defaultGlobalObject(globalObject);
         if (auto* process = zigGlobalObject->processObject()) {

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -18,6 +18,7 @@
 
 #include "PathInlines.h"
 #include "ZigGlobalObject.h"
+#include "BunProcess.h"
 #include "headers.h"
 #include "ErrorCode.h"
 
@@ -782,6 +783,23 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto arg1 = callFrame->argument(0);
+
+    // Node defaults the argument to process.argv[1] (the main entry point):
+    // `function executeUserEntryPoint(main = process.argv[1])`. Without this,
+    // `runMain()` with no argument would coerce `undefined` to the literal
+    // string "undefined" and fail to resolve it as a module.
+    if (arg1.isUndefined()) {
+        auto* zigGlobalObject = defaultGlobalObject(globalObject);
+        if (auto* process = zigGlobalObject->processObject()) {
+            JSValue argv = process->getArgv(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (auto* argvArray = dynamicDowncast<JSArray>(argv)) {
+                arg1 = argvArray->getIndex(globalObject, 1);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        }
+    }
+
     auto name = arg1.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -790,10 +790,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
         if (auto* process = zigGlobalObject->processObject()) {
             JSValue argv = process->getArgv(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
-            if (auto* argvArray = dynamicDowncast<JSArray>(argv)) {
-                arg1 = argvArray->getIndex(globalObject, 1);
+            if (argv.isObject()) {
+                arg1 = argv.getObject()->get(globalObject, 1u);
                 RETURN_IF_EXCEPTION(scope, {});
             }
+        }
+        if (arg1.isUndefined()) {
+            // Node: resolveMainPath() calls path.resolve(process.argv[1]) and throws this
+            return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "paths[0]"_s, "string"_s, arg1);
         }
     }
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -890,6 +890,32 @@ console.log("survived", require("./late.js"));`,
     expect(stdout.trim()).toBe("pass");
     expect(await proc.exited).toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/31773
+  // runMain() with no argument must default to process.argv[1] (the current
+  // main entry) like Node, instead of coercing `undefined` to the string
+  // "undefined" and failing to resolve it as a module.
+  test.each([
+    ["esm", "entry.mjs", `import { runMain } from "node:module";\nrunMain();\nconsole.log("ran");\n`],
+    ["cjs", "entry.cjs", `const { runMain } = require("node:module");\nrunMain();\nconsole.log("ran");\n`],
+  ])("runMain() with no argument defaults to the main entry (%s)", async (_name, filename, source) => {
+    using dir = tempDir("run-main-no-arg", { [filename]: source });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), filename],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout.trim()).toBe("ran");
+    expect(exitCode).toBe(0);
+  });
+
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -895,25 +895,27 @@ console.log("survived", require("./late.js"));`,
   // runMain() with no argument must default to process.argv[1] (the current
   // main entry) like Node, instead of coercing `undefined` to the string
   // "undefined" and failing to resolve it as a module.
-  test.each([
+  describe.each([
     ["esm", "entry.mjs", `import { runMain } from "node:module";\nrunMain();\nconsole.log("ran");\n`],
     ["cjs", "entry.cjs", `const { runMain } = require("node:module");\nrunMain();\nconsole.log("ran");\n`],
-  ])("runMain() with no argument defaults to the main entry (%s)", async (_name, filename, source) => {
-    using dir = tempDir("run-main-no-arg", { [filename]: source });
+  ])("runMain() with no argument (%s)", (_name, filename, source) => {
+    test("defaults to the main entry", async () => {
+      using dir = tempDir("run-main-no-arg", { [filename]: source });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), filename],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), filename],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).not.toContain("Cannot find package");
+      expect(stdout.trim()).toBe("ran");
+      expect(exitCode).toBe(0);
     });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).not.toContain("Cannot find package");
-    expect(stdout.trim()).toBe("ran");
-    expect(exitCode).toBe(0);
   });
 
   // With `-e` there is no process.argv[1]. Node throws ERR_INVALID_ARG_TYPE
@@ -921,46 +923,76 @@ console.log("survived", require("./late.js"));`,
   // "undefined". Non-string arguments take the same path: Node's default
   // parameter only substitutes `undefined`, so `runMain(null)` reaches
   // path.resolve(null) and throws the same error.
-  test.each([
+  describe.each([
     ["no argument, no main entry", `require("node:module").runMain()`],
     ["null argument", `require("node:module").runMain(null)`],
     ["number argument", `require("node:module").runMain(42)`],
-  ])("runMain() throws ERR_INVALID_ARG_TYPE (%s)", async (_name, source) => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", source],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
+  ])("runMain() with an invalid main (%s)", (_name, source) => {
+    test("throws ERR_INVALID_ARG_TYPE", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", source],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).not.toContain("Cannot find package");
+      expect(stderr).toContain('The "paths[0]" argument must be of type string');
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
     });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).not.toContain("Cannot find package");
-    expect(stderr).toContain('The "paths[0]" argument must be of type string');
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(1);
   });
 
   // Node reads the default through a plain property get (`process.argv[1]`),
-  // so a non-array replacement of process.argv must still work.
-  test("runMain() with no argument reads a replaced array-like process.argv", async () => {
-    using dir = tempDir("run-main-argv-like", {
-      "entry.cjs": `process.argv = { 1: process.argv[1] };\nrequire("node:module").runMain();\nconsole.log("ran");\n`,
+  // so any replacement of process.argv behaves like JS property access: an
+  // array-like object works, a string indexes, and null throws a TypeError.
+  describe.each([
+    [
+      "array-like object works",
+      `process.argv = { 1: process.argv[1] };\nrequire("node:module").runMain();\nconsole.log("ran");\n`,
+      proc => {
+        expect(proc.stderr).not.toContain("Cannot find package");
+        expect(proc.stdout.trim()).toBe("ran");
+        expect(proc.exitCode).toBe(0);
+      },
+    ],
+    [
+      "string indexes like Node",
+      // "x/"[1] is "/": resolution fails on module "/", not on "undefined"
+      // and not with the paths[0] TypeError. An absolute path never triggers
+      // auto-install, so the failure is deterministic and offline.
+      `process.argv = "x/";\ntry { require("node:module").runMain(); console.log("bad: no throw"); } catch (e) { console.log(e.message.includes("undefined") || e.message.includes("paths[0]") ? "bad" : "indexed"); }\n`,
+      proc => {
+        expect(proc.stdout.trim()).toBe("indexed");
+        expect(proc.exitCode).toBe(0);
+      },
+    ],
+    [
+      "null throws a property-access TypeError",
+      `process.argv = null;\ntry { require("node:module").runMain(); console.log("bad: no throw"); } catch (e) { console.log(e instanceof TypeError && !e.message.includes("paths[0]") ? "typeerror" : "bad"); }\n`,
+      proc => {
+        expect(proc.stdout.trim()).toBe("typeerror");
+        expect(proc.exitCode).toBe(0);
+      },
+    ],
+  ])("runMain() with a replaced process.argv (%s)", (_name, source, check) => {
+    test("matches Node property access", async () => {
+      using dir = tempDir("run-main-argv-replaced", { "entry.cjs": source });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      check({ stdout, stderr, exitCode });
     });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "entry.cjs"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).not.toContain("Cannot find package");
-    expect(stdout.trim()).toBe("ran");
-    expect(exitCode).toBe(0);
   });
 
   test.each(["no args", "--access-early"])("children, %s", async arg => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -406,15 +406,15 @@ console.log("survived", require("./late.js"));`,
     expect(Module._resolveFilename("fs")).toBe("fs");
   });
 
-  test("Module.runMain propagates an error from stringifying its argument", () => {
-    const boom = new Error("boom");
+  test("Module.runMain rejects a non-string argument without stringifying it", () => {
+    // Node validates typeof before any coercion, so the toString never runs.
     expect(() =>
       Module.runMain({
         toString() {
-          throw boom;
+          throw new Error("boom");
         },
       }),
-    ).toThrow(boom);
+    ).toThrow('The "paths[0]" argument must be of type string');
   });
 
   test("module.filename/id/path setters propagate a failed string conversion", () => {
@@ -918,19 +918,26 @@ console.log("survived", require("./late.js"));`,
 
   // With `-e` there is no process.argv[1]. Node throws ERR_INVALID_ARG_TYPE
   // from path.resolve(undefined) instead of resolving a module named
-  // "undefined".
-  test("runMain() with no argument and no main entry throws ERR_INVALID_ARG_TYPE", async () => {
+  // "undefined". Non-string arguments take the same path: Node's default
+  // parameter only substitutes `undefined`, so `runMain(null)` reaches
+  // path.resolve(null) and throws the same error.
+  test.each([
+    ["no argument, no main entry", `require("node:module").runMain()`],
+    ["null argument", `require("node:module").runMain(null)`],
+    ["number argument", `require("node:module").runMain(42)`],
+  ])("runMain() throws ERR_INVALID_ARG_TYPE (%s)", async (_name, source) => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `require("node:module").runMain()`],
+      cmd: [bunExe(), "-e", source],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",
     });
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("Cannot find package");
     expect(stderr).toContain('The "paths[0]" argument must be of type string');
+    expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -916,6 +916,46 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  // With `-e` there is no process.argv[1]. Node throws ERR_INVALID_ARG_TYPE
+  // from path.resolve(undefined) instead of resolving a module named
+  // "undefined".
+  test("runMain() with no argument and no main entry throws ERR_INVALID_ARG_TYPE", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `require("node:module").runMain()`],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stderr).toContain('The "paths[0]" argument must be of type string');
+    expect(exitCode).toBe(1);
+  });
+
+  // Node reads the default through a plain property get (`process.argv[1]`),
+  // so a non-array replacement of process.argv must still work.
+  test("runMain() with no argument reads a replaced array-like process.argv", async () => {
+    using dir = tempDir("run-main-argv-like", {
+      "entry.cjs": `process.argv = { 1: process.argv[1] };\nrequire("node:module").runMain();\nconsole.log("ran");\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout.trim()).toBe("ran");
+    expect(exitCode).toBe(0);
+  });
+
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],


### PR DESCRIPTION
Closes #31773. Supersedes #31774 (same change; that PR was stale-closed and its head branch was renamed, which closed it for good).

### Problem

- `import { runMain } from "node:module"; runMain();` throws `Cannot find package 'undefined' from ''`. Still reproduces on 1.4.1-canary (a6c4cc276).
- Cause: `jsFunctionRunMain` (`src/jsc/modules/NodeModuleModule.cpp`) passes `callFrame->argument(0)` straight to `toWTFString()`. With no argument that coerces `undefined` to the string `"undefined"`, and module resolution fails.

### Fix

- When no argument is passed, default to `process.argv[1]`, matching Node's `executeUserEntryPoint(main = process.argv[1])`. The default is a plain property get, so a replaced array-like `process.argv` works like in Node.
- After the default, a non-string value throws `ERR_INVALID_ARG_TYPE` for `"paths[0]"`, exactly like Node's `resolveMainPath` -> `path.resolve(main)`. This covers `bun -e` (no `argv[1]`), `runMain(null)`, and `runMain(42)`. Node validates `typeof` before any coercion, so a throwing `toString` is never called. Verified against node v24.
- Correct because `process.argv[1]` is the same string as the entry path the module registry already holds, so `loadAndEvaluateModule` finds the evaluated main module and the call is a cached no-op.
- Verified: `test/js/node/module/node-module-module.test.js` (5 new tests plus 1 updated). The no-arg tests fail on the released build with the exact reported error and pass with this change. All 55 runnable tests in the file pass.

### Background

- `Module.runMain()` is Node's entry-point runner. Calling it with no argument from an already-running script is a documented pattern and a no-op in Node.
- `runMain` is also overridable (tools patch it). The override path is unchanged. Bun's own startup always passes an explicit specifier.
- One pre-existing test asserted that a throwing `toString` on the argument propagates. Node throws `ERR_INVALID_ARG_TYPE` without calling `toString`, so the test now expects that error. The no-crash intent of that test (#40069) still holds.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->