### PR TITLE
FileSystemRouter: derive route names from the directory walk and normalize dir

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -112,13 +112,11 @@ impl Router {
         log: &mut bun_ast::Log,
         root_dir_info: &DirInfo,
         resolver: &mut R,
-        base_dir: &[u8],
     ) -> Result<(), CoreError> {
         if self.loaded_routes {
             return Ok(());
         }
-        self.routes =
-            RouteLoader::load_all(self.config.clone(), log, resolver, root_dir_info, base_dir);
+        self.routes = RouteLoader::load_all(self.config.clone(), log, resolver, root_dir_info);
         self.loaded_routes = true;
         Ok(())
     }
@@ -339,7 +337,6 @@ struct RouteLoader<'a> {
     // allocator dropped — global mimalloc
     fs: &'static FileSystem,
     config: RouteConfig,
-    route_dirname_len: u16,
 
     dedupe_dynamic: ArrayHashMap<u32, &'static [u8]>,
     log: &'a mut bun_ast::Log,
@@ -460,17 +457,7 @@ impl<'a> RouteLoader<'a> {
         log: &'a mut bun_ast::Log,
         resolver: &mut R,
         root_dir_info: &DirInfo,
-        base_dir: &[u8],
     ) -> Routes {
-        let mut route_dirname_len: u16 = 0;
-
-        // Call bun_paths directly to avoid the higher-tier bun_resolver dep.
-        let relative_dir = bun_paths::resolve_path::relative(base_dir, &config.dir);
-        if !relative_dir.starts_with(b"..") {
-            route_dirname_len =
-                (relative_dir.len() + usize::from(config.dir[config.dir.len() - 1] != SEP)) as u16;
-        }
-
         let mut this = RouteLoader {
             log,
             fs: resolver.fs(),
@@ -479,9 +466,9 @@ impl<'a> RouteLoader<'a> {
             dedupe_dynamic: ArrayHashMap::new(),
             all_routes: Vec::new(),
             index: None,
-            route_dirname_len,
         };
-        this.load(resolver, root_dir_info, base_dir);
+        let mut public_dir = Vec::new();
+        this.load(resolver, root_dir_info, &mut public_dir);
         if this.all_routes.is_empty() {
             return Routes {
                 static_: this.static_list,
@@ -542,11 +529,15 @@ impl<'a> RouteLoader<'a> {
         }
     }
 
+    /// `public_dir` is the path of `dir_info` below the routes directory, one
+    /// `SEP` + name per level (empty for the routes directory itself). It is
+    /// built from the walk, so it does not depend on how the resolver spelled
+    /// the cached directory paths.
     fn load<R: ResolverLike>(
         &mut self,
         resolver: &mut R,
-        root_dir_info: &DirInfo,
-        base_dir: &[u8],
+        dir_info: &DirInfo,
+        public_dir: &mut Vec<u8>,
     ) {
         let fs = self.fs;
 
@@ -555,7 +546,7 @@ impl<'a> RouteLoader<'a> {
         // under that lock, so iterating it live would walk freed buckets.
         let entry_ptrs: Vec<*mut Fs::Entry> = {
             let _entries_lock = fs.fs.entries_mutex.lock_guard();
-            match root_dir_info.get_entries_const() {
+            match dir_info.get_entries_const() {
                 Some(entries) => entries.data.values().copied().collect(),
                 None => return,
             }
@@ -594,7 +585,11 @@ impl<'a> RouteLoader<'a> {
                     let abs_parts = [entry.dir(), entry.base()];
                     if let Some(dir_info) = resolver.read_dir_info_ignore_error(fs.abs(&abs_parts))
                     {
-                        self.load(resolver, &dir_info, base_dir);
+                        let parent_len = public_dir.len();
+                        public_dir.push(SEP);
+                        public_dir.extend_from_slice(entry.base());
+                        self.load(resolver, &dir_info, public_dir);
+                        public_dir.truncate(parent_len);
                     }
                 }
 
@@ -607,32 +602,10 @@ impl<'a> RouteLoader<'a> {
 
                     for _extname in self.config.extensions.iter() {
                         if &extname[1..] == _extname.as_ref() {
-                            // `entry.dir()` is `base_dir` or a subdirectory of it, cached
-                            // with or without a trailing slash depending on which resolver
-                            // spelled it first (`base_dir` always has one). Both spellings
-                            // trim to the same `public_dir`.
-                            let entry_dir = entry.dir();
-                            debug_assert!(entry_dir.len() + 1 >= base_dir.len());
-                            if entry_dir.len() >= base_dir.len() {
-                                debug_assert!(bun_paths::resolve_path::is_sep_any(
-                                    entry_dir[base_dir.len() - 1]
-                                ));
-                            }
-
-                            // SAFETY: entry.dir is at least base_dir.len()-1 bytes; verified above in debug
-                            let public_dir = &entry_dir[base_dir.len() - 1..entry_dir.len()];
-
                             // SAFETY: `entry_ptr` is EntryStore-owned (process
                             // lifetime) with no other live `&mut` borrow here.
                             let route = unsafe {
-                                Route::parse(
-                                    entry.base(),
-                                    extname,
-                                    entry_ptr,
-                                    self.log,
-                                    public_dir,
-                                    self.route_dirname_len,
-                                )
+                                Route::parse(entry.base(), extname, entry_ptr, self.log, public_dir)
                             };
                             if let Some(route) = route {
                                 self.append_route(route);
@@ -714,6 +687,9 @@ pub struct Route {
 impl Route {
     pub(crate) const INDEX_ROUTE_NAME: &'static [u8] = b"/";
 
+    /// `public_dir_` is the file's directory below the routes directory,
+    /// empty for a file in the routes directory itself.
+    ///
     /// # Safety
     /// `entry` must point to a live `Fs::Entry` (EntryStore-owned) with no
     /// other active `&mut` borrow for the duration of the call. `base_` and
@@ -724,7 +700,6 @@ impl Route {
         entry: *mut Fs::Entry,
         log: &mut bun_ast::Log,
         public_dir_: &[u8],
-        routes_dirname_len: u16,
     ) -> Option<Route> {
         // NOTE: `entry` is a raw `*mut Entry`
         // because `base_`/`extname` may borrow `(*entry).base_` (tiny inline
@@ -792,8 +767,6 @@ impl Route {
             while name.len() > 1 && name[name.len() - 1] == b'/' {
                 name = &name[0..name.len() - 1];
             }
-
-            name = &name[routes_dirname_len as usize..];
 
             if name.ends_with(b"/index") {
                 name = &name[0..name.len() - 6];

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -120,7 +120,8 @@ impl FileSystemRouter {
         }
         let vm = global_this.bun_vm().as_mut();
 
-        let mut out_buf = [0u8; MAX_PATH_BYTES * 2];
+        // Backs `root_dir_path` until `path_to_use` copies it below.
+        let mut dir_buf = path::path_buffer_pool::get();
         let mut root_dir_path = Utf8Bytes::Borrowed(vm.top_level_dir());
         let mut origin_str = Utf8Bytes::EMPTY;
         let mut asset_prefix_slice = Utf8Bytes::EMPTY;
@@ -146,20 +147,22 @@ impl FileSystemRouter {
             }
             let root_dir_path_ = dir.to_utf8(global_this)?;
             if !(root_dir_path_.slice().is_empty() || root_dir_path_.slice() == b".") {
-                // resolve relative path if needed
-                let path_ = root_dir_path_.slice();
-                if path::Platform::AUTO.is_absolute(path_) {
-                    root_dir_path = root_dir_path_;
-                } else {
-                    let parts: [&[u8]; 1] = [path_];
-                    root_dir_path = Utf8Bytes::Borrowed(path::resolve_path::join_abs_string_buf::<
-                        path::platform::Auto,
-                    >(
+                // Resolve a relative path, and drop `.` and `..` segments from an
+                // absolute one, the way the resolver spells the directories it
+                // caches.
+                let Some(joined) =
+                    path::resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
                         Fs::FileSystem::instance().top_level_dir,
-                        &mut out_buf,
-                        &parts,
-                    ));
-                }
+                        &mut dir_buf[..],
+                        &[root_dir_path_.slice()],
+                    )
+                else {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected dir to resolve to a path of at most {} bytes",
+                        MAX_PATH_BYTES
+                    )));
+                };
+                root_dir_path = Utf8Bytes::Borrowed(joined);
             }
         } else {
             // dir is not optional
@@ -257,20 +260,16 @@ impl FileSystemRouter {
         })
         .expect("unreachable");
 
+        if router
+            .load_routes(
+                &mut log,
+                &root_dir_info,
+                &mut RouterResolver(&mut vm.transpiler.resolver),
+            )
+            .is_err()
         {
-            let config_dir = router.config.dir.clone();
-            if router
-                .load_routes(
-                    &mut log,
-                    &root_dir_info,
-                    &mut RouterResolver(&mut vm.transpiler.resolver),
-                    &config_dir,
-                )
-                .is_err()
-            {
-                let err_value = log.to_js(global_this, format_args!("loading routes"));
-                return Err(global_this.throw_value(err_value?));
-            }
+            let err_value = log.to_js(global_this, format_args!("loading routes"));
+            return Err(global_this.throw_value(err_value?));
         }
 
         if let Some(origin) = argument.get(global_this, "origin")? {
@@ -487,20 +486,16 @@ impl FileSystemRouter {
             ..Default::default()
         })
         .expect("unreachable");
+        if router
+            .load_routes(
+                &mut log,
+                &root_dir_info,
+                &mut RouterResolver(&mut vm.transpiler.resolver),
+            )
+            .is_err()
         {
-            let config_dir = router.config.dir.clone();
-            if router
-                .load_routes(
-                    &mut log,
-                    &root_dir_info,
-                    &mut RouterResolver(&mut vm.transpiler.resolver),
-                    &config_dir,
-                )
-                .is_err()
-            {
-                let err_value = log.to_js(global_this, format_args!("loading routes"));
-                return Err(global_this.throw_value(err_value?));
-            }
+            let err_value = log.to_js(global_this, format_args!("loading routes"));
+            return Err(global_this.throw_value(err_value?));
         }
 
         // `this.router.deinit(); this.arena.deinit(); destroy(this.arena)` — drop old values.

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -490,6 +490,183 @@ it("dir should be validated", async () => {
   }).toThrow("Expected dir to be a string");
 });
 
+it("resolves . and .. segments in an absolute dir before it trims route names", async () => {
+  // Subdirectory paths are normalized when the loader joins them, but `dir`
+  // used to keep its spelling. With `..` in `dir`, a file in a subdirectory had
+  // a shorter directory path than `dir` itself and slicing it panicked. With
+  // `.`, the names lost characters (`/sub/page` became `/ub/page`). Run in a
+  // subprocess so the panic on an unfixed build is a nonzero exit instead of
+  // taking down the test runner.
+  using dir = tempDir("fsr-dot-segments", {
+    "fixture.ts": /* ts */ `
+      import path from "path";
+      const root = import.meta.dir;
+      const sep = path.sep;
+      const pagesDir = path.join(root, "pages");
+      const spellings = {
+        plain: pagesDir,
+        dot: root + sep + "." + sep + "pages",
+        dotdot: root + sep + "pages" + sep + ".." + sep + "pages",
+        trailingDotdot: pagesDir + sep + "sub" + sep + "..",
+        trailingSep: pagesDir + sep,
+        relative: "." + sep + "pages" + sep + "sub" + sep + "..",
+      };
+      const out = {};
+      for (const [name, dir] of Object.entries(spellings)) {
+        const router = new Bun.FileSystemRouter({ dir, style: "nextjs", fileExtensions: [".tsx"] });
+        out[name] = {
+          routes: router.routes,
+          index: router.match("/")?.filePath,
+          sub: router.match("/sub/page")?.filePath,
+          dynamic: router.match("/sub/123")?.name,
+        };
+      }
+      console.log(JSON.stringify(out));
+    `,
+    "pages/index.tsx": "export default 1;\n",
+    "pages/sub/page.tsx": "export default 2;\n",
+    "pages/sub/[id].tsx": "export default 3;\n",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const expected = {
+    routes: {
+      "/": "<dir>/pages/index.tsx",
+      "/sub/page": "<dir>/pages/sub/page.tsx",
+      "/sub/[id]": "<dir>/pages/sub/[id].tsx",
+    },
+    index: "<dir>/pages/index.tsx",
+    sub: "<dir>/pages/sub/page.tsx",
+    dynamic: "/sub/[id]",
+  };
+  expect({
+    stdout: stdout === "" ? stdout : JSON.parse(normalizeBunSnapshot(stdout, String(dir))),
+    stderr: normalizeBunSnapshot(stderr, String(dir)),
+    exitCode,
+    signalCode: proc.signalCode,
+  }).toEqual({
+    stdout: {
+      plain: expected,
+      dot: expected,
+      dotdot: expected,
+      trailingDotdot: expected,
+      trailingSep: expected,
+      relative: expected,
+    },
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+it("reload() keeps route names when dir is reached through a symlink", async () => {
+  // The constructor stores the resolved real path of `dir`, which has no
+  // trailing separator, and reload() loads routes against it. The loader used
+  // to slice each entry's directory at the length of that path, so after a
+  // reload every name carried the last character of the directory name:
+  // `/b` became `s/b`. With an index route the name collapsed to one character
+  // and route validation looped forever, so this fixture has no index route.
+  using dir = tempDir("fsr-reload-symlink", {
+    "fixture.ts": /* ts */ `
+      import path from "path";
+      const router = new Bun.FileSystemRouter({
+        dir: path.join(import.meta.dir, "link", "pages"),
+        style: "nextjs",
+        fileExtensions: [".tsx"],
+      });
+      const before = Object.keys(router.routes).sort().join(" ");
+      router.reload();
+      console.log(before, "|", Object.keys(router.routes).sort().join(" "), router.match("/sub/c")?.name);
+    `,
+    "real/pages/b.tsx": "export default 1;\n",
+    "real/pages/sub/c.tsx": "export default 2;\n",
+  });
+  fs.symlinkSync(path.join(String(dir), "real"), path.join(String(dir), "link"), "junction");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({
+    stdout: normalizeBunSnapshot(stdout, String(dir)),
+    stderr: normalizeBunSnapshot(stderr, String(dir)),
+    exitCode,
+    signalCode: proc.signalCode,
+  }).toEqual({ stdout: "/b /sub/c | /b /sub/c /sub/c", stderr: "", exitCode: 0, signalCode: null });
+});
+
+it("throws instead of aborting when dir does not fit in a path buffer", async () => {
+  // `dir` is resolved against the cwd inside a MAX_PATH_BYTES buffer
+  // (src/bun_core/util.rs). The constructor used to write a long relative
+  // `dir` past the end of that buffer and abort the process, so run the cases
+  // in a subprocess.
+  const maxPathBytes = isWindows ? 32767 * 3 + 1 : isMacOS ? 1024 : 4096;
+  const tooLong = `TypeError: Expected dir to resolve to a path of at most ${maxPathBytes} bytes`;
+  using dir = tempDir("fsr-long-dir", {
+    "pages/index.tsx": "export default 1;\n",
+  });
+
+  const code = /* ts */ `
+    import path from "path";
+    function construct(dir: string) {
+      try {
+        const router = new Bun.FileSystemRouter({ dir, style: "nextjs", fileExtensions: [".tsx"] });
+        return Object.keys(router.routes);
+      } catch (e: any) {
+        return e.name + ": " + e.message.replace(dir, "<dir>").replace(process.cwd(), "<cwd>");
+      }
+    }
+    // The resolved path is cwd + separator + dir.
+    const resolvingTo = (bytes: number) => Buffer.alloc(bytes - Buffer.byteLength(process.cwd()) - 1, "a").toString();
+    // Longer than MAX_PATH_BYTES on every platform.
+    const longDir = Buffer.alloc(250_000, "a").toString();
+    console.log(JSON.stringify({
+      relative: construct(longDir),
+      absolute: construct(path.parse(process.cwd()).root + longDir),
+      atLimit: construct(resolvingTo(${maxPathBytes})),
+      oneByteOverLimit: construct(resolvingTo(${maxPathBytes} + 1)),
+      afterwards: construct("pages"),
+    }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({
+    stdout: stdout === "" ? stdout : JSON.parse(stdout),
+    stderr: normalizeBunSnapshot(stderr, String(dir)),
+    exitCode,
+    signalCode: proc.signalCode,
+  }).toEqual({
+    stdout: {
+      relative: tooLong,
+      absolute: tooLong,
+      atLimit: `Error: Unable to find directory: <cwd>${path.sep}<dir>`,
+      oneByteOverLimit: tooLong,
+      afterwards: ["/"],
+    },
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
 it("origin should be validated", async () => {
   const { dir } = make(["posts.tsx"]);
 


### PR DESCRIPTION
### Problem
- `new Bun.FileSystemRouter({ dir })` panics when an absolute `dir` has a `..` segment: `range start index 77 out of range for slice of length 54` (Sentry BUN-4T6C, BUN-4T6B, `RouteLoader::load`). With `.` the route `/sub/page` becomes `/ub/page`.
- The loader sliced `base_dir.len() - 1` bytes off each entry's cached directory path (`src/router/lib.rs:623`). An absolute `dir` kept its spelling, but subdirectories go through `fs.abs()`, which drops `.` and `..` segments.
- `reload()` loads against the real path of `dir`, which has no trailing separator. Under a symlink the slice turns `/b` into `s/b`, and an index route makes `Pattern::validate` loop forever.

### Fix
- `RouteLoader::load` builds the public directory from the walk: a separator and the entry name on descent, truncated on return. No cached path is sliced. `base_dir` and `route_dirname_len` are gone.
- The constructor resolves every `dir` through `join_abs_string_buf_checked` into a pooled buffer. A `dir` that does not fit throws a TypeError instead of writing past a stack array (#39307).
- Verified: three new tests in `test/js/bun/util/filesystem_router.test.ts` (the released build panics, prints `s/b s/sub/c`, and aborts). The file passes on Linux and Windows.

### Background
- `Route::parse` joins `public_dir` (the directory below the routes directory) and the file name into the route name: `/sub` and `page.tsx` give `/sub/page`.
- The resolver caches each directory under the path it was first read with. The walk reads subdirectories through `fs.abs([entry.dir(), entry.base()])`, a `path.resolve` over bytes.
- `route_dirname_len` was 0, or 1 when `config.dir` lacked a trailing separator: both callers passed the same path for `base_dir` and `config.dir`.

<details><summary>Notes</summary>

Repro on the released 1.4.1 (Linux):

```
mkdir -p app/pages/sub && echo 'export default 1' > app/pages/index.tsx && echo 'export default 1' > app/pages/sub/page.tsx
bun -e "console.log(new Bun.FileSystemRouter({ style: 'nextjs', dir: process.cwd() + '/app/../app/pages' }).routes)"
# panic: range start index 25 out of range for slice of length 23
bun -e "console.log(new Bun.FileSystemRouter({ style: 'nextjs', dir: process.cwd() + '/app/./pages' }).routes)"
# {"/ub/page": ".../app/pages/sub/page.tsx", "/": ".../app/pages/index.tsx"}
ln -s "$PWD/app" link
bun -e "const r = new Bun.FileSystemRouter({ style: 'nextjs', dir: process.cwd() + '/link/pages' }); r.reload()"
# never returns, 100% CPU
```

On Windows the unfixed build panics on the `.` case as well, because the resolver normalizes the path it caches (`normalize_buf` in `dir_info_cached_maybe_log`) while `base_dir` kept the user's spelling. A junction triggers the reload case there, so the reload test runs on Windows too.

Supersedes #33464 (reload livelock, reached through a failed relative resolve instead of a symlink; its scenario passes with this change) and #39307 (the abort on an overlong relative `dir`; its test is ported here with the absolute case now a TypeError as well).

`join_abs_string_buf_checked` treats an absolute part like `path.resolve`: the part becomes the base and is normalized, on POSIX and on Windows (drive roots, UNC). It is the function `fs.abs()` uses for subdirectories. `Unable to find directory` stays the error for a path that fits the buffer but is `MAX_PATH_BYTES` or longer, because `read_dir_info` rejects those.

Self-reviewed: 4 concerns raised, 3 addressed (a loader-side "not inside" error that `reload()` would have swallowed is replaced by the structural public directory, the constructor now matches #39307's pooled buffer and error, #33464 and #39307 are folded in). Rejected one: a claimed `<dir>` substitution problem in the test on Windows. The test passes on a Windows debug build because route file paths use forward slashes there.

Also ran: the full `test/js/bun/util/filesystem_router.test.ts` on Linux (38 pass) and Windows (35 pass, 3 platform skips), `cargo fmt --check` and `cargo clippy` on `bun_router` and `bun_runtime`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->