### PR TITLE
macros: move a worker thread's macro VM to the build it serves

### DIFF
--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -251,6 +251,8 @@ pub mod options {
     /// `options.Format` — many ported call-sites spell this `OutputFormat`.
     pub use bun_options_types::Format as OutputFormat;
     pub use bun_options_types::schema::api::DotEnvBehavior as EnvBehavior;
+    /// The type behind `TransformOptions::target`.
+    pub use bun_options_types::schema::api::Target as TransformTarget;
     /// The type behind `BundleOptions::transform_options`.
     pub use bun_options_types::schema::api::TransformOptions;
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -747,6 +747,10 @@ impl<'a> Transpiler<'a> {
 
     /// Rebuilds `options` and the resolver's copy from `opts`. Call `configure_defines` after.
     pub fn reset_transform_options(&mut self, opts: api::TransformOptions) -> crate::Result<()> {
+        // It copied the old options and env loader; the next parse makes a new one.
+        if let Some(ctx) = self.macro_context.take() {
+            ctx.deinit();
+        }
         // `from_api` leaves this at its default; the VM path applies it.
         let preserve_symlinks = opts.preserve_symlinks.unwrap_or(false);
         self.options = options::BundleOptions::from_api(self.fs_mut(), self.log, opts)?;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -726,8 +726,7 @@ impl<'a> Transpiler<'a> {
         self.configure_linker_with_auto_jsx(true);
     }
 
-    /// Takes the JSX pragma (unless the options set one), the decorator flags
-    /// and `useDefineForClassFields` from the root `tsconfig.json`.
+    /// Root `tsconfig.json`: JSX pragma (unless the options set one), decorators, class fields.
     fn apply_root_tsconfig(&mut self) {
         // Most of the time, this will already be cached
         let top_level_dir = self.fs().top_level_dir;
@@ -746,10 +745,7 @@ impl<'a> Transpiler<'a> {
         }
     }
 
-    /// Rebuilds `options`, and the resolver's projection of it, from `opts` the
-    /// way a VM's `init_runtime_state` does. The resolver caches, the linker
-    /// and the env loader stay. The new `options` has no defines loaded: call
-    /// [`Self::configure_defines`] afterwards.
+    /// Rebuilds `options` and the resolver's copy from `opts`. Call `configure_defines` after.
     pub fn reset_transform_options(&mut self, opts: api::TransformOptions) -> crate::Result<()> {
         // `from_api` leaves this at its default; the VM path applies it.
         let preserve_symlinks = opts.preserve_symlinks.unwrap_or(false);

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -716,21 +716,7 @@ impl<'a> Transpiler<'a> {
         );
 
         if auto_jsx {
-            // Most of the time, this will already be cached
-            let top_level_dir = self.fs().top_level_dir;
-            if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
-                if let Some(tsconfig) = root_dir.tsconfig_json() {
-                    // If we don't explicitly pass JSX, try to get it from the root tsconfig
-                    if self.options.transform_options.jsx.is_none() {
-                        self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx);
-                    }
-                    self.options.emit_decorator_metadata = tsconfig.emit_decorator_metadata;
-                    self.options.experimental_decorators = tsconfig.experimental_decorators;
-                    if let Some(v) = tsconfig.use_define_for_class_fields {
-                        self.options.use_define_for_class_fields = v;
-                    }
-                }
-            }
+            self.apply_root_tsconfig();
         }
     }
 
@@ -738,6 +724,40 @@ impl<'a> Transpiler<'a> {
     #[inline]
     pub fn configure_linker(&mut self) {
         self.configure_linker_with_auto_jsx(true);
+    }
+
+    /// Takes the JSX pragma (unless the options set one), the decorator flags
+    /// and `useDefineForClassFields` from the root `tsconfig.json`.
+    fn apply_root_tsconfig(&mut self) {
+        // Most of the time, this will already be cached
+        let top_level_dir = self.fs().top_level_dir;
+        if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
+            if let Some(tsconfig) = root_dir.tsconfig_json() {
+                // If we don't explicitly pass JSX, try to get it from the root tsconfig
+                if self.options.transform_options.jsx.is_none() {
+                    self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx);
+                }
+                self.options.emit_decorator_metadata = tsconfig.emit_decorator_metadata;
+                self.options.experimental_decorators = tsconfig.experimental_decorators;
+                if let Some(v) = tsconfig.use_define_for_class_fields {
+                    self.options.use_define_for_class_fields = v;
+                }
+            }
+        }
+    }
+
+    /// Rebuilds `options`, and the resolver's projection of it, from `opts` the
+    /// way a VM's `init_runtime_state` does. The resolver caches, the linker
+    /// and the env loader stay. The new `options` has no defines loaded: call
+    /// [`Self::configure_defines`] afterwards.
+    pub fn reset_transform_options(&mut self, opts: api::TransformOptions) -> crate::Result<()> {
+        // `from_api` leaves this at its default; the VM path applies it.
+        let preserve_symlinks = opts.preserve_symlinks.unwrap_or(false);
+        self.options = options::BundleOptions::from_api(self.fs_mut(), self.log, opts)?;
+        self.options.preserve_symlinks = preserve_symlinks;
+        self.sync_resolver_opts();
+        self.apply_root_tsconfig();
+        Ok(())
     }
 
     /// Load `.env` files into the env loader according to

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -468,9 +468,12 @@ impl Macro {
         // macro VM moved to this build) and have no defines loaded yet.
         let (vm, needs_defines): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
             let vm = VirtualMachine::get_mut_ptr();
-            // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
+            // `Transpiler::init` always sets `env`, and `MacroContext` copies it.
+            let env = NonNull::new(env).expect("MacroContext.env is set");
+            // SAFETY: `vm` is the per-thread VM; uniquely accessed here. `env`
+            // is the build's loader and outlives every macro call of the build.
             let moved = unsafe {
-                (*vm).serve_macro_build(build_options, || {
+                (*vm).serve_macro_build(env, build_options, || {
                     macro_vm_transform_options(build_options)
                 })?
             };

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use bun_ast::DisableStoreReset;
 use bun_ast::{E, Expr, ExprData, ExprNodeList, G, ToJSError};
 use bun_ast::{Log, Range, Source};
-use bun_bundler::options::TransformOptions;
+use bun_bundler::options::{TransformOptions, TransformTarget};
 use bun_bundler::{Transpiler, entry_points::MacroEntryPoint};
 use bun_collections::{ArrayHashMap, HashMap};
 use bun_core::Output;
@@ -182,16 +182,23 @@ impl MacroContext {
         );
 
         let macro_entry = self.macros.get_or_put(hash).expect("unreachable");
-        if !macro_entry.found_existing {
-            *macro_entry.value_ptr = match Macro::init(
+        // An entry loaded before another build moved this thread's VM to its
+        // options (`VirtualMachine::serve_macro_build`) points at a module
+        // graph that is gone. Load it again, under this build's options.
+        let stale = macro_entry.found_existing
+            && !macro_entry.value_ptr.disabled
+            && macro_entry.value_ptr.generation != VirtualMachine::get().macro_options_generation;
+        if !macro_entry.found_existing || stale {
+            let loaded = Macro::init(
                 input_specifier,
-                log,
                 self.env,
                 &self.transform_options,
                 function_name,
                 &specifier_buf[0..specifier_buf_len as usize],
                 hash,
-            ) {
+            );
+            drain_macro_vm_log(log);
+            *macro_entry.value_ptr = match loaded {
                 Ok(m) => m,
                 Err(e) => {
                     *macro_entry.value_ptr = Macro::disabled_sentinel();
@@ -243,8 +250,29 @@ impl MacroContext {
                 javascript_object,
             )
         });
+        drain_macro_vm_log(log);
         Ok(ret?)
         // this.macros.getOrPut(key: K)
+    }
+}
+
+/// Moves what a macro VM logged into `log`, the build's log. A macro VM (see
+/// `VirtualMachine::macro_build_options`) outlives every build, so it keeps a
+/// log of its own instead of writing into a build's. Runtime and Worker VMs log
+/// into the program's log and are left alone.
+fn drain_macro_vm_log(log: &mut Log) {
+    if !VirtualMachine::is_loaded() {
+        return;
+    }
+    let vm = VirtualMachine::get();
+    if vm.macro_build_options.is_none() {
+        return;
+    }
+    if let Some(vm_log) = vm.log_mut() {
+        if !vm_log.msgs.is_empty() {
+            vm_log.append_to_with_recycled(log, true);
+        }
+        vm_log.reset();
     }
 }
 
@@ -380,6 +408,8 @@ fn __bun_macro_context_get_remap(
 // is checked before any access (see `MacroContext::call`).
 pub struct Macro {
     pub(crate) vm: Option<NonNull<VirtualMachine>>,
+    /// `VirtualMachine::macro_options_generation` when the macro was loaded.
+    pub(crate) generation: u32,
 
     pub(crate) disabled: bool,
 }
@@ -390,12 +420,27 @@ impl Default for Macro {
     }
 }
 
+/// The build's options as the macro VM's transpiler takes them.
+fn macro_vm_transform_options(build: &TransformOptions) -> TransformOptions {
+    let mut transform_options = build.clone();
+    // Build-only flags about the output bundle. The macro module's own
+    // imports must still resolve.
+    transform_options.external = Vec::new();
+    transform_options.packages = None;
+    // What `init_runtime_state` forces for every VM: the macro VM runs on bun
+    // and never writes the build's output directory.
+    transform_options.write = Some(false);
+    transform_options.target = Some(TransformTarget::Bun);
+    transform_options
+}
+
 impl Macro {
     /// Sentinel stored in the `MacroMap` when `Macro::init` fails, so subsequent
     /// calls with the same hash short-circuit instead of retrying the load.
     fn disabled_sentinel() -> Self {
         Macro {
             vm: None,
+            generation: 0,
             disabled: true,
         }
     }
@@ -413,33 +458,38 @@ impl Macro {
 
     pub(crate) fn init(
         input_specifier: &[u8],
-        log: &mut Log,
         env: *mut DotEnvLoader,
-        transform_options: &TransformOptions,
+        build_options: &Arc<TransformOptions>,
         function_name: &[u8],
         specifier: &[u8],
         hash: i32,
     ) -> crate::Result<Macro> {
-        let (vm, is_new_vm): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
-            (VirtualMachine::get_mut_ptr(), false)
+        // `needs_defines`: the VM's transpiler options are new (a new VM, or a
+        // macro VM moved to this build) and have no defines loaded yet.
+        let (vm, needs_defines): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
+            let vm = VirtualMachine::get_mut_ptr();
+            // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
+            let moved = unsafe {
+                (*vm).serve_macro_build(build_options, || {
+                    macro_vm_transform_options(build_options)
+                })?
+            };
+            (vm, moved)
         } else {
-            let mut transform_options = transform_options.clone();
-            // Build-only flags about the output bundle. The macro module's own
-            // imports must still resolve.
-            transform_options.external = Vec::new();
-            transform_options.packages = None;
-
             // JSC needs to be initialized if building from CLI
             jsc::initialize(jsc::InitializeOptions::default());
 
-            let _vm = VirtualMachine::init(VirtualMachineInitOptions {
-                transform_options,
-                log: Some(NonNull::from(&mut *log)),
+            // No `log`: the VM outlives the build, so it keeps a log of its
+            // own that `drain_macro_vm_log` moves into the build's.
+            let vm = VirtualMachine::init(VirtualMachineInitOptions {
+                transform_options: macro_vm_transform_options(build_options),
                 env_loader: NonNull::new(env),
                 is_main_thread: false,
                 ..Default::default()
             })?;
-            (_vm, true)
+            // SAFETY: `vm` is the freshly-allocated per-thread VM.
+            unsafe { (*vm).macro_build_options = Some(Arc::clone(build_options)) };
+            (vm, true)
         };
 
         // Covers `configure_defines` (new-VM path) and `load_macro_entry_point`
@@ -451,8 +501,8 @@ impl Macro {
         let _init_guard = MacroModeGuard::new(vm);
         // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
         unsafe { (*(*vm).event_loop()).ensure_waker() };
-        if is_new_vm {
-            // SAFETY: `vm` is the freshly-allocated per-thread VM.
+        if needs_defines {
+            // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
             unsafe { (*vm).transpiler.configure_defines()? };
         }
 
@@ -477,6 +527,8 @@ impl Macro {
 
         Ok(Macro {
             vm: NonNull::new(vm),
+            // SAFETY: `vm` is the per-thread VM; a plain field read.
+            generation: unsafe { (*vm).macro_options_generation },
             disabled: false,
         })
     }

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -182,9 +182,7 @@ impl MacroContext {
         );
 
         let macro_entry = self.macros.get_or_put(hash).expect("unreachable");
-        // An entry loaded before another build moved this thread's VM to its
-        // options (`VirtualMachine::serve_macro_build`) points at a module
-        // graph that is gone. Load it again, under this build's options.
+        // Loaded before another build moved this VM (`serve_macro_build`): that module graph is gone.
         let stale = macro_entry.found_existing
             && !macro_entry.value_ptr.disabled
             && macro_entry.value_ptr.generation != VirtualMachine::get().macro_options_generation;
@@ -256,10 +254,7 @@ impl MacroContext {
     }
 }
 
-/// Moves what a macro VM logged into `log`, the build's log. A macro VM (see
-/// `VirtualMachine::macro_build_options`) outlives every build, so it keeps a
-/// log of its own instead of writing into a build's. Runtime and Worker VMs log
-/// into the program's log and are left alone.
+/// Moves what a macro VM logged into the build's `log`; the VM outlives the build, so it has its own.
 fn drain_macro_vm_log(log: &mut Log) {
     if !VirtualMachine::is_loaded() {
         return;
@@ -423,12 +418,10 @@ impl Default for Macro {
 /// The build's options as the macro VM's transpiler takes them.
 fn macro_vm_transform_options(build: &TransformOptions) -> TransformOptions {
     let mut transform_options = build.clone();
-    // Build-only flags about the output bundle. The macro module's own
-    // imports must still resolve.
+    // Build-only flags about the output bundle; the macro module's own imports must still resolve.
     transform_options.external = Vec::new();
     transform_options.packages = None;
-    // What `init_runtime_state` forces for every VM: the macro VM runs on bun
-    // and never writes the build's output directory.
+    // What `init_runtime_state` forces for every VM.
     transform_options.write = Some(false);
     transform_options.target = Some(TransformTarget::Bun);
     transform_options
@@ -464,8 +457,7 @@ impl Macro {
         specifier: &[u8],
         hash: i32,
     ) -> crate::Result<Macro> {
-        // `needs_defines`: the VM's transpiler options are new (a new VM, or a
-        // macro VM moved to this build) and have no defines loaded yet.
+        // `needs_defines`: new transpiler options (a new VM, or one moved to this build).
         let (vm, needs_defines): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
             let vm = VirtualMachine::get_mut_ptr();
             // `Transpiler::init` always sets `env`, and `MacroContext` copies it.
@@ -482,8 +474,7 @@ impl Macro {
             // JSC needs to be initialized if building from CLI
             jsc::initialize(jsc::InitializeOptions::default());
 
-            // No `log`: the VM outlives the build, so it keeps a log of its
-            // own that `drain_macro_vm_log` moves into the build's.
+            // No `log`: the VM outlives the build; `drain_macro_vm_log` moves its own log out.
             let vm = VirtualMachine::init(VirtualMachineInitOptions {
                 transform_options: macro_vm_transform_options(build_options),
                 env_loader: NonNull::new(env),

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -250,21 +250,10 @@ pub struct VirtualMachine {
     // LAYERING: values are `MacroEntryPoint` from `bun_bundler::entry_points`
     // (forward dep); stored type-erased and cast back by the consumers.
     pub macro_entry_points: bun_collections::ArrayHashMap<i32, *mut c_void>,
-    /// The options of the build whose macros this VM ran last. `Some` only for
-    /// a VM that `Macro::init` created on a bundler or transpiler worker
-    /// thread. Such a VM outlives the build that created it;
-    /// [`serve_macro_build`] moves it to the next build. Every transpiler of
-    /// one build shares one `Arc`, so pointer identity tells the builds apart;
-    /// this strong reference keeps a later build from allocating its options
-    /// at the same address.
-    ///
-    /// [`serve_macro_build`]: Self::serve_macro_build
+    /// Last build this macro VM served. `Some` only for a VM that `Macro::init` created.
     pub macro_build_options:
         Option<std::sync::Arc<bun_options_types::schema::api::TransformOptions>>,
-    /// Bumped when [`serve_macro_build`](Self::serve_macro_build) moves the VM
-    /// to other options. A `Macro` entry records the value it was loaded under,
-    /// so a call that comes after another build moved the VM loads the macro
-    /// again instead of calling into a module graph that is gone.
+    /// Bumped when `serve_macro_build` moves the VM; a `Macro` loaded under an older value reloads.
     pub macro_options_generation: u32,
     pub macro_mode: bool,
     /// Depth of live [`MacroModeGuard`]s on this thread. Nonzero exactly while
@@ -1633,24 +1622,7 @@ impl VirtualMachine {
         promise.ok_or(crate::CrateError::JSError)
     }
 
-    /// The start of a macro load for `build` on a macro VM (see
-    /// [`macro_build_options`]). A no-op on every other VM, and while macro JS
-    /// runs on this thread (a `Bun.Transpiler` used inside a macro keeps the
-    /// VM as it is).
-    ///
-    /// The VM takes the build's `env` loader. The loader it was created with
-    /// belongs to the VM that ran that build, and a `Worker` frees its loader
-    /// when it exits. If `build` is not the build the VM served last, the VM
-    /// moves to it. The transpiler options come from `transform_options` (the
-    /// build's options as the macro VM takes them), and everything the VM
-    /// evaluated for the previous build goes: the module registry, the
-    /// require map and the registered macro callbacks. The next
-    /// [`load_macro_entry_point`] then transpiles the macro modules again,
-    /// with the build's `--define` and loaders. Returns whether the VM moved;
-    /// the caller then loads the defines, as it does for a new VM.
-    ///
-    /// [`macro_build_options`]: Self::macro_build_options
-    /// [`load_macro_entry_point`]: Self::load_macro_entry_point
+    /// Points a macro VM at `build`: its env loader, and for another build its options (modules dropped).
     pub fn serve_macro_build(
         &mut self,
         env: NonNull<bun_dotenv::Loader>,
@@ -1660,15 +1632,18 @@ impl VirtualMachine {
         let Some(current) = &self.macro_build_options else {
             return Ok(false);
         };
+        // A `Bun.Transpiler` used inside a running macro keeps the VM as it is.
         if self.macro_guard_depth != 0 {
             return Ok(false);
         }
+        // A `Worker` frees its loader when it exits; the VM may have been created from its build.
         self.transpiler.env = env.as_ptr();
+        // Held strongly, so no later build can reuse this address: identity means the same build.
         if std::sync::Arc::ptr_eq(current, build) {
             return Ok(false);
         }
-        self.transpiler
-            .reset_transform_options(transform_options())?;
+        // Modules first: should the options fail to rebuild, the VM is the old build's, only empty.
+        self.macro_options_generation += 1;
         for callback in self.macros.values() {
             callback.unprotect();
         }
@@ -1676,7 +1651,8 @@ impl VirtualMachine {
         // The same clear as `bun --hot`: every module, ESM and CommonJS, goes.
         self.run_with_api_lock(|| VirtualMachine::get().global().reload())
             .map_err(|_| crate::CrateError::JSError)?;
-        self.macro_options_generation += 1;
+        self.transpiler
+            .reset_transform_options(transform_options())?;
         self.macro_build_options = Some(std::sync::Arc::clone(build));
         Ok(true)
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -250,6 +250,22 @@ pub struct VirtualMachine {
     // LAYERING: values are `MacroEntryPoint` from `bun_bundler::entry_points`
     // (forward dep); stored type-erased and cast back by the consumers.
     pub macro_entry_points: bun_collections::ArrayHashMap<i32, *mut c_void>,
+    /// The options of the build whose macros this VM ran last. `Some` only for
+    /// a VM that `Macro::init` created on a bundler or transpiler worker
+    /// thread. Such a VM outlives the build that created it;
+    /// [`serve_macro_build`] moves it to the next build. Every transpiler of
+    /// one build shares one `Arc`, so pointer identity tells the builds apart;
+    /// this strong reference keeps a later build from allocating its options
+    /// at the same address.
+    ///
+    /// [`serve_macro_build`]: Self::serve_macro_build
+    pub macro_build_options:
+        Option<std::sync::Arc<bun_options_types::schema::api::TransformOptions>>,
+    /// Bumped when [`serve_macro_build`](Self::serve_macro_build) moves the VM
+    /// to other options. A `Macro` entry records the value it was loaded under,
+    /// so a call that comes after another build moved the VM loads the macro
+    /// again instead of calling into a module graph that is gone.
+    pub macro_options_generation: u32,
     pub macro_mode: bool,
     /// Depth of live [`MacroModeGuard`]s on this thread. Nonzero exactly while
     /// macro JS may be executing — both `MacroContext::call` and `Macro::init`
@@ -1617,6 +1633,47 @@ impl VirtualMachine {
         promise.ok_or(crate::CrateError::JSError)
     }
 
+    /// The start of a macro load for `build` on a macro VM (see
+    /// [`macro_build_options`]). A no-op on every other VM, and while macro JS
+    /// runs on this thread (a `Bun.Transpiler` used inside a macro keeps the
+    /// VM as it is).
+    ///
+    /// If `build` is not the build the VM served last, the VM moves to it. The
+    /// transpiler options come from `transform_options` (the build's options
+    /// as the macro VM takes them), and everything the VM evaluated for the
+    /// previous build goes: the module registry, the require map and the
+    /// registered macro callbacks. The next [`load_macro_entry_point`] then
+    /// transpiles the macro modules again, with the build's `--define` and
+    /// loaders. Returns whether the VM moved; the caller then loads the
+    /// defines, as it does for a new VM.
+    ///
+    /// [`macro_build_options`]: Self::macro_build_options
+    /// [`load_macro_entry_point`]: Self::load_macro_entry_point
+    pub fn serve_macro_build(
+        &mut self,
+        build: &std::sync::Arc<bun_options_types::schema::api::TransformOptions>,
+        transform_options: impl FnOnce() -> bun_options_types::schema::api::TransformOptions,
+    ) -> crate::CrateResult<bool> {
+        let Some(current) = &self.macro_build_options else {
+            return Ok(false);
+        };
+        if self.macro_guard_depth != 0 || std::sync::Arc::ptr_eq(current, build) {
+            return Ok(false);
+        }
+        self.transpiler
+            .reset_transform_options(transform_options())?;
+        for callback in self.macros.values() {
+            callback.unprotect();
+        }
+        self.macros.clear_retaining_capacity();
+        // The same clear as `bun --hot`: every module, ESM and CommonJS, goes.
+        self.run_with_api_lock(|| VirtualMachine::get().global().reload())
+            .map_err(|_| crate::CrateError::JSError)?;
+        self.macro_options_generation += 1;
+        self.macro_build_options = Some(std::sync::Arc::clone(build));
+        Ok(true)
+    }
+
     pub fn is_watcher_enabled(&self) -> bool {
         !self.bun_watcher.is_null()
     }
@@ -2667,6 +2724,7 @@ impl VirtualMachine {
             addr_of_mut!((*vm).resolved_path_dups).write(Vec::new());
             addr_of_mut!((*vm).macros).write(Default::default());
             addr_of_mut!((*vm).macro_entry_points).write(Default::default());
+            addr_of_mut!((*vm).macro_build_options).write(None);
             addr_of_mut!((*vm).auto_killer).write(Default::default());
             addr_of_mut!((*vm).commonjs_custom_extensions).write(Default::default());
             addr_of_mut!((*vm).entry_point).write(Default::default());
@@ -4887,6 +4945,7 @@ impl VirtualMachine {
 
         drop(core::mem::take(&mut self.resolved_path_dups));
         drop(core::mem::take(&mut self.main_resolved_path));
+        self.macro_build_options = None;
 
         self.overridden_main.deinit();
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1638,26 +1638,33 @@ impl VirtualMachine {
     /// runs on this thread (a `Bun.Transpiler` used inside a macro keeps the
     /// VM as it is).
     ///
-    /// If `build` is not the build the VM served last, the VM moves to it. The
-    /// transpiler options come from `transform_options` (the build's options
-    /// as the macro VM takes them), and everything the VM evaluated for the
-    /// previous build goes: the module registry, the require map and the
-    /// registered macro callbacks. The next [`load_macro_entry_point`] then
-    /// transpiles the macro modules again, with the build's `--define` and
-    /// loaders. Returns whether the VM moved; the caller then loads the
-    /// defines, as it does for a new VM.
+    /// The VM takes the build's `env` loader. The loader it was created with
+    /// belongs to the VM that ran that build, and a `Worker` frees its loader
+    /// when it exits. If `build` is not the build the VM served last, the VM
+    /// moves to it. The transpiler options come from `transform_options` (the
+    /// build's options as the macro VM takes them), and everything the VM
+    /// evaluated for the previous build goes: the module registry, the
+    /// require map and the registered macro callbacks. The next
+    /// [`load_macro_entry_point`] then transpiles the macro modules again,
+    /// with the build's `--define` and loaders. Returns whether the VM moved;
+    /// the caller then loads the defines, as it does for a new VM.
     ///
     /// [`macro_build_options`]: Self::macro_build_options
     /// [`load_macro_entry_point`]: Self::load_macro_entry_point
     pub fn serve_macro_build(
         &mut self,
+        env: NonNull<bun_dotenv::Loader>,
         build: &std::sync::Arc<bun_options_types::schema::api::TransformOptions>,
         transform_options: impl FnOnce() -> bun_options_types::schema::api::TransformOptions,
     ) -> crate::CrateResult<bool> {
         let Some(current) = &self.macro_build_options else {
             return Ok(false);
         };
-        if self.macro_guard_depth != 0 || std::sync::Arc::ptr_eq(current, build) {
+        if self.macro_guard_depth != 0 {
+            return Ok(false);
+        }
+        self.transpiler.env = env.as_ptr();
+        if std::sync::Arc::ptr_eq(current, build) {
             return Ok(false);
         }
         self.transpiler

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2862,10 +2862,9 @@ describe("bundler", () => {
     run: { stdout: '[true,true,null,"{\\"__proto__\\":{\\"x\\":1},\\"a\\":2}"]' },
   });
   // The macro module is transpiled by the macro VM, not by the bundler. That
-  // VM has to be created from the build's transform options, or the macro
-  // module does not see `--define` and `--loader`. The `Bun.build()` variant
-  // lives in transpiler/macro-test.test.ts: the macro VM of a worker thread
-  // outlives the build that created it, so that test needs its own process.
+  // VM takes the build's transform options, or the macro module does not see
+  // `--define` and `--loader`. `define` picks the CLI backend; the `Bun.build()`
+  // variants live in transpiler/macro-test.test.ts.
   itBundled("edgecase/MacroSeesBuildDefinesAndLoaders", {
     files: {
       "/entry.ts": /* js */ `
@@ -2883,7 +2882,6 @@ describe("bundler", () => {
       `,
       "/banner.dat": "hello from a text loader",
     },
-    backend: "cli",
     define: { "process.env.MODE": '"prod"' },
     loader: { ".dat": "text" },
     target: "bun",
@@ -2891,6 +2889,8 @@ describe("bundler", () => {
   });
   // `--external` and `--packages=external` describe the output bundle, not the
   // macro VM. A package the macro module imports has to resolve at build time.
+  // The API backend runs in this process, on worker VMs that earlier tests'
+  // builds created with other options.
   itBundled("edgecase/MacroImportsPackageMarkedExternal", {
     files: {
       "/entry.ts": /* js */ `
@@ -2907,7 +2907,6 @@ describe("bundler", () => {
       "/node_modules/foo/package.json": `{ "name": "foo", "version": "1.0.0", "main": "index.js" }`,
       "/node_modules/foo/index.js": `module.exports = "foo-value";`,
     },
-    backend: "cli",
     external: ["foo"],
     packages: "external",
     target: "bun",

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -466,8 +466,8 @@ test("a macro in a module transpiled off the main thread sees --define", async (
 });
 
 // `Bun.build()` parses on the process-wide worker pool. The macro VM a worker creates takes the
-// options of the build that creates it and lives on after that build, so this runs in its own
-// process: an earlier build in the same process would otherwise decide what the macro sees.
+// options of the build that creates it. Its own process, so that no other test's macros share
+// those VMs.
 test("Bun.build() passes define and loader to the macro VM", async () => {
   using dir = tempDir("macro-build-api-options", {
     "entry.ts": `import { mode, banner } from "./macro.ts" with { type: "macro" };\nconsole.log(mode(), banner());\n`,
@@ -498,6 +498,92 @@ test("Bun.build() passes define and loader to the macro VM", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
     lastLine: `console.log("prod", "hello from a text loader");`,
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
+// The macro VM of a worker thread lives on after the build that created it. A later build whose
+// parse lands on that thread has other options, so the VM moves to them: the macro module and what
+// it imports are evaluated again with the new `define`. A pool of two threads and four files that
+// use the macro make sure that every build after the first meets a VM an earlier build created.
+test.concurrent("sequential Bun.build() calls with different defines each reach the macro", async () => {
+  const libs = [0, 1, 2, 3];
+  using dir = tempDir("macro-build-api-sequential-defines", {
+    "config.ts": `declare const BUILD_TAG: string;\nexport const tag = BUILD_TAG;\n`,
+    "macro.ts": `import { tag } from "./config.ts";\nexport function tagAtBuildTime() {\n  return tag;\n}\n`,
+    ...Object.fromEntries(
+      libs.map(i => [
+        `lib${i}.ts`,
+        `import { tagAtBuildTime } from "./macro.ts" with { type: "macro" };\nexport const tag${i} = tagAtBuildTime();\n`,
+      ]),
+    ),
+    "entry.ts": [
+      ...libs.map(i => `import { tag${i} } from "./lib${i}.ts";`),
+      `console.log(${libs.map(i => `tag${i}`).join(", ")});`,
+      ``,
+    ].join("\n"),
+    "build.ts": `
+      const stale: string[] = [];
+      for (let i = 0; i < 16; i++) {
+        const tag = "tag-" + i;
+        const result = await Bun.build({
+          entrypoints: ["./entry.ts"],
+          target: "bun",
+          define: { BUILD_TAG: JSON.stringify(tag) },
+        });
+        if (!result.success) throw new AggregateError(result.logs, "build " + tag + " failed");
+        const out = await result.outputs[0].text();
+        const seen = [...out.matchAll(/"tag-\\d+"/g)].map(m => m[0]);
+        if (seen.length === 0 || seen.some(s => s !== JSON.stringify(tag))) {
+          stale.push(tag + " => " + seen.join(","));
+        }
+      }
+      console.log(JSON.stringify(stale));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "build.ts"],
+    env: { ...bunEnv, UV_THREADPOOL_SIZE: "2" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({ lastLine: "[]", stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
+// A module the program imports later is transpiled on the same worker pool. Its macro runs with the
+// program's options, not with the `define` of a `Bun.build()` that ran before it. Eight imports on
+// a pool of two threads: some of them land on the thread whose VM ran the build's macro.
+test.concurrent("a runtime import after Bun.build() does not see the build's define", async () => {
+  const libs = [0, 1, 2, 3, 4, 5, 6, 7];
+  using dir = tempDir("macro-build-api-then-runtime-import", {
+    "macro.ts": `declare const MY_DEF: string;\nexport function d() {\n  return typeof MY_DEF !== "undefined" ? MY_DEF : "undef";\n}\n`,
+    "entry.ts": `import { d } from "./macro.ts" with { type: "macro" };\nconsole.log(d());\n`,
+    ...Object.fromEntries(
+      libs.map(i => [`lib${i}.ts`, `import { d } from "./macro.ts" with { type: "macro" };\nexport const v = d();\n`]),
+    ),
+    "main.ts": `
+      const result = await Bun.build({ entrypoints: ["./entry.ts"], target: "bun", define: { MY_DEF: '"from-build"' } });
+      if (!result.success) throw new AggregateError(result.logs, "build failed");
+      const built = (await result.outputs[0].text()).trim().split("\\n").pop();
+      const runtime = [];
+      for (let i = 0; i < ${libs.length}; i++) runtime.push((await import("./lib" + i + ".ts")).v);
+      console.log(JSON.stringify({ built, runtime }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "main.ts"],
+    env: { ...bunEnv, UV_THREADPOOL_SIZE: "2" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
+    lastLine: JSON.stringify({ built: `console.log("from-build");`, runtime: libs.map(() => "undef") }),
     stderr: "",
   });
   expect(exitCode).toBe(0);

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -589,6 +589,74 @@ test.concurrent("a runtime import after Bun.build() does not see the build's def
   expect(exitCode).toBe(0);
 });
 
+// A `Bun.build()` from a Worker creates macro VMs that read the Worker's env. The Worker frees its
+// env when it exits. The main thread's build that follows moves those VMs to its own env, which the
+// macro reads through `process.env`.
+test.concurrent("a Bun.build() after a Worker's build with macros reads the main thread's env", async () => {
+  const libs = [0, 1, 2, 3];
+  using dir = tempDir("macro-build-api-after-worker", {
+    "macro.ts": [
+      `declare const BUILD_TAG: string;`,
+      `export function tag() {`,
+      `  return BUILD_TAG + ":" + process.env.MACRO_ENV;`,
+      `}`,
+      ``,
+    ].join("\n"),
+    ...Object.fromEntries(
+      libs.map(i => [
+        `lib${i}.ts`,
+        `import { tag } from "./macro.ts" with { type: "macro" };\nexport const tag${i} = tag();\n`,
+      ]),
+    ),
+    "entry.ts": [
+      ...libs.map(i => `import { tag${i} } from "./lib${i}.ts";`),
+      `console.log(${libs.map(i => `tag${i}`).join(", ")});`,
+      ``,
+    ].join("\n"),
+    "build.ts": `
+      export async function build(tagValue: string) {
+        const result = await Bun.build({
+          entrypoints: ["./entry.ts"],
+          target: "bun",
+          define: { BUILD_TAG: JSON.stringify(tagValue) },
+        });
+        if (!result.success) throw new AggregateError(result.logs, "build " + tagValue + " failed");
+        return [...(await result.outputs[0].text()).matchAll(/"[a-z]+:[a-z]+"/g)].map(m => m[0]);
+      }
+    `,
+    "worker.ts": `
+      import { parentPort } from "node:worker_threads";
+      import { build } from "./build.ts";
+      parentPort.postMessage(await build("worker"));
+    `,
+    "main.ts": `
+      import { Worker } from "node:worker_threads";
+      import { build } from "./build.ts";
+      const worker = new Worker("./worker.ts");
+      const fromWorker = await new Promise(resolve => worker.once("message", resolve));
+      await worker.terminate();
+      const fromMain = await build("main");
+      console.log(JSON.stringify({ fromWorker, fromMain }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "main.ts"],
+    env: { ...bunEnv, UV_THREADPOOL_SIZE: "2", MACRO_ENV: "env" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
+    lastLine: JSON.stringify({
+      fromWorker: libs.map(() => `"worker:env"`),
+      fromMain: libs.map(() => `"main:env"`),
+    }),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -633,7 +633,10 @@ test.concurrent("a Bun.build() after a Worker's build with macros reads the main
       import { Worker } from "node:worker_threads";
       import { build } from "./build.ts";
       const worker = new Worker("./worker.ts");
-      const fromWorker = await new Promise(resolve => worker.once("message", resolve));
+      const { promise, resolve, reject } = Promise.withResolvers();
+      worker.once("message", resolve);
+      worker.once("error", reject);
+      const fromWorker = await promise;
       await worker.terminate();
       const fromMain = await build("main");
       console.log(JSON.stringify({ fromWorker, fromMain }));


### PR DESCRIPTION
### Problem
- Sequential `Bun.build()` calls in one process get stale macro results. A macro that reads a `define` returns the value of the build that first created the macro VM on that worker thread. A runtime `import()` transpiled on that thread gets the build's `define` too. On the current canary, 15 of 16 builds in the new test inline an earlier build's value.
- `Macro::init` (`src/js_parser_jsc/Macro.rs`) reuses the thread's VM as it is. Only a new VM takes the build's transform options and runs `configure_defines`, and JSC's module registry keeps the first build's macro module. The VM also keeps that build's log and env loader. A `Worker` frees its env loader when it exits, so a later build read freed memory.

### Fix
- `VirtualMachine::macro_build_options` records the build the VM served last, by the `Arc<TransformOptions>` every transpiler of one build shares. `serve_macro_build` runs at the start of each macro load: it points the VM at the build's env loader and, for another build, drops the registered macro callbacks, clears the module registry and the require map (`GlobalObject::reload`, the `--hot` path), rebuilds the transpiler options (`Transpiler::reset_transform_options`), then records the build. `Macro::init` loads the defines again, as for a new VM.
- A `Macro` entry records the generation it was loaded under and reloads after a move. The VM keeps a log of its own. `MacroContext::call` moves what it logged into the build's log.
- Verified: `test/bundler/transpiler/macro-test.test.ts` (three new tests, all fail on stock bun). Also the macro regression tests, `bundler_edgecase.test.ts`, `transpiler.test.js`, `bun-build-api.test.ts`.

### Background
- A macro import (`with { type: "macro" }`) runs the imported module in a JSC VM at build time and splices the result into the AST. `Bun.build()` parses on the process-wide worker pool. A pool thread has no VM, so `Macro::init` creates one per thread. It lives as long as the thread.
- `api::TransformOptions` is the option bag a build starts from. `BundleOptions::from_api` projects it into the transpiler's options. Each worker gets a copy of the build's transpiler, and the copies share the build's `Arc<TransformOptions>`.
- The VM's module registry caches every evaluated module by path. The VM's own transpiler transpiles the macro module and its imports, with the defines it had at the time.

<details><summary>Notes</summary>

- Repro on stock 1.4.1: twelve `Bun.build()` calls with `define: { MY_DEF: JSON.stringify("v" + i) }` on an entry that uses a macro reading `MY_DEF`. Seven to eight outputs carry an earlier value. With `UV_THREADPOOL_SIZE=2` every later build is stale.
- The same VM leaks a build's `define` into the program: after `Bun.build({ define: { MY_DEF: '"from-build"' } })`, a runtime `import()` of a module that uses the macro, transpiled on a pool thread, returns `"from-build"`. The second new test covers this.
- The Worker case: a `Bun.build()` from a `Worker` creates pool VMs with the Worker's env loader. After the Worker exits, a build from the main thread crashed on stock bun (segfault in the macro's `process.env` read) and under ASAN in `Loader::load_process`. The third new test covers this.
- A build is identified by pointer. Two `Bun.build()` calls with equal options are two builds, so the macro modules are evaluated once per build per thread, as `bun build` evaluates them once per invocation. `bun build --watch` and the dev server reuse one transpiler across rebuilds, so their macro VMs keep their modules, as before.
- A move that fails at any step leaves the VM on the old build with an empty registry: the callbacks and the registry go first, the options rebuild second, and the build is recorded last. The failed load returns an error, and the next load for the new build moves again.
- `--external`, `--packages=external`, `write` and `target` are cleared or forced on the copy the macro VM takes, the way the first VM already took them (#40750, `init_runtime_state`). `reset_transform_options` also applies `preserve_symlinks`, which `from_api` leaves at its default and `init_runtime_state` applies to a new VM.
- A macro VM is moved only while no macro JS runs on its thread. A `Bun.Transpiler` used inside a macro body keeps the VM as it is.
- `MacroImportsPackageMarkedExternal` in `bundler_edgecase.test.ts` no longer pins the CLI backend. Its API variant runs in the test process, on worker VMs that earlier tests' builds created.
- Not changed: `Bun.build({ features })` does not reach `TransformOptions.feature_flags` yet (#41099). A macro module that fails to load in `Bun.build()` still ends the process, and on a debug build that path hits a JSC API lock assertion. #40631 fixes the assertion.
- Related: #40059 moves every macro to one dedicated VM thread. The new tests describe what such a host must keep: each build's macros see that build's options and env.
- Two bytecode tests in `bun-build-api.test.ts` hit the 5 s timeout on an unmodified debug build in this container as well. Unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/macro-test.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [567.28ms]
(pass) bundler > edgecase/EmptyCommonJSModule [420.41ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [435.34ms]
(pass) bundler > edgecase/ImportStarFunction [402.85ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [411.26ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [106.07ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [497.49ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [364.95ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [355.16ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [286.14ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [112.21ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [403.79ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/Impo
... (truncated)

release without fix: 1 failed, 11 skipped
bun test v1.4.1-canary.1 (a5a23ceed)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [15.24ms]
(pass) bundler > edgecase/EmptyCommonJSModule [12.29ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [14.47ms]
(pass) bundler > edgecase/ImportStarFunction [13.50ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [14.14ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [6.78ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [12.32ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [6.32ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [6.03ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [6.18ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [5.93ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [11.75ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [10.58ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [6.14ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [2.59ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDefaul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/macro-test.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [579.15ms]
(pass) bundler > edgecase/EmptyCommonJSModule [415.99ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [497.65ms]
(pass) bundler > edgecase/ImportStarFunction [434.59ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [428.94ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [129.87ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [415.85ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [283.35ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [346.04ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [286.33ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [124.28ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [417.78ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/Impo
... (truncated)

release with fix: 11 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 671ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/lib.rs                         |   2 +
 src/bundler/transpiler.rs                  |  50 ++++++---
 src/js_parser_jsc/Macro.rs                 |  88 ++++++++++++----
 src/jsc/VirtualMachine.rs                  |  42 ++++++++
 test/bundler/bundler_edgecase.test.ts      |  11 +-
 test/bundler/transpiler/macro-test.test.ts | 161 ++++++++++++++++++++++++++++-
 6 files changed, 310 insertions(+), 44 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/bundler/lib.rs                              1      2     26
src/bundler/transpiler.rs                       7      5     26
src/js_parser_jsc/Macro.rs                     11     21     26
src/jsc/VirtualMachine.rs                      16     19     26
test/bundler/bundler_edgecase.test.ts           2      3      7
test/bundler/transpiler/macro-test.test.ts      5     11     22
```

</details>

<!-- robobun:evidence:end -->