### PR TITLE
Remove dead code from bun_url, bun_react_compiler, the class codegen, and bun-error

### DIFF
--- a/packages/bun-error/index.tsx
+++ b/packages/bun-error/index.tsx
@@ -29,19 +29,6 @@ export enum JSErrorCode {
   UserErrorCode = 254,
 }
 
-const JSErrorCodeLabel = {
-  0: "Error",
-  1: "EvalError",
-  2: "RangeError",
-  3: "ReferenceError",
-  4: "SyntaxError",
-  5: "TypeError",
-  6: "URIError",
-  7: "AggregateError",
-  253: "StackOverflow",
-  8: "OutOfMemory",
-};
-
 const BUN_ERROR_CONTAINER_ID = "__bun-error__";
 
 enum RuntimeType {

--- a/packages/bun-error/runtime-error.ts
+++ b/packages/bun-error/runtime-error.ts
@@ -35,7 +35,6 @@ export class StackFrame implements StackFrameType {
   }
 }
 
-const FIREFOX_SAFARI_STACK_REGEXP = /(^|@)\S+:\d+/;
 const CHROME_IE_STACK_REGEXP = /^\s*at .*(\S+:\d+|\(native\))/m;
 const SAFARI_NATIVE_CODE_REGEXP = /^(eval@)?(\[native code])?$/;
 

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -170,7 +170,6 @@ new!(pub BUN_INTERNAL_WEBVIEW_HOST: string, "BUN_INTERNAL_WEBVIEW_HOST", {});
 new!(pub NODE_PENDING_DEPRECATION: string, "NODE_PENDING_DEPRECATION", {});
 new!(pub NODE_PRESERVE_SYMLINKS_MAIN: boolean, "NODE_PRESERVE_SYMLINKS_MAIN", { default: false });
 new!(pub NODE_USE_SYSTEM_CA: boolean, "NODE_USE_SYSTEM_CA", { default: false });
-new!(pub npm_lifecycle_event: string, "npm_lifecycle_event", {});
 new!(pub PATH: string, "PATH", {});
 new!(pub REPL_ID: boolean, "REPL_ID", { default: false });
 new!(pub RUNNER_DEBUG: boolean, "RUNNER_DEBUG", { default: false });
@@ -246,7 +245,6 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_MEMFD, "BUN_FEATURE_FLAG_DISABLE_MEMFD", {});
     // The RedisClient supports auto-pipelining by default. This flag disables that behavior.
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING", {});
-    new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK, "BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK", {});
     // Fall back to the scalar byte-at-a-time VLQ decode in
     // bun_sourcemap::mapping::parse (skips the Highway-dispatched path).
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SIMD_SOURCEMAP, "BUN_FEATURE_FLAG_DISABLE_SIMD_SOURCEMAP", {});

--- a/src/codegen/class-definitions.ts
+++ b/src/codegen/class-definitions.ts
@@ -7,7 +7,6 @@ interface PropertyAttribute {
    * from the prototype hash table, instead setting it using `putDirect()`.
    */
   privateSymbol?: string;
-  publicSymbol?: string;
   name?: string;
 }
 
