### PR TITLE
Accept any object target in the default Error.prepareStackTrace

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -686,7 +686,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    auto errorObject = dynamicDowncast<JSC::ErrorInstance>(callFrame->argument(0));
+    // V8's default formatting accepts any object (Error.captureStackTrace
+    // works on plain objects), so a delegating wrapper like
+    // `Error.prepareStackTrace = (err, trace) => old(err, trace)` must too.
+    // https://github.com/oven-sh/bun/issues/41151
+    auto* errorObject = callFrame->argument(0).getObject();
     auto callSites = dynamicDowncast<JSC::JSArray>(callFrame->argument(1));
     if (!errorObject) {
         throwTypeError(lexicalGlobalObject, scope, "First argument must be an Error object"_s);

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -686,10 +686,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    // V8's default formatting accepts any object (Error.captureStackTrace
-    // works on plain objects), so a delegating wrapper like
-    // `Error.prepareStackTrace = (err, trace) => old(err, trace)` must too.
-    // https://github.com/oven-sh/bun/issues/41151
+    // Any object is accepted, like V8: Error.captureStackTrace works on
+    // plain objects and delegating wrappers pass them here (#41151).
     auto* errorObject = callFrame->argument(0).getObject();
     auto callSites = dynamicDowncast<JSC::JSArray>(callFrame->argument(1));
     if (!errorObject) {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -693,7 +693,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace, (JSGlobalObjec
     auto* errorObject = callFrame->argument(0).getObject();
     auto callSites = dynamicDowncast<JSC::JSArray>(callFrame->argument(1));
     if (!errorObject) {
-        throwTypeError(lexicalGlobalObject, scope, "First argument must be an Error object"_s);
+        throwTypeError(lexicalGlobalObject, scope, "First argument must be an object"_s);
         return {};
     }
     if (!callSites) {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -686,8 +686,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    // Any object is accepted, like V8: Error.captureStackTrace works on
-    // plain objects and delegating wrappers pass them here (#41151).
     auto* errorObject = callFrame->argument(0).getObject();
     auto callSites = dynamicDowncast<JSC::JSArray>(callFrame->argument(1));
     if (!errorObject) {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -28,6 +28,34 @@ test("throw inside Error.prepareStackTrace doesnt crash", () => {
   expect(() => new Error().stack).toThrow("wat");
 });
 
+test("captureStackTrace on a non-Error target with a delegating prepareStackTrace wrapper", () => {
+  // https://github.com/oven-sh/bun/issues/41151
+  // Babel and source-map-support install wrappers that call the saved
+  // original prepareStackTrace. The native default must accept any object,
+  // because Error.captureStackTrace works on plain objects.
+  const old = Error.prepareStackTrace;
+  Error.prepareStackTrace = (err, trace) => old(err, trace);
+
+  function CustomError() {
+    // this.constructor is Error (inherited), not on the stack, so V8
+    // elides every frame. Node produces exactly "Error" here.
+    Error.captureStackTrace(this, this.constructor);
+  }
+  CustomError.prototype = new Error();
+
+  const err = new CustomError();
+  expect(err.stack).toBe("Error");
+
+  function CustomError2() {
+    Error.captureStackTrace(this, CustomError2);
+  }
+  CustomError2.prototype = new Error();
+
+  const err2 = new CustomError2();
+  expect(err2.stack).toStartWith("Error");
+  expect(err2.stack).toContain("\n    at ");
+});
+
 test("capture stack trace", () => {
   function f1() {
     f2();


### PR DESCRIPTION
### Problem

- After a delegating `Error.prepareStackTrace` wrapper is installed (`Error.prepareStackTrace = (err, trace) => old(err, trace)`, the pattern Babel and source-map-support use), every `Error.captureStackTrace(target)` on a non-native-Error target throws `TypeError: First argument must be an Error object`. Node runs the same code fine. Fixes #41151.
- The cause: `jsFunctionDefaultErrorPrepareStackTrace` (src/jsc/bindings/FormatStackTraceForJS.cpp:689) requires a `JSC::ErrorInstance`. A target like `this` in a constructor with `CustomError.prototype = new Error()` passes `instanceof Error` but is a plain object, so the downcast fails and the default throws.

### Fix

- The default `prepareStackTrace` now accepts any object, the same set of targets `Error.captureStackTrace` itself accepts. It still throws for a non-object first argument.
- `formatStackTraceToJSValue` already takes a `JSObject*` and reads `message` with a generic property lookup, so no other change is needed.
- This matches V8: its default formatting reads `name` and `message` off any object.
- Verified: new test in `test/js/node/v8/capture-stack-trace.test.js` (fails on the released bun with the reported TypeError). All 47 tests in that file pass, plus `error-prepare-stack-default-fixture.js`, `util.test.js`, and `vm.test.ts`.

### Background

- Bun exposes its default stack formatter as a native function on `Error.prepareStackTrace` (Node leaves it undefined). So wrappers that delegate to the saved original call this native function directly.
- For a non-Error target, `captureStackTrace` computes the stack string through the installed `prepareStackTrace`. The user wrapper runs, calls the native default, and the default threw before this change.
- The expected output for the issue's exact repro is `"Error"` with zero frames: the `caller` argument (`this.constructor`, which is `Error`) is not on the stack, so every frame is elided. Verified against Node v26. The test covers both that shape and a variant that keeps frames.

<details><summary>Notes</summary>

Repro from the issue:

```js
const old = Error.prepareStackTrace
Error.prepareStackTrace = (err, trace) => old(err, trace)
function CustomError() {
  Error.captureStackTrace(this, this.constructor)
}
CustomError.prototype = new Error()
new CustomError()
console.log("OK")
```

Before: `TypeError: First argument must be an Error object`, exit 1. After: prints `OK`.

Related but independent: #35640 makes the non-Error branch of `captureStackTrace` compute `.stack` lazily. Even with that change, a delegating wrapper that reaches the native default with a plain-object target would still throw without this fix.

Real-world impact: `@vue/cli-service serve` crashes at startup under bun because Babel installs a delegating rewriter and `follow-redirects` constructors then call `Error.captureStackTrace(this, this.constructor)`.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.1 (a6c4cc276)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.62ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [20.39ms]
37 |   Error.prepareStackTrace = (err, trace) => old(err, trace);
38 | 
39 |   function CustomError() {
40 |     // this.constructor is Error (inherited), not on the stack, so V8
41 |     // elides every frame. Node produces exactly "Error" here.
42 |     Error.captureStackTrace(this, this.constructor);
               ^
TypeError: First argument must be an Error object
      at new CustomError (/workspace/bun/test/js/node/v8/capture-stack-trace.test.js:42:11)
      at <anonymous> (/workspace/bun/test/js/node/v8/capture-stack-trace.test.js:46:15)
(fail) captureStackTrace on a non-Error target with a delegating prepareStackTrace wrapper [10.08ms]
(pass) capture stack trace [6.26ms]
(pass) capture stack trace with message [7.02ms]
(pass) capture stack trace with constructor [4.93ms]
(pass) capture stack trace limit [21.72ms]
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.13ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.11ms]
37 |   Error.prepareStackTrace = (err, trace) => old(err, trace);
38 | 
39 |   function CustomError() {
40 |     // this.constructor is Error (inherited), not on the stack, so V8
41 |     // elides every frame. Node produces exactly "Error" here.
42 |     Error.captureStackTrace(this, this.constructor);
               ^
TypeError: First argument must be an Error object
      at new CustomError (/workspace/bun/test/js/node/v8/capture-stack-trace.test.js:42:11)
      at <anonymous> (/workspace/bun/test/js/node/v8/capture-stack-trace.test.js:46:15)
(fail) captureStackTrace on a non-Error target with a delegating prepareStackTrace wrapper [0.22ms]
(pass) capture stack trace [0.07ms]
(pass) capture stack trace with message [0.06ms]
(pass) capture stack trace with constructor [0.06ms]
(pass) capture stack trace limit [0.19ms]
(pass) prepare stack trace [0.10ms]
(pass) capture stack trace second argument [0.15ms]
(pass) capture stack trace edge cases [0.11ms]
(pass) Error.captureStackTrace instal
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.1 (a6c4cc276)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.37ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [19.28ms]
(pass) captureStackTrace on a non-Error target with a delegating prepareStackTrace wrapper [9.54ms]
(pass) capture stack trace [6.22ms]
(pass) capture stack trace with message [6.91ms]
(pass) capture stack trace with constructor [5.28ms]
(pass) capture stack trace limit [21.69ms]
(pass) prepare stack trace [10.01ms]
(pass) capture stack trace second argument [16.84ms]
(pass) capture stack trace edge cases [9.97ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [18.01ms]
(pass) prepare stack trace call sites [11.04ms]
(pass) sanity check [12.57ms]
(pass) CallFrame isEval works as expected [7.19ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.19ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.18ms]
(pass) CallFrame.p.isConstructor [3.27ms]
(pass) CallFra
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 599ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/FormatStackTraceForJS.cpp  |  4 ++--
 test/js/node/v8/capture-stack-trace.test.js | 28 ++++++++++++++++++++++++++++
 2 files changed, 30 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/FormatStackTraceForJS.cpp       5      5      9
test/js/node/v8/capture-stack-trace.test.js      1      2      9
```

</details>

<!-- robobun:evidence:end -->