### PR TITLE
bundler: build the min-chunk-size dependency graph from the edges that assign chunks

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -383,13 +383,11 @@ impl<'a> LinkerContext<'a> {
     }
 
     /// The bundled file that a live part's import record makes the importer's
-    /// chunk depend on, if any. A split `import()` (or `require()`) loads
-    /// another entry point's chunk on demand instead. An `import` or
-    /// `export ... from` of a side-effect-free file prints nothing: the
-    /// bindings it brings in are part dependencies, which callers follow on
-    /// their own. Code splitting assigns chunks along these edges
-    /// (`mark_file_reachable_for_code_splitting`), so every pass that reasons
-    /// about which chunks load together uses the same ones.
+    /// chunk depend on, if any: not a split `import()`, which loads on demand,
+    /// and not an `import` or `export ... from` of a side-effect-free file,
+    /// which prints nothing (its bindings are part dependencies). Chunk
+    /// assignment follows these edges, so every pass that reasons about which
+    /// chunks load together must use the same ones.
     pub(crate) fn file_loaded_by_import(
         &self,
         record: &ImportRecord,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -382,6 +382,30 @@ impl<'a> LinkerContext<'a> {
             && !self.options.ignore_dce_annotations
     }
 
+    /// The bundled file that a live part's import record makes the importer's
+    /// chunk depend on, if any. A split `import()` (or `require()`) loads
+    /// another entry point's chunk on demand instead. An `import` or
+    /// `export ... from` of a side-effect-free file prints nothing: the
+    /// bindings it brings in are part dependencies, which callers follow on
+    /// their own. Code splitting assigns chunks along these edges
+    /// (`mark_file_reachable_for_code_splitting`), so every pass that reasons
+    /// about which chunks load together uses the same ones.
+    pub(crate) fn file_loaded_by_import(
+        &self,
+        record: &ImportRecord,
+        source_index: u32,
+    ) -> Option<u32> {
+        if !record.source_index.is_valid() || self.is_external_dynamic_import(record, source_index)
+        {
+            return None;
+        }
+        let other = record.source_index.get();
+        if record.kind == ImportKind::Stmt && self.file_has_no_side_effects(other) {
+            return None;
+        }
+        Some(other)
+    }
+
     /// Note: this should call a `MimallocArena` debug hook
     /// (`helpCatchMemoryIssues`), but `Graph.heap` is currently
     /// `bun_alloc::Arena = bumpalo::Bump`, which has no such hook, so this is a
@@ -2791,19 +2815,11 @@ impl<'a> LinkerContext<'a> {
                 }
 
                 for &import_index in part.import_record_indices.iter() {
-                    let record = &records[import_index as usize];
-                    if !record.source_index.is_valid()
-                        || self.is_external_dynamic_import(record, source_index)
-                    {
+                    let Some(other) =
+                        self.file_loaded_by_import(&records[import_index as usize], source_index)
+                    else {
                         continue;
-                    }
-                    let other = record.source_index.get();
-
-                    // Prints nothing; its bindings are the part dependencies below.
-                    if record.kind == ImportKind::Stmt && self.file_has_no_side_effects(other) {
-                        continue;
-                    }
-
+                    };
                     if !ctx.file_entry_bits[other as usize].is_set(entry_points_count) {
                         ctx.queue.push_back((other, out_dist));
                     }

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -384,11 +384,9 @@ fn inert_chunks(c: &LinkerContext, chunks: &[Chunk]) -> Result<AutoBitSet, bun_a
                     continue;
                 }
                 for &i in part.import_record_indices.iter() {
-                    let record = &records[i as usize];
-                    if record.source_index.is_valid()
-                        && !c.is_external_dynamic_import(record, source_index)
+                    if let Some(other) = c.file_loaded_by_import(&records[i as usize], source_index)
                     {
-                        add(record.source_index.get());
+                        add(other);
                     }
                 }
                 for dep in part.dependencies.iter() {

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -111,10 +111,9 @@ struct Group {
     merged_into: Option<usize>,
 }
 
-/// Fold `from` into `into`: `into` inherits the size, dependencies, load
-/// conditions and impurity; the files are re-keyed through `resolve` at the
-/// end. The merged dependency list is resolved, so a group folded into
-/// either side is listed once, under the group that now owns its files.
+/// Fold `from` into `into`: `into` inherits the size, dependencies (resolved,
+/// so each group appears once), load conditions and impurity; the files are
+/// re-keyed through `resolve` at the end.
 fn fold(groups: &mut [Group], from: usize, into: usize) {
     groups[from].merged_into = Some(into);
     let mut deps = core::mem::take(&mut groups[from].deps);
@@ -199,13 +198,11 @@ fn collect_newly_loaded(
     true
 }
 
-/// Folding `candidate` into `target` hands the merged group both groups'
-/// dependencies and both groups' importers. If one of those dependencies
-/// reaches either group again, the result is a static import cycle between
-/// the merged chunk and the chunks on that path. Cross-chunk bindings are
-/// `var`s, so whichever chunk of the cycle runs first reads `undefined` from
-/// the other. (A direct edge between the two becomes a self-import and
-/// disappears.) Uses `scratch.visited` and `scratch.stack` only.
+/// The merged group imports both groups' dependencies; if one of them reaches
+/// either group, the fold closes a static import cycle, and whichever chunk
+/// runs first reads the other's `var` bindings as `undefined`. A direct edge
+/// between the two becomes a self-import and is fine. Leaves
+/// `scratch.newly_loaded` alone.
 fn fold_creates_cycle(
     groups: &[Group],
     candidate: usize,
@@ -683,10 +680,9 @@ pub(crate) fn merge_small_chunks(
         groups.put(key, group)?;
     }
 
-    // Static dependencies between groups: the edges `File.entry_bits` was
-    // assigned along (`mark_file_reachable_for_code_splitting`), so a
-    // dependency's key is a superset of its importer's. Only rule 2 consults
-    // them.
+    // Static dependencies between groups, along the edges that assigned
+    // `File.entry_bits`, so a dependency's key is a superset of its importer's.
+    // Only rule 2 consults them.
     for (source_index, &group_index) in group_of_file.iter().enumerate() {
         if !fold_pure {
             break;

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -113,11 +113,19 @@ struct Group {
 
 /// Fold `from` into `into`: `into` inherits the size, dependencies, load
 /// conditions and impurity; the files are re-keyed through `resolve` at the
-/// end.
+/// end. The merged dependency list is resolved, so a group folded into
+/// either side is listed once, under the group that now owns its files.
 fn fold(groups: &mut [Group], from: usize, into: usize) {
-    let deps = core::mem::take(&mut groups[from].deps);
-    let (size, pure) = (groups[from].size, groups[from].pure);
     groups[from].merged_into = Some(into);
+    let mut deps = core::mem::take(&mut groups[from].deps);
+    deps.extend(core::mem::take(&mut groups[into].deps));
+    for dep in deps.iter_mut() {
+        *dep = resolve(groups, *dep);
+    }
+    deps.sort_unstable();
+    deps.dedup();
+    deps.retain(|&d| d != into);
+    let (size, pure) = (groups[from].size, groups[from].pure);
     let (from, target) = if from < into {
         let (a, b) = groups.split_at_mut(into);
         (&a[from], &mut b[0])
@@ -128,10 +136,7 @@ fn fold(groups: &mut [Group], from: usize, into: usize) {
     target.size += size;
     target.pure &= pure;
     target.loaded.set_union(&from.loaded);
-    target.deps.extend(deps);
-    target.deps.sort_unstable();
-    target.deps.dedup();
-    target.deps.retain(|&d| d != into);
+    target.deps = deps;
 }
 
 /// Follow `merged_into` links to the group that now owns the files.
@@ -192,6 +197,47 @@ fn collect_newly_loaded(
             .extend(dep.deps.iter().map(|&e| resolve(groups, e)));
     }
     true
+}
+
+/// Folding `candidate` into `target` hands the merged group both groups'
+/// dependencies and both groups' importers. If one of those dependencies
+/// reaches either group again, the result is a static import cycle between
+/// the merged chunk and the chunks on that path. Cross-chunk bindings are
+/// `var`s, so whichever chunk of the cycle runs first reads `undefined` from
+/// the other. (A direct edge between the two becomes a self-import and
+/// disappears.) Uses `scratch.visited` and `scratch.stack` only.
+fn fold_creates_cycle(
+    groups: &[Group],
+    candidate: usize,
+    target: usize,
+    scratch: &mut Scratch,
+) -> bool {
+    scratch.epoch += 1;
+    let epoch = scratch.epoch;
+    scratch.stack.clear();
+    for &d in groups[candidate]
+        .deps
+        .iter()
+        .chain(groups[target].deps.iter())
+    {
+        let d = resolve(groups, d);
+        if d != candidate && d != target {
+            scratch.stack.push(d);
+        }
+    }
+    while let Some(d) = scratch.stack.pop() {
+        if core::mem::replace(&mut scratch.visited[d], epoch) == epoch {
+            continue;
+        }
+        for &e in groups[d].deps.iter() {
+            let e = resolve(groups, e);
+            if e == candidate || e == target {
+                return true;
+            }
+            scratch.stack.push(e);
+        }
+    }
+    false
 }
 
 const UNREACHED: u32 = u32::MAX;
@@ -281,7 +327,8 @@ fn immediate_dominators<'a>(
 ///    already loaded wherever that target is (or is side-effect free too); the
 ///    extra entries then carry some unused definitions, but no side effect
 ///    runs earlier than before. What an entry gains this way is capped
-///    relative to what it already loaded.
+///    relative to what it already loaded, and the merged chunk must not end
+///    up importing a chunk that imports it back (`fold_creates_cycle`).
 ///
 /// Runs before `compute_chunks` groups files by `entry_bits`; it rewrites
 /// `File.entry_bits` in place so everything downstream (chunk membership,
@@ -636,8 +683,10 @@ pub(crate) fn merge_small_chunks(
         groups.put(key, group)?;
     }
 
-    // Static dependencies between groups, from the live parts' import records
-    // and symbol dependencies. Only rule 2 consults them.
+    // Static dependencies between groups: the edges `File.entry_bits` was
+    // assigned along (`mark_file_reachable_for_code_splitting`), so a
+    // dependency's key is a superset of its importer's. Only rule 2 consults
+    // them.
     for (source_index, &group_index) in group_of_file.iter().enumerate() {
         if !fold_pure {
             break;
@@ -653,10 +702,8 @@ pub(crate) fn merge_small_chunks(
             }
             for &record_index in part.import_record_indices.iter() {
                 let record = &import_records[source_index][record_index as usize];
-                if record.source_index.is_valid()
-                    && !this.is_external_dynamic_import(record, source_index as u32)
-                {
-                    deps.push(group_of_file[record.source_index.get() as usize]);
+                if let Some(other) = this.file_loaded_by_import(record, source_index as u32) {
+                    deps.push(group_of_file[other as usize]);
                 }
             }
             for dependency in part.dependencies.iter() {
@@ -852,7 +899,7 @@ pub(crate) fn merge_small_chunks(
                     }
                     gained.push((entry_id, bytes));
                 }
-                true
+                !fold_creates_cycle(groups.values(), candidate, target, &mut scratch)
             });
             if let Some(target) = chosen {
                 for &(entry_id, bytes) in &gained {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -506,10 +506,15 @@ describe("bundler", () => {
   const jsOutput = (api: BundlerTestBundleAPI, name: string) =>
     api.readFile("/out/" + jsFilesIn(api).find(f => f === `${name}.js` || f.startsWith(`${name}-`))!);
 
-  // The files each JS output file statically imports (`... from "./x"`).
+  // The files each JS output file statically imports (`... from "./x"` and
+  // the bare `import "./x"` an entry chunk uses to load a chunk it binds
+  // nothing from).
   const staticImports = (api: BundlerTestBundleAPI) =>
     new Map(
-      jsFilesIn(api).map(f => [f, [...api.readFile("/out/" + f).matchAll(/\bfrom\s*"\.\/([^"]+)"/g)].map(m => m[1])]),
+      jsFilesIn(api).map(f => [
+        f,
+        [...api.readFile("/out/" + f).matchAll(/\b(?:import|from)\s*"\.\/([^"]+)"/g)].map(m => m[1]),
+      ]),
     );
 
   // Cross-chunk bindings are `var`s, so a chunk that runs before a chunk it

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -506,6 +506,30 @@ describe("bundler", () => {
   const jsOutput = (api: BundlerTestBundleAPI, name: string) =>
     api.readFile("/out/" + jsFilesIn(api).find(f => f === `${name}.js` || f.startsWith(`${name}-`))!);
 
+  // The files each JS output file statically imports (`... from "./x"`).
+  const staticImports = (api: BundlerTestBundleAPI) =>
+    new Map(
+      jsFilesIn(api).map(f => [f, [...api.readFile("/out/" + f).matchAll(/\bfrom\s*"\.\/([^"]+)"/g)].map(m => m[1])]),
+    );
+
+  // Cross-chunk bindings are `var`s, so a chunk that runs before a chunk it
+  // statically imports reads `undefined`: the static import graph must be
+  // acyclic.
+  const expectNoStaticImportCycle = (imports: Map<string, string[]>) => {
+    const onPath: string[] = [];
+    const done = new Set<string>();
+    const visit = (file: string) => {
+      if (done.has(file)) return;
+      const at = onPath.indexOf(file);
+      if (at !== -1) throw new Error(`static import cycle: ${[...onPath.slice(at), file].join(" -> ")}`);
+      onPath.push(file);
+      for (const other of imports.get(file) ?? []) visit(other);
+      onPath.pop();
+      done.add(file);
+    };
+    for (const file of imports.keys()) visit(file);
+  };
+
   itBundled("splitting/FoldsSharedIntoEntry", {
     files: {
       "/entry.js": /* js */ `
@@ -1993,6 +2017,81 @@ describe("bundler", () => {
       expect(api.readFile("/out/main.js").length).toBeGreaterThan(12000);
     },
     run: { file: "/out/main.js", stdout: "main 12000" },
+  });
+
+  // The entry chunk holds a `"sideEffects": false` barrel whose re-export of
+  // card.js prints nothing, so card.js is loaded by the routes that use it,
+  // not by the entry. card.js imports CommonJS react (a require_react() call
+  // at its top level), which lives in the entry chunk. If the small pure
+  // {r1, r2} chunk that uses Card were folded into the entry chunk, the entry
+  // chunk would import card.js's chunk and card.js's chunk would import
+  // require_react back from it: a static import cycle in which card.js runs
+  // first, while `require_react` is still undefined.
+  itBundled("splitting/MinChunkSizeNoCycleThroughSideEffectFreeReExport", {
+    files: {
+      "/node_modules/react/package.json": JSON.stringify({ name: "react", main: "index.js" }),
+      "/node_modules/react/index.js": /* js */ `
+        module.exports = { createElement(tag) { return "<" + tag + ">" } }
+      `,
+      "/node_modules/ui/package.json": JSON.stringify({ name: "ui", main: "index.js", sideEffects: false }),
+      "/node_modules/ui/index.js": /* js */ `
+        export { Button } from './button.js'
+        export { Card } from './card.js'
+      `,
+      // Padded so that what the entry may gain from a fold covers cards.js.
+      "/node_modules/ui/button.js": /* js */ `
+        import React from 'react'
+        export function Button() { return React.createElement('button') }
+        // ${Buffer.alloc(16 * 1024, "padding ").toString()}
+      `,
+      "/node_modules/ui/card.js": /* js */ `
+        import React from 'react'
+        export function Card() { return React.createElement('div') }
+      `,
+      "/entry.js": /* js */ `
+        import { Button } from 'ui'
+        console.log('entry', Button())
+        import('./r1.js')
+          .then(m => m.default())
+          .then(() => import('./r2.js'))
+          .then(m => m.default())
+          .then(() => import('./r3.js'))
+          .then(m => m.default())
+      `,
+      "/cards.js": /* js */ `
+        import { Card } from 'ui'
+        export function Cards() { return Card() + Card() }
+      `,
+      "/r1.js": /* js */ `
+        import { Cards } from './cards.js'
+        export default function () { console.log('r1', Cards()) }
+      `,
+      "/r2.js": /* js */ `
+        import { Cards } from './cards.js'
+        export default function () { console.log('r2', Cards()) }
+      `,
+      "/r3.js": /* js */ `
+        import { Card } from 'ui'
+        export default function () { console.log('r3', Card()) }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    minChunkSize: 1024,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      // entry, r1, r2, r3, and the {r1, r2, r3} chunk holding card.js, into
+      // which cards.js folds.
+      expect(jsFilesIn(api)).toHaveLength(5);
+      const cardChunk = chunkContaining(api, 'createElement("div")');
+      api.expectFile("/out/" + cardChunk).toContain("Card() + Card()");
+      const imports = staticImports(api);
+      expect(imports.get(cardChunk)).toEqual(["entry.js"]);
+      expect(imports.get("entry.js")).toEqual([]);
+      expectNoStaticImportCycle(imports);
+    },
+    run: { file: "/out/entry.js", stdout: "entry <button>\nr1 <div><div>\nr2 <div><div>\nr3 <div>" },
   });
 
   // Import attributes describe the source file; once the target is a chunk


### PR DESCRIPTION
### Problem
- `bun build ./index.html --production --splitting --min-chunk-size=16384` on the Medusa admin dashboard emits static import cycles: a small chunk runs `import{r,i}from"./index-….js"; var n=r(i())` and the entry chunk imports it back. `i` is `require_react`, a `var` in the entry chunk, still undefined: `TypeError: i is not a function`. #41145 exposed it.
- The cause is the dependency graph in `merge_small_chunks` (`mergeSmallChunks.rs:698`). It followed every live import record, but since #41145 the entry-bit walk (`LinkerContext.rs:2817`) skips an `import` or `export ... from` of a side-effect-free file. A `"sideEffects": false` barrel in the entry chunk re-exports `card.js`, so the stale edge said `card.js`'s chunk is loaded wherever the entry is, and a small pure chunk using `Card` folded into the entry chunk.

### Fix
- One predicate, `file_loaded_by_import`, decides which file an import record makes the importer's chunk depend on. The entry-bit walk, `merge_small_chunks` and `inert_chunks` use it.
- `fold_creates_cycle` rejects a fold when the merged group would import a chunk that reaches it again. Cross-chunk bindings are `var`s, so the pass must never close a static import cycle.
- Correct because a dependency edge now implies that the dependency's key is a superset of the importer's, which is what `loaded` and rule 2 assume.
- Verified: `test/bundler/bundler_splitting.test.ts` (`MinChunkSizeNoCycleThroughSideEffectFreeReExport`, fails on main with `require_react is not a function`), the other bundler suites (Notes), and the Medusa build: 0 cycles here, 6 on main.

### Background
- Code splitting keys each file by the entry points whose chunk loads it (`File.entry_bits`); equal keys form one chunk. A static import gives the target every bit of the importer, so a chunk only imports chunks keyed by a superset of its bits: no cycles.
- `--min-chunk-size` folds a side-effect-free chunk into a chunk loaded by a superset of its entries (`loaded`) when everything it imports is loaded there too. `loaded` comes from the graph this PR fixes.
- A static import of a CommonJS module prints as a top-level `require_x()` call on a `var` in the chunk that holds the module. The first chunk of a cycle to run reads it unassigned.

<details><summary>Notes</summary>

Reproduction of the Medusa build: `@medusajs/dashboard@2.8.4` ships `src/`. With an `index.html` that loads `src/main.tsx`, stubs for the `virtual:medusa/*` modules and `bun install` of its dependencies, `bun build ./index.html --production --splitting --min-chunk-size=16384` gives 278 JS files and 6 static cycles on main at 4e1eeff48 (entry `index-rka9fb5j.js`, 4.4 MB, and six chunks of 150 to 900 bytes in one strongly connected component). With this branch: 282 JS files, 0 cycles, entry 4.37 MB. The extra chunks are the small pure chunks that now stay with the routes that use them instead of folding into the entry.

With `fold_creates_cycle`'s verdict ignored, the Medusa output is byte for byte the same as with it, so the dependency-graph fix alone removes the cycles there. The guard exists because rule 2 compares `loaded` sets, not evaluation order: two distinct groups with equal `loaded` on one dependency path would otherwise still fold into a cycle. `fold` resolves the merged dependency list so the check walks each group once.

The synthetic test mirrors the Medusa structure: `ui` is a `"sideEffects": false` package whose barrel re-exports `button.js` (used by the entry) and `card.js` (used by three lazy routes). `card.js` imports CommonJS `react`, so its chunk has a top-level `require_react()` and cannot fold. `cards.js` is pure, small, used by two routes, and uses `Card`. Before the fix it folds into `entry.js`, which then imports the card chunk; the card chunk imports `__toESM` and `require_react` from `entry.js`. After the fix it folds into the card chunk.

`inert_chunks` (`computeCrossChunkDependencies.rs`) followed the same stale edges. There the effect was only an extra side-effect import of a chunk that loads nothing the entry runs.

Suites run with the debug build: `test/bundler/esbuild/`, `bundler_splitting`, `bundler_barrel`, `bundler_compile_splitting`, `html-import-manifest`, `bundler_edgecase`, `bundler_regressions`, `bundler_html`, `bundler_cjs2esm`, `bundler_dynamic_import_dce`, `bundler_npm`, `bundler_browser`, `bundler_bun`, `metafile`. All pass.

Debug build timings for the Medusa bundle are unchanged within noise (6.4 s with the guard, 6.7 s without).
</details>
