### PR TITLE
bake: keep the stale bitset in step with the graph, and skip the asset URL for a cached json module

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6678,8 +6678,7 @@ pub mod bv2_impl {
                             >(
                                 self.transpiler.fs().top_level_dir, path.text
                             );
-                            // `Asset` is any cached module that is not JavaScript-like. Only a
-                            // copied file has an asset URL; a json or text module does not.
+                            // A cached json or text module is an `Asset` with no asset URL.
                             let asset_hash = if loader == Loader::Html
                                 && entry.kind == bake_types::CacheKind::Asset
                             {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6678,13 +6678,18 @@ pub mod bv2_impl {
                             >(
                                 self.transpiler.fs().top_level_dir, path.text
                             );
-                            if loader == Loader::Html && entry.kind == bake_types::CacheKind::Asset
+                            // `Asset` is any cached module that is not JavaScript-like. Only a
+                            // copied file has an asset URL; a json or text module does not.
+                            let asset_hash = if loader == Loader::Html
+                                && entry.kind == bake_types::CacheKind::Asset
                             {
+                                dev_server.asset_hash(path.text)
+                            } else {
+                                None
+                            };
+                            if let Some(hash) = asset_hash {
                                 // Overload `path.text` to point to the final URL
                                 // This information cannot be queried while printing because a lock wouldn't get held.
-                                let hash = dev_server
-                                    .asset_hash(path.text)
-                                    .expect("cached asset not found");
                                 import_record.path.text = path.text;
                                 import_record.path.namespace = b"file";
                                 // SAFETY: `alloc_str` returns into the bundler arena which

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -82,7 +82,11 @@ pub enum Content {
     Unknown,
     /// When stale, the code is "", otherwise it contains at least one
     /// non-whitespace character (empty chunks contain a function wrapper).
+    /// Also used for html, json and text modules.
     Js(Box<[u8]>),
+    /// JavaScript of a module that exports the `/_bun/asset/` URL of a copied
+    /// file (`Loader::should_copy_for_bundling`). Every `Asset` path is in
+    /// `DevServer::assets`.
     Asset(Box<[u8]>),
     /// First file in a CSS bundle (the one HTML/JS points into). Re-bundles
     /// of any downstream `CssChild` re-queue the root.
@@ -635,10 +639,10 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     }
                     ReceiveChunkContent::Js { code, source_map } => {
                         let len = code.len();
-                        let kind = if ctx.loaders[index.get() as usize].is_javascript_like() {
-                            Content::Js(code)
-                        } else {
+                        let kind = if ctx.loaders[index.get() as usize].should_copy_for_bundling() {
                             Content::Asset(code)
+                        } else {
+                            Content::Js(code)
                         };
                         if source_map.is_some() {
                             debug_assert!(html_route_bundle_index.is_none()); // suspect behind #17956
@@ -1320,9 +1324,8 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         if !found_existing {
             self.edge_lists.push(EdgeLists::default());
         }
-        if self.stale_files.bit_length > idx {
-            self.stale_files.set(idx);
-        }
+        self.ensure_stale_bit_capacity(true)?;
+        self.stale_files.set(idx);
 
         match SIDE {
             Side::Client => {

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -83,9 +83,7 @@ pub enum Content {
     /// When stale, the code is "", otherwise it contains at least one
     /// non-whitespace character (empty chunks contain a function wrapper).
     Js(Box<[u8]>),
-    /// JavaScript of a module whose loader is not JavaScript-like: a copied
-    /// file, json, toml, text, or the html route's module. Only a copied file
-    /// (`Loader::should_copy_for_bundling`) has an entry in `DevServer::assets`.
+    /// A module whose loader is not JavaScript-like. Only a copied file is in `DevServer::assets`.
     Asset(Box<[u8]>),
     /// First file in a CSS bundle (the one HTML/JS points into). Re-bundles
     /// of any downstream `CssChild` re-queue the root.

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -82,11 +82,10 @@ pub enum Content {
     Unknown,
     /// When stale, the code is "", otherwise it contains at least one
     /// non-whitespace character (empty chunks contain a function wrapper).
-    /// Also used for html, json and text modules.
     Js(Box<[u8]>),
-    /// JavaScript of a module that exports the `/_bun/asset/` URL of a copied
-    /// file (`Loader::should_copy_for_bundling`). Every `Asset` path is in
-    /// `DevServer::assets`.
+    /// JavaScript of a module whose loader is not JavaScript-like: a copied
+    /// file, json, toml, text, or the html route's module. Only a copied file
+    /// (`Loader::should_copy_for_bundling`) has an entry in `DevServer::assets`.
     Asset(Box<[u8]>),
     /// First file in a CSS bundle (the one HTML/JS points into). Re-bundles
     /// of any downstream `CssChild` re-queue the root.
@@ -639,10 +638,10 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     }
                     ReceiveChunkContent::Js { code, source_map } => {
                         let len = code.len();
-                        let kind = if ctx.loaders[index.get() as usize].should_copy_for_bundling() {
-                            Content::Asset(code)
-                        } else {
+                        let kind = if ctx.loaders[index.get() as usize].is_javascript_like() {
                             Content::Js(code)
+                        } else {
+                            Content::Asset(code)
                         };
                         if source_map.is_some() {
                             debug_assert!(html_route_bundle_index.is_none()); // suspect behind #17956
@@ -1397,6 +1396,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         if !found_existing {
             self.edge_lists.push(EdgeLists::default());
             self.ensure_stale_bit_capacity(true)?;
+            self.stale_files.set(idx);
         }
         Ok(InsertEmptyResult {
             index: FileIndex::init(idx as u32),
@@ -1426,6 +1426,9 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         };
         if !found_existing {
             self.edge_lists.push(EdgeLists::default());
+        }
+        if self.stale_files.bit_length > file_index.get() as usize {
+            self.stale_files.unset(file_index.get() as usize);
         }
         *ctx.get_cached_index(Side::Server, index) =
             CachedFileIndex::from(Some::<FileIndex<SIDE>>(file_index));

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -99,6 +99,47 @@ devTest("importing a file before it is created", {
     await c.expectMessage("value: 456");
   },
 });
+devTest("a file with a failed import is imported again in the same bundle", {
+  // The first bundle inserts "lib.ts" into the incremental graph as stale when
+  // its import fails. A file resolved after that asks the graph whether
+  // "lib.ts" is cached. The stale bitset must cover "lib.ts" by then.
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import './lib';
+      import './a';
+    `,
+    "lib.ts": `
+      import './missing';
+      console.log('lib');
+    `,
+    // Three levels deep so that "lib.ts" fails to resolve before "c.ts" is resolved.
+    "a.ts": `
+      import './b';
+    `,
+    "b.ts": `
+      import './c';
+    `,
+    "c.ts": `
+      import './lib';
+      console.log('c');
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/", {
+      errors: [`lib.ts:1:8: error: Could not resolve: "./missing"`],
+    });
+
+    await c.expectReload(async () => {
+      await dev.write("missing.ts", `export {};`);
+    });
+
+    await c.expectMessage("lib", "c");
+  },
+});
 devTest("default export same-scope handling", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -128,6 +128,36 @@ devTest("image import in JS", {
     // await dev.fetch(img1).expect404();
   },
 });
+devTest("html references a json file that is cached as a module", {
+  // "manifest.json" is bundled as a module first. It is not in the asset
+  // store, so a later HTML reference to it must not look up an asset URL.
+  files: {
+    "index.html": `
+      <!DOCTYPE html><html><head></head><body>
+      <script type="module" src="script.ts"></script>
+      </body></html>
+    `,
+    "script.ts": `
+      import manifest from "./manifest.json";
+      console.log(manifest.name);
+    `,
+    "manifest.json": `{ "name": "app" }`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("app");
+
+    await c.expectReload(async () => {
+      await dev.patch("index.html", {
+        find: "<head></head>",
+        replace: '<head><link rel="manifest" href="./manifest.json"></head>',
+      });
+    });
+    await c.expectMessage("app");
+
+    await dev.fetch("/").expect.toInclude("<script");
+  },
+});
 devTest("import then create", {
   files: {
     "index.html": `


### PR DESCRIPTION
### Problem
- Two dev server panics from crash reports (`bun ./index.html`, HTML routes in `Bun.serve`). BUN-4QTH: `index out of bounds: the len is 0 but the index is 0` in `DynamicBitSetUnmanaged::is_set`, called from `DevServer::is_file_cached` (`src/runtime/bake/DevServer.rs:5083`). BUN-4VCK: `cached asset not found` in `BundleV2::resolve_import_records` (`src/bundler/bundle_v2.rs:6687`), the same panic as #25001 in a second ordering.
- 4QTH: `IncrementalGraph::insert_stale_extra` (`incremental_graph.rs:1323`) set the stale bit only when the bitset already covered the new index. Without a React refresh runtime the bitset is empty until the first bundle ends. A file whose import fails is inserted as stale during that bundle. When a second file imports it, `is_file_cached` indexes the empty bitset.
- 4VCK: the graph stores every module whose loader is not JavaScript-like as `Content::Asset` (json, toml, text, the html route module). Only copied files (`file`, `wasm`) register in `DevServer::assets`. An HTML `<link rel="manifest" href="./manifest.json">` that found a json module cached by an earlier script import asked for an asset hash that does not exist. #27039 fixed the reverse ordering (URL reference first) by forcing the `file` loader.

### Fix
- `insert_stale_extra` grows the bitset with `ensure_stale_bit_capacity(true)` and then sets the bit, like `insert_failure` does. `insert_empty` sets the bit of a new file and `insert_css_file_on_server` clears its bit, so every insert defines the bit instead of inheriting the fill of the last resize. #39488 carries the `insert_stale_extra` hunk.
- In the bundler, an HTML reference to a cached `Asset` module uses the asset URL only when `asset_hash` has one. Otherwise the record takes the cached module path and is disabled, as a cached script is. The element is dropped from the dev output instead of crashing the server.
- The kind stays "not JavaScript-like" because `invalidate` and `trace_dependencies` key on it: an edit to a URL referenced json file must re-bundle the html and hard reload, which a kind change to `should_copy_for_bundling` broke (the html root module landed in a soft update).
- Verified: `test/bake/dev/bundle.test.ts` ("a file with a failed import is imported again in the same bundle") and `test/bake/dev/html.test.ts` ("html references a json file that is cached as a module"). Both crash the dev server on bun 1.4.1 and pass with this change. Also ran all of `test/bake/dev/*`, `framework-router`, `deinitialization`.

### Background
- The dev server keeps one `IncrementalGraph` per side (client, server). `bundled_files` maps an absolute path to a `File`. `stale_files` is a bitset parallel to it: a set bit means the file must be bundled again. The bitset grows lazily in steps of 512 bits, and a resize fills the new bits with one value.
- `is_file_cached` is how the bundler asks the dev server, while it resolves import records, whether a path already has up to date output. A hit skips the parse and only records the path.
- `DevServer::assets` is a content addressed store behind `/_bun/asset/<hash>.<ext>`. Files with a copy loader are put there when they are parsed. An HTML reference to a cached asset is rewritten to that URL.
- `log_for_resolution_failures` inserts the importer of a failed import into the graph as stale, so that a later rebuild can report the error against it.

<details><summary>Notes</summary>

Repro for 4QTH (no react installed, first bundle): `index.ts` imports `./lib` and `./a`; `lib.ts` imports `./missing`; `a.ts` -> `b.ts` -> `c.ts` -> `./lib`. `lib.ts` fails to resolve and is inserted as stale while the bitset is empty. `c.ts` then asks `is_file_cached("lib.ts")`, which indexes the bitset. The chain is three levels deep so that `lib.ts` is resolved first; it crashed 6 of 6 runs on 1.4.1. A failing file's own resolve queue is cleared, so the second importer must be reached through another path.

Repro for 4VCK: `script.ts` imports `./manifest.json` (bundled as a json module, kind `Asset`, no asset entry). Add `<link rel="manifest" href="./manifest.json">` to the html. The rebuild finds the cached "asset" and `asset_hash` returns `None`. A fall through to the `file` loader would instead replace the json module with a URL module in the graph and in the page, so the script import is kept and the link is dropped. One path has one loader per bundle; #39488 records the bundled loader per file, which is the route to serving both.

Same bug in the Zig dev server: `isSet` past `bit_length` was an out of bounds read in ReleaseFast, and `assets.getHash(path) orelse @panic("cached asset not found")` was the same panic. The Zig comment on `FileKind.asset` read "code is JavaScript code of a module exporting a single file path. This is used when the loader is not css nor isJavaScriptLike()". The second sentence is what the code does, and `invalidate` and `trace_dependencies` grew on it.

A first version of this PR changed the kind to `should_copy_for_bundling`. With it, editing a URL referenced `manifest.json` (re-bundled with the json loader, see #38041) produced a soft update that carried `index.html`, and the HMR runtime logged `ASSERTION FAILED` at `hmr-module.ts:694`. Reverted.

The `insert_empty` bit: before, a new placeholder inherited the fill of the last resize (true after an `insert_*` resize, false after the resize at the end of a bundle), so a new asset or css child was stale or cached by chance. React projects always hit the `true` case because the refresh runtime grows the bitset at startup. There is no deterministic test for the inherited value, so none is added.

`receive_chunk` still guards its `unset` with `bit_length > idx`. It runs only inside `finalize_bundle`, which ends with `ensure_stale_bit_capacity(false)` before anything can query the graph. #40115 adds a new `insert_stale` caller and needs the `insert_stale_extra` change to give its placeholder a bit.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/bundle.test.ts test/bake/dev/html.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-xVDBqs
[0;30mdev|[0m Started development server: http://localhost:42073
[0;30mdev|[0m [32mBundled page in 173ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 78ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 57ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 76ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 47ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waitin
... (truncated)

release without fix: 3 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-CrtLdP
[0;30mdev|[0m Started development server: http://localhost:36347
[0;30mdev|[0m [32mBundled page in 2ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 1ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 2ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 1ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 1ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:html-1: html file is watched [724.85ms]
[0;30mdev|[0m Started development server: http://localhost:42873
[0;30mdev|[0m [32mBundled page in 3ms[0m[2m:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/bundle.test.ts test/bake/dev/html.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-pejihz
[0;30mdev|[0m Started development server: http://localhost:37921
[0;30mdev|[0m [32mBundled page in 158ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 75ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 122ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 123ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 42ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, wait
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 753ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs                         | 12 ++++---
 src/runtime/bake/dev_server/incremental_graph.rs | 10 ++++--
 test/bake/dev/bundle.test.ts                     | 41 ++++++++++++++++++++++++
 test/bake/dev/html.test.ts                       | 30 +++++++++++++++++
 4 files changed, 86 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/bundler/bundle_v2.rs                              4      2     11
src/runtime/bake/dev_server/incremental_graph.rs      8      8     12
test/bake/dev/bundle.test.ts                          2      1      9
test/bake/dev/html.test.ts                            2      1      8
```

</details>

<!-- robobun:evidence:end -->