### PR TITLE
fix(bun:test): handle a non-numeric `size` property when formatting a Set or Map diff

### DIFF
--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1718,7 +1718,11 @@ impl<'a> Formatter<'a> {
                     let length_value = value
                         .get(self.global_this, "size")?
                         .unwrap_or_else(|| JSValue::js_number_from_int32(0));
-                    let length = length_value.to_int32();
+                    let length = if length_value.is_number() {
+                        length_value.coerce_to_i32(self.global_this)?
+                    } else {
+                        0
+                    };
 
                     let prev_quote_strings = self.quote_strings;
                     self.quote_strings = true;
@@ -1762,7 +1766,11 @@ impl<'a> Formatter<'a> {
                     let length_value = value
                         .get(self.global_this, "size")?
                         .unwrap_or_else(|| JSValue::js_number_from_int32(0));
-                    let length = length_value.to_int32();
+                    let length = if length_value.is_number() {
+                        length_value.coerce_to_i32(self.global_this)?
+                    } else {
+                        0
+                    };
 
                     let prev_quote_strings = self.quote_strings;
                     self.quote_strings = true;

--- a/test/js/bun/test/pretty-format-overridden-size.test.ts
+++ b/test/js/bun/test/pretty-format-overridden-size.test.ts
@@ -1,0 +1,62 @@
+// Regression test for the jest pretty formatter reading an overridden `size`
+// property off (Weak)Set/(Weak)Map values while printing a toEqual diff.
+// Previously a non-numeric `size` hit the isInt32() assertion in
+// JSC::JSValue::asInt32() on debug builds.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("pretty_format should handle collections with an overridden `size` property", () => {
+  test("non-numeric `size` on (Weak)Set/(Weak)Map still produces a toEqual diff", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const values = [];
+{
+  const weakSet = new WeakSet();
+  weakSet.size = BigUint64Array;
+  values.push(weakSet);
+}
+{
+  const weakMap = new WeakMap();
+  weakMap.size = "not a number";
+  values.push(weakMap);
+}
+{
+  const set = new Set([1]);
+  Object.defineProperty(set, "size", { value: {} });
+  values.push(set);
+}
+{
+  const map = new Map([[1, 2]]);
+  Object.defineProperty(map, "size", { value: BigUint64Array });
+  values.push(map);
+}
+{
+  const weakSet = new WeakSet();
+  weakSet.size = Symbol("size");
+  values.push(weakSet);
+}
+for (const value of values) {
+  try {
+    Bun.jest().expect(BigUint64Array).toEqual(value);
+    console.log("DID NOT THROW");
+  } catch (e) {
+    console.log(e.message.includes("expect(received).toEqual(expected)") ? "DIFF OK" : "UNEXPECTED: " + e.message);
+  }
+}
+`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim().split("\n")).toEqual(["DIFF OK", "DIFF OK", "DIFF OK", "DIFF OK", "DIFF OK"]);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion failure in the jest pretty formatter:

```
ASSERTION FAILED: isInt32()
JSCJSValue.h : int32_t JSC::JSValue::asInt32() const
```

The formatter in `src/runtime/test_runner/pretty_format.rs` reads the `size` property of `Set`, `Map`, `WeakSet` and `WeakMap` values while it renders an `expect().toEqual()` failure diff. It called `to_int32()` on that value. `WeakSet` and `WeakMap` have no `size` accessor on their prototype. A `Set` or `Map` instance can also shadow its accessor with `Object.defineProperty`. In both cases a user-defined own `size` property comes back as is. When that value is not a number, `to_int32()` falls through to `JSC__JSValue__toInt32`, which calls `JSValue::asInt32()`. A debug build aborts on the assertion. A release build reads a garbage length and reports a bare `TypeError` instead of the diff.

Repro. This aborts a debug build before this change:

```js
const ws = new WeakSet();
ws.size = BigUint64Array;
Bun.jest(import.meta.path).expect(BigUint64Array).toEqual(ws);
```

The fix coerces the value only when it is a number. Any other value counts as 0. ToNumber never runs on the user value, so a `Symbol` or a throwing `valueOf` cannot replace the diff with its own error. The repro now prints the normal diff:

```
expect(received).toEqual(expected)

Expected: WeakSet {}
Received: [class BigUint64Array]
```

This supersedes #31292. The stale bot closed that PR after 90 days. The change is the same, rebased onto current main, where the crash still reproduces. The earlier review threads (CodeRabbit and the Symbol edge case) are already addressed in this diff. #30373 covers the weak-collection case with a different approach. The two changes compose.

### How did you verify your code works?

- The repro above no longer aborts a debug build. It prints the normal `toEqual` error.
- Added `test/js/bun/test/pretty-format-overridden-size.test.ts`. It covers `WeakSet`, `WeakMap`, `Set` and `Map` with a constructor, a string, a plain object and a symbol as `size`. It fails without the fix (a debug build aborts, a release build prints `Type error` for three of the five cases) and passes with the fix.
- Normal `Set` and `Map` diff output is unchanged.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 6 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/pretty-format-overridden-size.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/pretty-format-overridden-size.test.ts:
54 |       stdout: "pipe",
55 |     });
56 | 
57 |     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
58 | 
59 |     expect(stdout.trim().split("\n")).toEqual(["DIFF OK", "DIFF OK", "DIFF OK", "DIFF OK", "DIFF OK"]);
                                           ^
error: expect(received).toEqual(expected)

  [
-   "DIFF OK",
-   "DIFF OK",
-   "DIFF OK",
-   "DIFF OK",
-   "DIFF OK",
+   "",
  ]

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/pretty-format-overridden-size.test.ts:59:39)
(fail) pretty_format should handle collections with an overridden `size` property > non-numeric `size` on (Weak)Set/(Weak)Map still produces a toEqual diff [509.39ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [2.46s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/test/pretty-format-overridden-size.test.ts:
54 |       stdout: "pipe",
55 |     });
56 | 
57 |     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
58 | 
59 |     expect(stdout.trim().split("\n")).toEqual(["DIFF OK", "DIFF OK", "DIFF OK", "DIFF OK", "DIFF OK"]);
                                           ^
error: expect(received).toEqual(expected)

  [
+   "UNEXPECTED: Type error",
+   "UNEXPECTED: Type error",
    "DIFF OK",
    "DIFF OK",
-   "DIFF OK",
-   "DIFF OK",
-   "DIFF OK",
+   "UNEXPECTED: Type error",
  ]

- Expected  - 3
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/test/pretty-format-overridden-size.test.ts:59:39)
(fail) pretty_format should handle collections with an overridden `size` property > non-numeric `size` on (Weak)Set/(Weak)Map still produces a toEqual diff [8.07ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [70.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/pretty-format-overridden-size.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/pretty-format-overridden-size.test.ts:
(pass) pretty_format should handle collections with an overridden `size` property > non-numeric `size` on (Weak)Set/(Weak)Map still produces a toEqual diff [324.98ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [2.32s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 624ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 14s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+611222352
[build] done
bun test v1.4.1-canary.1 (611222352)

test/js/bun/test/pretty-format-overridden-size.test.ts:
(pass) pretty_format should handle collections with an overridden `size` property > non-numeric `size` on (Weak)Set/(Weak)Map still produces a toEqual diff [6.93ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [68.00ms]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/pretty_format.rs           | 12 ++++-
 .../bun/test/pretty-format-overridden-size.test.ts | 62 ++++++++++++++++++++++
 2 files changed, 72 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/runtime/test_runner/pretty_format.rs                    2      2     12
test/js/bun/test/pretty-format-overridden-size.test.ts      0      2     10
```

</details>

<!-- robobun:evidence:end -->