### PR TITLE
bake: report a disabled framework specifier instead of panicking

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -547,11 +547,11 @@ impl<'a> Transpiler<'a> {
     ) -> crate::Result<resolver::Result> {
         let is_builtin = if resolved.flags.is_external() {
             true
-        } else if resolved.path_const().is_some() {
-            return Ok(resolved);
         } else {
-            // Stubbed builtins carry the "node" namespace; anything else came from a "browser" map.
-            resolved.path_pair.primary.namespace == b"node"
+            match resolved.path_or_disabled() {
+                Ok(_) => return Ok(resolved),
+                Err(reason) => reason == resolver::DisabledReason::NodeBuiltin,
+            }
         };
 
         if is_builtin {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -52,9 +52,9 @@ pub use tsconfig_json::TSConfigJSON;
 pub use ::bun_install_types::resolver_hooks as install_types;
 pub use resolver::{AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver};
 pub use result::{
-    DebugLogs, DirEntryResolveQueueItem, ExternalKind, FlushMode, LoadResult, MatchResult,
-    MatchStatus, PathPair, PendingResolution, PendingResolutionTag, Result, ResultFlags,
-    ResultUnion,
+    DebugLogs, DirEntryResolveQueueItem, DisabledReason, ExternalKind, FlushMode, LoadResult,
+    MatchResult, MatchStatus, PathPair, PendingResolution, PendingResolutionTag, Result,
+    ResultFlags, ResultUnion,
 };
 pub use standalone_module_graph::StandaloneModuleGraph;
 

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -149,11 +149,10 @@ pub enum ExternalKind {
     ExternalRewritePath,
 }
 
-/// Why a successful resolve has no path to load (every path is `is_disabled`).
-/// An import of such a module becomes `{}`.
+/// Why a successful resolve has no path to load: every path is `is_disabled`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum DisabledReason {
-    /// A Node.js builtin stubbed out under the browser target (`node:*`, or `fs`).
+    /// A Node.js builtin stubbed out under the browser target.
     NodeBuiltin,
     /// The package.json `"browser"` field maps the module to `false`.
     BrowserField,

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -149,6 +149,16 @@ pub enum ExternalKind {
     ExternalRewritePath,
 }
 
+/// Why a successful resolve has no path to load (every path is `is_disabled`).
+/// An import of such a module becomes `{}`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DisabledReason {
+    /// A Node.js builtin stubbed out under the browser target (`node:*`, or `fs`).
+    NodeBuiltin,
+    /// The package.json `"browser"` field maps the module to `false`.
+    BrowserField,
+}
+
 impl ResultFlags {
     #[inline]
     pub fn is_external(self) -> bool {
@@ -276,6 +286,19 @@ impl Result {
         }
 
         None
+    }
+
+    /// The path to load, or why there is none.
+    pub fn path_or_disabled(&self) -> core::result::Result<&Path, DisabledReason> {
+        if let Some(path) = self.path_const() {
+            return Ok(path);
+        }
+        // Stubbed builtins carry the "node" namespace; anything else came from a "browser" map.
+        Err(if self.path_pair.primary.namespace == b"node" {
+            DisabledReason::NodeBuiltin
+        } else {
+            DisabledReason::BrowserField
+        })
     }
 }
 

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -663,26 +663,9 @@ impl Framework {
             return;
         }
 
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-        let mut result = match r.resolve(top_level_dir, *path, bun_ast::ImportKind::Stmt) {
-            Ok(res) => res,
-            Err(err) => {
-                Output::err(
-                    err,
-                    "Failed to resolve '{}' for framework ({})",
-                    (bstr::BStr::new(path), bstr::BStr::new(desc)),
-                );
-                *had_errors = true;
-                return;
-            }
-        };
-        // `resolver::Result::path().text` is `&'static [u8]` already (resolver's
-        // `Path` alias is `bun_paths::fs::Path<'static>`, populated from the
-        // `FilenameStore` singleton). No widen needed; the previous
-        // `arena_erase` here laundered an already-`'static` slice and falsely
-        // implied arena ownership. See `bun_ptr::Interned` for the type that
-        // `Path::text` should eventually become.
-        *path = result.path().unwrap().text;
+        if let Some(resolved) = super::Framework::resolve_specifier(r, path, had_errors, desc) {
+            *path = resolved;
+        }
     }
 
     fn from_js(

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -412,10 +412,7 @@ impl Framework {
         }
     }
 
