### PR TITLE
bundler: inline single-use vars, drop unused locals, and re-merge after each edit

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -294,10 +294,7 @@ pub enum CallUnwrap {
     Never,
     IfUnused,
     IfUnusedAndToStringSafe,
-    /// The call has no side effects and does not throw as long as every
-    /// argument is a primitive other than a BigInt (`Math.floor(1.5)`). With
-    /// an argument of unknown type the call stays: converting an object can
-    /// run its `valueOf`.
+    /// Pure and non-throwing when every argument is a non-BigInt primitive (`Math.floor(1.5)`); an object argument could run `valueOf`, so then the call stays.
     IfUnusedAndPrimitiveArgs,
 }
 

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -294,6 +294,11 @@ pub enum CallUnwrap {
     Never,
     IfUnused,
     IfUnusedAndToStringSafe,
+    /// The call has no side effects and does not throw as long as every
+    /// argument is a primitive other than a BigInt (`Math.floor(1.5)`). With
+    /// an argument of unknown type the call stays: converting an object can
+    /// run its `valueOf`.
+    IfUnusedAndPrimitiveArgs,
 }
 
 pub struct Dot {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1424,6 +1424,28 @@ impl PrimitiveType {
             PrimitiveType::Mixed
         }
     }
+
+    /// A known primitive whose arithmetic conversions never run code and
+    /// never throw: anything but a BigInt (which throws when mixed with a
+    /// number) or a type that is not known.
+    pub fn is_non_bigint_primitive(self) -> bool {
+        matches!(
+            self,
+            PrimitiveType::Null
+                | PrimitiveType::Undefined
+                | PrimitiveType::Boolean
+                | PrimitiveType::Number
+                | PrimitiveType::String
+        )
+    }
+}
+
+/// The numeric constants on the `Math` global.
+fn is_math_numeric_constant(name: &[u8]) -> bool {
+    matches!(
+        name,
+        b"E" | b"LN10" | b"LN2" | b"LOG10E" | b"LOG2E" | b"PI" | b"SQRT1_2" | b"SQRT2"
+    )
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -2427,6 +2449,19 @@ impl Data {
                 .yes
                 .data
                 .merge_known_primitive_with_check(&e_if.no.data, stack_check),
+            // `Math.PI` and the other numeric constants on `Math`. The define
+            // table only marks the access side-effect free when `Math` is the
+            // real global, so the value is known to be a number.
+            Data::EDot(dot) => {
+                if dot.can_be_removed_if_unused
+                    && matches!(dot.target.data, Data::EIdentifier(id) if id.can_be_removed_if_unused())
+                    && is_math_numeric_constant(dot.name.slice())
+                {
+                    PrimitiveType::Number
+                } else {
+                    PrimitiveType::Unknown
+                }
+            }
             Data::EBinary(binary) => 'brk: {
                 match binary.op {
                     crate::OpCode::BinStrictEq
@@ -2512,7 +2547,14 @@ impl Data {
                     | crate::OpCode::BinShr
                     | crate::OpCode::BinShrAssign
                     | crate::OpCode::BinUShr
-                    | crate::OpCode::BinUShrAssign => break 'brk PrimitiveType::Mixed, // Can be number or bigint (or an exception)
+                    | crate::OpCode::BinUShrAssign => {
+                        let left = binary.left.data.known_primitive_with_check(stack_check);
+                        let right = binary.right.data.known_primitive_with_check(stack_check);
+                        if left.is_non_bigint_primitive() && right.is_non_bigint_primitive() {
+                            break 'brk PrimitiveType::Number;
+                        }
+                        break 'brk PrimitiveType::Mixed; // Can be number or bigint (or an exception)
+                    }
 
                     crate::OpCode::BinAssign | crate::OpCode::BinComma => {
                         break 'brk binary.right.data.known_primitive_with_check(stack_check);

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1438,14 +1438,6 @@ impl PrimitiveType {
     }
 }
 
-/// The numeric constants on the `Math` global.
-fn is_math_numeric_constant(name: &[u8]) -> bool {
-    matches!(
-        name,
-        b"E" | b"LN10" | b"LN2" | b"LOG10E" | b"LOG2E" | b"PI" | b"SQRT1_2" | b"SQRT2"
-    )
-}
-
 // ───────────────────────────────────────────────────────────────────────────
 // Data
 // ───────────────────────────────────────────────────────────────────────────
@@ -2447,17 +2439,6 @@ impl Data {
                 .yes
                 .data
                 .merge_known_primitive_with_check(&e_if.no.data, stack_check),
-            // `Math.PI` and friends: the define flags are only set when `Math` is the real global.
-            Data::EDot(dot) => {
-                if dot.can_be_removed_if_unused
-                    && matches!(dot.target.data, Data::EIdentifier(id) if id.can_be_removed_if_unused())
-                    && is_math_numeric_constant(dot.name.slice())
-                {
-                    PrimitiveType::Number
-                } else {
-                    PrimitiveType::Unknown
-                }
-            }
             Data::EBinary(binary) => 'brk: {
                 match binary.op {
                     crate::OpCode::BinStrictEq
@@ -2543,14 +2524,7 @@ impl Data {
                     | crate::OpCode::BinShr
                     | crate::OpCode::BinShrAssign
                     | crate::OpCode::BinUShr
-                    | crate::OpCode::BinUShrAssign => {
-                        let left = binary.left.data.known_primitive_with_check(stack_check);
-                        let right = binary.right.data.known_primitive_with_check(stack_check);
-                        if left.is_non_bigint_primitive() && right.is_non_bigint_primitive() {
-                            break 'brk PrimitiveType::Number;
-                        }
-                        break 'brk PrimitiveType::Mixed; // Can be number or bigint (or an exception)
-                    }
+                    | crate::OpCode::BinUShrAssign => break 'brk PrimitiveType::Mixed, // Can be number or bigint (or an exception)
 
                     crate::OpCode::BinAssign | crate::OpCode::BinComma => {
                         break 'brk binary.right.data.known_primitive_with_check(stack_check);

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1425,9 +1425,7 @@ impl PrimitiveType {
         }
     }
 
-    /// A known primitive whose arithmetic conversions never run code and
-    /// never throw: anything but a BigInt (which throws when mixed with a
-    /// number) or a type that is not known.
+    /// A known primitive whose numeric conversion never runs code or throws (a BigInt throws when mixed with a number).
     pub fn is_non_bigint_primitive(self) -> bool {
         matches!(
             self,
@@ -2449,9 +2447,7 @@ impl Data {
                 .yes
                 .data
                 .merge_known_primitive_with_check(&e_if.no.data, stack_check),
-            // `Math.PI` and the other numeric constants on `Math`. The define
-            // table only marks the access side-effect free when `Math` is the
-            // real global, so the value is known to be a number.
+            // `Math.PI` and friends: the define flags are only set when `Math` is the real global.
             Data::EDot(dot) => {
                 if dot.can_be_removed_if_unused
                     && matches!(dot.target.data, Data::EIdentifier(id) if id.can_be_removed_if_unused())

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -122,6 +122,12 @@ bitflags::bitflags! {
         /// `arguments` object can). Set on the root of the symbol's link
         /// chain. Read by HMR live bindings and the printer's same-target fold.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
+
+        /// Another symbol's `link` points at this one: a redeclaration in the
+        /// same scope, a `var` hoisted out of a nested block, or a parameter
+        /// shadowed by a `var`. Uses of the name can be counted on that other
+        /// symbol, so `use_count_estimate` is not a complete count for this one.
+        const IS_LINK_TARGET = 1 << 6;
     }
 }
 
@@ -147,6 +153,7 @@ symbol_flag_accessors! {
     must_not_be_renamed, set_must_not_be_renamed => MUST_NOT_BE_RENAMED;
     remove_overwritten_function_declaration, set_remove_overwritten_function_declaration => REMOVE_OVERWRITTEN_FUNCTION_DECLARATION;
     has_been_assigned_to, set_has_been_assigned_to => HAS_BEEN_ASSIGNED_TO;
+    is_link_target, set_is_link_target => IS_LINK_TARGET;
 }
 
 const _: () = assert!(core::mem::size_of::<Option<bun_alloc::AstBox<G::NamespaceAlias>>>() == 8);

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -123,10 +123,7 @@ bitflags::bitflags! {
         /// chain. Read by HMR live bindings and the printer's same-target fold.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
 
-        /// Another symbol's `link` points at this one: a redeclaration in the
-        /// same scope, a `var` hoisted out of a nested block, or a parameter
-        /// shadowed by a `var`. Uses of the name can be counted on that other
-        /// symbol, so `use_count_estimate` is not a complete count for this one.
+        /// Another symbol's `link` points here (a redeclaration, a `var` hoisted out of a nested block, a parameter shadowed by `var`), so uses counted on that symbol are missing from this `use_count_estimate`.
         const IS_LINK_TARGET = 1 << 6;
     }
 }

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -142,8 +142,7 @@ impl DefineExt for Define {
         let key = global[global.len() - 1];
         let parts: Vec<Box<[u8]>> = global.iter().map(|p| Box::<[u8]>::from(*p)).collect();
         if let Some(existing) = self.dots.get_mut(key) {
-            // The parser takes the first define whose parts match, so a later
-            // table entry for the same chain replaces the earlier one.
+            // The parser takes the first define whose parts match, so a later entry for the same chain replaces the earlier one.
             if let Some(same) = existing.iter_mut().find(|d| d.parts == parts) {
                 same.data = value_define.clone();
             } else {
@@ -201,8 +200,7 @@ impl DefineExt for Define {
             for global in global_no_side_effect_function_calls_safe_for_to_string.iter() {
                 define.insert_global(global, &to_string_safe)?;
             }
-            // These are also in the property-access table; `insert_global`
-            // replaces that entry so the call flag wins.
+            // These are also in the property-access table; the call flag replaces that entry.
             let primitive_args = DefineData::init(Options {
                 value: ExprData::EUndefined(bun_ast::E::Undefined),
                 valueless: true,

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -6,6 +6,7 @@ use bun_js_parser::lexer as js_lexer;
 
 use crate::defines_table::{
     GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_SAFE_FOR_TO_STRING as global_no_side_effect_function_calls_safe_for_to_string,
+    GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS as global_no_side_effect_function_calls_with_primitive_args,
     GLOBAL_NO_SIDE_EFFECT_PROPERTY_ACCESSES as global_no_side_effect_property_accesses,
 };
 
@@ -141,10 +142,16 @@ impl DefineExt for Define {
         let key = global[global.len() - 1];
         let parts: Vec<Box<[u8]>> = global.iter().map(|p| Box::<[u8]>::from(*p)).collect();
         if let Some(existing) = self.dots.get_mut(key) {
-            existing.push(DotDefine {
-                parts,
-                data: value_define.clone(),
-            });
+            // The parser takes the first define whose parts match, so a later
+            // table entry for the same chain replaces the earlier one.
+            if let Some(same) = existing.iter_mut().find(|d| d.parts == parts) {
+                same.data = value_define.clone();
+            } else {
+                existing.push(DotDefine {
+                    parts,
+                    data: value_define.clone(),
+                });
+            }
         } else {
             self.dots.put_assume_capacity(
                 key,
@@ -193,6 +200,18 @@ impl DefineExt for Define {
         if omit_unused_global_calls {
             for global in global_no_side_effect_function_calls_safe_for_to_string.iter() {
                 define.insert_global(global, &to_string_safe)?;
+            }
+            // These are also in the property-access table; `insert_global`
+            // replaces that entry so the call flag wins.
+            let primitive_args = DefineData::init(Options {
+                value: ExprData::EUndefined(bun_ast::E::Undefined),
+                valueless: true,
+                can_be_removed_if_unused: true,
+                call_can_be_unwrapped_if_unused: bun_ast::E::CallUnwrap::IfUnusedAndPrimitiveArgs,
+                ..Default::default()
+            });
+            for global in global_no_side_effect_function_calls_with_primitive_args.iter() {
+                define.insert_global(global, &primitive_args)?;
             }
         } else {
             for global in global_no_side_effect_function_calls_safe_for_to_string.iter() {

--- a/src/js_parser/defines_table.rs
+++ b/src/js_parser/defines_table.rs
@@ -188,7 +188,58 @@ pub static GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_SAFE_FOR_TO_STRING: &[&[&[u8]]] 
     // Calling Symbol.for("foo") never throws (unless it's a rope string)
     // This improves React bundle sizes slightly.
     &[b"Symbol", b"for"],
-    // Haven't seen a bundle size improvement from adding more to this list yet.
+];
+
+/// Calls to these globals have no side effects and never throw when every
+/// argument is a primitive other than a BigInt (no `valueOf` / `toString` can
+/// run, and no BigInt conversion can throw). An unused call with such
+/// arguments is dropped. `Math.random` is left out because it advances the
+/// generator state.
+pub static GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS: &[&[&[u8]]] = &[
+    &[b"Array", b"isArray"],
+    &[b"Array", b"of"],
+    &[b"Math", b"abs"],
+    &[b"Math", b"acos"],
+    &[b"Math", b"acosh"],
+    &[b"Math", b"asin"],
+    &[b"Math", b"asinh"],
+    &[b"Math", b"atan"],
+    &[b"Math", b"atan2"],
+    &[b"Math", b"atanh"],
+    &[b"Math", b"cbrt"],
+    &[b"Math", b"ceil"],
+    &[b"Math", b"clz32"],
+    &[b"Math", b"cos"],
+    &[b"Math", b"cosh"],
+    &[b"Math", b"exp"],
+    &[b"Math", b"expm1"],
+    &[b"Math", b"floor"],
+    &[b"Math", b"fround"],
+    &[b"Math", b"hypot"],
+    &[b"Math", b"imul"],
+    &[b"Math", b"log"],
+    &[b"Math", b"log10"],
+    &[b"Math", b"log1p"],
+    &[b"Math", b"log2"],
+    &[b"Math", b"max"],
+    &[b"Math", b"min"],
+    &[b"Math", b"pow"],
+    &[b"Math", b"round"],
+    &[b"Math", b"sign"],
+    &[b"Math", b"sin"],
+    &[b"Math", b"sinh"],
+    &[b"Math", b"sqrt"],
+    &[b"Math", b"tan"],
+    &[b"Math", b"tanh"],
+    &[b"Math", b"trunc"],
+    &[b"Number", b"isFinite"],
+    &[b"Number", b"isInteger"],
+    &[b"Number", b"isNaN"],
+    &[b"Number", b"isSafeInteger"],
+    &[b"Number", b"parseFloat"],
+    &[b"Number", b"parseInt"],
+    &[b"Object", b"is"],
+    &[b"String", b"fromCharCode"],
 ];
 
 // `OnceLock` for lazily-initialised statics (`DefineData` is not const-constructible).

--- a/src/js_parser/defines_table.rs
+++ b/src/js_parser/defines_table.rs
@@ -190,11 +190,7 @@ pub static GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_SAFE_FOR_TO_STRING: &[&[&[u8]]] 
     &[b"Symbol", b"for"],
 ];
 
-/// Calls to these globals have no side effects and never throw when every
-/// argument is a primitive other than a BigInt (no `valueOf` / `toString` can
-/// run, and no BigInt conversion can throw). An unused call with such
-/// arguments is dropped. `Math.random` is left out because it advances the
-/// generator state.
+/// Pure and non-throwing when every argument is a non-BigInt primitive, so an unused call is dropped. `Math.random` advances the generator state and is not here.
 pub static GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS: &[&[&[u8]]] = &[
     &[b"Array", b"isArray"],
     &[b"Array", b"of"],

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -317,11 +317,10 @@ pub mod defines {
         }
         #[inline]
         pub(crate) fn call_can_be_unwrapped_if_unused(self) -> E::CallUnwrap {
-            // 2-bit field; `E::CallUnwrap` only has discriminants 0/1/2, so
-            // an explicit match keeps bit-pattern 3 sound.
             match (self.0 & Self::CALL_UNWRAP_MASK) >> Self::CALL_UNWRAP_SHIFT {
                 1 => E::CallUnwrap::IfUnused,
                 2 => E::CallUnwrap::IfUnusedAndToStringSafe,
+                3 => E::CallUnwrap::IfUnusedAndPrimitiveArgs,
                 _ => E::CallUnwrap::Never,
             }
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2754,6 +2754,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         return Substitution::Failure(expr);
                     }
 
+                    // The right side of "&&", "||" and "??" does not always run, so a value with side effects must not move into it.
+                    let right_is_conditional = matches!(
+                        e.op,
+                        js_ast::op::Code::BinLogicalAnd
+                            | js_ast::op::Code::BinLogicalOr
+                            | js_ast::op::Code::BinNullishCoalescing
+                    );
+                    if right_is_conditional && !replacement_can_be_removed {
+                        return Substitution::Failure(expr);
+                    }
+
                     // If we get here then it should be safe to attempt to substitute the
                     // replacement past the left operand into the right operand.
                     if let Some(done) = self.substitute_single_use_symbol_in_child(
@@ -2998,7 +3009,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // A side-effecting replacement can still move past a read that cannot throw, run code, or change.
         match expr.data {
-            js_ast::ExprData::EThis(_) => true,
+            js_ast::ExprData::EThis(_) | js_ast::ExprData::ESuper(_) => true,
             js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id),
             // A known global property access such as `console.log` or `Math.floor`.
             js_ast::ExprData::EDot(dot) => dot.can_be_removed_if_unused,
@@ -5653,7 +5664,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// Parse pass: `target` is assigned to; records the name of every identifier in it.
     pub(crate) fn record_parse_time_assignment_target(&mut self, target: &Expr) {
-        if !self.stack_check.is_safe_to_recurse() {
+        if !self.options.bundle || !self.stack_check.is_safe_to_recurse() {
             return;
         }
         match target.data {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -25,8 +25,9 @@ use crate::{
     ImportItemForNamespaceMap, InvalidLoc, JSXImport, JSXTransformType, Jest,
     LOC_MODULE_SCOPE as loc_module_scope, LocList, MacroState, ParseStatementOptions, ParsedPath,
     PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap, RuntimeImports, ScopeOrder,
-    ScopeOrderList, StrictModeFeature, StringBoolMap, Substitution, TempRef, ThenCatchChain,
-    TransposeState, WrapMode, fs, is_eval_or_arguments, options, statement_cares_about_scope,
+    ScopeOrderList, StmtSubstitution, StrictModeFeature, StringBoolMap, Substitution, TempRef,
+    ThenCatchChain, TransposeState, WrapMode, fs, is_eval_or_arguments, options,
+    statement_cares_about_scope,
 };
 use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
@@ -303,6 +304,15 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     // Used for forcing CommonJS
     pub(crate) has_with_scope: bool,
+
+    /// Hashes of every identifier name the parse pass saw as an assignment
+    /// target (`x = 1`, `x++`, `[x] = a`, `for (x of a)`). Complete for the
+    /// whole file before the visit pass starts, which the per-symbol
+    /// `has_been_assigned_to` flag is not.
+    pub(crate) assigned_identifier_names: HashMap<u64, ()>,
+    /// The parse pass saw a call to the identifier `eval` somewhere in the
+    /// file. Such a call can assign any binding in scope by name.
+    pub(crate) parse_pass_saw_direct_eval: bool,
 
     pub(crate) is_file_considered_to_have_esm_exports: bool,
 
@@ -2478,7 +2488,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: Stmt,
         r#ref: Ref,
         replacement: Expr,
-    ) -> bool {
+    ) -> StmtSubstitution {
         // `StmtData` stores `StoreRef<S::*>` (Copy NonNull); matching by value yields
         // an owned `StoreRef` whose `DerefMut` reaches the underlying arena slot,
         // so writing to `*expr` below mutates the AST in place.
@@ -2513,7 +2523,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 _ => {}
             }
-            return false;
+            return StmtSubstitution::Blocked;
         };
         // `StoreRef<Expr>: DerefMut` — arena-owned slot, parser holds exclusive
         // access during the single-threaded visit pass.
@@ -2558,12 +2568,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 } else {
                     *expr = result;
                 }
-                return true;
+                StmtSubstitution::Substituted
             }
-            _ => {}
+            Substitution::Continue => StmtSubstitution::NotFound,
+            Substitution::Failure(_) => StmtSubstitution::Blocked,
         }
-
-        false
     }
 
     fn substitute_single_use_symbol_in_expr(
@@ -2723,13 +2732,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ) {
                             return done;
                         }
-                    } else if !self.expr_can_be_removed_if_unused(&e.left) {
+                    } else if !self.expr_can_be_removed_if_unused(&e.left)
+                        && !(self.options.bundle && replacement.can_be_const_value())
+                    {
                         // Do not reorder past a side effect in an assignment target, as that may
                         // change the replacement value. For example, "fn()" may change "a" here:
                         //
-                        //   let a = 1;
+                        //   let a = b;
                         //   foo[fn()] = a;
                         //
+                        // A literal cannot change, so it may move past the target.
                         return Substitution::Failure(expr);
                     } else if js_ast::op::Code::binary_assign_target(e.op)
                         == js_ast::AssignTarget::Update
@@ -2966,8 +2978,90 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Substitution::Continue;
         }
 
+        if self.options.bundle && self.can_reorder_replacement_past(&expr, &replacement) {
+            return Substitution::Continue;
+        }
+
         // Otherwise we should stop trying to substitute past this point
         Substitution::Failure(expr)
+    }
+
+    /// Whether the initializer of a single-use binding can be evaluated after
+    /// `expr` instead of before it. `expr` was already checked for a use of the
+    /// binding, so this only has to rule out an observable change in order.
+    fn can_reorder_replacement_past(&self, expr: &Expr, replacement: &Expr) -> bool {
+        // A literal reads no state, so nothing `expr` does can change its
+        // value, and it has no side effects that `expr` could observe. The
+        // same holds for creating a function (it captures variables, not
+        // values) or a regular expression.
+        if replacement.can_be_const_value()
+            || matches!(
+                replacement.data,
+                js_ast::ExprData::EArrow(_)
+                    | js_ast::ExprData::EFunction(_)
+                    | js_ast::ExprData::ERegExp(_)
+            )
+        {
+            return true;
+        }
+
+        // Otherwise the replacement may have side effects. It can still move
+        // past a read that cannot throw, cannot run code, and reads a value
+        // that no side effect can change.
+        match expr.data {
+            js_ast::ExprData::EThis(_) => true,
+            js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id),
+            // A known global property access such as `console.log` or `Math.floor`.
+            js_ast::ExprData::EDot(dot) => dot.can_be_removed_if_unused,
+            _ => false,
+        }
+    }
+
+    /// A read of `id` that cannot throw, cannot run code, and yields the same
+    /// value no matter what code runs before it.
+    fn is_stable_identifier_read(&self, id: E::Identifier) -> bool {
+        if id.must_keep_due_to_with_stmt() {
+            return false;
+        }
+        let symbol = &self.symbols[id.ref_.inner_index() as usize];
+        if symbol.must_not_be_renamed() || symbol.has_link() || symbol.is_link_target() {
+            return false;
+        }
+        match symbol.kind {
+            // A known global such as `Math` or `console`.
+            js_ast::symbol::Kind::Unbound => id.can_be_removed_if_unused(),
+            // When bundling, an assignment to a `const` is a compile error.
+            js_ast::symbol::Kind::Constant => true,
+            // A binding that can only change through an assignment, and the
+            // whole file has none (a `var` or a parameter can also change
+            // through a redeclaration or a mapped `arguments` object, so
+            // those are not here). A direct `eval` could assign by name.
+            js_ast::symbol::Kind::Other
+            | js_ast::symbol::Kind::Class
+            | js_ast::symbol::Kind::HoistedFunction
+            | js_ast::symbol::Kind::GeneratorOrAsyncFunction => {
+                if symbol.has_been_assigned_to() || self.parse_pass_saw_direct_eval {
+                    return false;
+                }
+                let name = symbol.original_name.slice();
+                if self.name_is_assigned_somewhere(name) {
+                    return false;
+                }
+                // The name must resolve to this very symbol from here. A
+                // generated symbol (a lowering temp) is not in any `members`
+                // map, and generated code may assign to it.
+                let hash = Scope::get_member_hash(name);
+                let mut scope = Some(self.current_scope_ref());
+                while let Some(s) = scope {
+                    if let Some(member) = s.get_member_with_hash(name, hash) {
+                        return member.ref_.eql(id.ref_);
+                    }
+                    scope = s.parent;
+                }
+                false
+            }
+            _ => false,
+        }
     }
 
     /// `None` is `Continue`; otherwise `slot` was rewritten and this is `parent`'s outcome.
@@ -3397,6 +3491,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             {
                                 // Silently merge this symbol into the existing symbol
                                 self.symbols[symbol_idx].link.set(member_in_scope.ref_);
+                                self.symbols[existing_idx].set_is_link_target(true);
                                 // `StringHashMap` get_or_put already stores the key on insert and
                                 // cannot hand out `&mut K` (see StringHashMapGetOrPut docs), so
                                 // no key write is needed here.
@@ -3457,6 +3552,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // If this is a catch identifier, silently merge the existing symbol
                             // into this symbol but continue hoisting past this catch scope
                             self.symbols[existing_idx].link.set(value.ref_);
+                            self.symbols[symbol_idx].set_is_link_target(true);
                             *_scope
                                 .get_or_put_member_with_hash(name, hash.unwrap())
                                 .value_ptr = value;
@@ -4894,6 +4990,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 MR::ReplaceWithNew => {
                     self.symbols[symbol_idx].link.set(ref_);
+                    self.symbols[ref_.inner_index() as usize].set_is_link_target(true);
 
                     // If these are both functions, remove the overwritten declaration
                     if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
@@ -5571,6 +5668,48 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         None
     }
 
+    /// Parse pass: `target` is being assigned to. Records the name of every
+    /// identifier in it (see `assigned_identifier_names`).
+    pub(crate) fn record_parse_time_assignment_target(&mut self, target: &Expr) {
+        if !self.stack_check.is_safe_to_recurse() {
+            return;
+        }
+        match target.data {
+            js_ast::ExprData::EIdentifier(id) => {
+                let name = self.load_name_from_ref(id.ref_);
+                self.assigned_identifier_names
+                    .insert(bun_wyhash::hash(name), ());
+            }
+            // Destructuring assignment patterns: `[a, b = 1, ...c] = d`, `({a, b: c} = d)`
+            js_ast::ExprData::EArray(array) => {
+                for item in array.items.slice() {
+                    self.record_parse_time_assignment_target(item);
+                }
+            }
+            js_ast::ExprData::EObject(object) => {
+                for property in object.properties.slice() {
+                    if let Some(value) = &property.value {
+                        self.record_parse_time_assignment_target(value);
+                    }
+                }
+            }
+            js_ast::ExprData::EBinary(bin) if bin.op == js_ast::op::Code::BinAssign => {
+                self.record_parse_time_assignment_target(&bin.left);
+            }
+            js_ast::ExprData::ESpread(spread) => {
+                self.record_parse_time_assignment_target(&spread.value);
+            }
+            _ => {}
+        }
+    }
+
+    /// Whether the parse pass saw `name` as an assignment target anywhere in
+    /// the file.
+    pub(crate) fn name_is_assigned_somewhere(&self, name: &[u8]) -> bool {
+        self.assigned_identifier_names
+            .contains_key(&bun_wyhash::hash(name))
+    }
+
     // PERF: takes `&Expr` — `Expr` inlines `ExprData`, so a by-value pass copies
     // the full union. The only caller (`visit_expr_in_out`) already holds `&mut Expr`.
     pub(crate) fn is_valid_assignment_target(&self, expr: &Expr) -> bool {
@@ -5578,6 +5717,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ExprData::EIdentifier(ident) => {
                 !is_eval_or_arguments(self.load_name_from_ref(ident.ref_))
             }
+            // `exports.x` after its first visit (the substitution revisit).
+            js_ast::ExprData::ECommonjsExportIdentifier(_) => true,
             js_ast::ExprData::EDot(e) => e.optional_chain.is_none(),
             js_ast::ExprData::EIndex(e) => e.optional_chain.is_none(),
             js_ast::ExprData::EArray(e) => !e.is_parenthesized,
@@ -5856,6 +5997,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return true;
             }
             js_ast::ExprData::ECall(ex) => {
+                if ex.can_be_unwrapped_if_unused == js_ast::CanBeUnwrapped::IfUnusedAndPrimitiveArgs
+                {
+                    return crate::scan::scan_side_effects::SideEffects::args_are_removable_primitives(
+                        self,
+                        ex.args.slice(),
+                    );
+                }
                 // A call that has been marked "__PURE__" can be removed if all arguments
                 // can be removed. The annotation causes us to ignore the target.
                 if ex.can_be_unwrapped_if_unused != js_ast::CanBeUnwrapped::Never {
@@ -5914,6 +6062,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     return self.expr_can_be_removed_if_unused_without_dce_check(&ex.value);
                 }
+                // Numeric conversion of a known primitive other than a BigInt
+                // ("+1n" throws) never runs code and never throws.
+                js_ast::op::Code::UnNeg | js_ast::op::Code::UnPos | js_ast::op::Code::UnCpl => {
+                    return self.options.features.minify_syntax
+                        && ex.value.data.known_primitive().is_non_bigint_primitive()
+                        && self.expr_can_be_removed_if_unused_without_dce_check(&ex.value);
+                }
                 _ => {}
             },
             js_ast::ExprData::EBinary(ex) => match ex.op {
@@ -5970,6 +6125,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         _ => {}
                     }
+                }
+                // Arithmetic on known primitives other than BigInt (mixing one
+                // with a number throws) never runs code and never throws:
+                // "Math.PI / 180" or "1 << 3".
+                js_ast::op::Code::BinAdd
+                | js_ast::op::Code::BinSub
+                | js_ast::op::Code::BinMul
+                | js_ast::op::Code::BinDiv
+                | js_ast::op::Code::BinRem
+                | js_ast::op::Code::BinPow
+                | js_ast::op::Code::BinShl
+                | js_ast::op::Code::BinShr
+                | js_ast::op::Code::BinUShr
+                | js_ast::op::Code::BinBitwiseAnd
+                | js_ast::op::Code::BinBitwiseOr
+                | js_ast::op::Code::BinBitwiseXor => {
+                    return self.options.features.minify_syntax
+                        && ex.left.data.known_primitive().is_non_bigint_primitive()
+                        && ex.right.data.known_primitive().is_non_bigint_primitive()
+                        && self.expr_can_be_removed_if_unused_without_dce_check(&ex.left)
+                        && self.expr_can_be_removed_if_unused_without_dce_check(&ex.right);
                 }
                 _ => {}
             },
@@ -9232,6 +9408,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             macro_call_count: 0,
             hoisted_ref_for_sloppy_mode_block_fn: Default::default(),
             has_with_scope: false,
+            assigned_identifier_names: Default::default(),
+            parse_pass_saw_direct_eval: false,
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,
             symbol_uses,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3010,15 +3010,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // A side-effecting replacement can still move past a read that cannot throw, run code, or change.
         match expr.data {
             js_ast::ExprData::EThis(_) | js_ast::ExprData::ESuper(_) => true,
-            js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id),
+            js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id, replacement),
             // A known global property access such as `console.log` or `Math.floor`.
             js_ast::ExprData::EDot(dot) => dot.can_be_removed_if_unused,
             _ => false,
         }
     }
 
-    /// A read of `id` that cannot throw or run code, and yields the same value whatever code runs before it.
-    fn is_stable_identifier_read(&self, id: E::Identifier) -> bool {
+    /// A read of `id` that cannot throw or run code, and yields the same value whether it happens before or after `replacement`.
+    fn is_stable_identifier_read(&self, id: E::Identifier, replacement: &Expr) -> bool {
         if id.must_keep_due_to_with_stmt() {
             return false;
         }
@@ -3029,32 +3029,110 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match symbol.kind {
             // A known global such as `Math` or `console`.
             js_ast::symbol::Kind::Unbound => id.can_be_removed_if_unused(),
-            // When bundling, an assignment to a `const` is a compile error.
-            js_ast::symbol::Kind::Constant => true,
-            // Only an assignment (or a direct `eval`) can change these; a `var` or parameter can also change through a redeclaration or a mapped `arguments` object.
-            js_ast::symbol::Kind::Other
+            js_ast::symbol::Kind::Constant
+            | js_ast::symbol::Kind::Other
             | js_ast::symbol::Kind::Class
             | js_ast::symbol::Kind::HoistedFunction
             | js_ast::symbol::Kind::GeneratorOrAsyncFunction => {
-                if symbol.has_been_assigned_to() || self.parse_pass_saw_direct_eval {
+                // When bundling an assignment to a `const` is a compile error; the others can only change through an assignment (or a direct `eval`). A `var` or a parameter can also change through a redeclaration or a mapped `arguments` object.
+                let is_const = symbol.kind == js_ast::symbol::Kind::Constant;
+                if !is_const && (symbol.has_been_assigned_to() || self.parse_pass_saw_direct_eval) {
                     return false;
                 }
                 let name = symbol.original_name.slice();
-                if self.name_is_assigned_somewhere(name) {
+                if !is_const && self.name_is_assigned_somewhere(name) {
                     return false;
                 }
+                // A `let`, `const` or `class` of an enclosing function can still be in its TDZ here and leave it while `replacement` suspends; a function declaration has no TDZ.
+                let has_tdz = symbol.kind != js_ast::symbol::Kind::HoistedFunction
+                    && symbol.kind != js_ast::symbol::Kind::GeneratorOrAsyncFunction;
                 // The name must resolve to this symbol from here; a generated temp is in no `members` map, and generated code may assign to it.
                 let hash = Scope::get_member_hash(name);
+                let mut crossed_function = false;
                 let mut scope = Some(self.current_scope_ref());
                 while let Some(s) = scope {
                     if let Some(member) = s.get_member_with_hash(name, hash) {
-                        return member.ref_.eql(id.ref_);
+                        if !member.ref_.eql(id.ref_) {
+                            return false;
+                        }
+                        return !(has_tdz
+                            && crossed_function
+                            && Self::expr_may_suspend(replacement));
                     }
+                    crossed_function |= s.kind_stops_hoisting();
                     scope = s.parent;
                 }
                 false
             }
             _ => false,
+        }
+    }
+
+    /// Whether evaluating `expr` can suspend the current function (`await` or `yield` outside a nested function). Unknown shapes count as suspending.
+    fn expr_may_suspend(expr: &Expr) -> bool {
+        match expr.data {
+            js_ast::ExprData::EAwait(_) | js_ast::ExprData::EYield(_) => true,
+            js_ast::ExprData::EFunction(_)
+            | js_ast::ExprData::EArrow(_)
+            | js_ast::ExprData::EClass(_)
+            | js_ast::ExprData::EIdentifier(_)
+            | js_ast::ExprData::EImportIdentifier(_)
+            | js_ast::ExprData::ECommonjsExportIdentifier(_)
+            | js_ast::ExprData::EThis(_)
+            | js_ast::ExprData::ESuper(_)
+            | js_ast::ExprData::ENull(_)
+            | js_ast::ExprData::EUndefined(_)
+            | js_ast::ExprData::EBoolean(_)
+            | js_ast::ExprData::EBranchBoolean(_)
+            | js_ast::ExprData::ENumber(_)
+            | js_ast::ExprData::EBigInt(_)
+            | js_ast::ExprData::EString(_)
+            | js_ast::ExprData::ERegExp(_)
+            | js_ast::ExprData::EImportMeta(_)
+            | js_ast::ExprData::ERequireString(_)
+            | js_ast::ExprData::EMissing(_) => false,
+            js_ast::ExprData::EDot(dot) => Self::expr_may_suspend(&dot.target),
+            js_ast::ExprData::EIndex(index) => {
+                Self::expr_may_suspend(&index.target) || Self::expr_may_suspend(&index.index)
+            }
+            js_ast::ExprData::EUnary(un) => Self::expr_may_suspend(&un.value),
+            js_ast::ExprData::EBinary(bin) => {
+                Self::expr_may_suspend(&bin.left) || Self::expr_may_suspend(&bin.right)
+            }
+            js_ast::ExprData::EIf(ternary) => {
+                Self::expr_may_suspend(&ternary.test)
+                    || Self::expr_may_suspend(&ternary.yes)
+                    || Self::expr_may_suspend(&ternary.no)
+            }
+            js_ast::ExprData::ECall(call) => {
+                Self::expr_may_suspend(&call.target)
+                    || call.args.slice().iter().any(Self::expr_may_suspend)
+            }
+            js_ast::ExprData::ENew(new) => {
+                Self::expr_may_suspend(&new.target)
+                    || new.args.slice().iter().any(Self::expr_may_suspend)
+            }
+            js_ast::ExprData::EArray(array) => {
+                array.items.slice().iter().any(Self::expr_may_suspend)
+            }
+            js_ast::ExprData::EObject(object) => object.properties.slice().iter().any(|property| {
+                property.key.as_ref().is_some_and(Self::expr_may_suspend)
+                    || property.value.as_ref().is_some_and(Self::expr_may_suspend)
+                    || property
+                        .initializer
+                        .as_ref()
+                        .is_some_and(Self::expr_may_suspend)
+            }),
+            js_ast::ExprData::ETemplate(template) => {
+                template.tag.as_ref().is_some_and(Self::expr_may_suspend)
+                    || template
+                        .parts()
+                        .iter()
+                        .any(|part| Self::expr_may_suspend(&part.value))
+            }
+            js_ast::ExprData::ESpread(spread) => Self::expr_may_suspend(&spread.value),
+            js_ast::ExprData::EInlinedEnum(inlined) => Self::expr_may_suspend(&inlined.value),
+            _ => true,
         }
     }
 
@@ -5870,6 +5948,67 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.expr_can_be_removed_if_unused_without_dce_check(expr)
     }
 
+    /// The bundler's `--minify-syntax`; the runtime transpiler has `minify_syntax` on too, and its output must not change.
+    pub(crate) fn bundler_minify_syntax(&self) -> bool {
+        self.options.bundle && self.options.features.minify_syntax
+    }
+
+    /// `known_primitive()` plus what the bundler's purity checks need: the `Math` numeric constants, and arithmetic or numeric conversion on such operands.
+    pub(crate) fn is_known_non_bigint_primitive(&self, expr: &Expr) -> bool {
+        if !self.stack_check.is_safe_to_recurse() {
+            return false;
+        }
+        match expr.data {
+            js_ast::ExprData::EDot(dot) => {
+                dot.can_be_removed_if_unused
+                    && matches!(dot.target.data, js_ast::ExprData::EIdentifier(id) if id.can_be_removed_if_unused())
+                    && matches!(
+                        dot.name.slice(),
+                        b"E" | b"LN10"
+                            | b"LN2"
+                            | b"LOG10E"
+                            | b"LOG2E"
+                            | b"PI"
+                            | b"SQRT1_2"
+                            | b"SQRT2"
+                    )
+            }
+            js_ast::ExprData::EUnary(un) => match un.op {
+                js_ast::op::Code::UnNeg | js_ast::op::Code::UnPos | js_ast::op::Code::UnCpl => {
+                    self.is_known_non_bigint_primitive(&un.value)
+                }
+                _ => expr.data.known_primitive().is_non_bigint_primitive(),
+            },
+            js_ast::ExprData::EBinary(bin) => match bin.op {
+                js_ast::op::Code::BinAdd
+                | js_ast::op::Code::BinSub
+                | js_ast::op::Code::BinMul
+                | js_ast::op::Code::BinDiv
+                | js_ast::op::Code::BinRem
+                | js_ast::op::Code::BinPow
+                | js_ast::op::Code::BinShl
+                | js_ast::op::Code::BinShr
+                | js_ast::op::Code::BinUShr
+                | js_ast::op::Code::BinBitwiseAnd
+                | js_ast::op::Code::BinBitwiseOr
+                | js_ast::op::Code::BinBitwiseXor => {
+                    self.is_known_non_bigint_primitive(&bin.left)
+                        && self.is_known_non_bigint_primitive(&bin.right)
+                }
+                _ => expr.data.known_primitive().is_non_bigint_primitive(),
+            },
+            _ => expr.data.known_primitive().is_non_bigint_primitive(),
+        }
+    }
+
+    /// A call in `GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS` whose result is unused can go when every argument is a side-effect free non-BigInt primitive. Bundler only.
+    pub(crate) fn pure_global_call_can_be_removed(&mut self, args: &[Expr]) -> bool {
+        self.bundler_minify_syntax()
+            && args.iter().all(|arg| {
+                self.is_known_non_bigint_primitive(arg) && self.expr_can_be_removed_if_unused(arg)
+            })
+    }
+
     fn expr_can_be_removed_if_unused_without_dce_check(&mut self, expr: &Expr) -> bool {
         if !self.stack_check.is_safe_to_recurse() || self.reported_stack_overflow.get() {
             self.report_stack_overflow(expr.loc);
@@ -5991,10 +6130,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ExprData::ECall(ex) => {
                 if ex.can_be_unwrapped_if_unused == js_ast::CanBeUnwrapped::IfUnusedAndPrimitiveArgs
                 {
-                    return crate::scan::scan_side_effects::SideEffects::args_are_removable_primitives(
-                        self,
-                        ex.args.slice(),
-                    );
+                    return self.pure_global_call_can_be_removed(ex.args.slice());
                 }
                 // A call that has been marked "__PURE__" can be removed if all arguments
                 // can be removed. The annotation causes us to ignore the target.
@@ -6056,8 +6192,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 // Numeric conversion of a non-BigInt primitive never runs code or throws ("+1n" throws).
                 js_ast::op::Code::UnNeg | js_ast::op::Code::UnPos | js_ast::op::Code::UnCpl => {
-                    return self.options.features.minify_syntax
-                        && ex.value.data.known_primitive().is_non_bigint_primitive()
+                    return self.bundler_minify_syntax()
+                        && self.is_known_non_bigint_primitive(&ex.value)
                         && self.expr_can_be_removed_if_unused_without_dce_check(&ex.value);
                 }
                 _ => {}
@@ -6130,9 +6266,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 | js_ast::op::Code::BinBitwiseAnd
                 | js_ast::op::Code::BinBitwiseOr
                 | js_ast::op::Code::BinBitwiseXor => {
-                    return self.options.features.minify_syntax
-                        && ex.left.data.known_primitive().is_non_bigint_primitive()
-                        && ex.right.data.known_primitive().is_non_bigint_primitive()
+                    return self.bundler_minify_syntax()
+                        && self.is_known_non_bigint_primitive(&ex.left)
+                        && self.is_known_non_bigint_primitive(&ex.right)
                         && self.expr_can_be_removed_if_unused_without_dce_check(&ex.left)
                         && self.expr_can_be_removed_if_unused_without_dce_check(&ex.right);
                 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -305,13 +305,9 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // Used for forcing CommonJS
     pub(crate) has_with_scope: bool,
 
-    /// Hashes of every identifier name the parse pass saw as an assignment
-    /// target (`x = 1`, `x++`, `[x] = a`, `for (x of a)`). Complete for the
-    /// whole file before the visit pass starts, which the per-symbol
-    /// `has_been_assigned_to` flag is not.
+    /// Hashes of every identifier name the parse pass saw as an assignment target; complete for the whole file before the visit pass, unlike `has_been_assigned_to`.
     pub(crate) assigned_identifier_names: HashMap<u64, ()>,
-    /// The parse pass saw a call to the identifier `eval` somewhere in the
-    /// file. Such a call can assign any binding in scope by name.
+    /// The parse pass saw a direct `eval` call somewhere in the file; it can assign any binding by name.
     pub(crate) parse_pass_saw_direct_eval: bool,
 
     pub(crate) is_file_considered_to_have_esm_exports: bool,
@@ -2986,14 +2982,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Substitution::Failure(expr)
     }
 
-    /// Whether the initializer of a single-use binding can be evaluated after
-    /// `expr` instead of before it. `expr` was already checked for a use of the
-    /// binding, so this only has to rule out an observable change in order.
+    /// Whether the initializer of a single-use binding may be evaluated after `expr` (which has no use of the binding) instead of before it.
     fn can_reorder_replacement_past(&self, expr: &Expr, replacement: &Expr) -> bool {
-        // A literal reads no state, so nothing `expr` does can change its
-        // value, and it has no side effects that `expr` could observe. The
-        // same holds for creating a function (it captures variables, not
-        // values) or a regular expression.
+        // A literal, a function (it captures variables, not values) or a regex reads no state and has no side effects.
         if replacement.can_be_const_value()
             || matches!(
                 replacement.data,
@@ -3005,9 +2996,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return true;
         }
 
-        // Otherwise the replacement may have side effects. It can still move
-        // past a read that cannot throw, cannot run code, and reads a value
-        // that no side effect can change.
+        // A side-effecting replacement can still move past a read that cannot throw, run code, or change.
         match expr.data {
             js_ast::ExprData::EThis(_) => true,
             js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id),
@@ -3017,8 +3006,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// A read of `id` that cannot throw, cannot run code, and yields the same
-    /// value no matter what code runs before it.
+    /// A read of `id` that cannot throw or run code, and yields the same value whatever code runs before it.
     fn is_stable_identifier_read(&self, id: E::Identifier) -> bool {
         if id.must_keep_due_to_with_stmt() {
             return false;
@@ -3032,10 +3020,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::symbol::Kind::Unbound => id.can_be_removed_if_unused(),
             // When bundling, an assignment to a `const` is a compile error.
             js_ast::symbol::Kind::Constant => true,
-            // A binding that can only change through an assignment, and the
-            // whole file has none (a `var` or a parameter can also change
-            // through a redeclaration or a mapped `arguments` object, so
-            // those are not here). A direct `eval` could assign by name.
+            // Only an assignment (or a direct `eval`) can change these; a `var` or parameter can also change through a redeclaration or a mapped `arguments` object.
             js_ast::symbol::Kind::Other
             | js_ast::symbol::Kind::Class
             | js_ast::symbol::Kind::HoistedFunction
@@ -3047,9 +3032,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if self.name_is_assigned_somewhere(name) {
                     return false;
                 }
-                // The name must resolve to this very symbol from here. A
-                // generated symbol (a lowering temp) is not in any `members`
-                // map, and generated code may assign to it.
+                // The name must resolve to this symbol from here; a generated temp is in no `members` map, and generated code may assign to it.
                 let hash = Scope::get_member_hash(name);
                 let mut scope = Some(self.current_scope_ref());
                 while let Some(s) = scope {
@@ -5668,8 +5651,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         None
     }
 
-    /// Parse pass: `target` is being assigned to. Records the name of every
-    /// identifier in it (see `assigned_identifier_names`).
+    /// Parse pass: `target` is assigned to; records the name of every identifier in it.
     pub(crate) fn record_parse_time_assignment_target(&mut self, target: &Expr) {
         if !self.stack_check.is_safe_to_recurse() {
             return;
@@ -5703,8 +5685,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Whether the parse pass saw `name` as an assignment target anywhere in
-    /// the file.
+    /// Whether the parse pass saw `name` as an assignment target anywhere in the file.
     pub(crate) fn name_is_assigned_somewhere(&self, name: &[u8]) -> bool {
         self.assigned_identifier_names
             .contains_key(&bun_wyhash::hash(name))
@@ -6062,8 +6043,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     return self.expr_can_be_removed_if_unused_without_dce_check(&ex.value);
                 }
-                // Numeric conversion of a known primitive other than a BigInt
-                // ("+1n" throws) never runs code and never throws.
+                // Numeric conversion of a non-BigInt primitive never runs code or throws ("+1n" throws).
                 js_ast::op::Code::UnNeg | js_ast::op::Code::UnPos | js_ast::op::Code::UnCpl => {
                     return self.options.features.minify_syntax
                         && ex.value.data.known_primitive().is_non_bigint_primitive()
@@ -6126,9 +6106,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         _ => {}
                     }
                 }
-                // Arithmetic on known primitives other than BigInt (mixing one
-                // with a number throws) never runs code and never throws:
-                // "Math.PI / 180" or "1 << 3".
+                // Arithmetic on non-BigInt primitives ("Math.PI / 180", "1 << 3") never runs code or throws.
                 js_ast::op::Code::BinAdd
                 | js_ast::op::Code::BinSub
                 | js_ast::op::Code::BinMul

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -309,8 +309,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) assigned_identifier_names: HashMap<u64, ()>,
     /// The parse pass saw a direct `eval` call somewhere in the file; it can assign any binding by name.
     pub(crate) parse_pass_saw_direct_eval: bool,
-    /// The statement list being minified is a switch case body, whose sibling cases are not visited yet.
-    pub(crate) mangling_switch_case: bool,
+    /// Visiting a switch case body or a list nested in one; the sibling cases are not visited yet.
+    pub(crate) in_switch_case: bool,
+    /// Start of the statement a single-use initializer is being substituted into.
+    pub(crate) substitution_target_loc: bun_ast::Loc,
 
     pub(crate) is_file_considered_to_have_esm_exports: bool,
 
@@ -2543,6 +2545,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         //   return (x == x) + replacement;
         //
         let replacement_can_be_removed = self.expr_can_be_removed_if_unused(&replacement);
+        self.substitution_target_loc = stmt.loc;
         match self.substitute_single_use_symbol_in_expr(
             *expr,
             r#ref,
@@ -3012,15 +3015,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // A side-effecting replacement can still move past a read that cannot throw, run code, or change.
         match expr.data {
             js_ast::ExprData::ESuper(_) => true,
-            js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id, expr.loc),
+            js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id),
             // A known global property access such as `console.log` or `Math.floor`.
             js_ast::ExprData::EDot(dot) => dot.can_be_removed_if_unused,
             _ => false,
         }
     }
 
-    /// A read of `id` at `use_loc` that cannot throw or run code, and yields the same value whatever code runs before it.
-    fn is_stable_identifier_read(&self, id: E::Identifier, use_loc: bun_ast::Loc) -> bool {
+    /// A read of `id` that cannot throw or run code, and yields the same value whatever code runs before it.
+    fn is_stable_identifier_read(&self, id: E::Identifier) -> bool {
         if id.must_keep_due_to_with_stmt() {
             return false;
         }
@@ -3045,10 +3048,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if !is_const && self.name_is_assigned_somewhere(name) {
                     return false;
                 }
-                // A `let`, `const` or `class` read in its TDZ throws. It is past it only when it is declared earlier in the same function, and not in another case of the switch being visited.
+                // A `let`, `const` or `class` read in its TDZ throws. It is past it only when declared by an earlier statement of the same function, and not in another case of the switch being visited.
                 let has_tdz = symbol.kind != js_ast::symbol::Kind::HoistedFunction
                     && symbol.kind != js_ast::symbol::Kind::GeneratorOrAsyncFunction;
-                if has_tdz && self.mangling_switch_case {
+                if has_tdz && self.in_switch_case {
                     return false;
                 }
                 // The name must resolve to this symbol from here; a generated temp is in no `members` map, and generated code may assign to it.
@@ -3060,7 +3063,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if !member.ref_.eql(id.ref_) {
                             return false;
                         }
-                        return !has_tdz || (!crossed_function && member.loc.start < use_loc.start);
+                        return !has_tdz
+                            || (!crossed_function
+                                && member.loc.start < self.substitution_target_loc.start);
                     }
                     crossed_function |= s.kind_stops_hoisting();
                     scope = s.parent;
@@ -9470,7 +9475,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_with_scope: false,
             assigned_identifier_names: Default::default(),
             parse_pass_saw_direct_eval: false,
-            mangling_switch_case: false,
+            in_switch_case: false,
+            substitution_target_loc: bun_ast::Loc::EMPTY,
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,
             symbol_uses,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -309,6 +309,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) assigned_identifier_names: HashMap<u64, ()>,
     /// The parse pass saw a direct `eval` call somewhere in the file; it can assign any binding by name.
     pub(crate) parse_pass_saw_direct_eval: bool,
+    /// The statement list being minified is a switch case body, whose sibling cases are not visited yet.
+    pub(crate) mangling_switch_case: bool,
 
     pub(crate) is_file_considered_to_have_esm_exports: bool,
 
@@ -3009,16 +3011,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // A side-effecting replacement can still move past a read that cannot throw, run code, or change.
         match expr.data {
-            js_ast::ExprData::EThis(_) | js_ast::ExprData::ESuper(_) => true,
-            js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id, replacement),
+            js_ast::ExprData::ESuper(_) => true,
+            js_ast::ExprData::EIdentifier(id) => self.is_stable_identifier_read(id, expr.loc),
             // A known global property access such as `console.log` or `Math.floor`.
             js_ast::ExprData::EDot(dot) => dot.can_be_removed_if_unused,
             _ => false,
         }
     }
 
-    /// A read of `id` that cannot throw or run code, and yields the same value whether it happens before or after `replacement`.
-    fn is_stable_identifier_read(&self, id: E::Identifier, replacement: &Expr) -> bool {
+    /// A read of `id` at `use_loc` that cannot throw or run code, and yields the same value whatever code runs before it.
+    fn is_stable_identifier_read(&self, id: E::Identifier, use_loc: bun_ast::Loc) -> bool {
         if id.must_keep_due_to_with_stmt() {
             return false;
         }
@@ -3043,9 +3045,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if !is_const && self.name_is_assigned_somewhere(name) {
                     return false;
                 }
-                // A `let`, `const` or `class` of an enclosing function can still be in its TDZ here and leave it while `replacement` suspends; a function declaration has no TDZ.
+                // A `let`, `const` or `class` read in its TDZ throws. It is past it only when it is declared earlier in the same function, and not in another case of the switch being visited.
                 let has_tdz = symbol.kind != js_ast::symbol::Kind::HoistedFunction
                     && symbol.kind != js_ast::symbol::Kind::GeneratorOrAsyncFunction;
+                if has_tdz && self.mangling_switch_case {
+                    return false;
+                }
                 // The name must resolve to this symbol from here; a generated temp is in no `members` map, and generated code may assign to it.
                 let hash = Scope::get_member_hash(name);
                 let mut crossed_function = false;
@@ -3055,9 +3060,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if !member.ref_.eql(id.ref_) {
                             return false;
                         }
-                        return !(has_tdz
-                            && crossed_function
-                            && Self::expr_may_suspend(replacement));
+                        return !has_tdz || (!crossed_function && member.loc.start < use_loc.start);
                     }
                     crossed_function |= s.kind_stops_hoisting();
                     scope = s.parent;
@@ -3065,74 +3068,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 false
             }
             _ => false,
-        }
-    }
-
-    /// Whether evaluating `expr` can suspend the current function (`await` or `yield` outside a nested function). Unknown shapes count as suspending.
-    fn expr_may_suspend(expr: &Expr) -> bool {
-        match expr.data {
-            js_ast::ExprData::EAwait(_) | js_ast::ExprData::EYield(_) => true,
-            js_ast::ExprData::EFunction(_)
-            | js_ast::ExprData::EArrow(_)
-            | js_ast::ExprData::EClass(_)
-            | js_ast::ExprData::EIdentifier(_)
-            | js_ast::ExprData::EImportIdentifier(_)
-            | js_ast::ExprData::ECommonjsExportIdentifier(_)
-            | js_ast::ExprData::EThis(_)
-            | js_ast::ExprData::ESuper(_)
-            | js_ast::ExprData::ENull(_)
-            | js_ast::ExprData::EUndefined(_)
-            | js_ast::ExprData::EBoolean(_)
-            | js_ast::ExprData::EBranchBoolean(_)
-            | js_ast::ExprData::ENumber(_)
-            | js_ast::ExprData::EBigInt(_)
-            | js_ast::ExprData::EString(_)
-            | js_ast::ExprData::ERegExp(_)
-            | js_ast::ExprData::EImportMeta(_)
-            | js_ast::ExprData::ERequireString(_)
-            | js_ast::ExprData::EMissing(_) => false,
-            js_ast::ExprData::EDot(dot) => Self::expr_may_suspend(&dot.target),
-            js_ast::ExprData::EIndex(index) => {
-                Self::expr_may_suspend(&index.target) || Self::expr_may_suspend(&index.index)
-            }
-            js_ast::ExprData::EUnary(un) => Self::expr_may_suspend(&un.value),
-            js_ast::ExprData::EBinary(bin) => {
-                Self::expr_may_suspend(&bin.left) || Self::expr_may_suspend(&bin.right)
-            }
-            js_ast::ExprData::EIf(ternary) => {
-                Self::expr_may_suspend(&ternary.test)
-                    || Self::expr_may_suspend(&ternary.yes)
-                    || Self::expr_may_suspend(&ternary.no)
-            }
-            js_ast::ExprData::ECall(call) => {
-                Self::expr_may_suspend(&call.target)
-                    || call.args.slice().iter().any(Self::expr_may_suspend)
-            }
-            js_ast::ExprData::ENew(new) => {
-                Self::expr_may_suspend(&new.target)
-                    || new.args.slice().iter().any(Self::expr_may_suspend)
-            }
-            js_ast::ExprData::EArray(array) => {
-                array.items.slice().iter().any(Self::expr_may_suspend)
-            }
-            js_ast::ExprData::EObject(object) => object.properties.slice().iter().any(|property| {
-                property.key.as_ref().is_some_and(Self::expr_may_suspend)
-                    || property.value.as_ref().is_some_and(Self::expr_may_suspend)
-                    || property
-                        .initializer
-                        .as_ref()
-                        .is_some_and(Self::expr_may_suspend)
-            }),
-            js_ast::ExprData::ETemplate(template) => {
-                template.tag.as_ref().is_some_and(Self::expr_may_suspend)
-                    || template
-                        .parts()
-                        .iter()
-                        .any(|part| Self::expr_may_suspend(&part.value))
-            }
-            js_ast::ExprData::ESpread(spread) => Self::expr_may_suspend(&spread.value),
-            js_ast::ExprData::EInlinedEnum(inlined) => Self::expr_may_suspend(&inlined.value),
-            _ => true,
         }
     }
 
@@ -9535,6 +9470,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_with_scope: false,
             assigned_identifier_names: Default::default(),
             parse_pass_saw_direct_eval: false,
+            mangling_switch_case: false,
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,
             symbol_uses,

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -509,6 +509,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
+        p.record_parse_time_assignment_target(&value);
         Ok(p.new_expr(
             E::Unary {
                 op: OpCode::UnPreDec,
@@ -523,6 +524,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
+        p.record_parse_time_assignment_target(&value);
         Ok(p.new_expr(
             E::Unary {
                 op: OpCode::UnPreInc,

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -619,6 +619,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // "in" expressions are allowed again
             p.allow_in = true;
 
+            // `for (x of y)` / `for (x in y)` assign to `x` on every iteration.
+            if (p.lexer.is_contextual_keyword(b"of") || is_for_await || p.lexer.token == T::TIn)
+                && let Some(init_stmt) = &init_
+                && let js_ast::StmtData::SExpr(s_expr) = init_stmt.data
+            {
+                p.record_parse_time_assignment_target(&s_expr.value);
+            }
+
             // Detect for-of loops
             if p.lexer.is_contextual_keyword(b"of") || is_for_await {
                 if let Some(r) = bad_let_range {

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -1606,8 +1606,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 Continuation::Done => break,
             }
 
-            // `left` is now the assignment (or update) expression the token
-            // started, with the target as its operand.
+            // `left` is now the assignment or update expression the token started, with the target as its operand.
             match token {
                 T::TEquals
                 | T::TPlusEquals

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -1502,7 +1502,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // Each of these tokens are split into a function to conserve
             // stack space.
-            let continuation = match p.lexer.token {
+            let token = p.lexer.token;
+            let continuation = match token {
                 T::TAmpersand => Self::sfx_t_ampersand(p, level, left),
                 T::TAmpersandAmpersandEquals => {
                     Self::sfx_t_ampersand_ampersand_equals(p, level, left)
@@ -1603,6 +1604,45 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match continuation? {
                 Continuation::Next => {}
                 Continuation::Done => break,
+            }
+
+            // `left` is now the assignment (or update) expression the token
+            // started, with the target as its operand.
+            match token {
+                T::TEquals
+                | T::TPlusEquals
+                | T::TMinusEquals
+                | T::TAsteriskEquals
+                | T::TAsteriskAsteriskEquals
+                | T::TSlashEquals
+                | T::TPercentEquals
+                | T::TLessThanLessThanEquals
+                | T::TGreaterThanGreaterThanEquals
+                | T::TGreaterThanGreaterThanGreaterThanEquals
+                | T::TAmpersandEquals
+                | T::TBarEquals
+                | T::TCaretEquals
+                | T::TAmpersandAmpersandEquals
+                | T::TBarBarEquals
+                | T::TQuestionQuestionEquals => {
+                    if let ExprData::EBinary(bin) = left.data {
+                        p.record_parse_time_assignment_target(&bin.left);
+                    }
+                }
+                T::TPlusPlus | T::TMinusMinus => {
+                    if let ExprData::EUnary(un) = left.data {
+                        p.record_parse_time_assignment_target(&un.value);
+                    }
+                }
+                T::TOpenParen => {
+                    if let ExprData::ECall(call) = left.data
+                        && let ExprData::EIdentifier(id) = call.target.data
+                        && p.load_name_from_ref(id.ref_) == b"eval"
+                    {
+                        p.parse_pass_saw_direct_eval = true;
+                    }
+                }
+                _ => {}
             }
         }
 

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -1634,7 +1634,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
                 T::TOpenParen => {
-                    if let ExprData::ECall(call) = left.data
+                    if p.options.bundle
+                        && let ExprData::ECall(call) = left.data
                         && let ExprData::EIdentifier(id) = call.target.data
                         && p.load_name_from_ref(id.ref_) == b"eval"
                     {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -662,6 +662,20 @@ pub(crate) enum Substitution {
     Continue,
 }
 
+/// Outcome of `substitute_single_use_symbol_in_stmt`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StmtSubstitution {
+    /// The single use was replaced with the initializer.
+    Substituted,
+    /// The statement does not use the symbol, and the initializer could be
+    /// moved past everything in it. Appending more code to the statement can
+    /// still make a substitution possible.
+    NotFound,
+    /// Something in the statement stops the initializer from moving past it.
+    /// Appending more code to the statement cannot change that.
+    Blocked,
+}
+
 /// If we are currently in a hoisted child of the module scope, relocate these
 /// declarations to the top level and return an equivalent assignment statement.
 /// Make sure to check that the declaration kind is "var" before calling this.

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -667,12 +667,9 @@ pub(crate) enum Substitution {
 pub(crate) enum StmtSubstitution {
     /// The single use was replaced with the initializer.
     Substituted,
-    /// The statement does not use the symbol, and the initializer could be
-    /// moved past everything in it. Appending more code to the statement can
-    /// still make a substitution possible.
+    /// The statement has no use of the symbol, and the initializer can move past all of it, so a longer statement may still take it.
     NotFound,
-    /// Something in the statement stops the initializer from moving past it.
-    /// Appending more code to the statement cannot change that.
+    /// Something in the statement stops the initializer; appending to the statement cannot change that.
     Blocked,
 }
 

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -216,11 +216,29 @@ impl SideEffects {
 
                         return Self::simplify_unused_expr(p, un.value);
                     }
+                    // Numeric conversion of a known primitive other than a BigInt
+                    // ("+1n" throws) never runs code and never throws.
+                    Op::Code::UnNeg | Op::Code::UnPos | Op::Code::UnCpl => {
+                        if p.options.features.minify_syntax
+                            && un.value.data.known_primitive().is_non_bigint_primitive()
+                        {
+                            return Self::simplify_unused_expr(p, un.value);
+                        }
+                    }
                     _ => {}
                 }
             }
 
             ExprData::ECall(call) => {
+                // The call itself is pure only while every argument is a known
+                // primitive, so it is all or nothing: either the whole call goes
+                // or the whole call stays.
+                if call.can_be_unwrapped_if_unused == CallUnwrap::IfUnusedAndPrimitiveArgs {
+                    if Self::args_are_removable_primitives(p, &call.args) {
+                        return None;
+                    }
+                    return Some(expr);
+                }
                 // A call that has been marked "__PURE__" can be removed if all arguments
                 // can be removed. The annotation causes us to ignore the target.
                 if call.can_be_unwrapped_if_unused != CallUnwrap::Never {
@@ -336,6 +354,38 @@ impl SideEffects {
 
                         if bin.right.is_empty() {
                             return Self::simplify_unused_expr(p, bin.left);
+                        }
+                    }
+
+                    // Arithmetic on known primitives other than BigInt (mixing one
+                    // with a number throws) never runs code and never throws.
+                    Op::Code::BinAdd
+                    | Op::Code::BinSub
+                    | Op::Code::BinMul
+                    | Op::Code::BinDiv
+                    | Op::Code::BinRem
+                    | Op::Code::BinPow
+                    | Op::Code::BinShl
+                    | Op::Code::BinShr
+                    | Op::Code::BinUShr
+                    | Op::Code::BinBitwiseAnd
+                    | Op::Code::BinBitwiseOr
+                    | Op::Code::BinBitwiseXor => {
+                        if p.options.features.minify_syntax
+                            && bin.left.data.known_primitive().is_non_bigint_primitive()
+                            && bin.right.data.known_primitive().is_non_bigint_primitive()
+                        {
+                            let left = bin.left;
+                            let right = bin.right;
+                            let left_simplified = Self::simplify_unused_expr(p, left);
+                            let right_simplified = Self::simplify_unused_expr(p, right);
+                            if left_simplified.is_none() && right_simplified.is_none() {
+                                return None;
+                            }
+                            return Some(Expr::join_with_comma(
+                                left_simplified.unwrap_or_else(|| left.to_empty()),
+                                right_simplified.unwrap_or_else(|| right.to_empty()),
+                            ));
                         }
                     }
 
@@ -465,6 +515,18 @@ impl SideEffects {
     /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.
     /// Hand-rolled because that helper takes `fn(&C, _)` and we need `&mut P` for the
     /// recursive `simplify_unused_expr` call.
+    /// Every argument is a side-effect free primitive other than a BigInt, so a
+    /// call in `GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS` can go.
+    pub(crate) fn args_are_removable_primitives<'a, const TS: bool, const SCAN: bool>(
+        p: &mut P<'a, TS, SCAN>,
+        args: &[Expr],
+    ) -> bool {
+        args.iter().all(|arg| {
+            arg.data.known_primitive().is_non_bigint_primitive()
+                && p.expr_can_be_removed_if_unused(arg)
+        })
+    }
+
     fn join_all_simplified<'a, const TS: bool, const SCAN: bool>(
         p: &mut P<'a, TS, SCAN>,
         items: &[Expr],

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -218,9 +218,7 @@ impl SideEffects {
                     }
                     // Numeric conversion of a non-BigInt primitive never runs code or throws ("+1n" throws).
                     Op::Code::UnNeg | Op::Code::UnPos | Op::Code::UnCpl => {
-                        if p.options.features.minify_syntax
-                            && un.value.data.known_primitive().is_non_bigint_primitive()
-                        {
+                        if p.bundler_minify_syntax() && p.is_known_non_bigint_primitive(&un.value) {
                             return Self::simplify_unused_expr(p, un.value);
                         }
                     }
@@ -231,7 +229,7 @@ impl SideEffects {
             ExprData::ECall(call) => {
                 // Pure only with known-primitive arguments, so the whole call goes or the whole call stays.
                 if call.can_be_unwrapped_if_unused == CallUnwrap::IfUnusedAndPrimitiveArgs {
-                    if Self::args_are_removable_primitives(p, &call.args) {
+                    if p.pure_global_call_can_be_removed(&call.args) {
                         return None;
                     }
                     return Some(expr);
@@ -367,9 +365,9 @@ impl SideEffects {
                     | Op::Code::BinBitwiseAnd
                     | Op::Code::BinBitwiseOr
                     | Op::Code::BinBitwiseXor => {
-                        if p.options.features.minify_syntax
-                            && bin.left.data.known_primitive().is_non_bigint_primitive()
-                            && bin.right.data.known_primitive().is_non_bigint_primitive()
+                        if p.bundler_minify_syntax()
+                            && p.is_known_non_bigint_primitive(&bin.left)
+                            && p.is_known_non_bigint_primitive(&bin.right)
                         {
                             let left = bin.left;
                             let right = bin.right;
@@ -506,17 +504,6 @@ impl SideEffects {
         }
 
         Some(expr)
-    }
-
-    /// Every argument is a side-effect free non-BigInt primitive, so a `GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS` call can go.
-    pub(crate) fn args_are_removable_primitives<'a, const TS: bool, const SCAN: bool>(
-        p: &mut P<'a, TS, SCAN>,
-        args: &[Expr],
-    ) -> bool {
-        args.iter().all(|arg| {
-            arg.data.known_primitive().is_non_bigint_primitive()
-                && p.expr_can_be_removed_if_unused(arg)
-        })
     }
 
     /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -508,9 +508,6 @@ impl SideEffects {
         Some(expr)
     }
 
-    /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.
-    /// Hand-rolled because that helper takes `fn(&C, _)` and we need `&mut P` for the
-    /// recursive `simplify_unused_expr` call.
     /// Every argument is a side-effect free non-BigInt primitive, so a `GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS` call can go.
     pub(crate) fn args_are_removable_primitives<'a, const TS: bool, const SCAN: bool>(
         p: &mut P<'a, TS, SCAN>,
@@ -522,6 +519,9 @@ impl SideEffects {
         })
     }
 
+    /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.
+    /// Hand-rolled because that helper takes `fn(&C, _)` and we need `&mut P` for the
+    /// recursive `simplify_unused_expr` call.
     fn join_all_simplified<'a, const TS: bool, const SCAN: bool>(
         p: &mut P<'a, TS, SCAN>,
         items: &[Expr],

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -216,8 +216,7 @@ impl SideEffects {
 
                         return Self::simplify_unused_expr(p, un.value);
                     }
-                    // Numeric conversion of a known primitive other than a BigInt
-                    // ("+1n" throws) never runs code and never throws.
+                    // Numeric conversion of a non-BigInt primitive never runs code or throws ("+1n" throws).
                     Op::Code::UnNeg | Op::Code::UnPos | Op::Code::UnCpl => {
                         if p.options.features.minify_syntax
                             && un.value.data.known_primitive().is_non_bigint_primitive()
@@ -230,9 +229,7 @@ impl SideEffects {
             }
 
             ExprData::ECall(call) => {
-                // The call itself is pure only while every argument is a known
-                // primitive, so it is all or nothing: either the whole call goes
-                // or the whole call stays.
+                // Pure only with known-primitive arguments, so the whole call goes or the whole call stays.
                 if call.can_be_unwrapped_if_unused == CallUnwrap::IfUnusedAndPrimitiveArgs {
                     if Self::args_are_removable_primitives(p, &call.args) {
                         return None;
@@ -357,8 +354,7 @@ impl SideEffects {
                         }
                     }
 
-                    // Arithmetic on known primitives other than BigInt (mixing one
-                    // with a number throws) never runs code and never throws.
+                    // Arithmetic on non-BigInt primitives never runs code or throws (a BigInt mixed with a number throws).
                     Op::Code::BinAdd
                     | Op::Code::BinSub
                     | Op::Code::BinMul
@@ -515,8 +511,7 @@ impl SideEffects {
     /// Inline equivalent of `Expr::join_all_with_comma_callback(slice, p, simplify_unused_expr, _)`.
     /// Hand-rolled because that helper takes `fn(&C, _)` and we need `&mut P` for the
     /// recursive `simplify_unused_expr` call.
-    /// Every argument is a side-effect free primitive other than a BigInt, so a
-    /// call in `GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS` can go.
+    /// Every argument is a side-effect free non-BigInt primitive, so a `GLOBAL_NO_SIDE_EFFECT_FUNCTION_CALLS_WITH_PRIMITIVE_ARGS` call can go.
     pub(crate) fn args_are_removable_primitives<'a, const TS: bool, const SCAN: bool>(
         p: &mut P<'a, TS, SCAN>,
         args: &[Expr],

--- a/src/js_parser/visit/mangle_stmts.rs
+++ b/src/js_parser/visit/mangle_stmts.rs
@@ -21,6 +21,8 @@ pub(crate) struct StmtListMangler {
     can_inline_locals: bool,
     /// Bundler only: declarations in this list that nothing uses may be dropped.
     can_drop_unused_locals: bool,
+    /// Bundler only: after a merge, look for an inlining target in the merged statement again.
+    can_retry_inline: bool,
     /// Bundler only: the outermost list of a function body, where every use of a `var` declared in it has been visited.
     can_touch_vars: bool,
     /// `output.len()` when the last declaration in `output` could not move into the statement after it; appending to that statement cannot change the outcome.
@@ -43,11 +45,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // The runtime transpiler keeps the old one-statement-at-a-time behavior so its output stays close to the source.
         let bundle = self.options.bundle;
         // A `let` declared in one `case` can be used by a later case, which is not visited yet.
-        let can_drop_unused_locals = can_inline_locals && bundle && kind != StmtsKind::SwitchStmt;
+        let counts_are_final = kind != StmtsKind::SwitchStmt;
         StmtListMangler {
             is_control_flow_dead: false,
             can_inline_locals,
-            can_drop_unused_locals,
+            can_drop_unused_locals: can_inline_locals && bundle && counts_are_final,
+            can_retry_inline: can_inline_locals && bundle && counts_are_final,
             can_touch_vars: can_inline_locals
                 && bundle
                 && kind == StmtsKind::FnBody
@@ -119,8 +122,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             .saturating_add(1);
             // `stmt` absorbed the statement before it, so a declaration two statements back is now right in front of it: `let x = 1; a(); return x` => `let x = 1; return a(), x` => `return a(), 1`.
-            try_inline = m.can_inline_locals
-                && self.options.bundle
+            try_inline = m.can_retry_inline
                 && m.blocked_tail_len != output.len()
                 && merge_count <= MAX_MERGES_TO_SEARCH;
         }

--- a/src/js_parser/visit/mangle_stmts.rs
+++ b/src/js_parser/visit/mangle_stmts.rs
@@ -42,10 +42,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // The runtime transpiler keeps the old one-statement-at-a-time behavior so its output stays close to the source.
         let bundle = self.options.bundle;
+        // A `let` declared in one `case` can be used by a later case, which is not visited yet.
+        let can_drop_unused_locals = can_inline_locals && bundle && kind != StmtsKind::SwitchStmt;
         StmtListMangler {
             is_control_flow_dead: false,
             can_inline_locals,
-            can_drop_unused_locals: can_inline_locals && bundle,
+            can_drop_unused_locals,
             can_touch_vars: can_inline_locals
                 && bundle
                 && kind == StmtsKind::FnBody
@@ -96,12 +98,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             _ => {}
         }
 
-        // don't merge super calls to ensure they are called before "this" is accessed
-        if stmt.is_super_call() {
-            output.push(stmt);
-            return;
-        }
-
         let mut try_inline = m.can_inline_locals;
         let mut merge_count: u32 = 0;
         loop {
@@ -112,7 +108,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return;
                 }
             }
-            if !self.merge_stmt_with_tail(output, &mut stmt) {
+            // don't merge super calls to ensure they are called before "this" is accessed
+            if stmt.is_super_call() || !self.merge_stmt_with_tail(output, &mut stmt) {
                 break;
             }
             merge_count = if merge_count == 0 {

--- a/src/js_parser/visit/mangle_stmts.rs
+++ b/src/js_parser/visit/mangle_stmts.rs
@@ -1,12 +1,5 @@
 #![warn(unused_must_use)]
-//! The statement-list minifier that runs at the end of `visit_stmts`, once
-//! every statement in the list has been visited. It inlines single-use
-//! declarations into the statement after them, drops declarations that
-//! nothing uses, and merges adjacent statements into one.
-//!
-//! Each edit to the end of the output list is followed by another look at the
-//! new end, so a statement that becomes mergeable only because of an earlier
-//! edit is still merged in this one pass.
+//! The minifier that runs over a statement list once every statement in it has been visited: single-use inlining, unused-declaration removal and statement merging, with another look at the list tail after every edit.
 
 use crate::p::P;
 use crate::parser::{StmtSubstitution, StmtsKind};
@@ -28,36 +21,26 @@ pub(crate) struct StmtListMangler {
     can_inline_locals: bool,
     /// Bundler only: declarations in this list that nothing uses may be dropped.
     can_drop_unused_locals: bool,
-    /// Bundler only: this is the outermost list of a function body, so every
-    /// use of a `var` declared in it has been visited.
+    /// Bundler only: the outermost list of a function body, where every use of a `var` declared in it has been visited.
     can_touch_vars: bool,
-    /// `output.len()` at the time the last declaration in `output` could not
-    /// be moved into the statement after it. Appending to that statement cannot
-    /// change the outcome, so the attempt is not repeated after a merge.
+    /// `output.len()` when the last declaration in `output` could not move into the statement after it; appending to that statement cannot change the outcome.
     blocked_tail_len: usize,
     /// How many statements were merged into the last statement of `output`.
     tail_merge_count: u32,
 }
 
-/// A merged statement is a left-deep comma chain, and every walk over it
-/// recurses once per statement in it. Past this many merges the chain is no
-/// longer searched for a place to inline the declaration before it.
+/// A merged statement is a left-deep comma chain that every walk recurses through; past this many merges it is no longer searched for an inlining target.
 const MAX_MERGES_TO_SEARCH: u32 = 32;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub(crate) fn stmt_list_mangler(&self, kind: StmtsKind) -> StmtListMangler {
         let scope = self.current_scope();
 
-        // Top-level declarations are left alone: something might do "export {id};"
-        // later on, and the bundler owns them. Declarations in a scope with a
-        // direct "eval" are left alone too: the eval'd code may reference them,
-        // so the use counts say nothing.
+        // Top-level declarations may still be exported ("export {id};"), and eval'd code may reference anything in scope.
         let can_inline_locals =
             self.current_scope != self.module_scope && !scope.contains_direct_eval;
 
-        // The runtime transpiler keeps the one-statement-at-a-time behavior
-        // below: it does not run the renamer, and its output should stay close
-        // to the source.
+        // The runtime transpiler keeps the old one-statement-at-a-time behavior so its output stays close to the source.
         let bundle = self.options.bundle;
         StmtListMangler {
             is_control_flow_dead: false,
@@ -124,8 +107,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loop {
             if try_inline {
                 self.inline_tail_decls_into(m, output, &mut stmt);
-                // An initializer that was inlined into an expression statement kept
-                // for its side effects may have made it side-effect free.
+                // Inlining into a statement kept for its side effects may have left it side-effect free.
                 if let StmtData::SEmpty(_) = stmt.data {
                     return;
                 }
@@ -139,11 +121,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 merge_count
             }
             .saturating_add(1);
-            // `stmt` absorbed the statement before it, so a declaration that
-            // was two statements back now sits right in front of it:
-            //
-            //   let x = 1; a(); return x;  =>  let x = 1; return a(), x;  =>  return a(), 1;
-            //
+            // `stmt` absorbed the statement before it, so a declaration two statements back is now right in front of it: `let x = 1; a(); return x` => `let x = 1; return a(), x` => `return a(), 1`.
             try_inline = m.can_inline_locals
                 && self.options.bundle
                 && m.blocked_tail_len != output.len()
@@ -164,34 +142,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         m.tail_merge_count = merge_count;
     }
 
-    /// Every use of a symbol resolves to the symbol the binding names, so its
-    /// use count is the whole truth about it.
+    /// Every use of the name resolves to this symbol, so its use count is complete.
     fn use_count_is_exact(symbol: &Symbol) -> bool {
         !symbol.has_link() && !symbol.is_link_target() && !symbol.must_not_be_renamed()
     }
 
-    /// Inline single-use variable declarations where possible:
-    ///
-    ///   // Before
-    ///   let x = fn();
-    ///   return x.y();
-    ///
-    ///   // After
-    ///   return fn().y();
-    ///
-    /// Keep inlining variables until a failure or until there are none left.
-    /// That handles cases like this:
-    ///
-    ///   // Before
-    ///   let x = fn();
-    ///   let y = x.prop;
-    ///   return y;
-    ///
-    ///   // After
-    ///   return fn().prop;
-    ///
-    /// A declaration at the end of `output` that nothing uses anymore (its
-    /// last use was in an initializer that was dropped) goes the same way.
+    /// Inlines single-use declarations at the end of `output` into `stmt` (`let x = fn(); return x.y()` => `return fn().y()`) until one stays, and drops declarations there that nothing uses anymore.
     fn inline_tail_decls_into(
         &mut self,
         m: &mut StmtListMangler,
@@ -203,16 +159,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 break;
             };
 
-            // Ignore "var" declarations since those have function-level scope and
-            // we may not have visited all of their uses yet by this point. We
-            // should have visited all the uses of "let" and "const" declarations
-            // by now since they are scoped to this block which we just finished
-            // visiting. The exception is the outermost list of a function body,
-            // where every use of a "var" has been visited as well.
-            //
-            // "using" / "await using" declarations have disposal side-effects on
-            // scope exit, so they must not be removed by inlining their
-            // initializer into the use.
+            // A `var` has function scope, so its uses are all visited only at the function body's own list; a `using` declaration has disposal side effects on scope exit.
             if local.decls.is_empty()
                 || local.kind.is_using()
                 || local.is_export
@@ -223,10 +170,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             let last: G::Decl = *local.decls.slice().last().unwrap();
 
-            // The binding must be an identifier. Ignore destructuring bindings
-            // since that's not the simple case. Destructuring bindings could
-            // potentially execute side-effecting code which would invalidate
-            // reordering.
+            // Destructuring can run code (getters, iterators), which would invalidate the reordering.
             let BData::BIdentifier(ident) = last.binding.data else {
                 break;
             };
@@ -252,8 +196,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
 
-            // The variable must be initialized, since we will be substituting
-            // the value into the usage.
+            // The value is what gets substituted into the use.
             let Some(replacement) = last.value else {
                 break;
             };
@@ -261,14 +204,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 break;
             }
 
-            // Try to substitute the identifier with the initializer. This will
-            // fail if something with side effects is in between the declaration
-            // and the usage.
+            // Fails when something with side effects sits between the declaration and the use.
             match self.substitute_single_use_symbol_in_stmt(*stmt, id, replacement) {
                 StmtSubstitution::Substituted => {
-                    // `const ns = await import(x); return ns` — the single use just
-                    // moved into `replacement`; unless it was an accounted-for read
-                    // (`f(ns.a)`), the namespace escapes there.
+                    // `const ns = await import(x); return ns`: the single use moved into `replacement`, and unless it was a tracked read (`f(ns.a)`) the namespace escapes there.
                     if self.dynamic_import_namespace_locals.contains_key(&id)
                         && self.namespace_tracked_uses.get(&id).copied().unwrap_or(0) == 0
                     {
@@ -278,9 +217,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     Self::pop_last_decl(output, &mut local);
                     m.blocked_tail_len = usize::MAX;
 
-                    // `const D = Math.PI / 180; D * 2;` (the statement is what was
-                    // left of an unused declaration): with `D` inlined, nothing in
-                    // the statement has a side effect anymore.
+                    // `const D = Math.PI / 180; D * 2;` (what an unused declaration left behind): with `D` inlined the statement has no side effect anymore.
                     if m.can_drop_unused_locals
                         && let StmtData::SExpr(mut s_expr) = stmt.data
                     {
@@ -305,8 +242,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Removes the last declaration of `local`, the statement at the end of
-    /// `output`, and the statement itself when that was its only declaration.
+    /// Removes the last declaration of `local` (the statement at the end of `output`), and the statement itself when that was its only one.
     fn pop_last_decl(output: &mut ListManaged<'a, Stmt>, local: &mut js_ast::StoreRef<S::Local>) {
         let n = local.decls.len() - 1;
         local.decls.truncate(n);
@@ -315,11 +251,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Merges `stmt` with the statement at the end of `output`. On success the
-    /// merged statement is in `stmt` and the old end of `output` is gone.
-    ///
-    /// The calls to `join_with_comma` are only enabled during bundling. We do
-    /// this to avoid changing line numbers too much for source maps.
+    /// Merges `stmt` with the statement at the end of `output`; on success `stmt` holds the merged statement and the old end is popped. Comma joins are bundler only, to keep line numbers close to the source.
     fn merge_stmt_with_tail(
         &mut self,
         output: &mut ListManaged<'a, Stmt>,
@@ -353,19 +285,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         && s_expr.does_not_affect_tree_shaking;
                     prev_expr.value = Expr::join_with_comma(prev_expr.value, s_expr.value);
                 }
-                // Input:
-                //      var f;
-                //      f = 123;
-                // Output:
-                //      var f = 123;
-                //
-                // This doesn't handle every case. Only the very simple one.
+                // `var f; f = 123;` => `var f = 123;` (only this simple case)
                 StmtData::SLocal(mut prev_local) => {
                     let ExprData::EBinary(bin_assign) = s_expr.value.data else {
                         return false;
                     };
-                    // we can only do this with var because var is hoisted
-                    // the statement we are merging into may use the statement before its defined.
+                    // Only `var` is hoisted, so only it may be used before the declaration it merges into.
                     if prev_local.decls.len() != 1
                         || bin_assign.op != OpCode::BinAssign
                         || prev_local.kind != LocalKind::KVar
@@ -379,9 +304,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let BData::BIdentifier(bid_ptr) = decl.binding.data else {
                         return false;
                     };
-                    // If the value was assigned, we shouldn't merge it incase it was used in the current statement
-                    // https://github.com/oven-sh/bun/issues/2948
-                    // We don't have a more granular way to check symbol usage so this is the best we can do
+                    // An initialized declaration may already be read by the assignment's right side (https://github.com/oven-sh/bun/issues/2948).
                     if !bid_ptr.r#ref.eql(left_id.ref_) || decl.value.is_some() {
                         return false;
                     }
@@ -455,19 +378,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         true
     }
 
-    /// Bundler only. Drops the declarations in `local` (the `S::Local` of
-    /// `stmt`) whose binding nothing uses. An initializer with side effects
-    /// stays behind as an expression statement, in its original position.
-    /// Returns `None` when every declaration stays.
+    /// Bundler only: drops the declarations of `stmt` (an `S::Local`) that nothing uses, keeping a side-effecting initializer as an expression statement in place. `None` when every declaration stays.
     fn drop_unused_decls(
         &mut self,
         stmt: Stmt,
         mut local: js_ast::StoreRef<S::Local>,
         can_touch_vars: bool,
     ) -> Option<ListManaged<'a, Stmt>> {
-        // The declaration must not be exported. We can't just check for the
-        // "export" keyword because something might do "export {id};" later on,
-        // so the caller already ruled out the top-level scope.
+        // The caller already ruled out the top-level scope, where "export {id};" can still follow.
         if local.is_export
             || local.origin.is_commonjs_export()
             || local.kind.is_using()
@@ -548,18 +466,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         symbol.use_count_estimate == 0 && Self::use_count_is_exact(symbol)
     }
 
-    /// `expr` is removed without being evaluated: take back the uses it
-    /// recorded, so that a binding it held the last use of can go as well.
-    /// Function and class bodies are not entered; their uses stay counted,
-    /// which at worst keeps a binding that could have gone.
+    /// `expr` is removed without being evaluated: take back the uses it recorded so a binding it held the last use of can go too. Function and class bodies are not entered, which at worst keeps a binding.
     fn ignore_usages_in_removed_expr(&mut self, expr: &Expr) {
         if !self.stack_check.is_safe_to_recurse() {
             return;
         }
         match expr.data {
             ExprData::EIdentifier(id) => {
-                // The escape analysis of a dynamic import namespace compares its
-                // use count with the uses it tracked. Leave those alone.
+                // The escape analysis of a dynamic import namespace compares its use count with its tracked uses.
                 if !self.dynamic_import_namespace_locals.contains_key(&id.ref_) {
                     self.ignore_usage(id.ref_);
                 }

--- a/src/js_parser/visit/mangle_stmts.rs
+++ b/src/js_parser/visit/mangle_stmts.rs
@@ -1,0 +1,624 @@
+#![warn(unused_must_use)]
+//! The statement-list minifier that runs at the end of `visit_stmts`, once
+//! every statement in the list has been visited. It inlines single-use
+//! declarations into the statement after them, drops declarations that
+//! nothing uses, and merges adjacent statements into one.
+//!
+//! Each edit to the end of the output list is followed by another look at the
+//! new end, so a statement that becomes mergeable only because of an earlier
+//! edit is still merged in this one pass.
+
+use crate::p::P;
+use crate::parser::{StmtSubstitution, StmtsKind};
+use crate::scan::scan_side_effects::SideEffects;
+use bun_alloc::ArenaVec as BumpVec;
+use bun_ast as js_ast;
+use bun_ast::b::B as BData;
+use bun_ast::s::Kind as LocalKind;
+use bun_ast::{Expr, ExprData, G, OpCode, S, Stmt, StmtData, Symbol};
+use bun_collections::VecExt;
+
+type ListManaged<'bump, T> = BumpVec<'bump, T>;
+
+/// State for the statement list being finalized.
+pub(crate) struct StmtListMangler {
+    /// A `return`, `throw`, `break` or `continue` was emitted: what follows is dead.
+    is_control_flow_dead: bool,
+    /// Declarations in this list may be inlined into the statement after them.
+    can_inline_locals: bool,
+    /// Bundler only: declarations in this list that nothing uses may be dropped.
+    can_drop_unused_locals: bool,
+    /// Bundler only: this is the outermost list of a function body, so every
+    /// use of a `var` declared in it has been visited.
+    can_touch_vars: bool,
+    /// `output.len()` at the time the last declaration in `output` could not
+    /// be moved into the statement after it. Appending to that statement cannot
+    /// change the outcome, so the attempt is not repeated after a merge.
+    blocked_tail_len: usize,
+    /// How many statements were merged into the last statement of `output`.
+    tail_merge_count: u32,
+}
+
+/// A merged statement is a left-deep comma chain, and every walk over it
+/// recurses once per statement in it. Past this many merges the chain is no
+/// longer searched for a place to inline the declaration before it.
+const MAX_MERGES_TO_SEARCH: u32 = 32;
+
+impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+    pub(crate) fn stmt_list_mangler(&self, kind: StmtsKind) -> StmtListMangler {
+        let scope = self.current_scope();
+
+        // Top-level declarations are left alone: something might do "export {id};"
+        // later on, and the bundler owns them. Declarations in a scope with a
+        // direct "eval" are left alone too: the eval'd code may reference them,
+        // so the use counts say nothing.
+        let can_inline_locals =
+            self.current_scope != self.module_scope && !scope.contains_direct_eval;
+
+        // The runtime transpiler keeps the one-statement-at-a-time behavior
+        // below: it does not run the renamer, and its output should stay close
+        // to the source.
+        let bundle = self.options.bundle;
+        StmtListMangler {
+            is_control_flow_dead: false,
+            can_inline_locals,
+            can_drop_unused_locals: can_inline_locals && bundle,
+            can_touch_vars: can_inline_locals
+                && bundle
+                && kind == StmtsKind::FnBody
+                && scope.kind_stops_hoisting(),
+            blocked_tail_len: usize::MAX,
+            tail_merge_count: 0,
+        }
+    }
+
+    /// Appends `stmt` to `output`, minified against what is already there.
+    pub(crate) fn mangle_stmt_into_list(
+        &mut self,
+        m: &mut StmtListMangler,
+        output: &mut ListManaged<'a, Stmt>,
+        stmt: Stmt,
+    ) {
+        if m.is_control_flow_dead
+            && self.options.features.dead_code_elimination
+            && !SideEffects::should_keep_stmt_in_dead_control_flow(stmt, self.arena)
+        {
+            // Strip unnecessary statements if the control flow is dead here
+            return;
+        }
+
+        if m.can_drop_unused_locals
+            && let StmtData::SLocal(local) = stmt.data
+            && let Some(rest) = self.drop_unused_decls(stmt, local, m.can_touch_vars)
+        {
+            for stmt in rest {
+                self.merge_stmt_into_list(m, output, stmt);
+            }
+            return;
+        }
+
+        self.merge_stmt_into_list(m, output, stmt);
+    }
+
+    fn merge_stmt_into_list(
+        &mut self,
+        m: &mut StmtListMangler,
+        output: &mut ListManaged<'a, Stmt>,
+        mut stmt: Stmt,
+    ) {
+        match stmt.data {
+            StmtData::SEmpty(_) => return,
+            // skip directives for now
+            StmtData::SDirective(_) => return,
+            _ => {}
+        }
+
+        // don't merge super calls to ensure they are called before "this" is accessed
+        if stmt.is_super_call() {
+            output.push(stmt);
+            return;
+        }
+
+        let mut try_inline = m.can_inline_locals;
+        let mut merge_count: u32 = 0;
+        loop {
+            if try_inline {
+                self.inline_tail_decls_into(m, output, &mut stmt);
+                // An initializer that was inlined into an expression statement kept
+                // for its side effects may have made it side-effect free.
+                if let StmtData::SEmpty(_) = stmt.data {
+                    return;
+                }
+            }
+            if !self.merge_stmt_with_tail(output, &mut stmt) {
+                break;
+            }
+            merge_count = if merge_count == 0 {
+                m.tail_merge_count
+            } else {
+                merge_count
+            }
+            .saturating_add(1);
+            // `stmt` absorbed the statement before it, so a declaration that
+            // was two statements back now sits right in front of it:
+            //
+            //   let x = 1; a(); return x;  =>  let x = 1; return a(), x;  =>  return a(), 1;
+            //
+            try_inline = m.can_inline_locals
+                && self.options.bundle
+                && m.blocked_tail_len != output.len()
+                && merge_count <= MAX_MERGES_TO_SEARCH;
+        }
+
+        match stmt.data {
+            StmtData::SReturn(_)
+            | StmtData::SThrow(_)
+            | StmtData::SBreak(_)
+            | StmtData::SContinue(_) => {
+                m.is_control_flow_dead = true;
+            }
+            _ => {}
+        }
+
+        output.push(stmt);
+        m.tail_merge_count = merge_count;
+    }
+
+    /// Every use of a symbol resolves to the symbol the binding names, so its
+    /// use count is the whole truth about it.
+    fn use_count_is_exact(symbol: &Symbol) -> bool {
+        !symbol.has_link() && !symbol.is_link_target() && !symbol.must_not_be_renamed()
+    }
+
+    /// Inline single-use variable declarations where possible:
+    ///
+    ///   // Before
+    ///   let x = fn();
+    ///   return x.y();
+    ///
+    ///   // After
+    ///   return fn().y();
+    ///
+    /// Keep inlining variables until a failure or until there are none left.
+    /// That handles cases like this:
+    ///
+    ///   // Before
+    ///   let x = fn();
+    ///   let y = x.prop;
+    ///   return y;
+    ///
+    ///   // After
+    ///   return fn().prop;
+    ///
+    /// A declaration at the end of `output` that nothing uses anymore (its
+    /// last use was in an initializer that was dropped) goes the same way.
+    fn inline_tail_decls_into(
+        &mut self,
+        m: &mut StmtListMangler,
+        output: &mut ListManaged<'a, Stmt>,
+        stmt: &mut Stmt,
+    ) {
+        while let Some(&prev) = output.last() {
+            let StmtData::SLocal(mut local) = prev.data else {
+                break;
+            };
+
+            // Ignore "var" declarations since those have function-level scope and
+            // we may not have visited all of their uses yet by this point. We
+            // should have visited all the uses of "let" and "const" declarations
+            // by now since they are scoped to this block which we just finished
+            // visiting. The exception is the outermost list of a function body,
+            // where every use of a "var" has been visited as well.
+            //
+            // "using" / "await using" declarations have disposal side-effects on
+            // scope exit, so they must not be removed by inlining their
+            // initializer into the use.
+            if local.decls.is_empty()
+                || local.kind.is_using()
+                || local.is_export
+                || (local.kind == LocalKind::KVar && !m.can_touch_vars)
+            {
+                break;
+            }
+
+            let last: G::Decl = *local.decls.slice().last().unwrap();
+
+            // The binding must be an identifier. Ignore destructuring bindings
+            // since that's not the simple case. Destructuring bindings could
+            // potentially execute side-effecting code which would invalidate
+            // reordering.
+            let BData::BIdentifier(ident) = last.binding.data else {
+                break;
+            };
+            let id = ident.r#ref;
+
+            let symbol = &self.symbols[id.inner_index() as usize];
+            if !Self::use_count_is_exact(symbol) {
+                break;
+            }
+            let use_count = symbol.use_count_estimate;
+
+            if use_count == 0 {
+                if !m.can_drop_unused_locals {
+                    break;
+                }
+                if let Some(value) = last.value {
+                    if !self.expr_can_be_removed_if_unused(&value) {
+                        break;
+                    }
+                    self.ignore_usages_in_removed_expr(&value);
+                }
+                Self::pop_last_decl(output, &mut local);
+                continue;
+            }
+
+            // The variable must be initialized, since we will be substituting
+            // the value into the usage.
+            let Some(replacement) = last.value else {
+                break;
+            };
+            if use_count != 1 {
+                break;
+            }
+
+            // Try to substitute the identifier with the initializer. This will
+            // fail if something with side effects is in between the declaration
+            // and the usage.
+            match self.substitute_single_use_symbol_in_stmt(*stmt, id, replacement) {
+                StmtSubstitution::Substituted => {
+                    // `const ns = await import(x); return ns` — the single use just
+                    // moved into `replacement`; unless it was an accounted-for read
+                    // (`f(ns.a)`), the namespace escapes there.
+                    if self.dynamic_import_namespace_locals.contains_key(&id)
+                        && self.namespace_tracked_uses.get(&id).copied().unwrap_or(0) == 0
+                    {
+                        // Read as "more uses than accounted for" when finalizing.
+                        self.namespace_tracked_uses.insert(id, u32::MAX);
+                    }
+                    Self::pop_last_decl(output, &mut local);
+                    m.blocked_tail_len = usize::MAX;
+
+                    // `const D = Math.PI / 180; D * 2;` (the statement is what was
+                    // left of an unused declaration): with `D` inlined, nothing in
+                    // the statement has a side effect anymore.
+                    if m.can_drop_unused_locals
+                        && let StmtData::SExpr(mut s_expr) = stmt.data
+                    {
+                        match SideEffects::simplify_unused_expr(self, s_expr.value) {
+                            Some(value) => s_expr.value = value,
+                            None => {
+                                *stmt = stmt.to_empty();
+                                break;
+                            }
+                        }
+                    }
+                }
+                StmtSubstitution::NotFound => {
+                    m.blocked_tail_len = usize::MAX;
+                    break;
+                }
+                StmtSubstitution::Blocked => {
+                    m.blocked_tail_len = output.len();
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Removes the last declaration of `local`, the statement at the end of
+    /// `output`, and the statement itself when that was its only declaration.
+    fn pop_last_decl(output: &mut ListManaged<'a, Stmt>, local: &mut js_ast::StoreRef<S::Local>) {
+        let n = local.decls.len() - 1;
+        local.decls.truncate(n);
+        if n == 0 {
+            output.pop();
+        }
+    }
+
+    /// Merges `stmt` with the statement at the end of `output`. On success the
+    /// merged statement is in `stmt` and the old end of `output` is gone.
+    ///
+    /// The calls to `join_with_comma` are only enabled during bundling. We do
+    /// this to avoid changing line numbers too much for source maps.
+    fn merge_stmt_with_tail(
+        &mut self,
+        output: &mut ListManaged<'a, Stmt>,
+        stmt: &mut Stmt,
+    ) -> bool {
+        let Some(&prev) = output.last() else {
+            return false;
+        };
+        let merge_expressions =
+            self.options.runtime_merge_adjacent_expression_statements() && !prev.is_super_call();
+
+        match stmt.data {
+            StmtData::SLocal(local) => {
+                // Merge adjacent local statements
+                let StmtData::SLocal(mut prev_local) = prev.data else {
+                    return false;
+                };
+                if !local.can_merge_with(&prev_local) {
+                    return false;
+                }
+                prev_local.decls.extend_from_slice(local.decls.slice());
+            }
+
+            StmtData::SExpr(s_expr) => match prev.data {
+                // Merge adjacent expression statements
+                StmtData::SExpr(mut prev_expr) => {
+                    if !merge_expressions {
+                        return false;
+                    }
+                    prev_expr.does_not_affect_tree_shaking = prev_expr.does_not_affect_tree_shaking
+                        && s_expr.does_not_affect_tree_shaking;
+                    prev_expr.value = Expr::join_with_comma(prev_expr.value, s_expr.value);
+                }
+                // Input:
+                //      var f;
+                //      f = 123;
+                // Output:
+                //      var f = 123;
+                //
+                // This doesn't handle every case. Only the very simple one.
+                StmtData::SLocal(mut prev_local) => {
+                    let ExprData::EBinary(bin_assign) = s_expr.value.data else {
+                        return false;
+                    };
+                    // we can only do this with var because var is hoisted
+                    // the statement we are merging into may use the statement before its defined.
+                    if prev_local.decls.len() != 1
+                        || bin_assign.op != OpCode::BinAssign
+                        || prev_local.kind != LocalKind::KVar
+                    {
+                        return false;
+                    }
+                    let ExprData::EIdentifier(left_id) = bin_assign.left.data else {
+                        return false;
+                    };
+                    let decl = &mut prev_local.decls.slice_mut()[0];
+                    let BData::BIdentifier(bid_ptr) = decl.binding.data else {
+                        return false;
+                    };
+                    // If the value was assigned, we shouldn't merge it incase it was used in the current statement
+                    // https://github.com/oven-sh/bun/issues/2948
+                    // We don't have a more granular way to check symbol usage so this is the best we can do
+                    if !bid_ptr.r#ref.eql(left_id.ref_) || decl.value.is_some() {
+                        return false;
+                    }
+                    decl.value = Some(bin_assign.right);
+                    self.ignore_usage(left_id.ref_);
+                }
+                _ => return false,
+            },
+
+            // Absorb a previous expression statement
+            StmtData::SSwitch(mut s_switch) => {
+                let StmtData::SExpr(prev_expr) = prev.data else {
+                    return false;
+                };
+                if !merge_expressions {
+                    return false;
+                }
+                s_switch.test = Expr::join_with_comma(prev_expr.value, s_switch.test);
+                output.pop();
+                return true;
+            }
+
+            // Absorb a previous expression statement
+            StmtData::SIf(mut s_if) => {
+                let StmtData::SExpr(prev_expr) = prev.data else {
+                    return false;
+                };
+                if !merge_expressions {
+                    return false;
+                }
+                s_if.test = Expr::join_with_comma(prev_expr.value, s_if.test);
+                output.pop();
+                return true;
+            }
+
+            // Merge return statements with the previous expression statement
+            StmtData::SReturn(mut ret) => {
+                let StmtData::SExpr(prev_expr) = prev.data else {
+                    return false;
+                };
+                let Some(value) = ret.value else {
+                    return false;
+                };
+                if !merge_expressions {
+                    return false;
+                }
+                ret.value = Some(Expr::join_with_comma(prev_expr.value, value));
+                output.pop();
+                return true;
+            }
+
+            // Merge throw statements with the previous expression statement
+            StmtData::SThrow(mut s_throw) => {
+                let StmtData::SExpr(prev_expr) = prev.data else {
+                    return false;
+                };
+                if !merge_expressions {
+                    return false;
+                }
+                s_throw.value = Expr::join_with_comma(prev_expr.value, s_throw.value);
+                output.pop();
+                return true;
+            }
+
+            _ => return false,
+        }
+
+        // `stmt` was folded into `prev`, which now stands for both.
+        *stmt = prev;
+        output.pop();
+        true
+    }
+
+    /// Bundler only. Drops the declarations in `local` (the `S::Local` of
+    /// `stmt`) whose binding nothing uses. An initializer with side effects
+    /// stays behind as an expression statement, in its original position.
+    /// Returns `None` when every declaration stays.
+    fn drop_unused_decls(
+        &mut self,
+        stmt: Stmt,
+        mut local: js_ast::StoreRef<S::Local>,
+        can_touch_vars: bool,
+    ) -> Option<ListManaged<'a, Stmt>> {
+        // The declaration must not be exported. We can't just check for the
+        // "export" keyword because something might do "export {id};" later on,
+        // so the caller already ruled out the top-level scope.
+        if local.is_export
+            || local.origin.is_commonjs_export()
+            || local.kind.is_using()
+            || (local.kind == LocalKind::KVar && !can_touch_vars)
+        {
+            return None;
+        }
+
+        let decls: &[G::Decl] = local.decls.slice();
+        if !decls.iter().any(|decl| self.decl_is_unused(decl)) {
+            return None;
+        }
+
+        let mut result: ListManaged<'a, Stmt> = ListManaged::new_in(self.arena);
+        let mut kept: G::DeclList = VecExt::init_capacity(decls.len());
+        for decl in decls.iter().copied() {
+            if !self.decl_is_unused(&decl) {
+                kept.push(decl);
+                continue;
+            }
+            let Some(value) = decl.value else {
+                continue;
+            };
+            if self.expr_can_be_removed_if_unused(&value) {
+                self.ignore_usages_in_removed_expr(&value);
+                continue;
+            }
+            let Some(side_effects) = SideEffects::simplify_unused_expr(self, value) else {
+                continue;
+            };
+            if !kept.is_empty() {
+                let decls = core::mem::replace(&mut kept, VecExt::init_capacity(decls.len()));
+                result.push(self.s(
+                    S::Local {
+                        kind: local.kind,
+                        decls,
+                        is_export: false,
+                        origin: local.origin,
+                    },
+                    stmt.loc,
+                ));
+            }
+            result.push(self.s(
+                S::SExpr {
+                    value: side_effects,
+                    ..Default::default()
+                },
+                value.loc,
+            ));
+        }
+
+        if !kept.is_empty() {
+            if result.is_empty() {
+                // Only the dropped declarations changed: keep the statement node.
+                local.decls = kept;
+                result.push(stmt);
+            } else {
+                result.push(self.s(
+                    S::Local {
+                        kind: local.kind,
+                        decls: kept,
+                        is_export: false,
+                        origin: local.origin,
+                    },
+                    stmt.loc,
+                ));
+            }
+        }
+
+        Some(result)
+    }
+
+    fn decl_is_unused(&self, decl: &G::Decl) -> bool {
+        let BData::BIdentifier(ident) = decl.binding.data else {
+            return false;
+        };
+        let symbol = &self.symbols[ident.r#ref.inner_index() as usize];
+        symbol.use_count_estimate == 0 && Self::use_count_is_exact(symbol)
+    }
+
+    /// `expr` is removed without being evaluated: take back the uses it
+    /// recorded, so that a binding it held the last use of can go as well.
+    /// Function and class bodies are not entered; their uses stay counted,
+    /// which at worst keeps a binding that could have gone.
+    fn ignore_usages_in_removed_expr(&mut self, expr: &Expr) {
+        if !self.stack_check.is_safe_to_recurse() {
+            return;
+        }
+        match expr.data {
+            ExprData::EIdentifier(id) => {
+                // The escape analysis of a dynamic import namespace compares its
+                // use count with the uses it tracked. Leave those alone.
+                if !self.dynamic_import_namespace_locals.contains_key(&id.ref_) {
+                    self.ignore_usage(id.ref_);
+                }
+            }
+            ExprData::EDot(dot) => self.ignore_usages_in_removed_expr(&dot.target),
+            ExprData::EIndex(index) => {
+                self.ignore_usages_in_removed_expr(&index.target);
+                self.ignore_usages_in_removed_expr(&index.index);
+            }
+            ExprData::EUnary(un) => self.ignore_usages_in_removed_expr(&un.value),
+            ExprData::EBinary(bin) => {
+                self.ignore_usages_in_removed_expr(&bin.left);
+                self.ignore_usages_in_removed_expr(&bin.right);
+            }
+            ExprData::EIf(ternary) => {
+                self.ignore_usages_in_removed_expr(&ternary.test);
+                self.ignore_usages_in_removed_expr(&ternary.yes);
+                self.ignore_usages_in_removed_expr(&ternary.no);
+            }
+            ExprData::EArray(array) => {
+                for item in array.items.slice() {
+                    self.ignore_usages_in_removed_expr(item);
+                }
+            }
+            ExprData::EObject(object) => {
+                for property in object.properties.slice() {
+                    if property.flags.contains(js_ast::flags::Property::IsComputed)
+                        && let Some(key) = &property.key
+                    {
+                        self.ignore_usages_in_removed_expr(key);
+                    }
+                    if let Some(value) = &property.value {
+                        self.ignore_usages_in_removed_expr(value);
+                    }
+                }
+            }
+            ExprData::ECall(call) => {
+                self.ignore_usages_in_removed_expr(&call.target);
+                for arg in call.args.slice() {
+                    self.ignore_usages_in_removed_expr(arg);
+                }
+            }
+            ExprData::ENew(new) => {
+                self.ignore_usages_in_removed_expr(&new.target);
+                for arg in new.args.slice() {
+                    self.ignore_usages_in_removed_expr(arg);
+                }
+            }
+            ExprData::ETemplate(template) => {
+                if let Some(tag) = &template.tag {
+                    self.ignore_usages_in_removed_expr(tag);
+                }
+                for part in template.parts().iter() {
+                    self.ignore_usages_in_removed_expr(&part.value);
+                }
+            }
+            ExprData::ESpread(spread) => self.ignore_usages_in_removed_expr(&spread.value),
+            ExprData::EInlinedEnum(inlined) => self.ignore_usages_in_removed_expr(&inlined.value),
+            _ => {}
+        }
+    }
+}

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1813,9 +1813,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut output: ListManaged<'a, Stmt> = ListManaged::with_capacity_in(stmts.len(), p.arena);
         let mut mangler = p.stmt_list_mangler(kind);
+        let was_mangling_switch_case = p.mangling_switch_case;
+        p.mangling_switch_case = kind == StmtsKind::SwitchStmt;
         for stmt in stmts.iter().copied() {
             p.mangle_stmt_into_list(&mut mangler, &mut output, stmt);
         }
+        p.mangling_switch_case = was_mangling_switch_case;
 
         *stmts = output;
         Ok(())

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1450,6 +1450,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             None
         };
 
+        // Every list nested in a case body shares the switch scope, whose other cases are not visited yet.
+        let was_in_switch_case = p.in_switch_case;
+        p.in_switch_case = match kind {
+            StmtsKind::SwitchStmt => true,
+            StmtsKind::FnBody => false,
+            _ => was_in_switch_case,
+        };
+
         #[cfg(debug_assertions)]
         let initial_scope: js_ast::StoreRef<js_ast::Scope> = p.current_scope;
 
@@ -1744,6 +1752,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         if !p.options.features.minify_syntax || !p.options.features.dead_code_elimination {
+            p.in_switch_case = was_in_switch_case;
             return Ok(());
         }
 
@@ -1813,12 +1822,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut output: ListManaged<'a, Stmt> = ListManaged::with_capacity_in(stmts.len(), p.arena);
         let mut mangler = p.stmt_list_mangler(kind);
-        let was_mangling_switch_case = p.mangling_switch_case;
-        p.mangling_switch_case = kind == StmtsKind::SwitchStmt;
         for stmt in stmts.iter().copied() {
             p.mangle_stmt_into_list(&mut mangler, &mut output, stmt);
         }
-        p.mangling_switch_case = was_mangling_switch_case;
+        p.in_switch_case = was_in_switch_case;
 
         *stmts = output;
         Ok(())

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -2,6 +2,7 @@
 //! AST visitor pass: visits statements, expressions, bindings, function bodies,
 //! classes, and declarations. This is the second pass after parsing.
 
+pub(crate) mod mangle_stmts;
 pub mod visit_binary;
 pub(crate) mod visit_expr;
 pub(crate) mod visit_stmt;
@@ -16,7 +17,6 @@ use crate::parser::{
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast as js_ast;
 use bun_ast::G::{Decl, PropertyKind};
-use bun_ast::OpCode;
 use bun_ast::b::B as BData;
 use bun_ast::flags;
 use bun_ast::s::Kind as LocalKind;
@@ -24,7 +24,7 @@ use bun_ast::scope::{Kind as ScopeKind, Member as ScopeMember};
 use bun_ast::symbol::Kind as SymbolKind;
 use bun_ast::{
     AssignTarget, B, Binding, BindingNodeIndex, E, Expr, ExprData, ExprNodeList, G, LocRef, S,
-    Stmt, StmtData, Symbol,
+    Stmt, StmtData,
 };
 use bun_collections::VecExt;
 // `parser::SideEffects` is a stub enum without the assoc fns; the real
@@ -1811,309 +1811,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        let mut is_control_flow_dead = false;
-
         let mut output: ListManaged<'a, Stmt> = ListManaged::with_capacity_in(stmts.len(), p.arena);
-
-        let dead_code_elimination = p.options.features.dead_code_elimination;
+        let mut mangler = p.stmt_list_mangler(kind);
         for stmt in stmts.iter().copied() {
-            if is_control_flow_dead
-                && dead_code_elimination
-                && !SideEffects::should_keep_stmt_in_dead_control_flow(stmt, p.arena)
-            {
-                // Strip unnecessary statements if the control flow is dead here
-                continue;
-            }
-
-            // Inline single-use variable declarations where possible:
-            //
-            //   // Before
-            //   let x = fn();
-            //   return x.y();
-            //
-            //   // After
-            //   return fn().y();
-            //
-            // The declaration must not be exported. We can't just check for the
-            // "export" keyword because something might do "export {id};" later on.
-            // Instead we just ignore all top-level declarations for now. That means
-            // this optimization currently only applies in nested scopes.
-            //
-            // Ignore declarations if the scope is shadowed by a direct "eval" call.
-            // The eval'd code may indirectly reference this symbol and the actual
-            // use count may be greater than 1.
-            // SAFETY: current_scope is a valid arena ptr for the parse.
-            if p.current_scope != p.module_scope && !p.current_scope().contains_direct_eval {
-                // Keep inlining variables until a failure or until there are none left.
-                // That handles cases like this:
-                //
-                //   // Before
-                //   let x = fn();
-                //   let y = x.prop;
-                //   return y;
-                //
-                //   // After
-                //   return fn().prop;
-                //
-                'inner: while output.len() > 0 {
-                    // Ignore "var" declarations since those have function-level scope and
-                    // we may not have visited all of their uses yet by this point. We
-                    // should have visited all the uses of "let" and "const" declarations
-                    // by now since they are scoped to this block which we just finished
-                    // visiting.
-                    let prev_idx = output.len() - 1;
-                    // borrowck: read the `StoreRef` (Copy) first, then re-borrow
-                    // `output` only when truncating.
-                    let StmtData::SLocal(mut local) = output[prev_idx].data else {
-                        break;
-                    };
-                    // "using" / "await using" declarations have disposal
-                    // side-effects on scope exit, so they must not be
-                    // removed by inlining their initializer into the use.
-                    if local.decls.len_u32() == 0
-                        || local.kind == LocalKind::KVar
-                        || local.kind.is_using()
-                        || local.is_export
-                    {
-                        break;
-                    }
-
-                    // The variable must be initialized, since we will be substituting
-                    // the value into the usage.
-                    let last_idx = (local.decls.len_u32() - 1) as usize;
-                    let last: &mut Decl = &mut local.decls.slice_mut()[last_idx];
-                    let Some(replacement) = last.value else { break };
-
-                    // The binding must be an identifier that is only used once.
-                    // Ignore destructuring bindings since that's not the simple case.
-                    // Destructuring bindings could potentially execute side-effecting
-                    // code which would invalidate reordering.
-                    let BData::BIdentifier(ident_ptr) = last.binding.data else {
-                        break;
-                    };
-                    let id = ident_ptr.r#ref;
-
-                    let symbol: &Symbol = &p.symbols[id.inner_index() as usize];
-
-                    // Try to substitute the identifier with the initializer. This will
-                    // fail if something with side effects is in between the declaration
-                    // and the usage.
-                    if symbol.use_count_estimate == 1
-                        && p.substitute_single_use_symbol_in_stmt(stmt, id, replacement)
-                    {
-                        // `const ns = await import(x); return ns` — the single use just
-                        // moved into `replacement`; unless it was an accounted-for read
-                        // (`f(ns.a)`), the namespace escapes there.
-                        if p.dynamic_import_namespace_locals.contains_key(&id)
-                            && p.namespace_tracked_uses.get(&id).copied().unwrap_or(0) == 0
-                        {
-                            // Read as "more uses than accounted for" when finalizing.
-                            p.namespace_tracked_uses.insert(id, u32::MAX);
-                        }
-                        match local.decls.len_u32() {
-                            1 => {
-                                local.decls.clear();
-                                let new_len = output.len() - 1;
-                                output.truncate(new_len);
-                                continue 'inner;
-                            }
-                            _ => {
-                                let n = local.decls.len() - 1;
-                                local.decls.truncate(n);
-                                continue 'inner;
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-
-            // don't merge super calls to ensure they are called before "this" is accessed
-            if stmt.is_super_call() {
-                output.push(stmt);
-                continue;
-            }
-
-            // The following calls to `joinWithComma` are only enabled during bundling. We do this
-            // to avoid changing line numbers too much for source maps
-
-            match stmt.data {
-                StmtData::SEmpty(_) => continue,
-
-                // skip directives for now
-                StmtData::SDirective(_) => continue,
-
-                StmtData::SLocal(local) => {
-                    // Merge adjacent local statements
-                    if output.len() > 0 {
-                        let prev_idx = output.len() - 1;
-                        let prev_stmt = &mut output[prev_idx];
-                        if let StmtData::SLocal(mut prev_local) = prev_stmt.data {
-                            if local.can_merge_with(&prev_local) {
-                                // `Vec::append_slice` requires `T: Clone`
-                                // but `G::Decl` lacks the derive (its fields are all
-                                // `Copy`). Per-element bitwise copy instead.
-                                //
-                                // The parse pass allocates `decls` in the bump arena
-                                // (`from_bump_slice` → `Origin::Borrowed`); promote to a
-                                // global-heap buffer before growing it.
-                                for d in local.decls.slice() {
-                                    // SAFETY: Decl is field-wise Copy (Binding, Option<Expr>).
-                                    prev_local.decls.push(unsafe { core::ptr::read(d) });
-                                }
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                StmtData::SExpr(s_expr) => {
-                    // Merge adjacent expression statements
-                    if output.len() > 0 {
-                        let prev_idx = output.len() - 1;
-                        let prev_stmt = &mut output[prev_idx];
-                        if let StmtData::SExpr(mut prev_expr) = prev_stmt.data {
-                            if !prev_stmt.is_super_call()
-                                && p.options.runtime_merge_adjacent_expression_statements()
-                            {
-                                prev_expr.does_not_affect_tree_shaking = prev_expr
-                                    .does_not_affect_tree_shaking
-                                    && s_expr.does_not_affect_tree_shaking;
-                                prev_expr.value =
-                                    Expr::join_with_comma(prev_expr.value, s_expr.value);
-                                continue;
-                            }
-                        } else if let StmtData::SLocal(prev_local) = prev_stmt.data {
-                            //
-                            // Input:
-                            //      var f;
-                            //      f = 123;
-                            // Output:
-                            //      var f = 123;
-                            //
-                            // This doesn't handle every case. Only the very simple one.
-                            if let ExprData::EBinary(bin_assign) = s_expr.value.data {
-                                if prev_local.decls.len_u32() == 1
-                                    && bin_assign.op == OpCode::BinAssign
-                                    // we can only do this with var because var is hoisted
-                                    // the statement we are merging into may use the statement before its defined.
-                                    && prev_local.kind == LocalKind::KVar
-                                {
-                                    if let ExprData::EIdentifier(left_id) = bin_assign.left.data {
-                                        // `prev_local` is a `StoreRef` (Copy) so
-                                        // re-slicing here writes through to the arena slot.
-                                        let mut prev_local = prev_local;
-                                        let decl = &mut prev_local.decls.slice_mut()[0];
-                                        if let BData::BIdentifier(bid_ptr) = decl.binding.data {
-                                            let bid_ref = bid_ptr.r#ref;
-                                            if bid_ref.eql(left_id.ref_)
-                                                // If the value was assigned, we shouldn't merge it incase it was used in the current statement
-                                                // https://github.com/oven-sh/bun/issues/2948
-                                                // We don't have a more granular way to check symbol usage so this is the best we can do
-                                                && decl.value.is_none()
-                                            {
-                                                decl.value = Some(bin_assign.right);
-                                                p.ignore_usage(left_id.ref_);
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                StmtData::SSwitch(mut s_switch) => {
-                    // Absorb a previous expression statement
-                    if output.len() > 0 && p.options.runtime_merge_adjacent_expression_statements()
-                    {
-                        let prev_idx = output.len() - 1;
-                        let prev_stmt = output[prev_idx];
-                        if let StmtData::SExpr(prev_expr) = prev_stmt.data {
-                            if !prev_stmt.is_super_call() {
-                                s_switch.test =
-                                    Expr::join_with_comma(prev_expr.value, s_switch.test);
-                                output.truncate(prev_idx);
-                            }
-                        }
-                    }
-                }
-                StmtData::SIf(mut s_if) => {
-                    // Absorb a previous expression statement
-                    if output.len() > 0 && p.options.runtime_merge_adjacent_expression_statements()
-                    {
-                        let prev_idx = output.len() - 1;
-                        let prev_stmt = output[prev_idx];
-                        if let StmtData::SExpr(prev_expr) = prev_stmt.data {
-                            if !prev_stmt.is_super_call() {
-                                s_if.test = Expr::join_with_comma(prev_expr.value, s_if.test);
-                                output.truncate(prev_idx);
-                            }
-                        }
-                    }
-
-                    // TODO: optimize jump
-                }
-
-                StmtData::SReturn(mut ret) => {
-                    // Merge return statements with the previous expression statement
-                    if output.len() > 0
-                        && ret.value.is_some()
-                        && p.options.runtime_merge_adjacent_expression_statements()
-                    {
-                        let prev_idx = output.len() - 1;
-                        let prev_stmt = output[prev_idx];
-                        if let StmtData::SExpr(prev_expr) = prev_stmt.data {
-                            if !prev_stmt.is_super_call() {
-                                ret.value = Some(Expr::join_with_comma(
-                                    prev_expr.value,
-                                    ret.value.unwrap(),
-                                ));
-                                output[prev_idx] = stmt;
-                                continue;
-                            }
-                        }
-                    }
-
-                    is_control_flow_dead = true;
-                }
-
-                StmtData::SBreak(_) | StmtData::SContinue(_) => {
-                    is_control_flow_dead = true;
-                }
-
-                StmtData::SThrow(s_throw) => {
-                    // Merge throw statements with the previous expression statement
-                    if output.len() > 0 && p.options.runtime_merge_adjacent_expression_statements()
-                    {
-                        let prev_idx = output.len() - 1;
-                        let prev_stmt = output[prev_idx];
-                        if let StmtData::SExpr(prev_expr) = prev_stmt.data {
-                            if !prev_stmt.is_super_call() {
-                                output[prev_idx] = p.s(
-                                    S::Throw {
-                                        value: Expr::join_with_comma(
-                                            prev_expr.value,
-                                            s_throw.value,
-                                        ),
-                                    },
-                                    stmt.loc,
-                                );
-                                continue;
-                            }
-                        }
-                    }
-
-                    is_control_flow_dead = true;
-                }
-
-                _ => {}
-            }
-
-            output.push(stmt);
+            p.mangle_stmt_into_list(&mut mangler, &mut output, stmt);
         }
 
-        // stmts.deinit(); — Drop handles freeing the old buffer (BumpVec is arena-backed).
         *stmts = output;
         Ok(())
     }

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -474,10 +474,10 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "e32d6712883a4ad95923ac1246d92e04fa2404c75529375417611cd5446f6c98",
+          "js": "9624c7158a6249c6eccc19e0eed3a1aa97263a2483fc3b6db0125dfde05cd8fb",
           "jsc": {
-            "bytes": 1997656,
-            "sha256": "ec5c63ab418d599425c7810b83760879817168270ee12b692156e3a446e17d99",
+            "bytes": 1997680,
+            "sha256": "7839dd4186a41c9a606e89c9d186890dad75959c9d14de20682fd92a73926d2d",
           },
         },
         "bun build --bytecode --minify features.js": {

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -474,24 +474,24 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "721d67b0c2135aad554c9962b4e4505a4d6856b50da537fee7566d43f6cfdbda",
+          "js": "e32d6712883a4ad95923ac1246d92e04fa2404c75529375417611cd5446f6c98",
           "jsc": {
-            "bytes": 1998992,
-            "sha256": "f2631b3ba2b532e52183d5e6a44a7dbf5c0515b368d95fc692bf0e5ad15eb8f6",
+            "bytes": 1997656,
+            "sha256": "ec5c63ab418d599425c7810b83760879817168270ee12b692156e3a446e17d99",
           },
         },
         "bun build --bytecode --minify features.js": {
-          "js": "d49da0aa39824bf9eba2af5d3a010525ad14ca5c1cedc0d8adcfdd5f4984a0d0",
+          "js": "51892b18f3ec465d94169e297a4fc445dd1a645a27be0c9867654857a368bae1",
           "jsc": {
-            "bytes": 46152,
-            "sha256": "db36543ec2430a8cbdce13a6a980148f502e2c6b135cf95f62b6743c3fa30968",
+            "bytes": 46040,
+            "sha256": "de4aae43f4911b7a9984c2e71ba0476d1b33ba8e920bd4c4c2fd1ab0417ed141",
           },
         },
         "bun build --bytecode --minify records.js": {
-          "js": "889cbb2c9525ff69a2676a6e81d97bb87760bdee65178b836c9c1d6808ac7c6e",
+          "js": "2e05d87ade664c537c7f04d7a19ecef5ef5725f1915b56f168f30090961416da",
           "jsc": {
-            "bytes": 89144,
-            "sha256": "3c3e86151fe78e6d56d7e7033dfa0e97b062af3b86d7ad75b723d91c77b11cba",
+            "bytes": 89008,
+            "sha256": "23b5463c59faeb49d657bad95058bbdc27b12836d6f4f9f5e222608afc40b3cd",
           },
         },
         "bun build --bytecode acorn/dist/acorn.mjs": {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1751,6 +1751,7 @@ describe("bundler", () => {
   itBundled("minify/InlineSingleUsePastStableReads", {
     files: {
       "/entry.js": /* js */ `
+        import { imported } from "./other.js";
         function g(...a) { return a.join(","); }
         const h = (...a) => a.join(",");
         let never = (x) => x;

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1771,8 +1771,10 @@ describe("bundler", () => {
         export function keepOuterConst() { const keep = f(); return h(keep); }
         export function keepOuterLet() { const keep = f(); return never(keep); }
         export function keepThis() { const keep = f(); return g(this, keep); }
-        export function keepLaterConst(c) { const keep = f(); if (c) return later(keep); const later = (x) => x; return later(1); }
+        export function keepLaterConst() { const keep = f(); const r = later(keep); const later = (x) => x; return r; }
+        export function keepSelfReference() { const keep = f(); const self = [self, keep]; return self; }
         export function keepSiblingCase(x) { switch (x) { case 1: const later = (y) => y; case 2: const keep = f(); return later(keep); } }
+        export function keepSiblingCaseNested(x) { switch (x) { case 1: const later = (y) => y; case 2: { const keep = f(); return later(keep); } } }
         export function keepAndBranch() { const keep = f(); return flag && keep; }
         export function keepOrBranch() { const keep = f(); return flag || keep; }
         export function keepNullishBranch() { const keep = f(); return flag ?? keep; }
@@ -1795,7 +1797,7 @@ describe("bundler", () => {
       expect(code).toContain("return later(f());");
       expect(code).toContain("return local(f()) + local(1);");
       expect(code).toContain("return flag && 1;");
-      expect(code.match(/let keep = f\(\);/g)).toHaveLength(14);
+      expect(code.match(/let keep = f\(\)[,;]/g)).toHaveLength(16);
     },
   });
 

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1681,6 +1681,247 @@ describe("bundler", () => {
       expect(code.match(/let keep = /g)).toHaveLength(10);
     },
   });
+
+  // A single-use `var` at the top level of a function body is inlined like a
+  // `let`: every use of it has been visited once the body is done. The
+  // declaration before the next statement, the next statement, and the
+  // statement after that collapse into one expression.
+  itBundled("minify/InlineSingleUseVarInFunctionBody", {
+    files: {
+      "/entry.js": /* js */ `
+        function f() { return 1; }
+        function g() { return 2; }
+        function h() { return 3; }
+        export function basic() { var r = 1, a = 2; g(r, a); var n = 3; return n; }
+        export function chain() { var a = f(); var b = a.prop; return b; }
+        export function staticBlock() { class K { static { var s = f(); g(s); } } return K; }
+
+        export function keepParamAlias(a) { var a = 2; return arguments[0]; }
+        export function keepBlockRedeclaration() { var x = 1; { var x = 2; g(x); } }
+        export function keepClosureUse() { var x = f(); return () => x; }
+        export function keepLoopUse() { var x = f(); while (g()) h(x); }
+        export function keepHoistedUse() { g(x); var x = f(); return 1; }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("return g(1, 2), 3;");
+      expect(code).toContain("return f().prop;");
+      expect(code).toContain("g(f());");
+      expect(code.match(/var /g)).toHaveLength(6);
+    },
+  });
+
+  // A declaration that nothing uses goes when its initializer has no side
+  // effects. An initializer with side effects stays behind as a statement, in
+  // its original position. Destructuring is left alone.
+  itBundled("minify/DropUnusedLocals", {
+    files: {
+      "/entry.js": /* js */ `
+        export function pure() { const DROP_A = Math.PI / 180; let DROP_B = 1 << 3; var DROP_C; return 1; }
+        export function cascade() { const DROP_D = Math.PI / 180; const DROP_E = DROP_D * 2; return 1; }
+        export function nested() { if (g()) { const DROP_F = [1, 2]; return 1; } }
+        export function sideEffects() { var DROP_G = f("first"), used = 2, DROP_H = f("third"); return used; }
+        export function closure() { const DROP_I = () => h(); return 1; }
+        export function keepDestructuring(o) { const { c } = o; return 1; }
+        export function keepUsed() { const keep = f(); return g(keep, keep); }
+        export function keepBlockVar() { if (g()) { var x = f(); } return 1; }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    dce: true,
+    dceKeepMarkerCount: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      // sideEffects(): both calls stay, in order, without the bindings.
+      expect(code).toContain('return f("first"), f("third"), 2;');
+      expect(code).toContain("let { c } = o;");
+      expect(code).toContain("let keep = f();");
+      expect(code).toContain("var x = f();");
+      expect(code).not.toContain("Math.PI");
+    },
+  });
+
+  // An initializer with side effects can still be moved past a read that no
+  // side effect can change: a `const`, a function or `let` the file never
+  // assigns to, `this`, and a known global like `console.log`.
+  itBundled("minify/InlineSingleUsePastStableReads", {
+    files: {
+      "/entry.js": /* js */ `
+        function g(...a) { return a.join(","); }
+        const h = (...a) => a.join(",");
+        let never = (x) => x;
+        let assigned = (x) => x;
+        assigned = (x) => x + 1;
+
+        export function intoFunction(n) { const t = n + 1; return g(t); }
+        export function intoConst() { const t = f(); return h(t); }
+        export function intoLet() { const t = f(); return never(t); }
+        export function intoGlobal() { const t = f(); return console.log(t); }
+        export function intoThis() { const t = f(); return g(this, t); }
+        export function intoLocalFunction() { const t = f(); return later(t); function later(x) { return x; } }
+
+        export function keepAssigned() { const keep = f(); return assigned(keep); }
+        export function keepUnbound() { const keep = f(); return unbound(keep); }
+        export function keepGetter(o) { const keep = f(); return o.m(keep); }
+        export function keepThisProperty() { const keep = f(); return this.m(keep); }
+        export function keepParam(p) { const keep = f(); return p(keep); }
+        export function keepImport() { const keep = f(); return imported(keep); }
+      `,
+      "/other.js": /* js */ `
+        export function imported(x) { return x; }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("return g(n + 1);");
+      expect(code).toContain("return h(f());");
+      expect(code).toContain("return never(f());");
+      expect(code).toContain("return console.log(f());");
+      expect(code).toContain("return g(this, f());");
+      expect(code).toContain("return later(f());");
+      expect(code.match(/let keep = f\(\);/g)).toHaveLength(6);
+    },
+  });
+
+  // A direct `eval` anywhere in the file can assign any binding by name, so
+  // nothing is moved past a read of a binding that is not a `const`.
+  itBundled("minify/InlineSingleUseStopsAtDirectEval", {
+    files: {
+      "/entry.js": /* js */ `
+        function g(x) { return x; }
+        export function stable() { const keep = f(); return g(keep); }
+        export function evil(code) { return eval(code); }
+        export function scoped() { var keep = 1; return eval("keep"); }
+        export function inWith(o) { var keep = 1; with (o) return keep; }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toMatch(/let keep\d* = f\(\);/);
+      expect(code.match(/var keep = 1;/g)).toHaveLength(2);
+    },
+  });
+
+  // An edit to the end of the list is followed by another look at the new
+  // end: after `return x` absorbs `a()`, the `let x = 1` before it is inlined.
+  itBundled("minify/RemergeAfterInlining", {
+    files: {
+      "/entry.js": /* js */ `
+        export function literalPastCall() { let x = 1; a(); return x; }
+        export function literalPastAssignment() { let x = 1; o[a()] = x; }
+        export function arrowPastCall() { const fn = () => 1; a(); return fn; }
+        export function unusedAfterInline() { const D = Math.PI / 180; const r = D * 2; return 1; }
+        export function ifTest() { let x = 1; a(); if (x) b(); }
+        export function keepSideEffectPastCall() { let keep = f(); a(); return keep; }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("return a(), 1;");
+      expect(code).toContain("o[a()] = 1;");
+      expect(code).toContain("return a(), () => 1;");
+      expect(code).toContain("unusedAfterInline() {\n  return 1;\n}");
+      expect(code).toContain("if (a(), 1)");
+      expect(code).toContain("let keep = f();");
+    },
+  });
+
+  // A call to a known pure global with primitive arguments is dropped when its
+  // result is unused. With an argument of unknown type the call stays, since
+  // converting an object runs its `valueOf`.
+  itBundled("minify/DropUnusedPureGlobalCalls", {
+    files: {
+      "/entry.js": /* js */ `
+        export function dropped() { Math.floor(1.5); Math.max(1, 2); Number.isNaN("x"); Array.isArray("x"); return 1; }
+        export function keptObjectArg(x) { Math.floor(x); return 1; }
+        export function keptRandom() { Math.random(); return 1; }
+        export function keptUsed() { return Math.floor(1.5); }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("dropped() {\n  return 1;\n}");
+      expect(code).toContain("Math.floor(x), 1;");
+      expect(code).toContain("Math.random(), 1;");
+      expect(code).toContain("return Math.floor(1.5);");
+      expect(code).not.toContain("Math.max");
+    },
+  });
+
+  // The bundled output behaves like the source: the order of side effects and
+  // the values are unchanged. (The expected output is what `bun entry.js`
+  // prints for the unbundled source.)
+  itBundled("minify/InlineAndDropPreservesSemantics", {
+    files: {
+      "/entry.js": /* js */ `
+        const log = [];
+        let counter = 0;
+        function side(tag) { log.push("side:" + tag); return ++counter; }
+        function g(...a) { log.push("g:" + a.join(",")); return a.length; }
+        let mutable = "m0";
+        let mutableSeq = 0;
+        function setMutable() { mutable = "m" + ++mutableSeq; return "set"; }
+
+        function t1() { var r = 1, a = 2; g(r, a); var n = 3; return n; }
+        function t2() { const t = side("t2"); return g(t); }
+        function t3() { const t = setMutable(); return g(mutable, t); }
+        function t4() { let m = mutable; const t = setMutable(); return g(m, t); }
+        function t5() { var x = side("t5a"), y = 2, z = side("t5b"); return y; }
+        function t6(a) { var a = 2; return a; }
+        function t7() { var x = 1; { var x = 2; g(x); } return x; }
+        function t8() { let x = 1; g("t8"); return x; }
+        function t9() { const o = { get p() { side("getter"); return "p"; } }; const t = o.p; return g(t); }
+        function t10() { let x = side("t10a"); let y = side("t10b"); return g(y, x); }
+        function t11() { const D = Math.PI / 180; const R = D * 2; return 1; }
+        function t12(x) { Math.floor(x); return 1; }
+        function t13() { var fns = []; for (var i = 0; i < 2; i++) { var j = i; fns.push(() => j); } return fns.map((f) => f()).join(); }
+        function t14() { let m = mutable; const t = setMutable(); return g(t, m); }
+
+        const results = [t1(), t2(), t3(), t4(), t5(), t6(7), t7(), t8(), t9(), t10(), t11(), t12({ valueOf() { log.push("valueOf"); return 1; } }), t13(), t14()];
+        console.log(JSON.stringify({ results, log }));
+        export {};
+      `,
+    },
+    minifySyntax: true,
+    run: {
+      stdout:
+        '{"results":[3,1,2,2,2,2,2,1,1,2,1,1,"1,1",2],"log":["g:1,2","side:t2","g:1","g:m1,set","g:m1,set","side:t5a","side:t5b","g:2","g:t8","side:getter","g:p","side:t10a","side:t10b","g:6,5","valueOf","g:set,m2"]}',
+    },
+  });
+
+  // All of the above is gated on bundling. The runtime transpiler forces
+  // minify-syntax on for bun targets, and its output must stay close to the
+  // source: `var` declarations and unused locals are kept in transform mode.
+  itBundled("minify/UnusedLocalsKeptWhenNotBundling", {
+    files: {
+      "/entry.js": /* js */ `
+        export function a() { var r = 1, a = 2; g(r, a); var n = 3; return n; }
+        export function b() { const D = Math.PI / 180; return 1; }
+        export function c() { let x = 1; g(); return x; }
+      `,
+    },
+    bundling: false,
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("var r = 1, a = 2;");
+      expect(code).toContain("const D = Math.PI / 180;");
+      expect(code).toContain("let x = 1;");
+    },
+  });
 });
 
 // The runtime transpiler (`bun run`/`bun test`) implicitly enables

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1745,9 +1745,11 @@ describe("bundler", () => {
     },
   });
 
-  // An initializer with side effects can still be moved past a read that no
-  // side effect can change: a `const`, a function or `let` the file never
-  // assigns to, `this`, and a known global like `console.log`.
+  // An initializer with side effects can still be moved past a read that
+  // cannot throw or change: a function declaration the file never assigns
+  // to, a known global like `console.log`, and a `const`, `let` or `class`
+  // declared earlier in the same function. A binding of an enclosing function
+  // can be in its TDZ, so reading it is not moved before the initializer.
   itBundled("minify/InlineSingleUsePastStableReads", {
     files: {
       "/entry.js": /* js */ `
@@ -1760,14 +1762,17 @@ describe("bundler", () => {
         assigned = (x) => x + 1;
 
         export function intoFunction(n) { const t = n + 1; return g(t); }
-        export function intoConst() { const t = f(); return h(t); }
-        export function intoLet() { const t = f(); return never(t); }
         export function intoGlobal() { const t = f(); return console.log(t); }
-        export function intoThis() { const t = f(); return g(this, t); }
         export function intoLocalFunction() { const t = f(); return later(t); function later(x) { return x; } }
+        export function intoLocalConst() { const local = (x) => x; const t = f(); return local(t) + local(1); }
         export function intoAndBranchLiteral() { const t = 1; return flag && t; }
 
         export function keepAssigned() { const keep = f(); return assigned(keep); }
+        export function keepOuterConst() { const keep = f(); return h(keep); }
+        export function keepOuterLet() { const keep = f(); return never(keep); }
+        export function keepThis() { const keep = f(); return g(this, keep); }
+        export function keepLaterConst(c) { const keep = f(); if (c) return later(keep); const later = (x) => x; return later(1); }
+        export function keepSiblingCase(x) { switch (x) { case 1: const later = (y) => y; case 2: const keep = f(); return later(keep); } }
         export function keepAndBranch() { const keep = f(); return flag && keep; }
         export function keepOrBranch() { const keep = f(); return flag || keep; }
         export function keepNullishBranch() { const keep = f(); return flag ?? keep; }
@@ -1786,13 +1791,11 @@ describe("bundler", () => {
     onAfterBundle(api) {
       const code = api.readFile("/out.js");
       expect(code).toContain("return g(n + 1);");
-      expect(code).toContain("return h(f());");
-      expect(code).toContain("return never(f());");
       expect(code).toContain("return console.log(f());");
-      expect(code).toContain("return g(this, f());");
       expect(code).toContain("return later(f());");
+      expect(code).toContain("return local(f()) + local(1);");
       expect(code).toContain("return flag && 1;");
-      expect(code.match(/let keep = f\(\);/g)).toHaveLength(9);
+      expect(code.match(/let keep = f\(\);/g)).toHaveLength(14);
     },
   });
 
@@ -1835,7 +1838,7 @@ describe("bundler", () => {
     onAfterBundle(api) {
       const code = api.readFile("/out.js");
       expect(code).toContain("let t = await gate;");
-      expect(code).toContain("return [v, await gate.then((x) => x)];");
+      expect(code).toContain("let t = gate.then((x) => x);");
     },
   });
 

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1813,6 +1813,32 @@ describe("bundler", () => {
     },
   });
 
+  // A `const` of an enclosing function can be in its TDZ when an `await`
+  // suspends, and initialized by the time it resumes. Reading it before the
+  // `await` would throw, so an initializer that suspends stays where it is.
+  itBundled("minify/KeepOuterBindingReadAfterAwait", {
+    files: {
+      "/entry.js": /* js */ `
+        let resolve;
+        const gate = new Promise((r) => { resolve = r; });
+        async function waits() { const t = await gate; return [v, t]; }
+        async function syncPart() { const t = gate.then((x) => x); return [v, await t]; }
+        const pending = waits();
+        const v = 42;
+        resolve("ok");
+        console.log(JSON.stringify([await pending, await syncPart()]));
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    run: { stdout: '[[42,"ok"],[42,"ok"]]' },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("let t = await gate;");
+      expect(code).toContain("return [v, await gate.then((x) => x)];");
+    },
+  });
+
   // A `super(...)` call is never merged with its neighbors (the class lowering
   // looks for it to place field initializers), but a single-use declaration
   // before it is still inlined into its arguments.
@@ -1962,6 +1988,7 @@ describe("bundler", () => {
         export function a() { var r = 1, a = 2; g(r, a); var n = 3; return n; }
         export function b() { const D = Math.PI / 180; return 1; }
         export function c() { let x = 1; g(); return x; }
+        export function d() { Math.floor(1.5); Math.PI / 180; return 1; }
       `,
     },
     bundling: false,
@@ -1972,6 +1999,8 @@ describe("bundler", () => {
       expect(code).toContain("var r = 1, a = 2;");
       expect(code).toContain("const D = Math.PI / 180;");
       expect(code).toContain("let x = 1;");
+      expect(code).toContain("Math.floor(1.5);");
+      expect(code).toContain("Math.PI / 180;");
     },
   });
 });

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1813,23 +1813,30 @@ describe("bundler", () => {
     },
   });
 
-  // A `super(...)` call is never merged with its neighbors, but a single-use
-  // declaration before it is still inlined into its arguments.
+  // A `super(...)` call is never merged with its neighbors (the class lowering
+  // looks for it to place field initializers), but a single-use declaration
+  // before it is still inlined into its arguments.
   itBundled("minify/InlineIntoSuperCall", {
     files: {
       "/entry.js": /* js */ `
-        function compute() { return 2; }
-        class B { constructor(x) { this.x = x; } }
-        export class Literal extends B { constructor() { const t = 1; super(t); } }
-        export class Call extends B { constructor() { const t = compute(); super(t); } }
+        const log = [];
+        function compute() { log.push("compute"); return 2; }
+        class B { constructor(x) { log.push("B:" + x); this.x = x; } }
+        class Literal extends B { constructor() { const t = 1; super(t); } }
+        class Call extends B { constructor() { const t = compute(); super(t); } }
+        class Field extends B { y = log.push("field"); constructor() { log.push("before"); super(3); log.push("after"); } }
+        log.push(new Literal().x, new Call().x, new Field().y);
+        console.log(JSON.stringify(log));
       `,
     },
     minifySyntax: true,
     minifyIdentifiers: false,
+    run: { stdout: '["B:1","compute","B:2","before","B:3","field","after",1,2,6]' },
     onAfterBundle(api) {
       const code = api.readFile("/out.js");
       expect(code).toContain("super(1);");
       expect(code).toContain("super(compute());");
+      expect(code).toContain("super(3);");
       expect(code).not.toContain("let t");
     },
   });

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1754,6 +1754,7 @@ describe("bundler", () => {
         import { imported } from "./other.js";
         function g(...a) { return a.join(","); }
         const h = (...a) => a.join(",");
+        const flag = g();
         let never = (x) => x;
         let assigned = (x) => x;
         assigned = (x) => x + 1;
@@ -1764,8 +1765,12 @@ describe("bundler", () => {
         export function intoGlobal() { const t = f(); return console.log(t); }
         export function intoThis() { const t = f(); return g(this, t); }
         export function intoLocalFunction() { const t = f(); return later(t); function later(x) { return x; } }
+        export function intoAndBranchLiteral() { const t = 1; return flag && t; }
 
         export function keepAssigned() { const keep = f(); return assigned(keep); }
+        export function keepAndBranch() { const keep = f(); return flag && keep; }
+        export function keepOrBranch() { const keep = f(); return flag || keep; }
+        export function keepNullishBranch() { const keep = f(); return flag ?? keep; }
         export function keepUnbound() { const keep = f(); return unbound(keep); }
         export function keepGetter(o) { const keep = f(); return o.m(keep); }
         export function keepThisProperty() { const keep = f(); return this.m(keep); }
@@ -1786,7 +1791,46 @@ describe("bundler", () => {
       expect(code).toContain("return console.log(f());");
       expect(code).toContain("return g(this, f());");
       expect(code).toContain("return later(f());");
-      expect(code.match(/let keep = f\(\);/g)).toHaveLength(6);
+      expect(code).toContain("return flag && 1;");
+      expect(code.match(/let keep = f\(\);/g)).toHaveLength(9);
+    },
+  });
+
+  // The cases of a switch share one scope but are visited one at a time, so a
+  // declaration in one case can have no visited use yet when its case is done.
+  itBundled("minify/UnusedLocalsKeptAcrossSwitchCases", {
+    files: {
+      "/entry.js": /* js */ `
+        function f(x) { switch (x) { case 1: let y = 42; case 2: return y; } }
+        console.log(f(1));
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    run: { stdout: "42" },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toContain("let y = 42;");
+    },
+  });
+
+  // A `super(...)` call is never merged with its neighbors, but a single-use
+  // declaration before it is still inlined into its arguments.
+  itBundled("minify/InlineIntoSuperCall", {
+    files: {
+      "/entry.js": /* js */ `
+        function compute() { return 2; }
+        class B { constructor(x) { this.x = x; } }
+        export class Literal extends B { constructor() { const t = 1; super(t); } }
+        export class Call extends B { constructor() { const t = compute(); super(t); } }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("super(1);");
+      expect(code).toContain("super(compute());");
+      expect(code).not.toContain("let t");
     },
   });
 

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -58,14 +58,14 @@ describe("bundler", () => {
           ["react.development.js:524:'getContextName'", "1:5623:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
           ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
-          ["entry.tsx:6:'\"Content-Type\"'", '100:18811:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19065:void"],
-          ["entry.tsx:23:'await'", "100:19164:await"],
+          ["entry.tsx:6:'\"Content-Type\"'", '100:18799:"Content-Type"'],
+          ["entry.tsx:11:'<html>'", "100:19053:void"],
+          ["entry.tsx:23:'await'", "100:19152:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221989,
+      "out/entry.js": 221717,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",


### PR DESCRIPTION
### Problem
- With `--minify-syntax`, `bun build` leaves code behind in function bodies: a single-use `var` is never inlined, an unused declaration is kept, and `const t = f(); return g(t)` stays because `f()` cannot move past the read of `g`. oxc removes all three.
- The minifier at the end of `visit_stmts` (`src/js_parser/visit/mod.rs`) looks at each statement once. An edit that makes the list tail mergeable again is not followed up.

### Fix
- `src/js_parser/visit/mangle_stmts.rs` replaces the merge loop. After every edit it looks at the new tail again, so `let x = 1; a(); return x` becomes `return a(), 1` in one pass. A blocked substitution is not retried.
- Bundler only: a `var` at the outermost list of a function body is inlined like a `let`. An unused declaration is dropped when its initializer is side-effect free; a side-effecting one stays as a statement. `Symbol::IS_LINK_TARGET` marks symbols whose use count is not complete; those are never touched. Switch case bodies are skipped.
- A side-effecting initializer may move past a read of `super`, a known global (`console.log`), a function declaration the file never assigns to, or a never-assigned `const`, `let` or `class` declared earlier in the same function (a binding of an enclosing function can still be in its TDZ). The parse pass records every assignment target and any direct `eval`. It never enters the right side of `&&`, `||` or `??`. Unused `Math.floor(1.5)`-style calls with primitive arguments are dropped, and `Math.PI / 180` is side-effect free.
- Verified: `test/bundler/bundler_minify.test.ts` (12 new cases). Also `bundler_npm`, `bundler_bytecode_portable`, `esbuild/dce`, `esbuild/default`, `transpiler.test.js`, all of `test/bundler/`.

### Background
- At the end of each statement list, `visit_stmts` inlines single-use `let`/`const` declarations into the next statement (`substitute_single_use_symbol_in_stmt`) and merges adjacent statements with the comma operator.
- `Symbol::use_count_estimate` is complete for a `let`/`const` once its block is visited, and for a `var` once the function body is visited, unless another symbol links to it.
- The substitution walk stops at the first sub-expression the initializer cannot be reordered past. With side effects, that used to be any identifier read: `has_been_assigned_to` is final only at the end of the file.
- The runtime transpiler has `minify_syntax` on and `bundle` off. Everything new is gated on `bundle`, so `bun run`, `bun test` and `Bun.Transpiler` output is unchanged.

<details><summary>Notes</summary>

Sizes with `--minify --target=bun`: `typescript/lib/typescript.js` 3,638,100 -> 3,632,429 bytes (gzip 1,031,446 -> 1,029,090). `react-dom/cjs/react-dom.development.js` + `prettier` + `@lezer/common` 4,085,978 -> 4,083,271.

`minify/InlineAndDropPreservesSemantics` runs the bundle and compares the side-effect log with what `bun entry.js` prints for the source.

Not inlined or dropped, on purpose: a use inside a closure or a loop body, a `var` that aliases a parameter or is redeclared in a nested block, a binding read inside `with`, anything in a scope with direct `eval`, destructuring bindings, `using` declarations, exports and top-level declarations, declarations in a switch case body (a later case can use them and is not visited yet). An initializer is not moved past a property read that could be a getter (`o.m(t)`, `this.m(t)`), past `this` (it throws in a derived constructor before `super()`), past an imported binding (live binding), past a binding the file assigns to anywhere, past a `const`, `let` or `class` of an enclosing function, of a sibling switch case (also from a block nested in a case body), or declared by the target statement itself as in `const x = [x, t]` (it can be in its TDZ, and a program that catches the error would miss the initializer's side effect: the shape of rolldown 9959 / svelte 18454), or into the conditional side of `&&`, `||`, `??`, `?:` or an optional chain.

The pure-call table (`CallUnwrap::IfUnusedAndPrimitiveArgs`) covers `Math.*` except `random`, `Number.isFinite/isInteger/isNaN/isSafeInteger/parseFloat/parseInt`, `Array.isArray/of`, `Object.is`, `String.fromCharCode`. A call with an argument of unknown type stays, since converting an object runs its `valueOf`. `Define::insert_global` now replaces an entry with the same parts instead of appending a second one: the parser takes the first matching define, and these names are also in the property-access table.

`P::is_known_non_bigint_primitive` is `known_primitive()` plus the `Math` numeric constants and arithmetic on such operands; `known_primitive()` itself is unchanged. The known-global rule (`console.log` or `Math` read before a side-effecting initializer) is the assumption the existing `if (a) console.log(b); else console.log(c)` to `console.log(a ? b : c)` merge already makes.

The old loop did not mark control flow dead when a `return` or `throw` absorbed the expression statement before it, so `a(); return 1; b();` kept `b()`. The new loop marks it after the merge.

The revisit of an already visited `exports.x = ...` tripped `is_valid_assignment_target`, because the first visit turned the left side into an `ECommonjsExportIdentifier`. That node is now accepted as an assignment target. Without this, bundling react-dom reported "Invalid assignment target" errors.

A long merged statement is a left-deep comma chain, and every walk over it recurses once per statement in it. After 32 merges the chain is no longer searched for a place to inline the declaration before it (`MAX_MERGES_TO_SEARCH`).

`test/bundler/bundler_npm.test.ts` (`npm/ReactSSR`) pins generated columns and the exact size of the minified React SSR bundle, and `test/bundler/bundler_bytecode_portable.test.ts` pins the hash of the three `--minify` bundles. Both are updated; every non-minify entry in the bytecode snapshot is unchanged.

oxc's extra passes (`maxIterations`) are not reproduced. The look at the new tail after each edit covers what a second pass would find inside one statement list.

#40791 (switch cases mangled once every case is visited) and #41159 (esbuild's `mangleStmts`/`mangleIf`/`mangleFor` ports, with a `minify_syntax_statements` feature) rewrite the same tail of `visit_stmts`. This PR keeps the switch-case bodies out of the new drop and retry paths until #40791 lands, and gates on `options.bundle`; whichever of the three lands last needs a rebase, and the gate can then move to the shared feature flag.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->