### PR TITLE
compile: fail the build when the embedded module graph would exceed 4 GiB

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -71,6 +71,10 @@ new!(pub BUN_DEBUG_FORCE_NIX_HOST: boolean, "BUN_DEBUG_FORCE_NIX_HOST", { defaul
 new!(pub BUN_INTERNAL_NAPI_FORCE_MUSL_CHECK: boolean, "BUN_INTERNAL_NAPI_FORCE_MUSL_CHECK", { default: false });
 new!(pub BUN_DEBUG_HASH_RANDOM_SEED: unsigned, "BUN_DEBUG_HASH_RANDOM_SEED", { deser: { error_handling: NotSet } });
 new!(pub BUN_DEBUG_QUIET_LOGS: boolean, "BUN_DEBUG_QUIET_LOGS", {});
+// Testing hook for `bun build --compile`, debug builds only: lowers the 4 GiB
+// size limit of the embedded module graph (`StandaloneModuleGraph::to_bytes`)
+// so a test can reach it without a 4 GiB input.
+new!(pub BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES: unsigned, "BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES", {});
 new!(pub BUN_DEBUG_TEST_TEXT_LOCKFILE: boolean, "BUN_DEBUG_TEST_TEXT_LOCKFILE", { default: false });
 new!(pub BUN_DEV_SERVER_TEST_RUNNER: string, "BUN_DEV_SERVER_TEST_RUNNER", {});
 // Debug-only: when set, `NumberRenamer` dumps the symbol table before

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1232,6 +1232,18 @@ fn module_dest_path(output_file: &OutputFile) -> &[u8] {
     bun_core::strings::remove_leading_dot_slash(&output_file.dest_path)
 }
 
+/// Every region of the serialized graph is addressed by a `StringPointer`, a `u32` offset and
+/// length, so the graph has to fit in 4 GiB. A debug build can lower the limit through
+/// `BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES` so a test reaches it without a 4 GiB input.
+fn max_graph_bytes() -> usize {
+    let limit = u32::MAX as usize;
+    #[cfg(debug_assertions)]
+    if let Some(test_limit) = bun_core::env_var::BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES.get() {
+        return usize::try_from(test_limit).map_or(limit, |test_limit| test_limit.min(limit));
+    }
+    limit
+}
+
 pub(crate) fn to_bytes(
     target: &CompileTarget,
     prefix: &[u8],
@@ -1573,6 +1585,12 @@ pub(crate) fn to_bytes(
         flags |= Flags::CROSS_COMPILED_BYTECODE;
     }
     let compile_exec_argv_ptr = string_builder.append_count_z(compile_exec_argv);
+
+    // Every region above is addressed by a `StringPointer`, so `len` itself has to fit in u32
+    // or the `as u32` casts that built those pointers have wrapped.
+    if string_builder.len > max_graph_bytes() {
+        return Err(crate::Error::ModuleGraphTooLarge);
+    }
 
     let offsets = Offsets {
         entry_point_id: entry_point_id as u32,

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     InvalidSourceMap,
     #[error("SourceMapTooLarge")]
     SourceMapTooLarge,
+    #[error("embedded module graph would exceed 4 GiB (its offsets are 32-bit)")]
+    ModuleGraphTooLarge,
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
     #[error(transparent)]
@@ -45,6 +47,9 @@ impl Error {
             Self::ExtractionFailed => "ExtractionFailed",
             Self::InvalidSourceMap => "InvalidSourceMap",
             Self::SourceMapTooLarge => "SourceMapTooLarge",
+            Self::ModuleGraphTooLarge => {
+                "embedded module graph would exceed 4 GiB (its offsets are 32-bit)"
+            }
             Self::Sys(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
             Self::Http(e) => e.name(),

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
+import { bunEnv, bunExe, isArm64, isDebug, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
+import { chmodSync, closeSync, cpSync, existsSync, openSync, readdirSync, readSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -953,6 +953,70 @@ describe("compiled binary in a deleted cwd", () => {
     },
     60_000,
   );
+});
+
+// Every region of the embedded module graph (file contents, names, bytecode, the
+// module table) is addressed by a 32-bit offset and length. `to_bytes` used to cast
+// every offset with `as u32`, so a graph past 4 GiB was written with wrapped
+// offsets: the build succeeded and the executable failed at startup
+// (`Module not found ''`) or read the wrong bytes. The build has to fail instead.
+//
+// Debug builds lower the limit through BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES
+// so the test does not need a 4 GiB input. The message still names the real limit.
+describe.concurrent("embedded module graph size limit", () => {
+  const asset = Buffer.alloc(8 * 1024 * 1024, "x");
+  const files = {
+    "app.js": `import big from "./big.bin" with { type: "file" };
+console.log(require("fs").statSync(big).size);`,
+    "big.bin": asset,
+  };
+
+  test.skipIf(!isDebug)("build --compile fails when the graph is larger than the offsets can address", async () => {
+    using dir = tempDir("build-compile-graph-too-large", files);
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "app.js", "--outfile", "app"],
+      env: { ...bunEnv, BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES: String(4 * 1024 * 1024) },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+
+    expect(stderr).toContain(
+      "failed to generate module graph bytes: embedded module graph would exceed 4 GiB (its offsets are 32-bit)",
+    );
+    expect(exitCode).toBe(1);
+    // No executable, not even a partial one.
+    expect(readdirSync(String(dir)).sort()).toEqual(["app.js", "big.bin"]);
+  });
+
+  test.skipIf(!isDebug)("build --compile still succeeds when the graph fits under the limit", async () => {
+    using dir = tempDir("build-compile-graph-fits", files);
+    const outfile = join(String(dir), isWindows ? "app.exe" : "app");
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "app.js", "--outfile", outfile],
+      env: { ...bunEnv, BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES: String(256 * 1024 * 1024) },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).not.toContain("error");
+    expect(buildExit).toBe(0);
+
+    await using proc = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`${asset.byteLength}\n`);
+    expect(exitCode).toBe(0);
+  });
 });
 
 // file command test works well


### PR DESCRIPTION
### Problem
- `bun build --compile` for a Linux or FreeBSD target accepts an embedded module graph larger than 4 GiB. The build exits 0. The executable fails at startup with `error: Module not found ''`, or reads the wrong bytes.
- `to_bytes` (`src/standalone_graph/StandaloneModuleGraph.rs:1247`) records every region as a `StringPointer { offset: u32, length: u32 }` built with `as u32` casts (`StringBuilder.rs:124` and three sites in `to_bytes`). The ELF writer stores a u64 length (`elf.rs:211`), so nothing rejects the size.

### Fix
- `to_bytes` checks the final length once, after the last region and before `Offsets` (line 1591). Every pointer has `offset + length <= len`, so `len <= u32::MAX` makes every pointer exact. Past that it returns the new `Error::ModuleGraphTooLarge`.
- `to_executable` already reports `to_bytes` errors: `failed to generate module graph bytes: embedded module graph would exceed 4 GiB (its offsets are 32-bit)`, exit 1, no output file. It fires before any container writer, on every target. Before, only ELF was silent: Mach-O panicked (Sentry BUN-4VCR, fixed by #41136, same wording), PE returned `Error::Overflow` (`pe.rs:195`).
- Verified: `test/bundler/bun-build-compile.test.ts` (two new tests, the first fails on an unfixed debug build). Also the other compile suites and `test/internal/source-lints`.

### Background
- A compiled executable is the bun binary plus one blob, the module graph: every embedded file, its name, bytecode and source map, then a module table.
- A `StringPointer` is the graph's address type: a u32 offset and length into that blob. Release builds never validate it.
- A 4 GiB input is too big for CI. `BUN_DEBUG_TEST_STANDALONE_GRAPH_MAX_BYTES` lowers the limit in debug builds only, like `BUN_INTERNAL_FAIL_PIPE_READER_START`. The test is `skipIf(!isDebug)`.

<details><summary>Notes</summary>

- Repro (release bun 1.4.1, Linux): `a.bin` and `b.bin` of 2.3 GB each (sparse, distinct headers), `import a from "./a.bin" with { type: "file" }` for both, `bun build --compile --target=bun-linux-x64`. The build printed `compile ./app` and exit 0, and wrote a 4.6 GB executable. `./app` printed `error: Module not found ''` and exit 1. A single 4.4 GB asset instead produced a 181 MB executable, see the next item.
- Out of scope, a separate bug: a single input file over 4 GiB is truncated to `len mod 2^32` by the bundler before `to_bytes` sees it. `Source.contents` is built from `ast::StoreStr` (`len: u32`, `debug_assert` only) at `src/bundler/ParseTask.rs:2443`. A plain `bun build --outdir` of the 4.4 GB asset wrote a 105 MB file. So today only the multi-file total reaches this check.
- Also out of scope: a `type: "text"` import of 2 GiB or more fits the graph but exceeds `WTF::StringImpl::MaxLength` when the runtime aliases it as a string.
- The three cast sites inside `to_bytes` are `encode_text_module`, the module-info copy, and `append_bytecode_aligned`.
- The check is after the blob is written, so a build that fails here has already done the copy. The cost is one extra memcpy of the graph on an error path that ends the build. The `StringBuilder` capacity is an over-estimate (source maps, UTF-16), so a check on it before the copy would reject some graphs that fit.
- `Bun.build({ compile })` goes through the same `to_executable`, so it gets the same error through `js_bundle_completion_task.rs`.
- Other `StringBuilder` pointer users (Valkey credentials, spawn argv) hold small strings. The graph is the one caller with user-sized inputs, so the limit lives in `to_bytes`, where the format that imposes it is defined.
- Self-review: the review accepted the guard and its placement. It asked for the per-platform facts, the #41136 and BUN-4VCR references, and wording aligned with #41136. All three are in this body and in the error string.
- Pre-existing local failures unrelated to this change: three `--bytecode` tests in `bun-build-compile.test.ts` time out under the debug ASAN build, and `compile/HelloWorldWithProcessVersionsBun` compares a `-debug` version string.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->