### PR TITLE
ipc: compare the send queue write count as usize, not i32

### DIFF
--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -1539,34 +1539,39 @@ impl SendQueue {
         let done = self.queue.with_mut(|queue| {
             let first = &mut queue[0];
             let to_send_len = first.data.list.len() - first.data.cursor;
-            if n as usize == to_send_len {
-                if first.handle.is_some() {
-                    // the message was fully written, but it had a handle.
-                    // we must wait for ACK or NACK before sending any more messages.
-                    let item = queue.remove(0);
-                    self.waiting_for_ack.with_mut(|w| {
-                        if w.is_some() {
-                            log!("[error] already waiting for ack. this should never happen.");
-                        }
-                        // shift the item off the queue and move it to waiting_for_ack
-                        *w = Some(item);
-                    });
-                    Done::AwaitAck
-                } else {
-                    // the message was fully sent, but there may be more items in the queue.
-                    // shift the queue and try to send the next item immediately.
-                    Done::Completed(queue.remove(0))
+            // `n` is the write count from the socket (at most i32::MAX per write).
+            // The coalesced item can be larger than that, so compare as usize.
+            match usize::try_from(n) {
+                Ok(written) if written == to_send_len => {
+                    if first.handle.is_some() {
+                        // the message was fully written, but it had a handle.
+                        // we must wait for ACK or NACK before sending any more messages.
+                        let item = queue.remove(0);
+                        self.waiting_for_ack.with_mut(|w| {
+                            if w.is_some() {
+                                log!("[error] already waiting for ack. this should never happen.");
+                            }
+                            // shift the item off the queue and move it to waiting_for_ack
+                            *w = Some(item);
+                        });
+                        Done::AwaitAck
+                    } else {
+                        // the message was fully sent, but there may be more items in the queue.
+                        // shift the queue and try to send the next item immediately.
+                        Done::Completed(queue.remove(0))
+                    }
                 }
-            } else if n > 0 && n < i32::try_from(first.data.list.len()).expect("int cast") {
-                // the item was partially sent; update the cursor and wait for writable to send the rest
-                // (if we tried to send a handle, a partial write means the handle wasn't sent yet.)
-                first.data.cursor += usize::try_from(n).expect("int cast");
-                Done::Partial
-            } else if n == 0 {
-                // no bytes written; wait for writable
-                Done::NoProgress
-            } else {
-                Done::Error
+                Ok(0) => {
+                    // no bytes written; wait for writable
+                    Done::NoProgress
+                }
+                Ok(written) if written < to_send_len => {
+                    // the item was partially sent; update the cursor and wait for writable to send the rest
+                    // (if we tried to send a handle, a partial write means the handle wasn't sent yet.)
+                    first.data.cursor += written;
+                    Done::Partial
+                }
+                _ => Done::Error,
             }
         });
         match done {
@@ -1577,7 +1582,13 @@ impl SendQueue {
                 item.complete(&global_this); // call the callback & deinit
                 self.continue_send(&global_this, ContinueSendReason::OnWritable);
             }
-            Done::Partial | Done::NoProgress => {}
+            Done::Partial => {
+                // libuv completes a request in full or fails. A partial write is
+                // the i32::MAX cap in `write`, and no writable event follows it.
+                #[cfg(windows)]
+                self.continue_send(&global_this, ContinueSendReason::OnWritable);
+            }
+            Done::NoProgress => {}
             Done::Error => {
                 // error. close socket.
                 self.close_socket(CloseReason::Failure, CloseFrom::User);

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -302,7 +302,10 @@ it.skipIf(isWindows)("advanced serialization advertises wire format version 2", 
 // completion compared the socket's i32 write count against that length as an i32
 // and panicked with "int cast: TryFromIntError(PosOverflow)". The child peaks at
 // 4 to 6 GB of RSS (the 2.2 GB buffer, its last capacity doubling, freed payloads).
-describe.skipIf(isWindows || totalmem() < 16 * 1024 ** 3)("send queue past 2 GiB", () => {
+// Inside a container os.totalmem() reports the host's RAM;
+// process.constrainedMemory() reports the cgroup limit there.
+const memory = Math.min(totalmem(), process.constrainedMemory() || Infinity);
+describe.skipIf(isWindows || memory < 16 * 1024 ** 3)("send queue past 2 GiB", () => {
   // Debug and ASAN builds copy the 2.2 GB about four times before the first message.
   const timeout = 60_000;
   it(

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, gcTick, isWindows } from "harness";
+import { totalmem } from "node:os";
 import path from "path";
 
 describe.each(["advanced", "json"])("ipc mode %s", mode => {
@@ -294,4 +295,48 @@ it.skipIf(isWindows)("advanced serialization advertises wire format version 2", 
   const [stdout, exitCode] = await Promise.all([child.stdout.text(), child.exited]);
   expect(JSON.parse(stdout.trim())).toEqual([1, 2, 0, 0, 0]);
   expect(exitCode).toBe(0);
+});
+
+// The send queue coalesces every message queued behind a partial write into one
+// buffer. When the peer has not read yet, that buffer can pass 2 GiB. The write
+// completion compared the socket's i32 write count against that length as an i32
+// and panicked with "int cast: TryFromIntError(PosOverflow)". The child peaks at
+// 4 to 6 GB of RSS (the 2.2 GB buffer, its last capacity doubling, freed payloads).
+describe.skipIf(isWindows || totalmem() < 16 * 1024 ** 3)("send queue past 2 GiB", () => {
+  // Debug and ASAN builds copy the 2.2 GB about four times before the first message.
+  const timeout = 60_000;
+  it(
+    "keeps sending after more than 2 GiB is queued before the first writable event",
+    async () => {
+      const chunkLength = 100 * 1024 * 1024;
+      // 22 chunks = 2200 MiB, all queued in one synchronous tick, so the head item
+      // passes i32::MAX bytes before the event loop sees the socket writable.
+      const childSource = `
+        const chunk = Buffer.alloc(${chunkLength}, "x").toString();
+        for (let i = 0; i < 22; i++) process.send(chunk);
+        process.on("message", () => process.exit(0));
+      `;
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      let received = 0;
+      await using child = spawn([bunExe(), "-e", childSource], {
+        env: bunEnv,
+        stdio: ["ignore", "inherit", "inherit"],
+        serialization: "advanced",
+        ipc(message, subprocess) {
+          // The first complete message proves the child kept writing past the cap.
+          // Stop the child there instead of draining the whole queue.
+          if (received++ === 0) {
+            resolve(message.length);
+            subprocess.send("stop");
+          }
+        },
+        onExit(_subprocess, exitCode, signalCode) {
+          reject(new Error(`child exited (${exitCode}, ${signalCode}) before the first message`));
+        },
+      });
+      expect(await promise).toBe(chunkLength);
+      expect(await child.exited).toBe(0);
+    },
+    timeout,
+  );
 });


### PR DESCRIPTION
### Problem
- A child that queues more than 2 GiB of `process.send()` data to a parent that has not read yet panics with `int cast: TryFromIntError(PosOverflow)` in `SendQueue::on_write_complete` and dies with SIGABRT (Sentry BUN-4T5Q, 4 events on 1.4.1-canary).
- `on_write_complete` (`src/runtime/ipc.rs:1560`) converted the head item's length to `i32` to compare it with the write count. The send queue coalesces every message queued behind a partial write into that item, so its length passes `i32::MAX`.

### Fix
- Convert the write count (an `i32` from the socket, at most `i32::MAX` per write) to `usize` and compare it with the `usize` lengths. The lengths are never cast.
- On Windows, a write request is capped at `i32::MAX` bytes and libuv completes it in full. A partial completion there now starts the next request at once. With only the `usize` change it would stall, because the Windows IPC path has no writable event.
- Verified: `test/js/bun/spawn/spawn.ipc.test.ts` (new block `send queue past 2 GiB`, stock bun fails it with the panic). Also the other IPC suites under `test/js/bun/spawn/` and `test/js/node/child_process/`, and the `test-child-process-*` and `test-cluster-*` node tests listed in Notes.
- Self-reviewed: 2 concerns raised, 2 addressed (the memory gate now also reads the cgroup limit, and the Windows check below is recorded here).

### Background
- `SendQueue` (`src/runtime/ipc.rs`) is the outgoing side of an IPC channel. `queue` holds `SendHandle` items. Each item owns a `StreamBuffer`: a `Vec<u8>` plus a `cursor` of bytes already written.
- `start_message` appends a new message to the last item when that item has no fd handle and is not being written. So under backpressure one item grows without bound. Node queues without bound too.
- On POSIX, `write` hands the remaining bytes to `us_socket_write`, which caps the length at `i32::MAX` and returns the count the kernel accepted. `on_write_complete` advances `cursor` and waits for the writable event to send the rest.

<details><summary>Notes</summary>

- Repro (release, Linux): a forked child does `process.send("x".repeat(8 MiB))` 300 times while the parent spins for 20 s. The child prints the panic and exits with SIGABRT on the first writable event. All sends happen in one synchronous tick, so the parent does not need to block for the bug to trigger: the head item already holds all the data before the child's event loop runs.
- The test queues 22 x 100 MiB (2200 MiB) in the child and stops the child after the parent receives the first complete message. That message proves the child survived about 1000 write completions with the 2.2 GB item. It takes 6.5 s under the debug ASAN build. It is gated on 16 GiB of memory (the smaller of `os.totalmem()` and `process.constrainedMemory()`, the same shape as `blob-oom.test.ts`) like the other 2 GiB tests in the tree, and skipped on Windows.
- Peak child RSS measured: 3.95 GiB under the debug ASAN build, 5.59 GiB under the release build (mimalloc retains the freed per-message payload buffers for a while).
- Windows check, done by hand with a debug build on a 64 GB machine, because the test skips Windows: the coalesced item was 2306867508 bytes. The first request completed with 2147483647 bytes, the queue then issued the 159383861-byte remainder, and the parent received all 22 messages. Without the Windows branch the second request is never issued.
- Other suites run with the debug build: `spawn.ipc.bun-node`, `spawn.ipc.node-bun`, `spawn-ipc-gc`, `bun-ipc-inherit`, `child_process_ipc`, `child_process_ipc_handle`, `child_process_ipc_large_disconnect`, `child_process_send_cb`, and the node tests `test-child-process-ipc`, `test-child-process-send-cb`, `test-child-process-send-utf8`, `test-child-process-fork`, `test-child-process-fork-net-socket`, `test-child-process-fork-net-server`, `test-child-process-send-keep-open`, `test-child-process-fork-closed-channel-segfault`, `test-cluster-basic`, `test-cluster-advanced-serialization`.
- A different cast at `ipc.rs:409` (`u32::try_from(serialized.data().len())`) is the 4 GiB wire-format limit of one message. It is not changed here.
- #32925 (backpressure signal from `send()`) edits the same test file. It is complementary: Node's `send()` returns `false` past the threshold but still queues, so the queue can still pass 2 GiB.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.ipc.test.ts

<!-- robobun:evidence:end -->