@@ -86,13 +85,6 @@ export class ClassDefinition {
    * function.
    */
   name: string;
-  /**
-   * Legacy. All classes emit implementer thunks into `generated_classes.rs`;
-   * this field is accepted for backward compatibility but has no effect.
-   *
-   * @default "rust"
-   */
-  lang?: "rust";
   /**
    * Fully-qualified Rust path of the native struct backing this class, e.g.
    * `crate::webcore::request::Request`. The codegen emits
@@ -219,7 +211,6 @@ export class ClassDefinition {
   configurable?: boolean;
   enumerable?: boolean;
   structuredClone?: { transferable: boolean; tag: number; storable: boolean };
-  inspectCustom?: boolean;
 
   constructor(options: Partial<ClassDefinition>) {
     this.name = options.name ?? "";
@@ -244,18 +235,9 @@ export function define(
     call = false,
     construct = false,
     structuredClone,
-    inspectCustom = false,
     ...rest
   } = {} as Partial<ClassDefinition>,
 ): ClassDefinition {
-  if (inspectCustom) {
-    proto.inspectCustom = {
-      fn: "inspectCustom",
-      length: 2,
-      publicSymbol: "inspectCustom",
-      name: "[nodejs.util.inspect.custom]",
-    };
-  }
   return new ClassDefinition({
     ...rest,
     // `refCounted` is a kind of finalize as far as the C++ wrapper is concerned.

--- a/src/codegen/cppbind.ts
+++ b/src/codegen/cppbind.ts
@@ -795,12 +795,6 @@ async function processFile(parser: CppParser, file: string, allFunctions: CppFn[
       if (nodeRef.name !== "FunctionDefinition") {
         return true; // Continue traversal
       }
-      // console.log(
-      //   `\n--- Found ZIG_EXPORT on function in ${file} at line ${lineInfo.get(nodeRef.node.from).line} ---\n`,
-      // );
-      // // Use the new pretty-printer to log the tree structure of the matched function
-      // console.log(prettyPrintLezerNode(nodeRef.node, ctx.sourceCode));
-      // console.log(`-------------------------------------------------------------------\n`);
 
       const fnNode = nodeRef.node;
       let zigExportAttr: SyntaxNode | null = null;

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -356,22 +356,6 @@ JSC_DECLARE_CUSTOM_GETTER(js${typeName}Constructor);
       continue;
     }
 
-    if (protoFields[name].publicSymbol !== undefined) {
-      const publicSymbol = protoFields[name].publicSymbol;
-      const fn = protoFields[name].fn;
-      if (!fn) throw Error(`(field: ${name}) public field needs 'fn' key `);
-      const observable_name = protoFields[name].name ?? fn;
-
-      specialSymbols += `
-    this->putDirect(vm, WebCore::clientData(vm)->builtinNames().${publicSymbol}PublicName(), JSFunction::create(vm, globalObject, ${
-      protoFields[name].length || 0
-    }, String("${observable_name}"_s), ${protoSymbolName(
-      typeName,
-      fn,
-    )}Callback, ImplementationVisibility::Public), PropertyAttribute::Function | 0);`;
-      continue;
-    }
-
     if (!name.startsWith("@@")) {
       continue;
     }

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -917,13 +917,6 @@ impl Drop for MarkedArrayBuffer {
 }
 
 impl MarkedArrayBuffer {
-    pub fn from_typed_array(ctx: &JSGlobalObject, value: JSValue) -> MarkedArrayBuffer {
-        MarkedArrayBuffer {
-            owns_buffer: false,
-            buffer: ArrayBuffer::from_typed_array(ctx, value),
-        }
-    }
-
     pub fn from_array_buffer(ctx: &JSGlobalObject, value: JSValue) -> MarkedArrayBuffer {
         MarkedArrayBuffer {
             owns_buffer: false,

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -14,7 +14,6 @@ type ErrorCodeMapping = Array<
 
 const errors: ErrorCodeMapping = [
   ["ABORT_ERR", Error, "AbortError"],
-  ["ERR_ACCESS_DENIED", Error],
   ["ERR_AMBIGUOUS_ARGUMENT", TypeError],
   ["ERR_ARG_NOT_ITERABLE", TypeError],
   ["ERR_ASSERTION", Error],
@@ -269,7 +268,6 @@ const errors: ErrorCodeMapping = [
   ["MODULE_NOT_FOUND", Error],
   ["ERR_INTERNAL_ASSERTION", Error],
   ["ERR_OSSL_EVP_INVALID_DIGEST", Error],
-  ["ERR_KEY_GENERATION_JOB_FAILED", Error],
   ["ERR_MISSING_OPTION", TypeError],
   ["ERR_REDIS_AUTHENTICATION_FAILED", Error, "RedisError"],
   ["ERR_REDIS_CONNECTION_CLOSED", Error, "RedisError"],

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -337,18 +337,6 @@ pub enum BlockKind {
     Catch,
 }
 
-impl std::fmt::Display for BlockKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BlockKind::Block => write!(f, "block"),
-            BlockKind::Value => write!(f, "value"),
-            BlockKind::Loop => write!(f, "loop"),
-            BlockKind::Sequence => write!(f, "sequence"),
-            BlockKind::Catch => write!(f, "catch"),
-        }
-    }
-}
-
 /// A basic block in the CFG
 #[derive(Debug, Clone)]
 pub struct BasicBlock {
@@ -634,16 +622,6 @@ pub enum LogicalOperator {
     And,
     Or,
     NullishCoalescing,
-}
-
-impl std::fmt::Display for LogicalOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LogicalOperator::And => write!(f, "&&"),
-            LogicalOperator::Or => write!(f, "||"),
-            LogicalOperator::NullishCoalescing => write!(f, "??"),
-        }
-    }
 }
 
 // =============================================================================
@@ -1024,35 +1002,6 @@ pub enum BinaryOperator {
     InstanceOf,
 }
 
-impl std::fmt::Display for BinaryOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BinaryOperator::Equal => write!(f, "=="),
-            BinaryOperator::NotEqual => write!(f, "!="),
-            BinaryOperator::StrictEqual => write!(f, "==="),
-            BinaryOperator::StrictNotEqual => write!(f, "!=="),
-            BinaryOperator::LessThan => write!(f, "<"),
-            BinaryOperator::LessEqual => write!(f, "<="),
-            BinaryOperator::GreaterThan => write!(f, ">"),
-            BinaryOperator::GreaterEqual => write!(f, ">="),
-            BinaryOperator::ShiftLeft => write!(f, "<<"),
-            BinaryOperator::ShiftRight => write!(f, ">>"),
-            BinaryOperator::UnsignedShiftRight => write!(f, ">>>"),
-            BinaryOperator::Add => write!(f, "+"),
-            BinaryOperator::Subtract => write!(f, "-"),
-            BinaryOperator::Multiply => write!(f, "*"),
-            BinaryOperator::Divide => write!(f, "/"),
-            BinaryOperator::Modulo => write!(f, "%"),
-            BinaryOperator::Exponent => write!(f, "**"),
-            BinaryOperator::BitwiseOr => write!(f, "|"),
-            BinaryOperator::BitwiseXor => write!(f, "^"),
-            BinaryOperator::BitwiseAnd => write!(f, "&"),
-            BinaryOperator::In => write!(f, "in"),
-            BinaryOperator::InstanceOf => write!(f, "instanceof"),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnaryOperator {
     Minus,
@@ -1063,32 +1012,10 @@ pub enum UnaryOperator {
     Void,
 }
 
-impl std::fmt::Display for UnaryOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UnaryOperator::Minus => write!(f, "-"),
-            UnaryOperator::Plus => write!(f, "+"),
-            UnaryOperator::Not => write!(f, "!"),
-            UnaryOperator::BitwiseNot => write!(f, "~"),
-            UnaryOperator::TypeOf => write!(f, "typeof"),
-            UnaryOperator::Void => write!(f, "void"),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateOperator {
     Increment,
     Decrement,
-}
-
-impl std::fmt::Display for UpdateOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UpdateOperator::Increment => write!(f, "++"),
-            UpdateOperator::Decrement => write!(f, "--"),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1296,15 +1223,6 @@ pub enum ObjectPropertyKey {
 pub enum ObjectPropertyType {
     Property,
     Method,
-}
-
-impl std::fmt::Display for ObjectPropertyType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ObjectPropertyType::Property => write!(f, "property"),
-            ObjectPropertyType::Method => write!(f, "method"),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1373,9 +1373,6 @@ impl ServerConfig {
                         );
                     }
                 }
-                // `base_url` (and so `hostname`/`pathname`) borrow into the
-                // original allocation; drop the borrow before reassigning.
-                drop(base_url);
                 args.base_uri = buf.into_boxed_slice();
             }
         } else {

--- a/src/runtime/socket/sockets.classes.ts
+++ b/src/runtime/socket/sockets.classes.ts
@@ -492,7 +492,6 @@ export default [
     call: false,
     refCounted: true,
     estimatedSize: true,
-    // inspectCustom: true,
     structuredClone: { transferable: false, tag: 251, storable: false },
     JSType: "0b11101110",
     klass: {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -3,7 +3,6 @@
 pub mod error;
 pub use error::{Error, Result};
 
-use core::cell::RefCell;
 use core::mem::MaybeUninit;
 
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
@@ -938,23 +937,9 @@ pub struct QueryStringMap {
     pub(crate) list: ParamList,
 }
 
-thread_local! {
-    // Unused in current code (commented-out path in get_name_count).
-    static NAME_COUNT_BUF: RefCell<[*const [u8]; 8]> = const { RefCell::new([std::ptr::from_ref::<[u8]>(&[]); 8]) };
-}
-
 impl QueryStringMap {
     pub fn get_name_count(&mut self) -> usize {
         self.list.len()
-        // if (this.name_count == null) {
-        //     var count: usize = 0;
-        //     var iterate = this.iter();
-        //     while (iterate.next(&_name_count) != null) {
-        //         count += 1;
-        //     }
-        //     this.name_count = count;
-        // }
-        // return this.name_count.?;
     }
 
     pub fn iter(&self) -> Iterator<'_> {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -206,9 +206,7 @@ pub struct URL<'a> {
     pub port: &'a [u8],
     pub protocol: &'a [u8],
     pub(crate) search: &'a [u8],
-    pub(crate) search_params: Option<QueryStringMap>,
     pub username: &'a [u8],
-    pub(crate) port_was_automatically_set: bool,
 }
 
 impl<'a> Default for URL<'a> {
@@ -225,9 +223,7 @@ impl<'a> Default for URL<'a> {
             port: b"",
             protocol: b"",
             search: b"",
-            search_params: None,
             username: b"",
-            port_was_automatically_set: false,
         }
     }
 }
@@ -315,9 +311,7 @@ impl<'a> URL<'a> {
             port: d(self.port),
             protocol: d(self.protocol),
             search: d(self.search),
-            search_params: self.search_params,
             username: d(self.username),
-            port_was_automatically_set: self.port_was_automatically_set,
         }
     }
 
@@ -937,39 +931,11 @@ pub(crate) type ParamList = Vec<Param>;
 /// QueryString array-backed hash table that does few allocations and preserves the original order
 pub struct QueryStringMap {
     // Allocator field dropped — global mimalloc per PORTING.md.
-    // `slice` is self-referential (points into `buffer`) when decoding
+    // `slice` is self-referential (points into `_buffer`) when decoding
     // happened, otherwise borrows the caller's query_string. Stored as raw fat ptr.
     slice: *const [u8],
-    pub(crate) buffer: Vec<u8>,
+    _buffer: Vec<u8>,
     pub(crate) list: ParamList,
-    pub(crate) name_count: Option<usize>,
-}
-
-impl Clone for QueryStringMap {
-    fn clone(&self) -> Self {
-        let buffer = self.buffer.clone();
-        // Re-derive `slice` so the clone doesn't dangle into the original buffer.
-        // If the original `slice` did NOT point into our own buffer (the
-        // nothing-needs-decoding fast path borrows the caller's query_string),
-        // keep it as-is — both clones borrow the same external slice.
-        // SAFETY: `self.slice` is valid for the lifetime of `self` — it either points
-        // into `self.buffer` (decoding path) or borrows an external query_string the
-        // caller keeps alive (nothing-needs-decoding fast path).
-        let self_slice = unsafe { &*self.slice };
-        let slice =
-            if !self.buffer.is_empty() && bun_alloc::is_slice_in_buffer(self_slice, &self.buffer) {
-                let len = self_slice.len();
-                &raw const buffer[..len]
-            } else {
-                self.slice
-            };
-        Self {
-            slice,
-            buffer,
-            list: self.list.clone(),
-            name_count: self.name_count,
-        }
-    }
 }
 
 thread_local! {
@@ -1154,9 +1120,8 @@ impl QueryStringMap {
         let slice_ptr: *const [u8] = &raw const buf[0..buf_writer_pos as usize];
         Ok(Some(QueryStringMap {
             list,
-            buffer: buf,
+            _buffer: buf,
             slice: slice_ptr,
-            name_count: None,
         }))
     }
 
@@ -1207,10 +1172,9 @@ impl QueryStringMap {
 
             return Ok(Some(QueryStringMap {
                 list,
-                buffer: Vec::new(),
+                _buffer: Vec::new(),
                 // `slice` borrows the caller's query_string; lifetime not tracked here
                 slice: std::ptr::from_ref::<[u8]>(query_string),
-                name_count: None,
             }));
         }
 
@@ -1282,9 +1246,8 @@ impl QueryStringMap {
         let slice_ptr: *const [u8] = &raw const buf[0..buf_writer_pos as usize];
         Ok(Some(QueryStringMap {
             list,
-            buffer: buf,
+            _buffer: buf,
             slice: slice_ptr,
-            name_count: None,
         }))
     }
 }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -963,7 +963,7 @@ impl QueryStringMap {
 
     pub(crate) fn str(&self, ptr: api::StringPointer) -> &[u8] {
         // SAFETY: `slice` is valid for the lifetime of `self` (either borrows
-        // `self.buffer` or an external query_string the caller keeps alive).
+        // `self._buffer` or an external query_string the caller keeps alive).
         let slice = unsafe { &*self.slice };
         &slice[ptr.offset as usize..ptr.offset as usize + ptr.length as usize]
     }


### PR DESCRIPTION
### Problem
- Each item below is code that nothing references: write-only struct fields, an unused constructor, unused `Display` impls, class-codegen options no class sets, error codes nothing throws, and two constants in the error page. The Rust items survived `dead_code` because they are `pub` or trait impls. The TypeScript items have no lint for unused exports.
- No open dead-code PR removes any of these symbols (checked against the diffs of all 19 open ones).

### Fix
- `src/url/lib.rs`: drop `URL::search_params` (never `Some`) and `URL::port_was_automatically_set` (never `true`), `QueryStringMap::name_count` (write-only) with the commented-out block and scratch `thread_local` that existed for it, and `impl Clone for QueryStringMap` (its only purpose was `#[derive(Clone)]` on `URL` through the dropped field). `buffer` becomes `_buffer`: it only keeps the decoded bytes alive for the raw `slice` pointer.
- `src/react_compiler/hir/mod.rs`: drop the `Display` impls for `BlockKind`, `LogicalOperator`, `BinaryOperator`, `UnaryOperator`, `UpdateOperator`, and `ObjectPropertyType`. Nothing formats these with `{}`. The printer that used them upstream was not ported.
- `src/runtime/server/ServerConfig.rs`: drop the explicit `drop(base_url)` in the `baseURI` normalization. `URL` has no destructor once `search_params` is gone, so the borrow ends at its last use and clippy rejects the call (`drop_non_drop`). `src/jsc/array_buffer.rs`: drop `MarkedArrayBuffer::from_typed_array`. `src/bun_core/env_var.rs`: drop the `npm_lifecycle_event` and `BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK` accessors. Both variables are read through raw `getenv` / `env.put` calls, never through these modules.
- `src/codegen/class-definitions.ts` and `generate-classes.ts`: drop the `lang` option (documented as a no-op), the `inspectCustom` option, and the `publicSymbol` attribute it was the only producer of. No `.classes.ts` sets them. `src/jsc/bindings/ErrorCode.ts`: drop `ERR_ACCESS_DENIED` and `ERR_KEY_GENERATION_JOB_FAILED`, which no Rust, C++, or JS code throws. `packages/bun-error`: drop the `JSErrorCodeLabel` table and the `FIREFOX_SAFARI_STACK_REGEXP` constant. `src/codegen/cppbind.ts`: drop a commented-out debug block.
- Verified: `bun bd`, `bun run rust:check-all`, `test/js/bun/util/filesystem_router.test.ts`, `test/js/web/url/url.test.ts`, `test/js/node/net/blocklist-gc.test.ts`, `test/js/bun/util/error-code-mirror.test.ts`, and the source lints for dead-code escapes, port-era markers, and pre-port identifiers.

### Background
- `QueryStringMap` is the ordered query-string table behind `Bun.FileSystemRouter` matches. `slice` is a raw pointer into its own `_buffer` when percent-decoding happened, so the struct is self-referential and a plain `#[derive(Clone)]` was never an option. The hand-written `Clone` re-derived the pointer, but no caller clones a map.
- The class codegen (`src/codegen/generate-classes.ts`) turns each `*.classes.ts` definition into the C++ `JS<Name>` wrapper and the Rust thunks. `publicSymbol` emitted a `putDirect` of a builtin public name onto the prototype. Only the `inspectCustom` shorthand produced it, and the one class that mentioned `inspectCustom` had it commented out.
- `ErrorCode.ts` is the single source for the C++ `ErrorCode` enum, the `errors[]` table, and the `$ERR_*` JS builtins. An entry nothing references costs a table row on each side.

<details><summary>Notes</summary>

Net -203 lines across 12 files.

Method: relinked `bun-debug` with `--gc-sections --print-gc-sections` (with `--whole-archive` around `libbun_runtime.a`) and took every Rust function whose every copy the linker dropped. That list was filtered against the removed lines of all 19 open dead-code PRs, then against `rg` for each survivor. A second pass removed every whole-line `#[allow(dead_code)]` in `src/` and ran `cargo check --workspace` with lints capped to warnings. Read-only scans covered `src/js/**`, `src/md`, `src/parsers`, `src/collections`, `src/semver`, `src/glob`, `src/hash`, `src/base64`, `src/zlib`, `src/url`, `src/ini`, `src/dotenv`, `scripts/**`, `packages/**`, `misctools/**`, `src/codegen/**`, and every `*.classes.ts` / `*.bind*.ts`. Also checked: no `.rs` file outside a `mod` tree, no `.cpp`/`.h` outside the build, no header nothing includes.

What the linker pass says about the rest: almost every other unreferenced Rust function on Linux is either claimed by an open PR, gated to Windows or macOS (`bun_paths::string_paths::*`, `bun_which::*`, `WStr`, `write_windows_env_block`, `heap_breakdown`), a `const fn` evaluated at compile time, a macro placeholder (`__jsc_host_*`), a debugger entry point (`dumpBtjsTrace` and its helpers), or code behind a `cfg!(debug_assertions)` early return that the debug build folds away.

Checked and deliberately left alone:
- The DOMJIT branch of the class codegen (`generate-classes.ts`, about 175 lines, plus the `DOMJIT: {}` blocks in `server.classes.ts`, `encoding.classes.ts`, `crypto.classes.ts`). `class-definitions.ts` has set `DOMJIT = undefined` on every field since #14005 (2024-09), so none of it runs, and no Rust fast-path implementations exist. Removing it is a design call, not a dead-code call.
- `misctools/gen-unicode-table.ts` and `unicode-generator.ts`: nothing runs them and they emit Zig, but `src/bun_core/string/identifier.rs` names them as the regeneration tool for its tables.
- `scripts/gamble.ts`, `scripts/debug-coredump.ts`, `scripts/github-metrics.ts`, `scripts/lldb-inline.sh` + `.cpp`: unreferenced standalone developer tools.
- `src/js/internal/fifo.ts` `Dequeue.{size,isEmpty,isNotEmpty,peek}`: only `test/internal/fifo.test.ts` uses them.
- `ErrorLocation`'s `Display` in `src/css/error.rs`, `FilePoll`'s `Display` and `FlagsFormatter` in `src/io/posix_event_loop.rs`: unused debug formatters.
- `bun_react_compiler::Environment::get_property_type`: used only by the crate's own unit tests.
- `ERR_REDIS_INVALID_{DATABASE,PASSWORD,USERNAME}`, `ERR_REDIS_TLS_{NOT_AVAILABLE,UPGRADE_FAILED}` in `ErrorCode.ts`, and `JENKINS_URL` in `env_var.rs`: unused, but the same hunks as deletions in #40690 and #40367. Follow-up once those merge. The commented-out `name_count` block in `src/url/lib.rs` is also deleted by #40367; both sides delete the same lines, so the conflict is trivial.
- `src/md/root.rs` `Options::hard_soft_breaks`: write-only. The documented `hardSoftBreaks` option is a no-op, which is a bug to fix rather than code to delete.
</details>