-    /// Resolves one framework specifier from the project root. Shared with
-    /// `bake_body::Framework::resolve_helper`. A resolve error or a disabled
-    /// result prints the reason to stderr, sets `had_errors` and returns
-    /// `None`. The text is `FilenameStore`-backed, so `'static`.
+    /// Resolves one framework specifier. A resolve error or a disabled result prints the reason, sets `had_errors` and returns `None`.
     pub(crate) fn resolve_specifier(
         r: &mut bun_resolver::Resolver,
         path: &[u8],

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -412,19 +412,10 @@ impl Framework {
         }
     }
 
-    /// Resolves one framework specifier (an entry point, the react refresh
-    /// runtime, ...) from the project root. Shared with
-    /// `bake_body::Framework::resolve_helper`.
-    ///
-    /// Returns `None` after it prints the reason to stderr (not `r.log`) and
-    /// sets `had_errors`: the resolver failed, or it succeeded with every path
-    /// disabled (a stubbed Node.js builtin, or a module the package.json
-    /// `"browser"` field maps to `false`). An import of such a module becomes
-    /// `{}`, but the framework needs a file to load.
-    ///
-    /// The returned text is `&'static [u8]`: the resolver's `Path` alias is
-    /// `bun_paths::fs::Path<'static>`, populated from the `FilenameStore`
-    /// singleton.
+    /// Resolves one framework specifier from the project root. Shared with
+    /// `bake_body::Framework::resolve_helper`. A resolve error or a disabled
+    /// result prints the reason to stderr, sets `had_errors` and returns
+    /// `None`. The text is `FilenameStore`-backed, so `'static`.
     pub(crate) fn resolve_specifier(
         r: &mut bun_resolver::Resolver,
         path: &[u8],

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -407,25 +407,61 @@ impl Framework {
             }
             return;
         }
