### PR TITLE
bundler: pick the __toESM interop from the importer's module type

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -878,9 +878,6 @@ impl ExportsKind {
             Self::EsmWithDynamicFallback | Self::EsmWithDynamicFallbackFromCjs
         )
     }
-
-    // `to_module_type()` lives in `bun_options_types` as
-    // `impl From<ExportsKind> for ModuleType` (would cycle here).
 }
 
 #[derive(Copy, Clone)]

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -545,6 +545,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             export_star_import_records: bun_alloc::AstAlloc::vec(),
             approximate_newline_count: 1,
             exports_kind: ExportsKind::Esm,
+            module_type: crate::options::ModuleType::Unknown,
             named_imports: core::mem::take(&mut self.named_imports),
             named_exports: core::mem::take(&mut self.named_exports),
             dynamic_import_aliases: Default::default(),

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2287,7 +2287,7 @@ impl<'a> LinkerContext<'a> {
 
             minify_whitespace: self.options.minify_whitespace,
             minify_syntax: self.options.minify_syntax,
-            input_module_type: ast.exports_kind.into(),
+            input_module_type: ast.module_type,
             module_type: self.options.output_format,
             print_dce_annotations: self.options.emit_dce_annotations,
             has_run_symbol_renamer: true,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2606,6 +2606,14 @@ pub mod parse_worker {
             topts.tree_shaking
         };
         opts.code_splitting = topts.code_splitting;
+        // A task that did not come through the resolver (a plugin `onResolve`
+        // result, an in-memory source) has no module type yet. The extension
+        // still decides it, as it does in the resolver.
+        if task.module_type == options::ModuleType::Unknown {
+            if let Some(from_ext) = _resolver::module_type_from_ext(task.path.name().ext) {
+                task.module_type = from_ext;
+            }
+        }
         opts.module_type = task.module_type;
         opts.is_entry_point = task.is_entry_point;
 
@@ -2667,6 +2675,7 @@ pub mod parse_worker {
         };
 
         ast.target = target;
+        ast.module_type = task.module_type;
         if ast.parts.len() <= 1
             && ast.css.is_none()
             && (task.loader.is_none() || task.loader.unwrap() != Loader::Html)

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2606,9 +2606,7 @@ pub mod parse_worker {
             topts.tree_shaking
         };
         opts.code_splitting = topts.code_splitting;
-        // A task that did not come through the resolver (a plugin `onResolve`
-        // result, an in-memory source) has no module type yet. The extension
-        // still decides it, as it does in the resolver.
+        // A task that bypassed the resolver (plugin result, in-memory source).
         if task.module_type == options::ModuleType::Unknown {
             if let Some(from_ext) = _resolver::module_type_from_ext(task.path.name().ext) {
                 task.module_type = from_ext;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7438,8 +7438,6 @@ pub mod bv2_impl {
                         // and `.clone()` where an owned copy is needed.
                         let source_loader: Loader =
                             this.graph.input_files.items_loader()[result_source_index];
-                        // The re-parsed copies keep the module type the resolver
-                        // found for the original file.
                         let source_module_type: options::ModuleType =
                             this.graph.ast.items_module_type()[result_source_index];
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3769,6 +3769,7 @@ pub mod bv2_impl {
             source: &mut bun_ast::Source,
             loader: Loader,
             known_target: options::Target,
+            module_type: options::ModuleType,
         ) -> Result<IndexInt, AllocError> {
             let source_index = Index::init(u32::try_from(self.graph.ast.len()).expect("int cast"));
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
@@ -3822,7 +3823,7 @@ pub mod bv2_impl {
                 side_effects: bun_ast::SideEffects::HasSideEffects,
                 jsx,
                 source_index: bun_ast::Index::init(source_index.get()),
-                module_type: options::ModuleType::Unknown,
+                module_type,
                 emit_decorator_metadata: false, // TODO
                 package_version: bun_ast::StoreStr::EMPTY,
                 loader: Some(loader),
@@ -7437,6 +7438,10 @@ pub mod bv2_impl {
                         // and `.clone()` where an owned copy is needed.
                         let source_loader: Loader =
                             this.graph.input_files.items_loader()[result_source_index];
+                        // The re-parsed copies keep the module type the resolver
+                        // found for the original file.
+                        let source_module_type: options::ModuleType =
+                            this.graph.ast.items_module_type()[result_source_index];
 
                         let (reference_source_index, ssr_index) = if separate_ssr_graph {
                             // Enqueue two files, one in server graph, one in ssr graph.
@@ -7476,6 +7481,7 @@ pub mod bv2_impl {
                                     &mut ssr_source,
                                     source_loader,
                                     Target::ServerComponentsSsr,
+                                    source_module_type,
                                 )
                                 .expect("oom");
 
@@ -7499,6 +7505,7 @@ pub mod bv2_impl {
                                     &mut server_source,
                                     source_loader,
                                     Target::Browser,
+                                    source_module_type,
                                 )
                                 .expect("oom");
 

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -52,8 +52,7 @@ pub struct BundledAst<'arena> {
 
     pub(crate) exports_kind: ExportsKind,
 
-    /// From the file extension or the nearest package.json `"type"`, not from
-    /// the syntax (that is `exports_kind`). `Esm` gives `__toESM` `isNodeMode = 1`.
+    /// Extension or package.json `"type"`, not syntax. `Esm` prints `__toESM(.., 1)`.
     pub(crate) module_type: ModuleType,
 
     /// These are stored at the AST level instead of on individual AST nodes so

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -52,12 +52,8 @@ pub struct BundledAst<'arena> {
 
     pub(crate) exports_kind: ExportsKind,
 
-    /// The module type from the file extension (`.mjs`, `.mts`, `.cjs`, `.cts`)
-    /// or else the nearest package.json `"type"`. Unlike `exports_kind` it does
-    /// not depend on the syntax the file uses. The printer passes
-    /// `isNodeMode = 1` to `__toESM` only when this is `Esm`: then a default
-    /// import of a CommonJS module is the whole `module.exports`, as in Node.
-    /// Every other importer honors the `__esModule` marker, as esbuild does.
+    /// From the file extension or the nearest package.json `"type"`, not from
+    /// the syntax (that is `exports_kind`). `Esm` gives `__toESM` `isNodeMode = 1`.
     pub(crate) module_type: ModuleType,
 
     /// These are stored at the AST level instead of on individual AST nodes so
@@ -307,8 +303,7 @@ impl<'arena> BundledAst<'arena> {
             nested_scope_slot_counts: ast.nested_scope_slot_counts,
 
             exports_kind: ast.exports_kind,
-            // The parser does not record it; `ParseTask::run` sets it from the
-            // resolver result after `init`, next to `target`.
+            // `ParseTask::run` sets it from the resolver result, like `target`.
             module_type: ModuleType::Unknown,
 
             import_records: ast.import_records,

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -30,6 +30,7 @@ pub(crate) type CssCol = Option<CssAstRef>;
 use bun_ast::import_record;
 use bun_core::strings;
 
+use crate::options::ModuleType;
 use bun_ast::ast_result::Ast;
 use bun_ast::{CharFreq, ExportsKind, Ref, Scope, SlotCounts, StoreStr, TlaCheck};
 use bun_ast::{part, symbol};
@@ -43,13 +44,21 @@ pub type TopLevelSymbolToParts = bun_ast::ast_result::TopLevelSymbolToParts;
 // `BundledAstColumns` (`items_named_imports()`,
 // `items_named_exports()`, …) at `crate::bundled_ast::*`.
 //
-// 26 fields ≤ `multi_array_list::MAX_FIELDS` (32).
+// 29 fields ≤ `multi_array_list::MAX_FIELDS` (32).
 
 pub struct BundledAst<'arena> {
     pub(crate) approximate_newline_count: u32,
     pub(crate) nested_scope_slot_counts: SlotCounts,
 
     pub(crate) exports_kind: ExportsKind,
+
+    /// The module type from the file extension (`.mjs`, `.mts`, `.cjs`, `.cts`)
+    /// or else the nearest package.json `"type"`. Unlike `exports_kind` it does
+    /// not depend on the syntax the file uses. The printer passes
+    /// `isNodeMode = 1` to `__toESM` only when this is `Esm`: then a default
+    /// import of a CommonJS module is the whole `module.exports`, as in Node.
+    /// Every other importer honors the `__esModule` marker, as esbuild does.
+    pub(crate) module_type: ModuleType,
 
     /// These are stored at the AST level instead of on individual AST nodes so
     /// they can be manipulated efficiently without a full AST traversal
@@ -106,6 +115,7 @@ bun_collections::multi_array_columns! {
         approximate_newline_count: u32,
         nested_scope_slot_counts: SlotCounts,
         exports_kind: ExportsKind,
+        module_type: ModuleType,
         import_records: import_record::List<'arena>,
         hashbang: StoreStr,
         export_default_alias_of_import: Ref,
@@ -163,6 +173,7 @@ impl<'arena> BundledAst<'arena> {
             approximate_newline_count: 0,
             nested_scope_slot_counts: SlotCounts::default(),
             exports_kind: ExportsKind::None,
+            module_type: ModuleType::Unknown,
             import_records: import_record::List::new_in(arena),
             hashbang: StoreStr::EMPTY,
             export_default_alias_of_import: Ref::NONE,
@@ -296,6 +307,9 @@ impl<'arena> BundledAst<'arena> {
             nested_scope_slot_counts: ast.nested_scope_slot_counts,
 
             exports_kind: ast.exports_kind,
+            // The parser does not record it; `ParseTask::run` sets it from the
+            // resolver result after `init`, next to `target`.
+            module_type: ModuleType::Unknown,
 
             import_records: ast.import_records,
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1352,8 +1352,11 @@ pub struct Options<'a> {
 
     pub require_or_import_meta_for_source_callback: RequireOrImportMetaCallback,
 
-    /// The module type of the importing file (after linking), used to determine interop helper behavior.
-    /// Controls whether __toESM uses Node ESM semantics (isNodeMode=1 for .esm) or respects __esModule markers.
+    /// The module type of the file being printed, from its extension (`.mjs`,
+    /// `.mts`, `.cjs`, `.cts`) or the nearest package.json `"type"`, not from
+    /// the syntax it uses. `Esm` makes `__toESM` run with `isNodeMode = 1`: a
+    /// default import of a CommonJS module is then the whole `module.exports`,
+    /// as in Node. Otherwise `__toESM` honors the `__esModule` marker.
     pub input_module_type: bundle_opts::ModuleType,
     pub module_type: bundle_opts::Format,
 
@@ -2935,6 +2938,11 @@ pub(crate) mod __gated_printer {
                 self.print(b")");
 
                 if wrap_with_to_esm {
+                    if self.options.input_module_type == bundle_opts::ModuleType::Esm {
+                        self.print(b",");
+                        self.print_space();
+                        self.print(b"1");
+                    }
                     self.print(b")");
                 }
                 if wrap {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1352,9 +1352,7 @@ pub struct Options<'a> {
 
     pub require_or_import_meta_for_source_callback: RequireOrImportMetaCallback,
 
-    /// The module type of the file being printed (extension or package.json
-    /// `"type"`, not syntax). `Esm` prints `__toESM(..., 1)`: Node's interop,
-    /// which ignores `__esModule`.
+    /// Module type of the file being printed. `Esm` prints `__toESM(.., 1)`, which ignores `__esModule`.
     pub input_module_type: bundle_opts::ModuleType,
     pub module_type: bundle_opts::Format,
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1352,11 +1352,9 @@ pub struct Options<'a> {
 
     pub require_or_import_meta_for_source_callback: RequireOrImportMetaCallback,
 
-    /// The module type of the file being printed, from its extension (`.mjs`,
-    /// `.mts`, `.cjs`, `.cts`) or the nearest package.json `"type"`, not from
-    /// the syntax it uses. `Esm` makes `__toESM` run with `isNodeMode = 1`: a
-    /// default import of a CommonJS module is then the whole `module.exports`,
-    /// as in Node. Otherwise `__toESM` honors the `__esModule` marker.
+    /// The module type of the file being printed (extension or package.json
+    /// `"type"`, not syntax). `Esm` prints `__toESM(..., 1)`: Node's interop,
+    /// which ignores `__esModule`.
     pub input_module_type: bundle_opts::ModuleType,
     pub module_type: bundle_opts::Format,
 

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -263,18 +263,3 @@ pub enum BuiltInModule {
     Import(Box<[u8]>),
     Code(Box<[u8]>),
 }
-
-// `ExportsKind::to_module_type` — moved here from `bun_ast::nodes` to avoid
-// the `bun_options_types → bun_ast → bun_options_types` cycle.
-impl From<bun_ast::ExportsKind> for ModuleType {
-    fn from(k: bun_ast::ExportsKind) -> Self {
-        use bun_ast::ExportsKind as K;
-        match k {
-            K::None => ModuleType::Unknown,
-            K::Cjs => ModuleType::Cjs,
-            K::EsmWithDynamicFallback | K::EsmWithDynamicFallbackFromCjs | K::Esm => {
-                ModuleType::Esm
-            }
-        }
-    }
-}

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -50,7 +50,9 @@ pub use tsconfig_json::TSConfigJSON;
 // `result` / `standalone_module_graph` sibling modules.
 /// Re-export so dependents can spell `bun_resolver::install_types::AutoInstaller`.
 pub use ::bun_install_types::resolver_hooks as install_types;
-pub use resolver::{AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver};
+pub use resolver::{
+    AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver, module_type_from_ext,
+};
 pub use result::{
     DebugLogs, DirEntryResolveQueueItem, ExternalKind, FlushMode, LoadResult, MatchResult,
     MatchStatus, PathPair, PendingResolution, PendingResolutionTag, Result, ResultFlags,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1255,8 +1255,6 @@ pub type ConditionsMap = StringArrayHashMap<()>;
 pub(crate) struct ESModule<'a> {
     pub(crate) debug_logs: Option<&'a mut resolver::DebugLogs>,
     pub(crate) conditions: &'a ConditionsMap,
-    // allocator dropped — global mimalloc
-    pub(crate) module_type: &'a mut ModuleType,
 }
 
 #[derive(Clone)]
@@ -1535,8 +1533,8 @@ fn module_bufs() -> *mut ModuleBufs {
     })
 }
 
-// `module_type` / `debug_logs` are `&'a mut T`, so reading/writing them
-// requires `&mut self`. All resolution methods take `&mut self`.
+// `debug_logs` is `&'a mut T`, so writing to it requires `&mut self`. All
+// resolution methods take `&mut self`.
 impl<'a> ESModule<'a> {
     pub(crate) fn resolve(
         &mut self,
@@ -2090,7 +2088,6 @@ impl<'a> ESModule<'a> {
                             ));
                         }
 
-                        let prev_module_type = *self.module_type;
                         let result = self.resolve_target::<PATTERN>(
                             package_url,
                             &entry.value,
@@ -2098,16 +2095,7 @@ impl<'a> ESModule<'a> {
                             internal,
                         );
                         if result.status.is_undefined() {
-                            *self.module_type = prev_module_type;
                             continue;
-                        }
-
-                        if key == b"import" {
-                            *self.module_type = ModuleType::Esm;
-                        }
-
-                        if key == b"require" {
-                            *self.module_type = ModuleType::Cjs;
                         }
 
                         return result;
@@ -2149,7 +2137,6 @@ impl<'a> ESModule<'a> {
 
                 for target_value in array.iter() {
                     // Let resolved be the result, continuing the loop on any Invalid Package Target error.
-                    let prev_module_type = *self.module_type;
                     let result = self.resolve_target::<PATTERN>(
                         package_url,
                         target_value,
@@ -2163,7 +2150,6 @@ impl<'a> ESModule<'a> {
                     }
 
                     if result.status.is_undefined() {
-                        *self.module_type = prev_module_type;
                         continue;
                     }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1533,8 +1533,6 @@ fn module_bufs() -> *mut ModuleBufs {
     })
 }
 
-// `debug_logs` is `&'a mut T`, so writing to it requires `&mut self`. All
-// resolution methods take `&mut self`.
 impl<'a> ESModule<'a> {
     pub(crate) fn resolve(
         &mut self,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1673,8 +1673,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // `.mjs`, `.mts`, `.cjs` and `.cts` decide the module type by
-        // themselves, over any package.json "type".
+        // The extension wins over a package.json "type".
         if !kind.is_from_css() {
             if let Some(from_ext) = module_type_from_ext(result.path_pair.primary.name().ext) {
                 module_type = from_ext;
@@ -6727,8 +6726,7 @@ bun_core::comptime_string_map! {
     };
 }
 
-/// The module type a file extension decides by itself: `.mjs` and `.mts` are
-/// ESM, `.cjs` and `.cts` are CommonJS. `None` for every other extension.
+/// `.mjs`/`.mts` are ESM, `.cjs`/`.cts` are CommonJS, anything else is `None`.
 #[inline]
 pub fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1570,17 +1570,6 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            // If you use mjs or mts, then you're using esm
-            // If you use cjs or cts, then you're using cjs
-            // This should win out over the module type from package.json
-            if !kind.is_from_css()
-                && module_type == options::ModuleType::Unknown
-                && name.ext.len() == 4
-            {
-                module_type =
-                    module_type_from_ext(name.ext).unwrap_or(options::ModuleType::Unknown);
-            }
-
             // Probe the listing in one `entries_mutex` critical section: a
             // concurrent resolver at a newer generation rewrites this `DirEntry`'s
             // map in place under that lock. The entry pointer stays valid after
@@ -1681,6 +1670,14 @@ impl<'a> Resolver<'a> {
         if !kind.is_from_css() && module_type == options::ModuleType::Unknown {
             if let Some(pkg) = result.package_json_ref() {
                 module_type = pkg.module_type;
+            }
+        }
+
+        // `.mjs`, `.mts`, `.cjs` and `.cts` decide the module type by
+        // themselves, over any package.json "type".
+        if !kind.is_from_css() {
+            if let Some(from_ext) = module_type_from_ext(result.path_pair.primary.name().ext) {
+                module_type = from_ext;
             }
         }
 
@@ -2623,7 +2620,6 @@ impl<'a> Resolver<'a> {
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import
-                                    let mut module_type = package_json.module_type;
                                     // NOTE: keeping a single
                                     // `ESModule` (which holds `&mut self.debug_logs`) alive across a
                                     // `&mut self` call is aliased-&mut UB. Build a fresh short-lived
@@ -2649,7 +2645,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
@@ -2666,7 +2661,6 @@ impl<'a> Resolver<'a> {
                                             .is_success()
                                         {
                                             out.is_node_module = true;
-                                            out.module_type = module_type;
                                             self.extension_order = prev_extension_order;
                                             if let Some(d) = self.debug_logs.as_mut() {
                                                 d.decrease_indent();
@@ -2706,7 +2700,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(
                                             b"/",
@@ -2725,7 +2718,6 @@ impl<'a> Resolver<'a> {
                                             .is_success()
                                         {
                                             out.is_node_module = true;
-                                            out.module_type = module_type;
                                             self.extension_order = prev_extension_order;
                                             if let Some(d) = self.debug_logs.as_mut() {
                                                 d.decrease_indent();
@@ -3123,7 +3115,6 @@ impl<'a> Resolver<'a> {
                     Ok(dir_info_to_use_) => {
                         if let Some(pkg_dir_info) = dir_info_to_use_ {
                             let abs_package_path = pkg_dir_info.abs_path;
-                            let mut module_type = options::ModuleType::Unknown;
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import
@@ -3144,7 +3135,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
@@ -3183,7 +3173,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(
                                             b"/",
@@ -4982,7 +4971,6 @@ impl<'a> Resolver<'a> {
             }
             return MatchStatus::NotFound;
         }
-        let mut module_type = options::ModuleType::Unknown;
 
         // NOTE: keeping the `ESModule`'s borrow of `self.debug_logs` alive
         // across the subsequent `&mut self` calls would be aliased-&mut UB, so
@@ -4996,10 +4984,8 @@ impl<'a> Resolver<'a> {
                 _ => &self.opts.conditions.import,
             },
             debug_logs: self.debug_logs.as_mut(),
-            module_type: &mut module_type,
         }
         .resolve_imports(import_path, &imports_map.root);
-        let _ = module_type;
 
         if esm_resolution.status == crate::package_json::Status::PackageResolve {
             // https://github.com/oven-sh/bun/issues/4972
@@ -6741,8 +6727,10 @@ bun_core::comptime_string_map! {
     };
 }
 
+/// The module type a file extension decides by itself: `.mjs` and `.mts` are
+/// ESM, `.cjs` and `.cts` are CommonJS. `None` for every other extension.
 #[inline]
-fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
+pub fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()
 }
 

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -523,10 +523,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode happy-dom/lib/index.js": {
-          "js": "239b4f0a41cb558ebbde682e021a8542a133e4f324c964b42c27f9a67c486f6c",
+          "js": "849979d9bb800fec4dabf8fcbe3ee271ac6cda55c8101a88c53b2c653cb1af0d",
           "jsc": {
-            "bytes": 2528848,
-            "sha256": "a15025be8413ef264c70eea105a8c515a7cf1dd8df9eec50e5d2b37da2b490cb",
+            "bytes": 2528944,
+            "sha256": "c21431868f727da4618628725b66d8b240f6fa4f85760d33e2f36468af8f8b19",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
@@ -537,10 +537,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "c41bbf4fa2f8278425484c1e04b482afcbaa6d43b9ce5e9c528adeca5e06c078",
+          "js": "afaba612f33e5f8c04081c1b0b92e0c1fff9717be918d27e713df3b473231ca4",
           "jsc": {
-            "bytes": 23789152,
-            "sha256": "59a7d7d28079dea684074f0e4bd97c1019f7390c0510b4d67504ed41eb84d565",
+            "bytes": 23789168,
+            "sha256": "bcc792480325de20c2f00b5a2e6aafe3dd9adc4fbf64e7f17076fddfd8f959f5",
           },
         },
         "bun build --bytecode lodash/lodash.js": {

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -3,28 +3,27 @@ import { itBundled } from "./expectBundled";
 
 // Tests for CommonJS <> ESM interop, specifically the __toESM helper behavior.
 //
-// The key insight from the code change:
-// - `input_module_type` is set based on the AST's exports_kind (whether the importing
-//   file uses ESM syntax like import/export or CJS syntax like require/module.exports)
-// - When a file uses ESM syntax (import/export), isNodeMode = 1
-// - When a file uses CJS syntax (require), __toESM is not used at all
+// `__toESM(mod, isNodeMode)` builds the ESM view of a CommonJS module. The
+// bundler picks `isNodeMode` from the module type of the *importing* file, the
+// same way esbuild does. The syntax the importer uses does not matter.
 //
-// This means:
-// - Any file using `import` will always get isNodeMode=1, which IGNORES __esModule
-//   and always wraps the CJS module as the default export
-// - This matches Node.js ESM behavior where importing CJS from .mjs always wraps
-//   the entire exports object as the default
+// - `.mjs`, `.mts`, or a `.js`/`.ts` file under package.json `"type": "module"`:
+//   isNodeMode=1. The default import is the whole `module.exports`, as in
+//   Node. `__esModule` is ignored.
+// - Every other importer (`.js`, `.ts`, no package.json `"type"`, or
+//   `"type": "commonjs"`): isNodeMode=0. When `module.exports.__esModule` is
+//   truthy, the default import is `module.exports.default`. Otherwise it is
+//   the whole `module.exports`. This matches `bun run` and esbuild.
 //
-// The __esModule marker is only respected in non-bundled scenarios or when using
-// actual CommonJS require() syntax.
+// A bare `require()` never goes through `__toESM`.
 
 describe("bundler", () => {
   // ============================================================================
-  // Tests with ESM syntax (import statements)
-  // These all use isNodeMode=1, which IGNORES __esModule
+  // Tests with a `.js` importer and no package.json "type"
+  // These use isNodeMode=0, which honors __esModule
   // ============================================================================
 
-  // Test 1: import with __esModule marker - IGNORED
+  // Test 1: import with __esModule marker - honored
   itBundled("cjs/__toESM_import_syntax_with_esModule", {
     files: {
       "/entry.js": /* js */ `
@@ -38,9 +37,9 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // With import syntax, isNodeMode=1, so __esModule is IGNORED
-      // The entire CJS exports object is wrapped as default
-      stdout: '{"__esModule":true,"default":{"value":"default export"},"named":"named export"}',
+      // The importer is a `.js` file with no package.json "type", so
+      // isNodeMode=0 and the default import is `exports.default`
+      stdout: '{"value":"default export"}',
     },
   });
 
@@ -131,7 +130,7 @@ describe("bundler", () => {
 
   // ============================================================================
   // Tests with different targets
-  // Target doesn't affect isNodeMode - it's based on syntax
+  // Target doesn't affect isNodeMode - it's based on the importer's module type
   // ============================================================================
 
   // Test 7: target=node
@@ -208,8 +207,8 @@ describe("bundler", () => {
     },
     format: "esm",
     run: {
-      // __esModule ignored because we're using import syntax
-      stdout: '{"__esModule":true,"default":"the default","other":"other"}',
+      // __esModule honored: the `.js` importer has no package.json "type"
+      stdout: '"the default"',
     },
   });
 
@@ -228,8 +227,8 @@ describe("bundler", () => {
     },
     format: "cjs",
     run: {
-      // Still ignores __esModule because entry uses import syntax
-      stdout: '{"__esModule":true,"default":"the default","other":"other"}',
+      // Output format does not change isNodeMode either
+      stdout: '"the default"',
     },
   });
 
@@ -257,7 +256,7 @@ describe("bundler", () => {
     },
   });
 
-  // Test 13: .mjs re-exporting with __esModule (still ignored)
+  // Test 13: .mjs re-exporting with __esModule (ignored: the importer is .mjs)
   itBundled("cjs/__toESM_mjs_reexport_with_esModule", {
     files: {
       "/entry.js": /* js */ `
@@ -274,7 +273,8 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // __esModule ignored - entire module wrapped as default
+      // The file that imports lib.cjs is wrapper.mjs, so isNodeMode=1 and the
+      // entire module is the default, as in Node
       stdout: '{"__esModule":true,"default":{"value":"from cjs"},"other":"other"}',
     },
   });
@@ -380,9 +380,8 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // Even if __esModule were respected, only `true` would work
-      // But it's ignored anyway due to import syntax
-      stdout: '{"__esModule":"truthy","default":{"value":"default"},"other":"other"}',
+      // __toESM tests __esModule for truthiness, like esbuild
+      stdout: '{"value":"default"}',
     },
   });
 
@@ -400,7 +399,7 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // Entire module wrapped as default (since we use import syntax)
+      // A falsy __esModule means the entire module is the default
       stdout: '{"__esModule":false,"default":{"value":"ignored"},"foo":"foo"}',
     },
   });
@@ -421,14 +420,14 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // __esModule is in the object but ignored due to import syntax
-      stdout: '{"__esModule":true,"default":{"value":"nested"},"other":"prop"}',
+      // __esModule on a replaced module.exports is honored too
+      stdout: '{"value":"nested"}',
     },
   });
 
   // Test 21: Input=ESM, output=CJS, importing CJS with __esModule and named imports
-  // This test covers the specific fix for printing __toESM when output format is CJS
-  // and input uses ESM syntax to import both default and named exports from CJS with __esModule
+  // This test covers printing __toESM when output format is CJS and the input
+  // uses ESM syntax to import both default and named exports from CJS with __esModule
   itBundled("cjs/__toESM_input_esm_output_cjs_wrapper_print", {
     files: {
       "/entry.js": /* js */ `
@@ -443,10 +442,8 @@ describe("bundler", () => {
     },
     format: "cjs",
     run: {
-      // With the fix: ignores __esModule, wraps entire module as default
-      // So default gets the whole exports object, named gets the named property
-      stdout:
-        '{"default":{"__esModule":true,"default":{"value":"default"},"named":"named export"},"named":"named export"}',
+      // default gets `exports.default`, named gets the named property
+      stdout: '{"default":{"value":"default"},"named":"named export"}',
     },
   });
 
@@ -595,6 +592,327 @@ describe("bundler", () => {
     format: "cjs",
     run: {
       stdout: "loaded ok",
+    },
+  });
+
+  // ============================================================================
+  // isNodeMode follows the importer's module type: the file extension first,
+  // then the nearest package.json "type". One test per importer kind.
+  //
+  // `dep.cjs` sets the marker with Object.defineProperty, the way TypeScript
+  // and Babel emit it. `typeof d` tells the two interops apart: "function" is
+  // `exports.default`, "object" is the whole `module.exports`.
+  // ============================================================================
+
+  const esModuleDep = /* js */ `
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.named = 1;
+    exports.default = function theDefault() {};
+  `;
+  const logDefaultAndNamed = /* js */ `
+    import d, { named } from "./dep.cjs";
+    console.log(typeof d, named);
+  `;
+
+  // Test 29: a `.ts` importer gets `exports.default`, the same as `bun run`
+  itBundled("cjs/__toESM_ts_importer_honors_esModule", {
+    files: {
+      "/entry.ts": logDefaultAndNamed,
+      "/dep.cjs": esModuleDep,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__toESM(require_dep())");
+    },
+    run: {
+      stdout: "function 1",
+    },
+  });
+
+  // Test 30: a `.mjs` importer gets the whole `module.exports`, as in Node
+  itBundled("cjs/__toESM_mjs_importer_node_mode", {
+    files: {
+      "/entry.mjs": logDefaultAndNamed,
+      "/dep.cjs": esModuleDep,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__toESM(require_dep(), 1)");
+    },
+    run: {
+      stdout: "object 1",
+    },
+  });
+
+  // Test 31: `.mts` behaves like `.mjs`
+  itBundled("cjs/__toESM_mts_importer_node_mode", {
+    files: {
+      "/entry.mts": logDefaultAndNamed,
+      "/dep.cjs": esModuleDep,
+    },
+    run: {
+      stdout: "object 1",
+    },
+  });
+
+  // Test 32: package.json "type": "module" makes a `.ts` importer ESM.
+  // The resolver reads "type" from the enclosing package.json, and it only
+  // treats a package.json with a "name" as enclosing.
+  itBundled("cjs/__toESM_type_module_importer_node_mode", {
+    files: {
+      "/entry.ts": logDefaultAndNamed,
+      "/dep.cjs": esModuleDep,
+      "/package.json": `{ "name": "app", "type": "module" }`,
+    },
+    run: {
+      stdout: "object 1",
+    },
+  });
+
+  // Test 33: package.json "type": "commonjs" keeps the `__esModule` interop
+  itBundled("cjs/__toESM_type_commonjs_importer_honors_esModule", {
+    files: {
+      "/entry.js": logDefaultAndNamed,
+      "/dep.cjs": esModuleDep,
+      "/package.json": `{ "name": "app", "type": "commonjs" }`,
+    },
+    run: {
+      stdout: "function 1",
+    },
+  });
+
+  // Test 34: the `.mjs` extension wins over package.json "type": "commonjs"
+  itBundled("cjs/__toESM_mjs_importer_overrides_type_commonjs", {
+    files: {
+      "/entry.mjs": logDefaultAndNamed,
+      "/dep.cjs": esModuleDep,
+      "/package.json": `{ "name": "app", "type": "commonjs" }`,
+    },
+    run: {
+      stdout: "object 1",
+    },
+  });
+
+  // Test 35: the rule applies per file. A `.ts` entry and a `.mjs` file that
+  // import the same CJS module each see their own interop.
+  itBundled("cjs/__toESM_per_importer_module_type", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import d from "./dep.cjs";
+        import { fromMjs } from "./other.mjs";
+        console.log(typeof d, typeof fromMjs);
+      `,
+      "/other.mjs": /* js */ `
+        import d from "./dep.cjs";
+        export const fromMjs = d;
+      `,
+      "/dep.cjs": esModuleDep,
+    },
+    run: {
+      stdout: "function object",
+    },
+  });
+
+  const dynamicImportLog = /* js */ `
+    const m = await import("./dep.cjs");
+    console.log(typeof m.default, m.named);
+  `;
+
+  // Test 36: dynamic import of a bundled CJS module, `.ts` importer
+  itBundled("cjs/__toESM_dynamic_import_ts_importer", {
+    files: {
+      "/entry.ts": dynamicImportLog,
+      "/dep.cjs": esModuleDep,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__toESM(require_dep())");
+    },
+    run: {
+      stdout: "function 1",
+    },
+  });
+
+  // Test 37: dynamic import of a bundled CJS module, `.mjs` importer
+  itBundled("cjs/__toESM_dynamic_import_mjs_importer", {
+    files: {
+      "/entry.mjs": dynamicImportLog,
+      "/dep.cjs": esModuleDep,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__toESM(require_dep(), 1)");
+    },
+    run: {
+      stdout: "object 1",
+    },
+  });
+
+  // Test 38: with splitting, the CJS module lands in its own chunk and the
+  // importer unwraps it with `.then((m) => __toESM(m.default))`
+  itBundled("cjs/__toESM_splitting_dynamic_import_ts_importer", {
+    files: {
+      "/entry.ts": dynamicImportLog,
+      "/dep.cjs": esModuleDep,
+    },
+    splitting: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("__toESM(m.default))");
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "function 1",
+    },
+  });
+
+  // Test 39: the same with a `.mjs` importer
+  itBundled("cjs/__toESM_splitting_dynamic_import_mjs_importer", {
+    files: {
+      "/entry.mjs": dynamicImportLog,
+      "/dep.cjs": esModuleDep,
+    },
+    splitting: true,
+    outdir: "/out",
+    outputPaths: ["/out/entry.js"],
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("__toESM(m.default,1))");
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "object 1",
+    },
+  });
+
+  const externalImportLog = /* js */ `
+    import d, { named } from "ext";
+    console.log(typeof d, named);
+  `;
+  const externalRuntimeFiles = {
+    "/node_modules/ext/package.json": `{ "name": "ext", "main": "index.js" }`,
+    "/node_modules/ext/index.js": esModuleDep,
+  };
+
+  // Test 40: an external CJS dependency in CJS output, `.ts` importer
+  itBundled("cjs/__toESM_external_require_ts_importer", {
+    files: {
+      "/entry.ts": externalImportLog,
+    },
+    runtimeFiles: externalRuntimeFiles,
+    external: ["ext"],
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('__toESM(require("ext"))');
+    },
+    run: {
+      stdout: "function 1",
+    },
+  });
+
+  // Test 41: an external CJS dependency in CJS output, `.mjs` importer
+  itBundled("cjs/__toESM_external_require_mjs_importer", {
+    files: {
+      "/entry.mjs": externalImportLog,
+    },
+    runtimeFiles: externalRuntimeFiles,
+    external: ["ext"],
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('__toESM(require("ext"), 1)');
+    },
+    run: {
+      stdout: "object 1",
+    },
+  });
+
+  // ============================================================================
+  // Files reached through a package.json "exports" map. The matched "import" or
+  // "require" condition is not a module type. Only the extension and the
+  // nearest package.json "type" are.
+  // ============================================================================
+
+  const cjsDepFiles = {
+    "/node_modules/cjs-dep/package.json": `{ "name": "cjs-dep", "main": "index.js" }`,
+    "/node_modules/cjs-dep/index.js": esModuleDep,
+  };
+  const reexportDefault = /* js */ `
+    import d from "cjs-dep";
+    export default d;
+  `;
+  const logTypeofDefault = /* ts */ `
+    import x from "pkg";
+    console.log(typeof x);
+  `;
+
+  // Test 42: "fake ESM" reached through the "import" condition of a package
+  // without "type" honors __esModule, like esbuild and `bun run`
+  itBundled("cjs/__toESM_exports_import_condition_without_type", {
+    files: {
+      "/entry.ts": logTypeofDefault,
+      "/node_modules/pkg/package.json": `{
+        "name": "pkg",
+        "exports": { "import": "./esm/index.js", "require": "./cjs/index.js" }
+      }`,
+      "/node_modules/pkg/esm/index.js": reexportDefault,
+      "/node_modules/pkg/cjs/index.js": /* js */ `module.exports = require("cjs-dep").default;`,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "function",
+    },
+  });
+
+  // Test 43: the same package with "type": "module" gets Node's interop
+  itBundled("cjs/__toESM_exports_import_condition_type_module", {
+    files: {
+      "/entry.ts": logTypeofDefault,
+      "/node_modules/pkg/package.json": `{
+        "name": "pkg",
+        "type": "module",
+        "exports": { "import": "./esm/index.js", "require": "./cjs/index.js" }
+      }`,
+      "/node_modules/pkg/esm/index.js": reexportDefault,
+      "/node_modules/pkg/cjs/index.js": /* js */ `module.exports = require("cjs-dep").default;`,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object",
+    },
+  });
+
+  // Test 44: a nested package.json with "type": "module" next to the resolved
+  // file makes it ESM, whatever the package root says
+  itBundled("cjs/__toESM_exports_nested_type_module", {
+    files: {
+      "/entry.ts": logTypeofDefault,
+      "/node_modules/pkg/package.json": `{
+        "name": "pkg",
+        "exports": { "import": "./esm/index.js", "require": "./cjs/index.js" }
+      }`,
+      "/node_modules/pkg/esm/package.json": `{ "type": "module" }`,
+      "/node_modules/pkg/esm/index.js": reexportDefault,
+      "/node_modules/pkg/cjs/index.js": /* js */ `module.exports = require("cjs-dep").default;`,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object",
+    },
+  });
+
+  // Test 45: a `.mjs` file is ESM even inside a "type": "commonjs" package
+  itBundled("cjs/__toESM_exports_mjs_in_type_commonjs_package", {
+    files: {
+      "/entry.ts": logTypeofDefault,
+      "/node_modules/pkg/package.json": `{
+        "name": "pkg",
+        "type": "commonjs",
+        "exports": { "import": "./index.mjs", "require": "./index.cjs" }
+      }`,
+      "/node_modules/pkg/index.mjs": reexportDefault,
+      "/node_modules/pkg/index.cjs": /* js */ `module.exports = require("cjs-dep").default;`,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object",
     },
   });
 });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1302,7 +1302,7 @@ describe("bundler", () => {
     snapshotSourceMap: {
       "entry.js.map": {
         files: ["../node_modules/react/index.js", "../entry.js"],
-        mappingsExactMatch: "2lBACA,WAAW,IAAQ,EAAE,ICDrB,eACA,QAAQ,IAAI,CAAK",
+        mappingsExactMatch: "2lBACA,WAAW,IAAQ,EAAE,ICDrB,aACA,QAAQ,IAAI,CAAK",
       },
     },
   });

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -58,14 +58,14 @@ describe("bundler", () => {
           ["react.development.js:524:'getContextName'", "1:5623:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
           ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
-          ["entry.tsx:6:'\"Content-Type\"'", '100:18817:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19071:void"],
-          ["entry.tsx:23:'await'", "100:19170:await"],
+          ["entry.tsx:6:'\"Content-Type\"'", '100:18811:"Content-Type"'],
+          ["entry.tsx:11:'<html>'", "100:19065:void"],
+          ["entry.tsx:23:'await'", "100:19164:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221995,
+      "out/entry.js": 221989,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
+++ b/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
@@ -134,7 +134,7 @@ var require_react = __commonJS(function(exports) {
 });
 
 // entry.tsx
-var import_react = __toESM(require_react(), 1);
+var import_react = __toESM(require_react());
 
 // node_modules/react/jsx-dev-runtime.js
 var $jsxDEV = () => null;


### PR DESCRIPTION
### Problem
- `bun build` returns the whole `module.exports` for a default import of a CommonJS module that sets `__esModule`, when the importer is a `.ts`, `.tsx` or `.js` file. `bun run`, esbuild and Rolldown return `exports.default` for the same files. They use Node's interop (the whole `module.exports`) only for a `.mjs`, `.mts` or `"type": "module"` importer. TypeScript and Babel emit that marker, so this breaks the default import of many packages (styled-components, react-bootstrap). Found while bundling Outline: a React invalid hook call at boot.
- Cause: `print_code_for_file_in_chunk_js` (`src/bundler/LinkerContext.rs:2290`) derived the printer's `input_module_type` from `ast.exports_kind`. Any file with ESM syntax counted as ESM, so every `__toESM` call got `isNodeMode = 1`, which ignores `__esModule`.
- A second source of the same bug: the resolver set `module_type` from the matched `"import"` or `"require"` export condition. A "fake ESM" file in a package without `"type"`, reached through `"exports": { "import": ... }`, was ESM to the printer too. Fixes #7709. Fixes #18615.

### Fix
- `BundledAst` carries the resolver's `module_type` (the extension, else the nearest package.json `"type"`). The linker passes that to the printer, so `isNodeMode = 1` only for an ESM-by-type importer. The external `require()` path now prints `, 1` under the same rule, as esbuild does.
- The resolver no longer turns an export condition into a module type, and `.mjs`/`.mts`/`.cjs`/`.cts` now win over any package.json `"type"`. Node decides a file's format from its extension and the nearest package.json only. A task that bypasses the resolver (a plugin result) falls back to the extension.
- Correct because it is esbuild's rule (`ModuleTypeData`, set from the extension or the enclosing package.json) and Node's. Checked against esbuild 0.21.5 for every importer kind below.
- Verified: `test/bundler/bundler_cjs.test.ts` (45 tests, 17 fail on the released bun). Also `test/bundler/esbuild/*`, `bundler_cjs2esm`, `bundler_splitting`, `bundler_npm`, `bundler_edgecase`, `bundler_regressions`, `bundler_barrel`, `transpiler/*`, `test/js/bun/resolve/*`, `cli/run/run-cjs`.

### Background
- `__toESM(mod, isNodeMode)` is the runtime helper that builds the ESM view of a CommonJS module. With `isNodeMode = 0` it honors `__esModule`: `default` is `mod.default`. With `isNodeMode = 1` it copies Node: `default` is `mod` itself.
- `ExportsKind` is what the parser found in a file (`import`/`export` syntax versus `exports`/`module` use). `ModuleType` is what the file system says: the extension or package.json `"type"`. Node's interop follows the second, never the first.
- Supersedes #35656, which found the export condition part.

<details><summary>Notes</summary>

Repro from the report (1.3.13, 1.4.0, canary):

```
# dep.cjs: Object.defineProperty(exports, "__esModule", { value: true }); exports.default = function () {}; exports.named = 1;
# entry.ts: import d, { named } from "./dep.cjs"; console.log(typeof d, named);
bun entry.ts                                       # function 1
bun build entry.ts --outfile=out.js && bun out.js  # object 1   (before this change)
esbuild entry.ts --bundle --format=esm | node --input-type=module   # function 1
```

esbuild 0.21.5 output for each importer, matched by the new tests:
`.ts`: `__toESM(require_dep())`. `.mts`: `__toESM(require_dep(), 1)`. `"type": "module"`: `, 1`. `"type": "commonjs"`: no `, 1`. External CJS in CJS output: `__toESM(require("ext"))` for `.ts`, `__toESM(require("ext"), 1)` for `.mjs`. Dynamic `import()` of a bundled or split CJS module: the same rule.

History: #23803 (Oct 2025) moved `isNodeMode` from the output format to `exports_kind`. Before that, the default `--format=esm` always used `isNodeMode = 1`, so `bun build` never honored `__esModule` for `.ts` importers.

Test expectation updates for the dropped `, 1` (2 bytes minified, 3 bytes otherwise): `EmitInvalidSourceMap2` mapping column, `npm/ReactSSR` mapping columns and file size (6 bytes: three `, 1`), and the `BundledReactPreservesImportRefs` snapshot. Six tests in `bundler_cjs.test.ts` asserted the old behavior for a `.js` entry and now assert `exports.default`. `regression/issue/03844` still sees `, 1`: the importer there is `ws/wrapper.mjs`.

Resolver change, what else it touches: `module_type` is also the parser's hint for a file with no `import`/`export` and no `exports`/`module` use. Such a file reached through an `"import"` condition was ESM by the condition. It now follows the `Unknown` rules (ESM unless it uses `require`, `__dirname` or `__filename`). A `.cjs` target of an `"import"` condition is now CommonJS.

Known gap, unchanged here: the resolver's `enclosing_package_json` skips a package.json without a `"name"` (#229). A nameless `{ "type": "module" }` above the importer does not make it ESM for this decision, except when it sits next to a file resolved through an exports map (`handle_esm_resolution` reads the file's own directory). Node and esbuild use the nearest package.json whatever its name.

Unrelated, found on the way: `bun build test/regression/issue/03844/03844.fixture.ts` from the repo root fails with `EISDIR reading file: "test"` and trips `assertion failed: crate::is_absolute(self.text)` in a debug build. Handed off separately.
</details>