+        if let Some(resolved) = Self::resolve_specifier(r, path, had_errors, desc) {
+            *path = Cow::Owned(resolved.to_vec());
+        }
+    }
+
+    /// Resolves one framework specifier (an entry point, the react refresh
+    /// runtime, ...) from the project root. Shared with
+    /// `bake_body::Framework::resolve_helper`.
+    ///
+    /// Returns `None` after it prints the reason to stderr (not `r.log`) and
+    /// sets `had_errors`: the resolver failed, or it succeeded with every path
+    /// disabled (a stubbed Node.js builtin, or a module the package.json
+    /// `"browser"` field maps to `false`). An import of such a module becomes
+    /// `{}`, but the framework needs a file to load.
+    ///
+    /// The returned text is `&'static [u8]`: the resolver's `Path` alias is
+    /// `bun_paths::fs::Path<'static>`, populated from the `FilenameStore`
+    /// singleton.
+    pub(crate) fn resolve_specifier(
+        r: &mut bun_resolver::Resolver,
+        path: &[u8],
+        had_errors: &mut bool,
+        desc: &[u8],
+    ) -> Option<&'static [u8]> {
+        use bun_resolver::DisabledReason;
+
         let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-        match r.resolve(top_level_dir, path, bun_ast::ImportKind::Stmt) {
-            Ok(mut result) => {
-                let p = result.path().expect("just resolved");
-                *path = Cow::Owned(p.text.to_vec());
-            }
+        let result = match r.resolve(top_level_dir, path, bun_ast::ImportKind::Stmt) {
+            Ok(res) => res,
             Err(err) => {
-                // This routes through `Output::err` (stderr), not
-                // `r.log`. The "Errors written into r.log" doc on `Framework.resolve`
-                // refers to entries the resolver itself pushed; this top-level
-                // "Failed to resolve" line goes to the terminal.
                 bun_core::Output::err(
                     err,
-                    "Failed to resolve '{s}' for framework ({s})",
+                    "Failed to resolve '{}' for framework ({})",
                     (bstr::BStr::new(path), bstr::BStr::new(desc)),
                 );
                 *had_errors = true;
+                return None;
             }
+        };
+
+        match result.path_or_disabled() {
+            Ok(p) => return Some(p.text),
+            Err(DisabledReason::NodeBuiltin) => bun_core::err_generic!(
+                "Cannot use \"{}\" for framework ({}): it resolves to a builtin module",
+                bstr::BStr::new(path),
+                bstr::BStr::new(desc),
+            ),
+            Err(DisabledReason::BrowserField) => bun_core::err_generic!(
+                "Cannot use \"{}\" for framework ({}): it is disabled due to \"browser\" field in package.json",
+                bstr::BStr::new(path),
+                bstr::BStr::new(desc),
+            ),
         }
+        *had_errors = true;
+        None
     }
 
     pub(crate) fn add_react_install_command_note(log: &mut bun_ast::Log) {

--- a/test/bake/app-options.test.ts
+++ b/test/bake/app-options.test.ts
@@ -84,9 +84,9 @@ const disabledSpecifierCases = [
   },
   {
     name: "reactFastRefresh.importSource is disabled by the browser field",
-    packageJson: `{ "name": "app", "browser": { "react-refresh/runtime": false } }`,
-    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "react-refresh/runtime" } }`,
-    error: `error: Cannot use "react-refresh/runtime" for framework (react refresh runtime): it is disabled due to "browser" field in package.json`,
+    packageJson: `{ "name": "app", "browser": { "react-refresh": false } }`,
+    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "react-refresh" } }`,
+    error: `error: Cannot use "react-refresh" for framework (react refresh runtime): it is disabled due to "browser" field in package.json`,
   },
 ];
 
@@ -137,7 +137,14 @@ for (const c of disabledSpecifierCases) {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", "--app", "./bun.app.ts"],
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        // The config loader of `bun build --app` has unchecked exception scopes
+        // (`bakeModuleLoaderResolve`, `BakeGetDefaultExportFromModule`) that
+        // abort a debug build under validation before the framework resolves.
+        BUN_JSC_validateExceptionChecks: undefined,
+        BUN_JSC_dumpSimulatedThrows: undefined,
+      },
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",

--- a/test/bake/app-options.test.ts
+++ b/test/bake/app-options.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { disabledSpecifierCases, frameworkFiles } from "./disabled-specifier-cases";
 
 // Every option here is declared as `string` or `boolean` in bake.d.ts. A value
 // of another type must throw ERR_INVALID_ARG_TYPE from Bun.serve, before any
@@ -58,43 +59,6 @@ test("Bun.serve({ app }) rejects wrong-typed framework options", async () => {
   expect(exitCode).toBe(0);
 });
 
-// A framework specifier (`reactFastRefresh.importSource`, an entry point, the
-// server components runtime) can resolve to a disabled module: a stubbed
-// Node.js builtin, or anything the package.json "browser" field maps to
-// `false`. The resolve succeeds, but the result has no path. Such a specifier
-// must be reported like a missing module, not crash the process.
-const disabledSpecifierCases = [
-  {
-    name: "reactFastRefresh.importSource is a Node.js builtin",
-    packageJson: `{ "name": "app" }`,
-    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "node:fs" } }`,
-    error: `error: Cannot use "node:fs" for framework (react refresh runtime): it resolves to a builtin module`,
-  },
-  {
-    name: "clientEntryPoint is a Node.js builtin",
-    packageJson: `{ "name": "app" }`,
-    framework: `{ fileSystemRouterTypes: [{ ...fsr, clientEntryPoint: "fs" }] }`,
-    error: `error: Cannot use "fs" for framework (client side entrypoint): it resolves to a builtin module`,
-  },
-  {
-    name: "serverComponents.serverRuntimeImportSource is a Node.js builtin",
-    packageJson: `{ "name": "app" }`,
-    framework: `{ fileSystemRouterTypes: [fsr], serverComponents: { separateSSRGraph: false, serverRuntimeImportSource: "node:fs" } }`,
-    error: `error: Cannot use "node:fs" for framework (server components runtime): it resolves to a builtin module`,
-  },
-  {
-    name: "reactFastRefresh.importSource is disabled by the browser field",
-    packageJson: `{ "name": "app", "browser": { "react-refresh": false } }`,
-    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "react-refresh" } }`,
-    error: `error: Cannot use "react-refresh" for framework (react refresh runtime): it is disabled due to "browser" field in package.json`,
-  },
-];
-
-const frameworkFiles = {
-  "server.ts": `export default function render() { return new Response("ok"); }`,
-  "routes/index.ts": `export default () => null;`,
-};
-
 for (const c of disabledSpecifierCases) {
   test.concurrent(`Bun.serve({ app }) reports a disabled ${c.name}`, async () => {
     using dir = tempDir("bake-app-disabled", {
@@ -123,36 +87,5 @@ for (const c of disabledSpecifierCases) {
     expect(stderr.trim()).toBe(c.error);
     expect(stdout).toBe("AggregateError: Framework is missing required files!\n");
     expect(exitCode).toBe(0);
-  });
-
-  test.concurrent(`bun build --app reports a disabled ${c.name}`, async () => {
-    using dir = tempDir("bake-build-app-disabled", {
-      ...frameworkFiles,
-      "package.json": c.packageJson,
-      "bun.app.ts": `
-        const fsr = { root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" };
-        export default { app: { framework: ${c.framework} } };
-      `,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--app", "./bun.app.ts"],
-      env: {
-        ...bunEnv,
-        // The config loader of `bun build --app` has unchecked exception scopes
-        // (`bakeModuleLoaderResolve`, `BakeGetDefaultExportFromModule`) that
-        // abort a debug build under validation before the framework resolves.
-        BUN_JSC_validateExceptionChecks: undefined,
-        BUN_JSC_dumpSimulatedThrows: undefined,
-      },
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).toContain(`\n${c.error}\nerror: Failed to resolve all imports required by the framework\n`);
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(1);
   });
 }

--- a/test/bake/app-options.test.ts
+++ b/test/bake/app-options.test.ts
@@ -57,3 +57,95 @@ test("Bun.serve({ app }) rejects wrong-typed framework options", async () => {
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
+
+// A framework specifier (`reactFastRefresh.importSource`, an entry point, the
+// server components runtime) can resolve to a disabled module: a stubbed
+// Node.js builtin, or anything the package.json "browser" field maps to
+// `false`. The resolve succeeds, but the result has no path. Such a specifier
+// must be reported like a missing module, not crash the process.
+const disabledSpecifierCases = [
+  {
+    name: "reactFastRefresh.importSource is a Node.js builtin",
+    packageJson: `{ "name": "app" }`,
+    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "node:fs" } }`,
+    error: `error: Cannot use "node:fs" for framework (react refresh runtime): it resolves to a builtin module`,
+  },
+  {
+    name: "clientEntryPoint is a Node.js builtin",
+    packageJson: `{ "name": "app" }`,
+    framework: `{ fileSystemRouterTypes: [{ ...fsr, clientEntryPoint: "fs" }] }`,
+    error: `error: Cannot use "fs" for framework (client side entrypoint): it resolves to a builtin module`,
+  },
+  {
+    name: "serverComponents.serverRuntimeImportSource is a Node.js builtin",
+    packageJson: `{ "name": "app" }`,
+    framework: `{ fileSystemRouterTypes: [fsr], serverComponents: { separateSSRGraph: false, serverRuntimeImportSource: "node:fs" } }`,
+    error: `error: Cannot use "node:fs" for framework (server components runtime): it resolves to a builtin module`,
+  },
+  {
+    name: "reactFastRefresh.importSource is disabled by the browser field",
+    packageJson: `{ "name": "app", "browser": { "react-refresh/runtime": false } }`,
+    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "react-refresh/runtime" } }`,
+    error: `error: Cannot use "react-refresh/runtime" for framework (react refresh runtime): it is disabled due to "browser" field in package.json`,
+  },
+];
+
+const frameworkFiles = {
+  "server.ts": `export default function render() { return new Response("ok"); }`,
+  "routes/index.ts": `export default () => null;`,
+};
+
+for (const c of disabledSpecifierCases) {
+  test.concurrent(`Bun.serve({ app }) reports a disabled ${c.name}`, async () => {
+    using dir = tempDir("bake-app-disabled", {
+      ...frameworkFiles,
+      "package.json": c.packageJson,
+      "fixture.ts": `
+        const fsr = { root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" };
+        try {
+          Bun.serve({ port: 0, development: true, app: { framework: ${c.framework} }, fetch: () => new Response() }).stop(true);
+          console.log("no error");
+        } catch (e) {
+          console.log(e.name + ": " + e.message);
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe(c.error);
+    expect(stdout).toBe("AggregateError: Framework is missing required files!\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent(`bun build --app reports a disabled ${c.name}`, async () => {
+    using dir = tempDir("bake-build-app-disabled", {
+      ...frameworkFiles,
+      "package.json": c.packageJson,
+      "bun.app.ts": `
+        const fsr = { root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" };
+        export default { app: { framework: ${c.framework} } };
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--app", "./bun.app.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(`\n${c.error}\nerror: Failed to resolve all imports required by the framework\n`);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+}

--- a/test/bake/build-app-options.test.ts
+++ b/test/bake/build-app-options.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { disabledSpecifierCases, frameworkFiles } from "./disabled-specifier-cases";
+
+// The `bun build --app` side of the cases in app-options.test.ts. This file is
+// listed in test/no-validate-exceptions.txt and test/no-validate-leaksan.txt:
+// the production config loader trips both validations before the framework
+// resolves, see the notes there.
+for (const c of disabledSpecifierCases) {
+  test.concurrent(`bun build --app reports a disabled ${c.name}`, async () => {
+    using dir = tempDir("bake-build-app-disabled", {
+      ...frameworkFiles,
+      "package.json": c.packageJson,
+      "bun.app.ts": `
+        const fsr = { root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" };
+        export default { app: { framework: ${c.framework} } };
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--app", "./bun.app.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(`\n${c.error}\nerror: Failed to resolve all imports required by the framework\n`);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+}

--- a/test/bake/disabled-specifier-cases.ts
+++ b/test/bake/disabled-specifier-cases.ts
@@ -1,0 +1,40 @@
+// Shared by app-options.test.ts (Bun.serve({ app })) and
+// build-app-options.test.ts (bun build --app).
+//
+// A framework specifier (`reactFastRefresh.importSource`, an entry point, the
+// server components runtime) can resolve to a disabled module: a stubbed
+// Node.js builtin, or anything the package.json "browser" field maps to
+// `false`. The resolve succeeds, but the result has no path. Such a specifier
+// must be reported like a missing module, not crash the process.
+export const disabledSpecifierCases = [
+  {
+    name: "reactFastRefresh.importSource is a Node.js builtin",
+    packageJson: `{ "name": "app" }`,
+    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "node:fs" } }`,
+    error: `error: Cannot use "node:fs" for framework (react refresh runtime): it resolves to a builtin module`,
+  },
+  {
+    name: "clientEntryPoint is a Node.js builtin",
+    packageJson: `{ "name": "app" }`,
+    framework: `{ fileSystemRouterTypes: [{ ...fsr, clientEntryPoint: "fs" }] }`,
+    error: `error: Cannot use "fs" for framework (client side entrypoint): it resolves to a builtin module`,
+  },
+  {
+    name: "serverComponents.serverRuntimeImportSource is a Node.js builtin",
+    packageJson: `{ "name": "app" }`,
+    framework: `{ fileSystemRouterTypes: [fsr], serverComponents: { separateSSRGraph: false, serverRuntimeImportSource: "node:fs" } }`,
+    error: `error: Cannot use "node:fs" for framework (server components runtime): it resolves to a builtin module`,
+  },
+  {
+    name: "reactFastRefresh.importSource is disabled by the browser field",
+    packageJson: `{ "name": "app", "browser": { "react-refresh": false } }`,
+    framework: `{ fileSystemRouterTypes: [fsr], reactFastRefresh: { importSource: "react-refresh" } }`,
+    error: `error: Cannot use "react-refresh" for framework (react refresh runtime): it is disabled due to "browser" field in package.json`,
+  },
+];
+
+// `fsr` in each case above is declared by the fixture that embeds the framework.
+export const frameworkFiles = {
+  "server.ts": `export default function render() { return new Response("ok"); }`,
+  "routes/index.ts": `export default () => null;`,
+};

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -13,6 +13,10 @@ test/js/third_party/astro/astro-post.test.js
 # hit a debug assert
 test/bundler/bundler_compile.test.ts
 
+# `bun build --app` config loading: unchecked throw scopes in bakeModuleLoaderResolve
+# (BakeGlobalObject.cpp) and BakeGetDefaultExportFromModule (BakeSourceProvider.cpp)
+test/bake/build-app-options.test.ts
+
 # 3rd party napi
 test/js/third_party/prisma/prisma.test.ts
 test/js/third_party/remix/remix.test.ts

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -339,6 +339,9 @@ test/napi/node-napi-tests/test/js-native-api/6_object_wrap/do.test.ts
 test/napi/uv_stub.test.ts
 
 test/bake/dev/production.test.ts
+# `bun build --app` leaks the Box<[u8]> fields of the arena-allocated bake_types::Framework
+# view (Framework::init_transpiler_with_options, bake_body.rs); reported at exit.
+test/bake/build-app-options.test.ts
 test/js/third_party/pg-gateway/pglite.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
 


### PR DESCRIPTION
### Problem
- `Bun.serve({ app })` aborts with `panic: just resolved` when a framework specifier resolves to a disabled module. `bun build --app` aborts with `panic: called Option::unwrap() on a None value`. Triggers: `reactFastRefresh: { importSource: "node:fs" }`, `clientEntryPoint: "fs"`, or a `"browser": false` map. Reported in the team chat, no issue.
- Cause: both copies of `Framework::resolve_helper` (`src/runtime/bake/mod.rs:413`, `src/runtime/bake/bake_body.rs:685`) unwrap `resolver::Result::path()`, which is `None` when every path is disabled.

### Fix
- `bun_resolver::Result::path_or_disabled()` returns the path to load, or a `DisabledReason` (`NodeBuiltin`, `BrowserField`). The bundler's entry point check now matches on it instead of its own namespace check.
- A new `bake::Framework::resolve_specifier` does the resolve for both `resolve_helper` copies. A disabled result prints `error: Cannot use "node:fs" for framework (react refresh runtime): it resolves to a builtin module` and sets `had_errors`, like a missing module. The dev server then throws `Framework is missing required files!` and the build exits 1.
- Verified: `test/bake/app-options.test.ts` (`Bun.serve`) and `test/bake/build-app-options.test.ts` (`bun build --app`), 4 specifiers each, all abort on 1.4.1. Other suites in the notes. Self-reviewed: 4 concerns raised, 4 addressed (notes).

### Background
- Bake is the `Bun.serve({ app })` framework integration. `Framework::resolve` turns the specifiers a framework needs (react refresh runtime, server components runtime, router entry points) into absolute paths before the dev server or the build starts.
- A disabled module exists but must not load: `node:*` and `fs` under the browser target, and anything the `"browser"` field maps to `false`. The resolve succeeds, but `path()` is `None`. #39799 and #39811 made the bundler report this for an entry point.
- Two `Framework` structs exist during the Zig port: `mod.rs` (dev server) and `bake_body.rs` (`bun build --app`). #40261 deletes the second, so the helper lives in `mod.rs`.

<details><summary>Notes</summary>

Repro on 1.4.1 (`BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1`, or canary):

```ts
// serve.ts
Bun.serve({
  port: 0,
  app: { framework: {
    fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.tsx" }],
    reactFastRefresh: { importSource: "node:fs" },
  } },
  fetch() { return new Response("hi"); },
});
```

`bun serve.ts` aborts with `panic: just resolved` (exit 134). The same `app` object as the default export of `bun.app.ts` makes `bun build --app ./bun.app.ts` abort with `panic: called Option::unwrap() on a None value`. With this branch both print one `error:` line and fail the way a missing module does. The browser field case prints `error: Cannot use "react-refresh/runtime" for framework (react refresh runtime): it is disabled due to "browser" field in package.json`.

Self-review concerns and what changed: the disabled-result classifier was a copy of the one in `reject_unbundleable_entry_point`, so it moved into the resolver as `path_or_disabled()` and the bundler matches on it. The shared helper first lived in `bake_body.rs`, which #40261 deletes, so it moved onto `bake::Framework` in `mod.rs` with `bake_body` delegating. The first wording said "not available in the browser", which is wrong for specifiers the server resolver handles, so the messages reuse the entry point wording from #39811 and #39799. A `serverComponents.serverRuntimeImportSource: "node:fs"` case pins the server role.

The server resolver returns a disabled result for `node:fs` during `Framework::resolve`. `BundleV2::init` sets `mark_builtins_as_external` for the bun target, but `Framework::resolve` runs before any bundle exists, so the server resolver still uses the stub path at that point. The resolver option state of the bake transpilers is not changed here, and neither is the fact that `entry_server` resolves with the client resolver.

`resolve_or_null` in `bake_body.rs` (the `Framework::auto` detection of `react-refresh`) still unwraps `path_const()`. It uses the runtime resolver, and #40246 rewrites that function, so it is left alone here.

The `bun build --app` cases are in their own file because the ASAN lane cannot validate the production path: `bakeModuleLoaderResolve` (BakeGlobalObject.cpp) and `BakeGetDefaultExportFromModule` (BakeSourceProvider.cpp) have unchecked throw scopes, and `Framework::init_transpiler_with_options` arena-allocates a `bake_types::Framework` view whose `Box<[u8]>` fields never drop (documented in the code). Both abort any `bun build --app` under `BUN_JSC_validateExceptionChecks=1` or LeakSanitizer before the framework resolves. `test/bake/dev/production.test.ts` is in both skip lists for the same reason, and `build-app-options.test.ts` joins it with the failures stated. The `Bun.serve({ app })` cases stay under full validation. The two production-path problems are pre-existing and in code that #40261 rewrites; they are reported separately.

The browser-field case uses a bare package name. On Windows a browser map key with a slash is stored with a backslash (`normalize_string_spill::<_, platform::Auto>` in `package_json.rs`) and `BrowserMapPath::check_path` never looks up the normalized input without an extension, so `"react-refresh/runtime": false` is not applied there. Verified on Windows with `bun build --target=browser`. Reported separately.

Suites run on the debug (ASAN) build: `test/bake/app-options.test.ts`, `test/bake/framework-router.test.ts`, `test/bake/dev/production.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/bake/dev/react-spa.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/bundler/bundler_browser.test.ts`, `test/bundler/bun-build-api.test.ts`, `test/js/web/workers/worker-entry-point.test.ts`. Five tests in `production.test.ts` and `bun-build-api.test.ts` hit their 5 s or 180 s budget in this container and pass with a longer timeout (the `thousands of builds` stress test was not re-run). None of them resolve a disabled module.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/app-options.test.ts test/bake/build-app-options.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/app-options.test.ts:
(pass) Bun.serve({ app }) rejects wrong-typed framework options [417.14ms]
82 |       stdout: "pipe",
83 |       stderr: "pipe",
84 |     });
85 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
86 | 
87 |     expect(stderr.trim()).toBe(c.error);
                               ^
error: expect(received).toBe(expected)

- "error: Cannot use "node:fs" for framework (react refresh runtime): it resolves to a builtin module"
+ "============================================================
+ Bun Debug v1.4.1 (a6c4cc276) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/debug/bun-debug" "fixture.ts"
+ Features: jsc dev_server 
+ Builtins: "bun:main" 
+ 
+ 
+ panic: just resolved"

- Expected  - 1
+ Received  + 10

      at <anonymous> (/workspace/bun/test/bake/app-options.test.ts:87:27)
(fail) Bu
... (truncated)

release without fix: 8 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bake/app-options.test.ts:
(pass) Bun.serve({ app }) rejects wrong-typed framework options [11.36ms]
82 |       stdout: "pipe",
83 |       stderr: "pipe",
84 |     });
85 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
86 | 
87 |     expect(stderr.trim()).toBe(c.error);
                               ^
error: expect(received).toBe(expected)

- "error: Cannot use "react-refresh" for framework (react refresh runtime): it is disabled due to "browser" field in package.json"
+ "============================================================
+ Bun Canary v1.4.1-canary.1 (a6c4cc276) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "fixture.ts"
+ Features: jsc dev_server 
+ Builtins: "bun:main" 
+ 
+ Elapsed: 5ms | User: 1ms | Sys: 4ms
+ RSS: 31.38 MB | Peak: 46.54 MB | Commit: 45.22 MB | Faults: 0 | Machine: 34.36 GB
+ 
+ panic: just resolved
+ oh no: Bun has crashed. This indicates a bug in Bun, not your code.
+ 
+ To send a redacted crash report to Bun's team,
+ please file a GitHub issue us
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/app-options.test.ts test/bake/build-app-options.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/app-options.test.ts:
(pass) Bun.serve({ app }) rejects wrong-typed framework options [380.57ms]
(pass) Bun.serve({ app }) reports a disabled reactFastRefresh.importSource is a Node.js builtin [316.54ms]
(pass) Bun.serve({ app }) reports a disabled serverComponents.serverRuntimeImportSource is a Node.js builtin [287.91ms]
(pass) Bun.serve({ app }) reports a disabled reactFastRefresh.importSource is disabled by the browser field [301.58ms]
(pass) Bun.serve({ app }) reports a disabled clientEntryPoint is a Node.js builtin [331.61ms]

test/bake/build-app-options.test.ts:
(pass) bun build --app reports a disabled reactFastRefresh.importSource is a Node.js builtin [376.52ms]
(pass) bun build --app reports a disabled clientEntryPoint is a Node.js builtin [436.52ms]
(pass) bun build --app reports a disabled serverComponents.serverRuntimeImportSource is a Node.js builtin [444.59ms]
(pass) bun build --app reports a disabled reactFastRefresh.im
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 679ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs             |  8 +++----
 src/resolver/lib.rs                   |  6 ++---
 src/resolver/result.rs                | 22 ++++++++++++++++++
 src/runtime/bake/bake_body.rs         | 23 +++---------------
 src/runtime/bake/mod.rs               | 44 +++++++++++++++++++++++++++--------
 test/bake/app-options.test.ts         | 32 +++++++++++++++++++++++++
 test/bake/build-app-options.test.ts   | 33 ++++++++++++++++++++++++++
 test/bake/disabled-specifier-cases.ts | 40 +++++++++++++++++++++++++++++++
 test/no-validate-exceptions.txt       |  4 ++++
 test/no-validate-leaksan.txt          |  3 +++
 10 files changed, 178 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/bundler/transpiler.rs                  2      1     22
src/resolver/lib.rs                        1      2     22
src/resolver/result.rs                     2      4     22
src/runtime/bake/bake_body.rs              4      7     22
src/runtime/bake/mod.rs                    6      6     22
test/bake/app-options.test.ts              4      4     22
test/bake/build-app-options.test.ts        0      1      3
test/bake/disabled-specifier-cases.ts      0      1     22
test/no-validate-exceptions.txt            1      1     24
test/no-validate-leaksan.txt               1      1     24
```

</details>

<!-- robobun:evidence:end -->